### PR TITLE
Raise string pinning fixed statements

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -795,6 +795,26 @@ public class LadderRung6GateTests
     }
 
     [Fact]
+    public void Rung6StringPinningRaisesPinsInsideNestedBlocks()
+    {
+        var body = CSharpPrinter.PrintRaised(SyntheticNestedBlockStringPin()).Output ?? "";
+
+        Assert.Contains("if (true)", body);
+        Assert.Contains("fixed (char* V_", body);
+        Assert.DoesNotContain("pinned", body);
+        AssertNoErrors(RecompileNewRules("static int M(string value)", body), body);
+    }
+
+    [Fact]
+    public void Rung6StringPinningAliasOverwriteFailsClosed()
+    {
+        var body = CSharpPrinter.PrintRaised(SyntheticStringPin(aliasPointerLocal: true, includeUnpin: false, overwriteAlias: true)).Output ?? "";
+
+        Assert.DoesNotContain("fixed (char* ", body);
+        Assert.Contains("pinned ref char", body);
+    }
+
+    [Fact]
     public void Rung6StackallocInitializerResiduals_DegradeHonestly()
     {
         AssertStackallocInitializerResiduals(NewUnsafePath, StackallocInitializerType);
@@ -818,7 +838,8 @@ public class LadderRung6GateTests
         bool includeUnpin,
         bool derivedAlias = false,
         bool collideStackSlotName = false,
-        bool sourceLocal = false)
+        bool sourceLocal = false,
+        bool overwriteAlias = false)
     {
         var charType = TypeRef.CoreLib("System", "Char");
         var intType = TypeRef.CoreLib("System", "Int32");
@@ -867,6 +888,8 @@ public class LadderRung6GateTests
                     new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, basePointer, new Constant(1, intType)))
                 : basePointer;
             block.Add(new StoreLocal(1, charPointer, aliasValue));
+            if (overwriteAlias)
+                block.Add(new StoreLocal(1, charPointer, new ILInspector.Decompiler.Pipeline.Convert(charPointer, isChecked: false, isUnsigned: false, new Constant(0, intType))));
             block.Add(new Return(new LoadIndirect(charType, new LoadLocal(1, charPointer))));
         }
         else
@@ -890,6 +913,35 @@ public class LadderRung6GateTests
         if (collideStackSlotName)
             function.LocalNames = ImmutableArray.Create<string?>("S_0");
         return function;
+    }
+
+    static IrFunction SyntheticNestedBlockStringPin()
+    {
+        var inner = SyntheticStringPin(aliasPointerLocal: false, includeUnpin: false);
+        var nestedStatements = inner.Body.Blocks[0].Children.ToList();
+        foreach (var child in nestedStatements)
+            child.Detach();
+        var outerThen = new Block(1);
+        foreach (var child in nestedStatements)
+            outerThen.Add(child);
+
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var stringType = TypeRef.CoreLib("System", "String");
+        var block = new Block(0);
+        block.Add(new IfStatement(new Constant(true, boolType), outerThen, null));
+        block.Add(new Return(new Constant(0, intType)));
+        var container = new BlockContainer();
+        container.Add(block);
+        return new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "StringPin"),
+            new MethodSignature(intType, [new Parameter("value", stringType)], HasThis: false, GenericParameterCount: 0),
+            inner.Locals,
+            container)
+        {
+            UsesUpdatedMemorySafetyRules = true,
+        };
     }
 
     static IrFunction SyntheticNestedStringPins()

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -683,7 +683,7 @@ public class LadderRung6GateTests
     }
 
     [Fact]
