### PR TITLE
Carry increment/decrement operator evidence in IR

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
@@ -92,6 +92,7 @@ public class IncrementDecrementPassTests
 
         var increment = Assert.IsType<IncrementDecrement>(Assert.IsType<ExpressionStatement>(Assert.Single(statements)).Expression);
         Assert.False(increment.IsIncrement);
+        Assert.Null(increment.ConsumedMethod);
     }
 
     [Fact]
@@ -143,6 +144,8 @@ public class IncrementDecrementPassTests
         Assert.True(increment.IsIncrement);
         Assert.False(increment.IsPrefix);
         Assert.False(increment.IsChecked);
+        Assert.Equal("op_Increment", increment.ConsumedMethod?.Name);
+        Assert.Equal(OperatorType, increment.ConsumedMethod?.DeclaringType);
     }
 
     [Fact]
@@ -172,6 +175,7 @@ public class IncrementDecrementPassTests
         Assert.True(increment.IsIncrement);
         Assert.True(increment.IsPrefix);
         Assert.True(increment.IsChecked);
+        Assert.Equal("op_CheckedIncrement", increment.ConsumedMethod?.Name);
     }
 
     [Fact]
@@ -453,6 +457,8 @@ public class IncrementDecrementPassTests
         var increment = Assert.IsType<IncrementDecrement>(
             Assert.IsType<ExpressionStatement>(Assert.Single(statements)).Expression);
         Assert.True(increment is { IsIncrement: true, IsUserDefined: true, IsChecked: false });
+        Assert.Equal("op_Increment", increment.ConsumedMethod?.Name);
+        Assert.Equal(ValueType, increment.ConsumedMethod?.DeclaringType);
     }
 
     [Fact]
@@ -465,6 +471,7 @@ public class IncrementDecrementPassTests
         var increment = Assert.IsType<IncrementDecrement>(
             Assert.IsType<ExpressionStatement>(Assert.Single(statements)).Expression);
         Assert.True(increment is { IsIncrement: false, IsUserDefined: true, IsChecked: true });
+        Assert.Equal("op_CheckedDecrement", increment.ConsumedMethod?.Name);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1305,12 +1305,13 @@ public sealed class AwaitExpression : IrExpression
     witness: "IncrementDecrementPassTests, corpus compile-back")]
 public sealed class IncrementDecrement : IrExpression
 {
-    public IncrementDecrement(IrExpression target, bool isIncrement, bool isPrefix, bool isUserDefined = false, bool isChecked = false)
+    public IncrementDecrement(IrExpression target, bool isIncrement, bool isPrefix, bool isUserDefined = false, bool isChecked = false, MethodRef? consumedMethod = null)
     {
         IsIncrement = isIncrement;
         IsPrefix = isPrefix;
         IsUserDefined = isUserDefined;
         IsChecked = isChecked;
+        ConsumedMethod = consumedMethod;
         AddChild(target);
     }
 
@@ -1320,6 +1321,8 @@ public sealed class IncrementDecrement : IrExpression
     public bool IsUserDefined { get; }
     /// <summary>True when folded from a user-defined <c>op_CheckedIncrement</c>/<c>op_CheckedDecrement</c> call, so the use must render in a <c>checked(...)</c> context.</summary>
     public bool IsChecked { get; }
+    /// <summary>The folded user-defined operator method (<c>op_Increment</c>/<c>op_Decrement</c> and their <c>op_Checked*</c> variants), or null for a primitive increment. Carries the typed member evidence so consumers (e.g. compile-back closure planning) route the exact operator rather than reconstructing its name.</summary>
+    public MethodRef? ConsumedMethod { get; }
     /// <summary>The incremented place — a local or argument load.</summary>
     public IrExpression Target => (IrExpression)Children[0];
     public override TypeRef? ResultType => Target.ResultType;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
@@ -103,6 +103,7 @@ public sealed class IncrementDecrementPass : IIrPass
         IrExpression lvalueLoad;
         bool isIncrement;
         bool isChecked;
+        MethodRef consumedMethod;
 
         if (AsIncrementCall(updateValue) is { } postOp && isTempLoad(postOp.Operand) && WritesSamePlaceAsRead(update, captureValue))
         {
@@ -111,6 +112,7 @@ public sealed class IncrementDecrementPass : IIrPass
             lvalueLoad = captureValue;
             isIncrement = postOp.IsIncrement;
             isChecked = postOp.IsChecked;
+            consumedMethod = postOp.Operator;
         }
         else if (AsIncrementCall(captureValue) is { } preOp && isTempLoad(updateValue) && WritesSamePlaceAsRead(update, preOp.Operand))
         {
@@ -119,6 +121,7 @@ public sealed class IncrementDecrementPass : IIrPass
             lvalueLoad = preOp.Operand;
             isIncrement = preOp.IsIncrement;
             isChecked = preOp.IsChecked;
+            consumedMethod = preOp.Operator;
         }
         else
         {
@@ -169,7 +172,7 @@ public sealed class IncrementDecrementPass : IIrPass
             return false;
 
         lvalueLoad.Detach();
-        var increment = new IncrementDecrement(lvalueLoad, isIncrement, isPrefix, isUserDefined: true, isChecked: isChecked);
+        var increment = new IncrementDecrement(lvalueLoad, isIncrement, isPrefix, isUserDefined: true, isChecked: isChecked, consumedMethod: consumedMethod);
         stepper.StepOver($"fold user-defined {(isIncrement ? "++" : "--")} value form into operator", useLoad);
         useLoad.ReplaceWith(increment);
         update.Detach();
@@ -283,14 +286,14 @@ public sealed class IncrementDecrementPass : IIrPass
             if (store.Parent is null || SelfIncrement(store) is not { } fold)
                 continue;
             fold.Target.Detach();
-            var increment = new IncrementDecrement(fold.Target, fold.IsIncrement, isPrefix: false, isUserDefined: true, isChecked: fold.IsChecked);
+            var increment = new IncrementDecrement(fold.Target, fold.IsIncrement, isPrefix: false, isUserDefined: true, isChecked: fold.IsChecked, consumedMethod: fold.Operator);
             stepper.StepOver($"fold user-defined {(fold.IsIncrement ? "++" : "--")} self-update into operator", store);
             store.ReplaceWith(new ExpressionStatement(increment));
         }
     }
 
     /// <summary>A <c>lvalue = op_Increment(lvalue)</c> store (any place whose re-read is side-effect-free), or null. The target expression is the operand load, reused as the <c>++</c> target.</summary>
