### PR TITLE
Add measurement-only MemoryPool lifecycle corpus sensor (#2439 Slice 3)

### DIFF
--- a/tools/AnalysisHarness/HarnessMemberResolution.cs
+++ b/tools/AnalysisHarness/HarnessMemberResolution.cs
@@ -47,6 +47,72 @@ internal static class HarnessMemberResolution
         }
     }
 
+    /// <summary>How a call consumes the owner value loaded immediately before it.</summary>
+    public enum ReceiverCallKind
+    {
+        /// <summary>Owner is an argument, or the call shape is unmodeled: treat as an escape.</summary>
+        Other,
+        /// <summary>Parameterless instance call with the owner as receiver, not <c>Dispose</c>
+        /// (e.g. <c>get_Memory</c>/<c>get_Span</c>): a non-consuming read - the owner stays owned.</summary>
+        ReceiverRead,
+        /// <summary>Parameterless instance <c>Dispose()</c> with the owner as receiver.</summary>
+        Dispose,
+    }
+
+    /// <summary>
+    /// Classify a call whose single relevant stack input is the owner value loaded right before it.
+    /// A parameterless <b>instance</b> method has the owner as its receiver: <c>Dispose()</c>
+    /// disposes it, any other parameterless instance call merely reads it (the owner stays owned).
+    /// A static or multi-arg call takes the owner as an argument (potential ownership transfer), so
+    /// it is <see cref="ReceiverCallKind.Other"/>. Fails closed to <see cref="ReceiverCallKind.Other"/>.
+    /// </summary>
+    public static ReceiverCallKind ClassifyReceiverCall(MetadataReader reader, int token)
+    {
+        try
+        {
+            var handle = MetadataTokens.EntityHandle(token);
+            if (handle.Kind == HandleKind.MethodSpecification)
+                handle = reader.GetMethodSpecification((MethodSpecificationHandle)handle).Method;
+
+            string name;
+            SignatureHeader header;
+            int parameterCount;
+            switch (handle.Kind)
+            {
+                case HandleKind.MethodDefinition:
+                {
+                    var md = reader.GetMethodDefinition((MethodDefinitionHandle)handle);
+                    var sig = md.DecodeSignature(SignatureTypeNameProvider.Instance, genericContext: null);
+                    name = reader.GetString(md.Name);
+                    header = sig.Header;
+                    parameterCount = sig.ParameterTypes.Length;
+                    break;
+                }
+                case HandleKind.MemberReference:
+                {
+                    var mr = reader.GetMemberReference((MemberReferenceHandle)handle);
+                    if (mr.GetKind() != MemberReferenceKind.Method)
+                        return ReceiverCallKind.Other;
+                    var sig = mr.DecodeMethodSignature(SignatureTypeNameProvider.Instance, genericContext: null);
+                    name = reader.GetString(mr.Name);
+                    header = sig.Header;
+                    parameterCount = sig.ParameterTypes.Length;
+                    break;
+                }
+                default:
+                    return ReceiverCallKind.Other;
+            }
+
+            if (!header.IsInstance || parameterCount != 0)
+                return ReceiverCallKind.Other;
+            return name == "Dispose" ? ReceiverCallKind.Dispose : ReceiverCallKind.ReceiverRead;
+        }
+        catch
+        {
+            return ReceiverCallKind.Other;
+        }
+    }
+
     static (string Type, string Name) ResolveMethodDef(MetadataReader reader, MethodDefinitionHandle handle)
     {
         var md = reader.GetMethodDefinition(handle);

--- a/tools/AnalysisHarness/HarnessMemberResolution.cs
+++ b/tools/AnalysisHarness/HarnessMemberResolution.cs
@@ -1,0 +1,173 @@
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Collections.Immutable;
+
+namespace ILInspector.AnalysisHarness;
+
+/// <summary>
+/// Shared SRM member/type-name resolution for the measurement-only harness sensors (leak
+/// actionability, MemoryPool lifecycle). Given a metadata token for a call target it returns the
+/// declaring type name and member name, resolving <see cref="HandleKind.MethodSpecification"/> and
+/// generic-instance (<see cref="HandleKind.TypeSpecification"/>) parents. These sensors run over
+/// arbitrary corpus assemblies, so every decode is bounded and fails closed rather than throwing.
+/// </summary>
+internal static class HarnessMemberResolution
+{
+    // SRM's SignatureDecoder.DecodeType recurses on the NATIVE stack once per nested blob element
+    // (e.g. each SZARRAY prefix) BEFORE any provider callback runs, so a pathologically deep blob
+    // StackOverflows uncatchably and kills the whole process. Blob length bounds that native depth
+    // (each level costs >= 1 byte), so refuse over-long blobs pre-decode. Real single-type TypeSpec
+    // blobs are tiny (CoreLib's largest is 57 bytes), so 1024 only trips on malformed/adversarial
+    // input. Mirrors ILInspector.Analysis.TypeRefDecoder's MaxSignatureBlobLength guard.
+    internal const int MaxTypeSpecBlobLength = 1024;
+
+    public static (string Type, string Name) ResolveToken(MetadataReader reader, int token)
+    {
+        var handle = MetadataTokens.EntityHandle(token);
+        switch (handle.Kind)
+        {
+            case HandleKind.MethodDefinition:
+                return ResolveMethodDef(reader, (MethodDefinitionHandle)handle);
+            case HandleKind.MemberReference:
+                return ResolveMemberRef(reader, (MemberReferenceHandle)handle);
+            case HandleKind.MethodSpecification:
+            {
+                // MethodSpec.Method is a MethodDefOrRef coded index (MethodDef or MemberRef only -
+                // never another MethodSpec), so resolve it directly rather than recursing.
+                var method = reader.GetMethodSpecification((MethodSpecificationHandle)handle).Method;
+                return method.Kind switch
+                {
+                    HandleKind.MethodDefinition => ResolveMethodDef(reader, (MethodDefinitionHandle)method),
+                    HandleKind.MemberReference => ResolveMemberRef(reader, (MemberReferenceHandle)method),
+                    _ => ("", $"(methodspec:{method.Kind})"),
+                };
+            }
+            default:
+                return ("", $"(token:{handle.Kind})");
+        }
+    }
+
+    static (string Type, string Name) ResolveMethodDef(MetadataReader reader, MethodDefinitionHandle handle)
+    {
+        var md = reader.GetMethodDefinition(handle);
+        return (TypeName(reader, md.GetDeclaringType()), reader.GetString(md.Name));
+    }
+
+    static (string Type, string Name) ResolveMemberRef(MetadataReader reader, MemberReferenceHandle handle)
+    {
+        var mr = reader.GetMemberReference(handle);
+        return (ParentName(reader, mr.Parent), reader.GetString(mr.Name));
+    }
+
+    static string TypeName(MetadataReader reader, TypeDefinitionHandle handle)
+    {
+        var td = reader.GetTypeDefinition(handle);
+        string ns = reader.GetString(td.Namespace), name = reader.GetString(td.Name);
+        return ns.Length == 0 ? name : $"{ns}.{name}";
+    }
+
+    public static string ParentName(MetadataReader reader, EntityHandle parent) => parent.Kind switch
+    {
+        HandleKind.TypeReference => TypeRefName(reader, (TypeReferenceHandle)parent),
+        HandleKind.TypeDefinition => TypeName(reader, (TypeDefinitionHandle)parent),
+        HandleKind.TypeSpecification => TypeSpecName(reader, (TypeSpecificationHandle)parent),
+        _ => $"({parent.Kind})",
+    };
+
+    // A generic type instance (e.g. Span<byte>, MemoryPool<byte>) names its declaring type through a
+    // TypeSpecification blob; decode it to the underlying generic type name (Span`1, MemoryPool`1)
+    // so callers see a real type, not "(typespec)". Bounded pre-decode against the SRM native-stack
+    // StackOverflow described on MaxTypeSpecBlobLength.
+    static string TypeSpecName(MetadataReader reader, TypeSpecificationHandle handle)
+    {
+        var typeSpec = reader.GetTypeSpecification(handle);
+        if (reader.GetBlobReader(typeSpec.Signature).Length > MaxTypeSpecBlobLength)
+            return "(typespec)";
+        try
+        {
+            return typeSpec.DecodeSignature(SignatureTypeNameProvider.Instance, genericContext: null);
+        }
+        catch
+        {
+            return "(typespec)";
+        }
+    }
+
+    static string TypeRefName(MetadataReader reader, TypeReferenceHandle handle)
+    {
+        var tr = reader.GetTypeReference(handle);
+        string ns = reader.GetString(tr.Namespace), name = reader.GetString(tr.Name);
+        return ns.Length == 0 ? name : $"{ns}.{name}";
+    }
+}
+
+/// <summary>A minimal signature decoder that yields type names as strings, used to name the
+/// declaring type behind a generic-instance parent (e.g. <c>Span`1</c>, <c>MemoryPool`1</c>).
+/// It keeps the outer generic type name and ignores type arguments - callers only need the
+/// declaring type, not its instantiation.</summary>
+sealed class SignatureTypeNameProvider : ISignatureTypeProvider<string, object?>
+{
+    public static readonly SignatureTypeNameProvider Instance = new();
+
+    public string GetPrimitiveType(PrimitiveTypeCode typeCode) => typeCode.ToString();
+
+    public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
+    {
+        var td = reader.GetTypeDefinition(handle);
+        string ns = reader.GetString(td.Namespace), name = reader.GetString(td.Name);
+        return ns.Length == 0 ? name : $"{ns}.{name}";
+    }
+
+    public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+    {
+        var tr = reader.GetTypeReference(handle);
+        string ns = reader.GetString(tr.Namespace), name = reader.GetString(tr.Name);
+        return ns.Length == 0 ? name : $"{ns}.{name}";
+    }
+
+    // A nested TypeSpecification reference (e.g. a custom modifier or a CLASS/VALUETYPE token that
+    // itself resolves to a TypeSpec) re-enters DecodeSignature. Each re-entry is a MANAGED frame
+    // here plus SRM native DecodeType frames, so a self-referential or long TypeSpec CHAIN - whose
+    // individual blobs each stay under MaxTypeSpecBlobLength - would recurse until an uncatchable
+    // StackOverflow kills the process. The outer TypeSpecName length cap only bounds the ENTRY
+    // blob's native depth, not this cross-TypeSpec re-entry, so bound both the re-entry depth and
+    // each nested blob's length here (mirrors ILInspector.Analysis.TypeRefDecoder). Callers never
+    // use a nested TypeSpec's decoded name (modifiers/type-args are discarded), so failing closed
+    // to "(typespec)" past the cap is loss-free.
+    const int MaxTypeSpecDepth = 16;
+
+    [ThreadStatic]
+    static int s_typeSpecDepth;
+
+    public string GetTypeFromSpecification(MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
+    {
+        var typeSpec = reader.GetTypeSpecification(handle);
+        if (s_typeSpecDepth >= MaxTypeSpecDepth ||
+            reader.GetBlobReader(typeSpec.Signature).Length > HarnessMemberResolution.MaxTypeSpecBlobLength)
+            return "(typespec)";
+        s_typeSpecDepth++;
+        try
+        {
+            return typeSpec.DecodeSignature(this, genericContext);
+        }
+        catch
+        {
+            return "(typespec)";
+        }
+        finally
+        {
+            s_typeSpecDepth--;
+        }
+    }
+
+    public string GetGenericInstantiation(string genericType, ImmutableArray<string> typeArguments) => genericType;
+    public string GetSZArrayType(string elementType) => elementType;
+    public string GetArrayType(string elementType, ArrayShape shape) => elementType;
+    public string GetByReferenceType(string elementType) => elementType;
+    public string GetPointerType(string elementType) => elementType;
+    public string GetPinnedType(string elementType) => elementType;
+    public string GetModifiedType(string modifier, string unmodifiedType, bool isRequired) => unmodifiedType;
+    public string GetGenericMethodParameter(object? genericContext, int index) => $"!!{index}";
+    public string GetGenericTypeParameter(object? genericContext, int index) => $"!{index}";
+    public string GetFunctionPointerType(MethodSignature<string> signature) => "(fnptr)";
+}

--- a/tools/AnalysisHarness/LeakActionabilitySensor.cs
+++ b/tools/AnalysisHarness/LeakActionabilitySensor.cs
@@ -159,7 +159,7 @@ public static class LeakActionabilitySensor
                 var opcode = instructions[i].OpCode;
                 if (opcode is not (ILOpCode.Call or ILOpCode.Callvirt or ILOpCode.Newobj))
                     continue;
-                var member = ResolveToken(reader, checked((int)instructions[i].OperandValue));
+                var member = HarnessMemberResolution.ResolveToken(reader, checked((int)instructions[i].OperandValue));
                 if (IsInertWrapper(member.Type, member.Name))
                     continue;
                 members.Add(member);
@@ -173,93 +173,6 @@ public static class LeakActionabilitySensor
         {
             return (Unknown, $"(err:{ex.GetType().Name})");
         }
-    }
-
-    static (string Type, string Name) ResolveToken(MetadataReader reader, int token)
-    {
-        var handle = MetadataTokens.EntityHandle(token);
-        switch (handle.Kind)
-        {
-            case HandleKind.MethodDefinition:
-                return ResolveMethodDef(reader, (MethodDefinitionHandle)handle);
-            case HandleKind.MemberReference:
-                return ResolveMemberRef(reader, (MemberReferenceHandle)handle);
-            case HandleKind.MethodSpecification:
-            {
-                // MethodSpec.Method is a MethodDefOrRef coded index (MethodDef or MemberRef only -
-                // never another MethodSpec), so resolve it directly rather than recursing.
-                var method = reader.GetMethodSpecification((MethodSpecificationHandle)handle).Method;
-                return method.Kind switch
-                {
-                    HandleKind.MethodDefinition => ResolveMethodDef(reader, (MethodDefinitionHandle)method),
-                    HandleKind.MemberReference => ResolveMemberRef(reader, (MemberReferenceHandle)method),
-                    _ => ("", $"(methodspec:{method.Kind})"),
-                };
-            }
-            default:
-                return ("", $"(token:{handle.Kind})");
-        }
-    }
-
-    static (string Type, string Name) ResolveMethodDef(MetadataReader reader, MethodDefinitionHandle handle)
-    {
-        var md = reader.GetMethodDefinition(handle);
-        return (TypeName(reader, md.GetDeclaringType()), reader.GetString(md.Name));
-    }
-
-    static (string Type, string Name) ResolveMemberRef(MetadataReader reader, MemberReferenceHandle handle)
-    {
-        var mr = reader.GetMemberReference(handle);
-        return (ParentName(reader, mr.Parent), reader.GetString(mr.Name));
-    }
-
-    static string TypeName(MetadataReader reader, TypeDefinitionHandle handle)
-    {
-        var td = reader.GetTypeDefinition(handle);
-        string ns = reader.GetString(td.Namespace), name = reader.GetString(td.Name);
-        return ns.Length == 0 ? name : $"{ns}.{name}";
-    }
-
-    static string ParentName(MetadataReader reader, EntityHandle parent) => parent.Kind switch
-    {
-        HandleKind.TypeReference => TypeRefName(reader, (TypeReferenceHandle)parent),
-        HandleKind.TypeDefinition => TypeName(reader, (TypeDefinitionHandle)parent),
-        HandleKind.TypeSpecification => TypeSpecName(reader, (TypeSpecificationHandle)parent),
-        _ => $"({parent.Kind})",
-    };
-
-    // A generic type instance (e.g. Span<byte>, INumberBase<T>) names its declaring type through a
-    // TypeSpecification blob; decode it to the underlying generic type name (Span`1, INumberBase`1)
-    // so wrapper-skipping and member classification see a real type, not "(typespec)".
-    //
-    // SRM's SignatureDecoder.DecodeType recurses on the NATIVE stack once per nested blob element
-    // (e.g. each SZARRAY prefix) BEFORE any provider callback runs, so a pathologically deep blob
-    // StackOverflows uncatchably and kills the whole process. Blob length bounds that native depth
-    // (each level costs >= 1 byte), so refuse over-long blobs pre-decode. Real single-type TypeSpec
-    // blobs are tiny (CoreLib's largest is 57 bytes), so 1024 only trips on malformed/adversarial
-    // input. Mirrors ILInspector.Analysis.TypeRefDecoder's MaxSignatureBlobLength guard.
-    internal const int MaxTypeSpecBlobLength = 1024;
-
-    static string TypeSpecName(MetadataReader reader, TypeSpecificationHandle handle)
-    {
-        var typeSpec = reader.GetTypeSpecification(handle);
-        if (reader.GetBlobReader(typeSpec.Signature).Length > MaxTypeSpecBlobLength)
-            return "(typespec)";
-        try
-        {
-            return typeSpec.DecodeSignature(SignatureTypeNameProvider.Instance, genericContext: null);
-        }
-        catch
-        {
-            return "(typespec)";
-        }
-    }
-
-    static string TypeRefName(MetadataReader reader, TypeReferenceHandle handle)
-    {
-        var tr = reader.GetTypeReference(handle);
-        string ns = reader.GetString(tr.Namespace), name = reader.GetString(tr.Name);
-        return ns.Length == 0 ? name : $"{ns}.{name}";
     }
 
     // A leak is actionable if ANY reachable boundary can throw on external input, so Untrusted
@@ -407,77 +320,6 @@ public static class LeakActionabilitySensor
             ByClass = [.. ClassRows(report).Select(r => new LeakActionabilitySectionClassRow("By class", r.Class, r.Count))],
             Examples = [.. ExampleRows(report, maxExamples).Select(r => new LeakActionabilitySectionExampleRow("Examples", r.Class, r.Assembly, r.Method, r.BoundarySet))],
         };