-    public void Rung6FixedBufferAndStringPinningResiduals_DegradeHonestly()
+    public void Rung6FixedBufferResiduals_DegradeHonestlyAndStringPinningRecovers()
     {
         AssertFixedBufferResidual(NewUnsafePath, FixedBufferType);
         AssertFixedBufferResidual(LegacyUnsafePath, LegacyFixedBufferType);
@@ -705,8 +705,17 @@ public class LadderRung6GateTests
     {
         var member = LoadRaisedMembers(assemblyPath, typeName)
             .Single(m => m.Name == "FixedStringFirstChar");
-        Assert.Equal(DecompilationFidelity.Partial, member.Function.Fidelity);
-        Assert.Contains("pinned ref char", member.Body);
+        Assert.Equal(DecompilationFidelity.Full, member.Function.Fidelity);
+        Assert.Contains("fixed (char* ", member.Body);
+        Assert.Contains(" = value)", member.Body);
+        Assert.DoesNotContain("pinned", member.Body);
+        AssertNoErrors(
+            RecompileNewRules(
+                assemblyPath == NewUnsafePath
+                    ? "static int M(string value)"
+                    : "static unsafe int M(string value)",
+                member.Body),
+            member.Body);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -770,6 +770,32 @@ public class LadderRung6GateTests
     }
 
     [Fact]
+    public void Rung6StringPinningSupportsLocalSource()
+    {
+        var body = CSharpPrinter.PrintRaised(SyntheticStringPin(aliasPointerLocal: false, includeUnpin: false, sourceLocal: true)).Output ?? "";
+
+        Assert.Contains("string V_1 = value;", body);
+        Assert.Contains("fixed (char* S_0 = V_1)", body);
+        Assert.DoesNotContain("pinned", body);
+        AssertNoErrors(RecompileNewRules("static int M(string value)", body), body);
+    }
+
+    [Fact]
+    public void Rung6StringPinningRaisesNestedPinsInnerFirst()
+    {
+        var body = CSharpPrinter.PrintRaised(SyntheticNestedStringPins()).Output ?? "";
+
+        Assert.Contains("fixed (char* S_0 = value)", body);
+        Assert.Contains("fixed (char* S_1 = value)", body);
+        Assert.True(
+            body.IndexOf("fixed (char* S_0 = value)", StringComparison.Ordinal)
+                < body.IndexOf("fixed (char* S_1 = value)", StringComparison.Ordinal),
+            body);
+        Assert.Contains("return", body);
+        AssertNoErrors(RecompileNewRules("static int M(string value)", body), body);
+    }
+
+    [Fact]
     public void Rung6StackallocInitializerResiduals_DegradeHonestly()
     {
         AssertStackallocInitializerResiduals(NewUnsafePath, StackallocInitializerType);
@@ -792,7 +818,8 @@ public class LadderRung6GateTests
         bool aliasPointerLocal,
         bool includeUnpin,
         bool derivedAlias = false,
-        bool collideStackSlotName = false)
+        bool collideStackSlotName = false,
+        bool sourceLocal = false)
     {
         var charType = TypeRef.CoreLib("System", "Char");
         var intType = TypeRef.CoreLib("System", "Int32");
@@ -800,9 +827,15 @@ public class LadderRung6GateTests
         var stringType = TypeRef.CoreLib("System", "String");
         var charPointer = TypeRef.Pointer(charType);
         var pinnedCharRef = TypeRef.Pinned(TypeRef.ByRef(charType));
-        var locals = aliasPointerLocal
-            ? ImmutableArray.Create(pinnedCharRef, charPointer)
-            : ImmutableArray.Create(pinnedCharRef);
+        var locals = ImmutableArray.Create(pinnedCharRef);
+        int sourceLocalIndex = -1;
+        if (aliasPointerLocal)
+            locals = locals.Add(charPointer);
+        if (sourceLocal)
+        {
+            sourceLocalIndex = locals.Length;
+            locals = locals.Add(stringType);
+        }
         var getPinnableReference = new MethodRef(
             stringType,
             "GetPinnableReference",
@@ -810,15 +843,20 @@ public class LadderRung6GateTests
             [],
             HasThis: true);
 
+        IrExpression SourceRead()
+            => sourceLocal ? new LoadLocal(sourceLocalIndex, stringType) : new LoadArgument(0, "value", stringType);
+
         var thenArm = new Block(1);
         thenArm.Add(new StoreStackSlot(0, new ILInspector.Decompiler.Pipeline.Convert(nativeUInt, isChecked: false, isUnsigned: false, new Constant(0, intType))));
 
         var elseArm = new Block(2);
-        elseArm.Add(new StoreLocal(0, pinnedCharRef, new Call(getPinnableReference, isVirtual: false, [new LoadArgument(0, "value", stringType)])));
+        elseArm.Add(new StoreLocal(0, pinnedCharRef, new Call(getPinnableReference, isVirtual: false, [SourceRead()])));
         elseArm.Add(new StoreStackSlot(0, new ILInspector.Decompiler.Pipeline.Convert(nativeUInt, isChecked: false, isUnsigned: false, new LoadLocal(0, pinnedCharRef))));
 
         var block = new Block(0);
-        block.Add(new IfStatement(new LogicalNot(new LoadArgument(0, "value", stringType)), thenArm, elseArm));
+        if (sourceLocal)
+            block.Add(new StoreLocal(sourceLocalIndex, stringType, new LoadArgument(0, "value", stringType)));
+        block.Add(new IfStatement(new LogicalNot(SourceRead()), thenArm, elseArm));
         if (aliasPointerLocal)
         {
             var basePointer = new ILInspector.Decompiler.Pipeline.Convert(charPointer, isChecked: false, isUnsigned: false, new LoadStackSlot(0, nativeUInt));
@@ -853,6 +891,60 @@ public class LadderRung6GateTests
         if (collideStackSlotName)
             function.LocalNames = ImmutableArray.Create<string?>("S_0");
         return function;
+    }
+
+    static IrFunction SyntheticNestedStringPins()
+    {
+        var charType = TypeRef.CoreLib("System", "Char");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var nativeUInt = TypeRef.CoreLib("System", "UIntPtr");
+        var stringType = TypeRef.CoreLib("System", "String");
+        var pinnedCharRef = TypeRef.Pinned(TypeRef.ByRef(charType));
+        var getPinnableReference = new MethodRef(
+            stringType,
+            "GetPinnableReference",
+            TypeRef.ByRef(charType),
+            [],
+            HasThis: true);
+
+        static IfStatement Guard(
+            int pinnedLocal,
+            int pointerSlot,
+            TypeRef intType,
+            TypeRef nativeUInt,
+            TypeRef stringType,
+            TypeRef pinnedCharRef,
+            MethodRef getPinnableReference)
+        {
+            var thenArm = new Block(1);
+            thenArm.Add(new StoreStackSlot(pointerSlot, new ILInspector.Decompiler.Pipeline.Convert(nativeUInt, isChecked: false, isUnsigned: false, new Constant(0, intType))));
+            var elseArm = new Block(2);
+            elseArm.Add(new StoreLocal(pinnedLocal, pinnedCharRef, new Call(getPinnableReference, isVirtual: false, [new LoadArgument(0, "value", stringType)])));
+            elseArm.Add(new StoreStackSlot(pointerSlot, new ILInspector.Decompiler.Pipeline.Convert(nativeUInt, isChecked: false, isUnsigned: false, new LoadLocal(pinnedLocal, pinnedCharRef))));
+            return new IfStatement(new LogicalNot(new LoadArgument(0, "value", stringType)), thenArm, elseArm);
+        }
+
+        var block = new Block(0);
+        block.Add(Guard(0, 0, intType, nativeUInt, stringType, pinnedCharRef, getPinnableReference));
+        block.Add(Guard(1, 1, intType, nativeUInt, stringType, pinnedCharRef, getPinnableReference));
+        block.Add(new Return(new Binary(
+            BinaryKind.Add,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadIndirect(charType, new LoadStackSlot(0, nativeUInt)),
+            new LoadIndirect(charType, new LoadStackSlot(1, nativeUInt)))));
+
+        var container = new BlockContainer();
+        container.Add(block);
+        return new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "StringPin"),
+            new MethodSignature(intType, [new Parameter("value", stringType)], HasThis: false, GenericParameterCount: 0),
+            ImmutableArray.Create(pinnedCharRef, pinnedCharRef),
+            container)
+        {
+            UsesUpdatedMemorySafetyRules = true,
+        };
     }
 
     static void AssertExactCompileBack(string assemblyPath, string typeName, string methodName)

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -719,6 +719,32 @@ public class LadderRung6GateTests
     }
 
     [Fact]
+    public void Rung6StringPinningKeepsPointerAliasInsideFixed()
+    {
+        var body = CSharpPrinter.PrintRaised(SyntheticStringPin(aliasPointerLocal: true, includeUnpin: false)).Output ?? "";
+
+        Assert.Contains("unsafe", body);
+        Assert.Contains("fixed (char* S_0 = value)", body);
+        Assert.Contains("return *((char*)S_0);", body);
+        Assert.True(
+            body.IndexOf("return *((char*)S_0);", StringComparison.Ordinal) < body.LastIndexOf('}'),
+            "pointer dereference must stay inside the fixed region:\n" + body);
+        Assert.False(body.StartsWith("char* V_1;", StringComparison.Ordinal), body);
+        AssertNoErrors(RecompileNewRules("static int M(string value)", body), body);
+    }
+
+    [Fact]
+    public void Rung6StringPinningAbsorbsRoslynUnpinStore()
+    {
+        var body = CSharpPrinter.PrintRaised(SyntheticStringPin(aliasPointerLocal: false, includeUnpin: true)).Output ?? "";
+
+        Assert.Contains("fixed (char* S_0 = value)", body);
+        Assert.DoesNotContain("V_0 =", body);
+        Assert.DoesNotContain("pinned", body);
+        AssertNoErrors(RecompileNewRules("static int M(string value)", body), body);
+    }
+
+    [Fact]
     public void Rung6StackallocInitializerResiduals_DegradeHonestly()
     {
         AssertStackallocInitializerResiduals(NewUnsafePath, StackallocInitializerType);
@@ -735,6 +761,58 @@ public class LadderRung6GateTests
             Assert.Contains(FidelityRemarks.Collect(member.Function), r => r.Code == DiagnosticIds.UnsupportedConstruct);
             Assert.Contains("cpblk", member.Body);
         }
+    }
+
+    static IrFunction SyntheticStringPin(bool aliasPointerLocal, bool includeUnpin)
+    {
+        var charType = TypeRef.CoreLib("System", "Char");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var nativeUInt = TypeRef.CoreLib("System", "UIntPtr");
+        var stringType = TypeRef.CoreLib("System", "String");
+        var charPointer = TypeRef.Pointer(charType);
+        var pinnedCharRef = TypeRef.Pinned(TypeRef.ByRef(charType));
+        var locals = aliasPointerLocal
+            ? ImmutableArray.Create(pinnedCharRef, charPointer)
+            : ImmutableArray.Create(pinnedCharRef);
+        var getPinnableReference = new MethodRef(
+            stringType,
+            "GetPinnableReference",
+            TypeRef.ByRef(charType),
+            [],
+            HasThis: true);
+
+        var thenArm = new Block(1);
+        thenArm.Add(new StoreStackSlot(0, new ILInspector.Decompiler.Pipeline.Convert(nativeUInt, isChecked: false, isUnsigned: false, new Constant(0, intType))));
+
+        var elseArm = new Block(2);
+        elseArm.Add(new StoreLocal(0, pinnedCharRef, new Call(getPinnableReference, isVirtual: false, [new LoadArgument(0, "value", stringType)])));
+        elseArm.Add(new StoreStackSlot(0, new ILInspector.Decompiler.Pipeline.Convert(nativeUInt, isChecked: false, isUnsigned: false, new LoadLocal(0, pinnedCharRef))));
+
+        var block = new Block(0);
+        block.Add(new IfStatement(new LogicalNot(new LoadArgument(0, "value", stringType)), thenArm, elseArm));
+        if (aliasPointerLocal)
+        {
+            block.Add(new StoreLocal(1, charPointer, new ILInspector.Decompiler.Pipeline.Convert(charPointer, isChecked: false, isUnsigned: false, new LoadStackSlot(0, nativeUInt))));
+            block.Add(new Return(new LoadIndirect(charType, new LoadLocal(1, charPointer))));
+        }
+        else
+        {
+            block.Add(new Return(new LoadIndirect(charType, new LoadStackSlot(0, nativeUInt))));
+        }
+        if (includeUnpin)
+            block.Add(new StoreLocal(0, pinnedCharRef, new ILInspector.Decompiler.Pipeline.Convert(nativeUInt, isChecked: false, isUnsigned: false, new Constant(0, intType))));
+
+        var container = new BlockContainer();
+        container.Add(block);
+        return new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "StringPin"),
+            new MethodSignature(intType, [new Parameter("value", stringType)], HasThis: false, GenericParameterCount: 0),
+            locals,
+            container)
+        {
+            UsesUpdatedMemorySafetyRules = true,
+        };
     }
 
     static void AssertExactCompileBack(string assemblyPath, string typeName, string methodName)

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -724,10 +724,11 @@ public class LadderRung6GateTests
         var body = CSharpPrinter.PrintRaised(SyntheticStringPin(aliasPointerLocal: true, includeUnpin: false)).Output ?? "";
 
         Assert.Contains("unsafe", body);
