### PR TITLE
Extract indexer source identity prototype

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -68,6 +68,8 @@
              Link="ReturnToSenderClosureEvidence.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\ReturnToSenderSourceProbe.cs"
              Link="ReturnToSenderSourceProbe.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\CSharpSourceIdentity.cs"
+             Link="CSharpSourceIdentity.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\ReturnToSenderCatalogReport.cs"
              Link="ReturnToSenderCatalogReport.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\GeneratedFixtures.cs"

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -9,6 +9,7 @@ using ILInspector.Metadata;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -764,6 +765,39 @@ public class ReturnToSenderFixtureCatalogTests
         {
             Directory.Delete(fixture.Directory, recursive: true);
         }
+    }
+
+    [Fact]
+    public void CSharpSourceIdentityContext_ResolvesCrossFilePartialIndexerIdentity()
+    {
+        var definition = CSharpSyntaxTree.ParseText("""
+            namespace SourceProbe;
+
+            public partial class Class1
+            {
+                [System.Runtime.CompilerServices.IndexerName("Custom")]
+                public partial int this[int index] { get; }
+            }
+            """, cancellationToken: TestContext.Current.CancellationToken)
+            .GetCompilationUnitRoot(TestContext.Current.CancellationToken);
+        var implementation = CSharpSyntaxTree.ParseText("""
+            namespace SourceProbe;
+
+            public partial class Class1
+            {
+                public partial int this[int index] => index;
+            }
+            """, cancellationToken: TestContext.Current.CancellationToken)
+            .GetCompilationUnitRoot(TestContext.Current.CancellationToken);
+        var indexer = Assert.Single(implementation.DescendantNodes().OfType<IndexerDeclarationSyntax>());
+
+        var context = CSharpSourceIdentityContext.Create([definition, implementation]);
+        var member = Assert.Single(context.IndexerMembers(indexer, "SourceProbe.Class1"));
+
+        Assert.Equal("get_Custom", member.MetadataName);
+        Assert.Equal("return index;", member.Body);
+        Assert.Contains("indexer-name-attribute", member.Evidence);
+        Assert.Contains("partial-implementation", member.Evidence);
     }
 
     static (string Directory, string AssemblyPath, IReadOnlyList<string> SourcePaths) CompileSourceFixture(

--- a/tools/DecompilerHarness/CSharpSourceIdentity.cs
+++ b/tools/DecompilerHarness/CSharpSourceIdentity.cs
@@ -1,0 +1,158 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace ILInspector.DecompilerHarness;
+
+internal sealed record CSharpSourceIndexerMember(
+    string MetadataName,
+    string? Body,
+    IReadOnlyList<string> Evidence);
+
+internal sealed class CSharpSourceIdentityContext
+{
+    readonly IReadOnlyDictionary<string, string> _partialIndexerNames;
+
+    CSharpSourceIdentityContext(IReadOnlyDictionary<string, string> partialIndexerNames)
+    {
+        _partialIndexerNames = partialIndexerNames;
+    }
+
+    public static CSharpSourceIdentityContext Create(IEnumerable<CompilationUnitSyntax> roots)
+    {
+        var partialIndexerNames = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var root in roots)
+            AddPartialIndexerNames(root.Members, namespaceName: "", containingTypes: [], partialIndexerNames);
+        return new CSharpSourceIdentityContext(partialIndexerNames);
+    }
+
+    public IReadOnlyList<CSharpSourceIndexerMember> IndexerMembers(IndexerDeclarationSyntax indexer, string fullType)
+    {
+        if (IsBodylessPartial(indexer))
+            return [];
+
+        string metadataName = IndexerMetadataName(indexer) ?? PartialIndexerMetadataName(fullType, indexer) ?? "Item";
+        var evidence = IndexerEvidence(indexer, metadataName).ToArray();
+        var members = new List<CSharpSourceIndexerMember>(2);
+        if (HasGetter(indexer))
+            members.Add(new CSharpSourceIndexerMember($"get_{metadataName}", GetterBodyText(indexer), evidence));
+        if (HasSetter(indexer))
+            members.Add(new CSharpSourceIndexerMember($"set_{metadataName}", SetterBodyText(indexer), evidence));
+        return members;
+    }
+
+    string? PartialIndexerMetadataName(string fullType, IndexerDeclarationSyntax indexer)
+        => _partialIndexerNames.TryGetValue(PartialIndexerKey(fullType, indexer), out var metadataName)
+            ? metadataName
+            : null;
+
+    static IEnumerable<string> IndexerEvidence(IndexerDeclarationSyntax indexer, string metadataName)
+    {
+        if (metadataName != "Item")
+            yield return "indexer-name-attribute";
+        if (indexer.Modifiers.Any(SyntaxKind.PartialKeyword))
+            yield return "partial-implementation";
+    }
+
+    static void AddPartialIndexerNames(
+        SyntaxList<MemberDeclarationSyntax> declarations,
+        string namespaceName,
+        IReadOnlyList<string> containingTypes,
+        Dictionary<string, string> names)
+    {
+        foreach (var declaration in declarations)
+        {
+            switch (declaration)
+            {
+                case BaseNamespaceDeclarationSyntax ns:
+                {
+                    string nextNamespace = namespaceName.Length == 0
+                        ? ns.Name.ToString()
+                        : $"{namespaceName}.{ns.Name}";
+                    AddPartialIndexerNames(ns.Members, nextNamespace, containingTypes, names);
+                    break;
+                }
+                case TypeDeclarationSyntax type:
+                {
+                    string typeName = type.Identifier.ValueText;
+                    var typeStack = containingTypes.Concat([typeName]).ToArray();
+                    string fullType = namespaceName.Length == 0
+                        ? string.Join(".", typeStack)
+                        : $"{namespaceName}.{string.Join(".", typeStack)}";
+                    foreach (var indexer in type.Members.OfType<IndexerDeclarationSyntax>().Where(IsBodylessPartial))
+                    {
+                        if (IndexerMetadataName(indexer) is { } metadataName)
+                            names.TryAdd(PartialIndexerKey(fullType, indexer), metadataName);
+                    }
+
+                    AddPartialIndexerNames(type.Members, namespaceName, typeStack, names);
+                    break;
+                }
+            }
+        }
+    }
+
+    static string PartialIndexerKey(string fullType, IndexerDeclarationSyntax indexer)
+        => $"{fullType}({string.Join(",", indexer.ParameterList.Parameters.Select(parameter => parameter.Type?.ToString() ?? ""))})";
+
+    static string? IndexerMetadataName(IndexerDeclarationSyntax indexer)
+    {
+        foreach (var attribute in indexer.AttributeLists.SelectMany(list => list.Attributes))
+        {
+            string name = attribute.Name.ToString();
+            if (!name.EndsWith("IndexerName", StringComparison.Ordinal)
+                && !name.EndsWith("IndexerNameAttribute", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (attribute.ArgumentList?.Arguments.FirstOrDefault()?.Expression is LiteralExpressionSyntax literal
+                && literal.IsKind(SyntaxKind.StringLiteralExpression)
+                && literal.Token.ValueText is { Length: > 0 } value)
+            {
+                return value;
+            }
+        }
+
+        return null;
+    }
+
+    static bool IsBodylessPartial(IndexerDeclarationSyntax indexer)
+        => indexer.Modifiers.Any(SyntaxKind.PartialKeyword)
+            && indexer.ExpressionBody is null
+            && indexer.AccessorList?.Accessors.All(accessor => accessor.Body is null && accessor.ExpressionBody is null) == true;
+
+    static bool HasGetter(IndexerDeclarationSyntax indexer)
+        => indexer.ExpressionBody is not null
+            || indexer.AccessorList?.Accessors.Any(accessor => accessor.IsKind(SyntaxKind.GetAccessorDeclaration)) == true;
+
+    static bool HasSetter(IndexerDeclarationSyntax indexer)
+        => indexer.AccessorList?.Accessors.Any(accessor =>
+            accessor.IsKind(SyntaxKind.SetAccessorDeclaration) || accessor.IsKind(SyntaxKind.InitAccessorDeclaration)) == true;
+
+    static string? GetterBodyText(IndexerDeclarationSyntax indexer)
+    {
+        if (indexer.ExpressionBody is { } expressionBody)
+            return $"return {expressionBody.Expression};";
+        var getter = indexer.AccessorList?.Accessors.FirstOrDefault(accessor => accessor.IsKind(SyntaxKind.GetAccessorDeclaration));
+        if (getter?.Body is { } body)
+            return StatementsText(body);
+        if (getter?.ExpressionBody is { } getterExpression)
+            return $"return {getterExpression.Expression};";
+        return null;
+    }
+
+    static string? SetterBodyText(IndexerDeclarationSyntax indexer)
+    {
+        var setter = indexer.AccessorList?.Accessors.FirstOrDefault(accessor =>
+            accessor.IsKind(SyntaxKind.SetAccessorDeclaration) || accessor.IsKind(SyntaxKind.InitAccessorDeclaration));
+        if (setter?.Body is { } body)
+            return StatementsText(body);
+        if (setter?.ExpressionBody is { } setterExpression)
+            return $"{setterExpression.Expression};";
+        return null;
+    }
+
+    static string StatementsText(BlockSyntax body)
+        => string.Join(Environment.NewLine, body.Statements.Select(statement => statement.ToString()));
+}

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -281,9 +281,9 @@ static class ReturnToSenderSourceProbe
                 sourceFiles.Add((sourcePath, root));
             }
 
-            var partialIndexerNames = PartialIndexerMetadataNames(sourceFiles.Select(file => file.Root));
+            var sourceIdentity = CSharpSourceIdentityContext.Create(sourceFiles.Select(file => file.Root));
             foreach (var sourceFile in sourceFiles)
-                AddSourceFile(members, overloads, sourceFile.Path, sourceFile.Root, partialIndexerNames);
+                AddSourceFile(members, overloads, sourceFile.Path, sourceFile.Root, sourceIdentity);
 
             return new FixtureSourceIndex(members);
         }
