### PR TITLE
Harden TypeRefDecoder against cyclic/over-deep metadata (#2159)

### DIFF
--- a/src/ILInspector.Analysis.Tests/TypeRefDecoderRecursionTests.cs
+++ b/src/ILInspector.Analysis.Tests/TypeRefDecoderRecursionTests.cs
@@ -108,6 +108,38 @@ public class TypeRefDecoderRecursionTests
         Assert.Equal(TypeRefKind.Unsupported, result.Kind);
     }
 
+    [Fact]
+    public void SelfReferentialModreqUnderBlobCap_DoesNotStackOverflow()
+    {
+        var reader = BuildMetadata(metadata =>
+        {
+            // Each blob is under the per-blob cap (1003 bytes) but cycles: 1000 SZARRAY (0x1d)
+            // prefixes, then a required custom modifier (CMOD_REQD, 0x1f) whose coded token
+            // (0x06) points back at this TypeSpec row, then I4 (0x08). Decoding it re-enters
+            // GetTypeFromSpecification, stacking another ~1000 SRM native frames per re-entry —
+            // so the per-blob cap alone would still StackOverflow. The cumulative-bytes cap must
+            // stop the chain.
+            var signature = new BlobBuilder();
+            for (int i = 0; i < 1000; i++)
+                signature.WriteByte(0x1d);
+            signature.WriteByte(0x1f);
+            signature.WriteByte(0x06);
+            signature.WriteByte(0x08);
+            metadata.AddTypeSpecification(metadata.GetOrAddBlob(signature));
+            return default(EntityHandle);
+        });
+
+        var result = TypeRefDecoder.Instance.GetTypeFromSpecification(
+            reader,
+            GenericScope.Empty,
+            MetadataTokens.TypeSpecificationHandle(1),
+            0);
+
+        // Reaching this assertion at all proves the cumulative cap stopped the cycle before it
+        // overflowed the native stack.
+        Assert.NotNull(result);
+    }
+
     static MetadataReader BuildMetadata(Func<MetadataBuilder, EntityHandle> addMalformedRow)
     {
         var metadata = new MetadataBuilder();

--- a/src/ILInspector.Analysis.Tests/TypeRefDecoderRecursionTests.cs
+++ b/src/ILInspector.Analysis.Tests/TypeRefDecoderRecursionTests.cs
@@ -82,6 +82,32 @@ public class TypeRefDecoderRecursionTests
         Assert.Equal(TypeRefKind.Unsupported, result.Kind);
     }
 
