### PR TITLE
Fix unsafe RTS source-probe frontiers

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -120,6 +120,22 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_PreservesFunctionPointerSignatureKeyword()
+    {
+        var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+            FixtureCatalog.DecompilerUnsafeLegacy.AssemblyPath(),
+            [
+                new ReturnToSender.RequestedTarget(
+                    "ILInspector.Decompiler.Fixtures.LegacyUnsafe.UnsafeFixtures",
+                    "InvokeFunctionPointer",
+                    Overload: 0),
+            ]));
+
+        Assert.NotEqual(ReturnToSenderSourceOutcome.Invalid, result.Outcome);
+        Assert.DoesNotContain("CS1001", result.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_ClassifiesBodylessSourceMembersAsUnsupported()
     {
         var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -3,6 +3,7 @@ using System.Reflection.PortableExecutable;
 using System.Reflection;
 
 using DotnetInspector.Fixtures;
+using ILInspector.Decompiler;
 using ILInspector.DecompilerHarness;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Metadata;
@@ -133,6 +134,13 @@ public class ReturnToSenderFixtureCatalogTests
 
         Assert.NotEqual(ReturnToSenderSourceOutcome.Invalid, result.Outcome);
         Assert.DoesNotContain("CS1001", result.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CompileBackCSharpNames_EscapesQualifiedDelegateIdentifier()
+    {
+        Assert.Equal("A.B.@delegate*", CompileBackCSharpNames.Clean("A.B.delegate*"));
+        Assert.Equal("delegate*<System.Int32, System.Int32>", CompileBackCSharpNames.Clean("delegate*<System.Int32, System.Int32>"));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -140,6 +140,7 @@ public class ReturnToSenderFixtureCatalogTests
     public void CompileBackCSharpNames_EscapesQualifiedDelegateIdentifier()
     {
         Assert.Equal("A.B.@delegate*", CompileBackCSharpNames.Clean("A.B.delegate*"));
+        Assert.Equal("@delegate*", CompileBackCSharpNames.Clean("delegate*"));
         Assert.Equal("delegate*<System.Int32, System.Int32>", CompileBackCSharpNames.Clean("delegate*<System.Int32, System.Int32>"));
     }
 

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.CSharp;
 
 using LegacyFixtures = ILInspector.Decompiler.Fixtures.LegacyUnsafe.UnsafeFixtures;
 using NewFixtures = ILInspector.Decompiler.Fixtures.NewUnsafe.UnsafeFixtures;
+using NewStackallocFixtures = ILInspector.Decompiler.Fixtures.NewUnsafe.StackallocInitializerResiduals;
 using ChainB = ILInspector.Decompiler.Fixtures.UnsafeChainB.LibraryB;
 using ChainC = ILInspector.Decompiler.Fixtures.UnsafeChainC.Program;
 
@@ -55,6 +56,9 @@ public class UnsafeEmitterTests
 
     static string DecompileLegacy(string method) =>
         Decompile(typeof(LegacyFixtures).Assembly.Location, typeof(LegacyFixtures).FullName!, method);
+
+    static string DecompileNewStackalloc(string method) =>
+        Decompile(typeof(NewStackallocFixtures).Assembly.Location, typeof(NewStackallocFixtures).FullName!, method);
 
     static string DecompileChainB(string method) =>
         Decompile(typeof(ChainB).Assembly.Location, typeof(ChainB).FullName!, method);
@@ -251,6 +255,17 @@ public class UnsafeEmitterTests
         // `scoped` to stay clean (otherwise CS9081). A stackalloc result is
         // always scoped, so this is mode-independent correctness, not a guess.
         Assert.Contains("scoped Span<int> s", output);
+    }
+
+    [Fact]
+    public void NewRulesModule_StackAllocPointerInitializer_HoistsStackSlotDeclaration()
+    {
+        var output = DecompileNewStackalloc(nameof(NewStackallocFixtures.StackallocPointerInitializer));
+        var block = FirstUnsafeBlockBody(output);
+
+        Assert.Contains("* S_", block);
+        Assert.Contains("stackalloc byte[", block);
+        Assert.Contains("_ = S_", block);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -303,6 +303,84 @@ public class UnsafeEmitterTests
     }
 
     [Fact]
+    public void NewRulesModule_UnsafeRunKeepsCapturedOuterLocalLambdaInScope()
+    {
+        var int32 = TypeRef.CoreLib("System", "Int32");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var bytePointer = TypeRef.Pointer(TypeRef.CoreLib("System", "Byte"));
+        var guid = TypeRef.CoreLib("System", "Guid");
+        var action = TypeRef.CoreLib("System", "Action");
+        var owner = TypeRef.Definition("Synthetic", "Holder", "Class1");
+        var getHashCode = new MethodRef(guid, "GetHashCode", int32, [], HasThis: true);
+
+        var lambdaBlock = new Block(0);
+        lambdaBlock.Add(new ExpressionStatement(new Call(getHashCode, isVirtual: true, [new LoadLocal(0, guid)])));
+        var lambdaBody = new BlockContainer();
+        lambdaBody.Add(lambdaBlock);
+
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new StackAllocate(new Constant(8, int32))));
+        block.Add(new InitObject(guid, new LoadLocalAddress(0, guid)));
+        block.Add(new ExpressionStatement(new LoadStackSlot(0, bytePointer)));
+        block.Add(new StoreLocal(1, action, new Lambda(action, [], [], [], usesUpdatedMemorySafetyRules: true, skipLocalsInit: false, lambdaBody)));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0),
+            [guid, action],
+            body)
+        {
+            UsesUpdatedMemorySafetyRules = true,
+        };
+
+        var unsafeBody = FirstUnsafeBlockBody(CSharpPrinter.Print(function).Output!);
+
+        Assert.Contains("Guid V_0 = default;", unsafeBody);
+        Assert.Contains("V_0.GetHashCode()", unsafeBody);
+    }
+
+    [Fact]
+    public void NewRulesModule_UnsafeRunIgnoresNestedLambdaLocalIndexCollisions()
+    {
+        var int32 = TypeRef.CoreLib("System", "Int32");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var bytePointer = TypeRef.Pointer(TypeRef.CoreLib("System", "Byte"));
+        var guid = TypeRef.CoreLib("System", "Guid");
+        var action = TypeRef.CoreLib("System", "Action");
+        var owner = TypeRef.Definition("Synthetic", "Holder", "Class1");
+        var getHashCode = new MethodRef(guid, "GetHashCode", int32, [], HasThis: true);
+
+        var lambdaBlock = new Block(0);
+        lambdaBlock.Add(new InitObject(guid, new LoadLocalAddress(0, guid)));
+        lambdaBlock.Add(new ExpressionStatement(new Call(getHashCode, isVirtual: true, [new LoadLocal(0, guid)])));
+        var lambdaBody = new BlockContainer();
+        lambdaBody.Add(lambdaBlock);
+
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new StackAllocate(new Constant(8, int32))));
+        block.Add(new InitObject(guid, new LoadLocalAddress(0, guid)));
+        block.Add(new ExpressionStatement(new LoadStackSlot(0, bytePointer)));
+        block.Add(new StoreLocal(1, action, new Lambda(action, [], [guid], [], usesUpdatedMemorySafetyRules: true, skipLocalsInit: false, lambdaBody)));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0),
+            [guid, action],
+            body)
+        {
+            UsesUpdatedMemorySafetyRules = true,
+        };
+
+        var unsafeBody = FirstUnsafeBlockBody(CSharpPrinter.Print(function).Output!);
+
+        Assert.DoesNotContain("=>", unsafeBody);
+    }
+
+    [Fact]
     public void NewRulesModule_StackAllocSpanDefault_EmitsNoUnsafeBlock()
     {
         // Without [SkipLocalsInit] the same stackalloc -> Span is safe under the

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -269,6 +269,40 @@ public class UnsafeEmitterTests
     }
 
     [Fact]
