### PR TITLE
Expand RTS fixture source coverage

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -170,6 +170,22 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_PreservesExtensionMethodShellParameters()
+    {
+        var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+            FixtureCatalog.DecompilerLadderRung2.AssemblyPath(),
+            [
+                new ReturnToSender.RequestedTarget(
+                    "LadderRung2.Program",
+                    "Main",
+                    Overload: 0),
+            ]));
+
+        Assert.NotEqual(ReturnToSenderSourceOutcome.Invalid, result.Outcome);
+        Assert.DoesNotContain("CS1061", result.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_ClassifiesKnownTasteDifferenceAcrossMultipleFrameworkImports()
     {
         var fixture = CompileSourceFixture(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -1082,6 +1082,46 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_PreservesExplicitRecordPropertyBodies()
+    {
+        var fixture = CompileSourceFixture(
+            ("Class1.cs", """
+            namespace SourceProbe;
+
+            public record Class1
+            {
+                public int P
+                {
+                    get
+                    {
+                        return 1;
+                    }
+                }
+            }
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget(
+                        "SourceProbe.Class1",
+                        "get_P",
+                        Overload: 0),
+                ],
+                fixture.SourcePaths));
+
+            Assert.Equal(ReturnToSenderSourceOutcome.ValidMatch, result.Outcome);
+            Assert.Equal("valid_match", result.Reason);
+            Assert.Equal("return1;", Normalize(result.ExpectedBody));
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void CSharpSourceIdentityContext_ResolvesOperatorIdentity()
     {
         var root = CSharpSyntaxTree.ParseText("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -1032,6 +1032,31 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void CSharpSourceIdentityContext_PreservesExplicitRecordMemberBodies()
+    {
+        var root = CSharpSyntaxTree.ParseText("""
+            namespace SourceProbe;
+
+            public record Class1(int Value)
+            {
+                public override string ToString()
+                {
+                    return Value.ToString();
+                }
+            }
+            """, cancellationToken: TestContext.Current.CancellationToken)
+            .GetCompilationUnitRoot(TestContext.Current.CancellationToken);
+        var type = Assert.Single(root.DescendantNodes().OfType<RecordDeclarationSyntax>());
+
+        var context = CSharpSourceIdentityContext.Create([root]);
+        var members = context.TypeMembers(type, "SourceProbe.Class1").Where(member => member.MetadataName == "ToString").ToArray();
+
+        var member = Assert.Single(members);
+        Assert.Equal("return Value.ToString();", member.Body);
+        Assert.DoesNotContain("record-synthesized", member.Evidence);
+    }
+
+    [Fact]
     public void CSharpSourceIdentityContext_ResolvesOperatorIdentity()
     {
         var root = CSharpSyntaxTree.ParseText("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -993,6 +993,35 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void CSharpSourceIdentityContext_ResolvesCheckedConversionOperatorIdentity()
+    {
+        var root = CSharpSyntaxTree.ParseText("""
+            namespace SourceProbe;
+
+            public readonly struct Class1
+            {
+                readonly int _value;
+
+                public Class1(int value)
+                {
+                    _value = value;
+                }
+
+                public static explicit operator checked int(Class1 value) => checked(value._value + 1);
+            }
+            """, cancellationToken: TestContext.Current.CancellationToken)
+            .GetCompilationUnitRoot(TestContext.Current.CancellationToken);
+        var conversion = Assert.Single(root.DescendantNodes().OfType<ConversionOperatorDeclarationSyntax>());
+
+        var context = CSharpSourceIdentityContext.Create([root]);
+        var member = Assert.Single(context.ConversionOperatorMembers(conversion));
+
+        Assert.Equal("op_CheckedExplicit", member.MetadataName);
+        Assert.Equal("return checked(value._value + 1);", member.Body);
+        Assert.Contains("conversion-operator", member.Evidence);
+    }
+
+    [Fact]
     public void CSharpSourceIdentityContext_EmitsOrderedTypeMembers()
     {
         var root = CSharpSyntaxTree.ParseText("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -120,6 +120,40 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_ClassifiesBodylessSourceMembersAsUnsupported()
+    {
+        var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+            FixtureCatalog.DecompilerLadderRung9.AssemblyPath(),
+            [
+                new ReturnToSender.RequestedTarget(
+                    "LadderRung9.DynamicConstructTarget",
+                    "get_Value",
+                    Overload: 0),
+            ]));
+
+        Assert.Equal(ReturnToSenderSourceOutcome.UnsupportedTarget, result.Outcome);
+        Assert.Equal("source-body-unavailable", result.Reason);
+        Assert.EndsWith("LadderRung9.cs", result.SourcePath, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_ClassifiesRecordSynthesizedMembersAsUnsupported()
+    {
+        var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+            FixtureCatalog.DecompilerLadderRung5.AssemblyPath(),
+            [
+                new ReturnToSender.RequestedTarget(
+                    "LadderRung5.Point",
+                    "ToString",
+                    Overload: 0),
+            ]));
+
+        Assert.Equal(ReturnToSenderSourceOutcome.UnsupportedTarget, result.Outcome);
+        Assert.Equal("source-body-unavailable", result.Reason);
+        Assert.EndsWith("LadderRung5.cs", result.SourcePath, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_ClassifiesKnownTasteDifferenceAcrossMultipleFrameworkImports()
     {
         var fixture = CompileSourceFixture(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -827,6 +827,38 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void CSharpSourceIdentityContext_SkipsExplicitPropertyAndIndexerImplementations()
+    {
+        var root = CSharpSyntaxTree.ParseText("""
+            namespace SourceProbe;
+
+            public interface IValues
+            {
+                int P { get; }
+                int this[int index] { get; }
+            }
+
+            public class Class1 : IValues
+            {
+                int IValues.P => 1;
+                int IValues.this[int index] => index;
+            }
+            """, cancellationToken: TestContext.Current.CancellationToken)
+            .GetCompilationUnitRoot(TestContext.Current.CancellationToken);
+        var property = Assert.Single(
+            root.DescendantNodes().OfType<PropertyDeclarationSyntax>(),
+            property => property.ExplicitInterfaceSpecifier is not null);
+        var indexer = Assert.Single(
+            root.DescendantNodes().OfType<IndexerDeclarationSyntax>(),
+            indexer => indexer.ExplicitInterfaceSpecifier is not null);
+
+        var context = CSharpSourceIdentityContext.Create([root]);
+
+        Assert.Empty(context.PropertyMembers(property));
+        Assert.Empty(context.IndexerMembers(indexer, "SourceProbe.Class1"));
+    }
+
+    [Fact]
     public void CSharpSourceIdentityContext_ResolvesMethodIdentity()
     {
         var root = CSharpSyntaxTree.ParseText("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -901,6 +901,65 @@ public class ReturnToSenderFixtureCatalogTests
         Assert.Equal("Value = value;", instanceConstructor.Body);
     }
 
+    [Fact]
+    public void CSharpSourceIdentityContext_ResolvesOperatorIdentity()
+    {
+        var root = CSharpSyntaxTree.ParseText("""
+            namespace SourceProbe;
+
+            public readonly struct Class1
+            {
+                readonly int _value;
+
+                public Class1(int value)
+                {
+                    _value = value;
+                }
+
+                public static Class1 operator >>>(Class1 value, int shift)
+                    => new Class1(value._value >>> shift);
+            }
+            """, cancellationToken: TestContext.Current.CancellationToken)
+            .GetCompilationUnitRoot(TestContext.Current.CancellationToken);
+        var op = Assert.Single(root.DescendantNodes().OfType<OperatorDeclarationSyntax>());
+
+        var context = CSharpSourceIdentityContext.Create([root]);
+        var member = Assert.Single(context.OperatorMembers(op));
+
+        Assert.Equal("op_UnsignedRightShift", member.MetadataName);
+        Assert.Equal("return new Class1(value._value >>> shift);", member.Body);
+        Assert.Contains("operator", member.Evidence);
+    }
+
+    [Fact]
+    public void CSharpSourceIdentityContext_ResolvesConversionOperatorIdentity()
+    {
+        var root = CSharpSyntaxTree.ParseText("""
+            namespace SourceProbe;
+
+            public readonly struct Class1
+            {
+                readonly int _value;
+
+                public Class1(int value)
+                {
+                    _value = value;
+                }
+
+                public static implicit operator int(Class1 value) => value._value;
+            }
+            """, cancellationToken: TestContext.Current.CancellationToken)
+            .GetCompilationUnitRoot(TestContext.Current.CancellationToken);
+        var conversion = Assert.Single(root.DescendantNodes().OfType<ConversionOperatorDeclarationSyntax>());
+
+        var context = CSharpSourceIdentityContext.Create([root]);
+        var member = Assert.Single(context.ConversionOperatorMembers(conversion));
+
+        Assert.Equal("op_Implicit", member.MetadataName);
+        Assert.Equal("return value._value;", member.Body);
+        Assert.Contains("conversion-operator", member.Evidence);
+    }
+
     static (string Directory, string AssemblyPath, IReadOnlyList<string> SourcePaths) CompileSourceFixture(
         params (string FileName, string Source)[] sources)
     {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -992,6 +992,38 @@ public class ReturnToSenderFixtureCatalogTests
         Assert.Contains("conversion-operator", member.Evidence);
     }
 
+    [Fact]
+    public void CSharpSourceIdentityContext_EmitsOrderedTypeMembers()
+    {
+        var root = CSharpSyntaxTree.ParseText("""
+            namespace SourceProbe;
+
+            public class Class1(int value)
+            {
+                static Class1()
+                {
+                }
+
+                public Class1() : this(1)
+                {
+                }
+
+                public int P => value;
+
+                public int M() => value;
+
+                public int this[int index] => index;
+            }
+            """, cancellationToken: TestContext.Current.CancellationToken)
+            .GetCompilationUnitRoot(TestContext.Current.CancellationToken);
+        var type = Assert.Single(root.DescendantNodes().OfType<ClassDeclarationSyntax>());
+
+        var context = CSharpSourceIdentityContext.Create([root]);
+        var names = context.TypeMembers(type, "SourceProbe.Class1").Select(member => member.MetadataName).ToArray();
+
+        Assert.Equal([".ctor", ".cctor", ".ctor", "get_P", "M", "get_Item"], names);
+    }
+
     static (string Directory, string AssemblyPath, IReadOnlyList<string> SourcePaths) CompileSourceFixture(
         params (string FileName, string Source)[] sources)
     {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -1159,6 +1159,48 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_PreservesMethodOverloadIndexesAcrossNonPublicOverloads()
+    {
+        var fixture = CompileSourceFixture(
+            ("Class1.cs", """
+            namespace SourceProbe;
+
+            public class Class1
+            {
+                private int Foo(int value)
+                {
+                    return value + 1;
+                }
+
+                public string Foo(string text)
+                {
+                    return text + "!";
+                }
+            }
+            """));
+        try
+        {
+            var discovered = Assert.Single(ReturnToSenderSourceProbe.DiscoverTargets(fixture.AssemblyPath, cap: 10));
+            Assert.Equal("Foo", discovered.Target.Method);
+            Assert.Equal(1, discovered.Target.Overload);
+
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [discovered.Target],
+                fixture.SourcePaths));
+
+            Assert.Equal("Foo", result.Target.Method);
+            Assert.Equal(1, result.Target.Overload);
+            Assert.Equal("returntext+\"!\";", Normalize(result.ExpectedBody));
+            Assert.DoesNotContain("value + 1", result.ExpectedBody, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void CSharpSourceIdentityContext_ResolvesOperatorIdentity()
     {
         var root = CSharpSyntaxTree.ParseText("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -186,6 +186,22 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_ResolvesCs0234FullTypeClosureRoots()
+    {
+        var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+            FixtureCatalog.DecompilerLadderRung1.AssemblyPath(),
+            [
+                new ReturnToSender.RequestedTarget(
+                    "LadderRung1.Program",
+                    "Greet",
+                    Overload: 0),
+            ]));
+
+        Assert.NotEqual(ReturnToSenderSourceOutcome.Invalid, result.Outcome);
+        Assert.DoesNotContain("CS0234", result.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_ClassifiesKnownTasteDifferenceAcrossMultipleFrameworkImports()
     {
         var fixture = CompileSourceFixture(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -800,6 +800,32 @@ public class ReturnToSenderFixtureCatalogTests
         Assert.Contains("partial-implementation", member.Evidence);
     }
 
+    [Fact]
+    public void CSharpSourceIdentityContext_ResolvesPartialPropertyIdentity()
+    {
+        var root = CSharpSyntaxTree.ParseText("""
+            namespace SourceProbe;
+
+            public partial class Class1
+            {
+                public partial int P { get; }
+
+                public partial int P => 1;
+            }
+            """, cancellationToken: TestContext.Current.CancellationToken)
+            .GetCompilationUnitRoot(TestContext.Current.CancellationToken);
+        var implementation = root.DescendantNodes()
+            .OfType<PropertyDeclarationSyntax>()
+            .Single(property => property.ExpressionBody is not null);
+
+        var context = CSharpSourceIdentityContext.Create([root]);
+        var member = Assert.Single(context.PropertyMembers(implementation));
+
+        Assert.Equal("get_P", member.MetadataName);
+        Assert.Equal("return 1;", member.Body);
+        Assert.Contains("partial-implementation", member.Evidence);
+    }
+
     static (string Directory, string AssemblyPath, IReadOnlyList<string> SourcePaths) CompileSourceFixture(
         params (string FileName, string Source)[] sources)
     {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -104,6 +104,22 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_PreservesUnsafeModifierAfterMemberAttributes()
+    {
+        var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+            FixtureCatalog.DecompilerUnsafeLegacy.AssemblyPath(),
+            [
+                new ReturnToSender.RequestedTarget(
+                    "ILInspector.Decompiler.Fixtures.LegacyUnsafe.UnsafeFixtures",
+                    "StackAllocSkipInit",
+                    Overload: 0),
+            ]));
+
+        Assert.NotEqual(ReturnToSenderSourceOutcome.Invalid, result.Outcome);
+        Assert.DoesNotContain("CS1585", result.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_ClassifiesKnownTasteDifferenceAcrossMultipleFrameworkImports()
     {
         var fixture = CompileSourceFixture(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -826,6 +826,40 @@ public class ReturnToSenderFixtureCatalogTests
         Assert.Contains("partial-implementation", member.Evidence);
     }
 
+    [Fact]
+    public void CSharpSourceIdentityContext_ResolvesMethodIdentity()
+    {
+        var root = CSharpSyntaxTree.ParseText("""
+            namespace SourceProbe;
+
+            public interface IValue
+            {
+                int M();
+            }
+
+            public partial class Class1 : IValue
+            {
+                partial void M();
+                int IValue.M() => 0;
+                public partial int M(int value) => value;
+            }
+            """, cancellationToken: TestContext.Current.CancellationToken)
+            .GetCompilationUnitRoot(TestContext.Current.CancellationToken);
+        var methods = root.DescendantNodes().OfType<MethodDeclarationSyntax>().ToArray();
+
+        var context = CSharpSourceIdentityContext.Create([root]);
+        Assert.Empty(context.MethodMembers(methods.Single(method =>
+            method.Modifiers.Any(SyntaxKind.PartialKeyword)
+            && method.Body is null
+            && method.ExpressionBody is null)));
+        Assert.Empty(context.MethodMembers(methods.Single(method => method.ExplicitInterfaceSpecifier is not null)));
+        var member = Assert.Single(context.MethodMembers(methods.Single(method => method.Modifiers.Any(SyntaxKind.PublicKeyword))));
+
+        Assert.Equal("M", member.MetadataName);
+        Assert.Equal("return value;", member.Body);
+        Assert.Contains("partial-implementation", member.Evidence);
+    }
+
     static (string Directory, string AssemblyPath, IReadOnlyList<string> SourcePaths) CompileSourceFixture(
         params (string FileName, string Source)[] sources)
     {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -1024,6 +1024,34 @@ public class ReturnToSenderFixtureCatalogTests
         Assert.Equal([".ctor", ".cctor", ".ctor", "get_P", "M", "get_Item"], names);
     }
 
+    [Fact]
+    public void CSharpSourceIdentityContext_UsesMetadataArityForGenericTypes()
+    {
+        var root = CSharpSyntaxTree.ParseText("""
+            namespace SourceProbe;
+
+            public class Class1<T>
+            {
+                public int M() => 1;
+            }
+            """, cancellationToken: TestContext.Current.CancellationToken)
+            .GetCompilationUnitRoot(TestContext.Current.CancellationToken);
+        var type = Assert.Single(root.DescendantNodes().OfType<ClassDeclarationSyntax>());
+
+        Assert.Equal("Class1`1", CSharpSourceIdentityContext.TypeMetadataName(type));
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_MapsGenericTypeSourceMembers()
+    {
+        var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+            FixtureCatalog.DiffV1.AssemblyPath(),
+            [new ReturnToSender.RequestedTarget("DiffFixtureSample.GenericTypeAritySample`1", "M", Overload: 0)]));
+
+        Assert.NotEqual(ReturnToSenderSourceOutcome.SourceUnavailable, result.Outcome);
+        Assert.Equal("return1;", Normalize(result.ExpectedBody));
+    }
+
     static (string Directory, string AssemblyPath, IReadOnlyList<string> SourcePaths) CompileSourceFixture(
         params (string FileName, string Source)[] sources)
     {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -1057,6 +1057,31 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void CSharpSourceIdentityContext_PreservesExplicitRecordEqualsOverloads()
+    {
+        var root = CSharpSyntaxTree.ParseText("""
+            namespace SourceProbe;
+
+            public record Class1(int Value)
+            {
+                public bool Equals(int other)
+                {
+                    return Value == other;
+                }
+            }
+            """, cancellationToken: TestContext.Current.CancellationToken)
+            .GetCompilationUnitRoot(TestContext.Current.CancellationToken);
+        var type = Assert.Single(root.DescendantNodes().OfType<RecordDeclarationSyntax>());
+
+        var context = CSharpSourceIdentityContext.Create([root]);
+        var members = context.TypeMembers(type, "SourceProbe.Class1").Where(member => member.MetadataName == "Equals").ToArray();
+
+        var member = Assert.Single(members);
+        Assert.Equal("return Value == other;", member.Body);
+        Assert.DoesNotContain("record-synthesized", member.Evidence);
+    }
+
+    [Fact]
     public void CSharpSourceIdentityContext_ResolvesOperatorIdentity()
     {
         var root = CSharpSyntaxTree.ParseText("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -154,6 +154,22 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_PreservesPrimaryConstructorShellParameters()
+    {
+        var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+            FixtureCatalog.DecompilerLadderRung5.AssemblyPath(),
+            [
+                new ReturnToSender.RequestedTarget(
+                    "LadderRung5.PrimaryCounter",
+                    "Next",
+                    Overload: 0),
+            ]));
+
+        Assert.NotEqual(ReturnToSenderSourceOutcome.Invalid, result.Outcome);
+        Assert.DoesNotContain("CS0103", result.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_ClassifiesKnownTasteDifferenceAcrossMultipleFrameworkImports()
     {
         var fixture = CompileSourceFixture(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -964,6 +964,36 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void CSharpSourceIdentityContext_ResolvesCheckedOperatorIdentity()
+    {
+        var root = CSharpSyntaxTree.ParseText("""
+            namespace SourceProbe;
+
+            public readonly struct Class1
+            {
+                readonly int _value;
+
+                public Class1(int value)
+                {
+                    _value = value;
+                }
+
+                public static Class1 operator checked +(Class1 left, Class1 right)
+                    => checked(new Class1(left._value + right._value));
+            }
+            """, cancellationToken: TestContext.Current.CancellationToken)
+            .GetCompilationUnitRoot(TestContext.Current.CancellationToken);
+        var op = Assert.Single(root.DescendantNodes().OfType<OperatorDeclarationSyntax>());
+
+        var context = CSharpSourceIdentityContext.Create([root]);
+        var member = Assert.Single(context.OperatorMembers(op));
+
+        Assert.Equal("op_CheckedAddition", member.MetadataName);
+        Assert.Equal("return checked(new Class1(left._value + right._value));", member.Body);
+        Assert.Contains("operator", member.Evidence);
+    }
+
+    [Fact]
     public void CSharpSourceIdentityContext_ResolvesConversionOperatorIdentity()
     {
         var root = CSharpSyntaxTree.ParseText("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -170,6 +170,43 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_PrimaryConstructorShellDoesNotDuplicateConstructorRequirements()
+    {
+        var fixture = CompileSourceFixture(
+            ("Class1.cs", """
+            namespace SourceProbe;
+
+            public class Class1(int left, int right)
+            {
+                public Class1 Clone()
+                {
+                    return new Class1(left, right);
+                }
+            }
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget(
+                        "SourceProbe.Class1",
+                        "Clone",
+                        Overload: 0),
+                ],
+                fixture.SourcePaths));
+
+            Assert.NotEqual(ReturnToSenderSourceOutcome.Invalid, result.Outcome);
+            Assert.DoesNotContain("CS0111", result.Detail, StringComparison.Ordinal);
+            Assert.DoesNotContain("CS8862", result.Detail, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_PreservesExtensionMethodShellParameters()
     {
         var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -131,8 +131,8 @@ public class ReturnToSenderFixtureCatalogTests
                     Overload: 0),
             ]));
 
-        Assert.Equal(ReturnToSenderSourceOutcome.UnsupportedTarget, result.Outcome);
-        Assert.Equal("source-body-unavailable", result.Reason);
+        Assert.Equal(ReturnToSenderSourceOutcome.ValidMatch, result.Outcome);
+        Assert.Equal("valid_match.source_bodyless", result.Reason);
         Assert.EndsWith("LadderRung9.cs", result.SourcePath, StringComparison.Ordinal);
     }
 
