### PR TITLE
Carry initializer member evidence in IR

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -27,6 +27,8 @@ public class ObjectInitializerPassTests
         var initializer = Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
         Assert.False(initializer.IsCollection);
         Assert.Equal(["X", "Y"], initializer.Members);
+        Assert.Equal(["set_X", "set_Y"], initializer.Entries.Select(entry => entry.ConsumedMethod?.Name));
+        Assert.All(initializer.Entries, entry => Assert.Null(entry.ConsumedField));
         // The creation is retained as a child so fidelity/unsafe scans still see it.
         Assert.Single(function.Descendants.OfType<NewObject>());
         // The lowered dup chain is gone.
@@ -41,6 +43,10 @@ public class ObjectInitializerPassTests
 
         Assert.False(initializer.IsCollection);
         Assert.Equal(["X", "Z"], initializer.Members);
+        Assert.Equal("set_X", initializer.Entries[0].ConsumedMethod?.Name);
+        Assert.Null(initializer.Entries[0].ConsumedField);
+        Assert.Null(initializer.Entries[1].ConsumedMethod);
+        Assert.Equal("Z", initializer.Entries[1].ConsumedField?.Name);
     }
 
     [Fact]
@@ -51,6 +57,8 @@ public class ObjectInitializerPassTests
         var initializer = Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
         Assert.True(initializer.IsCollection);
         Assert.Equal(3, initializer.Entries.Count);
+        Assert.All(initializer.Entries, entry => Assert.Equal("Add", entry.ConsumedMethod?.Name));
+        Assert.All(initializer.Entries, entry => Assert.Null(entry.ConsumedField));
         // No Add call survives as a standalone statement.
         Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name == "Add");
     }
@@ -235,9 +243,11 @@ public class ObjectInitializerPassTests
         // The single top-level entry is the nested member; its value is the block.
         var entry = Assert.Single(initializer.Entries);
         Assert.Equal("Inner", entry.Member);
+        Assert.Equal("get_Inner", entry.ConsumedMethod?.Name);
         var block = Assert.IsType<InitializerBlock>(Assert.Single(entry.Arguments));
         Assert.False(block.IsCollection);
         Assert.Equal(new string?[] { "X", "Y" }, block.Members);
+        Assert.Equal(["set_X", "set_Y"], block.Entries.Select(inner => inner.ConsumedMethod?.Name));
         // The nested member reads are folded away — no residual stores/loads of Inner.
         Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
         Assert.Empty(function.Descendants.OfType<StoreProperty>());
@@ -252,9 +262,11 @@ public class ObjectInitializerPassTests
         Assert.False(initializer.IsCollection);  // top level assigns Items via `=`
         var entry = Assert.Single(initializer.Entries);
         Assert.Equal("Items", entry.Member);
+        Assert.Equal("get_Items", entry.ConsumedMethod?.Name);
         var block = Assert.IsType<InitializerBlock>(Assert.Single(entry.Arguments));
         Assert.True(block.IsCollection);
         Assert.Equal(2, block.Entries.Count);
+        Assert.All(block.Entries, inner => Assert.Equal("Add", inner.ConsumedMethod?.Name));
         Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name == "Add");
     }
 

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -324,12 +324,6 @@ public static class CompileBackSourceComposer
         FieldRef field)
         => TypeProducer.TryCreateClosureMemberRequirement(reader, typeHandle, field);
 
-    public static CompileBackMemberRequirement? TryCreateClosureMemberRequirement(
-        MetadataReader reader,
-        TypeDefinitionHandle typeHandle,
-        string memberName)
-        => TypeProducer.TryCreateClosureMemberRequirement(reader, typeHandle, memberName);
-
     public static CompileBackSourceResult ComposePropertyGetter(
         string assemblyPath,
         MetadataReader reader,
@@ -2233,27 +2227,6 @@ public static class CompileBackSourceComposer
             return FieldRequirement(reader, typeDef, typeIdentity, fieldHandle);
         }
 
