### PR TITLE
Fix nightly SDK lane package feeds

### DIFF
--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -214,6 +214,7 @@ jobs:
       DOTNETUP_CHANNEL: 11.0-daily
       DOTNET_ROOT: ${{ github.workspace }}/.dotnet-nightly
       DOTNET_DOTNETUP_DATA_DIR: ${{ github.workspace }}/artifacts/.dotnetup
+      NIGHTLY_NUGET_CONFIG: ${{ runner.temp }}/NuGet.Config
     steps:
       - uses: actions/checkout@v6
 
@@ -248,6 +249,39 @@ jobs:
           restore-keys: |
             nuget-nightly-${{ runner.os }}-${{ runner.arch }}-
 
+      - name: Write nightly NuGet config
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cat > "$NIGHTLY_NUGET_CONFIG" <<'EOF'
+          <?xml version="1.0" encoding="utf-8"?>
+          <configuration>
+            <packageSources>
+              <clear />
+              <add key="dotnet11" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json" />
+              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+            </packageSources>
+            <packageSourceMapping>
+              <packageSource key="dotnet11">
+                <package pattern="Microsoft.AspNetCore.App.*" />
+                <package pattern="Microsoft.DotNet.ILCompiler" />
+                <package pattern="Microsoft.NET.ILLink.Tasks" />
+                <package pattern="Microsoft.NETCore.App.*" />
+                <package pattern="runtime.*.Microsoft.DotNet.ILCompiler" />
+              </packageSource>
+              <packageSource key="nuget.org">
+                <package pattern="*" />
+                <package pattern="Microsoft.AspNetCore.App.*" />
+                <package pattern="Microsoft.DotNet.ILCompiler" />
+                <package pattern="Microsoft.NET.ILLink.Tasks" />
+                <package pattern="Microsoft.NETCore.App.*" />
+                <package pattern="runtime.*.Microsoft.DotNet.ILCompiler" />
+              </packageSource>
+            </packageSourceMapping>
+          </configuration>
+          EOF
+
       - name: Probe unsafe expression compiler support
         continue-on-error: true
         shell: bash
@@ -267,8 +301,11 @@ jobs:
 
           dotnet run "$check"
 
+      - name: Restore with nightly package feeds
+        run: dotnet restore dotnet-inspect.slnx --configfile "$NIGHTLY_NUGET_CONFIG"
+
       - name: Build with nightly SDK
-        run: dotnet build dotnet-inspect.slnx -c Release
+        run: dotnet build dotnet-inspect.slnx -c Release --no-restore
 
       - name: Run unsafe decompiler tests with nightly SDK
-        run: dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/UnsafeEmitterTests/*"
+        run: dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/UnsafeEmitterTests/*"

--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -263,6 +263,12 @@ jobs:
               <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
             </packageSources>
             <packageSourceMapping>
+              <!--
+                These pack IDs must map to both sources. NuGet source mapping is
+                package-ID based, not version-aware: net11 daily runtime/AOT/linker
+                packs come from the dotnet11 feed, while net10 packs used by some
+                fixture projects still come from nuget.org.
+              -->
               <packageSource key="dotnet11">
                 <package pattern="Microsoft.AspNetCore.App.*" />
                 <package pattern="Microsoft.DotNet.ILCompiler" />

--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -214,7 +214,6 @@ jobs:
       DOTNETUP_CHANNEL: 11.0-daily
       DOTNET_ROOT: ${{ github.workspace }}/.dotnet-nightly
       DOTNET_DOTNETUP_DATA_DIR: ${{ github.workspace }}/artifacts/.dotnetup
-      NIGHTLY_NUGET_CONFIG: ${{ runner.temp }}/NuGet.Config
     steps:
       - uses: actions/checkout@v6
 
@@ -254,7 +253,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          cat > "$NIGHTLY_NUGET_CONFIG" <<'EOF'
+          nightly_nuget_config="$RUNNER_TEMP/NuGet.Config"
+          echo "NIGHTLY_NUGET_CONFIG=$nightly_nuget_config" >> "$GITHUB_ENV"
+
+          cat > "$nightly_nuget_config" <<'EOF'
           <?xml version="1.0" encoding="utf-8"?>
           <configuration>
             <packageSources>


### PR DESCRIPTION
## Summary
- Generate a temporary NuGet.Config for the opt-in Deep Inspect nightly lane.
- Add the .NET 11 daily package feed with source mapping so nightly runtime/AOT/linker packs resolve without NU1507.
- Restore explicitly with that config, then build and run focused unsafe tests with `--no-restore`.

## Validation
- `dotnet restore dotnet-inspect.slnx --configfile /tmp/nightly.dual.mapped.nuget.config` under `11.0.100-preview.7.26357.101`
- `dotnet build dotnet-inspect.slnx -c Release --no-restore` under `11.0.100-preview.7.26357.101`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/UnsafeEmitterTests/*"`
- `dotnet run /tmp/unsafe-expression.cs` with `/tmp/NuGet.Config` containing the nightly feed mapping

CI-only follow-up to #2509; low-risk workflow fix.