### PR TITLE
Preserve typed RTS IL diff evidence

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -1151,6 +1151,7 @@ public class GeneratedFixtureCatalogTests
                                 "ldc.i4 2",
                                 "Added IL operation 'ldc.i4 2'"),
                         ]),
+                    IlDiff: null,
                     MemberAnchor: new MemberAnchor(
                         "Method1~abcdef1234",
                         "M:TestType.Method1()",
@@ -1269,6 +1270,7 @@ public class GeneratedFixtureCatalogTests
                         Failure: failure.UnifiedLine,
                         Rows: [],
                         FailureRows: [failure]),
+                    IlDiff: null,
                     MemberAnchor: new MemberAnchor(
                         "Method1~abcdef1234",
                         "M:TestType.Method1()",

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderEvidenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderEvidenceTests.cs
@@ -24,6 +24,9 @@ public class ReturnToSenderEvidenceTests
         Assert.NotNull(row.Anchor);
         Assert.StartsWith("Method1~", row.Anchor.StableSelector, StringComparison.Ordinal);
         Assert.Null(row.IlDiffDiagnostic);
+        Assert.NotNull(row.IlDiff);
+        Assert.True(row.IlDiff.Diff.IsExact);
+        Assert.Equal(row.IlDiff.Old.Identity, row.IlDiff.New.Identity);
 
         var research = ReturnToSenderEvidence.ToResearchDiff(evidence);
         var subject = Assert.Single(research.MembersWhere(member => member.Subject.Id == row.Anchor.StableSelector));
@@ -43,6 +46,30 @@ public class ReturnToSenderEvidenceTests
             "abcdef1234",
             "TestType",
             "Method1");
+        var typedDiff = new IlMemberDiffResult(
+            new IlMemberDiffSubject("old-id", "old-label"),
+            new IlMemberDiffSubject("new-id", "new-label"),
+            new IlBodyDiffResult(
+                IsExact: false,
+                Failure: null,
+                Rows:
+                [
+                    new IlDiffRow(
+                        0,
+                        IlDiffKind.Context,
+                        new CanonicalIlOperation(0, "nop", Operand: null),
+                        "Unchanged IL operation 'nop'"),
+                    new IlDiffRow(
+                        1,
+                        IlDiffKind.Remove,
+                        new CanonicalIlOperation(1, "ldc.i4", new IlOperandIdentity(IlOperandIdentityKind.Immediate, "1")),
+                        "Removed IL operation 'ldc.i4 1'"),
+                    new IlDiffRow(
+                        1,
+                        IlDiffKind.Add,
+                        new CanonicalIlOperation(1, "ldc.i4", new IlOperandIdentity(IlOperandIdentityKind.Immediate, "2")),
+                        "Added IL operation 'ldc.i4 2'"),
+                ]));
         var evidence = new ReturnToSenderEvidenceRow(
             anchor,
             "TestType",
@@ -52,44 +79,8 @@ public class ReturnToSenderEvidenceTests
             FidelityCheck.CompileBackStatus.OpcodeDiff,
             "opcode-diff",
             Detail: null,
-            IlDiffDiagnostic: new IlDiffDisplayResult(
-                Failure: null,
-                Rows:
-                [
-                    new IlDiffDisplayRow(
-                        0,
-                        IlDiffKind.Context,
-                        " ",
-                        0,
-                        "IL_0000",
-                        "nop",
-                        OperandKind: null,
-                        OperandValue: null,
-                        "nop",
-                        "Unchanged IL operation 'nop'"),
-                    new IlDiffDisplayRow(
-                        1,
-                        IlDiffKind.Remove,
-                        "-",
-                        1,
-                        "IL_0001",
-                        "ldc.i4",
-                        IlOperandIdentityKind.Immediate,
-                        "1",
-                        "ldc.i4 1",
-                        "Removed IL operation 'ldc.i4 1'"),
-                    new IlDiffDisplayRow(
-                        1,
-                        IlDiffKind.Add,
-                        "+",
-                        1,
-                        "IL_0001",
-                        "ldc.i4",
-                        IlOperandIdentityKind.Immediate,
-                        "2",
-                        "ldc.i4 2",
-                        "Added IL operation 'ldc.i4 2'"),
-                ]));
+            IlDiffDiagnostic: null,
+            IlDiff: typedDiff);
 
         var research = ReturnToSenderEvidence.ToResearchDiff([evidence]);
 
