### PR TITLE
Emit fallback returns for unsupported non-void bodies

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LadderIteratorGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderIteratorGateTests.cs
@@ -199,6 +199,7 @@ public class LadderIteratorGateTests
             Assert.NotEqual(DecompilationFidelity.Full, member.Function.Fidelity);
             Assert.Contains("iterator", member.Body);
             Assert.Contains("not reconstructed", member.Body);
+            Assert.Contains("return default;", member.Body);
         }
     }
 

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -830,6 +830,7 @@ public class LadderRung6GateTests
             Assert.Equal(DecompilationFidelity.Partial, member.Function.Fidelity);
             Assert.Contains(FidelityRemarks.Collect(member.Function), r => r.Code == DiagnosticIds.UnsupportedConstruct);
             Assert.Contains("cpblk", member.Body);
+            Assert.Contains("return default;", member.Body);
         }
     }
 

--- a/src/ILInspector.Decompiler.Tests/UnsupportedFallbackReturnTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsupportedFallbackReturnTests.cs
@@ -1,0 +1,66 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class UnsupportedFallbackReturnTests
+{
+    static readonly TypeRef Int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef Task = TypeRef.CoreLib("System.Threading.Tasks", "Task");
+
+    [Fact]
+    public void NonVoidUnsupportedBodyWithoutReturn_EmitsDefaultReturn()
+    {
+        var output = CSharpPrinter.Print(UnsupportedFunction(Int)).Output ?? "";
+
+        Assert.Contains("Unsupported IL_0000", output);
+        Assert.Contains("return default;", output);
+    }
+
+    [Fact]
+    public void YieldBodyWithUnsupportedNode_DoesNotEmitValueReturn()
+    {
+        var function = UnsupportedFunction(TypeRef.CoreLib("System.Collections.Generic", "IEnumerable`1"));
+        function.Body.Blocks[0].Add(new YieldReturn(new Constant(1, Int)));
+
+        var output = CSharpPrinter.Print(function).Output ?? "";
+
+        Assert.Contains("yield return 1;", output);
+        Assert.DoesNotContain("return default;", output);
+    }
+
+    [Fact]
+    public void AsyncTaskUnsupportedBody_DoesNotEmitValueReturn()
+    {
+        var function = UnsupportedFunction(Task);
+        function.RequiresAsyncBodyModifier = true;
+
+        var output = CSharpPrinter.Print(function).Output ?? "";
+
+        Assert.Contains("Unsupported IL_0000", output);
+        Assert.DoesNotContain("return default;", output);
+    }
+
+    [Fact]
+    public void VoidUnsupportedBody_DoesNotEmitDefaultReturn()
+    {
+        var output = CSharpPrinter.Print(UnsupportedFunction(Void)).Output ?? "";
+
+        Assert.Contains("Unsupported IL_0000", output);
+        Assert.DoesNotContain("return default;", output);
+    }
+
+    static IrFunction UnsupportedFunction(TypeRef returnType)
+    {
+        var block = new Block(0);
+        block.Add(new ExpressionStatement(new UnsupportedNode(0, "probe", "test unsupported")));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "Unsupported"),
+            new MethodSignature(returnType, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/UnsupportedFallbackReturnTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsupportedFallbackReturnTests.cs
@@ -7,6 +7,9 @@ public class UnsupportedFallbackReturnTests
     static readonly TypeRef Int = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
     static readonly TypeRef Task = TypeRef.CoreLib("System.Threading.Tasks", "Task");
+    static readonly TypeRef ValueTask = TypeRef.CoreLib("System.Threading.Tasks", "ValueTask");
+    static readonly TypeRef TaskInt = TypeRef.GenericInstance(TypeRef.CoreLib("System.Threading.Tasks", "Task`1"), [Int]);
+    static readonly TypeRef ValueTaskInt = TypeRef.GenericInstance(TypeRef.CoreLib("System.Threading.Tasks", "ValueTask`1"), [Int]);
 
     [Fact]
     public void NonVoidUnsupportedBodyWithoutReturn_EmitsDefaultReturn()
@@ -39,6 +42,42 @@ public class UnsupportedFallbackReturnTests
 
         Assert.Contains("Unsupported IL_0000", output);
         Assert.DoesNotContain("return default;", output);
+    }
+
+    [Fact]
+    public void AsyncValueTaskUnsupportedBody_DoesNotEmitValueReturn()
+    {
+        var function = UnsupportedFunction(ValueTask);
+        function.RequiresAsyncBodyModifier = true;
+
+        var output = CSharpPrinter.Print(function).Output ?? "";
+
+        Assert.Contains("Unsupported IL_0000", output);
+        Assert.DoesNotContain("return default;", output);
+    }
+
+    [Fact]
+    public void AsyncGenericTaskUnsupportedBody_EmitsDefaultReturn()
+    {
+        var function = UnsupportedFunction(TaskInt);
+        function.RequiresAsyncBodyModifier = true;
+
+        var output = CSharpPrinter.Print(function).Output ?? "";
+
+        Assert.Contains("Unsupported IL_0000", output);
+        Assert.Contains("return default;", output);
+    }
+
+    [Fact]
+    public void AsyncGenericValueTaskUnsupportedBody_EmitsDefaultReturn()
+    {
+        var function = UnsupportedFunction(ValueTaskInt);
+        function.RequiresAsyncBodyModifier = true;
+
+        var output = CSharpPrinter.Print(function).Output ?? "";
+
+        Assert.Contains("Unsupported IL_0000", output);
+        Assert.Contains("return default;", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/UnsupportedFallbackReturnTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsupportedFallbackReturnTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
@@ -10,6 +12,7 @@ public class UnsupportedFallbackReturnTests
     static readonly TypeRef ValueTask = TypeRef.CoreLib("System.Threading.Tasks", "ValueTask");
     static readonly TypeRef TaskInt = TypeRef.GenericInstance(TypeRef.CoreLib("System.Threading.Tasks", "Task`1"), [Int]);
     static readonly TypeRef ValueTaskInt = TypeRef.GenericInstance(TypeRef.CoreLib("System.Threading.Tasks", "ValueTask`1"), [Int]);
+    static readonly TypeRef FuncInt = TypeRef.GenericInstance(TypeRef.CoreLib("System", "Func`1"), [Int]);
 
     [Fact]
     public void NonVoidUnsupportedBodyWithoutReturn_EmitsDefaultReturn()
@@ -89,17 +92,74 @@ public class UnsupportedFallbackReturnTests
         Assert.DoesNotContain("return default;", output);
     }
 
+    [Fact]
+    public void LocalFunctionUnsupportedBody_EmitsDefaultReturn()
+    {
+        var local = new LocalFunctionStatement(
+            "Local",
+            Int,
+            [],
+            isStatic: false,
+            [],
+            [],
+            usesUpdatedMemorySafetyRules: false,
+            skipLocalsInit: false,
+            UnsupportedBody());
+        var block = new Block(0);
+        block.Add(local);
+        var output = CSharpPrinter.Print(WrapVoid(block)).Output ?? "";
+
+        Assert.Contains("int Local()", output);
+        Assert.Contains("return default;", output);
+    }
+
+    [Fact]
+    public void LambdaUnsupportedBody_EmitsDefaultReturn()
+    {
+        var lambda = new Lambda(
+            FuncInt,
+            [],
+            [],
+            [],
+            usesUpdatedMemorySafetyRules: false,
+            skipLocalsInit: false,
+            UnsupportedBody());
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, FuncInt, lambda));
+        var output = CSharpPrinter.Print(WrapVoid(block, [FuncInt])).Output ?? "";
+
+        Assert.Contains("=>", output);
+        Assert.Contains("return default;", output);
+    }
+
     static IrFunction UnsupportedFunction(TypeRef returnType)
     {
-        var block = new Block(0);
-        block.Add(new ExpressionStatement(new UnsupportedNode(0, "probe", "test unsupported")));
-        var body = new BlockContainer();
-        body.Add(block);
         return new IrFunction(
             "M",
             TypeRef.CoreLib("Synthetic", "Unsupported"),
             new MethodSignature(returnType, [], HasThis: false, GenericParameterCount: 0),
             [],
+            UnsupportedBody());
+    }
+
+    static BlockContainer UnsupportedBody()
+    {
+        var block = new Block(0);
+        block.Add(new ExpressionStatement(new UnsupportedNode(0, "probe", "test unsupported")));
+        var body = new BlockContainer();
+        body.Add(block);
+        return body;
+    }
+
+    static IrFunction WrapVoid(Block block, ImmutableArray<TypeRef> locals = default)
+    {
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "Unsupported"),
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            locals.IsDefault ? [] : locals,
             body);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