-    static (IrExpression Target, bool IsIncrement, bool IsChecked)? SelfIncrement(IrNode store)
+    static (IrExpression Target, bool IsIncrement, bool IsChecked, MethodRef Operator)? SelfIncrement(IrNode store)
     {
         IrExpression? value = store switch
         {
@@ -302,7 +305,7 @@ public sealed class IncrementDecrementPass : IIrPass
             _ => null,
         };
         return value is not null && AsIncrementCall(value) is { } op && WritesSamePlaceAsRead(store, op.Operand)
-            ? (op.Operand, op.IsIncrement, op.IsChecked)
+            ? (op.Operand, op.IsIncrement, op.IsChecked, op.Operator)
             : null;
     }
 
@@ -358,6 +361,7 @@ public sealed class IncrementDecrementPass : IIrPass
         bool isPrefix;
         bool isUserDefined = false;
         bool isChecked = false;
+        MethodRef? consumedMethod = null;
 
         if (IsPlaceLoad(slotStore.Value, place)
             && updateValue is Binary { IsChecked: false, Kind: var postKind } post
@@ -388,6 +392,7 @@ public sealed class IncrementDecrementPass : IIrPass
             isIncrement = postOp.IsIncrement;
             isUserDefined = true;
             isChecked = postOp.IsChecked;
+            consumedMethod = postOp.Operator;
         }
         else if (AsIncrementCall(slotStore.Value) is { } preOp
             && IsPlaceLoad(preOp.Operand, place)
@@ -398,6 +403,7 @@ public sealed class IncrementDecrementPass : IIrPass
             isIncrement = preOp.IsIncrement;
             isUserDefined = true;
             isChecked = preOp.IsChecked;
+            consumedMethod = preOp.Operator;
         }
         else
         {
@@ -438,7 +444,7 @@ public sealed class IncrementDecrementPass : IIrPass
         }
 
         stepper.StepOver($"fold dup {(isIncrement ? "++" : "--")} idiom into operator", useLoad);
-        useLoad.ReplaceWith(new IncrementDecrement(ClonePlace(place), isIncrement, isPrefix, isUserDefined, isChecked));
+        useLoad.ReplaceWith(new IncrementDecrement(ClonePlace(place), isIncrement, isPrefix, isUserDefined, isChecked, consumedMethod));
         update.Detach();
         slotStore.Detach();
         return true;
@@ -697,7 +703,7 @@ public sealed class IncrementDecrementPass : IIrPass
         ? expression is LoadLocal local && local.Index == place.Index
         : expression is LoadArgument argument && argument.Index == place.Index;
 
-    readonly record struct IncrementOp(bool IsIncrement, bool IsChecked, IrExpression Operand);
+    readonly record struct IncrementOp(bool IsIncrement, bool IsChecked, IrExpression Operand, MethodRef Operator);
 
     /// <summary>A user-defined increment/decrement operator call (<c>op_Increment</c>, <c>op_Decrement</c>, and their <c>op_Checked*</c> variants) on a single operand, or null. Requires operator metadata evidence so an ordinary method that happens to be named <c>op_Increment</c> is not mistaken for the operator.</summary>
     static IncrementOp? AsIncrementCall(IrExpression value)
@@ -711,7 +717,7 @@ public sealed class IncrementDecrementPass : IIrPass
                 "op_CheckedDecrement" => (false, true),
                 _ => ((bool IsIncrement, bool IsChecked)?)null,
             } is { } kind
