### PR TITLE
Add member-scoped implementation diff

### DIFF
--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -23,6 +23,12 @@ the input is a pair of assemblies or `ResearchDiffInput` values. The result is a
 list of changed implementation members. Each member can carry C# evidence, IL
 evidence, or both; exact members are omitted.
 
+Use `ImplementationDiff.CompareMembers` when the caller already resolved exact
+old/new `MethodDefinitionHandle` values in live `MetadataSource` instances. The
+member result keeps the typed C# diff, typed IL diff, joined implementation
+evidence, and a single `ResearchSubjectKey`; exact members return an empty
+evidence list with `IsExact` set.
+
 Use `ImplementationDiff.ToIlEvidence` when a caller already has a scoped
 `IlMemberDiffResult`, such as ReturnToSender comparing one original method to a
 recompiled artifact method. This preserves typed IL diff evidence and projects

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -8,6 +8,7 @@ using ILInspector.DecompilerHarness;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Instructions;
 using ILInspector.Metadata;
+using ILInspector.Research;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -151,7 +152,8 @@ public class ReturnToSenderFixtureCatalogTests
             File.ReadAllBytes(assemblyPath),
             fullType,
             nameof(DecompilerResult_ExposesEffectiveOptionsAndTasteDecisions),
-            overload: 0);
+            overload: 0,
+            ImplementationDiffMechanism.All);
 
         Assert.NotNull(diff);
         Assert.True(diff!.HasCSharpEvidence);

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -135,6 +135,32 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderImplementationDiff_ProjectsMemberScopedCSharpAndIlEvidence()
+    {
+        string assemblyPath = typeof(ReturnToSenderFixtureCatalogTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+        string fullType = typeof(ReturnToSenderFixtureCatalogTests).FullName!;
+        var original = FindMethod(reader, fullType, nameof(FixtureCatalog_ExposesCheckedInSourcePaths));
+
+        var diff = ReturnToSender.BuildImplementationDiff(
+            assemblyPath,
+            reader,
+            original,
+            File.ReadAllBytes(assemblyPath),
+            fullType,
+            nameof(DecompilerResult_ExposesEffectiveOptionsAndTasteDecisions),
+            overload: 0);
+
+        Assert.NotNull(diff);
+        Assert.True(diff!.HasCSharpEvidence);
+        Assert.True(diff.HasIlEvidence);
+        Assert.NotNull(diff.IlDiff);
+        Assert.False(diff.IlDiff.Diff.IsExact);
+    }
+
+    [Fact]
     public void ReturnToSenderIlDiffDiagnostic_SuppressesBodylessMethods()
     {
         using var stream = File.OpenRead(typeof(ReturnToSenderFixtureCatalogTests).Assembly.Location);

--- a/src/ILInspector.Decompiler/CSharpBodyDiff.cs
+++ b/src/ILInspector.Decompiler/CSharpBodyDiff.cs
@@ -178,6 +178,31 @@ public static class CSharpBodyDiff
     public static CSharpBodyDiffResult CompareAssemblies(string oldPath, string newPath, bool includeNonPublic = false, IReadOnlySet<string>? typeFilters = null)
         => CompareAssemblies([oldPath], [newPath], includeNonPublic, typeFilters);
 
+    public static CSharpBodyDiffResult CompareMembers(
+        MetadataSource oldSource,
+        MethodDefinitionHandle oldMethod,
+        MetadataSource newSource,
+        MethodDefinitionHandle newMethod)
+    {
+        ArgumentNullException.ThrowIfNull(oldSource);
+        ArgumentNullException.ThrowIfNull(newSource);
+        if (oldMethod.IsNil)
+            throw new ArgumentException("Old method handle must not be nil.", nameof(oldMethod));
+        if (newMethod.IsNil)
+            throw new ArgumentException("New method handle must not be nil.", nameof(newMethod));
+
+        var oldEntry = CreateMethodEntry(oldSource, oldSource.Reader.GetMethodDefinition(oldMethod).GetDeclaringType(), oldMethod, StableAssemblyKey(oldSource));
+        var newEntry = CreateMethodEntry(newSource, newSource.Reader.GetMethodDefinition(newMethod).GetDeclaringType(), newMethod, StableAssemblyKey(newSource));
+        if (oldEntry.BodyFingerprint == newEntry.BodyFingerprint)
+            return new CSharpBodyDiffResult([]);
+
+        var rows = ImmutableArray.CreateBuilder<CSharpDiffRow>();
+        var failureRows = ImmutableArray.CreateBuilder<CSharpDiffFailureRow>();
+        int hunkId = 0;
+        AddLineDiffRows(rows, failureRows, oldEntry, Decompile(oldEntry, oldSource), Decompile(newEntry, newSource), ref hunkId);
+        return new CSharpBodyDiffResult(rows.ToImmutable(), failureRows.ToImmutable());
+    }
+
     public static CSharpBodyDiffResult CompareAssemblies(IReadOnlyList<string> oldPaths, IReadOnlyList<string> newPaths, bool includeNonPublic = false, IReadOnlySet<string>? typeFilters = null)
     {
         ArgumentNullException.ThrowIfNull(oldPaths);
@@ -257,10 +282,15 @@ public static class CSharpBodyDiff
 
     static CSharpMethodRender Decompile(CSharpMethodEntry entry, SourceCache sources)
     {
+        var source = sources.Open(entry.Path);
+        return Decompile(entry, source);
+    }
+
+    static CSharpMethodRender Decompile(CSharpMethodEntry entry, MetadataSource source)
+    {
         if (!entry.HasBody)
             return new CSharpMethodRender(CSharpMethodRenderState.NoBody, ["/* no method body */"], DecompilationFidelity.IlOnly);
 
-        var source = sources.Open(entry.Path);
         var function = IrImporter.Import(source, entry.TypeFullName, entry.MethodName, entry.OverloadIndex, publicOnly: false);
         if (function is null)
             return new CSharpMethodRender(CSharpMethodRenderState.NoBody, ["/* no method body */"], DecompilationFidelity.IlOnly);
@@ -282,8 +312,6 @@ public static class CSharpBodyDiff
         {
             var type = reader.GetTypeDefinition(typeHandle);
             string typeFullName = reader.GetFullTypeName(type);
-            string typeKey = TypeIdentityKey(reader, typeHandle);
-            string typeDisplay = typeFullName;
             if (!includeNonPublic && !IsVisibleSurfaceType(reader, typeHandle, typeDefinitionsByName))
                 continue;
             if (!MatchesTypeFilters(typeFullName, typeFilters))
@@ -301,33 +329,65 @@ public static class CSharpBodyDiff
                 if (!includeNonPublic && !IsPublicSurface(method) && !explicitImplementationBodies.Contains(methodHandle))
                     continue;
 
-                var signature = method.DecodeSignature(TypeRefDecoder.Instance, GenericScope.Empty);
-                string returnType = CanonicalTypeName(signature.ReturnType);
-                var parameters = signature.ParameterTypes.Select(CanonicalTypeName).ToImmutableArray();
-                int genericArity = method.GetGenericParameters().Count;
-                string methodGeneric = GenericParameterList(genericArity, isMethod: true);
-                string returnSuffix = IsConversionOperator(methodName) ? $"~{returnType}" : "";
-                string canonicalName = CanonicalMemberName(methodName);
-                string rawKey = $"M:{typeKey}.{canonicalName}{methodGeneric}({string.Join(",", parameters)}){returnSuffix}";
-                var anchor = ApiMemberIdentity.CreateMethodAnchor(reader, typeHandle, method, IsExtensionMethod(reader, type, method));
-                string displayName = methodName == ".ctor" ? "#ctor" : methodName;
-                string display = $"{typeDisplay}.{displayName}{GenericAritySuffix(genericArity)}({string.Join(", ", parameters)})";
-                yield return new CSharpMethodEntry(
-                    path,
-                    source.AssemblyName,
-                    stableAssemblyKey,
-                    anchor,
-                    rawKey,
-                    $"{stableAssemblyKey}|{rawKey}",
-                    DuplicateDiscriminator(reader, method),
-                    display,
-                    typeFullName,
-                    methodName,
-                    overloadIndex,
-                    method.RelativeVirtualAddress != 0,
-                    BodyFingerprint(source, method));
+                yield return CreateMethodEntry(source, typeHandle, methodHandle, stableAssemblyKey);
             }
         }
+    }
+
+    static CSharpMethodEntry CreateMethodEntry(
+        MetadataSource source,
+        TypeDefinitionHandle typeHandle,
+        MethodDefinitionHandle methodHandle,
+        string stableAssemblyKey)
+    {
+        var reader = source.Reader;
+        var type = reader.GetTypeDefinition(typeHandle);
+        var method = reader.GetMethodDefinition(methodHandle);
+        string typeFullName = reader.GetFullTypeName(type);
+        string typeKey = TypeIdentityKey(reader, typeHandle);
+        string methodName = reader.GetString(method.Name);
+        var signature = method.DecodeSignature(TypeRefDecoder.Instance, GenericScope.Empty);
+        string returnType = CanonicalTypeName(signature.ReturnType);
+        var parameters = signature.ParameterTypes.Select(CanonicalTypeName).ToImmutableArray();
+        int genericArity = method.GetGenericParameters().Count;
+        string methodGeneric = GenericParameterList(genericArity, isMethod: true);
+        string returnSuffix = IsConversionOperator(methodName) ? $"~{returnType}" : "";
+        string canonicalName = CanonicalMemberName(methodName);
+        string rawKey = $"M:{typeKey}.{canonicalName}{methodGeneric}({string.Join(",", parameters)}){returnSuffix}";
+        var anchor = ApiMemberIdentity.CreateMethodAnchor(reader, typeHandle, method, IsExtensionMethod(reader, type, method));
+        string displayName = methodName == ".ctor" ? "#ctor" : methodName;
+        string display = $"{typeFullName}.{displayName}{GenericAritySuffix(genericArity)}({string.Join(", ", parameters)})";
+        string duplicateDiscriminator = DuplicateDiscriminator(reader, method);
+        return new CSharpMethodEntry(
+            source.Path,
+            source.AssemblyName,
+            stableAssemblyKey,
+            anchor,
+            rawKey,
+            $"{stableAssemblyKey}|{rawKey}#{duplicateDiscriminator}",
+            duplicateDiscriminator,
+            display,
+            typeFullName,
+            methodName,
+            OverloadIndex(reader, type, methodHandle, methodName),
+            method.RelativeVirtualAddress != 0,
+            BodyFingerprint(source, method));
+    }
+
+    static int OverloadIndex(MetadataReader reader, TypeDefinition type, MethodDefinitionHandle targetMethod, string methodName)
+    {
+        int index = 0;
+        foreach (var methodHandle in type.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (reader.GetString(method.Name) != methodName)
+                continue;
+            if (methodHandle == targetMethod)
+                return index;
+            index++;
+        }
+
+        throw new ArgumentException("Method handle does not belong to the supplied declaring type.", nameof(targetMethod));
     }
 
     static string GenericAritySuffix(int arity)

--- a/src/ILInspector.Decompiler/CSharpBodyDiff.cs
+++ b/src/ILInspector.Decompiler/CSharpBodyDiff.cs
@@ -312,6 +312,7 @@ public static class CSharpBodyDiff
         {
             var type = reader.GetTypeDefinition(typeHandle);
             string typeFullName = reader.GetFullTypeName(type);
+            string typeKey = TypeIdentityKey(reader, typeHandle);
             if (!includeNonPublic && !IsVisibleSurfaceType(reader, typeHandle, typeDefinitionsByName))
                 continue;
             if (!MatchesTypeFilters(typeFullName, typeFilters))
@@ -329,7 +330,7 @@ public static class CSharpBodyDiff
                 if (!includeNonPublic && !IsPublicSurface(method) && !explicitImplementationBodies.Contains(methodHandle))
                     continue;
 
-                yield return CreateMethodEntry(source, typeHandle, methodHandle, stableAssemblyKey);
+                yield return CreateMethodEntry(source, typeHandle, methodHandle, stableAssemblyKey, typeFullName, typeKey, overloadIndex);
             }
         }
     }
