### PR TITLE
Credit catch-all cleanup in leak-triage exception-path protection (#2439)

### DIFF
--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -48,6 +48,25 @@ public sealed class LeakTriageAnalyzerTests
     }
 
     [Fact]
+    public void CatchAllCleanup_SuppressesExceptionPathCandidate()
+    {
+        var result = FixtureResult();
+
+        // A catch-all (`catch {}` or `catch (Exception)`) that returns the buffer protects the
+        // exception path, so no exception-path-leak-candidate (the JsonDocument.Parse FP class).
+        AssertNoCandidate(result, nameof(ArrayPoolLeakFixtures.RentCrossCallCatchAllReturn), "exception-path-leak-candidate");
+        AssertNoCandidate(result, nameof(ArrayPoolLeakFixtures.RentCrossCallCatchExceptionReturn), "exception-path-leak-candidate");
+
+        // Near miss: a typed catch does not cover every exception type, so it stays a candidate.
+        AssertCandidate(result, nameof(ArrayPoolLeakFixtures.RentCrossCallTypedCatchReturn), "exception-path-leak-candidate");
+
+        // The fix is measurement-only: it changes no finding.
+        Assert.Empty(ForMethod(result.Findings, nameof(ArrayPoolLeakFixtures.RentCrossCallCatchAllReturn)));
+        Assert.Empty(ForMethod(result.Findings, nameof(ArrayPoolLeakFixtures.RentCrossCallCatchExceptionReturn)));
+        Assert.Empty(ForMethod(result.Findings, nameof(ArrayPoolLeakFixtures.RentCrossCallTypedCatchReturn)));
+    }
+
+    [Fact]
     public void AmbiguousArrayPoolFixtures_FailClosed()
     {
         var findings = FixtureFindings();
@@ -651,8 +670,65 @@ internal sealed class ArrayPoolLeakFixtures
         throw new InvalidOperationException(buffer.Length.ToString());
     }
 
+    // A cross-method throwing boundary returned on both the normal path and a catch-ALL cleanup
+    // (`catch {}`) - correct code with no try/finally. The exception path is protected, so it must
+    // NOT produce an exception-path-leak-candidate once catch-all cleanup is modeled (mirrors
+    // System.Text.Json's JsonDocument.Parse idiom).
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void RentCrossCallCatchAllReturn()
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        try
+        {
+            Sink(buffer);
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+        catch
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+            throw;
+        }
+    }
+
+    // Same shape with `catch (Exception)`, which also runs for every managed exception type.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void RentCrossCallCatchExceptionReturn()
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        try
+        {
+            Sink(buffer);
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+        catch (Exception)
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+            throw;
+        }
+    }
+
+    // Near miss: a TYPED catch only covers InvalidOperationException; another exception type from
+    // Sink would bypass it and leak, so this MUST still be an exception-path-leak-candidate.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void RentCrossCallTypedCatchReturn()
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        try
+        {
+            Sink(buffer);
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+        catch (InvalidOperationException)
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+            throw;
+        }
+    }
+
     static void ReturnHelper(byte[] buffer)
         => ArrayPool<byte>.Shared.Return(buffer);
