### PR TITLE
Fix lazy field getter fidelity

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2888,6 +2888,13 @@ public class CfgSampleClass
         return holder.Cache;
     }
 
+    public string? LazyFieldCache;
+
+    public string LazyFieldGetter(string fallback)
+    {
+        return LazyFieldCache ??= fallback;
+    }
+
     public static string NullCoalescingAssignFieldWithExtraThenStatement(CacheHolder holder, string fallback)
     {
         if (holder.Cache == null)

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -149,7 +149,9 @@ public class FidelityGateTests
     /// dispatch (relational pivots over linear == chains) back into a `switch`.
     /// NullCoalescingAssignStaticField and NullCoalescingAssignInstanceField must
     /// keep folding the field null-test diamond into `field ??= fallback` whose
-    /// two member loads recompile opcode-exact. WhileTrueWithReturns and
+    /// two member loads recompile opcode-exact. LazyFieldGetter must keep folding
+    /// csc's expression-valued lazy field getter into `return field ??= fallback`,
+    /// preserving the dup/null-test/result-slot lowering opcode-exact. WhileTrueWithReturns and
     /// WhileTrueWithBreak must keep raising csc's unconditional back-edge into a
     /// `while (true)` loop whose break/return exits recompile opcode-exact.
     /// SubIntPromotionToUInt must keep re-inserting the `(uint)` cast C# requires
@@ -242,6 +244,7 @@ public class FidelityGateTests
         "NthCharFromEnd",
         "NullCoalescingAssignStaticField",
         "NullCoalescingAssignInstanceField",
+        "LazyFieldGetter",
         "SubIntPromotionToUInt",
         "WhileTrueWithReturns",
         "WhileTrueWithBreak",

--- a/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
@@ -1,4 +1,5 @@
 using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -139,6 +140,7 @@ public class NullCoalescingAssignmentPassTests
         Assert.Equal("Cache", assignment.Field.Name);
         Assert.True(assignment.HasInstance);
         Assert.IsType<LoadArgument>(assignment.Instance);
+        Assert.Empty(function.Descendants.OfType<NullCoalescingFieldAssignmentExpression>());
         Assert.DoesNotContain(function.Descendants.OfType<IfStatement>(), _ => true);
     }
 
@@ -152,11 +154,50 @@ public class NullCoalescingAssignmentPassTests
     }
 
     [Fact]
