### PR TITLE
Seed typed RTS minimal member requirements

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -365,6 +365,110 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_UsesTargetBackingFieldWriteForConstructorAssignment()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public Class1(string message)
+                {
+                    Method1 = message;
+                }
+
+                public string Method1 { get; }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", ".ctor", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            var type = Assert.Single(result.Plan.Types);
+            Assert.DoesNotContain(type.SourceFacts, fact => fact.Producer == "roslyn" && fact.Id == "closure-member");
+            Assert.Contains(type.Members, member =>
+                member.Name == "Method1"
+                && member.Kind == CompileBackMemberKind.PropertyGet
+                && member.SourceFacts.Any(fact => fact.Id == "target-backing-field-write" && fact.Detail == "<Method1>k__BackingField"));
+            Assert.Contains("public string Method1 { get; }", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_SeedsTargetInterfaceRoot()
+    {
+        var assemblyPath = CompileFixture("""
+            public interface IValue
+            {
+                int GetValue();
+            }
+
+            public class Class1 : IValue
+            {
+                public int GetValue() => 42;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", "GetValue", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains(result.Plan.Types, type =>
+                type.Name == "IValue"
+                && type.SourceFacts.Any(fact => fact.Producer == "metadata" && fact.Id == "target-interface"));
+            Assert.DoesNotContain(result.Plan.Types.SelectMany(type => type.SourceFacts), fact =>
+                fact.Producer == "roslyn" && fact.Id == "closure-root");
+            Assert.Contains("public interface IValue", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_UsesTypedObjectInitializerPropertyRequirement()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Helper
+            {
+                public int Value { get; set; }
+            }
+
+            public class Class1
+            {
+                public Helper Method1(int value) => new Helper { Value = value };
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", "Method1", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            var helper = Assert.Single(result.Plan.Types, type => type.Name == "Helper");
+            Assert.DoesNotContain(helper.SourceFacts, fact => fact.Producer == "roslyn" && fact.Id == "closure-member");
+            Assert.Contains(helper.Members, member =>
+                member.Name == "Value"
+                && member.Kind == CompileBackMemberKind.PropertyGet
+                && member.SourceFacts.Any(fact => fact.Id == "typed-closure-property" && fact.Detail == "set_Value"));
+            Assert.Contains("public int Value { get; set; }", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_KeepsTypeResolvedCs0117PropertyFallback()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -400,6 +400,67 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_DoesNotDuplicatePrimaryConstructorAutoPropertyInitializer()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1(int value)
+            {
+                public int Value { get; } = value;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", ".ctor", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.DoesNotContain("already contains a definition", result.Detail ?? "", StringComparison.Ordinal);
+            Assert.Equal(1, Assert.Single(result.Plan.Types).Members.Count(member => member.Name == "Value"));
+            Assert.Contains("public int Value", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_UsesTargetBackingFieldWriteForStaticConstructorAssignment()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                static Class1()
+                {
+                    Value = 42;
+                }
+
+                public static int Value { get; }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", ".cctor", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            var type = Assert.Single(result.Plan.Types);
+            Assert.DoesNotContain(type.SourceFacts, fact => fact.Producer == "roslyn" && fact.Id == "closure-member");
+            Assert.Contains(type.Members, member =>
+                member.Name == "Value"
+                && member.IsStatic
+                && member.SourceFacts.Any(fact => fact.Id == "target-backing-field-write" && fact.Detail == "<Value>k__BackingField"));
+            Assert.Contains("public static int Value { get; }", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_SeedsTargetInterfaceRoot()
     {
         var assemblyPath = CompileFixture("""
@@ -457,6 +518,38 @@ public class ReturnToSenderPrototypeTests
             var helper = Assert.Single(result.Plan.Types, type => type.Name == "Helper");
             Assert.DoesNotContain(helper.SourceFacts, fact => fact.Producer == "roslyn" && fact.Id == "closure-member");
             Assert.Contains(helper.Members, member =>
+                member.Name == "Value"
+                && member.Kind == CompileBackMemberKind.PropertyGet
+                && member.SourceFacts.Any(fact => fact.Id == "typed-closure-property" && fact.Detail == "set_Value"));
+            Assert.Contains("public int Value { get; set; }", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_UsesTypedTargetObjectInitializerPropertyRequirement()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public int Value { get; set; }
+
+                public Class1 Method1(int value) => new Class1 { Value = value };
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", "Method1", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            var type = Assert.Single(result.Plan.Types);
+            Assert.DoesNotContain(type.SourceFacts, fact => fact.Producer == "roslyn" && fact.Id == "closure-member");
+            Assert.Contains(type.Members, member =>
                 member.Name == "Value"
                 && member.Kind == CompileBackMemberKind.PropertyGet
                 && member.SourceFacts.Any(fact => fact.Id == "typed-closure-property" && fact.Detail == "set_Value"));

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -324,6 +324,12 @@ public static class CompileBackSourceComposer
         FieldRef field)
         => TypeProducer.TryCreateClosureMemberRequirement(reader, typeHandle, field);
 
+    public static CompileBackMemberRequirement? TryCreateClosureMemberRequirement(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        string memberName)
+        => TypeProducer.TryCreateClosureMemberRequirement(reader, typeHandle, memberName);
+
     public static CompileBackSourceResult ComposePropertyGetter(
         string assemblyPath,
         MetadataReader reader,
@@ -657,6 +663,8 @@ public static class CompileBackSourceComposer
         ];
         if (!isConstructor && IsRecordGeneratedFieldReadHelper(reader, targetTypeDef, targetIdentity, methodName, signature, function))
             targetMembers.AddRange(TargetBackingFieldReadMembers(reader, targetTypeDef, targetIdentity, function));
+        if (isConstructor)
+            targetMembers.AddRange(TargetBackingFieldWriteMembers(reader, targetTypeDef, targetIdentity, function));
         if (!isConstructor
             && EqualityOperatorSibling(reader, targetTypeDef, targetIdentity, methodName, signature) is { } equalitySibling)
         {
@@ -1910,6 +1918,62 @@ public static class CompileBackSourceComposer
             yield return address.Field;
     }
 
+    static IReadOnlyList<CompileBackMemberRequirement> TargetBackingFieldWriteMembers(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        CompileBackTypeIdentity targetIdentity,
+        IrFunction function)
+    {
+        var members = new List<CompileBackMemberRequirement>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var store in function.Descendants.OfType<StoreField>())
+        {
+            if (store is not { HasInstance: true, Instance: LoadArgument { Index: 0 } })
+                continue;
+            var fieldRef = store.Field;
+            if (fieldRef.BackingPropertyName is not { Length: > 0 } propertyName)
+                continue;
+            if (!IsSelfType(fieldRef.DeclaringType, targetIdentity))
+                continue;
+            if (AutoPropertyNameForBackingField(reader, typeDef, fieldRef.Name) != propertyName)
+                continue;
+            if (FindField(reader, typeDef, fieldRef.Name) is not { } fieldHandle)
+                continue;
+
+            var field = reader.GetFieldDefinition(fieldHandle);
+            if (!MethodDefinitionFacts.HasCompilerGeneratedAttribute(reader, field.GetCustomAttributes()))
+                continue;
+
+            string memberName = Identifier(propertyName);
+            if (!seen.Add(memberName))
+                continue;
+
+            string fieldType;
+            try
+            {
+                fieldType = field.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForType(reader, typeDef));
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+            {
+                continue;
+            }
+
+            members.Add(new CompileBackMemberRequirement(
+                new CompileBackMethodIdentity(targetIdentity.FullName, memberName, 0, $"property {fieldType}"),
+                CompileBackMemberKind.PropertyGet,
+                IsStatic: false,
+                Parameters: [],
+                CompileBackTypeSignature.Display(fieldType),
+                TypeParameters: [],
+                CompileBackStubBodyKind.AutoProperty,
+                TargetBody: null,
+                [new CompileBackFact("metadata", "target-backing-field-write", fieldRef.Name)]));
+        }
+
+        return members;
+    }
+
     static string? AutoPropertyNameForBackingField(MetadataReader reader, TypeDefinition typeDef, string fieldName)
     {
         if (!fieldName.StartsWith("<", StringComparison.Ordinal) || !fieldName.EndsWith(">k__BackingField", StringComparison.Ordinal))
@@ -2160,6 +2224,36 @@ public static class CompileBackSourceComposer
             var typeIdentity = CompileBackTypeIdentity.FromDefinition(reader, typeDef);
             if (FindField(reader, typeDef, fieldRef.Name) is not { } fieldHandle)
                 return null;
+            return FieldRequirement(reader, typeDef, typeIdentity, fieldHandle);
+        }
+
+        public static CompileBackMemberRequirement? TryCreateClosureMemberRequirement(
+            MetadataReader reader,
+            TypeDefinitionHandle typeHandle,
+            string memberName)
+        {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            var typeIdentity = CompileBackTypeIdentity.FromDefinition(reader, typeDef);
+            if (TryFindPropertyByName(reader, typeDef, memberName) is { } propertyHandle)
+            {
+                var property = reader.GetPropertyDefinition(propertyHandle);
+                var setter = property.GetAccessors().Setter;
+                if (!setter.IsNil)
+                    return PropertyRequirement(reader, typeDef, typeIdentity, propertyHandle, $"set_{memberName}");
+            }
+
+            if (FindField(reader, typeDef, memberName) is { } fieldHandle)
+                return FieldRequirement(reader, typeDef, typeIdentity, fieldHandle);
+
+            return null;
+        }
+
+        static CompileBackMemberRequirement? FieldRequirement(
+            MetadataReader reader,
+            TypeDefinition typeDef,
+            CompileBackTypeIdentity typeIdentity,
+            FieldDefinitionHandle fieldHandle)
+        {
             var field = reader.GetFieldDefinition(fieldHandle);
             string fieldType;
             try
@@ -2261,6 +2355,22 @@ public static class CompileBackSourceComposer
             }
 
             return null;
+        }
+
+        static PropertyDefinitionHandle? TryFindPropertyByName(
+            MetadataReader reader,
+            TypeDefinition typeDef,
+            string propertyName)
+        {
+            var matches = new List<PropertyDefinitionHandle>();
+            foreach (var propertyHandle in typeDef.GetProperties())
+            {
+                var property = reader.GetPropertyDefinition(propertyHandle);
+                if (reader.GetString(property.Name) == propertyName)
+                    matches.Add(propertyHandle);
+            }
+
+            return matches.Count == 1 ? matches[0] : null;
         }
 
         static MethodDefinitionHandle? TryFindMethod(

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -663,8 +663,10 @@ public static class CompileBackSourceComposer
         ];
         if (!isConstructor && IsRecordGeneratedFieldReadHelper(reader, targetTypeDef, targetIdentity, methodName, signature, function))
             targetMembers.AddRange(TargetBackingFieldReadMembers(reader, targetTypeDef, targetIdentity, function));
-        if (isConstructor)
-            targetMembers.AddRange(TargetBackingFieldWriteMembers(reader, targetTypeDef, targetIdentity, function));
+        if (isConstructor && primaryConstructor is null)
+            targetMembers.AddRange(TargetBackingFieldWriteMembers(reader, targetTypeDef, targetIdentity, function, allowStaticStores: false));
+        if (methodName == ".cctor")
+            targetMembers.AddRange(TargetBackingFieldWriteMembers(reader, targetTypeDef, targetIdentity, function, allowStaticStores: true));
         if (!isConstructor
             && EqualityOperatorSibling(reader, targetTypeDef, targetIdentity, methodName, signature) is { } equalitySibling)
         {
@@ -1922,15 +1924,19 @@ public static class CompileBackSourceComposer
         MetadataReader reader,
         TypeDefinition typeDef,
         CompileBackTypeIdentity targetIdentity,
-        IrFunction function)
+        IrFunction function,
+        bool allowStaticStores)
     {
         var members = new List<CompileBackMemberRequirement>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (var store in function.Descendants.OfType<StoreField>())
         {
-            if (store is not { HasInstance: true, Instance: LoadArgument { Index: 0 } })
+            if (store is not { HasInstance: true, Instance: LoadArgument { Index: 0 } }
+                && !(allowStaticStores && store is { HasInstance: false }))
+            {
                 continue;
+            }
             var fieldRef = store.Field;
             if (fieldRef.BackingPropertyName is not { Length: > 0 } propertyName)
                 continue;
@@ -1962,7 +1968,7 @@ public static class CompileBackSourceComposer
             members.Add(new CompileBackMemberRequirement(
                 new CompileBackMethodIdentity(targetIdentity.FullName, memberName, 0, $"property {fieldType}"),
                 CompileBackMemberKind.PropertyGet,
-                IsStatic: false,
+                field.Attributes.HasFlag(FieldAttributes.Static),
                 Parameters: [],
                 CompileBackTypeSignature.Display(fieldType),
                 TypeParameters: [],

--- a/src/ILInspector.Research/ResearchReturnToSenderShells.cs
+++ b/src/ILInspector.Research/ResearchReturnToSenderShells.cs
@@ -21,6 +21,12 @@ public static class ResearchReturnToSenderShells
         FieldRef field)
         => CompileBackSourceComposer.TryCreateClosureMemberRequirement(reader, typeHandle, field);
 
+    public static CompileBackMemberRequirement? TryCreateClosureMemberRequirement(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        string memberName)
+        => CompileBackSourceComposer.TryCreateClosureMemberRequirement(reader, typeHandle, memberName);
+
     public static CompileBackSourceResult ComposePropertyGetter(
         string assemblyPath,
         MetadataReader reader,

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -656,7 +656,7 @@ static class ReturnToSender
         };
         var closureFacts = new Dictionary<TypeDefinitionHandle, List<CompileBackFact>>();
         var closureMemberRequirements = new Dictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>>();
-        SeedTypedClosureRoots(reader, function, targetRoot, closureRoots, closureFacts, closureMemberRequirements);
+        SeedTypedClosureRoots(reader, function, typeHandle, targetRoot, closureRoots, closureFacts, closureMemberRequirements);
         const int maxRoots = 200;
         const int maxIterations = 80;
         Diagnostic? firstError = null;
@@ -815,7 +815,7 @@ static class ReturnToSender
         };
         var closureFacts = new Dictionary<TypeDefinitionHandle, List<CompileBackFact>>();
         var closureMemberRequirements = new Dictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>>();
-        SeedTypedClosureRoots(reader, function, targetRoot, closureRoots, closureFacts, closureMemberRequirements);
+        SeedTypedClosureRoots(reader, function, typeHandle, targetRoot, closureRoots, closureFacts, closureMemberRequirements);
         const int maxRoots = 200;
         const int maxIterations = 80;
         Diagnostic? firstError = null;
@@ -973,7 +973,7 @@ static class ReturnToSender
         };
         var closureFacts = new Dictionary<TypeDefinitionHandle, List<CompileBackFact>>();
         var closureMemberRequirements = new Dictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>>();
-        SeedTypedClosureRoots(reader, function, targetRoot, closureRoots, closureFacts, closureMemberRequirements);
+        SeedTypedClosureRoots(reader, function, typeHandle, targetRoot, closureRoots, closureFacts, closureMemberRequirements);
         const int maxRoots = 200;
         const int maxIterations = 80;
         Diagnostic? firstError = null;
@@ -1400,6 +1400,7 @@ static class ReturnToSender
     static void SeedTypedClosureRoots(
         MetadataReader reader,
         IrFunction function,
+        TypeDefinitionHandle targetType,
         TypeDefinitionHandle targetRoot,
         HashSet<TypeDefinitionHandle> closureRoots,
         Dictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
@@ -1407,6 +1408,7 @@ static class ReturnToSender
     {
         string assemblyName = reader.GetString(reader.GetAssemblyDefinition().Name);
         var definitions = TypeDefinitionsByTypeRefIdentity(reader);
+        AddTargetInterfaceRoots(targetType);
         foreach (var node in function.Descendants.Prepend(function))
         {
             foreach (var type in node.DirectTypes)
@@ -1445,6 +1447,32 @@ static class ReturnToSender
                     foreach (var argument in type.TypeArguments)
                         AddTypedClosureRoot(argument);
                     break;
+            }
+        }
+
+        void AddTargetInterfaceRoots(TypeDefinitionHandle handle)
+        {
+            var typeDef = reader.GetTypeDefinition(handle);
+            foreach (var implementationHandle in typeDef.GetInterfaceImplementations())
+            {
+                var implementation = reader.GetInterfaceImplementation(implementationHandle);
+                if (implementation.Interface.Kind != HandleKind.TypeDefinition)
+                    continue;
+
+                var interfaceHandle = (TypeDefinitionHandle)implementation.Interface;
+                var interfaceDef = reader.GetTypeDefinition(interfaceHandle);
+                if (!IsSupportedClosureRoot(reader, interfaceDef))
+                    continue;
+
+                var root = TopLevelRootOf(reader, interfaceHandle);
+                if (root == targetRoot)
+                    continue;
+
+                closureRoots.Add(root);
+                AddClosureFact(
+                    closureFacts,
+                    root,
+                    new CompileBackFact("metadata", "target-interface", reader.GetFullTypeName(interfaceDef)));
             }
         }
 
@@ -1505,6 +1533,14 @@ static class ReturnToSender
                 field.DeclaringType,
                 root => ResearchReturnToSenderShells.TryCreateClosureMemberRequirement(reader, root, field),
                 allowTargetRoot: true);
+        }
+
+        void AddNamedMemberRequirement(TypeRef declaringType, string memberName)
+        {
+            AddMemberRequirement(
+                declaringType,
+                root => ResearchReturnToSenderShells.TryCreateClosureMemberRequirement(reader, root, memberName),
+                allowTargetRoot: false);
         }
 
         void AddMemberRequirement(TypeRef declaringType, Func<TypeDefinitionHandle, CompileBackMemberRequirement?> create, bool allowTargetRoot)
