### PR TITLE
Route RTS IL diagnostics through member diff

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -17,11 +17,6 @@ namespace ILInspector.Decompiler.Tests;
 
 public class ReturnToSenderFixtureCatalogTests
 {
-    public abstract class BodylessDiagnosticFixture
-    {
-        public abstract int MissingBody();
-    }
-
     [Fact]
     public void ReturnToSenderCandidates_ProvideBuiltAssemblyInputs()
     {
@@ -35,6 +30,11 @@ public class ReturnToSenderFixtureCatalogTests
             Assert.True(peReader.HasMetadata);
             Assert.NotEmpty(peReader.GetMetadataReader().MethodDefinitions);
         });
+    }
+
+    public abstract class BodylessDiagnosticFixture
+    {
+        public abstract int MissingBody();
     }
 
     [Fact]
@@ -141,7 +141,7 @@ public class ReturnToSenderFixtureCatalogTests
         using var pe = new PEReader(stream);
         var reader = pe.GetMetadataReader();
         string fullType = typeof(ReturnToSenderFixtureCatalogTests).FullName!;
-        var bodyless = FindMethod(reader, typeof(BodylessDiagnosticFixture).FullName!, nameof(BodylessDiagnosticFixture.MissingBody));
+        var bodyless = FindMethod(reader, MetadataFullName(typeof(BodylessDiagnosticFixture)), nameof(BodylessDiagnosticFixture.MissingBody));
 
         var display = ReturnToSender.BuildIlDiffDiagnostic(
             pe,
@@ -1575,6 +1575,9 @@ public class ReturnToSenderFixtureCatalogTests
         => text is null
             ? null
             : string.Concat(text.Where(c => !char.IsWhiteSpace(c)));
+
+    static string MetadataFullName(Type type)
+        => type.FullName!.Replace('+', '.');
 
     static MethodDefinitionHandle FindMethod(MetadataReader reader, string fullType, string methodName)
     {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -17,6 +17,11 @@ namespace ILInspector.Decompiler.Tests;
 
 public class ReturnToSenderFixtureCatalogTests
 {
+    public abstract class BodylessDiagnosticFixture
+    {
+        public abstract int MissingBody();
+    }
+
     [Fact]
     public void ReturnToSenderCandidates_ProvideBuiltAssemblyInputs()
     {
@@ -127,6 +132,27 @@ public class ReturnToSenderFixtureCatalogTests
         Assert.NotEmpty(display!.Rows);
         Assert.Contains(display.Rows, row => row.Kind == IlDiffKind.Remove);
         Assert.Contains(display.Rows, row => row.Kind == IlDiffKind.Add);
+    }
+
+    [Fact]
+    public void ReturnToSenderIlDiffDiagnostic_SuppressesBodylessMethods()
+    {
+        using var stream = File.OpenRead(typeof(ReturnToSenderFixtureCatalogTests).Assembly.Location);
+        using var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+        string fullType = typeof(ReturnToSenderFixtureCatalogTests).FullName!;
+        var bodyless = FindMethod(reader, typeof(BodylessDiagnosticFixture).FullName!, nameof(BodylessDiagnosticFixture.MissingBody));
+
+        var display = ReturnToSender.BuildIlDiffDiagnostic(
+            pe,
+            reader,
+            bodyless,
+            pe,
+            fullType,
+            nameof(DecompilerResult_ExposesEffectiveOptionsAndTasteDecisions),
+            overload: 0);
+
+        Assert.Null(display);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -6,6 +6,7 @@ using DotnetInspector.Fixtures;
 using ILInspector.Decompiler;
 using ILInspector.DecompilerHarness;
 using ILInspector.Decompiler.Pipeline;
+using ILInspector.Instructions;
 using ILInspector.Metadata;
 
 using Microsoft.CodeAnalysis;
@@ -102,6 +103,30 @@ public class ReturnToSenderFixtureCatalogTests
         Assert.Contains("System.Math", result.Detail);
         Assert.Equal("returnSystem.Math.Abs(value);", Normalize(result.ExpectedBody));
         Assert.Equal("returnMath.Abs(value);", Normalize(result.ActualBody));
+    }
+
+    [Fact]
+    public void ReturnToSenderIlDiffDiagnostic_ProjectsMemberScopedDiffEvidence()
+    {
+        using var stream = File.OpenRead(typeof(ReturnToSenderFixtureCatalogTests).Assembly.Location);
+        using var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+        string fullType = typeof(ReturnToSenderFixtureCatalogTests).FullName!;
+        var original = FindMethod(reader, fullType, nameof(FixtureCatalog_ExposesCheckedInSourcePaths));
+
+        var display = ReturnToSender.BuildIlDiffDiagnostic(
+            pe,
+            reader,
+            original,
+            pe,
+            fullType,
+            nameof(DecompilerResult_ExposesEffectiveOptionsAndTasteDecisions),
+            overload: 0);
+
+        Assert.NotNull(display);
+        Assert.NotEmpty(display!.Rows);
+        Assert.Contains(display.Rows, row => row.Kind == IlDiffKind.Remove);
+        Assert.Contains(display.Rows, row => row.Kind == IlDiffKind.Add);
     }
 
     [Fact]
@@ -1524,4 +1549,23 @@ public class ReturnToSenderFixtureCatalogTests
         => text is null
             ? null
             : string.Concat(text.Where(c => !char.IsWhiteSpace(c)));
+
+    static MethodDefinitionHandle FindMethod(MetadataReader reader, string fullType, string methodName)
+    {
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var type = reader.GetTypeDefinition(typeHandle);
+            if (reader.GetFullTypeName(type) != fullType)
+                continue;
+
+            foreach (var methodHandle in type.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (reader.GetString(method.Name) == methodName)
+                    return methodHandle;
+            }
+        }
+
+        throw new InvalidOperationException($"{fullType}::{methodName} not found.");
+    }
 }

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -703,7 +703,7 @@ static class ReturnToSender
                 var recompiledOps = FindAndDisassemble(recompiled, fullType, methodName, overload: 0)
                     ?.Select(instruction => CanonicalOpcode(instruction.OpCodeName))
                     .ToArray();
-                var ilDiffDiagnostic = BuildIlDiffDiagnostic(reader, pe, getter, recompiled, fullType, methodName, overload: 0);
+                var ilDiffDiagnostic = BuildIlDiffDiagnostic(pe, reader, getterHandle, recompiled, fullType, methodName, overload: 0);
 
                 if (recompiledOps is null)
                 {
@@ -861,7 +861,7 @@ static class ReturnToSender
                 var recompiledOps = FindAndDisassemble(recompiled, fullType, methodName, overload: 0)
                     ?.Select(instruction => CanonicalOpcode(instruction.OpCodeName))
                     .ToArray();
-                var ilDiffDiagnostic = BuildIlDiffDiagnostic(reader, pe, method, recompiled, fullType, methodName, overload: 0);
+                var ilDiffDiagnostic = BuildIlDiffDiagnostic(pe, reader, methodHandle, recompiled, fullType, methodName, overload: 0);
 
                 if (recompiledOps is null)
                 {
@@ -1020,7 +1020,7 @@ static class ReturnToSender
                 var recompiledOps = FindAndDisassemble(recompiled, fullType, methodName, overload: 0)
                     ?.Select(instruction => CanonicalOpcode(instruction.OpCodeName))
                     .ToArray();
-                var ilDiffDiagnostic = BuildIlDiffDiagnostic(reader, pe, setter, recompiled, fullType, methodName, overload: 0);
+                var ilDiffDiagnostic = BuildIlDiffDiagnostic(pe, reader, setterHandle, recompiled, fullType, methodName, overload: 0);
 
                 if (recompiledOps is null)
                 {
@@ -1290,7 +1290,7 @@ static class ReturnToSender
             ? ILDisassembler.Disassemble(pe, found.Reader, found.Method)
             : null;
 
-    static (MetadataReader Reader, MethodDefinition Method)? FindMethodDefinition(
+    static (MetadataReader Reader, MethodDefinitionHandle Handle, MethodDefinition Method)? FindMethodDefinition(
         PEReader pe,
         string fullType,
         string methodName,
@@ -1314,35 +1314,35 @@ static class ReturnToSender
                     continue;
                 if (seen++ != overload)
                     continue;
-                return (reader, method);
+                return (reader, methodHandle, method);
             }
         }
 
         return null;
     }
 
-    static IlDiffDisplayResult? BuildIlDiffDiagnostic(
-        MetadataReader originalReader,
+    internal static IlDiffDisplayResult? BuildIlDiffDiagnostic(
         PEReader originalPe,
-        MethodDefinition originalMethod,
+        MetadataReader originalReader,
+        MethodDefinitionHandle originalMethod,
         PEReader recompiledPe,
         string fullType,
         string methodName,
         int overload)
     {
-        if (originalMethod.RelativeVirtualAddress == 0)
-            return null;
         if (FindMethodDefinition(recompiledPe, fullType, methodName, overload) is not { } recompiled)
             return null;
-        if (recompiled.Method.RelativeVirtualAddress == 0)
-            return null;
 
-        var diff = IlBodyDiff.Compare(
+        var diff = IlAssemblyDiff.CompareMembers(
+            originalPe,
             originalReader,
-            originalPe.GetMethodBody(originalMethod.RelativeVirtualAddress),
+            originalMethod,
+            recompiledPe,
             recompiled.Reader,
-            recompiledPe.GetMethodBody(recompiled.Method.RelativeVirtualAddress));
-        var display = IlDiffPrinter.ToDisplayResult(diff);
+            recompiled.Handle,
+            oldLabel: $"{fullType}::{methodName}",
+            newLabel: $"{fullType}::{methodName}");
+        var display = IlDiffPrinter.ToDisplayResult(diff.Diff);
         return display.IsEmpty ? null : display;
     }
 

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1330,7 +1330,11 @@ static class ReturnToSender
         string methodName,
         int overload)
     {
+        if (originalReader.GetMethodDefinition(originalMethod).RelativeVirtualAddress == 0)
+            return null;
         if (FindMethodDefinition(recompiledPe, fullType, methodName, overload) is not { } recompiled)
+            return null;
+        if (recompiled.Method.RelativeVirtualAddress == 0)
             return null;
 
         var diff = IlAssemblyDiff.CompareMembers(


### PR DESCRIPTION
## Summary

- Route `ReturnToSender` IL diagnostics through `IlAssemblyDiff.CompareMembers`.
- Keep the existing `IlDiffDisplayResult` projection via `IlDiffPrinter`, so report/card consumers continue to see the same display shape.
- Add a focused RTS fixture test that projects member-scoped IL diff evidence through the RTS diagnostic helper.

## Validation

- `dotnetup dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -class ILInspector.Decompiler.Tests.ReturnToSenderFixtureCatalogTests`
- `dotnetup dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --no-restore`
- `dotnetup dotnet build dotnet-inspect.slnx -c Release --no-restore`

Note: the harness/solution build logged transient MSB3026 copy retries from concurrent local builds, then succeeded with 0 errors.