-}
-
-/// <summary>A minimal signature decoder that yields type names as strings, used to name the
-/// declaring type behind a generic-instance boundary (e.g. <c>Span`1</c>, <c>INumberBase`1</c>).
-/// It keeps the outer generic type name and ignores type arguments - the classifier only needs the
-/// declaring type, not its instantiation.</summary>
-sealed class SignatureTypeNameProvider : ISignatureTypeProvider<string, object?>
-{
-    public static readonly SignatureTypeNameProvider Instance = new();
-
-    public string GetPrimitiveType(PrimitiveTypeCode typeCode) => typeCode.ToString();
-
-    public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
-    {
-        var td = reader.GetTypeDefinition(handle);
-        string ns = reader.GetString(td.Namespace), name = reader.GetString(td.Name);
-        return ns.Length == 0 ? name : $"{ns}.{name}";
-    }
-
-    public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
-    {
-        var tr = reader.GetTypeReference(handle);
-        string ns = reader.GetString(tr.Namespace), name = reader.GetString(tr.Name);
-        return ns.Length == 0 ? name : $"{ns}.{name}";
-    }
-
-    // A nested TypeSpecification reference (e.g. a custom modifier or a CLASS/VALUETYPE token that
-    // itself resolves to a TypeSpec) re-enters DecodeSignature. Each re-entry is a MANAGED frame
-    // here plus SRM native DecodeType frames, so a self-referential or long TypeSpec CHAIN - whose
-    // individual blobs each stay under MaxTypeSpecBlobLength - would recurse until an uncatchable
-    // StackOverflow kills the process. The outer TypeSpecName length cap only bounds the ENTRY
-    // blob's native depth, not this cross-TypeSpec re-entry, so bound both the re-entry depth and
-    // each nested blob's length here (mirrors ILInspector.Analysis.TypeRefDecoder). The classifier
-    // never uses a nested TypeSpec's decoded name (modifiers/type-args are discarded), so failing
-    // closed to "(typespec)" past the cap is loss-free.
-    const int MaxTypeSpecDepth = 16;
-
-    [ThreadStatic]
-    static int s_typeSpecDepth;
-
-    public string GetTypeFromSpecification(MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
-    {
-        var typeSpec = reader.GetTypeSpecification(handle);
-        if (s_typeSpecDepth >= MaxTypeSpecDepth ||
-            reader.GetBlobReader(typeSpec.Signature).Length > LeakActionabilitySensor.MaxTypeSpecBlobLength)
-            return "(typespec)";
-        s_typeSpecDepth++;
-        try
-        {
-            return typeSpec.DecodeSignature(this, genericContext);
-        }
-        catch
-        {
-            return "(typespec)";
-        }
-        finally
-        {
-            s_typeSpecDepth--;
-        }
-    }
-
-    public string GetGenericInstantiation(string genericType, ImmutableArray<string> typeArguments) => genericType;
-    public string GetSZArrayType(string elementType) => elementType;
-    public string GetArrayType(string elementType, ArrayShape shape) => elementType;
-    public string GetByReferenceType(string elementType) => elementType;
-    public string GetPointerType(string elementType) => elementType;
-    public string GetPinnedType(string elementType) => elementType;
-    public string GetModifiedType(string modifier, string unmodifiedType, bool isRequired) => unmodifiedType;
-    public string GetGenericMethodParameter(object? genericContext, int index) => $"!!{index}";
-    public string GetGenericTypeParameter(object? genericContext, int index) => $"!{index}";
-    public string GetFunctionPointerType(MethodSignature<string> signature) => "(fnptr)";
 }
 
 [MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]

--- a/tools/AnalysisHarness/MemoryPoolLifecycleSensor.cs
+++ b/tools/AnalysisHarness/MemoryPoolLifecycleSensor.cs
@@ -1,0 +1,517 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Collections.Immutable;
+using System.Runtime.InteropServices;
+
+using Markout;
+using Markout.Formatting;
+
+using ILInspector.Analysis;
+using ILInspector.Instructions;
+
+namespace ILInspector.AnalysisHarness;
+
+/// <summary>One classified MemoryPool.Rent site: its lifecycle class, the method it lives in, and a
+/// short human detail describing how the rented owner is (or is not) released.</summary>
+public sealed record MemoryPoolLifecycleExample(string Class, string Method, string Detail);
+
+/// <summary>Per-assembly MemoryPool lifecycle result: whether it opened, how many Rent sites it
+/// produced, the per-class histogram, and a few example rows.</summary>
+public sealed record MemoryPoolLifecycleAssembly(
+    string Name,
+    bool Opened,
+    bool TimedOut,
+    int Sites,
+    IReadOnlyDictionary<string, int> ClassCounts,
+    IReadOnlyList<MemoryPoolLifecycleExample> Examples);
+
+/// <summary>A MemoryPool lifecycle census: per-assembly rows plus aggregate per-class totals.</summary>
+public sealed record MemoryPoolLifecycleReport(
+    IReadOnlyList<MemoryPoolLifecycleAssembly> Assemblies,
+    IReadOnlyDictionary<string, int> TotalsByClass,
+    int Total);
+
+public enum MemoryPoolLifecycleFormat { Markdown, Tsv, Jsonl }
+
+/// <summary>
+/// The MemoryPool lifecycle corpus sensor (#2439 Slice 3): a measurement-only census that adds a
+/// second resource family alongside the ArrayPool leak-triage work. It reads each assembly with
+/// SRM, finds every call to <c>MemoryPool&lt;T&gt;.Rent</c> (the acquire), tracks the returned
+/// <c>IMemoryOwner&lt;T&gt;</c> through the shared reaching-definitions def/use web, and classifies
+/// the site by how the owner is released:
+/// <list type="bullet">
+/// <item><b>disposed-in-scope</b> - the owner is <c>Dispose</c>d inside a <c>finally</c>/fault
+/// handler covering the acquire (the <c>using</c> idiom): exception-safe.</item>
+/// <item><b>exception-path-leak-candidate</b> - the owner is disposed, but only on the normal path
+/// (no covering handler): an exception between Rent and Dispose leaks it.</item>
+/// <item><b>normal-path-leak-candidate</b> - the owner is never disposed and never escapes (e.g.
+/// rented then popped, or rented and never used): it leaks on the normal path.</item>
+/// <item><b>ownership-transfer-suppressed</b> - the owner is returned, stored to a field, or passed
+/// to another method/constructor: its lifetime is owned elsewhere, so no accusation.</item>
+/// <item><b>incomplete-or-ambiguous-suppressed</b> - incomplete CFG/RD, an address-taken or
+/// multiply-defined owner slot, or an unmodeled disposition: fail-closed.</item>
+/// </list>
+/// It changes no analyzer behavior and wires no product surface. Like the ArrayPool census it is
+/// precision-first: anything not provably disposed or leaked is suppressed. Attribution is
+/// immediate-consumer based (the instruction a def/use load feeds); a fully stack-precise
+/// attribution is the natural follow-up.
+///
+/// <para>Known limitation: when the owner is kept purely on the evaluation stack (the Release
+/// C# idiom <c>Rent(); dup; ...; Dispose()</c> with no local), there is no owner slot for the
+/// def/use web to track, so the site is reported <c>incomplete-or-ambiguous-suppressed</c> rather
+/// than guessed. The <c>using</c>/exception-safe shape reliably uses a local (the finally must
+/// reload the owner), so <c>disposed-in-scope</c> is detected regardless of optimization.</para>
+/// </summary>
+public static class MemoryPoolLifecycleSensor
+{
+    public const string DisposedInScope = "disposed-in-scope";
+    public const string ExceptionPathLeak = "exception-path-leak-candidate";
+    public const string NormalPathLeak = "normal-path-leak-candidate";
+    public const string OwnershipTransfer = "ownership-transfer-suppressed";
+    public const string Ambiguous = "incomplete-or-ambiguous-suppressed";
+
+    static readonly string[] ClassOrder =
+        [DisposedInScope, ExceptionPathLeak, NormalPathLeak, OwnershipTransfer, Ambiguous];
+
+    public static MemoryPoolLifecycleReport Measure(IReadOnlyList<string> assemblyPaths, int perAssemblyTimeoutSeconds = 120, int examplesPerAssembly = 5)
+    {
+        var assemblies = new List<MemoryPoolLifecycleAssembly>(assemblyPaths.Count);
+        foreach (var path in assemblyPaths)
+            assemblies.Add(MeasureWithTimeout(path, perAssemblyTimeoutSeconds, examplesPerAssembly));
+        assemblies.Sort((a, b) => string.CompareOrdinal(a.Name, b.Name));
+
+        var totals = new SortedDictionary<string, int>(StringComparer.Ordinal);
+        foreach (var assembly in assemblies)
+            foreach (var (cls, count) in assembly.ClassCounts)
+                totals[cls] = totals.GetValueOrDefault(cls) + count;
+
+        return new MemoryPoolLifecycleReport(assemblies, totals, assemblies.Sum(a => a.Sites));
+    }
+
+    static MemoryPoolLifecycleAssembly MeasureWithTimeout(string path, int timeoutSeconds, int examplesPerAssembly)
+    {
+        string name = Path.GetFileName(path);
+        MemoryPoolLifecycleAssembly? result = null;
+        var worker = new Thread(() => result = MeasureOne(path, examplesPerAssembly)) { IsBackground = true };
+        worker.Start();
+        if (worker.Join(TimeSpan.FromSeconds(timeoutSeconds)) && result is not null)
+            return result;
+        return new MemoryPoolLifecycleAssembly(name, Opened: false, TimedOut: true, 0, new Dictionary<string, int>(), []);
+    }
+
+    static MemoryPoolLifecycleAssembly MeasureOne(string path, int examplesPerAssembly)
+    {
+        string name = Path.GetFileName(path);
+        try
+        {
+            // Read into memory so no file handle is held during the per-assembly timeout window.
+            using var pe = new PEReader(ImmutableCollectionsMarshal.AsImmutableArray(File.ReadAllBytes(path)));
+            if (!pe.HasMetadata)
+                return new MemoryPoolLifecycleAssembly(name, Opened: false, TimedOut: false, 0, new Dictionary<string, int>(), []);
+            var reader = pe.GetMetadataReader();
+
+            var classCounts = new SortedDictionary<string, int>(StringComparer.Ordinal);
+            var examples = new List<MemoryPoolLifecycleExample>();
+            int sites = 0;
+
+            foreach (var typeHandle in reader.TypeDefinitions)
+            {
+                var typeDef = reader.GetTypeDefinition(typeHandle);
+                foreach (var methodHandle in typeDef.GetMethods())
+                {
+                    var methodDef = reader.GetMethodDefinition(methodHandle);
+                    if (methodDef.RelativeVirtualAddress == 0)
+                        continue;
+                    foreach (var (cls, detail, methodName) in ClassifyMethod(reader, pe, typeDef, methodDef))
+                    {
+                        sites++;
+                        classCounts[cls] = classCounts.GetValueOrDefault(cls) + 1;
+                        if (examples.Count < examplesPerAssembly)
+                            examples.Add(new MemoryPoolLifecycleExample(cls, methodName, detail));
+                    }
+                }
+            }
+
+            return new MemoryPoolLifecycleAssembly(name, Opened: true, TimedOut: false, sites, classCounts, examples);
+        }
+        catch
+        {
+            return new MemoryPoolLifecycleAssembly(name, Opened: false, TimedOut: false, 0, new Dictionary<string, int>(), []);
+        }
+    }
+
+    // One row per MemoryPool.Rent call site in the method.
+    static IEnumerable<(string Class, string Detail, string Method)> ClassifyMethod(
+        MetadataReader reader, PEReader pe, TypeDefinition typeDef, MethodDefinition methodDef)
+    {
+        string methodName = $"{reader.GetString(typeDef.Name)}::{reader.GetString(methodDef.Name)}";
+        MethodBodyBlock body;
+        ImmutableArray<DecodedInstruction> instructions;
+        try
+        {
+            body = pe.GetMethodBody(methodDef.RelativeVirtualAddress);
+            var il = body.GetILBytes();
+            if (il is null || il.Length == 0)
+                yield break;
+            instructions = InstructionDecoder.Decode(il);
+        }
+        catch
+        {
+            yield break;
+        }
+
+        // Locate MemoryPool.Rent acquire sites first; most methods have none.
+        List<int>? rentIndices = null;
+        for (int i = 0; i < instructions.Length; i++)
+        {
+            if (!IsCall(instructions[i].OpCode))
+                continue;
+            var (type, member) = HarnessMemberResolution.ResolveToken(reader, unchecked((int)instructions[i].OperandValue));
+            if (member == "Rent" && ShortName(type) == "MemoryPool")
+                (rentIndices ??= []).Add(i);
+        }
+        if (rentIndices is null)
+            yield break;
+
+        // Reaching definitions give the precise def/use web for the owner slot. Fail closed if the
+        // analysis is incomplete for this method.
+        ReachingDefinitionsResult? rd = null;
+        try
+        {
+            int argSlots = ArgumentSlotCount(reader, methodDef);
+            var il = body.GetILBytes();
+            if (il is not null)
+                rd = ReachingDefinitions.Analyze(il, argSlots, body.ExceptionRegions);
+        }
+        catch
+        {
+            rd = null;
+        }
+
+        foreach (int rentIndex in rentIndices)
+        {
+            var (cls, detail) = ClassifySite(reader, instructions, body.ExceptionRegions, rd, rentIndex);
+            yield return (cls, detail, methodName);
+        }
+    }
+
+    static (string Class, string Detail) ClassifySite(
+        MetadataReader reader,
+        ImmutableArray<DecodedInstruction> instructions,
+        ImmutableArray<ExceptionRegion> regions,
+        ReachingDefinitionsResult? rd,
+        int rentIndex)
+    {
+        if (rentIndex + 1 >= instructions.Length)
+            return (Ambiguous, "Rent result has no consumer.");
+
+        var next = instructions[rentIndex + 1];
+
+        // Owner consumed directly off the stack (no store-to-local).
+        if (next.OpCode == ILOpCode.Ret)
+            return (OwnershipTransfer, "Owner is returned directly to the caller.");
+        if (IsFieldStore(next.OpCode))
+            return (OwnershipTransfer, "Owner is stored directly to a field.");
+        if (next.OpCode == ILOpCode.Pop)
+            return (NormalPathLeak, "Rent result is popped and discarded.");
+        if (IsCall(next.OpCode))
+        {
+            var (t, m) = HarnessMemberResolution.ResolveToken(reader, unchecked((int)next.OperandValue));
+            return m == "Dispose"
+                ? (ExceptionPathLeak, $"Owner is disposed immediately with no covering handler ({ShortName(t)}::{m}).")
+                : (OwnershipTransfer, $"Owner is passed directly to {ShortName(t)}::{m}.");
+        }
+
+        if (!TryGetStoreSlot(next.OpCode, next, out int ownerSlot))
+            return (Ambiguous, $"Owner disposition after Rent is unmodeled ({next.OpCode}).");
+
+        // Owner stored to a local: use the def/use web to classify how every use consumes it.
+        if (rd is null || !rd.IsComplete)
+            return (Ambiguous, "Incomplete reaching-definitions evidence.");
+
+        var ownerDef = rd.Definitions.FirstOrDefault(d => !d.IsArgument && d.Slot == ownerSlot && d.Offset == next.Offset);
+        if (ownerDef is null)
+            return (Ambiguous, "Owner definition is missing from reaching definitions.");
+
+        var uses = rd.UsesOf(ownerDef);
+        if (uses.Any(u => u.Address))
+            return (Ambiguous, "Owner slot is address-taken.");
+
+        bool disposedProtected = false, disposedNormal = false, escaped = false, hasUse = false;
+        int ownerReadyOffset = next.NextOffset;
+        foreach (var use in uses)
+        {
+            hasUse = true;
+            switch (ConsumerOf(reader, instructions, use.Offset))
+            {
+                case (UseDisposition.Dispose, int disposeOffset):
+                    if (DisposeProtects(regions, ownerReadyOffset, disposeOffset))
+                        disposedProtected = true;
+                    else
+                        disposedNormal = true;
+                    break;
+                case (UseDisposition.Escape, _):
+                    escaped = true;
+                    break;
+                default:
+                    // Unmodeled consumer (e.g. a null-check branch, or passed as a call argument
+                    // through intermediate stack ops): treat as an escape and suppress.
+                    escaped = true;
+                    break;
+            }
+        }
+
+        if (disposedProtected)
+            return (DisposedInScope, "Owner is disposed in a finally/fault handler covering Rent.");
+        if (disposedNormal)
+            return (ExceptionPathLeak, "Owner is disposed only on the normal path (no covering handler).");
+        if (escaped)
+            return (OwnershipTransfer, "Owner escapes (returned, stored, or passed onward).");
+        if (!hasUse)
+            return (NormalPathLeak, "Rented owner is stored but never used or disposed.");
+        return (Ambiguous, "Owner disposition could not be determined.");
+    }
+
+    enum UseDisposition { Unknown, Dispose, Escape }
+
+    // Classify how the load at useOffset feeds the following instruction. Immediate-consumer only:
+    // exact for the dominant `ldloc; callvirt Dispose` / `ldloc; ret` / `ldloc; stfld` shapes, and
+    // fail-closed (Unknown) otherwise.
+    static (UseDisposition, int) ConsumerOf(MetadataReader reader, ImmutableArray<DecodedInstruction> instructions, int useOffset)
+    {
+        int idx = IndexOfOffset(instructions, useOffset);
+        if (idx < 0 || idx + 1 >= instructions.Length)
+            return (UseDisposition.Unknown, 0);
+        var consumer = instructions[idx + 1];
+        if (consumer.OpCode == ILOpCode.Ret)
+            return (UseDisposition.Escape, consumer.Offset);
+        if (IsFieldStore(consumer.OpCode))
+            return (UseDisposition.Escape, consumer.Offset);
+        if (IsCall(consumer.OpCode))
+        {
+            var (_, member) = HarnessMemberResolution.ResolveToken(reader, unchecked((int)consumer.OperandValue));
+            return member == "Dispose"
+                ? (UseDisposition.Dispose, consumer.Offset)
+                : (UseDisposition.Escape, consumer.Offset);
+        }
+        return (UseDisposition.Unknown, 0);
+    }
+
+    // True when disposeOffset sits inside a finally/fault handler whose protected try covers the
+    // point right after the owner is established (ownerReadyOffset). The `using` idiom acquires the
+    // owner, stores it, then opens the try - so the try starts at the owner-ready offset, not at the
+    // Rent itself. Requiring coverage of ownerReadyOffset (rather than the Rent) both credits the
+    // `using` shape and still declines credit when risky work sits between acquisition and the try.
+    static bool DisposeProtects(ImmutableArray<ExceptionRegion> regions, int ownerReadyOffset, int disposeOffset)
+    {
+        foreach (var er in regions)
+        {
+            if (er.Kind is not (ExceptionRegionKind.Finally or ExceptionRegionKind.Fault))
+                continue;
+            bool disposeInHandler = er.HandlerOffset <= disposeOffset && disposeOffset < er.HandlerOffset + er.HandlerLength;
+            bool tryCoversOwner = er.TryOffset <= ownerReadyOffset && ownerReadyOffset < er.TryOffset + er.TryLength;
+            if (disposeInHandler && tryCoversOwner)
+                return true;
+        }
+        return false;
+    }
+
+    static int ArgumentSlotCount(MetadataReader reader, MethodDefinition methodDef)
+    {
+        int parameters = 0;
+        try
+        {
+            parameters = methodDef.DecodeSignature(SignatureTypeNameProvider.Instance, genericContext: null).ParameterTypes.Length;
+        }
+        catch
+        {
+            // Fall back to the parameter table count if the signature blob will not decode.
+            parameters = methodDef.GetParameters().Count;
+        }
+        bool isStatic = (methodDef.Attributes & System.Reflection.MethodAttributes.Static) != 0;
+        return parameters + (isStatic ? 0 : 1);
+    }
+
+    static bool IsCall(ILOpCode op) => op is ILOpCode.Call or ILOpCode.Callvirt or ILOpCode.Newobj;
+
+    static bool IsFieldStore(ILOpCode op) => op is ILOpCode.Stfld or ILOpCode.Stsfld;
+
+    static bool TryGetStoreSlot(ILOpCode op, DecodedInstruction instruction, out int slot)
+    {
+        switch (op)
+        {
+            case ILOpCode.Stloc_0: slot = 0; return true;
+            case ILOpCode.Stloc_1: slot = 1; return true;
+            case ILOpCode.Stloc_2: slot = 2; return true;
+            case ILOpCode.Stloc_3: slot = 3; return true;
+            case ILOpCode.Stloc:
+            case ILOpCode.Stloc_s:
+                slot = unchecked((int)instruction.OperandValue);
+                return true;
+            default:
+                slot = -1;
+                return false;
+        }
+    }
+
+    static int IndexOfOffset(ImmutableArray<DecodedInstruction> instructions, int offset)
+    {
+        for (int i = 0; i < instructions.Length; i++)
+            if (instructions[i].Offset == offset)
+                return i;
+        return -1;
+    }
+
+    static string ShortName(string type)
+    {
+        if (type.Contains('.'))
+            type = type[(type.LastIndexOf('.') + 1)..];
+        int tick = type.IndexOf('`');
+        return tick >= 0 ? type[..tick] : type;
+    }
+
+    public static string Format(MemoryPoolLifecycleReport report, int maxExamples, MemoryPoolLifecycleFormat format)
+    {
+        var output = new StringWriter();
+        if (format == MemoryPoolLifecycleFormat.Markdown)
+        {
+            MarkoutSerializer.Serialize(
+                BuildMarkdownView(report, maxExamples),
+                output,
+                new MarkdownFormatter(),
+                MemoryPoolLifecycleViewContext.Default,
+                new MarkoutWriterOptions());
+        }
+        else
+        {
+            MarkoutSerializer.Serialize(
+                BuildTableView(report, maxExamples),
+                output,
+                new TableFormatter(showHeader: true),
+                MemoryPoolLifecycleViewContext.Default,
+                format == MemoryPoolLifecycleFormat.Tsv
+                    ? new MarkoutWriterOptions { TableMode = MarkoutTableMode.Tsv, OmitEmptyJsonFields = true }
+                    : new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, OmitEmptyJsonFields = true });
+        }
+
+        string rendered = output.ToString();
+        return format == MemoryPoolLifecycleFormat.Jsonl
+            ? string.Join(Environment.NewLine, rendered.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries)) + Environment.NewLine
+            : rendered;
+    }
+
+    static IReadOnlyList<(string Metric, string Value)> SummaryRows(MemoryPoolLifecycleReport report)
+        => new (string, string)[]
+        {
+            ("assemblies", report.Assemblies.Count.ToString()),
+            ("opened", report.Assemblies.Count(a => a.Opened).ToString()),
+            ("failed", report.Assemblies.Count(a => !a.Opened && !a.TimedOut).ToString()),
+            ("timed out", report.Assemblies.Count(a => a.TimedOut).ToString()),
+            ("MemoryPool.Rent sites", report.Total.ToString()),
+            ("leak candidates", (report.TotalsByClass.GetValueOrDefault(ExceptionPathLeak) + report.TotalsByClass.GetValueOrDefault(NormalPathLeak)).ToString()),
+        };
+
+    static IReadOnlyList<(string Class, string Count)> ClassRows(MemoryPoolLifecycleReport report)
+        => [.. ClassOrder
+            .Where(cls => report.TotalsByClass.ContainsKey(cls))
+            .Select(cls => (cls, report.TotalsByClass[cls].ToString()))];
+
+    static IReadOnlyList<(string Class, string Assembly, string Method, string Detail)> ExampleRows(MemoryPoolLifecycleReport report, int maxExamples)
+    {
+        var rows = new List<(string, string, string, string)>();
+        foreach (var cls in ClassOrder)
+        {
+            int taken = 0;
+            foreach (var assembly in report.Assemblies)
+            {
+                foreach (var example in assembly.Examples.Where(e => e.Class == cls))
+                {
+                    if (taken >= maxExamples) break;
+                    rows.Add((cls, assembly.Name, example.Method, example.Detail));
+                    taken++;
+                }
+                if (taken >= maxExamples) break;
+            }
+        }
+        return rows;
+    }
+
+    static MemoryPoolLifecycleCardMarkdownView BuildMarkdownView(MemoryPoolLifecycleReport report, int maxExamples)
+        => new()
+        {
+            Summary = [.. SummaryRows(report).Select(r => new MemoryPoolLifecycleMetricRow(r.Metric, r.Value))],
+            ByClass = [.. ClassRows(report).Select(r => new MemoryPoolLifecycleClassRow(r.Class, r.Count))],
+            Examples = [.. ExampleRows(report, maxExamples).Select(r => new MemoryPoolLifecycleExampleRow(r.Class, r.Assembly, r.Method, r.Detail))],
+        };
+
+    static MemoryPoolLifecycleCardTableView BuildTableView(MemoryPoolLifecycleReport report, int maxExamples)
+        => new()
+        {
+            Summary = [.. SummaryRows(report).Select(r => new MemoryPoolLifecycleSectionMetricRow("Summary", r.Metric, r.Value))],
+            ByClass = [.. ClassRows(report).Select(r => new MemoryPoolLifecycleSectionClassRow("By class", r.Class, r.Count))],
+            Examples = [.. ExampleRows(report, maxExamples).Select(r => new MemoryPoolLifecycleSectionExampleRow("Examples", r.Class, r.Assembly, r.Method, r.Detail))],
+        };
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
+sealed class MemoryPoolLifecycleCardMarkdownView
+{
+    [MarkoutIgnore]
+    public string Title => "MemoryPool Lifecycle Corpus Sensor";
+
+    [MarkoutSection(Name = "Summary")]
+    public List<MemoryPoolLifecycleMetricRow>? Summary { get; init; }
+
+    [MarkoutSection(Name = "By class", EmptyText = "None - no MemoryPool.Rent sites in this corpus.")]
+    public List<MemoryPoolLifecycleClassRow>? ByClass { get; init; }
+
+    [MarkoutSection(Name = "Examples", EmptyText = "None")]
+    public List<MemoryPoolLifecycleExampleRow>? Examples { get; init; }
+}
+
+[MarkoutSerializable]
+sealed class MemoryPoolLifecycleCardTableView
+{
+    [MarkoutIgnore]
+    public string Title => "MemoryPool Lifecycle Corpus Sensor";
+
+    [MarkoutSection(Name = "Summary")]
+    public List<MemoryPoolLifecycleSectionMetricRow>? Summary { get; init; }
+
+    [MarkoutSection(Name = "By class")]
+    public List<MemoryPoolLifecycleSectionClassRow>? ByClass { get; init; }
+
+    [MarkoutSection(Name = "Examples")]
+    public List<MemoryPoolLifecycleSectionExampleRow>? Examples { get; init; }
+}
+
+[MarkoutSerializable]
+sealed record MemoryPoolLifecycleMetricRow(string Metric, string Count);
+
+[MarkoutSerializable]
+sealed record MemoryPoolLifecycleSectionMetricRow(string Section, string Metric, string Count);
+
+[MarkoutSerializable]
+sealed record MemoryPoolLifecycleClassRow(string Class, string Count);
+
+[MarkoutSerializable]
+sealed record MemoryPoolLifecycleSectionClassRow(string Section, string Class, string Count);
+
+[MarkoutSerializable]
+sealed record MemoryPoolLifecycleExampleRow(string Class, string Assembly, string Method, string Detail);
+
+[MarkoutSerializable]
+sealed record MemoryPoolLifecycleSectionExampleRow(string Section, string Class, string Assembly, string Method, string Detail);
+
+[MarkoutContextOptions(SuppressTableWarnings = true)]
+[MarkoutContext(typeof(MemoryPoolLifecycleCardMarkdownView))]
+[MarkoutContext(typeof(MemoryPoolLifecycleCardTableView))]
+[MarkoutContext(typeof(MemoryPoolLifecycleMetricRow))]
+[MarkoutContext(typeof(MemoryPoolLifecycleSectionMetricRow))]
+[MarkoutContext(typeof(MemoryPoolLifecycleClassRow))]
+[MarkoutContext(typeof(MemoryPoolLifecycleSectionClassRow))]
+[MarkoutContext(typeof(MemoryPoolLifecycleExampleRow))]
+[MarkoutContext(typeof(MemoryPoolLifecycleSectionExampleRow))]
+partial class MemoryPoolLifecycleViewContext : MarkoutSerializerContext
+{
+}