@@ -366,9 +366,9 @@ static class ReturnToSenderSourceProbe
             Dictionary<string, Dictionary<string, int>> overloads,
             string sourcePath,
             CompilationUnitSyntax root,
-            IReadOnlyDictionary<string, string> partialIndexerNames)
+            CSharpSourceIdentityContext sourceIdentity)
         {
-            foreach (var member in SourceMembers(root, sourcePath, overloads, partialIndexerNames))
+            foreach (var member in SourceMembers(root, sourcePath, overloads, sourceIdentity))
                 members.TryAdd(Key(member.Type, member.Method, member.Overload), member);
         }
 
@@ -376,9 +376,9 @@ static class ReturnToSenderSourceProbe
             CompilationUnitSyntax root,
             string sourcePath,
             Dictionary<string, Dictionary<string, int>> overloads,
-            IReadOnlyDictionary<string, string> partialIndexerNames)
+            CSharpSourceIdentityContext sourceIdentity)
         {
-            foreach (var member in SourceMembers(root.Members, namespaceName: "", containingTypes: [], sourcePath, overloads, partialIndexerNames))
+            foreach (var member in SourceMembers(root.Members, namespaceName: "", containingTypes: [], sourcePath, overloads, sourceIdentity))
                 yield return member;
         }
 
