### PR TITLE
Add measurement-only leak-actionability corpus sensor (#2439)

### DIFF
--- a/tools/AnalysisHarness/AnalysisHarness.csproj
+++ b/tools/AnalysisHarness/AnalysisHarness.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../../src/ILInspector.Analysis/ILInspector.Analysis.csproj" />
+    <ProjectReference Include="../../src/ILInspector.Instructions/ILInspector.Instructions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/AnalysisHarness/LeakActionabilitySensor.cs
+++ b/tools/AnalysisHarness/LeakActionabilitySensor.cs
@@ -238,7 +238,7 @@ public static class LeakActionabilitySensor
     // (each level costs >= 1 byte), so refuse over-long blobs pre-decode. Real single-type TypeSpec
     // blobs are tiny (CoreLib's largest is 57 bytes), so 1024 only trips on malformed/adversarial
     // input. Mirrors ILInspector.Analysis.TypeRefDecoder's MaxSignatureBlobLength guard.
-    const int MaxTypeSpecBlobLength = 1024;
+    internal const int MaxTypeSpecBlobLength = 1024;
 
     static string TypeSpecName(MetadataReader reader, TypeSpecificationHandle handle)
     {
@@ -433,8 +433,40 @@ sealed class SignatureTypeNameProvider : ISignatureTypeProvider<string, object?>
         return ns.Length == 0 ? name : $"{ns}.{name}";
     }
 
+    // A nested TypeSpecification reference (e.g. a custom modifier or a CLASS/VALUETYPE token that
+    // itself resolves to a TypeSpec) re-enters DecodeSignature. Each re-entry is a MANAGED frame
+    // here plus SRM native DecodeType frames, so a self-referential or long TypeSpec CHAIN - whose
+    // individual blobs each stay under MaxTypeSpecBlobLength - would recurse until an uncatchable
+    // StackOverflow kills the process. The outer TypeSpecName length cap only bounds the ENTRY
+    // blob's native depth, not this cross-TypeSpec re-entry, so bound both the re-entry depth and
+    // each nested blob's length here (mirrors ILInspector.Analysis.TypeRefDecoder). The classifier
+    // never uses a nested TypeSpec's decoded name (modifiers/type-args are discarded), so failing
+    // closed to "(typespec)" past the cap is loss-free.
+    const int MaxTypeSpecDepth = 16;
+
+    [ThreadStatic]
+    static int s_typeSpecDepth;
+
     public string GetTypeFromSpecification(MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
-        => reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+    {
+        var typeSpec = reader.GetTypeSpecification(handle);
+        if (s_typeSpecDepth >= MaxTypeSpecDepth ||
+            reader.GetBlobReader(typeSpec.Signature).Length > LeakActionabilitySensor.MaxTypeSpecBlobLength)
+            return "(typespec)";
+        s_typeSpecDepth++;
+        try
+        {
+            return typeSpec.DecodeSignature(this, genericContext);
+        }
+        catch
+        {
+            return "(typespec)";
+        }
+        finally
+        {
+            s_typeSpecDepth--;
+        }
+    }
 
     public string GetGenericInstantiation(string genericType, ImmutableArray<string> typeArguments) => genericType;
     public string GetSZArrayType(string elementType) => elementType;

--- a/tools/AnalysisHarness/LeakActionabilitySensor.cs
+++ b/tools/AnalysisHarness/LeakActionabilitySensor.cs
@@ -231,11 +231,23 @@ public static class LeakActionabilitySensor
     // A generic type instance (e.g. Span<byte>, INumberBase<T>) names its declaring type through a
     // TypeSpecification blob; decode it to the underlying generic type name (Span`1, INumberBase`1)
     // so wrapper-skipping and member classification see a real type, not "(typespec)".
+    //
+    // SRM's SignatureDecoder.DecodeType recurses on the NATIVE stack once per nested blob element
+    // (e.g. each SZARRAY prefix) BEFORE any provider callback runs, so a pathologically deep blob
+    // StackOverflows uncatchably and kills the whole process. Blob length bounds that native depth
+    // (each level costs >= 1 byte), so refuse over-long blobs pre-decode. Real single-type TypeSpec
+    // blobs are tiny (CoreLib's largest is 57 bytes), so 1024 only trips on malformed/adversarial
+    // input. Mirrors ILInspector.Analysis.TypeRefDecoder's MaxSignatureBlobLength guard.
+    const int MaxTypeSpecBlobLength = 1024;
+
     static string TypeSpecName(MetadataReader reader, TypeSpecificationHandle handle)
     {
+        var typeSpec = reader.GetTypeSpecification(handle);
+        if (reader.GetBlobReader(typeSpec.Signature).Length > MaxTypeSpecBlobLength)
+            return "(typespec)";
         try
         {
-            return reader.GetTypeSpecification(handle).DecodeSignature(SignatureTypeNameProvider.Instance, genericContext: null);
+            return typeSpec.DecodeSignature(SignatureTypeNameProvider.Instance, genericContext: null);
         }
         catch
         {
@@ -266,7 +278,7 @@ public static class LeakActionabilitySensor
         string type = Short(declaringType);
         if (member is "op_Implicit" or "op_Explicit")
             return true;
-        if (member is ".ctor" && type is "Span`1" or "ReadOnlySpan`1" or "Memory`1" or "ReadOnlyMemory`1")
+        if (member is ".ctor" && type is "Span" or "ReadOnlySpan" or "Memory" or "ReadOnlyMemory")
             return true;
         return member is "AsSpan" or "AsMemory" or "Slice" or "GetPinnableReference" or "GetArrayDataReference";
     }
@@ -279,7 +291,7 @@ public static class LeakActionabilitySensor
 
         // Untrusted: read / decode / parse external input.
         if (IsStreamLike(type) && m.StartsWith("Read")) return Untrusted; // Read/ReadByte/ReadAsync/ReadExactly[Async]/ReadAtLeast[Async]
-        if (type is "Decoder" && m is "GetChars" or "Convert") return Untrusted;
+        if ((type is "Decoder" || type.EndsWith("Decoder")) && m is "GetChars" or "GetString" or "Convert") return Untrusted;
         if ((type is "Encoding" || type.EndsWith("Encoding")) && m is "GetChars" or "GetString") return Untrusted;
         if (type is "Socket" && m.StartsWith("Receive")) return Untrusted;
         if (type is "TextReader" or "StreamReader" or "BinaryReader" && m.StartsWith("Read")) return Untrusted;
@@ -303,7 +315,15 @@ public static class LeakActionabilitySensor
 
     static bool IsStreamLike(string type) => type is "Stream" || type.EndsWith("Stream");
 
-    static string Short(string type) => type.Contains('.') ? type[(type.LastIndexOf('.') + 1)..] : type;
+    // Strip the namespace and any generic-arity backtick suffix so classifier checks (which use bare
+    // names like "Stream"/"Encoding"/"Span") match generic instances too (System.Span`1 -> Span).
+    static string Short(string type)
+    {
+        if (type.Contains('.'))
+            type = type[(type.LastIndexOf('.') + 1)..];
+        int tick = type.IndexOf('`');
+        return tick >= 0 ? type[..tick] : type;
+    }
 
     public static string Format(LeakActionabilityReport report, int maxExamples, LeakActionabilityFormat format)
     {

--- a/tools/AnalysisHarness/LeakActionabilitySensor.cs
+++ b/tools/AnalysisHarness/LeakActionabilitySensor.cs
@@ -1,6 +1,8 @@
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
+using System.Collections.Immutable;
+using System.Runtime.InteropServices;
 
 using Markout;
 using Markout.Formatting;
@@ -102,8 +104,9 @@ public static class LeakActionabilitySensor
             if (exceptionPath.Count == 0)
                 return new LeakActionabilityAssembly(name, Opened: true, TimedOut: false, 0, new Dictionary<string, int>(), []);
 
-            using var stream = File.OpenRead(path);
-            using var pe = new PEReader(stream);
+            // Read into memory so no file handle is held during token resolution
+            // (resolution runs under the outer per-assembly timeout).
+            using var pe = new PEReader(ImmutableCollectionsMarshal.AsImmutableArray(File.ReadAllBytes(path)));
             var reader = pe.GetMetadataReader();
 
             var classCounts = new SortedDictionary<string, int>(StringComparer.Ordinal);
@@ -178,20 +181,36 @@ public static class LeakActionabilitySensor
         switch (handle.Kind)
         {
             case HandleKind.MethodDefinition:
-            {
-                var md = reader.GetMethodDefinition((MethodDefinitionHandle)handle);
-                return (TypeName(reader, md.GetDeclaringType()), reader.GetString(md.Name));
-            }
+                return ResolveMethodDef(reader, (MethodDefinitionHandle)handle);
             case HandleKind.MemberReference:
-            {
-                var mr = reader.GetMemberReference((MemberReferenceHandle)handle);
-                return (ParentName(reader, mr.Parent), reader.GetString(mr.Name));
-            }
+                return ResolveMemberRef(reader, (MemberReferenceHandle)handle);
             case HandleKind.MethodSpecification:
-                return ResolveToken(reader, MetadataTokens.GetToken(reader.GetMethodSpecification((MethodSpecificationHandle)handle).Method));
+            {
+                // MethodSpec.Method is a MethodDefOrRef coded index (MethodDef or MemberRef only -
+                // never another MethodSpec), so resolve it directly rather than recursing.
+                var method = reader.GetMethodSpecification((MethodSpecificationHandle)handle).Method;
+                return method.Kind switch
+                {
+                    HandleKind.MethodDefinition => ResolveMethodDef(reader, (MethodDefinitionHandle)method),
+                    HandleKind.MemberReference => ResolveMemberRef(reader, (MemberReferenceHandle)method),
+                    _ => ("", $"(methodspec:{method.Kind})"),
+                };
+            }
             default:
                 return ("", $"(token:{handle.Kind})");
         }
+    }
+
+    static (string Type, string Name) ResolveMethodDef(MetadataReader reader, MethodDefinitionHandle handle)
+    {
+        var md = reader.GetMethodDefinition(handle);
+        return (TypeName(reader, md.GetDeclaringType()), reader.GetString(md.Name));
+    }
+
+    static (string Type, string Name) ResolveMemberRef(MetadataReader reader, MemberReferenceHandle handle)
+    {
+        var mr = reader.GetMemberReference(handle);
+        return (ParentName(reader, mr.Parent), reader.GetString(mr.Name));
     }
 
     static string TypeName(MetadataReader reader, TypeDefinitionHandle handle)
@@ -205,9 +224,24 @@ public static class LeakActionabilitySensor
     {
         HandleKind.TypeReference => TypeRefName(reader, (TypeReferenceHandle)parent),
         HandleKind.TypeDefinition => TypeName(reader, (TypeDefinitionHandle)parent),
-        HandleKind.TypeSpecification => "(typespec)",
+        HandleKind.TypeSpecification => TypeSpecName(reader, (TypeSpecificationHandle)parent),
         _ => $"({parent.Kind})",
     };
+
+    // A generic type instance (e.g. Span<byte>, INumberBase<T>) names its declaring type through a
+    // TypeSpecification blob; decode it to the underlying generic type name (Span`1, INumberBase`1)
+    // so wrapper-skipping and member classification see a real type, not "(typespec)".
+    static string TypeSpecName(MetadataReader reader, TypeSpecificationHandle handle)
+    {
+        try
+        {
+            return reader.GetTypeSpecification(handle).DecodeSignature(SignatureTypeNameProvider.Instance, genericContext: null);
+        }
+        catch
+        {
+            return "(typespec)";
+        }
+    }
 
     static string TypeRefName(MetadataReader reader, TypeReferenceHandle handle)
     {
@@ -244,7 +278,7 @@ public static class LeakActionabilitySensor
         string m = member;
 
         // Untrusted: read / decode / parse external input.
-        if (IsStreamLike(type) && m is "Read" or "ReadAsync" or "ReadByte" or "ReadAtLeast" or "ReadExactly") return Untrusted;
+        if (IsStreamLike(type) && m.StartsWith("Read")) return Untrusted; // Read/ReadByte/ReadAsync/ReadExactly[Async]/ReadAtLeast[Async]
         if (type is "Decoder" && m is "GetChars" or "Convert") return Untrusted;
         if ((type is "Encoding" || type.EndsWith("Encoding")) && m is "GetChars" or "GetString") return Untrusted;
         if (type is "Socket" && m.StartsWith("Receive")) return Untrusted;
@@ -253,7 +287,7 @@ public static class LeakActionabilitySensor
         if ((m is "Parse" or "TryParse" || m.StartsWith("Parse")) && (type.Contains("Document") || type.Contains("Reader") || type.Contains("Parser"))) return Untrusted;
 
         // Trusted: produce / transform validated in-memory data.
-        if (m.Contains("Escape")) return Trusted;
+        if (m.StartsWith("Escape")) return Trusted; // EscapeString/... - NOT Unescape (which decodes external input)
         if ((type is "Encoding" || type.EndsWith("Encoding")) && m is "GetBytes" or "GetByteCount") return Trusted;
         if (m.StartsWith("Encode") || m.StartsWith("Transcode") || m is "ToUtf8" or "EncodeHelper") return Trusted;
         if (type is "Array" && m is "Copy" or "Clear" or "Resize" or "Fill") return Trusted;
@@ -353,6 +387,45 @@ public static class LeakActionabilitySensor
             ByClass = [.. ClassRows(report).Select(r => new LeakActionabilitySectionClassRow("By class", r.Class, r.Count))],
             Examples = [.. ExampleRows(report, maxExamples).Select(r => new LeakActionabilitySectionExampleRow("Examples", r.Class, r.Assembly, r.Method, r.BoundarySet))],
         };
+}
+
+/// <summary>A minimal signature decoder that yields type names as strings, used to name the
+/// declaring type behind a generic-instance boundary (e.g. <c>Span`1</c>, <c>INumberBase`1</c>).
+/// It keeps the outer generic type name and ignores type arguments - the classifier only needs the
+/// declaring type, not its instantiation.</summary>
+sealed class SignatureTypeNameProvider : ISignatureTypeProvider<string, object?>
+{
+    public static readonly SignatureTypeNameProvider Instance = new();
+
+    public string GetPrimitiveType(PrimitiveTypeCode typeCode) => typeCode.ToString();
+
+    public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
+    {
+        var td = reader.GetTypeDefinition(handle);
+        string ns = reader.GetString(td.Namespace), name = reader.GetString(td.Name);
+        return ns.Length == 0 ? name : $"{ns}.{name}";
+    }
+
+    public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+    {
+        var tr = reader.GetTypeReference(handle);
+        string ns = reader.GetString(tr.Namespace), name = reader.GetString(tr.Name);
+        return ns.Length == 0 ? name : $"{ns}.{name}";
+    }
+
+    public string GetTypeFromSpecification(MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
+        => reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+
+    public string GetGenericInstantiation(string genericType, ImmutableArray<string> typeArguments) => genericType;
+    public string GetSZArrayType(string elementType) => elementType;
+    public string GetArrayType(string elementType, ArrayShape shape) => elementType;
+    public string GetByReferenceType(string elementType) => elementType;
+    public string GetPointerType(string elementType) => elementType;
+    public string GetPinnedType(string elementType) => elementType;
+    public string GetModifiedType(string modifier, string unmodifiedType, bool isRequired) => unmodifiedType;
+    public string GetGenericMethodParameter(object? genericContext, int index) => $"!!{index}";
+    public string GetGenericTypeParameter(object? genericContext, int index) => $"!{index}";
+    public string GetFunctionPointerType(MethodSignature<string> signature) => "(fnptr)";
 }
 
 [MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]

--- a/tools/AnalysisHarness/LeakActionabilitySensor.cs
+++ b/tools/AnalysisHarness/LeakActionabilitySensor.cs
@@ -1,0 +1,419 @@
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+using Markout;
+using Markout.Formatting;
+
+using ILInspector.Analysis;
+using ILInspector.Instructions;
+
+namespace ILInspector.AnalysisHarness;
+
+/// <summary>One classified exception-path candidate: its actionability class, method, and the
+/// distinct boundary members the rented array flows into between Rent and return.</summary>
+public sealed record LeakActionabilityExample(string Class, string Method, string BoundarySet);
+
+/// <summary>Per-assembly actionability result: whether it opened, how many exception-path
+/// candidates it produced, the per-class histogram, and a few example rows.</summary>
+public sealed record LeakActionabilityAssembly(
+    string Name,
+    bool Opened,
+    bool TimedOut,
+    int Candidates,
+    IReadOnlyDictionary<string, int> ClassCounts,
+    IReadOnlyList<LeakActionabilityExample> Examples);
+
+/// <summary>An actionability census: per-assembly rows plus aggregate per-class totals.</summary>
+public sealed record LeakActionabilityReport(
+    IReadOnlyList<LeakActionabilityAssembly> Assemblies,
+    IReadOnlyDictionary<string, int> TotalsByClass,
+    int Total);
+
+public enum LeakActionabilityFormat { Markdown, Tsv, Jsonl }
+
+/// <summary>
+/// The leak-actionability corpus sensor (#2439): a measurement-only classifier for the
+/// <see cref="LeakTriageAnalyzer"/> <c>exception-path-leak-candidate</c> bucket. It changes no
+/// analyzer behavior and wires no product surface - it reads the analyzer's public candidates and,
+/// per candidate, re-resolves via SRM every call the rented array flows into between Rent and the
+/// method's end, then classifies the boundary set by what it touches:
+/// <list type="bullet">
+/// <item><b>Untrusted</b> - a boundary reads/decodes/parses <i>external</i> input (Stream.Read,
+/// Decoder.GetChars, Encoding.GetString, Parse/Tokenize/Deserialize): genuinely actionable, since
+/// the exception is one a caller commonly catches.</item>
+/// <item><b>Trusted</b> - every boundary is an in-memory transform of already-validated data
+/// (Escape, Encode/Transcode, Array.Copy, format/write, new string): low actionability - the
+/// deliberate high-perf no-<c>finally</c> BCL idiom that leaks only on a rare/invariant-violating
+/// exception.</item>
+/// <item><b>Unknown</b> - unclassified boundary; stays measurement-only.</item>
+/// </list>
+/// A candidate is Untrusted if <i>any</i> boundary is untrusted, else Trusted if any is a known
+/// in-memory transform, else Unknown. This is the evidence engine for the #2439 Slice-4 decision
+/// about which exception-path candidates could graduate toward findings; the split is deliberately
+/// separate from the analyzer so it never affects a user-facing accusation.
+///
+/// <para>Precision note: boundary attribution is a Rent-to-end window scan, coarser than the
+/// analyzer's def-use set (it can include an unrelated call in the window). It is exact for the
+/// small single-rent methods this bucket is dominated by; a def-use-precise attribution is the
+/// natural follow-up.</para>
+/// </summary>
+public static class LeakActionabilitySensor
+{
+    public const string Untrusted = "untrusted-actionable";
+    public const string Trusted = "trusted-low-actionability";
+    public const string Unknown = "unknown";
+
+    static readonly string[] ClassOrder = [Untrusted, Trusted, Unknown];
+
+    public static LeakActionabilityReport Measure(IReadOnlyList<string> assemblyPaths, int perAssemblyTimeoutSeconds = 120, int examplesPerAssembly = 5)
+    {
+        var assemblies = new List<LeakActionabilityAssembly>(assemblyPaths.Count);
+        foreach (var path in assemblyPaths)
+            assemblies.Add(MeasureWithTimeout(path, perAssemblyTimeoutSeconds, examplesPerAssembly));
+        assemblies.Sort((a, b) => string.CompareOrdinal(a.Name, b.Name));
+
+        var totals = new SortedDictionary<string, int>(StringComparer.Ordinal);
+        foreach (var assembly in assemblies)
+            foreach (var (cls, count) in assembly.ClassCounts)
+                totals[cls] = totals.GetValueOrDefault(cls) + count;
+
+        return new LeakActionabilityReport(assemblies, totals, assemblies.Sum(a => a.Candidates));
+    }
+
+    static LeakActionabilityAssembly MeasureWithTimeout(string path, int timeoutSeconds, int examplesPerAssembly)
+    {
+        string name = Path.GetFileName(path);
+        LeakActionabilityAssembly? result = null;
+        var worker = new Thread(() => result = MeasureOne(path, examplesPerAssembly)) { IsBackground = true };
+        worker.Start();
+        if (worker.Join(TimeSpan.FromSeconds(timeoutSeconds)) && result is not null)
+            return result;
+        return new LeakActionabilityAssembly(name, Opened: false, TimedOut: true, 0, new Dictionary<string, int>(), []);
+    }
+
+    static LeakActionabilityAssembly MeasureOne(string path, int examplesPerAssembly)
+    {
+        string name = Path.GetFileName(path);
+        try
+        {
+            var result = LeakTriageAnalyzer.AnalyzeAssemblyDetailed(path);
+            var exceptionPath = result.Candidates.Where(c => c.Shape == "exception-path-leak-candidate").ToList();
+            if (exceptionPath.Count == 0)
+                return new LeakActionabilityAssembly(name, Opened: true, TimedOut: false, 0, new Dictionary<string, int>(), []);
+
+            using var stream = File.OpenRead(path);
+            using var pe = new PEReader(stream);
+            var reader = pe.GetMetadataReader();
+
+            var classCounts = new SortedDictionary<string, int>(StringComparer.Ordinal);
+            var examples = new List<LeakActionabilityExample>();
+            foreach (var candidate in exceptionPath)
+            {
+                var (cls, boundarySet) = Classify(pe, reader, candidate.Method.MetadataToken, candidate.RentOffset ?? candidate.ILOffset);
+                classCounts[cls] = classCounts.GetValueOrDefault(cls) + 1;
+                if (examples.Count < examplesPerAssembly)
+                    examples.Add(new LeakActionabilityExample(
+                        cls,
+                        $"{candidate.Method.DeclaringType.Name}::{candidate.Method.Name}",
+                        boundarySet));
+            }
+
+            return new LeakActionabilityAssembly(name, Opened: true, TimedOut: false, exceptionPath.Count, classCounts, examples);
+        }
+        // Per-assembly boundary on a background thread: convert any input failure (a directory, a
+        // truncated PE, ...) into a failed row and keep sweeping the corpus.
+        catch (Exception)
+        {
+            return new LeakActionabilityAssembly(name, Opened: false, TimedOut: false, 0, new Dictionary<string, int>(), []);
+        }
+    }
+
+    // Resolve the boundary set for one candidate and aggregate its actionability class.
+    static (string Class, string BoundarySet) Classify(PEReader pe, MetadataReader reader, int methodToken, int? offset)
+    {
+        if (offset is not { } startOffset)
+            return (Unknown, "(no-offset)");
+        try
+        {
+            var md = reader.GetMethodDefinition((MethodDefinitionHandle)MetadataTokens.EntityHandle(methodToken));
+            if (md.RelativeVirtualAddress == 0)
+                return (Unknown, "(no-body)");
+            var il = pe.GetMethodBody(md.RelativeVirtualAddress).GetILBytes() ?? [];
+            var instructions = InstructionDecoder.Decode(il);
+            int start = -1;
+            for (int i = 0; i < instructions.Length; i++)
+                if (instructions[i].Offset == startOffset) { start = i; break; }
+            if (start < 0)
+                return (Unknown, "(offset-miss)");
+
+            // The array typically flows through non-throwing Span/Memory wrappers before its real
+            // boundary, and a rent can have several boundary uses (write-into then consume). Collect
+            // every substantive (non-wrapper) call from the rented-array use to the method's end.
+            var members = new List<(string Type, string Name)>();
+            for (int i = start; i < instructions.Length; i++)
+            {
+                var opcode = instructions[i].OpCode;
+                if (opcode is not (ILOpCode.Call or ILOpCode.Callvirt or ILOpCode.Newobj))
+                    continue;
+                var member = ResolveToken(reader, checked((int)instructions[i].OperandValue));
+                if (IsInertWrapper(member.Type, member.Name))
+                    continue;
+                members.Add(member);
+            }
+            if (members.Count == 0)
+                return (Unknown, "(only-wrappers)");
+
+            return (Aggregate(members), string.Join(" + ", members.Select(m => $"{Short(m.Type)}::{m.Name}").Distinct()));
+        }
+        catch (Exception ex)
+        {
+            return (Unknown, $"(err:{ex.GetType().Name})");
+        }
+    }
+
+    static (string Type, string Name) ResolveToken(MetadataReader reader, int token)
+    {
+        var handle = MetadataTokens.EntityHandle(token);
+        switch (handle.Kind)
+        {
+            case HandleKind.MethodDefinition:
+            {
+                var md = reader.GetMethodDefinition((MethodDefinitionHandle)handle);
+                return (TypeName(reader, md.GetDeclaringType()), reader.GetString(md.Name));
+            }
+            case HandleKind.MemberReference:
+            {
+                var mr = reader.GetMemberReference((MemberReferenceHandle)handle);
+                return (ParentName(reader, mr.Parent), reader.GetString(mr.Name));
+            }
+            case HandleKind.MethodSpecification:
+                return ResolveToken(reader, MetadataTokens.GetToken(reader.GetMethodSpecification((MethodSpecificationHandle)handle).Method));
+            default:
+                return ("", $"(token:{handle.Kind})");
+        }
+    }
+
+    static string TypeName(MetadataReader reader, TypeDefinitionHandle handle)
+    {
+        var td = reader.GetTypeDefinition(handle);
+        string ns = reader.GetString(td.Namespace), name = reader.GetString(td.Name);
+        return ns.Length == 0 ? name : $"{ns}.{name}";
+    }
+
+    static string ParentName(MetadataReader reader, EntityHandle parent) => parent.Kind switch
+    {
+        HandleKind.TypeReference => TypeRefName(reader, (TypeReferenceHandle)parent),
+        HandleKind.TypeDefinition => TypeName(reader, (TypeDefinitionHandle)parent),
+        HandleKind.TypeSpecification => "(typespec)",
+        _ => $"({parent.Kind})",
+    };
+
+    static string TypeRefName(MetadataReader reader, TypeReferenceHandle handle)
+    {
+        var tr = reader.GetTypeReference(handle);
+        string ns = reader.GetString(tr.Namespace), name = reader.GetString(tr.Name);
+        return ns.Length == 0 ? name : $"{ns}.{name}";
+    }
+
+    // A leak is actionable if ANY reachable boundary can throw on external input, so Untrusted
+    // dominates; else Trusted if any boundary is a known in-memory transform; else Unknown.
+    static string Aggregate(List<(string Type, string Name)> members)
+    {
+        var classes = members.Select(m => ClassifyMember(m.Type, m.Name)).ToList();
+        if (classes.Contains(Untrusted)) return Untrusted;
+        if (classes.Contains(Trusted)) return Trusted;
+        return Unknown;
+    }
+
+    // Non-throwing Span/Memory adapters the rented array flows through before its real boundary.
+    static bool IsInertWrapper(string declaringType, string member)
+    {
+        string type = Short(declaringType);
+        if (member is "op_Implicit" or "op_Explicit")
+            return true;
+        if (member is ".ctor" && type is "Span`1" or "ReadOnlySpan`1" or "Memory`1" or "ReadOnlyMemory`1")
+            return true;
+        return member is "AsSpan" or "AsMemory" or "Slice" or "GetPinnableReference" or "GetArrayDataReference";
+    }
+
+    // Consume-external => Untrusted; produce-from-memory => Trusted; otherwise Unknown.
+    static string ClassifyMember(string declaringType, string member)
+    {
+        string type = Short(declaringType);
+        string m = member;
+
+        // Untrusted: read / decode / parse external input.
+        if (IsStreamLike(type) && m is "Read" or "ReadAsync" or "ReadByte" or "ReadAtLeast" or "ReadExactly") return Untrusted;
+        if (type is "Decoder" && m is "GetChars" or "Convert") return Untrusted;
+        if ((type is "Encoding" || type.EndsWith("Encoding")) && m is "GetChars" or "GetString") return Untrusted;
+        if (type is "Socket" && m.StartsWith("Receive")) return Untrusted;
+        if (type is "TextReader" or "StreamReader" or "BinaryReader" && m.StartsWith("Read")) return Untrusted;
+        if (m.StartsWith("Deserialize") || m.StartsWith("Tokenize") || m is "Decode") return Untrusted;
+        if ((m is "Parse" or "TryParse" || m.StartsWith("Parse")) && (type.Contains("Document") || type.Contains("Reader") || type.Contains("Parser"))) return Untrusted;
+
+        // Trusted: produce / transform validated in-memory data.
+        if (m.Contains("Escape")) return Trusted;
+        if ((type is "Encoding" || type.EndsWith("Encoding")) && m is "GetBytes" or "GetByteCount") return Trusted;
+        if (m.StartsWith("Encode") || m.StartsWith("Transcode") || m is "ToUtf8" or "EncodeHelper") return Trusted;
+        if (type is "Array" && m is "Copy" or "Clear" or "Resize" or "Fill") return Trusted;
+        if (type is "Buffer" && m.StartsWith("Block")) return Trusted;
+        if (type is "Unsafe" or "MemoryMarshal") return Trusted;
+        if (type is "String" && m is ".ctor") return Trusted;
+        if (m is "CopyTo" && !IsStreamLike(type)) return Trusted;
+        if (m.StartsWith("TryFormat") || m.StartsWith("Format")) return Trusted;
+        if (m.StartsWith("WriteString") || m.StartsWith("WriteValue") || m is "WriteStringByOptions" or "WriteStringByOptionsPropertyName") return Trusted;
+
+        return Unknown;
+    }
+
+    static bool IsStreamLike(string type) => type is "Stream" || type.EndsWith("Stream");
+
+    static string Short(string type) => type.Contains('.') ? type[(type.LastIndexOf('.') + 1)..] : type;
+
+    public static string Format(LeakActionabilityReport report, int maxExamples, LeakActionabilityFormat format)
+    {
+        var output = new StringWriter();
+        if (format == LeakActionabilityFormat.Markdown)
+        {
+            MarkoutSerializer.Serialize(
+                BuildMarkdownView(report, maxExamples),
+                output,
+                new MarkdownFormatter(),
+                LeakActionabilityViewContext.Default,
+                new MarkoutWriterOptions());
+        }
+        else
+        {
+            MarkoutSerializer.Serialize(
+                BuildTableView(report, maxExamples),
+                output,
+                new TableFormatter(showHeader: true),
+                LeakActionabilityViewContext.Default,
+                format == LeakActionabilityFormat.Tsv
+                    ? new MarkoutWriterOptions { TableMode = MarkoutTableMode.Tsv, OmitEmptyJsonFields = true }
+                    : new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, OmitEmptyJsonFields = true });
+        }
+
+        string rendered = output.ToString();
+        return format == LeakActionabilityFormat.Jsonl
+            ? string.Join(Environment.NewLine, rendered.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries)) + Environment.NewLine
+            : rendered;
+    }
+
+    static IReadOnlyList<(string Metric, string Value)> SummaryRows(LeakActionabilityReport report)
+        => new (string, string)[]
+        {
+            ("assemblies", report.Assemblies.Count.ToString()),
+            ("opened", report.Assemblies.Count(a => a.Opened).ToString()),
+            ("failed", report.Assemblies.Count(a => !a.Opened && !a.TimedOut).ToString()),
+            ("timed out", report.Assemblies.Count(a => a.TimedOut).ToString()),
+            ("exception-path candidates", report.Total.ToString()),
+            ("untrusted (actionable)", report.TotalsByClass.GetValueOrDefault(Untrusted).ToString()),
+        };
+
+    // Classes in canonical order (Untrusted, Trusted, Unknown), skipping any that never fired.
+    static IReadOnlyList<(string Class, string Count)> ClassRows(LeakActionabilityReport report)
+        => [.. ClassOrder
+            .Where(cls => report.TotalsByClass.ContainsKey(cls))
+            .Select(cls => (cls, report.TotalsByClass[cls].ToString()))];
+
+    static IReadOnlyList<(string Class, string Assembly, string Method, string BoundarySet)> ExampleRows(LeakActionabilityReport report, int maxExamples)
+    {
+        var rows = new List<(string, string, string, string)>();
+        foreach (var cls in ClassOrder)
+        {
+            int taken = 0;
+            foreach (var assembly in report.Assemblies)
+            {
+                foreach (var example in assembly.Examples.Where(e => e.Class == cls))
+                {
+                    if (taken >= maxExamples) break;
+                    rows.Add((cls, assembly.Name, example.Method, example.BoundarySet));
+                    taken++;
+                }
+                if (taken >= maxExamples) break;
+            }
+        }
+        return rows;
+    }
+
+    static LeakActionabilityCardMarkdownView BuildMarkdownView(LeakActionabilityReport report, int maxExamples)
+        => new()
+        {
+            Summary = [.. SummaryRows(report).Select(r => new LeakActionabilityMetricRow(r.Metric, r.Value))],
+            ByClass = [.. ClassRows(report).Select(r => new LeakActionabilityClassRow(r.Class, r.Count))],
+            Examples = [.. ExampleRows(report, maxExamples).Select(r => new LeakActionabilityExampleRow(r.Class, r.Assembly, r.Method, r.BoundarySet))],
+        };
+
+    static LeakActionabilityCardTableView BuildTableView(LeakActionabilityReport report, int maxExamples)
+        => new()
+        {
+            Summary = [.. SummaryRows(report).Select(r => new LeakActionabilitySectionMetricRow("Summary", r.Metric, r.Value))],
+            ByClass = [.. ClassRows(report).Select(r => new LeakActionabilitySectionClassRow("By class", r.Class, r.Count))],
+            Examples = [.. ExampleRows(report, maxExamples).Select(r => new LeakActionabilitySectionExampleRow("Examples", r.Class, r.Assembly, r.Method, r.BoundarySet))],
+        };
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
+sealed class LeakActionabilityCardMarkdownView
+{
+    [MarkoutIgnore]
+    public string Title => "Leak Actionability Corpus Sensor";
+
+    [MarkoutSection(Name = "Summary")]
+    public List<LeakActionabilityMetricRow>? Summary { get; init; }
+
+    [MarkoutSection(Name = "By class", EmptyText = "None - no exception-path candidates in this corpus.")]
+    public List<LeakActionabilityClassRow>? ByClass { get; init; }
+
+    [MarkoutSection(Name = "Examples", EmptyText = "None")]
+    public List<LeakActionabilityExampleRow>? Examples { get; init; }
+}
+
+[MarkoutSerializable]
+sealed class LeakActionabilityCardTableView
+{
+    [MarkoutIgnore]
+    public string Title => "Leak Actionability Corpus Sensor";
+
+    [MarkoutSection(Name = "Summary")]
+    public List<LeakActionabilitySectionMetricRow>? Summary { get; init; }
+
+    [MarkoutSection(Name = "By class")]
+    public List<LeakActionabilitySectionClassRow>? ByClass { get; init; }
+
+    [MarkoutSection(Name = "Examples")]
+    public List<LeakActionabilitySectionExampleRow>? Examples { get; init; }
+}
+
+[MarkoutSerializable]
+sealed record LeakActionabilityMetricRow(string Metric, string Count);
+
+[MarkoutSerializable]
+sealed record LeakActionabilitySectionMetricRow(string Section, string Metric, string Count);
+
+[MarkoutSerializable]
+sealed record LeakActionabilityClassRow(string Class, string Count);
+
+[MarkoutSerializable]
+sealed record LeakActionabilitySectionClassRow(string Section, string Class, string Count);
+
+[MarkoutSerializable]
+sealed record LeakActionabilityExampleRow(string Class, string Assembly, string Method, string Boundaries);
+
+[MarkoutSerializable]
+sealed record LeakActionabilitySectionExampleRow(string Section, string Class, string Assembly, string Method, string Boundaries);
+
+[MarkoutContextOptions(SuppressTableWarnings = true)]
+[MarkoutContext(typeof(LeakActionabilityCardMarkdownView))]
+[MarkoutContext(typeof(LeakActionabilityCardTableView))]
+[MarkoutContext(typeof(LeakActionabilityMetricRow))]
+[MarkoutContext(typeof(LeakActionabilitySectionMetricRow))]
+[MarkoutContext(typeof(LeakActionabilityClassRow))]
+[MarkoutContext(typeof(LeakActionabilitySectionClassRow))]
+[MarkoutContext(typeof(LeakActionabilityExampleRow))]
+[MarkoutContext(typeof(LeakActionabilitySectionExampleRow))]
+partial class LeakActionabilityViewContext : MarkoutSerializerContext
+{
+}

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -47,6 +47,14 @@ const string Usage =
           for #1992 - the analyzer is precision-first, so an empty card means recall (not a
           user-facing section) is the next lever. --top bounds examples per assembly.
 
+      --leak-actionability <file> [--top N] [--tsv | --jsonl]
+          Classify the leak-triage `exception-path-leak-candidate` bucket by actionability
+          (#2439), measurement-only: for each candidate, resolve the boundary members the rented
+          array flows into and bucket the candidate as untrusted-actionable (a boundary reads/
+          decodes/parses external input), trusted-low-actionability (only in-memory transforms -
+          the deliberate no-finally BCL idiom), or unknown. Changes no analyzer behavior. Formats
+          match --leak-triage; --top bounds examples per class.
+
       Common: --json machine-readable output; --keep keep generated fixture projects.
     """;
 
@@ -74,6 +82,7 @@ string? annotationParityCategory = null;
 string? annotationParityExpected = null;
 string? annotationParityActual = null;
 string? leakTriageList = null;
+string? leakActionabilityList = null;
 bool tsv = false;
 bool jsonl = false;
 int top = 20;
@@ -117,6 +126,9 @@ for (int i = 0; i < args.Length; i++)
         case "--leak-triage":
             leakTriageList = NextPathValue(args, ref i);
             break;
+        case "--leak-actionability":
+            leakActionabilityList = NextPathValue(args, ref i);
+            break;
         case "--tsv":
             tsv = true;
             break;
@@ -148,11 +160,11 @@ for (int i = 0; i < args.Length; i++)
     }
 }
 
-// --tsv/--jsonl are leak-triage-specific format selectors; other modes use --json.
-// Reject them outside --leak-triage rather than silently accepting-and-ignoring them.
-if ((tsv || jsonl) && leakTriageList is null)
+// --tsv/--jsonl are tabular-format selectors for the leak cards; other modes use --json.
+// Reject them elsewhere rather than silently accepting-and-ignoring them.
+if ((tsv || jsonl) && leakTriageList is null && leakActionabilityList is null)
 {
-    Console.Error.WriteLine("--tsv and --jsonl apply only to --leak-triage; other modes use --json.");
+    Console.Error.WriteLine("--tsv and --jsonl apply only to --leak-triage / --leak-actionability; other modes use --json.");
     return 2;
 }
 
@@ -173,6 +185,9 @@ if (annotationParityExpected is not null)
 
 if (leakTriageList is not null)
     return RunLeakTriage(leakTriageList, top, tsv, jsonl || json);
+
+if (leakActionabilityList is not null)
+    return RunLeakActionability(leakActionabilityList, top, tsv, jsonl || json);
 
 if (corpusList is not null)
     return RunCorpus(corpusList, diffBaseline, emitSnapshot, json);
@@ -261,6 +276,37 @@ static int RunLeakTriage(string corpusList, int top, bool tsv, bool jsonl)
 
     var report = LeakTriageSensor.Measure(paths, examplesPerAssembly: top);
     Console.Write(LeakTriageSensor.Format(report, top, format));
+    return 0;
+}
+
+static int RunLeakActionability(string corpusList, int top, bool tsv, bool jsonl)
+{
+    if (!File.Exists(corpusList))
+    {
+        Console.Error.WriteLine($"Corpus list not found: {corpusList}");
+        return 2;
+    }
+
+    if (tsv && jsonl)
+    {
+        Console.Error.WriteLine("--tsv and --jsonl are mutually exclusive.");
+        return 2;
+    }
+
+    LeakActionabilityFormat format = jsonl ? LeakActionabilityFormat.Jsonl : tsv ? LeakActionabilityFormat.Tsv : LeakActionabilityFormat.Markdown;
+
+    var paths = File.ReadAllLines(corpusList)
+        .Select(line => line.Trim())
+        .Where(line => line.Length > 0 && !line.StartsWith('#'))
+        .ToList();
+    if (paths.Count == 0)
+    {
+        Console.Error.WriteLine($"Corpus list is empty: {corpusList}");
+        return 2;
+    }
+
+    var report = LeakActionabilitySensor.Measure(paths, examplesPerAssembly: top);
+    Console.Write(LeakActionabilitySensor.Format(report, top, format));
     return 0;
 }
 

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -156,6 +156,44 @@ model next. A 2026-07-05 run over CoreLib, `Microsoft.CodeAnalysis`, and
 assembly's three known-misuse methods surfaced exactly once each. Wire the section only once this
 card shows non-zero, high-precision rows on real assemblies.
 
+## Leak actionability corpus sensor (#2439)
+
+`--leak-actionability` classifies the leak-triage `exception-path-leak-candidate` bucket by
+**actionability**, as a [Markout](https://github.com/richlander/markout) card:
+
+```bash
+dotnet "$DLL" --leak-actionability assemblies.txt --top 5      # Markdown card (default)
+dotnet "$DLL" --leak-actionability assemblies.txt --tsv        # section-tagged TSV
+dotnet "$DLL" --leak-actionability assemblies.txt --jsonl      # one JSON record per row
+```
+
+Like `--leak-triage`, this is **measurement-only** — it changes no analyzer behavior and wires no
+product surface. For each `exception-path-leak-candidate`, it re-resolves via SRM every call the
+rented array flows into between `Rent` and the method's end, then classifies the boundary set by
+what it touches:
+
+- `untrusted-actionable` — a boundary **reads/decodes/parses external input**
+  (`Stream.Read`, `Decoder.GetChars`, `Encoding.GetString`, `Parse`/`Tokenize`/`Deserialize`):
+  genuinely actionable, since the exception is one a caller commonly catches.
+- `trusted-low-actionability` — every boundary is an **in-memory transform of validated data**
+  (`Escape`, `Encode`/`Transcode`, `Array.Copy`, format/write, `new string`): low actionability —
+  the deliberate high-perf no-`finally` BCL idiom that leaks only on a rare/invariant-violating
+  exception.
+- `unknown` — unclassified boundary; stays measurement-only.
+
+A candidate is `untrusted-actionable` if **any** boundary is untrusted, else
+`trusted-low-actionability` if any is a known in-memory transform, else `unknown`. This is the
+evidence engine for the #2439 Slice-4 decision about which exception-path candidates could graduate
+toward findings; keeping the split out of the analyzer means it never affects a user-facing
+accusation. A 2026-07-07 run over the .NET 9.0.14 shared framework (305 assemblies) classified the
+34 exception-path candidates as 6 `untrusted-actionable` (e.g. `MessagePackReader::ReadStringSlow`,
+`HashAlgorithm::ComputeHash`), 19 `trusted-low-actionability` (e.g. `Utf8JsonWriter` escape
+writers, `BinaryWriter::Write`), and 9 `unknown`.
+
+Boundary attribution is a `Rent`-to-end window scan, coarser than the analyzer's def-use set (it
+can include an unrelated call in the window); it is exact for the small single-rent methods this
+bucket is dominated by. A def-use-precise attribution is the natural follow-up.
+
 ## Allocation convergence parity
 
 The Rung 4 allocation-convergence build must prove that a candidate


### PR DESCRIPTION
## Intent

Graduate the actionability discriminator (prototyped and validated on #2439) into a
harness mode. **Measurement-only**: no analyzer behavior changes, no product surface.

`analysis-harness --leak-actionability <corpus>` classifies the leak-triage
`exception-path-leak-candidate` bucket by what each candidate's throwing boundary touches:

- `untrusted-actionable` — a boundary reads/decodes/parses **external input** (`Stream.Read`,
  `Decoder.GetChars`, `Encoding.GetString`, `Parse`/`Tokenize`/`Deserialize`): genuinely
  actionable, since the exception is one a caller commonly catches.
- `trusted-low-actionability` — only **in-memory transforms** of validated data (`Escape`,
  `Encode`/`Transcode`, `Array.Copy`, format/write, `new string`): the deliberate no-`finally`
  high-perf BCL idiom that leaks only on a rare/invariant-violating exception.
- `unknown` — unclassified boundary; stays measurement-only.

Aggregation is fail-toward-actionable (any untrusted boundary ⇒ actionable). It reads
`LeakTriageAnalyzer`'s public candidates and re-resolves boundaries via SRM; it never touches the
analyzer or a user-facing accusation. This is the evidence engine for the #2439 Slice-4 decision
about which exception-path candidates could graduate toward findings.

## What landed

- `tools/AnalysisHarness/LeakActionabilitySensor.cs` (new) — the classifier + Markout card
  (Summary / By class / Examples), Markdown/TSV/JSONL, mirroring `--leak-triage`.
- `Program.cs` — `--leak-actionability` mode + format guard.
- `README.md` — a documented section.
- Harness gains an `ILInspector.Instructions` project reference (for `InstructionDecoder`).

## Measurement (.NET 9.0.14 shared framework, 305 assemblies)

The 34 `exception-path-leak-candidate` rows classify as:

| Class | Count | Examples |
| --- | ---: | --- |
| `untrusted-actionable` | 6 | `MessagePackReader::ReadStringSlow` (Decoder.GetChars), `HashAlgorithm::ComputeHash` (Stream.Read), `JsonDocument::Parse` |
| `trusted-low-actionability` | 19 | `Utf8JsonWriter` escape writers, `BinaryWriter::Write`, `EncodingExtensions::GetBytes` |
| `unknown` | 9 | `INumberBase<T>::Parse` (generic-param `Parse` boundary), `ECDsa::SignDataCore` |

(Note: the 3 `JsonDocument::Parse`/`TryParseValue` rows are the catch-cleanup FPs that PR #2521
removes from the candidate input; once #2521 merges they drop out of this sensor automatically.)

## Attack points for review

1. **Classifier soundness / direction.** Is the consume-external (untrusted) vs
   produce-from-memory (trusted) verb dichotomy right? Any member that's dangerously
   misclassified — e.g. a *trusted* label on a genuinely-external-input boundary (the risk
   direction for a "this leak is not actionable" signal)?
2. **Boundary attribution.** The `Rent`-to-end window scan can include an unrelated call; is the
   inert-wrapper skip (Span/Memory conversions) correct, and does the aggregation (any-untrusted)
   hold up on multi-boundary methods?
3. **Robustness.** Crash-safety / determinism on adversarial IL; per-assembly timeout + failed-row
   handling; SRM-only, NativeAOT-friendly, Roslyn-free, no inspected-assembly loading.
4. **Measurement-only claim.** Confirm it changes no analyzer behavior and produces no findings.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` — succeeds.
- `--leak-actionability` renders valid Markdown/TSV/JSONL; empty corpus / missing file handled;
  `--tsv`/`--jsonl` rejected outside leak modes.
- `markdownlint` on the changed README — clean.
- No harness test project exists (existing sensors are validated by running); classification is
  validated against labeled anchors on #2439 and the framework run above.

## Adversarial review

Two-model adversarial review requested per policy (I run as Claude Opus 4.8 → reviewers from the
other roster entries). Reconciliation will be posted here.
