### PR TITLE
Fix reference coalesce stack-slot unification

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SlotResidualCensusTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SlotResidualCensusTests.cs
@@ -63,46 +63,75 @@ public class SlotResidualCensusTests
     }
 
     [Fact]
-    public void StackSlotUnifierTelemetry_UnifiesReferenceCoalesceAtBaseTarget()
+    public void StackSlotUnifierTelemetry_UnifiesReferenceCoalesceAtObjectTarget()
     {
-        var baseReader = TypeRef.Definition("Synthetic", "Samples", "JsonReader", ValueTypeHint.ReferenceType);
-        var traceReader = TypeRef.Definition("Synthetic", "Samples", "TraceJsonReader", ValueTypeHint.ReferenceType);
+        var obj = TypeRef.CoreLib("System", "Object");
+        var str = TypeRef.CoreLib("System", "String");
         var owner = TypeRef.Definition("Synthetic", "Samples", "Owner", ValueTypeHint.ReferenceType);
         var voidType = TypeRef.CoreLib("System", "Void");
 
         var block = new Block();
         block.Add(new StoreStackSlot(0, new Coalesce(
-            new LoadLocal(0, traceReader),
-            new LoadArgument(0, "reader", baseReader))));
+            new LoadLocal(0, str),
+            new LoadArgument(0, "fallback", obj))));
         block.Add(new ExpressionStatement(new Call(
-            new MethodRef(owner, "Use", voidType, [baseReader], HasThis: false),
+            new MethodRef(owner, "Use", voidType, [obj], HasThis: false),
             isVirtual: false,
-            [new LoadStackSlot(0, baseReader)])));
+            [new LoadStackSlot(0, obj)])));
         var body = new BlockContainer();
         body.Add(block);
         var function = new IrFunction(
             "M",
             owner,
             new MethodSignature(voidType, [
-                new Parameter("reader", baseReader),
+                new Parameter("fallback", obj),
             ], HasThis: false, GenericParameterCount: 0),
-            [traceReader],
-            body)
-        {
-            TypeShapes = new Dictionary<TypeRef, TypeShape>
-            {
-                [baseReader] = TypeShape.Reference,
-                [traceReader] = TypeShape.Reference,
-            },
-        };
+            [str],
+            body);
 
         var telemetry = CSharpPrinter.CollectStackSlotUnifierTelemetry(function);
         var output = CSharpPrinter.Print(function).Output;
 
         Assert.Equal(0, telemetry.UnunifiedSplitSlots);
         Assert.DoesNotContain("S_0_1", output);
-        Assert.Contains("JsonReader S_0 = V_0 ?? reader;", output);
+        Assert.Contains("object S_0 = V_0 ?? fallback;", output);
         Assert.Contains("Use(S_0);", output);
+    }
+
+    [Fact]
+    public void StackSlotUnifierTelemetry_DoesNotUnifyObjectCoalesceToStringTarget()
+    {
+        var obj = TypeRef.CoreLib("System", "Object");
+        var str = TypeRef.CoreLib("System", "String");
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner", ValueTypeHint.ReferenceType);
+        var voidType = TypeRef.CoreLib("System", "Void");
+
+        var block = new Block();
+        block.Add(new StoreStackSlot(0, new Coalesce(
+            new LoadArgument(0, "left", obj),
+            new LoadArgument(1, "right", str))));
+        block.Add(new ExpressionStatement(new Call(
+            new MethodRef(owner, "Use", voidType, [str], HasThis: false),
+            isVirtual: false,
+            [new LoadStackSlot(0, str)])));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(voidType, [
+                new Parameter("left", obj),
+                new Parameter("right", str),
+            ], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        var telemetry = CSharpPrinter.CollectStackSlotUnifierTelemetry(function);
+        var output = CSharpPrinter.Print(function).Output;
+
+        Assert.Equal(1, telemetry.UnunifiedSplitSlots);
+        Assert.Contains("object S_0 = left ?? right;", output);
+        Assert.Contains("Use(S_0_1);", output);
     }
 
     static string CaptureConsole(Func<int> action)

--- a/src/ILInspector.Decompiler.Tests/SlotResidualCensusTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SlotResidualCensusTests.cs
@@ -134,6 +134,72 @@ public class SlotResidualCensusTests
         Assert.Contains("Use(S_0_1);", output);
     }
 