--- a/tools/AnalysisHarness/MemoryPoolLifecycleSensor.cs
+++ b/tools/AnalysisHarness/MemoryPoolLifecycleSensor.cs
@@ -389,20 +389,28 @@ public static class MemoryPoolLifecycleSensor
 
     static bool IsCall(ILOpCode op) => op is ILOpCode.Call or ILOpCode.Callvirt or ILOpCode.Newobj;
 
-    // True when a potentially-throwing call sits in [fromOffset, toOffset). Only a real call
-    // (call/callvirt/newobj/calli) is counted as the throwing operation - the conservative signal
-    // that an exception could occur between acquisition and a normal-path dispose (an exception-path
-    // leak). Non-call ops that could also throw are ignored so the leak accusation stays precise.
+    // True when a potentially-throwing call is GUARANTEED to execute between the acquisition and a
+    // normal-path dispose - i.e. the window [fromOffset, toOffset) is a single straight-line run
+    // (every instruction falls through, none branches) that contains a call. Requiring straight-line
+    // control flow is what makes this sound with only linear IL order: if any instruction in the
+    // window branches, a physically-intervening call might execute on a different path (e.g. a later
+    // loop iteration) than the one reaching this dispose, so we cannot confirm a throwing gap and
+    // fail closed (suppress) rather than risk a false leak accusation. Only a real call
+    // (call/callvirt/newobj/calli) is the throwing signal.
     static bool HasThrowingCallBetween(ImmutableArray<DecodedInstruction> instructions, int fromOffset, int toOffset)
     {
+        bool sawCall = false;
         foreach (var instruction in instructions)
         {
             if (instruction.Offset < fromOffset || instruction.Offset >= toOffset)
                 continue;
+            // Any branch or non-fallthrough in the window breaks the straight-line guarantee.
+            if (instruction.Branches || !instruction.FallsThrough)
+                return false;
             if (instruction.OpCode is ILOpCode.Call or ILOpCode.Callvirt or ILOpCode.Newobj or ILOpCode.Calli)
-                return true;
+                sawCall = true;
         }
-        return false;
+        return sawCall;
     }
 
     static bool IsFieldStore(ILOpCode op) => op is ILOpCode.Stfld or ILOpCode.Stsfld;

