### PR TITLE
Add printer-owned stack-slot unifier telemetry

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -88,6 +88,8 @@
              Link="RenderAbSensor.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\SlotResidualCensus.cs"
              Link="SlotResidualCensus.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\SlotUnifierCensus.cs"
+             Link="SlotUnifierCensus.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\AnnotationCheck.cs"
              Link="AnnotationCheck.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\VolatileFieldDetector.cs"

--- a/src/ILInspector.Decompiler.Tests/SlotResidualCensusTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SlotResidualCensusTests.cs
@@ -1,4 +1,5 @@
 using ILInspector.DecompilerHarness;
+using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -17,6 +18,48 @@ public class SlotResidualCensusTests
         Assert.Contains("Before late F2", output);
         Assert.Contains("After late F2", output);
         Assert.Contains("Post-F2 residual deferral classes", output);
+    }
+
+    [Fact]
+    public void SlotUnifierCensus_PrintsPrinterTelemetryCard()
+    {
+        string output = CaptureConsole(() => SlotUnifierCensus.Run([FixturePath], cap: 20, maxExamples: 2));
+
+        Assert.Contains("STACK-SLOT UNIFIER CENSUS", output);
+        Assert.Contains("Object-fallback slots", output);
+        Assert.Contains("Multi-candidate slots unified by printer", output);
+        Assert.Contains("Render declaration names emitted", output);
+    }
+
+    [Fact]
+    public void StackSlotUnifierTelemetry_UsesActualPrinterObjectFallback()
+    {
+        var obj = TypeRef.CoreLib("System", "Object");
+        var str = TypeRef.CoreLib("System", "String");
+        var i32 = TypeRef.CoreLib("System", "Int32");
+        var voidType = TypeRef.CoreLib("System", "Void");
+
+        var block = new Block();
+        block.Add(new StoreStackSlot(0, new Constant(null, obj)));
+        block.Add(new StoreStackSlot(0, new Constant("x", str)));
+        block.Add(new StoreStackSlot(0, new Constant(1, i32)));
+        block.Add(new Return(new LoadStackSlot(0, obj)));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "T"),
+            new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        var telemetry = CSharpPrinter.CollectStackSlotUnifierTelemetry(function);
+
+        Assert.Equal(3, telemetry.StoreNodes);
+        Assert.Equal(1, telemetry.LoadNodes);
+        Assert.Equal(1, telemetry.DistinctSlots);
+        Assert.Equal(1, telemetry.ObjectFallbackSlots);
+        Assert.Equal(0, telemetry.MultiCandidateUnifiedSlots);
     }
 
     static string CaptureConsole(Func<int> action)

--- a/src/ILInspector.Decompiler.Tests/SlotResidualCensusTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SlotResidualCensusTests.cs
@@ -26,13 +26,13 @@ public class SlotResidualCensusTests
         string output = CaptureConsole(() => SlotUnifierCensus.Run([FixturePath], cap: 20, maxExamples: 2));
 
         Assert.Contains("STACK-SLOT UNIFIER CENSUS", output);
-        Assert.Contains("Object-fallback slots", output);
+        Assert.Contains("Un-unified split slots", output);
         Assert.Contains("Multi-candidate slots unified by printer", output);
-        Assert.Contains("Render declaration names emitted", output);
+        Assert.Contains("Stack-slot declarations emitted", output);
     }
 
     [Fact]
