### PR TITLE
Split RTS Roslyn fallback evidence

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -1162,6 +1162,10 @@ public class GeneratedFixtureCatalogTests
                         RequiredMembers: 1,
                         RoslynRecoveredTypes: 1,
                         RoslynRecoveredMemberSurfaces: 1,
+                        RoslynFallbacks:
+                        [
+                            new ReturnToSenderRoslynFallback("CS0103", "closure-root", 1),
+                        ],
                         Requirements:
                         [
                             new ReturnToSenderClosureRequirement(
@@ -1183,6 +1187,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("h0 + IL_0000 ldc.i4 2", report);
         Assert.Contains("member: Method1~abcdef1234  canonical=M:TestType.Method1()", report);
         Assert.Contains("closure: types=2 members=1 roslyn-types=1 roslyn-member-surfaces=1", report);
+        Assert.Contains("roslyn-fallbacks=CS0103/closure-root:1", report);
         Assert.Contains("Research evidence:", report);
         Assert.Contains("rts.status.fail: 1", report);
         Assert.Contains("il.operation.added: 1", report);

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1709,14 +1709,6 @@ static class ReturnToSender
                     var typeGrew = AddRoots(indexes, index, key, diagnostic, $"{typeName}.{names[1]}", targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts, out var typeResolved);
                     grew |= typeGrew;
                 }
-                else
-                {
-                    foreach (var name in names)
-                    {
-                        grew |= AddRoots(indexes, indexes.Methods, NormalizeTypeName(name), diagnostic, name, targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts);
-                        grew |= AddRoots(indexes, indexes.Properties, NormalizeTypeName(name), diagnostic, name, targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts);
-                    }
-                }
             }
             else if (diagnostic.Id is "CS0117")
             {

--- a/tools/DecompilerHarness/ReturnToSenderCatalogReport.cs
+++ b/tools/DecompilerHarness/ReturnToSenderCatalogReport.cs
@@ -173,7 +173,7 @@ internal static class ReturnToSenderCatalogReport
         string actual = row.ActualStatus?.ToString() ?? "Missing";
         string closure = row.ClosureEvidence is null
             ? ""
-            : $"types={row.ClosureEvidence.RequiredTypes} members={row.ClosureEvidence.RequiredMembers} roslyn-types={row.ClosureEvidence.RoslynRecoveredTypes} roslyn-member-surfaces={row.ClosureEvidence.RoslynRecoveredMemberSurfaces}";
+            : ClosureText(row.ClosureEvidence);
         return new ReturnToSenderFailedFixtureRow(
             fixtureId,
             row.DisplayMember,
@@ -192,6 +192,14 @@ internal static class ReturnToSenderCatalogReport
             .OrderByDescending(group => group.Count())
             .ThenBy(group => group.Key, StringComparer.Ordinal)
             .Select(group => new ReturnToSenderCatalogReportBucket(group.Key, group.Count()))];
+
+    static string ClosureText(ReturnToSenderClosureEvidence evidence)
+    {
+        var text = $"types={evidence.RequiredTypes} members={evidence.RequiredMembers} roslyn-types={evidence.RoslynRecoveredTypes} roslyn-member-surfaces={evidence.RoslynRecoveredMemberSurfaces}";
+        if (evidence.RoslynFallbacks.Count == 0)
+            return text;
+        return $"{text} roslyn-fallbacks={string.Join(",", evidence.RoslynFallbacks.Select(fallback => $"{fallback.Diagnostic}/{fallback.Recovery}:{fallback.Count}"))}";
+    }
 
     static void AppendResearchEvidence(StringBuilder sb, ReturnToSenderCatalogResearchSection? research)
     {
@@ -270,8 +278,7 @@ internal static class ReturnToSenderCatalogReport
         if (row.ClosureEvidence is not null)
         {
             sb.AppendLine(
-                $"      closure: types={row.ClosureEvidence.RequiredTypes} members={row.ClosureEvidence.RequiredMembers} " +
-                $"roslyn-types={row.ClosureEvidence.RoslynRecoveredTypes} roslyn-member-surfaces={row.ClosureEvidence.RoslynRecoveredMemberSurfaces}");
+                $"      closure: {ClosureText(row.ClosureEvidence)}");
         }
         if (!string.IsNullOrWhiteSpace(row.Detail))
             sb.AppendLine($"      detail: {row.Detail}");

--- a/tools/DecompilerHarness/ReturnToSenderClosureEvidence.cs
+++ b/tools/DecompilerHarness/ReturnToSenderClosureEvidence.cs
@@ -7,7 +7,10 @@ internal sealed record ReturnToSenderClosureEvidence(
     int RequiredMembers,
     int RoslynRecoveredTypes,
     int RoslynRecoveredMemberSurfaces,
+    IReadOnlyList<ReturnToSenderRoslynFallback> RoslynFallbacks,
     IReadOnlyList<ReturnToSenderClosureRequirement> Requirements);
+
+internal sealed record ReturnToSenderRoslynFallback(string Diagnostic, string Recovery, int Count);
 
 internal sealed record ReturnToSenderClosureRequirement(
     string Type,
@@ -23,11 +26,21 @@ internal static class ReturnToSenderClosureEvidenceBuilder
         ArgumentNullException.ThrowIfNull(plan);
 
         var requirements = plan.TypeRequirements.Select(Requirement).ToArray();
+        var fallbacks = requirements
+            .SelectMany(requirement => requirement.Facts)
+            .Select(ParseRoslynFallback)
+            .OfType<ReturnToSenderRoslynFallback>()
+            .GroupBy(fallback => (fallback.Diagnostic, fallback.Recovery))
+            .Select(group => new ReturnToSenderRoslynFallback(group.Key.Diagnostic, group.Key.Recovery, group.Sum(fallback => fallback.Count)))
+            .OrderBy(fallback => fallback.Diagnostic, StringComparer.Ordinal)
+            .ThenBy(fallback => fallback.Recovery, StringComparer.Ordinal)
+            .ToArray();
         return new ReturnToSenderClosureEvidence(
             plan.TypeRequirements.Count,
             plan.TypeRequirements.Sum(requirement => requirement.RequiredMembers.Count),
             requirements.Count(requirement => requirement.RoslynRecovered),
             requirements.Count(requirement => requirement.RoslynRecoveredMemberSurface),
+            fallbacks,
             requirements);
     }
 
@@ -42,5 +55,22 @@ internal static class ReturnToSenderClosureEvidenceBuilder
             requirement.SourceFacts.Any(fact => fact.Producer == "roslyn" && fact.Id == "closure-root"),
             requirement.SourceFacts.Any(fact => fact.Producer == "roslyn" && fact.Id == "closure-member"),
             facts);