--- a/tools/AnalysisHarness/MemoryPoolLifecycleSensor.cs
+++ b/tools/AnalysisHarness/MemoryPoolLifecycleSensor.cs
@@ -167,7 +167,7 @@ public static class MemoryPoolLifecycleSensor
             if (!IsCall(instructions[i].OpCode))
                 continue;
             var (type, member) = HarnessMemberResolution.ResolveToken(reader, unchecked((int)instructions[i].OperandValue));
-            if (member == "Rent" && ShortName(type) == "MemoryPool")
+            if (member == "Rent" && IsMemoryPoolType(type))
                 (rentIndices ??= []).Add(i);
         }
         if (rentIndices is null)
@@ -216,10 +216,14 @@ public static class MemoryPoolLifecycleSensor
             return (NormalPathLeak, "Rent result is popped and discarded.");
         if (IsCall(next.OpCode))
         {
-            var (t, m) = HarnessMemberResolution.ResolveToken(reader, unchecked((int)next.OperandValue));
-            return m == "Dispose"
-                ? (ExceptionPathLeak, $"Owner is disposed immediately with no covering handler ({ShortName(t)}::{m}).")
-                : (OwnershipTransfer, $"Owner is passed directly to {ShortName(t)}::{m}.");
+            int token = unchecked((int)next.OperandValue);
+            var (t, m) = HarnessMemberResolution.ResolveToken(reader, token);
+            // A parameterless instance Dispose() / receiver read consumes the owner (as receiver)
+            // immediately, with no throwing gap between Rent and the call - not a clean scope, so
+            // suppress. Anything else takes the owner as an argument: an ownership escape.
+            return HarnessMemberResolution.ClassifyReceiverCall(reader, token) == HarnessMemberResolution.ReceiverCallKind.Other
+                ? (OwnershipTransfer, $"Owner is passed directly to {ShortName(t)}::{m}.")
+                : (Ambiguous, $"Owner is consumed directly off the stack by {ShortName(t)}::{m} (no scope).");
         }
 
         if (!TryGetStoreSlot(next.OpCode, next, out int ownerSlot))
