### PR TITLE
Guard Decompiler TypeRefDecoder decode sites (#2490 increment 2)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GuardedDecodeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GuardedDecodeTests.cs
@@ -61,6 +61,19 @@ public class GuardedDecodeTests
         Assert.Equal(TypeRefKind.Unsupported, result.Kind);
     }
 
+    [Fact]
+    public void GuardedTypeSpecification_HugeArrayShapeCount_DegradesToUnsupported()
+    {
+        // Same malformed TypeSpec through the GuardedDecode.TypeSpecification wrapper (used by the
+        // CSharpBodyDiff fingerprint paths): it must route through the hardened GetTypeFromSpecification.
+        byte[] blob = [0x14, 0x08, 0x01, 0xdf, 0xff, 0xff, 0xff];
+        var (reader, handle) = BuildTypeSpec(blob);
+
+        var result = GuardedDecode.TypeSpecification(reader, handle, GenericScope.Empty);
+
+        Assert.Equal(TypeRefKind.Unsupported, result.Kind);
+    }
+
     static (MetadataReader Reader, TypeSpecificationHandle Handle) BuildTypeSpec(byte[] typeBlob)
     {
         var md = NewModule();

--- a/src/ILInspector.Decompiler.Tests/GuardedDecodeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GuardedDecodeTests.cs
@@ -47,17 +47,51 @@ public class GuardedDecodeTests
         Assert.Empty(locals);
     }
 
+    [Fact]
+    public void GetTypeFromSpecification_HugeArrayShapeCount_DegradesToUnsupported()
+    {
+        // A 7-byte TypeSpec (ARRAY I4 rank=1 sizesCount~536M) is under #2489's 1024-byte length cap,
+        // so only SignatureBlobGuard's count bound stops SRM from pre-allocating gigabytes. Exercises
+        // the guard now applied inside GetTypeFromSpecification (covering its direct callers).
+        byte[] blob = [0x14 /* ARRAY */, 0x08 /* I4 */, 0x01 /* rank */, 0xdf, 0xff, 0xff, 0xff /* sizesCount */];
+        var (reader, handle) = BuildTypeSpec(blob);
+
+        var result = TypeRefDecoder.Instance.GetTypeFromSpecification(reader, GenericScope.Empty, handle, 0);
+
+        Assert.Equal(TypeRefKind.Unsupported, result.Kind);
+    }
+
+    static (MetadataReader Reader, TypeSpecificationHandle Handle) BuildTypeSpec(byte[] typeBlob)
+    {
+        var md = NewModule();
+        var bb = new BlobBuilder();
+        bb.WriteBytes(typeBlob);
+        var handle = md.AddTypeSpecification(md.GetOrAddBlob(bb));
+        return (Serialize(md), handle);
+    }
+
     static (MetadataReader Reader, StandaloneSignatureHandle Handle) BuildStandaloneSig(BlobBuilder sig)
+    {
+        var md = NewModule();
+        var handle = md.AddStandaloneSignature(md.GetOrAddBlob(sig));
+        return (Serialize(md), handle);
+    }
+
+    static MetadataBuilder NewModule()
     {
         var md = new MetadataBuilder();
         md.AddModule(0, md.GetOrAddString("m.dll"), md.GetOrAddGuid(Guid.NewGuid()), default, default);
         md.AddAssembly(md.GetOrAddString("m"), new Version(1, 0, 0, 0), default, default, default, default);
         md.AddTypeDefinition(default, default, md.GetOrAddString("<Module>"), default,
             MetadataTokens.FieldDefinitionHandle(1), MetadataTokens.MethodDefinitionHandle(1));
-        var handle = md.AddStandaloneSignature(md.GetOrAddBlob(sig));
+        return md;
+    }
+
+    static MetadataReader Serialize(MetadataBuilder md)
+    {
         var root = new MetadataRootBuilder(md, suppressValidation: true);
         var image = new BlobBuilder();
         root.Serialize(image, 0, 0);
-        return (MetadataReaderProvider.FromMetadataImage(ImmutableArray.Create(image.ToArray())).GetMetadataReader(), handle);
+        return MetadataReaderProvider.FromMetadataImage(ImmutableArray.Create(image.ToArray())).GetMetadataReader();
     }
 }