@@ -106,6 +97,7 @@ public class ReturnToSenderEvidenceTests
             && item.ChangeId == "il.operation.removed"
             && item.OldValue == "ldc.i4 1"
             && item.OldIlOffset == 1
+            && item.IlMemberDiff == typedDiff
             && item.IlDisplayRows.Length == 1
             && item.IlDisplayRows[0].UnifiedLine == "h1 - IL_0001 ldc.i4 1");
         Assert.Contains(subject.Evidence, item =>
@@ -113,6 +105,7 @@ public class ReturnToSenderEvidenceTests
             && item.ChangeId == "il.operation.added"
             && item.NewValue == "ldc.i4 2"
             && item.NewIlOffset == 1
+            && item.IlMemberDiff == typedDiff
             && item.IlDisplayRows.Length == 1
             && item.IlDisplayRows[0].UnifiedLine == "h1 + IL_0001 ldc.i4 2");
         Assert.DoesNotContain(subject.Evidence, item => item.ChangeId == "il.operation.context");
@@ -144,7 +137,8 @@ public class ReturnToSenderEvidenceTests
             IlDiffDiagnostic: new IlDiffDisplayResult(
                 Failure: failure.UnifiedLine,
                 Rows: [],
-                FailureRows: [failure]));
+                FailureRows: [failure]),
+            IlDiff: null);
 
         var research = ReturnToSenderEvidence.ToResearchDiff([evidence]);
 

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -119,6 +119,7 @@ public sealed record ResearchDiffEvidence(
     bool InLoop = false,
     ImmutableArray<IlDiffDisplayRow> IlDisplayRows = default,
     IlDiffDisplayFailureRow? IlDisplayFailureRow = null,
+    IlMemberDiffResult? IlMemberDiff = null,
     CSharpDiffDisplayFailureRow? CSharpDisplayFailureRow = null)
 {
     public ImmutableArray<CSharpDiffDisplayRow> CSharpDisplayRows { get; init; } = default;

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -2066,6 +2066,7 @@ internal sealed record GeneratedFixtureReturnToSenderResult(
     string Reason,
     string? Detail,
     IlDiffDisplayResult? IlDiffDiagnostic,
+    IlMemberDiffResult? IlDiff,
     MemberAnchor? MemberAnchor,
     ReturnToSenderClosureEvidence? ClosureEvidence,
     bool IsFrontier,
@@ -2201,6 +2202,7 @@ internal static class GeneratedFixtureRunner
                                 ? $"missing expected target body fragment: {missingTargetBodyFragment}"
                                 : actual.Detail,
                         actual.IlDiffDiagnostic,
+                        actual.IlDiff,
                         actual.MemberAnchor,
                         ReturnToSenderClosureEvidenceBuilder.FromPlan(actual.Plan),
                         target.IsFrontier,
@@ -2237,6 +2239,7 @@ internal static class GeneratedFixtureRunner
             reason,
             Detail: null,
             IlDiffDiagnostic: null,
+            IlDiff: null,
             MemberAnchor: null,
             ClosureEvidence: null,
             target.IsFrontier,
@@ -2364,6 +2367,7 @@ internal static class GeneratedFixtureRunner
             result.Reason,
             result.Detail,
             IlDiffDiagnostic = SerializableIlDiffDisplayResult(result.IlDiffDiagnostic),
+            IlDiff = SerializableIlMemberDiff(result.IlDiff),
             result.MemberAnchor,
             result.ClosureEvidence,
             result.IsFrontier,
@@ -2379,7 +2383,19 @@ internal static class GeneratedFixtureRunner
                 result.Failure,
                 Rows = result.Rows.IsDefault ? Array.Empty<IlDiffDisplayRow>() : result.Rows.ToArray(),
                 FailureRows = result.FailureRows.IsDefault ? Array.Empty<IlDiffDisplayFailureRow>() : result.FailureRows.ToArray(),
-                result.IsEmpty,
+            };
+
+    static object? SerializableIlMemberDiff(IlMemberDiffResult? result)
+        => result is null
+            ? null
+            : new
+            {
+                result.Old,
+                result.New,
+                result.Diff.IsExact,
+                result.Diff.Failure,
+                Rows = result.Diff.Rows.IsDefault ? Array.Empty<IlDiffRow>() : result.Diff.Rows.ToArray(),
+                FailureRows = result.Diff.FailureRows.IsDefault ? Array.Empty<IlDiffFailureRow>() : result.Diff.FailureRows.ToArray(),
             };
 
     static object SerializableResearchDiff(ResearchDiffResult research)
@@ -2429,6 +2445,7 @@ internal static class GeneratedFixtureRunner
             evidence.InLoop,
             IlDisplayRows = evidence.IlDisplayRows.IsDefault ? Array.Empty<IlDiffDisplayRow>() : evidence.IlDisplayRows.ToArray(),
             evidence.IlDisplayFailureRow,
+            IlMemberDiff = SerializableIlMemberDiff(evidence.IlMemberDiff),
         };
 
     public static string FormatList(IReadOnlyList<GeneratedFixtureDefinition> fixtures)

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -32,6 +32,7 @@ static class ReturnToSender
         string? Detail,
         string TargetBody = "",
         IlDiffDisplayResult? IlDiffDiagnostic = null,
