### PR TITLE
Centralize consumed member evidence

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/Ir/ConsumedMemberEvidence.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/ConsumedMemberEvidence.cs
@@ -1,0 +1,111 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Product-owned typed member evidence consumed by raised and lowered IR nodes.
+/// Consumers such as ReturnToSender route these references instead of switching
+/// over C# surface shapes or reconstructing member names.
+/// </summary>
+public sealed record ConsumedMemberEvidence(
+    MethodRef? Method = null,
+    FieldRef? Field = null,
+    TypeRef? RecordShellType = null,
+    bool AllowTargetRoot = false)
+{
+    public static IEnumerable<ConsumedMemberEvidence> From(IrNode node)
+    {
+        switch (node)
+        {
+            case Call call:
+                yield return new(Method: call.Callee);
+                break;
+            case NewObject creation:
+                yield return new(Method: creation.Constructor, AllowTargetRoot: true);
+                break;
+            case LoadProperty load:
+                yield return new(Method: load.Accessor);
+                break;
+            case StoreProperty store:
+                yield return new(Method: store.Accessor);
+                break;
+            case EventSubscription subscription:
+                yield return new(Method: subscription.Accessor);
+                break;
+            case LoadFunctionPointer load:
+                yield return new(Method: load.Method);
+                break;
+            case AddressOfMethod address:
+                yield return new(Method: address.Method);
+                break;
+            case DelegateCreation creation:
+                yield return new(Method: creation.Method);
+                break;
+            case IncrementDecrement { ConsumedMethod: { } operatorMethod }:
+                yield return new(Method: operatorMethod);
+                break;
+            case RecursivePropertyDeclarationPattern pattern:
+                yield return new(Method: pattern.Accessor);
+                break;
+            case NullCoalescingPropertyAssignment assignment:
+                yield return new(Method: assignment.Setter);
+                break;
+            case DeconstructionAssignment deconstruction:
+                if (deconstruction.ConsumedDeconstructMethod is { } deconstruct)
+                    yield return new(Method: deconstruct);
+                foreach (var target in deconstruction.Targets)
+                {
+                    if (target.Accessor is { } accessor)
+                        yield return new(Method: accessor);
+                    if (target.Field is { } field)
+                        yield return new(Field: field);
+                }
+                break;
+            case ForeachStatement foreachStatement:
+                foreach (var method in foreachStatement.ConsumedMemberRefs)
+                    yield return new(Method: method);
+                break;
+            case UsingStatement usingStatement:
+                foreach (var method in usingStatement.ConsumedMemberRefs)
+                    yield return new(Method: method);
+                break;
+            case LoadField load:
+                yield return new(Field: load.Field);
+                break;
+            case StoreField store:
+                yield return new(Field: store.Field);
+                break;
+            case LoadFieldAddress address:
+                yield return new(Field: address.Field);
+                break;
+            case NullCoalescingFieldAssignment assignment:
+                yield return new(Field: assignment.Field);
+                break;
+            case NullCoalescingFieldAssignmentExpression assignment:
+                yield return new(Field: assignment.Field);
+                break;
+            case ObjectInitializerExpression initializer:
+                yield return new(Method: initializer.Creation.Constructor, AllowTargetRoot: true);
+                foreach (var evidence in FromInitializerEntries(initializer.Entries))
+                    yield return evidence;
+                break;
+            case WithExpression withExpression:
+                yield return new(RecordShellType: withExpression.ResultType);
+                foreach (var evidence in FromInitializerEntries(withExpression.Entries))
+                    yield return evidence;
+                break;
+        }
+    }
+
+    static IEnumerable<ConsumedMemberEvidence> FromInitializerEntries(IEnumerable<InitializerEntry> entries)
+    {
+        foreach (var entry in entries)
+        {
+            if (entry.ConsumedMethod is { } method)
+                yield return new(Method: method, AllowTargetRoot: true);
+            if (entry.ConsumedField is { } field)
+                yield return new(Field: field);
+            foreach (var block in entry.Arguments.OfType<InitializerBlock>())
+                foreach (var evidence in FromInitializerEntries(block.Entries))
+                    yield return evidence;
+        }
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/ConsumedMemberEvidence.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/ConsumedMemberEvidence.cs
@@ -5,107 +5,104 @@ namespace ILInspector.Decompiler.Pipeline;
 /// Consumers such as ReturnToSender route these references instead of switching
 /// over C# surface shapes or reconstructing member names.
 /// </summary>
-public sealed record ConsumedMemberEvidence(
+public readonly record struct ConsumedMemberEvidence(
     MethodRef? Method = null,
     FieldRef? Field = null,
     TypeRef? RecordShellType = null,
     bool AllowTargetRoot = false)
 {
-    public static IEnumerable<ConsumedMemberEvidence> From(IrNode node)
+    public static void AddFrom(IrNode node, List<ConsumedMemberEvidence> evidence)
     {
         switch (node)
         {
             case Call call:
-                yield return new(Method: call.Callee);
+                evidence.Add(new(Method: call.Callee));
                 break;
             case NewObject creation:
-                yield return new(Method: creation.Constructor, AllowTargetRoot: true);
+                evidence.Add(new(Method: creation.Constructor, AllowTargetRoot: true));
                 break;
             case LoadProperty load:
-                yield return new(Method: load.Accessor);
+                evidence.Add(new(Method: load.Accessor));
                 break;
             case StoreProperty store:
-                yield return new(Method: store.Accessor);
+                evidence.Add(new(Method: store.Accessor));
                 break;
             case EventSubscription subscription:
-                yield return new(Method: subscription.Accessor);
+                evidence.Add(new(Method: subscription.Accessor));
                 break;
             case LoadFunctionPointer load:
-                yield return new(Method: load.Method);
+                evidence.Add(new(Method: load.Method));
                 break;
             case AddressOfMethod address:
-                yield return new(Method: address.Method);
+                evidence.Add(new(Method: address.Method));
                 break;
             case DelegateCreation creation:
-                yield return new(Method: creation.Method);
+                evidence.Add(new(Method: creation.Method));
                 break;
             case IncrementDecrement { ConsumedMethod: { } operatorMethod }:
-                yield return new(Method: operatorMethod);
+                evidence.Add(new(Method: operatorMethod));
                 break;
             case RecursivePropertyDeclarationPattern pattern:
-                yield return new(Method: pattern.Accessor);
+                evidence.Add(new(Method: pattern.Accessor));
                 break;
             case NullCoalescingPropertyAssignment assignment:
-                yield return new(Method: assignment.Setter);
+                evidence.Add(new(Method: assignment.Setter));
                 break;
             case DeconstructionAssignment deconstruction:
                 if (deconstruction.ConsumedDeconstructMethod is { } deconstruct)
-                    yield return new(Method: deconstruct);
+                    evidence.Add(new(Method: deconstruct));
                 foreach (var target in deconstruction.Targets)
                 {
                     if (target.Accessor is { } accessor)
-                        yield return new(Method: accessor);
+                        evidence.Add(new(Method: accessor));
                     if (target.Field is { } field)
-                        yield return new(Field: field);
+                        evidence.Add(new(Field: field));
                 }
                 break;
             case ForeachStatement foreachStatement:
                 foreach (var method in foreachStatement.ConsumedMemberRefs)
-                    yield return new(Method: method);
+                    evidence.Add(new(Method: method));
                 break;
             case UsingStatement usingStatement:
                 foreach (var method in usingStatement.ConsumedMemberRefs)
-                    yield return new(Method: method);
+                    evidence.Add(new(Method: method));
                 break;
             case LoadField load:
-                yield return new(Field: load.Field);
+                evidence.Add(new(Field: load.Field));
                 break;
             case StoreField store:
-                yield return new(Field: store.Field);
+                evidence.Add(new(Field: store.Field));
                 break;
             case LoadFieldAddress address:
-                yield return new(Field: address.Field);
+                evidence.Add(new(Field: address.Field));
                 break;
             case NullCoalescingFieldAssignment assignment:
-                yield return new(Field: assignment.Field);
+                evidence.Add(new(Field: assignment.Field));
                 break;
             case NullCoalescingFieldAssignmentExpression assignment:
-                yield return new(Field: assignment.Field);
+                evidence.Add(new(Field: assignment.Field));
                 break;
             case ObjectInitializerExpression initializer:
-                yield return new(Method: initializer.Creation.Constructor, AllowTargetRoot: true);
-                foreach (var evidence in FromInitializerEntries(initializer.Entries))
-                    yield return evidence;
+                evidence.Add(new(Method: initializer.Creation.Constructor, AllowTargetRoot: true));
+                AddFromInitializerEntries(initializer.Entries, evidence);
                 break;
             case WithExpression withExpression:
-                yield return new(RecordShellType: withExpression.ResultType);
-                foreach (var evidence in FromInitializerEntries(withExpression.Entries))
-                    yield return evidence;
+                evidence.Add(new(RecordShellType: withExpression.ResultType));
+                AddFromInitializerEntries(withExpression.Entries, evidence);
                 break;
         }
     }
 
-    static IEnumerable<ConsumedMemberEvidence> FromInitializerEntries(IEnumerable<InitializerEntry> entries)
+    static void AddFromInitializerEntries(IEnumerable<InitializerEntry> entries, List<ConsumedMemberEvidence> evidence)
     {
         foreach (var entry in entries)
         {
             if (entry.ConsumedMethod is { } method)
-                yield return new(Method: method, AllowTargetRoot: true);
+                evidence.Add(new(Method: method, AllowTargetRoot: true));
             if (entry.ConsumedField is { } field)
-                yield return new(Field: field);
+                evidence.Add(new(Field: field));
             foreach (var block in entry.Arguments.OfType<InitializerBlock>())
-                foreach (var evidence in FromInitializerEntries(block.Entries))
-                    yield return evidence;
+                AddFromInitializerEntries(block.Entries, evidence);
         }
     }
 }

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1491,6 +1491,7 @@ static class ReturnToSender
         // fail to resolve its own definitions and drop their closure roots/facts.
         string assemblyName = TypeRefDecoder.Canonical(reader.GetString(reader.GetAssemblyDefinition().Name));
         var definitions = TypeDefinitionsByTypeRefIdentity(reader);
+        var consumedMemberEvidence = new List<ConsumedMemberEvidence>();
         AddTargetInterfaceRoots(targetType);
         foreach (var node in function.Descendants.Prepend(function))
         {
@@ -1653,7 +1654,9 @@ static class ReturnToSender
 
         void AddTypedClosureMemberFacts(IrNode node)
         {
-            foreach (var evidence in ConsumedMemberEvidence.From(node))
+            consumedMemberEvidence.Clear();
+            ConsumedMemberEvidence.AddFrom(node, consumedMemberEvidence);
+            foreach (var evidence in consumedMemberEvidence)
             {
                 if (evidence.Method is { } method)
                     AddMethodFact(method, evidence.AllowTargetRoot);

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1653,101 +1653,14 @@ static class ReturnToSender
 
         void AddTypedClosureMemberFacts(IrNode node)
         {
-            switch (node)
+            foreach (var evidence in ConsumedMemberEvidence.From(node))
             {
-                case Call call:
-                    AddMethodFact(call.Callee);
-                    break;
-                case NewObject creation:
-                    AddMethodFact(creation.Constructor, allowTargetRootOverride: true);
-                    break;
-                case LoadProperty load:
-                    AddMethodFact(load.Accessor);
-                    break;
-                case StoreProperty store:
-                    AddMethodFact(store.Accessor);
-                    break;
-                case EventSubscription subscription:
-                    AddMethodFact(subscription.Accessor);
-                    break;
-                case LoadFunctionPointer load:
-                    AddMethodFact(load.Method);
-                    break;
-                case AddressOfMethod address:
-                    AddMethodFact(address.Method);
-                    break;
-                case DelegateCreation creation:
-                    AddMethodFact(creation.Method);
-                    break;
-                case IncrementDecrement { ConsumedMethod: { } operatorMethod }:
-                    AddMethodFact(operatorMethod);
-                    break;
-                case RecursivePropertyDeclarationPattern pattern:
-                    AddMethodFact(pattern.Accessor);
-                    break;
-                case NullCoalescingPropertyAssignment assignment:
-                    AddMethodFact(assignment.Setter);
-                    break;
-                case DeconstructionAssignment deconstruction:
-                    if (deconstruction.ConsumedDeconstructMethod is { } deconstruct)
-                        AddMethodFact(deconstruct);
-                    foreach (var target in deconstruction.Targets)
-                    {
-                        if (target.Accessor is { } accessor)
-                            AddMethodFact(accessor);
-                        if (target.Field is { } field)
-                            AddFieldFact(field);
-                    }
-                    break;
-                case ForeachStatement foreachStatement:
-                    foreach (var method in foreachStatement.ConsumedMemberRefs)
-                        AddMethodFact(method);
-                    break;
-                case UsingStatement usingStatement:
-                    foreach (var method in usingStatement.ConsumedMemberRefs)
-                        AddMethodFact(method);
-                    break;
-                case LoadField load:
-                    AddFieldFact(load.Field);
-                    break;
-                case StoreField store:
-                    AddFieldFact(store.Field);
-                    break;
-                case LoadFieldAddress address:
-                    AddFieldFact(address.Field);
-                    break;
-                case NullCoalescingFieldAssignment assignment:
-                    AddFieldFact(assignment.Field);
-                    break;
-                case NullCoalescingFieldAssignmentExpression assignment:
-                    AddFieldFact(assignment.Field);
-                    break;
-                case ObjectInitializerExpression initializer:
-                    AddObjectInitializerFacts(initializer);
-                    break;
-                case WithExpression withExpression:
-                    AddRecordShellFact(withExpression.ResultType);
-                    AddInitializerEntryFacts(withExpression.Entries);
-                    break;
-            }
-        }
-
-        void AddObjectInitializerFacts(ObjectInitializerExpression initializer)
-        {
-            AddMethodFact(initializer.Creation.Constructor, allowTargetRootOverride: true);
-            AddInitializerEntryFacts(initializer.Entries);
-        }
-
-        void AddInitializerEntryFacts(IEnumerable<InitializerEntry> entries)
-        {
-            foreach (var entry in entries)
-            {
-                if (entry.ConsumedMethod is { } method)
-                    AddMethodFact(method, allowTargetRootOverride: true);
-                if (entry.ConsumedField is { } field)
+                if (evidence.Method is { } method)
+                    AddMethodFact(method, evidence.AllowTargetRoot);
+                if (evidence.Field is { } field)
                     AddFieldFact(field);
-                foreach (var block in entry.Arguments.OfType<InitializerBlock>())
-                    AddInitializerEntryFacts(block.Entries);
+                if (evidence.RecordShellType is { } recordShell)
+                    AddRecordShellFact(recordShell);
             }
         }
     }


### PR DESCRIPTION
- Advances #2529.
- Centralizes product-owned consumed member evidence for RTS.
- Evidence revision: `f10f5f46`

## Change

**Conclusion:** **PASS** — RTS now consumes a uniform product-owned `ConsumedMemberEvidence` surface instead of switching over concrete IR node types.

Before:

```text
ReturnToSender.SeedTypedClosureRoots:
  switch (node)
    case Call / NewObject / StoreProperty / Deconstruction / Foreach / Using / Initializers / With / ...
```

After:

```text
Product IR:
  ConsumedMemberEvidence.From(node)
RTS:
  route MethodRef / FieldRef / record-shell TypeRef evidence
```

## Scope and safety

- **Root cause:** even after recent typed-evidence migrations, RTS still had a long per-node switch that knew which member property each IR node consumed.
- **Fix shape:** add `ConsumedMemberEvidence` under product IR and move that switch there. RTS performs only closure bookkeeping and Research shell routing.
- **Product impact:** no printed C# behavior change; this is an evidence API/refactor.
- **Scope boundary:** this does not yet remove target-interface root seeding or method-kind prefix logic from RTS; it centralizes consumed member evidence first.
- **RTS boundary:** RTS now routes uniform product evidence instead of enumerating concrete IR shapes.

## Evidence

| Check | Result |
| --- | --- |
| ObjectInitializerPassTests | Pass |
| IncrementDecrementPassTests | Pass |
| Checked binary RTS canary | Pass |
| GeneratedFixtureCatalogTests | Pass |
| Solution build | Pass |
| `minimal` RTS catalog JSON | `RoslynFallbacks: []` |
| `record` RTS catalog JSON | `RoslynFallbacks: []` |
| `rts.candidates` source probe | ValidMatch 52, ValidDifferent 50, Invalid 0, SourceUnavailable 0, UnsupportedTarget 0 |

## Validation

```bash
dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ObjectInitializerPassTests/*"
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/IncrementDecrementPassTests/*"
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderPrototypeTests/CompileBackTargets_PreservesCheckedBinaryOperatorSibling"
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/GeneratedFixtureCatalogTests/*"
dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog minimal --json --max-examples 1
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog record --json --max-examples 1
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures rts.candidates --return-to-sender-source-probe --cap 10000 --max-examples 40
```

## Review

Adversarial review requested after PR creation.