+    [Fact]
+    public void StackSlotUnifierTelemetry_DoesNotUnifyIncompatibleReferencesToObjectTarget()
+    {
+        var obj = TypeRef.CoreLib("System", "Object");
+        var str = TypeRef.CoreLib("System", "String");
+        var exception = TypeRef.CoreLib("System", "Exception");
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner", ValueTypeHint.ReferenceType);
+        var voidType = TypeRef.CoreLib("System", "Void");
+
+        var block = new Block();
+        block.Add(new StoreStackSlot(0, new Coalesce(
+            new LoadArgument(0, "left", str),
+            new LoadArgument(1, "right", exception))));
+        block.Add(new ExpressionStatement(new Call(
+            new MethodRef(owner, "Use", voidType, [obj], HasThis: false),
+            isVirtual: false,
+            [new LoadStackSlot(0, obj)])));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(voidType, [
+                new Parameter("left", str),
+                new Parameter("right", exception),
+            ], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        var telemetry = CSharpPrinter.CollectStackSlotUnifierTelemetry(function);
+        var output = CSharpPrinter.Print(function).Output;
+
+        Assert.Equal(1, telemetry.UnunifiedSplitSlots);
+        Assert.Contains("string S_0 = left ?? right;", output);
+        Assert.Contains("Use(S_0_1);", output);
+    }
+
+    [Fact]
+    public void StackSlotUnifierTelemetry_DoesNotUnifyNullNullCoalesceToObjectTarget()
+    {
+        var obj = TypeRef.CoreLib("System", "Object");
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner", ValueTypeHint.ReferenceType);
+        var voidType = TypeRef.CoreLib("System", "Void");
+
+        var block = new Block();
+        block.Add(new StoreStackSlot(0, new Coalesce(
+            new Constant(null, obj),
+            new Constant(null, obj))));
+        block.Add(new ExpressionStatement(new Call(
+            new MethodRef(owner, "Use", voidType, [obj], HasThis: false),
+            isVirtual: false,
+            [new LoadStackSlot(0, obj)])));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        var telemetry = CSharpPrinter.CollectStackSlotUnifierTelemetry(function);
+
+        Assert.Equal(1, telemetry.UnunifiedSplitSlots);
+    }
+
     static string CaptureConsole(Func<int> action)
     {
         lock (ConsoleGate)

--- a/src/ILInspector.Decompiler.Tests/SlotResidualCensusTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SlotResidualCensusTests.cs
@@ -62,6 +62,49 @@ public class SlotResidualCensusTests
         Assert.Equal(0, telemetry.MultiCandidateUnifiedSlots);
     }
 
+    [Fact]
+    public void StackSlotUnifierTelemetry_UnifiesReferenceCoalesceAtBaseTarget()
+    {
+        var baseReader = TypeRef.Definition("Synthetic", "Samples", "JsonReader", ValueTypeHint.ReferenceType);
+        var traceReader = TypeRef.Definition("Synthetic", "Samples", "TraceJsonReader", ValueTypeHint.ReferenceType);
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner", ValueTypeHint.ReferenceType);
+        var voidType = TypeRef.CoreLib("System", "Void");
+
+        var block = new Block();
+        block.Add(new StoreStackSlot(0, new Coalesce(
+            new LoadLocal(0, traceReader),
+            new LoadArgument(0, "reader", baseReader))));
+        block.Add(new ExpressionStatement(new Call(
+            new MethodRef(owner, "Use", voidType, [baseReader], HasThis: false),
+            isVirtual: false,
+            [new LoadStackSlot(0, baseReader)])));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(voidType, [
+                new Parameter("reader", baseReader),
+            ], HasThis: false, GenericParameterCount: 0),
+            [traceReader],
+            body)
+        {
+            TypeShapes = new Dictionary<TypeRef, TypeShape>
+            {
+                [baseReader] = TypeShape.Reference,
+                [traceReader] = TypeShape.Reference,
+            },
+        };
+
+        var telemetry = CSharpPrinter.CollectStackSlotUnifierTelemetry(function);
+        var output = CSharpPrinter.Print(function).Output;
+
+        Assert.Equal(0, telemetry.UnunifiedSplitSlots);
+        Assert.DoesNotContain("S_0_1", output);
+        Assert.Contains("JsonReader S_0 = V_0 ?? reader;", output);
+        Assert.Contains("Use(S_0);", output);
+    }
+
     static string CaptureConsole(Func<int> action)
     {
         lock (ConsoleGate)

--- a/src/ILInspector.Decompiler.Tests/SlotResidualCensusTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SlotResidualCensusTests.cs
@@ -200,6 +200,42 @@ public class SlotResidualCensusTests
         Assert.Equal(1, telemetry.UnunifiedSplitSlots);
     }
 