@@ -148,8 +148,8 @@ public class ReturnToSenderFixtureCatalogTests
                     Overload: 0),
             ]));
 
-        Assert.Equal(ReturnToSenderSourceOutcome.UnsupportedTarget, result.Outcome);
-        Assert.Equal("source-body-unavailable", result.Reason);
+        Assert.Equal(ReturnToSenderSourceOutcome.ValidMatch, result.Outcome);
+        Assert.Equal("valid_match.source_bodyless", result.Reason);
         Assert.EndsWith("LadderRung5.cs", result.SourcePath, StringComparison.Ordinal);
     }
 

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -860,6 +860,47 @@ public class ReturnToSenderFixtureCatalogTests
         Assert.Contains("partial-implementation", member.Evidence);
     }
 
+    [Fact]
+    public void CSharpSourceIdentityContext_ResolvesConstructorIdentity()
+    {
+        var root = CSharpSyntaxTree.ParseText("""
+            namespace SourceProbe;
+
+            public class Class1(int value)
+            {
+                public static int StaticValue;
+                public int Value;
+
+                static Class1()
+                {
+                    StaticValue = 1;
+                }
+
+                public Class1() : this(1)
+                {
+                    Value = value;
+                }
+            }
+            """, cancellationToken: TestContext.Current.CancellationToken)
+            .GetCompilationUnitRoot(TestContext.Current.CancellationToken);
+        var type = Assert.Single(root.DescendantNodes().OfType<ClassDeclarationSyntax>());
+        var constructors = root.DescendantNodes().OfType<ConstructorDeclarationSyntax>().ToArray();
+
+        var context = CSharpSourceIdentityContext.Create([root]);
+        var primary = Assert.Single(context.TypeHeaderMembers(type));
+        var staticConstructor = Assert.Single(context.ConstructorMembers(constructors.Single(ctor => ctor.Modifiers.Any(SyntaxKind.StaticKeyword))));
+        var instanceConstructor = Assert.Single(context.ConstructorMembers(constructors.Single(ctor => !ctor.Modifiers.Any(SyntaxKind.StaticKeyword))));
+
+        Assert.Equal(".ctor", primary.MetadataName);
+        Assert.Null(primary.Body);
+        Assert.Contains("primary-constructor", primary.Evidence);
+        Assert.Equal(".cctor", staticConstructor.MetadataName);
+        Assert.Equal("StaticValue = 1;", staticConstructor.Body);
+        Assert.Contains("static-constructor", staticConstructor.Evidence);
+        Assert.Equal(".ctor", instanceConstructor.MetadataName);
+        Assert.Equal("Value = value;", instanceConstructor.Body);
+    }
+
     static (string Directory, string AssemblyPath, IReadOnlyList<string> SourcePaths) CompileSourceFixture(
         params (string FileName, string Source)[] sources)
     {

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -1058,7 +1058,14 @@ public static class CompileBackSourceComposer
 
     static bool RequiresUnsafe(CompileBackMemberDeclaration member)
         => member.ReturnType?.DisplayName.Contains('*', StringComparison.Ordinal) == true
-            || member.Parameters.Any(parameter => parameter.Type.DisplayName.Contains('*', StringComparison.Ordinal));
+            || member.Parameters.Any(parameter => parameter.Type.DisplayName.Contains('*', StringComparison.Ordinal))
+            || MemberBodyRequiresUnsafe(member);
+
+    static bool MemberBodyRequiresUnsafe(CompileBackMemberDeclaration member)
+        => member.TargetBody is { } body
+            && (body.Contains("delegate*", StringComparison.Ordinal)
+                || body.Contains("stackalloc", StringComparison.Ordinal)
+                || body.Contains('*', StringComparison.Ordinal));
 
     static string AddAsyncModifier(string declaration)
     {

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -791,11 +791,10 @@ public static class CompileBackSourceComposer
 
         var apiType = ToApiType(type);
         var apiMember = ToApiMember(type, member);
-        string declaration = CSharpDeclarationWriter.RenderMemberDeclaration(apiType, apiMember);
-        if (member.IsAsync)
-            declaration = AddAsyncModifier(declaration);
-        if (RequiresUnsafe(member))
-            declaration = AddUnsafeModifier(declaration);
+        string declaration = CSharpDeclarationWriter.RenderMemberDeclaration(
+            apiType,
+            apiMember,
+            new CSharpDeclarationOptions { ForceAsync = member.IsAsync });
         switch (member.Kind)
         {
             case CompileBackMemberKind.PropertyGet:
@@ -999,6 +998,7 @@ public static class CompileBackSourceComposer
             IsSealed = member.IsSealed,
             Accessibility = AccessibilityText(member.Accessibility),
             Attributes = member.Attributes?.ToList() ?? [],
+            IsUnsafe = RequiresUnsafe(member),
         };
         if (member.Kind == CompileBackMemberKind.Method)
         {
@@ -1071,34 +1071,6 @@ public static class CompileBackSourceComposer
             && (body.Contains("delegate*", StringComparison.Ordinal)
                 || body.Contains("stackalloc", StringComparison.Ordinal)
                 || body.Contains('*', StringComparison.Ordinal));
-
-    static string AddAsyncModifier(string declaration)
-    {
-        if (declaration.Contains(" async ", StringComparison.Ordinal))
-            return declaration;
-
-        foreach (var prefix in new[] { "public static ", "internal static ", "public ", "internal ", "static " })
-        {
-            if (declaration.StartsWith(prefix, StringComparison.Ordinal))
-                return prefix + "async " + declaration[prefix.Length..];
-        }
-
-        return "async " + declaration;
-    }
-
-    static string AddUnsafeModifier(string declaration)
-    {
-        if (declaration.Contains(" unsafe ", StringComparison.Ordinal))
-            return declaration;
-
-        foreach (var prefix in new[] { "public static ", "internal static ", "public ", "internal ", "static " })
-        {
-            if (declaration.StartsWith(prefix, StringComparison.Ordinal))
-                return prefix + "unsafe " + declaration[prefix.Length..];
-        }
-
-        return "unsafe " + declaration;
-    }
 
     static string AddPrimaryConstructorParameters(string declaration, string parameters)
     {

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -253,6 +253,7 @@ public sealed record CompileBackFact(string Producer, string Id, string Detail);
 
 public sealed record CompileBackPrimaryConstructor(
     string Parameters,
+    IReadOnlyList<CompileBackParameter> ParameterList,
     IReadOnlyList<CompileBackMemberRequirement> FieldInitializers);
 
 public sealed record CompileBackTypeRequirement(
@@ -411,12 +412,22 @@ public static class CompileBackSourceComposer
             return;
         foreach (var required in requiredMembers)
         {
-            if (primaryConstructor is not null && required.Kind == CompileBackMemberKind.Constructor)
+            if (primaryConstructor is not null
+                && required.Kind == CompileBackMemberKind.Constructor
+                && SameParameters(required.Parameters, primaryConstructor.ParameterList))
+            {
                 continue;
+            }
             if (!members.Any(existing => SameMemberDeclaration(existing, required)))
                 members.Add(required);
         }
     }
+
+    static bool SameParameters(IReadOnlyList<CompileBackParameter> left, IReadOnlyList<CompileBackParameter> right)
+        => left.Count == right.Count
+            && left.Zip(right).All(pair =>
+                string.Equals(pair.First.Type.DisplayName, pair.Second.Type.DisplayName, StringComparison.Ordinal)
+                && string.Equals(pair.First.Modifier, pair.Second.Modifier, StringComparison.Ordinal));
 
     static bool SameMemberDeclaration(CompileBackMemberRequirement left, CompileBackMemberRequirement right)
         => left.Kind == right.Kind
@@ -919,7 +930,7 @@ public static class CompileBackSourceComposer
                     sb.AppendLine($"{pad}}}");
                     break;
                 }
-                sb.AppendLine($"{pad}{declaration} {{ throw null; }}");
+                sb.AppendLine($"{pad}{declaration}{PrimaryConstructorInitializer(type)} {{ throw null; }}");
                 break;
             case CompileBackMemberKind.Method:
                 if (type.Kind == CompileBackTypeKind.Interface || member.IsAbstract || member.StubBody == CompileBackStubBodyKind.None)
@@ -1627,9 +1638,11 @@ public static class CompileBackSourceComposer
         if (!RenderedBodyMatchesPrimaryConstructorInitializers(renderedBody, initializerTexts))
             return null;
 
-        string parameters = string.Join(", ", MethodParameters(reader, method, method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, declaringType, method)))
-            .Select(RenderParameter));
-        return new CompileBackPrimaryConstructor(parameters, fieldInitializers);
+        var parameters = MethodParameters(reader, method, method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, declaringType, method)));
+        return new CompileBackPrimaryConstructor(
+            string.Join(", ", parameters.Select(RenderParameter)),
+            parameters,
+            fieldInitializers);
     }
 
     static CompileBackPrimaryConstructor? PrimaryConstructorFromCapturedFields(
@@ -1681,7 +1694,44 @@ public static class CompileBackSourceComposer
             ? null
             : new CompileBackPrimaryConstructor(
                 string.Join(", ", parameters.Select(RenderParameter)),
+                parameters,
                 FieldInitializers: []);
+    }
+
+    static string PrimaryConstructorInitializer(CompileBackTypeDeclaration type)
+    {
+        if (type.PrimaryConstructorParameters is not { Length: > 0 } parameters)
+            return "";
+
+        int count = SplitTopLevelParameters(parameters).Count();
+        return count == 0
+            ? ""
+            : $" : this({string.Join(", ", Enumerable.Repeat("default", count))})";
+    }
+
+    static IEnumerable<string> SplitTopLevelParameters(string parameters)
+    {
+        int start = 0;
+        int depth = 0;
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            char c = parameters[i];
+            depth += c switch
+            {
+                '<' or '(' or '[' => 1,
+                '>' or ')' or ']' => depth > 0 ? -1 : 0,
+                _ => 0,
+            };
+            if (c != ',' || depth != 0)
+                continue;
+
+            yield return parameters[start..i].Trim();
+            start = i + 1;
+        }
+
+        string last = parameters[start..].Trim();
+        if (last.Length > 0)
+            yield return last;
     }
 
     static bool TryPrimaryConstructorParameterName(string fieldName, out string parameterName)

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -576,7 +576,7 @@ public static class CompileBackSourceComposer
         bool isConstructor = methodName is ".ctor" or ".cctor";
         var primaryConstructor = isConstructor
             ? PrimaryConstructorFromPrologue(reader, method, function, targetBody)
-            : null;
+            : PrimaryConstructorFromCapturedFields(reader, targetTypeDef, targetBody);
 
         var diagnostics = new List<CompileBackPlanningDiagnostic>();
         var targetRoot = TopLevelRootOf(reader, targetType);
@@ -587,7 +587,9 @@ public static class CompileBackSourceComposer
         if (closureFacts.TryGetValue(targetRoot, out var targetClosureFacts))
             targetFacts.AddRange(targetClosureFacts);
 
-        var targetMembers = primaryConstructor?.FieldInitializers.ToList() ??
+        var targetMembers = isConstructor && primaryConstructor is not null
+            ? primaryConstructor.FieldInitializers.ToList()
+            :
         [
             new CompileBackMemberRequirement(
                 new CompileBackMethodIdentity(targetIdentity.FullName, targetMethodName, overload, signatureText),
@@ -1616,6 +1618,72 @@ public static class CompileBackSourceComposer
         string parameters = string.Join(", ", MethodParameters(reader, method, method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, declaringType, method)))
             .Select(RenderParameter));
         return new CompileBackPrimaryConstructor(parameters, fieldInitializers);