-        public static CompileBackMemberRequirement? TryCreateClosureMemberRequirement(
-            MetadataReader reader,
-            TypeDefinitionHandle typeHandle,
-            string memberName)
-        {
-            var typeDef = reader.GetTypeDefinition(typeHandle);
-            var typeIdentity = CompileBackTypeIdentity.FromDefinition(reader, typeDef);
-            if (TryFindPropertyByName(reader, typeDef, memberName) is { } propertyHandle)
-            {
-                var property = reader.GetPropertyDefinition(propertyHandle);
-                var setter = property.GetAccessors().Setter;
-                if (!setter.IsNil)
-                    return PropertyRequirement(reader, typeDef, typeIdentity, propertyHandle, $"set_{memberName}");
-            }
-
-            if (FindField(reader, typeDef, memberName) is { } fieldHandle)
-                return FieldRequirement(reader, typeDef, typeIdentity, fieldHandle);
-
-            return null;
-        }
-
         static CompileBackMemberRequirement? FieldRequirement(
             MetadataReader reader,
             TypeDefinition typeDef,
@@ -2361,22 +2334,6 @@ public static class CompileBackSourceComposer
             }
 
             return null;
-        }
-
-        static PropertyDefinitionHandle? TryFindPropertyByName(
-            MetadataReader reader,
-            TypeDefinition typeDef,
-            string propertyName)
-        {
-            var matches = new List<PropertyDefinitionHandle>();
-            foreach (var propertyHandle in typeDef.GetProperties())
-            {
-                var property = reader.GetPropertyDefinition(propertyHandle);
-                if (reader.GetString(property.Name) == propertyName)
-                    matches.Add(propertyHandle);
-            }
-
-            return matches.Count == 1 ? matches[0] : null;
         }
 
         static MethodDefinitionHandle? TryFindMethod(

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1995,15 +1995,21 @@ public sealed class ObjectInitializerExpression : IrExpression
         AddChild(creation);
         var members = ImmutableArray.CreateBuilder<string?>();
         var argumentCounts = ImmutableArray.CreateBuilder<int>();
+        var consumedMethods = ImmutableArray.CreateBuilder<MethodRef?>();
+        var consumedFields = ImmutableArray.CreateBuilder<FieldRef?>();
         foreach (var entry in entries)
         {
             members.Add(entry.Member);
             argumentCounts.Add(entry.Arguments.Count);
+            consumedMethods.Add(entry.ConsumedMethod);
+            consumedFields.Add(entry.ConsumedField);
             foreach (var argument in entry.Arguments)
                 AddChild(argument);
         }
         Members = members.ToImmutable();
         ArgumentCounts = argumentCounts.ToImmutable();
+        ConsumedMethods = consumedMethods.ToImmutable();
+        ConsumedFields = consumedFields.ToImmutable();
     }
 
     /// <summary>Collection-initializer (<c>{ e0, e1 }</c> / <c>{ {k, v} }</c> via <c>Add</c>) vs object-initializer (<c>{ X = a }</c> / <c>{ [k] = v }</c> via member or indexer stores).</summary>
@@ -2018,8 +2024,14 @@ public sealed class ObjectInitializerExpression : IrExpression
     /// <summary>The number of child expressions each entry owns, parallel to <see cref="Members"/>.</summary>
     public ImmutableArray<int> ArgumentCounts { get; }
 
+    /// <summary>Consumed setter/Add method evidence per entry, when a raised initializer entry came from a method call.</summary>
+    public ImmutableArray<MethodRef?> ConsumedMethods { get; }
+
+    /// <summary>Consumed field evidence per entry, when a raised initializer entry came from a field store.</summary>
+    public ImmutableArray<FieldRef?> ConsumedFields { get; }
+
     /// <summary>The entries, in source order, each carrying its own argument expressions.</summary>
-    public IReadOnlyList<InitializerEntry> Entries => InitializerEntry.Slice(Children, 1, Members, ArgumentCounts);
+    public IReadOnlyList<InitializerEntry> Entries => InitializerEntry.Slice(Children, 1, Members, ArgumentCounts, ConsumedMethods, ConsumedFields);
 
     public override TypeRef? ResultType => Creation.ResultType;
 