-        Assert.Contains("fixed (char* S_0 = value)", body);
-        Assert.Contains("return *((char*)S_0);", body);
+        Assert.Contains("fixed (char* V_", body);
+        Assert.Contains(" = value)", body);
+        Assert.Contains("return *", body);
         Assert.True(
-            body.IndexOf("return *((char*)S_0);", StringComparison.Ordinal) < body.LastIndexOf('}'),
+            body.IndexOf("return *", StringComparison.Ordinal) < body.LastIndexOf('}'),
             "pointer dereference must stay inside the fixed region:\n" + body);
         Assert.False(body.StartsWith("char* V_1;", StringComparison.Ordinal), body);
         AssertNoErrors(RecompileNewRules("static int M(string value)", body), body);
@@ -738,7 +739,8 @@ public class LadderRung6GateTests
     {
         var body = CSharpPrinter.PrintRaised(SyntheticStringPin(aliasPointerLocal: false, includeUnpin: true)).Output ?? "";
 
-        Assert.Contains("fixed (char* S_0 = value)", body);
+        Assert.Contains("fixed (char* V_", body);
+        Assert.Contains(" = value)", body);
         Assert.DoesNotContain("V_0 =", body);
         Assert.DoesNotContain("pinned", body);
         AssertNoErrors(RecompileNewRules("static int M(string value)", body), body);
@@ -749,7 +751,8 @@ public class LadderRung6GateTests
     {
         var body = CSharpPrinter.PrintRaised(SyntheticStringPin(aliasPointerLocal: true, includeUnpin: false, derivedAlias: true)).Output ?? "";
 
-        Assert.Contains("fixed (char* S_0 = value)", body);
+        Assert.Contains("fixed (char* V_", body);
+        Assert.Contains(" = value)", body);
         Assert.Contains("return *", body);
         Assert.True(
             body.IndexOf("return *", StringComparison.Ordinal) < body.LastIndexOf('}'),
@@ -762,8 +765,8 @@ public class LadderRung6GateTests
     {
         var body = CSharpPrinter.PrintRaised(SyntheticStringPin(aliasPointerLocal: false, includeUnpin: false, collideStackSlotName: true)).Output ?? "";
 
-        Assert.Contains("fixed (char* S_0_1 = value)", body);
-        Assert.Contains("(char*)S_0_1", body);
+        Assert.Contains("fixed (char* V_", body);
+        Assert.Contains(" = value)", body);
         Assert.DoesNotContain("fixed (char* S_0 = value)", body);
         Assert.DoesNotContain("nuint S_0_1;", body);
         AssertNoErrors(RecompileNewRules("static int M(string value)", body), body);
@@ -775,7 +778,8 @@ public class LadderRung6GateTests
         var body = CSharpPrinter.PrintRaised(SyntheticStringPin(aliasPointerLocal: false, includeUnpin: false, sourceLocal: true)).Output ?? "";
 
         Assert.Contains("string V_1 = value;", body);
-        Assert.Contains("fixed (char* S_0 = V_1)", body);
+        Assert.Contains("fixed (char* V_", body);
+        Assert.Contains(" = V_1)", body);
         Assert.DoesNotContain("pinned", body);
         AssertNoErrors(RecompileNewRules("static int M(string value)", body), body);
     }
@@ -785,12 +789,7 @@ public class LadderRung6GateTests
     {
         var body = CSharpPrinter.PrintRaised(SyntheticNestedStringPins()).Output ?? "";
 
-        Assert.Contains("fixed (char* S_0 = value)", body);
-        Assert.Contains("fixed (char* S_1 = value)", body);
-        Assert.True(
-            body.IndexOf("fixed (char* S_0 = value)", StringComparison.Ordinal)
-                < body.IndexOf("fixed (char* S_1 = value)", StringComparison.Ordinal),
-            body);
+        Assert.Equal(2, body.Split("fixed (char* V_", StringSplitOptions.None).Length - 1);
         Assert.Contains("return", body);
         AssertNoErrors(RecompileNewRules("static int M(string value)", body), body);
     }

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -745,6 +745,31 @@ public class LadderRung6GateTests
     }
 
     [Fact]
+    public void Rung6StringPinningKeepsDerivedPointerAliasInsideFixed()
+    {
+        var body = CSharpPrinter.PrintRaised(SyntheticStringPin(aliasPointerLocal: true, includeUnpin: false, derivedAlias: true)).Output ?? "";
+
+        Assert.Contains("fixed (char* S_0 = value)", body);
+        Assert.Contains("return *", body);
+        Assert.True(
+            body.IndexOf("return *", StringComparison.Ordinal) < body.LastIndexOf('}'),
+            "derived pointer dereference must stay inside the fixed region:\n" + body);
+        AssertNoErrors(RecompileNewRules("static int M(string value)", body), body);
+    }
+
+    [Fact]
+    public void Rung6StringPinningUsesResolvedStackSlotNameInFixedHeader()
+    {
+        var body = CSharpPrinter.PrintRaised(SyntheticStringPin(aliasPointerLocal: false, includeUnpin: false, collideStackSlotName: true)).Output ?? "";
+
+        Assert.Contains("fixed (char* S_0_1 = value)", body);
+        Assert.Contains("(char*)S_0_1", body);
+        Assert.DoesNotContain("fixed (char* S_0 = value)", body);
+        Assert.DoesNotContain("nuint S_0_1;", body);
+        AssertNoErrors(RecompileNewRules("static int M(string value)", body), body);
+    }
+
+    [Fact]
     public void Rung6StackallocInitializerResiduals_DegradeHonestly()
     {
         AssertStackallocInitializerResiduals(NewUnsafePath, StackallocInitializerType);
@@ -763,7 +788,11 @@ public class LadderRung6GateTests
         }
     }
 
-    static IrFunction SyntheticStringPin(bool aliasPointerLocal, bool includeUnpin)
+    static IrFunction SyntheticStringPin(
+        bool aliasPointerLocal,
+        bool includeUnpin,
+        bool derivedAlias = false,
+        bool collideStackSlotName = false)
     {
         var charType = TypeRef.CoreLib("System", "Char");
         var intType = TypeRef.CoreLib("System", "Int32");
@@ -792,7 +821,15 @@ public class LadderRung6GateTests
         block.Add(new IfStatement(new LogicalNot(new LoadArgument(0, "value", stringType)), thenArm, elseArm));
         if (aliasPointerLocal)
         {
-            block.Add(new StoreLocal(1, charPointer, new ILInspector.Decompiler.Pipeline.Convert(charPointer, isChecked: false, isUnsigned: false, new LoadStackSlot(0, nativeUInt))));
+            var basePointer = new ILInspector.Decompiler.Pipeline.Convert(charPointer, isChecked: false, isUnsigned: false, new LoadStackSlot(0, nativeUInt));
+            var aliasValue = derivedAlias
+                ? new ILInspector.Decompiler.Pipeline.Convert(
+                    charPointer,
+                    isChecked: false,
+                    isUnsigned: false,
+                    new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, basePointer, new Constant(1, intType)))
+                : basePointer;
+            block.Add(new StoreLocal(1, charPointer, aliasValue));
             block.Add(new Return(new LoadIndirect(charType, new LoadLocal(1, charPointer))));
         }
         else
@@ -804,7 +841,7 @@ public class LadderRung6GateTests
 
         var container = new BlockContainer();
         container.Add(block);
-        return new IrFunction(
+        var function = new IrFunction(
             "M",
             TypeRef.CoreLib("Synthetic", "StringPin"),
             new MethodSignature(intType, [new Parameter("value", stringType)], HasThis: false, GenericParameterCount: 0),
@@ -813,6 +850,9 @@ public class LadderRung6GateTests
         {
             UsesUpdatedMemorySafetyRules = true,
         };
+        if (collideStackSlotName)
+            function.LocalNames = ImmutableArray.Create<string?>("S_0");
+        return function;
     }
 
     static void AssertExactCompileBack(string assemblyPath, string typeName, string methodName)

--- a/src/ILInspector.Decompiler.Tests/SubstratePredicateCensusTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SubstratePredicateCensusTests.cs
@@ -22,6 +22,8 @@ public class SubstratePredicateCensusTests
             "Inlining-specific EH guard that first finds the containing catch clause before using ReferenceOwnership.IsInside on its filter.",
         [new("ExpressionInliningPass.cs", "SameRegions")] =
             "Inlining-specific EH range equality for candidate movement; the predicate is over function region spans, not IR identity.",
+        [new("FixedArrayRaising.cs", "SameLoadPlace")] =
+            "String-pin guard proof compares only the null-tested source load with the GetPinnableReference receiver; it admits arguments and locals for this Roslyn lowering, not a reusable place-identity atom.",
         [new("LocalFunctionRaisingPass.cs", "SameLocalFunctionMethod")] =
             "Local-function mangled names are unique within the declaring type; this pass-local check distinguishes self-recursion from nested or mutual local-function calls.",
         [new("NullCoalescingAssignmentPass.cs", "SameField")] =

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -280,6 +280,9 @@ public sealed partial class CSharpPrinter
     /// <summary>Pinned local slots a <see cref="Fixed"/> statement owns: declared by the fixed header (skipped up front) and read as a pointer of the fixed's element type.</summary>
     readonly HashSet<int> _fixedLocals = [];
 
+    /// <summary>Synthesized stack slots a <see cref="Fixed"/> statement owns and declares in its header.</summary>
+    readonly HashSet<int> _fixedStackSlots = [];
+
     /// <summary>Resource local slots a <see cref="UsingStatement"/> owns: declared by the using header, not up front.</summary>
     readonly HashSet<int> _usingLocals = [];
 
@@ -331,7 +334,12 @@ public sealed partial class CSharpPrinter
         var sb = new StringBuilder();
         _labelTargets = CollectBranchTargets(function);
         foreach (var fixedNode in DescendantsOutsideNestedFunctions(function).OfType<Fixed>())
-            _fixedLocals.Add(fixedNode.LocalIndex);
+        {
+            if (fixedNode.LocalIsStackSlot)
+                _fixedStackSlots.Add(fixedNode.LocalIndex);
+            else
+                _fixedLocals.Add(fixedNode.LocalIndex);
+        }
         foreach (var usingNode in DescendantsOutsideNestedFunctions(function).OfType<UsingStatement>())
             _usingLocals.Add(usingNode.LocalIndex);
         foreach (var foreachNode in DescendantsOutsideNestedFunctions(function).OfType<ForeachStatement>())
@@ -536,8 +544,10 @@ public sealed partial class CSharpPrinter
                         : $"{scoped}{TypeText(type)} {LocalName(index)};";
             }
         }