@@ -388,7 +388,7 @@ static class ReturnToSenderSourceProbe
             IReadOnlyList<string> containingTypes,
             string sourcePath,
             Dictionary<string, Dictionary<string, int>> overloads,
-            IReadOnlyDictionary<string, string> partialIndexerNames)
+            CSharpSourceIdentityContext sourceIdentity)
         {
             foreach (var declaration in declarations)
             {
@@ -399,7 +399,7 @@ static class ReturnToSenderSourceProbe
                         string nextNamespace = namespaceName.Length == 0
                             ? ns.Name.ToString()
                             : $"{namespaceName}.{ns.Name}";
-                        foreach (var member in SourceMembers(ns.Members, nextNamespace, containingTypes, sourcePath, overloads, partialIndexerNames))
+                        foreach (var member in SourceMembers(ns.Members, nextNamespace, containingTypes, sourcePath, overloads, sourceIdentity))
                             yield return member;
                         break;
                     }
@@ -411,9 +411,9 @@ static class ReturnToSenderSourceProbe
                             ? string.Join(".", typeStack)
                             : $"{namespaceName}.{string.Join(".", typeStack)}";
 
-                        foreach (var member in TypeMembers(type, fullType, sourcePath, overloads, partialIndexerNames))
+                        foreach (var member in TypeMembers(type, fullType, sourcePath, overloads, sourceIdentity))
                             yield return member;
-                        foreach (var member in SourceMembers(type.Members, namespaceName, typeStack, sourcePath, overloads, partialIndexerNames))
+                        foreach (var member in SourceMembers(type.Members, namespaceName, typeStack, sourcePath, overloads, sourceIdentity))
                             yield return member;
                         break;
                     }