+
+    static int Sink(byte[] buffer) => buffer.Length;
 
     static void Consume(int value)
     {

--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -60,6 +60,10 @@ public sealed class LeakTriageAnalyzerTests
         // Near miss: a typed catch does not cover every exception type, so it stays a candidate.
         AssertCandidate(result, nameof(ArrayPoolLeakFixtures.RentCrossCallTypedCatchReturn), "exception-path-leak-candidate");
 
+        // Near miss: a sibling typed catch precedes the catch-all and can handle an exception
+        // without releasing, so the catch-all must not be credited - stays a candidate.
+        AssertCandidate(result, nameof(ArrayPoolLeakFixtures.RentCrossCallSiblingTypedThenCatchAllReturn), "exception-path-leak-candidate");
+
         // The fix is measurement-only: it changes no finding.
         Assert.Empty(ForMethod(result.Findings, nameof(ArrayPoolLeakFixtures.RentCrossCallCatchAllReturn)));
         Assert.Empty(ForMethod(result.Findings, nameof(ArrayPoolLeakFixtures.RentCrossCallCatchExceptionReturn)));
@@ -719,6 +723,29 @@ internal sealed class ArrayPoolLeakFixtures
             ArrayPool<byte>.Shared.Return(buffer);
         }
         catch (InvalidOperationException)
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+            throw;
+        }
+    }
+
+    // Near miss: a sibling typed catch precedes the catch-all. An InvalidOperationException is
+    // handled by the FIRST catch, which does NOT return, so the buffer leaks - the catch-all must
+    // NOT be credited, and this MUST still be an exception-path-leak-candidate.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void RentCrossCallSiblingTypedThenCatchAllReturn()
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        try
+        {
+            Sink(buffer);
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+        catch (InvalidOperationException)
+        {
+            throw;
+        }
+        catch
         {
             ArrayPool<byte>.Shared.Return(buffer);
             throw;

--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -64,6 +64,10 @@ public sealed class LeakTriageAnalyzerTests
         // without releasing, so the catch-all must not be credited - stays a candidate.
         AssertCandidate(result, nameof(ArrayPoolLeakFixtures.RentCrossCallSiblingTypedThenCatchAllReturn), "exception-path-leak-candidate");
 
+        // Near miss: an inner typed catch on a nested try intercepts and swallows before the outer
+        // catch-all, so the catch-all must not be credited - stays a candidate.
+        AssertCandidate(result, nameof(ArrayPoolLeakFixtures.RentNestedInnerCatchSwallowThenCatchAll), "exception-path-leak-candidate");
+
         // The fix is measurement-only: it changes no finding.
         Assert.Empty(ForMethod(result.Findings, nameof(ArrayPoolLeakFixtures.RentCrossCallCatchAllReturn)));
         Assert.Empty(ForMethod(result.Findings, nameof(ArrayPoolLeakFixtures.RentCrossCallCatchExceptionReturn)));
@@ -744,6 +748,32 @@ internal sealed class ArrayPoolLeakFixtures
         catch (InvalidOperationException)
         {
             throw;
+        }
+        catch
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+            throw;
+        }
+    }
+
+    // Near miss: an INNER typed catch on a nested try intercepts the boundary's exception first
+    // and swallows it without releasing, so the outer catch-all never runs for that exception -
+    // the array leaks. The outer catch-all must NOT be credited (reviewers, PR #2521).
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void RentNestedInnerCatchSwallowThenCatchAll()
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        try
+        {
+            try
+            {
+                Sink(buffer);
+            }
+            catch (InvalidOperationException)
+            {
+                return;
+            }
+            ArrayPool<byte>.Shared.Return(buffer);
         }
         catch
         {

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -94,16 +94,30 @@ public static class LeakTriageAnalyzer
         MethodIdentity method,
         byte[] il,
         IReadOnlyCollection<ExceptionRegion> exceptionRegions,
+        Func<int, MemberRef> resolveMethod)
+        => AnalyzeMethodDetailed(method, il, exceptionRegions, resolveMethod, null).Findings;
+
+    public static ImmutableArray<LeakTriageFinding> AnalyzeMethod(
+        MethodIdentity method,
+        byte[] il,
+        IReadOnlyCollection<ExceptionRegion> exceptionRegions,
         Func<int, MemberRef> resolveMethod,
-        Func<int, TypeRef?>? resolveCatchType = null)
+        Func<int, TypeRef?>? resolveCatchType)
         => AnalyzeMethodDetailed(method, il, exceptionRegions, resolveMethod, resolveCatchType).Findings;
 
     public static LeakTriageResult AnalyzeMethodDetailed(
         MethodIdentity method,
         byte[] il,
         IReadOnlyCollection<ExceptionRegion> exceptionRegions,
+        Func<int, MemberRef> resolveMethod)
+        => AnalyzeMethodDetailed(method, il, exceptionRegions, resolveMethod, null);
+
+    public static LeakTriageResult AnalyzeMethodDetailed(
+        MethodIdentity method,
+        byte[] il,
+        IReadOnlyCollection<ExceptionRegion> exceptionRegions,
         Func<int, MemberRef> resolveMethod,
-        Func<int, TypeRef?>? resolveCatchType = null)
+        Func<int, TypeRef?>? resolveCatchType)
     {
         ArgumentNullException.ThrowIfNull(method);
         ArgumentNullException.ThrowIfNull(il);
@@ -130,7 +144,7 @@ public static class LeakTriageAnalyzer
             if (!reaching.IsComplete)
                 return Suppressed(method, "incomplete-cfg-or-rd-suppressed", reaching.IncompleteReason ?? "Incomplete CFG/RD evidence.", null, null);
 
-            var catchAllCleanupHandlers = ComputeCatchAllCleanupHandlers(exceptionRegions, resolveCatchType);
+            var catchAllCleanup = ComputeCreditableCatchCleanup(exceptionRegions, resolveCatchType);
             var candidates = ImmutableArray.CreateBuilder<LeakTriageCandidate>();
             var rents = FindRents(method, instructions, graph, reaching, calls, candidates).ToImmutableArray();
             if (rents.Length == 0)
@@ -138,7 +152,7 @@ public static class LeakTriageAnalyzer
 
             var findings = ImmutableArray.CreateBuilder<LeakTriageFinding>();
             foreach (var rent in rents)
-                AnalyzeRent(method, instructions, graph, reaching, calls, exceptionRegions, catchAllCleanupHandlers, rent, findings, candidates);
+                AnalyzeRent(method, instructions, graph, reaching, calls, exceptionRegions, catchAllCleanup, rent, findings, candidates);
 
             return new LeakTriageResult(findings.ToImmutable(), candidates.ToImmutable());
         }