+    public void NewRulesModule_UnsafeStackSlotReadInLaterBlockDeclaresUpFront()
+    {
+        var int32 = TypeRef.CoreLib("System", "Int32");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var bytePointer = TypeRef.Pointer(TypeRef.CoreLib("System", "Byte"));
+        var owner = TypeRef.Definition("Synthetic", "Holder", "Class1");
+
+        var first = new Block(0);
+        first.Add(new StoreStackSlot(0, new StackAllocate(new Constant(8, int32))));
+        var second = new Block(1);
+        second.Add(new ExpressionStatement(new LoadStackSlot(0, bytePointer)));
+        var body = new BlockContainer();
+        body.Add(first);
+        body.Add(second);
+        var function = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body)
+        {
+            UsesUpdatedMemorySafetyRules = true,
+        };
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.True(
+            output.IndexOf("* S_", StringComparison.Ordinal)
+                < output.IndexOf("unsafe", StringComparison.Ordinal),
+            "the stack-slot declaration must be hoisted above the unsafe block:\n" + output);
+        Assert.Contains("_ = S_", output);
+    }
+
+    [Fact]
     public void NewRulesModule_UnsafeRunKeepsInitObjectDeclarationInScope()
     {
         var int32 = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -332,8 +332,12 @@ public class UnsafeEmitterTests
         var output = CSharpPrinter.Print(function).Output!;
         var unsafeBody = FirstUnsafeBlockBody(output);
 
-        Assert.Contains("Guid V_0 = default;", unsafeBody);
-        Assert.Contains("V_0.GetHashCode()", unsafeBody);
+        Assert.True(
+            output.IndexOf("Guid V_0;", StringComparison.Ordinal)
+                < output.IndexOf("unsafe", StringComparison.Ordinal),
+            "the InitObject declaration must be hoisted above the unsafe block:\n" + output);
+        Assert.Contains("V_0 = default;", unsafeBody);
+        Assert.Contains("V_0.GetHashCode()", output);
     }
 
     [Fact]
@@ -369,6 +373,103 @@ public class UnsafeEmitterTests
             output.IndexOf("int V_0;", StringComparison.Ordinal)
                 < output.IndexOf("unsafe", StringComparison.Ordinal),
             "the safe local declaration must be hoisted above the unsafe block:\n" + output);
