### PR TITLE
Carry constructor kind as typed IR evidence for backing-field writes

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -461,6 +461,35 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void IrImporter_ClassifiesConstructorMethodKinds()
+    {
+        // Typed constructor evidence (migration 3): the importer decodes the
+        // reserved metadata method name into IrFunction.MethodKind so compile-back
+        // composition routes it instead of re-matching ".ctor"/".cctor" strings.
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                static Class1() { Value = 42; }
+                public Class1(int other) { Other = other; }
+                public void M() { }
+                public static int Value { get; }
+                public int Other { get; }
+            }
+            """);
+        try
+        {
+            using var source = MetadataSource.Open(assemblyPath);
+            Assert.Equal(IrMethodKind.StaticConstructor, IrImporter.Import(source, "Class1", ".cctor", publicOnly: false)!.MethodKind);
+            Assert.Equal(IrMethodKind.Constructor, IrImporter.Import(source, "Class1", ".ctor", publicOnly: false)!.MethodKind);
+            Assert.Equal(IrMethodKind.Method, IrImporter.Import(source, "Class1", "M", publicOnly: false)!.MethodKind);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_SeedsTargetInterfaceRoot()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -668,7 +668,7 @@ public static class CompileBackSourceComposer
         var signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, targetTypeDef, method));
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
         string targetMethodName = Identifier(methodName);
-        bool isConstructor = methodName is ".ctor" or ".cctor";
+        bool isConstructor = function.MethodKind is IrMethodKind.Constructor or IrMethodKind.StaticConstructor;
         var primaryConstructor = isConstructor
             ? PrimaryConstructorFromPrologue(reader, method, function, targetBody)
             : PrimaryConstructorFromCapturedFields(reader, targetTypeDef, targetBody);
@@ -712,7 +712,7 @@ public static class CompileBackSourceComposer
         }
         if (isConstructor && primaryConstructor is null)
             targetMembers.AddRange(TargetBackingFieldWriteMembers(reader, targetTypeDef, targetIdentity, function, allowStaticStores: false));
-        if (methodName == ".cctor")
+        if (function.MethodKind is IrMethodKind.StaticConstructor)
             targetMembers.AddRange(TargetBackingFieldWriteMembers(reader, targetTypeDef, targetIdentity, function, allowStaticStores: true));
         if (!isConstructor
             && EqualityOperatorSibling(reader, targetTypeDef, targetIdentity, methodName, signature) is { } equalitySibling)
@@ -1719,7 +1719,7 @@ public static class CompileBackSourceComposer
                 return null;
             }
 
-            string fieldName = AutoPropertyNameForBackingField(reader, declaringType, store.Field.Name)
+            string fieldName = store.Field.BackingPropertyName
                 ?? store.Field.Name;
             initializerTexts.Add((fieldName, parameterName));
             fieldInitializers.Add(new CompileBackMemberRequirement(
@@ -1940,8 +1940,6 @@ public static class CompileBackSourceComposer
                 continue;
             if (!IsSelfType(fieldRef.DeclaringType, targetIdentity))
                 continue;
-            if (AutoPropertyNameForBackingField(reader, typeDef, fieldRef.Name) != propertyName)
-                continue;
             if (FindField(reader, typeDef, fieldRef.Name) is not { } fieldHandle)
                 continue;
 
@@ -2008,8 +2006,6 @@ public static class CompileBackSourceComposer
                 continue;
             if (!IsSelfType(fieldRef.DeclaringType, targetIdentity))
                 continue;
-            if (AutoPropertyNameForBackingField(reader, typeDef, fieldRef.Name) != propertyName)
-                continue;
             if (FindField(reader, typeDef, fieldRef.Name) is not { } fieldHandle)
                 continue;
 
@@ -2044,21 +2040,6 @@ public static class CompileBackSourceComposer
         }
 
         return members;
-    }
-
-    static string? AutoPropertyNameForBackingField(MetadataReader reader, TypeDefinition typeDef, string fieldName)
-    {
-        if (!fieldName.StartsWith("<", StringComparison.Ordinal) || !fieldName.EndsWith(">k__BackingField", StringComparison.Ordinal))
-            return null;
-
-        string propertyName = fieldName[1..^">k__BackingField".Length];
-        foreach (var propertyHandle in typeDef.GetProperties())
-        {
-            var property = reader.GetPropertyDefinition(propertyHandle);
-            if (reader.GetString(property.Name) == propertyName)
-                return propertyName;
-        }
-        return null;
     }
 
     static int CountInstanceConstructors(MetadataReader reader, TypeDefinition typeDef)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -394,7 +394,10 @@ public static class IrImporter
         var container = new BlockContainer();
         container.Add(block);
         var signature = new MethodSignature(TypeRef.Unsupported("import failed"), [], false, 0);
-        var function = new IrFunction(methodName, TypeRef.Definition("", "", typeName), signature, [], container);
+        var function = new IrFunction(methodName, TypeRef.Definition("", "", typeName), signature, [], container)
+        {
+            MethodKind = ClassifyMethodKind(methodName),
+        };
         block.Add(new ExpressionStatement(new UnsupportedNode(0, "(importer crash)", $"{ex.GetType().Name}: {ex.Message}")));
         function.Diagnostics.Add(new DecompilerDiagnostic(
             DiagnosticIds.InternalError, $"importer crash: {ex.GetType().Name}: {ex.Message}"));

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -414,6 +414,7 @@ public static class IrImporter
             AssemblyPath = source.Path,
             MetadataToken = method.MetadataToken,
             BaseType = source.ResolveBaseType(method.DeclaringType),
+            MethodKind = ClassifyMethodKind(method.Name),
             Regions = method.Body.Handlers,
             LocalNames = method.Body.LocalNames,
             UsesUpdatedMemorySafetyRules = source.SimulateNewRules || ModuleUsesUpdatedMemorySafetyRules(source.Reader),
@@ -2403,6 +2404,14 @@ public static class IrImporter
 
     static FieldRef ResolveField(MetadataSource source, EntityHandle handle, GenericScope callerScope)
         => source.CrossAssembly.Upgrade(ResolveField(source.Reader, handle, callerScope));
+
+    static IrMethodKind ClassifyMethodKind(string methodName)
+        => methodName switch
+        {
+            ".cctor" => IrMethodKind.StaticConstructor,
+            ".ctor" => IrMethodKind.Constructor,
+            _ => IrMethodKind.Method,
+        };
 
     static string? BackingPropertyName(MetadataReader reader, TypeDefinition declaringType, string fieldName)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -178,6 +178,9 @@ public sealed record FieldRef(TypeRef DeclaringType, string Name, TypeRef Type)
     public string? BackingPropertyName { get; init; }
 }
 
+/// <summary>The C# method kind decoded from a reserved metadata method name: an ordinary method, an instance constructor (<c>.ctor</c>), or a static constructor (<c>.cctor</c>).</summary>
+public enum IrMethodKind { Method, Constructor, StaticConstructor }
+
 /// <summary>The root of one method's IR: signature plus a body container, with diagnostics accumulated during construction and passes.</summary>
 public sealed class IrFunction : IrNode
 {
@@ -196,6 +199,13 @@ public sealed class IrFunction : IrNode
     public int MetadataToken { get; set; }
     public TypeRef? BaseType { get; set; }
     public MethodSignature Signature { get; }
+    /// <summary>
+    /// Typed constructor evidence decoded from the reserved metadata method name
+    /// (<c>.ctor</c>/<c>.cctor</c>) at import time. Consumers (e.g. compile-back
+    /// source composition) route this instead of re-matching the method-name
+    /// string.
+    /// </summary>
+    public IrMethodKind MethodKind { get; set; } = IrMethodKind.Method;
     public ImmutableArray<TypeRef> Locals { get; private set; }
     public MetadataFactState CompilerGenerated { get; set; } = MetadataFactState.Unknown;
     public MetadataFactState DeclaringTypeCompilerGenerated { get; set; } = MetadataFactState.Unknown;


### PR DESCRIPTION
Part of #2529 (migration 3 — constructor backing-field writes). Base: latest `origin/main`.

## Change

**Conclusion:** **PASS** — constructor/static-constructor backing-field-write shell composition now runs on typed product IR evidence instead of two name-string heuristics.

Before:

```text
CompileBackSourceComposer:
  isConstructor  = methodName is ".ctor" or ".cctor"      (method-name gate)
  static ctor    = methodName == ".cctor"
  property↔field = AutoPropertyNameForBackingField(...)   (parses "<Prop>k__BackingField")
```

After:

```text
Product IR evidence:
  IrImporter decodes reserved name -> IrFunction.MethodKind {Method,Constructor,StaticConstructor}
  IrImporter already populates FieldRef.BackingPropertyName (typed property↔field association)
  CompileBackSourceComposer routes MethodKind + BackingPropertyName; no name-string parsing
```

## Scope and safety

- **`.ctor`/`.cctor` gate → typed kind:** `IrImporter.Build` classifies the reserved metadata method name into a new typed `IrFunction.MethodKind`; `ComposeMethod` derives `isConstructor` and the static-constructor branch from it. The reserved-name decode stays in the product importer (the metadata-owning layer), matching #2534's "discovery is product knowledge" shape.
- **`<Prop>k__BackingField` parse → typed evidence:** the composer's `AutoPropertyNameForBackingField` re-parse was fully redundant with the importer-populated `FieldRef.BackingPropertyName` (both use the same `<Prop>k__BackingField` decode + property-existence check against the same self-type, gated by `IsSelfType`). Removed the re-check from the backing-field **write** and **read** shells and the primary-constructor prologue; deleted the now-unused helper.
- **Behavior-preserving:** the routed truth values are identical; nothing else consumes `MethodKind`; render output is unchanged.
- **Out of scope:** unchanged sibling helpers still take `methodName` for other reasons; not touched.

## Evidence

| Check | Result |
| --- | --- |
| New `IrImporter_ClassifiesConstructorMethodKinds` (typed evidence: `.cctor`→StaticConstructor, `.ctor`→Constructor, `M`→Method) | Pass |
| Importer/ctor/record/initializer/catalog subset (`PipelineImporter`, `PrimaryConstructorPass`, `ObjectInitializerPass`, `RecordPass`, `GeneratedFixtureCatalog`) | 47/47 pass |
| `ReturnToSenderPrototypeTests` | 8 pre-existing failures, **identical to unmodified current `origin/main`** (SDK preview.5 Roslyn recompile-back; the backing-field canary fails at `Status` on both) — no new failures |
| RTS source-probe A/B (`rts.candidates`, same SDK, baseline vs head) | **identical**: ValidMatch 52, ValidDifferent 50, Invalid 0, SourceUnavailable 0, UnsupportedTarget 0 |

## Validation

```bash
dotnet build src/ILInspector.Decompiler -c Release --configfile nuget.config
dotnet build src/ILInspector.Decompiler.Tests -c Release --configfile nuget.config
# xUnit v3 EXE
dotnet artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll -method "*IrImporter_ClassifiesConstructorMethodKinds"
dotnet run --project tools/DecompilerHarness -c Release --no-build -- \
  --return-to-sender-fixtures rts.candidates --return-to-sender-source-probe --cap 10000 --max-examples 0
```

> Note: this box runs SDK 11.0.100-preview.5 (central), not the repo's .NET 11 daily. The 8 `ReturnToSenderPrototypeTests` failures (incl. `CompileBackTargets_UsesTargetBackingFieldWriteForStaticConstructorAssignment`) reproduce identically on unmodified `origin/main` at `Status: Expected Exact, Actual RecompileFail`, so they are pre-existing/environment, not introduced here; CI on the correct SDK is the authoritative gate for the canary.

## Review

Adversarial review requested after PR creation (two reviewers, non-Claude family, per policy).