@@ -162,7 +176,7 @@ public static class LeakTriageAnalyzer
         ReachingDefinitionsResult reaching,
         IReadOnlyDictionary<int, MemberRef> calls,
         IReadOnlyCollection<ExceptionRegion> exceptionRegions,
-        IReadOnlySet<int> catchAllCleanupHandlers,
+        IReadOnlySet<(int TryOffset, int TryLength, int HandlerOffset)> catchAllCleanup,
         RentedLocal rent,
         ImmutableArray<LeakTriageFinding>.Builder findings,
         ImmutableArray<LeakTriageCandidate>.Builder candidates)
@@ -212,7 +226,7 @@ public static class LeakTriageAnalyzer
         if (firstAmbiguous is { } ambiguous)
         {
             if (ambiguous.Shape == "cross-method-suppressed"
-                && FirstUnprotectedThrowingBoundary(graph, exceptionRegions, catchAllCleanupHandlers, releaseOffsets, throwingBoundaries.ToImmutable()) is { } throwingBoundary)
+                && FirstUnprotectedThrowingBoundary(graph, exceptionRegions, catchAllCleanup, releaseOffsets, throwingBoundaries.ToImmutable()) is { } throwingBoundary)
             {
                 AddCandidate(
                     candidates,
@@ -394,14 +408,14 @@ public static class LeakTriageAnalyzer
     static int? FirstUnprotectedThrowingBoundary(
         BlockGraph graph,
         IReadOnlyCollection<ExceptionRegion> exceptionRegions,
-        IReadOnlySet<int> catchAllCleanupHandlers,
+        IReadOnlySet<(int TryOffset, int TryLength, int HandlerOffset)> catchAllCleanup,
         ImmutableArray<int> releases,
         ImmutableArray<int> throwingBoundaries)
     {
         foreach (int boundary in throwingBoundaries)
         {
             if (!ReleasedBeforeUseInSameBlock(graph, releases, boundary)
-                && !HasCleanupReleaseForUse(exceptionRegions, catchAllCleanupHandlers, releases, boundary))
+                && !HasCleanupReleaseForUse(exceptionRegions, catchAllCleanup, releases, boundary))
             {
                 return boundary;
             }
@@ -412,19 +426,21 @@ public static class LeakTriageAnalyzer
 
     static bool HasCleanupReleaseForUse(
         IReadOnlyCollection<ExceptionRegion> exceptionRegions,
-        IReadOnlySet<int> catchAllCleanupHandlers,
+        IReadOnlySet<(int TryOffset, int TryLength, int HandlerOffset)> catchAllCleanup,
         ImmutableArray<int> releases,
         int useOffset)
     {
         foreach (var region in exceptionRegions)
         {
-            // A `finally`/`fault` always runs on the exception path; a catch-all
-            // (`catch {}` / `catch (Exception)`) also runs for every exception type, so a release
-            // inside either handler protects an in-try throwing boundary against a leak. A more
-            // specific typed catch is not credited: an exception of another type would bypass it
-            // and leak.
+            // A `finally`/`fault` always runs on the exception path; a *sole* catch-all
+            // (`catch {}` / `catch (Exception)`) also runs for every exception from its try, so a
+            // release inside either handler protects an in-try throwing boundary against a leak.
+            // Only a catch-all that is the sole handler for its try is credited: a sibling typed
+            // or filter catch could handle an exception first without releasing, and a more
+            // specific typed catch lets other exception types bypass it.
             bool isCleanupHandler = region.Kind is ExceptionRegionKind.Finally or ExceptionRegionKind.Fault
-                || (region.Kind is ExceptionRegionKind.Catch && catchAllCleanupHandlers.Contains(region.HandlerOffset));
+                || (region.Kind is ExceptionRegionKind.Catch
+                    && catchAllCleanup.Contains((region.TryOffset, region.TryLength, region.HandlerOffset)));
             if (!isCleanupHandler)
                 continue;
             if (!ContainsOffset(region.TryOffset, region.TryLength, useOffset))
@@ -436,35 +452,60 @@ public static class LeakTriageAnalyzer
         return false;
     }
 
-    // Handler offsets of catch-all regions - a catch that runs for every exception type, so the
-    // only catch shape that can credit exception-path protection. `catch (System.Object)` (bare
-    // `catch {}`) and `catch (System.Exception)` both qualify: in managed code every throwable
-    // derives from Exception, and non-CLS throws are wrapped as RuntimeWrappedException by the
-    // default RuntimeCompatibility(WrapNonExceptionThrows=true), so both catch every exception.
-    // A more specific typed catch is deliberately excluded - another exception type would bypass
-    // it and leak. Empty when no catch-type resolver is supplied (e.g. direct AnalyzeMethod
-    // callers), preserving the prior finally/fault-only behavior.
-    static IReadOnlySet<int> ComputeCatchAllCleanupHandlers(
+    // Try-range/handler identity of catch clauses that can credit exception-path protection: a
+    // catch-all (`catch {}` = `System.Object`, or `catch (Exception)`) that is the SOLE handler
+    // for its try. Both catch every managed exception (non-CLS throws are wrapped as
+    // RuntimeWrappedException by the default RuntimeCompatibility(WrapNonExceptionThrows=true)),
+    // so with no sibling handler on the same try the catch runs for every exception from it. A
+    // catch-all preceded by a sibling typed/filter catch is NOT credited: that sibling could
+    // handle an exception first without releasing, so the leak would be real. Empty when no
+    // catch-type resolver is supplied (e.g. direct AnalyzeMethod callers), preserving the prior
+    // finally/fault-only behavior. Conditional releases inside the handler are credited at the
+    // same fidelity as the existing finally/fault check (containment, not post-domination).
+    static IReadOnlySet<(int TryOffset, int TryLength, int HandlerOffset)> ComputeCreditableCatchCleanup(
         IReadOnlyCollection<ExceptionRegion> exceptionRegions,
         Func<int, TypeRef?>? resolveCatchType)
     {
         if (resolveCatchType is null)
-            return ImmutableHashSet<int>.Empty;
+            return EmptyCatchCleanup;
 
-        HashSet<int>? handlers = null;
+        HashSet<(int, int, int)>? creditable = null;
         foreach (var region in exceptionRegions)
         {
             if (region.Kind is not ExceptionRegionKind.Catch || region.CatchType.IsNil)
                 continue;
             var catchType = resolveCatchType(MetadataTokens.GetToken(region.CatchType));
-            if (catchType is not null
-                && (FrameworkIdentity.IsCoreLibraryType(catchType, "System", "Object")
+            if (catchType is null
+                || !(FrameworkIdentity.IsCoreLibraryType(catchType, "System", "Object")
                     || FrameworkIdentity.IsCoreLibraryType(catchType, "System", "Exception")))
-                (handlers ??= []).Add(region.HandlerOffset);
+                continue;
+            if (HasSiblingHandler(exceptionRegions, region))
+                continue;
+            (creditable ??= []).Add((region.TryOffset, region.TryLength, region.HandlerOffset));
         }
 
-        return handlers is null ? ImmutableHashSet<int>.Empty : handlers;
+        return creditable is null ? EmptyCatchCleanup : creditable;
     }
+
+    // Another catch/filter clause guarding the exact same try range (a sibling handler that could
+    // handle an exception before the catch-all runs).
+    static bool HasSiblingHandler(IReadOnlyCollection<ExceptionRegion> exceptionRegions, ExceptionRegion region)
+    {
+        foreach (var other in exceptionRegions)
+        {
+            if (other.Kind is not (ExceptionRegionKind.Catch or ExceptionRegionKind.Filter))
+                continue;
+            if (other.TryOffset != region.TryOffset || other.TryLength != region.TryLength)
+                continue;
+            if (other.HandlerOffset != region.HandlerOffset)
+                return true;
+        }
+
+        return false;
+    }
+
+    static readonly IReadOnlySet<(int TryOffset, int TryLength, int HandlerOffset)> EmptyCatchCleanup =
+        ImmutableHashSet<(int, int, int)>.Empty;
 
     static TypeRef? ResolveCatchTypeRef(MetadataReader reader, EntityHandle handle, GenericScope scope) => handle.Kind switch
     {

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -74,7 +74,8 @@ public static class LeakTriageAnalyzer
                         method,
                         body.GetILBytes() ?? [],
                         body.ExceptionRegions,
-                        token => MemberResolver.ResolveMethod(reader, MetadataTokens.EntityHandle(token), scope));
+                        token => MemberResolver.ResolveMethod(reader, MetadataTokens.EntityHandle(token), scope),
+                        token => ResolveCatchTypeRef(reader, MetadataTokens.EntityHandle(token), scope));
                     findings.AddRange(result.Findings);
                     candidates.AddRange(result.Candidates);
                 }
@@ -93,14 +94,16 @@ public static class LeakTriageAnalyzer
         MethodIdentity method,
         byte[] il,
         IReadOnlyCollection<ExceptionRegion> exceptionRegions,
-        Func<int, MemberRef> resolveMethod)
-        => AnalyzeMethodDetailed(method, il, exceptionRegions, resolveMethod).Findings;
+        Func<int, MemberRef> resolveMethod,
+        Func<int, TypeRef?>? resolveCatchType = null)
+        => AnalyzeMethodDetailed(method, il, exceptionRegions, resolveMethod, resolveCatchType).Findings;
 
     public static LeakTriageResult AnalyzeMethodDetailed(
         MethodIdentity method,
         byte[] il,
         IReadOnlyCollection<ExceptionRegion> exceptionRegions,
-        Func<int, MemberRef> resolveMethod)
+        Func<int, MemberRef> resolveMethod,
+        Func<int, TypeRef?>? resolveCatchType = null)
     {
         ArgumentNullException.ThrowIfNull(method);
         ArgumentNullException.ThrowIfNull(il);
@@ -127,6 +130,7 @@ public static class LeakTriageAnalyzer
             if (!reaching.IsComplete)
                 return Suppressed(method, "incomplete-cfg-or-rd-suppressed", reaching.IncompleteReason ?? "Incomplete CFG/RD evidence.", null, null);
 
+            var catchAllCleanupHandlers = ComputeCatchAllCleanupHandlers(exceptionRegions, resolveCatchType);
             var candidates = ImmutableArray.CreateBuilder<LeakTriageCandidate>();
             var rents = FindRents(method, instructions, graph, reaching, calls, candidates).ToImmutableArray();
             if (rents.Length == 0)
@@ -134,7 +138,7 @@ public static class LeakTriageAnalyzer
 
             var findings = ImmutableArray.CreateBuilder<LeakTriageFinding>();
             foreach (var rent in rents)
-                AnalyzeRent(method, instructions, graph, reaching, calls, exceptionRegions, rent, findings, candidates);
+                AnalyzeRent(method, instructions, graph, reaching, calls, exceptionRegions, catchAllCleanupHandlers, rent, findings, candidates);
 
             return new LeakTriageResult(findings.ToImmutable(), candidates.ToImmutable());
         }
@@ -158,6 +162,7 @@ public static class LeakTriageAnalyzer
         ReachingDefinitionsResult reaching,
         IReadOnlyDictionary<int, MemberRef> calls,
         IReadOnlyCollection<ExceptionRegion> exceptionRegions,
+        IReadOnlySet<int> catchAllCleanupHandlers,
         RentedLocal rent,
         ImmutableArray<LeakTriageFinding>.Builder findings,
         ImmutableArray<LeakTriageCandidate>.Builder candidates)
@@ -207,7 +212,7 @@ public static class LeakTriageAnalyzer
         if (firstAmbiguous is { } ambiguous)
         {
             if (ambiguous.Shape == "cross-method-suppressed"
-                && FirstUnprotectedThrowingBoundary(graph, exceptionRegions, releaseOffsets, throwingBoundaries.ToImmutable()) is { } throwingBoundary)
+                && FirstUnprotectedThrowingBoundary(graph, exceptionRegions, catchAllCleanupHandlers, releaseOffsets, throwingBoundaries.ToImmutable()) is { } throwingBoundary)
             {
                 AddCandidate(
                     candidates,
@@ -389,13 +394,14 @@ public static class LeakTriageAnalyzer
     static int? FirstUnprotectedThrowingBoundary(
         BlockGraph graph,
         IReadOnlyCollection<ExceptionRegion> exceptionRegions,
+        IReadOnlySet<int> catchAllCleanupHandlers,
         ImmutableArray<int> releases,
         ImmutableArray<int> throwingBoundaries)
     {
         foreach (int boundary in throwingBoundaries)
         {
             if (!ReleasedBeforeUseInSameBlock(graph, releases, boundary)
-                && !HasCleanupReleaseForUse(exceptionRegions, releases, boundary))
+                && !HasCleanupReleaseForUse(exceptionRegions, catchAllCleanupHandlers, releases, boundary))
             {
                 return boundary;
             }
@@ -406,12 +412,20 @@ public static class LeakTriageAnalyzer
 
     static bool HasCleanupReleaseForUse(
         IReadOnlyCollection<ExceptionRegion> exceptionRegions,
+        IReadOnlySet<int> catchAllCleanupHandlers,
         ImmutableArray<int> releases,
         int useOffset)
     {
         foreach (var region in exceptionRegions)
         {
-            if (region.Kind is not (ExceptionRegionKind.Finally or ExceptionRegionKind.Fault))
+            // A `finally`/`fault` always runs on the exception path; a catch-all
+            // (`catch {}` / `catch (Exception)`) also runs for every exception type, so a release
+            // inside either handler protects an in-try throwing boundary against a leak. A more
+            // specific typed catch is not credited: an exception of another type would bypass it
+            // and leak.
+            bool isCleanupHandler = region.Kind is ExceptionRegionKind.Finally or ExceptionRegionKind.Fault
+                || (region.Kind is ExceptionRegionKind.Catch && catchAllCleanupHandlers.Contains(region.HandlerOffset));
+            if (!isCleanupHandler)
                 continue;
             if (!ContainsOffset(region.TryOffset, region.TryLength, useOffset))
                 continue;
@@ -421,6 +435,44 @@ public static class LeakTriageAnalyzer
 
         return false;
     }
+
+    // Handler offsets of catch-all regions - a catch that runs for every exception type, so the
+    // only catch shape that can credit exception-path protection. `catch (System.Object)` (bare
+    // `catch {}`) and `catch (System.Exception)` both qualify: in managed code every throwable
+    // derives from Exception, and non-CLS throws are wrapped as RuntimeWrappedException by the
+    // default RuntimeCompatibility(WrapNonExceptionThrows=true), so both catch every exception.
+    // A more specific typed catch is deliberately excluded - another exception type would bypass
+    // it and leak. Empty when no catch-type resolver is supplied (e.g. direct AnalyzeMethod
+    // callers), preserving the prior finally/fault-only behavior.
+    static IReadOnlySet<int> ComputeCatchAllCleanupHandlers(
+        IReadOnlyCollection<ExceptionRegion> exceptionRegions,
+        Func<int, TypeRef?>? resolveCatchType)
+    {
+        if (resolveCatchType is null)
+            return ImmutableHashSet<int>.Empty;
+
+        HashSet<int>? handlers = null;
+        foreach (var region in exceptionRegions)
+        {
+            if (region.Kind is not ExceptionRegionKind.Catch || region.CatchType.IsNil)
+                continue;
+            var catchType = resolveCatchType(MetadataTokens.GetToken(region.CatchType));
+            if (catchType is not null
+                && (FrameworkIdentity.IsCoreLibraryType(catchType, "System", "Object")
+                    || FrameworkIdentity.IsCoreLibraryType(catchType, "System", "Exception")))
+                (handlers ??= []).Add(region.HandlerOffset);
+        }
+
+        return handlers is null ? ImmutableHashSet<int>.Empty : handlers;
+    }
+
+    static TypeRef? ResolveCatchTypeRef(MetadataReader reader, EntityHandle handle, GenericScope scope) => handle.Kind switch
+    {
+        HandleKind.TypeDefinition => TypeRefDecoder.Instance.GetTypeFromDefinition(reader, (TypeDefinitionHandle)handle, 0),
+        HandleKind.TypeReference => TypeRefDecoder.Instance.GetTypeFromReference(reader, (TypeReferenceHandle)handle, 0),
+        HandleKind.TypeSpecification => TypeRefDecoder.Instance.GetTypeFromSpecification(reader, scope, (TypeSpecificationHandle)handle, 0),
+        _ => null,
+    };
 
     static bool ContainsOffset(int start, int length, int offset)
         => offset >= start && offset < start + length;

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -430,38 +430,49 @@ public static class LeakTriageAnalyzer
         ImmutableArray<int> releases,
         int useOffset)
     {
+        // Exception regions are ordered innermost-first (ECMA-335 II.19: most-nested clauses
+        // precede enclosing ones), which is also EH search order. Walk the handlers that cover the
+        // boundary in that order: a `finally`/`fault` always runs, so a release inside one protects
+        // the boundary. A catch-all (`catch {}` / `catch (Exception)`) protects the boundary only
+        // if it is the FIRST catch/filter that covers it - any earlier catch/filter (a sibling
+        // typed catch, or an inner catch on a nested try) would handle the exception first and, if
+        // it does not release, the array still leaks.
+        bool interceptingCatchSeen = false;
         foreach (var region in exceptionRegions)
         {
-            // A `finally`/`fault` always runs on the exception path; a *sole* catch-all
-            // (`catch {}` / `catch (Exception)`) also runs for every exception from its try, so a
-            // release inside either handler protects an in-try throwing boundary against a leak.
-            // Only a catch-all that is the sole handler for its try is credited: a sibling typed
-            // or filter catch could handle an exception first without releasing, and a more
-            // specific typed catch lets other exception types bypass it.
-            bool isCleanupHandler = region.Kind is ExceptionRegionKind.Finally or ExceptionRegionKind.Fault
-                || (region.Kind is ExceptionRegionKind.Catch
-                    && catchAllCleanup.Contains((region.TryOffset, region.TryLength, region.HandlerOffset)));
-            if (!isCleanupHandler)
-                continue;
             if (!ContainsOffset(region.TryOffset, region.TryLength, useOffset))
                 continue;
-            if (releases.Any(release => ContainsOffset(region.HandlerOffset, region.HandlerLength, release)))
+
+            if (region.Kind is ExceptionRegionKind.Finally or ExceptionRegionKind.Fault)
+            {
+                if (releases.Any(release => ContainsOffset(region.HandlerOffset, region.HandlerLength, release)))
+                    return true;
+                continue;
+            }
+
+            if (region.Kind is not (ExceptionRegionKind.Catch or ExceptionRegionKind.Filter))
+                continue;
+
+            if (!interceptingCatchSeen
+                && catchAllCleanup.Contains((region.TryOffset, region.TryLength, region.HandlerOffset))
+                && releases.Any(release => ContainsOffset(region.HandlerOffset, region.HandlerLength, release)))
                 return true;
+
+            interceptingCatchSeen = true;
         }
 
         return false;
     }
 
-    // Try-range/handler identity of catch clauses that can credit exception-path protection: a
-    // catch-all (`catch {}` = `System.Object`, or `catch (Exception)`) that is the SOLE handler
-    // for its try. Both catch every managed exception (non-CLS throws are wrapped as
-    // RuntimeWrappedException by the default RuntimeCompatibility(WrapNonExceptionThrows=true)),
-    // so with no sibling handler on the same try the catch runs for every exception from it. A
-    // catch-all preceded by a sibling typed/filter catch is NOT credited: that sibling could
-    // handle an exception first without releasing, so the leak would be real. Empty when no
-    // catch-type resolver is supplied (e.g. direct AnalyzeMethod callers), preserving the prior
-    // finally/fault-only behavior. Conditional releases inside the handler are credited at the
-    // same fidelity as the existing finally/fault check (containment, not post-domination).
+    // Try-range/handler identity of catch-all clauses (`catch {}` = `System.Object`, or
+    // `catch (Exception)`) - the catch shapes that catch every managed exception (non-CLS throws
+    // are wrapped as RuntimeWrappedException by the default
+    // RuntimeCompatibility(WrapNonExceptionThrows=true)). Whether such a clause actually protects a
+    // given boundary is decided per-boundary in HasCleanupReleaseForUse, which fails closed if an
+    // earlier catch/filter could intercept the exception first. Empty when no catch-type resolver
+    // is supplied (e.g. direct AnalyzeMethod callers), preserving the prior finally/fault-only
+    // behavior. Conditional releases inside the handler are credited at the same fidelity as the
+    // existing finally/fault check (containment, not post-domination).
     static IReadOnlySet<(int TryOffset, int TryLength, int HandlerOffset)> ComputeCreditableCatchCleanup(
         IReadOnlyCollection<ExceptionRegion> exceptionRegions,
         Func<int, TypeRef?>? resolveCatchType)
@@ -479,29 +490,10 @@ public static class LeakTriageAnalyzer
                 || !(FrameworkIdentity.IsCoreLibraryType(catchType, "System", "Object")
                     || FrameworkIdentity.IsCoreLibraryType(catchType, "System", "Exception")))
                 continue;
-            if (HasSiblingHandler(exceptionRegions, region))
-                continue;
             (creditable ??= []).Add((region.TryOffset, region.TryLength, region.HandlerOffset));
         }
 
         return creditable is null ? EmptyCatchCleanup : creditable;
-    }
-
-    // Another catch/filter clause guarding the exact same try range (a sibling handler that could
-    // handle an exception before the catch-all runs).
-    static bool HasSiblingHandler(IReadOnlyCollection<ExceptionRegion> exceptionRegions, ExceptionRegion region)
-    {
-        foreach (var other in exceptionRegions)
-        {
-            if (other.Kind is not (ExceptionRegionKind.Catch or ExceptionRegionKind.Filter))
-                continue;
-            if (other.TryOffset != region.TryOffset || other.TryLength != region.TryLength)
-                continue;
-            if (other.HandlerOffset != region.HandlerOffset)
-                return true;
-        }
-
-        return false;
     }
 
     static readonly IReadOnlySet<(int TryOffset, int TryLength, int HandlerOffset)> EmptyCatchCleanup =


### PR DESCRIPTION
## Intent

Fix a measured false-positive class in the ArrayPool leak-triage analyzer's
`exception-path-leak-candidate` bucket. Part of #2439 (surfaced by the actionability
measurement on that issue). **Measurement-only: no user-facing finding changes.**