+        Assert.Contains("_ = V_0;", output);
+    }
+
+    [Fact]
+    public void NewRulesModule_SafeCrossBlockLocalWithoutUnsafeStaysInline()
+    {
+        var int32 = TypeRef.CoreLib("System", "Int32");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var owner = TypeRef.Definition("Synthetic", "Holder", "Class1");
+
+        var first = new Block(0);
+        first.Add(new StoreLocal(0, int32, new Constant(1, int32)));
+        var second = new Block(1);
+        second.Add(new ExpressionStatement(new LoadLocal(0, int32)));
+        var body = new BlockContainer();
+        body.Add(first);
+        body.Add(second);
+        var function = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0),
+            [int32],
+            body)
+        {
+            UsesUpdatedMemorySafetyRules = true,
+        };
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("int V_0 = 1;", output);
+        Assert.DoesNotContain("unsafe", output);
+    }
+
+    [Fact]
+    public void NewRulesModule_UnsafeRunHoistsSafeLocalBetweenUnsafeDeclarationAndUse()
+    {
+        var int32 = TypeRef.CoreLib("System", "Int32");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var bytePointer = TypeRef.Pointer(TypeRef.CoreLib("System", "Byte"));
+        var owner = TypeRef.Definition("Synthetic", "Holder", "Class1");
+
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new StackAllocate(new Constant(8, int32))));
+        block.Add(new StoreLocal(0, int32, new Constant(1, int32)));
+        block.Add(new ExpressionStatement(new LoadStackSlot(0, bytePointer)));
+        block.Add(new ExpressionStatement(new LoadLocal(0, int32)));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0),
+            [int32],
+            body)
+        {
+            UsesUpdatedMemorySafetyRules = true,
+        };
+
+        var output = CSharpPrinter.Print(function).Output!;
+        var unsafeBody = FirstUnsafeBlockBody(output);
+
+        Assert.DoesNotContain("int V_0 = 1;", unsafeBody);
+        Assert.Contains("V_0 = 1;", unsafeBody);
+        Assert.Contains("_ = V_0;", output);
+    }
+
+    [Fact]
+    public void NewRulesModule_UnsafePointerLocalReadInLaterBlockDeclaresUpFront()
+    {
+        var int32 = TypeRef.CoreLib("System", "Int32");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var bytePointer = TypeRef.Pointer(TypeRef.CoreLib("System", "Byte"));
+        var owner = TypeRef.Definition("Synthetic", "Holder", "Class1");
+
+        var first = new Block(0);
+        first.Add(new StoreLocal(0, bytePointer, new StackAllocate(new Constant(8, int32))));
+        var second = new Block(1);
+        second.Add(new ExpressionStatement(new LoadLocal(0, bytePointer)));
+        var body = new BlockContainer();
+        body.Add(first);
+        body.Add(second);
+        var function = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0),
+            [bytePointer],
+            body)
+        {
+            UsesUpdatedMemorySafetyRules = true,
+        };
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.True(
+            output.IndexOf("byte* V_0;", StringComparison.Ordinal)
+                < output.IndexOf("unsafe", StringComparison.Ordinal),
+            "the pointer local declaration must be hoisted above the unsafe block:\n" + output);
         Assert.Contains("_ = V_0;", output);
     }
 
@@ -451,8 +552,8 @@ public class UnsafeEmitterTests
 
         var unsafeBody = FirstUnsafeBlockBody(CSharpPrinter.Print(function).Output!);
 
-        Assert.Contains("Guid V_0 = default;", unsafeBody);
-        Assert.Contains("V_0.GetHashCode()", unsafeBody);
+        Assert.Contains("V_0 = default;", unsafeBody);
+        Assert.DoesNotContain("=>", unsafeBody);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -269,6 +269,40 @@ public class UnsafeEmitterTests
     }
 
     [Fact]
+    public void NewRulesModule_UnsafeRunKeepsInitObjectDeclarationInScope()
+    {
+        var int32 = TypeRef.CoreLib("System", "Int32");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var bytePointer = TypeRef.Pointer(TypeRef.CoreLib("System", "Byte"));
+        var guid = TypeRef.CoreLib("System", "Guid");
+        var owner = TypeRef.Definition("Synthetic", "Holder", "Class1");
+        var getHashCode = new MethodRef(guid, "GetHashCode", int32, [], HasThis: true);
+
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new StackAllocate(new Constant(8, int32))));
+        block.Add(new InitObject(guid, new LoadLocalAddress(0, guid)));
+        block.Add(new ExpressionStatement(new LoadStackSlot(0, bytePointer)));
+        block.Add(new ExpressionStatement(new Call(getHashCode, isVirtual: true, [new LoadLocal(0, guid)])));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0),
+            [guid],
+            body)
+        {
+            UsesUpdatedMemorySafetyRules = true,
+        };
+
+        var output = CSharpPrinter.Print(function).Output!;
+        var unsafeBody = FirstUnsafeBlockBody(output);
+
+        Assert.Contains("Guid V_0 = default;", unsafeBody);
+        Assert.Contains("V_0.GetHashCode()", unsafeBody);
+    }
+
+    [Fact]
     public void NewRulesModule_StackAllocSpanDefault_EmitsNoUnsafeBlock()
     {
         // Without [SkipLocalsInit] the same stackalloc -> Span is safe under the

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -440,6 +440,36 @@ public class UnsafeEmitterTests
     }
 
     [Fact]
+    public void NewRulesModule_SafeLocalAfterClosedUnsafeRunStaysInline()
+    {
+        var int32 = TypeRef.CoreLib("System", "Int32");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var bytePointer = TypeRef.Pointer(TypeRef.CoreLib("System", "Byte"));
+        var owner = TypeRef.Definition("Synthetic", "Holder", "Class1");
+
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new StackAllocate(new Constant(8, int32))));
+        block.Add(new StoreLocal(0, int32, new Constant(42, int32)));
+        block.Add(new ExpressionStatement(new LoadLocal(0, int32)));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0),
+            [int32],
+            body)
+        {
+            UsesUpdatedMemorySafetyRules = true,
+        };
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("int V_0 = 42;", output);
+        Assert.DoesNotContain("\nV_0 = 42;", output);
+    }
+
+    [Fact]
     public void NewRulesModule_UnsafePointerLocalReadInLaterBlockDeclaresUpFront()
     {
         var int32 = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -381,6 +381,53 @@ public class UnsafeEmitterTests
     }
 
     [Fact]