--- a/src/ILInspector.Decompiler.Tests/GuardedDecodeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GuardedDecodeTests.cs
@@ -1,0 +1,63 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// GuardedDecode routes every Decompiler signature decode of untrusted metadata through
+// SignatureBlobGuard, so a malformed deeply-nested signature degrades to an unresolved shape
+// instead of overflowing the native stack inside SRM. These tests craft over-deep signatures and
+// assert the graceful fallback.
+public class GuardedDecodeTests
+{
+    [Fact]
+    public void DeepMethodSignature_DegradesToUnsupported()
+    {
+        // void M(int[][]...[]) with a 600-deep array parameter (over the 512 guard limit).
+        var sig = new BlobBuilder();
+        sig.WriteByte(0x00); // default calling convention
+        sig.WriteByte(0x01); // 1 parameter
+        sig.WriteByte(0x01); // return type VOID
+        for (int i = 0; i < 600; i++)
+            sig.WriteByte(0x1d); // SZARRAY
+        sig.WriteByte(0x08);     // I4
+
+        var (reader, handle) = BuildStandaloneSig(sig);
+        var decoded = GuardedDecode.MethodSignature(reader, reader.GetStandaloneSignature(handle), GenericScope.Empty);
+
+        Assert.Equal(TypeRefKind.Unsupported, decoded.ReturnType.Kind);
+        Assert.Empty(decoded.ParameterTypes);
+    }
+
+    [Fact]
+    public void DeepLocalSignature_DegradesToEmpty()
+    {
+        // LOCAL_SIG with one local that is a 600-deep array.
+        var sig = new BlobBuilder();
+        sig.WriteByte(0x07); // LOCAL_SIG
+        sig.WriteByte(0x01); // 1 local
+        for (int i = 0; i < 600; i++)
+            sig.WriteByte(0x1d); // SZARRAY
+        sig.WriteByte(0x08);     // I4
+
+        var (reader, handle) = BuildStandaloneSig(sig);
+        var locals = GuardedDecode.LocalTypes(reader, reader.GetStandaloneSignature(handle), GenericScope.Empty);
+
+        Assert.Empty(locals);
+    }
+
+    static (MetadataReader Reader, StandaloneSignatureHandle Handle) BuildStandaloneSig(BlobBuilder sig)
+    {
+        var md = new MetadataBuilder();
+        md.AddModule(0, md.GetOrAddString("m.dll"), md.GetOrAddGuid(Guid.NewGuid()), default, default);
+        md.AddAssembly(md.GetOrAddString("m"), new Version(1, 0, 0, 0), default, default, default, default);
+        md.AddTypeDefinition(default, default, md.GetOrAddString("<Module>"), default,
+            MetadataTokens.FieldDefinitionHandle(1), MetadataTokens.MethodDefinitionHandle(1));
+        var handle = md.AddStandaloneSignature(md.GetOrAddBlob(sig));
+        var root = new MetadataRootBuilder(md, suppressValidation: true);
+        var image = new BlobBuilder();
+        root.Serialize(image, 0, 0);
+        return (MetadataReaderProvider.FromMetadataImage(ImmutableArray.Create(image.ToArray())).GetMetadataReader(), handle);
+    }
+}

--- a/src/ILInspector.Decompiler/CSharpBodyDiff.cs
+++ b/src/ILInspector.Decompiler/CSharpBodyDiff.cs
@@ -350,7 +350,7 @@ public static class CSharpBodyDiff
         typeFullName ??= reader.GetFullTypeName(type);
         typeKey ??= TypeIdentityKey(reader, typeHandle);
         string methodName = reader.GetString(method.Name);
-        var signature = method.DecodeSignature(TypeRefDecoder.Instance, GenericScope.Empty);
+        var signature = GuardedDecode.MethodSignature(reader, method, GenericScope.Empty);
         string returnType = CanonicalTypeName(signature.ReturnType);
         var parameters = signature.ParameterTypes.Select(CanonicalTypeName).ToImmutableArray();
         int genericArity = method.GetGenericParameters().Count;
