### PR TITLE
Surface RTS Roslyn fallback census

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -1188,6 +1188,8 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("member: Method1~abcdef1234  canonical=M:TestType.Method1()", report);
         Assert.Contains("closure: types=2 members=1 roslyn-types=1 roslyn-member-surfaces=1", report);
         Assert.Contains("roslyn-fallbacks=CS0103/closure-root:1", report);
+        Assert.Contains("Roslyn fallback evidence:", report);
+        Assert.Contains("CS0103/closure-root: 1", report);
         Assert.Contains("Research evidence:", report);
         Assert.Contains("rts.status.fail: 1", report);
         Assert.Contains("il.operation.added: 1", report);
@@ -1200,6 +1202,9 @@ public class GeneratedFixtureCatalogTests
         Assert.Equal(1, view.Targets.Failed);
         Assert.NotNull(view.Research);
         Assert.Single(view.Research.Summary.ActionableSubjects);
+        var fallback = Assert.Single(view.RoslynFallbacks);
+        Assert.Equal("CS0103/closure-root", fallback.Key);
+        Assert.Equal(1, fallback.Count);
         Assert.Single(view.FailedTargetBuckets);
         Assert.Single(view.FailedFixtures);
 
@@ -1208,6 +1213,8 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("## Summary", markout);
         Assert.Contains("## Research evidence", markout);
         Assert.Contains("## Actionable subjects", markout);
+        Assert.Contains("## Roslyn fallback evidence", markout);
+        Assert.Contains("CS0103/closure-root", markout);
         Assert.Contains("Method1~abcdef1234", markout);
         Assert.Contains("il.operation.added: 1", markout);
         Assert.Contains("IL display:", markout);
@@ -1220,6 +1227,9 @@ public class GeneratedFixtureCatalogTests
 
         string json = GeneratedFixtureRunner.FormatReturnToSenderCatalogJson(run);
         using var document = JsonDocument.Parse(json);
