### PR TITLE
Add IL assembly diff path wrappers

### DIFF
--- a/docs/design/il-diff-canonicalization.md
+++ b/docs/design/il-diff-canonicalization.md
@@ -8,9 +8,12 @@ amount of canonicalization, then projects producer-owned rows through
 `IlAssemblyDiff` is the assembly/member producer above that substrate. It owns
 method identity for pairing bodies, runs self-diff and pair-diff checks, and
 emits summary counts, failure buckets, operation-family buckets, and typed
-example diffs. Harnesses own rendering and Markout/card projection; they should
-consume `IlAssemblyDiffResult` rather than reimplementing method matching or
-bucket wording.
+example diffs. Use `CompareFiles` / `CompareStreams` when the caller starts from
+assembly paths or streams; use the lower-level `Compare` overload only when the
+caller already owns `PEReader` / `MetadataReader` instances. Harnesses own
+rendering and Markout/card projection; they should consume
+`IlAssemblyDiffResult` / `IlAssemblyDiffPairResult` rather than reimplementing
+method matching or bucket wording.
 
 The boundary is intentionally narrow: the diff answers "which decoded IL
 operations changed?" It does not claim source equivalence, semantic equivalence,

--- a/src/ILInspector.Instructions.Tests/IlAssemblyDiffTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlAssemblyDiffTests.cs
@@ -26,4 +26,34 @@ public class IlAssemblyDiffTests
         Assert.Empty(result.TopOpcodeFamilies);
         Assert.Empty(result.Examples);
     }
+
+    [Fact]
+    public void CompareFiles_SameAssembly_PreservesInputPaths()
+    {
+        var assemblyPath = typeof(IlAssemblyDiffTests).Assembly.Location;
+
+        var pair = IlAssemblyDiff.CompareFiles(assemblyPath, assemblyPath, maxExamples: 3);
+
+        Assert.Equal(assemblyPath, pair.Old);
+        Assert.Equal(assemblyPath, pair.New);
+        Assert.True(pair.Diff.ComparedBodyCount > 0);
+        Assert.Equal(0, pair.Diff.ChangedBodyCount);
+        Assert.Equal(0, pair.Diff.FailureCount);
+    }
+
+    [Fact]
+    public void CompareStreams_SameAssembly_PreservesSourceNames()
+    {
+        var assemblyPath = typeof(IlAssemblyDiffTests).Assembly.Location;
+        using var oldStream = File.OpenRead(assemblyPath);
+        using var newStream = File.OpenRead(assemblyPath);
+
+        var pair = IlAssemblyDiff.CompareStreams(oldStream, "old.dll", newStream, "new.dll", maxExamples: 3);
+
+        Assert.Equal("old.dll", pair.Old);
+        Assert.Equal("new.dll", pair.New);
+        Assert.True(pair.Diff.ComparedBodyCount > 0);
+        Assert.Equal(0, pair.Diff.ChangedBodyCount);
+        Assert.Equal(0, pair.Diff.FailureCount);
+    }
 }

--- a/src/ILInspector.Instructions.Tests/IlAssemblyDiffTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlAssemblyDiffTests.cs
@@ -56,4 +56,17 @@ public class IlAssemblyDiffTests
         Assert.Equal(0, pair.Diff.ChangedBodyCount);
         Assert.Equal(0, pair.Diff.FailureCount);
     }
+
+    [Fact]
+    public void CompareStreams_DoesNotDisposeCallerOwnedStreams()
+    {
+        var assemblyPath = typeof(IlAssemblyDiffTests).Assembly.Location;
+        using var oldStream = File.OpenRead(assemblyPath);
+        using var newStream = File.OpenRead(assemblyPath);
+
+        _ = IlAssemblyDiff.CompareStreams(oldStream, "old.dll", newStream, "new.dll", maxExamples: 0);
+
+        Assert.True(oldStream.CanRead);
+        Assert.True(newStream.CanRead);
+    }
 }

--- a/src/ILInspector.Instructions/IlAssemblyDiff.cs
+++ b/src/ILInspector.Instructions/IlAssemblyDiff.cs
@@ -20,11 +20,47 @@ public sealed record IlAssemblyDiffResult(
     ImmutableArray<IlDiffBucket> TopOpcodeFamilies,
     ImmutableArray<IlAssemblyDiffExample> Examples);
 
