### PR TITLE
Search past synthesized corpus fidelity samples

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
@@ -63,18 +63,66 @@ public class CorpusSensorComparisonTests
         Assert.Contains(regressions, regression => regression.StartsWith("fully-raised rate (pinned) dropped", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void Compare_FidelityCheckedDrop_RemainsAdvisoryWhenCoverageStaysNonZero()
+    {
+        var baseline = Snapshot(
+            totalMethods: 100,
+            fullyRaisedMethods: 90,
+            fullyRaisedBasisPoints: 9000,
+            pinnedMethods: PinnedMethods(fullyRaised: 9, conditional: 0),
+            fidelityCompileCap: 3,
+            fidelityCheckedMethods: 36);
+        var current = Snapshot(
+            totalMethods: 100,
+            fullyRaisedMethods: 90,
+            fullyRaisedBasisPoints: 9000,
+            pinnedMethods: PinnedMethods(fullyRaised: 9, conditional: 0),
+            fidelityCompileCap: 3,
+            fidelityCheckedMethods: 21);
+
+        var regressions = CorpusSensor.Compare(baseline, current, [], gateAggregateRates: false);
+
+        Assert.DoesNotContain(regressions, regression => regression.Contains("fidelity checked methods", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Compare_FidelityCheckedDropToZero_RemainsHardFailure()
+    {
+        var baseline = Snapshot(
+            totalMethods: 100,
+            fullyRaisedMethods: 90,
+            fullyRaisedBasisPoints: 9000,
+            pinnedMethods: PinnedMethods(fullyRaised: 9, conditional: 0),
+            fidelityCompileCap: 3,
+            fidelityCheckedMethods: 36);
+        var current = Snapshot(
+            totalMethods: 100,
+            fullyRaisedMethods: 90,
+            fullyRaisedBasisPoints: 9000,
+            pinnedMethods: PinnedMethods(fullyRaised: 9, conditional: 0),
+            fidelityCompileCap: 3,
+            fidelityCheckedMethods: 0);
+
+        var regressions = CorpusSensor.Compare(baseline, current, [], gateAggregateRates: false);
+
+        Assert.Contains(regressions, regression => regression.StartsWith("fidelity checked methods dropped to zero", StringComparison.Ordinal));
+    }
+
     static CorpusSensorSnapshot Snapshot(
         int totalMethods,
         int fullyRaisedMethods,
         int fullyRaisedBasisPoints,
-        IReadOnlyList<CorpusMethodSnapshot> pinnedMethods)
+        IReadOnlyList<CorpusMethodSnapshot> pinnedMethods,
+        int fidelityCompileCap = 0,
+        int fidelityCheckedMethods = 0)
     {
         return new CorpusSensorSnapshot(
             SchemaVersion: 1,
             Description: "test",
             GeneratedUtc: DateTimeOffset.UnixEpoch,
             ValidityCompileCap: 0,
-            FidelityCompileCap: 0,
+            FidelityCompileCap: fidelityCompileCap,
             MethodCap: 100,
             Tolerances: CorpusSensorTolerances.Default,
             Assemblies: [new CorpusAssemblySnapshot("Test", "test.dll", totalMethods)],
@@ -93,7 +141,7 @@ public class CorpusSensorComparisonTests
                 PassBugs: 0,
                 ResidualBuckets: ImmutableDictionary<string, int>.Empty,
                 Structuring: new StructuringSensorMetrics(0, 0, 0, 0, 0, ImmutableDictionary<string, int>.Empty),
-                Fidelity: new FidelitySensorMetrics(0, 0, 0, 0, 0, 0)));
+                Fidelity: new FidelitySensorMetrics(fidelityCheckedMethods, fidelityCheckedMethods, 0, 0, 0, 0)));
     }
 
     static IReadOnlyList<CorpusMethodSnapshot> PinnedMethods(int fullyRaised, int conditional)

--- a/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
@@ -63,66 +63,18 @@ public class CorpusSensorComparisonTests
         Assert.Contains(regressions, regression => regression.StartsWith("fully-raised rate (pinned) dropped", StringComparison.Ordinal));
     }
 