+        IlMemberDiffResult? IlDiff = null,
         MemberAnchor? MemberAnchor = null,
         IReadOnlyList<DecompilerDecision>? Decisions = null);
 
@@ -705,7 +706,8 @@ static class ReturnToSender
                 var recompiledOps = FindAndDisassemble(recompiled, fullType, methodName, overload: 0)
                     ?.Select(instruction => CanonicalOpcode(instruction.OpCodeName))
                     .ToArray();
-                var ilDiffDiagnostic = BuildIlDiffDiagnostic(pe, reader, getterHandle, recompiled, fullType, methodName, overload: 0);
+                var ilDiff = BuildIlDiff(pe, reader, getterHandle, recompiled, fullType, methodName, overload: 0);
+                var ilDiffDiagnostic = ToDisplayDiagnostic(ilDiff);
 
                 if (recompiledOps is null)
                 {
@@ -729,6 +731,7 @@ static class ReturnToSender
                     null,
                     TargetBody: printed.Output,
                     IlDiffDiagnostic: ilDiffDiagnostic,
+                    IlDiff: ilDiff,
                     MemberAnchor: memberAnchor,
                     Decisions: printed.Decisions);
             }
@@ -863,7 +866,8 @@ static class ReturnToSender
                 var recompiledOps = FindAndDisassemble(recompiled, fullType, methodName, overload: 0)
                     ?.Select(instruction => CanonicalOpcode(instruction.OpCodeName))
                     .ToArray();
-                var ilDiffDiagnostic = BuildIlDiffDiagnostic(pe, reader, methodHandle, recompiled, fullType, methodName, overload: 0);
+                var ilDiff = BuildIlDiff(pe, reader, methodHandle, recompiled, fullType, methodName, overload: 0);
+                var ilDiffDiagnostic = ToDisplayDiagnostic(ilDiff);
 
                 if (recompiledOps is null)
                 {
@@ -887,6 +891,7 @@ static class ReturnToSender
                     null,
                     TargetBody: printed.Output,
                     IlDiffDiagnostic: ilDiffDiagnostic,
+                    IlDiff: ilDiff,
                     MemberAnchor: memberAnchor,
                     Decisions: printed.Decisions);
             }