@@ -338,13 +339,16 @@ public static class CSharpBodyDiff
         MetadataSource source,
         TypeDefinitionHandle typeHandle,
         MethodDefinitionHandle methodHandle,
-        string stableAssemblyKey)
+        string stableAssemblyKey,
+        string? typeFullName = null,
+        string? typeKey = null,
+        int? overloadIndex = null)
     {
         var reader = source.Reader;
         var type = reader.GetTypeDefinition(typeHandle);
         var method = reader.GetMethodDefinition(methodHandle);
-        string typeFullName = reader.GetFullTypeName(type);
-        string typeKey = TypeIdentityKey(reader, typeHandle);
+        typeFullName ??= reader.GetFullTypeName(type);
+        typeKey ??= TypeIdentityKey(reader, typeHandle);
         string methodName = reader.GetString(method.Name);
         var signature = method.DecodeSignature(TypeRefDecoder.Instance, GenericScope.Empty);
         string returnType = CanonicalTypeName(signature.ReturnType);
@@ -369,7 +373,7 @@ public static class CSharpBodyDiff
             display,
             typeFullName,
             methodName,
-            OverloadIndex(reader, type, methodHandle, methodName),
+            overloadIndex ?? OverloadIndex(reader, type, methodHandle, methodName),
             method.RelativeVirtualAddress != 0,
             BodyFingerprint(source, method));
     }

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -1,9 +1,12 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using DotnetInspector.Fixtures;
 using ILInspector.Analysis;
 using ILInspector.Decompiler;
 using ILInspector.Metadata;
 using ILInspector.MetadataPrimitives;
 using ILInspector.Instructions;