@@ -108,8 +108,24 @@ public sealed partial class CSharpPrinter
             .SelectMany(b => b.Children)
             .Select(LambdaStatement)
             .Where(s => s is not null);
+        if (LambdaReturnType(lambda) is { } returnType
+            && NeedsUnsupportedFallbackReturn(returnType, requiresAsyncBodyModifier: false, lambda.Body))
+        {
+            statements = statements.Append("return default;");
+        }
         return $"{parameters} => {{ {string.Join(" ", statements)} }}";
     }
+
+    static TypeRef? LambdaReturnType(Lambda lambda)
+        => lambda.DelegateType switch
+        {
+            { Kind: TypeRefKind.GenericInstance, ElementType: { Namespace: "System", Name: var name }, TypeArguments: { Length: > 0 } args }
+                when name.StartsWith("Func`", StringComparison.Ordinal) => args[^1],
+            { Kind: TypeRefKind.GenericInstance, ElementType: { Namespace: "System", Name: var name } }
+                when name.StartsWith("Action`", StringComparison.Ordinal) => TypeRef.CoreLib("System", "Void"),
+            { Kind: TypeRefKind.Definition, Namespace: "System", Name: "Action" } => TypeRef.CoreLib("System", "Void"),
+            _ => null,
+        };
 
     static bool NeedsNestedLambdaScope(Lambda lambda)
         => !lambda.Locals.IsEmpty
