### PR TITLE
Reduce RTS source-probe syntax frontiers

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CSharpNamingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpNamingTests.cs
@@ -24,8 +24,13 @@ public class CSharpNamingTests
     [InlineData("class", "@class")]
     [InlineData("class`1", "@class")]
     [InlineData("Normal`1", "Normal")]
+    [InlineData("<>c__DisplayClass0_0", "___c__DisplayClass0_0")]
     public void TypeNameSegment_StripsArityAndEscapesKeywords(string metadataName, string expected)
         => Assert.Equal(expected, CSharpNaming.TypeNameSegment(metadataName));
+
+    [Fact]
+    public void SafeIdentifier_PreservesAstralPlaneIdentifiers()
+        => Assert.Equal("\U0001d4cd", CSharpNaming.SafeIdentifier("\U0001d4cd"));
 
     [Theory]
     [InlineData("<seed>P", "seed")]                 // C# 12 primary-ctor capture

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -153,6 +153,64 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void CompileBackCSharpNames_SanitizesGeneratedTypeSegmentsWithoutBreakingGenerics()
+    {
+        Assert.Equal("System.Threading.Tasks.Task<int>", CompileBackCSharpNames.Clean("System.Threading.Tasks.Task<int>"));
+        Assert.Equal(
+            "ILInspector.Decompiler.Fixtures.NewUnsafe.FixedBufferResiduals.__Data_e__FixedBuffer",
+            CompileBackCSharpNames.Clean("ILInspector.Decompiler.Fixtures.NewUnsafe.FixedBufferResiduals.<Data>e__FixedBuffer"));
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_CompilesGeneratedDynamicClosureShells()
+    {
+        var results = ReturnToSenderSourceProbe.EvaluateTargets(
+            FixtureCatalog.DecompilerLadderRung9.AssemblyPath(),
+            [
+                new ReturnToSender.RequestedTarget("LadderRung9.DynamicAndExpressionTrees", "DynamicAdd", Overload: 0),
+                new ReturnToSender.RequestedTarget("LadderRung9.DynamicAndExpressionTrees", "CapturedExpressionTree", Overload: 0),
+            ]);
+
+        Assert.All(results, result =>
+        {
+            Assert.NotEqual(ReturnToSenderSourceOutcome.Invalid, result.Outcome);
+            Assert.DoesNotContain("CS1525", result.Detail, StringComparison.Ordinal);
+            Assert.DoesNotContain("CS0234", result.Detail, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_CompilesFixedBufferResidualShells()
+    {
+        var results = new[]
+        {
+            Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                FixtureCatalog.DecompilerUnsafeLegacy.AssemblyPath(),
+                [
+                    new ReturnToSender.RequestedTarget(
+                        "ILInspector.Decompiler.Fixtures.LegacyUnsafe.FixedBufferResiduals",
+                        "Sum",
+                        Overload: 0),
+                ])),
+            Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                FixtureCatalog.DecompilerUnsafeNew.AssemblyPath(),
+                [
+                    new ReturnToSender.RequestedTarget(
+                        "ILInspector.Decompiler.Fixtures.NewUnsafe.FixedBufferResiduals",
+                        "Sum",
+                        Overload: 0),
+                ])),
+        };
+
+        Assert.All(results, result =>
+        {
+            Assert.NotEqual(ReturnToSenderSourceOutcome.Invalid, result.Outcome);
+            Assert.DoesNotContain("CS1525", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("Unsafe.Add", result.ActualBody, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_ClassifiesBodylessSourceMembersAsUnsupported()
     {
         var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -15,6 +15,8 @@ static class CompileBackCSharpNames
         if (type.Contains('!'))
             return "object";
 
+        type = SanitizeGeneratedTypeSegments(type);
+
         type = type.Replace("modreq(", "", StringComparison.Ordinal)
             .Replace("modopt(", "", StringComparison.Ordinal)
             .Replace(")", "", StringComparison.Ordinal)
@@ -31,13 +33,57 @@ static class CompileBackCSharpNames
         return EscapeTypeKeywords(type);
     }
 
+    static string SanitizeGeneratedTypeSegments(string type)
+    {
+        var sb = new StringBuilder(type.Length);
+        int i = 0;
+        while (i < type.Length)
+        {
+            if (type[i] == '<' && IsGeneratedSegmentStart(type, i))
+            {
+                int close = i + 1;
+                while (close < type.Length && IsGeneratedTypeSegmentChar(type[close]))
+                    close++;
+                if (close < type.Length && type[close] == '>')
+                {
+                    int end = close + 1;
+                    while (end < type.Length && IsGeneratedTypeSuffixChar(type[end]))
+                        end++;
+                    sb.Append(CSharpNaming.SafeIdentifier(type[i..end]));
+                    i = end;
+                    continue;
+                }
+            }
+
+            sb.Append(type[i]);
+            i++;
+        }
+
+        return sb.ToString();
+    }
+
+    static bool IsGeneratedTypeSegmentChar(char c)
+        => c != '>'
+            && c != '.'
+            && c != ','
+            && c != '['
+            && c != ']'
+            && c != '*'
+            && !char.IsWhiteSpace(c);
+
+    static bool IsGeneratedTypeSuffixChar(char c)
+        => char.IsLetterOrDigit(c) || c == '_';
+
+    static bool IsGeneratedSegmentStart(string text, int index)
+        => index == 0 || text[index - 1] is '.' or '+';
+
     public static string StripArity(string name)
     {
         int tick = name.IndexOf('`');
         return tick >= 0 ? name[..tick] : name;
     }
 
-    public static string Identifier(string name) => IsCSharpKeyword(name) ? "@" + name : name;
+    public static string Identifier(string name) => CSharpNaming.SafeIdentifier(name);
 
     public static string EscapeNamespace(string ns)
         => string.Join(".", ns.Split('.').Select(Identifier));
@@ -988,7 +1034,7 @@ public static class CompileBackSourceComposer
         => new()
         {
             Namespace = type.Namespace,
-            Name = type.Identity.MetadataName,
+            Name = type.Name,
             Kind = type.Kind switch
             {
                 CompileBackTypeKind.Class => "class",
@@ -2175,8 +2221,7 @@ public static class CompileBackSourceComposer
                 return null;
 
             string fieldName = reader.GetString(field.Name);
-            if (fieldName.Contains('<', StringComparison.Ordinal)
-                || fieldName.Contains('.', StringComparison.Ordinal))
+            if (fieldName.Contains('.', StringComparison.Ordinal))
             {
                 return null;
             }
@@ -2376,7 +2421,8 @@ public static class CompileBackSourceComposer
             string name = reader.GetString(method.Name);
             bool isConstructor = name == ".ctor";
             if (name == ".cctor"
-                || name.Contains('<', StringComparison.Ordinal)
+                || (name.Contains('<', StringComparison.Ordinal)
+                    && CSharpNaming.MethodName(name) == name)
                 || (!isConstructor && name.Contains('.', StringComparison.Ordinal)))
                 return null;
 
@@ -2397,30 +2443,38 @@ public static class CompileBackSourceComposer
                 return null;
             }
 
-            var methodDeclaration = MetadataDeclarationQuery.GetMethod(reader, typeDef, method, signature);
-            var parameters = ToCompileBackParameters(methodDeclaration.Signature.Parameters);
-            if (methodDeclaration.Signature.ReturnType is not { } methodReturnType
+            var generatedLocalFunction = IsGeneratedLocalFunctionName(name);
+            var methodDeclaration = generatedLocalFunction
+                ? null
+                : MetadataDeclarationQuery.GetMethod(reader, typeDef, method, signature);
+            var parameters = generatedLocalFunction
+                ? Parameters(reader, method, signature)
+                : ToCompileBackParameters(methodDeclaration!.Signature.Parameters);
+            var methodReturnType = generatedLocalFunction
+                ? signature.ReturnType
+                : methodDeclaration!.Signature.ReturnType;
+            if (methodReturnType is null
                 || IsUnsupportedSurfaceSignature(methodReturnType)
                 || parameters.Any(parameter => IsUnsupportedSurfaceSignature(parameter.Type.DisplayName)))
             {
                 return null;
             }
 
-            string identifierName = Identifier(name);
+            string identifierName = CSharpNaming.SourceMethodName(name);
             return new CompileBackMemberRequirement(
                 new CompileBackMethodIdentity(typeIdentity.FullName, identifierName, DeclaringOverloadIndex(reader, typeDef, methodHandle, name), MethodSignatureText(identifierName, signature)),
                 isConstructor ? CompileBackMemberKind.Constructor : CompileBackMemberKind.Method,
                 method.Attributes.HasFlag(MethodAttributes.Static),
                 parameters,
                 isConstructor ? null : CompileBackTypeSignature.Display(methodReturnType),
-                ToCompileBackTypeParameters(methodDeclaration.Signature.TypeParameters),
+                generatedLocalFunction ? [] : ToCompileBackTypeParameters(methodDeclaration!.Signature.TypeParameters),
                 (typeDef.Attributes & TypeAttributes.Interface) != 0 || IsAbstractMethod(method)
                     ? CompileBackStubBodyKind.None
                     : CompileBackStubBodyKind.Throw,
                 null,
                 [new CompileBackFact("metadata", isConstructor ? "typed-closure-constructor" : "typed-closure-method", name)],
-                isConstructor ? null : methodDeclaration.Attributes,
-                isConstructor ? null : methodDeclaration.Signature.ReturnAttributes,
+                isConstructor ? null : methodDeclaration?.Attributes,
+                isConstructor ? null : methodDeclaration?.Signature.ReturnAttributes,
                 IsAbstract: !isConstructor && IsAbstractMethod(method),
                 IsVirtual: !isConstructor && IsVirtualMethod(method),
                 IsOverride: false,
@@ -2526,8 +2580,7 @@ public static class CompileBackSourceComposer
             {
                 var nestedDef = reader.GetTypeDefinition(nestedHandle);
                 string name = reader.GetString(nestedDef.Name);
-                if (name.Contains('<', StringComparison.Ordinal)
-                    || IsDelegate(reader, nestedDef))
+                if (IsDelegate(reader, nestedDef))
                 {
                     continue;
                 }
@@ -2543,7 +2596,8 @@ public static class CompileBackSourceComposer
                     SourceFacts: [new CompileBackFact("metadata", "nested-closure-type", identity.FullName)]);
                 var members = RequiredMemberDeclarations(requirement);
                 bool includeNestedMemberSurface = includeMemberSurface
-                    || requirement.SourceFacts.Any(fact => fact.Id == "closure-member");
+                    || requirement.SourceFacts.Any(fact => fact.Id == "closure-member")
+                    || IsGeneratedMetadataName(name);
                 if (includeNestedMemberSurface)
                     AddClosureMemberSurface(reader, nestedDef, requirement, members, diagnostics, allowUnsafeSurface: true);
                 nestedTypes.Add(new CompileBackTypeDeclaration(
@@ -2629,9 +2683,7 @@ public static class CompileBackSourceComposer
             {
                 var field = reader.GetFieldDefinition(fieldHandle);
                 string fieldName = reader.GetString(field.Name);
-                if (fieldName.Contains('<', StringComparison.Ordinal)
-                    || fieldName.Contains('>', StringComparison.Ordinal)
-                    || fieldName.Contains('.', StringComparison.Ordinal))
+                if (fieldName.Contains('.', StringComparison.Ordinal))
                 {
                     continue;
                 }
@@ -2751,14 +2803,15 @@ public static class CompileBackSourceComposer
                 string name = reader.GetString(method.Name);
                 if (accessorMethods.Contains(methodHandle)
                     || name == ".cctor"
-                    || name.Contains('<', StringComparison.Ordinal)
+                    || (name.Contains('<', StringComparison.Ordinal)
+                        && CSharpNaming.MethodName(name) == name)
                     || name.Contains('.', StringComparison.Ordinal))
                 {
                     continue;
                 }
 
                 bool isConstructor = name == ".ctor";
-                string identifierName = Identifier(name);
+                string identifierName = CSharpNaming.SourceMethodName(name);
                 if (members.Any(member =>
                         member.Kind == (isConstructor ? CompileBackMemberKind.Constructor : CompileBackMemberKind.Method)
                         && member.Name == identifierName))
@@ -2784,9 +2837,17 @@ public static class CompileBackSourceComposer
                     continue;
                 }
 
-                var methodDeclaration = MetadataDeclarationQuery.GetMethod(reader, typeDef, method, signature);
-                var parameters = ToCompileBackParameters(methodDeclaration.Signature.Parameters);
-                if (methodDeclaration.Signature.ReturnType is not { } methodReturnType
+                var generatedLocalFunction = IsGeneratedLocalFunctionName(name);
+                var methodDeclaration = generatedLocalFunction
+                    ? null
+                    : MetadataDeclarationQuery.GetMethod(reader, typeDef, method, signature);
+                var parameters = generatedLocalFunction
+                    ? Parameters(reader, method, signature)
+                    : ToCompileBackParameters(methodDeclaration!.Signature.Parameters);
+                var methodReturnType = generatedLocalFunction
+                    ? signature.ReturnType
+                    : methodDeclaration!.Signature.ReturnType;
+                if (methodReturnType is null
                     || IsUnsupportedSurfaceSignature(methodReturnType)
                     || parameters.Any(parameter => IsUnsupportedSurfaceSignature(parameter.Type.DisplayName))
                     || (!allowUnsafeSurface
@@ -2802,14 +2863,14 @@ public static class CompileBackSourceComposer
                     method.Attributes.HasFlag(MethodAttributes.Static),
                     isConstructor ? null : CompileBackTypeSignature.Display(methodReturnType),
                     parameters,
-                    ToCompileBackTypeParameters(methodDeclaration.Signature.TypeParameters),
+                    generatedLocalFunction ? [] : ToCompileBackTypeParameters(methodDeclaration!.Signature.TypeParameters),
                     requirement.RequiredKind == CompileBackTypeKind.Interface || IsAbstractMethod(method)
                         ? CompileBackStubBodyKind.None
                         : CompileBackStubBodyKind.Throw,
                     TargetBody: null,
                     [new CompileBackFact("metadata", isConstructor ? "closure-constructor" : "closure-method", name)],
-                    isConstructor ? null : methodDeclaration.Attributes,
-                    isConstructor ? null : methodDeclaration.Signature.ReturnAttributes,
+                    isConstructor ? null : methodDeclaration?.Attributes,
+                    isConstructor ? null : methodDeclaration?.Signature.ReturnAttributes,
                     IsAbstract: !isConstructor && IsAbstractMethod(method),
                     IsVirtual: !isConstructor && IsVirtualMethod(method),
                     IsOverride: false,
@@ -2817,6 +2878,7 @@ public static class CompileBackSourceComposer
             }
 
             if (requirement.RequiredKind == CompileBackTypeKind.Class
+                && !IsStaticType(typeDef)
                 && requirement.PrimaryConstructor is null
                 && !members.Any(member => member.Kind == CompileBackMemberKind.Constructor && member.Parameters.Count == 0)
                 && !HasParameterlessInstanceConstructor(reader, typeDef))
@@ -2837,7 +2899,15 @@ public static class CompileBackSourceComposer
 
         static bool IsUnsupportedSurfaceSignature(string signature)
             => signature.Contains("delegate*", StringComparison.Ordinal)
-                || signature.Contains("@delegate*", StringComparison.Ordinal);
+                || signature.Contains("@delegate*", StringComparison.Ordinal)
+                || signature.Contains("<>", StringComparison.Ordinal)
+                || signature.Contains('{', StringComparison.Ordinal);
+
+        static bool IsGeneratedMetadataName(string name)
+            => name.Contains('<', StringComparison.Ordinal) || name.Contains('>', StringComparison.Ordinal);
+
+        static bool IsGeneratedLocalFunctionName(string name)
+            => name.Contains('<', StringComparison.Ordinal) && CSharpNaming.MethodName(name) != name;
 
         static bool IsPointerSignature(string signature)
             => signature.Contains('*', StringComparison.Ordinal);

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -2898,10 +2898,13 @@ public static class CompileBackSourceComposer
         }
 
         static bool IsUnsupportedSurfaceSignature(string signature)
-            => signature.Contains("delegate*", StringComparison.Ordinal)
-                || signature.Contains("@delegate*", StringComparison.Ordinal)
-                || signature.Contains("<>", StringComparison.Ordinal)
-                || signature.Contains('{', StringComparison.Ordinal);
+        {
+            string displayName = CompileBackTypeSignature.Display(signature).DisplayName;
+            return displayName.Contains("delegate*", StringComparison.Ordinal)
+                || displayName.Contains("@delegate*", StringComparison.Ordinal)
+                || displayName.Contains("<>", StringComparison.Ordinal)
+                || displayName.Contains('{', StringComparison.Ordinal);
+        }
 
         static bool IsGeneratedMetadataName(string name)
             => name.Contains('<', StringComparison.Ordinal) || name.Contains('>', StringComparison.Ordinal);

--- a/src/ILInspector.Decompiler/Pipeline/FidelityRemarks.cs
+++ b/src/ILInspector.Decompiler/Pipeline/FidelityRemarks.cs
@@ -58,7 +58,7 @@ public static class FidelityRemarks
                 ?? ((node as IrExpression)?.ResultType is { ContainsUnsupported: true } rt ? rt : null);
             if (unsupportedType is not null)
                 Add(remarks, DiagnosticIds.UnsupportedType, OffsetOf(node), node,
-                    $"references an unrepresentable type ({unsupportedType.ToDisplayString()})");
+                    $"references an unrepresentable type ({UnrepresentableTypeText(unsupportedType)})");
 
             if (CSharpSpellability.UnrepresentableMetadataNameReason(node) is { } nameReason)
                 Add(remarks, DiagnosticIds.UnrepresentableMetadataName, OffsetOf(node), node, nameReason);
@@ -72,6 +72,26 @@ public static class FidelityRemarks
 
     static void Add(List<Remark> remarks, string code, int offset, IrNode node, string reason)
         => remarks.Add(new Remark(code, offset, node.Describe(), reason));
+
+    static string UnrepresentableTypeText(TypeRef type)
+    {
+        string display = type.ToDisplayString();
+        string raw = RawTypeText(type);
+        return raw == display ? display : $"{display}; metadata: {raw}";
+    }
+
+    static string RawTypeText(TypeRef type)
+        => type.Kind switch
+        {
+            TypeRefKind.Definition => type.Namespace.Length == 0 ? type.Name : $"{type.Namespace}.{type.Name}",
+            TypeRefKind.GenericInstance => $"{RawTypeText(type.ElementType!)}<{string.Join(", ", type.TypeArguments.Select(RawTypeText))}>",
+            TypeRefKind.SzArray => $"{RawTypeText(type.ElementType!)}[]",
+            TypeRefKind.Array => $"{RawTypeText(type.ElementType!)}[{new string(',', type.Rank - 1)}]",
+            TypeRefKind.ByRef => $"ref {RawTypeText(type.ElementType!)}",
+            TypeRefKind.Pointer => $"{RawTypeText(type.ElementType!)}*",
+            TypeRefKind.Pinned => $"pinned {RawTypeText(type.ElementType!)}",
+            _ => type.ToDisplayString(),
+        };
 
     /// <summary>The enclosing block's offset, climbing parents; -1 when the node hangs off the signature.</summary>
     static int OffsetOf(IrNode node)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
@@ -41,7 +41,7 @@ internal static class CSharpNaming
         => RequiresEscape(name) ? "@" + name : name;
 
     public static string SafeIdentifier(string name)
-        => IsEscapableIdentifier(name) ? EscapeIdentifier(name) : SanitizeUnspellableIdentifier(name);
+        => IsIdentifierLike(name) ? EscapeIdentifier(name) : SanitizeUnspellableIdentifier(name);
 
     public static string SourceMethodName(string metadataName)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
@@ -40,11 +40,17 @@ internal static class CSharpNaming
     public static string EscapeIdentifier(string name)
         => RequiresEscape(name) ? "@" + name : name;
 
+    public static string SafeIdentifier(string name)
+        => IsEscapableIdentifier(name) ? EscapeIdentifier(name) : SanitizeUnspellableIdentifier(name);
+
     public static string SourceMethodName(string metadataName)
-        => EscapeIdentifier(MethodName(metadataName));
+    {
+        string sourceName = MethodName(metadataName);
+        return sourceName == metadataName ? EscapeIdentifier(sourceName) : SafeIdentifier(sourceName);
+    }
 
     public static string TypeNameSegment(string metadataName)
-        => EscapeIdentifier(StripArity(metadataName));
+        => SafeIdentifier(StripArity(metadataName));
 
     static bool RequiresEscape(string name)
         => ReservedKeywords.Contains(name) || name == "await";
@@ -156,5 +162,15 @@ internal static class CSharpNaming
     {
         int tick = name.IndexOf('`');
         return tick < 0 ? name : name[..tick];
+    }
+
+    static string SanitizeUnspellableIdentifier(string name)
+    {
+        var sb = new System.Text.StringBuilder(name.Length + 1);
+        if (name.Length == 0 || !(char.IsLetter(name[0]) || name[0] == '_'))
+            sb.Append('_');
+        foreach (char c in name)
+            sb.Append(char.IsLetterOrDigit(c) || c == '_' ? c : '_');
+        return RequiresEscape(sb.ToString()) ? "@" + sb : sb.ToString();
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -40,7 +40,7 @@ public sealed partial class CSharpPrinter
                 _ => $"{ReceiverText(instance)}.{captured}",
             };
         }
-        string fieldName = CSharpNaming.EscapeIdentifier(field.Name);
+        string fieldName = CSharpNaming.SafeIdentifier(field.Name);
         return instance switch
         {
             null => $"{TypeText(field.DeclaringType)}.{fieldName}",

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2178,11 +2178,19 @@ public sealed partial class CSharpPrinter
         TypeOf t => $"typeof({TypeOfTypeText(t.Type)})",
         LoadToken t => t.Kind == RuntimeTokenKind.Type && t.Type is not null
             ? $"typeof({TypeOfTypeText(t.Type)})"
-            : $"/* {t.Describe()} */",
+            : TokenPlaceholder(t),
         CaughtException => "__exception",
         UnsupportedNode u => $"/* {u.Describe()} */",
         _ => $"/* {node.Describe()} */",
     };
+
+    static string TokenPlaceholder(LoadToken token)
+        => token.Kind switch
+        {
+            RuntimeTokenKind.Field => $"/* {token.Describe()} */ default(System.RuntimeFieldHandle)",
+            RuntimeTokenKind.Method => $"/* {token.Describe()} */ default(System.RuntimeMethodHandle)",
+            _ => $"/* {token.Describe()} */ null",
+        };
 
     string CoalesceText(Coalesce co, TypeRef? target = null)
     {
@@ -2656,6 +2664,9 @@ public sealed partial class CSharpPrinter
 
     string? PointerElementAccessText(LoadIndirect load)
     {
+        if (FixedBufferElementAccessText(load) is { } fixedBufferAccess)
+            return fixedBufferAccess;
+
         if (load.Type is not { } element
             || load.Address is not Binary { Kind: BinaryKind.Add } address
             || !TrySplitPointerAdd(address, out var pointer, out var offset)
@@ -2668,6 +2679,44 @@ public sealed partial class CSharpPrinter
 
         return $"{Operand(pointer)}[{Expression(index)}]";
     }
+
+    string? FixedBufferElementAccessText(LoadIndirect load)
+    {
+        if (load.Type is not { } element
+            || load.Address is not Binary { Kind: BinaryKind.Add } address
+            || !TrySplitFixedBufferElementAdd(address, out var elementFieldAddress, out var offset)
+            || !elementFieldAddress.Field.Type.Equals(element)
+            || !TryScaledPointerIndex(offset, element, out var index))
+        {
+            return null;
+        }
+
+        return $"System.Runtime.CompilerServices.Unsafe.Add(ref {FieldTarget(elementFieldAddress.Field, elementFieldAddress.Instance)}, {Expression(index)})";
+    }
+
+    static bool TrySplitFixedBufferElementAdd(Binary add, out LoadFieldAddress fieldAddress, out IrExpression offset)
+    {
+        if (add.Left is LoadFieldAddress left && IsFixedBufferElementAddress(left))
+        {
+            fieldAddress = left;
+            offset = add.Right;
+            return true;
+        }
+        if (add.Right is LoadFieldAddress right && IsFixedBufferElementAddress(right))
+        {
+            fieldAddress = right;
+            offset = add.Left;
+            return true;
+        }
+
+        fieldAddress = null!;
+        offset = add.Right;
+        return false;
+    }
+
+    static bool IsFixedBufferElementAddress(LoadFieldAddress address)
+        => address.Field.Name == "FixedElementField"
+            && address.Instance is LoadFieldAddress;
 
     static bool TrySplitPointerAdd(Binary add, out IrExpression pointer, out IrExpression offset)
     {


### PR DESCRIPTION
## Summary

Reduces the #2505 RTS source-probe invalid frontier from `21` to `3` by making generated-name and fixed-buffer residual shells compile:

- sanitizes compiler-generated metadata identifiers in residual C# and compile-back shell declarations without breaking normal generic type spelling;
- lets generated closure shells carry generated fields/local-function helpers needed by dynamic and captured-expression-tree residuals;
- renders fixed-buffer residual element reads as `Unsafe.Add(ref Data.FixedElementField, i)` and sanitizes the generated nested fixed-buffer type segment.

The remaining rows are deliberate follow-up frontiers:

- `CS0117` x2: dynamic named-out/ref-argument call sites need generated delegate declarations (`<>A{...}` shapes).
- `CS8858` x1: record/with shell support needs record shell kind plus synthesized-member suppression; a broad record-kind attempt fixed `Shift` but regressed synthesized record member targets, so it was not kept.

## Evidence

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/ReturnToSenderFixtureCatalogTests/*"`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --no-restore --nologo`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures rts.candidates --return-to-sender-source-probe --cap 10000 --max-examples 260` => Invalid 0
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures decompiler --return-to-sender-source-probe --cap 10000 --max-examples 260`
  - Before: Invalid 21, buckets `CS1525: 20`, `CS8858: 1`
  - After: Invalid 3, buckets `CS0117: 2`, `CS8858: 1`
- Render-text A/B against explicit merge-base `65a11c9b` over 623 decompiler fixture methods:
  - Changed 169; semantic `invalid->invalid: 169`; no `valid->invalid` or `valid->valid` movement.
  - Changed examples are generated-name residuals such as async state-machine fields/types moving from raw `<...>` to sanitized `__...` spellings.

Adversarial review requested; results will be posted before ready-to-merge.