### PR TITLE
Fix ref readonly compile-back returns

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LadderRung4GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung4GateTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
@@ -131,6 +132,20 @@ public class LadderRung4GateTests
 
         var writableReturn = Assert.Single(type.Members, m => m.Name == "SelectRef");
         Assert.Equal("ref int SelectRef(bool useLeft, ref int left, ref int right)", writableReturn.Signature);
+    }
+
+    [Fact]
+    public void Rung4Fixture_MetadataDeclarationQueryRendersRefReadonlyReturn()
+    {
+        using var pe = new PEReader(File.OpenRead(FixturePath));
+        var reader = pe.GetMetadataReader();
+        var typeHandle = reader.TypeDefinitions.Single(handle =>
+            reader.GetFullTypeName(reader.GetTypeDefinition(handle)) == FixtureType);
+        var type = MetadataDeclarationQuery.GetTypeSurface(reader, typeHandle, includeNonPublicMembers: true);
+
+        var readOnlyReturn = Assert.Single(type.Members, m => m.Name == "SelectReadonlyRef");
+        Assert.Equal("ref readonly int SelectReadonlyRef(bool useLeft, in int left, in int right)", readOnlyReturn.Signature);
+        Assert.Empty(readOnlyReturn.SignatureModel?.ReturnAttributes ?? []);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/LadderRung4GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung4GateTests.cs
@@ -145,7 +145,6 @@ public class LadderRung4GateTests
 
         var readOnlyReturn = Assert.Single(type.Members, m => m.Name == "SelectReadonlyRef");
         Assert.Equal("ref readonly int SelectReadonlyRef(bool useLeft, in int left, in int right)", readOnlyReturn.Signature);
-        Assert.Empty(readOnlyReturn.SignatureModel?.ReturnAttributes ?? []);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -145,6 +145,14 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void CompileBackCSharpNames_PreservesReadonlyOnlyInRefReadonlyModifier()
+    {
+        Assert.Equal("ref readonly int", CompileBackCSharpNames.Clean("ref readonly int"));
+        Assert.Equal("ref @readonly", CompileBackCSharpNames.Clean("ref readonly"));
+        Assert.Equal("ref Example.@readonly", CompileBackCSharpNames.Clean("ref Example.readonly"));
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_ClassifiesBodylessSourceMembersAsUnsupported()
     {
         var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1353,6 +1353,39 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_RendersRefReadonlyReturnShell()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public static ref readonly int SelectReadonlyRef(bool useLeft, in int left, in int right)
+                {
+                    if (useLeft)
+                    {
+                        return ref left;
+                    }
+
+                    return ref right;
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", "SelectReadonlyRef", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains("public static ref readonly int SelectReadonlyRef(bool useLeft, in int left, in int right)", result.Source);
+            Assert.DoesNotContain("ref @readonly", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_RoundTripsIndexerSetter()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -64,6 +64,7 @@ static class CompileBackCSharpNames
                     && type[i] == '*'
                     && (type[i + 1] == '<' || char.IsWhiteSpace(type[i + 1]));
                 bool bareSpelling = ((word is "void" or "ref" || IsPrimitiveTypeName(word)) && !qualifiedSegment)
+                    || (word == "readonly" && !qualifiedSegment && PreviousWordIsRef(type, start))
                     || functionPointerKeyword;
                 if (!alreadyEscaped && !bareSpelling && IsCSharpKeyword(word))
                     sb.Append('@');
@@ -77,6 +78,17 @@ static class CompileBackCSharpNames
         }
 
         return sb.ToString();
+    }
+
+    static bool PreviousWordIsRef(string text, int wordStart)
+    {
+        int i = wordStart - 1;
+        while (i >= 0 && char.IsWhiteSpace(text[i]))
+            i--;
+        int end = i + 1;
+        while (i >= 0 && (char.IsLetterOrDigit(text[i]) || text[i] == '_'))
+            i--;
+        return end > i + 1 && text[(i + 1)..end] == "ref";
     }
 
     static bool IsPrimitiveTypeName(string name)
@@ -622,7 +634,7 @@ public static class CompileBackSourceComposer
                 isConstructor ? CompileBackMemberKind.Constructor : CompileBackMemberKind.Method,
                 method.Attributes.HasFlag(MethodAttributes.Static),
                 MethodParameters(reader, method, signature),
-                isConstructor ? null : CompileBackTypeSignature.Display(signature.ReturnType),
+                isConstructor ? null : CompileBackTypeSignature.Display(MethodReturnType(reader, targetTypeDef, method)),
                 MethodTypeParameters(reader, method),
                 CompileBackStubBodyKind.TargetBody,
                 targetBody,
@@ -1188,6 +1200,10 @@ public static class CompileBackSourceComposer
             reader,
             reader.GetTypeDefinition(method.GetDeclaringType()),
             method).Signature.ReturnAttributes;
+
+    static string MethodReturnType(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)
+        => MetadataDeclarationQuery.GetMethod(reader, typeDef, method).Signature.ReturnType
+            ?? method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method)).ReturnType;
 
     static CompileBackMemberRequirement? EqualityOperatorSibling(
         MetadataReader reader,

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -64,7 +64,7 @@ static class CompileBackCSharpNames
                     && type[i] == '*'
                     && (type[i + 1] == '<' || char.IsWhiteSpace(type[i + 1]));
                 bool bareSpelling = ((word is "void" or "ref" || IsPrimitiveTypeName(word)) && !qualifiedSegment)
-                    || (word == "readonly" && !qualifiedSegment && PreviousWordIsRef(type, start))
+                    || (word == "readonly" && !qualifiedSegment && PreviousWordIsRef(type, start) && HasFollowingWord(type, i))
                     || functionPointerKeyword;
                 if (!alreadyEscaped && !bareSpelling && IsCSharpKeyword(word))
                     sb.Append('@');
@@ -89,6 +89,14 @@ static class CompileBackCSharpNames
         while (i >= 0 && (char.IsLetterOrDigit(text[i]) || text[i] == '_'))
             i--;
         return end > i + 1 && text[(i + 1)..end] == "ref";
+    }
+
+    static bool HasFollowingWord(string text, int wordEnd)
+    {
+        int i = wordEnd;
+        while (i < text.Length && char.IsWhiteSpace(text[i]))
+            i++;
+        return i < text.Length && (char.IsLetter(text[i]) || text[i] == '_' || text[i] == '@');
     }
 
     static bool IsPrimitiveTypeName(string name)
