### PR TITLE
Align deep inspect corpus cap with baseline

### DIFF
--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -122,7 +122,7 @@ jobs:
           dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
             --emit-corpus-snapshot artifacts/deep-inspect/corpus-snapshot.json \
             --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json \
-            --compile-cap 25 \
+            --compile-cap 4000 \
             --corpus-fidelity-cap 3 \
             --max-examples 3
 


### PR DESCRIPTION
## Summary

- updates the Deep Inspect corpus sensor to use `--compile-cap 4000`, matching `tools/DecompilerHarness/corpus/real-world-baseline.json`
- fixes the false red from #2523 where the sensor compared a 25-cap run against a 4000-cap baseline

Fixes #2523.

## Validation

- Verified `deep-inspect.yml` corpus sensor cap matches `real-world-baseline.json` `validityCompileCap` (`4000`).
- `git diff --check`

## Risk

Workflow-only signal fix. Product code and corpus baseline are unchanged. This may increase Deep Inspect census lane runtime, but it restores a meaningful baseline comparison instead of failing on a cap mismatch.