+using DecompilerMetadataSource = ILInspector.Decompiler.Pipeline.MetadataSource;
 
 namespace ILInspector.Research.Tests;
 
@@ -749,6 +752,45 @@ public class ResearchDiffTests
     }
 
     [Fact]
+    public void ImplementationDiff_CompareMembers_SameMemberIsExact()
+    {
+        using var source = DecompilerMetadataSource.OpenWithoutSymbols(FixtureCatalog.DiffPair.OldAssemblyPath());
+        var stable = FindMethodHandle(FixtureCatalog.DiffPair.OldAssemblyPath(), "DiffFixtureSample.DiffSample", "Stable");
+
+        var diff = ImplementationDiff.CompareMembers(source, stable, source, stable);
+
+        Assert.True(diff.IsExact);
+        Assert.Equal("Stable", diff.Subject.MemberName);
+        Assert.NotNull(diff.CSharpDiff);
+        Assert.True(diff.CSharpDiff.IsExact);
+        Assert.NotNull(diff.IlDiff);
+        Assert.True(diff.IlDiff.Diff.IsExact);
+        Assert.Empty(diff.Evidence);
+    }
+
+    [Fact]
+    public void ImplementationDiff_CompareMembers_GroupsCSharpAndIlEvidence()
+    {
+        using var oldSource = DecompilerMetadataSource.OpenWithoutSymbols(FixtureCatalog.DiffPair.OldAssemblyPath());
+        using var newSource = DecompilerMetadataSource.OpenWithoutSymbols(FixtureCatalog.DiffPair.NewAssemblyPath());
+        var oldMethod = FindMethodHandle(FixtureCatalog.DiffPair.OldAssemblyPath(), "DiffFixtureSample.DiffSample", "ConstantValue");
+        var newMethod = FindMethodHandle(FixtureCatalog.DiffPair.NewAssemblyPath(), "DiffFixtureSample.DiffSample", "ConstantValue");
+
+        var diff = ImplementationDiff.CompareMembers(oldSource, oldMethod, newSource, newMethod);
+
+        Assert.False(diff.IsExact);
+        Assert.Equal("ConstantValue", diff.Subject.MemberName);
+        Assert.True(diff.HasCSharpEvidence);
+        Assert.True(diff.HasIlEvidence);
+        Assert.Contains(diff.Evidence, evidence =>
+            evidence.Kind == ImplementationDiffEvidenceKind.CSharp
+            && evidence.UnifiedLines.Any(line => line.Contains("return 1", StringComparison.Ordinal)));
+        Assert.Contains(diff.Evidence, evidence =>
+            evidence.Kind == ImplementationDiffEvidenceKind.IlBody
+            && evidence.UnifiedLines.Any(line => line.Contains("ldc.i4 1", StringComparison.Ordinal)));
+    }
+
+    [Fact]
     public void ImplementationDiff_ToIlEvidence_ProjectsTypedMemberDiffRows()
     {
         var typedDiff = new IlMemberDiffResult(
@@ -836,6 +878,31 @@ public class ResearchDiffTests
                 }
             ],
         };