-    public void StackSlotUnifierTelemetry_UsesActualPrinterObjectFallback()
+    public void StackSlotUnifierTelemetry_RecordsUnunifiedSplitSlots()
     {
         var obj = TypeRef.CoreLib("System", "Object");
         var str = TypeRef.CoreLib("System", "String");
@@ -58,7 +58,7 @@ public class SlotResidualCensusTests
         Assert.Equal(3, telemetry.StoreNodes);
         Assert.Equal(1, telemetry.LoadNodes);
         Assert.Equal(1, telemetry.DistinctSlots);
-        Assert.Equal(1, telemetry.ObjectFallbackSlots);
+        Assert.Equal(1, telemetry.UnunifiedSplitSlots);
         Assert.Equal(0, telemetry.MultiCandidateUnifiedSlots);
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -44,7 +44,11 @@ public sealed partial class CSharpPrinter
     readonly List<DecompilerDecision> _decisions = [];
     readonly HashSet<string> _decisionKeys = [];
 
-    CSharpPrinter(IrFunction function, PrinterOptions? options = null, IEnumerable<string>? reservedScopeNames = null)
+    CSharpPrinter(
+        IrFunction function,
+        PrinterOptions? options = null,
+        IEnumerable<string>? reservedScopeNames = null,
+        StackSlotUnifierTelemetryBuilder? stackSlotTelemetry = null)
     {
         _function = function;
         _options = options ?? PrinterOptions.Default;
@@ -53,6 +57,7 @@ public sealed partial class CSharpPrinter
         _reservedScopeNames = reservedScopeNames is null
             ? []
             : new HashSet<string>(reservedScopeNames, StringComparer.Ordinal);
+        _stackSlotTelemetry = stackSlotTelemetry;
     }
 
     // The output-path pass context: stepping off, plus the optional cross-method
@@ -295,12 +300,31 @@ public sealed partial class CSharpPrinter
 
     readonly record struct StackSlotRenderKey(int Slot, string TypeKey);
 
+    internal sealed record StackSlotUnifierTelemetry(
+        int StoreNodes,
+        int LoadNodes,
+        int DistinctSlots,
+        int CandidateSlots,
+        int SingleCandidateSlots,
+        int MultiCandidateUnifiedSlots,
+        int ObjectFallbackSlots,
+        int RenderDeclarationNames);
+
     readonly Dictionary<StackSlotRenderKey, string> _stackSlotNames = [];
     readonly Dictionary<StoreStackSlot, TypeRef?> _stackSlotStoreTypes = [];
     readonly Dictionary<int, TypeRef> _stackSlotUnifiedTypes = [];
     readonly SortedDictionary<(int Slot, int Ordinal), (string Name, TypeRef? Type)> _stackSlotDeclarations = [];
+    readonly StackSlotUnifierTelemetryBuilder? _stackSlotTelemetry;
     readonly Dictionary<StoreElement, StoreLocal> _inlineReceiverTempStores = [];
     readonly HashSet<int> _inlineReceiverTempLocals = [];
+
+    internal static StackSlotUnifierTelemetry CollectStackSlotUnifierTelemetry(IrFunction function)
+    {
+        var telemetry = new StackSlotUnifierTelemetryBuilder();
+        var printer = new CSharpPrinter(function, stackSlotTelemetry: telemetry);
+        _ = printer.PrintBody(function);
+        return telemetry.ToTelemetry();
+    }
 
     string PrintBody(IrFunction function)
     {
@@ -547,6 +571,9 @@ public sealed partial class CSharpPrinter
                     break;
             }
         }
+        _stackSlotTelemetry?.RecordNodes(
+            storesBySlot.Values.Sum(stores => stores.Count),
+            loadsBySlot.Values.Sum(loads => loads.Count));
 
         foreach (var storeElement in nodes.OfType<StoreElement>())
         {
@@ -563,6 +590,14 @@ public sealed partial class CSharpPrinter
 
         foreach (int slot in storesBySlot.Keys.Concat(loadsBySlot.Keys).Distinct())
         {
+            if (_stackSlotTelemetry is { } telemetry)
+            {
+                telemetry.RecordCandidate(
+                    CandidateCount(
+                        storesBySlot.GetValueOrDefault(slot) ?? [],
+                        loadsBySlot.GetValueOrDefault(slot) ?? [],
+                        extraLoadTargetsBySlot.GetValueOrDefault(slot) ?? []));
+            }
             if (TryChooseUnifiedStackSlotType(
                 storesBySlot.GetValueOrDefault(slot) ?? [],
                 loadsBySlot.GetValueOrDefault(slot) ?? [],
@@ -570,6 +605,12 @@ public sealed partial class CSharpPrinter
                 out var unifiedType))
             {
                 _stackSlotUnifiedTypes[slot] = unifiedType;
+                if (_stackSlotTelemetry is { } telemetryAfter)
+                    telemetryAfter.RecordUnified(unifiedType);
+            }
+            else if (_stackSlotTelemetry is { } telemetryAfter)
+            {
+                telemetryAfter.RecordFallback();
             }
         }
 
@@ -606,6 +647,67 @@ public sealed partial class CSharpPrinter
                     break;
             }
         }
