### PR TITLE
Add Return Address census baseline drift gate to Deep Inspect (#2440)

### DIFF
--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -135,7 +135,7 @@ jobs:
             --emit-return-address-snapshot artifacts/deep-inspect/return-address-snapshot.json \
             --diff-return-address-baseline tools/DecompilerHarness/corpus/return-address-baseline.json \
             --max-examples 10 \
-            | tee artifacts/deep-inspect/return-address-census.txt
+            2>&1 | tee artifacts/deep-inspect/return-address-census.txt
 
       - name: Run validity predicate scan
         shell: bash

--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -125,6 +125,18 @@ jobs:
             --corpus-fidelity-cap 3 \
             --max-examples 3
 
+      - name: Run return-address equivalence census
+        shell: bash
+        run: |
+          set -o pipefail
+          mapfile -t assemblies < corpus-assemblies.txt
+          mkdir -p artifacts/deep-inspect
+          dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
+            --emit-return-address-snapshot artifacts/deep-inspect/return-address-snapshot.json \
+            --diff-return-address-baseline tools/DecompilerHarness/corpus/return-address-baseline.json \
+            --max-examples 10 \
+            | tee artifacts/deep-inspect/return-address-census.txt
+
       - name: Run validity predicate scan
         shell: bash
         run: |

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -54,6 +54,8 @@ static class Program
         bool fidelityCheck = false;
         bool returnToSender = false;
         bool returnAddress = false;
+        string? emitReturnAddressSnapshot = null;
+        string? diffReturnAddressBaseline = null;
         bool censusTsv = false;
         bool censusJsonl = false;
         bool returnToSenderAb = false;
@@ -144,6 +146,8 @@ static class Program
                 case "--fidelity-check": fidelityCheck = true; break;
                 case "--return-to-sender": returnToSender = true; break;
                 case "--return-address": returnAddress = true; break;
+                case "--emit-return-address-snapshot": emitReturnAddressSnapshot = args[++i]; returnAddress = true; break;
+                case "--diff-return-address-baseline": diffReturnAddressBaseline = args[++i]; returnAddress = true; break;
                 case "--tsv": censusTsv = true; break;
                 case "--jsonl": censusJsonl = true; break;
                 case "--return-to-sender-ab": returnToSenderAb = true; break;
@@ -312,7 +316,9 @@ static class Program
                 maxExamples,
                 censusJsonl || json ? RaCensusFormat.Jsonl
                     : censusTsv ? RaCensusFormat.Tsv
-                    : RaCensusFormat.Markdown);
+                    : RaCensusFormat.Markdown,
+                emitReturnAddressSnapshot,
+                diffReturnAddressBaseline);
 
         if (returnToSenderAb)
             return ReturnToSender.RunComparison(assemblies, cap, maxExamples);
@@ -1556,6 +1562,14 @@ static class Program
                                 agreement rate plus example divergences. Thin
                                 observer; --tsv/--jsonl select the format,
                                 --max-examples caps divergence rows. See #2440.
+          --emit-return-address-snapshot <f>
+                                run the return-address census and write a JSON
+                                baseline snapshot to <f> (implies --return-address).
+          --diff-return-address-baseline <f>
+                                run the return-address census and fail (exit 1) if
+                                the agree rate regressed below baseline <f> beyond
+                                its tolerance (implies --return-address). The Deep
+                                Inspect census lane runs this as a drift gate.
           --return-to-sender-ab   compare current compile-back and ReturnToSender
                                 over the same ReturnToSender property-getter targets.
           --return-to-sender-source-probe

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -146,8 +146,12 @@ static class Program
                 case "--fidelity-check": fidelityCheck = true; break;
                 case "--return-to-sender": returnToSender = true; break;
                 case "--return-address": returnAddress = true; break;
