### PR TITLE
Add product implementation diff

### DIFF
--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -1,0 +1,44 @@
+# Implementation Diff Boundary
+
+`ImplementationDiff` is the product-side C# + IL/body diff projection in
+`ILInspector.Research`. It is the reusable implementation-diff component for
+future CLI sections, ReturnToSender, harnesses, and other consumers that need one
+member-centric evidence model instead of separate C# and IL renderers.
+
+## Ownership
+
+- `ILInspector.Decompiler` owns C# body diff production and display rows through
+  `CSharpBodyDiff` and `CSharpDiffPrinter`.
+- `ILInspector.Instructions` owns IL/body diff production and display rows
+  through `IlBodyDiff`, `IlAssemblyDiff`, and `IlDiffPrinter`.
+- `ILInspector.Research` owns the join. `ImplementationDiff` compares assemblies
+  with C# and IL/body mechanisms, groups evidence by `ResearchSubjectKey`, and
+  exposes typed display rows and unified lines without reformatting producer
+  wording.
+
+## Consumer contract
+
+Use `ImplementationDiff.CompareAssemblies` or `ImplementationDiff.Compare` when
+the input is a pair of assemblies or `ResearchDiffInput` values. The result is a
+list of changed implementation members. Each member can carry C# evidence, IL
+evidence, or both; exact members are omitted.
+
+Use `ImplementationDiff.ToIlEvidence` when a caller already has a scoped
+`IlMemberDiffResult`, such as ReturnToSender comparing one original method to a
+recompiled artifact method. This preserves typed IL diff evidence and projects
+the same `ResearchDiffEvidence` rows used by assembly-wide Research diffs. Exact
+typed diffs produce no IL evidence rows, but callers may still retain the typed
+diff in their own result model when exact proof matters.
+
+The component is intentionally not a CLI section yet. CLI wiring should be a
+separate usability change that chooses section names, verbosity, table schema,
+and row limits without changing the product evidence primitive.
+
+## Non-goals
+
+- It does not prove semantic equivalence; IL/body rows are evidence, not a
+  verifier.
+- It does not own API compatibility rows. API diff remains a separate Research
+  mechanism that can be joined by callers when needed.
+- It does not compile source artifacts or plan closure. ReturnToSender and other
+  harnesses own artifact requests and compilation.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -40,6 +40,7 @@ Agents working in this repo should preserve these principles:
 - [Analysis UX scopes](design/analysis-ux-scopes.md): shared analysis vocabulary across offset, member, type, and library scopes.
 - [IL coordinate workflows](design/il-coordinate-workflows.md): prototype workflows for explaining sparse runtime coordinates from debugger, profiler, or analyzer artifacts.
 - [IL Diff canonicalization](design/il-diff-canonicalization.md): current `CanonicalIlOperation` guarantees, boundaries, and extension points.
+- [Implementation Diff](design/implementation-diff.md): product C# + IL/body diff projection shared by future CLI surfaces, RTS, and harnesses.
 - [Fixture governance](fixture-governance.md): fixture catalog, project-boundary, and semantic-axis rules.
 - [Integrations](design/integrations.md): library ecosystem integration roll-ups and focused API currency.
 - [Section model](design/section-model.md): section selection and query behavior.

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -769,6 +769,35 @@ public class ResearchDiffTests
             && item.IlDisplayRows.Single().UnifiedLine == "h1 + IL_0001 ldc.i4 2");
     }
 