+    [Fact]
+    public void StackSlotUnifierTelemetry_UnifiesNullableValueCoalesceAtValueTarget()
+    {
+        var int32 = TypeRef.CoreLib("System", "Int32");
+        var nullableInt32 = TypeRef.GenericInstance(TypeRef.CoreLib("System", "Nullable`1"), [int32]);
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner", ValueTypeHint.ReferenceType);
+        var voidType = TypeRef.CoreLib("System", "Void");
+
+        var block = new Block();
+        block.Add(new StoreStackSlot(0, new Coalesce(
+            new LoadArgument(0, "left", nullableInt32),
+            new Constant(0, int32))));
+        block.Add(new ExpressionStatement(new Call(
+            new MethodRef(owner, "Use", voidType, [int32], HasThis: false),
+            isVirtual: false,
+            [new LoadStackSlot(0, int32)])));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(voidType, [
+                new Parameter("left", nullableInt32),
+            ], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        var telemetry = CSharpPrinter.CollectStackSlotUnifierTelemetry(function);
+        var output = CSharpPrinter.Print(function).Output;
+
+        Assert.Equal(0, telemetry.UnunifiedSplitSlots);
+        Assert.DoesNotContain("S_0_1", output);
+        Assert.Contains("int S_0 = left ?? 0;", output);
+        Assert.Contains("Use(S_0);", output);
+    }
+
     static string CaptureConsole(Func<int> action)
     {
         lock (ConsoleGate)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -858,19 +858,38 @@ public sealed partial class CSharpPrinter
                 || (conditional.ResultType is { } condType && CanAssignType(condType, target));
         if (value is Coalesce coalesce)
             return CanRenderCoalesceForTarget(coalesce, target)
-                || (coalesce.ResultType is { } coalesceType && CanAssignType(coalesceType, target));
+                || (coalesce.ResultType is { } coalesceType
+                    && CanAssignType(coalesceType, target)
+                    && CanRenderCoalesceForTarget(coalesce, coalesceType));
         return value.ResultType is { } source && CanAssignType(source, target);
     }
 
     bool CanRenderCoalesceForTarget(Coalesce coalesce, TypeRef target)
-        => IsProvenReference(target)
-            && IsReferenceCoalesceArmAssignableTo(coalesce.Left, target)
-            && IsReferenceCoalesceArmAssignableTo(coalesce.Right, target);
+    {
+        if (!IsProvenReference(target))
+            return false;
 
-    bool IsReferenceCoalesceArmAssignableTo(IrExpression arm, TypeRef target)
-        => arm is Constant { Value: null }
-            || EffectiveType(arm)?.Equals(target) == true
-            || (EffectiveType(arm) is { } type && IsProvenReference(type) && CanAssignType(type, target));
+        bool leftNull = coalesce.Left is Constant { Value: null };
+        bool rightNull = coalesce.Right is Constant { Value: null };
+        var leftType = EffectiveType(coalesce.Left);
+        var rightType = EffectiveType(coalesce.Right);
+
+        if (leftNull && rightNull)
+            return false;
+        if (leftNull)
+            return rightType is { } right && IsProvenReference(right) && CanAssignType(right, target);
+        if (rightNull)
+            return leftType is { } left && IsProvenReference(left) && CanAssignType(left, target);
+        if (leftType is not { } leftNonNull || rightType is not { } rightNonNull)
+            return false;
+        if (!IsProvenReference(leftNonNull) || !IsProvenReference(rightNonNull))
+            return false;
+        if (CanAssignType(rightNonNull, leftNonNull))
+            return CanAssignType(leftNonNull, target);
+        if (CanAssignType(leftNonNull, rightNonNull))
+            return CanAssignType(rightNonNull, target);
+        return false;
+    }
 
     /// <summary>
     /// A type known to be a reference WITHOUT resolution — a stack-O family

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -860,7 +860,7 @@ public sealed partial class CSharpPrinter
             return CanRenderCoalesceForTarget(coalesce, target)
                 || (coalesce.ResultType is { } coalesceType
                     && CanAssignType(coalesceType, target)
-                    && CanRenderCoalesceForTarget(coalesce, coalesceType));
+                    && !IsReferenceLike(coalesceType));
         return value.ResultType is { } source && CanAssignType(source, target);
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -864,13 +864,13 @@ public sealed partial class CSharpPrinter
 
     bool CanRenderCoalesceForTarget(Coalesce coalesce, TypeRef target)
         => IsProvenReference(target)