+    [Fact]
+    public void OverlongTypeSpecificationBlob_DoesNotStackOverflow()
+    {
+        var reader = BuildMetadata(metadata =>
+        {
+            // A signature of 100000 nested SZARRAY (0x1d) prefixes then I4 (0x08). SRM's
+            // SignatureDecoder.DecodeType recurses on the native stack once per prefix, before
+            // any provider callback, so the depth counter cannot catch it — only refusing the
+            // over-long blob up front prevents the StackOverflow.
+            var signature = new BlobBuilder();
+            for (int i = 0; i < 100_000; i++)
+                signature.WriteByte(0x1d);
+            signature.WriteByte(0x08);
+            metadata.AddTypeSpecification(metadata.GetOrAddBlob(signature));
+            return default(EntityHandle);
+        });
+
+        var result = TypeRefDecoder.Instance.GetTypeFromSpecification(
+            reader,
+            GenericScope.Empty,
+            MetadataTokens.TypeSpecificationHandle(1),
+            0);
+
+        Assert.Equal(TypeRefKind.Unsupported, result.Kind);
+    }
+
     static MetadataReader BuildMetadata(Func<MetadataBuilder, EntityHandle> addMalformedRow)
     {
         var metadata = new MetadataBuilder();

--- a/src/ILInspector.Analysis.Tests/TypeRefDecoderRecursionTests.cs
+++ b/src/ILInspector.Analysis.Tests/TypeRefDecoderRecursionTests.cs
@@ -1,0 +1,118 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+namespace ILInspector.Analysis.Tests;
+
+// Malformed metadata can encode a type-reference resolution scope or a nested-type chain
+// that points back at itself. Without a recursion guard the decoder recurses until it hits
+// an *uncatchable* StackOverflowException and terminates the process. These tests craft
+// those cycles and assert the decoder fails closed to Unsupported instead of crashing.
+//
+// WARNING: if the recursion guard in TypeRefDecoder is removed, these tests do not fail —
+// they StackOverflow and take down the whole test runner.
+public class TypeRefDecoderRecursionTests
+{
+    [Fact]
+    public void SelfReferentialResolutionScope_DoesNotStackOverflow()
+    {
+        var reader = BuildMetadata(metadata =>
+            metadata.AddTypeReference(
+                // ResolutionScope points at this very TypeReference row (token 1) -> a cycle.
+                MetadataTokens.TypeReferenceHandle(1),
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("Loop")));
+
+        var result = TypeRefDecoder.Instance.GetTypeFromReference(
+            reader,
+            MetadataTokens.TypeReferenceHandle(1),
+            0);
+
+        Assert.Equal(TypeRefKind.Unsupported, result.Kind);
+    }
+
+    [Fact]
+    public void SelfNestedTypeDefinition_DoesNotStackOverflow()
+    {
+        TypeDefinitionHandle typeHandle = default;
+        var reader = BuildMetadata(metadata =>
+        {
+            typeHandle = metadata.AddTypeDefinition(
+                TypeAttributes.NestedPublic,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("Loop"),
+                baseType: default,
+                fieldList: MetadataTokens.FieldDefinitionHandle(1),
+                methodList: MetadataTokens.MethodDefinitionHandle(1));
+            // Declares the type as nested inside itself -> GetDeclaringType() returns it -> a cycle.
+            metadata.AddNestedType(typeHandle, typeHandle);
+            return default(EntityHandle);
+        });
+
+        var result = TypeRefDecoder.Instance.GetTypeFromDefinition(reader, typeHandle, 0);
+
+        Assert.Equal(TypeRefKind.Unsupported, result.Kind);
+    }
+
+    [Fact]
+    public void SelfReferentialTypeSpecification_DoesNotStackOverflow()
+    {
+        var reader = BuildMetadata(metadata =>
+        {
+            // A signature whose first element is a required custom modifier (CMOD_REQD,
+            // 0x1f) referencing this very TypeSpec row via its TypeDefOrRefOrSpec coded token
+            // ((row 1 << 2) | tag 2 for TypeSpec = 0x06), followed by I4 (0x08) as the
+            // modified type. Custom modifiers decode with allowTypeSpecifications: true, so
+            // resolving the modifier re-enters GetTypeFromSpecification on this row -> a cycle.
+            var signature = new BlobBuilder();
+            signature.WriteByte(0x1f);
+            signature.WriteByte(0x06);
+            signature.WriteByte(0x08);
+            metadata.AddTypeSpecification(metadata.GetOrAddBlob(signature));
+            return default(EntityHandle);
+        });
+
+        var result = TypeRefDecoder.Instance.GetTypeFromSpecification(
+            reader,
+            GenericScope.Empty,
+            MetadataTokens.TypeSpecificationHandle(1),
+            0);
+
+        Assert.Equal(TypeRefKind.Unsupported, result.Kind);
+    }
+
+    static MetadataReader BuildMetadata(Func<MetadataBuilder, EntityHandle> addMalformedRow)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("Synthetic.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Synthetic"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        // The module (<Module>) pseudo-type must be row 1; the malformed rows come after it.
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        addMalformedRow(metadata);
+
+        var rootBuilder = new MetadataRootBuilder(metadata, suppressValidation: true);
+        var image = new BlobBuilder();
+        rootBuilder.Serialize(image, methodBodyStreamRva: 0, mappedFieldDataStreamRva: 0);
+        var provider = MetadataReaderProvider.FromMetadataImage(ImmutableArray.Create(image.ToArray()));
+        return provider.GetMetadataReader();
+    }
+}

--- a/src/ILInspector.Analysis/TypeRefDecoder.cs
+++ b/src/ILInspector.Analysis/TypeRefDecoder.cs
@@ -12,6 +12,16 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
 {
     public static readonly TypeRefDecoder Instance = new();
 
+    // Attacker-controlled metadata can encode a self-referential resolution scope,
+    // TypeSpecification, or nested-type chain, which recurses into an *uncatchable*
+    // StackOverflow (the try/catch filters around these calls cannot catch it). Guard the
+    // recursive descents with a per-thread depth limit — the decoder is a shared singleton
+    // used under Parallel, so the counter must be thread-local — and fail closed to
+    // Unsupported. Real metadata nests shallowly, so the limit only trips on malformed input.
+    [ThreadStatic]
+    static int s_recursionDepth;
+    const int MaxRecursionDepth = 256;
+
     public TypeRef GetPrimitiveType(PrimitiveTypeCode typeCode)
         => TypeRef.CoreLib("System", typeCode switch
         {
@@ -43,8 +53,20 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
         string ns = reader.GetString(typeDef.Namespace);
         if (typeDef.IsNested)
         {
-            var declaring = GetTypeFromDefinition(reader, typeDef.GetDeclaringType(), 0);
-            return TypeRef.Definition(declaring.Assembly, declaring.Namespace, $"{declaring.Name}+{name}", declaring.TrustedFrameworkAssembly, declaring.TrustedProtobufAssembly);
+            if (s_recursionDepth >= MaxRecursionDepth)
+                return TypeRef.Unsupported("type-definition nesting depth exceeded");
+            s_recursionDepth++;
+            try
+            {
+                var declaring = GetTypeFromDefinition(reader, typeDef.GetDeclaringType(), 0);
+                if (declaring.Kind == TypeRefKind.Unsupported)
+                    return declaring;
+                return TypeRef.Definition(declaring.Assembly, declaring.Namespace, $"{declaring.Name}+{name}", declaring.TrustedFrameworkAssembly, declaring.TrustedProtobufAssembly);
+            }
+            finally
+            {
+                s_recursionDepth--;
+            }
         }
         string assembly = reader.IsAssembly
             ? reader.GetString(reader.GetAssemblyDefinition().Name)
@@ -81,7 +103,19 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
     }
 
     public TypeRef GetTypeFromSpecification(MetadataReader reader, GenericScope genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
-        => reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+    {
+        if (s_recursionDepth >= MaxRecursionDepth)
+            return TypeRef.Unsupported("type-specification recursion depth exceeded");
+        s_recursionDepth++;
+        try
+        {
+            return reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+        }
+        finally
+        {
+            s_recursionDepth--;
+        }
+    }
 
     public TypeRef GetSZArrayType(TypeRef elementType) => TypeRef.SzArray(elementType);
     public TypeRef GetArrayType(TypeRef elementType, ArrayShape shape) => TypeRef.MdArray(elementType, shape.Rank);
@@ -100,8 +134,20 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
 
     static TypeRef NestedReference(MetadataReader reader, TypeReferenceHandle declaringHandle, string nestedName)
     {
-        var declaring = Instance.GetTypeFromReference(reader, declaringHandle, 0);
-        return TypeRef.Definition(declaring.Assembly, declaring.Namespace, $"{declaring.Name}+{nestedName}", declaring.TrustedFrameworkAssembly, declaring.TrustedProtobufAssembly);
+        if (s_recursionDepth >= MaxRecursionDepth)
+            return TypeRef.Unsupported("type-reference resolution-scope recursion depth exceeded");
+        s_recursionDepth++;
+        try
+        {
+            var declaring = Instance.GetTypeFromReference(reader, declaringHandle, 0);
+            if (declaring.Kind == TypeRefKind.Unsupported)
+                return declaring;
+            return TypeRef.Definition(declaring.Assembly, declaring.Namespace, $"{declaring.Name}+{nestedName}", declaring.TrustedFrameworkAssembly, declaring.TrustedProtobufAssembly);
+        }
+        finally
+        {
+            s_recursionDepth--;
+        }
     }
 
     static string NameAt(ImmutableArray<string> names, int index)

--- a/src/ILInspector.Analysis/TypeRefDecoder.cs
+++ b/src/ILInspector.Analysis/TypeRefDecoder.cs
@@ -31,6 +31,16 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
     // input.
     const int MaxSignatureBlobLength = 1024;
 
+    // A self-referential TypeSpecification (reached via a modreq custom modifier) re-enters
+    // GetTypeFromSpecification, and each re-entry stacks another blob's worth of SRM native
+    // DecodeType frames on top of the live ones. The per-blob cap alone would let a cycle
+    // multiply into MaxSignatureBlobLength * MaxRecursionDepth native frames — still an
+    // uncatchable StackOverflow — so also bound the CUMULATIVE decoded blob bytes across the
+    // live re-entry chain, which is what actually bounds the native stack depth.
+    [ThreadStatic]
+    static int s_cumulativeSignatureBytes;
+    const int MaxCumulativeSignatureBytes = 4096;
+
     public TypeRef GetPrimitiveType(PrimitiveTypeCode typeCode)
         => TypeRef.CoreLib("System", typeCode switch
         {
@@ -116,8 +126,12 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
         if (s_recursionDepth >= MaxRecursionDepth)
             return TypeRef.Unsupported("type-specification recursion depth exceeded");
         var spec = reader.GetTypeSpecification(handle);
-        if (reader.GetBlobReader(spec.Signature).Length > MaxSignatureBlobLength)
+        int blobLength = reader.GetBlobReader(spec.Signature).Length;
+        if (blobLength > MaxSignatureBlobLength)
             return TypeRef.Unsupported("type-specification signature blob too large");
+        if (s_cumulativeSignatureBytes + blobLength > MaxCumulativeSignatureBytes)
+            return TypeRef.Unsupported("type-specification cumulative signature blob too large");
+        s_cumulativeSignatureBytes += blobLength;
         s_recursionDepth++;
         try
         {
@@ -126,6 +140,7 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
         finally
         {
             s_recursionDepth--;
+            s_cumulativeSignatureBytes -= blobLength;
         }
     }
 

--- a/src/ILInspector.Analysis/TypeRefDecoder.cs
+++ b/src/ILInspector.Analysis/TypeRefDecoder.cs
@@ -22,6 +22,15 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
     static int s_recursionDepth;
     const int MaxRecursionDepth = 256;
 
+    // SRM's own SignatureDecoder.DecodeType recurses on the native stack for each nested
+    // structural element (pointer/array/byref/pinned/generic-inst) within a *single* signature
+    // blob, before any provider callback runs, so the depth counter above cannot catch it — a
+    // long enough blob StackOverflows inside SRM. Blob length bounds that native depth (each
+    // level costs >= 1 byte), so refuse over-long TypeSpecification blobs. Real single-type
+    // blobs are tiny (CoreLib's largest TypeSpec is 57 bytes), so this only trips on malformed
+    // input.
+    const int MaxSignatureBlobLength = 1024;
+
     public TypeRef GetPrimitiveType(PrimitiveTypeCode typeCode)
         => TypeRef.CoreLib("System", typeCode switch
         {
@@ -106,10 +115,13 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
     {
         if (s_recursionDepth >= MaxRecursionDepth)
             return TypeRef.Unsupported("type-specification recursion depth exceeded");
+        var spec = reader.GetTypeSpecification(handle);
+        if (reader.GetBlobReader(spec.Signature).Length > MaxSignatureBlobLength)
+            return TypeRef.Unsupported("type-specification signature blob too large");
         s_recursionDepth++;
         try
         {
-            return reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+            return spec.DecodeSignature(this, genericContext);
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/TypeRefDecoderRecursionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeRefDecoderRecursionTests.cs
@@ -88,6 +88,32 @@ public class TypeRefDecoderRecursionTests
         Assert.Equal("Int32", result.Name);
     }
 
+    [Fact]
+    public void OverlongTypeSpecificationBlob_DoesNotStackOverflow()
+    {
+        var reader = BuildMetadata(metadata =>
+        {
+            // A signature of 100000 nested SZARRAY (0x1d) prefixes then I4 (0x08). SRM's
+            // SignatureDecoder.DecodeType recurses on the native stack once per prefix, before
+            // any provider callback, so the depth counter cannot catch it — only refusing the
+            // over-long blob up front prevents the StackOverflow.
+            var signature = new BlobBuilder();
+            for (int i = 0; i < 100_000; i++)
+                signature.WriteByte(0x1d);
+            signature.WriteByte(0x08);
+            metadata.AddTypeSpecification(metadata.GetOrAddBlob(signature));
+            return default(EntityHandle);
+        });
+
+        var result = TypeRefDecoder.Instance.GetTypeFromSpecification(
+            reader,
+            GenericScope.Empty,
+            MetadataTokens.TypeSpecificationHandle(1),
+            0);
+
+        Assert.Equal(TypeRefKind.Unsupported, result.Kind);
+    }
+
     static MetadataReader BuildMetadata(Func<MetadataBuilder, EntityHandle> addMalformedRow)
     {
         var metadata = new MetadataBuilder();

--- a/src/ILInspector.Decompiler.Tests/TypeRefDecoderRecursionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeRefDecoderRecursionTests.cs
@@ -1,0 +1,124 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Malformed metadata can encode a type-reference resolution scope or a nested-type chain
+// that points back at itself. Without a recursion guard the decoder recurses until it hits
+// an *uncatchable* StackOverflowException and terminates the process. These tests craft
+// those cycles and assert the decoder fails closed to Unsupported instead of crashing.
+//
+// WARNING: if the recursion guard in TypeRefDecoder is removed, these tests do not fail —
+// they StackOverflow and take down the whole test runner.
+public class TypeRefDecoderRecursionTests
+{
+    [Fact]
+    public void SelfReferentialResolutionScope_DoesNotStackOverflow()
+    {
+        var reader = BuildMetadata(metadata =>
+            metadata.AddTypeReference(
+                // ResolutionScope points at this very TypeReference row (token 1) -> a cycle.
+                MetadataTokens.TypeReferenceHandle(1),
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("Loop")));
+
+        var result = TypeRefDecoder.Instance.GetTypeFromReference(
+            reader,
+            MetadataTokens.TypeReferenceHandle(1),
+            0);
+
+        Assert.Equal(TypeRefKind.Unsupported, result.Kind);
+    }
+
+    [Fact]
+    public void SelfNestedTypeDefinition_DoesNotStackOverflow()
+    {
+        TypeDefinitionHandle typeHandle = default;
+        var reader = BuildMetadata(metadata =>
+        {
+            typeHandle = metadata.AddTypeDefinition(
+                TypeAttributes.NestedPublic,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("Loop"),
+                baseType: default,
+                fieldList: MetadataTokens.FieldDefinitionHandle(1),
+                methodList: MetadataTokens.MethodDefinitionHandle(1));
+            // Declares the type as nested inside itself -> GetDeclaringType() returns it -> a cycle.
+            metadata.AddNestedType(typeHandle, typeHandle);
+            return default(EntityHandle);
+        });
+
+        var result = TypeRefDecoder.Instance.GetTypeFromDefinition(reader, typeHandle, 0);
+
+        Assert.Equal(TypeRefKind.Unsupported, result.Kind);
+    }
+
+    [Fact]
+    public void SelfReferentialTypeSpecification_DoesNotStackOverflow()
+    {
+        var reader = BuildMetadata(metadata =>
+        {
+            // A signature whose first element is a required custom modifier (CMOD_REQD,
+            // 0x1f) referencing this very TypeSpec row via its TypeDefOrRefOrSpec coded token
+            // ((row 1 << 2) | tag 2 for TypeSpec = 0x06), followed by I4 (0x08) as the
+            // modified type. Custom modifiers decode with allowTypeSpecifications: true, so
+            // resolving the modifier re-enters GetTypeFromSpecification on this row -> a cycle.
+            var signature = new BlobBuilder();
+            signature.WriteByte(0x1f);
+            signature.WriteByte(0x06);
+            signature.WriteByte(0x08);
+            metadata.AddTypeSpecification(metadata.GetOrAddBlob(signature));
+            return default(EntityHandle);
+        });
+
+        var result = TypeRefDecoder.Instance.GetTypeFromSpecification(
+            reader,
+            GenericScope.Empty,
+            MetadataTokens.TypeSpecificationHandle(1),
+            0);
+
+        // The decompiler intentionally drops custom modifiers (GetModifiedType returns the
+        // unmodified type), so this modreq cycle degrades to the underlying I4 rather than
+        // Unsupported. The guard's contract here is purely crash-avoidance: reaching this
+        // assertion at all proves the decode terminated instead of overflowing the stack.
+        Assert.NotNull(result);
+        Assert.Equal("Int32", result.Name);
+    }
+
+    static MetadataReader BuildMetadata(Func<MetadataBuilder, EntityHandle> addMalformedRow)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("Synthetic.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Synthetic"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        // The module (<Module>) pseudo-type must be row 1; the malformed rows come after it.
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        addMalformedRow(metadata);
+
+        var rootBuilder = new MetadataRootBuilder(metadata, suppressValidation: true);
+        var image = new BlobBuilder();
+        rootBuilder.Serialize(image, methodBodyStreamRva: 0, mappedFieldDataStreamRva: 0);
+        var provider = MetadataReaderProvider.FromMetadataImage(ImmutableArray.Create(image.ToArray()));
+        return provider.GetMetadataReader();
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/TypeRefDecoderRecursionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeRefDecoderRecursionTests.cs
@@ -114,6 +114,38 @@ public class TypeRefDecoderRecursionTests
         Assert.Equal(TypeRefKind.Unsupported, result.Kind);
     }
 
+    [Fact]
+    public void SelfReferentialModreqUnderBlobCap_DoesNotStackOverflow()
+    {
+        var reader = BuildMetadata(metadata =>
+        {
+            // Each blob is under the per-blob cap (1003 bytes) but cycles: 1000 SZARRAY (0x1d)
+            // prefixes, then a required custom modifier (CMOD_REQD, 0x1f) whose coded token
+            // (0x06) points back at this TypeSpec row, then I4 (0x08). Decoding it re-enters
+            // GetTypeFromSpecification, stacking another ~1000 SRM native frames per re-entry —
+            // so the per-blob cap alone would still StackOverflow. The cumulative-bytes cap must
+            // stop the chain.
+            var signature = new BlobBuilder();
+            for (int i = 0; i < 1000; i++)
+                signature.WriteByte(0x1d);
+            signature.WriteByte(0x1f);
+            signature.WriteByte(0x06);
+            signature.WriteByte(0x08);
+            metadata.AddTypeSpecification(metadata.GetOrAddBlob(signature));
+            return default(EntityHandle);
+        });
+
+        var result = TypeRefDecoder.Instance.GetTypeFromSpecification(
+            reader,
+            GenericScope.Empty,
+            MetadataTokens.TypeSpecificationHandle(1),
+            0);
+
+        // Reaching this assertion at all proves the cumulative cap stopped the cycle before it
+        // overflowed the native stack.
+        Assert.NotNull(result);
+    }
+
     static MetadataReader BuildMetadata(Func<MetadataBuilder, EntityHandle> addMalformedRow)
     {
         var metadata = new MetadataBuilder();

--- a/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
@@ -40,6 +40,16 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
     // input.
     const int MaxSignatureBlobLength = 1024;
 
+    // A self-referential TypeSpecification (reached via a modreq custom modifier) re-enters
+    // GetTypeFromSpecification, and each re-entry stacks another blob's worth of SRM native
+    // DecodeType frames on top of the live ones. The per-blob cap alone would let a cycle
+    // multiply into MaxSignatureBlobLength * MaxRecursionDepth native frames — still an
+    // uncatchable StackOverflow — so also bound the CUMULATIVE decoded blob bytes across the
+    // live re-entry chain, which is what actually bounds the native stack depth.
+    [ThreadStatic]
+    static int s_cumulativeSignatureBytes;
+    const int MaxCumulativeSignatureBytes = 4096;
+
     public TypeRef GetPrimitiveType(PrimitiveTypeCode typeCode)
         => TypeRef.CoreLib("System", typeCode switch
         {
@@ -132,8 +142,12 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
         if (s_recursionDepth >= MaxRecursionDepth)
             return TypeRef.Unsupported("type-specification recursion depth exceeded");
         var spec = reader.GetTypeSpecification(handle);
-        if (reader.GetBlobReader(spec.Signature).Length > MaxSignatureBlobLength)
+        int blobLength = reader.GetBlobReader(spec.Signature).Length;
+        if (blobLength > MaxSignatureBlobLength)
             return TypeRef.Unsupported("type-specification signature blob too large");
+        if (s_cumulativeSignatureBytes + blobLength > MaxCumulativeSignatureBytes)
+            return TypeRef.Unsupported("type-specification cumulative signature blob too large");
+        s_cumulativeSignatureBytes += blobLength;
         s_recursionDepth++;
         try
         {
@@ -142,6 +156,7 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
         finally
         {
             s_recursionDepth--;
+            s_cumulativeSignatureBytes -= blobLength;
         }
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
@@ -31,6 +31,15 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
     static int s_recursionDepth;
     const int MaxRecursionDepth = 256;
 
+    // SRM's own SignatureDecoder.DecodeType recurses on the native stack for each nested
+    // structural element (pointer/array/byref/pinned/generic-inst) within a *single* signature
+    // blob, before any provider callback runs, so the depth counter above cannot catch it — a
+    // long enough blob StackOverflows inside SRM. Blob length bounds that native depth (each
+    // level costs >= 1 byte), so refuse over-long TypeSpecification blobs. Real single-type
+    // blobs are tiny (CoreLib's largest TypeSpec is 57 bytes), so this only trips on malformed
+    // input.
+    const int MaxSignatureBlobLength = 1024;
+
     public TypeRef GetPrimitiveType(PrimitiveTypeCode typeCode)
         => TypeRef.CoreLib("System", typeCode switch
         {
@@ -122,10 +131,13 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
     {
         if (s_recursionDepth >= MaxRecursionDepth)
             return TypeRef.Unsupported("type-specification recursion depth exceeded");
+        var spec = reader.GetTypeSpecification(handle);
+        if (reader.GetBlobReader(spec.Signature).Length > MaxSignatureBlobLength)
+            return TypeRef.Unsupported("type-specification signature blob too large");
         s_recursionDepth++;
         try
         {
-            return reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+            return spec.DecodeSignature(this, genericContext);
         }
         finally
         {

--- a/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
@@ -21,6 +21,16 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
 {
     public static readonly TypeRefDecoder Instance = new();
 
+    // Attacker-controlled metadata can encode a self-referential resolution scope,
+    // TypeSpecification, or nested-type chain, which recurses into an *uncatchable*
+    // StackOverflow (the try/catch filters around these calls cannot catch it). Guard the
+    // recursive descents with a per-thread depth limit — the decoder is a shared singleton
+    // used under Parallel, so the counter must be thread-local — and fail closed to
+    // Unsupported. Real metadata nests shallowly, so the limit only trips on malformed input.
+    [ThreadStatic]
+    static int s_recursionDepth;
+    const int MaxRecursionDepth = 256;
+
     public TypeRef GetPrimitiveType(PrimitiveTypeCode typeCode)
         => TypeRef.CoreLib("System", typeCode switch
         {
@@ -52,13 +62,25 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
         string ns = reader.GetString(typeDef.Namespace);
         if (typeDef.IsNested)
         {
-            var declaring = GetTypeFromDefinition(reader, typeDef.GetDeclaringType(), 0);
-            return TypeRef.Definition(
-                declaring.Assembly,
-                declaring.Namespace,
-                $"{declaring.Name}+{name}",
-                HintFrom(rawTypeKind),
-                InlineArrayFact(reader, typeDef));
+            if (s_recursionDepth >= MaxRecursionDepth)
+                return TypeRef.Unsupported("type-definition nesting depth exceeded");
+            s_recursionDepth++;
+            try
+            {
+                var declaring = GetTypeFromDefinition(reader, typeDef.GetDeclaringType(), 0);
+                if (declaring.Kind == TypeRefKind.Unsupported)
+                    return declaring;
+                return TypeRef.Definition(
+                    declaring.Assembly,
+                    declaring.Namespace,
+                    $"{declaring.Name}+{name}",
+                    HintFrom(rawTypeKind),
+                    InlineArrayFact(reader, typeDef));
+            }
+            finally
+            {
+                s_recursionDepth--;
+            }
         }
         string assembly = reader.IsAssembly
             ? Canonical(reader.GetString(reader.GetAssemblyDefinition().Name))
@@ -77,15 +99,39 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
                 var assembly = reader.GetAssemblyReference((AssemblyReferenceHandle)typeRef.ResolutionScope);
                 return TypeRef.Definition(Canonical(reader.GetString(assembly.Name)), ns, name, HintFrom(rawTypeKind));
             case HandleKind.TypeReference:
-                var declaring = GetTypeFromReference(reader, (TypeReferenceHandle)typeRef.ResolutionScope, 0);
-                return TypeRef.Definition(declaring.Assembly, declaring.Namespace, $"{declaring.Name}+{name}", HintFrom(rawTypeKind));
+                if (s_recursionDepth >= MaxRecursionDepth)
+                    return TypeRef.Unsupported("type-reference resolution-scope recursion depth exceeded");
+                s_recursionDepth++;
+                try
+                {
+                    var declaring = GetTypeFromReference(reader, (TypeReferenceHandle)typeRef.ResolutionScope, 0);
+                    if (declaring.Kind == TypeRefKind.Unsupported)
+                        return declaring;
+                    return TypeRef.Definition(declaring.Assembly, declaring.Namespace, $"{declaring.Name}+{name}", HintFrom(rawTypeKind));
+                }
+                finally
+                {
+                    s_recursionDepth--;
+                }
             default:
                 return TypeRef.Definition("", ns, name, HintFrom(rawTypeKind));
         }
     }
 
     public TypeRef GetTypeFromSpecification(MetadataReader reader, GenericScope genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
-        => reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+    {
+        if (s_recursionDepth >= MaxRecursionDepth)
+            return TypeRef.Unsupported("type-specification recursion depth exceeded");
+        s_recursionDepth++;
+        try
+        {
+            return reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+        }
+        finally
+        {
+            s_recursionDepth--;
+        }
+    }
 
     public TypeRef GetSZArrayType(TypeRef elementType) => TypeRef.SzArray(elementType);
 


### PR DESCRIPTION
Fixes #2159.

## Problem

Both copies of `TypeRefDecoder` (`src/ILInspector.Analysis/TypeRefDecoder.cs` and
`src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs`) resolve attacker-controlled
metadata **without a recursion/cycle guard**. Malformed metadata can encode:

- a `TypeReference` whose `ResolutionScope` chains back to itself
  (`GetTypeFromReference` -> nested reference -> `GetTypeFromReference` ...),
- a `TypeDefinition` declared as nested inside itself
  (`GetTypeFromDefinition` -> `GetDeclaringType()` -> same handle), or
- a `TypeSpecification` signature that references itself via a `modreq` custom modifier
  (the only signature position that decodes with `allowTypeSpecifications: true`, re-entering
  `GetTypeFromSpecification`).

Each recurses unboundedly and terminates the process with an **uncatchable
`StackOverflowException`** — the `BadImageFormatException`/`InvalidOperationException`/... filters
wrapped around these calls cannot catch it. These `GetTypeFrom*` paths run pervasively when
inspecting untrusted assemblies (e.g. the allocation escape classifier resolves every
`call`/`callvirt`/`newobj` target through the same decoder), so this is a tool-wide crash-safety hole.

## Fix

Guard the three recursive descent sites in **both** decoder copies with a per-thread depth
limit and fail closed to `TypeRef.Unsupported`:

- `[ThreadStatic] static int s_recursionDepth` + `const int MaxRecursionDepth = 256`. Thread-local
  because the decoder is a shared singleton used under `Parallel` (e.g. `LibraryBodyIndex`).
- Guards wrap only the **recursive branches** (nested reference, nested definition,
  `GetTypeFromSpecification`), not the hot common path, so there is no per-call overhead on
  ordinary types.
- Nested type/reference sites now **propagate** an `Unsupported` declaring type instead of
  wrapping it back into a `Definition` with an empty assembly name.

`256` is far above real metadata nesting/generic depth, so valid inputs are unaffected.

## Evidence

- **Return-address census byte-identical** on net9.0 CoreLib: 32046 matched / 7895 agree /
  **24.64%** / 6462 unmatched — unchanged from baseline. No legitimate deep type hits the cap;
  no new `Unsupported`.
- **Regression tests** in both test projects synthesize all three cycle shapes via
  `MetadataBuilder` (self-referential resolution scope, self-nested type definition, and a
  `modreq`-based self-referential `TypeSpecification`) and assert the decode degrades gracefully
  instead of crashing. Without the guard these tests StackOverflow and take down the runner —
  which is exactly the regression they pin.
  - Analysis: all three assert `Unsupported`.
  - Decompiler: the `modreq` case degrades to the underlying type because the decompiler
    intentionally drops custom modifiers (correct C# behavior); the guard's contract there is
    crash-avoidance.
- `ILInspector.Analysis.Tests` **403/0**; `ILInspector.Decompiler.Tests` (excl. `Speed=Slow`)
  **2054/0**; full `dotnet-inspect.slnx` build clean.

## Review

Decoder crash-safety hardening with a subtle recursion/thread-locality invariant -> requesting
two-model adversarial review (GPT-5.5 + Gemini 3.1 Pro) per policy; results reconciled on the PR.


---

### Update (adversarial review)

Review (GPT-5.5 + Gemini 3.1 Pro) verified an additional real crash: SRM's own
`SignatureDecoder.DecodeType` recurses on the native stack for a deep *single* signature
blob (e.g. 100000 nested `SZARRAY`) before any provider callback, bypassing the depth
counter. Commit `44b1e486` adds a TypeSpecification **blob-length cap** in
`GetTypeFromSpecification` (both decoders), failing closed to `Unsupported`; the largest
real CoreLib TypeSpec blob is 57 bytes so the 1024-byte cap never trips on valid input.
The tool-wide remainder (method/field/local/member-ref/method-spec entry points, which
need a non-recursive depth prescan) is tracked in #2490. See the reconciliation comment for
details.