@@ -425,7 +425,7 @@ static class ReturnToSenderSourceProbe
                 string fullType,
                 string path,
                 Dictionary<string, Dictionary<string, int>> overloadsByType,
-                IReadOnlyDictionary<string, string> partialIndexerNames)
+                CSharpSourceIdentityContext sourceIdentity)
             {
                 if (!overloadsByType.TryGetValue(fullType, out var overloads))
                     overloadsByType[fullType] = overloads = new Dictionary<string, int>(StringComparer.Ordinal);
@@ -485,22 +485,11 @@ static class ReturnToSenderSourceProbe
                             break;
                         case IndexerDeclarationSyntax indexer:
                         {
-                            if (IsBodylessPartial(indexer))
-                                break;
-                            string metadataName = IndexerMetadataName(indexer, type, fullType, partialIndexerNames);
-                            if (HasGetter(indexer))
+                            foreach (var indexerMember in sourceIdentity.IndexerMembers(indexer, fullType))
                             {
-                                string methodName = $"get_{metadataName}";
+                                string methodName = indexerMember.MetadataName;
                                 int overload = NextOverload(overloads, methodName);
-                                if (GetterBodyText(indexer) is { } body)
-                                    yield return new SourceMember(fullType, methodName, overload, path, body);
-                            }
-
-                            if (HasSetter(indexer))
-                            {
-                                string methodName = $"set_{metadataName}";
-                                int overload = NextOverload(overloads, methodName);
-                                if (SetterBodyText(indexer) is { } body)
+                                if (indexerMember.Body is { } body)
                                     yield return new SourceMember(fullType, methodName, overload, path, body);
                             }
 
@@ -536,51 +525,6 @@ static class ReturnToSenderSourceProbe
             }
         }
 
-        static IReadOnlyDictionary<string, string> PartialIndexerMetadataNames(IEnumerable<CompilationUnitSyntax> roots)
-        {
-            var names = new Dictionary<string, string>(StringComparer.Ordinal);
-            foreach (var root in roots)
-                AddPartialIndexerNames(root.Members, namespaceName: "", containingTypes: [], names);
-            return names;
-        }
-
-        static void AddPartialIndexerNames(
-            SyntaxList<MemberDeclarationSyntax> declarations,
-            string namespaceName,
-            IReadOnlyList<string> containingTypes,
-            Dictionary<string, string> names)
-        {
-            foreach (var declaration in declarations)
-            {
-                switch (declaration)
-                {
-                    case BaseNamespaceDeclarationSyntax ns:
-                    {
-                        string nextNamespace = namespaceName.Length == 0
-                            ? ns.Name.ToString()
-                            : $"{namespaceName}.{ns.Name}";
-                        AddPartialIndexerNames(ns.Members, nextNamespace, containingTypes, names);
-                        break;
-                    }
-                    case TypeDeclarationSyntax type:
-                    {
-                        string typeName = type.Identifier.ValueText;
-                        var typeStack = containingTypes.Concat([typeName]).ToArray();
-                        string fullType = namespaceName.Length == 0
-                            ? string.Join(".", typeStack)
-                            : $"{namespaceName}.{string.Join(".", typeStack)}";
-                        foreach (var indexer in type.Members.OfType<IndexerDeclarationSyntax>().Where(IsBodylessPartial))
-                        {
-                            if (IndexerMetadataName(indexer) is { } metadataName)
-                                names.TryAdd(PartialIndexerKey(fullType, indexer), metadataName);
-                        }
-
-                        AddPartialIndexerNames(type.Members, namespaceName, typeStack, names);
-                        break;
-                    }
-                }
-            }
-        }
     }
 
     static IReadOnlyList<ProbeTarget> DiscoverTargets(string assemblyPath, int cap)
@@ -742,11 +686,6 @@ static class ReturnToSenderSourceProbe
             && property.ExpressionBody is null
             && property.AccessorList?.Accessors.All(accessor => accessor.Body is null && accessor.ExpressionBody is null) == true;
 