@@ -1022,7 +1027,8 @@ static class ReturnToSender
                 var recompiledOps = FindAndDisassemble(recompiled, fullType, methodName, overload: 0)
                     ?.Select(instruction => CanonicalOpcode(instruction.OpCodeName))
                     .ToArray();
-                var ilDiffDiagnostic = BuildIlDiffDiagnostic(pe, reader, setterHandle, recompiled, fullType, methodName, overload: 0);
+                var ilDiff = BuildIlDiff(pe, reader, setterHandle, recompiled, fullType, methodName, overload: 0);
+                var ilDiffDiagnostic = ToDisplayDiagnostic(ilDiff);
 
                 if (recompiledOps is null)
                 {
@@ -1046,6 +1052,7 @@ static class ReturnToSender
                     null,
                     TargetBody: printed.Output,
                     IlDiffDiagnostic: ilDiffDiagnostic,
+                    IlDiff: ilDiff,
                     MemberAnchor: memberAnchor,
                     Decisions: printed.Decisions);
             }
@@ -1331,6 +1338,16 @@ static class ReturnToSender
         string fullType,
         string methodName,
         int overload)
+        => ToDisplayDiagnostic(BuildIlDiff(originalPe, originalReader, originalMethod, recompiledPe, fullType, methodName, overload));
+
+    internal static IlMemberDiffResult? BuildIlDiff(
+        PEReader originalPe,
+        MetadataReader originalReader,
+        MethodDefinitionHandle originalMethod,
+        PEReader recompiledPe,
+        string fullType,
+        string methodName,
+        int overload)
     {
         if (originalReader.GetMethodDefinition(originalMethod).RelativeVirtualAddress == 0)
             return null;
@@ -1339,7 +1356,7 @@ static class ReturnToSender
         if (recompiled.Method.RelativeVirtualAddress == 0)
             return null;
 
-        var diff = IlAssemblyDiff.CompareMembers(
+        return IlAssemblyDiff.CompareMembers(
             originalPe,
             originalReader,
             originalMethod,
@@ -1348,6 +1365,12 @@ static class ReturnToSender
             recompiled.Handle,
             oldLabel: $"{fullType}::{methodName}",
             newLabel: $"{fullType}::{methodName}");
+    }
+
+    static IlDiffDisplayResult? ToDisplayDiagnostic(IlMemberDiffResult? diff)
+    {
+        if (diff is null)
+            return null;
         var display = IlDiffPrinter.ToDisplayResult(diff.Diff);
         return display.IsEmpty ? null : display;
     }

--- a/tools/DecompilerHarness/ReturnToSenderCatalogReport.cs
+++ b/tools/DecompilerHarness/ReturnToSenderCatalogReport.cs
@@ -187,7 +187,14 @@ internal static class ReturnToSenderCatalogReport
             row.MemberAnchor?.CanonicalSignature,
             closure,
             row.Detail,
-            row.IlDiffDiagnostic is null ? [] : [.. IlDiffPrinter.ToUnifiedLines(row.IlDiffDiagnostic)]);
+            IlDiffLines(row));
+    }
+
+    static List<string> IlDiffLines(GeneratedFixtureReturnToSenderResult row)
+    {
+        if (row.IlDiff is { } typed)
+            return [.. IlDiffPrinter.ToUnifiedLines(typed.Diff)];
+        return row.IlDiffDiagnostic is null ? [] : [.. IlDiffPrinter.ToUnifiedLines(row.IlDiffDiagnostic)];
     }
 
     static IReadOnlyList<ReturnToSenderCatalogReportBucket> Buckets(IEnumerable<GeneratedFixtureReturnToSenderResult> rows)