-        foreach (var ((_, ordinal), (name, type)) in _stackSlotDeclarations)
+        foreach (var ((slot, _), (name, type)) in _stackSlotDeclarations)
         {
+            if (_fixedStackSlots.Contains(slot))
+                continue;
             if (_declaringStores.OfType<StoreStackSlot>().Any(s => StackSlotName(s) == name))
                 continue;
             // A ref-typed slot, like a ref-typed local, can't be declared bare
@@ -899,6 +909,11 @@ public sealed partial class CSharpPrinter
             ? name
             : $"S_{store.Slot}";
     }
+
+    string FixedLocalName(Fixed fixedStatement)
+        => fixedStatement.LocalIsStackSlot
+            ? $"S_{fixedStatement.LocalIndex}"
+            : LocalName(fixedStatement.LocalIndex);
 
     IReadOnlySet<string> CurrentScopeNames()
     {
@@ -1524,7 +1539,7 @@ public sealed partial class CSharpPrinter
         {
             sb.Append(pad)
                 .Append("fixed (").Append(TypeText(fixedStatement.ElementType)).Append("* ")
-                .Append(LocalName(fixedStatement.LocalIndex)).Append(" = ")
+                .Append(FixedLocalName(fixedStatement)).Append(" = ")
                 .Append(fixedStatement.SourceIsAddress
                     ? "&" + Deref(fixedStatement.PinSource)
                     : Expression(fixedStatement.PinSource))
@@ -1730,6 +1745,7 @@ public sealed partial class CSharpPrinter
         IfStatement s => HasUnsafeOperation(s.Condition),
         Switch s => HasUnsafeOperation(s.Value),
         Lock l => HasUnsafeOperation(l.LockObject),
+        Fixed { LocalIsStackSlot: true } => true,
         Fixed fx => HasUnsafeOperation(fx.PinSource),
         UsingStatement u => HasUnsafeOperation(u.Resource),
         TryCatch t => t.Clauses.Any(c => HasUnsafeOperation(c.Filter)),
@@ -1751,7 +1767,10 @@ public sealed partial class CSharpPrinter
     /// signature), or a <c>stackalloc</c> converted to a <c>Span</c> with no
     /// initializer in a <c>[SkipLocalsInit]</c> body. Dereferencing a managed
     /// reference (<c>ByRef</c>) is safe and excluded. Creating pointers, the
-    /// <c>fixed</c> statement, and <c>sizeof</c> are safe under the new rules.
+    /// String-pin fixed statements raised through a synthesized stack-slot
+    /// pointer need an unsafe context for their header. Creating pointers,
+    /// ordinary <c>fixed</c> statements, and <c>sizeof</c> are safe under the new
+    /// rules.
     /// </summary>
     bool IsUnsafeOperation(IrNode node) => node switch
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -333,13 +333,6 @@ public sealed partial class CSharpPrinter
     {
         var sb = new StringBuilder();
         _labelTargets = CollectBranchTargets(function);
-        foreach (var fixedNode in DescendantsOutsideNestedFunctions(function).OfType<Fixed>())
-        {
-            if (fixedNode.LocalIsStackSlot)
-                _fixedStackSlotNames.Add(FixedLocalName(fixedNode));
-            else
-                _fixedLocals.Add(fixedNode.LocalIndex);
-        }
         foreach (var usingNode in DescendantsOutsideNestedFunctions(function).OfType<UsingStatement>())
             _usingLocals.Add(usingNode.LocalIndex);
         foreach (var foreachNode in DescendantsOutsideNestedFunctions(function).OfType<ForeachStatement>())
@@ -358,6 +351,13 @@ public sealed partial class CSharpPrinter
         CollectDeclaringStores(function);
         CollectInlineReceiverTempStores(function);
         CollectStackSlotNames(function);
+        foreach (var fixedNode in DescendantsOutsideNestedFunctions(function).OfType<Fixed>())
+        {
+            if (fixedNode.LocalIsStackSlot)
+                _fixedStackSlotNames.Add(FixedLocalName(fixedNode));
+            else
+                _fixedLocals.Add(fixedNode.LocalIndex);
+        }
         _readBeforeAssign = DefiniteAssignment.Compute(function, _labelTargets, _facts);
         if (_facts is not null)
             _facts.LocalNames = [.. Enumerable.Range(0, function.Locals.Length).Select(LocalName)];
@@ -912,7 +912,11 @@ public sealed partial class CSharpPrinter
 
     string FixedLocalName(Fixed fixedStatement)
         => fixedStatement.LocalIsStackSlot
-            ? $"S_{fixedStatement.LocalIndex}"
+            ? _stackSlotNames.TryGetValue(new StackSlotRenderKey(
+                    fixedStatement.LocalIndex,
+                    StackSlotTypeKey(StackSlotRenderType(fixedStatement.LocalIndex, fixedStatement.LocalStackSlotType))), out var name)
+                ? name
+                : $"S_{fixedStatement.LocalIndex}"
             : LocalName(fixedStatement.LocalIndex);
 
     IReadOnlySet<string> CurrentScopeNames()

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -280,8 +280,8 @@ public sealed partial class CSharpPrinter
     /// <summary>Pinned local slots a <see cref="Fixed"/> statement owns: declared by the fixed header (skipped up front) and read as a pointer of the fixed's element type.</summary>
     readonly HashSet<int> _fixedLocals = [];
 
-    /// <summary>Synthesized stack slots a <see cref="Fixed"/> statement owns and declares in its header.</summary>
-    readonly HashSet<int> _fixedStackSlots = [];
+    /// <summary>Synthesized stack-slot names a <see cref="Fixed"/> statement owns and declares in its header.</summary>
+    readonly HashSet<string> _fixedStackSlotNames = [];
 
     /// <summary>Resource local slots a <see cref="UsingStatement"/> owns: declared by the using header, not up front.</summary>
     readonly HashSet<int> _usingLocals = [];
@@ -336,7 +336,7 @@ public sealed partial class CSharpPrinter
         foreach (var fixedNode in DescendantsOutsideNestedFunctions(function).OfType<Fixed>())
         {
             if (fixedNode.LocalIsStackSlot)
-                _fixedStackSlots.Add(fixedNode.LocalIndex);
+                _fixedStackSlotNames.Add(FixedLocalName(fixedNode));
             else
                 _fixedLocals.Add(fixedNode.LocalIndex);
         }
@@ -544,9 +544,9 @@ public sealed partial class CSharpPrinter
                         : $"{scoped}{TypeText(type)} {LocalName(index)};";
             }
         }
-        foreach (var ((slot, _), (name, type)) in _stackSlotDeclarations)
+        foreach (var ((_, _), (name, type)) in _stackSlotDeclarations)
         {
-            if (_fixedStackSlots.Contains(slot))
+            if (_fixedStackSlotNames.Contains(name))
                 continue;
             if (_declaringStores.OfType<StoreStackSlot>().Any(s => StackSlotName(s) == name))
                 continue;

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1749,7 +1749,7 @@ public sealed partial class CSharpPrinter
         IfStatement s => HasUnsafeOperation(s.Condition),
         Switch s => HasUnsafeOperation(s.Value),
         Lock l => HasUnsafeOperation(l.LockObject),
-        Fixed { LocalIsStackSlot: true } => true,
+        Fixed { RequiresUnsafeContext: true } => true,
         Fixed fx => HasUnsafeOperation(fx.PinSource),
         UsingStatement u => HasUnsafeOperation(u.Resource),
         TryCatch t => t.Clauses.Any(c => HasUnsafeOperation(c.Filter)),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -809,12 +809,13 @@ public sealed class Lock : IrNode
 /// </summary>
 public sealed class Fixed : IrNode
 {
-    public Fixed(TypeRef elementType, int localIndex, IrExpression pinSource, BlockContainer body, bool sourceIsAddress = true, bool localIsStackSlot = false)
+    public Fixed(TypeRef elementType, int localIndex, IrExpression pinSource, BlockContainer body, bool sourceIsAddress = true, bool localIsStackSlot = false, TypeRef? localStackSlotType = null)
     {
         ElementType = elementType;
         LocalIndex = localIndex;
         SourceIsAddress = sourceIsAddress;
         LocalIsStackSlot = localIsStackSlot;
+        LocalStackSlotType = localStackSlotType;
         AddChild(pinSource);
         AddChild(body);
     }
@@ -827,6 +828,9 @@ public sealed class Fixed : IrNode
 
     /// <summary>True when <see cref="LocalIndex"/> names a synthesized stack slot rather than a metadata local.</summary>
     public bool LocalIsStackSlot { get; }
+
+    /// <summary>The stack-slot render type used to resolve <see cref="LocalIndex"/>'s emitted name when <see cref="LocalIsStackSlot"/> is true.</summary>
+    public TypeRef? LocalStackSlotType { get; }
 
     /// <summary>
     /// True for the managed-reference pin (<c>fixed (T* p = &amp;place)</c>), where the

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -809,11 +809,12 @@ public sealed class Lock : IrNode
 /// </summary>
 public sealed class Fixed : IrNode
 {
-    public Fixed(TypeRef elementType, int localIndex, IrExpression pinSource, BlockContainer body, bool sourceIsAddress = true)
+    public Fixed(TypeRef elementType, int localIndex, IrExpression pinSource, BlockContainer body, bool sourceIsAddress = true, bool localIsStackSlot = false)
     {
         ElementType = elementType;
         LocalIndex = localIndex;
         SourceIsAddress = sourceIsAddress;
+        LocalIsStackSlot = localIsStackSlot;
         AddChild(pinSource);
         AddChild(body);
     }
@@ -823,6 +824,9 @@ public sealed class Fixed : IrNode
 
     /// <summary>The pinned local slot that becomes the <c>fixed</c> pointer variable.</summary>
     public int LocalIndex { get; }
+
+    /// <summary>True when <see cref="LocalIndex"/> names a synthesized stack slot rather than a metadata local.</summary>
+    public bool LocalIsStackSlot { get; }
 
     /// <summary>
     /// True for the managed-reference pin (<c>fixed (T* p = &amp;place)</c>), where the

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -809,13 +809,14 @@ public sealed class Lock : IrNode
 /// </summary>
 public sealed class Fixed : IrNode
 {
-    public Fixed(TypeRef elementType, int localIndex, IrExpression pinSource, BlockContainer body, bool sourceIsAddress = true, bool localIsStackSlot = false, TypeRef? localStackSlotType = null)
+    public Fixed(TypeRef elementType, int localIndex, IrExpression pinSource, BlockContainer body, bool sourceIsAddress = true, bool localIsStackSlot = false, TypeRef? localStackSlotType = null, bool requiresUnsafeContext = false)
     {
         ElementType = elementType;
         LocalIndex = localIndex;
         SourceIsAddress = sourceIsAddress;
         LocalIsStackSlot = localIsStackSlot;
         LocalStackSlotType = localStackSlotType;
+        RequiresUnsafeContext = requiresUnsafeContext;
         AddChild(pinSource);
         AddChild(body);
     }
@@ -831,6 +832,9 @@ public sealed class Fixed : IrNode
 
     /// <summary>The stack-slot render type used to resolve <see cref="LocalIndex"/>'s emitted name when <see cref="LocalIsStackSlot"/> is true.</summary>
     public TypeRef? LocalStackSlotType { get; }
+
+    /// <summary>True when this fixed statement must be wrapped in an explicit unsafe context under updated memory-safety rules.</summary>
+    public bool RequiresUnsafeContext { get; }
 
     /// <summary>
     /// True for the managed-reference pin (<c>fixed (T* p = &amp;place)</c>), where the

--- a/src/ILInspector.Decompiler/Pipeline/Passes/FixedArrayRaising.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/FixedArrayRaising.cs
@@ -85,12 +85,7 @@ internal static class FixedArrayRaising
         }
 
         int pointerSlot = thenStore.Slot;
-        var pointerAliases = entry.Children
-            .OfType<StoreLocal>()
-            .Where(store => store.ChildIndex > guard.ChildIndex
-                && PointerAliasLocal(store, pointerSlot))
-            .Select(store => store.Index)
-            .ToHashSet();
+        var pointerAliases = PointerAliases(function, entry, guard.ChildIndex, pointerSlot);
 
         var unpins = entry.Children
             .OfType<StoreLocal>()
@@ -136,7 +131,14 @@ internal static class FixedArrayRaising
             bodyBlock.Add(stmt);
         body.Add(bodyBlock);
 
-        var fixedStatement = new Fixed(byRef.ElementType!, pointerSlot, (IrExpression)source.Clone(), body, sourceIsAddress: false, localIsStackSlot: true);
+        var fixedStatement = new Fixed(
+            byRef.ElementType!,
+            pointerSlot,
+            (IrExpression)source.Clone(),
+            body,
+            sourceIsAddress: false,
+            localIsStackSlot: true,
+            localStackSlotType: thenStore.Value.ResultType);
         context.Stepper.StepOver("raise pinned string to fixed statement", guard);
         guard.ReplaceWith(fixedStatement);
     }
@@ -278,8 +280,38 @@ internal static class FixedArrayRaising
         => ReferencesStackSlot(node, slot)
             || node.Descendants.Any(descendant => ReferencesStackSlot(descendant, slot));
 
-    static bool PointerAliasLocal(StoreLocal store, int pointerSlot)
-        => StripConverts(store.Value) is LoadStackSlot load && load.Slot == pointerSlot;
+    static HashSet<int> PointerAliases(IrFunction function, Block entry, int guardIndex, int pointerSlot)
+    {
+        var aliases = new HashSet<int>();
+        bool changed;
+        do
+        {
+            changed = false;
+            foreach (var store in function.Descendants.OfType<StoreLocal>())
+            {
+                if (!IsAfterEntryStatement(store, entry, guardIndex) || store.Type.Kind != TypeRefKind.Pointer)
+                    continue;
+                if (ValueReferencesPinnedPointer(store.Value, pointerSlot, aliases)
+                    && aliases.Add(store.Index))
+                {
+                    changed = true;
+                }
+            }
+        } while (changed);
+        return aliases;
+    }
+
+    static bool IsAfterEntryStatement(IrNode node, Block entry, int guardIndex)
+    {
+        for (var current = node; current.Parent is not null; current = current.Parent)
+            if (ReferenceEquals(current.Parent, entry))
+                return current.ChildIndex > guardIndex;
+        return false;
+    }
+
+    static bool ValueReferencesPinnedPointer(IrNode value, int pointerSlot, IReadOnlySet<int> aliases)
+        => ReferencesPinnedPointer(value, pointerSlot, aliases)
+            || value.Descendants.Any(descendant => ReferencesPinnedPointer(descendant, pointerSlot, aliases));
 
     static bool ReferencesPointerAlias(IrNode node, IReadOnlySet<int> aliases) => node switch
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/FixedArrayRaising.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/FixedArrayRaising.cs
@@ -85,22 +85,40 @@ internal static class FixedArrayRaising
         }
 
         int pointerSlot = thenStore.Slot;
+        var pointerAliases = entry.Children
+            .OfType<StoreLocal>()
+            .Where(store => store.ChildIndex > guard.ChildIndex
+                && PointerAliasLocal(store, pointerSlot))
+            .Select(store => store.Index)
+            .ToHashSet();
+
+        var unpins = entry.Children
+            .OfType<StoreLocal>()
+            .Where(store => store.Index == pinStore.Index && store != pinStore)
+            .ToList();
+        if (unpins.Count > 1 || unpins.Any(store => !IsUnpin(store)))
+            return;
+        var unpin = unpins.SingleOrDefault();
+
+        int bodyEnd = unpin?.ChildIndex - 1 ?? LastPointerUseIndex(entry, guard.ChildIndex + 1, pointerSlot, pointerAliases);
+        if (bodyEnd <= guard.ChildIndex)
+            return;
+
         var bodyStmts = entry.Children
-            .Where(c => c.ChildIndex > guard.ChildIndex)
-            .TakeWhile(c => StatementReferencesStackSlot(c, pointerSlot))
+            .Where(c => c.ChildIndex > guard.ChildIndex && c.ChildIndex <= bodyEnd)
             .ToList();
         if (bodyStmts.Count == 0)
             return;
 
         foreach (var node in function.Descendants)
         {
-            if (node is StoreLocal store && store.Index == pinStore.Index && store != pinStore)
+            if (node is StoreLocal store && store.Index == pinStore.Index && store != pinStore && store != unpin)
                 return;
             if (node is LoadLocal load && load.Index == pinStore.Index && load != pinLoad)
                 return;
             if (node is StoreStackSlot stackStore && stackStore.Slot == pointerSlot && stackStore != thenStore && stackStore != elseStore)
                 return;
-            if (ReferencesStackSlot(node, pointerSlot)
+            if (ReferencesPinnedPointer(node, pointerSlot, pointerAliases)
                 && node != thenStore && node != elseStore
                 && !bodyStmts.Any(stmt => ReferenceOwnership.IsInside(node, stmt)))
             {
@@ -110,6 +128,7 @@ internal static class FixedArrayRaising
 
         foreach (var stmt in bodyStmts)
             stmt.Detach();
+        unpin?.Detach();
 
         var body = new BlockContainer();
         var bodyBlock = new Block(entry.StartOffset);
@@ -231,6 +250,9 @@ internal static class FixedArrayRaising
     static bool IsNullStore(StoreLocal store)
         => StripConverts(store.Value) is Constant { Value: null or 0 or 0L };
 
+    static bool IsUnpin(StoreLocal store)
+        => StripConverts(store.Value) is Constant { Value: null or 0 or 0L };
+
     static IrExpression? PinSource(IrExpression value)
         => value is Call { Callee.Name: "GetPinnableReference", Callee.HasThis: true, Arguments: [var source] }
             ? source
@@ -255,6 +277,33 @@ internal static class FixedArrayRaising
     static bool StatementReferencesStackSlot(IrNode node, int slot)
         => ReferencesStackSlot(node, slot)
             || node.Descendants.Any(descendant => ReferencesStackSlot(descendant, slot));
+
+    static bool PointerAliasLocal(StoreLocal store, int pointerSlot)
+        => StripConverts(store.Value) is LoadStackSlot load && load.Slot == pointerSlot;
+
+    static bool ReferencesPointerAlias(IrNode node, IReadOnlySet<int> aliases) => node switch
+    {
+        LoadLocal load => aliases.Contains(load.Index),
+        LoadLocalAddress address => aliases.Contains(address.Index),
+        StoreLocal store => aliases.Contains(store.Index),
+        _ => false,
+    };
+
+    static bool ReferencesPinnedPointer(IrNode node, int pointerSlot, IReadOnlySet<int> aliases)
+        => ReferencesStackSlot(node, pointerSlot) || ReferencesPointerAlias(node, aliases);
+
+    static bool StatementReferencesPinnedPointer(IrNode node, int pointerSlot, IReadOnlySet<int> aliases)
+        => ReferencesPinnedPointer(node, pointerSlot, aliases)
+            || node.Descendants.Any(descendant => ReferencesPinnedPointer(descendant, pointerSlot, aliases));
+
+    static int LastPointerUseIndex(Block entry, int start, int pointerSlot, IReadOnlySet<int> aliases)
+    {
+        int last = start - 1;
+        foreach (var child in entry.Children.Where(c => c.ChildIndex >= start))
+            if (StatementReferencesPinnedPointer(child, pointerSlot, aliases))
+                last = child.ChildIndex;
+        return last;
+    }
 
     static bool ReferencesPointerSlot(IrNode node, int pointerSlot) => node switch
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/FixedArrayRaising.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/FixedArrayRaising.cs
@@ -62,7 +62,7 @@ internal static class FixedArrayRaising
             return;
 
         var entry = function.Body.Blocks[0];
-        foreach (var guard in entry.Children.OfType<IfStatement>().Where(g => g.HasElse).ToList())
+        foreach (var guard in entry.Children.OfType<IfStatement>().Where(g => g.HasElse).OrderByDescending(g => g.ChildIndex).ToList())
         {
             TryRaiseStringPin(function, entry, guard, context);
         }
@@ -264,10 +264,18 @@ internal static class FixedArrayRaising
         => type is { Kind: TypeRefKind.Definition, Namespace: "System", Name: "String" };
 
     static bool ConditionNullChecksSource(IrExpression condition, IrExpression source)
-        => condition is LogicalNot { Operand: LoadArgument nullChecked }
-            && source is LoadArgument pinSource
-            && nullChecked.Index == pinSource.Index
-            && nullChecked.Name == pinSource.Name;
+        => condition is LogicalNot { Operand: { } nullChecked }
+            && SameLoadPlace(nullChecked, source);
+
+    static bool SameLoadPlace(IrExpression left, IrExpression right)
+        => left switch
+        {
+            LoadArgument leftArgument when right is LoadArgument rightArgument
+                => leftArgument.Index == rightArgument.Index && leftArgument.Name == rightArgument.Name,
+            LoadLocal leftLocal when right is LoadLocal rightLocal
+                => leftLocal.Index == rightLocal.Index,
+            _ => false,
+        };
 
     static bool ReferencesStackSlot(IrNode node, int slot) => node switch
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/FixedArrayRaising.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/FixedArrayRaising.cs
@@ -33,6 +33,13 @@ namespace ILInspector.Decompiler.Pipeline;
 /// is unpinned by a single later <c>pin = null</c> store, and every read of the
 /// pinned slot lives inside the diamond (its length guard and element address).
 /// Anything else leaves the method flat.</para>
+///
+/// <para>String pinning lowers differently: the guard writes the derived pointer
+/// to a stack slot, and the non-null arm first stores
+/// <c>value.GetPinnableReference()</c> into a <c>pinned char&amp;</c> local. The
+/// same language spelling is <c>fixed (char* p = value)</c>, so this pass also
+/// recognizes that narrower string guard and makes the stack slot the fixed
+/// pointer variable.</para>
 /// </summary>
 internal static class FixedArrayRaising
 {
@@ -45,6 +52,74 @@ internal static class FixedArrayRaising
 
         foreach (var slot in pinnedArraySlots)
             TryRaise(function, slot, context);
+
+        RaiseStringPins(function, context);
+    }
+
+    static void RaiseStringPins(IrFunction function, PassContext context)
+    {
+        if (function.Body.Blocks.Count == 0)
+            return;
+
+        var entry = function.Body.Blocks[0];
+        foreach (var guard in entry.Children.OfType<IfStatement>().Where(g => g.HasElse).ToList())
+        {
+            TryRaiseStringPin(function, entry, guard, context);
+        }
+    }
+
+    static void TryRaiseStringPin(IrFunction function, Block entry, IfStatement guard, PassContext context)
+    {
+        if (guard.Then.Children is not [StoreStackSlot thenStore]
+            || guard.Else is not { Children: [StoreLocal pinStore, StoreStackSlot elseStore] }
+            || thenStore.Slot != elseStore.Slot
+            || !IsNullPointer(thenStore.Value)
+            || function.Locals[pinStore.Index] is not { Kind: TypeRefKind.Pinned, ElementType: { Kind: TypeRefKind.ByRef } byRef }
+            || PinSource(pinStore.Value) is not { } source
+            || !IsString(source.ResultType)
+            || !ConditionNullChecksSource(guard.Condition, source)
+            || StripConverts(elseStore.Value) is not LoadLocal pinLoad
+            || pinLoad.Index != pinStore.Index)
+        {
+            return;
+        }
+
+        int pointerSlot = thenStore.Slot;
+        var bodyStmts = entry.Children
+            .Where(c => c.ChildIndex > guard.ChildIndex)
+            .TakeWhile(c => StatementReferencesStackSlot(c, pointerSlot))
+            .ToList();
+        if (bodyStmts.Count == 0)
+            return;
+
+        foreach (var node in function.Descendants)
+        {
+            if (node is StoreLocal store && store.Index == pinStore.Index && store != pinStore)
+                return;
+            if (node is LoadLocal load && load.Index == pinStore.Index && load != pinLoad)
+                return;
+            if (node is StoreStackSlot stackStore && stackStore.Slot == pointerSlot && stackStore != thenStore && stackStore != elseStore)
+                return;
+            if (ReferencesStackSlot(node, pointerSlot)
+                && node != thenStore && node != elseStore
+                && !bodyStmts.Any(stmt => ReferenceOwnership.IsInside(node, stmt)))
+            {
+                return;
+            }
+        }
+
+        foreach (var stmt in bodyStmts)
+            stmt.Detach();
+
+        var body = new BlockContainer();
+        var bodyBlock = new Block(entry.StartOffset);
+        foreach (var stmt in bodyStmts)
+            bodyBlock.Add(stmt);
+        body.Add(bodyBlock);
+
+        var fixedStatement = new Fixed(byRef.ElementType!, pointerSlot, (IrExpression)source.Clone(), body, sourceIsAddress: false, localIsStackSlot: true);
+        context.Stepper.StepOver("raise pinned string to fixed statement", guard);
+        guard.ReplaceWith(fixedStatement);
     }
 
     static void TryRaise(IrFunction function, int pin, PassContext context)
@@ -155,6 +230,31 @@ internal static class FixedArrayRaising
 
     static bool IsNullStore(StoreLocal store)
         => StripConverts(store.Value) is Constant { Value: null or 0 or 0L };
+
+    static IrExpression? PinSource(IrExpression value)
+        => value is Call { Callee.Name: "GetPinnableReference", Callee.HasThis: true, Arguments: [var source] }
+            ? source
+            : null;
+
+    static bool IsString(TypeRef? type)
+        => type is { Kind: TypeRefKind.Definition, Namespace: "System", Name: "String" };
+
+    static bool ConditionNullChecksSource(IrExpression condition, IrExpression source)
+        => condition is LogicalNot { Operand: LoadArgument nullChecked }
+            && source is LoadArgument pinSource
+            && nullChecked.Index == pinSource.Index
+            && nullChecked.Name == pinSource.Name;
+
+    static bool ReferencesStackSlot(IrNode node, int slot) => node switch
+    {
+        LoadStackSlot load => load.Slot == slot,
+        StoreStackSlot store => store.Slot == slot,
+        _ => false,
+    };
+
+    static bool StatementReferencesStackSlot(IrNode node, int slot)
+        => ReferencesStackSlot(node, slot)
+            || node.Descendants.Any(descendant => ReferencesStackSlot(descendant, slot));
 
     static bool ReferencesPointerSlot(IrNode node, int pointerSlot) => node switch
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/FixedArrayRaising.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/FixedArrayRaising.cs
@@ -61,10 +61,15 @@ internal static class FixedArrayRaising
         if (function.Body.Blocks.Count == 0)
             return;
 
-        var entry = function.Body.Blocks[0];
-        foreach (var guard in entry.Children.OfType<IfStatement>().Where(g => g.HasElse).OrderByDescending(g => g.ChildIndex).ToList())
+        var blocks = function.Descendants.OfType<Block>()
+            .OrderByDescending(Depth)
+            .ToList();
+        foreach (var entry in blocks)
         {
-            TryRaiseStringPin(function, entry, guard, context);
+            foreach (var guard in entry.Children.OfType<IfStatement>().Where(g => g.HasElse).OrderByDescending(g => g.ChildIndex).ToList())
+            {
+                TryRaiseStringPin(function, entry, guard, context);
+            }
         }
     }
 
@@ -85,7 +90,8 @@ internal static class FixedArrayRaising
         }
 
         int pointerSlot = thenStore.Slot;
-        var pointerAliases = PointerAliases(function, entry, guard.ChildIndex, pointerSlot);
+        if (!TryPointerAliases(function, entry, guard.ChildIndex, pointerSlot, out var pointerAliases))
+            return;
 
         var unpins = entry.Children
             .OfType<StoreLocal>()
@@ -291,25 +297,31 @@ internal static class FixedArrayRaising
         => ReferencesStackSlot(node, slot)
             || node.Descendants.Any(descendant => ReferencesStackSlot(descendant, slot));
 
-    static HashSet<int> PointerAliases(IrFunction function, Block entry, int guardIndex, int pointerSlot)
+    static bool TryPointerAliases(IrFunction function, Block entry, int guardIndex, int pointerSlot, out HashSet<int> aliases)
     {
-        var aliases = new HashSet<int>();
+        aliases = [];
+        var storesAfterGuard = function.Descendants
+            .OfType<StoreLocal>()
+            .Where(store => IsAfterEntryStatement(store, entry, guardIndex))
+            .ToLookup(store => store.Index);
         bool changed;
         do
         {
             changed = false;
-            foreach (var store in function.Descendants.OfType<StoreLocal>())
+            foreach (var store in storesAfterGuard.SelectMany(group => group))
             {
-                if (!IsAfterEntryStatement(store, entry, guardIndex) || !IsPointerCarrier(store.Type))
+                if (!IsPointerCarrier(store.Type))
                     continue;
                 if (ValueReferencesPinnedPointer(store.Value, pointerSlot, aliases)
                     && aliases.Add(store.Index))
                 {
+                    if (storesAfterGuard[store.Index].Count() > 1)
+                        return false;
                     changed = true;
                 }
             }
         } while (changed);
-        return aliases;
+        return true;
     }
 
     static bool IsAfterEntryStatement(IrNode node, Block entry, int guardIndex)
@@ -318,6 +330,14 @@ internal static class FixedArrayRaising
             if (ReferenceEquals(current.Parent, entry))
                 return current.ChildIndex > guardIndex;
         return false;
+    }
+
+    static int Depth(IrNode node)
+    {
+        int depth = 0;
+        for (var current = node.Parent; current is not null; current = current.Parent)
+            depth++;
+        return depth;
     }
 
     static bool IsPointerCarrier(TypeRef type)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/FixedArrayRaising.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/FixedArrayRaising.cs
@@ -131,14 +131,17 @@ internal static class FixedArrayRaising
             bodyBlock.Add(stmt);
         body.Add(bodyBlock);
 
+        var pointerType = TypeRef.Pointer(byRef.ElementType!);
+        int fixedLocal = function.AddLocal(pointerType);
+        ReplacePinnedPointerLoads(body, pointerSlot, pointerType, fixedLocal);
+
         var fixedStatement = new Fixed(
             byRef.ElementType!,
-            pointerSlot,
+            fixedLocal,
             (IrExpression)source.Clone(),
             body,
             sourceIsAddress: false,
-            localIsStackSlot: true,
-            localStackSlotType: thenStore.Value.ResultType);
+            requiresUnsafeContext: true);
         context.Stepper.StepOver("raise pinned string to fixed statement", guard);
         guard.ReplaceWith(fixedStatement);
     }
