### PR TITLE
Shared signature-blob depth guard + Analysis decode sites (#2490 increment 1)

### DIFF
--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -57,6 +57,8 @@ public static class LeakTriageAnalyzer
                 try
                 {
                     var scope = CreateScope(reader, typeDef, methodDef);
+                    if (!ILInspector.Metadata.SignatureBlobGuard.IsSafeToDecode(reader, methodDef.Signature, ILInspector.Metadata.SignatureBlobGuard.Kind.Method))
+                        continue;
                     var signature = methodDef.DecodeSignature(TypeRefDecoder.Instance, scope);
                     var method = new MethodIdentity(
                         assemblyName,

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -2416,18 +2416,30 @@ public sealed class LibraryBodyIndex
         MethodIdentity CreateMethodIdentity(TypeDefinitionHandle typeHandle, MethodDefinitionHandle methodHandle, MethodDefinition methodDef, GenericScope scope)
         {
             var declaringType = TypeRefDecoder.Instance.GetTypeFromDefinition(_reader, typeHandle, 0);
-            var signature = methodDef.DecodeSignature(TypeRefDecoder.Instance, scope);
+            ImmutableArray<TypeRef> parameterTypes;
+            TypeRef returnType;
+            if (SignatureBlobGuard.IsSafeToDecode(_reader, methodDef.Signature, SignatureBlobGuard.Kind.Method))
+            {
+                var signature = methodDef.DecodeSignature(TypeRefDecoder.Instance, scope);
+                parameterTypes = signature.ParameterTypes;
+                returnType = signature.ReturnType;
+            }
+            else
+            {
+                parameterTypes = [];
+                returnType = TypeRef.Unsupported("method signature nesting depth exceeded");
+            }
             return new MethodIdentity(
                 _assemblyName,
                 _mvid,
                 declaringType,
                 _reader.GetString(methodDef.Name),
-                signature.ParameterTypes,
-                signature.ReturnType,
+                parameterTypes,
+                returnType,
                 MetadataTokens.GetToken(methodHandle),
                 (methodDef.Attributes & MethodAttributes.Static) != 0,
                 IsExtensionMethod(typeHandle, methodDef),
-                ComputeCallerUnsafeMode(typeHandle, methodDef, signature.ParameterTypes, signature.ReturnType),
+                ComputeCallerUnsafeMode(typeHandle, methodDef, parameterTypes, returnType),
                 methodDef.GetGenericParameters().Count,
                 GenericParameterNames(methodDef));
         }
@@ -2592,6 +2604,8 @@ public sealed class LibraryBodyIndex
 
             bool found = false;
             var signature = _reader.GetStandaloneSignature(body.LocalSignature);
+            if (!SignatureBlobGuard.IsSafeToDecode(_reader, signature.Signature, SignatureBlobGuard.Kind.LocalVariables))
+                return false;
             var locals = signature.DecodeLocalSignature(TypeRefDecoder.Instance, scope);
             for (int i = 0; i < locals.Length; i++)
             {
@@ -3095,6 +3109,8 @@ public sealed class LibraryBodyIndex
             try
             {
                 var signature = _reader.GetStandaloneSignature(body.LocalSignature);
+                if (!SignatureBlobGuard.IsSafeToDecode(_reader, signature.Signature, SignatureBlobGuard.Kind.LocalVariables))
+                    return [];
                 return signature.DecodeLocalSignature(TypeRefDecoder.Instance, scope);
             }
             catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
@@ -3172,8 +3188,10 @@ public sealed class LibraryBodyIndex
                 var handle = MetadataTokens.EntityHandle(token);
                 if (handle.Kind != HandleKind.StandaloneSignature)
                     return null;
-                var signature = _reader.GetStandaloneSignature((StandaloneSignatureHandle)handle)
-                    .DecodeMethodSignature(TypeRefDecoder.Instance, scope);
+                var standalone = _reader.GetStandaloneSignature((StandaloneSignatureHandle)handle);
+                if (!SignatureBlobGuard.IsSafeToDecode(_reader, standalone.Signature, SignatureBlobGuard.Kind.Method))
+                    return null;
+                var signature = standalone.DecodeMethodSignature(TypeRefDecoder.Instance, scope);
                 return signature.ReturnType.ToDisplayString();
             }
             catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)

--- a/src/ILInspector.Analysis/MemberResolver.cs
+++ b/src/ILInspector.Analysis/MemberResolver.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
+using ILInspector.Metadata;
 
 namespace ILInspector.Analysis;
 
@@ -18,6 +19,8 @@ internal static class MemberResolver
                 var typeScope = new GenericScope(
                     GenericParameterNames(reader, declaringType.GetGenericParameters()),
                     GenericParameterNames(reader, method.GetGenericParameters()));
+                if (!SignatureBlobGuard.IsSafeToDecode(reader, method.Signature, SignatureBlobGuard.Kind.Method))
+                    return MemberRef.Unsupported("method signature nesting depth exceeded");
                 var signature = method.DecodeSignature(TypeRefDecoder.Instance, typeScope);
                 string name = reader.GetString(method.Name);
                 return new MemberRef(declaring, name, signature.ParameterTypes, signature.ReturnType, KindFor(name))
@@ -31,6 +34,8 @@ internal static class MemberResolver
             {
                 var member = reader.GetMemberReference((MemberReferenceHandle)handle);
                 var declaring = ResolveParentType(reader, member.Parent, callerScope);
+                if (!SignatureBlobGuard.IsSafeToDecode(reader, member.Signature, SignatureBlobGuard.Kind.Method))
+                    return MemberRef.Unsupported("member-reference signature nesting depth exceeded");
                 var signature = member.DecodeMethodSignature(TypeRefDecoder.Instance, GenericScope.Empty);
                 var typeArguments = declaring.Kind == TypeRefKind.GenericInstance ? declaring.TypeArguments : [];
                 string name = reader.GetString(member.Name);
@@ -51,6 +56,8 @@ internal static class MemberResolver
             {
                 var spec = reader.GetMethodSpecification((MethodSpecificationHandle)handle);
                 var generic = ResolveMethod(reader, spec.Method, callerScope);
+                if (!SignatureBlobGuard.IsSafeToDecode(reader, spec.Signature, SignatureBlobGuard.Kind.MethodSpecification))
+                    return MemberRef.Unsupported("method-specification signature nesting depth exceeded");
                 var methodArguments = spec.DecodeSignature(TypeRefDecoder.Instance, callerScope);
                 return generic with
                 {

--- a/src/ILInspector.Metadata/SignatureBlobGuard.cs
+++ b/src/ILInspector.Metadata/SignatureBlobGuard.cs
@@ -85,8 +85,11 @@ public static class SignatureBlobGuard
     {
         // Work items are read strictly left-to-right; the stack only tracks *what* to read next and
         // at what depth, so recursion lives on the heap and can never overflow the native stack.
+        // Every Type work item consumes at least one blob byte, and count-driven pushes are bounded
+        // by the remaining blob length (see PushTypes), so the stack size is O(blob length).
         var work = new Stack<WorkItem>();
-        SeedRoots(ref blob, kind, work);
+        if (SeedRoots(ref blob, kind, work))
+            return true;
 
         while (work.Count > 0)
         {
@@ -96,7 +99,8 @@ public static class SignatureBlobGuard
                 case Op.Type:
                     if (item.Depth > maxDepth)
                         return true;
-                    ReadType(ref blob, item.Depth, work);
+                    if (ReadType(ref blob, item.Depth, work))
+                        return true;
                     break;
 
                 case Op.ArrayShape:
@@ -108,124 +112,126 @@ public static class SignatureBlobGuard
         return false;
     }
 
-    static void SeedRoots(ref BlobReader blob, Kind kind, Stack<WorkItem> work)
+    /// <summary>Pushes <paramref name="count"/> Type slots at <paramref name="depth"/>. Returns true
+    /// (unsafe) if the count exceeds the bytes left in the blob: every Type consumes at least one
+    /// byte, so a larger count is malformed and must not be materialized (a compressed integer can
+    /// encode ~536M, which would otherwise OOM the work-stack before SRM ever sees the blob).</summary>
+    static bool PushTypes(Stack<WorkItem> work, int count, int depth, ref BlobReader blob)
+    {
+        if (count < 0 || count > blob.RemainingBytes)
+            return true;
+        for (int i = 0; i < count; i++)
+            work.Push(WorkItem.Type(depth));
+        return false;
+    }
+
+    static bool SeedRoots(ref BlobReader blob, Kind kind, Stack<WorkItem> work)
     {
         switch (kind)
         {
             case Kind.TypeSpecification:
                 work.Push(WorkItem.Type(1));
-                break;
+                return false;
 
             case Kind.Field:
                 blob.ReadSignatureHeader();
                 work.Push(WorkItem.Type(1));
-                break;
+                return false;
 
             case Kind.MethodSpecification:
-            {
-                blob.ReadSignatureHeader();
-                int count = blob.ReadCompressedInteger();
-                for (int i = 0; i < count; i++)
-                    work.Push(WorkItem.Type(1));
-                break;
-            }
-
             case Kind.LocalVariables:
             {
                 blob.ReadSignatureHeader();
                 int count = blob.ReadCompressedInteger();
-                for (int i = 0; i < count; i++)
-                    work.Push(WorkItem.Type(1));
-                break;
+                return PushTypes(work, count, 1, ref blob);
             }
 
             case Kind.Method:
-            {
-                SeedMethodRoots(ref blob, work, depth: 1);
-                break;
-            }
+                return SeedMethodRoots(ref blob, work, depth: 1);
+
+            default:
+                return false;
         }
     }
 
-    static void SeedMethodRoots(ref BlobReader blob, Stack<WorkItem> work, int depth)
+    static bool SeedMethodRoots(ref BlobReader blob, Stack<WorkItem> work, int depth)
     {
         var header = blob.ReadSignatureHeader();
         if (header.IsGeneric)
             blob.ReadCompressedInteger(); // generic parameter count
         int paramCount = blob.ReadCompressedInteger();
-        // Return type, then each parameter, are Type slots (with the usual leading modifiers /
-        // by-ref / typedbyref / sentinel handled inside ReadType). Ordering among siblings does not
-        // affect the maximum depth, so push them all at the same depth.
-        work.Push(WorkItem.Type(depth));
+        // Return type + each parameter are Type slots (leading modifiers / by-ref / typedbyref /
+        // sentinel are handled inside ReadType). Ordering among siblings does not affect the maximum
+        // depth. Bound paramCount + 1 (the return type) against the remaining blob before pushing.
+        if (paramCount < 0 || (long)paramCount + 1 > blob.RemainingBytes)
+            return true;
+        work.Push(WorkItem.Type(depth)); // return type
         for (int i = 0; i < paramCount; i++)
             work.Push(WorkItem.Type(depth));
+        return false;
     }
 
     /// <summary>Reads one Type at <paramref name="depth"/>, consuming its own bytes and pushing its
-    /// child Type slots (at <paramref name="depth"/> + 1) for the main loop to process.</summary>
-    static void ReadType(ref BlobReader blob, int depth, Stack<WorkItem> work)
+    /// child Type slots for the main loop to process. Returns true (unsafe) if a malformed count is
+    /// encountered. Every prefix that SRM recurses through (custom modifier, by-ref, pinned) pushes
+    /// the modified type at <paramref name="depth"/> + 1 so a long prefix chain is bounded exactly
+    /// like a chain of pointers.</summary>
+    static bool ReadType(ref BlobReader blob, int depth, Stack<WorkItem> work)
     {
-        // Skip any leading prefixes that modify the following type without adding a structural
-        // frame worth bounding separately: custom modifiers (each carries a coded token), by-ref,
-        // pinned, and the vararg sentinel.
-        while (true)
+        byte code = blob.ReadByte();
+        switch (code)
         {
-            byte code = blob.ReadByte();
-            switch (code)
+            case ElementTypeCmodReqd:
+            case ElementTypeCmodOpt:
+                blob.ReadTypeHandle();               // modifier's TypeDefOrRefOrSpec token
+                work.Push(WorkItem.Type(depth + 1)); // SRM recurses through the modified type
+                return false;
+
+            case ElementTypeByRef:
+            case ElementTypePinned:
+            case ElementTypeSentinel:
+                work.Push(WorkItem.Type(depth + 1)); // SRM recurses through the referenced type
+                return false;
+
+            case ElementTypePtr:
+            case ElementTypeSzArray:
+                work.Push(WorkItem.Type(depth + 1));
+                return false;
+
+            case ElementTypeArray:
+                // ELEMENT_TYPE_ARRAY: Type ArrayShape. The shape trails the element in the blob, so
+                // schedule it to be read *after* the element subtree (pushed first here, popped last).
+                work.Push(WorkItem.ArrayShape());
+                work.Push(WorkItem.Type(depth + 1));
+                return false;
+
+            case ElementTypeGenericInst:
             {
-                case ElementTypeCmodReqd:
-                case ElementTypeCmodOpt:
-                    blob.ReadTypeHandle(); // modifier's TypeDefOrRefOrSpec token
-                    continue;
-                case ElementTypeByRef:
-                case ElementTypePinned:
-                case ElementTypeSentinel:
-                    continue;
-
-                case ElementTypePtr:
-                case ElementTypeSzArray:
-                    work.Push(WorkItem.Type(depth + 1));
-                    return;
-
-                case ElementTypeArray:
-                    // ELEMENT_TYPE_ARRAY: Type ArrayShape. The shape trails the element in the blob,
-                    // so schedule it to be read *after* the element subtree (pushed first here, so it
-                    // pops last).
-                    work.Push(WorkItem.ArrayShape());
-                    work.Push(WorkItem.Type(depth + 1));
-                    return;
-
-                case ElementTypeGenericInst:
-                {
-                    // GENERICINST (CLASS|VALUETYPE) TypeToken GenArgCount Type*
-                    blob.ReadByte();       // CLASS / VALUETYPE
-                    blob.ReadTypeHandle(); // generic type token
-                    int args = blob.ReadCompressedInteger();
-                    for (int i = 0; i < args; i++)
-                        work.Push(WorkItem.Type(depth + 1));
-                    return;
-                }
-
-                case ElementTypeFnPtr:
-                    // FNPTR MethodSig: its return type and parameters are the children.
-                    SeedMethodRoots(ref blob, work, depth + 1);
-                    return;
-
-                case ElementTypeClass:
-                case ElementTypeValueType:
-                    blob.ReadTypeHandle();
-                    return;
-
-                case ElementTypeVar:
-                case ElementTypeMVar:
-                    blob.ReadCompressedInteger(); // generic parameter index
-                    return;
-
-                default:
-                    // Primitive / VOID / OBJECT / STRING / TYPEDBYREF / I / U and anything else:
-                    // a leaf that consumes no further bytes here.
-                    return;
+                // GENERICINST (CLASS|VALUETYPE) TypeToken GenArgCount Type*
+                blob.ReadByte();       // CLASS / VALUETYPE
+                blob.ReadTypeHandle(); // generic type token
+                int args = blob.ReadCompressedInteger();
+                return PushTypes(work, args, depth + 1, ref blob);
             }
+
+            case ElementTypeFnPtr:
+                // FNPTR MethodSig: its return type and parameters are the children.
+                return SeedMethodRoots(ref blob, work, depth + 1);
+
+            case ElementTypeClass:
+            case ElementTypeValueType:
+                blob.ReadTypeHandle();
+                return false;
+
+            case ElementTypeVar:
+            case ElementTypeMVar:
+                blob.ReadCompressedInteger(); // generic parameter index
+                return false;
+
+            default:
+                // Primitive / VOID / OBJECT / STRING / TYPEDBYREF / I / U and anything else:
+                // a leaf that consumes no further bytes here.
+                return false;
         }
     }
 

--- a/src/ILInspector.Metadata/SignatureBlobGuard.cs
+++ b/src/ILInspector.Metadata/SignatureBlobGuard.cs
@@ -104,7 +104,8 @@ public static class SignatureBlobGuard
                     break;
 
                 case Op.ArrayShape:
-                    SkipArrayShape(ref blob);
+                    if (SkipArrayShape(ref blob))
+                        return true;
                     break;
             }
         }
@@ -235,15 +236,24 @@ public static class SignatureBlobGuard
         }
     }
 
-    static void SkipArrayShape(ref BlobReader blob)
+    /// <summary>Skips an ArrayShape (rank, sizes, lower bounds). Returns true (unsafe) if either
+    /// count exceeds the remaining blob: SRM's array decoder pre-allocates a builder from these
+    /// counts before reading elements, so an unbounded count (a compressed integer can encode ~536M)
+    /// would OOM SRM even though the blob is only a few bytes.</summary>
+    static bool SkipArrayShape(ref BlobReader blob)
     {
         blob.ReadCompressedInteger();           // rank
         int numSizes = blob.ReadCompressedInteger();
+        if (numSizes < 0 || numSizes > blob.RemainingBytes)
+            return true;
         for (int i = 0; i < numSizes; i++)
             blob.ReadCompressedInteger();        // size
         int numLoBounds = blob.ReadCompressedInteger();
+        if (numLoBounds < 0 || numLoBounds > blob.RemainingBytes)
+            return true;
         for (int i = 0; i < numLoBounds; i++)
             blob.ReadCompressedSignedInteger();  // lower bound
+        return false;
     }
 
     // ECMA-335 II.23.1.16 element types, by raw byte value (the SignatureTypeCode enum does not

--- a/src/ILInspector.Metadata/SignatureBlobGuard.cs
+++ b/src/ILInspector.Metadata/SignatureBlobGuard.cs
@@ -1,0 +1,270 @@
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Bounds the structural nesting depth of a metadata signature blob *before* it is handed to
+/// <c>System.Reflection.Metadata</c>'s <c>SignatureDecoder</c>.
+///
+/// SRM decodes a signature by recursing on the native stack once per nested structural element
+/// (pointer / array / by-ref / pinned / generic-instantiation argument / function-pointer
+/// parameter / custom modifier), *before* any <see cref="ISignatureTypeProvider{TType,TContext}"/>
+/// callback runs. Attacker-controlled metadata can therefore encode a signature whose nesting is
+/// deep enough to overflow the stack with an <b>uncatchable</b> <c>StackOverflowException</c> that
+/// terminates the process — no provider-side guard can stop it, because the overflow happens on
+/// the descent before the first callback fires.
+///
+/// This guard walks the blob *iteratively* (an explicit heap work-stack, never the native stack),
+/// computing the maximum type-nesting depth, and reports whether it exceeds a safe limit so the
+/// caller can fail closed (skip the decode and degrade to an unresolved shape) instead of crashing.
+/// A raw blob-length cap is deliberately avoided: a legitimately <i>wide</i> method signature (many
+/// parameters or generic arguments) is long but structurally shallow, so length would false-reject
+/// real code. Depth does not.
+/// </summary>
+public static class SignatureBlobGuard
+{
+    /// <summary>
+    /// Maximum structural type-nesting depth allowed before a signature is treated as unsafe to
+    /// decode. Real signatures nest only a handful of levels deep (CoreLib's deepest is in the
+    /// single digits); the limit is far above that yet far below the native depth that overflows a
+    /// default managed thread stack, so it only trips on malformed / adversarial metadata.
+    /// </summary>
+    public const int DefaultMaxDepth = 512;
+
+    /// <summary>The kind of signature the blob encodes, which determines its header layout.</summary>
+    public enum Kind
+    {
+        /// <summary>A MethodDefSig / MethodRefSig (also property signatures): header, [generic
+        /// param count], param count, return type, parameters.</summary>
+        Method,
+
+        /// <summary>A FieldSig: header, custom-mods, type.</summary>
+        Field,
+
+        /// <summary>A LocalVarSig: header, local count, locals.</summary>
+        LocalVariables,
+
+        /// <summary>A MethodSpec instantiation signature: header, arg count, type args.</summary>
+        MethodSpecification,
+
+        /// <summary>A TypeSpec signature: a single Type with no header.</summary>
+        TypeSpecification,
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the signature is shallow enough to hand to SRM safely.
+    /// Returns <see langword="false"/> if its structural nesting exceeds <paramref name="maxDepth"/>
+    /// (or the blob is malformed in a way that makes the depth unknowable), in which case the caller
+    /// must not decode it. Truncated-but-shallow blobs return <see langword="true"/>: SRM raises a
+    /// catchable <c>BadImageFormatException</c> for those, which is not the crash this guards.
+    /// </summary>
+    public static bool IsSafeToDecode(BlobReader blob, Kind kind, int maxDepth = DefaultMaxDepth)
+    {
+        try
+        {
+            return !ExceedsDepth(blob, kind, maxDepth);
+        }
+        catch (BadImageFormatException)
+        {
+            // The blob underran while we were reading a length/token. It is structurally shallow up
+            // to the truncation (a deep blob would have tripped the depth check first), so SRM's own
+            // catchable BadImageFormatException is the appropriate failure — allow the decode.
+            return true;
+        }
+    }
+
+    /// <summary>Convenience overload that reads the blob for <paramref name="signature"/>.</summary>
+    public static bool IsSafeToDecode(MetadataReader reader, BlobHandle signature, Kind kind, int maxDepth = DefaultMaxDepth)
+    {
+        if (signature.IsNil)
+            return true;
+        return IsSafeToDecode(reader.GetBlobReader(signature), kind, maxDepth);
+    }
+
+    static bool ExceedsDepth(BlobReader blob, Kind kind, int maxDepth)
+    {
+        // Work items are read strictly left-to-right; the stack only tracks *what* to read next and
+        // at what depth, so recursion lives on the heap and can never overflow the native stack.
+        var work = new Stack<WorkItem>();
+        SeedRoots(ref blob, kind, work);
+
+        while (work.Count > 0)
+        {
+            var item = work.Pop();
+            switch (item.Op)
+            {
+                case Op.Type:
+                    if (item.Depth > maxDepth)
+                        return true;
+                    ReadType(ref blob, item.Depth, work);
+                    break;
+
+                case Op.ArrayShape:
+                    SkipArrayShape(ref blob);
+                    break;
+            }
+        }
+
+        return false;
+    }
+
+    static void SeedRoots(ref BlobReader blob, Kind kind, Stack<WorkItem> work)
+    {
+        switch (kind)
+        {
+            case Kind.TypeSpecification:
+                work.Push(WorkItem.Type(1));
+                break;
+
+            case Kind.Field:
+                blob.ReadSignatureHeader();
+                work.Push(WorkItem.Type(1));
+                break;
+
+            case Kind.MethodSpecification:
+            {
+                blob.ReadSignatureHeader();
+                int count = blob.ReadCompressedInteger();
+                for (int i = 0; i < count; i++)
+                    work.Push(WorkItem.Type(1));
+                break;
+            }
+
+            case Kind.LocalVariables:
+            {
+                blob.ReadSignatureHeader();
+                int count = blob.ReadCompressedInteger();
+                for (int i = 0; i < count; i++)
+                    work.Push(WorkItem.Type(1));
+                break;
+            }
+
+            case Kind.Method:
+            {
+                SeedMethodRoots(ref blob, work, depth: 1);
+                break;
+            }
+        }
+    }
+
+    static void SeedMethodRoots(ref BlobReader blob, Stack<WorkItem> work, int depth)
+    {
+        var header = blob.ReadSignatureHeader();
+        if (header.IsGeneric)
+            blob.ReadCompressedInteger(); // generic parameter count
+        int paramCount = blob.ReadCompressedInteger();
+        // Return type, then each parameter, are Type slots (with the usual leading modifiers /
+        // by-ref / typedbyref / sentinel handled inside ReadType). Ordering among siblings does not
+        // affect the maximum depth, so push them all at the same depth.
+        work.Push(WorkItem.Type(depth));
+        for (int i = 0; i < paramCount; i++)
+            work.Push(WorkItem.Type(depth));
+    }
+
+    /// <summary>Reads one Type at <paramref name="depth"/>, consuming its own bytes and pushing its
+    /// child Type slots (at <paramref name="depth"/> + 1) for the main loop to process.</summary>
+    static void ReadType(ref BlobReader blob, int depth, Stack<WorkItem> work)
+    {
+        // Skip any leading prefixes that modify the following type without adding a structural
+        // frame worth bounding separately: custom modifiers (each carries a coded token), by-ref,
+        // pinned, and the vararg sentinel.
+        while (true)
+        {
+            byte code = blob.ReadByte();
+            switch (code)
+            {
+                case ElementTypeCmodReqd:
+                case ElementTypeCmodOpt:
+                    blob.ReadTypeHandle(); // modifier's TypeDefOrRefOrSpec token
+                    continue;
+                case ElementTypeByRef:
+                case ElementTypePinned:
+                case ElementTypeSentinel:
+                    continue;
+
+                case ElementTypePtr:
+                case ElementTypeSzArray:
+                    work.Push(WorkItem.Type(depth + 1));
+                    return;
+
+                case ElementTypeArray:
+                    // ELEMENT_TYPE_ARRAY: Type ArrayShape. The shape trails the element in the blob,
+                    // so schedule it to be read *after* the element subtree (pushed first here, so it
+                    // pops last).
+                    work.Push(WorkItem.ArrayShape());
+                    work.Push(WorkItem.Type(depth + 1));
+                    return;
+
+                case ElementTypeGenericInst:
+                {
+                    // GENERICINST (CLASS|VALUETYPE) TypeToken GenArgCount Type*
+                    blob.ReadByte();       // CLASS / VALUETYPE
+                    blob.ReadTypeHandle(); // generic type token
+                    int args = blob.ReadCompressedInteger();
+                    for (int i = 0; i < args; i++)
+                        work.Push(WorkItem.Type(depth + 1));
+                    return;
+                }
+
+                case ElementTypeFnPtr:
+                    // FNPTR MethodSig: its return type and parameters are the children.
+                    SeedMethodRoots(ref blob, work, depth + 1);
+                    return;
+
+                case ElementTypeClass:
+                case ElementTypeValueType:
+                    blob.ReadTypeHandle();
+                    return;
+
+                case ElementTypeVar:
+                case ElementTypeMVar:
+                    blob.ReadCompressedInteger(); // generic parameter index
+                    return;
+
+                default:
+                    // Primitive / VOID / OBJECT / STRING / TYPEDBYREF / I / U and anything else:
+                    // a leaf that consumes no further bytes here.
+                    return;
+            }
+        }
+    }
+
+    static void SkipArrayShape(ref BlobReader blob)
+    {
+        blob.ReadCompressedInteger();           // rank
+        int numSizes = blob.ReadCompressedInteger();
+        for (int i = 0; i < numSizes; i++)
+            blob.ReadCompressedInteger();        // size
+        int numLoBounds = blob.ReadCompressedInteger();
+        for (int i = 0; i < numLoBounds; i++)
+            blob.ReadCompressedSignedInteger();  // lower bound
+    }
+
+    // ECMA-335 II.23.1.16 element types, by raw byte value (the SignatureTypeCode enum does not
+    // name the modifier / prefix codes we care about, so spell them all out to avoid ambiguity).
+    const byte ElementTypePtr = 0x0f;         // ELEMENT_TYPE_PTR
+    const byte ElementTypeByRef = 0x10;       // ELEMENT_TYPE_BYREF
+    const byte ElementTypeValueType = 0x11;   // ELEMENT_TYPE_VALUETYPE
+    const byte ElementTypeClass = 0x12;       // ELEMENT_TYPE_CLASS
+    const byte ElementTypeVar = 0x13;         // ELEMENT_TYPE_VAR
+    const byte ElementTypeArray = 0x14;       // ELEMENT_TYPE_ARRAY
+    const byte ElementTypeGenericInst = 0x15; // ELEMENT_TYPE_GENERICINST
+    const byte ElementTypeFnPtr = 0x1b;       // ELEMENT_TYPE_FNPTR
+    const byte ElementTypeSzArray = 0x1d;     // ELEMENT_TYPE_SZARRAY
+    const byte ElementTypeMVar = 0x1e;        // ELEMENT_TYPE_MVAR
+    const byte ElementTypeCmodReqd = 0x1f;    // ELEMENT_TYPE_CMOD_REQD
+    const byte ElementTypeCmodOpt = 0x20;     // ELEMENT_TYPE_CMOD_OPT
+    const byte ElementTypeSentinel = 0x41;    // ELEMENT_TYPE_SENTINEL
+    const byte ElementTypePinned = 0x45;      // ELEMENT_TYPE_PINNED
+
+    enum Op : byte { Type, ArrayShape }
+
+    readonly struct WorkItem
+    {
+        public Op Op { get; }
+        public int Depth { get; }
+        WorkItem(Op op, int depth) { Op = op; Depth = depth; }
+        public static WorkItem Type(int depth) => new(Op.Type, depth);
+        public static WorkItem ArrayShape() => new(Op.ArrayShape, 0);
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/SignatureBlobGuardTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SignatureBlobGuardTests.cs
@@ -167,6 +167,15 @@ public class SignatureBlobGuardTests
         Assert.False(SignatureBlobGuard.IsSafeToDecode(reader, reader.GetStandaloneSignature(handle).Signature, SignatureBlobGuard.Kind.Method));
     }
 
+    [Fact]
+    public void HugeArrayShapeCount_IsUnsafe()
+    {
+        // ELEMENT_TYPE_ARRAY I4, rank 1, sizesCount ~536M: SRM pre-allocates a builder from the
+        // shape counts before reading elements, so an unbounded count OOMs even from a 7-byte blob.
+        byte[] blob = [0x14 /* ARRAY */, I4, 0x01 /* rank */, 0xdf, 0xff, 0xff, 0xff /* sizesCount */];
+        Assert.False(GuardTypeSpec(blob));
+    }
+
     static bool GuardTypeSpec(byte[] typeBlob)
     {
         var (reader, handle) = BuildTypeSpec(typeBlob);

--- a/tests/ILInspector.Metadata.Tests/SignatureBlobGuardTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SignatureBlobGuardTests.cs
@@ -1,0 +1,200 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata.Tests;
+
+// SignatureBlobGuard bounds the structural nesting depth of a signature blob before SRM decodes
+// it, so a malformed deep/cyclic signature degrades gracefully instead of overflowing the native
+// stack. These tests craft deep synthetic blobs (must be rejected), shallow/wide ones (must be
+// accepted), and sweep a real assembly (no false-positives).
+public class SignatureBlobGuardTests
+{
+    const byte Ptr = 0x0f, ByRef = 0x10, ValueType = 0x11, Class = 0x12, Var = 0x13, Array = 0x14,
+        GenericInst = 0x15, FnPtr = 0x1b, SzArray = 0x1d, CmodReqd = 0x1f, CmodOpt = 0x20, I4 = 0x08;
+
+    [Fact]
+    public void ShallowType_IsSafe()
+    {
+        Assert.True(GuardTypeSpec(Nested(SzArray, 5)));
+        Assert.True(GuardTypeSpec(Nested(Ptr, 10)));
+        Assert.True(GuardTypeSpec([I4]));
+    }
+
+    [Fact]
+    public void DepthAtLimit_IsSafe_JustOver_IsUnsafe()
+    {
+        // Depth = number of wrappers + 1 for the leaf. 511 wrappers -> leaf at depth 512 (== limit).
+        Assert.True(GuardTypeSpec(Nested(SzArray, 511)));
+        Assert.False(GuardTypeSpec(Nested(SzArray, 512)));
+    }
+
+    [Fact]
+    public void DeepPointerArraySzArray_AreUnsafe()
+    {
+        Assert.False(GuardTypeSpec(Nested(SzArray, 100_000)));
+        Assert.False(GuardTypeSpec(Nested(Ptr, 100_000)));
+        Assert.False(GuardTypeSpec(NestedArray(2_000)));
+    }
+
+    [Fact]
+    public void DeepGenericInstantiationNesting_IsUnsafe()
+    {
+        // List`1<List`1<... I4 ...>> nested 2000 deep.
+        var blob = new List<byte>();
+        for (int i = 0; i < 2_000; i++)
+        {
+            blob.Add(GenericInst);
+            blob.Add(Class);
+            blob.Add(0x06); // TypeDefOrRefOrSpec coded token (some TypeRef row)
+            blob.Add(0x01); // one generic argument follows
+        }
+        blob.Add(I4);
+        Assert.False(GuardTypeSpec(blob.ToArray()));
+    }
+
+    [Fact]
+    public void SelfModreqCycleShape_IsUnsafe()
+    {
+        // The shape that bypassed the earlier per-blob cap: 1000 SZARRAY then a modreq + I4. As a
+        // single blob its structural depth is ~1001, which the depth guard rejects outright.
+        var blob = new List<byte>();
+        for (int i = 0; i < 1_000; i++)
+            blob.Add(SzArray);
+        blob.Add(CmodReqd);
+        blob.Add(0x06);
+        blob.Add(I4);
+        Assert.False(GuardTypeSpec(blob.ToArray()));
+    }
+
+    [Fact]
+    public void WideButShallowMethodSignature_IsSafe()
+    {
+        // void M(int, int, ... 5000 params): long blob, but structurally shallow. A length cap
+        // would false-reject this; the depth guard must not.
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig)
+            .MethodSignature(isInstanceMethod: false)
+            .Parameters(5_000, ret => ret.Void(), pars =>
+            {
+                for (int i = 0; i < 5_000; i++)
+                    pars.AddParameter().Type().Int32();
+            });
+        Assert.True(GuardMethodSig(sig));
+    }
+
+    [Fact]
+    public void DeeplyNestedMethodParameter_IsUnsafe()
+    {
+        // void M(int[][]...[]) with a 2000-deep array parameter: shallow arity, deep structure.
+        var sig = new BlobBuilder();
+        new BlobEncoder(sig)
+            .MethodSignature(isInstanceMethod: false)
+            .Parameters(1, ret => ret.Void(), pars =>
+            {
+                var t = pars.AddParameter().Type();
+                for (int i = 0; i < 2_000; i++)
+                    t = t.SZArray();
+                t.Int32();
+            });
+        Assert.False(GuardMethodSig(sig));
+    }
+
+    [Fact]
+    public void RealAssembly_HasNoFalsePositives()
+    {
+        // Every real signature in this test assembly must be accepted.
+        using var pe = new PEReader(File.OpenRead(typeof(SignatureBlobGuardTests).Assembly.Location));
+        var r = pe.GetMetadataReader();
+        int rejected = 0, total = 0;
+
+        foreach (var mh in r.MethodDefinitions)
+        {
+            var sig = r.GetMethodDefinition(mh).Signature;
+            if (sig.IsNil) continue;
+            total++;
+            if (!SignatureBlobGuard.IsSafeToDecode(r, sig, SignatureBlobGuard.Kind.Method)) rejected++;
+        }
+        foreach (var fh in r.FieldDefinitions)
+        {
+            var sig = r.GetFieldDefinition(fh).Signature;
+            if (sig.IsNil) continue;
+            total++;
+            if (!SignatureBlobGuard.IsSafeToDecode(r, sig, SignatureBlobGuard.Kind.Field)) rejected++;
+        }
+
+        Assert.True(total > 0);
+        Assert.Equal(0, rejected);
+    }
+
+    static bool GuardTypeSpec(byte[] typeBlob)
+    {
+        var (reader, handle) = BuildTypeSpec(typeBlob);
+        return SignatureBlobGuard.IsSafeToDecode(reader, reader.GetTypeSpecification(handle).Signature, SignatureBlobGuard.Kind.TypeSpecification);
+    }
+
+    static bool GuardMethodSig(BlobBuilder sig)
+    {
+        var (reader, handle) = BuildStandaloneSig(sig);
+        return SignatureBlobGuard.IsSafeToDecode(reader, reader.GetStandaloneSignature(handle).Signature, SignatureBlobGuard.Kind.Method);
+    }
+
+    static byte[] Nested(byte wrapper, int count)
+    {
+        var blob = new byte[count + 1];
+        for (int i = 0; i < count; i++)
+            blob[i] = wrapper;
+        blob[count] = I4;
+        return blob;
+    }
+
+    static byte[] NestedArray(int count)
+    {
+        var blob = new List<byte>();
+        for (int i = 0; i < count; i++)
+            blob.Add(Array);
+        blob.Add(I4);
+        for (int i = 0; i < count; i++)
+        {
+            blob.Add(0x01); // rank 1
+            blob.Add(0x00); // 0 sizes
+            blob.Add(0x00); // 0 lo-bounds
+        }
+        return blob.ToArray();
+    }
+
+    static (MetadataReader Reader, TypeSpecificationHandle Handle) BuildTypeSpec(byte[] typeBlob)
+    {
+        var md = NewModule();
+        var bb = new BlobBuilder();
+        bb.WriteBytes(typeBlob);
+        var handle = md.AddTypeSpecification(md.GetOrAddBlob(bb));
+        return (Serialize(md), handle);
+    }
+
+    static (MetadataReader Reader, StandaloneSignatureHandle Handle) BuildStandaloneSig(BlobBuilder sig)
+    {
+        var md = NewModule();
+        var handle = md.AddStandaloneSignature(md.GetOrAddBlob(sig));
+        return (Serialize(md), handle);
+    }
+
+    static MetadataBuilder NewModule()
+    {
+        var md = new MetadataBuilder();
+        md.AddModule(0, md.GetOrAddString("m.dll"), md.GetOrAddGuid(Guid.NewGuid()), default, default);
+        md.AddAssembly(md.GetOrAddString("m"), new Version(1, 0, 0, 0), default, default, default, default);
+        md.AddTypeDefinition(default, default, md.GetOrAddString("<Module>"), default,
+            MetadataTokens.FieldDefinitionHandle(1), MetadataTokens.MethodDefinitionHandle(1));
+        return md;
+    }
+
+    static MetadataReader Serialize(MetadataBuilder md)
+    {
+        var root = new MetadataRootBuilder(md, suppressValidation: true);
+        var image = new BlobBuilder();
+        root.Serialize(image, 0, 0);
+        return MetadataReaderProvider.FromMetadataImage(ImmutableArray.Create(image.ToArray())).GetMetadataReader();
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/SignatureBlobGuardTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SignatureBlobGuardTests.cs
@@ -128,6 +128,45 @@ public class SignatureBlobGuardTests
         Assert.Equal(0, rejected);
     }
 
+    [Fact]
+    public void DeepPrefixChains_AreUnsafe()
+    {
+        // SRM recurses natively through by-ref, pinned, and custom-modifier prefixes, so a long
+        // chain of them must be rejected exactly like a chain of pointers.
+        Assert.False(GuardTypeSpec(Nested(ByRef, 1_000)));
+        Assert.False(GuardTypeSpec(Nested(0x45 /* PINNED */, 1_000)));
+
+        var cmods = new List<byte>();
+        for (int i = 0; i < 1_000; i++)
+        {
+            cmods.Add(CmodReqd);
+            cmods.Add(0x06); // modifier's TypeDefOrRefOrSpec coded token
+        }
+        cmods.Add(I4);
+        Assert.False(GuardTypeSpec(cmods.ToArray()));
+    }
+
+    [Fact]
+    public void HugeDeclaredCount_IsUnsafe_AndDoesNotAllocate()
+    {
+        // A tiny FNPTR blob declaring ~536M parameters must be rejected without materializing a
+        // work item per declared slot (which would OOM). Bounding the count by the remaining blob
+        // length makes this cheap.
+        byte[] blob = [FnPtr, 0x00, 0xdf, 0xff, 0xff, 0xff];
+        Assert.False(GuardTypeSpec(blob));
+
+        // A method signature declaring a huge parameter count is likewise rejected cheaply.
+        var method = new BlobBuilder();
+        method.WriteByte(0x00);       // default calling convention
+        method.WriteByte(0xdf);       // compressed ~536M param count
+        method.WriteByte(0xff);
+        method.WriteByte(0xff);
+        method.WriteByte(0xff);
+        method.WriteByte(0x01);       // (truncated) return type VOID
+        var (reader, handle) = BuildStandaloneSig(method);
+        Assert.False(SignatureBlobGuard.IsSafeToDecode(reader, reader.GetStandaloneSignature(handle).Signature, SignatureBlobGuard.Kind.Method));
+    }
+
     static bool GuardTypeSpec(byte[] typeBlob)
     {
         var (reader, handle) = BuildTypeSpec(typeBlob);


### PR DESCRIPTION
Part of #2490 (increment 1).

## Problem

#2489 hardened `TypeRefDecoder.GetTypeFromSpecification` against deep/cyclic malformed
metadata, but the same **uncatchable `StackOverflowException`** is reachable through *every other*
signature decode of untrusted metadata — method, field, local-variable, member-reference, and
method-spec signatures — because SRM's `SignatureDecoder.DecodeType` recurses on the **native
stack** once per nested structural element (`PTR`/`SZARRAY`/`ARRAY`/`GENERICINST` arg/`FNPTR`
param/`CMOD`) **before any provider callback runs**. A provider-side depth counter cannot stop it
(the overflow happens on the descent, before the first callback), and a raw blob-length cap would
false-reject legitimately *wide* method signatures (long but structurally shallow).

## This increment

**1. Shared depth guard** — `ILInspector.Metadata.SignatureBlobGuard` (below both Analysis and
Decompiler; SRM-only, Roslyn-free, NativeAOT-friendly). It walks a signature blob **iteratively**
(an explicit heap work-stack, never the native stack) over the ECMA-335 §II.23.2 grammar and
reports whether structural type-nesting exceeds a safe limit (default **512** — far above real
signatures, far below the native depth that overflows a default stack). Callers fail closed.

**2. Applied at the Analysis untrusted-input decode sites** — the pervasive exposure #2159 called
out (the escape/allocation classifier resolving every `call`/`callvirt`/`newobj` target):
`MemberResolver` (method / member-ref / method-spec), `LibraryBodyIndex` (method identity + local
scan + local types + `calli` return), `LeakTriage` (method). Each degrades to an unresolved
shape / skip when the guard trips.

## Evidence

- **Zero false-positives**: swept all **53,236** signatures in net9.0 CoreLib (methods, fields,
  typespecs, standalone sigs) — `0` rejected, `0` throws.
- **Detection + boundary**: unit tests reject deep `PTR`/`SZARRAY`/`ARRAY`/`GENERICINST`/self-`modreq`
  shapes and a 2000-deep method parameter; accept the 511-wrapper boundary and a **5000-parameter**
  (wide-but-shallow) method signature. `ILInspector.Metadata.Tests` **377/0**.
- No behavior change on real code (guard never trips): `ILInspector.Analysis.Tests` **406/0**;
  full `dotnet-inspect.slnx` build clean.

## Scope / follow-up

The remaining **Decompiler-side** decode entry points (`MethodImporter`, `IrImporter`,
`CrossAssemblyTypeResolver`, `MetadataSource`, `CompileBackSourceComposer`, `TypeSourceComposer`,
`CSharpBodyDiff` — ~30 sites across the `TypeRefDecoder` and `SignatureDecoder` providers) are the
next increment, tracked in #2490. Consolidating the #2489 TypeSpec caps onto this shared guard is
also noted there.

## Review

New security-critical parser (subtle grammar walk) → requesting two-model adversarial review
(GPT-5.5 + Gemini 3.1 Pro) with a confirmatory pass, per policy.