@@ -237,7 +241,7 @@ public static class MemoryPoolLifecycleSensor
         if (uses.Any(u => u.Address))
             return (Ambiguous, "Owner slot is address-taken.");
 
-        bool disposedProtected = false, disposedNormal = false, escaped = false, hasUse = false;
+        bool disposedProtected = false, disposedInCatch = false, disposedNormal = false, escaped = false, hasUse = false;
         int ownerReadyOffset = next.NextOffset;
         foreach (var use in uses)
         {
@@ -245,38 +249,53 @@ public static class MemoryPoolLifecycleSensor
             switch (ConsumerOf(reader, instructions, use.Offset))
             {
                 case (UseDisposition.Dispose, int disposeOffset):
-                    if (DisposeProtects(regions, ownerReadyOffset, disposeOffset))
-                        disposedProtected = true;
-                    else
-                        disposedNormal = true;
+                    switch (DisposeLocation(regions, ownerReadyOffset, disposeOffset))
+                    {
+                        case DisposeSite.Protected: disposedProtected = true; break;
+                        case DisposeSite.InCatch: disposedInCatch = true; break;
+                        default: disposedNormal = true; break;
+                    }
                     break;
                 case (UseDisposition.Escape, _):
                     escaped = true;
                     break;
+                case (UseDisposition.Read, _):
+                    // Non-consuming receiver read (e.g. owner.Memory): owner stays owned locally.
+                    break;
                 default:
-                    // Unmodeled consumer (e.g. a null-check branch, or passed as a call argument
-                    // through intermediate stack ops): treat as an escape and suppress.
+                    // Unmodeled consumer (e.g. a null-check branch, or the owner passed as a call
+                    // argument through intermediate stack ops): treat as an escape and suppress.
                     escaped = true;
                     break;
             }
         }
 
