### PR TITLE
Document nightly SDK repo development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,20 +69,44 @@ Repository development tracks .NET 11 daily SDKs so decompiler work can follow
 compiler-produced shapes before monthly previews. Published tool users are not
 affected by this repo-development requirement.
 
-Use `dotnetup` for local SDK acquisition:
+Before installing an SDK or changing PATH, inspect the current `dotnet`:
+
+```bash
+command -v dotnet
+dotnet --info
+```
+
+If `dotnet` is centrally installed (for example under `/usr/bin`,
+`/usr/local/share/dotnet`, `/snap`, or `C:\Program Files\dotnet`), stop and ask
+for guidance before installing an additional user-level SDK or changing shell
+configuration. Do not remove, shadow, or replace a centrally managed install
+unless the user explicitly approves it.
+
+Use `dotnetup` for non-invasive local SDK acquisition:
 
 ```bash
 curl -fsSL --retry 3 https://aka.ms/dotnetup/get-dotnetup.sh -o /tmp/get-dotnetup.sh
 bash /tmp/get-dotnetup.sh --install-dir "$HOME/.local/bin"
-mkdir -p "$HOME/.dotnetup/dotnet"
-dotnetup sdk install 11.0-daily \
-  --install-path "$HOME/.dotnetup/dotnet" \
-  --set-default-install false \
-  --interactive false
-eval "$(dotnetup print-env-script --shell bash --dotnet-install-path "$HOME/.dotnetup/dotnet")"
+dotnetup sdk install 11.0-daily --interactive false
 ```
 
-Verify `dotnet --version` reports the dotnetup-managed daily SDK before building.
+Prefer running repo commands through dotnetup so the nightly SDK is selected
+only for that command:
+
+```bash
+dotnetup dotnet build dotnet-inspect.slnx -c Release
+dotnetup dotnet run --project src/ILInspector.Decompiler.Tests -c Release
+```
+
+Only if the user explicitly wants this repo's shell to prefer the
+dotnetup-managed SDK, opt in through dotnetup's supported environment script:
+
+```bash
+eval "$(dotnetup print-env-script --shell bash)"
+```
+
+Verify the selected `dotnet --version` reports the dotnetup-managed daily SDK
+before building.
 
 Build the normal product/test/fixture graph:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,12 +103,17 @@ dotnetup dotnet build dotnet-inspect.slnx -c Release
 dotnetup dotnet run --project src/ILInspector.Decompiler.Tests -c Release
 ```
 
-Only if the user explicitly wants this repo's shell to prefer the
-dotnetup-managed SDK, opt in through dotnetup's supported environment script:
+For a temporary shell/process override, evaluate dotnetup's supported
+environment script before running repo commands:
 
 ```bash
 eval "$(dotnetup print-env-script --shell bash)"
+dotnet build dotnet-inspect.slnx -c Release
 ```
+
+That affects only the current shell process and its children. Do not write this
+line to startup files such as `.bashrc`, `.profile`, or `.zshrc` unless the user
+explicitly asks for a persistent shell change.
 
 Verify the selected `dotnet --version` reports the dotnetup-managed daily SDK
 before building.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,25 @@ Console.WriteLine($"Found {items.Count} items");
 
 ## Building and Testing
 
+Repository development tracks .NET 11 daily SDKs so decompiler work can follow
+compiler-produced shapes before monthly previews. Published tool users are not
+affected by this repo-development requirement.
+
+Use `dotnetup` for local SDK acquisition:
+
+```bash
+curl -fsSL --retry 3 https://aka.ms/dotnetup/get-dotnetup.sh -o /tmp/get-dotnetup.sh
+bash /tmp/get-dotnetup.sh --install-dir "$HOME/.local/bin"
+mkdir -p "$HOME/.dotnetup/dotnet"
+dotnetup sdk install 11.0-daily \
+  --install-path "$HOME/.dotnetup/dotnet" \
+  --set-default-install false \
+  --interactive false
+eval "$(dotnetup print-env-script --shell bash --dotnet-install-path "$HOME/.dotnetup/dotnet")"
+```
+
+Verify `dotnet --version` reports the dotnetup-managed daily SDK before building.
+
 Build the normal product/test/fixture graph:
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,9 +94,10 @@ bash /tmp/get-dotnetup.sh --install-dir "$HOME/.local/bin"
 dotnetup sdk install 11.0-daily --interactive false
 ```
 
-When the default `dotnet` is not the repo SDK and the user has approved a
-user-level dotnetup install, run repo commands through dotnetup so the nightly
-SDK is selected only for that command:
+When the default `dotnet` for commands run from this repository is not the
+dotnetup-managed .NET 11 daily SDK, and the user has approved a user-level
+dotnetup install, run repo commands through dotnetup so the nightly SDK is
+selected only for that command:
 
 ```bash
 dotnetup dotnet build dotnet-inspect.slnx -c Release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,8 +73,12 @@ Before installing an SDK or changing PATH, inspect the current `dotnet`:
 
 ```bash
 command -v dotnet