+    public void LazyFieldGetter_RaisesToExpressionNullCoalescingAssignment()
+    {
+        var function = Raised(nameof(CfgSampleClass.LazyFieldGetter));
+
+        var assignment = Assert.Single(function.Descendants.OfType<NullCoalescingFieldAssignmentExpression>());
+        Assert.Equal("LazyFieldCache", assignment.Field.Name);
+        Assert.True(assignment.HasInstance);
+        Assert.IsType<LoadArgument>(assignment.Instance);
+        Assert.Empty(function.Descendants.OfType<IfStatement>());
+        Assert.Empty(function.Descendants.OfType<NullCoalescingFieldAssignment>());
+    }
+
+    [Fact]
+    public void LazyFieldGetter_RendersExpressionNullCoalescingAssignment()
+    {
+        var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.LazyFieldGetter))).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("return LazyFieldCache ??= fallback;", output);
+    }
+
+    [Fact]
+    public void LazyFieldGetter_RecompilesOpcodeExact()
+    {
+        var assembly = typeof(CfgSampleClass).Assembly.Location;
+        var result = Assert.Single(FidelityCheck.EvaluateTargets(
+            [assembly],
+            [new FidelityCheck.CompileBackTarget(
+                assembly,
+                typeof(CfgSampleClass).FullName!,
+                nameof(CfgSampleClass.LazyFieldGetter),
+                Overload: 0,
+                Signature: "(corelib:System.String) -> corelib:System.String")]));
+
+        Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+    }
+
+    [Fact]
     public void FieldNullAssignmentWithExtraThenStatement_IsNotRaised()
     {
         var function = Raised(nameof(CfgSampleClass.NullCoalescingAssignFieldWithExtraThenStatement));
 
         Assert.Empty(function.Descendants.OfType<NullCoalescingFieldAssignment>());
+        Assert.Empty(function.Descendants.OfType<NullCoalescingFieldAssignmentExpression>());
         var output = CSharpPrinter.Print(function).Output;
         Assert.NotNull(output);
         Assert.DoesNotContain("??=", output);

--- a/src/ILInspector.Decompiler/Pipeline/CSharpSpellability.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CSharpSpellability.cs
@@ -37,6 +37,7 @@ internal static class CSharpSpellability
             LoadProperty load => PropertyReason(load.PropertyName),
             StoreProperty store => PropertyReason(store.PropertyName),
             NullCoalescingFieldAssignment assignment => FieldReason(assignment.Field),
+            NullCoalescingFieldAssignmentExpression assignment => FieldReason(assignment.Field),
             NullCoalescingPropertyAssignment assignment => PropertyReason(assignment.PropertyName),
             AnonymousObject anonymous => InitializerMembersReason(anonymous.PropertyNames),
             ObjectInitializerExpression initializer => InitializerMembersReason(initializer.Members),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrecedence.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrecedence.cs
@@ -67,6 +67,7 @@ public static class CSharpPrecedence
     {
         // Loosest structural forms first.
         Conditional or SwitchExpression or UnionSwitchExpression => Precedence.Conditional,
+        NullCoalescingFieldAssignmentExpression => Precedence.Assignment,
         Coalesce => Precedence.NullCoalescing,
         LogicalBinary { Kind: LogicalKind.Or } => Precedence.ConditionalOr,
         LogicalBinary => Precedence.ConditionalAnd,

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2148,6 +2148,7 @@ public sealed partial class CSharpPrinter
         Conditional t => ConditionalText(t),
         SwitchExpression se => SwitchExpressionInline(se),
         UnionSwitchExpression se => UnionSwitchExpressionInline(se),
+        NullCoalescingFieldAssignmentExpression n => $"{FieldTarget(n.Field, n.Instance)} ??= {CoerceText(n.Value, n.Field.Type)}",
         Coalesce co => CoalesceText(co),
         NullConditional nc => NullConditionalText(nc),
         Unary { Kind: UnaryKind.Negate } u => $"-{Operand(u.Operand)}",

--- a/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
@@ -95,6 +95,13 @@ static class DefiniteAssignment
                     CheckReads(coalesce.Right, rightSet);
                     return;
                 }
+                case NullCoalescingFieldAssignmentExpression assignment:
+                {
+                    CheckReads(assignment.Instance, assigned);
+                    var rightSet = new HashSet<int>(assigned);
+                    CheckReads(assignment.Value, rightSet);
+                    return;
+                }
                 case SwitchExpression switchExpression:
                 {
                     CheckReads(switchExpression.Value, assigned);
@@ -377,6 +384,11 @@ static class DefiniteAssignment
                             var cfgFieldCoalesceSet = new HashSet<int>(running);
                             CheckReads(assignment.Value, cfgFieldCoalesceSet);
                             break;
+                        case ExpressionStatement { Expression: NullCoalescingFieldAssignmentExpression assignment }:
+                            CheckReads(assignment.Instance, running);
+                            var cfgFieldCoalesceExpressionSet = new HashSet<int>(running);
+                            CheckReads(assignment.Value, cfgFieldCoalesceExpressionSet);
+                            break;
                         case DeconstructionAssignment deconstruction:
                             CheckReads(deconstruction.Source, running);
                             foreach (var target in deconstruction.Targets)
@@ -428,6 +440,11 @@ static class DefiniteAssignment
                     CheckReads(assignment.Instance, assigned);
                     var fieldCoalesceSet = new HashSet<int>(assigned);
                     CheckReads(assignment.Value, fieldCoalesceSet);
+                    return DefiniteFlow.FallThrough;
+                case ExpressionStatement { Expression: NullCoalescingFieldAssignmentExpression assignment }:
+                    CheckReads(assignment.Instance, assigned);
+                    var fieldCoalesceExpressionSet = new HashSet<int>(assigned);
+                    CheckReads(assignment.Value, fieldCoalesceExpressionSet);
                     return DefiniteFlow.FallThrough;
                 case DeconstructionAssignment deconstruction:
                     CheckReads(deconstruction.Source, assigned);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1114,6 +1114,33 @@ public sealed class NullCoalescingFieldAssignment : IrNode
 }
 
 /// <summary>
+/// A field null-coalescing assignment used as an expression (<c>obj.field ??= fallback</c>).
+/// Produced from csc's lazy field-initializing getter lowering, where the
+/// assignment result is returned through a compiler result slot.
+/// </summary>
+public sealed class NullCoalescingFieldAssignmentExpression : IrExpression
+{
+    public NullCoalescingFieldAssignmentExpression(FieldRef field, IrExpression? instance, IrExpression value)
+    {
+        Field = field;
+        HasInstance = instance is not null;
+        if (instance is not null)
+            AddChild(instance);
+        AddChild(value);
+    }
+
+    public FieldRef Field { get; }
+    public bool HasInstance { get; }
+    public IrExpression? Instance => HasInstance ? (IrExpression)Children[0] : null;
+    public IrExpression Value => (IrExpression)Children[HasInstance ? 1 : 0];
+    public override TypeRef? ResultType => Field.Type;
+    public override IEnumerable<TypeRef> DirectTypes => [Field.DeclaringType, Field.Type];
+
+    public override string Describe()
+        => $"NullCoalescingFieldAssignmentExpression {Field.DeclaringType.ToDisplayString()}.{Field.Name}";
+}
+
+/// <summary>
 /// A raised property null-coalescing assignment (<c>obj.Prop ??= fallback</c>, or
 /// <c>Type.Prop ??= fallback</c> for a static property), or an indexer form
 /// (<c>d[k] ??= fallback</c>). Produced from csc's property null-test diamond:

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
@@ -213,6 +213,9 @@ public static class CoercionSinks
                 case NullCoalescingFieldAssignment { Value: { } value, Field.Type: { } type }:
                     yield return new(value, type);
                     break;
+                case NullCoalescingFieldAssignmentExpression { Value: { } value, Field.Type: { } type }:
+                    yield return new(value, type);
+                    break;
                 case NullCoalescingPropertyAssignment { Value: { } value, PropertyType: { } type }:
                     yield return new(value, type);
                     break;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
@@ -25,6 +25,10 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
+        while (TryFoldLazyFieldGetter(function, context.Stepper))
+        {
+        }
+
         foreach (var statement in function.Descendants.OfType<IfStatement>().ToList())
         {
             if (TryMatchLocal(function, statement) is { } local)
@@ -62,6 +66,86 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
                 statement.ReplaceWith(replacement);
             }
         }