+        _stackSlotTelemetry?.RecordRenderDeclarations(_stackSlotDeclarations.Count);
+
+        static int CandidateCount(
+            IReadOnlyList<IrExpression> stores,
+            IReadOnlyList<LoadStackSlot> loads,
+            IReadOnlyList<TypeRef> extraLoadTargets)
+            => loads.Select(load => load.Type)
+                .Concat(extraLoadTargets)
+                .Concat(stores.Select(store => store.ResultType))
+                .Where(type => type is not null)
+                .Cast<TypeRef>()
+                .Distinct()
+                .Count();
+    }
+
+    sealed class StackSlotUnifierTelemetryBuilder
+    {
+        int _lastCandidateCount;
+
+        public int StoreNodes { get; private set; }
+        public int LoadNodes { get; private set; }
+        public int CandidateSlots { get; private set; }
+        public int SingleCandidateSlots { get; private set; }
+        public int MultiCandidateUnifiedSlots { get; private set; }
+        public int ObjectFallbackSlots { get; private set; }
+        public int RenderDeclarationNames { get; private set; }
+
+        public void RecordNodes(int stores, int loads)
+        {
+            StoreNodes += stores;
+            LoadNodes += loads;
+        }
+
+        public void RecordCandidate(int candidateCount)
+        {
+            CandidateSlots++;
+            _lastCandidateCount = candidateCount;
+            if (candidateCount == 1)
+                SingleCandidateSlots++;
+        }
+
+        public void RecordUnified(TypeRef _)
+        {
+            if (_lastCandidateCount > 1)
+                MultiCandidateUnifiedSlots++;
+        }
+
+        public void RecordFallback() => ObjectFallbackSlots++;
+
+        public void RecordRenderDeclarations(int count) => RenderDeclarationNames += count;
+
+        public StackSlotUnifierTelemetry ToTelemetry()
+            => new(
+                StoreNodes,
+                LoadNodes,
+                DistinctSlots: CandidateSlots,
+                CandidateSlots,
+                SingleCandidateSlots,
+                MultiCandidateUnifiedSlots,
+                ObjectFallbackSlots,
+                RenderDeclarationNames);
     }
 
     bool TryChooseUnifiedStackSlotType(
@@ -1180,7 +1282,7 @@ public sealed partial class CSharpPrinter
         };
 
         string pad = new(' ', indent * 4);
-        foreach (var line in new CSharpPrinter(function, _options, CurrentScopeNames()).PrintBody(function).TrimEnd().Split(Environment.NewLine))
+        foreach (var line in new CSharpPrinter(function, _options, CurrentScopeNames(), _stackSlotTelemetry).PrintBody(function).TrimEnd().Split(Environment.NewLine))
             sb.Append(pad).AppendLine(line);
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -307,8 +307,8 @@ public sealed partial class CSharpPrinter
         int CandidateSlots,
         int SingleCandidateSlots,
         int MultiCandidateUnifiedSlots,
-        int ObjectFallbackSlots,
-        int RenderDeclarationNames);
+        int UnunifiedSplitSlots,
+        int EmittedDeclarationNames);
 
     readonly Dictionary<StackSlotRenderKey, string> _stackSlotNames = [];
     readonly Dictionary<StoreStackSlot, TypeRef?> _stackSlotStoreTypes = [];
@@ -610,7 +610,7 @@ public sealed partial class CSharpPrinter
             }
             else if (_stackSlotTelemetry is { } telemetryAfter)
             {
-                telemetryAfter.RecordFallback();
+                telemetryAfter.RecordUnunifiedSplit();
             }
         }
 
@@ -647,7 +647,7 @@ public sealed partial class CSharpPrinter
                     break;
             }
         }
-        _stackSlotTelemetry?.RecordRenderDeclarations(_stackSlotDeclarations.Count);
+        _stackSlotTelemetry?.RecordEmittedDeclarations(EmittedStackSlotDeclarationCount());
 
         static int CandidateCount(
             IReadOnlyList<IrExpression> stores,
@@ -662,6 +662,18 @@ public sealed partial class CSharpPrinter
                 .Count();
     }
 