-dotnet --info
+dotnet --version
 ```
+
+If `dotnet` already resolves to a dotnetup-managed .NET 11 daily SDK, use normal
+`dotnet` commands for this repo. Do not wrap those commands in `dotnetup dotnet`
+unless you need to force an isolated dotnetup install.
 
 If `dotnet` is centrally installed (for example under `/usr/bin`,
 `/usr/local/share/dotnet`, `/snap`, or `C:\Program Files\dotnet`), stop and ask
@@ -90,8 +94,9 @@ bash /tmp/get-dotnetup.sh --install-dir "$HOME/.local/bin"
 dotnetup sdk install 11.0-daily --interactive false
 ```
 
-Prefer running repo commands through dotnetup so the nightly SDK is selected
-only for that command:
+When the default `dotnet` is not the repo SDK and the user has approved a
+user-level dotnetup install, run repo commands through dotnetup so the nightly
+SDK is selected only for that command:
 
 ```bash
 dotnetup dotnet build dotnet-inspect.slnx -c Release

--- a/README.md
+++ b/README.md
@@ -15,6 +15,45 @@ Run without installing:
 dnx dotnet-inspect -y -- <command>
 ```
 
+## Repository development SDK
+
+Published tool users can install or run `dotnet-inspect` with the commands
+above. Contributors building this repository should use a .NET 11 daily SDK.
+The decompiler tracks compiler-produced C# shapes, and some correctness work
+needs daily compiler/runtime packs before the next public preview ships.
+
+Use `dotnetup` to install and track the daily SDK:
+
+```bash
+curl -fsSL --retry 3 https://aka.ms/dotnetup/get-dotnetup.sh -o /tmp/get-dotnetup.sh
+bash /tmp/get-dotnetup.sh --install-dir "$HOME/.local/bin"
+
+mkdir -p "$HOME/.dotnetup/dotnet"
+dotnetup sdk install 11.0-daily \
+  --install-path "$HOME/.dotnetup/dotnet" \
+  --set-default-install false \
+  --interactive false
+```
+
+Configure the shell through dotnetup's supported environment script:
+
+```bash
+eval "$(dotnetup print-env-script --shell bash --dotnet-install-path "$HOME/.dotnetup/dotnet")"
+```
+
+Verify the repo SDK:
+
+```bash
+command -v dotnet
+dotnet --version
+dotnetup list
+```
+
+The Deep Inspect `nightly` lane uses the same pattern. It restores with a
+temporary NuGet config that includes both the .NET 11 daily feed and nuget.org:
+most projects target the nightly `net11.0` SDK, while a few fixture projects
+still target stable `net10.0` packs.
+
 ## What it inspects
 
 | Source | Examples | Notes |

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ That affects only the current shell process and its children. It changes future
 shells only if you add the line to a startup file such as `.bashrc`, `.profile`,
 or `.zshrc`.
 
-Verify the selected SDK:
+Verify the `dotnet` selected for commands run from this repository:
 
 ```bash
 command -v dotnet

--- a/README.md
+++ b/README.md
@@ -22,30 +22,37 @@ above. Contributors building this repository should use a .NET 11 daily SDK.
 The decompiler tracks compiler-produced C# shapes, and some correctness work
 needs daily compiler/runtime packs before the next public preview ships.
 
-Before changing any shell configuration, check how `dotnet` is installed:
+First check how `dotnet` is installed and which SDK it selects:
 
 ```bash
 command -v dotnet
-dotnet --info
+dotnet --version
+```
+
+If that already resolves to a dotnetup-managed .NET 11 daily SDK, use normal
+`dotnet` commands:
+
+```bash
+dotnet build dotnet-inspect.slnx -c Release
+dotnet run --project src/ILInspector.Decompiler.Tests -c Release
 ```
 
 If `dotnet` comes from a centrally managed location such as `/usr/bin`,
 `/usr/local/share/dotnet`, `/snap`, or `C:\Program Files\dotnet`, do not replace
 it or prepend another `dotnet` to PATH unless that is intentional for your
-machine. Use the non-invasive dotnetup mode below, or ask your system
+machine. Use dotnetup in command-isolation mode, or ask your system
 administrator which setup is appropriate.
 
-Use `dotnetup` to install and track the daily SDK in a user-managed location:
+Install and track the daily SDK with dotnetup:
 
 ```bash
 curl -fsSL --retry 3 https://aka.ms/dotnetup/get-dotnetup.sh -o /tmp/get-dotnetup.sh
 bash /tmp/get-dotnetup.sh --install-dir "$HOME/.local/bin"