+    }
+
+    static ReturnToSenderRoslynFallback? ParseRoslynFallback(string fact)
+    {
+        const string prefix = "roslyn/";
+        if (!fact.StartsWith(prefix, StringComparison.Ordinal))
+            return null;
+        int kindEnd = fact.IndexOf(':', prefix.Length);
+        if (kindEnd < 0)
+            return null;
+        string recovery = fact[prefix.Length..kindEnd];
+        string detail = fact[(kindEnd + 1)..].TrimStart();
+        int codeEnd = detail.IndexOf(':');
+        string diagnostic = codeEnd > 0 ? detail[..codeEnd] : detail.Split(' ', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ?? "";
+        if (!diagnostic.StartsWith("CS", StringComparison.Ordinal))
+            return null;
+        return new ReturnToSenderRoslynFallback(diagnostic, recovery, 1);
     }
 }


### PR DESCRIPTION
## Summary

- add grouped `RoslynFallbacks` evidence to RTS closure evidence (`diagnostic`, `recovery`, `count`)
- surface the grouped fallback summary in RTS catalog closure lines / Markout rows
- remove the malformed-message CS1061 branch that searched methods/properties when no receiver/member pair was available

This bundles telemetry and a small cleanup in one branch, after #2455/#2472/#2484 narrowed the dead broad fallback paths.

## Validation

- `dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config --verbosity quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderPrototypeTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/GeneratedFixtureCatalogTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderEvidenceTests/*"`
- `dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog minimal.property.literal --max-examples 3`

Adversarial review requested separately.