+    public void NewRulesModule_UnsafeRunIgnoresNestedLocalFunctionLocalIndexCollisions()
+    {
+        var int32 = TypeRef.CoreLib("System", "Int32");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var bytePointer = TypeRef.Pointer(TypeRef.CoreLib("System", "Byte"));
+        var guid = TypeRef.CoreLib("System", "Guid");
+        var owner = TypeRef.Definition("Synthetic", "Holder", "Class1");
+        var getHashCode = new MethodRef(guid, "GetHashCode", int32, [], HasThis: true);
+
+        var localBlock = new Block(0);
+        localBlock.Add(new InitObject(guid, new LoadLocalAddress(0, guid)));
+        localBlock.Add(new Return(new Call(getHashCode, isVirtual: true, [new LoadLocal(0, guid)])));
+        var localBody = new BlockContainer();
+        localBody.Add(localBlock);
+
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new StackAllocate(new Constant(8, int32))));
+        block.Add(new InitObject(guid, new LoadLocalAddress(0, guid)));
+        block.Add(new ExpressionStatement(new LoadStackSlot(0, bytePointer)));
+        block.Add(new LocalFunctionStatement(
+            "Local",
+            int32,
+            [],
+            isStatic: false,
+            [guid],
+            [],
+            usesUpdatedMemorySafetyRules: true,
+            skipLocalsInit: false,
+            localBody));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0),
+            [guid],
+            body)
+        {
+            UsesUpdatedMemorySafetyRules = true,
+        };
+
+        var unsafeBody = FirstUnsafeBlockBody(CSharpPrinter.Print(function).Output!);
+
+        Assert.DoesNotContain("Local()", unsafeBody);
+    }
+
+    [Fact]
     public void NewRulesModule_StackAllocSpanDefault_EmitsNoUnsafeBlock()
     {
         // Without [SkipLocalsInit] the same stackalloc -> Span is safe under the

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -337,6 +337,86 @@ public class UnsafeEmitterTests
     }
 
     [Fact]
+    public void NewRulesModule_UnsafeRunHoistsSafeLocalReadInLaterBlock()
+    {
+        var int32 = TypeRef.CoreLib("System", "Int32");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var bytePointer = TypeRef.Pointer(TypeRef.CoreLib("System", "Byte"));
+        var owner = TypeRef.Definition("Synthetic", "Holder", "Class1");
+
+        var first = new Block(0);
+        first.Add(new StoreStackSlot(0, new StackAllocate(new Constant(8, int32))));
+        first.Add(new StoreLocal(0, int32, new Constant(1, int32)));
+        first.Add(new ExpressionStatement(new LoadStackSlot(0, bytePointer)));
+        var second = new Block(1);
+        second.Add(new ExpressionStatement(new LoadLocal(0, int32)));
+        var body = new BlockContainer();
+        body.Add(first);
+        body.Add(second);
+        var function = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0),
+            [int32],
+            body)
+        {
+            UsesUpdatedMemorySafetyRules = true,
+        };
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.True(
+            output.IndexOf("int V_0;", StringComparison.Ordinal)
+                < output.IndexOf("unsafe", StringComparison.Ordinal),
+            "the safe local declaration must be hoisted above the unsafe block:\n" + output);
+        Assert.Contains("_ = V_0;", output);
+    }
+
+    [Fact]
+    public void NewRulesModule_UnsafeRunHoistsInitObjectCapturedByLaterLambda()
+    {
+        var int32 = TypeRef.CoreLib("System", "Int32");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var bytePointer = TypeRef.Pointer(TypeRef.CoreLib("System", "Byte"));
+        var guid = TypeRef.CoreLib("System", "Guid");
+        var action = TypeRef.CoreLib("System", "Action");
+        var owner = TypeRef.Definition("Synthetic", "Holder", "Class1");
+        var getHashCode = new MethodRef(guid, "GetHashCode", int32, [], HasThis: true);
+
+        var lambdaBlock = new Block(0);
+        lambdaBlock.Add(new ExpressionStatement(new Call(getHashCode, isVirtual: true, [new LoadLocal(0, guid)])));
+        var lambdaBody = new BlockContainer();
+        lambdaBody.Add(lambdaBlock);
+
+        var first = new Block(0);
+        first.Add(new StoreStackSlot(0, new StackAllocate(new Constant(8, int32))));
+        first.Add(new InitObject(guid, new LoadLocalAddress(0, guid)));
+        first.Add(new ExpressionStatement(new LoadStackSlot(0, bytePointer)));
+        var second = new Block(1);
+        second.Add(new StoreLocal(1, action, new Lambda(action, [], [], [], usesUpdatedMemorySafetyRules: true, skipLocalsInit: false, lambdaBody)));
+        var body = new BlockContainer();
+        body.Add(first);
+        body.Add(second);
+        var function = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0),
+            [guid, action],
+            body)
+        {
+            UsesUpdatedMemorySafetyRules = true,
+        };
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.True(
+            output.IndexOf("Guid V_0;", StringComparison.Ordinal)
+                < output.IndexOf("unsafe", StringComparison.Ordinal),
+            "the captured InitObject local declaration must be hoisted above the unsafe block:\n" + output);
+        Assert.Contains("V_0.GetHashCode()", output);
+    }
+
+    [Fact]
     public void NewRulesModule_UnsafeRunKeepsCapturedOuterLocalLambdaInScope()
     {
         var int32 = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -58,7 +58,9 @@ static class CompileBackCSharpNames
                 string word = type[start..i];
                 bool alreadyEscaped = start > 0 && type[start - 1] == '@';
                 bool qualifiedSegment = start > 0 && type[start - 1] == '.';
-                bool bareSpelling = (word is "void" or "ref" || IsPrimitiveTypeName(word)) && !qualifiedSegment;
+                bool functionPointerKeyword = word == "delegate" && i < type.Length && type[i] == '*';
+                bool bareSpelling = ((word is "void" or "ref" || IsPrimitiveTypeName(word)) && !qualifiedSegment)
+                    || functionPointerKeyword;
                 if (!alreadyEscaped && !bareSpelling && IsCSharpKeyword(word))
                     sb.Append('@');
                 sb.Append(word);

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -58,7 +58,11 @@ static class CompileBackCSharpNames
                 string word = type[start..i];
                 bool alreadyEscaped = start > 0 && type[start - 1] == '@';
                 bool qualifiedSegment = start > 0 && type[start - 1] == '.';
-                bool functionPointerKeyword = !qualifiedSegment && word == "delegate" && i < type.Length && type[i] == '*';
+                bool functionPointerKeyword = !qualifiedSegment
+                    && word == "delegate"
+                    && i + 1 < type.Length
+                    && type[i] == '*'
+                    && (type[i + 1] == '<' || char.IsWhiteSpace(type[i + 1]));
                 bool bareSpelling = ((word is "void" or "ref" || IsPrimitiveTypeName(word)) && !qualifiedSegment)
                     || functionPointerKeyword;
                 if (!alreadyEscaped && !bareSpelling && IsCSharpKeyword(word))

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -58,7 +58,7 @@ static class CompileBackCSharpNames
                 string word = type[start..i];
                 bool alreadyEscaped = start > 0 && type[start - 1] == '@';
                 bool qualifiedSegment = start > 0 && type[start - 1] == '.';
-                bool functionPointerKeyword = word == "delegate" && i < type.Length && type[i] == '*';
+                bool functionPointerKeyword = !qualifiedSegment && word == "delegate" && i < type.Length && type[i] == '*';
                 bool bareSpelling = ((word is "void" or "ref" || IsPrimitiveTypeName(word)) && !qualifiedSegment)
                     || functionPointerKeyword;
                 if (!alreadyEscaped && !bareSpelling && IsCSharpKeyword(word))

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1132,6 +1132,22 @@ public sealed partial class CSharpPrinter
         return DescendantsOutsideNestedFunctions(node).Any(n => IsLocalReference(n, index));
     }
 