+    }
+
+    static bool TryFoldLazyFieldGetter(IrFunction function, Stepper stepper)
+    {
+        foreach (var block in function.Descendants.OfType<Block>().ToList())
+        {
+            var children = block.Children;
+            for (int i = 0; i + 3 < children.Count; i++)
+            {
+                if (children[i] is StoreStackSlot loadStore
+                    && children[i + 1] is StoreStackSlot initialResult
+                    && children[i + 2] is IfStatement statement
+                    && children[i + 3] is Return finalReturn
+                    && TryMatchLazyFieldGetter(function, loadStore, initialResult, statement, finalReturn) is { } match)
+                {
+                    var loadedChildren = loadStore.DetachChildren();
+                    var loaded = (LoadField)loadedChildren[0];
+                    IrExpression? instance = null;
+                    if (loaded.Instance is not null)
+                    {
+                        var loadChildren = loaded.DetachChildren();
+                        instance = (IrExpression)loadChildren[0];
+                    }
+
+                    match.Value.Detach();
+                    var replacement = new Return(new NullCoalescingFieldAssignmentExpression(match.Store.Field, instance, match.Value));
+                    stepper.StepOver("raise lazy field null check assignment to expression ??=", statement);
+                    loadStore.ReplaceWith(replacement);
+                    initialResult.Detach();
+                    statement.Detach();
+                    finalReturn.Detach();
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    sealed record LazyFieldGetterMatch(StoreField Store, IrExpression Value);
+
+    static LazyFieldGetterMatch? TryMatchLazyFieldGetter(
+        IrFunction function,
+        StoreStackSlot loadStore,
+        StoreStackSlot initialResult,
+        IfStatement statement,
+        Return finalReturn)
+    {
+        if (statement.HasElse
+            || loadStore.Value is not LoadField loaded
+            || initialResult.Value is not LoadStackSlot initialLoad
+            || initialLoad.Slot != loadStore.Slot
+            || NullTested(statement.Condition) is not LoadStackSlot tested
+            || tested.Slot != loadStore.Slot
+            || finalReturn.Value is not LoadStackSlot returned
+            || returned.Slot != initialResult.Slot
+            || statement.Then.Children is not [StoreStackSlot spill, .., StoreField store, StoreStackSlot resultStore]
+            || !SameField(loaded.Field, store.Field)
+            || !SameReceiver(loaded.Instance, store.Instance)
+            || resultStore.Slot != initialResult.Slot)
+        {
+            return null;
+        }
+
+        if (IsNonNullableValue(function, store.Field.Type))
+            return null;
+
+        var value = RecoverSpilledFieldExpressionValue(function, statement.Then, store, spill, resultStore);
+        if (value is null)
+            return null;
+
+        if (function.Descendants.OfType<StoreStackSlot>().Count(s => s.Slot == loadStore.Slot) != 1
+            || function.Descendants.OfType<LoadStackSlot>().Count(l => l.Slot == loadStore.Slot) != 2
+            || function.Descendants.OfType<StoreStackSlot>().Count(s => s.Slot == initialResult.Slot) != 2
+            || function.Descendants.OfType<LoadStackSlot>().Count(l => l.Slot == initialResult.Slot) != 1)
+        {
+            return null;
+        }
+
+        return new LazyFieldGetterMatch(store, value);
     }
 
     sealed record LocalMatch(LoadLocal Local, StoreLocal Store);
@@ -191,6 +275,54 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
         int expectedLoads = children.Count - 1;
         if (function.Descendants.OfType<StoreStackSlot>().Count(s => s.Slot == slot.Slot) != 1
             || function.Descendants.OfType<LoadStackSlot>().Count(l => l.Slot == slot.Slot) != expectedLoads)
+        {
+            return null;
+        }
+
+        return spill.Value;
+    }
+
+    static IrExpression? RecoverSpilledFieldExpressionValue(
+        IrFunction function,
+        Block then,
+        StoreField store,
+        StoreStackSlot spill,
+        StoreStackSlot resultStore)
+    {
+        if (store.Value is not LoadStackSlot slot || slot.Slot != spill.Slot)
+            return null;
+
+        var children = then.Children;
+        var allowedResultLocals = new HashSet<int>();
+        for (int i = 1; i < children.Count - 2; i++)
+        {
+            if (children[i] is not StoreLocal { Value: LoadStackSlot read } dead || read.Slot != slot.Slot)
+                return null;
+            allowedResultLocals.Add(dead.Index);
+        }
+
+        switch (resultStore.Value)
+        {
+            case LoadStackSlot resultSlot when resultSlot.Slot == slot.Slot:
+                break;
+            case LoadLocal resultLocal when allowedResultLocals.Contains(resultLocal.Index):
+                break;
+            default:
+                return null;
+        }
+
+        foreach (int local in allowedResultLocals)
+        {
+            if (function.Descendants.OfType<LoadLocal>().Any(load =>
+                    load.Index == local && !ReferenceEquals(load, resultStore.Value)))
+            {
+                return null;
+            }
+        }
+
+        if (function.Descendants.OfType<StoreStackSlot>().Count(s => s.Slot == slot.Slot) != 1
+            || function.Descendants.OfType<LoadStackSlot>().Any(load =>
+                load.Slot == slot.Slot && load.Parent is not StoreLocal and not StoreField and not StoreStackSlot))
         {
             return null;
         }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
@@ -70,7 +70,7 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
 
     static bool TryFoldLazyFieldGetter(IrFunction function, Stepper stepper)
     {
-        foreach (var block in function.Descendants.OfType<Block>().ToList())
+        foreach (var block in CoercionSinks.ScopeNodes(function.Body).OfType<Block>().ToList())
         {
             var children = block.Children;
             for (int i = 0; i + 3 < children.Count; i++)
@@ -137,10 +137,11 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
         if (value is null)
             return null;
 
-        if (function.Descendants.OfType<StoreStackSlot>().Count(s => s.Slot == loadStore.Slot) != 1
-            || function.Descendants.OfType<LoadStackSlot>().Count(l => l.Slot == loadStore.Slot) != 2
-            || function.Descendants.OfType<StoreStackSlot>().Count(s => s.Slot == initialResult.Slot) != 2
-            || function.Descendants.OfType<LoadStackSlot>().Count(l => l.Slot == initialResult.Slot) != 1)
+        var scopeNodes = CoercionSinks.ScopeNodes(function.Body).ToList();
+        if (scopeNodes.OfType<StoreStackSlot>().Count(s => s.Slot == loadStore.Slot) != 1
+            || scopeNodes.OfType<LoadStackSlot>().Count(l => l.Slot == loadStore.Slot) != 2
+            || scopeNodes.OfType<StoreStackSlot>().Count(s => s.Slot == initialResult.Slot) != 2
+            || scopeNodes.OfType<LoadStackSlot>().Count(l => l.Slot == initialResult.Slot) != 1)
         {
             return null;
         }
@@ -311,17 +312,18 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
                 return null;
         }
 
+        var scopeNodes = CoercionSinks.ScopeNodes(function.Body).ToList();
         foreach (int local in allowedResultLocals)
         {
-            if (function.Descendants.OfType<LoadLocal>().Any(load =>
+            if (scopeNodes.OfType<LoadLocal>().Any(load =>
                     load.Index == local && !ReferenceEquals(load, resultStore.Value)))
             {
                 return null;
             }
         }
 
-        if (function.Descendants.OfType<StoreStackSlot>().Count(s => s.Slot == slot.Slot) != 1
-            || function.Descendants.OfType<LoadStackSlot>().Any(load =>
+        if (scopeNodes.OfType<StoreStackSlot>().Count(s => s.Slot == slot.Slot) != 1
+            || scopeNodes.OfType<LoadStackSlot>().Any(load =>
                 load.Slot == slot.Slot && load.Parent is not StoreLocal and not StoreField and not StoreStackSlot))
         {
             return null;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
@@ -71,6 +71,9 @@ public sealed class TypedConstantsPass : IIrPass
                 case NullCoalescingFieldAssignment { Value: { } value } assign:
                     Retype(value, assign.Field.Type, shapes, stepper);
                     break;
+                case NullCoalescingFieldAssignmentExpression { Value: { } value } assign:
+                    Retype(value, assign.Field.Type, shapes, stepper);
+                    break;
                 case NullCoalescingPropertyAssignment { Value: { } value } assign:
                     Retype(value, assign.PropertyType, shapes, stepper);
                     break;

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1670,6 +1670,9 @@ static class ReturnToSender
                 case NullCoalescingFieldAssignment assignment:
                     AddFieldFact(assignment.Field);
                     break;
+                case NullCoalescingFieldAssignmentExpression assignment:
+                    AddFieldFact(assignment.Field);
+                    break;
                 case ObjectInitializerExpression initializer:
                     AddObjectInitializerFacts(initializer);
                     break;


### PR DESCRIPTION
- Fixes #2525; part of #1599
- Row: `Row 7 targeted-library high fidelity`
- Evidence revision: `ffaae0e9`

## Fix

**Conclusion:** **PASS** — lazy field-initializing getters now raise from the compiler result-slot shape to expression-form `field ??= value`, converting the measured System.CommandLine lazy getter opcode diffs to exact compile-back while preserving valid output.

Before:

```csharp
List<Action<ArgumentResult>> S_256 = _validators;
S_0 = S_256;
if (S_256 is null)
{
    S_257 = new List<Action<ArgumentResult>>();
    V_0 = S_257;
    _validators = S_257;
    S_0 = V_0;
}
return S_0;
```

After:

```csharp
return _validators ??= new List<Action<ArgumentResult>>();
```

## Root cause and scope

- **Root cause:** `NullCoalescingAssignmentPass` only folded statement-form field `??=`. The lazy getter lowering uses the assignment as the returned expression, carrying the initial field load through a stack slot and the assigned value through a compiler result slot, so it stayed as stack-slot C# and recompiled with extra temps.
- **Fix shape:** adds a field `??=` expression IR node and a narrow matcher for the exact lazy getter slot/result pattern: initial field spill, null-tested slot, value spill, field store, result-slot return.
- **Scope boundary:** this fixes expression-valued lazy field getters. Other row-7 field-update opcode diffs, such as `Newtonsoft.Json.DefaultJsonNameTable::AddEntry`, remain separate patterns.

## Witnesses

| Witness | Before | After |
| --- | --- | --- |
| `System.CommandLine.Argument::get_Validators` | opcode diff from stack-slot lazy getter rendering | `return _validators ??= new List<Action<ArgumentResult>>();`, no longer in opcode-diff sample |
| `CfgSampleClass::LazyFieldGetter` | unguarded before this PR | `return LazyFieldCache ??= fallback;`, targeted compile-back `Exact` |
| `CfgSampleClass::NullCoalescingAssignFieldWithExtraThenStatement` | stayed expanded | still no `??=` raise |

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --no-incremental` |
| Focused tests | Pass: `NullCoalescingAssignmentPassTests` 36/36 |
| Targeted fixture fidelity | Pass: `LazyFieldGetter_RecompilesOpcodeExact` |
| System.CommandLine fidelity sample | improved from 244 exact / 50 opcode diffs to 256 exact / 38 opcode diffs at compile-cap 400 |
| Newtonsoft.Json fidelity sample | unchanged at 325 exact / 48 opcode diffs at compile-cap 400; remaining `AddEntry` row is a different field-update pattern |
| Render A/B | capped target set: 1 structural change, semantic `valid->valid: 1`, `valid->invalid: 0`; uncapped System.CommandLine + Newtonsoft.Json: 21 structural changes, all `valid->valid` |
| PR quick quality card | Verdict matched baseline tolerances; pinned gate fully raised +0.16 pp, conditional residual 0 pp, Full malformed 0 -> 0 |

## Corpus validity

**Conclusion:** **PASS** — PR quick card has no pinned regression and no Full malformed output.

The card reports aggregate advisory movement from baseline staleness (ILInspector.MetadataPrimitives +25 methods) but pinned-subset gates match tolerances.

## Out of scope / sibling rows

- #2526 generated support state blocks compile-back.
- #2527 member-identity/context compile-back failures.
- Non-lazy field-update opcode diffs such as `Newtonsoft.Json.DefaultJsonNameTable::AddEntry` stay in row-7 burndown.

## Review

Adversarial reviews requested; reconciliation will be posted before this PR is marked ready.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --no-incremental
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -noLogo -noColor -class ILInspector.Decompiler.Tests.NullCoalescingAssignmentPassTests
dotnet run --project tools/DecompilerHarness -c Release -- /home/rich/.nuget/packages/system.commandline/3.0.0-preview.5.26302.115/lib/net10.0/System.CommandLine.dll --fidelity-check --compile-cap 400 --max-examples 10
dotnet run --project tools/DecompilerHarness -c Release -- /home/rich/.nuget/packages/newtonsoft.json/13.0.4/lib/net6.0/Newtonsoft.Json.dll --fidelity-check --compile-cap 400 --max-examples 10
dotnet run --project tools/DecompilerHarness -c Release -- /home/rich/.nuget/packages/system.commandline/3.0.0-preview.5.26302.115/lib/net10.0/System.CommandLine.dll /home/rich/.nuget/packages/newtonsoft.json/13.0.4/lib/net6.0/Newtonsoft.Json.dll --workers 20 --corpus-method-cap 100 --render-ab /tmp/2525-base-cap.renderab
bash eng/prepare-decompiler-pr-corpus.sh /tmp/2525-pr-corpus.txt
mapfile -t assemblies < /tmp/2525-pr-corpus.txt
dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" --diff-corpus-baseline tools/DecompilerHarness/corpus/pr-quick-baseline.json --quality-diff-card --corpus-method-cap 100 --compile-cap 25 --max-examples 3
```