+        // Precedence is fail-closed. A finally/fault dispose is exception-safe (using). An escape
+        // beats a normal-path dispose because the callee may take ownership (disposing here would
+        // then be ambiguous, not a clean leak). A dispose inside a catch handler means the
+        // exception path is handled somewhere, so we do not accuse a leak. A dispose solely on the
+        // normal path, with no handler and no escape, is an exception-path leak. An owner that is
+        // only read (or never used) and never disposed or escaped leaks on the normal path.
         if (disposedProtected)
-            return (DisposedInScope, "Owner is disposed in a finally/fault handler covering Rent.");
-        if (disposedNormal)
-            return (ExceptionPathLeak, "Owner is disposed only on the normal path (no covering handler).");
+            return (DisposedInScope, "Owner is disposed in a finally/fault handler covering the acquisition.");
         if (escaped)
             return (OwnershipTransfer, "Owner escapes (returned, stored, or passed onward).");
-        if (!hasUse)
-            return (NormalPathLeak, "Rented owner is stored but never used or disposed.");
-        return (Ambiguous, "Owner disposition could not be determined.");
+        if (disposedInCatch)
+            return (Ambiguous, "Owner is disposed inside a catch/filter handler; exception coverage is unmodeled.");
+        if (disposedNormal)
+            return (ExceptionPathLeak, "Owner is disposed only on the normal path (no covering handler).");
+        return (NormalPathLeak, hasUse
+            ? "Owner is used but never disposed and never escapes."
+            : "Rented owner is stored but never used or disposed.");
     }
 
-    enum UseDisposition { Unknown, Dispose, Escape }
+    enum UseDisposition { Unknown, Dispose, Escape, Read }
+
+    enum DisposeSite { Normal, Protected, InCatch }
 
     // Classify how the load at useOffset feeds the following instruction. Immediate-consumer only:
-    // exact for the dominant `ldloc; callvirt Dispose` / `ldloc; ret` / `ldloc; stfld` shapes, and
-    // fail-closed (Unknown) otherwise.
+    // exact for the dominant `ldloc; callvirt Dispose` / `ldloc; ret` / `ldloc; stfld` /
+    // `ldloc; callvirt get_Memory` shapes, and fail-closed (Unknown) otherwise.
     static (UseDisposition, int) ConsumerOf(MetadataReader reader, ImmutableArray<DecodedInstruction> instructions, int useOffset)
     {
         int idx = IndexOfOffset(instructions, useOffset);
@@ -289,32 +308,53 @@ public static class MemoryPoolLifecycleSensor
             return (UseDisposition.Escape, consumer.Offset);
         if (IsCall(consumer.OpCode))
         {
-            var (_, member) = HarnessMemberResolution.ResolveToken(reader, unchecked((int)consumer.OperandValue));
-            return member == "Dispose"
-                ? (UseDisposition.Dispose, consumer.Offset)
-                : (UseDisposition.Escape, consumer.Offset);
+            int token = unchecked((int)consumer.OperandValue);
+            return HarnessMemberResolution.ClassifyReceiverCall(reader, token) switch
+            {
+                // Only a parameterless instance Dispose() disposes the owner (as receiver).
+                HarnessMemberResolution.ReceiverCallKind.Dispose => (UseDisposition.Dispose, consumer.Offset),
+                // A parameterless instance read (owner.Memory / owner.Span) keeps local ownership.
+                HarnessMemberResolution.ReceiverCallKind.ReceiverRead => (UseDisposition.Read, consumer.Offset),
+                // Owner passed as an argument / static call: potential ownership transfer.
+                _ => (UseDisposition.Escape, consumer.Offset),
+            };
         }
         return (UseDisposition.Unknown, 0);
     }
 
-    // True when disposeOffset sits inside a finally/fault handler whose protected try covers the
-    // point right after the owner is established (ownerReadyOffset). The `using` idiom acquires the
-    // owner, stores it, then opens the try - so the try starts at the owner-ready offset, not at the
-    // Rent itself. Requiring coverage of ownerReadyOffset (rather than the Rent) both credits the
-    // `using` shape and still declines credit when risky work sits between acquisition and the try.
-    static bool DisposeProtects(ImmutableArray<ExceptionRegion> regions, int ownerReadyOffset, int disposeOffset)
+    // Where a Dispose call sits relative to the owner's acquisition:
+    //  - Protected: inside a finally/fault handler whose try covers the point right after the owner
+    //    is established (ownerReadyOffset). The `using` idiom acquires the owner, stores it, then
+    //    opens the try - so the try starts at the owner-ready offset, not at the Rent itself.
+    //    Requiring coverage of ownerReadyOffset (not the Rent) credits the `using` shape and still
+    //    declines credit when risky work sits between acquisition and the try.
+    //  - InCatch: inside a catch/filter handler covering the owner - the exception path is handled,
+    //    but proving full coverage needs more than this sensor models, so it is treated as unknown.
+    //  - Normal: anywhere else (a plain normal-path Dispose).
+    static DisposeSite DisposeLocation(ImmutableArray<ExceptionRegion> regions, int ownerReadyOffset, int disposeOffset)
     {
+        bool inCatch = false;
         foreach (var er in regions)
         {
-            if (er.Kind is not (ExceptionRegionKind.Finally or ExceptionRegionKind.Fault))
-                continue;
             bool disposeInHandler = er.HandlerOffset <= disposeOffset && disposeOffset < er.HandlerOffset + er.HandlerLength;
+            if (!disposeInHandler)
+                continue;
             bool tryCoversOwner = er.TryOffset <= ownerReadyOffset && ownerReadyOffset < er.TryOffset + er.TryLength;
-            if (disposeInHandler && tryCoversOwner)
-                return true;
+            if (!tryCoversOwner)
+                continue;
+            if (er.Kind is ExceptionRegionKind.Finally or ExceptionRegionKind.Fault)
+                return DisposeSite.Protected;
+            if (er.Kind is ExceptionRegionKind.Catch or ExceptionRegionKind.Filter)
+                inCatch = true;
         }
-        return false;
+        return inCatch ? DisposeSite.InCatch : DisposeSite.Normal;
     }