+    static bool ReferencesLocalIncludingSharedNestedScopes(IrNode node, int index)
+    {
+        if (IsLocalReference(node, index))
+            return true;
+        foreach (var child in node.Children)
+        {
+            if (child is Lambda lambda && NeedsNestedLambdaScope(lambda))
+                continue;
+            if (child is LocalFunctionStatement localFunction && NeedsNestedLocalFunctionScope(localFunction))
+                continue;
+            if (ReferencesLocalIncludingSharedNestedScopes(child, index))
+                return true;
+        }
+        return false;
+    }
+
     static bool ReferencesStackSlot(IrNode node, int slot)
     {
         if (IsStackSlotReference(node, slot))
@@ -1622,14 +1638,14 @@ public sealed partial class CSharpPrinter
                 case StoreLocal store when _declaringStores.Contains(store):
                     for (int j = candidate; j < statements.Count; j++)
                     {
-                        if (ReferencesLocal(statements[j], store.Index))
+                        if (ReferencesLocalIncludingSharedNestedScopes(statements[j], store.Index))
                             return true;
                     }
                     break;
                 case InitObject { Address: LoadLocalAddress local } init when _declaringStores.Contains(init):
                     for (int j = candidate; j < statements.Count; j++)
                     {
-                        if (ReferencesLocal(statements[j], local.Index))
+                        if (ReferencesLocalIncludingSharedNestedScopes(statements[j], local.Index))
                             return true;
                     }
                     break;

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1576,8 +1576,12 @@ public sealed partial class CSharpPrinter
             if (_newMemorySafetyRules && _unsafeDepth == 0 && NeedsUnsafeContext(statements[i]))
             {
                 int j = i + 1;
-                while (j < statements.Count && NeedsUnsafeContext(statements[j]))
+                while (j < statements.Count
+                    && (NeedsUnsafeContext(statements[j])
+                        || UnsafeRunNeedsToReachFutureDeclarationReference(statements, i, j)))
+                {
                     j++;
+                }
                 string pad = new(' ', indent * 4);
                 sb.Append(pad).AppendLine("unsafe");
                 sb.Append(pad).AppendLine("{");
@@ -1600,6 +1604,48 @@ public sealed partial class CSharpPrinter
                 i++;
             }
         }
+    }
+
+    bool UnsafeRunNeedsToReachFutureDeclarationReference(IReadOnlyList<IrNode> statements, int start, int candidate)
+    {
+        for (int i = start; i < candidate; i++)
+        {
+            switch (statements[i])
+            {
+                case StoreStackSlot store when _declaringStores.Contains(store):
+                    for (int j = candidate; j < statements.Count; j++)
+                    {
+                        if (ReferencesStackSlot(statements[j], store.Slot))
+                            return true;
+                    }
+                    break;
+                case StoreLocal store when _declaringStores.Contains(store):
+                    for (int j = candidate; j < statements.Count; j++)
+                    {
+                        if (ReferencesLocal(statements[j], store.Index))
+                            return true;
+                    }
+                    break;
+            }
+        }
+
+        return false;
+    }
+
+    bool UnsafeRunDeclaresStackSlotReferencedBy(IReadOnlyList<IrNode> statements, int start, int candidate)
+    {
+        for (int i = start; i < candidate; i++)
+        {
+            if (statements[i] is StoreStackSlot store
+                && _declaringStores.Contains(store)
+                && HasUnsafeOperation(store.Value)
+                && ReferencesStackSlot(statements[candidate], store.Slot))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     void AppendStatementLabel(StringBuilder sb, IrNode statement, int indent)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1132,6 +1132,13 @@ public sealed partial class CSharpPrinter
         return DescendantsOutsideNestedFunctions(node).Any(n => IsLocalReference(n, index));
     }
 
+    static bool ReferencesLocalIncludingNestedFunctions(IrNode node, int index)
+    {
+        if (IsLocalReference(node, index))
+            return true;
+        return node.Descendants.Any(n => IsLocalReference(n, index));
+    }
+
     static bool ReferencesStackSlot(IrNode node, int slot)
     {
         if (IsStackSlotReference(node, slot))
@@ -1622,26 +1629,17 @@ public sealed partial class CSharpPrinter
                 case StoreLocal store when _declaringStores.Contains(store):
                     for (int j = candidate; j < statements.Count; j++)
                     {
-                        if (ReferencesLocal(statements[j], store.Index))
+                        if (ReferencesLocalIncludingNestedFunctions(statements[j], store.Index))
                             return true;
                     }
                     break;
-            }
-        }
-
-        return false;
-    }
-
-    bool UnsafeRunDeclaresStackSlotReferencedBy(IReadOnlyList<IrNode> statements, int start, int candidate)
-    {
-        for (int i = start; i < candidate; i++)
-        {
-            if (statements[i] is StoreStackSlot store
-                && _declaringStores.Contains(store)
-                && HasUnsafeOperation(store.Value)
-                && ReferencesStackSlot(statements[candidate], store.Slot))
-            {
-                return true;
+                case InitObject { Address: LoadLocalAddress local } init when _declaringStores.Contains(init):
+                    for (int j = candidate; j < statements.Count; j++)
+                    {
+                        if (ReferencesLocalIncludingNestedFunctions(statements[j], local.Index))
+                            return true;
+                    }
+                    break;
             }
         }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1033,7 +1033,7 @@ public sealed partial class CSharpPrinter
                         _scopedLocals.Add(store.Index);
                     continue;
                 }