+    int EmittedStackSlotDeclarationCount()
+    {
+        int count = 0;
+        foreach (var (_, (name, _)) in _stackSlotDeclarations)
+        {
+            if (_declaringStores.OfType<StoreStackSlot>().Any(s => StackSlotName(s) == name))
+                continue;
+            count++;
+        }
+        return count;
+    }
+
     sealed class StackSlotUnifierTelemetryBuilder
     {
         int _lastCandidateCount;
@@ -671,8 +683,8 @@ public sealed partial class CSharpPrinter
         public int CandidateSlots { get; private set; }
         public int SingleCandidateSlots { get; private set; }
         public int MultiCandidateUnifiedSlots { get; private set; }
-        public int ObjectFallbackSlots { get; private set; }
-        public int RenderDeclarationNames { get; private set; }
+        public int UnunifiedSplitSlots { get; private set; }
+        public int EmittedDeclarationNames { get; private set; }
 
         public void RecordNodes(int stores, int loads)
         {
@@ -694,9 +706,9 @@ public sealed partial class CSharpPrinter
                 MultiCandidateUnifiedSlots++;
         }
 
-        public void RecordFallback() => ObjectFallbackSlots++;
+        public void RecordUnunifiedSplit() => UnunifiedSplitSlots++;
 
-        public void RecordRenderDeclarations(int count) => RenderDeclarationNames += count;
+        public void RecordEmittedDeclarations(int count) => EmittedDeclarationNames += count;
 
         public StackSlotUnifierTelemetry ToTelemetry()
             => new(
@@ -706,8 +718,8 @@ public sealed partial class CSharpPrinter
                 CandidateSlots,
                 SingleCandidateSlots,
                 MultiCandidateUnifiedSlots,
-                ObjectFallbackSlots,
-                RenderDeclarationNames);
+                UnunifiedSplitSlots,
+                EmittedDeclarationNames);
     }
 
     bool TryChooseUnifiedStackSlotType(

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -35,6 +35,7 @@ static class Program
         string? emitRenderAb = null;
         bool idempotenceCheck = false;
         bool slotResidualCensus = false;
+        bool slotUnifierCensus = false;
 
         string? dumpMethod = null;
         int dumpIndex = 0;
@@ -218,6 +219,7 @@ static class Program
                 case "--emit-render-ab": emitRenderAb = args[++i]; break;
                 case "--idempotence-check": idempotenceCheck = true; break;
                 case "--slot-residual-census": slotResidualCensus = true; break;
+                case "--slot-unifier-census": slotUnifierCensus = true; break;
                 case "--help" or "-h": PrintUsage(); return 0;
                 default: inputs.Add(args[i]); break;
             }
@@ -346,6 +348,9 @@ static class Program
 
         if (slotResidualCensus)
             return SlotResidualCensus.Run(assemblies, corpusMethodCap, maxExamples);
+
+        if (slotUnifierCensus)
+            return SlotUnifierCensus.Run(assemblies, corpusMethodCap, maxExamples);
 
         if (libraryReport)
             return LibraryReport.Run(assemblies, compileCap, maxExamples, json, topPatterns, topLibraries);
@@ -1546,6 +1551,9 @@ static class Program
                                 and report StoreStackSlot/LoadStackSlot burn-down
                                 plus post-F2 residual deferral classes. Uses
                                 --corpus-method-cap to bound the sweep.
+          --slot-unifier-census   run the full pipeline and report the
+                                CSharpPrinter's own stack-slot unifier telemetry.
+                                Uses --corpus-method-cap to bound the sweep.
           --return-to-sender      prototype fact-planned compile-back harness:
                                 build module/type shells for the first property
                                 getter in each assembly, compile, and compare IL

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -606,6 +606,13 @@ classifies the remaining stack-slot webs by deferral class (`multi-use`,
 and store/load-only residuals). This is C2 entry evidence, not a correctness
 gate; use `--corpus-method-cap N` for a quick bounded read.
 
