### PR TITLE
Unify unknown enum constant stack slots

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SlotResidualCensusTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SlotResidualCensusTests.cs
@@ -236,6 +236,36 @@ public class SlotResidualCensusTests
         Assert.Contains("Use(S_0);", output);
     }
 
+    [Fact]
+    public void StackSlotUnifierTelemetry_UnifiesUnknownEnumConstantStore()
+    {
+        var int32 = TypeRef.CoreLib("System", "Int32");
+        var enumLike = TypeRef.Definition("Synthetic", "Samples", "MaybeEnum", ValueTypeHint.ValueType);
+        var voidType = TypeRef.CoreLib("System", "Void");
+
+        var block = new Block();
+        block.Add(new StoreStackSlot(0, new LoadArgument(0, "value", enumLike)));
+        block.Add(new StoreStackSlot(0, new Constant(0, int32)));
+        block.Add(new Return(new LoadStackSlot(0, enumLike)));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner", ValueTypeHint.ReferenceType),
+            new MethodSignature(enumLike, [
+                new Parameter("value", enumLike),
+            ], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        var telemetry = CSharpPrinter.CollectStackSlotUnifierTelemetry(function);
+        var output = CSharpPrinter.Print(function).Output;
+
+        Assert.Equal(0, telemetry.UnunifiedSplitSlots);
+        Assert.DoesNotContain("S_0_1", output);
+        Assert.Contains("S_0 = (MaybeEnum)0;", output);
+    }
+
     static string CaptureConsole(Func<int> action)
     {
         lock (ConsoleGate)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -861,6 +861,10 @@ public sealed partial class CSharpPrinter
                 || (coalesce.ResultType is { } coalesceType
                     && CanAssignType(coalesceType, target)
                     && !IsReferenceLike(coalesceType));
+        if (value is Constant { Value: int or long } constant
+            && target.DeclaredValueTypeHint == ValueTypeHint.ValueType
+            && CoercionRendering.CanSpellUnknownEnumConstant(constant.ResultType, target, _function.TypeShapes))
+            return true;
         return value.ResultType is { } source && CanAssignType(source, target);
     }
 


### PR DESCRIPTION
- Advances #2209
- Changes the printer-owned stack-slot unifier so integer constants can share a signature-proven value-type slot target when the printer's existing unknown-enum cast path can spell the value.
- Card revision: `b33b9de8`

## Change

**Conclusion:** **REVIEW** — this is a narrow C2 reduction that uses an existing printer cast path; it reduces un-unified split slots from 227 to 209 without introducing valid-to-invalid render changes.

Before:

```csharp
RefKind S_20;
int S_20_1;
var S_20_2;
...
S_20 = V_1[V_22];
S_20_1 = 0;
S_21 = S_20_2;
```

After:

```csharp
RefKind S_20;
...
S_20 = V_1[V_22];
S_20 = (RefKind)0;
S_21 = S_20;
```

Real witness: `Microsoft.CodeAnalysis.CSharp.Binder::GetMethodGroupOrLambdaDelegateType` (`4 -> 2` split slots).

## Evidence

| Check | Result |
| --- | --- |
| SDK | `/home/rich/.dotnetup/dotnet/dotnet`, `11.0.100-preview.7.26357.101` |
| Product/test build | Pass: `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --nologo` |
| Focused tests | Pass: `SlotResidualCensusTests` |
| Printer-owned C2 census | Pass: 89,065 methods, 0 pass bugs, un-unified split slots `227 -> 209` |
| Render A/B semantic lane | Pass: 89,065 methods, changed 15, semantic `valid->invalid: 0` |
| Quality card | Advisory: pinned quick gate improved/neutral; generated verdict is a cap artifact because PR run used `--compile-cap 25` against a baseline with higher semantic/fidelity coverage |
| Local PR-fast decompiler subset | Advisory: red on two tests that reproduce on clean `origin/main` (`LockSugarTests.CoreLibStaticFieldLock_PreservesCopiedReceiverLocal`, `TypeSourceComposerUnionTests.ClassUnionSwitchExpression_RendersTypePatternArms`) |

## C2 census

Before:

```text
STACK-SLOT UNIFIER CENSUS over 89065 methods (0 pass bugs)
Un-unified split slots: 227
Multi-candidate slots unified by printer: 339
Stack-slot declarations emitted: 19654
```

After this PR:

```text
STACK-SLOT UNIFIER CENSUS over 89065 methods (0 pass bugs)
Un-unified split slots: 209
Multi-candidate slots unified by printer: 357
Stack-slot declarations emitted: 19618
```

## Render A/B

```text
Render A/B Check: 89065 methods evaluated
Changed: 15 (structural: 13, paren-equivalent: 0, unparsed: 2)
Semantic: valid->valid: 0, invalid->valid: 0, valid->invalid: 0, invalid->invalid: 15
Added:   0
Removed: 0
```

Changed rows are the intended unresolved enum-default split collapse shape; all changed methods were already invalid and remain invalid.

## Decompiler quality

**Conclusion:** **ADVISORY** — pinned corpus signal is improved/neutral; generated regression verdict is from lower validation sample caps, not product movement.

```text
Fully raised (+) 78,399 (88.02%) -> 78,406 (88.03%) (+7)
Full malformed (-) 0 -> 0
Semantic defects (-) 74 -> 1 (-73)
Fidelity opcode diffs (-) 5 -> 3 (-2)
Pass bugs (-) 0 -> 0
```

## Review

Adversarial review requested; reconciliation will be posted before Ready to merge.

## Validation commands

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --nologo
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/SlotResidualCensusTests/*"
mapfile -t assemblies < /tmp/issue2209-c2-next-corpus.txt
dotnet run --project tools/DecompilerHarness -c Release --no-build -- "${assemblies[@]}" --slot-unifier-census --max-examples 80
dotnet run --project ../c2-next-render-base/tools/DecompilerHarness -c Release -- "${assemblies[@]}" --workers 20 --emit-render-ab /tmp/c2-next-base.renderab
dotnet run --project tools/DecompilerHarness -c Release --no-build -- "${assemblies[@]}" --workers 20 --render-ab /tmp/c2-next-base.renderab
dotnet run --project tools/DecompilerHarness -c Release --no-build -- "${assemblies[@]}" --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json --quality-diff-card --compile-cap 25 --corpus-fidelity-cap 3 --max-examples 3
```