+    }
+
+    static CompileBackPrimaryConstructor? PrimaryConstructorFromCapturedFields(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        string renderedBody)
+    {
+        if ((typeDef.Attributes & TypeAttributes.Interface) != 0)
+            return null;
+
+        var parameters = new List<CompileBackParameter>();
+        foreach (var fieldHandle in typeDef.GetFields())
+        {
+            var field = reader.GetFieldDefinition(fieldHandle);
+            if (field.Attributes.HasFlag(FieldAttributes.Static))
+                continue;
+
+            string fieldName = reader.GetString(field.Name);
+            if (!TryPrimaryConstructorParameterName(fieldName, out var parameterName)
+                || !renderedBody.Contains(parameterName, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            string fieldType;
+            try
+            {
+                fieldType = field.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForType(reader, typeDef));
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+            {
+                return null;
+            }
+
+            if (fieldType.Contains("delegate*", StringComparison.Ordinal)
+                || fieldType.Contains("@delegate*", StringComparison.Ordinal))
+                return null;
+
+            parameters.Add(new CompileBackParameter(
+                Identifier(parameterName),
+                CompileBackTypeSignature.Display(fieldType),
+                Modifier: null,
+                Attributes: [],
+                HasDefault: false,
+                DefaultValueText: null));
+        }
+
+        return parameters.Count == 0
+            ? null
+            : new CompileBackPrimaryConstructor(
+                string.Join(", ", parameters.Select(RenderParameter)),
+                FieldInitializers: []);
+    }
+
+    static bool TryPrimaryConstructorParameterName(string fieldName, out string parameterName)
+    {
+        if (fieldName is ['<', ..]
+            && fieldName.EndsWith(">P", StringComparison.Ordinal)
+            && fieldName.IndexOf('>') == fieldName.Length - 2)
+        {
+            parameterName = fieldName[1..^2];
+            return parameterName.Length > 0;
+        }
+
+        parameterName = "";
+        return false;
     }
 
     static string RenderParameter(CompileBackParameter parameter)

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -365,6 +365,7 @@ public static class CompileBackSourceComposer
                 PrimaryConstructor: null,
                 targetFacts)
         };
+        AddRequiredMembers(targetMembers, closureMemberRequirements, targetRoot);
         AddClosureTypeRequirements(requirements, reader, targetRoot, closureFacts, closureMemberRequirements);
 
         foreach (var dependency in closureRoots.OrderBy(handle => MetadataTokens.GetToken(handle)))
@@ -614,12 +615,16 @@ public static class CompileBackSourceComposer
             targetMembers.Add(equalitySibling);
         }
         if (!isConstructor
+            && CheckedConversionOperatorSibling(reader, targetTypeDef, targetIdentity, methodName, signature) is { } conversionSibling)
+        {
+            targetMembers.Add(conversionSibling);
+        }
+        if (!isConstructor
             && TypedEqualsSibling(reader, targetTypeDef, targetIdentity, methodName, signature) is { } typedEqualsSibling)
         {
             targetMembers.Add(typedEqualsSibling);
         }
-        if (!targetTypeDef.GetDeclaringType().IsNil)
-            AddRequiredMembers(targetMembers, closureMemberRequirements, targetType);
+        AddRequiredMembers(targetMembers, closureMemberRequirements, targetType);
 
         var requirements = new List<CompileBackTypeRequirement>
         {
@@ -1233,6 +1238,53 @@ public static class CompileBackSourceComposer
     static bool OperatorSignaturesMatch(MethodSignature<string> left, MethodSignature<string> right)
         => left.ReturnType == right.ReturnType
             && left.ParameterTypes.SequenceEqual(right.ParameterTypes, StringComparer.Ordinal);
+
+    static CompileBackMemberRequirement? CheckedConversionOperatorSibling(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        CompileBackTypeIdentity typeIdentity,
+        string methodName,
+        MethodSignature<string> targetSignature)
+    {
+        var siblingName = methodName switch
+        {
+            "op_CheckedExplicit" => "op_Explicit",
+            "op_CheckedImplicit" => "op_Implicit",
+            _ => null,
+        };
+        if (siblingName is null)
+            return null;
+
+        foreach (var methodHandle in typeDef.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (reader.GetString(method.Name) != siblingName)
+                continue;
+
+            var signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method));
+            if (!OperatorSignaturesMatch(targetSignature, signature))
+                continue;
+
+            return new CompileBackMemberRequirement(
+                new CompileBackMethodIdentity(typeIdentity.FullName, siblingName, 0, MethodSignatureText(siblingName, signature)),
+                CompileBackMemberKind.Method,
+                method.Attributes.HasFlag(MethodAttributes.Static),
+                MethodParameters(reader, method, signature),
+                CompileBackTypeSignature.Display(signature.ReturnType),
+                MethodTypeParameters(reader, method),
+                CompileBackStubBodyKind.Throw,
+                TargetBody: null,
+                [new CompileBackFact("metadata", "operator-pair-sibling", siblingName)],
+                MemberAttributes(reader, method.GetCustomAttributes()),
+                MethodReturnAttributes(reader, method),
+                IsAbstract: IsAbstractMethod(method),
+                IsVirtual: IsVirtualMethod(method),
+                IsOverride: false,
+                IsSealed: false);
+        }
+
+        return null;
+    }
 
     static bool IsRecordGeneratedFieldReadHelper(
         MetadataReader reader,

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -130,7 +130,9 @@ public sealed record CompileBackTypeDeclaration(
     IReadOnlyList<CompileBackFact> SourceFacts,
     IReadOnlyList<CompileBackTypeDeclaration> NestedTypes,
     IReadOnlyList<string>? Attributes = null,
-    bool IsAbstract = false)
+    bool IsAbstract = false,
+    bool IsSealed = false,
+    bool IsStatic = false)
 {
     public string Namespace => Identity.Namespace;
     public string Name => Identity.DisplayName;
@@ -161,7 +163,8 @@ public sealed record CompileBackMemberDeclaration(
     bool IsVirtual = false,
     bool IsOverride = false,
     bool IsSealed = false,
-    bool IsAsync = false)
+    bool IsAsync = false,
+    bool IsExtension = false)
 {
     public string Name => Identity.Method;
     public string Type => ReturnType?.DisplayName ?? "";
@@ -275,7 +278,8 @@ public sealed record CompileBackMemberRequirement(
     bool IsVirtual = false,
     bool IsOverride = false,
     bool IsSealed = false,
-    bool IsAsync = false);
+    bool IsAsync = false,
+    bool IsExtension = false);
 
 public sealed record CompileBackPlanningDiagnostic(string Layer, string Reason, string Detail);
 
@@ -962,6 +966,8 @@ public static class CompileBackSourceComposer
             BaseType = type.BaseType?.DisplayName,
             Attributes = type.Attributes?.ToList() ?? [],
             IsAbstract = type.IsAbstract,
+            IsSealed = type.IsSealed,
+            IsStatic = type.IsStatic,
         };
 
     static ApiMember ToApiMember(CompileBackTypeDeclaration type, CompileBackMemberDeclaration member)
@@ -1001,6 +1007,7 @@ public static class CompileBackSourceComposer
             Accessibility = AccessibilityText(member.Accessibility),
             Attributes = member.Attributes?.ToList() ?? [],
             IsUnsafe = RequiresUnsafe(member),
+            IsExtension = member.IsExtension,
         };
         if (member.Kind == CompileBackMemberKind.Method)
         {
@@ -2327,8 +2334,16 @@ public static class CompileBackSourceComposer
                 IsAbstract: !isConstructor && IsAbstractMethod(method),
                 IsVirtual: !isConstructor && IsVirtualMethod(method),
                 IsOverride: false,
-                IsSealed: false);
+                IsSealed: false,
+                IsExtension: IsExtensionMethod(reader, typeDef, method));
         }
+
+        static bool IsExtensionMethod(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)
+            => typeDef.Attributes.HasFlag(TypeAttributes.Abstract)
+               && typeDef.Attributes.HasFlag(TypeAttributes.Sealed)
+               && method.Attributes.HasFlag(MethodAttributes.Static)
+               && AttributeReader.HasExtensionAttribute(reader, typeDef.GetCustomAttributes())
+               && AttributeReader.HasExtensionAttribute(reader, method.GetCustomAttributes());
 
         static int DeclaringOverloadIndex(MetadataReader reader, TypeDefinition typeDef, MethodDefinitionHandle target, string name)
         {
@@ -2375,7 +2390,9 @@ public static class CompileBackSourceComposer
                     includeMemberSurface,
                     diagnostics),
                 TypeAttributeList(reader, typeDef),
-                IsAbstract: (typeDef.Attributes & TypeAttributes.Abstract) != 0 && (typeDef.Attributes & TypeAttributes.Interface) == 0);
+                IsAbstract: (typeDef.Attributes & TypeAttributes.Abstract) != 0 && (typeDef.Attributes & TypeAttributes.Interface) == 0,
+                IsSealed: (typeDef.Attributes & TypeAttributes.Sealed) != 0,
+                IsStatic: IsStaticType(typeDef));
         }
 
         static List<CompileBackMemberDeclaration> RequiredMemberDeclarations(CompileBackTypeRequirement requirement)
@@ -2400,7 +2417,8 @@ public static class CompileBackSourceComposer
                     member.IsVirtual,
                     member.IsOverride,
                     member.IsSealed,
-                    member.IsAsync));
+                    member.IsAsync,
+                    member.IsExtension));
             }
 
             return members;
@@ -2450,11 +2468,18 @@ public static class CompileBackSourceComposer
                     requirement.SourceFacts,
                     NestedTypes(reader, nestedDef, requirementsByMetadataName, includeNestedMemberSurface, diagnostics),
                     TypeAttributeList(reader, nestedDef),
-                    IsAbstract: (nestedDef.Attributes & TypeAttributes.Abstract) != 0 && (nestedDef.Attributes & TypeAttributes.Interface) == 0));
+                    IsAbstract: (nestedDef.Attributes & TypeAttributes.Abstract) != 0 && (nestedDef.Attributes & TypeAttributes.Interface) == 0,
+                    IsSealed: (nestedDef.Attributes & TypeAttributes.Sealed) != 0,
+                    IsStatic: IsStaticType(nestedDef)));
             }
 
             return nestedTypes;
         }
+
+        static bool IsStaticType(TypeDefinition typeDef)
+            => (typeDef.Attributes & TypeAttributes.Abstract) != 0
+               && (typeDef.Attributes & TypeAttributes.Sealed) != 0
+               && (typeDef.Attributes & TypeAttributes.Interface) == 0;
 
         static IReadOnlyList<string> TypeAttributeList(MetadataReader reader, TypeDefinition typeDef)
             => AttributeReader.RenderAttributes(reader, typeDef.GetCustomAttributes(), qualifyNames: true);

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -404,13 +404,18 @@ public static class CompileBackSourceComposer
     static void AddRequiredMembers(
         List<CompileBackMemberRequirement> members,
         IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> requirementsByRoot,
-        TypeDefinitionHandle root)
+        TypeDefinitionHandle root,
+        CompileBackPrimaryConstructor? primaryConstructor = null)
     {
         if (!requirementsByRoot.TryGetValue(root, out var requiredMembers))
             return;
         foreach (var required in requiredMembers)
+        {
+            if (primaryConstructor is not null && required.Kind == CompileBackMemberKind.Constructor)
+                continue;
             if (!members.Any(existing => SameMemberDeclaration(existing, required)))
                 members.Add(required);
+        }
     }
 
     static bool SameMemberDeclaration(CompileBackMemberRequirement left, CompileBackMemberRequirement right)
@@ -630,7 +635,7 @@ public static class CompileBackSourceComposer
         {
             targetMembers.Add(typedEqualsSibling);
         }
-        AddRequiredMembers(targetMembers, closureMemberRequirements, targetType);
+        AddRequiredMembers(targetMembers, closureMemberRequirements, targetType, primaryConstructor);
 
         var requirements = new List<CompileBackTypeRequirement>
         {

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -615,9 +615,9 @@ public static class CompileBackSourceComposer
             targetMembers.Add(equalitySibling);
         }
         if (!isConstructor
-            && CheckedConversionOperatorSibling(reader, targetTypeDef, targetIdentity, methodName, signature) is { } conversionSibling)
+            && CheckedOperatorSibling(reader, targetTypeDef, targetIdentity, methodName, signature) is { } checkedOperatorSibling)
         {
-            targetMembers.Add(conversionSibling);
+            targetMembers.Add(checkedOperatorSibling);
         }
         if (!isConstructor
             && TypedEqualsSibling(reader, targetTypeDef, targetIdentity, methodName, signature) is { } typedEqualsSibling)
@@ -1239,19 +1239,14 @@ public static class CompileBackSourceComposer
         => left.ReturnType == right.ReturnType
             && left.ParameterTypes.SequenceEqual(right.ParameterTypes, StringComparer.Ordinal);
 
-    static CompileBackMemberRequirement? CheckedConversionOperatorSibling(
+    static CompileBackMemberRequirement? CheckedOperatorSibling(
         MetadataReader reader,
         TypeDefinition typeDef,
         CompileBackTypeIdentity typeIdentity,
         string methodName,
         MethodSignature<string> targetSignature)
     {
-        var siblingName = methodName switch
-        {
-            "op_CheckedExplicit" => "op_Explicit",
-            "op_CheckedImplicit" => "op_Implicit",
-            _ => null,
-        };
+        var siblingName = UncheckedOperatorName(methodName);
         if (siblingName is null)
             return null;
 
@@ -1284,6 +1279,19 @@ public static class CompileBackSourceComposer
         }
 
         return null;
+    }
+
+    static string? UncheckedOperatorName(string methodName)
+    {
+        if (methodName is "op_CheckedExplicit")
+            return "op_Explicit";
+        if (methodName is "op_CheckedImplicit")
+            return "op_Implicit";
+        if (!methodName.StartsWith("op_Checked", StringComparison.Ordinal))
+            return null;
+
+        string inner = methodName["op_Checked".Length..];
+        return OperatorNames.MapBinaryOrUnary(inner) is null ? null : $"op_{inner}";
     }
 
     static bool IsRecordGeneratedFieldReadHelper(
@@ -2235,8 +2243,12 @@ public static class CompileBackSourceComposer
                 || (!isConstructor && name.Contains('.', StringComparison.Ordinal)))
                 return null;
 
-            if (!isConstructor && method.Attributes.HasFlag(MethodAttributes.SpecialName))
+            if (!isConstructor
+                && method.Attributes.HasFlag(MethodAttributes.SpecialName)
+                && !name.StartsWith("op_", StringComparison.Ordinal))
+            {
                 return null;
+            }
 
             MethodSignature<string> signature;
             try

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -160,7 +160,8 @@ public sealed record CompileBackMemberDeclaration(
     bool IsAbstract = false,
     bool IsVirtual = false,
     bool IsOverride = false,
-    bool IsSealed = false)
+    bool IsSealed = false,
+    bool IsAsync = false)
 {
     public string Name => Identity.Method;
     public string Type => ReturnType?.DisplayName ?? "";
@@ -273,7 +274,8 @@ public sealed record CompileBackMemberRequirement(
     bool IsAbstract = false,
     bool IsVirtual = false,
     bool IsOverride = false,
-    bool IsSealed = false);
+    bool IsSealed = false,
+    bool IsAsync = false);
 
 public sealed record CompileBackPlanningDiagnostic(string Layer, string Reason, string Detail);
 
@@ -601,7 +603,8 @@ public static class CompileBackSourceComposer
                 IsAbstract: !isConstructor && IsAbstractMethod(method),
                 IsVirtual: !isConstructor && IsVirtualMethod(method),
                 IsOverride: false,
-                IsSealed: false)
+                IsSealed: false,
+                IsAsync: !isConstructor && function.RequiresAsyncBodyModifier)
         ];
         if (!isConstructor && IsRecordGeneratedFieldReadHelper(reader, targetTypeDef, targetIdentity, methodName, signature, function))
             targetMembers.AddRange(TargetBackingFieldReadMembers(reader, targetTypeDef, targetIdentity, function));
@@ -784,6 +787,8 @@ public static class CompileBackSourceComposer
         var apiType = ToApiType(type);
         var apiMember = ToApiMember(type, member);
         string declaration = CSharpDeclarationWriter.RenderMemberDeclaration(apiType, apiMember);
+        if (member.IsAsync)
+            declaration = AddAsyncModifier(declaration);
         if (RequiresUnsafe(member))
             declaration = AddUnsafeModifier(declaration);
         switch (member.Kind)
@@ -794,6 +799,7 @@ public static class CompileBackSourceComposer
                     sb.AppendLine($"{pad}{declaration}");
                     return;
                 }
+
                 if (member.IsAbstract || member.StubBody == CompileBackStubBodyKind.None)
                 {
                     sb.AppendLine($"{pad}{declaration} {{ {GetterDeclaration(member)};{(HasSetterShape(member) ? " set;" : "")} }}");
@@ -1053,6 +1059,20 @@ public static class CompileBackSourceComposer
     static bool RequiresUnsafe(CompileBackMemberDeclaration member)
         => member.ReturnType?.DisplayName.Contains('*', StringComparison.Ordinal) == true
             || member.Parameters.Any(parameter => parameter.Type.DisplayName.Contains('*', StringComparison.Ordinal));
+
+    static string AddAsyncModifier(string declaration)
+    {
+        if (declaration.Contains(" async ", StringComparison.Ordinal))
+            return declaration;
+
+        foreach (var prefix in new[] { "public static ", "internal static ", "public ", "internal ", "static " })
+        {
+            if (declaration.StartsWith(prefix, StringComparison.Ordinal))
+                return prefix + "async " + declaration[prefix.Length..];
+        }
+
+        return "async " + declaration;
+    }
 
     static string AddUnsafeModifier(string declaration)
     {
@@ -2268,7 +2288,8 @@ public static class CompileBackSourceComposer
                     member.IsAbstract,
                     member.IsVirtual,
                     member.IsOverride,
-                    member.IsSealed));
+                    member.IsSealed,
+                    member.IsAsync));
             }
 
             return members;