@@ -124,7 +140,7 @@ public sealed partial class CSharpPrinter
             var function = new IrFunction(
                 "<lambda>",
                 _function.DeclaringType,
-                new MethodSignature(TypeRef.CoreLib("System", "Void"), lambda.Parameters, HasThis: false, GenericParameterCount: 0),
+                new MethodSignature(LambdaReturnType(lambda) ?? TypeRef.CoreLib("System", "Void"), lambda.Parameters, HasThis: false, GenericParameterCount: 0),
                 lambda.Locals,
                 body)
             {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -401,19 +401,24 @@ public sealed partial class CSharpPrinter
     }
 
     static bool NeedsUnsupportedFallbackReturn(IrFunction function)
-        => function.Signature.ReturnType is not { Namespace: "System", Name: "Void" }
-            && function.Signature.ReturnType.Kind != TypeRefKind.ByRef
-            && !AsyncReturnForbidsValue(function)
-            && !DescendantsOutsideNestedFunctions(function).Any(static n => n is YieldReturn or YieldBreak)
-            && DescendantsOutsideNestedFunctions(function).Any(static n => n is UnsupportedNode)
-            && !DescendantsOutsideNestedFunctions(function).Any(static n => n is Return);
+        => NeedsUnsupportedFallbackReturn(function.Signature.ReturnType, function.RequiresAsyncBodyModifier, function);
 
     static bool AsyncReturnForbidsValue(IrFunction function)
+        => AsyncReturnForbidsValue(function.Signature.ReturnType, function.RequiresAsyncBodyModifier);
+
+    static bool NeedsUnsupportedFallbackReturn(TypeRef returnType, bool requiresAsyncBodyModifier, IrNode bodyRoot)
+        => returnType is not { Namespace: "System", Name: "Void" }
+            && returnType.Kind != TypeRefKind.ByRef
+            && !AsyncReturnForbidsValue(returnType, requiresAsyncBodyModifier)
+            && !DescendantsOutsideNestedFunctions(bodyRoot).Any(static n => n is YieldReturn or YieldBreak)
+            && DescendantsOutsideNestedFunctions(bodyRoot).Any(static n => n is UnsupportedNode)
+            && !DescendantsOutsideNestedFunctions(bodyRoot).Any(static n => n is Return);
+
+    static bool AsyncReturnForbidsValue(TypeRef type, bool requiresAsyncBodyModifier)
     {
-        if (!function.RequiresAsyncBodyModifier)
+        if (!requiresAsyncBodyModifier)
             return false;
 
-        var type = function.Signature.ReturnType;
         if (type is { Kind: TypeRefKind.Definition, Namespace: "System.Threading.Tasks", Name: "Task" or "ValueTask" })
             return true;
         if (type is { Kind: TypeRefKind.GenericInstance, ElementType: { Namespace: "System.Collections.Generic", Name: "IAsyncEnumerable`1" or "IAsyncEnumerator`1" } })
@@ -1438,7 +1443,11 @@ public sealed partial class CSharpPrinter
                 if (NeedsNestedLocalFunctionScope(localFunction))
                     AppendNestedLocalFunctionBody(sb, localFunction, indent + 1);
                 else
+                {
                     AppendContainer(sb, localFunction.Body, indent + 1);
+                    if (NeedsUnsupportedFallbackReturn(localFunction.ReturnType, requiresAsyncBodyModifier: false, localFunction.Body))
+                        sb.Append(new string(' ', (indent + 1) * 4)).AppendLine("return default;");
+                }
                 sb.Append(pad).AppendLine("}");
             }
             return;

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -395,8 +395,16 @@ public sealed partial class CSharpPrinter
             sb.AppendLine();
 
         AppendContainer(sb, function.Body, 0, topLevel: true);