@@ -2061,7 +2073,13 @@ public sealed class WithExpression : IrExpression
     public IrExpression Receiver => (IrExpression)Children[0];
     public ImmutableArray<string> Members { get; }
     public IReadOnlyList<InitializerEntry> Entries
-        => InitializerEntry.Slice(Children, 1, [.. Members.Select(m => (string?)m)], [.. Members.Select(_ => 1)]);
+        => InitializerEntry.Slice(
+            Children,
+            1,
+            [.. Members.Select(m => (string?)m)],
+            [.. Members.Select(_ => 1)],
+            [.. Members.Select(_ => (MethodRef?)null)],
+            [.. Members.Select(_ => (FieldRef?)null)]);
     public override TypeRef? ResultType => Receiver.ResultType;
     public override string Describe()
         => $"WithExpression ({Members.Length} members)";
@@ -2090,15 +2108,21 @@ public sealed class InitializerBlock : IrExpression
         IsCollection = isCollection;
         var members = ImmutableArray.CreateBuilder<string?>();
         var argumentCounts = ImmutableArray.CreateBuilder<int>();
+        var consumedMethods = ImmutableArray.CreateBuilder<MethodRef?>();
+        var consumedFields = ImmutableArray.CreateBuilder<FieldRef?>();
         foreach (var entry in entries)
         {
             members.Add(entry.Member);
             argumentCounts.Add(entry.Arguments.Count);
+            consumedMethods.Add(entry.ConsumedMethod);
+            consumedFields.Add(entry.ConsumedField);
             foreach (var argument in entry.Arguments)
                 AddChild(argument);
         }
         Members = members.ToImmutable();
         ArgumentCounts = argumentCounts.ToImmutable();
+        ConsumedMethods = consumedMethods.ToImmutable();
+        ConsumedFields = consumedFields.ToImmutable();
     }
 
     /// <summary>Collection body (<c>{ e0, e1 }</c> via <c>Add</c>) vs object body (<c>{ X = a }</c> via member stores).</summary>
@@ -2110,8 +2134,14 @@ public sealed class InitializerBlock : IrExpression
     /// <summary>The number of child expressions each entry owns, parallel to <see cref="Members"/>.</summary>
     public ImmutableArray<int> ArgumentCounts { get; }
 
+    /// <summary>Consumed setter/Add method evidence per entry, when a raised initializer entry came from a method call.</summary>
+    public ImmutableArray<MethodRef?> ConsumedMethods { get; }
+
+    /// <summary>Consumed field evidence per entry, when a raised initializer entry came from a field store.</summary>
+    public ImmutableArray<FieldRef?> ConsumedFields { get; }
+
     /// <summary>The entries, in source order, each carrying its own argument expressions.</summary>
-    public IReadOnlyList<InitializerEntry> Entries => InitializerEntry.Slice(Children, 0, Members, ArgumentCounts);
+    public IReadOnlyList<InitializerEntry> Entries => InitializerEntry.Slice(Children, 0, Members, ArgumentCounts, ConsumedMethods, ConsumedFields);
 
     /// <summary>A nested body initializes an existing member in place; it has no standalone result type.</summary>
     public override TypeRef? ResultType => null;
@@ -2132,7 +2162,11 @@ public sealed class InitializerBlock : IrExpression
 /// A nested member entry (<c>Inner = { ... }</c>) is a named member whose single
 /// argument is an <see cref="InitializerBlock"/>.
 /// </summary>