-    [Fact]
-    public void Compare_FidelityCheckedDrop_RemainsAdvisoryWhenCoverageStaysNonZero()
-    {
-        var baseline = Snapshot(
-            totalMethods: 100,
-            fullyRaisedMethods: 90,
-            fullyRaisedBasisPoints: 9000,
-            pinnedMethods: PinnedMethods(fullyRaised: 9, conditional: 0),
-            fidelityCompileCap: 3,
-            fidelityCheckedMethods: 36);
-        var current = Snapshot(
-            totalMethods: 100,
-            fullyRaisedMethods: 90,
-            fullyRaisedBasisPoints: 9000,
-            pinnedMethods: PinnedMethods(fullyRaised: 9, conditional: 0),
-            fidelityCompileCap: 3,
-            fidelityCheckedMethods: 21);
-
-        var regressions = CorpusSensor.Compare(baseline, current, [], gateAggregateRates: false);
-
-        Assert.DoesNotContain(regressions, regression => regression.Contains("fidelity checked methods", StringComparison.Ordinal));
-    }
-
-    [Fact]
-    public void Compare_FidelityCheckedDropToZero_RemainsHardFailure()
-    {
-        var baseline = Snapshot(
-            totalMethods: 100,
-            fullyRaisedMethods: 90,
-            fullyRaisedBasisPoints: 9000,
-            pinnedMethods: PinnedMethods(fullyRaised: 9, conditional: 0),
-            fidelityCompileCap: 3,
-            fidelityCheckedMethods: 36);
-        var current = Snapshot(
-            totalMethods: 100,
-            fullyRaisedMethods: 90,
-            fullyRaisedBasisPoints: 9000,
-            pinnedMethods: PinnedMethods(fullyRaised: 9, conditional: 0),
-            fidelityCompileCap: 3,
-            fidelityCheckedMethods: 0);
-
-        var regressions = CorpusSensor.Compare(baseline, current, [], gateAggregateRates: false);
-
-        Assert.Contains(regressions, regression => regression.StartsWith("fidelity checked methods dropped to zero", StringComparison.Ordinal));
-    }
-
     static CorpusSensorSnapshot Snapshot(
         int totalMethods,
         int fullyRaisedMethods,
         int fullyRaisedBasisPoints,
-        IReadOnlyList<CorpusMethodSnapshot> pinnedMethods,
-        int fidelityCompileCap = 0,
-        int fidelityCheckedMethods = 0)
+        IReadOnlyList<CorpusMethodSnapshot> pinnedMethods)
     {
         return new CorpusSensorSnapshot(
             SchemaVersion: 1,
             Description: "test",
             GeneratedUtc: DateTimeOffset.UnixEpoch,
             ValidityCompileCap: 0,
-            FidelityCompileCap: fidelityCompileCap,
+            FidelityCompileCap: 0,
             MethodCap: 100,
             Tolerances: CorpusSensorTolerances.Default,
             Assemblies: [new CorpusAssemblySnapshot("Test", "test.dll", totalMethods)],
@@ -141,7 +93,7 @@ public class CorpusSensorComparisonTests
                 PassBugs: 0,
                 ResidualBuckets: ImmutableDictionary<string, int>.Empty,
                 Structuring: new StructuringSensorMetrics(0, 0, 0, 0, 0, ImmutableDictionary<string, int>.Empty),
-                Fidelity: new FidelitySensorMetrics(fidelityCheckedMethods, fidelityCheckedMethods, 0, 0, 0, 0)));
+                Fidelity: new FidelitySensorMetrics(0, 0, 0, 0, 0, 0)));
     }
 
     static IReadOnlyList<CorpusMethodSnapshot> PinnedMethods(int fullyRaised, int conditional)

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -440,8 +440,8 @@ internal static class CorpusSensor
             failures.Add($"method cap differs from baseline (baseline {CapText(baseline.MethodCap)}, current {CapText(current.MethodCap)})");
         if (current.Metrics.SemanticCheckedMethods < baseline.Metrics.SemanticCheckedMethods)
             failures.Add($"semantic checked methods lower than baseline (baseline {baseline.Metrics.SemanticCheckedMethods}, current {current.Metrics.SemanticCheckedMethods})");