@@ -1600,6 +1636,22 @@ static class ReturnToSender
                 case NullCoalescingFieldAssignment assignment:
                     AddFieldFact(assignment.Field);
                     break;
+                case ObjectInitializerExpression initializer:
+                    AddObjectInitializerFacts(initializer);
+                    break;
+            }
+        }
+
+        void AddObjectInitializerFacts(ObjectInitializerExpression initializer)
+        {
+            AddMethodFact(initializer.Creation.Constructor, allowTargetRootOverride: true);
+            if (initializer.IsCollection)
+                return;
+
+            foreach (var entry in initializer.Entries)
+            {
+                if (entry.Member is { } memberName)
+                    AddNamedMemberRequirement(initializer.Creation.Constructor.DeclaringType, memberName);
             }
         }
 

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1535,12 +1535,12 @@ static class ReturnToSender
                 allowTargetRoot: true);
         }
 
-        void AddNamedMemberRequirement(TypeRef declaringType, string memberName)
+        void AddNamedMemberRequirement(TypeRef declaringType, string memberName, bool allowTargetRoot = false)
         {
             AddMemberRequirement(
                 declaringType,
                 root => ResearchReturnToSenderShells.TryCreateClosureMemberRequirement(reader, root, memberName),
-                allowTargetRoot: false);
+                allowTargetRoot);
         }
 
         void AddMemberRequirement(TypeRef declaringType, Func<TypeDefinitionHandle, CompileBackMemberRequirement?> create, bool allowTargetRoot)