--- a/tools/DecompilerHarness/ReturnToSenderEvidence.cs
+++ b/tools/DecompilerHarness/ReturnToSenderEvidence.cs
@@ -13,7 +13,8 @@ internal sealed record ReturnToSenderEvidenceRow(
     FidelityCheck.CompileBackStatus? CompileBackStatus,
     string Reason,
     string? Detail,
-    IlDiffDisplayResult? IlDiffDiagnostic)
+    IlDiffDisplayResult? IlDiffDiagnostic,
+    IlMemberDiffResult? IlDiff)
 {
     public string DisplayMember => $"{Type}::{Method}#{Overload}";
 }
@@ -59,7 +60,8 @@ internal static class ReturnToSenderEvidence
             result.ActualStatus,
             result.Reason,
             result.Detail,
-            result.IlDiffDiagnostic))];
+            result.IlDiffDiagnostic,
+            result.IlDiff))];
     }
 
     public static ResearchDiffResult ToResearchDiff(IEnumerable<ReturnToSenderEvidenceRow> rows)
@@ -172,7 +174,8 @@ internal static class ReturnToSenderEvidence
             Detail: row.Detail ?? row.Reason,
             Category: ResearchDiffChangeCategory.RoundTrip);
 
-        if (row.IlDiffDiagnostic is not { } diagnostic)
+        var diagnostic = Diagnostic(row);
+        if (diagnostic is null)
             yield break;
 
         var failureRows = diagnostic.FailureRows.IsDefault
@@ -186,7 +189,8 @@ internal static class ReturnToSenderEvidence
                 ResearchDiffDirection.Changed,
                 Detail: failureRow.Detail ?? failureRow.Message,
                 Category: ResearchDiffChangeCategory.IlBody,
-                IlDisplayFailureRow: failureRow);
+                IlDisplayFailureRow: failureRow,
+                IlMemberDiff: row.IlDiff);
         }
 
         if (failureRows.IsDefaultOrEmpty && diagnostic.Failure is { Length: > 0 } failure)
@@ -220,9 +224,15 @@ internal static class ReturnToSenderEvidence
                 NewIlOffset: displayRow.Kind == IlDiffKind.Add ? displayRow.RawOffset : null,
                 Detail: displayRow.Message,
                 Category: ResearchDiffChangeCategory.IlBody,
-                IlDisplayRows: [displayRow]);
+                IlDisplayRows: [displayRow],
+                IlMemberDiff: row.IlDiff);
         }
     }
+
+    static IlDiffDisplayResult? Diagnostic(ReturnToSenderEvidenceRow row)
+        => row.IlDiff is { } typed
+            ? IlDiffPrinter.ToDisplayResult(typed.Diff)
+            : row.IlDiffDiagnostic;
 
     static string StatusId(GeneratedFixtureReturnToSenderStatus status)
         => status switch


### PR DESCRIPTION
## Summary

- Carry `IlMemberDiffResult` through RTS results, generated fixture rows, Research evidence, and catalog JSON.
- Keep existing `IlDiffDiagnostic` display projection for compatibility and Markout/report rendering.
- Prefer typed IL evidence when projecting Research/display rows, falling back to existing display diagnostics for older/manual test rows.
- Add focused tests proving exact rows carry typed IL diff evidence and opcode-diff Research rows retain the typed member diff while still exposing display rows.

## Validation

- `dotnetup dotnet build dotnet-inspect.slnx -c Release --no-restore`
- `dotnetup dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.ReturnToSenderEvidenceTests -class ILInspector.Decompiler.Tests.ReturnToSenderFixtureCatalogTests -class ILInspector.Decompiler.Tests.GeneratedFixtureCatalogTests`
- `dotnetup dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --no-restore`

Note: build logged a transient MSB3026 copy retry from local concurrent access and completed with 0 errors.