+
+    static MethodDefinitionHandle FindMethodHandle(string assemblyPath, string typeName, string methodName, int overload = 0)
+    {
+        using var stream = File.OpenRead(assemblyPath);
+        using var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var type = reader.GetTypeDefinition(typeHandle);
+            if (reader.GetFullTypeName(type) != typeName)
+                continue;
+
+            int seen = 0;
+            foreach (var methodHandle in type.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (reader.GetString(method.Name) != methodName)
+                    continue;
+                if (seen++ == overload)
+                    return methodHandle;
+            }
+        }
+
+        throw new InvalidOperationException($"Method not found: {typeName}.{methodName}#{overload}");
+    }
 
     static ApiMember Member(string name, IReadOnlyList<string>? attributes = null)
         => new()

--- a/src/ILInspector.Research/ImplementationDiff.cs
+++ b/src/ILInspector.Research/ImplementationDiff.cs
@@ -1,6 +1,11 @@
 using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
 using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
 using ILInspector.Instructions;
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
 
 namespace ILInspector.Research;
 
@@ -37,6 +42,20 @@ public sealed record ImplementationDiffMember(
 {
     public bool HasCSharpEvidence => Evidence.Any(evidence => evidence.Kind == ImplementationDiffEvidenceKind.CSharp);
     public bool HasIlEvidence => Evidence.Any(evidence => evidence.Kind == ImplementationDiffEvidenceKind.IlBody);
+}
+
+public sealed record ImplementationMemberDiffResult(
+    ResearchSubjectKey Subject,
+    CSharpBodyDiffResult? CSharpDiff,
+    IlMemberDiffResult? IlDiff,
+    IReadOnlyList<ImplementationDiffEvidence> Evidence)
+{
+    public bool HasCSharpEvidence => Evidence.Any(evidence => evidence.Kind == ImplementationDiffEvidenceKind.CSharp);
+    public bool HasIlEvidence => Evidence.Any(evidence => evidence.Kind == ImplementationDiffEvidenceKind.IlBody);
+    public bool IsExact
+        => Evidence.Count == 0
+           && (CSharpDiff is null || CSharpDiff.IsExact)
+           && (IlDiff is null || IlDiff.Diff.IsExact);
 }
 
 public sealed record ImplementationDiffEvidence(
@@ -89,6 +108,52 @@ public static class ImplementationDiff
             ResearchDiffInput.FromAssembly(oldAssemblyPath),
             ResearchDiffInput.FromAssembly(newAssemblyPath),
             options);
+    }
+
+    public static ImplementationMemberDiffResult CompareMembers(
+        MetadataSource oldSource,
+        MethodDefinitionHandle oldMethod,
+        MetadataSource newSource,
+        MethodDefinitionHandle newMethod,
+        ImplementationDiffMechanism mechanisms = ImplementationDiffMechanism.All,
+        ResearchSubjectKey? subject = null)
+    {
+        ArgumentNullException.ThrowIfNull(oldSource);
+        ArgumentNullException.ThrowIfNull(newSource);
+        if (oldMethod.IsNil)
+            throw new ArgumentException("Old method handle must not be nil.", nameof(oldMethod));
+        if (newMethod.IsNil)
+            throw new ArgumentException("New method handle must not be nil.", nameof(newMethod));
+
+        subject ??= SubjectFromMethod(oldSource, oldMethod);
+        CSharpBodyDiffResult? csharpDiff = null;
+        IlMemberDiffResult? ilDiff = null;
+        var evidence = ImmutableArray.CreateBuilder<ImplementationDiffEvidence>();
+
+        if (mechanisms.HasFlag(ImplementationDiffMechanism.CSharp))
+        {
+            csharpDiff = CSharpBodyDiff.CompareMembers(oldSource, oldMethod, newSource, newMethod);
+            evidence.AddRange(ToCSharpImplementationEvidence(csharpDiff));
+        }
+
+        if (mechanisms.HasFlag(ImplementationDiffMechanism.IlBody))
+        {
+            string label = subject.TypeName is { Length: > 0 } typeName && subject.MemberName is { Length: > 0 } memberName
+                ? $"{typeName}::{memberName}"
+                : subject.Display;
+            ilDiff = IlAssemblyDiff.CompareMembers(
+                oldSource.Pe,
+                oldSource.Reader,
+                oldMethod,
+                newSource.Pe,
+                newSource.Reader,
+                newMethod,
+                oldLabel: label,
+                newLabel: label);
+            evidence.AddRange(ToIlEvidence(ilDiff).Select(item => ToImplementationEvidence(item)!));
+        }
+
+        return new ImplementationMemberDiffResult(subject, csharpDiff, ilDiff, evidence.ToImmutable());
     }
 
     public static ImplementationDiffResult Compare(
@@ -199,6 +264,52 @@ public static class ImplementationDiff
         return evidence.ToImmutable();
     }
 