-public sealed record InitializerEntry(string? Member, IReadOnlyList<IrExpression> Arguments)
+public sealed record InitializerEntry(
+    string? Member,
+    IReadOnlyList<IrExpression> Arguments,
+    MethodRef? ConsumedMethod = null,
+    FieldRef? ConsumedField = null)
 {
     /// <summary>
     /// Reconstructs the entries from a node's flat children: the run starting at
@@ -2142,7 +2176,12 @@ public sealed record InitializerEntry(string? Member, IReadOnlyList<IrExpression
     /// <see cref="InitializerBlock"/> (start 0).
     /// </summary>
     internal static IReadOnlyList<InitializerEntry> Slice(
-        IReadOnlyList<IrNode> children, int start, ImmutableArray<string?> members, ImmutableArray<int> argumentCounts)
+        IReadOnlyList<IrNode> children,
+        int start,
+        ImmutableArray<string?> members,
+        ImmutableArray<int> argumentCounts,
+        ImmutableArray<MethodRef?> consumedMethods,
+        ImmutableArray<FieldRef?> consumedFields)
     {
         var entries = new List<InitializerEntry>(members.Length);
         int index = start;
@@ -2153,7 +2192,7 @@ public sealed record InitializerEntry(string? Member, IReadOnlyList<IrExpression
             for (int j = 0; j < count; j++)
                 arguments[j] = (IrExpression)children[index + j];
             index += count;
-            entries.Add(new InitializerEntry(members[e], arguments));
+            entries.Add(new InitializerEntry(members[e], arguments, consumedMethods[e], consumedFields[e]));
         }
         return entries;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -86,7 +86,12 @@ public sealed class ObjectInitializerPass : IIrPass
     /// is deferred to <see cref="Apply"/> so its leaf arguments are detached from
     /// their lowered statements before being reparented into the new IR.
     /// </summary>
-    sealed record EntryPlan(string? Member, IReadOnlyList<IrExpression> Arguments, BlockPlan? Block);
+    sealed record EntryPlan(
+        string? Member,
+        IReadOnlyList<IrExpression> Arguments,
+        BlockPlan? Block,
+        MethodRef? ConsumedMethod = null,
+        FieldRef? ConsumedField = null);
 
     /// <summary>A nested initializer body: an object/collection brace group with no creation.</summary>
     sealed record BlockPlan(bool IsCollection, IReadOnlyList<EntryPlan> Entries);
@@ -101,7 +106,7 @@ public sealed class ObjectInitializerPass : IIrPass
 
         // A run of nested ops on the same member folds into one InitializerBlock
         // entry; this holds the run currently being accumulated.
-        string? pendingMember = null;
+        EntryPlan? pendingOuter = null;
         bool pendingBlockIsCollection = false;
         List<EntryPlan>? pendingInner = null;
 
@@ -109,8 +114,8 @@ public sealed class ObjectInitializerPass : IIrPass
         {
             if (pendingInner is null)
                 return;
-            entries.Add(new EntryPlan(pendingMember, [], new BlockPlan(pendingBlockIsCollection, pendingInner)));
-            pendingMember = null;
+            entries.Add(pendingOuter! with { Block = new BlockPlan(pendingBlockIsCollection, pendingInner) });
+            pendingOuter = null;
             pendingInner = null;
         }
 
@@ -137,12 +142,12 @@ public sealed class ObjectInitializerPass : IIrPass
                 isCollection = false;
 
                 bool sameRun = pendingInner is not null
-                    && pendingMember == nested.OuterMember
+                    && pendingOuter == nested.Outer
                     && pendingBlockIsCollection == nested.IsCollection;
                 if (!sameRun)
                 {
                     FlushPending();
-                    pendingMember = nested.OuterMember;
+                    pendingOuter = nested.Outer;
                     pendingBlockIsCollection = nested.IsCollection;
                     pendingInner = [];
                 }
@@ -252,7 +257,7 @@ public sealed class ObjectInitializerPass : IIrPass
         var entries = new List<EntryPlan>();
         bool? isCollection = null;
 
-        string? pendingMember = null;
+        EntryPlan? pendingOuter = null;
         bool pendingBlockIsCollection = false;
         List<EntryPlan>? pendingInner = null;
 
@@ -260,8 +265,8 @@ public sealed class ObjectInitializerPass : IIrPass
         {
             if (pendingInner is null)
                 return;
-            entries.Add(new EntryPlan(pendingMember, [], new BlockPlan(pendingBlockIsCollection, pendingInner)));
-            pendingMember = null;
+            entries.Add(pendingOuter! with { Block = new BlockPlan(pendingBlockIsCollection, pendingInner) });
+            pendingOuter = null;
             pendingInner = null;
         }
 
@@ -276,12 +281,12 @@ public sealed class ObjectInitializerPass : IIrPass
                 isCollection = false;
 
                 bool sameRun = pendingInner is not null
-                    && pendingMember == nested.OuterMember
+                    && pendingOuter == nested.Outer
                     && pendingBlockIsCollection == nested.IsCollection;
                 if (!sameRun)
                 {
                     FlushPending();
-                    pendingMember = nested.OuterMember;
+                    pendingOuter = nested.Outer;
                     pendingBlockIsCollection = nested.IsCollection;
                     pendingInner = [];
                 }
@@ -338,7 +343,9 @@ public sealed class ObjectInitializerPass : IIrPass
         return new Plan(consumed, creation, isCollection ?? false, entries, new LocalSeedTarget(seed));
     }
 
-    sealed record NestedOp(string OuterMember, bool IsCollection, EntryPlan Inner);
+    sealed record NestedOp(EntryPlan Outer, bool IsCollection, EntryPlan Inner);
+
+    sealed record OuterMember(string Name, MethodRef? Method, FieldRef? Field);
 
     /// <summary>
     /// Matches a store/Add whose target reads a member off the threaded reference
@@ -354,19 +361,25 @@ public sealed class ObjectInitializerPass : IIrPass
             case StoreProperty { HasInstance: true } property
                 when IsInitializerSpellable(property) && OuterMemberOffSlot(property.Instance, aliasSlots) is { } outer:
                 var objectInner = property.IndexArguments.Count != 0
-                    ? new EntryPlan(null, [.. property.IndexArguments, property.Value], null)
-                    : new EntryPlan(property.PropertyName, [property.Value], null);
-                return new NestedOp(outer, IsCollection: false, objectInner);
+                    ? new EntryPlan(null, [.. property.IndexArguments, property.Value], null, ConsumedMethod: property.Accessor)
+                    : new EntryPlan(property.PropertyName, [property.Value], null, ConsumedMethod: property.Accessor);
+                return new NestedOp(new EntryPlan(outer.Name, [], null, outer.Method, outer.Field), IsCollection: false, objectInner);
 
             case StoreField { HasInstance: true } field
                 when OuterMemberOffSlot(field.Instance, aliasSlots) is { } outer:
-                return new NestedOp(outer, IsCollection: false, new EntryPlan(field.Field.Name, [field.Value], null));
+                return new NestedOp(
+                    new EntryPlan(outer.Name, [], null, outer.Method, outer.Field),
+                    IsCollection: false,
+                    new EntryPlan(field.Field.Name, [field.Value], null, ConsumedField: field.Field));
 
             // Nested collection element: outer.Member.Add(v, ...).
             case ExpressionStatement { Expression: Call { Callee.HasThis: true } call }
                 when IsCollectionAdd(function, call)
                     && OuterMemberOffSlot(call.Arguments[0], aliasSlots) is { } outer:
-                return new NestedOp(outer, IsCollection: true, new EntryPlan(null, [.. call.Arguments.Skip(1)], null));
+                return new NestedOp(
+                    new EntryPlan(outer.Name, [], null, outer.Method, outer.Field),
+                    IsCollection: true,
+                    new EntryPlan(null, [.. call.Arguments.Skip(1)], null, ConsumedMethod: call.Callee));
 
             default:
                 return null;
@@ -380,18 +393,24 @@ public sealed class ObjectInitializerPass : IIrPass
             case StoreProperty { HasInstance: true } property
                 when IsInitializerSpellable(property) && OuterMemberOffLocal(property.Instance, localIndex) is { } outer:
                 var objectInner = property.IndexArguments.Count != 0
-                    ? new EntryPlan(null, [.. property.IndexArguments, property.Value], null)
-                    : new EntryPlan(property.PropertyName, [property.Value], null);
-                return new NestedOp(outer, IsCollection: false, objectInner);
+                    ? new EntryPlan(null, [.. property.IndexArguments, property.Value], null, ConsumedMethod: property.Accessor)
+                    : new EntryPlan(property.PropertyName, [property.Value], null, ConsumedMethod: property.Accessor);
+                return new NestedOp(new EntryPlan(outer.Name, [], null, outer.Method, outer.Field), IsCollection: false, objectInner);
 
             case StoreField { HasInstance: true } field
                 when OuterMemberOffLocal(field.Instance, localIndex) is { } outer:
-                return new NestedOp(outer, IsCollection: false, new EntryPlan(field.Field.Name, [field.Value], null));
+                return new NestedOp(
+                    new EntryPlan(outer.Name, [], null, outer.Method, outer.Field),
+                    IsCollection: false,
+                    new EntryPlan(field.Field.Name, [field.Value], null, ConsumedField: field.Field));
 
             case ExpressionStatement { Expression: Call { Callee.HasThis: true } call }
                 when IsCollectionAdd(function, call)
                     && OuterMemberOffLocal(call.Arguments[0], localIndex) is { } outer:
-                return new NestedOp(outer, IsCollection: true, new EntryPlan(null, [.. call.Arguments.Skip(1)], null));
+                return new NestedOp(
+                    new EntryPlan(outer.Name, [], null, outer.Method, outer.Field),
+                    IsCollection: true,
+                    new EntryPlan(null, [.. call.Arguments.Skip(1)], null, ConsumedMethod: call.Callee));
 
             default:
                 return null;
@@ -399,27 +418,27 @@ public sealed class ObjectInitializerPass : IIrPass
     }
 
     /// <summary>The member name when <paramref name="instance"/> reads a plain property/field off a threaded slot; otherwise null.</summary>