+
+    // MemoryPool<T>.Rent - the acquire. Match the full System.Buffers.MemoryPool identity (the
+    // resolved declaring type of a generic instance is "System.Buffers.MemoryPool`1") rather than a
+    // bare "MemoryPool" short name, so a user type coincidentally named MemoryPool is not counted.
+    static bool IsMemoryPoolType(string type)
+        => type is "System.Buffers.MemoryPool`1" or "System.Buffers.MemoryPool";
 
     static int ArgumentSlotCount(MetadataReader reader, MethodDefinition methodDef)
     {

--- a/tools/AnalysisHarness/MemoryPoolLifecycleSensor.cs
+++ b/tools/AnalysisHarness/MemoryPoolLifecycleSensor.cs
@@ -241,19 +241,28 @@ public static class MemoryPoolLifecycleSensor
         if (uses.Any(u => u.Address))
             return (Ambiguous, "Owner slot is address-taken.");
 
-        bool disposedProtected = false, disposedInCatch = false, disposedNormal = false, escaped = false, hasUse = false;
+        bool disposedProtected = false, disposedInCatch = false, disposedNormal = false,
+             disposedImmediate = false, escaped = false, hasUse = false;
         int ownerReadyOffset = next.NextOffset;
         foreach (var use in uses)
         {
             hasUse = true;
             switch (ConsumerOf(reader, instructions, use.Offset))
             {
-                case (UseDisposition.Dispose, int disposeOffset):
-                    switch (DisposeLocation(regions, ownerReadyOffset, disposeOffset))
+                case (UseDisposition.Dispose, int _):
+                    switch (DisposeLocation(regions, ownerReadyOffset, use.Offset))
                     {
                         case DisposeSite.Protected: disposedProtected = true; break;
                         case DisposeSite.InCatch: disposedInCatch = true; break;
-                        default: disposedNormal = true; break;
+                        default:
+                            // A normal-path dispose only leaks if a potentially-throwing call sits
+                            // between acquisition and the dispose. With no such gap (e.g. an
+                            // immediate `Rent(); owner.Dispose();`), no exception can bypass it.
+                            if (HasThrowingCallBetween(instructions, ownerReadyOffset, use.Offset))
+                                disposedNormal = true;
+                            else
+                                disposedImmediate = true;
+                            break;
                     }
                     break;
                 case (UseDisposition.Escape, _):
@@ -274,8 +283,9 @@ public static class MemoryPoolLifecycleSensor
         // beats a normal-path dispose because the callee may take ownership (disposing here would
         // then be ambiguous, not a clean leak). A dispose inside a catch handler means the
         // exception path is handled somewhere, so we do not accuse a leak. A dispose solely on the
-        // normal path, with no handler and no escape, is an exception-path leak. An owner that is
-        // only read (or never used) and never disposed or escaped leaks on the normal path.
+        // normal path with a throwing call between acquisition and dispose is an exception-path
+        // leak; an immediate dispose with no such gap is safe. An owner that is only read (or never
+        // used) and never disposed or escaped leaks on the normal path.
         if (disposedProtected)
             return (DisposedInScope, "Owner is disposed in a finally/fault handler covering the acquisition.");
         if (escaped)
@@ -284,6 +294,8 @@ public static class MemoryPoolLifecycleSensor
             return (Ambiguous, "Owner is disposed inside a catch/filter handler; exception coverage is unmodeled.");
         if (disposedNormal)
             return (ExceptionPathLeak, "Owner is disposed only on the normal path (no covering handler).");
+        if (disposedImmediate)
+            return (Ambiguous, "Owner is disposed with no throwing call before Dispose (no exception gap).");
         // No dispose and no escape was seen. If the owner had reads (parameterless instance calls),
         // those calls could in principle consume it (e.g. a property getter that disposes `this`),
         // so suppress rather than accuse. Only a genuinely unused owner is an unambiguous leak.
@@ -376,6 +388,22 @@ public static class MemoryPoolLifecycleSensor
     }
 
     static bool IsCall(ILOpCode op) => op is ILOpCode.Call or ILOpCode.Callvirt or ILOpCode.Newobj;
+
+    // True when a potentially-throwing call sits in [fromOffset, toOffset). Only a real call
+    // (call/callvirt/newobj/calli) is counted as the throwing operation - the conservative signal
+    // that an exception could occur between acquisition and a normal-path dispose (an exception-path
+    // leak). Non-call ops that could also throw are ignored so the leak accusation stays precise.
+    static bool HasThrowingCallBetween(ImmutableArray<DecodedInstruction> instructions, int fromOffset, int toOffset)
+    {
+        foreach (var instruction in instructions)
+        {
+            if (instruction.Offset < fromOffset || instruction.Offset >= toOffset)
+                continue;
+            if (instruction.OpCode is ILOpCode.Call or ILOpCode.Callvirt or ILOpCode.Newobj or ILOpCode.Calli)
+                return true;
+        }
+        return false;
+    }
 
     static bool IsFieldStore(ILOpCode op) => op is ILOpCode.Stfld or ILOpCode.Stsfld;
 

--- a/tools/AnalysisHarness/MemoryPoolLifecycleSensor.cs
+++ b/tools/AnalysisHarness/MemoryPoolLifecycleSensor.cs
@@ -284,9 +284,12 @@ public static class MemoryPoolLifecycleSensor
             return (Ambiguous, "Owner is disposed inside a catch/filter handler; exception coverage is unmodeled.");
         if (disposedNormal)
             return (ExceptionPathLeak, "Owner is disposed only on the normal path (no covering handler).");
-        return (NormalPathLeak, hasUse
-            ? "Owner is used but never disposed and never escapes."
-            : "Rented owner is stored but never used or disposed.");
+        // No dispose and no escape was seen. If the owner had reads (parameterless instance calls),
+        // those calls could in principle consume it (e.g. a property getter that disposes `this`),
+        // so suppress rather than accuse. Only a genuinely unused owner is an unambiguous leak.
+        if (hasUse)
+            return (Ambiguous, "Owner is only read (never disposed or escaped); a read could consume it, so disposition is unmodeled.");
+        return (NormalPathLeak, "Rented owner is stored but never used or disposed.");
     }
 
     enum UseDisposition { Unknown, Dispose, Escape, Read }

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -55,6 +55,16 @@ const string Usage =
           the deliberate no-finally BCL idiom), or unknown. Changes no analyzer behavior. Formats
           match --leak-triage; --top bounds examples per class.
 