@@ -1651,7 +1651,7 @@ static class ReturnToSender
             foreach (var entry in initializer.Entries)
             {
                 if (entry.Member is { } memberName)
-                    AddNamedMemberRequirement(initializer.Creation.Constructor.DeclaringType, memberName);
+                    AddNamedMemberRequirement(initializer.Creation.Constructor.DeclaringType, memberName, allowTargetRoot: true);
             }
         }
 


### PR DESCRIPTION
- Changes RTS typed evidence for the remaining minimal catalog fallback rows.
- Evidence revision: `a5dd4e1f`

## Change

**Conclusion:** **PASS** — the minimal generated catalog now has no aggregate Roslyn fallback buckets; record `EqualityContract` fallbacks remain isolated for a later PR.

Before:

```text
minimal Roslyn fallback evidence:
  CS0234/closure-root: 2
  CS0117/closure-member: 1
  CS1061/closure-member: 1
```

After:

```text
minimal Roslyn fallback evidence:
  []
```

## Scope and safety

- **Root cause:** three minimal rows still needed Roslyn recovery for type/member surfaces:
  - target interface roots (`IValue`) were only discovered after `CS0234`.
  - raised object initializer entries kept only member names, so `Helper.Value` setter was only discovered after `CS0117`.
  - constructor assignment to a get-only auto-property writes the backing field; the target property shell was only discovered after `CS1061`.