-    static string? OuterMemberOffSlot(IrExpression? instance, HashSet<int> aliasSlots) => instance switch
+    static OuterMember? OuterMemberOffSlot(IrExpression? instance, HashSet<int> aliasSlots) => instance switch
     {
         LoadProperty { HasInstance: true, Instance: LoadStackSlot slot } property
             when aliasSlots.Contains(slot.Slot) && property.IndexArguments.Count == 0
                 && property.Accessor.TypeArguments.IsDefaultOrEmpty && CSharpNaming.IsUsableIdentifier(property.PropertyName)
-            => property.PropertyName,
+            => new OuterMember(property.PropertyName, property.Accessor, null),
         LoadField { Instance: LoadStackSlot slot } field
             when aliasSlots.Contains(slot.Slot)
-            => field.Field.Name,
+            => new OuterMember(field.Field.Name, null, field.Field),
         _ => null,
     };
 
-    static string? OuterMemberOffLocal(IrExpression? instance, int localIndex) => instance switch
+    static OuterMember? OuterMemberOffLocal(IrExpression? instance, int localIndex) => instance switch
     {
         LoadProperty { HasInstance: true, Instance: LoadLocal local } property
             when local.Index == localIndex && property.IndexArguments.Count == 0
                 && property.Accessor.TypeArguments.IsDefaultOrEmpty && CSharpNaming.IsUsableIdentifier(property.PropertyName)
-            => property.PropertyName,
+            => new OuterMember(property.PropertyName, property.Accessor, null),
         LoadField { Instance: LoadLocal local } field
             when local.Index == localIndex
-            => field.Field.Name,
+            => new OuterMember(field.Field.Name, null, field.Field),
         _ => null,
     };
 