@@ -542,7 +542,7 @@ public static class CSharpBodyDiff
         {
             HandleKind.TypeDefinition => $"type-def:{reader.GetFullTypeName(reader.GetTypeDefinition((TypeDefinitionHandle)handle))}",
             HandleKind.TypeReference => $"type-ref:{reader.GetFullTypeName(reader.GetTypeReference((TypeReferenceHandle)handle))}",
-            HandleKind.TypeSpecification => $"type-spec:{CanonicalTypeName(reader.GetTypeSpecification((TypeSpecificationHandle)handle).DecodeSignature(TypeRefDecoder.Instance, GenericScope.Empty))}",
+            HandleKind.TypeSpecification => $"type-spec:{CanonicalTypeName(GuardedDecode.TypeSpecification(reader, (TypeSpecificationHandle)handle, GenericScope.Empty))}",
             HandleKind.MethodDefinition => MethodDefinitionFingerprint(reader, (MethodDefinitionHandle)handle),
             HandleKind.MemberReference => MemberReferenceFingerprint(reader, (MemberReferenceHandle)handle),
             HandleKind.MethodSpecification => MethodSpecificationFingerprint(reader, (MethodSpecificationHandle)handle),
@@ -560,22 +560,22 @@ public static class CSharpBodyDiff
     {
         var member = reader.GetMemberReference(handle);
         string signature = member.GetKind() == MemberReferenceKind.Method
-            ? MethodSignatureFingerprint(member.DecodeMethodSignature(TypeRefDecoder.Instance, GenericScope.Empty))
-            : CanonicalTypeName(member.DecodeFieldSignature(TypeRefDecoder.Instance, GenericScope.Empty));
+            ? MethodSignatureFingerprint(GuardedDecode.MethodSignature(reader, member, GenericScope.Empty))
+            : CanonicalTypeName(GuardedDecode.FieldType(reader, member, GenericScope.Empty));
         return $"member-ref:{MemberParentFingerprint(reader, member.Parent)}.{reader.GetString(member.Name)}:{signature}";
     }
 
     static string MethodSpecificationFingerprint(MetadataReader reader, MethodSpecificationHandle handle)
     {
         var spec = reader.GetMethodSpecification(handle);
-        var typeArguments = spec.DecodeSignature(TypeRefDecoder.Instance, GenericScope.Empty);
+        var typeArguments = GuardedDecode.MethodSpecArguments(reader, spec, GenericScope.Empty);
         return $"method-spec:{EntityFingerprint(reader, spec.Method)}<{string.Join(",", typeArguments.Select(CanonicalTypeName))}>";
     }
 
     static string FieldDefinitionFingerprint(MetadataReader reader, FieldDefinitionHandle handle)
     {
         var field = reader.GetFieldDefinition(handle);
-        return $"field-def:{reader.GetFullTypeName(reader.GetTypeDefinition(field.GetDeclaringType()))}.{reader.GetString(field.Name)}:{CanonicalTypeName(field.DecodeSignature(TypeRefDecoder.Instance, GenericScope.Empty))}";
+        return $"field-def:{reader.GetFullTypeName(reader.GetTypeDefinition(field.GetDeclaringType()))}.{reader.GetString(field.Name)}:{CanonicalTypeName(GuardedDecode.FieldType(reader, field, GenericScope.Empty))}";
     }
 
     static string MemberParentFingerprint(MetadataReader reader, EntityHandle handle)
@@ -586,7 +586,7 @@ public static class CSharpBodyDiff
         };
 
     static string MethodSignatureFingerprint(MetadataReader reader, MethodDefinition method)
-        => MethodSignatureFingerprint(method.DecodeSignature(TypeRefDecoder.Instance, GenericScope.Empty));
+        => MethodSignatureFingerprint(GuardedDecode.MethodSignature(reader, method, GenericScope.Empty));
 
     static string MethodSignatureFingerprint(System.Reflection.Metadata.MethodSignature<TypeRef> signature)
         => $"{(signature.Header.IsInstance ? "instance" : "static")}:{signature.GenericParameterCount}:{CanonicalTypeName(signature.ReturnType)}({string.Join(",", signature.ParameterTypes.Select(CanonicalTypeName))})";