--- a/src/ILInspector.Research/ResearchReturnToSenderShells.cs
+++ b/src/ILInspector.Research/ResearchReturnToSenderShells.cs
@@ -1,0 +1,114 @@
+using System.Reflection.Metadata;
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Research;
+
+/// <summary>
+/// Research-owned request boundary for ReturnToSender compile-back shell composition.
+/// </summary>
+public static class ResearchReturnToSenderShells
+{
+    public static CompileBackMemberRequirement? TryCreateClosureMemberRequirement(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        MethodRef method)
+        => CompileBackSourceComposer.TryCreateClosureMemberRequirement(reader, typeHandle, method);
+
+    public static CompileBackMemberRequirement? TryCreateClosureMemberRequirement(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        FieldRef field)
+        => CompileBackSourceComposer.TryCreateClosureMemberRequirement(reader, typeHandle, field);
+
+    public static CompileBackSourceResult ComposePropertyGetter(
+        string assemblyPath,
+        MetadataReader reader,
+        IrFunction function,
+        TypeDefinitionHandle targetType,
+        PropertyDefinitionHandle targetProperty,
+        MethodDefinitionHandle targetGetter,
+        string targetBody,
+        string fullType,
+        string methodName,
+        int overload,
+        string signatureText,
+        IReadOnlySet<TypeDefinitionHandle> closureRoots,
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements)
+        => CompileBackSourceComposer.ComposePropertyGetter(
+            assemblyPath,
+            reader,
+            function,
+            targetType,
+            targetProperty,
+            targetGetter,
+            targetBody,
+            fullType,
+            methodName,
+            overload,
+            signatureText,
+            closureRoots,
+            closureFacts,
+            closureMemberRequirements);
+
+    public static CompileBackSourceResult ComposePropertySetter(
+        string assemblyPath,
+        MetadataReader reader,
+        IrFunction function,
+        TypeDefinitionHandle targetType,
+        PropertyDefinitionHandle targetProperty,
+        MethodDefinitionHandle targetSetter,
+        string targetBody,
+        string fullType,
+        string methodName,
+        int overload,
+        string signatureText,
+        IReadOnlySet<TypeDefinitionHandle> closureRoots,
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements)
+        => CompileBackSourceComposer.ComposePropertySetter(
+            assemblyPath,
+            reader,
+            function,
+            targetType,
+            targetProperty,
+            targetSetter,
+            targetBody,
+            fullType,
+            methodName,
+            overload,
+            signatureText,
+            closureRoots,
+            closureFacts,
+            closureMemberRequirements);
+
+    public static CompileBackSourceResult ComposeMethod(
+        string assemblyPath,
+        MetadataReader reader,
+        IrFunction function,
+        TypeDefinitionHandle targetType,
+        MethodDefinitionHandle targetMethod,
+        string targetBody,
+        string fullType,
+        string methodName,
+        int overload,
+        string signatureText,
+        IReadOnlySet<TypeDefinitionHandle> closureRoots,
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements)
+        => CompileBackSourceComposer.ComposeMethod(
+            assemblyPath,
+            reader,
+            function,
+            targetType,
+            targetMethod,
+            targetBody,
+            fullType,
+            methodName,
+            overload,
+            signatureText,
+            closureRoots,
+            closureFacts,
+            closureMemberRequirements);
+}

--- a/tests/DotnetInspector.Fixtures.Tests/FixtureCatalogTests.cs
+++ b/tests/DotnetInspector.Fixtures.Tests/FixtureCatalogTests.cs
@@ -81,6 +81,16 @@ public class FixtureCatalogTests
     }
 
     [Fact]