+**Slot unifier census** (`--slot-unifier-census`): the C2/#2209 burn-down view
+from the printer's own stack-slot unifier path. It runs the full product
+pipeline, then asks `CSharpPrinter` to collect its stack-slot naming/type
+telemetry without emitting C#. The key lines are `Multi-candidate slots unified
+by printer` and `Object-fallback slots`; C2 slices should drive both down until
+no `LoadStackSlot`/`StoreStackSlot` reaches the printer.
+
 **Gaps** (`--gaps`): the *self-contained* real-gap view. It inspects only the raised tree: a method is a gap iff it still holds **unstructured control flow** — a `Branch`/`ConditionalBranch`/`SwitchBranch` the structuring passes could not consume, or an EH `Leave` (a surviving `goto`) — or an `UnsupportedNode`. A fully-raised tree holds only structured nodes (`IfStatement`, loops, `Switch`, `TryCatch`), so the residual is exact: reading the tree alone tells you the gap, no recompile or comparison needed. It reports "fully raised" (the metric to drive up) and a residual-kind docket (the prioritized work). It measures completeness, not correctness, so pair it with `--fidelity-check` for fidelity.
 
 *When to use it.* Track the structuring completeness with `--gaps`. Over CoreLib it currently reads ~97% fully raised, the residual dominated by `structuring: conditional-branch` (the forward-branch-to-common-exit work). Add `--by-shape` to sub-classify the `switch-branch` bucket by the structural shape of its residual switch, classifying the imported (pre-pass) tree where the switch is still a block terminator. The buckets, in priority order, are `loop-back-edge` (a section block branches backward — a loop/iterator), `nested-switch` (a case body is itself a switch, or the method has more than one), `default-routes-into-cases` (the default is a case target or branches into one), `external-entry-into-cases` (a block before the switch jumps into a case body), `multi-block-case-section` (a case body carries its own `if`/`?:` — raised by the section-as-region relaxation), and `single-block-clean` (none of the above — a clean switch that nonetheless did not raise, i.e. a pass bug to investigate). A bucket count becomes a per-shape slice docket that scopes the next `SwitchRaisingPass` relaxation.

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -610,7 +610,7 @@ gate; use `--corpus-method-cap N` for a quick bounded read.
 from the printer's own stack-slot unifier path. It runs the full product
 pipeline, then asks `CSharpPrinter` to collect its stack-slot naming/type
 telemetry without emitting C#. The key lines are `Multi-candidate slots unified
-by printer` and `Object-fallback slots`; C2 slices should drive both down until
+by printer` and `Un-unified split slots`; C2 slices should drive both down until
 no `LoadStackSlot`/`StoreStackSlot` reaches the printer.
 
 **Gaps** (`--gaps`): the *self-contained* real-gap view. It inspects only the raised tree: a method is a gap iff it still holds **unstructured control flow** — a `Branch`/`ConditionalBranch`/`SwitchBranch` the structuring passes could not consume, or an EH `Leave` (a surviving `goto`) — or an `UnsupportedNode`. A fully-raised tree holds only structured nodes (`IfStatement`, loops, `Switch`, `TryCatch`), so the residual is exact: reading the tree alone tells you the gap, no recompile or comparison needed. It reports "fully raised" (the metric to drive up) and a residual-kind docket (the prioritized work). It measures completeness, not correctness, so pair it with `--fidelity-check` for fidelity.