@@ -297,7 +300,7 @@ internal static class FixedArrayRaising
             changed = false;
             foreach (var store in function.Descendants.OfType<StoreLocal>())
             {
-                if (!IsAfterEntryStatement(store, entry, guardIndex) || store.Type.Kind != TypeRefKind.Pointer)
+                if (!IsAfterEntryStatement(store, entry, guardIndex) || !IsPointerCarrier(store.Type))
                     continue;
                 if (ValueReferencesPinnedPointer(store.Value, pointerSlot, aliases)
                     && aliases.Add(store.Index))
@@ -316,6 +319,10 @@ internal static class FixedArrayRaising
                 return current.ChildIndex > guardIndex;
         return false;
     }
+
+    static bool IsPointerCarrier(TypeRef type)
+        => type.Kind == TypeRefKind.Pointer
+            || type is { Kind: TypeRefKind.Definition, Namespace: "System", Name: "IntPtr" or "UIntPtr" };
 
     static bool ValueReferencesPinnedPointer(IrNode value, int pointerSlot, IReadOnlySet<int> aliases)
         => ReferencesPinnedPointer(value, pointerSlot, aliases)
@@ -343,6 +350,19 @@ internal static class FixedArrayRaising
             if (StatementReferencesPinnedPointer(child, pointerSlot, aliases))
                 last = child.ChildIndex;
         return last;
