### PR TITLE
Use record shells for with-expression dependencies

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -258,6 +258,18 @@ public class ReturnToSenderFixtureCatalogTests
 
         Assert.NotEqual(ReturnToSenderSourceOutcome.Invalid, result.Outcome);
         Assert.DoesNotContain("CS8858", result.Detail, StringComparison.Ordinal);
+
+        var compileBack = Assert.Single(ReturnToSender.CompileBackTargets(
+            FixtureCatalog.DecompilerLadderRung5.AssemblyPath(),
+            [
+                new ReturnToSender.RequestedTarget(
+                    "LadderRung5.Program",
+                    "Shift",
+                    Overload: 0),
+            ]));
+
+        Assert.Contains("return point with { X = point.X + dx };", compileBack.Source);
+        Assert.Contains("public record Point", compileBack.Source);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -443,6 +443,51 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_CompilesNestedTargetRecordWithExpressionShell()
+    {
+        var fixture = CompileSourceFixture(
+            ("Outer.cs", """
+            namespace SourceProbe;
+
+            public class Outer
+            {
+                public record Point(int X, int Y)
+                {
+                    public Point ShiftY() => this with { Y = 100 };
+                }
+            }
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget(
+                        "SourceProbe.Outer.Point",
+                        "ShiftY",
+                        Overload: 0),
+                ],
+                fixture.SourcePaths));
+            var compileBack = Assert.Single(ReturnToSender.CompileBackTargets(
+                fixture.AssemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget(
+                        "SourceProbe.Outer.Point",
+                        "ShiftY",
+                        Overload: 0),
+                ]));
+
+            Assert.NotEqual(ReturnToSenderSourceOutcome.Invalid, result.Outcome);
+            Assert.Contains("public record Point", compileBack.Source);
+            Assert.DoesNotContain("public class Point", compileBack.Source);
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_PreservesPrimaryConstructorShellParameters()
     {
         var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -357,6 +357,92 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_CompilesTargetRootRecordWithExpressionShell()
+    {
+        var fixture = CompileSourceFixture(
+            ("Point.cs", """
+            namespace SourceProbe;
+
+            public record Point(int X, int Y)
+            {
+                public Point ShiftY() => this with { Y = 100 };
+            }
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget(
+                        "SourceProbe.Point",
+                        "ShiftY",
+                        Overload: 0),
+                ],
+                fixture.SourcePaths));
+            var compileBack = Assert.Single(ReturnToSender.CompileBackTargets(
+                fixture.AssemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget(
+                        "SourceProbe.Point",
+                        "ShiftY",
+                        Overload: 0),
+                ]));
+
+            Assert.NotEqual(ReturnToSenderSourceOutcome.Invalid, result.Outcome);
+            Assert.Contains("public record Point", compileBack.Source);
+            Assert.DoesNotContain("public class Point", compileBack.Source);
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_CompilesNestedRecordWithExpressionShell()
+    {
+        var fixture = CompileSourceFixture(
+            ("Class1.cs", """
+            namespace SourceProbe;
+
+            public class Class1
+            {
+                public Point ShiftY(Point point) => point with { Y = 100 };
+
+                public record Point(int X, int Y);
+            }
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget(
+                        "SourceProbe.Class1",
+                        "ShiftY",
+                        Overload: 0),
+                ],
+                fixture.SourcePaths));
+            var compileBack = Assert.Single(ReturnToSender.CompileBackTargets(
+                fixture.AssemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget(
+                        "SourceProbe.Class1",
+                        "ShiftY",
+                        Overload: 0),
+                ]));
+
+            Assert.NotEqual(ReturnToSenderSourceOutcome.Invalid, result.Outcome);
+            Assert.Contains("public record Point", compileBack.Source);
+            Assert.DoesNotContain("public class Point", compileBack.Source);
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_PreservesPrimaryConstructorShellParameters()
     {
         var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -309,6 +309,54 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_KeepsStructWithExpressionShellAsStruct()
+    {
+        var fixture = CompileSourceFixture(
+            ("Class1.cs", """
+            namespace SourceProbe;
+
+            public class Class1
+            {
+                public Point ShiftY(Point point) => point with { Y = 100 };
+            }
+
+            public struct Point
+            {
+                public int X { get; set; }
+                public int Y { get; set; }
+            }
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget(
+                        "SourceProbe.Class1",
+                        "ShiftY",
+                        Overload: 0),
+                ],
+                fixture.SourcePaths));
+            var compileBack = Assert.Single(ReturnToSender.CompileBackTargets(
+                fixture.AssemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget(
+                        "SourceProbe.Class1",
+                        "ShiftY",
+                        Overload: 0),
+                ]));
+
+            Assert.NotEqual(ReturnToSenderSourceOutcome.Invalid, result.Outcome);
+            Assert.Contains("public struct Point", compileBack.Source);
+            Assert.DoesNotContain("public record Point", compileBack.Source);
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_PreservesPrimaryConstructorShellParameters()
     {
         var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -273,6 +273,42 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_UsesWithExpressionSetterEvidence()
+    {
+        var fixture = CompileSourceFixture(
+            ("Class1.cs", """
+            namespace SourceProbe;
+
+            public class Class1
+            {
+                public Point ShiftY(Point point) => point with { Y = 100 };
+            }
+
+            public record Point(int X, int Y);
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget(
+                        "SourceProbe.Class1",
+                        "ShiftY",
+                        Overload: 0),
+                ],
+                fixture.SourcePaths));
+
+            Assert.NotEqual(ReturnToSenderSourceOutcome.Invalid, result.Outcome);
+            Assert.DoesNotContain("CS0117", result.Detail, StringComparison.Ordinal);
+            Assert.DoesNotContain("CS8869", result.Detail, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_PreservesPrimaryConstructorShellParameters()
     {
         var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -245,6 +245,22 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_CompilesRecordWithExpressionShell()
+    {
+        var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+            FixtureCatalog.DecompilerLadderRung5.AssemblyPath(),
+            [
+                new ReturnToSender.RequestedTarget(
+                    "LadderRung5.Program",
+                    "Shift",
+                    Overload: 0),
+            ]));
+
+        Assert.NotEqual(ReturnToSenderSourceOutcome.Invalid, result.Outcome);
+        Assert.DoesNotContain("CS8858", result.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_PreservesPrimaryConstructorShellParameters()
     {
         var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(

--- a/src/ILInspector.Decompiler.Tests/WithExpressionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/WithExpressionPassTests.cs
@@ -17,6 +17,7 @@ public class WithExpressionPassTests
 
         var withExpression = Assert.Single(function.Descendants.OfType<WithExpression>());
         Assert.Equal(["X"], withExpression.Members);
+        Assert.Equal("set_X", Assert.Single(withExpression.Entries).ConsumedMethod?.Name);
         Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
         Assert.Empty(function.Descendants.OfType<StoreProperty>());
         Assert.DoesNotContain(function.Descendants.OfType<Call>(), call => call.Callee.Name == "<Clone>$");
@@ -36,6 +37,7 @@ public class WithExpressionPassTests
 
         var withExpression = Assert.Single(function.Descendants.OfType<WithExpression>());
         Assert.Equal(["X", "Y"], withExpression.Members);
+        Assert.Equal(["set_X", "set_Y"], withExpression.Entries.Select(entry => entry.ConsumedMethod?.Name));
         function.CheckInvariant();
 
         var output = CSharpPrinter.Print(function).Output;

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -438,7 +438,7 @@ public static class CompileBackSourceComposer
         {
             new(
                 targetIdentity,
-                ShellKind(reader, targetTypeDef),
+                ShellKind(reader, targetTypeDef, targetFacts),
                 targetMembers,
                 PrimaryConstructor: null,
                 targetFacts)
@@ -611,7 +611,7 @@ public static class CompileBackSourceComposer
         {
             new(
                 targetIdentity,
-                ShellKind(reader, targetTypeDef),
+                ShellKind(reader, targetTypeDef, targetFacts),
                 targetMembers,
                 PrimaryConstructor: null,
                 targetFacts)
@@ -730,7 +730,7 @@ public static class CompileBackSourceComposer
         {
             new(
                 targetIdentity,
-                ShellKind(reader, targetTypeDef),
+                ShellKind(reader, targetTypeDef, targetFacts),
                 targetMembers,
                 primaryConstructor,
                 targetFacts)
@@ -2666,8 +2666,8 @@ public static class CompileBackSourceComposer
                 }
 
                 var identity = CompileBackTypeIdentity.FromDefinition(reader, nestedDef);
-                var kind = ShellKind(reader, nestedDef);
                 requirementsByMetadataName.TryGetValue(identity.MetadataFullName, out var requirement);
+                var kind = requirement?.RequiredKind ?? ShellKind(reader, nestedDef);
                 requirement ??= new CompileBackTypeRequirement(
                     identity,
                     kind,

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -2160,9 +2160,11 @@ public static class CompileBackSourceComposer
 
         if (baseName == "System.Enum")
             return CompileBackTypeKind.Enum;
+        if (baseName == "System.ValueType")
+            return CompileBackTypeKind.Struct;
         if (facts?.Any(fact => fact.Producer == "metadata" && fact.Id == "record-shell") == true)
             return CompileBackTypeKind.Record;
-        return baseName == "System.ValueType" ? CompileBackTypeKind.Struct : CompileBackTypeKind.Class;
+        return CompileBackTypeKind.Class;
     }
 
     static bool IsSupportedClosureRoot(MetadataReader reader, TypeDefinition typeDef)

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -405,7 +405,7 @@ public static class CompileBackSourceComposer
         {
             new("metadata", "target-type", targetIdentity.FullName),
         };
-        if (closureFacts.TryGetValue(targetRoot, out var targetClosureFacts))
+        if (closureFacts.TryGetValue(targetType, out var targetClosureFacts))
             targetFacts.AddRange(targetClosureFacts);
 
         var targetMembers = new List<CompileBackMemberRequirement>
@@ -579,7 +579,7 @@ public static class CompileBackSourceComposer
         {
             new("metadata", "target-type", targetIdentity.FullName),
         };
-        if (closureFacts.TryGetValue(targetRoot, out var targetClosureFacts))
+        if (closureFacts.TryGetValue(targetType, out var targetClosureFacts))
             targetFacts.AddRange(targetClosureFacts);
 
         var indexerParameterCount = propertySignature.ParameterTypes.Length;
@@ -678,7 +678,7 @@ public static class CompileBackSourceComposer
         {
             new("metadata", "target-type", targetIdentity.FullName),
         };
-        if (closureFacts.TryGetValue(targetRoot, out var targetClosureFacts))
+        if (closureFacts.TryGetValue(targetType, out var targetClosureFacts))
             targetFacts.AddRange(targetClosureFacts);
 
         var targetMembers = isConstructor && primaryConstructor is not null

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -213,6 +213,7 @@ public sealed record CompileBackTypeDeclaration(
 public enum CompileBackTypeKind
 {
     Class,
+    Record,
     Struct,
     Interface,
     Enum,
@@ -529,15 +530,16 @@ public static class CompileBackSourceComposer
             var identity = CompileBackTypeIdentity.FromDefinition(reader, typeDef);
             if (requirements.Any(requirement => requirement.Type.MetadataFullName == identity.MetadataFullName))
                 return;
+            var facts = closureFacts.TryGetValue(handle, out var foundFacts) ? foundFacts : [];
 
             requirements.Add(new CompileBackTypeRequirement(
                 identity,
-                ShellKind(reader, typeDef),
+                ShellKind(reader, typeDef, facts),
                 RequiredMembers: closureMemberRequirements.TryGetValue(handle, out var requiredMembers)
                     ? requiredMembers.ToArray()
                     : [],
                 PrimaryConstructor: null,
-                SourceFacts: closureFacts.TryGetValue(handle, out var facts)
+                SourceFacts: facts.Count != 0
                     ? facts.ToArray()
                     : handle == root
                         ? [new CompileBackFact("closure", "closure-root", identity.FullName)]
@@ -1042,6 +1044,7 @@ public static class CompileBackSourceComposer
             Kind = type.Kind switch
             {
                 CompileBackTypeKind.Class => "class",
+                CompileBackTypeKind.Record => "record",
                 CompileBackTypeKind.Struct => "struct",
                 CompileBackTypeKind.Interface => "interface",
                 CompileBackTypeKind.Enum => "enum",
@@ -2143,7 +2146,7 @@ public static class CompileBackSourceComposer
         return false;
     }
 
-    static CompileBackTypeKind ShellKind(MetadataReader reader, TypeDefinition typeDef)
+    static CompileBackTypeKind ShellKind(MetadataReader reader, TypeDefinition typeDef, IReadOnlyList<CompileBackFact>? facts = null)
     {
         if ((typeDef.Attributes & TypeAttributes.Interface) != 0)
             return CompileBackTypeKind.Interface;
@@ -2157,6 +2160,8 @@ public static class CompileBackSourceComposer
 
         if (baseName == "System.Enum")
             return CompileBackTypeKind.Enum;
+        if (facts?.Any(fact => fact.Producer == "metadata" && fact.Id == "record-shell") == true)
+            return CompileBackTypeKind.Record;
         return baseName == "System.ValueType" ? CompileBackTypeKind.Struct : CompileBackTypeKind.Class;
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -2057,6 +2057,8 @@ public sealed class WithExpression : IrExpression
     {
         AddChild(receiver);
         var members = ImmutableArray.CreateBuilder<string>();
+        var consumedMethods = ImmutableArray.CreateBuilder<MethodRef?>();
+        var consumedFields = ImmutableArray.CreateBuilder<FieldRef?>();
         foreach (var entry in entries)
         {
             if (entry.Member is null)
@@ -2065,21 +2067,27 @@ public sealed class WithExpression : IrExpression
                 throw new ArgumentException("With-expression entries must contain exactly one value.", nameof(entries));
 
             members.Add(entry.Member);
+            consumedMethods.Add(entry.ConsumedMethod);
+            consumedFields.Add(entry.ConsumedField);
             AddChild(entry.Arguments[0]);
         }
         Members = members.ToImmutable();
+        ConsumedMethods = consumedMethods.ToImmutable();
+        ConsumedFields = consumedFields.ToImmutable();
     }
 
     public IrExpression Receiver => (IrExpression)Children[0];
     public ImmutableArray<string> Members { get; }
+    public ImmutableArray<MethodRef?> ConsumedMethods { get; }
+    public ImmutableArray<FieldRef?> ConsumedFields { get; }
     public IReadOnlyList<InitializerEntry> Entries
         => InitializerEntry.Slice(
             Children,
             1,
             [.. Members.Select(m => (string?)m)],
             [.. Members.Select(_ => 1)],
-            [.. Members.Select(_ => (MethodRef?)null)],
-            [.. Members.Select(_ => (FieldRef?)null)]);
+            ConsumedMethods,
+            ConsumedFields);
     public override TypeRef? ResultType => Receiver.ResultType;
     public override string Describe()
         => $"WithExpression ({Members.Length} members)";

--- a/src/ILInspector.Decompiler/Pipeline/Passes/WithExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/WithExpressionPass.cs
@@ -104,11 +104,11 @@ public sealed class WithExpressionPass : IIrPass
             when receiver.Slot == slot
                 && property.IndexArguments.Count == 0
                 && ObjectInitializerPass.IsInitializerSpellable(property)
-            => new InitializerEntry(property.PropertyName, [property.Value]),
+            => new InitializerEntry(property.PropertyName, [property.Value], ConsumedMethod: property.Accessor),
 
         StoreField { Instance: LoadStackSlot receiver } field
             when receiver.Slot == slot && CSharpNaming.IsUsableIdentifier(field.Field.Name)
-            => new InitializerEntry(field.Field.Name, [field.Value]),
+            => new InitializerEntry(field.Field.Name, [field.Value], ConsumedField: field.Field),
 
         _ => null,
     };

--- a/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
@@ -138,7 +138,7 @@ public static class CSharpDeclarationWriter
     static string RenderTypeDeclarationCore(ApiType type, CSharpDeclarationOptions options)
     {
         var parts = new List<string> { "public" };
-        if (type.Kind == "class")
+        if (type.Kind is "class" or "record")
         {
             if (type.IsStatic)
                 parts.Add("static");

--- a/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
+++ b/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
@@ -5,6 +5,31 @@ namespace ILInspector.Metadata.Tests;
 public sealed class CSharpDeclarationWriterTests
 {
     [Fact]
+    public void TypeDeclaration_PreservesRecordModifiers()
+    {
+        var abstractType = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Shape",
+            Kind = "record",
+            IsAbstract = true,
+        };
+        var sealedType = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "ClosedShape",
+            Kind = "record",
+            IsSealed = true
+        };
+
+        var abstractDeclaration = CSharpDeclarationWriter.RenderTypeDeclaration(abstractType);
+        var sealedDeclaration = CSharpDeclarationWriter.RenderTypeDeclaration(sealedType);
+
+        Assert.Equal("public abstract record Shape", abstractDeclaration);
+        Assert.Equal("public sealed record ClosedShape", sealedDeclaration);
+    }
+
+    [Fact]
     public void QualifiedMemberDeclaration_KeepsFullyQualifiedTypeNames()
     {
         var type = CreateSampleType();

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1545,8 +1545,6 @@ static class ReturnToSender
             if (TryResolveHandle(definition) is not { } handle)
                 return;
             var root = TopLevelRootOf(reader, handle);
-            if (root == targetRoot)
-                return;
             closureRoots.Add(root);
             AddClosureFact(
                 closureFacts,

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1535,6 +1535,23 @@ static class ReturnToSender
                 allowTargetRoot: true);
         }
 
+        void AddRecordShellFact(TypeRef? type)
+        {
+            var definition = type?.Kind == TypeRefKind.GenericInstance
+                ? type.ElementType ?? type
+                : type;
+            if (TryResolveHandle(definition) is not { } handle)
+                return;
+            var root = TopLevelRootOf(reader, handle);
+            if (root == targetRoot)
+                return;
+            closureRoots.Add(root);
+            AddClosureFact(
+                closureFacts,
+                handle,
+                new CompileBackFact("metadata", "record-shell", TypeRefIdentityKey(definition!.Namespace, definition.Name, separator: ".")));
+        }
+
         void AddMemberRequirement(TypeRef declaringType, Func<TypeDefinitionHandle, CompileBackMemberRequirement?> create, bool allowTargetRoot)
         {
             var definition = declaringType.Kind == TypeRefKind.GenericInstance
@@ -1630,6 +1647,9 @@ static class ReturnToSender
                     break;
                 case ObjectInitializerExpression initializer:
                     AddObjectInitializerFacts(initializer);
+                    break;
+                case WithExpression withExpression:
+                    AddRecordShellFact(withExpression.ResultType);
                     break;
             }
         }

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -656,6 +656,8 @@ static class ReturnToSender
         };
         var closureFacts = new Dictionary<TypeDefinitionHandle, List<CompileBackFact>>();
         var closureMemberRequirements = new Dictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>>();
+        // PrintRaised mutates the imported function in place, so raised evidence
+        // such as WithExpression is available to typed shell seeding here.
         SeedTypedClosureRoots(reader, function, typeHandle, targetRoot, closureRoots, closureFacts, closureMemberRequirements);
         const int maxRoots = 200;
         const int maxIterations = 80;

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1652,6 +1652,7 @@ static class ReturnToSender
                     break;
                 case WithExpression withExpression:
                     AddRecordShellFact(withExpression.ResultType);
+                    AddInitializerEntryFacts(withExpression.Entries);
                     break;
             }
         }


### PR DESCRIPTION
## Summary

Fixes the remaining #2505 `CS8858` source-probe row by making record shell emission fact-driven for with-expression dependencies.

`ReturnToSender` now seeds a typed `record-shell` fact from `WithExpression` receiver/result type evidence, and `CompileBackSourceComposer` uses that fact to emit only that dependency shell as `record`. This avoids the broad record-kind approach that previously made synthesized record member targets collide with compiler-generated record members.

Remaining #2505 invalid rows are the two generated dynamic delegate `CS0117` rows (`DynamicNamedOut`, `DynamicRefArgument`).

## Evidence

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/ReturnToSenderFixtureCatalogTests/ReturnToSenderSourceProbe_CompilesRecordWithExpressionShell"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/ReturnToSenderFixtureCatalogTests/*"`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --no-restore --nologo`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog record --json --max-examples 10` => 12/12 pass
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog minimal --json --max-examples 10` => unchanged known baseline (`minimal.static-constructor`, `minimal.static-class`, `minimal.switch-two-case-lowers-if`)
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures decompiler --return-to-sender-source-probe --cap 10000 --max-examples 260`
  - Before: Invalid 3 (`CS0117: 2`, `CS8858: 1`)
  - After: Invalid 2 (`CS0117: 2`)
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures rts.candidates --return-to-sender-source-probe --cap 10000 --max-examples 260` => Invalid 0

Render-text A/B is not included because this changes ReturnToSender/compile-back shell composition only; product rendered C# output is unchanged.

Adversarial review requested; results will be posted before ready-to-merge.