--- a/tools/DecompilerHarness/SlotUnifierCensus.cs
+++ b/tools/DecompilerHarness/SlotUnifierCensus.cs
@@ -1,0 +1,104 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// C2/#2209 measurement: ask the actual printer stack-slot unifier how many
+/// residual slots it sees after the full product pipeline. Unlike a target-type
+/// proxy, this is owned by the printer's private unifier path.
+/// </summary>
+static class SlotUnifierCensus
+{
+    public static int Run(IReadOnlyList<string> assemblies, int cap, int maxExamples)
+    {
+        var totals = new Totals();
+        var examples = new List<string>();
+        bool capped = false;
+
+        using var metadata = CorpusMetadata.Create(assemblies);
+        foreach (var assemblyPath in assemblies)
+        {
+            using var source = MetadataSource.Open(assemblyPath, context: metadata);
+            foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+            {
+                if (totals.Methods >= cap)
+                {
+                    capped = true;
+                    break;
+                }
+                totals.Methods++;
+
+                try
+                {
+                    IrPasses.Run(function, IrPasses.Default, PassContext.ForImport(method => IrImporter.Import(source, method)));
+                    var telemetry = CSharpPrinter.CollectStackSlotUnifierTelemetry(function);
+                    totals.Add(telemetry);
+                    if (telemetry.DistinctSlots > 0)
+                        totals.MethodsWithSlots++;
+                    if (telemetry.ObjectFallbackSlots > 0 && examples.Count < maxExamples)
+                        examples.Add($"{typeName}::{methodName} ({telemetry.ObjectFallbackSlots} object-fallback slot{(telemetry.ObjectFallbackSlots == 1 ? "" : "s")})");
+                }
+                catch (Exception ex)
+                {
+                    totals.PassBugs++;
+                    if (examples.Count < maxExamples)
+                        examples.Add($"PASS BUG {ex.GetType().Name}: {ex.Message} ({typeName}::{methodName})");
+                }
+            }
+            if (capped)
+                break;
+        }
+
+        string scope = capped ? $"{totals.Methods} methods (capped)" : $"{totals.Methods} methods";
+        Console.WriteLine();
+        Console.WriteLine($"STACK-SLOT UNIFIER CENSUS over {scope} ({totals.PassBugs} pass bugs)");
+        Console.WriteLine();
+        Console.WriteLine("| Metric | Count |");
+        Console.WriteLine("| --- | ---: |");
+        Console.WriteLine($"| StoreStackSlot nodes reaching printer | {totals.StoreNodes} |");
+        Console.WriteLine($"| LoadStackSlot nodes reaching printer | {totals.LoadNodes} |");
+        Console.WriteLine($"| Distinct slots considered by printer unifier | {totals.DistinctSlots} |");
+        Console.WriteLine($"| Methods with residual stack slots | {totals.MethodsWithSlots} |");
+        Console.WriteLine($"| Single-candidate slots | {totals.SingleCandidateSlots} |");
+        Console.WriteLine($"| Multi-candidate slots unified by printer | {totals.MultiCandidateUnifiedSlots} |");
+        Console.WriteLine($"| Object-fallback slots | {totals.ObjectFallbackSlots} |");
+        Console.WriteLine($"| Render declaration names emitted | {totals.RenderDeclarationNames} |");
+
+        if (examples.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Examples:");
+            foreach (var example in examples)
+                Console.WriteLine($"  {example}");
+        }
+
+        return totals.PassBugs > 0 ? 1 : 0;
+    }
+
+    sealed class Totals
+    {
+        public long Methods;
+        public long PassBugs;
+        public long StoreNodes;
+        public long LoadNodes;
+        public long DistinctSlots;
+        public long CandidateSlots;
+        public long SingleCandidateSlots;
+        public long MultiCandidateUnifiedSlots;
+        public long ObjectFallbackSlots;
+        public long RenderDeclarationNames;
+        public long MethodsWithSlots;
+
+        public void Add(CSharpPrinter.StackSlotUnifierTelemetry telemetry)
+        {
+            StoreNodes += telemetry.StoreNodes;
+            LoadNodes += telemetry.LoadNodes;
+            DistinctSlots += telemetry.DistinctSlots;
+            CandidateSlots += telemetry.CandidateSlots;
+            SingleCandidateSlots += telemetry.SingleCandidateSlots;
+            MultiCandidateUnifiedSlots += telemetry.MultiCandidateUnifiedSlots;
+            ObjectFallbackSlots += telemetry.ObjectFallbackSlots;
+            RenderDeclarationNames += telemetry.RenderDeclarationNames;
+        }
+    }
+}

--- a/tools/DecompilerHarness/SlotUnifierCensus.cs
+++ b/tools/DecompilerHarness/SlotUnifierCensus.cs
@@ -35,8 +35,8 @@ static class SlotUnifierCensus
                     totals.Add(telemetry);
                     if (telemetry.DistinctSlots > 0)
                         totals.MethodsWithSlots++;
