### PR TITLE
Seed typed RTS target field requirements

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -311,6 +311,60 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackFirstPropertyGetter_UsesTypedTargetFieldForUnqualifiedFieldAccess()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                private readonly int _value = 42;
+
+                public int Value => _value;
+            }
+            """);
+        try
+        {
+            var result = ReturnToSender.CompileBackFirstPropertyGetter(assemblyPath);
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            var type = Assert.Single(result.Plan.Types);
+            Assert.DoesNotContain(type.SourceFacts, fact => fact.Producer == "roslyn" && fact.Id == "closure-member");
+            Assert.Contains(type.Members, member =>
+                member.Name == "_value"
+                && member.Kind == CompileBackMemberKind.Field
+                && member.SourceFacts.Any(fact => fact.Id == "typed-closure-field" && fact.Detail == "_value"));
+            Assert.Contains("public int _value;", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackFirstPropertyGetter_DoesNotEmitGeneratedBackingFieldRequirement()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public int Value { get; } = 42;
+            }
+            """);
+        try
+        {
+            var result = ReturnToSender.CompileBackFirstPropertyGetter(assemblyPath);
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            var type = Assert.Single(result.Plan.Types);
+            Assert.DoesNotContain(type.Members, member => member.Name.Contains('<', StringComparison.Ordinal));
+            Assert.DoesNotContain(result.Source, "<Value>", StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_KeepsTypeResolvedCs0117PropertyFallback()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -2152,6 +2152,12 @@ public static class CompileBackSourceComposer
                 return null;
 
             string fieldName = reader.GetString(field.Name);
+            if (fieldName.Contains('<', StringComparison.Ordinal)
+                || fieldName.Contains('.', StringComparison.Ordinal))
+            {
+                return null;
+            }
+
             return new CompileBackMemberRequirement(
                 new CompileBackMethodIdentity(typeIdentity.FullName, Identifier(fieldName), 0, $"field {fieldType}"),
                 CompileBackMemberKind.Field,

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1504,7 +1504,7 @@ static class ReturnToSender
             AddMemberRequirement(
                 field.DeclaringType,
                 root => ResearchReturnToSenderShells.TryCreateClosureMemberRequirement(reader, root, field),
-                allowTargetRoot: false);
+                allowTargetRoot: true);
         }
 
         void AddMemberRequirement(TypeRef declaringType, Func<TypeDefinitionHandle, CompileBackMemberRequirement?> create, bool allowTargetRoot)


### PR DESCRIPTION
- Changes RTS typed closure evidence for exact target-root field refs.
- Evidence revision: `f159b8dd`

## Change

**Conclusion:** **PASS** — unqualified target-field access now seeds precise typed field requirements, removing the `CS0103/closure-member` fallback bucket from the minimal generated catalog while preserving record catalog pass status.

Before:

```text
minimal Roslyn fallback evidence:
  CS0103/closure-member: 14
  CS0117/closure-member: 6
  CS0234/closure-root: 2
  CS1061/closure-member: 1
```

After:

```text
minimal Roslyn fallback evidence:
  CS0234/closure-root: 2
  CS0117/closure-member: 1
  CS1061/closure-member: 1
```

## Scope and safety

- **Root cause:** target-root field refs were intentionally blocked from typed member requirements, so normal unqualified target fields relied on Roslyn `CS0103` recovery.
- **Fix shape:** allow target-root field refs to seed precise typed field requirements; keep generated/unspellable backing fields out of `TryCreateClosureMemberRequirement`.
- **Product impact:** compile-back/RTS shell evidence only; no decompiler output behavior change.
- **Scope boundary:** record `EqualityContract` still uses existing `CS0103/CS1061` member fallback; this PR does not remove property/method fallbacks.
- **RTS boundary:** RTS consumes typed field evidence through the Research shell boundary; product/shared code owns shell declaration creation.

## Evidence

| Check | Result |
| --- | --- |
| Focused target-field canary | Pass |
| Generated backing-field canary | Pass |
| GeneratedFixtureCatalogTests | Pass |
| Solution build | Pass, existing metadata nullable warnings only |
| `minimal` RTS catalog JSON | `CS0103/closure-member` 14 -> 0 |
| `record` RTS catalog JSON | all 12 targets pass; `CS0103/closure-member` remains 2 for `EqualityContract` |
| `rts.candidates` source probe | ValidMatch 52, ValidDifferent 50, Invalid 0, SourceUnavailable 0, UnsupportedTarget 0 |

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `record.field-read-helpers` `EqualityContract` | Left as fallback | This is property/member-surface recovery, not normal target field access. |
| Full `ReturnToSenderPrototypeTests` class | Not used as gating evidence | Two record-helper assertion tests also fail on clean `origin/main` under the current SDK; focused new canaries pass. |

## Validation

```bash
dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderPrototypeTests/CompileBackFirstPropertyGetter_UsesTypedTargetFieldForUnqualifiedFieldAccess"
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderPrototypeTests/CompileBackFirstPropertyGetter_DoesNotEmitGeneratedBackingFieldRequirement"
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/GeneratedFixtureCatalogTests/*"
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog minimal --json --max-examples 1
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog record --json --max-examples 1
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures rts.candidates --return-to-sender-source-probe --cap 10000 --max-examples 60
```

## Review

Adversarial review requested after PR creation.
