### PR TITLE
Fix release version and pruned project assets

### DIFF
--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.16.0
+version: 0.16.1
 description: Find evidence instead of guessing for .NET packages, platform libraries, local assemblies, APIs, dependencies, and version-to-version API changes.
 ---
 

--- a/src/DotnetInspector.Services.Tests/ProjectAssetsParserTests.cs
+++ b/src/DotnetInspector.Services.Tests/ProjectAssetsParserTests.cs
@@ -107,6 +107,90 @@ public class ProjectAssetsParserTests
     }
 
     [Fact]
+    public void Parse_PrunePlaceholderFallsBackToPackageFiles()
+    {
+        var packageRoot = CreateNuGetPackageAsset("pruned.fallback", "1.0.0", "lib/net10.0/Pruned.Fallback.dll");
+        var json = """
+        {
+            "targets": {
+                "net11.0": {
+                    "Pruned.Fallback/1.0.0": {
+                        "compile": { "lib/net10.0/_._": {} },
+                        "runtime": { "lib/net10.0/_._": {} }
+                    }
+                }
+            },
+            "libraries": {
+                "Pruned.Fallback/1.0.0": {
+                    "type": "package",
+                    "path": "pruned.fallback/1.0.0",
+                    "files": [
+                        "lib/net10.0/Pruned.Fallback.dll"
+                    ]
+                }
+            }
+        }
+        """;
+
+        var assetsPath = WriteTempFile(json);
+        try
+        {
+            var result = Assert.Single(ProjectAssetsParser.Parse(assetsPath, null, null));
+
+            Assert.Equal("Pruned.Fallback", result.PackageName);
+            Assert.Equal("1.0.0", result.Version);
+            Assert.Equal(Path.Combine(packageRoot, "lib", "net10.0", "Pruned.Fallback.dll"), result.Path);
+        }
+        finally
+        {
+            File.Delete(assetsPath);
+            Directory.Delete(packageRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Parse_PrunePlaceholderUsesPlaceholderTfmOverHigherPackageFile()
+    {
+        var packageRoot = CreateNuGetPackageAsset("pruned.multitfm", "1.0.0",
+            "lib/net8.0/Pruned.MultiTfm.dll",
+            "lib/net10.0/Pruned.MultiTfm.dll");
+        var json = """
+        {
+            "targets": {
+                "net11.0": {
+                    "Pruned.MultiTfm/1.0.0": {
+                        "compile": { "lib/net8.0/_._": {} }
+                    }
+                }
+            },
+            "libraries": {
+                "Pruned.MultiTfm/1.0.0": {
+                    "type": "package",
+                    "path": "pruned.multitfm/1.0.0",
+                    "files": [
+                        "lib/net8.0/Pruned.MultiTfm.dll",
+                        "lib/net10.0/Pruned.MultiTfm.dll"
+                    ]
+                }
+            }
+        }
+        """;
+
+        var assetsPath = WriteTempFile(json);
+        try
+        {
+            var result = Assert.Single(ProjectAssetsParser.Parse(assetsPath, null, null));
+
+            Assert.Equal(Path.Combine(packageRoot, "lib", "net8.0", "Pruned.MultiTfm.dll"), result.Path);
+        }
+        finally
+        {
+            File.Delete(assetsPath);
+            Directory.Delete(packageRoot, recursive: true);
+        }
+    }
+
+    [Fact]
     public void Parse_WithTfmFilter_SelectsMatchingTfm()
     {
         var json = """
@@ -468,5 +552,21 @@ public class ProjectAssetsParserTests
         var path = Path.Combine(Path.GetTempPath(), $"project-assets-test-{Guid.NewGuid():N}.json");
         File.WriteAllText(path, content);
         return path;
+    }
+
+    private static string CreateNuGetPackageAsset(string packageId, string version, params string[] relativeAssets)
+    {
+        var packageRoot = Path.Combine(DotnetInspector.Packages.NuGetCache.GetNuGetCachePath(), packageId, version);
+        if (Directory.Exists(packageRoot))
+            Directory.Delete(packageRoot, recursive: true);
+
+        foreach (var relativeAsset in relativeAssets)
+        {
+            var assetPath = Path.Combine(packageRoot, relativeAsset.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(assetPath)!);
+            File.WriteAllText(assetPath, "fake assembly");
+        }
+
+        return packageRoot;
     }
 }

--- a/src/DotnetInspector.Services/ProjectAssetsParser.cs
+++ b/src/DotnetInspector.Services/ProjectAssetsParser.cs
@@ -180,6 +180,7 @@ public static class ProjectAssetsParser
 
                 if (dep.Value.TryGetProperty("compile", out var compile))
                 {
+                    var addedFromCompile = false;
                     foreach (var asm in compile.EnumerateObject())
                     {
                         if (!asm.Name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
@@ -192,7 +193,14 @@ public static class ProjectAssetsParser
                         if (File.Exists(fullPath))
                         {
                             results.Add((fullPath, packageName, version));
+                            addedFromCompile = true;
                         }
+                    }
+
+                    if (!addedFromCompile)
+                    {
+                        foreach (var fallbackPath in GetFallbackCompileAssets(libInfo, compile, packageName, packagePath, nugetCache, tfmFilter))
+                            results.Add((fallbackPath, packageName, version));
                     }
                 }
             }
@@ -203,6 +211,93 @@ public static class ProjectAssetsParser
         }
 
         return results;
+    }
+
+    private static IEnumerable<string> GetFallbackCompileAssets(
+        JsonElement library,
+        JsonElement compile,
+        string packageName,
+        string packagePath,
+        string nugetCache,
+        string? tfmFilter)
+    {
+        if (!library.TryGetProperty("files", out var files) || files.ValueKind != JsonValueKind.Array)
+            yield break;
+
+        var fileCandidates = files.EnumerateArray()
+            .Select(file => file.GetString())
+            .Where(path => path is not null && IsAssemblyAsset(path))
+            .Select(path => path!)
+            .ToList();
+        if (fileCandidates.Count == 0)
+            yield break;
+
+        var tfmHints = compile.EnumerateObject()
+            .Where(asset => asset.Name.Contains("_._", StringComparison.Ordinal))
+            .Select(asset => TfmResolver.ExtractTfmFromPath(asset.Name))
+            .Where(tfm => !string.IsNullOrWhiteSpace(tfm))
+            .Select(tfm => tfm!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var selected = SelectFallbackAssetGroup(fileCandidates, tfmHints, tfmFilter);
+        foreach (var relativePath in selected)
+        {
+            var fullPath = Path.Combine(nugetCache, packagePath, relativePath.Replace('/', Path.DirectorySeparatorChar));
+            if (File.Exists(fullPath))
+                yield return fullPath;
+        }
+    }
+
+    private static bool IsAssemblyAsset(string? path)
+        => path is { Length: > 0 }
+           && path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+           && !path.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase)
+           && (path.StartsWith("ref/", StringComparison.OrdinalIgnoreCase)
+               || path.StartsWith("lib/", StringComparison.OrdinalIgnoreCase));
+
+    private static IReadOnlyList<string> SelectFallbackAssetGroup(
+        IReadOnlyList<string> candidates,
+        IReadOnlyList<string> tfmHints,
+        string? tfmFilter)
+    {
+        var grouped = candidates
+            .Select(path => new
+            {
+                Path = path,
+                Tfm = TfmResolver.ExtractTfmFromPath(path),
+                Prefix = path.Split('/', 2)[0]
+            })
+            .Where(candidate => !string.IsNullOrWhiteSpace(candidate.Tfm))
+            .GroupBy(candidate => candidate.Tfm!, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.ToList(), StringComparer.OrdinalIgnoreCase);
+
+        if (grouped.Count == 0)
+            return [];
+
+        string? selectedTfm = null;
+        if (!string.IsNullOrWhiteSpace(tfmFilter) && grouped.ContainsKey(tfmFilter))
+            selectedTfm = tfmFilter;
+        else if (tfmHints.Count > 0)
+            selectedTfm = TfmSelector.SelectHighestTfm(tfmHints.Where(grouped.ContainsKey));
+        selectedTfm ??= TfmSelector.SelectHighestTfm(grouped.Keys);
+        if (selectedTfm is null || !grouped.TryGetValue(selectedTfm, out var selectedGroup))
+            return [];
+
+        var hintPrefixes = candidates
+            .Where(path => tfmHints.Contains(TfmResolver.ExtractTfmFromPath(path) ?? "", StringComparer.OrdinalIgnoreCase))
+            .Select(path => path.Split('/', 2)[0])
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var prefixPriority = hintPrefixes.Length > 0
+            ? hintPrefixes
+            : ["ref", "lib"];
+
+        return selectedGroup
+            .OrderBy(candidate => Array.FindIndex(prefixPriority, prefix => prefix.Equals(candidate.Prefix, StringComparison.OrdinalIgnoreCase)) is var index && index >= 0 ? index : int.MaxValue)
+            .ThenBy(candidate => candidate.Path, StringComparer.OrdinalIgnoreCase)
+            .Select(candidate => candidate.Path)
+            .ToList();
     }
 
     /// <summary>

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -24,7 +24,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.16.0</VersionPrefix>
+    <VersionPrefix>0.16.1</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## v0.16.1
+
+### Release packaging and project lookup
+
+- Bumps the package version so the next production package is publishable after
+  `0.16.0`.
+- Recovers project-scoped API lookup for restored projects whose NuGet assets
+  are package-pruned to `_._` compile placeholders by falling back to the
+  package file list's compatible assemblies.
+
 ## v0.16.0
 
 ### Research overlay and performance analysis (experimental)


### PR DESCRIPTION
## Summary

Fixes the remaining release usability blockers from the production package hard run:

- bump `dotnet-inspect` package metadata and embedded base skill from `0.16.0` to `0.16.1`
- add `v0.16.1` release notes
- recover project-scoped API lookup when restored `project.assets.json` entries are package-pruned to `_._` compile/runtime placeholders by falling back to compatible assemblies listed in the package file list

Fixes #2475
Fixes #2476

## Validation

- `dotnet run --project src/DotnetInspector.Services.Tests -c Release`: 243 total, 0 failed
- `dotnet build src/dotnet-inspect/dotnet-inspect.csproj -c Release --configfile nuget.config -p:PublishAot=false`
- `dotnet run --project src/dotnet-inspect -c Release --no-build -- skill`: reports `version: 0.16.1`
- `npx markdownlint-cli src/dotnet-inspect/release-notes.md skills/dotnet-inspect/SKILL.md`
- pruned `net11.0` project repro: `project`, `find ILogger`, `type ILogger`, and `member ILogger --show-index` all succeed
- production-style package check: packed `dotnet-inspect.linux-x64.0.16.1.nupkg` and pointer `dotnet-inspect.0.16.1.nupkg`; local-only `dotnet tool install` reports `0.16.1+589a19b`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`: succeeded with existing nullable warnings in `tests/ILInspector.Metadata.Tests`
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build`: 1693 total, 0 failed, 10 skipped

Adversarial review requested separately per policy; results will be posted as a PR comment.