+public sealed record IlAssemblyDiffPairResult(
+    string Old,
+    string New,
+    IlAssemblyDiffResult Diff);
+
 /// <summary>
 /// Product-owned IL/body diff producer over two metadata-backed assemblies.
 /// </summary>
 public static class IlAssemblyDiff
 {
+    public static IlAssemblyDiffPairResult CompareFiles(
+        string oldPath,
+        string newPath,
+        int maxExamples = 5)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(oldPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(newPath);
+
+        using var oldStream = File.OpenRead(oldPath);
+        using var newStream = File.OpenRead(newPath);
+        return CompareStreams(oldStream, oldPath, newStream, newPath, maxExamples);
+    }
+
+    public static IlAssemblyDiffPairResult CompareStreams(
+        Stream oldStream,
+        string oldName,
+        Stream newStream,
+        string newName,
+        int maxExamples = 5)
+    {
+        ArgumentNullException.ThrowIfNull(oldStream);
+        ArgumentException.ThrowIfNullOrWhiteSpace(oldName);
+        ArgumentNullException.ThrowIfNull(newStream);
+        ArgumentException.ThrowIfNullOrWhiteSpace(newName);
+
+        using var oldPe = new PEReader(oldStream);
+        using var newPe = new PEReader(newStream);
+        var result = Compare(oldPe, oldPe.GetMetadataReader(), newPe, newPe.GetMetadataReader(), maxExamples);
+        return new IlAssemblyDiffPairResult(oldName, newName, result);
+    }
+
     public static IlAssemblyDiffResult Compare(
         PEReader oldPe,
         MetadataReader oldReader,

--- a/src/ILInspector.Instructions/IlAssemblyDiff.cs
+++ b/src/ILInspector.Instructions/IlAssemblyDiff.cs
@@ -55,8 +55,8 @@ public static class IlAssemblyDiff
         ArgumentNullException.ThrowIfNull(newStream);
         ArgumentException.ThrowIfNullOrWhiteSpace(newName);
 
-        using var oldPe = new PEReader(oldStream);
-        using var newPe = new PEReader(newStream);
+        using var oldPe = new PEReader(oldStream, PEStreamOptions.LeaveOpen);
+        using var newPe = new PEReader(newStream, PEStreamOptions.LeaveOpen);
         var result = Compare(oldPe, oldPe.GetMetadataReader(), newPe, newPe.GetMetadataReader(), maxExamples);
         return new IlAssemblyDiffPairResult(oldName, newName, result);
     }

--- a/tools/IlDiffHarness/Program.cs
+++ b/tools/IlDiffHarness/Program.cs
@@ -1,6 +1,4 @@
 using System.Collections.Immutable;
-using System.Reflection.Metadata;
-using System.Reflection.PortableExecutable;
 using System.Text.Json;
 
 using ILInspector.DiffHarnessCommon;
@@ -180,25 +178,12 @@ catch (Exception ex) when (ex is BadImageFormatException or IOException or Inval
 
 static IlDiffPairCard BuildPairCard(AssemblyPair pair, int maxExamples)
 {
-    using var oldFile = File.OpenRead(pair.OldPath);
-    using var newFile = File.OpenRead(pair.NewPath);
-    using var oldPe = new PEReader(oldFile);
-    using var newPe = new PEReader(newFile);
-    var oldReader = oldPe.GetMetadataReader();
-    var newReader = newPe.GetMetadataReader();
-    var card = BuildCard(oldPe, oldReader, newPe, newReader, maxExamples);
-    return new IlDiffPairCard(pair.OldPath, pair.NewPath, card);
+    var pairResult = IlAssemblyDiff.CompareFiles(pair.OldPath, pair.NewPath, maxExamples);
+    return new IlDiffPairCard(pairResult.Old, pairResult.New, BuildCard(pairResult.Diff));
 }
 
-static IlDiffCard BuildCard(
-    PEReader oldPe,
-    MetadataReader oldReader,
-    PEReader newPe,
-    MetadataReader newReader,
-    int maxExamples)
+static IlDiffCard BuildCard(IlAssemblyDiffResult result)
 {
-    var result = IlAssemblyDiff.Compare(oldPe, oldReader, newPe, newReader, maxExamples);
-
     return new IlDiffCard(
         result.ComparedBodyCount,
         result.SelfDiffExactCount,


### PR DESCRIPTION
## Summary

- Add path/stream-oriented `IlAssemblyDiff` entry points:
  - `CompareFiles(oldPath, newPath, maxExamples)`
  - `CompareStreams(oldStream, oldName, newStream, newName, maxExamples)`
- Return `IlAssemblyDiffPairResult` with caller-owned old/new labels plus the typed `IlAssemblyDiffResult`.
- Route `IlDiffHarness` through `CompareFiles` while preserving Markout/card/snapshot rendering.
- Document the wrapper boundary in `docs/design/il-diff-canonicalization.md`.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- `dotnet run --project src/ILInspector.Instructions.Tests -c Release --no-build`
- IL Diff smoke: snapshot JSONL + exact baseline JSONL + JSONL parse
- `npx markdownlint-cli docs/design/il-diff-canonicalization.md`