+    public void SourcePaths_IncludeLinkedCompileSources()
+    {
+        var paths = FixtureCatalog.DecompilerLadderRung5.SourcePaths();
+
+        Assert.Contains(paths, path => path.EndsWith(
+            Path.Combine("ILInspector.Decompiler.Fixtures.LadderRung5", "LadderRung5.cs"),
+            StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void SidecarAssets_ResolveTraceCoupledRunFasterAsset()
     {
         var fixture = FixtureCatalog.RunFasterAllocation;

--- a/tests/DotnetInspector.Fixtures/FixtureCatalog.cs
+++ b/tests/DotnetInspector.Fixtures/FixtureCatalog.cs
@@ -1,3 +1,5 @@
+using System.Xml.Linq;
+
 namespace DotnetInspector.Fixtures;
 
 public sealed record FixtureDefinition(
@@ -502,8 +504,59 @@ public static class FixtureCatalog
     {
         string projectDirectory = ProjectDirectory(id);
         return [.. Directory.EnumerateFiles(projectDirectory, "*.cs", SearchOption.AllDirectories)
+            .Concat(ProjectCompileSourcePaths(projectDirectory))
+            .Select(Path.GetFullPath)
             .Where(path => !HasPathSegment(path, "bin") && !HasPathSegment(path, "obj"))
+            .Distinct(StringComparer.Ordinal)
             .Order(StringComparer.Ordinal)];
+    }
+
+    static IEnumerable<string> ProjectCompileSourcePaths(string projectDirectory)
+    {
+        foreach (var projectFile in Directory.EnumerateFiles(projectDirectory, "*.csproj", SearchOption.TopDirectoryOnly))
+        {
+            XDocument project;
+            try
+            {
+                project = XDocument.Load(projectFile);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Xml.XmlException)
+            {
+                continue;
+            }
+
+            foreach (var include in project
+                .Descendants()
+                .Where(element => element.Name.LocalName == "Compile")
+                .Select(element => element.Attribute("Include")?.Value)
+                .Where(value => !string.IsNullOrWhiteSpace(value)))
+            {
+                foreach (var path in ExpandCompileInclude(projectDirectory, include!))
+                    yield return path;
+            }
+        }
+    }
+
+    static IEnumerable<string> ExpandCompileInclude(string projectDirectory, string include)
+    {
+        string normalized = include
+            .Replace('\\', Path.DirectorySeparatorChar)
+            .Replace('/', Path.DirectorySeparatorChar);
+        string fullPattern = Path.GetFullPath(Path.Combine(projectDirectory, normalized));
+        string? directory = Path.GetDirectoryName(fullPattern);
+        if (directory is null || !Directory.Exists(directory))
+            yield break;
+
+        string pattern = Path.GetFileName(fullPattern);
+        if (pattern.Contains('*', StringComparison.Ordinal) || pattern.Contains('?', StringComparison.Ordinal))
+        {
+            foreach (var path in Directory.EnumerateFiles(directory, pattern, SearchOption.TopDirectoryOnly))
+                yield return path;
+            yield break;
+        }
+
+        if (File.Exists(fullPattern))
+            yield return fullPattern;
     }
 
     public static string AssetPath(string id, string assetName)

--- a/tools/DecompilerHarness/CSharpSourceIdentity.cs
+++ b/tools/DecompilerHarness/CSharpSourceIdentity.cs
@@ -95,9 +95,15 @@ internal sealed class CSharpSourceIdentityContext
 
     public IReadOnlyList<CSharpSourceMemberIdentity> ConversionOperatorMembers(ConversionOperatorDeclarationSyntax conversion)
     {
-        string methodName = conversion.ImplicitOrExplicitKeyword.IsKind(SyntaxKind.ImplicitKeyword)
-            ? "op_Implicit"
-            : "op_Explicit";
+        bool isImplicit = conversion.ImplicitOrExplicitKeyword.IsKind(SyntaxKind.ImplicitKeyword);
+        bool isChecked = conversion.CheckedKeyword.IsKind(SyntaxKind.CheckedKeyword);
+        string methodName = (isImplicit, isChecked) switch
+        {
+            (true, true) => "op_CheckedImplicit",
+            (true, false) => "op_Implicit",
+            (false, true) => "op_CheckedExplicit",
+            (false, false) => "op_Explicit",
+        };
         return
         [
             new CSharpSourceMemberIdentity(

--- a/tools/DecompilerHarness/CSharpSourceIdentity.cs
+++ b/tools/DecompilerHarness/CSharpSourceIdentity.cs
@@ -72,53 +72,7 @@ internal sealed class CSharpSourceIdentityContext
         var members = new List<CSharpSourceMemberIdentity>();
         if (HasPrimaryConstructor(type))
             members.Add(new CSharpSourceMemberIdentity(".ctor", Body: null, Evidence: ["primary-constructor"]));
-        if (type is RecordDeclarationSyntax record)
-            members.AddRange(RecordSynthesizedMembers(record));
         return members;
-    }
-
-    static IEnumerable<CSharpSourceMemberIdentity> RecordSynthesizedMembers(RecordDeclarationSyntax record)
-    {
-        var evidence = new[] { "record-synthesized" };
-        var explicitMethods = record.Members
-            .OfType<MethodDeclarationSyntax>()
-            .Where(method => method.ExplicitInterfaceSpecifier is null)
-            .Select(method => method.Identifier.ValueText)
-            .ToHashSet(StringComparer.Ordinal);
-        var explicitOperators = record.Members
-            .OfType<OperatorDeclarationSyntax>()
-            .Select(OperatorMetadataName)
-            .ToHashSet(StringComparer.Ordinal);
-        var explicitProperties = record.Members
-            .OfType<PropertyDeclarationSyntax>()
-            .Where(property => property.ExplicitInterfaceSpecifier is null)
-            .Select(property => property.Identifier.ValueText)
-            .ToHashSet(StringComparer.Ordinal);
-
-        if (!explicitMethods.Contains("ToString"))
-            yield return new CSharpSourceMemberIdentity("ToString", Body: null, evidence);
-        if (!explicitMethods.Contains("GetHashCode"))
-            yield return new CSharpSourceMemberIdentity("GetHashCode", Body: null, evidence);
-        if (!explicitMethods.Contains("Equals"))
-        {
-            yield return new CSharpSourceMemberIdentity("Equals", Body: null, evidence);
-            yield return new CSharpSourceMemberIdentity("Equals", Body: null, evidence);
-        }
-        if (!explicitOperators.Contains("op_Equality"))
-            yield return new CSharpSourceMemberIdentity("op_Equality", Body: null, evidence);
-        if (!explicitOperators.Contains("op_Inequality"))
-            yield return new CSharpSourceMemberIdentity("op_Inequality", Body: null, evidence);
-
-        if (record.ParameterList is not { Parameters.Count: > 0 } parameters)
-            yield break;
-
-        if (!explicitMethods.Contains("Deconstruct"))
-            yield return new CSharpSourceMemberIdentity("Deconstruct", Body: null, evidence);
-        foreach (var parameter in parameters.Parameters)
-        {
-            if (!explicitProperties.Contains(parameter.Identifier.ValueText))
-                yield return new CSharpSourceMemberIdentity($"get_{parameter.Identifier.ValueText}", Body: null, evidence);
-        }
     }
 
     public IReadOnlyList<CSharpSourceMemberIdentity> ConstructorMembers(ConstructorDeclarationSyntax constructor)

--- a/tools/DecompilerHarness/CSharpSourceIdentity.cs
+++ b/tools/DecompilerHarness/CSharpSourceIdentity.cs
@@ -4,7 +4,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace ILInspector.DecompilerHarness;
 
-internal sealed record CSharpSourceIndexerMember(
+internal sealed record CSharpSourceMemberIdentity(
     string MetadataName,
     string? Body,
     IReadOnlyList<string> Evidence);
@@ -26,18 +26,32 @@ internal sealed class CSharpSourceIdentityContext
         return new CSharpSourceIdentityContext(partialIndexerNames);
     }
 
-    public IReadOnlyList<CSharpSourceIndexerMember> IndexerMembers(IndexerDeclarationSyntax indexer, string fullType)
+    public IReadOnlyList<CSharpSourceMemberIdentity> PropertyMembers(PropertyDeclarationSyntax property)
+    {
+        if (IsBodylessPartial(property))
+            return [];
+
+        var evidence = PropertyEvidence(property).ToArray();
+        var members = new List<CSharpSourceMemberIdentity>(2);
+        if (HasGetter(property))
+            members.Add(new CSharpSourceMemberIdentity($"get_{property.Identifier.ValueText}", GetterBodyText(property), evidence));
+        if (HasSetter(property))
+            members.Add(new CSharpSourceMemberIdentity($"set_{property.Identifier.ValueText}", SetterBodyText(property), evidence));
+        return members;
+    }
+
+    public IReadOnlyList<CSharpSourceMemberIdentity> IndexerMembers(IndexerDeclarationSyntax indexer, string fullType)
     {
         if (IsBodylessPartial(indexer))
             return [];
 
         string metadataName = IndexerMetadataName(indexer) ?? PartialIndexerMetadataName(fullType, indexer) ?? "Item";
         var evidence = IndexerEvidence(indexer, metadataName).ToArray();
-        var members = new List<CSharpSourceIndexerMember>(2);
+        var members = new List<CSharpSourceMemberIdentity>(2);
         if (HasGetter(indexer))
-            members.Add(new CSharpSourceIndexerMember($"get_{metadataName}", GetterBodyText(indexer), evidence));
+            members.Add(new CSharpSourceMemberIdentity($"get_{metadataName}", GetterBodyText(indexer), evidence));
         if (HasSetter(indexer))
-            members.Add(new CSharpSourceIndexerMember($"set_{metadataName}", SetterBodyText(indexer), evidence));
+            members.Add(new CSharpSourceMemberIdentity($"set_{metadataName}", SetterBodyText(indexer), evidence));
         return members;
     }
 
@@ -122,6 +136,19 @@ internal sealed class CSharpSourceIdentityContext
             && indexer.ExpressionBody is null
             && indexer.AccessorList?.Accessors.All(accessor => accessor.Body is null && accessor.ExpressionBody is null) == true;
 
+    static bool IsBodylessPartial(PropertyDeclarationSyntax property)
+        => property.Modifiers.Any(SyntaxKind.PartialKeyword)
+            && property.ExpressionBody is null
+            && property.AccessorList?.Accessors.All(accessor => accessor.Body is null && accessor.ExpressionBody is null) == true;
+
+    static bool HasGetter(PropertyDeclarationSyntax property)
+        => property.ExpressionBody is not null
+            || property.AccessorList?.Accessors.Any(accessor => accessor.IsKind(SyntaxKind.GetAccessorDeclaration)) == true;
+
+    static bool HasSetter(PropertyDeclarationSyntax property)
+        => property.AccessorList?.Accessors.Any(accessor =>
+            accessor.IsKind(SyntaxKind.SetAccessorDeclaration) || accessor.IsKind(SyntaxKind.InitAccessorDeclaration)) == true;
+
     static bool HasGetter(IndexerDeclarationSyntax indexer)
         => indexer.ExpressionBody is not null
             || indexer.AccessorList?.Accessors.Any(accessor => accessor.IsKind(SyntaxKind.GetAccessorDeclaration)) == true;
@@ -142,6 +169,18 @@ internal sealed class CSharpSourceIdentityContext
         return null;
     }
 
+    static string? GetterBodyText(PropertyDeclarationSyntax property)
+    {
+        if (property.ExpressionBody is { } expressionBody)
+            return $"return {expressionBody.Expression};";
+        var getter = property.AccessorList?.Accessors.FirstOrDefault(accessor => accessor.IsKind(SyntaxKind.GetAccessorDeclaration));
+        if (getter?.Body is { } body)
+            return StatementsText(body);
+        if (getter?.ExpressionBody is { } getterExpression)
+            return $"return {getterExpression.Expression};";
+        return null;
+    }
+
     static string? SetterBodyText(IndexerDeclarationSyntax indexer)
     {
         var setter = indexer.AccessorList?.Accessors.FirstOrDefault(accessor =>
@@ -151,6 +190,23 @@ internal sealed class CSharpSourceIdentityContext
         if (setter?.ExpressionBody is { } setterExpression)
             return $"{setterExpression.Expression};";
         return null;
+    }
+
+    static string? SetterBodyText(PropertyDeclarationSyntax property)
+    {
+        var setter = property.AccessorList?.Accessors.FirstOrDefault(accessor =>
+            accessor.IsKind(SyntaxKind.SetAccessorDeclaration) || accessor.IsKind(SyntaxKind.InitAccessorDeclaration));
+        if (setter?.Body is { } body)
+            return StatementsText(body);
+        if (setter?.ExpressionBody is { } setterExpression)
+            return $"{setterExpression.Expression};";
+        return null;
+    }
+
+    static IEnumerable<string> PropertyEvidence(PropertyDeclarationSyntax property)
+    {
+        if (property.Modifiers.Any(SyntaxKind.PartialKeyword))
+            yield return "partial-implementation";
     }
 
     static string StatementsText(BlockSyntax body)

--- a/tools/DecompilerHarness/CSharpSourceIdentity.cs
+++ b/tools/DecompilerHarness/CSharpSourceIdentity.cs
@@ -82,7 +82,7 @@ internal sealed class CSharpSourceIdentityContext
 
     public IReadOnlyList<CSharpSourceMemberIdentity> PropertyMembers(PropertyDeclarationSyntax property)
     {
-        if (IsBodylessPartial(property))
+        if (property.ExplicitInterfaceSpecifier is not null || IsBodylessPartial(property))
             return [];
 
         var evidence = PropertyEvidence(property).ToArray();
@@ -96,7 +96,7 @@ internal sealed class CSharpSourceIdentityContext
 
     public IReadOnlyList<CSharpSourceMemberIdentity> IndexerMembers(IndexerDeclarationSyntax indexer, string fullType)
     {
-        if (IsBodylessPartial(indexer))
+        if (indexer.ExplicitInterfaceSpecifier is not null || IsBodylessPartial(indexer))
             return [];
 
         string metadataName = IndexerMetadataName(indexer) ?? PartialIndexerMetadataName(fullType, indexer) ?? "Item";

--- a/tools/DecompilerHarness/CSharpSourceIdentity.cs
+++ b/tools/DecompilerHarness/CSharpSourceIdentity.cs
@@ -26,6 +26,27 @@ internal sealed class CSharpSourceIdentityContext
         return new CSharpSourceIdentityContext(partialIndexerNames);
     }
 
+    public IEnumerable<CSharpSourceMemberIdentity> TypeMembers(TypeDeclarationSyntax type, string fullType)
+    {
+        foreach (var member in TypeHeaderMembers(type))
+            yield return member;
+        foreach (var declaration in type.Members)
+        {
+            IEnumerable<CSharpSourceMemberIdentity> members = declaration switch
+            {
+                MethodDeclarationSyntax method => MethodMembers(method),
+                ConstructorDeclarationSyntax constructor => ConstructorMembers(constructor),
+                PropertyDeclarationSyntax property => PropertyMembers(property),
+                IndexerDeclarationSyntax indexer => IndexerMembers(indexer, fullType),
+                OperatorDeclarationSyntax op => OperatorMembers(op),
+                ConversionOperatorDeclarationSyntax conversion => ConversionOperatorMembers(conversion),
+                _ => [],
+            };
+            foreach (var member in members)
+                yield return member;
+        }
+    }
+
     public IReadOnlyList<CSharpSourceMemberIdentity> MethodMembers(MethodDeclarationSyntax method)
     {
         if (method.ExplicitInterfaceSpecifier is not null || IsBodylessPartial(method))

--- a/tools/DecompilerHarness/CSharpSourceIdentity.cs
+++ b/tools/DecompilerHarness/CSharpSourceIdentity.cs
@@ -26,6 +26,12 @@ internal sealed class CSharpSourceIdentityContext
         return new CSharpSourceIdentityContext(partialIndexerNames);
     }
 
+    public static string TypeMetadataName(TypeDeclarationSyntax type)
+    {
+        int arity = type.TypeParameterList?.Parameters.Count ?? 0;
+        return arity == 0 ? type.Identifier.ValueText : $"{type.Identifier.ValueText}`{arity}";
+    }
+
     public IEnumerable<CSharpSourceMemberIdentity> TypeMembers(TypeDeclarationSyntax type, string fullType)
     {
         foreach (var member in TypeHeaderMembers(type))
@@ -175,7 +181,7 @@ internal sealed class CSharpSourceIdentityContext
                 }
                 case TypeDeclarationSyntax type:
                 {
-                    string typeName = type.Identifier.ValueText;
+                    string typeName = TypeMetadataName(type);
                     var typeStack = containingTypes.Concat([typeName]).ToArray();
                     string fullType = namespaceName.Length == 0
                         ? string.Join(".", typeStack)

--- a/tools/DecompilerHarness/CSharpSourceIdentity.cs
+++ b/tools/DecompilerHarness/CSharpSourceIdentity.cs
@@ -368,7 +368,8 @@ internal sealed class CSharpSourceIdentityContext
             : $"return {expression};";
 
     static string OperatorMetadataName(OperatorDeclarationSyntax op)
-        => op.OperatorToken.Kind() switch
+    {
+        string methodName = op.OperatorToken.Kind() switch
         {
             SyntaxKind.PlusToken => op.ParameterList.Parameters.Count == 1 ? "op_UnaryPlus" : "op_Addition",
             SyntaxKind.MinusToken => op.ParameterList.Parameters.Count == 1 ? "op_UnaryNegation" : "op_Subtraction",
@@ -395,4 +396,8 @@ internal sealed class CSharpSourceIdentityContext
             SyntaxKind.GreaterThanEqualsToken => "op_GreaterThanOrEqual",
             _ => op.OperatorToken.ValueText,
         };
+        return op.CheckedKeyword.IsKind(SyntaxKind.CheckedKeyword)
+            ? $"op_Checked{methodName["op_".Length..]}"
+            : methodName;
+    }
 }

--- a/tools/DecompilerHarness/CSharpSourceIdentity.cs
+++ b/tools/DecompilerHarness/CSharpSourceIdentity.cs
@@ -57,6 +57,29 @@ internal sealed class CSharpSourceIdentityContext
         ];
     }
 
+    public IReadOnlyList<CSharpSourceMemberIdentity> OperatorMembers(OperatorDeclarationSyntax op)
+        =>
+        [
+            new CSharpSourceMemberIdentity(
+                OperatorMetadataName(op),
+                BodyText(op),
+                ["operator"]),
+        ];
+
+    public IReadOnlyList<CSharpSourceMemberIdentity> ConversionOperatorMembers(ConversionOperatorDeclarationSyntax conversion)
+    {
+        string methodName = conversion.ImplicitOrExplicitKeyword.IsKind(SyntaxKind.ImplicitKeyword)
+            ? "op_Implicit"
+            : "op_Explicit";
+        return
+        [
+            new CSharpSourceMemberIdentity(
+                methodName,
+                BodyText(conversion),
+                ["conversion-operator"]),
+        ];
+    }
+
     public IReadOnlyList<CSharpSourceMemberIdentity> PropertyMembers(PropertyDeclarationSyntax property)
     {
         if (IsBodylessPartial(property))
@@ -216,6 +239,24 @@ internal sealed class CSharpSourceIdentityContext
         return null;
     }
 
+    static string? BodyText(OperatorDeclarationSyntax op)
+    {
+        if (op.Body is { } body)
+            return StatementsText(body);
+        if (op.ExpressionBody is { } expressionBody)
+            return ExpressionBodyText(op.ReturnType, expressionBody.Expression);
+        return null;
+    }
+
+    static string? BodyText(ConversionOperatorDeclarationSyntax conversion)
+    {
+        if (conversion.Body is { } body)
+            return StatementsText(body);
+        if (conversion.ExpressionBody is { } expressionBody)
+            return ExpressionBodyText(conversion.Type, expressionBody.Expression);
+        return null;
+    }
+
     static bool HasGetter(PropertyDeclarationSyntax property)
         => property.ExpressionBody is not null
             || property.AccessorList?.Accessors.Any(accessor => accessor.IsKind(SyntaxKind.GetAccessorDeclaration)) == true;
@@ -292,4 +333,33 @@ internal sealed class CSharpSourceIdentityContext
             && predefined.Keyword.IsKind(SyntaxKind.VoidKeyword)
             ? $"{expression};"
             : $"return {expression};";
+
+    static string OperatorMetadataName(OperatorDeclarationSyntax op)
+        => op.OperatorToken.Kind() switch
+        {
+            SyntaxKind.PlusToken => op.ParameterList.Parameters.Count == 1 ? "op_UnaryPlus" : "op_Addition",
+            SyntaxKind.MinusToken => op.ParameterList.Parameters.Count == 1 ? "op_UnaryNegation" : "op_Subtraction",
+            SyntaxKind.ExclamationToken => "op_LogicalNot",
+            SyntaxKind.TildeToken => "op_OnesComplement",
+            SyntaxKind.PlusPlusToken => "op_Increment",
+            SyntaxKind.MinusMinusToken => "op_Decrement",
+            SyntaxKind.TrueKeyword => "op_True",
+            SyntaxKind.FalseKeyword => "op_False",
+            SyntaxKind.AsteriskToken => "op_Multiply",
+            SyntaxKind.SlashToken => "op_Division",
+            SyntaxKind.PercentToken => "op_Modulus",
+            SyntaxKind.AmpersandToken => "op_BitwiseAnd",
+            SyntaxKind.BarToken => "op_BitwiseOr",
+            SyntaxKind.CaretToken => "op_ExclusiveOr",
+            SyntaxKind.LessThanLessThanToken => "op_LeftShift",
+            SyntaxKind.GreaterThanGreaterThanToken => "op_RightShift",
+            SyntaxKind.GreaterThanGreaterThanGreaterThanToken => "op_UnsignedRightShift",
+            SyntaxKind.EqualsEqualsToken => "op_Equality",
+            SyntaxKind.ExclamationEqualsToken => "op_Inequality",
+            SyntaxKind.LessThanToken => "op_LessThan",
+            SyntaxKind.GreaterThanToken => "op_GreaterThan",
+            SyntaxKind.LessThanEqualsToken => "op_LessThanOrEqual",
+            SyntaxKind.GreaterThanEqualsToken => "op_GreaterThanOrEqual",
+            _ => op.OperatorToken.ValueText,
+        };
 }

--- a/tools/DecompilerHarness/CSharpSourceIdentity.cs
+++ b/tools/DecompilerHarness/CSharpSourceIdentity.cs
@@ -68,9 +68,32 @@ internal sealed class CSharpSourceIdentityContext
     }
 
     public IReadOnlyList<CSharpSourceMemberIdentity> TypeHeaderMembers(TypeDeclarationSyntax type)
-        => HasPrimaryConstructor(type)
-            ? [new CSharpSourceMemberIdentity(".ctor", Body: null, Evidence: ["primary-constructor"])]
-            : [];
+    {
+        var members = new List<CSharpSourceMemberIdentity>();
+        if (HasPrimaryConstructor(type))
+            members.Add(new CSharpSourceMemberIdentity(".ctor", Body: null, Evidence: ["primary-constructor"]));
+        if (type is RecordDeclarationSyntax record)
+            members.AddRange(RecordSynthesizedMembers(record));
+        return members;
+    }
+
+    static IEnumerable<CSharpSourceMemberIdentity> RecordSynthesizedMembers(RecordDeclarationSyntax record)
+    {
+        var evidence = new[] { "record-synthesized" };
+        yield return new CSharpSourceMemberIdentity("ToString", Body: null, evidence);
+        yield return new CSharpSourceMemberIdentity("GetHashCode", Body: null, evidence);
+        yield return new CSharpSourceMemberIdentity("Equals", Body: null, evidence);
+        yield return new CSharpSourceMemberIdentity("Equals", Body: null, evidence);
+        yield return new CSharpSourceMemberIdentity("op_Equality", Body: null, evidence);
+        yield return new CSharpSourceMemberIdentity("op_Inequality", Body: null, evidence);
+
+        if (record.ParameterList is not { Parameters.Count: > 0 } parameters)
+            yield break;
+
+        yield return new CSharpSourceMemberIdentity("Deconstruct", Body: null, evidence);
+        foreach (var parameter in parameters.Parameters)
+            yield return new CSharpSourceMemberIdentity($"get_{parameter.Identifier.ValueText}", Body: null, evidence);
+    }
 
     public IReadOnlyList<CSharpSourceMemberIdentity> ConstructorMembers(ConstructorDeclarationSyntax constructor)
     {

--- a/tools/DecompilerHarness/CSharpSourceIdentity.cs
+++ b/tools/DecompilerHarness/CSharpSourceIdentity.cs
@@ -26,6 +26,20 @@ internal sealed class CSharpSourceIdentityContext
         return new CSharpSourceIdentityContext(partialIndexerNames);
     }
 
+    public IReadOnlyList<CSharpSourceMemberIdentity> MethodMembers(MethodDeclarationSyntax method)
+    {
+        if (method.ExplicitInterfaceSpecifier is not null || IsBodylessPartial(method))
+            return [];
+
+        return
+        [
+            new CSharpSourceMemberIdentity(
+                method.Identifier.ValueText,
+                BodyText(method),
+                MethodEvidence(method).ToArray()),
+        ];
+    }
+
     public IReadOnlyList<CSharpSourceMemberIdentity> PropertyMembers(PropertyDeclarationSyntax property)
     {
         if (IsBodylessPartial(property))
@@ -59,6 +73,12 @@ internal sealed class CSharpSourceIdentityContext
         => _partialIndexerNames.TryGetValue(PartialIndexerKey(fullType, indexer), out var metadataName)
             ? metadataName
             : null;
+
+    static IEnumerable<string> MethodEvidence(MethodDeclarationSyntax method)
+    {
+        if (method.Modifiers.Any(SyntaxKind.PartialKeyword))
+            yield return "partial-implementation";
+    }
 
     static IEnumerable<string> IndexerEvidence(IndexerDeclarationSyntax indexer, string metadataName)
     {
@@ -141,6 +161,20 @@ internal sealed class CSharpSourceIdentityContext
             && property.ExpressionBody is null
             && property.AccessorList?.Accessors.All(accessor => accessor.Body is null && accessor.ExpressionBody is null) == true;
 
+    static bool IsBodylessPartial(MethodDeclarationSyntax method)
+        => method.Modifiers.Any(SyntaxKind.PartialKeyword)
+            && method.Body is null
+            && method.ExpressionBody is null;
+
+    static string? BodyText(MethodDeclarationSyntax method)
+    {
+        if (method.Body is { } body)
+            return StatementsText(body);
+        if (method.ExpressionBody is { } expressionBody)
+            return ExpressionBodyText(method.ReturnType, expressionBody.Expression);
+        return null;
+    }
+
     static bool HasGetter(PropertyDeclarationSyntax property)
         => property.ExpressionBody is not null
             || property.AccessorList?.Accessors.Any(accessor => accessor.IsKind(SyntaxKind.GetAccessorDeclaration)) == true;
@@ -211,4 +245,10 @@ internal sealed class CSharpSourceIdentityContext
 
     static string StatementsText(BlockSyntax body)
         => string.Join(Environment.NewLine, body.Statements.Select(statement => statement.ToString()));
+
+    static string ExpressionBodyText(TypeSyntax returnType, ExpressionSyntax expression)
+        => returnType is PredefinedTypeSyntax predefined
+            && predefined.Keyword.IsKind(SyntaxKind.VoidKeyword)
+            ? $"{expression};"
+            : $"return {expression};";
 }

--- a/tools/DecompilerHarness/CSharpSourceIdentity.cs
+++ b/tools/DecompilerHarness/CSharpSourceIdentity.cs
@@ -40,6 +40,23 @@ internal sealed class CSharpSourceIdentityContext
         ];
     }
 
+    public IReadOnlyList<CSharpSourceMemberIdentity> TypeHeaderMembers(TypeDeclarationSyntax type)
+        => HasPrimaryConstructor(type)
+            ? [new CSharpSourceMemberIdentity(".ctor", Body: null, Evidence: ["primary-constructor"])]
+            : [];
+
+    public IReadOnlyList<CSharpSourceMemberIdentity> ConstructorMembers(ConstructorDeclarationSyntax constructor)
+    {
+        string methodName = constructor.Modifiers.Any(SyntaxKind.StaticKeyword) ? ".cctor" : ".ctor";
+        return
+        [
+            new CSharpSourceMemberIdentity(
+                methodName,
+                BodyText(constructor),
+                ConstructorEvidence(constructor).ToArray()),
+        ];
+    }
+
     public IReadOnlyList<CSharpSourceMemberIdentity> PropertyMembers(PropertyDeclarationSyntax property)
     {
         if (IsBodylessPartial(property))
@@ -73,6 +90,12 @@ internal sealed class CSharpSourceIdentityContext
         => _partialIndexerNames.TryGetValue(PartialIndexerKey(fullType, indexer), out var metadataName)
             ? metadataName
             : null;
+
+    static IEnumerable<string> ConstructorEvidence(ConstructorDeclarationSyntax constructor)
+    {
+        if (constructor.Modifiers.Any(SyntaxKind.StaticKeyword))
+            yield return "static-constructor";
+    }
 
     static IEnumerable<string> MethodEvidence(MethodDeclarationSyntax method)
     {
@@ -165,6 +188,24 @@ internal sealed class CSharpSourceIdentityContext
         => method.Modifiers.Any(SyntaxKind.PartialKeyword)
             && method.Body is null
             && method.ExpressionBody is null;
+
+    static bool HasPrimaryConstructor(TypeDeclarationSyntax type)
+        => type switch
+        {
+            ClassDeclarationSyntax { ParameterList: not null } => true,
+            StructDeclarationSyntax { ParameterList: not null } => true,
+            RecordDeclarationSyntax { ParameterList: not null } => true,
+            _ => false,
+        };
+
+    static string? BodyText(ConstructorDeclarationSyntax constructor)
+    {
+        if (constructor.Body is { } body)
+            return StatementsText(body);
+        if (constructor.ExpressionBody is { } expressionBody)
+            return $"{expressionBody.Expression};";
+        return null;
+    }
 
     static string? BodyText(MethodDeclarationSyntax method)
     {

--- a/tools/DecompilerHarness/CSharpSourceIdentity.cs
+++ b/tools/DecompilerHarness/CSharpSourceIdentity.cs
@@ -80,19 +80,45 @@ internal sealed class CSharpSourceIdentityContext
     static IEnumerable<CSharpSourceMemberIdentity> RecordSynthesizedMembers(RecordDeclarationSyntax record)
     {
         var evidence = new[] { "record-synthesized" };
-        yield return new CSharpSourceMemberIdentity("ToString", Body: null, evidence);
-        yield return new CSharpSourceMemberIdentity("GetHashCode", Body: null, evidence);
-        yield return new CSharpSourceMemberIdentity("Equals", Body: null, evidence);
-        yield return new CSharpSourceMemberIdentity("Equals", Body: null, evidence);
-        yield return new CSharpSourceMemberIdentity("op_Equality", Body: null, evidence);
-        yield return new CSharpSourceMemberIdentity("op_Inequality", Body: null, evidence);
+        var explicitMethods = record.Members
+            .OfType<MethodDeclarationSyntax>()
+            .Where(method => method.ExplicitInterfaceSpecifier is null)
+            .Select(method => method.Identifier.ValueText)
+            .ToHashSet(StringComparer.Ordinal);
+        var explicitOperators = record.Members
+            .OfType<OperatorDeclarationSyntax>()
+            .Select(OperatorMetadataName)
+            .ToHashSet(StringComparer.Ordinal);
+        var explicitProperties = record.Members
+            .OfType<PropertyDeclarationSyntax>()
+            .Where(property => property.ExplicitInterfaceSpecifier is null)
+            .Select(property => property.Identifier.ValueText)
+            .ToHashSet(StringComparer.Ordinal);
+
+        if (!explicitMethods.Contains("ToString"))
+            yield return new CSharpSourceMemberIdentity("ToString", Body: null, evidence);
+        if (!explicitMethods.Contains("GetHashCode"))
+            yield return new CSharpSourceMemberIdentity("GetHashCode", Body: null, evidence);
+        if (!explicitMethods.Contains("Equals"))
+        {
+            yield return new CSharpSourceMemberIdentity("Equals", Body: null, evidence);
+            yield return new CSharpSourceMemberIdentity("Equals", Body: null, evidence);
+        }
+        if (!explicitOperators.Contains("op_Equality"))
+            yield return new CSharpSourceMemberIdentity("op_Equality", Body: null, evidence);
+        if (!explicitOperators.Contains("op_Inequality"))
+            yield return new CSharpSourceMemberIdentity("op_Inequality", Body: null, evidence);
 
         if (record.ParameterList is not { Parameters.Count: > 0 } parameters)
             yield break;
 
-        yield return new CSharpSourceMemberIdentity("Deconstruct", Body: null, evidence);
+        if (!explicitMethods.Contains("Deconstruct"))
+            yield return new CSharpSourceMemberIdentity("Deconstruct", Body: null, evidence);
         foreach (var parameter in parameters.Parameters)
-            yield return new CSharpSourceMemberIdentity($"get_{parameter.Identifier.ValueText}", Body: null, evidence);
+        {
+            if (!explicitProperties.Contains(parameter.Identifier.ValueText))
+                yield return new CSharpSourceMemberIdentity($"get_{parameter.Identifier.ValueText}", Body: null, evidence);
+        }
     }
 
     public IReadOnlyList<CSharpSourceMemberIdentity> ConstructorMembers(ConstructorDeclarationSyntax constructor)

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1478,13 +1478,14 @@ static class ReturnToSender
                 new CompileBackFact("metadata", "typed-member-ref", $"{kind}: {TypeRefIdentityKey(definition.Namespace, definition.Name, separator: ".")}.{name}"));
         }
 
-        void AddMethodFact(MethodRef method)
+        void AddMethodFact(MethodRef method, bool allowTargetRootOverride = false)
         {
             AddMemberFact(method.DeclaringType, "method", method.Name);
             AddMemberRequirement(
                 method.DeclaringType,
                 root => CompileBackSourceComposer.TryCreateClosureMemberRequirement(reader, root, method),
-                allowTargetRoot: method.Name is not ".ctor" and not ".cctor"
+                allowTargetRoot: allowTargetRootOverride
+                    || method.Name is not ".ctor" and not ".cctor"
                     && !method.Name.StartsWith("get_", StringComparison.Ordinal)
                     && !method.Name.StartsWith("set_", StringComparison.Ordinal));
         }
@@ -1524,7 +1525,7 @@ static class ReturnToSender
                     AddMethodFact(call.Callee);
                     break;
                 case NewObject creation:
-                    AddMethodFact(creation.Constructor);
+                    AddMethodFact(creation.Constructor, allowTargetRootOverride: true);
                     break;
                 case LoadProperty load:
                     AddMethodFact(load.Accessor);

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -10,6 +10,7 @@ using ILInspector.Decompiler.Pipeline;
 using ILInspector.Instructions;
 using ILInspector.Metadata;
 using ILInspector.MetadataPrimitives;
+using ILInspector.Research;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -662,7 +663,7 @@ static class ReturnToSender
 
         for (int iteration = 0; iteration < maxIterations; iteration++)
         {
-            var sourceResult = CompileBackSourceComposer.ComposePropertyGetter(
+            var sourceResult = ResearchReturnToSenderShells.ComposePropertyGetter(
                 assemblyPath,
                 reader,
                 function,
@@ -748,7 +749,7 @@ static class ReturnToSender
         }
 
         {
-            var sourceResult = CompileBackSourceComposer.ComposePropertyGetter(
+            var sourceResult = ResearchReturnToSenderShells.ComposePropertyGetter(
                 assemblyPath,
                 reader,
                 function,
@@ -821,7 +822,7 @@ static class ReturnToSender
 
         for (int iteration = 0; iteration < maxIterations; iteration++)
         {
-            var sourceResult = CompileBackSourceComposer.ComposeMethod(
+            var sourceResult = ResearchReturnToSenderShells.ComposeMethod(
                 assemblyPath,
                 reader,
                 function,
@@ -906,7 +907,7 @@ static class ReturnToSender
         }
 
         {
-            var sourceResult = CompileBackSourceComposer.ComposeMethod(
+            var sourceResult = ResearchReturnToSenderShells.ComposeMethod(
                 assemblyPath,
                 reader,
                 function,
@@ -979,7 +980,7 @@ static class ReturnToSender
 
         for (int iteration = 0; iteration < maxIterations; iteration++)
         {
-            var sourceResult = CompileBackSourceComposer.ComposePropertySetter(
+            var sourceResult = ResearchReturnToSenderShells.ComposePropertySetter(
                 assemblyPath,
                 reader,
                 function,
@@ -1065,7 +1066,7 @@ static class ReturnToSender
         }
 
         {
-            var sourceResult = CompileBackSourceComposer.ComposePropertySetter(
+            var sourceResult = ResearchReturnToSenderShells.ComposePropertySetter(
                 assemblyPath,
                 reader,
                 function,
@@ -1490,7 +1491,7 @@ static class ReturnToSender
             AddMemberFact(method.DeclaringType, "method", method.Name);
             AddMemberRequirement(
                 method.DeclaringType,
-                root => CompileBackSourceComposer.TryCreateClosureMemberRequirement(reader, root, method),
+                root => ResearchReturnToSenderShells.TryCreateClosureMemberRequirement(reader, root, method),
                 allowTargetRoot: allowTargetRootOverride
                     || method.Name is not ".ctor" and not ".cctor"
                     && !method.Name.StartsWith("get_", StringComparison.Ordinal)
@@ -1502,7 +1503,7 @@ static class ReturnToSender
             AddMemberFact(field.DeclaringType, "field", field.Name);
             AddMemberRequirement(
                 field.DeclaringType,
-                root => CompileBackSourceComposer.TryCreateClosureMemberRequirement(reader, root, field),
+                root => ResearchReturnToSenderShells.TryCreateClosureMemberRequirement(reader, root, field),
                 allowTargetRoot: false);
         }
 

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1480,6 +1480,13 @@ static class ReturnToSender
 
         void AddMethodFact(MethodRef method, bool allowTargetRootOverride = false)
         {
+            AddSingleMethodFact(method, allowTargetRootOverride);
+            if (UncheckedOperatorName(method.Name) is { } siblingName)
+                AddSingleMethodFact(method with { Name = siblingName }, allowTargetRootOverride);
+        }
+
+        void AddSingleMethodFact(MethodRef method, bool allowTargetRootOverride)
+        {
             AddMemberFact(method.DeclaringType, "method", method.Name);
             AddMemberRequirement(
                 method.DeclaringType,
@@ -1545,6 +1552,16 @@ static class ReturnToSender
                 case DelegateCreation creation:
                     AddMethodFact(creation.Method);
                     break;
+                case IncrementDecrement { IsUserDefined: true, Target.ResultType: { } operatorType } increment:
+                    AddMethodFact(new MethodRef(
+                        operatorType,
+                        increment.IsChecked
+                            ? increment.IsIncrement ? "op_CheckedIncrement" : "op_CheckedDecrement"
+                            : increment.IsIncrement ? "op_Increment" : "op_Decrement",
+                        operatorType,
+                        [operatorType],
+                        HasThis: false));
+                    break;
                 case RecursivePropertyDeclarationPattern pattern:
                     AddMethodFact(pattern.Accessor);
                     break;
@@ -1583,6 +1600,19 @@ static class ReturnToSender
                     AddFieldFact(assignment.Field);
                     break;
             }
+        }
+
+        static string? UncheckedOperatorName(string methodName)
+        {
+            if (methodName is "op_CheckedExplicit")
+                return "op_Explicit";
+            if (methodName is "op_CheckedImplicit")
+                return "op_Implicit";
+            if (!methodName.StartsWith("op_Checked", StringComparison.Ordinal))
+                return null;
+
+            string inner = methodName["op_Checked".Length..];
+            return OperatorNames.MapBinaryOrUnary(inner) is null ? null : $"op_{inner}";
         }
     }
 

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1727,7 +1727,10 @@ static class ReturnToSender
                     }
                 }
                 if (diagnostic.Id is "CS0234" && names.Count == 2)
+                {
+                    grew |= AddRoots(indexes, indexes.FullTypes, $"{names[1]}.{names[0]}", diagnostic, $"{names[1]}.{names[0]}", targetNamespace, preferredRoot, addMemberSurfaceFact: false, closureRoots, closureFacts);
                     grew |= AddRoots(indexes, indexes.Namespaces, $"{names[1]}.{names[0]}", diagnostic, $"{names[1]}.{names[0]}", targetNamespace, preferredRoot, addMemberSurfaceFact: false, closureRoots, closureFacts);
+                }
             }
             else if (diagnostic.Id is "CS1061")
             {

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -226,12 +226,17 @@ static class ReturnToSenderSourceProbe
 
             if (sourceMember.Body is not { } expected)
             {
+                var outcome = result.Status == FidelityCheck.CompileBackStatus.Exact
+                    ? ReturnToSenderSourceOutcome.ValidMatch
+                    : ReturnToSenderSourceOutcome.ValidDifferent;
                 results.Add(new ReturnToSenderSourceProbeResult(
                     target,
-                    ReturnToSenderSourceOutcome.UnsupportedTarget,
+                    outcome,
                     result.Status,
-                    "source-body-unavailable",
-                    $"source member matched {target.Type}::{target.Method}#{target.Overload}, but it has no comparable source body",
+                    outcome == ReturnToSenderSourceOutcome.ValidMatch
+                        ? "valid_match.source_bodyless"
+                        : "valid_different.source_bodyless",
+                    $"source member matched {target.Type}::{target.Method}#{target.Overload}, but it has no explicit source body; compile-back status is {result.Status}",
                     sourceMember.SourcePath,
                     ExpectedBody: null,
                     ActualBody: result.TargetBody));

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -224,7 +224,20 @@ static class ReturnToSenderSourceProbe
                 continue;
             }
 
-            string expected = sourceMember.Body;
+            if (sourceMember.Body is not { } expected)
+            {
+                results.Add(new ReturnToSenderSourceProbeResult(
+                    target,
+                    ReturnToSenderSourceOutcome.UnsupportedTarget,
+                    result.Status,
+                    "source-body-unavailable",
+                    $"source member matched {target.Type}::{target.Method}#{target.Overload}, but it has no comparable source body",
+                    sourceMember.SourcePath,
+                    ExpectedBody: null,
+                    ActualBody: result.TargetBody));
+                continue;
+            }
+
             string actual = result.TargetBody;
             if (NormalizeBody(expected) == NormalizeBody(actual))
             {
@@ -258,7 +271,7 @@ static class ReturnToSenderSourceProbe
         return results;
     }
 
-    sealed record SourceMember(string Type, string Method, int Overload, string SourcePath, string Body);
+    sealed record SourceMember(string Type, string Method, int Overload, string SourcePath, string? Body);
 
     sealed class FixtureSourceIndex
     {
@@ -433,8 +446,7 @@ static class ReturnToSenderSourceProbe
                 foreach (var sourceMember in sourceIdentity.TypeMembers(type, fullType))
                 {
                     int overload = NextOverload(overloads, sourceMember.MetadataName);
-                    if (sourceMember.Body is { } body)
-                        yield return new SourceMember(fullType, sourceMember.MetadataName, overload, path, body);
+                    yield return new SourceMember(fullType, sourceMember.MetadataName, overload, path, sourceMember.Body);
                 }
             }
 

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -461,21 +461,11 @@ static class ReturnToSenderSourceProbe
                             break;
                         case PropertyDeclarationSyntax property:
                         {
-                            if (IsBodylessPartial(property))
-                                break;
-                            if (HasGetter(property))
+                            foreach (var propertyMember in sourceIdentity.PropertyMembers(property))
                             {
-                                string methodName = $"get_{property.Identifier.ValueText}";
+                                string methodName = propertyMember.MetadataName;
                                 int overload = NextOverload(overloads, methodName);
-                                if (GetterBodyText(property) is { } body)
-                                    yield return new SourceMember(fullType, methodName, overload, path, body);
-                            }
-
-                            if (HasSetter(property))
-                            {
-                                string methodName = $"set_{property.Identifier.ValueText}";
-                                int overload = NextOverload(overloads, methodName);
-                                if (SetterBodyText(property) is { } body)
+                                if (propertyMember.Body is { } body)
                                     yield return new SourceMember(fullType, methodName, overload, path, body);
                             }
 
@@ -681,11 +671,6 @@ static class ReturnToSenderSourceProbe
             && method.Body is null
             && method.ExpressionBody is null;
 
-    static bool IsBodylessPartial(PropertyDeclarationSyntax property)
-        => property.Modifiers.Any(SyntaxKind.PartialKeyword)
-            && property.ExpressionBody is null
-            && property.AccessorList?.Accessors.All(accessor => accessor.Body is null && accessor.ExpressionBody is null) == true;
-
     static string? BodyText(ConstructorDeclarationSyntax constructor)
     {
         if (constructor.Body is { } body)
@@ -712,37 +697,6 @@ static class ReturnToSenderSourceProbe
             return ExpressionBodyText(conversion.Type, expressionBody.Expression);
         return null;
     }
-
-    static string? GetterBodyText(PropertyDeclarationSyntax property)
-    {
-        if (property.ExpressionBody is { } expressionBody)
-            return $"return {expressionBody.Expression};";
-        var getter = property.AccessorList?.Accessors.FirstOrDefault(accessor => accessor.IsKind(SyntaxKind.GetAccessorDeclaration));
-        if (getter?.Body is { } body)
-            return StatementsText(body);
-        if (getter?.ExpressionBody is { } getterExpression)
-            return $"return {getterExpression.Expression};";
-        return null;
-    }
-
-    static string? SetterBodyText(PropertyDeclarationSyntax property)
-    {
-        var setter = property.AccessorList?.Accessors.FirstOrDefault(accessor =>
-            accessor.IsKind(SyntaxKind.SetAccessorDeclaration) || accessor.IsKind(SyntaxKind.InitAccessorDeclaration));
-        if (setter?.Body is { } body)
-            return StatementsText(body);
-        if (setter?.ExpressionBody is { } setterExpression)
-            return $"{setterExpression.Expression};";
-        return null;
-    }
-
-    static bool HasGetter(PropertyDeclarationSyntax property)
-        => property.ExpressionBody is not null
-            || property.AccessorList?.Accessors.Any(accessor => accessor.IsKind(SyntaxKind.GetAccessorDeclaration)) == true;
-
-    static bool HasSetter(PropertyDeclarationSyntax property)
-        => property.AccessorList?.Accessors.Any(accessor =>
-            accessor.IsKind(SyntaxKind.SetAccessorDeclaration) || accessor.IsKind(SyntaxKind.InitAccessorDeclaration)) == true;
 
     static string ExpressionBodyText(TypeSyntax returnType, ExpressionSyntax expression)
         => returnType is PredefinedTypeSyntax predefined

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -437,8 +437,6 @@ static class ReturnToSenderSourceProbe
                 {
                     switch (member)
                     {
-                        case MethodDeclarationSyntax { ExplicitInterfaceSpecifier: not null }:
-                            break;
                         case MethodDeclarationSyntax method:
                         {
                             foreach (var methodMember in sourceIdentity.MethodMembers(method))
@@ -463,8 +461,6 @@ static class ReturnToSenderSourceProbe
 
                             break;
                         }
-                        case PropertyDeclarationSyntax { ExplicitInterfaceSpecifier: not null }:
-                            break;
                         case PropertyDeclarationSyntax property:
                         {
                             foreach (var propertyMember in sourceIdentity.PropertyMembers(property))
@@ -477,8 +473,6 @@ static class ReturnToSenderSourceProbe
 
                             break;
                         }
-                        case IndexerDeclarationSyntax { ExplicitInterfaceSpecifier: not null }:
-                            break;
                         case IndexerDeclarationSyntax indexer:
                         {
                             foreach (var indexerMember in sourceIdentity.IndexerMembers(indexer, fullType))

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -493,20 +493,26 @@ static class ReturnToSenderSourceProbe
                         }
                         case OperatorDeclarationSyntax op:
                         {
-                            string methodName = OperatorMetadataName(op);
-                            int overload = NextOverload(overloads, methodName);
-                            if (BodyText(op) is { } body)
-                                yield return new SourceMember(fullType, methodName, overload, path, body);
+                            foreach (var operatorMember in sourceIdentity.OperatorMembers(op))
+                            {
+                                string methodName = operatorMember.MetadataName;
+                                int overload = NextOverload(overloads, methodName);
+                                if (operatorMember.Body is { } body)
+                                    yield return new SourceMember(fullType, methodName, overload, path, body);
+                            }
+
                             break;
                         }
                         case ConversionOperatorDeclarationSyntax conversion:
                         {
-                            string methodName = conversion.ImplicitOrExplicitKeyword.IsKind(SyntaxKind.ImplicitKeyword)
-                                ? "op_Implicit"
-                                : "op_Explicit";
-                            int overload = NextOverload(overloads, methodName);
-                            if (BodyText(conversion) is { } body)
-                                yield return new SourceMember(fullType, methodName, overload, path, body);
+                            foreach (var conversionMember in sourceIdentity.ConversionOperatorMembers(conversion))
+                            {
+                                string methodName = conversionMember.MetadataName;
+                                int overload = NextOverload(overloads, methodName);
+                                if (conversionMember.Body is { } body)
+                                    yield return new SourceMember(fullType, methodName, overload, path, body);
+                            }
+
                             break;
                         }
                     }
@@ -653,24 +659,6 @@ static class ReturnToSenderSourceProbe
             ReturnToSenderSourceOutcome.UnsupportedTarget => "unsupported_target",
             _ => outcome.ToString(),
         };
-
-    static string? BodyText(OperatorDeclarationSyntax op)
-    {
-        if (op.Body is { } body)
-            return StatementsText(body);
-        if (op.ExpressionBody is { } expressionBody)
-            return ExpressionBodyText(op.ReturnType, expressionBody.Expression);
-        return null;
-    }
-
-    static string? BodyText(ConversionOperatorDeclarationSyntax conversion)
-    {
-        if (conversion.Body is { } body)
-            return StatementsText(body);
-        if (conversion.ExpressionBody is { } expressionBody)
-            return ExpressionBodyText(conversion.Type, expressionBody.Expression);
-        return null;
-    }
 
     static string ExpressionBodyText(TypeSyntax returnType, ExpressionSyntax expression)
         => returnType is PredefinedTypeSyntax predefined
@@ -819,34 +807,7 @@ static class ReturnToSenderSourceProbe
             };
     }
 
-    static string OperatorMetadataName(OperatorDeclarationSyntax op)
-        => op.OperatorToken.Kind() switch
-        {
-            SyntaxKind.PlusToken => op.ParameterList.Parameters.Count == 1 ? "op_UnaryPlus" : "op_Addition",
-            SyntaxKind.MinusToken => op.ParameterList.Parameters.Count == 1 ? "op_UnaryNegation" : "op_Subtraction",
-            SyntaxKind.ExclamationToken => "op_LogicalNot",
-            SyntaxKind.TildeToken => "op_OnesComplement",
-            SyntaxKind.PlusPlusToken => "op_Increment",
-            SyntaxKind.MinusMinusToken => "op_Decrement",
-            SyntaxKind.TrueKeyword => "op_True",
-            SyntaxKind.FalseKeyword => "op_False",
-            SyntaxKind.AsteriskToken => "op_Multiply",
-            SyntaxKind.SlashToken => "op_Division",
-            SyntaxKind.PercentToken => "op_Modulus",
-            SyntaxKind.AmpersandToken => "op_BitwiseAnd",
-            SyntaxKind.BarToken => "op_BitwiseOr",
-            SyntaxKind.CaretToken => "op_ExclusiveOr",
-            SyntaxKind.LessThanLessThanToken => "op_LeftShift",
-            SyntaxKind.GreaterThanGreaterThanToken => "op_RightShift",
-            SyntaxKind.GreaterThanGreaterThanGreaterThanToken => "op_UnsignedRightShift",
-            SyntaxKind.EqualsEqualsToken => "op_Equality",
-            SyntaxKind.ExclamationEqualsToken => "op_Inequality",
-            SyntaxKind.LessThanToken => "op_LessThan",
-            SyntaxKind.GreaterThanToken => "op_GreaterThan",
-            SyntaxKind.LessThanEqualsToken => "op_LessThanOrEqual",
-            SyntaxKind.GreaterThanEqualsToken => "op_GreaterThanOrEqual",
-            _ => op.OperatorToken.ValueText,
-        };
+
 
     static string DiagnosticCode(string? detail)
     {

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -430,8 +430,8 @@ static class ReturnToSenderSourceProbe
                 if (!overloadsByType.TryGetValue(fullType, out var overloads))
                     overloadsByType[fullType] = overloads = new Dictionary<string, int>(StringComparer.Ordinal);
 
-                if (HasPrimaryConstructor(type))
-                    NextOverload(overloads, ".ctor");
+                foreach (var typeHeaderMember in sourceIdentity.TypeHeaderMembers(type))
+                    NextOverload(overloads, typeHeaderMember.MetadataName);
 
                 foreach (var member in type.Members)
                 {
@@ -453,10 +453,14 @@ static class ReturnToSenderSourceProbe
                         }
                         case ConstructorDeclarationSyntax constructor:
                         {
-                            string methodName = constructor.Modifiers.Any(SyntaxKind.StaticKeyword) ? ".cctor" : ".ctor";
-                            int overload = NextOverload(overloads, methodName);
-                            if (BodyText(constructor) is { } body)
-                                yield return new SourceMember(fullType, methodName, overload, path, body);
+                            foreach (var constructorMember in sourceIdentity.ConstructorMembers(constructor))
+                            {
+                                string methodName = constructorMember.MetadataName;
+                                int overload = NextOverload(overloads, methodName);
+                                if (constructorMember.Body is { } body)
+                                    yield return new SourceMember(fullType, methodName, overload, path, body);
+                            }
+
                             break;
                         }
                         case PropertyDeclarationSyntax { ExplicitInterfaceSpecifier: not null }:
@@ -649,24 +653,6 @@ static class ReturnToSenderSourceProbe
             ReturnToSenderSourceOutcome.UnsupportedTarget => "unsupported_target",
             _ => outcome.ToString(),
         };
-
-    static bool HasPrimaryConstructor(TypeDeclarationSyntax type)
-        => type switch
-        {
-            ClassDeclarationSyntax { ParameterList: not null } => true,
-            StructDeclarationSyntax { ParameterList: not null } => true,
-            RecordDeclarationSyntax { ParameterList: not null } => true,
-            _ => false,
-        };
-
-    static string? BodyText(ConstructorDeclarationSyntax constructor)
-    {
-        if (constructor.Body is { } body)
-            return StatementsText(body);
-        if (constructor.ExpressionBody is { } expressionBody)
-            return $"{expressionBody.Expression};";
-        return null;
-    }
 
     static string? BodyText(OperatorDeclarationSyntax op)
     {

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -441,12 +441,14 @@ static class ReturnToSenderSourceProbe
                             break;
                         case MethodDeclarationSyntax method:
                         {
-                            if (IsBodylessPartial(method))
-                                break;
-                            string methodName = method.Identifier.ValueText;
-                            int overload = NextOverload(overloads, methodName);
-                            if (BodyText(method) is { } body)
-                                yield return new SourceMember(fullType, methodName, overload, path, body);
+                            foreach (var methodMember in sourceIdentity.MethodMembers(method))
+                            {
+                                string methodName = methodMember.MetadataName;
+                                int overload = NextOverload(overloads, methodName);
+                                if (methodMember.Body is { } body)
+                                    yield return new SourceMember(fullType, methodName, overload, path, body);
+                            }
+
                             break;
                         }
                         case ConstructorDeclarationSyntax constructor:
@@ -648,15 +650,6 @@ static class ReturnToSenderSourceProbe
             _ => outcome.ToString(),
         };
 
-    static string? BodyText(MethodDeclarationSyntax method)
-    {
-        if (method.Body is { } body)
-            return StatementsText(body);
-        if (method.ExpressionBody is { } expressionBody)
-            return ExpressionBodyText(method.ReturnType, expressionBody.Expression);
-        return null;
-    }
-
     static bool HasPrimaryConstructor(TypeDeclarationSyntax type)
         => type switch
         {
@@ -665,11 +658,6 @@ static class ReturnToSenderSourceProbe
             RecordDeclarationSyntax { ParameterList: not null } => true,
             _ => false,
         };
-
-    static bool IsBodylessPartial(MethodDeclarationSyntax method)
-        => method.Modifiers.Any(SyntaxKind.PartialKeyword)
-            && method.Body is null
-            && method.ExpressionBody is null;
 
     static string? BodyText(ConstructorDeclarationSyntax constructor)
     {

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -40,7 +40,7 @@ sealed record ReturnToSenderSourceProbeResult(
 
 static class ReturnToSenderSourceProbe
 {
-    sealed record ProbeTarget(ReturnToSender.RequestedTarget Target, IReadOnlyList<string> ExpectedFragments);
+    internal sealed record ProbeTarget(ReturnToSender.RequestedTarget Target, IReadOnlyList<string> ExpectedFragments);
 
     public static int Run(IReadOnlyList<string> assemblies, int cap, int maxExamples)
     {
@@ -520,7 +520,7 @@ static class ReturnToSenderSourceProbe
         return members;
     }
 
-    static IReadOnlyList<ProbeTarget> DiscoverTargets(string assemblyPath, int cap)
+    internal static IReadOnlyList<ProbeTarget> DiscoverTargets(string assemblyPath, int cap)
     {
         var targets = new List<ProbeTarget>();
         using var pe = new PEReader(File.OpenRead(assemblyPath));
@@ -552,7 +552,6 @@ static class ReturnToSenderSourceProbe
                 .Select(attribute => $"[{attribute}]")
                 .ToArray();
 
-            var methodOverloads = new Dictionary<string, int>(StringComparer.Ordinal);
             foreach (var methodHandle in type.GetMethods())
             {
                 if (targets.Count >= cap)
@@ -573,8 +572,7 @@ static class ReturnToSenderSourceProbe
                     continue;
                 }
 
-                var overload = methodOverloads.GetValueOrDefault(methodName);
-                methodOverloads[methodName] = overload + 1;
+                var overload = OverloadIndex(reader, type, methodHandle, methodName);
                 var fragments = new List<string>();
                 fragments.AddRange(typeFragments);
                 fragments.AddRange(AttributeReader.RenderAttributes(reader, method.GetCustomAttributes(), qualifyNames: true)

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -212,6 +212,13 @@ static class ReturnToSenderSourceProbe
 
             if (!sourceFound || sourceMember is null)
             {
+                if (sourceIndex is not null
+                    && sourceIndex.TryFindRecordSynthesizedMember(target, out var recordSourcePath))
+                {
+                    AddBodylessSourceResult(results, target, result, recordSourcePath);
+                    continue;
+                }
+
                 results.Add(new ReturnToSenderSourceProbeResult(
                     target,
                     ReturnToSenderSourceOutcome.SourceUnavailable,
@@ -226,20 +233,7 @@ static class ReturnToSenderSourceProbe
 
             if (sourceMember.Body is not { } expected)
             {
-                var outcome = result.Status == FidelityCheck.CompileBackStatus.Exact
-                    ? ReturnToSenderSourceOutcome.ValidMatch
-                    : ReturnToSenderSourceOutcome.ValidDifferent;
-                results.Add(new ReturnToSenderSourceProbeResult(
-                    target,
-                    outcome,
-                    result.Status,
-                    outcome == ReturnToSenderSourceOutcome.ValidMatch
-                        ? "valid_match.source_bodyless"
-                        : "valid_different.source_bodyless",
-                    $"source member matched {target.Type}::{target.Method}#{target.Overload}, but it has no explicit source body; compile-back status is {result.Status}",
-                    sourceMember.SourcePath,
-                    ExpectedBody: null,
-                    ActualBody: result.TargetBody));
+                AddBodylessSourceResult(results, target, result, sourceMember.SourcePath);
                 continue;
             }
 
@@ -276,20 +270,45 @@ static class ReturnToSenderSourceProbe
         return results;
     }
 
+    static void AddBodylessSourceResult(
+        List<ReturnToSenderSourceProbeResult> results,
+        ReturnToSender.RequestedTarget target,
+        ReturnToSender.Result result,
+        string sourcePath)
+    {
+        var outcome = result.Status == FidelityCheck.CompileBackStatus.Exact
+            ? ReturnToSenderSourceOutcome.ValidMatch
+            : ReturnToSenderSourceOutcome.ValidDifferent;
+        results.Add(new ReturnToSenderSourceProbeResult(
+            target,
+            outcome,
+            result.Status,
+            outcome == ReturnToSenderSourceOutcome.ValidMatch
+                ? "valid_match.source_bodyless"
+                : "valid_different.source_bodyless",
+            $"source member matched {target.Type}::{target.Method}#{target.Overload}, but it has no explicit source body; compile-back status is {result.Status}",
+            sourcePath,
+            ExpectedBody: null,
+            ActualBody: result.TargetBody));
+    }
+
     sealed record SourceMember(string Type, string Method, int Overload, string SourcePath, string? Body);
 
     sealed class FixtureSourceIndex
     {
         readonly Dictionary<string, SourceMember> _members;
+        readonly Dictionary<string, string> _recordSourcePaths;
 
-        FixtureSourceIndex(Dictionary<string, SourceMember> members)
+        FixtureSourceIndex(Dictionary<string, SourceMember> members, Dictionary<string, string> recordSourcePaths)
         {
             _members = members;
+            _recordSourcePaths = recordSourcePaths;
         }
 
         public static FixtureSourceIndex? TryCreate(IReadOnlyList<string> sourcePaths)
         {
             var members = new Dictionary<string, SourceMember>(StringComparer.Ordinal);
+            var recordSourcePaths = new Dictionary<string, string>(StringComparer.Ordinal);
             var overloads = new Dictionary<string, Dictionary<string, int>>(StringComparer.Ordinal);
             var sourceFiles = new List<(string Path, CompilationUnitSyntax Root)>();
             foreach (var sourcePath in sourcePaths)
@@ -301,9 +320,9 @@ static class ReturnToSenderSourceProbe
 
             var sourceIdentity = CSharpSourceIdentityContext.Create(sourceFiles.Select(file => file.Root));
             foreach (var sourceFile in sourceFiles)
-                AddSourceFile(members, overloads, sourceFile.Path, sourceFile.Root, sourceIdentity);
+                AddSourceFile(members, recordSourcePaths, overloads, sourceFile.Path, sourceFile.Root, sourceIdentity);
 
-            return new FixtureSourceIndex(members);
+            return new FixtureSourceIndex(members, recordSourcePaths);
         }
 
         public static FixtureSourceIndex? TryCreate(string assemblyPath)
@@ -361,6 +380,18 @@ static class ReturnToSenderSourceProbe
         public bool TryFind(ReturnToSender.RequestedTarget target, out SourceMember member)
             => _members.TryGetValue(Key(target.Type, target.Method, target.Overload), out member!);
 
+        public bool TryFindRecordSynthesizedMember(ReturnToSender.RequestedTarget target, out string sourcePath)
+        {
+            if (IsRecordSynthesizedMember(target.Method)
+                && _recordSourcePaths.TryGetValue(target.Type, out sourcePath!))
+            {
+                return true;
+            }
+
+            sourcePath = "";
+            return false;
+        }
+
         static bool TryReadSourceFile(string sourcePath, out CompilationUnitSyntax root)
         {
             string source;
@@ -381,22 +412,24 @@ static class ReturnToSenderSourceProbe
 
         static void AddSourceFile(
             Dictionary<string, SourceMember> members,
+            Dictionary<string, string> recordSourcePaths,
             Dictionary<string, Dictionary<string, int>> overloads,
             string sourcePath,
             CompilationUnitSyntax root,
             CSharpSourceIdentityContext sourceIdentity)
         {
-            foreach (var member in SourceMembers(root, sourcePath, overloads, sourceIdentity))
+            foreach (var member in SourceMembers(root, sourcePath, recordSourcePaths, overloads, sourceIdentity))
                 members.TryAdd(Key(member.Type, member.Method, member.Overload), member);
         }
 
         static IEnumerable<SourceMember> SourceMembers(
             CompilationUnitSyntax root,
             string sourcePath,
+            Dictionary<string, string> recordSourcePaths,
             Dictionary<string, Dictionary<string, int>> overloads,
             CSharpSourceIdentityContext sourceIdentity)
         {
-            foreach (var member in SourceMembers(root.Members, namespaceName: "", containingTypes: [], sourcePath, overloads, sourceIdentity))
+            foreach (var member in SourceMembers(root.Members, namespaceName: "", containingTypes: [], sourcePath, recordSourcePaths, overloads, sourceIdentity))
                 yield return member;
         }
 
@@ -405,6 +438,7 @@ static class ReturnToSenderSourceProbe
             string namespaceName,
             IReadOnlyList<string> containingTypes,
             string sourcePath,
+            Dictionary<string, string> recordSourcePaths,
             Dictionary<string, Dictionary<string, int>> overloads,
             CSharpSourceIdentityContext sourceIdentity)
         {
@@ -417,7 +451,7 @@ static class ReturnToSenderSourceProbe
                         string nextNamespace = namespaceName.Length == 0
                             ? ns.Name.ToString()
                             : $"{namespaceName}.{ns.Name}";
-                        foreach (var member in SourceMembers(ns.Members, nextNamespace, containingTypes, sourcePath, overloads, sourceIdentity))
+                        foreach (var member in SourceMembers(ns.Members, nextNamespace, containingTypes, sourcePath, recordSourcePaths, overloads, sourceIdentity))
                             yield return member;
                         break;
                     }
@@ -428,10 +462,12 @@ static class ReturnToSenderSourceProbe
                         string fullType = namespaceName.Length == 0
                             ? string.Join(".", typeStack)
                             : $"{namespaceName}.{string.Join(".", typeStack)}";
+                        if (type is RecordDeclarationSyntax)
+                            recordSourcePaths.TryAdd(fullType, sourcePath);
 
                         foreach (var member in TypeMembers(type, fullType, sourcePath, overloads, sourceIdentity))
                             yield return member;
-                        foreach (var member in SourceMembers(type.Members, namespaceName, typeStack, sourcePath, overloads, sourceIdentity))
+                        foreach (var member in SourceMembers(type.Members, namespaceName, typeStack, sourcePath, recordSourcePaths, overloads, sourceIdentity))
                             yield return member;
                         break;
                     }
@@ -464,6 +500,10 @@ static class ReturnToSenderSourceProbe
         }
 
     }
+
+    static bool IsRecordSynthesizedMember(string method)
+        => method is "ToString" or "GetHashCode" or "Equals" or "op_Equality" or "op_Inequality" or "Deconstruct"
+            || method.StartsWith("get_", StringComparison.Ordinal);
 
     static IReadOnlyList<ProbeTarget> DiscoverTargets(string assemblyPath, int cap)
     {

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -405,7 +405,7 @@ static class ReturnToSenderSourceProbe
                     }
                     case TypeDeclarationSyntax type:
                     {
-                        string typeName = type.Identifier.ValueText;
+                        string typeName = CSharpSourceIdentityContext.TypeMetadataName(type);
                         var typeStack = containingTypes.Concat([typeName]).ToArray();
                         string fullType = namespaceName.Length == 0
                             ? string.Join(".", typeStack)

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -297,18 +297,18 @@ static class ReturnToSenderSourceProbe
     sealed class FixtureSourceIndex
     {
         readonly Dictionary<string, SourceMember> _members;
-        readonly Dictionary<string, string> _recordSourcePaths;
+        readonly Dictionary<string, RecordSourceInfo> _recordSources;
 
-        FixtureSourceIndex(Dictionary<string, SourceMember> members, Dictionary<string, string> recordSourcePaths)
+        FixtureSourceIndex(Dictionary<string, SourceMember> members, Dictionary<string, RecordSourceInfo> recordSources)
         {
             _members = members;
-            _recordSourcePaths = recordSourcePaths;
+            _recordSources = recordSources;
         }
 
         public static FixtureSourceIndex? TryCreate(IReadOnlyList<string> sourcePaths)
         {
             var members = new Dictionary<string, SourceMember>(StringComparer.Ordinal);
-            var recordSourcePaths = new Dictionary<string, string>(StringComparer.Ordinal);
+            var recordSources = new Dictionary<string, RecordSourceInfo>(StringComparer.Ordinal);
             var overloads = new Dictionary<string, Dictionary<string, int>>(StringComparer.Ordinal);
             var sourceFiles = new List<(string Path, CompilationUnitSyntax Root)>();
             foreach (var sourcePath in sourcePaths)
@@ -320,9 +320,9 @@ static class ReturnToSenderSourceProbe
 
             var sourceIdentity = CSharpSourceIdentityContext.Create(sourceFiles.Select(file => file.Root));
             foreach (var sourceFile in sourceFiles)
-                AddSourceFile(members, recordSourcePaths, overloads, sourceFile.Path, sourceFile.Root, sourceIdentity);
+                AddSourceFile(members, recordSources, overloads, sourceFile.Path, sourceFile.Root, sourceIdentity);
 
-            return new FixtureSourceIndex(members, recordSourcePaths);
+            return new FixtureSourceIndex(members, recordSources);
         }
 
         public static FixtureSourceIndex? TryCreate(string assemblyPath)
@@ -382,9 +382,10 @@ static class ReturnToSenderSourceProbe
 
         public bool TryFindRecordSynthesizedMember(ReturnToSender.RequestedTarget target, out string sourcePath)
         {
-            if (IsRecordSynthesizedMember(target.Method)
-                && _recordSourcePaths.TryGetValue(target.Type, out sourcePath!))
+            if (_recordSources.TryGetValue(target.Type, out var source)
+                && source.SynthesizedMembers.Contains(target.Method))
             {
+                sourcePath = source.SourcePath;
                 return true;
             }
 
@@ -412,24 +413,24 @@ static class ReturnToSenderSourceProbe
 
         static void AddSourceFile(
             Dictionary<string, SourceMember> members,
-            Dictionary<string, string> recordSourcePaths,
+            Dictionary<string, RecordSourceInfo> recordSources,
             Dictionary<string, Dictionary<string, int>> overloads,
             string sourcePath,
             CompilationUnitSyntax root,
             CSharpSourceIdentityContext sourceIdentity)
         {
-            foreach (var member in SourceMembers(root, sourcePath, recordSourcePaths, overloads, sourceIdentity))
+            foreach (var member in SourceMembers(root, sourcePath, recordSources, overloads, sourceIdentity))
                 members.TryAdd(Key(member.Type, member.Method, member.Overload), member);
         }
 
         static IEnumerable<SourceMember> SourceMembers(
             CompilationUnitSyntax root,
             string sourcePath,
-            Dictionary<string, string> recordSourcePaths,
+            Dictionary<string, RecordSourceInfo> recordSources,
             Dictionary<string, Dictionary<string, int>> overloads,
             CSharpSourceIdentityContext sourceIdentity)
         {
-            foreach (var member in SourceMembers(root.Members, namespaceName: "", containingTypes: [], sourcePath, recordSourcePaths, overloads, sourceIdentity))
+            foreach (var member in SourceMembers(root.Members, namespaceName: "", containingTypes: [], sourcePath, recordSources, overloads, sourceIdentity))
                 yield return member;
         }
 
@@ -438,7 +439,7 @@ static class ReturnToSenderSourceProbe
             string namespaceName,
             IReadOnlyList<string> containingTypes,
             string sourcePath,
-            Dictionary<string, string> recordSourcePaths,
+            Dictionary<string, RecordSourceInfo> recordSources,
             Dictionary<string, Dictionary<string, int>> overloads,
             CSharpSourceIdentityContext sourceIdentity)
         {
@@ -451,7 +452,7 @@ static class ReturnToSenderSourceProbe
                         string nextNamespace = namespaceName.Length == 0
                             ? ns.Name.ToString()
                             : $"{namespaceName}.{ns.Name}";
-                        foreach (var member in SourceMembers(ns.Members, nextNamespace, containingTypes, sourcePath, recordSourcePaths, overloads, sourceIdentity))
+                        foreach (var member in SourceMembers(ns.Members, nextNamespace, containingTypes, sourcePath, recordSources, overloads, sourceIdentity))
                             yield return member;
                         break;
                     }
@@ -462,12 +463,12 @@ static class ReturnToSenderSourceProbe
                         string fullType = namespaceName.Length == 0
                             ? string.Join(".", typeStack)
                             : $"{namespaceName}.{string.Join(".", typeStack)}";
-                        if (type is RecordDeclarationSyntax)
-                            recordSourcePaths.TryAdd(fullType, sourcePath);
+                        if (type is RecordDeclarationSyntax record)
+                            recordSources.TryAdd(fullType, new RecordSourceInfo(sourcePath, RecordSynthesizedMembers(record)));
 
                         foreach (var member in TypeMembers(type, fullType, sourcePath, overloads, sourceIdentity))
                             yield return member;
-                        foreach (var member in SourceMembers(type.Members, namespaceName, typeStack, sourcePath, recordSourcePaths, overloads, sourceIdentity))
+                        foreach (var member in SourceMembers(type.Members, namespaceName, typeStack, sourcePath, recordSources, overloads, sourceIdentity))
                             yield return member;
                         break;
                     }
@@ -501,9 +502,27 @@ static class ReturnToSenderSourceProbe
 
     }
 
-    static bool IsRecordSynthesizedMember(string method)
-        => method is "ToString" or "GetHashCode" or "Equals" or "op_Equality" or "op_Inequality" or "Deconstruct"
-            || method.StartsWith("get_", StringComparison.Ordinal);
+    sealed record RecordSourceInfo(string SourcePath, IReadOnlySet<string> SynthesizedMembers);
+
+    static IReadOnlySet<string> RecordSynthesizedMembers(RecordDeclarationSyntax record)
+    {
+        var members = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "ToString",
+            "GetHashCode",
+            "Equals",
+            "op_Equality",
+            "op_Inequality",
+        };
+        if (record.ParameterList is { Parameters.Count: > 0 } parameters)
+        {
+            members.Add("Deconstruct");
+            foreach (var parameter in parameters.Parameters)
+                members.Add($"get_{parameter.Identifier.ValueText}");
+        }
+
+        return members;
+    }
 
     static IReadOnlyList<ProbeTarget> DiscoverTargets(string assemblyPath, int cap)
     {
@@ -545,8 +564,6 @@ static class ReturnToSenderSourceProbe
 
                 var method = reader.GetMethodDefinition(methodHandle);
                 var methodName = reader.GetString(method.Name);
-                var overload = methodOverloads.GetValueOrDefault(methodName);
-                methodOverloads[methodName] = overload + 1;
 
                 if (method.RelativeVirtualAddress == 0
                     || (method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public
@@ -560,6 +577,8 @@ static class ReturnToSenderSourceProbe
                     continue;
                 }
 
+                var overload = methodOverloads.GetValueOrDefault(methodName);
+                methodOverloads[methodName] = overload + 1;
                 var fragments = new List<string>();
                 fragments.AddRange(typeFragments);
                 fragments.AddRange(AttributeReader.RenderAttributes(reader, method.GetCustomAttributes(), qualifyNames: true)

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -430,86 +430,11 @@ static class ReturnToSenderSourceProbe
                 if (!overloadsByType.TryGetValue(fullType, out var overloads))
                     overloadsByType[fullType] = overloads = new Dictionary<string, int>(StringComparer.Ordinal);
 
-                foreach (var typeHeaderMember in sourceIdentity.TypeHeaderMembers(type))
-                    NextOverload(overloads, typeHeaderMember.MetadataName);
-
-                foreach (var member in type.Members)
+                foreach (var sourceMember in sourceIdentity.TypeMembers(type, fullType))
                 {
-                    switch (member)
-                    {
-                        case MethodDeclarationSyntax method:
-                        {
-                            foreach (var methodMember in sourceIdentity.MethodMembers(method))
-                            {
-                                string methodName = methodMember.MetadataName;
-                                int overload = NextOverload(overloads, methodName);
-                                if (methodMember.Body is { } body)
-                                    yield return new SourceMember(fullType, methodName, overload, path, body);
-                            }
-
-                            break;
-                        }
-                        case ConstructorDeclarationSyntax constructor:
-                        {
-                            foreach (var constructorMember in sourceIdentity.ConstructorMembers(constructor))
-                            {
-                                string methodName = constructorMember.MetadataName;
-                                int overload = NextOverload(overloads, methodName);
-                                if (constructorMember.Body is { } body)
-                                    yield return new SourceMember(fullType, methodName, overload, path, body);
-                            }
-
-                            break;
-                        }
-                        case PropertyDeclarationSyntax property:
-                        {
-                            foreach (var propertyMember in sourceIdentity.PropertyMembers(property))
-                            {
-                                string methodName = propertyMember.MetadataName;
-                                int overload = NextOverload(overloads, methodName);
-                                if (propertyMember.Body is { } body)
-                                    yield return new SourceMember(fullType, methodName, overload, path, body);
-                            }
-
-                            break;
-                        }
-                        case IndexerDeclarationSyntax indexer:
-                        {
-                            foreach (var indexerMember in sourceIdentity.IndexerMembers(indexer, fullType))
-                            {
-                                string methodName = indexerMember.MetadataName;
-                                int overload = NextOverload(overloads, methodName);
-                                if (indexerMember.Body is { } body)
-                                    yield return new SourceMember(fullType, methodName, overload, path, body);
-                            }
-
-                            break;
-                        }
-                        case OperatorDeclarationSyntax op:
-                        {
-                            foreach (var operatorMember in sourceIdentity.OperatorMembers(op))
-                            {
-                                string methodName = operatorMember.MetadataName;
-                                int overload = NextOverload(overloads, methodName);
-                                if (operatorMember.Body is { } body)
-                                    yield return new SourceMember(fullType, methodName, overload, path, body);
-                            }
-
-                            break;
-                        }
-                        case ConversionOperatorDeclarationSyntax conversion:
-                        {
-                            foreach (var conversionMember in sourceIdentity.ConversionOperatorMembers(conversion))
-                            {
-                                string methodName = conversionMember.MetadataName;
-                                int overload = NextOverload(overloads, methodName);
-                                if (conversionMember.Body is { } body)
-                                    yield return new SourceMember(fullType, methodName, overload, path, body);
-                            }
-
-                            break;
-                        }
-                    }
+                    int overload = NextOverload(overloads, sourceMember.MetadataName);
+                    if (sourceMember.Body is { } body)
+                        yield return new SourceMember(fullType, sourceMember.MetadataName, overload, path, body);
                 }
             }
 

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -276,16 +276,12 @@ static class ReturnToSenderSourceProbe
         ReturnToSender.Result result,
         string sourcePath)
     {
-        var outcome = result.Status == FidelityCheck.CompileBackStatus.Exact
-            ? ReturnToSenderSourceOutcome.ValidMatch
-            : ReturnToSenderSourceOutcome.ValidDifferent;
+        var exact = result.Status == FidelityCheck.CompileBackStatus.Exact;
         results.Add(new ReturnToSenderSourceProbeResult(
             target,
-            outcome,
+            exact ? ReturnToSenderSourceOutcome.ValidMatch : ReturnToSenderSourceOutcome.Invalid,
             result.Status,
-            outcome == ReturnToSenderSourceOutcome.ValidMatch
-                ? "valid_match.source_bodyless"
-                : "valid_different.source_bodyless",
+            exact ? "valid_match.source_bodyless" : "invalid.source_bodyless_non_exact",
             $"source member matched {target.Type}::{target.Method}#{target.Overload}, but it has no explicit source body; compile-back status is {result.Status}",
             sourcePath,
             ExpectedBody: null,


### PR DESCRIPTION
## Summary

Expands the RTS fixture-source oracle from the original indexer prototype into a broader source-identity and source-probe path:

- centralizes source identity for properties, methods, constructors, operators/conversions, explicit-interface skips, generic type arity, and ordered type members
- preserves compile-back shell facts needed by RTS source probes through a Research shell request boundary
- treats source-bodyless/synthesized members as covered when RTS compile-back is exact
- resolves current fixture source lookup gaps for the broader decompiler fixture group

## Evidence

Focused tests:

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/ReturnToSenderFixtureCatalogTests/*"
```

Fixture/source probe:

```text
RETURNTOSENDER SOURCE PROBE over 102 target(s)
  ValidMatch       : 52
  ValidDifferent   : 50
  Invalid          : 0
  SourceUnavailable: 0
  UnsupportedTarget: 0
```

Broader decompiler fixture probe after rebase:

```text
RETURNTOSENDER SOURCE PROBE over 204 target(s)
  ValidMatch       : 93
  ValidDifferent   : 74
  Invalid          : 37/38 class of remaining rows, depending on latest main fixture/compiler baseline
  SourceUnavailable: 0
  UnsupportedTarget: 0
```

Full build:

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --no-restore
```

## Notes

This PR does not claim the remaining invalid source-probe rows are fixed. They are tracked separately as decompiler/renderability frontiers. Shell composition is requested through Research (`ResearchReturnToSenderShells`) rather than direct harness-owned shell composition.

Adversarial review requested separately before ready-to-merge.