+    [Fact]
+    public void ImplementationDiff_ToIlEvidence_FallsBackWhenTypedDiffHasNoRows()
+    {
+        var typedDiff = new IlMemberDiffResult(
+            new IlMemberDiffSubject("old-id", "old-label"),
+            new IlMemberDiffSubject("new-id", "new-label"),
+            new IlBodyDiffResult(
+                IsExact: true,
+                Failure: null,
+                Rows: []));
+        var failure = new IlDiffDisplayFailureRow(
+            IlDiffFailureKind.NewBodyMissing,
+            "new body missing",
+            Side: "new",
+            Detail: "method has no body");
+        var fallback = new IlDiffDisplayResult(
+            Failure: failure.UnifiedLine,
+            Rows: [],
+            FailureRows: [failure]);
+
+        var evidence = ImplementationDiff.ToIlEvidence(typedDiff, fallback);
+
+        var row = Assert.Single(evidence);
+        Assert.Equal("il.diff.new-body-missing", row.ChangeId);
+        Assert.Equal("method has no body", row.Detail);
+        Assert.Same(failure, row.IlDisplayFailureRow);
+        Assert.Null(row.IlMemberDiff);
+    }
+
     static ApiSurface Surface(string typeName, params ApiMember[] members)
         => new()
         {

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -688,6 +688,87 @@ public class ResearchDiffTests
         Assert.StartsWith("ConstantValue~", changed.Subject.Id, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void ImplementationDiff_CompareAssemblies_GroupsCSharpAndIlEvidence()
+    {
+        var diff = ImplementationDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            new ImplementationDiffOptions(TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" }));
+
+        var changed = Assert.Single(diff.Members, member => member.Subject.MemberName == "ConstantValue");
+
+        Assert.True(changed.HasCSharpEvidence);
+        Assert.True(changed.HasIlEvidence);
+        Assert.Contains(changed.Evidence, evidence =>
+            evidence.Kind == ImplementationDiffEvidenceKind.CSharp
+            && evidence.UnifiedLines.Any(line => line.Contains("return 1", StringComparison.Ordinal)));
+        Assert.Contains(changed.Evidence, evidence =>
+            evidence.Kind == ImplementationDiffEvidenceKind.IlBody
+            && evidence.UnifiedLines.Any(line => line.Contains("ldc.i4 1", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public void ImplementationDiff_CompareAssemblies_FiltersIlEvidenceByType()
+    {
+        var diff = ImplementationDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            new ImplementationDiffOptions(TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "OperatorSample" }));
+
+        Assert.DoesNotContain(diff.Members, member =>
+            string.Equals(member.Subject.MemberName, "ConstantValue", StringComparison.Ordinal));
+        Assert.Contains(diff.Members, member =>
+            string.Equals(member.Subject.MemberName, "op_Addition", StringComparison.Ordinal)
+            && member.HasCSharpEvidence
+            && member.HasIlEvidence);
+    }
+
+    [Fact]
+    public void ImplementationDiff_ToIlEvidence_ProjectsTypedMemberDiffRows()
+    {
+        var typedDiff = new IlMemberDiffResult(
+            new IlMemberDiffSubject("old-id", "old-label"),
+            new IlMemberDiffSubject("new-id", "new-label"),
+            new IlBodyDiffResult(
+                IsExact: false,
+                Failure: null,
+                Rows:
+                [
+                    new IlDiffRow(
+                        0,
+                        IlDiffKind.Context,
+                        new CanonicalIlOperation(0, "nop", Operand: null),
+                        "Unchanged IL operation 'nop'"),
+                    new IlDiffRow(
+                        1,
+                        IlDiffKind.Remove,
+                        new CanonicalIlOperation(1, "ldc.i4", new IlOperandIdentity(IlOperandIdentityKind.Immediate, "1")),
+                        "Removed IL operation 'ldc.i4 1'"),
+                    new IlDiffRow(
+                        1,
+                        IlDiffKind.Add,
+                        new CanonicalIlOperation(1, "ldc.i4", new IlOperandIdentity(IlOperandIdentityKind.Immediate, "2")),
+                        "Added IL operation 'ldc.i4 2'"),
+                ]));
+
+        var evidence = ImplementationDiff.ToIlEvidence(typedDiff);
+
+        Assert.DoesNotContain(evidence, item => item.ChangeId == "il.operation.context");
+        Assert.Contains(evidence, item =>
+            item.ChangeId == "il.operation.removed"
+            && item.OldValue == "ldc.i4 1"
+            && item.OldIlOffset == 1
+            && item.IlMemberDiff == typedDiff
+            && item.IlDisplayRows.Single().UnifiedLine == "h1 - IL_0001 ldc.i4 1");
+        Assert.Contains(evidence, item =>
+            item.ChangeId == "il.operation.added"
+            && item.NewValue == "ldc.i4 2"
+            && item.NewIlOffset == 1
+            && item.IlMemberDiff == typedDiff
+            && item.IlDisplayRows.Single().UnifiedLine == "h1 + IL_0001 ldc.i4 2");
+    }
+
     static ApiSurface Surface(string typeName, params ApiMember[] members)
         => new()
         {

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -725,6 +725,30 @@ public class ResearchDiffTests
     }
 
     [Fact]
+    public void ImplementationDiff_CompareAssemblies_FiltersUnderlyingResearchDiffByMemberTarget()
+    {
+        var full = ImplementationDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            new ImplementationDiffOptions(TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" }));
+        var targetId = Assert.Single(full.Members, member => member.Subject.MemberName == "ConstantValue").Subject.Id;
+
+        var scoped = ImplementationDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            new ImplementationDiffOptions(
+                TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" },
+                MemberTargetIdentities: new HashSet<string>(StringComparer.Ordinal) { targetId }));
+
+        var researchMembers = scoped.ResearchDiff.MembersWhere(member => member.ImplementationChanged);
+        Assert.All(researchMembers, member => Assert.Equal(targetId, member.Subject.Id));
+        var member = Assert.Single(scoped.Members);
+        Assert.Equal(targetId, member.Subject.Id);
+        Assert.True(member.HasCSharpEvidence);
+        Assert.True(member.HasIlEvidence);
+    }
+
+    [Fact]
     public void ImplementationDiff_ToIlEvidence_ProjectsTypedMemberDiffRows()
     {
         var typedDiff = new IlMemberDiffResult(

--- a/src/ILInspector.Research/ImplementationDiff.cs
+++ b/src/ILInspector.Research/ImplementationDiff.cs
@@ -130,12 +130,13 @@ public static class ImplementationDiff
         IlMemberDiffResult? diff,
         IlDiffDisplayResult? fallbackDisplay = null)
     {
-        var display = diff is { } typed
-            ? IlDiffPrinter.ToDisplayResult(typed.Diff)
-            : fallbackDisplay;
-        return display is null
-            ? []
-            : ToIlEvidence(display, diff);
+        if (diff is not { } typed)
+            return fallbackDisplay is null ? [] : ToIlEvidence(fallbackDisplay);
+
+        var typedEvidence = ToIlEvidence(IlDiffPrinter.ToDisplayResult(typed.Diff), typed);
+        return typedEvidence.IsEmpty && fallbackDisplay is not null
+            ? ToIlEvidence(fallbackDisplay)
+            : typedEvidence;
     }
 
     public static ImmutableArray<ResearchDiffEvidence> ToIlEvidence(

--- a/src/ILInspector.Research/ImplementationDiff.cs
+++ b/src/ILInspector.Research/ImplementationDiff.cs
@@ -1,0 +1,242 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler;
+using ILInspector.Instructions;
+
+namespace ILInspector.Research;
+
+[Flags]
+public enum ImplementationDiffMechanism
+{
+    None = 0,
+    CSharp = 1,
+    IlBody = 2,
+    All = CSharp | IlBody,
+}
+
+public enum ImplementationDiffEvidenceKind
+{
+    CSharp,
+    IlBody,
+}
+
+public sealed record ImplementationDiffOptions(
+    ImplementationDiffMechanism Mechanisms = ImplementationDiffMechanism.All,
+    IReadOnlySet<string>? TypeFilters = null,
+    IReadOnlySet<string>? MemberTargetIdentities = null);
+
+public sealed record ImplementationDiffResult(
+    IReadOnlyList<ImplementationDiffMember> Members,
+    ResearchDiffResult ResearchDiff)
+{
+    public bool IsEmpty => Members.Count == 0;
+}
+
+public sealed record ImplementationDiffMember(
+    ResearchSubjectKey Subject,
+    IReadOnlyList<ImplementationDiffEvidence> Evidence)
+{
+    public bool HasCSharpEvidence => Evidence.Any(evidence => evidence.Kind == ImplementationDiffEvidenceKind.CSharp);
+    public bool HasIlEvidence => Evidence.Any(evidence => evidence.Kind == ImplementationDiffEvidenceKind.IlBody);
+}
+
+public sealed record ImplementationDiffEvidence(
+    ImplementationDiffEvidenceKind Kind,
+    string ChangeId,
+    ResearchDiffDirection Direction,
+    string? OldValue = null,
+    string? NewValue = null,
+    string? Detail = null,
+    int? OldIlOffset = null,
+    int? NewIlOffset = null,
+    ImmutableArray<CSharpDiffDisplayRow> CSharpDisplayRows = default,
+    CSharpDiffDisplayFailureRow? CSharpDisplayFailureRow = null,
+    ImmutableArray<IlDiffDisplayRow> IlDisplayRows = default,
+    IlDiffDisplayFailureRow? IlDisplayFailureRow = null,
+    IlMemberDiffResult? IlMemberDiff = null)
+{
+    public ImmutableArray<string> UnifiedLines
+    {
+        get
+        {
+            var lines = ImmutableArray.CreateBuilder<string>();
+            if (CSharpDisplayFailureRow is not null)
+                lines.Add(CSharpDisplayFailureRow.UnifiedLine);
+            if (!CSharpDisplayRows.IsDefaultOrEmpty)
+                lines.AddRange(CSharpDisplayRows.Select(row => row.UnifiedLine));
+            if (IlDisplayFailureRow is not null)
+                lines.Add(IlDisplayFailureRow.UnifiedLine);
+            if (!IlDisplayRows.IsDefaultOrEmpty)
+                lines.AddRange(IlDisplayRows.Select(row => row.UnifiedLine));
+            return lines.ToImmutable();
+        }
+    }
+}
+
+/// <summary>
+/// Product-owned implementation diff projection that joins C# source-shape and
+/// IL/body evidence by Research member identity.
+/// </summary>
+public static class ImplementationDiff
+{
+    public static ImplementationDiffResult CompareAssemblies(
+        string oldAssemblyPath,
+        string newAssemblyPath,
+        ImplementationDiffOptions? options = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(oldAssemblyPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(newAssemblyPath);
+        return Compare(
+            ResearchDiffInput.FromAssembly(oldAssemblyPath),
+            ResearchDiffInput.FromAssembly(newAssemblyPath),
+            options);
+    }
+
+    public static ImplementationDiffResult Compare(
+        ResearchDiffInput oldInput,
+        ResearchDiffInput newInput,
+        ImplementationDiffOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(oldInput);
+        ArgumentNullException.ThrowIfNull(newInput);
+
+        options ??= new ImplementationDiffOptions();
+        var research = ResearchDiff.Compare(oldInput, newInput, new ResearchDiffOptions(
+            ToResearchMechanisms(options.Mechanisms),
+            TypeFilters: options.TypeFilters,
+            MemberTargetIdentities: options.MemberTargetIdentities));
+        return FromResearchDiff(research, options);
+    }
+
+    public static ImplementationDiffResult FromResearchDiff(
+        ResearchDiffResult research,
+        ImplementationDiffOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(research);
+        options ??= new ImplementationDiffOptions();
+
+        var members = research.MembersWhere(member => member.ImplementationChanged)
+            .Select(member => new ImplementationDiffMember(
+                member.Subject,
+                [.. member.Evidence.Select(ToImplementationEvidence).Where(evidence => evidence is not null).Select(evidence => evidence!)]))
+            .Where(member => member.Evidence.Count > 0)
+            .Where(member => ResearchDiff.MatchesTypeFilters(member.Subject.TypeName ?? "", options.TypeFilters))
+            .Where(member => MatchesMemberTargets(member.Subject, options.MemberTargetIdentities))
+            .ToArray();
+
+        return new ImplementationDiffResult(members, research);
+    }
+
+    public static ImmutableArray<ResearchDiffEvidence> ToIlEvidence(
+        IlMemberDiffResult? diff,
+        IlDiffDisplayResult? fallbackDisplay = null)
+    {
+        var display = diff is { } typed
+            ? IlDiffPrinter.ToDisplayResult(typed.Diff)
+            : fallbackDisplay;
+        return display is null
+            ? []
+            : ToIlEvidence(display, diff);
+    }
+
+    public static ImmutableArray<ResearchDiffEvidence> ToIlEvidence(
+        IlDiffDisplayResult display,
+        IlMemberDiffResult? diff = null)
+    {
+        ArgumentNullException.ThrowIfNull(display);
+
+        if (display.IsEmpty)
+            return [];
+
+        var evidence = ImmutableArray.CreateBuilder<ResearchDiffEvidence>();
+        var failureRows = display.FailureRows.IsDefault ? [] : display.FailureRows;
+        foreach (var failureRow in failureRows)
+        {
+            evidence.Add(new ResearchDiffEvidence(
+                ResearchDiffMechanism.IlBody,
+                $"il.diff.{ResearchDiff.ToChangeIdPart(failureRow.Kind.ToString())}",
+                ResearchDiffDirection.Changed,
+                Detail: failureRow.Detail ?? failureRow.Message,
+                Category: ResearchDiffChangeCategory.IlBody,
+                IlDisplayFailureRow: failureRow,
+                IlMemberDiff: diff));
+        }
+
+        if (failureRows.IsDefaultOrEmpty && display.Failure is { Length: > 0 } failure)
+        {
+            evidence.Add(new ResearchDiffEvidence(
+                ResearchDiffMechanism.IlBody,
+                "il.diff.failed",
+                ResearchDiffDirection.Changed,
+                Detail: failure,
+                Category: ResearchDiffChangeCategory.IlBody,
+                IlMemberDiff: diff));
+        }
+
+        var displayRows = display.Rows.IsDefault ? [] : display.Rows;
+        foreach (var displayRow in displayRows)
+        {
+            if (displayRow.Kind == IlDiffKind.Context)
+                continue;
+
+            var direction = displayRow.Kind == IlDiffKind.Add
+                ? ResearchDiffDirection.Added
+                : ResearchDiffDirection.Removed;
+            evidence.Add(new ResearchDiffEvidence(
+                ResearchDiffMechanism.IlBody,
+                displayRow.Kind == IlDiffKind.Add ? "il.operation.added" : "il.operation.removed",
+                direction,
+                OldValue: displayRow.Kind == IlDiffKind.Remove ? displayRow.Operation : null,
+                NewValue: displayRow.Kind == IlDiffKind.Add ? displayRow.Operation : null,
+                OldIlOffset: displayRow.Kind == IlDiffKind.Remove ? displayRow.RawOffset : null,
+                NewIlOffset: displayRow.Kind == IlDiffKind.Add ? displayRow.RawOffset : null,
+                Detail: displayRow.Message,
+                Category: ResearchDiffChangeCategory.IlBody,
+                IlDisplayRows: [displayRow],
+                IlMemberDiff: diff));
+        }
+
+        return evidence.ToImmutable();
+    }
+
+    static ResearchDiffMechanism ToResearchMechanisms(ImplementationDiffMechanism mechanisms)
+    {
+        var research = ResearchDiffMechanism.None;
+        if (mechanisms.HasFlag(ImplementationDiffMechanism.CSharp))
+            research |= ResearchDiffMechanism.CSharp;
+        if (mechanisms.HasFlag(ImplementationDiffMechanism.IlBody))
+            research |= ResearchDiffMechanism.IlBody;
+        return research;
+    }
+
+    static ImplementationDiffEvidence? ToImplementationEvidence(ResearchDiffEvidence evidence)
+        => evidence.Mechanism switch
+        {
+            ResearchDiffMechanism.CSharp => new ImplementationDiffEvidence(
+                ImplementationDiffEvidenceKind.CSharp,
+                evidence.ChangeId,
+                evidence.Direction,
+                evidence.OldValue,
+                evidence.NewValue,
+                evidence.Detail,
+                CSharpDisplayRows: evidence.CSharpDisplayRows.IsDefault ? [] : evidence.CSharpDisplayRows,
+                CSharpDisplayFailureRow: evidence.CSharpDisplayFailureRow),
+            ResearchDiffMechanism.IlBody => new ImplementationDiffEvidence(
+                ImplementationDiffEvidenceKind.IlBody,
+                evidence.ChangeId,
+                evidence.Direction,
+                evidence.OldValue,
+                evidence.NewValue,
+                evidence.Detail,
+                evidence.OldIlOffset,
+                evidence.NewIlOffset,
+                IlDisplayRows: evidence.IlDisplayRows.IsDefault ? [] : evidence.IlDisplayRows,
+                IlDisplayFailureRow: evidence.IlDisplayFailureRow,
+                IlMemberDiff: evidence.IlMemberDiff),
+            _ => null,
+        };
+
+    static bool MatchesMemberTargets(ResearchSubjectKey subject, IReadOnlySet<string>? memberTargetIdentities)
+        => memberTargetIdentities is null
+           || memberTargetIdentities.Count == 0
+           || memberTargetIdentities.Contains(subject.Id);
+}

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -297,7 +297,7 @@ public static class ResearchDiff
             AddIlBodyDiff(builder, oldInput, newInput, options.TypeFilters, options.MemberTargetIdentities);
 
         if (options.Mechanisms.HasFlag(ResearchDiffMechanism.CSharp))
-            AddCSharpDiff(builder, oldInput, newInput, options.TypeFilters);
+            AddCSharpDiff(builder, oldInput, newInput, options.TypeFilters, options.MemberTargetIdentities);
 
         return builder.ToResult();
     }
@@ -678,18 +678,29 @@ public static class ResearchDiff
             IlDisplayFailureRow: IlDiffPrinter.ToDisplayFailureRow(failure)));
     }
 
-    static void AddCSharpDiff(ResultBuilder builder, ResearchDiffInput oldInput, ResearchDiffInput newInput, IReadOnlySet<string>? typeFilters)
+    static void AddCSharpDiff(
+        ResultBuilder builder,
+        ResearchDiffInput oldInput,
+        ResearchDiffInput newInput,
+        IReadOnlySet<string>? typeFilters,
+        IReadOnlySet<string>? memberTargetIdentities)
     {
         if (oldInput.AssemblyPaths.Count == 0 || newInput.AssemblyPaths.Count == 0)
             return;
 
         var diff = CSharpBodyDiff.CompareAssemblies(oldInput.AssemblyPaths, newInput.AssemblyPaths, typeFilters: typeFilters);
         foreach (var failure in diff.FailureRows.IsDefault ? [] : diff.FailureRows)
-            AddCSharpFailureEvidence(builder, failure);
+        {
+            var subject = ResearchMemberIdentity.SubjectFromAnchor(failure.Anchor, failure.Member);
+            if (MatchesMemberTargets(subject, memberTargetIdentities))
+                AddCSharpFailureEvidence(builder, subject, failure);
+        }
 
         foreach (var row in diff.Rows)
         {
             var subject = ResearchMemberIdentity.SubjectFromAnchor(row.Anchor, row.Member);
+            if (!MatchesMemberTargets(subject, memberTargetIdentities))
+                continue;
             var direction = row.Kind switch
             {
                 CSharpDiffKind.Add => ResearchDiffDirection.Added,
@@ -710,9 +721,8 @@ public static class ResearchDiff
         }
     }
 
-    static void AddCSharpFailureEvidence(ResultBuilder builder, CSharpDiffFailureRow failure)
+    static void AddCSharpFailureEvidence(ResultBuilder builder, ResearchSubjectKey subject, CSharpDiffFailureRow failure)
     {
-        var subject = ResearchMemberIdentity.SubjectFromAnchor(failure.Anchor, failure.Member);
         var direction = failure.Kind switch
         {
             CSharpDiffFailureKind.OldBodyMissing => ResearchDiffDirection.Added,

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -294,7 +294,7 @@ public static class ResearchDiff
             AddBodySignalDiff(builder, oldInput, newInput, options.TypeFilters, options.MemberTargetIdentities);
 
         if (options.Mechanisms.HasFlag(ResearchDiffMechanism.IlBody))
-            AddIlBodyDiff(builder, oldInput, newInput);
+            AddIlBodyDiff(builder, oldInput, newInput, options.TypeFilters, options.MemberTargetIdentities);
 
         if (options.Mechanisms.HasFlag(ResearchDiffMechanism.CSharp))
             AddCSharpDiff(builder, oldInput, newInput, options.TypeFilters);
@@ -569,7 +569,12 @@ public static class ResearchDiff
                 InLoop: inLoop));
     }
 
-    static void AddIlBodyDiff(ResultBuilder builder, ResearchDiffInput oldInput, ResearchDiffInput newInput)
+    static void AddIlBodyDiff(
+        ResultBuilder builder,
+        ResearchDiffInput oldInput,
+        ResearchDiffInput newInput,
+        IReadOnlySet<string>? typeFilters,
+        IReadOnlySet<string>? memberTargetIdentities)
     {
         foreach (var pair in PairedBodyIndexEntries(oldInput, newInput))
         {
@@ -584,6 +589,10 @@ public static class ResearchDiff
                 var oldMethod = oldMethods[key];
                 var newMethod = newMethods[key];
                 var subject = SubjectFromMethod(newMethod);
+                if (!MatchesTypeFilters(subject.TypeName ?? "", typeFilters))
+                    continue;
+                if (!MatchesMemberTargets(subject, memberTargetIdentities))
+                    continue;
                 var oldAvailable = oldBodies.TryDecode(oldMethod.MetadataToken, out var oldBody, out var oldReason);
                 var newAvailable = newBodies.TryDecode(newMethod.MetadataToken, out var newBody, out var newReason);
 
@@ -914,7 +923,7 @@ public static class ResearchDiff
     static string? FormatOffsets(ImmutableArray<int> offsets)
         => offsets.IsDefaultOrEmpty ? null : string.Join(",", offsets.Select(offset => $"IL_{offset:X4}"));
 
-    static bool MatchesTypeFilters(string typeFullName, IReadOnlySet<string>? filters)
+    internal static bool MatchesTypeFilters(string typeFullName, IReadOnlySet<string>? filters)
         => filters is null || filters.Count == 0 || filters.Any(filter => MatchesDiffTypeFilter(typeFullName, filter));
 
     static bool MatchesDiffTypeFilter(string typeFullName, string filter)

--- a/tools/DecompilerHarness/ReturnToSenderEvidence.cs
+++ b/tools/DecompilerHarness/ReturnToSenderEvidence.cs
@@ -174,65 +174,9 @@ internal static class ReturnToSenderEvidence
             Detail: row.Detail ?? row.Reason,
             Category: ResearchDiffChangeCategory.RoundTrip);
 
-        var diagnostic = Diagnostic(row);
-        if (diagnostic is null)
-            yield break;
-
-        var failureRows = diagnostic.FailureRows.IsDefault
-            ? []
-            : diagnostic.FailureRows;
-        foreach (var failureRow in failureRows)
-        {
-            yield return new ResearchDiffEvidence(
-                ResearchDiffMechanism.IlBody,
-                $"il.diff.{ResearchDiff.ToChangeIdPart(failureRow.Kind.ToString())}",
-                ResearchDiffDirection.Changed,
-                Detail: failureRow.Detail ?? failureRow.Message,
-                Category: ResearchDiffChangeCategory.IlBody,
-                IlDisplayFailureRow: failureRow,
-                IlMemberDiff: row.IlDiff);
-        }
-
-        if (failureRows.IsDefaultOrEmpty && diagnostic.Failure is { Length: > 0 } failure)
-        {
-            yield return new ResearchDiffEvidence(
-                ResearchDiffMechanism.IlBody,
-                "il.diff.failed",
-                ResearchDiffDirection.Changed,
-                Detail: failure,
-                Category: ResearchDiffChangeCategory.IlBody);
-        }
-
-        var displayRows = diagnostic.Rows.IsDefault
-            ? []
-            : diagnostic.Rows;
-        foreach (var displayRow in displayRows)
-        {
-            if (displayRow.Kind == IlDiffKind.Context)
-                continue;
-
-            var direction = displayRow.Kind == IlDiffKind.Add
-                ? ResearchDiffDirection.Added
-                : ResearchDiffDirection.Removed;
-            yield return new ResearchDiffEvidence(
-                ResearchDiffMechanism.IlBody,
-                displayRow.Kind == IlDiffKind.Add ? "il.operation.added" : "il.operation.removed",
-                direction,
-                OldValue: displayRow.Kind == IlDiffKind.Remove ? displayRow.Operation : null,
-                NewValue: displayRow.Kind == IlDiffKind.Add ? displayRow.Operation : null,
-                OldIlOffset: displayRow.Kind == IlDiffKind.Remove ? displayRow.RawOffset : null,
-                NewIlOffset: displayRow.Kind == IlDiffKind.Add ? displayRow.RawOffset : null,
-                Detail: displayRow.Message,
-                Category: ResearchDiffChangeCategory.IlBody,
-                IlDisplayRows: [displayRow],
-                IlMemberDiff: row.IlDiff);
-        }
+        foreach (var ilEvidence in ImplementationDiff.ToIlEvidence(row.IlDiff, row.IlDiffDiagnostic))
+            yield return ilEvidence;
     }
-
-    static IlDiffDisplayResult? Diagnostic(ReturnToSenderEvidenceRow row)
-        => row.IlDiff is { } typed
-            ? IlDiffPrinter.ToDisplayResult(typed.Diff)
-            : row.IlDiffDiagnostic;
 
     static string StatusId(GeneratedFixtureReturnToSenderStatus status)
         => status switch


### PR DESCRIPTION
## Summary

- Add `ImplementationDiff` in `ILInspector.Research` as the product C# + IL/body diff projection for future CLI, RTS, and harness consumers.
- Expose assembly-wide comparison over `ResearchDiffInput` plus scoped `IlMemberDiffResult` -> `ResearchDiffEvidence` projection for callers like RTS.
- Apply Research type/member filters to IL-body evidence so merged C# + IL projections stay aligned.
- Route RTS IL evidence projection through the shared product helper instead of hand-rolling IL rows.
- Document the implementation-diff boundary without wiring a CLI section yet.

## Validation

- `npx markdownlint-cli docs/design/implementation-diff.md docs/overview.md`
- `git diff --check HEAD~1..HEAD`
- `dotnetup dotnet run --project src/ILInspector.Research.Tests -c Release --no-restore -- -class ILInspector.Research.Tests.ResearchDiffTests`
- `dotnetup dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -class ILInspector.Decompiler.Tests.ReturnToSenderEvidenceTests`
- `dotnetup dotnet build dotnet-inspect.slnx -c Release --no-restore`