+      --memorypool-lifecycle <file> [--top N] [--tsv | --jsonl]
+          MemoryPool lifecycle census (#2439 Slice 3), measurement-only: find every
+          MemoryPool<T>.Rent site (one assembly path per line in <file>), track the returned
+          IMemoryOwner<T> through the reaching-definitions def/use web, and bucket each site as
+          disposed-in-scope (using/finally), exception-path-leak-candidate (disposed only on the
+          normal path), normal-path-leak-candidate (never disposed, never escapes),
+          ownership-transfer-suppressed (returned/stored/passed onward), or
+          incomplete-or-ambiguous-suppressed. Precision-first; changes no analyzer behavior.
+          Formats match --leak-triage; --top bounds examples per class.
+
       Common: --json machine-readable output; --keep keep generated fixture projects.
     """;
 
@@ -83,6 +93,7 @@ string? annotationParityExpected = null;
 string? annotationParityActual = null;
 string? leakTriageList = null;
 string? leakActionabilityList = null;
+string? memoryPoolLifecycleList = null;
 bool tsv = false;
 bool jsonl = false;
 int top = 20;
@@ -129,6 +140,9 @@ for (int i = 0; i < args.Length; i++)
         case "--leak-actionability":
             leakActionabilityList = NextPathValue(args, ref i);
             break;
+        case "--memorypool-lifecycle":
+            memoryPoolLifecycleList = NextPathValue(args, ref i);
+            break;
         case "--tsv":
             tsv = true;
             break;
@@ -162,9 +176,9 @@ for (int i = 0; i < args.Length; i++)
 
 // --tsv/--jsonl are tabular-format selectors for the leak cards; other modes use --json.
 // Reject them elsewhere rather than silently accepting-and-ignoring them.
-if ((tsv || jsonl) && leakTriageList is null && leakActionabilityList is null)
+if ((tsv || jsonl) && leakTriageList is null && leakActionabilityList is null && memoryPoolLifecycleList is null)
 {
-    Console.Error.WriteLine("--tsv and --jsonl apply only to --leak-triage / --leak-actionability; other modes use --json.");
+    Console.Error.WriteLine("--tsv and --jsonl apply only to --leak-triage / --leak-actionability / --memorypool-lifecycle; other modes use --json.");
     return 2;
 }
 
@@ -188,6 +202,9 @@ if (leakTriageList is not null)
 
 if (leakActionabilityList is not null)
     return RunLeakActionability(leakActionabilityList, top, tsv, jsonl || json);
+
+if (memoryPoolLifecycleList is not null)
+    return RunMemoryPoolLifecycle(memoryPoolLifecycleList, top, tsv, jsonl || json);
 
 if (corpusList is not null)
     return RunCorpus(corpusList, diffBaseline, emitSnapshot, json);
@@ -307,6 +324,37 @@ static int RunLeakActionability(string corpusList, int top, bool tsv, bool jsonl
 
     var report = LeakActionabilitySensor.Measure(paths, examplesPerAssembly: top);
     Console.Write(LeakActionabilitySensor.Format(report, top, format));
+    return 0;
+}
+
+static int RunMemoryPoolLifecycle(string corpusList, int top, bool tsv, bool jsonl)
+{
+    if (!File.Exists(corpusList))
+    {
+        Console.Error.WriteLine($"Corpus list not found: {corpusList}");
+        return 2;
+    }
+
+    if (tsv && jsonl)
+    {
+        Console.Error.WriteLine("--tsv and --jsonl are mutually exclusive.");
+        return 2;
+    }
+
+    MemoryPoolLifecycleFormat format = jsonl ? MemoryPoolLifecycleFormat.Jsonl : tsv ? MemoryPoolLifecycleFormat.Tsv : MemoryPoolLifecycleFormat.Markdown;
+
+    var paths = File.ReadAllLines(corpusList)
+        .Select(line => line.Trim())
+        .Where(line => line.Length > 0 && !line.StartsWith('#'))
+        .ToList();
+    if (paths.Count == 0)
+    {
+        Console.Error.WriteLine($"Corpus list is empty: {corpusList}");
+        return 2;
+    }
+
+    var report = MemoryPoolLifecycleSensor.Measure(paths, examplesPerAssembly: top);
+    Console.Write(MemoryPoolLifecycleSensor.Format(report, top, format));
     return 0;
 }
 

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -194,6 +194,49 @@ Boundary attribution is a `Rent`-to-end window scan, coarser than the analyzer's
 can include an unrelated call in the window); it is exact for the small single-rent methods this
 bucket is dominated by. A def-use-precise attribution is the natural follow-up.
 
+## MemoryPool lifecycle corpus sensor (#2439, Slice 3)
+
+`--memorypool-lifecycle` is the second resource family alongside the ArrayPool leak-triage work: a
+**measurement-only** census of `MemoryPool<T>.Rent` sites, as a
+[Markout](https://github.com/richlander/markout) card.
+
+```bash
+dotnet "$DLL" --memorypool-lifecycle assemblies.txt --top 5   # Markdown card (default)
+dotnet "$DLL" --memorypool-lifecycle assemblies.txt --tsv     # section-tagged TSV
+dotnet "$DLL" --memorypool-lifecycle assemblies.txt --jsonl   # one JSON record per row
+```
+
+For every `MemoryPool<T>.Rent` call it tracks the returned `IMemoryOwner<T>` through the shared
+reaching-definitions def/use web and buckets the site by how the owner is released:
+
+- `disposed-in-scope` — the owner is `Dispose`d in a `finally`/fault handler covering the
+  acquisition (the `using` idiom): exception-safe.
+- `exception-path-leak-candidate` — the owner is disposed, but only on the normal path (no covering
+  handler): an exception between `Rent` and `Dispose` leaks it.
+- `normal-path-leak-candidate` — the owner is never disposed and never escapes (e.g. rented then
+  popped, or rented and never used): it leaks on the normal path.
+- `ownership-transfer-suppressed` — the owner is returned, stored to a field, or passed to another
+  method/constructor: its lifetime is owned elsewhere, so no accusation.
+- `incomplete-or-ambiguous-suppressed` — incomplete CFG/RD, an address-taken or multiply-defined
+  owner slot, or an unmodeled disposition: fail-closed.
+
+Like `--leak-triage` this changes no analyzer behavior and wires no product surface, and it is
+**precision-first**: anything not provably disposed or leaked is suppressed. A run over the .NET
+9.0.14 shared framework (`Microsoft.NETCore.App` + `Microsoft.AspNetCore.App`, 308 assemblies)
+found 19 `MemoryPool<T>.Rent` sites — **all 19 `ownership-transfer-suppressed`** (the owner is
+handed to a `BufferSegment`/`DiagnosticPoolBlock`/field that owns disposal), with **zero** false
+leak accusations. Synthetic positive-control fixtures confirm every bucket fires: `using` →
+`disposed-in-scope`, normal-path `Dispose` (no `finally`) → `exception-path-leak-candidate`,
+rent-then-discard → `normal-path-leak-candidate`, and return/field/pass →
+`ownership-transfer-suppressed`.
+
+Attribution is immediate-consumer based; a fully stack-precise attribution is the natural
+follow-up. Known limitation: when the owner is kept purely on the evaluation stack (the Release
+idiom `Rent(); dup; ...; Dispose()` with no local) there is no slot for the def/use web to track,
+so the site is reported `incomplete-or-ambiguous-suppressed` rather than guessed. The
+exception-safe `using` shape always uses a local (the finally must reload the owner), so
+`disposed-in-scope` is detected regardless of optimization level.
+
 ## Allocation convergence parity
 
 The Rung 4 allocation-convergence build must prove that a candidate


### PR DESCRIPTION
## What

Adds a **measurement-only** MemoryPool lifecycle corpus sensor — the second resource family for
[#2439](https://github.com/richlander/dotnet-inspect/issues/2439) (Slice 3). New harness mode
`analysis-harness --memorypool-lifecycle <list>`. It changes **no analyzer behavior** and wires
**no product surface** (matches the `--leak-triage` / `--leak-actionability` sensor pattern).

For every `MemoryPool<T>.Rent` call it tracks the returned `IMemoryOwner<T>` through the shared
reaching-definitions def/use web and buckets the site by how the owner is released:

| Bucket | Meaning |
| --- | --- |
| `disposed-in-scope` | `Dispose` in a `finally`/fault handler covering the acquisition (the `using` idiom): exception-safe. |
| `exception-path-leak-candidate` | disposed, but only on the normal path (no covering handler). |
| `normal-path-leak-candidate` | never disposed and never escapes (rented then popped / never used). |
| `ownership-transfer-suppressed` | returned, stored to a field, or passed onward — owned elsewhere. |
| `incomplete-or-ambiguous-suppressed` | incomplete CFG/RD, address-taken/multi-def slot, or unmodeled disposition (fail-closed). |

Precision-first: anything not provably disposed or leaked is **suppressed** (the crux for MemoryPool,
whose usage is dominated by ownership transfer to segments/pools).

## Evidence

**Framework corpus** (.NET 9.0.14 `Microsoft.NETCore.App` + `Microsoft.AspNetCore.App`, 308 asm):
`308 opened / 0 failed / 0 timed out`, **19 `MemoryPool<T>.Rent` sites, all 19
`ownership-transfer-suppressed`, zero false leak accusations**. The details are precise, e.g.:

- `Pipe::RentMemory`, `StreamPipe{Reader,Writer}::AllocateSegment` → *passed to
  `BufferSegment::SetOwnedMemory`*
- `DiagnosticMemoryPool::Rent` (×5) → *passed to `DiagnosticPoolBlock::.ctor`*
- `NativeRequestContext::.ctor`, `*OutputProducer::GetFakeMemory` → *stored to a field*

**Positive-control fixtures** (built in Debug so owners are local-resident) confirm every bucket fires:

| Fixture method | Bucket |
| --- | --- |
| `using IMemoryOwner<byte> owner = MemoryPool<byte>.Shared.Rent(n);` | `disposed-in-scope` |
| rent; use; `owner.Dispose()` (no `finally`) | `exception-path-leak-candidate` |
| `MemoryPool<byte>.Shared.Rent(n);` (discarded) | `normal-path-leak-candidate` |
| `return MemoryPool<byte>.Shared.Rent(n);` / field store / pass onward | `ownership-transfer-suppressed` |

<details><summary>Fixture source (build <code>-c Debug</code>, run <code>--memorypool-lifecycle</code>)</summary>

```csharp
using System;
using System.Buffers;

public static class MemoryPoolFixtures
{
    public static int UsingPattern(int n)
    {
        using IMemoryOwner<byte> owner = MemoryPool<byte>.Shared.Rent(n);
        return owner.Memory.Length;
    }
    public static int DisposeNormalPathOnly(int n)
    {
        IMemoryOwner<byte> owner = MemoryPool<byte>.Shared.Rent(n);
        Span<byte> span = owner.Memory.Span; span[0] = 1;
        int len = owner.Memory.Length;
        owner.Dispose();
        return len + span.Length;
    }
    public static void RentAndDiscard(int n) => MemoryPool<byte>.Shared.Rent(n);
    public static IMemoryOwner<byte> RentAndReturn(int n) => MemoryPool<byte>.Shared.Rent(n);
    sealed class Holder { IMemoryOwner<byte>? _o; public Holder(int n){ _o = MemoryPool<byte>.Shared.Rent(n); } }
    public static object MakeHolder(int n) => new Holder(n);
    public static void PassOnward(int n) => Consume(MemoryPool<byte>.Shared.Rent(n));
    static void Consume(IMemoryOwner<byte> o) => o.Dispose();
}
```

</details>

## Known limitation (documented, fail-closed)

When the owner is kept purely on the evaluation stack (the Release idiom `Rent(); dup; ...; Dispose()`
with no local), there is no owner slot for the def/use web, so the site is reported
`incomplete-or-ambiguous-suppressed` rather than guessed. The exception-safe `using` shape always
uses a local (the `finally` must reload the owner), so `disposed-in-scope` is detected regardless of
optimization. A fully stack-precise attribution is the natural follow-up.

## Refactor

Extracts the SRM member/type-name resolution shared by the harness sensors into
`HarnessMemberResolution` (moved out of `LeakActionabilitySensor` unchanged, including the
TypeSpec blob-length + nested-depth StackOverflow guards from #2524). The leak-actionability
framework census is unchanged: **4 untrusted / 18 trusted / 9 unknown**.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` green.
- `markdownlint` clean.
- Framework + fixture runs above.

Measurement-only, but non-trivial (new heuristic/shapes), so requesting two-model adversarial review.