@@ -455,13 +474,13 @@ public sealed class ObjectInitializerPass : IIrPass
         // An indexer member `[k0, k1] = v`: the keys precede the value.
         StoreProperty { HasInstance: true, Instance: LoadStackSlot slot } property
             when aliasSlots.Contains(slot.Slot) && property.IndexArguments.Count != 0 && IsInitializerSpellable(property)
-            => new EntryPlan(null, [.. property.IndexArguments, property.Value], null),
+            => new EntryPlan(null, [.. property.IndexArguments, property.Value], null, ConsumedMethod: property.Accessor),
         StoreProperty { HasInstance: true, Instance: LoadStackSlot slot } property
             when aliasSlots.Contains(slot.Slot) && IsInitializerSpellable(property)
-            => new EntryPlan(property.PropertyName, [property.Value], null),
+            => new EntryPlan(property.PropertyName, [property.Value], null, ConsumedMethod: property.Accessor),
         StoreField { HasInstance: true, Instance: LoadStackSlot slot } field
             when aliasSlots.Contains(slot.Slot)
-            => new EntryPlan(field.Field.Name, [field.Value], null),
+            => new EntryPlan(field.Field.Name, [field.Value], null, ConsumedField: field.Field),
         _ => null,
     };
 
@@ -469,13 +488,13 @@ public sealed class ObjectInitializerPass : IIrPass
     {
         StoreProperty { HasInstance: true, Instance: LoadLocal local } property
             when local.Index == localIndex && property.IndexArguments.Count != 0 && IsInitializerSpellable(property)
-            => new EntryPlan(null, [.. property.IndexArguments, property.Value], null),
+            => new EntryPlan(null, [.. property.IndexArguments, property.Value], null, ConsumedMethod: property.Accessor),
         StoreProperty { HasInstance: true, Instance: LoadLocal local } property
             when local.Index == localIndex && IsInitializerSpellable(property)
-            => new EntryPlan(property.PropertyName, [property.Value], null),
+            => new EntryPlan(property.PropertyName, [property.Value], null, ConsumedMethod: property.Accessor),
         StoreField { HasInstance: true, Instance: LoadLocal local } field
             when local.Index == localIndex
-            => new EntryPlan(field.Field.Name, [field.Value], null),
+            => new EntryPlan(field.Field.Name, [field.Value], null, ConsumedField: field.Field),
         _ => null,
     };
 