-            && (EffectiveType(coalesce.Left)?.Equals(target) == true || EffectiveType(coalesce.Right)?.Equals(target) == true)
-            && IsReferenceCoalesceArm(coalesce.Left)
-            && IsReferenceCoalesceArm(coalesce.Right);
+            && IsReferenceCoalesceArmAssignableTo(coalesce.Left, target)
+            && IsReferenceCoalesceArmAssignableTo(coalesce.Right, target);
 
-    bool IsReferenceCoalesceArm(IrExpression arm)
+    bool IsReferenceCoalesceArmAssignableTo(IrExpression arm, TypeRef target)
         => arm is Constant { Value: null }
-            || (EffectiveType(arm) is { } type && IsProvenReference(type));
+            || EffectiveType(arm)?.Equals(target) == true
+            || (EffectiveType(arm) is { } type && IsProvenReference(type) && CanAssignType(type, target));
 
     /// <summary>
     /// A type known to be a reference WITHOUT resolution — a stack-O family

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -856,8 +856,21 @@ public sealed partial class CSharpPrinter
                     && CanAssignTo(conditional.WhenTrue, target)
                     && CanAssignTo(conditional.WhenFalse, target))
                 || (conditional.ResultType is { } condType && CanAssignType(condType, target));
+        if (value is Coalesce coalesce)
+            return CanRenderCoalesceForTarget(coalesce, target)
+                || (coalesce.ResultType is { } coalesceType && CanAssignType(coalesceType, target));
         return value.ResultType is { } source && CanAssignType(source, target);
     }
+
+    bool CanRenderCoalesceForTarget(Coalesce coalesce, TypeRef target)
+        => IsProvenReference(target)
+            && (EffectiveType(coalesce.Left)?.Equals(target) == true || EffectiveType(coalesce.Right)?.Equals(target) == true)
+            && IsReferenceCoalesceArm(coalesce.Left)
+            && IsReferenceCoalesceArm(coalesce.Right);
+
+    bool IsReferenceCoalesceArm(IrExpression arm)
+        => arm is Constant { Value: null }
+            || (EffectiveType(arm) is { } type && IsProvenReference(type));
 
     /// <summary>
     /// A type known to be a reference WITHOUT resolution — a stack-O family


### PR DESCRIPTION
- Advances #2209
- Changes the printer-owned stack-slot unifier so a reference `??` store can use a proven reference load target when that target is already one coalesce arm type, avoiding a split into an unassigned shadow stack-slot name.
- Card revision: `73ba3e45`