-                if (!UnsafeDeclarationBeforeInSameBlock(store))
+                if (!DeclarationIsInsideUnsafeRun(store))
                 {
                     continue;
                 }
@@ -1049,7 +1049,7 @@ public sealed partial class CSharpPrinter
             {
                 if (init.Address is not LoadLocalAddress local)
                     continue;
-                if (!UnsafeDeclarationBeforeInSameBlock(init))
+                if (!DeclarationIsInsideUnsafeRun(init))
                 {
                     continue;
                 }
@@ -1091,14 +1091,17 @@ public sealed partial class CSharpPrinter
         return true;
     }
 
-    bool UnsafeDeclarationBeforeInSameBlock(IrNode statement)
+    bool DeclarationIsInsideUnsafeRun(IrNode statement)
     {
         if (statement.Parent is not Block block || statement.ChildIndex <= 0)
             return false;
         for (int i = 0; i < statement.ChildIndex; i++)
         {
-            if (NeedsUnsafeContext(block.Children[i]))
+            if (NeedsUnsafeContext(block.Children[i])
+                && UnsafeRunEnd(block.Children, i) > statement.ChildIndex)
+            {
                 return true;
+            }
         }
         return false;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1020,17 +1020,24 @@ public sealed partial class CSharpPrinter
         {
             foreach (var store in _declaringStores.OfType<StoreLocal>().ToList())
             {
-                if (!HasUnsafeOperation(store.Value) || !LocalIsRead(function, store.Index))
+                if (store.Type.Kind is TypeRefKind.Pointer or TypeRefKind.FunctionPointer)
                     continue;
-                if (LocalReadsStayInsideUnsafeRun(function, store))
+                if (HasUnsafeOperation(store.Value)
+                    && LocalIsRead(function, store.Index)
+                    && !LocalReadsStayInsideUnsafeRun(function, store))
+                {
+                    _declaringStores.Remove(store);
+                    // A stackalloc-initialized span loses its inline `scoped`
+                    // inference when split from its declaration, so the hoisted
+                    // declaration must restore it (else CS9081). A stackalloc result
+                    // can never escape, so `scoped` is always correct here.
+                    if (store.Value is StackAllocArray)
+                        _scopedLocals.Add(store.Index);
+                    continue;
+                }
+                if (LocalReferencesStayInBlockAfterStore(function, store))
                     continue;
                 _declaringStores.Remove(store);
-                // A stackalloc-initialized span loses its inline `scoped`
-                // inference when split from its declaration, so the hoisted
-                // declaration must restore it (else CS9081). A stackalloc result
-                // can never escape, so `scoped` is always correct here.
-                if (store.Value is StackAllocArray)
-                    _scopedLocals.Add(store.Index);
             }
             foreach (var store in _declaringStores.OfType<StoreStackSlot>().ToList())
             {
@@ -1098,14 +1105,15 @@ public sealed partial class CSharpPrinter
         var allowed = block.Children.Skip(statement.ChildIndex).ToList();
         if (HasBranchTargetAfterStatement(statement))
             return false;
-        foreach (var node in DescendantsOutsideNestedFunctions(function))
+        foreach (var candidateBlock in function.Body.Blocks)
         {
-            if (node is StoreLocal s && s.Index == index
-                || node is LoadLocal l && l.Index == index
-                || node is LoadLocalAddress a && a.Index == index)
+            foreach (var node in candidateBlock.Children)
             {
-                if (!allowed.Any(statement => IsDescendantOrSelf(node, statement)))
+                if (ReferencesLocalIncludingSharedNestedScopes(node, index)
+                    && !allowed.Any(statement => IsDescendantOrSelf(node, statement)))
+                {
                     return false;
+                }
             }
         }
         return true;
@@ -1181,7 +1189,8 @@ public sealed partial class CSharpPrinter
     }
 
     static bool IsLocalReference(IrNode node, int index)
-        => node is LoadLocal load && load.Index == index
+        => node is StoreLocal store && store.Index == index
+            || node is LoadLocal load && load.Index == index
             || node is LoadLocalAddress address && address.Index == index;
 
     static bool IsStackSlotReference(IrNode node, int slot)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1020,8 +1020,6 @@ public sealed partial class CSharpPrinter
         {
             foreach (var store in _declaringStores.OfType<StoreLocal>().ToList())
             {
-                if (store.Type.Kind is TypeRefKind.Pointer or TypeRefKind.FunctionPointer)
-                    continue;
                 if (HasUnsafeOperation(store.Value)
                     && LocalIsRead(function, store.Index)
                     && !LocalReadsStayInsideUnsafeRun(function, store))
@@ -1035,8 +1033,10 @@ public sealed partial class CSharpPrinter
                         _scopedLocals.Add(store.Index);
                     continue;
                 }
-                if (LocalReferencesStayInBlockAfterStore(function, store))
+                if (!UnsafeDeclarationBeforeInSameBlock(store))
+                {
                     continue;
+                }
                 _declaringStores.Remove(store);
             }
             foreach (var store in _declaringStores.OfType<StoreStackSlot>().ToList())
@@ -1047,8 +1047,12 @@ public sealed partial class CSharpPrinter
             }
             foreach (var init in _declaringStores.OfType<InitObject>().ToList())
             {
-                if (init.Address is not LoadLocalAddress local || LocalReferencesStayInBlockAfterStatement(function, init, local.Index))
+                if (init.Address is not LoadLocalAddress local)
                     continue;
+                if (!UnsafeDeclarationBeforeInSameBlock(init))
+                {
+                    continue;
+                }
                 _declaringStores.Remove(init);
             }
         }