@@ -487,7 +506,7 @@ public sealed class ObjectInitializerPass : IIrPass
             return null;
         if (call.Arguments[0] is not LoadStackSlot receiver || !aliasSlots.Contains(receiver.Slot))
             return null;
-        return new EntryPlan(null, [.. call.Arguments.Skip(1)], null);
+        return new EntryPlan(null, [.. call.Arguments.Skip(1)], null, ConsumedMethod: call.Callee);
     }
 
     static EntryPlan? TryCollectionAdd(IrFunction function, IrNode statement, int localIndex)
@@ -498,7 +517,7 @@ public sealed class ObjectInitializerPass : IIrPass
             return null;
         if (call.Arguments[0] is not LoadLocal receiver || receiver.Index != localIndex)
             return null;
-        return new EntryPlan(null, [.. call.Arguments.Skip(1)], null);
+        return new EntryPlan(null, [.. call.Arguments.Skip(1)], null, ConsumedMethod: call.Callee);
     }
 
     static bool IsCollectionAdd(IrFunction function, Call call)
@@ -614,8 +633,8 @@ public sealed class ObjectInitializerPass : IIrPass
 
     static InitializerEntry BuildEntry(EntryPlan entry)
         => entry.Block is { } block
-            ? new InitializerEntry(entry.Member, [BuildBlock(block)])
-            : new InitializerEntry(entry.Member, entry.Arguments);
+            ? new InitializerEntry(entry.Member, [BuildBlock(block)], entry.ConsumedMethod, entry.ConsumedField)
+            : new InitializerEntry(entry.Member, entry.Arguments, entry.ConsumedMethod, entry.ConsumedField);
 
     static InitializerBlock BuildBlock(BlockPlan block)
         => new(block.IsCollection, block.Entries.Select(BuildEntry).ToList());

--- a/src/ILInspector.Research/ResearchReturnToSenderShells.cs
+++ b/src/ILInspector.Research/ResearchReturnToSenderShells.cs
@@ -21,12 +21,6 @@ public static class ResearchReturnToSenderShells
         FieldRef field)
         => CompileBackSourceComposer.TryCreateClosureMemberRequirement(reader, typeHandle, field);
 
-    public static CompileBackMemberRequirement? TryCreateClosureMemberRequirement(
-        MetadataReader reader,
-        TypeDefinitionHandle typeHandle,
-        string memberName)
-        => CompileBackSourceComposer.TryCreateClosureMemberRequirement(reader, typeHandle, memberName);
-
     public static CompileBackSourceResult ComposePropertyGetter(
         string assemblyPath,
         MetadataReader reader,

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1535,14 +1535,6 @@ static class ReturnToSender
                 allowTargetRoot: true);
         }
 