- **Fix shape:** seed target interface roots, seed raised object-initializer named members via Research shell composition, and add a constructor backing-field-write shell that emits a get-only auto-property.
- **Product impact:** compile-back/RTS shell evidence only; product decompiler output behavior is unchanged.
- **Scope boundary:** record `EqualityContract` `CS0103/CS1061` fallbacks are intentionally left unchanged.
- **RTS boundary:** RTS still requests shell composition through Research; product/shared compile-back source composition owns the shell declarations.

## Evidence

| Check | Result |
| --- | --- |
| Constructor backing-field write canary | Pass |
| Target interface root canary | Pass |
| Object initializer property requirement canary | Pass |
| GeneratedFixtureCatalogTests | Pass |
| Solution build | Pass, existing metadata nullable warnings only |
| `minimal` RTS catalog JSON | RoslynFallbacks `[CS0234:2, CS0117:1, CS1061:1]` -> `[]` |
| `record` RTS catalog JSON | unchanged: `CS0103/closure-member: 2`, `CS1061/closure-member: 1` |
| `rts.candidates` source probe | ValidMatch 52, ValidDifferent 50, Invalid 0, SourceUnavailable 0, UnsupportedTarget 0 |

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `record.field-read-helpers` `EqualityContract` | Left as fallback | Record-generated protected virtual property semantics are subtler and should be reviewed separately. |
| `minimal` remaining failure count | Unchanged known frontier | `minimal` still has one non-fallback failing target; this PR only removes fallback evidence buckets. |

## Validation

```bash
dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderPrototypeTests/CompileBackTargets_UsesTargetBackingFieldWriteForConstructorAssignment"
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderPrototypeTests/CompileBackTargets_SeedsTargetInterfaceRoot"
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderPrototypeTests/CompileBackTargets_UsesTypedObjectInitializerPropertyRequirement"
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/GeneratedFixtureCatalogTests/*"
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog minimal --json --max-examples 1
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog record --json --max-examples 1
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures rts.candidates --return-to-sender-source-probe --cap 10000 --max-examples 60
```

## Review

Adversarial review requested after PR creation.