@@ -1085,6 +1089,18 @@ public sealed partial class CSharpPrinter
             }
         }
         return true;
+    }
+
+    bool UnsafeDeclarationBeforeInSameBlock(IrNode statement)
+    {
+        if (statement.Parent is not Block block || statement.ChildIndex <= 0)
+            return false;
+        for (int i = 0; i < statement.ChildIndex; i++)
+        {
+            if (NeedsUnsafeContext(block.Children[i]))
+                return true;
+        }
+        return false;
     }
 
     bool LocalReferencesStayInBlockAfterStore(IrFunction function, StoreLocal store)
@@ -1676,10 +1692,8 @@ public sealed partial class CSharpPrinter
         {
             StoreStackSlot store when _declaringStores.Contains(store)
                 => LastReferenceEnd(statements, searchStart, node => ReferencesStackSlot(node, store.Slot)),
-            StoreLocal store when _declaringStores.Contains(store)
+            StoreLocal store when _declaringStores.Contains(store) && HasUnsafeOperation(store.Value)
                 => LastReferenceEnd(statements, searchStart, node => ReferencesLocalIncludingSharedNestedScopes(node, store.Index)),
-            InitObject { Address: LoadLocalAddress local } init when _declaringStores.Contains(init)
-                => LastReferenceEnd(statements, searchStart, node => ReferencesLocalIncludingSharedNestedScopes(node, local.Index)),
             _ => searchStart,
         };
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1132,13 +1132,6 @@ public sealed partial class CSharpPrinter
         return DescendantsOutsideNestedFunctions(node).Any(n => IsLocalReference(n, index));
     }
 
-    static bool ReferencesLocalIncludingNestedFunctions(IrNode node, int index)
-    {
-        if (IsLocalReference(node, index))
-            return true;
-        return node.Descendants.Any(n => IsLocalReference(n, index));
-    }
-
     static bool ReferencesStackSlot(IrNode node, int slot)
     {
         if (IsStackSlotReference(node, slot))
@@ -1629,14 +1622,14 @@ public sealed partial class CSharpPrinter
                 case StoreLocal store when _declaringStores.Contains(store):
                     for (int j = candidate; j < statements.Count; j++)
                     {
-                        if (ReferencesLocalIncludingNestedFunctions(statements[j], store.Index))
+                        if (ReferencesLocal(statements[j], store.Index))
                             return true;
                     }
                     break;
                 case InitObject { Address: LoadLocalAddress local } init when _declaringStores.Contains(init):
                     for (int j = candidate; j < statements.Count; j++)
                     {
-                        if (ReferencesLocalIncludingNestedFunctions(statements[j], local.Index))
+                        if (ReferencesLocal(statements[j], local.Index))
                             return true;
                     }
                     break;

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1134,6 +1134,10 @@ public sealed partial class CSharpPrinter
 
     static bool ReferencesLocalIncludingSharedNestedScopes(IrNode node, int index)
     {
+        if (node is Lambda nestedLambda && NeedsNestedLambdaScope(nestedLambda))
+            return false;
+        if (node is LocalFunctionStatement nestedLocalFunction && NeedsNestedLocalFunctionScope(nestedLocalFunction))
+            return false;
         if (IsLocalReference(node, index))
             return true;
         foreach (var child in node.Children)
@@ -1591,13 +1595,7 @@ public sealed partial class CSharpPrinter
 
             if (_newMemorySafetyRules && _unsafeDepth == 0 && NeedsUnsafeContext(statements[i]))
             {
-                int j = i + 1;
-                while (j < statements.Count
-                    && (NeedsUnsafeContext(statements[j])
-                        || UnsafeRunNeedsToReachFutureDeclarationReference(statements, i, j)))
-                {
-                    j++;
-                }
+                int j = UnsafeRunEnd(statements, i);
                 string pad = new(' ', indent * 4);
                 sb.Append(pad).AppendLine("unsafe");
                 sb.Append(pad).AppendLine("{");
@@ -1622,37 +1620,47 @@ public sealed partial class CSharpPrinter
         }
     }
 
-    bool UnsafeRunNeedsToReachFutureDeclarationReference(IReadOnlyList<IrNode> statements, int start, int candidate)
+    int UnsafeRunEnd(IReadOnlyList<IrNode> statements, int start)
     {
-        for (int i = start; i < candidate; i++)
+        int end = start + 1;
+        while (end < statements.Count && NeedsUnsafeContext(statements[end]))
+            end++;
+
+        for (int i = start; i < end; i++)
         {
-            switch (statements[i])
+            int requiredEnd = UnsafeRunRequiredEnd(statements, i, end);
+            if (requiredEnd > end)
             {
-                case StoreStackSlot store when _declaringStores.Contains(store):
-                    for (int j = candidate; j < statements.Count; j++)
-                    {
-                        if (ReferencesStackSlot(statements[j], store.Slot))
-                            return true;
-                    }
-                    break;
-                case StoreLocal store when _declaringStores.Contains(store):
-                    for (int j = candidate; j < statements.Count; j++)
-                    {
-                        if (ReferencesLocalIncludingSharedNestedScopes(statements[j], store.Index))
-                            return true;
-                    }
-                    break;
-                case InitObject { Address: LoadLocalAddress local } init when _declaringStores.Contains(init):
-                    for (int j = candidate; j < statements.Count; j++)
-                    {
-                        if (ReferencesLocalIncludingSharedNestedScopes(statements[j], local.Index))
-                            return true;
-                    }
-                    break;
+                end = requiredEnd;
+                while (end < statements.Count && NeedsUnsafeContext(statements[end]))
+                    end++;
             }
         }
 
-        return false;
+        return end;
+    }
+
+    int UnsafeRunRequiredEnd(IReadOnlyList<IrNode> statements, int declarationIndex, int searchStart)
+    {
+        return statements[declarationIndex] switch
+        {
+            StoreStackSlot store when _declaringStores.Contains(store)
+                => LastReferenceEnd(statements, searchStart, node => ReferencesStackSlot(node, store.Slot)),
+            StoreLocal store when _declaringStores.Contains(store)
+                => LastReferenceEnd(statements, searchStart, node => ReferencesLocalIncludingSharedNestedScopes(node, store.Index)),
+            InitObject { Address: LoadLocalAddress local } init when _declaringStores.Contains(init)
+                => LastReferenceEnd(statements, searchStart, node => ReferencesLocalIncludingSharedNestedScopes(node, local.Index)),
+            _ => searchStart,
+        };
+    }
+
+    static int LastReferenceEnd(IReadOnlyList<IrNode> statements, int start, Func<IrNode, bool> hasReference)
+    {
+        int end = start;
+        for (int i = start; i < statements.Count; i++)
+            if (hasReference(statements[i]))
+                end = i + 1;
+        return end;
     }
 
     void AppendStatementLabel(StringBuilder sb, IrNode statement, int indent)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1032,6 +1032,18 @@ public sealed partial class CSharpPrinter
                 if (store.Value is StackAllocArray)
                     _scopedLocals.Add(store.Index);
             }