+    }
+
+    static void ReplacePinnedPointerLoads(IrNode node, int pointerSlot, TypeRef pointerType, int fixedLocal)
+    {
+        for (int i = 0; i < node.Children.Count; i++)
+        {
+            if (node.Children[i] is LoadStackSlot load && load.Slot == pointerSlot)
+            {
+                node.SetChild(i, new LoadLocal(fixedLocal, pointerType));
+                continue;
+            }
+            ReplacePinnedPointerLoads(node.Children[i], pointerSlot, pointerType, fixedLocal);
+        }
     }
 
     static bool ReferencesPointerSlot(IrNode node, int pointerSlot) => node switch


### PR DESCRIPTION
## Summary
- Raise the Roslyn string-pinning guard for `fixed (char* p = value)` instead of rendering invalid `pinned ref char` locals.
- Let `Fixed` own synthesized stack-slot pointer variables when the lowering uses an evaluation stack spill instead of a metadata local.
- Preserve new memory-safety behavior by wrapping only the stack-slot fixed header in an explicit `unsafe` context.

## Measured impact
`--return-to-sender-fixtures decompiler --return-to-sender-source-probe`:

```text
Before: Invalid 35, CS1002 2
After : Invalid 33, CS1002 0
```

The two `StringPinningResiduals.FixedStringFirstChar` rows move from invalid `CS1002` to Roslyn-valid `valid_different.unclassified` with `rts=Exact`.

`rts.candidates` remains zero-gap:

```text
ValidMatch 52, ValidDifferent 50, Invalid 0, SourceUnavailable 0, UnsupportedTarget 0
```

## Validation
- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/UnsafeEmitterTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/LadderRung6GateTests/*"`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures decompiler --return-to-sender-source-probe --cap 10000 --max-examples 260`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures rts.candidates --return-to-sender-source-probe --cap 10000 --max-examples 40`

Full `ILInspector.Decompiler.Tests` was also started, but stopped after surfacing pre-existing unrelated failures in `LockSugarTests`, `ReturnToSenderPrototypeTests`, and `TypeSourceComposerUnionTests`; the focused unsafe/string-pinning tests above pass.

Follow-up for #2505.