@@ -1202,8 +1210,7 @@ public static class CompileBackSourceComposer
             method).Signature.ReturnAttributes;
 
     static string MethodReturnType(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)
-        => MetadataDeclarationQuery.GetMethod(reader, typeDef, method).Signature.ReturnType
-            ?? method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method)).ReturnType;
+        => MetadataDeclarationQuery.GetMethodReturnType(reader, typeDef, method);
 
     static CompileBackMemberRequirement? EqualityOperatorSibling(
         MetadataReader reader,

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -227,7 +227,7 @@ public static class MetadataDeclarationQuery
             isOverride && (attributes & MethodAttributes.Final) != 0,
             new ApiSignature
             {
-                ReturnType = signature.ReturnType,
+                ReturnType = FormatMethodReturnType(reader, signature.ReturnType, method.GetParameters()),
                 ReturnAttributes = ReturnAttributes(reader, method.GetParameters()).ToList(),
                 MemberName = methodName,
                 TypeParameters = typeParameters.ToList(),
@@ -501,10 +501,34 @@ public static class MetadataDeclarationQuery
         foreach (var handle in handles)
         {
             if (reader.GetParameter(handle).SequenceNumber == 0)
-                return AttributeReader.RenderParameterAttributes(reader, handle);
+                return AttributeReader.RenderParameterAttributes(reader, handle)
+                    .Where(attribute => attribute is not "System.Runtime.CompilerServices.IsReadOnlyAttribute"
+                        and not "System.Runtime.CompilerServices.RequiresLocationAttribute")
+                    .ToArray();
         }
 
         return [];
+    }
+
+    static string FormatMethodReturnType(MetadataReader reader, string returnType, ParameterHandleCollection handles)
+        => returnType.StartsWith("ref ", StringComparison.Ordinal)
+            && ReturnIsReadOnlyRef(reader, handles)
+            ? $"ref readonly {returnType["ref ".Length..]}"
+            : returnType;
+
+    static bool ReturnIsReadOnlyRef(MetadataReader reader, ParameterHandleCollection handles)
+    {
+        foreach (var handle in handles)
+        {
+            var parameter = reader.GetParameter(handle);
+            if (parameter.SequenceNumber == 0
+                && (AttributeReader.HasAttribute(reader, parameter.GetCustomAttributes(), KnownAttributeNames.IsReadOnlyAttribute)
+                    || AttributeReader.HasAttribute(reader, parameter.GetCustomAttributes(), KnownAttributeNames.RequiresLocationAttribute)))
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     static IReadOnlyList<TypeParameter> MethodTypeParameters(

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -192,6 +192,15 @@ public static class MetadataDeclarationQuery
         return GetMethod(reader, typeDef, method, signature);
     }
 
+    public static string GetMethodReturnType(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        MethodDefinition method)
+    {
+        var signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method));
+        return FormatMethodReturnType(reader, signature.ReturnType, method.GetParameters());
+    }
+
     public static MetadataMethodDeclaration GetMethod(
         MetadataReader reader,
         TypeDefinition typeDef,
@@ -501,10 +510,7 @@ public static class MetadataDeclarationQuery
         foreach (var handle in handles)
         {
             if (reader.GetParameter(handle).SequenceNumber == 0)
-                return AttributeReader.RenderParameterAttributes(reader, handle)
-                    .Where(attribute => attribute is not "System.Runtime.CompilerServices.IsReadOnlyAttribute"
-                        and not "System.Runtime.CompilerServices.RequiresLocationAttribute")
-                    .ToArray();
+                return AttributeReader.RenderParameterAttributes(reader, handle);
         }
 
         return [];


### PR DESCRIPTION
## Summary

Fixes the #2505 `CS8333` source-probe row by rendering ref-readonly method returns in metadata declaration queries and reusing that declaration spelling for compile-back target shells. This keeps method bodies as valid C# (`return ref left;`) while making the shell signature `ref readonly`, matching the fixture source and Roslyn requirements.

Also filters compiler-reserved readonly-ref return attributes from emitted return attributes so shells do not produce invalid `[return: IsReadOnly]` syntax.

## Evidence

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/LadderRung4GateTests/*"`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --no-restore --nologo`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures decompiler --return-to-sender-source-probe --cap 10000 --max-examples 260`
  - Invalid: `22 -> 21`
  - Buckets: `CS1525: 20`, `CS8858: 1`
  - `CS8333` removed
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures rts.candidates --return-to-sender-source-probe --cap 10000 --max-examples 260`
  - Invalid: `0`

Adversarial review requested; results will be posted before ready-to-merge.