## Change

**Conclusion:** **REVIEW** — this is a narrow C2 split-slot reduction that fixes a measured invalid split-name shape and reduces printer split slots from 174 to 162.

Before:

```csharp
TraceJsonReader S_2 = V_6 ?? reader;
object S_256 = S_1.Deserialize(S_2_1, objectType, CheckAdditionalContent);
```

After:

```csharp
JsonReader S_2 = V_6 ?? reader;
object S_256 = S_1.Deserialize(S_2, objectType, CheckAdditionalContent);
```

Real witness: `Newtonsoft.Json.JsonSerializer::DeserializeInternal`.

## Evidence

| Check | Result |
| --- | --- |
| SDK | `/home/rich/.dotnetup/dotnet/dotnet`, `11.0.100-preview.7.26357.101` |
| Product/test build | Pass: `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --nologo` |
| Focused tests | Pass: `SlotResidualCensusTests` |
| Printer-owned C2 census | Pass: 89,065 methods, 0 pass bugs, un-unified split slots `174 -> 162` |
| Render A/B semantic lane | Pass: 89,065 methods, changed 12, semantic `valid->invalid: 0` |
| Quality card | Advisory: pinned quick gate improved/neutral; generated verdict is a cap artifact because PR run used `--compile-cap 25` against a baseline with higher semantic/fidelity coverage |
| Full decompiler suite | Advisory: currently red on `origin/main` too for `FidelityGateTests.NoNewOpcodeDiffsBeyondKnownDocket` (`PointerStoreUsesOriginalAddress`); not introduced by this branch |

## C2 census

Before (#2493 baseline):

```text
Un-unified split slots: 174
Multi-candidate slots unified by printer: 340
Stack-slot declarations emitted: 19635
```

After this PR:

```text
STACK-SLOT UNIFIER CENSUS over 89065 methods (0 pass bugs)
Un-unified split slots: 162
Multi-candidate slots unified by printer: 352
Stack-slot declarations emitted: 19622
```

## Render A/B

```text
Render A/B Check: 89065 methods evaluated
Changed: 12 (structural: 11, paren-equivalent: 0, unparsed: 1)
Semantic: valid->valid: 8, invalid->valid: 0, valid->invalid: 0, invalid->invalid: 4
Added:   0
Removed: 0
```

Changed rows are the intended split-name collapse shape, e.g. Roslyn nullable walker rows replace a stale split read such as `S_11_1.Syntax.GetLocation()` with the unified `S_11.Syntax.GetLocation()`.

## Decompiler quality

**Conclusion:** **ADVISORY** — pinned corpus signal is improved/neutral; generated regression verdict is from lower validation sample caps, not product movement.

```text
Fully raised (+) 78,399 (88.02%) -> 78,406 (88.03%) (+7)
Full malformed (-) 0 -> 0
Semantic defects (-) 74 -> 1 (-73)
Fidelity opcode diffs (-) 5 -> 3 (-2)
Pass bugs (-) 0 -> 0
```

## Review

Adversarial review requested; reconciliation will be posted before Ready to merge.

## Validation commands

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --nologo
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/SlotResidualCensusTests/*"
mapfile -t assemblies < /tmp/issue2209-c2-corpus.txt
dotnet run --project tools/DecompilerHarness -c Release --no-build -- "${assemblies[@]}" --slot-unifier-census --max-examples 40
dotnet run --project ../c2-render-base/tools/DecompilerHarness -c Release -- "${assemblies[@]}" --workers 20 --emit-render-ab /tmp/c2-base.renderab
dotnet run --project tools/DecompilerHarness -c Release --no-build -- "${assemblies[@]}" --workers 20 --render-ab /tmp/c2-base.renderab
dotnet run --project tools/DecompilerHarness -c Release --no-build -- "${assemblies[@]}" --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json --quality-diff-card --compile-cap 25 --corpus-fidelity-cap 3 --max-examples 3
```