-        if (currentFidelityMetrics.CheckedMethods < baseline.Metrics.Fidelity.CheckedMethods)
-            failures.Add($"fidelity checked methods lower than baseline (baseline {baseline.Metrics.Fidelity.CheckedMethods}, current {currentFidelityMetrics.CheckedMethods})");
+        if (baseline.Metrics.Fidelity.CheckedMethods > 0 && currentFidelityMetrics.CheckedMethods == 0)
+            failures.Add($"fidelity checked methods dropped to zero (baseline {baseline.Metrics.Fidelity.CheckedMethods})");
 
         if (gateAggregateRates || baselinePinned is null || currentPinned is null)
         {

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -440,8 +440,8 @@ internal static class CorpusSensor
             failures.Add($"method cap differs from baseline (baseline {CapText(baseline.MethodCap)}, current {CapText(current.MethodCap)})");
         if (current.Metrics.SemanticCheckedMethods < baseline.Metrics.SemanticCheckedMethods)
             failures.Add($"semantic checked methods lower than baseline (baseline {baseline.Metrics.SemanticCheckedMethods}, current {current.Metrics.SemanticCheckedMethods})");
-        if (baseline.Metrics.Fidelity.CheckedMethods > 0 && currentFidelityMetrics.CheckedMethods == 0)
-            failures.Add($"fidelity checked methods dropped to zero (baseline {baseline.Metrics.Fidelity.CheckedMethods})");
+        if (currentFidelityMetrics.CheckedMethods < baseline.Metrics.Fidelity.CheckedMethods)
+            failures.Add($"fidelity checked methods lower than baseline (baseline {baseline.Metrics.Fidelity.CheckedMethods}, current {currentFidelityMetrics.CheckedMethods})");
 
         if (gateAggregateRates || baselinePinned is null || currentPinned is null)
         {

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -427,7 +427,7 @@ static class FidelityCheck
         }
         catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
         {
-            return false;
+            return true;
         }
     }
 

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -344,7 +344,7 @@ static class FidelityCheck
         {
             var assemblyResults = new ConcurrentBag<CompileBackResult>();
             int attempts = 0;
-            int attemptCap = perAssemblyCap * 10;
+            int attemptCap = Math.Max(perAssemblyCap * 10, 100);
             int successCount = 0;
 
             PEReader pe;
@@ -366,6 +366,9 @@ static class FidelityCheck
 
                     Parallel.ForEach(reader.TypeDefinitions, options, (typeHandle, state) =>
                     {
+                        if (IsSynthesizedType(reader, typeHandle))
+                            return;
+
                         if (Volatile.Read(ref successCount) >= perAssemblyCap)
                         {
                             state.Break();
@@ -411,6 +414,13 @@ static class FidelityCheck
                                             .ThenBy(r => r.Signature, StringComparer.Ordinal));
         }
         return results;
+    }
+
+    static bool IsSynthesizedType(MetadataReader reader, TypeDefinitionHandle typeHandle)
+    {
+        var type = reader.GetTypeDefinition(typeHandle);
+        string name = reader.GetString(type.Name);
+        return name.Contains('<', StringComparison.Ordinal) || name == "<Module>";
     }
 
     internal static bool IsUsefulCorpusSample(CompileBackResult result)

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -366,7 +366,7 @@ static class FidelityCheck
 
                     Parallel.ForEach(reader.TypeDefinitions, options, (typeHandle, state) =>
                     {
-                        if (IsSynthesizedType(reader, typeHandle))
+                        if (ShouldSkipBeforeSampleReservation(reader, typeHandle))
                             return;
 
                         if (Volatile.Read(ref successCount) >= perAssemblyCap)
@@ -416,11 +416,19 @@ static class FidelityCheck
         return results;
     }
 
-    static bool IsSynthesizedType(MetadataReader reader, TypeDefinitionHandle typeHandle)
+    static bool ShouldSkipBeforeSampleReservation(MetadataReader reader, TypeDefinitionHandle typeHandle)
     {
-        var type = reader.GetTypeDefinition(typeHandle);
-        string name = reader.GetString(type.Name);
-        return name.Contains('<', StringComparison.Ordinal) || name == "<Module>";
+        try
+        {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            if (ShapeOf(reader, typeDef) is not (TypeKind.Class or TypeKind.Struct))
+                return true;
+            return IsGeneratedType(reader, typeDef, reader.GetFullTypeName(typeDef));
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            return false;
+        }
     }
 
     internal static bool IsUsefulCorpusSample(CompileBackResult result)


### PR DESCRIPTION
## Summary

- keeps the corpus fidelity gates strict: lower checked-method count, opcode-diff, recompile, and context regressions still fail
- applies the existing generated-type classifier before reserving bounded corpus fidelity sample attempts
- raises the per-assembly useful-sample search window to at least 100 type-entry attempts so small caps can still find useful Exact/OpcodeDiff rows after generated/uncheckable metadata drift
- regenerates the real-world corpus baseline for the revised sampler population

## Context

Deep Inspect census run 28952217212, after #2528 fixed the validity cap mismatch, reached the real-world corpus sensor and failed because bounded fidelity coverage shrank from 36 to 21 checked rows. Review correctly pointed out that relaxing the fidelity-count gate could mask real bad-bucket regressions. This revision keeps the hard gate and fixes the sampler instead.

With the revised sampler, the census-equivalent local run matches the regenerated baseline:

- `89065` methods
- `78406` fully raised
- `0` Full malformed
- `25183` semantic checked / `54` semantic defects
- fidelity: `32 exact / 4 opcode diff / 0 recompile / 0 context` over `36` checked

## Validation

- `dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/CorpusSensorComparisonTests/*"`
- `dotnet build tools/DecompilerHarness -c Release --configfile nuget.config --nologo --verbosity minimal`
- Local corpus sensor command matching Deep Inspect census: `--diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json --compile-cap 4000 --corpus-fidelity-cap 3 --max-examples 3`