-                    if (telemetry.ObjectFallbackSlots > 0 && examples.Count < maxExamples)
-                        examples.Add($"{typeName}::{methodName} ({telemetry.ObjectFallbackSlots} object-fallback slot{(telemetry.ObjectFallbackSlots == 1 ? "" : "s")})");
+                    if (telemetry.UnunifiedSplitSlots > 0 && examples.Count < maxExamples)
+                        examples.Add($"{typeName}::{methodName} ({telemetry.UnunifiedSplitSlots} un-unified split slot{(telemetry.UnunifiedSplitSlots == 1 ? "" : "s")})");
                 }
                 catch (Exception ex)
                 {
@@ -61,8 +61,8 @@ static class SlotUnifierCensus
         Console.WriteLine($"| Methods with residual stack slots | {totals.MethodsWithSlots} |");
         Console.WriteLine($"| Single-candidate slots | {totals.SingleCandidateSlots} |");
         Console.WriteLine($"| Multi-candidate slots unified by printer | {totals.MultiCandidateUnifiedSlots} |");
-        Console.WriteLine($"| Object-fallback slots | {totals.ObjectFallbackSlots} |");
-        Console.WriteLine($"| Render declaration names emitted | {totals.RenderDeclarationNames} |");
+        Console.WriteLine($"| Un-unified split slots | {totals.UnunifiedSplitSlots} |");
+        Console.WriteLine($"| Stack-slot declarations emitted | {totals.EmittedDeclarationNames} |");
 
         if (examples.Count > 0)
         {
@@ -85,8 +85,8 @@ static class SlotUnifierCensus
         public long CandidateSlots;
         public long SingleCandidateSlots;
         public long MultiCandidateUnifiedSlots;
-        public long ObjectFallbackSlots;
-        public long RenderDeclarationNames;
+        public long UnunifiedSplitSlots;
+        public long EmittedDeclarationNames;
         public long MethodsWithSlots;
 
         public void Add(CSharpPrinter.StackSlotUnifierTelemetry telemetry)
@@ -97,8 +97,8 @@ static class SlotUnifierCensus
             CandidateSlots += telemetry.CandidateSlots;
             SingleCandidateSlots += telemetry.SingleCandidateSlots;
             MultiCandidateUnifiedSlots += telemetry.MultiCandidateUnifiedSlots;
-            ObjectFallbackSlots += telemetry.ObjectFallbackSlots;
-            RenderDeclarationNames += telemetry.RenderDeclarationNames;
+            UnunifiedSplitSlots += telemetry.UnunifiedSplitSlots;
+            EmittedDeclarationNames += telemetry.EmittedDeclarationNames;
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds printer-owned telemetry for the #2209/C2 stack-slot unifier burn-down. This replaces the rejected proxy approach: `DecompilerHarness --slot-unifier-census` now asks the actual `CSharpPrinter` stack-slot unifier path for read-only metrics instead of re-deriving target/assignability rules in the harness.

- Adds optional, disabled-by-default `CSharpPrinter` stack-slot unifier telemetry.
- Aggregates it through `DecompilerHarness --slot-unifier-census`.
- Propagates telemetry into nested local-function printers.
- Reports true printer metrics: single-candidate slots, multi-candidate slots unified by printer, un-unified split slots, and stack-slot declarations actually emitted after inline-declaration filtering.
- Keeps product rendered output unchanged.

## Full corpus result

Command:

```bash
bash eng/prepare-decompiler-corpus.sh /tmp/issue2209-printer-telemetry-corpus.txt
mapfile -t assemblies < /tmp/issue2209-printer-telemetry-corpus.txt
dotnet run --project tools/DecompilerHarness -c Release --no-build -- "${assemblies[@]}" --slot-unifier-census --max-examples 10
```

Result over 14 assemblies / 89,065 methods:

| Metric | Count |
| --- | ---: |
| StoreStackSlot nodes reaching printer | 50805 |
| LoadStackSlot nodes reaching printer | 78283 |
| Distinct slots considered by printer unifier | 44413 |
| Methods with residual stack slots | 8216 |
| Single-candidate slots | 43900 |
| Multi-candidate slots unified by printer | 340 |
| Un-unified split slots | 174 |
| Stack-slot declarations emitted | 19635 |
| Pass bugs | 0 |

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --nologo`
- `dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --no-restore --nologo`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/SlotResidualCensusTests/*"`
- `npx markdownlint-cli tools/DecompilerHarness/README.md`
- Bounded render A/B vs `origin/main` over 200 methods from the same cwd: `Changed: 0`, `Added: 0`, `Removed: 0`
- Full 14-assembly `--slot-unifier-census` above

## Adversarial review

Two-model review was run in isolated worktrees.

- Gemini 3.1 Pro: no blockers; verified the census is driven by existing `CSharpPrinter` stack-slot unifier logic, telemetry is optional/null-by-default, and focused tests pass.
- MAI-Code-1-Flash: no blockers; verified nested local-function printer propagation, disabled-path zero impact, accurate `un-unified split slots` terminology, emitted declaration filtering, and per-function telemetry lifetime.

No follow-up commits were required from final review.

Closes #2209 measurement ask; supports C2 monotone burn-down.