### PR TITLE
Seed record EqualityContract shell evidence

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -2567,6 +2567,43 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_UsesRecordEqualityContractShellForFieldReadHelpers()
+    {
+        var assemblyPath = CompileFixture("""
+            public record Row(string Name, string Value);
+            """);
+        try
+        {
+            var results = ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget("Row", "GetHashCode", 0),
+                    new ReturnToSender.RequestedTarget("Row", "Equals", 1),
+                ]);
+
+            Assert.Collection(
+                results,
+                getHashCode => AssertRecordEqualityContractRequirement(getHashCode),
+                typedEquals => AssertRecordEqualityContractRequirement(typedEquals));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+
+        static void AssertRecordEqualityContractRequirement(ReturnToSender.Result result)
+        {
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            var type = Assert.Single(result.Plan.Types);
+            Assert.DoesNotContain(type.SourceFacts, fact => fact.Producer == "roslyn" && fact.Id == "closure-member");
+            Assert.Contains(type.Members, member =>
+                member.Name == "EqualityContract"
+                && member.SourceFacts.Any(fact => fact.Id == "record-equality-contract" && fact.Detail == "get_EqualityContract"));
+            Assert.Contains("EqualityContract", result.Source);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_UsesFieldShellForRecordStructGeneratedFieldReadHelpers()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -702,7 +702,11 @@ public static class CompileBackSourceComposer
                 IsAsync: !isConstructor && function.RequiresAsyncBodyModifier)
         ];
         if (!isConstructor && IsRecordGeneratedFieldReadHelper(reader, targetTypeDef, targetIdentity, methodName, signature, function))
+        {
+            if (TypeProducer.TryCreateRecordEqualityContractRequirement(reader, targetType) is { } equalityContract)
+                targetMembers.Add(equalityContract);
             targetMembers.AddRange(TargetBackingFieldReadMembers(reader, targetTypeDef, targetIdentity, function));
+        }
         if (isConstructor && primaryConstructor is null)
             targetMembers.AddRange(TargetBackingFieldWriteMembers(reader, targetTypeDef, targetIdentity, function, allowStaticStores: false));
         if (methodName == ".cctor")
@@ -2273,6 +2277,29 @@ public static class CompileBackSourceComposer
             return FieldRequirement(reader, typeDef, typeIdentity, fieldHandle);
         }
 
+        public static CompileBackMemberRequirement? TryCreateRecordEqualityContractRequirement(
+            MetadataReader reader,
+            TypeDefinitionHandle typeHandle)
+        {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            var typeIdentity = CompileBackTypeIdentity.FromDefinition(reader, typeDef);
+            foreach (var propertyHandle in typeDef.GetProperties())
+            {
+                var property = reader.GetPropertyDefinition(propertyHandle);
+                if (reader.GetString(property.Name) != "EqualityContract")
+                    continue;
+                var accessors = property.GetAccessors();
+                if (accessors.Getter.IsNil)
+                    continue;
+                var getter = reader.GetMethodDefinition(accessors.Getter);
+                if (!MethodDefinitionFacts.HasCompilerGeneratedAttribute(reader, getter.GetCustomAttributes()))
+                    continue;
+                return PropertyRequirement(reader, typeDef, typeIdentity, propertyHandle, reader.GetString(getter.Name), factId: "record-equality-contract");
+            }
+
+            return null;
+        }
+
         static CompileBackMemberRequirement? FieldRequirement(
             MetadataReader reader,
             TypeDefinition typeDef,
@@ -2425,7 +2452,8 @@ public static class CompileBackSourceComposer
             TypeDefinition typeDef,
             CompileBackTypeIdentity typeIdentity,
             PropertyDefinitionHandle propertyHandle,
-            string accessorName)
+            string accessorName,
+            string factId = "typed-closure-property")
         {
             var property = reader.GetPropertyDefinition(propertyHandle);
             var accessors = property.GetAccessors();
@@ -2477,7 +2505,7 @@ public static class CompileBackSourceComposer
                 [],
                 stubBody,
                 null,
-                [new CompileBackFact("metadata", "typed-closure-property", accessorName)],
+                [new CompileBackFact("metadata", factId, accessorName)],
                 propertyDeclaration.Attributes,
                 propertyDeclaration.Signature.ReturnAttributes,
                 IsAbstract: isAbstractAccessor,


### PR DESCRIPTION
- Advances #2529.
- Changes product-owned compile-back shell evidence for record `EqualityContract`.
- Evidence revision: `fe98ca21`

## Change

**Conclusion:** **PASS** — record field-read helpers now get a precise product-owned `EqualityContract` shell requirement, removing the remaining RTS Roslyn fallback buckets from the record catalog.

Before:

```text
record Roslyn fallback evidence:
  CS0103/closure-member: 2
  CS1061/closure-member: 1
```

After:

```text
record Roslyn fallback evidence:
  []
```

## Scope and safety

- **Root cause:** generated record helpers (`GetHashCode`, typed `Equals`) read `EqualityContract`, but the shell requirement previously arrived through Roslyn `CS0103`/`CS1061` member-surface recovery.
- **Fix shape:** `CompileBackSourceComposer` detects record-generated field-read helpers and adds a precise `record-equality-contract` property shell requirement when metadata proves the compiler-generated getter.
- **Product impact:** compile-back shell evidence only; product decompiler output behavior is unchanged.
- **Scope boundary:** this does not address the broader uniform evidence surface from #2529; it is the focused `record EqualityContract` slice claimed there.
- **RTS boundary:** no RTS C#-name recovery was added; the shell evidence is product-owned and RTS only consumes the resulting plan.

## Evidence

| Check | Result |
| --- | --- |
| Focused record canary | Pass |
| GeneratedFixtureCatalogTests | Pass |
| Solution build | Pass |
| `minimal` RTS catalog JSON | `RoslynFallbacks: []` |
| `record` RTS catalog JSON | `RoslynFallbacks: []` |
| `rts.candidates` source probe | ValidMatch 52, ValidDifferent 50, Invalid 0, SourceUnavailable 0, UnsupportedTarget 0 |

## Validation

```bash
dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderPrototypeTests/CompileBackTargets_UsesRecordEqualityContractShellForFieldReadHelpers"
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/GeneratedFixtureCatalogTests/*"
dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog minimal --json --max-examples 1
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog record --json --max-examples 1
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures rts.candidates --return-to-sender-source-probe --cap 10000 --max-examples 40
```

## Review

Adversarial review requested after PR creation.