+    static ImmutableArray<ImplementationDiffEvidence> ToCSharpImplementationEvidence(CSharpBodyDiffResult diff)
+    {
+        ArgumentNullException.ThrowIfNull(diff);
+        if (diff.IsExact)
+            return [];
+
+        var evidence = ImmutableArray.CreateBuilder<ImplementationDiffEvidence>();
+        foreach (var failure in diff.FailureRows.IsDefault ? [] : diff.FailureRows)
+        {
+            var direction = failure.Kind switch
+            {
+                CSharpDiffFailureKind.OldBodyMissing => ResearchDiffDirection.Added,
+                CSharpDiffFailureKind.NewBodyMissing => ResearchDiffDirection.Removed,
+                _ => ResearchDiffDirection.Changed,
+            };
+            evidence.Add(new ImplementationDiffEvidence(
+                ImplementationDiffEvidenceKind.CSharp,
+                $"csharp.diff.{ResearchDiff.ToChangeIdPart(failure.Kind.ToString())}",
+                direction,
+                OldValue: failure.Side == "old" ? failure.Detail ?? failure.Message : null,
+                NewValue: failure.Side == "new" ? failure.Detail ?? failure.Message : null,
+                Detail: failure.Detail ?? failure.Message,
+                CSharpDisplayFailureRow: CSharpDiffPrinter.ToDisplayFailureRow(failure)));
+        }
+
+        foreach (var row in diff.Rows.IsDefault ? [] : diff.Rows)
+        {
+            var direction = row.Kind switch
+            {
+                CSharpDiffKind.Add => ResearchDiffDirection.Added,
+                CSharpDiffKind.Remove => ResearchDiffDirection.Removed,
+                _ => ResearchDiffDirection.Changed,
+            };
+            evidence.Add(new ImplementationDiffEvidence(
+                ImplementationDiffEvidenceKind.CSharp,
+                row.ChangeId,
+                direction,
+                OldValue: row.OldOperation?.Value ?? row.OldValue ?? (direction == ResearchDiffDirection.Removed ? row.Text : null),
+                NewValue: row.NewOperation?.Value ?? row.NewValue ?? (direction == ResearchDiffDirection.Added ? row.Text : null),
+                Detail: row.Message,
+                CSharpDisplayRows: [CSharpDiffPrinter.ToDisplayRow(row)]));
+        }
+
+        return evidence.ToImmutable();
+    }
+
     static ResearchDiffMechanism ToResearchMechanisms(ImplementationDiffMechanism mechanisms)
     {
         var research = ResearchDiffMechanism.None;
@@ -240,4 +351,23 @@ public static class ImplementationDiff
         => memberTargetIdentities is null
            || memberTargetIdentities.Count == 0
            || memberTargetIdentities.Contains(subject.Id);
+
+    static ResearchSubjectKey SubjectFromMethod(MetadataSource source, MethodDefinitionHandle methodHandle)
+    {
+        var reader = source.Reader;
+        var method = reader.GetMethodDefinition(methodHandle);
+        var typeHandle = method.GetDeclaringType();
+        var type = reader.GetTypeDefinition(typeHandle);
+        var anchor = ApiMemberIdentity.CreateMethodAnchor(reader, typeHandle, method, IsExtensionMethod(reader, type, method));
+        string typeFullName = reader.GetFullTypeName(type);
+        string memberName = reader.GetString(method.Name);
+        return ResearchMemberIdentity.SubjectFromAnchor(anchor, $"{typeFullName}.{memberName}");
+    }
+
+    static bool IsExtensionMethod(MetadataReader reader, TypeDefinition type, MethodDefinition method)
+        => type.Attributes.HasFlag(TypeAttributes.Abstract)
+           && type.Attributes.HasFlag(TypeAttributes.Sealed)
+           && method.Attributes.HasFlag(MethodAttributes.Static)
+           && AttributeReader.HasExtensionAttribute(reader, type.GetCustomAttributes())
+           && AttributeReader.HasExtensionAttribute(reader, method.GetCustomAttributes());
 }

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -701,12 +701,14 @@ static class ReturnToSender
             var emit = compilation.Emit(ms);
             if (emit.Success)
             {
-                ms.Position = 0;
-                using var recompiled = new PEReader(ms);
+                var recompiledBytes = ms.ToArray();
+                using var recompiledStream = new MemoryStream(recompiledBytes, writable: false);
+                using var recompiled = new PEReader(recompiledStream);
                 var recompiledOps = FindAndDisassemble(recompiled, fullType, methodName, overload: 0)
                     ?.Select(instruction => CanonicalOpcode(instruction.OpCodeName))
                     .ToArray();
-                var ilDiff = BuildIlDiff(pe, reader, getterHandle, recompiled, fullType, methodName, overload: 0);
+                var implementationDiff = BuildImplementationDiff(assemblyPath, reader, getterHandle, recompiledBytes, fullType, methodName, overload: 0);
+                var ilDiff = implementationDiff?.IlDiff;
                 var ilDiffDiagnostic = ToDisplayDiagnostic(ilDiff);
 
                 if (recompiledOps is null)
@@ -861,12 +863,14 @@ static class ReturnToSender
             var emit = compilation.Emit(ms);
             if (emit.Success)
             {
-                ms.Position = 0;
-                using var recompiled = new PEReader(ms);
+                var recompiledBytes = ms.ToArray();
+                using var recompiledStream = new MemoryStream(recompiledBytes, writable: false);
+                using var recompiled = new PEReader(recompiledStream);
                 var recompiledOps = FindAndDisassemble(recompiled, fullType, methodName, overload: 0)
                     ?.Select(instruction => CanonicalOpcode(instruction.OpCodeName))
                     .ToArray();
-                var ilDiff = BuildIlDiff(pe, reader, methodHandle, recompiled, fullType, methodName, overload: 0);
+                var implementationDiff = BuildImplementationDiff(assemblyPath, reader, methodHandle, recompiledBytes, fullType, methodName, overload: 0);
+                var ilDiff = implementationDiff?.IlDiff;
                 var ilDiffDiagnostic = ToDisplayDiagnostic(ilDiff);
 
                 if (recompiledOps is null)
@@ -1022,12 +1026,14 @@ static class ReturnToSender
             var emit = compilation.Emit(ms);
             if (emit.Success)
             {
-                ms.Position = 0;
-                using var recompiled = new PEReader(ms);
+                var recompiledBytes = ms.ToArray();
+                using var recompiledStream = new MemoryStream(recompiledBytes, writable: false);
+                using var recompiled = new PEReader(recompiledStream);
                 var recompiledOps = FindAndDisassemble(recompiled, fullType, methodName, overload: 0)
                     ?.Select(instruction => CanonicalOpcode(instruction.OpCodeName))
                     .ToArray();
-                var ilDiff = BuildIlDiff(pe, reader, setterHandle, recompiled, fullType, methodName, overload: 0);
+                var implementationDiff = BuildImplementationDiff(assemblyPath, reader, setterHandle, recompiledBytes, fullType, methodName, overload: 0);
+                var ilDiff = implementationDiff?.IlDiff;
                 var ilDiffDiagnostic = ToDisplayDiagnostic(ilDiff);
 
                 if (recompiledOps is null)
@@ -1309,6 +1315,15 @@ static class ReturnToSender
             return null;
 
         var reader = pe.GetMetadataReader();
+        return FindMethodDefinition(reader, fullType, methodName, overload);
+    }
+
+    static (MetadataReader Reader, MethodDefinitionHandle Handle, MethodDefinition Method)? FindMethodDefinition(
+        MetadataReader reader,
+        string fullType,
+        string methodName,
+        int overload)
+    {
         foreach (var typeHandle in reader.TypeDefinitions)
         {
             var typeDef = reader.GetTypeDefinition(typeHandle);
@@ -1365,6 +1380,38 @@ static class ReturnToSender
             recompiled.Handle,
             oldLabel: $"{fullType}::{methodName}",
             newLabel: $"{fullType}::{methodName}");
+    }
+
+    internal static ImplementationMemberDiffResult? BuildImplementationDiff(
+        string assemblyPath,
+        MetadataReader originalReader,
+        MethodDefinitionHandle originalMethod,
+        byte[] recompiledAssembly,
+        string fullType,
+        string methodName,
+        int overload)
+    {
+        if (originalReader.GetMethodDefinition(originalMethod).RelativeVirtualAddress == 0)
+            return null;
+
+        var recompiledReference = new ResolvedAssemblyReference(
+            new AssemblyReferenceIdentity("return-to-sender", Version: null, Culture: null, PublicKeyToken: null),
+            Path: null,
+            OpenRead: () => new MemoryStream(recompiledAssembly, writable: false),
+            Provenance: "ReturnToSender");
+        var resolver = MetadataSource.DefaultAssemblyReferenceResolver(assemblyPath);
+        using var originalSource = MetadataSource.OpenWithoutSymbols(assemblyPath);
+        using var recompiledSource = MetadataSource.OpenWithoutSymbols(recompiledReference, resolver);
+        if (FindMethodDefinition(recompiledSource.Reader, fullType, methodName, overload) is not { } recompiled)
+            return null;
+        if (recompiled.Method.RelativeVirtualAddress == 0)
+            return null;
+
+        return ImplementationDiff.CompareMembers(
+            originalSource,
+            originalMethod,
+            recompiledSource,
+            recompiled.Handle);
     }
 
     static IlDiffDisplayResult? ToDisplayDiagnostic(IlMemberDiffResult? diff)

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1389,7 +1389,8 @@ static class ReturnToSender
         byte[] recompiledAssembly,
         string fullType,
         string methodName,
-        int overload)
+        int overload,
+        ImplementationDiffMechanism mechanisms = ImplementationDiffMechanism.IlBody)
     {
         if (originalReader.GetMethodDefinition(originalMethod).RelativeVirtualAddress == 0)
             return null;
@@ -1411,7 +1412,8 @@ static class ReturnToSender
             originalSource,
             originalMethod,
             recompiledSource,
-            recompiled.Handle);
+            recompiled.Handle,
+            mechanisms);
     }
 
     static IlDiffDisplayResult? ToDisplayDiagnostic(IlMemberDiffResult? diff)