+            foreach (var store in _declaringStores.OfType<StoreStackSlot>().ToList())
+            {
+                if (!HasUnsafeOperation(store.Value) || StackSlotReferencesStayInBlockAfterStore(function, store))
+                    continue;
+                _declaringStores.Remove(store);
+            }
+            foreach (var init in _declaringStores.OfType<InitObject>().ToList())
+            {
+                if (init.Address is not LoadLocalAddress local || LocalReferencesStayInBlockAfterStatement(function, init, local.Index))
+                    continue;
+                _declaringStores.Remove(init);
+            }
         }
     }
 
@@ -1074,14 +1086,23 @@ public sealed partial class CSharpPrinter
             return false;
         if (StoreValueReferencesLocal(store))
             return false;
-        var allowed = block.Children.Skip(store.ChildIndex).ToList();
         if (HasBranchTargetAfterStatement(store))
+            return false;
+        return LocalReferencesStayInBlockAfterStatement(function, store, store.Index);
+    }
+
+    bool LocalReferencesStayInBlockAfterStatement(IrFunction function, IrNode statement, int index)
+    {
+        if (statement.Parent is not Block block || statement.ChildIndex < 0)
+            return false;
+        var allowed = block.Children.Skip(statement.ChildIndex).ToList();
+        if (HasBranchTargetAfterStatement(statement))
             return false;
         foreach (var node in DescendantsOutsideNestedFunctions(function))
         {
-            if (node is StoreLocal s && s.Index == store.Index
-                || node is LoadLocal l && l.Index == store.Index
-                || node is LoadLocalAddress a && a.Index == store.Index)
+            if (node is StoreLocal s && s.Index == index
+                || node is LoadLocal l && l.Index == index
+                || node is LoadLocalAddress a && a.Index == index)
             {
                 if (!allowed.Any(statement => IsDescendantOrSelf(node, statement)))
                     return false;


### PR DESCRIPTION
## Summary

Addresses two measured #2505 RTS source-probe invalid buckets without reintroducing harness-owned shell composition:

- keeps stack-slot declarations introduced by unsafe stackalloc operations in scope under new memory-safety rules, removing the `CS0103` / transient `CS8346` stackalloc temp bucket
- preserves `delegate*` in compile-back function-pointer signatures instead of escaping it as `@delegate*`, removing the `CS1001` function-pointer signature bucket

## Evidence

Focused tests:

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/UnsafeEmitterTests/*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/ReturnToSenderFixtureCatalogTests/*"
```

Build:

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --no-restore
```

RTS source-probe over broader decompiler fixtures:

```text
RETURNTOSENDER SOURCE PROBE over 204 target(s)
  ValidMatch       : 95
  ValidDifferent   : 74
  Invalid          : 35
  SourceUnavailable: 0
  UnsupportedTarget: 0

Buckets:
  20: CS1525
  11: CS0161
  2: CS1002
  1: CS8333
  1: CS8858
```

The removed buckets are `CS0103`, `CS1001`, and the transient `CS8346` exposed while fixing stackalloc scoping.

## Notes

The remaining invalid categories stay tracked in #2505. `CS1002` string pinning still needs a separate pinned-ref/fixed rendering design.