-    static bool IsBodylessPartial(IndexerDeclarationSyntax indexer)
-        => indexer.Modifiers.Any(SyntaxKind.PartialKeyword)
-            && indexer.ExpressionBody is null
-            && indexer.AccessorList?.Accessors.All(accessor => accessor.Body is null && accessor.ExpressionBody is null) == true;
-
     static string? BodyText(ConstructorDeclarationSyntax constructor)
     {
         if (constructor.Body is { } body)
@@ -786,32 +725,9 @@ static class ReturnToSenderSourceProbe
         return null;
     }
 
-    static string? GetterBodyText(IndexerDeclarationSyntax indexer)
-    {
-        if (indexer.ExpressionBody is { } expressionBody)
-            return $"return {expressionBody.Expression};";
-        var getter = indexer.AccessorList?.Accessors.FirstOrDefault(accessor => accessor.IsKind(SyntaxKind.GetAccessorDeclaration));
-        if (getter?.Body is { } body)
-            return StatementsText(body);
-        if (getter?.ExpressionBody is { } getterExpression)
-            return $"return {getterExpression.Expression};";
-        return null;
-    }
-
     static string? SetterBodyText(PropertyDeclarationSyntax property)
     {
         var setter = property.AccessorList?.Accessors.FirstOrDefault(accessor =>
-            accessor.IsKind(SyntaxKind.SetAccessorDeclaration) || accessor.IsKind(SyntaxKind.InitAccessorDeclaration));
-        if (setter?.Body is { } body)
-            return StatementsText(body);
-        if (setter?.ExpressionBody is { } setterExpression)
-            return $"{setterExpression.Expression};";
-        return null;
-    }
-
-    static string? SetterBodyText(IndexerDeclarationSyntax indexer)
-    {
-        var setter = indexer.AccessorList?.Accessors.FirstOrDefault(accessor =>
             accessor.IsKind(SyntaxKind.SetAccessorDeclaration) || accessor.IsKind(SyntaxKind.InitAccessorDeclaration));
         if (setter?.Body is { } body)
             return StatementsText(body);
@@ -828,14 +744,6 @@ static class ReturnToSenderSourceProbe
         => property.AccessorList?.Accessors.Any(accessor =>
             accessor.IsKind(SyntaxKind.SetAccessorDeclaration) || accessor.IsKind(SyntaxKind.InitAccessorDeclaration)) == true;
 
-    static bool HasGetter(IndexerDeclarationSyntax indexer)
-        => indexer.ExpressionBody is not null
-            || indexer.AccessorList?.Accessors.Any(accessor => accessor.IsKind(SyntaxKind.GetAccessorDeclaration)) == true;
-
-    static bool HasSetter(IndexerDeclarationSyntax indexer)
-        => indexer.AccessorList?.Accessors.Any(accessor =>
-            accessor.IsKind(SyntaxKind.SetAccessorDeclaration) || accessor.IsKind(SyntaxKind.InitAccessorDeclaration)) == true;
-
     static string ExpressionBodyText(TypeSyntax returnType, ExpressionSyntax expression)
         => returnType is PredefinedTypeSyntax predefined
             && predefined.Keyword.IsKind(SyntaxKind.VoidKeyword)
@@ -847,64 +755,6 @@ static class ReturnToSenderSourceProbe
 
     static string NormalizeBody(string text)
         => Regex.Replace(text, @"\s+", "");
-
-    static string IndexerMetadataName(
-        IndexerDeclarationSyntax indexer,
-        TypeDeclarationSyntax declaringType,
-        string fullType,
-        IReadOnlyDictionary<string, string> partialIndexerNames)
-        => IndexerMetadataName(indexer)
-            ?? (partialIndexerNames.TryGetValue(PartialIndexerKey(fullType, indexer), out var partialMetadataName)
-                ? partialMetadataName
-                : null)
-            ?? declaringType.Members
-                .OfType<IndexerDeclarationSyntax>()
-                .Where(candidate => !ReferenceEquals(candidate, indexer)
-                    && IsBodylessPartial(candidate)
-                    && IndexerParametersMatch(candidate, indexer))
-                .Select(IndexerMetadataName)
-                .FirstOrDefault(name => name is not null)
-            ?? "Item";
-
-    static string? IndexerMetadataName(IndexerDeclarationSyntax indexer)
-    {
-        foreach (var attribute in indexer.AttributeLists.SelectMany(list => list.Attributes))
-        {
-            string name = attribute.Name.ToString();
-            if (!name.EndsWith("IndexerName", StringComparison.Ordinal)
-                && !name.EndsWith("IndexerNameAttribute", StringComparison.Ordinal))
-            {
-                continue;
-            }
-
-            if (attribute.ArgumentList?.Arguments.FirstOrDefault()?.Expression is LiteralExpressionSyntax literal
-                && literal.IsKind(SyntaxKind.StringLiteralExpression)
-                && literal.Token.ValueText is { Length: > 0 } value)
-            {
-                return value;
-            }
-        }
-
-        return null;
-    }
-
-    static string PartialIndexerKey(string fullType, IndexerDeclarationSyntax indexer)
-        => $"{fullType}({string.Join(",", indexer.ParameterList.Parameters.Select(parameter => parameter.Type?.ToString() ?? ""))})";
-
-    static bool IndexerParametersMatch(IndexerDeclarationSyntax left, IndexerDeclarationSyntax right)
-    {
-        var leftParameters = left.ParameterList.Parameters;
-        var rightParameters = right.ParameterList.Parameters;
-        if (leftParameters.Count != rightParameters.Count)
-            return false;
-        for (int i = 0; i < leftParameters.Count; i++)
-        {
-            if (!string.Equals(leftParameters[i].Type?.ToString(), rightParameters[i].Type?.ToString(), StringComparison.Ordinal))
-                return false;
-        }
-
-        return true;
-    }
 
     static bool TryKnownTasteDifference(
         string expected,


### PR DESCRIPTION
- Follows #2452
- Prototype slice for Roslyn-backed C# source identity, starting with indexers
- Evidence revision: `08059282`

## Change

**Conclusion:** **REVIEW** — extracts indexer metadata-name/source-body resolution out of `ReturnToSenderSourceProbe` into `CSharpSourceIdentityContext`, a harness-layer Roslyn source identity component.

Before:

```text
ReturnToSenderSourceProbe directly owned indexer rules: default Item naming, IndexerName, partial definitions, cross-file fragments, getter/setter bodies.
```

After:

```text
ReturnToSenderSourceProbe asks CSharpSourceIdentityContext for indexer members and only assigns metadata overload slots.
```

## Scope and safety

- **Root cause:** indexer source identity was encoded as RTS-local syntax cases rather than reusable harness identity logic.
- **Fix shape:** add `tools/DecompilerHarness/CSharpSourceIdentity.cs` with `CSharpSourceIdentityContext.IndexerMembers(...)`; wire source probe through it.
- **Product impact:** none; harness/test-only Roslyn code.
- **Scope boundary:** indexers only. Methods/properties/operators/constructors remain in the existing probe until follow-up slices.
- **RTS boundary:** RTS remains a consumer of source identity; it no longer owns the indexer metadata-name rules.

## Evidence

| Check | Result |
| --- | --- |
| Focused tests | `ReturnToSenderFixtureCatalogTests` passed, 28 tests |
| Harness build | `dotnet build tools/DecompilerHarness -c Release --no-restore` passed |
| Source probe smoke | `rts.candidates`, cap 8: 6 `valid_match`, 1 `valid_different.known_taste`, 1 `valid_different.unclassified` |
| Solution build | `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config` passed |

## New canary

`CSharpSourceIdentityContext_ResolvesCrossFilePartialIndexerIdentity` directly verifies the new component resolves:

```text
get_Custom
return index;
indexer-name-attribute
partial-implementation
```

from a cross-file partial indexer where `[IndexerName("Custom")]` lives on the erased definition fragment.

## Validation

```bash
dotnet restore src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/ReturnToSenderFixtureCatalogTests/*"
dotnet restore tools/DecompilerHarness/DecompilerHarness.csproj --configfile nuget.config
dotnet build tools/DecompilerHarness -c Release --no-restore
dotnet run --project tools/DecompilerHarness -c Release --no-restore -- --return-to-sender-fixtures rts.candidates --return-to-sender-source-probe --cap 8 --max-examples 8
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config
```

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| GPT | Pending | Requested |
| Gemini | Pending | Requested |
| MAI | Pending | Requested |