## The bug

`LeakTriage.HasCleanupReleaseForUse` credits a rented-array `Return` as protecting a
throwing boundary only when the `Return` is inside a `finally`/`fault` handler
(`LeakTriage.cs`). It does not model the equally-common **catch cleanup idiom**:

```csharp
byte[] buf = ArrayPool<byte>.Shared.Rent(length);
try { ...use buf... }
catch { ArrayPool<byte>.Shared.Return(buf); throw; }   // exception path IS protected
```

This is exactly how `System.Text.Json`'s `JsonDocument.Parse` / `TryParseValue` return
their pooled input buffer on failure. The analyzer flagged all of them as
`exception-path-leak-candidate` — false positives.

## The fix

Model catch-all cleanup: a `Return` inside a **catch-all** handler whose `try` covers
the throwing boundary now credits exception-path protection. Only a catch-all is
credited — catch type `System.Object` (bare `catch {}`) or `System.Exception`
(`catch (Exception)`), both of which run for every managed exception type. A more
specific typed catch (`catch (IOException)`) is **deliberately not** credited: another
exception type would bypass it and leak.

Catch-type identity is resolved through a new optional `resolveCatchType` delegate on
`AnalyzeMethod` / `AnalyzeMethodDetailed` (mirroring the existing `resolveMethod`).
When it is absent — every direct/synthetic caller — the prior finally/fault-only
behavior is preserved, so this is additive.

