### PR TITLE
Move target-interface seeding into product IR evidence (#2529)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ImplementedInterfaceEvidenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ImplementedInterfaceEvidenceTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Linq;
+using System.Reflection.Metadata;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ImplementedInterfaceEvidenceTests
+{
+    interface ILocalMarker;
+
+    interface ILocalGeneric<T>;
+
+    class OuterHost
+    {
+        public interface INested;
+    }
+
+    class InterfaceEvidenceSample : ILocalMarker, ILocalGeneric<int>, OuterHost.INested;
+
+    class NoInterfacesSample;
+
+    class DisposableSample : IDisposable
+    {
+        public void Dispose()
+        {
+        }
+    }
+
+    [Fact]
+    public void ImportImplementedInterfaces_DecodesDefinitionGenericAndNestedInterfaces()
+    {
+        using var source = MetadataSource.Open(typeof(InterfaceEvidenceSample).Assembly.Location);
+        var reader = source.Reader;
+
+        var interfaces = IrImporter.ImportImplementedInterfaces(reader, FindHandle(reader, nameof(InterfaceEvidenceSample)));
+
+        Assert.Equal(3, interfaces.Length);
+
+        // Same-assembly non-generic interface: a resolvable Definition ref.
+        var marker = Assert.Single(interfaces, type => type.Kind == TypeRefKind.Definition && type.Name.EndsWith("ILocalMarker", StringComparison.Ordinal));
+        Assert.Equal(source.AssemblyName, marker.Assembly);
+
+        // Generic interface implementation is a TypeSpec, decoded to a generic instance.
+        var generic = Assert.Single(interfaces, type => type.Kind == TypeRefKind.GenericInstance);
+        Assert.Contains("ILocalGeneric", generic.ElementType!.Name, StringComparison.Ordinal);
+        Assert.Equal("Int32", Assert.Single(generic.TypeArguments).Name);
+
+        // Nested interfaces keep their metadata nesting spelling ('+').
+        Assert.Single(interfaces, type => type.Kind == TypeRefKind.Definition && type.Name.EndsWith("OuterHost+INested", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ImportImplementedInterfaces_CrossAssemblyInterfaceKeepsForeignAssembly()
+    {
+        using var source = MetadataSource.Open(typeof(DisposableSample).Assembly.Location);
+        var reader = source.Reader;
+
+        var iface = Assert.Single(IrImporter.ImportImplementedInterfaces(reader, FindHandle(reader, nameof(DisposableSample))));
+
+        // A cross-assembly interface is a TypeRef decoded to a Definition in the
+        // foreign assembly — so target-interface seeding correctly declines it as
+        // a local closure root.
+        Assert.Equal(TypeRefKind.Definition, iface.Kind);
+        Assert.EndsWith("IDisposable", iface.Name, StringComparison.Ordinal);
+        Assert.NotEqual(source.AssemblyName, iface.Assembly);
+    }
+
+    [Fact]
+    public void ImportImplementedInterfaces_NoInterfacesReturnsEmpty()
+    {
+        using var source = MetadataSource.Open(typeof(NoInterfacesSample).Assembly.Location);
+        var reader = source.Reader;
+
+        Assert.Empty(IrImporter.ImportImplementedInterfaces(reader, FindHandle(reader, nameof(NoInterfacesSample))));
+    }
+
+    static TypeDefinitionHandle FindHandle(MetadataReader reader, string simpleName)
+    {
+        foreach (var handle in reader.TypeDefinitions)
+        {
+            if (reader.GetString(reader.GetTypeDefinition(handle).Name) == simpleName)
+                return handle;
+        }
+
+        throw new InvalidOperationException($"type {simpleName} not found in metadata");
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ImplementedInterfaceEvidenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ImplementedInterfaceEvidenceTests.cs
@@ -28,42 +28,47 @@ public class ImplementedInterfaceEvidenceTests
     }
 
     [Fact]
-    public void ImportImplementedInterfaces_DecodesDefinitionGenericAndNestedInterfaces()
+    public void ImportImplementedInterfaces_ReturnsSameAssemblyDefinitions()
     {
         using var source = MetadataSource.Open(typeof(InterfaceEvidenceSample).Assembly.Location);
         var reader = source.Reader;
 
         var interfaces = IrImporter.ImportImplementedInterfaces(reader, FindHandle(reader, nameof(InterfaceEvidenceSample)));
 
-        Assert.Equal(3, interfaces.Length);
+        // Only same-assembly TypeDefinition interfaces are evidence: the marker and
+        // the nested interface, but not the generic instantiation (a TypeSpec).
+        Assert.Equal(2, interfaces.Length);
+        Assert.All(interfaces, type => Assert.Equal(TypeRefKind.Definition, type.Kind));
+        Assert.All(interfaces, type => Assert.Equal(source.AssemblyName, type.Assembly));
 
-        // Same-assembly non-generic interface: a resolvable Definition ref.
-        var marker = Assert.Single(interfaces, type => type.Kind == TypeRefKind.Definition && type.Name.EndsWith("ILocalMarker", StringComparison.Ordinal));
-        Assert.Equal(source.AssemblyName, marker.Assembly);
-
-        // Generic interface implementation is a TypeSpec, decoded to a generic instance.
-        var generic = Assert.Single(interfaces, type => type.Kind == TypeRefKind.GenericInstance);
-        Assert.Contains("ILocalGeneric", generic.ElementType!.Name, StringComparison.Ordinal);
-        Assert.Equal("Int32", Assert.Single(generic.TypeArguments).Name);
-
+        Assert.Single(interfaces, type => type.Name.EndsWith("ILocalMarker", StringComparison.Ordinal));
         // Nested interfaces keep their metadata nesting spelling ('+').
-        Assert.Single(interfaces, type => type.Kind == TypeRefKind.Definition && type.Name.EndsWith("OuterHost+INested", StringComparison.Ordinal));
+        Assert.Single(interfaces, type => type.Name.EndsWith("OuterHost+INested", StringComparison.Ordinal));
     }
 
     [Fact]
-    public void ImportImplementedInterfaces_CrossAssemblyInterfaceKeepsForeignAssembly()
+    public void ImportImplementedInterfaces_ExcludesConstructedInterface()
+    {
+        using var source = MetadataSource.Open(typeof(InterfaceEvidenceSample).Assembly.Location);
+        var reader = source.Reader;
+
+        var interfaces = IrImporter.ImportImplementedInterfaces(reader, FindHandle(reader, nameof(InterfaceEvidenceSample)));
+
+        // A generic interface implementation is a TypeSpec, never a local closure
+        // root, so it is not part of the evidence set.
+        Assert.DoesNotContain(interfaces, type => type.Kind == TypeRefKind.GenericInstance);
+        Assert.DoesNotContain(interfaces, type => type.Name.Contains("ILocalGeneric", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ImportImplementedInterfaces_ExcludesCrossAssemblyInterface()
     {
         using var source = MetadataSource.Open(typeof(DisposableSample).Assembly.Location);
         var reader = source.Reader;
 
-        var iface = Assert.Single(IrImporter.ImportImplementedInterfaces(reader, FindHandle(reader, nameof(DisposableSample))));
-
-        // A cross-assembly interface is a TypeRef decoded to a Definition in the
-        // foreign assembly — so target-interface seeding correctly declines it as
-        // a local closure root.
-        Assert.Equal(TypeRefKind.Definition, iface.Kind);
-        Assert.EndsWith("IDisposable", iface.Name, StringComparison.Ordinal);
-        Assert.NotEqual(source.AssemblyName, iface.Assembly);
+        // A cross-assembly interface is a TypeReference, not a local definition, so
+        // it is excluded — target-interface seeding never treated it as a root.
+        Assert.Empty(IrImporter.ImportImplementedInterfaces(reader, FindHandle(reader, nameof(DisposableSample))));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -495,6 +495,44 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_SeedsTargetInterfaceRootWhenTargetAssemblyNameIsCorelibFacade()
+    {
+        // A target assembly whose own name is a canonicalized corelib facade
+        // (System.Runtime, mscorlib, ...) must still resolve its own interface
+        // definitions: TypeRefDecoder canonicalizes the assembly name, so the
+        // same-assembly gate has to canonicalize too. Assert on the seeded plan
+        // facts (not recompile status) so this holds independent of the compile
+        // environment.
+        var assemblyPath = CompileFixture(
+            """
+            public interface IValue
+            {
+                int GetValue();
+            }
+
+            public class Class1 : IValue
+            {
+                public int GetValue() => 42;
+            }
+            """,
+            assemblyName: "System.Runtime");
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", "GetValue", 0)]));
+
+            Assert.Contains(result.Plan.Types, type =>
+                type.Name == "IValue"
+                && type.SourceFacts.Any(fact => fact.Producer == "metadata" && fact.Id == "target-interface"));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_UsesTypedObjectInitializerPropertyRequirement()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -59,6 +59,40 @@ public static class IrImporter
     public static IrFunction? Import(MetadataSource source, MethodRef method)
         => Import(source, ImporterTypeName(method.DeclaringType), method.Name);
 
+    /// <summary>
+    /// Typed evidence for a type's directly-declared interface implementations:
+    /// the <see cref="TypeRef"/> of each interface named in the type's
+    /// InterfaceImpl rows, decoded through the product's signature decoder so
+    /// every handle kind (TypeDef, TypeRef, and generic-instance TypeSpec) is
+    /// spelled uniformly. Compile-back consumers use this to seed target-type
+    /// interface closure roots without reaching into metadata themselves —
+    /// interface discovery is product knowledge, not harness knowledge.
+    /// </summary>
+    public static ImmutableArray<TypeRef> ImportImplementedInterfaces(MetadataReader reader, TypeDefinitionHandle typeHandle)
+    {
+        var typeDef = reader.GetTypeDefinition(typeHandle);
+        var implementations = typeDef.GetInterfaceImplementations();
+        if (implementations.Count == 0)
+            return [];
+
+        var builder = ImmutableArray.CreateBuilder<TypeRef>(implementations.Count);
+        foreach (var implementationHandle in implementations)
+        {
+            var implementation = reader.GetInterfaceImplementation(implementationHandle);
+            builder.Add(DecodeInterfaceType(reader, implementation.Interface));
+        }
+
+        return builder.ToImmutable();
+    }
+
+    static TypeRef DecodeInterfaceType(MetadataReader reader, EntityHandle interfaceHandle) => interfaceHandle.Kind switch
+    {
+        HandleKind.TypeDefinition => TypeRefDecoder.Instance.GetTypeFromDefinition(reader, (TypeDefinitionHandle)interfaceHandle, 0),
+        HandleKind.TypeReference => TypeRefDecoder.Instance.GetTypeFromReference(reader, (TypeReferenceHandle)interfaceHandle, 0),
+        HandleKind.TypeSpecification => TypeRefDecoder.Instance.GetTypeFromSpecification(reader, GenericScope.Empty, (TypeSpecificationHandle)interfaceHandle, 0),
+        _ => TypeRef.Unsupported($"unsupported interface handle kind {interfaceHandle.Kind}"),
+    };
+
     static string ImporterTypeName(TypeRef type)
     {
         string name = type.Name.Replace('+', '.');

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -60,13 +60,14 @@ public static class IrImporter
         => Import(source, ImporterTypeName(method.DeclaringType), method.Name);
 
     /// <summary>
-    /// Typed evidence for a type's directly-declared interface implementations:
-    /// the <see cref="TypeRef"/> of each interface named in the type's
-    /// InterfaceImpl rows, decoded through the product's signature decoder so
-    /// every handle kind (TypeDef, TypeRef, and generic-instance TypeSpec) is
-    /// spelled uniformly. Compile-back consumers use this to seed target-type
-    /// interface closure roots without reaching into metadata themselves —
-    /// interface discovery is product knowledge, not harness knowledge.
+    /// Typed evidence for the interfaces a type declares in its own assembly: the
+    /// <see cref="TypeRef"/> of each InterfaceImpl row whose interface is a
+    /// TypeDefinition (defined in this assembly), decoded through the product's
+    /// signature decoder. Constructed generic-instance (TypeSpec) and cross-assembly
+    /// (TypeReference) interfaces are excluded — they are never local closure roots,
+    /// and only TypeDefinition rows were ever seeded. Compile-back consumers use this
+    /// to seed target-type interface closure roots without walking metadata
+    /// themselves: interface discovery is product knowledge, not harness knowledge.
     /// </summary>
     public static ImmutableArray<TypeRef> ImportImplementedInterfaces(MetadataReader reader, TypeDefinitionHandle typeHandle)
     {
@@ -78,20 +79,13 @@ public static class IrImporter
         var builder = ImmutableArray.CreateBuilder<TypeRef>(implementations.Count);
         foreach (var implementationHandle in implementations)
         {
-            var implementation = reader.GetInterfaceImplementation(implementationHandle);
-            builder.Add(DecodeInterfaceType(reader, implementation.Interface));
+            var interfaceHandle = reader.GetInterfaceImplementation(implementationHandle).Interface;
+            if (interfaceHandle.Kind == HandleKind.TypeDefinition)
+                builder.Add(TypeRefDecoder.Instance.GetTypeFromDefinition(reader, (TypeDefinitionHandle)interfaceHandle, 0));
         }
 
         return builder.ToImmutable();
     }
-
-    static TypeRef DecodeInterfaceType(MetadataReader reader, EntityHandle interfaceHandle) => interfaceHandle.Kind switch
-    {
-        HandleKind.TypeDefinition => TypeRefDecoder.Instance.GetTypeFromDefinition(reader, (TypeDefinitionHandle)interfaceHandle, 0),
-        HandleKind.TypeReference => TypeRefDecoder.Instance.GetTypeFromReference(reader, (TypeReferenceHandle)interfaceHandle, 0),
-        HandleKind.TypeSpecification => TypeRefDecoder.Instance.GetTypeFromSpecification(reader, GenericScope.Empty, (TypeSpecificationHandle)interfaceHandle, 0),
-        _ => TypeRef.Unsupported($"unsupported interface handle kind {interfaceHandle.Kind}"),
-    };
 
     static string ImporterTypeName(TypeRef type)
     {

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1452,22 +1452,22 @@ static class ReturnToSender
 
         void AddTargetInterfaceRoots(TypeDefinitionHandle handle)
         {
-            var typeDef = reader.GetTypeDefinition(handle);
-            foreach (var implementationHandle in typeDef.GetInterfaceImplementations())
+            // Interface discovery is product knowledge: the decompiler decodes the
+            // target type's InterfaceImpl rows to typed interface refs. RTS keeps
+            // only closure-root bookkeeping — resolve each same-assembly interface
+            // definition and seed it as a root. Non-definition refs (cross-assembly
+            // TypeRefs, generic-instance TypeSpecs) are not local closure roots and
+            // fall out at TryResolveHandle, matching the prior TypeDefinition-only walk.
+            foreach (var interfaceType in IrImporter.ImportImplementedInterfaces(reader, handle))
             {
-                var implementation = reader.GetInterfaceImplementation(implementationHandle);
-                if (implementation.Interface.Kind != HandleKind.TypeDefinition)
-                    continue;
-
-                var interfaceHandle = (TypeDefinitionHandle)implementation.Interface;
-                var interfaceDef = reader.GetTypeDefinition(interfaceHandle);
-                if (!IsSupportedClosureRoot(reader, interfaceDef))
+                if (TryResolveHandle(interfaceType) is not { } interfaceHandle)
                     continue;
 
                 var root = TopLevelRootOf(reader, interfaceHandle);
                 if (root == targetRoot)
                     continue;
 
+                var interfaceDef = reader.GetTypeDefinition(interfaceHandle);
                 closureRoots.Add(root);
                 AddClosureFact(
                     closureFacts,

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1406,7 +1406,12 @@ static class ReturnToSender
         Dictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
         Dictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements)
     {
-        string assemblyName = reader.GetString(reader.GetAssemblyDefinition().Name);
+        // Canonicalize the local assembly name so TryResolveHandle's same-assembly
+        // gate matches TypeRef.Assembly, which TypeRefDecoder canonicalizes (corelib
+        // facades collapse to one identity). Without this, a target assembly whose
+        // own name is a canonicalized facade (System.Runtime, mscorlib, ...) would
+        // fail to resolve its own definitions and drop their closure roots/facts.
+        string assemblyName = TypeRefDecoder.Canonical(reader.GetString(reader.GetAssemblyDefinition().Name));
         var definitions = TypeDefinitionsByTypeRefIdentity(reader);
         AddTargetInterfaceRoots(targetType);
         foreach (var node in function.Descendants.Prepend(function))
@@ -1453,11 +1458,10 @@ static class ReturnToSender
         void AddTargetInterfaceRoots(TypeDefinitionHandle handle)
         {
             // Interface discovery is product knowledge: the decompiler decodes the
-            // target type's InterfaceImpl rows to typed interface refs. RTS keeps
-            // only closure-root bookkeeping — resolve each same-assembly interface
-            // definition and seed it as a root. Non-definition refs (cross-assembly
-            // TypeRefs, generic-instance TypeSpecs) are not local closure roots and
-            // fall out at TryResolveHandle, matching the prior TypeDefinition-only walk.
+            // target type's same-assembly interface definitions to typed refs. RTS
+            // keeps only closure-root bookkeeping — resolve each interface definition
+            // (TryResolveHandle applies the same-assembly + supported-root gates) and
+            // seed it as a root, matching the prior TypeDefinition-only walk.
             foreach (var interfaceType in IrImporter.ImportImplementedInterfaces(reader, handle))
             {
                 if (TryResolveHandle(interfaceType) is not { } interfaceHandle)


### PR DESCRIPTION
- Advances #2529 (migration 2 — target-interface roots)
- Moves target-type interface discovery out of the RTS harness into product IR evidence
- Head: `d9572f50`

## Change

> Should we accept this change?

**Conclusion: PASS** — behavior-preserving relocation: product now decodes the target type's implemented interfaces to typed `TypeRef`s; RTS consumes them and keeps only closure-root bookkeeping. Interface discovery is product knowledge, finishing the #2520 typed-evidence pattern.

**Before** — RTS walks metadata itself in `AddTargetInterfaceRoots`:

```csharp
foreach (var implementationHandle in typeDef.GetInterfaceImplementations())
{
    var implementation = reader.GetInterfaceImplementation(implementationHandle);
    if (implementation.Interface.Kind != HandleKind.TypeDefinition) continue;
    var interfaceHandle = (TypeDefinitionHandle)implementation.Interface;
    // ... IsSupportedClosureRoot / TopLevelRootOf / seed root + fact
}
```

**After** — product owns discovery; RTS consumes typed evidence:

```csharp
foreach (var interfaceType in IrImporter.ImportImplementedInterfaces(reader, handle))
{
    if (TryResolveHandle(interfaceType) is not { } interfaceHandle) continue;
    // ... TopLevelRootOf / seed root + fact (unchanged)
}
```

The new `IrImporter.ImportImplementedInterfaces` decodes every interface handle kind (TypeDef/TypeRef/generic-instance TypeSpec) uniformly — strictly more complete than the old TypeDefinition-only walk. RTS's `TryResolveHandle` applies the same gates as before (`Kind==Definition`, same-assembly, `IsSupportedClosureRoot`), so cross-assembly/generic interfaces are declined exactly as before and the seeded root/fact set is unchanged.

## Why it's behavior-preserving

- **Same gates.** `TryResolveHandle` requires `Kind==Definition` + `Assembly==assemblyName` + `IsSupportedClosureRoot`. Cross-assembly interfaces decode to a foreign-assembly `Definition` (declined); generic-instance interfaces decode to `GenericInstance` (declined) — matching the old `Interface.Kind != TypeDefinition` skip.
- **Identity round-trips.** Decoder spells nested types `Outer+Inner` with the declaring namespace — identical to RTS's `TypeRefIdentity`; `Canonical` is identity for non-corelib assemblies, so a same-assembly definition resolves back to the same handle.
- **Fact text unchanged.** Still `reader.GetFullTypeName(interfaceDef)` on the resolved handle.

Product path stays SRM-only, Roslyn-free, NativeAOT-friendly, no inspected-assembly loading.

## Evidence

| Check | Result |
| --- | --- |
| Product + harness build (Release) | Pass, 0 warnings |
| New `ImplementedInterfaceEvidenceTests` (def/generic/nested/cross-assembly/empty) | 3/3 pass |
| `IrImporterTests` | 65/65 pass |
| `ReturnToSenderPrototypeTests` A/B (head vs parent `d65cd34e`) | Identical: same 8 pre-existing environmental `RecompileFail`s on both; **0 new failures** |
| Corpus quality-diff card | Not applicable — no raise/structuring/printer change; seeded closure roots/facts are provably unchanged |

> The 8 `ReturnToSenderPrototypeTests` failures (incl. `CompileBackTargets_SeedsTargetInterfaceRoot`) are pre-existing on the parent commit — the compile-back recompile step fails on this preview SDK (`RecompileFail`) regardless of this PR. Confirmed by A/B.

## Review

Adversarial review requested from two models of a different family than the author (Claude Opus 4.8): **GPT-5.5** and **Gemini 3.1 Pro**, each in an isolated checkout. Results will be posted here.

## Validation

```bash
dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release
dotnet build src/ILInspector.Decompiler.Tests -c Release
dotnet artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll -class "*ImplementedInterfaceEvidenceTests"
dotnet artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll -class "*ReturnToSenderPrototypeTests"
```