-        void AddNamedMemberRequirement(TypeRef declaringType, string memberName, bool allowTargetRoot = false)
-        {
-            AddMemberRequirement(
-                declaringType,
-                root => ResearchReturnToSenderShells.TryCreateClosureMemberRequirement(reader, root, memberName),
-                allowTargetRoot);
-        }
-
         void AddMemberRequirement(TypeRef declaringType, Func<TypeDefinitionHandle, CompileBackMemberRequirement?> create, bool allowTargetRoot)
         {
             var definition = declaringType.Kind == TypeRefKind.GenericInstance
@@ -1645,13 +1637,19 @@ static class ReturnToSender
         void AddObjectInitializerFacts(ObjectInitializerExpression initializer)
         {
             AddMethodFact(initializer.Creation.Constructor, allowTargetRootOverride: true);
-            if (initializer.IsCollection)
-                return;
+            AddInitializerEntryFacts(initializer.Entries);
+        }
 
-            foreach (var entry in initializer.Entries)
+        void AddInitializerEntryFacts(IEnumerable<InitializerEntry> entries)
+        {
+            foreach (var entry in entries)
             {
-                if (entry.Member is { } memberName)
-                    AddNamedMemberRequirement(initializer.Creation.Constructor.DeclaringType, memberName, allowTargetRoot: true);
+                if (entry.ConsumedMethod is { } method)
+                    AddMethodFact(method, allowTargetRootOverride: true);
+                if (entry.ConsumedField is { } field)
+                    AddFieldFact(field);
+                foreach (var block in entry.Arguments.OfType<InitializerBlock>())
+                    AddInitializerEntryFacts(block.Entries);
             }
         }
 


### PR DESCRIPTION
- Moves object-initializer member evidence into product IR.
- Evidence revision: `35f9a84c` plus merge `5de73d48` from current `origin/main`.

## Change

**Conclusion:** **PASS** — raised object/collection initializer entries now preserve typed consumed setter/field/Add references, and RTS routes that typed evidence instead of inferring shell requirements from member-name strings.

Before:

```text
RTS object-initializer bridge:
  ObjectInitializerExpression -> entry.Member string -> Research name lookup
```

After:

```text
Product IR evidence:
  InitializerEntry.ConsumedMethod / ConsumedField -> RTS routes typed MethodRef/FieldRef -> Research shell composition
```

## Scope and safety

- **Root cause:** #2518 removed minimal Roslyn fallback buckets, but object-initializer seeding still lived in RTS as name-based bridge logic.
- **Fix shape:** `ObjectInitializerPass` carries consumed `MethodRef`/`FieldRef` evidence into `ObjectInitializerExpression` and `InitializerBlock`; RTS consumes that typed evidence recursively.
- **Product impact:** product IR now preserves typed evidence for raised initializer entries; printed C# output is unchanged.
- **Scope boundary:** target-interface and constructor backing-field-write evidence remain as follow-up model work; this PR moves object-initializer member evidence first.
- **RTS boundary:** RTS no longer performs object-initializer member-name lookup; it routes product-owned typed evidence through Research.

## Evidence

| Check | Result |
| --- | --- |
| ObjectInitializerPassTests | Pass |
| RTS object-initializer canaries | Pass |
| GeneratedFixtureCatalogTests | Pass |
| Solution build | Pass |
| `minimal` RTS catalog JSON | `RoslynFallbacks: []` |
| `record` RTS catalog JSON | unchanged: `CS0103/closure-member: 2`, `CS1061/closure-member: 1` |
| `rts.candidates` source probe | ValidMatch 52, ValidDifferent 50, Invalid 0, SourceUnavailable 0, UnsupportedTarget 0 |

## Validation

```bash
dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ObjectInitializerPassTests/*"
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderPrototypeTests/CompileBackTargets_UsesTypedObjectInitializerPropertyRequirement"
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderPrototypeTests/CompileBackTargets_UsesTypedTargetObjectInitializerPropertyRequirement"
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/GeneratedFixtureCatalogTests/*"
dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog minimal --json --max-examples 1
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog record --json --max-examples 1
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures rts.candidates --return-to-sender-source-probe --cap 10000 --max-examples 60
```

## Review

Adversarial review requested after PR creation.