## Attack points for review

1. **Soundness of catch-all restriction.** Is crediting only `System.Object` /
   `System.Exception` correct? A typed catch must *not* be credited (covered by the
   `RentCrossCallTypedCatchReturn` near-miss fixture, which stays a candidate).
2. **Scope.** The change touches only the cross-method exception-path path
   (`FirstUnprotectedThrowingBoundary` → `HasCleanupReleaseForUse`). Normal-path and
   use-after/double-return paths are untouched. Is that the right scope, or is there a
   catch-cleanup FP reachable via `PathExitsWithoutRelease` too?
3. **`region.HandlerOffset` keying.** The catch-all set is keyed by handler offset;
   handler offsets are unique per region, and the release must be *this* rent's release
   inside *that* handler. Any collision or mis-credit?
4. **API change.** Optional `resolveCatchType` param — source-compatible; verify no
   caller breaks and null-path preserves behavior.

## Measurement (40-DLL ArrayPool corpus, current main vs this branch)

`analysis-harness --leak-triage`: exception-path candidates **24 → 21**, removing
exactly the 3 System.Text.Json `JsonDocument.Parse`/`TryParseValue` FPs; every other
bucket unchanged. Full method-by-method: the only rows that disappear are the 3
catch-protected ones (verified via SRM that all 3 are catch-all).

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` — succeeds.
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release` — **407 passed**
  (incl. the new `CatchAllCleanup_SuppressesExceptionPathCandidate` and the unchanged
  existing leak-triage tests).

## Adversarial review

Two-model adversarial review requested per policy (I run as Claude Opus 4.8 →
reviewers from the other roster entries). Reconciliation will be posted here.