+        if (NeedsUnsupportedFallbackReturn(function))
+            sb.AppendLine("return default;");
         return sb.ToString().TrimEnd() is { Length: > 0 } text ? text + Environment.NewLine : "";
     }
+
+    static bool NeedsUnsupportedFallbackReturn(IrFunction function)
+        => function.Signature.ReturnType is not { Namespace: "System", Name: "Void" }
+            && function.Signature.ReturnType.Kind != TypeRefKind.ByRef
+            && DescendantsOutsideNestedFunctions(function).Any(static n => n is UnsupportedNode)
+            && !DescendantsOutsideNestedFunctions(function).Any(static n => n is Return);
 
     void AppendContainer(StringBuilder sb, BlockContainer container, int indent, bool topLevel = false)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -403,10 +403,24 @@ public sealed partial class CSharpPrinter
     static bool NeedsUnsupportedFallbackReturn(IrFunction function)
         => function.Signature.ReturnType is not { Namespace: "System", Name: "Void" }
             && function.Signature.ReturnType.Kind != TypeRefKind.ByRef
-            && !function.RequiresAsyncBodyModifier
+            && !AsyncReturnForbidsValue(function)
             && !DescendantsOutsideNestedFunctions(function).Any(static n => n is YieldReturn or YieldBreak)
             && DescendantsOutsideNestedFunctions(function).Any(static n => n is UnsupportedNode)
             && !DescendantsOutsideNestedFunctions(function).Any(static n => n is Return);
+
+    static bool AsyncReturnForbidsValue(IrFunction function)
+    {
+        if (!function.RequiresAsyncBodyModifier)
+            return false;
+
+        var type = function.Signature.ReturnType;
+        if (type is { Kind: TypeRefKind.Definition, Namespace: "System.Threading.Tasks", Name: "Task" or "ValueTask" })
+            return true;
+        if (type is { Kind: TypeRefKind.GenericInstance, ElementType: { Namespace: "System.Collections.Generic", Name: "IAsyncEnumerable`1" or "IAsyncEnumerator`1" } })
+            return true;
+
+        return false;
+    }
 
     void AppendContainer(StringBuilder sb, BlockContainer container, int indent, bool topLevel = false)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -403,6 +403,8 @@ public sealed partial class CSharpPrinter
     static bool NeedsUnsupportedFallbackReturn(IrFunction function)
         => function.Signature.ReturnType is not { Namespace: "System", Name: "Void" }
             && function.Signature.ReturnType.Kind != TypeRefKind.ByRef
+            && !function.RequiresAsyncBodyModifier
+            && !DescendantsOutsideNestedFunctions(function).Any(static n => n is YieldReturn or YieldBreak)
             && DescendantsOutsideNestedFunctions(function).Any(static n => n is UnsupportedNode)
             && !DescendantsOutsideNestedFunctions(function).Any(static n => n is Return);
 


### PR DESCRIPTION
## Summary
- Emit `return default;` for non-void Partial bodies that contain unsupported residual nodes and no return statement.
- Keeps honest unsupported iterator/stackalloc residual output Roslyn-valid without promoting fidelity.
- Add assertions for iterator and stackalloc residuals.

## Measured impact
`--return-to-sender-fixtures decompiler --return-to-sender-source-probe`:

```text
Before: Invalid 33, CS0161 11
After : Invalid 22, CS0161 0
```

`rts.candidates` remains zero-gap:

```text
ValidMatch 52, ValidDifferent 50, Invalid 0, SourceUnavailable 0, UnsupportedTarget 0
```

## Validation
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/LadderIteratorGateTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/LadderRung6GateTests/*"`
- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures decompiler --return-to-sender-source-probe --cap 10000 --max-examples 260`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures rts.candidates --return-to-sender-source-probe --cap 10000 --max-examples 40`

Follow-up for #2505.