+        var fallbackJson = Assert.Single(document.RootElement.GetProperty("RoslynFallbacks").EnumerateArray());
+        Assert.Equal("CS0103/closure-root", fallbackJson.GetProperty("Key").GetString());
+        Assert.Equal(1, fallbackJson.GetProperty("Count").GetInt32());
         var actionable = Assert.Single(document.RootElement
             .GetProperty("ResearchSummary")
             .GetProperty("ActionableSubjects")

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -2339,6 +2339,7 @@ internal static class GeneratedFixtureRunner
     public static string FormatReturnToSenderCatalogJson(GeneratedFixtureReturnToSenderRunResult run)
     {
         var research = ReturnToSenderEvidence.ToResearchDiff(ReturnToSenderEvidence.FromCatalog(run));
+        var report = ReturnToSenderCatalogReport.Build(run, int.MaxValue);
         var payload = new
         {
             ProjectDirectory = Directory.Exists(run.ProjectDirectory) ? run.ProjectDirectory : null,
@@ -2346,6 +2347,7 @@ internal static class GeneratedFixtureRunner
             Results = run.Results.Select(SerializableReturnToSenderResult).ToArray(),
             ResearchDiff = SerializableResearchDiff(research),
             ResearchSummary = ReturnToSenderEvidence.Summarize(research, int.MaxValue),
+            report.RoslynFallbacks,
             run.Passed,
         };
         return JsonSerializer.Serialize(payload, s_jsonOptions);

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -2339,7 +2339,6 @@ internal static class GeneratedFixtureRunner
     public static string FormatReturnToSenderCatalogJson(GeneratedFixtureReturnToSenderRunResult run)
     {
         var research = ReturnToSenderEvidence.ToResearchDiff(ReturnToSenderEvidence.FromCatalog(run));
-        var report = ReturnToSenderCatalogReport.Build(run, int.MaxValue);
         var payload = new
         {
             ProjectDirectory = Directory.Exists(run.ProjectDirectory) ? run.ProjectDirectory : null,
@@ -2347,7 +2346,7 @@ internal static class GeneratedFixtureRunner
             Results = run.Results.Select(SerializableReturnToSenderResult).ToArray(),
             ResearchDiff = SerializableResearchDiff(research),
             ResearchSummary = ReturnToSenderEvidence.Summarize(research, int.MaxValue),
-            report.RoslynFallbacks,
+            RoslynFallbacks = ReturnToSenderCatalogReport.RoslynFallbackBuckets(run.Results),
             run.Passed,
         };
         return JsonSerializer.Serialize(payload, s_jsonOptions);

--- a/tools/DecompilerHarness/ReturnToSenderCatalogReport.cs
+++ b/tools/DecompilerHarness/ReturnToSenderCatalogReport.cs
@@ -26,6 +26,7 @@ internal sealed record ReturnToSenderCatalogReportView(
     ReturnToSenderCatalogReportCounts Fixtures,
     ReturnToSenderCatalogReportCounts Targets,
     ReturnToSenderCatalogResearchSection? Research,
+    IReadOnlyList<ReturnToSenderCatalogReportBucket> RoslynFallbacks,
     IReadOnlyList<ReturnToSenderCatalogReportBucket> SkippedTargetReasons,
     IReadOnlyList<ReturnToSenderCatalogReportBucket> FailedTargetBuckets,
     IReadOnlyList<ReturnToSenderCatalogFixtureGroup> FailedFixtures,
@@ -78,6 +79,7 @@ internal static class ReturnToSenderCatalogReport
                 run.Results.Count(row => row.Status == GeneratedFixtureReturnToSenderStatus.Skip),
                 run.Results.Count(row => row.Status == GeneratedFixtureReturnToSenderStatus.Fail)),
             researchSection,
+            RoslynFallbackBuckets(run.Results),
             Buckets(run.Results.Where(row => row.Status == GeneratedFixtureReturnToSenderStatus.Skip)),
             Buckets(run.Results.Where(row => row.Status == GeneratedFixtureReturnToSenderStatus.Fail)),
             [.. fixtureRows.Where(row => row.Status == GeneratedFixtureReturnToSenderStatus.Fail).Take(maxExamples)],
@@ -103,6 +105,7 @@ internal static class ReturnToSenderCatalogReport
 
         AppendResearchEvidence(sb, view.Research);
         AppendActionableSubjects(sb, view.Research?.Summary);
+        AppendBuckets(sb, "Roslyn fallback evidence:", view.RoslynFallbacks);
         AppendBuckets(sb, "Skipped target reasons:", view.SkippedTargetReasons);
         AppendBuckets(sb, "Failed target buckets:", view.FailedTargetBuckets);
         AppendFailedFixtures(sb, view);
@@ -144,6 +147,7 @@ internal static class ReturnToSenderCatalogReport
             ActionableSubjects = view.Research?.Summary.ActionableSubjects.Count > 0
                 ? [.. view.Research.Summary.ActionableSubjects.Select(ActionableRow)]
                 : null,
+            RoslynFallbacks = view.RoslynFallbacks.Count == 0 ? null : [.. view.RoslynFallbacks.Select(BucketRow)],
             SkippedTargetReasons = view.SkippedTargetReasons.Count == 0 ? null : [.. view.SkippedTargetReasons.Select(BucketRow)],
             FailedTargetBuckets = view.FailedTargetBuckets.Count == 0 ? null : [.. view.FailedTargetBuckets.Select(BucketRow)],
             FailedFixtures = view.FailedFixtures.Count == 0 ? null : [.. view.FailedFixtures.SelectMany(fixture => fixture.Rows.Where(row => row.Status == GeneratedFixtureReturnToSenderStatus.Fail).Select(row => FailedRow(fixture.FixtureId, row)))],
@@ -193,13 +197,25 @@ internal static class ReturnToSenderCatalogReport
             .ThenBy(group => group.Key, StringComparer.Ordinal)
             .Select(group => new ReturnToSenderCatalogReportBucket(group.Key, group.Count()))];
 
+    static IReadOnlyList<ReturnToSenderCatalogReportBucket> RoslynFallbackBuckets(IEnumerable<GeneratedFixtureReturnToSenderResult> rows)
+        => [.. rows
+            .Where(row => row.ClosureEvidence is not null)
+            .SelectMany(row => row.ClosureEvidence!.RoslynFallbacks)
+            .GroupBy(RoslynFallbackKey, StringComparer.Ordinal)
+            .Select(group => new ReturnToSenderCatalogReportBucket(group.Key, group.Sum(fallback => fallback.Count)))
+            .OrderByDescending(bucket => bucket.Count)
+            .ThenBy(bucket => bucket.Key, StringComparer.Ordinal)];
+
     static string ClosureText(ReturnToSenderClosureEvidence evidence)
     {
         var text = $"types={evidence.RequiredTypes} members={evidence.RequiredMembers} roslyn-types={evidence.RoslynRecoveredTypes} roslyn-member-surfaces={evidence.RoslynRecoveredMemberSurfaces}";
         if (evidence.RoslynFallbacks.Count == 0)
             return text;
-        return $"{text} roslyn-fallbacks={string.Join(",", evidence.RoslynFallbacks.Select(fallback => $"{fallback.Diagnostic}/{fallback.Recovery}:{fallback.Count}"))}";
+        return $"{text} roslyn-fallbacks={string.Join(",", evidence.RoslynFallbacks.Select(fallback => $"{RoslynFallbackKey(fallback)}:{fallback.Count}"))}";
     }
+
+    static string RoslynFallbackKey(ReturnToSenderRoslynFallback fallback)
+        => $"{fallback.Diagnostic}/{fallback.Recovery}";
 
     static void AppendResearchEvidence(StringBuilder sb, ReturnToSenderCatalogResearchSection? research)
     {
@@ -316,6 +332,9 @@ internal sealed class ReturnToSenderCatalogMarkoutView
 
     [MarkoutSection(Name = "Actionable subjects", EmptyText = "None")]
     public List<ReturnToSenderActionableRow>? ActionableSubjects { get; init; }
+
+    [MarkoutSection(Name = "Roslyn fallback evidence", EmptyText = "None")]
+    public List<ReturnToSenderBucketRow>? RoslynFallbacks { get; init; }
 
     [MarkoutSection(Name = "Skipped target reasons", EmptyText = "None")]
     public List<ReturnToSenderBucketRow>? SkippedTargetReasons { get; init; }

--- a/tools/DecompilerHarness/ReturnToSenderCatalogReport.cs
+++ b/tools/DecompilerHarness/ReturnToSenderCatalogReport.cs
@@ -197,7 +197,7 @@ internal static class ReturnToSenderCatalogReport
             .ThenBy(group => group.Key, StringComparer.Ordinal)
             .Select(group => new ReturnToSenderCatalogReportBucket(group.Key, group.Count()))];
 
-    static IReadOnlyList<ReturnToSenderCatalogReportBucket> RoslynFallbackBuckets(IEnumerable<GeneratedFixtureReturnToSenderResult> rows)
+    internal static IReadOnlyList<ReturnToSenderCatalogReportBucket> RoslynFallbackBuckets(IEnumerable<GeneratedFixtureReturnToSenderResult> rows)
         => [.. rows
             .Where(row => row.ClosureEvidence is not null)
             .SelectMany(row => row.ClosureEvidence!.RoslynFallbacks)


### PR DESCRIPTION
- Changes harness-only RTS catalog reporting so grouped Roslyn fallback buckets are visible even when all targets pass.
- Evidence revision: `80de8ffe`

## Change

**Conclusion:** **PASS** — the RTS catalog now reports aggregate `Diagnostic/Recovery` fallback buckets in plain, Markout, and JSON output, making the remaining fallback population visible without expanding product behavior.

Before:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 7 fixture(s), 12 target(s)
...
Passed fixtures (first 7 of 7):
  record.equality-operators
```

After:

```text
Roslyn fallback evidence:
  CS0103/closure-member: 2
  CS1061/closure-member: 1
```

## Scope and safety

- **Root cause:** per-row closure evidence only appeared on failed rows in the plain report, so passing rows could still hide live Roslyn fallback use.
- **Fix shape:** report/view aggregation over existing `ReturnToSenderClosureEvidence.RoslynFallbacks`; no new fallback recovery behavior.
- **Product impact:** none; Decompiler output and compile-back orchestration are unchanged.
- **Scope boundary:** this does not remove any remaining fallback branch because the new census shows the current buckets are still live in passing catalog rows.
- **RTS boundary:** RTS only reports existing closure + Roslyn evidence; product/shared code ownership is unchanged.

## Evidence

| Check | Result |
| --- | --- |
| Focused tests | `GeneratedFixtureCatalogTests` passed |
| Harness build | `tools/DecompilerHarness` passed |
| Targeted RTS catalog | `record` plain/JSON/Markout shows fallback buckets |
| Known frontier catalog | `minimal` JSON reports expected fallback buckets while preserving existing failing frontier status |

### RTS catalog census

`record` plain/JSON/Markout now all expose:

```text
CS0103/closure-member: 2
CS1061/closure-member: 1
```

`minimal` JSON exposes:

```text
CS0103/closure-member: 14
CS0117/closure-member: 6
CS0234/closure-root: 2
CS1061/closure-member: 1
```

## Review

Adversarial review requested after PR creation.

## Validation

```bash
dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/GeneratedFixtureCatalogTests/*"
dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog record --max-examples 20
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog record --json --max-examples 1
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog record --return-to-sender-markout --max-examples 20
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog minimal --json --max-examples 1
```