-                case "--emit-return-address-snapshot": emitReturnAddressSnapshot = args[++i]; returnAddress = true; break;
-                case "--diff-return-address-baseline": diffReturnAddressBaseline = args[++i]; returnAddress = true; break;
+                case "--emit-return-address-snapshot":
+                    if (i + 1 >= args.Length) return Fail("--emit-return-address-snapshot requires <file>.");
+                    emitReturnAddressSnapshot = args[++i]; returnAddress = true; break;
+                case "--diff-return-address-baseline":
+                    if (i + 1 >= args.Length) return Fail("--diff-return-address-baseline requires <file>.");
+                    diffReturnAddressBaseline = args[++i]; returnAddress = true; break;
                 case "--tsv": censusTsv = true; break;
                 case "--jsonl": censusJsonl = true; break;
                 case "--return-to-sender-ab": returnToSenderAb = true; break;

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -674,6 +674,32 @@ or API-filtered) that have no ApiSurface member, so they are counted for coverag
 but never miscompared. The sweep never crashes on unreadable file inputs — a bad
 path is reported as an unopened assembly.
 
+#### Baseline drift gate (Deep Inspect)
+
+The census runs in the Deep Inspect **census lane** as a committed-baseline drift
+gate, mirroring the real-world corpus sensor:
+
+```bash
+# Refresh the committed baseline (run when the agree rate legitimately improves):
+dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
+  --emit-return-address-snapshot tools/DecompilerHarness/corpus/return-address-baseline.json
+
+# Gate against the committed baseline (fails with exit 1 on regression):
+dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
+  --diff-return-address-baseline tools/DecompilerHarness/corpus/return-address-baseline.json \
+  --max-examples 10
+```
+
+The baseline is the pinned real-world corpus (`eng/prepare-decompiler-corpus.sh`),
+the same corpus used by the real-world corpus sensor. The gate compares only the
+**global agree rate** (stored in basis points): it fails if the rate drops below
+the baseline beyond the tolerance embedded in the snapshot
+(`agreeRateDropBasisPoints`, default 50 bps). This makes the baseline a **floor**
+that ratchets toward 100% as identity consolidation (#2440) lands — improvements
+never fail; re-emit the baseline to raise the floor. `matched`/`unmatched` counts
+drift with corpus composition (framework/NuGet version bumps), so they are
+reported in the card for triage but not gated.
+
 ## Usage
 
 ```bash

--- a/tools/DecompilerHarness/ReturnAddressCensus.cs
+++ b/tools/DecompilerHarness/ReturnAddressCensus.cs
@@ -75,7 +75,8 @@ internal static class ReturnAddressCensus
         {
             Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(emitSnapshot)) ?? ".");
             File.WriteAllText(emitSnapshot, JsonSerializer.Serialize(snapshot, JsonOptions()));
-            Console.WriteLine($"Wrote return-address baseline: {emitSnapshot}");
+            // Status/gate messages go to stderr so stdout stays pristine for --tsv/--jsonl.
+            Console.Error.WriteLine($"Wrote return-address baseline: {emitSnapshot}");
         }
 
         if (diffBaseline is null)
@@ -86,13 +87,13 @@ internal static class ReturnAddressCensus
         var regressions = Compare(baseline, snapshot);
         if (regressions.Count == 0)
         {
-            Console.WriteLine($"Return-address census matched baseline: {diffBaseline}");
+            Console.Error.WriteLine($"Return-address census matched baseline: {diffBaseline}");
             return 0;
         }
 
-        Console.WriteLine("Return-address census regressions:");
+        Console.Error.WriteLine("Return-address census regressions:");
         foreach (var regression in regressions)
-            Console.WriteLine($"- {regression}");
+            Console.Error.WriteLine($"- {regression}");
         return 1;
     }
 

--- a/tools/DecompilerHarness/ReturnAddressCensus.cs
+++ b/tools/DecompilerHarness/ReturnAddressCensus.cs
@@ -1,6 +1,7 @@
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
+using System.Text.Json;
 using ILInspector.Metadata;
 using Markout;
 using Markout.Formatting;
@@ -30,13 +31,69 @@ internal sealed record RaCensusAssembly(
 
 internal sealed record RaCensusReport(IReadOnlyList<RaCensusAssembly> Assemblies);
 
+// Committed-baseline snapshot for the Deep Inspect drift gate. Serialized with camelCase
+// (see JsonOptions); the agree rate is stored in basis points to keep the pinned baseline
+// integer-stable across runs.
+internal sealed record RaCensusSnapshot(
+    int SchemaVersion,
+    string Description,
+    DateTimeOffset GeneratedUtc,
+    RaCensusTolerances? Tolerances,
+    int Matched,
+    int Agree,
+    int Unmatched,
+    int AgreeBasisPoints,
+    IReadOnlyList<RaCensusAssemblySnapshot> Assemblies);
+
+internal sealed record RaCensusAssemblySnapshot(string Assembly, int Matched, int Agree, int Unmatched, int AgreeBasisPoints);
+
+internal sealed record RaCensusTolerances(int AgreeRateDropBasisPoints)
+{
+    // 50 bps (0.50%) absorbs corpus-composition drift (member counts shift with framework/NuGet
+    // version bumps) while still catching real agreement regressions, which move by whole points.
+    public static readonly RaCensusTolerances Default = new(AgreeRateDropBasisPoints: 50);
+}
+
 internal static class ReturnAddressCensus
 {
-    public static int Run(IReadOnlyList<string> assemblies, int maxExamples, RaCensusFormat format)
+    public static int Run(
+        IReadOnlyList<string> assemblies,
+        int maxExamples,
+        RaCensusFormat format,
+        string? emitSnapshot = null,
+        string? diffBaseline = null)
     {
         var report = Measure(assemblies, maxExamples);
         Console.Write(Format(report, maxExamples, format));
-        return 0;
+
+        if (emitSnapshot is null && diffBaseline is null)
+            return 0;
+
+        var snapshot = BuildSnapshot(report);
+
+        if (emitSnapshot is not null)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(emitSnapshot)) ?? ".");
+            File.WriteAllText(emitSnapshot, JsonSerializer.Serialize(snapshot, JsonOptions()));
+            Console.WriteLine($"Wrote return-address baseline: {emitSnapshot}");
+        }
+
+        if (diffBaseline is null)
+            return 0;
+
+        var baseline = JsonSerializer.Deserialize<RaCensusSnapshot>(File.ReadAllText(diffBaseline), JsonOptions())
+            ?? throw new InvalidOperationException($"Could not read return-address baseline '{diffBaseline}'.");
+        var regressions = Compare(baseline, snapshot);
+        if (regressions.Count == 0)
+        {
+            Console.WriteLine($"Return-address census matched baseline: {diffBaseline}");
+            return 0;
+        }
+
+        Console.WriteLine("Return-address census regressions:");
+        foreach (var regression in regressions)
+            Console.WriteLine($"- {regression}");
+        return 1;
     }
 
     static RaCensusReport Measure(IReadOnlyList<string> assemblies, int maxExamples)
@@ -153,6 +210,56 @@ internal static class ReturnAddressCensus
     static int TotalUnmatched(RaCensusReport report) => report.Assemblies.Sum(a => a.Unmatched);
 
     static string Pct(int n, int total) => total == 0 ? "n/a" : $"{100.0 * n / total:0.00}%";
+
+    // --- Baseline snapshot + drift gate (mirrors CorpusSensor's emit/diff idiom) ---
+
+    static RaCensusSnapshot BuildSnapshot(RaCensusReport report)
+    {
+        int matched = TotalMatched(report), agree = TotalAgree(report), unmatched = TotalUnmatched(report);
+        return new RaCensusSnapshot(
+            SchemaVersion: 1,
+            Description: "#2440 Return Address member-identity equivalence census: agreement between the two "
+                + "Metadata producers (A = ApiMemberIdentity.GetMemberAnchor, B = ApiMemberIdentity.CreateMethodAnchor) "
+                + "over the pinned corpus. The agree rate is a floor that should ratchet toward 100% as identity "
+                + "consolidation lands; refresh this baseline upward when it legitimately improves.",
+            GeneratedUtc: DateTimeOffset.UtcNow,
+            Tolerances: RaCensusTolerances.Default,
+            Matched: matched,
+            Agree: agree,
+            Unmatched: unmatched,
+            AgreeBasisPoints: RateBasisPoints(agree, matched),
+            Assemblies: report.Assemblies
+                .Where(a => a.Opened)
+                .OrderBy(a => a.Name, StringComparer.Ordinal)
+                .Select(a => new RaCensusAssemblySnapshot(a.Name, a.Matched, a.Agree, a.Unmatched, RateBasisPoints(a.Agree, a.Matched)))
+                .ToList());
+    }
+
+    static IReadOnlyList<string> Compare(RaCensusSnapshot baseline, RaCensusSnapshot current)
+    {
+        var regressions = new List<string>();
+        int tolerance = baseline.Tolerances?.AgreeRateDropBasisPoints ?? RaCensusTolerances.Default.AgreeRateDropBasisPoints;
+
+        // The consolidation signal is the agree rate: it must not regress below the baseline
+        // floor. Improvements never fail (raise the floor by re-emitting the baseline). Matched
+        // and unmatched counts drift with corpus composition (framework/NuGet version bumps), so
+        // they are reported in the card for triage but not gated.
+        int drop = baseline.AgreeBasisPoints - current.AgreeBasisPoints;
+        if (drop > tolerance)
+            regressions.Add(
+                $"agree rate dropped {FormatBps(drop)} ({FormatBps(baseline.AgreeBasisPoints)} -> "
+                + $"{FormatBps(current.AgreeBasisPoints)}), tolerance {FormatBps(tolerance)}");
+
+        return regressions;
+    }
+
+    static int RateBasisPoints(int part, int whole)
+        => whole <= 0 ? 0 : (int)Math.Round(10_000.0 * part / whole, MidpointRounding.AwayFromZero);
+
+    static string FormatBps(int basisPoints) => $"{basisPoints / 100.0:F2}%";
+
+    static JsonSerializerOptions JsonOptions()
+        => new() { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
     static IReadOnlyList<(string Metric, string Value)> SummaryRows(RaCensusReport report)
     {

--- a/tools/DecompilerHarness/corpus/return-address-baseline.json
+++ b/tools/DecompilerHarness/corpus/return-address-baseline.json
@@ -1,0 +1,112 @@
+{
+  "schemaVersion": 1,
+  "description": "#2440 Return Address member-identity equivalence census: agreement between the two Metadata producers (A = ApiMemberIdentity.GetMemberAnchor, B = ApiMemberIdentity.CreateMethodAnchor) over the pinned corpus. The agree rate is a floor that should ratchet toward 100% as identity consolidation lands; refresh this baseline upward when it legitimately improves.",
+  "generatedUtc": "2026-07-07T00:31:09.578845+00:00",
+  "tolerances": {
+    "agreeRateDropBasisPoints": 50
+  },
+  "matched": 53628,
+  "agree": 26346,
+  "unmatched": 38995,
+  "agreeBasisPoints": 4913,
+  "assemblies": [
+    {
+      "assembly": "DotnetInspector.Core.dll",
+      "matched": 186,
+      "agree": 94,
+      "unmatched": 99,
+      "agreeBasisPoints": 5054
+    },
+    {
+      "assembly": "DotnetInspector.Packages.dll",
+      "matched": 148,
+      "agree": 52,
+      "unmatched": 155,
+      "agreeBasisPoints": 3514
+    },
+    {
+      "assembly": "DotnetInspector.Services.dll",
+      "matched": 181,
+      "agree": 59,
+      "unmatched": 269,
+      "agreeBasisPoints": 3260
+    },
+    {
+      "assembly": "ILInspector.Analysis.dll",
+      "matched": 349,
+      "agree": 152,
+      "unmatched": 376,
+      "agreeBasisPoints": 4355
+    },
+    {
+      "assembly": "ILInspector.Decompiler.dll",
+      "matched": 2822,
+      "agree": 1493,
+      "unmatched": 2627,
+      "agreeBasisPoints": 5291
+    },
+    {
+      "assembly": "ILInspector.Metadata.dll",
+      "matched": 857,
+      "agree": 329,
+      "unmatched": 992,
+      "agreeBasisPoints": 3839
+    },
+    {
+      "assembly": "ILInspector.MetadataPrimitives.dll",
+      "matched": 53,
+      "agree": 20,
+      "unmatched": 8,
+      "agreeBasisPoints": 3774
+    },
+    {
+      "assembly": "Microsoft.ApplicationInsights.dll",
+      "matched": 1379,
+      "agree": 728,
+      "unmatched": 1263,
+      "agreeBasisPoints": 5279
+    },
+    {
+      "assembly": "Microsoft.CodeAnalysis.CSharp.dll",
+      "matched": 27889,
+      "agree": 15162,
+      "unmatched": 15208,
+      "agreeBasisPoints": 5437
+    },
+    {
+      "assembly": "Microsoft.CodeAnalysis.dll",
+      "matched": 12534,
+      "agree": 4711,
+      "unmatched": 7033,
+      "agreeBasisPoints": 3759
+    },
+    {
+      "assembly": "Newtonsoft.Json.dll",
+      "matched": 2622,
+      "agree": 1149,
+      "unmatched": 1606,
+      "agreeBasisPoints": 4382
+    },
+    {
+      "assembly": "NuGet.Versioning.dll",
+      "matched": 230,
+      "agree": 80,
+      "unmatched": 80,
+      "agreeBasisPoints": 3478
+    },
+    {
+      "assembly": "System.CommandLine.dll",
+      "matched": 371,
+      "agree": 193,
+      "unmatched": 626,
+      "agreeBasisPoints": 5202
+    },
+    {
+      "assembly": "dotnet-inspect.dll",
+      "matched": 4007,
+      "agree": 2124,
+      "unmatched": 8653,
+      "agreeBasisPoints": 5301
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Promotes the **Return Address (RA) member-identity equivalence census** (#2440) from an
on-demand harness sensor to a **committed-baseline drift gate** in the **Deep Inspect** census
lane — the leading-signal guard the census was designed to be.

Previously the census (`--return-address`) only printed a card on demand; nothing pinned the
agree rate, so an identity-consolidation change that *lowered* producer agreement could land
unnoticed.

## What changed

Mirrors the existing real-world corpus sensor's `--emit-*`/`--diff-*` idiom:

- **Sensor** (`ReturnAddressCensus.cs`): new `--emit-return-address-snapshot <f>` (write a JSON
  baseline) and `--diff-return-address-baseline <f>` (gate, exit 1 on regression). The snapshot
  stores the global agree rate in **basis points** (integer-stable across runs) plus per-assembly
  rows and an embedded tolerance. `Compare` gates **only the global agree rate**: it fails if the
  rate drops below the baseline floor beyond the tolerance (default **50 bps**). `matched`/
  `unmatched` counts drift with corpus composition (framework/NuGet bumps), so they are reported
  in the card for triage but not gated. Improvements never fail — the baseline is a **floor**
  that ratchets toward 100% as consolidation lands; re-emit to raise it.
- **Baseline** (`tools/DecompilerHarness/corpus/return-address-baseline.json`): generated over the
  pinned real-world corpus (`eng/prepare-decompiler-corpus.sh`, same corpus as the real-world
  sensor) — **53628 matched, 49.13% agree** across 14 assemblies.
- **Workflow** (`deep-inspect.yml` census lane): a step that emits the snapshot and runs the drift
  gate, `tee`'d to `artifacts/deep-inspect/return-address-census.txt` and archived under the
  existing `deep-inspect-census` artifact upload.
- **Docs**: harness README documents the gate flags and the floor/refresh policy.

## Design notes

- **Why a rate ratchet, not an exact pin?** #2440's whole point is that agreement climbs toward
  100% as the two producers (A = `GetMemberAnchor` keyword grammar, B = `CreateMethodAnchor`
  full-name grammar) converge. A floor gate catches regressions without forcing a baseline refresh
  on every improvement. The dominant divergence today is exactly the keyword-vs-full-name axis
  (e.g. `byte` vs `System.Byte`, `string` vs `System.String`), confirming the census measures the
  consolidation signal.
- **Why gate only the global rate?** Per-assembly gating is noisy (assemblies enter/leave with
  framework/NuGet version bumps). The global rate over the pinned corpus is the stable signal.
- Deep Inspect is opt-in (`workflow_dispatch`, `census` lane), so the gate is a triage safety net
  that surfaces regressions in the run — it does not block PR merges.

## Validation

- Harness build clean; full `dotnet-inspect.slnx` build clean; README markdownlint clean; workflow
  YAML validated.
- **Gate pass**: `--diff-return-address-baseline` against the committed baseline → exit 0
  ("matched baseline").
- **Gate fail**: a baseline doctored to claim 90.00% agree → exit 1 with
  `agree rate dropped 40.87% (90.00% -> 49.13%), tolerance 0.50%`.

## Review

Adds gate/comparison logic (basis-point math, regression direction, tolerance) → requesting
two-model adversarial review (GPT-5.5 + Gemini 3.1 Pro) per policy; results reconciled on the PR.