-
 dotnetup sdk install 11.0-daily --interactive false
 ```
 
-Run repo commands through dotnetup when you want the nightly SDK without making
-it your shell default:
+Then run repo commands through dotnetup when you want the nightly SDK without
+making it your shell default:
 
 ```bash
 dotnetup dotnet build dotnet-inspect.slnx -c Release

--- a/README.md
+++ b/README.md
@@ -22,26 +22,44 @@ above. Contributors building this repository should use a .NET 11 daily SDK.
 The decompiler tracks compiler-produced C# shapes, and some correctness work
 needs daily compiler/runtime packs before the next public preview ships.
 
-Use `dotnetup` to install and track the daily SDK:
+Before changing any shell configuration, check how `dotnet` is installed:
+
+```bash
+command -v dotnet
+dotnet --info
+```
+
+If `dotnet` comes from a centrally managed location such as `/usr/bin`,
+`/usr/local/share/dotnet`, `/snap`, or `C:\Program Files\dotnet`, do not replace
+it or prepend another `dotnet` to PATH unless that is intentional for your
+machine. Use the non-invasive dotnetup mode below, or ask your system
+administrator which setup is appropriate.
+
+Use `dotnetup` to install and track the daily SDK in a user-managed location:
 
 ```bash
 curl -fsSL --retry 3 https://aka.ms/dotnetup/get-dotnetup.sh -o /tmp/get-dotnetup.sh
 bash /tmp/get-dotnetup.sh --install-dir "$HOME/.local/bin"
 
-mkdir -p "$HOME/.dotnetup/dotnet"
-dotnetup sdk install 11.0-daily \
-  --install-path "$HOME/.dotnetup/dotnet" \
-  --set-default-install false \
-  --interactive false
+dotnetup sdk install 11.0-daily --interactive false
 ```
 
-Configure the shell through dotnetup's supported environment script:
+Run repo commands through dotnetup when you want the nightly SDK without making
+it your shell default:
 
 ```bash
-eval "$(dotnetup print-env-script --shell bash --dotnet-install-path "$HOME/.dotnetup/dotnet")"
+dotnetup dotnet build dotnet-inspect.slnx -c Release
+dotnetup dotnet run --project src/ILInspector.Decompiler.Tests -c Release
 ```
 
-Verify the repo SDK:
+If you intentionally want this repo's shell to prefer the dotnetup-managed SDK,
+opt in through dotnetup's supported environment script:
+
+```bash
+eval "$(dotnetup print-env-script --shell bash)"
+```
+
+Verify the selected SDK:
 
 ```bash
 command -v dotnet
@@ -49,10 +67,10 @@ dotnet --version
 dotnetup list
 ```
 
-The Deep Inspect `nightly` lane uses the same pattern. It restores with a
-temporary NuGet config that includes both the .NET 11 daily feed and nuget.org:
-most projects target the nightly `net11.0` SDK, while a few fixture projects
-still target stable `net10.0` packs.
+The Deep Inspect `nightly` lane uses the same acquisition model in an isolated
+workspace install. It restores with a temporary NuGet config that includes both
+the .NET 11 daily feed and nuget.org: most projects target the nightly
+`net11.0` SDK, while a few fixture projects still target stable `net10.0` packs.
 
 ## What it inspects
 

--- a/README.md
+++ b/README.md
@@ -59,12 +59,17 @@ dotnetup dotnet build dotnet-inspect.slnx -c Release
 dotnetup dotnet run --project src/ILInspector.Decompiler.Tests -c Release
 ```
 
-If you intentionally want this repo's shell to prefer the dotnetup-managed SDK,
-opt in through dotnetup's supported environment script:
+For a temporary shell/process override, evaluate dotnetup's supported
+environment script before running repo commands:
 
 ```bash
 eval "$(dotnetup print-env-script --shell bash)"
+dotnet build dotnet-inspect.slnx -c Release
 ```
+
+That affects only the current shell process and its children. It changes future
+shells only if you add the line to a startup file such as `.bashrc`, `.profile`,
+or `.zshrc`.
 
 Verify the selected SDK:
 


### PR DESCRIPTION
## Summary
- Document that repo development tracks .NET 11 daily SDKs while published tool users are unaffected.
- Recommend dotnetup for installing/tracking `11.0-daily` and configuring the shell.
- Add the same SDK requirement to `AGENTS.md` for future agent build/test work.

## Validation
- `npx markdownlint-cli --fix README.md AGENTS.md`
- `npx markdownlint-cli README.md AGENTS.md`

Docs-only; no adversarial review needed.

Closes #2510.