-            ? new IncrementOp(kind.IsIncrement, kind.IsChecked, operand)
+            ? new IncrementOp(kind.IsIncrement, kind.IsChecked, operand, callee)
             : null;
 
     static IrExpression ClonePlace(PlaceRef place) => place.IsLocal

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1581,15 +1581,8 @@ static class ReturnToSender
                 case DelegateCreation creation:
                     AddMethodFact(creation.Method);
                     break;
-                case IncrementDecrement { IsUserDefined: true, Target.ResultType: { } operatorType } increment:
-                    AddMethodFact(new MethodRef(
-                        operatorType,
-                        increment.IsChecked
-                            ? increment.IsIncrement ? "op_CheckedIncrement" : "op_CheckedDecrement"
-                            : increment.IsIncrement ? "op_Increment" : "op_Decrement",
-                        operatorType,
-                        [operatorType],
-                        HasThis: false));
+                case IncrementDecrement { ConsumedMethod: { } operatorMethod }:
+                    AddMethodFact(operatorMethod);
                     break;
                 case RecursivePropertyDeclarationPattern pattern:
                     AddMethodFact(pattern.Accessor);


### PR DESCRIPTION
Part of #2529 (residual leak #1). Base: `origin/main` @ `1828309b`.

## Change

**Conclusion:** **PASS** — the folded user-defined increment/decrement operator is now carried as typed `ConsumedMethod` evidence on the `IncrementDecrement` IR node, and ReturnToSender routes that typed evidence for compile-back closure membership instead of re-synthesizing the operator name in the harness.

Before:

```text
RTS increment bridge:
  IncrementDecrement{IsIncrement,IsChecked} + Target.ResultType
    -> RTS constructs new MethodRef(operatorType, "op_Increment"/"op_CheckedIncrement"/...)
```

After:

```text
Product IR evidence:
  IncrementDecrementPass folds op_Increment(...) Call
    -> IncrementDecrement.ConsumedMethod = callee (real MethodRef)
    -> RTS routes node.ConsumedMethod -> Research shell composition
```

## Scope and safety

- **Root cause:** `SeedTypedClosureRoots` in `ReturnToSender.cs` reconstructed the operator method name from `IsIncrement`/`IsChecked` booleans and the operand's `ResultType` — C# operator-naming knowledge living in the harness.
- **Fix shape:** thread the folded operator `MethodRef` (already matched by `AsIncrementCall`/`SelfIncrement`) through to a new `IncrementDecrement.ConsumedMethod`; RTS routes it via the existing `AddMethodFact`.
- **Metadata-accurate:** the routed requirement uses the real callee (correct declaring type/signature) rather than a synthesized `MethodRef` whose declaring type was the operand result type.
- **Render-unaffected by construction:** the printer does not read `ConsumedMethod`, and the fold decisions (`IsIncrement`/`IsPrefix`/`IsChecked`/`IsUserDefined`) are unchanged, so C# output is identical.
- **Out of scope (follow-up):** the generic `op_Checked* -> op_*` sibling expansion (`UncheckedOperatorName` in `AddMethodFact`) is retained — it applies to all operators, not just `++`/`--` (the `operator.checked-sibling` role in #2529). Separate from the claimed record `EqualityContract` slice.

## Evidence

| Check | Result |
| --- | --- |
| `IncrementDecrementPassTests` (incl. new `ConsumedMethod` assertions across all 3 user-defined fold sites + primitive null) | 38/38 pass |
| Increment-touching classes (`ForLoop`, `LadderRung5/6`, `ExpressionInlining`, `CSharpPrinterReceiver`, `CheckedUncheckedInsert`) | 88/88 pass |
| `ReturnToSenderPrototypeTests` | 8 pre-existing failures, **identical to clean `origin/main`** (environment: SDK preview.5, not the repo .NET 11 daily) — no new failures |
| RTS source-probe A/B (`rts.candidates`, same SDK, baseline vs head) | **identical**: ValidMatch 52, ValidDifferent 50, Invalid 0, SourceUnavailable 0, UnsupportedTarget 0 |

## Validation

```bash
dotnet build src/ILInspector.Decompiler -c Release --configfile nuget.config
dotnet build tools/DecompilerHarness -c Release --configfile nuget.config
dotnet build src/ILInspector.Decompiler.Tests -c Release --configfile nuget.config
# xUnit v3 EXE
dotnet artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll -class "*IncrementDecrementPassTests"
# RTS source-probe A/B (baseline worktree vs head)
dotnet run --project tools/DecompilerHarness -c Release --no-build -- \
  --return-to-sender-fixtures rts.candidates --return-to-sender-source-probe --cap 10000 --max-examples 0
```

> Note: this box runs SDK 11.0.100-preview.5 (central), not the repo's .NET 11 daily. The 8 `ReturnToSenderPrototypeTests` failures reproduce identically on unmodified `origin/main`, so they are pre-existing/environment, not introduced here; CI on the correct SDK is the authoritative RTS gate.

## Review

Adversarial review requested after PR creation (two reviewers, non-Claude family, per policy).