### PR DESCRIPTION
## Summary

- Add `CSharpBodyDiff.CompareMembers(...)` for exact method-handle C# body diffs over live `MetadataSource` instances.
- Add `ImplementationDiff.CompareMembers(...)` returning one member-scoped result with typed C# diff, typed IL diff, joined evidence, shared `ResearchSubjectKey`, and exact/empty state.
- Route RTS compile-success IL-diff construction through product `ImplementationDiff.CompareMembers(...)` while preserving existing `IlDiff` / `IlDiffDiagnostic` result shape and bodyless/missing-method suppression.
- Document the member-scoped `ImplementationDiff` contract.

## Validation

- `npx markdownlint-cli docs/design/implementation-diff.md`
- `git diff --check HEAD~1..HEAD`
- `dotnetup dotnet run --project src/ILInspector.Research.Tests -c Release --no-restore -- -class ILInspector.Research.Tests.ResearchDiffTests`
- `dotnetup dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -class ILInspector.Decompiler.Tests.CSharpBodyDiffTests -class ILInspector.Decompiler.Tests.ReturnToSenderFixtureCatalogTests -class ILInspector.Decompiler.Tests.ReturnToSenderEvidenceTests`
- `dotnetup dotnet build dotnet-inspect.slnx -c Release --no-restore`