### PR TITLE
Use precedence model for coalesce left operand

### DIFF
--- a/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
@@ -238,6 +238,50 @@ public class PrinterPrecedenceTests
         Assert.DoesNotContain("return a - b - c;", output);
     }
 
+    [Fact]
+    public void CoalesceLeft_NestedCoalesce_StaysParenthesized()
+    {
+        var nested = new Coalesce(
+            new LoadArgument(0, "a", s_string),
+            new LoadArgument(1, "b", s_string));
+        var outer = new Coalesce(
+            nested,
+            new LoadArgument(2, "c", s_string));
+
+        var output = PrintReturn(
+            outer,
+            s_string,
+            [new Parameter("a", s_string), new Parameter("b", s_string), new Parameter("c", s_string)]);
+
+        Assert.Contains("return (a ?? b) ?? c;", output);
+        Assert.DoesNotContain("return a ?? b ?? c;", output);
+    }
+
+    [Fact]
+    public void CoalesceLeft_Conditional_StaysParenthesized()
+    {
+        var conditional = new Conditional(
+            new LoadArgument(0, "flag", s_bool),
+            new LoadArgument(1, "a", s_string),
+            new LoadArgument(2, "b", s_string));
+        var coalesce = new Coalesce(
+            conditional,
+            new LoadArgument(3, "c", s_string));
+
+        var output = PrintReturn(
+            coalesce,
+            s_string,
+            [
+                new Parameter("flag", s_bool),
+                new Parameter("a", s_string),
+                new Parameter("b", s_string),
+                new Parameter("c", s_string),
+            ]);
+
+        Assert.Contains("return (flag ? a : b) ?? c;", output);
+        Assert.DoesNotContain("return flag ? a : b ?? c;", output);
+    }
+
     static string PrintReturn(IrExpression value, TypeRef returnType, ImmutableArray<Parameter> parameters)
     {
         var block = new Block();

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2039,7 +2039,7 @@ public sealed partial class CSharpPrinter
                     ? nodeType
                     : null;
         }
-        return $"{CoalesceOperand(co.Left)} ?? {CoalesceRightText(co.Right, coalesceTarget, primitiveCoercionSourceType)}";
+        return $"{CoalesceLeftText(co.Left)} ?? {CoalesceRightText(co.Right, coalesceTarget, primitiveCoercionSourceType)}";
     }
 
     string CoalesceRightText(IrExpression right, TypeRef? target, TypeRef? primitiveCoercionSourceType = null)
@@ -2075,7 +2075,7 @@ public sealed partial class CSharpPrinter
             ? value
             : null;
 
-    string CoalesceOperand(IrExpression expression)
+    string CoalesceLeftText(IrExpression expression)
         => expression is LoadIndirect
         {
             Type:
@@ -2086,7 +2086,9 @@ public sealed partial class CSharpPrinter
             Address.ResultType.Kind: TypeRefKind.ByRef,
         } load
             ? DerefLoad(load)
-            : Operand(expression);
+            // `??` is right-associative, so the left operand is the equal-precedence
+            // hazard side: `(a ?? b) ?? c` must not render as `a ?? b ?? c`.
+            : RenderedExpression(expression).At(TighterThan(Precedence.NullCoalescing));
 
     /// <summary>Conditions render brtrue's raw value as-is; LogicalNot over a comparison folds via the shared type-aware duals (float folds flip the unordered flag).</summary>
     string Condition(IrExpression condition) => condition switch


### PR DESCRIPTION
## Summary

Continues #2376 by replacing the `??` left-operand `Operand(...)` fallback with the existing `Rendered`/`Precedence` model.

- Preserves the nullable `ldind Nullable<T>` deref special-case.
- Ordinary left operands render at a tighter-than-`??` demand, because `??` is right-associative and the left side is the equal-precedence hazard: `(a ?? b) ?? c` must not become `a ?? b ?? c`.
- Adds canaries for both nested-coalesce and conditional-left hazards.

## Evidence

- Focused canaries:
  - `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/PrinterPrecedenceTests/CoalesceLeft_NestedCoalesce_StaysParenthesized"`
  - `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/PrinterPrecedenceTests/CoalesceLeft_Conditional_StaysParenthesized"`
- Fast decompiler suite: `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"`
- Build: `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- Render A/B over 89,065 methods vs explicit merge-base (`ceb07619`), `--workers 20`:
  - `Changed: 27 (structural: 3, paren-equivalent: 21, unparsed: 3)`
  - `Semantic: valid->valid: 22, invalid->valid: 0, valid->invalid: 0, invalid->invalid: 5`
  - Structural rows are semantic-neutral precedence simplifications such as `((T)x) ?? y` → `(T)x ?? y`; semantic lane reports **0 valid→invalid**.

## Review

Two-model adversarial review complete. Gemini and MAI both report clean reviews with no blocking findings; reconciliation is posted in the PR comments.
