### PR TITLE
Move checked-operator sibling naming into OperatorNames (#2529)

### DIFF
--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -1329,7 +1329,7 @@ public static class CompileBackSourceComposer
         string methodName,
         MethodSignature<string> targetSignature)
     {
-        var siblingName = UncheckedOperatorName(methodName);
+        var siblingName = OperatorNames.UncheckedOperator(methodName);
         if (siblingName is null)
             return null;
 
@@ -1362,19 +1362,6 @@ public static class CompileBackSourceComposer
         }
 
         return null;
-    }
-
-    static string? UncheckedOperatorName(string methodName)
-    {
-        if (methodName is "op_CheckedExplicit")
-            return "op_Explicit";
-        if (methodName is "op_CheckedImplicit")
-            return "op_Implicit";
-        if (!methodName.StartsWith("op_Checked", StringComparison.Ordinal))
-            return null;
-
-        string inner = methodName["op_Checked".Length..];
-        return OperatorNames.MapBinaryOrUnary(inner) is null ? null : $"op_{inner}";
     }
 
     static bool IsRecordGeneratedFieldReadHelper(

--- a/src/ILInspector.Metadata/OperatorNames.cs
+++ b/src/ILInspector.Metadata/OperatorNames.cs
@@ -83,4 +83,25 @@ public static class OperatorNames
         "UnaryNegation" => "-",
         _ => null
     };
+
+    /// <summary>
+    /// The unchecked operator method name paired with a checked operator method
+    /// name — <c>op_CheckedAddition → op_Addition</c>, <c>op_CheckedExplicit →
+    /// op_Explicit</c>, <c>op_CheckedImplicit → op_Implicit</c> — or null when
+    /// <paramref name="methodName"/> is not a checked operator with a defined
+    /// unchecked sibling. C# requires a checked operator's unchecked form to be
+    /// declared, so consumers pair the two when composing operator surfaces.
+    /// </summary>
+    public static string? UncheckedOperator(string methodName)
+    {
+        if (methodName is "op_CheckedExplicit")
+            return "op_Explicit";
+        if (methodName is "op_CheckedImplicit")
+            return "op_Implicit";
+        if (!methodName.StartsWith("op_Checked", StringComparison.Ordinal))
+            return null;
+
+        string inner = methodName["op_Checked".Length..];
+        return MapBinaryOrUnary(inner) is null ? null : $"op_{inner}";
+    }
 }

--- a/tests/ILInspector.Metadata.Tests/OperatorNamesTests.cs
+++ b/tests/ILInspector.Metadata.Tests/OperatorNamesTests.cs
@@ -75,4 +75,27 @@ public class OperatorNamesTests
     [Fact]
     public void Unknown_op_prefix_passes_through()
         => Assert.Equal("op_SomeFutureOp", OperatorNames.FormatDisplayName("op_SomeFutureOp"));
+
+    [Theory]
+    [InlineData("op_CheckedAddition", "op_Addition")]
+    [InlineData("op_CheckedSubtraction", "op_Subtraction")]
+    [InlineData("op_CheckedMultiply", "op_Multiply")]
+    [InlineData("op_CheckedDivision", "op_Division")]
+    [InlineData("op_CheckedIncrement", "op_Increment")]
+    [InlineData("op_CheckedDecrement", "op_Decrement")]
+    [InlineData("op_CheckedUnaryNegation", "op_UnaryNegation")]
+    [InlineData("op_CheckedExplicit", "op_Explicit")]
+    [InlineData("op_CheckedImplicit", "op_Implicit")]
+    public void UncheckedOperator_maps_checked_operator_to_its_sibling(string input, string expected)
+        => Assert.Equal(expected, OperatorNames.UncheckedOperator(input));
+
+    [Theory]
+    [InlineData("op_Addition")]
+    [InlineData("op_Explicit")]
+    [InlineData("op_CheckedModulus")]
+    [InlineData("op_Checked")]
+    [InlineData("get_Length")]
+    [InlineData("ToString")]
+    public void UncheckedOperator_returns_null_for_non_checked_or_unpaired_names(string input)
+        => Assert.Null(OperatorNames.UncheckedOperator(input));
 }

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1520,7 +1520,7 @@ static class ReturnToSender
         void AddMethodFact(MethodRef method, bool allowTargetRootOverride = false)
         {
             AddSingleMethodFact(method, allowTargetRootOverride);
-            if (UncheckedOperatorName(method.Name) is { } siblingName)
+            if (OperatorNames.UncheckedOperator(method.Name) is { } siblingName)
                 AddSingleMethodFact(method with { Name = siblingName }, allowTargetRootOverride);
         }
 
@@ -1673,19 +1673,6 @@ static class ReturnToSender
                 foreach (var block in entry.Arguments.OfType<InitializerBlock>())
                     AddInitializerEntryFacts(block.Entries);
             }
-        }
-
-        static string? UncheckedOperatorName(string methodName)
-        {
-            if (methodName is "op_CheckedExplicit")
-                return "op_Explicit";
-            if (methodName is "op_CheckedImplicit")
-                return "op_Implicit";
-            if (!methodName.StartsWith("op_Checked", StringComparison.Ordinal))
-                return null;
-
-            string inner = methodName["op_Checked".Length..];
-            return OperatorNames.MapBinaryOrUnary(inner) is null ? null : $"op_{inner}";
         }
     }
 


### PR DESCRIPTION
- Advances #2529 (leak #1: "delete `UncheckedOperatorName` from RTS" — the `operator.checked-sibling` role)
- Moves the `op_Checked*→op_*` operator-pair naming out of the RTS harness into the shared product helper
- Head: latest `origin/main`

## Change

> Should we accept this change?

**Conclusion: PASS** — byte-identical relocation. The checked→unchecked operator-name mapping lived as two identical private `UncheckedOperatorName` copies (RTS harness + product composer). It now lives once in `ILInspector.Metadata.OperatorNames.UncheckedOperator`, and both callers route through it.

- `tools/DecompilerHarness/ReturnToSender.cs`: `AddMethodFact` calls `OperatorNames.UncheckedOperator`; private copy deleted. This removes the residual C# operator-naming knowledge from the harness (the leak #1 acceptance item).
- `src/ILInspector.Decompiler/CompileBackSourceComposer.cs`: `CheckedOperatorSibling` calls the shared helper; private copy deleted (de-dup).
- `src/ILInspector.Metadata/OperatorNames.cs`: new `UncheckedOperator(methodName)` — the exact mapping (`op_CheckedExplicit→op_Explicit`, `op_CheckedImplicit→op_Implicit`, else `op_Checked{X}→op_{X}` when `X` is a mapped binary/unary operator), unchanged.

## Evidence

| Check | Result |
| --- | --- |
| Harness build (Metadata + Decompiler + RTS, Release) | Pass, 0 warnings |
| New `OperatorNamesTests` (`UncheckedOperator` mapping + null cases) | 56/56 pass |
| `ReturnToSenderPrototypeTests` operator-pair-sibling tests | 3/3 pass |
| `IncrementDecrementPassTests` | 38/38 pass |
| `ReturnToSenderPrototypeTests` (full) | 8 failures — the pre-existing environmental `RecompileFail`s (compile-back recompile on this preview SDK), all `CompileBack*`; none operator-related |
| Corpus quality-diff card | Not applicable — byte-identical string-mapping relocation; no raise/printer/structuring change |

## Review

Adversarial review requested from two models of a different family than the author (Claude Opus 4.8): **GPT-5.5** and **Gemini 3.1 Pro**, isolated checkouts. Results posted here. Low-risk mechanical relocation.
