### PR TITLE
Add member-scoped IL diff API

### DIFF
--- a/docs/design/il-diff-canonicalization.md
+++ b/docs/design/il-diff-canonicalization.md
@@ -15,6 +15,12 @@ rendering and Markout/card projection; they should consume
 `IlAssemblyDiffResult` / `IlAssemblyDiffPairResult` rather than reimplementing
 method matching or bucket wording.
 
+`CompareMembers` is the member-scoped entry point for callers that already
+resolved exact `MethodDefinitionHandle` values. It returns old/new
+`IlMemberDiffSubject` identity labels plus the underlying `IlBodyDiffResult`,
+so RTS, Research, and diagnostics can attach IL diff evidence to their own
+member identity without running an assembly-wide card.
+
 The boundary is intentionally narrow: the diff answers "which decoded IL
 operations changed?" It does not claim source equivalence, semantic equivalence,
 or durable identity for every operand category.

--- a/src/ILInspector.Instructions.Tests/IlAssemblyDiffTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlAssemblyDiffTests.cs
@@ -7,6 +7,15 @@ namespace ILInspector.Instructions.Tests;
 
 public class IlAssemblyDiffTests
 {
+    public static int MemberA() => 1;
+
+    public static int MemberB() => 2;
+
+    public abstract class Bodyless
+    {
+        public abstract int Missing();
+    }
+
     [Fact]
     public void Compare_SameAssembly_HasNoPairChangesOrFailures()
     {
@@ -68,5 +77,88 @@ public class IlAssemblyDiffTests
 
         Assert.True(oldStream.CanRead);
         Assert.True(newStream.CanRead);
+    }
+
+    [Fact]
+    public void CompareMembers_SameMethod_IsExactAndPreservesDefaultSubject()
+    {
+        using var stream = File.OpenRead(typeof(IlAssemblyDiffTests).Assembly.Location);
+        using var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+        var method = FindMethod(reader, nameof(MemberA));
+
+        var result = IlAssemblyDiff.CompareMembers(pe, reader, method, pe, reader, method);
+
+        Assert.True(result.Diff.IsExact);
+        Assert.Equal(result.Old.Identity, result.Old.Label);
+        Assert.Equal(result.Old.Identity, result.New.Identity);
+        Assert.Contains(nameof(MemberA), result.Old.Identity, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CompareMembers_DifferentMethods_ReturnsChangedBodyDiffAndCustomLabels()
+    {
+        using var stream = File.OpenRead(typeof(IlAssemblyDiffTests).Assembly.Location);
+        using var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+
+        var result = IlAssemblyDiff.CompareMembers(
+            pe,
+            reader,
+            FindMethod(reader, nameof(MemberA)),
+            pe,
+            reader,
+            FindMethod(reader, nameof(MemberB)),
+            oldLabel: "old-member",
+            newLabel: "new-member");
+
+        Assert.False(result.Diff.IsExact);
+        Assert.NotEmpty(result.Diff.Rows);
+        Assert.Equal("old-member", result.Old.Label);
+        Assert.Equal("new-member", result.New.Label);
+        Assert.Contains(nameof(MemberA), result.Old.Identity, StringComparison.Ordinal);
+        Assert.Contains(nameof(MemberB), result.New.Identity, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CompareMembers_BodylessOldMethod_ReturnsOldBodyMissing()
+    {
+        using var stream = File.OpenRead(typeof(IlAssemblyDiffTests).Assembly.Location);
+        using var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+
+        var result = IlAssemblyDiff.CompareMembers(
+            pe,
+            reader,
+            FindMethod(reader, nameof(Bodyless), nameof(Bodyless.Missing)),
+            pe,
+            reader,
+            FindMethod(reader, nameof(MemberA)));
+
+        var failure = Assert.Single(result.Diff.FailureRows);
+        Assert.Equal(IlDiffFailureKind.OldBodyMissing, failure.Kind);
+        Assert.Equal("old", failure.Side);
+    }
+
+    static MethodDefinitionHandle FindMethod(MetadataReader reader, string methodName)
+        => FindMethod(reader, nameof(IlAssemblyDiffTests), methodName);
+
+    static MethodDefinitionHandle FindMethod(MetadataReader reader, string typeName, string methodName)
+    {
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var type = reader.GetTypeDefinition(typeHandle);
+            if (reader.GetString(type.Name) != typeName)
+                continue;
+
+            foreach (var methodHandle in type.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (reader.GetString(method.Name) == methodName)
+                    return methodHandle;
+            }
+        }
+
+        throw new InvalidOperationException($"{typeName}.{methodName} not found.");
     }
 }

--- a/src/ILInspector.Instructions/IlAssemblyDiff.cs
+++ b/src/ILInspector.Instructions/IlAssemblyDiff.cs
@@ -25,6 +25,15 @@ public sealed record IlAssemblyDiffPairResult(
     string New,
     IlAssemblyDiffResult Diff);
 
+public sealed record IlMemberDiffSubject(
+    string Identity,
+    string Label);
+
+public sealed record IlMemberDiffResult(
+    IlMemberDiffSubject Old,
+    IlMemberDiffSubject New,
+    IlBodyDiffResult Diff);
+
 /// <summary>
 /// Product-owned IL/body diff producer over two metadata-backed assemblies.
 /// </summary>
@@ -177,6 +186,62 @@ public static class IlAssemblyDiff
             Buckets(hunkKinds),
             Buckets(opcodeFamilies),
             examples.ToImmutable());
+    }
+
+    public static IlMemberDiffResult CompareMembers(
+        PEReader oldPe,
+        MetadataReader oldReader,
+        MethodDefinitionHandle oldMethod,
+        PEReader newPe,
+        MetadataReader newReader,
+        MethodDefinitionHandle newMethod,
+        string? oldLabel = null,
+        string? newLabel = null)
+    {
+        ArgumentNullException.ThrowIfNull(oldPe);
+        ArgumentNullException.ThrowIfNull(oldReader);
+        ArgumentNullException.ThrowIfNull(newPe);
+        ArgumentNullException.ThrowIfNull(newReader);
+        if (oldMethod.IsNil)
+            throw new ArgumentException("Old method handle must not be nil.", nameof(oldMethod));
+        if (newMethod.IsNil)
+            throw new ArgumentException("New method handle must not be nil.", nameof(newMethod));
+
+        var oldDefinition = oldReader.GetMethodDefinition(oldMethod);
+        var newDefinition = newReader.GetMethodDefinition(newMethod);
+        var oldIdentity = MethodKey(oldReader, oldDefinition);
+        var newIdentity = MethodKey(newReader, newDefinition);
+        var oldSubject = new IlMemberDiffSubject(oldIdentity, oldLabel ?? oldIdentity);
+        var newSubject = new IlMemberDiffSubject(newIdentity, newLabel ?? newIdentity);
+
+        var oldBody = TryGetBody(oldPe, oldDefinition, "old");
+        var newBody = TryGetBody(newPe, newDefinition, "new");
+        var diff = oldBody.Result ?? newBody.Result ?? IlBodyDiff.Compare(oldReader, oldBody.Body!, newReader, newBody.Body!);
+        return new IlMemberDiffResult(oldSubject, newSubject, diff);
+    }
+
+    static (MethodBodyBlock? Body, IlBodyDiffResult? Result) TryGetBody(PEReader pe, MethodDefinition method, string side)
+    {
+        if (method.RelativeVirtualAddress == 0)
+        {
+            var result = side == "old"
+                ? IlBodyDiffResult.OldBodyMissing("method has no body")
+                : IlBodyDiffResult.NewBodyMissing("method has no body");
+            return (null, result);
+        }
+
+        try
+        {
+            return (pe.GetMethodBody(method.RelativeVirtualAddress), null);
+        }
+        catch (BadImageFormatException ex)
+        {
+            return (null, IlBodyDiffResult.Failed(
+                IlDiffFailureKind.DecodeFailure,
+                "body read failed",
+                side,
+                ex.Message));
+        }
     }
 
     static Dictionary<string, MethodDefinitionHandle> MethodMap(MetadataReader reader)


### PR DESCRIPTION
## Summary

- Add member-scoped IL diff records:
  - `IlMemberDiffSubject`
  - `IlMemberDiffResult`
- Add `IlAssemblyDiff.CompareMembers(...)` for callers that already resolved exact `MethodDefinitionHandle` pairs.
- Return old/new identity labels plus the underlying `IlBodyDiffResult`, keeping rendering in `IlDiffPrinter`/consumers.
- Document the member-scoped boundary in `docs/design/il-diff-canonicalization.md`.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- `dotnet run --project src/ILInspector.Instructions.Tests -c Release --no-build`
- `npx markdownlint-cli docs/design/il-diff-canonicalization.md`