### PR TITLE
Classify known RTS source deltas

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -210,6 +210,32 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_DoesNotHideDocumentationTriviaOnCheckedStatement()
+    {
+        var reason = ReturnToSenderSourceProbe.ClassifyValidDifference(
+            """
+            checked
+            {
+                return value;
+            }
+            """,
+            """
+            /// residual
+            checked
+            {
+                return value;
+            }
+            """,
+            FidelityCheck.CompileBackStatus.Exact,
+            decisions: [],
+            out var detail);
+
+        Assert.Equal("valid_different.source_shape_frontier.checked_context.exact", reason);
+        Assert.DoesNotContain("known_compiler_option", reason);
+        Assert.Contains("checked_context", detail);
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_StripsNestedCheckedStatementForKnownCompilerOption()
     {
         var reason = ReturnToSenderSourceProbe.ClassifyValidDifference(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -170,6 +170,46 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_DoesNotHideResidualTriviaOnCheckedExpression()
+    {
+        var reason = ReturnToSenderSourceProbe.ClassifyValidDifference(
+            "return left + right;",
+            "return checked(/* residual */ left + right);",
+            FidelityCheck.CompileBackStatus.Exact,
+            decisions: [],
+            out var detail);
+
+        Assert.Equal("valid_different.source_shape_frontier.checked_context.exact", reason);
+        Assert.DoesNotContain("known_compiler_option", reason);
+        Assert.Contains("checked_context", detail);
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_DoesNotHideResidualTriviaOnCheckedStatement()
+    {
+        var reason = ReturnToSenderSourceProbe.ClassifyValidDifference(
+            """
+            checked
+            {
+                return value;
+            }
+            """,
+            """
+            /* residual */ checked
+            {
+                return value;
+            }
+            """,
+            FidelityCheck.CompileBackStatus.Exact,
+            decisions: [],
+            out var detail);
+
+        Assert.Equal("valid_different.source_shape_frontier.checked_context.exact", reason);
+        Assert.DoesNotContain("known_compiler_option", reason);
+        Assert.Contains("checked_context", detail);
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_ClassifiesIteratorCompilerLowering()
     {
         var reason = ReturnToSenderSourceProbe.ClassifyValidDifference(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -112,7 +112,7 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
-    public void ReturnToSenderSourceProbe_ClassifiesCheckedContextSourceShapeFrontier()
+    public void ReturnToSenderSourceProbe_ClassifiesCheckedContextExactAsKnownCompilerOption()
     {
         var reason = ReturnToSenderSourceProbe.ClassifyValidDifference(
             "return left + right;",
@@ -121,9 +121,54 @@ public class ReturnToSenderFixtureCatalogTests
             decisions: [],
             out var detail);
 
-        Assert.Equal("valid_different.source_shape_frontier.checked_context.exact", reason);
+        Assert.Equal("valid_different.known_compiler_option.checked_context", reason);
+        Assert.Contains("checked arithmetic option", detail);
+        Assert.Contains("compile-back exact", detail);
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_KeepsCheckedContextOpcodeDiffActionable()
+    {
+        var reason = ReturnToSenderSourceProbe.ClassifyValidDifference(
+            "return left + right;",
+            "return checked(left + right);",
+            FidelityCheck.CompileBackStatus.OpcodeDiff,
+            decisions: [],
+            out var detail);
+
+        Assert.Equal("valid_different.semantic_opcode_diff.checked_context", reason);
         Assert.Contains("checked_context", detail);
-        Assert.Contains("Exact", detail);
+        Assert.Contains("OpcodeDiff", detail);
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_ClassifiesUnsafeResidualExactAsKnownStandaloneContext()
+    {
+        var reason = ReturnToSenderSourceProbe.ClassifyValidDifference(
+            "int* p = null;\nreturn *p;",
+            "unsafe\n{\n    int* p = null;\n    return *p;\n}",
+            FidelityCheck.CompileBackStatus.Exact,
+            decisions: [],
+            out var detail);
+
+        Assert.Equal("valid_different.known_standalone_context.unsafe_residual", reason);
+        Assert.Contains("standalone-context", detail);
+        Assert.Contains("compile-back exact", detail);
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_KeepsUnsafeResidualOpcodeDiffActionable()
+    {
+        var reason = ReturnToSenderSourceProbe.ClassifyValidDifference(
+            "int* p = null;\nreturn *p;",
+            "unsafe\n{\n    int* p = null;\n    return *p;\n}",
+            FidelityCheck.CompileBackStatus.OpcodeDiff,
+            decisions: [],
+            out var detail);
+
+        Assert.Equal("valid_different.semantic_opcode_diff.unsafe_residual", reason);
+        Assert.Contains("unsafe_residual", detail);
+        Assert.Contains("OpcodeDiff", detail);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -210,6 +210,35 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_StripsNestedCheckedStatementForKnownCompilerOption()
+    {
+        var reason = ReturnToSenderSourceProbe.ClassifyValidDifference(
+            """
+            if (value > 0)
+            {
+                value += 1;
+            }
+            return value;
+            """,
+            """
+            if (value > 0)
+            {
+                checked
+                {
+                    value += 1;
+                }
+            }
+            return value;
+            """,
+            FidelityCheck.CompileBackStatus.Exact,
+            decisions: [],
+            out var detail);
+
+        Assert.Equal("valid_different.known_compiler_option.checked_context", reason);
+        Assert.Contains("checked arithmetic option", detail);
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_ClassifiesIteratorCompilerLowering()
     {
         var reason = ReturnToSenderSourceProbe.ClassifyValidDifference(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -142,33 +142,31 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
-    public void ReturnToSenderSourceProbe_ClassifiesUnsafeResidualExactAsKnownStandaloneContext()
+    public void ReturnToSenderSourceProbe_DoesNotHideResidualInsideCheckedContext()
     {
         var reason = ReturnToSenderSourceProbe.ClassifyValidDifference(
-            "int* p = null;\nreturn *p;",
-            "unsafe\n{\n    int* p = null;\n    return *p;\n}",
+            """
+            checked
+            {
+                int value = 1;
+                return value;
+            }
+            """,
+            """
+            checked
+            {
+                int value = 1;
+                /* residual */
+                return value;
+            }
+            """,
             FidelityCheck.CompileBackStatus.Exact,
             decisions: [],
             out var detail);
 
-        Assert.Equal("valid_different.known_standalone_context.unsafe_residual", reason);
-        Assert.Contains("standalone-context", detail);
-        Assert.Contains("compile-back exact", detail);
-    }
-
-    [Fact]
-    public void ReturnToSenderSourceProbe_KeepsUnsafeResidualOpcodeDiffActionable()
-    {
-        var reason = ReturnToSenderSourceProbe.ClassifyValidDifference(
-            "int* p = null;\nreturn *p;",
-            "unsafe\n{\n    int* p = null;\n    return *p;\n}",
-            FidelityCheck.CompileBackStatus.OpcodeDiff,
-            decisions: [],
-            out var detail);
-
-        Assert.Equal("valid_different.semantic_opcode_diff.unsafe_residual", reason);
-        Assert.Contains("unsafe_residual", detail);
-        Assert.Contains("OpcodeDiff", detail);
+        Assert.Equal("valid_different.source_shape_frontier.checked_context.exact", reason);
+        Assert.DoesNotContain("known_compiler_option", reason);
+        Assert.Contains("checked_context", detail);
     }
 
     [Fact]

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -172,7 +172,8 @@ The source probe also supports `--json` for machine-readable census rows. The
 `reason` field classifies valid-but-different rows by the source-fidelity
 frontier and compile-back status, for example
 `valid_different.compiler_lowering.iterator.opcode_diff`,
-`valid_different.source_shape_frontier.checked_context.exact`, or
+`valid_different.known_compiler_option.checked_context`,
+`valid_different.known_standalone_context.unsafe_residual`, or
 `valid_different.semantic_opcode_diff.unsafe_residual`.
 Rows may carry two independent expectations: a Roslyn `SyntaxKind` shape verdict
 for the intended C# idiom, and a compile-back opcode verdict for semantic

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -172,8 +172,7 @@ The source probe also supports `--json` for machine-readable census rows. The
 `reason` field classifies valid-but-different rows by the source-fidelity
 frontier and compile-back status, for example
 `valid_different.compiler_lowering.iterator.opcode_diff`,
-`valid_different.known_compiler_option.checked_context`,
-`valid_different.known_standalone_context.unsafe_residual`, or
+`valid_different.known_compiler_option.checked_context`, or
 `valid_different.semantic_opcode_diff.unsafe_residual`.
 Rows may carry two independent expectations: a Roslyn `SyntaxKind` shape verdict
 for the intended C# idiom, and a compile-back opcode verdict for semantic

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -788,7 +788,7 @@ static class ReturnToSenderSourceProbe
 
         var shape = SourceDifferenceShape(expected, actual);
         if (status == FidelityCheck.CompileBackStatus.Exact
-            && TryKnownExactDifference(shape, out var knownReason, out var knownDetail))
+            && TryKnownExactDifference(expected, actual, shape, out var knownReason, out var knownDetail))
         {
             detail = knownDetail;
             return knownReason;
@@ -809,23 +809,57 @@ static class ReturnToSenderSourceProbe
         return reason;
     }
 
-    static bool TryKnownExactDifference(string shape, out string reason, out string detail)
+    static bool TryKnownExactDifference(string expected, string actual, string shape, out string reason, out string detail)
     {
         switch (shape)
         {
-            case "source_shape_frontier.checked_context":
+            case "source_shape_frontier.checked_context" when ContextStrippedBodiesMatch(expected, actual):
                 reason = "valid_different.known_compiler_option.checked_context";
                 detail = "decompiled body is Roslyn-valid and compile-back exact; the source delta is an intentional checked-context spelling caused by standalone compile-back losing the fixture project's checked arithmetic option";
-                return true;
-            case "source_shape_frontier.unsafe_residual":
-                reason = "valid_different.known_standalone_context.unsafe_residual";
-                detail = "decompiled body is Roslyn-valid and compile-back exact; the source delta is an intentional standalone-context spelling for unsafe or residual operations required by the reconstructed compile-back unit";
                 return true;
             default:
                 reason = "";
                 detail = "";
                 return false;
         }
+    }
+
+    static bool ContextStrippedBodiesMatch(string expected, string actual)
+        => NormalizeBody(CheckedContextStrippedBody(expected)) == NormalizeBody(CheckedContextStrippedBody(actual));
+
+    static string CheckedContextStrippedBody(string body)
+    {
+        var tree = CSharpSyntaxTree.ParseText("class __Probe { void __M() {" + Environment.NewLine + body + Environment.NewLine + "} }");
+        var method = tree.GetCompilationUnitRoot()
+            .DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .FirstOrDefault();
+        if (method?.Body is not { } methodBody)
+            return body;
+
+        return string.Join(Environment.NewLine, FlattenCheckedStatements(methodBody.Statements).Select(statement => statement.ToFullString()));
+    }
+
+    static IEnumerable<StatementSyntax> FlattenCheckedStatements(SyntaxList<StatementSyntax> statements)
+    {
+        var checkedRewriter = new CheckedExpressionRemover();
+        foreach (var statement in statements)
+        {
+            if (statement is CheckedStatementSyntax checkedStatement)
+            {
+                foreach (var inner in FlattenCheckedStatements(checkedStatement.Block.Statements))
+                    yield return inner;
+                continue;
+            }
+
+            yield return (StatementSyntax)(checkedRewriter.Visit(statement) ?? statement);
+        }
+    }
+
+    sealed class CheckedExpressionRemover : CSharpSyntaxRewriter
+    {
+        public override SyntaxNode? VisitCheckedExpression(CheckedExpressionSyntax node)
+            => Visit(node.Expression) ?? node.Expression;
     }
 
     static string SourceDifferenceShape(string expected, string actual)

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -787,6 +787,13 @@ static class ReturnToSenderSourceProbe
         }
 
         var shape = SourceDifferenceShape(expected, actual);
+        if (status == FidelityCheck.CompileBackStatus.Exact
+            && TryKnownExactDifference(shape, out var knownReason, out var knownDetail))
+        {
+            detail = knownDetail;
+            return knownReason;
+        }
+
         string statusId = status == FidelityCheck.CompileBackStatus.OpcodeDiff
             ? "opcode_diff"
             : status == FidelityCheck.CompileBackStatus.Exact
@@ -800,6 +807,25 @@ static class ReturnToSenderSourceProbe
                 : $"valid_different.{shape}.{statusId}";
         detail = $"decompiled body is Roslyn-valid but differs from the fixture source slice; classification={shape}; compile-back={status}";
         return reason;
+    }
+
+    static bool TryKnownExactDifference(string shape, out string reason, out string detail)
+    {
+        switch (shape)
+        {
+            case "source_shape_frontier.checked_context":
+                reason = "valid_different.known_compiler_option.checked_context";
+                detail = "decompiled body is Roslyn-valid and compile-back exact; the source delta is an intentional checked-context spelling caused by standalone compile-back losing the fixture project's checked arithmetic option";
+                return true;
+            case "source_shape_frontier.unsafe_residual":
+                reason = "valid_different.known_standalone_context.unsafe_residual";
+                detail = "decompiled body is Roslyn-valid and compile-back exact; the source delta is an intentional standalone-context spelling for unsafe or residual operations required by the reconstructed compile-back unit";
+                return true;
+            default:
+                reason = "";
+                detail = "";
+                return false;
+        }
     }
 
     static string SourceDifferenceShape(string expected, string actual)

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -813,7 +813,9 @@ static class ReturnToSenderSourceProbe
     {
         switch (shape)
         {
-            case "source_shape_frontier.checked_context" when ContextStrippedBodiesMatch(expected, actual):
+            case "source_shape_frontier.checked_context" when !ContainsCommentTrivia(expected)
+                && !ContainsCommentTrivia(actual)
+                && ContextStrippedBodiesMatch(expected, actual):
                 reason = "valid_different.known_compiler_option.checked_context";
                 detail = "decompiled body is Roslyn-valid and compile-back exact; the source delta is an intentional checked-context spelling caused by standalone compile-back losing the fixture project's checked arithmetic option";
                 return true;
@@ -822,6 +824,14 @@ static class ReturnToSenderSourceProbe
                 detail = "";
                 return false;
         }
+    }
+
+    static bool ContainsCommentTrivia(string body)
+    {
+        var tree = CSharpSyntaxTree.ParseText("class __Probe { void __M() {" + Environment.NewLine + body + Environment.NewLine + "} }");
+        return tree.GetCompilationUnitRoot()
+            .DescendantTrivia(descendIntoTrivia: true)
+            .Any(trivia => trivia.IsKind(SyntaxKind.SingleLineCommentTrivia) || trivia.IsKind(SyntaxKind.MultiLineCommentTrivia));
     }
 
     static bool ContextStrippedBodiesMatch(string expected, string actual)

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -831,7 +831,11 @@ static class ReturnToSenderSourceProbe
         var tree = CSharpSyntaxTree.ParseText("class __Probe { void __M() {" + Environment.NewLine + body + Environment.NewLine + "} }");
         return tree.GetCompilationUnitRoot()
             .DescendantTrivia(descendIntoTrivia: true)
-            .Any(trivia => trivia.IsKind(SyntaxKind.SingleLineCommentTrivia) || trivia.IsKind(SyntaxKind.MultiLineCommentTrivia));
+            .Any(trivia =>
+                trivia.IsKind(SyntaxKind.SingleLineCommentTrivia)
+                || trivia.IsKind(SyntaxKind.MultiLineCommentTrivia)
+                || trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia)
+                || trivia.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia));
     }
 
     static bool ContextStrippedBodiesMatch(string expected, string actual)

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -847,27 +847,37 @@ static class ReturnToSenderSourceProbe
         if (method?.Body is not { } methodBody)
             return body;
 
-        return string.Join(Environment.NewLine, FlattenCheckedStatements(methodBody.Statements).Select(statement => statement.ToFullString()));
+        var rewrittenBody = new CheckedContextRemover().Visit(methodBody) as BlockSyntax;
+        return rewrittenBody is null
+            ? body
+            : string.Join(Environment.NewLine, rewrittenBody.Statements.Select(statement => statement.ToFullString()));
     }
 
-    static IEnumerable<StatementSyntax> FlattenCheckedStatements(SyntaxList<StatementSyntax> statements)
+    sealed class CheckedContextRemover : CSharpSyntaxRewriter
     {
-        var checkedRewriter = new CheckedExpressionRemover();
-        foreach (var statement in statements)
+        static readonly SyntaxAnnotation s_unwrappedCheckedBlock = new("unwrapped-checked-block");
+
+        public override SyntaxNode? VisitBlock(BlockSyntax node)
         {
-            if (statement is CheckedStatementSyntax checkedStatement)
+            var visited = (BlockSyntax)base.VisitBlock(node)!;
+            var statements = new List<StatementSyntax>(visited.Statements.Count);
+            foreach (var statement in visited.Statements)
             {
-                foreach (var inner in FlattenCheckedStatements(checkedStatement.Block.Statements))
-                    yield return inner;
-                continue;
+                if (statement is BlockSyntax block && block.HasAnnotation(s_unwrappedCheckedBlock))
+                    statements.AddRange(block.Statements);
+                else
+                    statements.Add(statement);
             }
 
-            yield return (StatementSyntax)(checkedRewriter.Visit(statement) ?? statement);
+            return visited.WithStatements(SyntaxFactory.List(statements));
         }
-    }
 
-    sealed class CheckedExpressionRemover : CSharpSyntaxRewriter
-    {
+        public override SyntaxNode? VisitCheckedStatement(CheckedStatementSyntax node)
+        {
+            var visited = (BlockSyntax)Visit(node.Block)!;
+            return visited.WithAdditionalAnnotations(s_unwrappedCheckedBlock);
+        }
+
         public override SyntaxNode? VisitCheckedExpression(CheckedExpressionSyntax node)
             => Visit(node.Expression) ?? node.Expression;
     }


### PR DESCRIPTION
## Summary

Refines the RTS source-probe valid-different census by moving only proven compile-back exact checked-context rows into an intentional known bucket:

- `valid_different.known_compiler_option.checked_context`

The classifier now verifies that stripping checked context accounts for the body delta before assigning the known bucket. Opcode-diff rows stay in `valid_different.semantic_opcode_diff.*`, and unsafe-residual exact rows remain in `valid_different.source_shape_frontier.unsafe_residual.exact` until a sharper discriminator can prove a standalone-context-only delta.

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --nologo -v:minimal`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/ReturnToSenderFixtureCatalogTests/*Classifies*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/ReturnToSenderFixtureCatalogTests/ReturnToSenderSourceProbe_KeepsCheckedContextOpcodeDiffActionable"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/ReturnToSenderFixtureCatalogTests/ReturnToSenderSourceProbe_DoesNotHideResidualInsideCheckedContext"`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures decompiler --return-to-sender-source-probe --cap 10000 --max-examples 260`
  - `ValidMatch: 97`
  - `ValidDifferent: 107`
  - `Invalid: 0`
  - new known bucket: `known_compiler_option.checked_context` 13
  - preserved actionable/frontier buckets: `source_shape_frontier.unsafe_residual.exact` 16, `semantic_opcode_diff.checked_context` 6, `semantic_opcode_diff.unsafe_residual` 5, `source_shape_frontier.checked_context.exact` 1
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures decompiler --return-to-sender-source-probe --cap 20 --max-examples 3 --json > /tmp/rts-source-probe-known-deltas-r4.json && dotnet run /tmp/check-rts-json.cs`
- `npx markdownlint-cli --fix tools/DecompilerHarness/README.md && npx markdownlint-cli tools/DecompilerHarness/README.md`

## Notes

Harness-only measurement refinement; product decompiler output is unchanged. Adversarial review requested before ready-to-merge.