@@ -599,14 +599,14 @@ public static class CSharpBodyDiff
         var signature = reader.GetStandaloneSignature(handle);
         try
         {
-            var locals = signature.DecodeLocalSignature(TypeRefDecoder.Instance, GenericScope.Empty);
+            var locals = GuardedDecode.LocalTypes(reader, signature, GenericScope.Empty);
             return $"locals({string.Join(",", locals.Select(CanonicalTypeName))})";
         }
         catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
         {
             try
             {
-                return $"method({MethodSignatureFingerprint(signature.DecodeMethodSignature(TypeRefDecoder.Instance, GenericScope.Empty))})";
+                return $"method({MethodSignatureFingerprint(GuardedDecode.MethodSignature(reader, signature, GenericScope.Empty))})";
             }
             catch (Exception inner) when (inner is BadImageFormatException or InvalidOperationException or ArgumentException)
             {
@@ -716,7 +716,7 @@ public static class CSharpBodyDiff
         TypeSpecificationHandle handle,
         IReadOnlyDictionary<string, TypeDefinitionHandle> typeDefinitionsByName)
     {
-        var type = reader.GetTypeSpecification(handle).DecodeSignature(TypeRefDecoder.Instance, GenericScope.Empty);
+        var type = GuardedDecode.TypeSpecification(reader, handle, GenericScope.Empty);
         var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
         if (definition is not { Kind: TypeRefKind.Definition })
             return true;

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -1532,7 +1532,7 @@ public static class CompileBackSourceComposer
     }
 
     static IReadOnlyList<TypeRef> MethodParameterTypes(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)
-        => method.DecodeSignature(TypeRefDecoder.Instance, IrImporter.CallerScope(reader, typeDef, method)).ParameterTypes;
+        => GuardedDecode.MethodSignature(reader, method, IrImporter.CallerScope(reader, typeDef, method)).ParameterTypes;
 
     static bool IsSelfType(TypeRef type, CompileBackTypeIdentity identity)
     {
@@ -2440,7 +2440,7 @@ public static class CompileBackSourceComposer
                 return false;
             try
             {
-                var signature = method.DecodeSignature(TypeRefDecoder.Instance, IrImporter.CallerScope(reader, typeDef, method));
+                var signature = GuardedDecode.MethodSignature(reader, method, IrImporter.CallerScope(reader, typeDef, method));
                 return signature.ParameterTypes.Length == methodRef.ParameterTypes.Length
                     && signature.ParameterTypes.SequenceEqual(methodRef.ParameterTypes);
             }

--- a/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
@@ -352,7 +352,7 @@ internal sealed class CrossAssemblyTypeResolver
                 if (!string.Equals(reader.GetString(candidate.Name), field.Name, StringComparison.Ordinal))
                     continue;
 
-                var fieldType = candidate.DecodeSignature(TypeRefDecoder.Instance, typeScope).Instantiate(typeArguments, []);
+                var fieldType = GuardedDecode.FieldType(reader, candidate, typeScope).Instantiate(typeArguments, []);
                 if (!SameSignatureType(fieldType, field.Type, allowCoreLibraryAliases))
                     continue;
 
@@ -394,7 +394,7 @@ internal sealed class CrossAssemblyTypeResolver
         var scope = new GenericScope(
             MethodDefinitionFacts.GenericParameterNames(reader, declaringType.GetGenericParameters()),
             MethodDefinitionFacts.GenericParameterNames(reader, method.GetGenericParameters()));
-        var signature = method.DecodeSignature(TypeRefDecoder.Instance, scope);
+        var signature = GuardedDecode.MethodSignature(reader, method, scope);
         if (signature.Header.IsInstance != callee.HasThis)
             return false;
         if (signature.GenericParameterCount != callee.TypeArguments.Length)

--- a/src/ILInspector.Decompiler/Pipeline/GuardedDecode.cs
+++ b/src/ILInspector.Decompiler/Pipeline/GuardedDecode.cs
@@ -53,12 +53,11 @@ internal static class GuardedDecode
             : TypeRef.Unsupported("field-reference signature nesting depth exceeded");
 
     public static TypeRef TypeSpecification(MetadataReader reader, TypeSpecificationHandle handle, GenericScope scope)
-    {
-        var spec = reader.GetTypeSpecification(handle);
-        return SignatureBlobGuard.IsSafeToDecode(reader, spec.Signature, SignatureBlobGuard.Kind.TypeSpecification)
-            ? spec.DecodeSignature(TypeRefDecoder.Instance, scope)
-            : TypeRef.Unsupported("type-specification nesting depth exceeded");
-    }
+        // Route through GetTypeFromSpecification so the TypeSpec length / cumulative caps run before
+        // SignatureBlobGuard (avoiding an O(count) work-stack on an over-long wide blob) and so the
+        // cross-blob modreq-cycle accounting also covers this top-level decode. It resolves to the
+        // same DecodeSignature(TypeRefDecoder.Instance, scope) on the success path.
+        => TypeRefDecoder.Instance.GetTypeFromSpecification(reader, scope, handle, 0);
 
     static MethodSignature<TypeRef> UnsupportedMethodSignature(string what)
         => new(default, TypeRef.Unsupported($"{what} signature nesting depth exceeded"), 0, 0, []);

--- a/src/ILInspector.Decompiler/Pipeline/GuardedDecode.cs
+++ b/src/ILInspector.Decompiler/Pipeline/GuardedDecode.cs
@@ -1,0 +1,65 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using ILInspector.Metadata;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Guarded wrappers around SRM's signature-decode entry points that use <see cref="TypeRefDecoder"/>.
+///
+/// Attacker-controlled metadata can encode a signature whose structural nesting is deep enough to
+/// overflow the native stack inside SRM's <c>SignatureDecoder</c> (an uncatchable
+/// <c>StackOverflowException</c>) or whose declared counts trigger a multi-gigabyte pre-allocation.
+/// <see cref="SignatureBlobGuard"/> detects both cheaply before decoding, so these helpers fail
+/// closed to an unresolved shape instead of crashing. Real signatures are shallow, so the guard
+/// only trips on malformed input. Every Decompiler decode of untrusted metadata should route through
+/// here rather than calling <c>Decode*Signature</c> directly.
+/// </summary>
+internal static class GuardedDecode
+{
+    public static MethodSignature<TypeRef> MethodSignature(MetadataReader reader, MethodDefinition method, GenericScope scope)
+        => SignatureBlobGuard.IsSafeToDecode(reader, method.Signature, SignatureBlobGuard.Kind.Method)
+            ? method.DecodeSignature(TypeRefDecoder.Instance, scope)
+            : UnsupportedMethodSignature("method");
+
+    public static MethodSignature<TypeRef> MethodSignature(MetadataReader reader, MemberReference member, GenericScope scope)
+        => SignatureBlobGuard.IsSafeToDecode(reader, member.Signature, SignatureBlobGuard.Kind.Method)
+            ? member.DecodeMethodSignature(TypeRefDecoder.Instance, scope)
+            : UnsupportedMethodSignature("member-reference");
+
+    public static MethodSignature<TypeRef> MethodSignature(MetadataReader reader, StandaloneSignature signature, GenericScope scope)
+        => SignatureBlobGuard.IsSafeToDecode(reader, signature.Signature, SignatureBlobGuard.Kind.Method)
+            ? signature.DecodeMethodSignature(TypeRefDecoder.Instance, scope)
+            : UnsupportedMethodSignature("standalone");
+
+    public static ImmutableArray<TypeRef> MethodSpecArguments(MetadataReader reader, MethodSpecification spec, GenericScope scope)
+        => SignatureBlobGuard.IsSafeToDecode(reader, spec.Signature, SignatureBlobGuard.Kind.MethodSpecification)
+            ? spec.DecodeSignature(TypeRefDecoder.Instance, scope)
+            : [];
+
+    public static ImmutableArray<TypeRef> LocalTypes(MetadataReader reader, StandaloneSignature signature, GenericScope scope)
+        => SignatureBlobGuard.IsSafeToDecode(reader, signature.Signature, SignatureBlobGuard.Kind.LocalVariables)
+            ? signature.DecodeLocalSignature(TypeRefDecoder.Instance, scope)
+            : [];
+
+    public static TypeRef FieldType(MetadataReader reader, FieldDefinition field, GenericScope scope)
+        => SignatureBlobGuard.IsSafeToDecode(reader, field.Signature, SignatureBlobGuard.Kind.Field)
+            ? field.DecodeSignature(TypeRefDecoder.Instance, scope)
+            : TypeRef.Unsupported("field signature nesting depth exceeded");
+
+    public static TypeRef FieldType(MetadataReader reader, MemberReference member, GenericScope scope)
+        => SignatureBlobGuard.IsSafeToDecode(reader, member.Signature, SignatureBlobGuard.Kind.Field)
+            ? member.DecodeFieldSignature(TypeRefDecoder.Instance, scope)
+            : TypeRef.Unsupported("field-reference signature nesting depth exceeded");
+
+    public static TypeRef TypeSpecification(MetadataReader reader, TypeSpecificationHandle handle, GenericScope scope)
+    {
+        var spec = reader.GetTypeSpecification(handle);
+        return SignatureBlobGuard.IsSafeToDecode(reader, spec.Signature, SignatureBlobGuard.Kind.TypeSpecification)
+            ? spec.DecodeSignature(TypeRefDecoder.Instance, scope)
+            : TypeRef.Unsupported("type-specification nesting depth exceeded");
+    }
+
+    static MethodSignature<TypeRef> UnsupportedMethodSignature(string what)
+        => new(default, TypeRef.Unsupported($"{what} signature nesting depth exceeded"), 0, 0, []);
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -164,7 +164,7 @@ public static class IrImporter
                 var method = reader.GetMethodDefinition(methodHandle);
                 if (reader.GetString(method.Name) != methodName)
                     continue;
-                var signature = method.DecodeSignature(TypeRefDecoder.Instance, CallerScope(reader, typeDef, method));
+                var signature = GuardedDecode.MethodSignature(reader, method, CallerScope(reader, typeDef, method));
                 bool isPublic = (method.Attributes & System.Reflection.MethodAttributes.MemberAccessMask)
                     == System.Reflection.MethodAttributes.Public;
                 result.Add(new OverloadInfo(
@@ -354,7 +354,7 @@ public static class IrImporter
 
     static string StableSampleKey(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method, string typeName, string methodName)
     {
-        var signature = method.DecodeSignature(TypeRefDecoder.Instance, CallerScope(reader, typeDef, method));
+        var signature = GuardedDecode.MethodSignature(reader, method, CallerScope(reader, typeDef, method));
         return string.Join("|",
             typeName,
             methodName,
@@ -1437,9 +1437,10 @@ public static class IrImporter
                     // the return and parameter types and whether the pointer is
                     // an instance function pointer. The function-pointer value
                     // is on top; the arguments are beneath it.
-                    var signature = source.Reader
-                        .GetStandaloneSignature((StandaloneSignatureHandle)MetadataTokens.EntityHandle(reader.ReadILToken()))
-                        .DecodeMethodSignature(TypeRefDecoder.Instance, callerScope);
+                    var signature = GuardedDecode.MethodSignature(
+                        source.Reader,
+                        source.Reader.GetStandaloneSignature((StandaloneSignatureHandle)MetadataTokens.EntityHandle(reader.ReadILToken())),
+                        callerScope);
                     var pointer = Pop(stack);
                     int argumentCount = signature.ParameterTypes.Length + (signature.Header.IsInstance ? 1 : 0);
                     var arguments = new IrExpression[argumentCount];
@@ -1950,7 +1951,7 @@ public static class IrImporter
                 var declaring = TypeRefDecoder.Instance.GetTypeFromDefinition(reader, declaringTypeHandle, 0);
                 var declaringType = reader.GetTypeDefinition(declaringTypeHandle);
                 var typeScope = new GenericScope(GenericParameterNames(reader, declaringType.GetGenericParameters()), []);
-                var signature = method.DecodeSignature(TypeRefDecoder.Instance, typeScope);
+                var signature = GuardedDecode.MethodSignature(reader, method, typeScope);
                 var parameterRefKinds = MethodDefinitionFacts.ReadParameterRefKinds(reader, method, signature.ParameterTypes);
                 bool methodCompilerGenerated = MethodDefinitionFacts.HasCompilerGeneratedAttribute(reader, method.GetCustomAttributes());
                 bool typeCompilerGenerated = MethodDefinitionFacts.HasCompilerGeneratedAttribute(reader, declaringType.GetCustomAttributes());
@@ -1978,7 +1979,7 @@ public static class IrImporter
             {
                 var member = reader.GetMemberReference((MemberReferenceHandle)handle);
                 var declaring = ResolveParentType(reader, member.Parent, callerScope);
-                var signature = member.DecodeMethodSignature(TypeRefDecoder.Instance, GenericScope.Empty);
+                var signature = GuardedDecode.MethodSignature(reader, member, GenericScope.Empty);
                 // The signature's !N are the declaring type's parameters;
                 // instantiate them against the parent's type arguments so a
                 // call on List<int> reports int, not T.
@@ -2028,7 +2029,7 @@ public static class IrImporter
                 // arguments so the call site reports concrete types.
                 var spec = reader.GetMethodSpecification((MethodSpecificationHandle)handle);
                 var generic = ResolveMethod(reader, spec.Method, callerScope);
-                var methodArguments = spec.DecodeSignature(TypeRefDecoder.Instance, callerScope);
+                var methodArguments = GuardedDecode.MethodSpecArguments(reader, spec, callerScope);
                 return generic with
                 {
                     TypeArguments = methodArguments,
@@ -2382,7 +2383,7 @@ public static class IrImporter
                 var declaringType = reader.GetTypeDefinition(declaringTypeHandle);
                 var typeScope = new GenericScope(GenericParameterNames(reader, declaringType.GetGenericParameters()), []);
                 var name = reader.GetString(field.Name);
-                return new FieldRef(declaring, name, field.DecodeSignature(TypeRefDecoder.Instance, typeScope))
+                return new FieldRef(declaring, name, GuardedDecode.FieldType(reader, field, typeScope))
                 {
                     BackingPropertyName = BackingPropertyName(reader, declaringType, name),
                 };
@@ -2391,7 +2392,7 @@ public static class IrImporter
             {
                 var member = reader.GetMemberReference((MemberReferenceHandle)handle);
                 var declaring = ResolveParentType(reader, member.Parent, callerScope);
-                var fieldType = member.DecodeFieldSignature(TypeRefDecoder.Instance, GenericScope.Empty);
+                var fieldType = GuardedDecode.FieldType(reader, member, GenericScope.Empty);
                 if (declaring.Kind == TypeRefKind.GenericInstance)
                     fieldType = fieldType.Instantiate(declaring.TypeArguments, []);
                 var name = reader.GetString(member.Name);
@@ -2450,6 +2451,8 @@ public static class IrImporter
         var field = source.Reader.GetFieldDefinition(handle);
         int rva = field.GetRelativeVirtualAddress();
         if (rva == 0)
+            return null;
+        if (!ILInspector.Metadata.SignatureBlobGuard.IsSafeToDecode(source.Reader, field.Signature, ILInspector.Metadata.SignatureBlobGuard.Kind.Field))
             return null;
         int size = field.DecodeSignature(FieldDataSizeProvider.Instance, null);
         if (size <= 0)

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -562,7 +562,7 @@ public sealed class MetadataSource : IDisposable
         {
             var field = Reader.GetFieldDefinition(fieldHandle);
             if (Reader.GetString(field.Name) == "value__")
-                return field.DecodeSignature(TypeRefDecoder.Instance, scope);
+                return GuardedDecode.FieldType(Reader, field, scope);
         }
         return null;
     }

--- a/src/ILInspector.Decompiler/Pipeline/MethodImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodImporter.cs
@@ -56,7 +56,7 @@ public static class MethodImporter
             ParameterNames(reader, method.GetGenericParameters()));
 
         var declaringType = TypeRefDecoder.Instance.GetTypeFromDefinition(reader, typeDefHandle, 0);
-        var decoded = method.DecodeSignature(TypeRefDecoder.Instance, scope);
+        var decoded = GuardedDecode.MethodSignature(reader, method, scope);
 
         var parameters = ImmutableArray.CreateBuilder<Parameter>(decoded.ParameterTypes.Length);
         var namesByIndex = new Dictionary<int, string>();
@@ -88,7 +88,7 @@ public static class MethodImporter
         if (!body.LocalSignature.IsNil)
         {
             var localSignature = reader.GetStandaloneSignature(body.LocalSignature);
-            locals = localSignature.DecodeLocalSignature(TypeRefDecoder.Instance, scope);
+            locals = GuardedDecode.LocalTypes(reader, localSignature, scope);
         }
 
         var handlers = ImmutableArray.CreateBuilder<HandlerRegion>(body.ExceptionRegions.Length);

--- a/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
@@ -142,18 +142,20 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
         if (s_recursionDepth >= MaxRecursionDepth)
             return TypeRef.Unsupported("type-specification recursion depth exceeded");
         var spec = reader.GetTypeSpecification(handle);
-        // Bound this blob's structural depth and count-driven allocations before SRM decodes it.
-        // The #2489 blob-length / cumulative caps below bound the cross-blob modreq *cycle*, but a
-        // single short blob with a huge count field (e.g. an array-shape size count) would still
-        // reach SRM and OOM — SignatureBlobGuard rejects those. Covers both direct callers of this
-        // method and SRM's recursive re-entry for a nested TypeSpec.
-        if (!ILInspector.Metadata.SignatureBlobGuard.IsSafeToDecode(reader, spec.Signature, ILInspector.Metadata.SignatureBlobGuard.Kind.TypeSpecification))
-            return TypeRef.Unsupported("type-specification signature nesting depth exceeded");
         int blobLength = reader.GetBlobReader(spec.Signature).Length;
+        // Apply the cheap #2489 length / cumulative caps FIRST: they reject an over-long blob in
+        // O(1), which also keeps the SignatureBlobGuard below from ever walking (and allocating a
+        // work item per element of) a huge blob. The length/cumulative caps bound the cross-blob
+        // modreq *cycle*; the guard then bounds this single (now <= 1024-byte) blob's structural
+        // depth and count-driven allocations — a short blob with a huge count field (e.g. an
+        // array-shape size count) would otherwise reach SRM and OOM. Covers both direct callers of
+        // this method and SRM's recursive re-entry for a nested TypeSpec.
         if (blobLength > MaxSignatureBlobLength)
             return TypeRef.Unsupported("type-specification signature blob too large");
         if (s_cumulativeSignatureBytes + blobLength > MaxCumulativeSignatureBytes)
             return TypeRef.Unsupported("type-specification cumulative signature blob too large");
+        if (!ILInspector.Metadata.SignatureBlobGuard.IsSafeToDecode(reader, spec.Signature, ILInspector.Metadata.SignatureBlobGuard.Kind.TypeSpecification))
+            return TypeRef.Unsupported("type-specification signature nesting depth exceeded");
         s_cumulativeSignatureBytes += blobLength;
         s_recursionDepth++;
         try

--- a/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
@@ -142,6 +142,13 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
         if (s_recursionDepth >= MaxRecursionDepth)
             return TypeRef.Unsupported("type-specification recursion depth exceeded");
         var spec = reader.GetTypeSpecification(handle);
+        // Bound this blob's structural depth and count-driven allocations before SRM decodes it.
+        // The #2489 blob-length / cumulative caps below bound the cross-blob modreq *cycle*, but a
+        // single short blob with a huge count field (e.g. an array-shape size count) would still
+        // reach SRM and OOM — SignatureBlobGuard rejects those. Covers both direct callers of this
+        // method and SRM's recursive re-entry for a nested TypeSpec.
+        if (!ILInspector.Metadata.SignatureBlobGuard.IsSafeToDecode(reader, spec.Signature, ILInspector.Metadata.SignatureBlobGuard.Kind.TypeSpecification))
+            return TypeRef.Unsupported("type-specification signature nesting depth exceeded");
         int blobLength = reader.GetBlobReader(spec.Signature).Length;
         if (blobLength > MaxSignatureBlobLength)
             return TypeRef.Unsupported("type-specification signature blob too large");


### PR DESCRIPTION
Increment 2 of #2490 (follows #2503).

## Problem

#2503 added the shared `SignatureBlobGuard` and applied it at the **Analysis** decode entry points. The **Decompiler**-side decodes of untrusted metadata were still exposed to the same **uncatchable native-stack `StackOverflowException`** and count-driven **OOM** (SRM's `SignatureDecoder` recurses natively per nested element and pre-allocates builders from declared counts, before any provider callback).

A subtlety this closes: a **top-level** `typeSpec.DecodeSignature(...)` is *not* protected by #2489's `GetTypeFromSpecification` caps — SRM invokes that provider override only for *nested* TypeSpec-by-handle references, not the top-level blob — so those sites were a genuine gap.

## This increment

- **`GuardedDecode`** — guarded wrappers around every `TypeRefDecoder` decode entry point (method / member-ref / standalone / method-spec / local / field / type-spec) that run `SignatureBlobGuard` first and fail closed to an unresolved `TypeRef` shape on trip.
- **Routed all `TypeRefDecoder.Instance` decode sites through it**: `MethodImporter`, `IrImporter` (including the `FieldDataSizeProvider` field-size decode, guarded inline), `CrossAssemblyTypeResolver`, `MetadataSource`, `CSharpBodyDiff`, and the two `CompileBackSourceComposer` `TypeRefDecoder` sites. `grep` confirms no unguarded `TypeRefDecoder.Instance.Decode*Signature` sites remain outside `GuardedDecode`.

## Evidence

- **No behavior change on real code** — the guard never trips on valid signatures (0 false-positives across 53,236 CoreLib signatures, established in #2503). `ILInspector.Decompiler.Tests` **2165/0** unchanged; full `dotnet-inspect.slnx` build clean.
- New **`GuardedDecodeTests`** assert a 600-deep method parameter and a 600-deep local both degrade to the unresolved fallback (Unsupported return / empty locals) with no crash.

## Scope / follow-up

The remaining **`SignatureDecoder.Instance`** sites (`CompileBackSourceComposer` / `TypeSourceComposer`, ~23 sites, a different provider) are the next increment, tracked in #2490.

## Review

Mechanical application of the (already-reviewed, merged) guard via a small tested helper, but it touches the core decompile path → requesting two-model adversarial review (GPT-5.5 + Gemini 3.1 Pro) with a confirmatory pass. Reviewers: please (a) confirm no `TypeRefDecoder` decode site was missed, (b) verify the fail-closed fallbacks are correct, and (c) run a render-text A/B on CoreLib against the merge base to confirm byte-identical decompiler output.
