### PR TITLE
Type-shape oracle + Not My Type census + RTS supported-type migration (#2548 finding #1)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeShapeClassificationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeShapeClassificationTests.cs
@@ -1,0 +1,65 @@
+using System.Reflection.Metadata;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class TypeShapeClassificationTests
+{
+    static string CoreLibPath => typeof(object).Assembly.Location;
+
+    // typeof(...) emits TypeReference rows into THIS test assembly, so opening it
+    // and classifying those references exercises the cross-assembly resolution path.
+    static readonly Type[] CrossAssemblyAnchors =
+        [typeof(DateTime), typeof(DayOfWeek), typeof(Action), typeof(IDisposable), typeof(string)];
+
+    static TypeShapeKind ClassifyDefinition(MetadataSource source, string fullTypeName)
+    {
+        foreach (var handle in source.Reader.TypeDefinitions)
+        {
+            if (source.Reader.GetFullTypeName(source.Reader.GetTypeDefinition(handle)) == fullTypeName)
+                return source.ClassifyType(handle);
+        }
+        return TypeShapeKind.Unknown;
+    }
+
+    static TypeShapeKind ClassifyReference(MetadataSource source, string fullTypeName)
+    {
+        foreach (var handle in source.Reader.TypeReferences)
+        {
+            if (source.Reader.GetFullTypeName(source.Reader.GetTypeReference(handle)) == fullTypeName)
+                return source.ClassifyType((EntityHandle)handle);
+        }
+        return TypeShapeKind.Unknown;
+    }
+
+    [Theory]
+    [InlineData("System.String", TypeShapeKind.Class)]
+    [InlineData("System.DateTime", TypeShapeKind.Struct)]
+    [InlineData("System.DayOfWeek", TypeShapeKind.Enum)]
+    [InlineData("System.IDisposable", TypeShapeKind.Interface)]
+    [InlineData("System.Action", TypeShapeKind.Delegate)]
+    public void ClassifyType_SameAssembly_ResolvesEveryKind(string fullName, TypeShapeKind expected)
+    {
+        using var source = MetadataSource.Open(CoreLibPath);
+        Assert.Equal(expected, ClassifyDefinition(source, fullName));
+    }
+
+    [Theory]
+    [InlineData("System.DateTime", TypeShapeKind.Struct)]
+    [InlineData("System.DayOfWeek", TypeShapeKind.Enum)]
+    [InlineData("System.Action", TypeShapeKind.Delegate)]
+    [InlineData("System.IDisposable", TypeShapeKind.Interface)]
+    [InlineData("System.String", TypeShapeKind.Class)]
+    public void ClassifyType_CrossAssembly_ResolvesCorelibShape(string fullName, TypeShapeKind expected)
+    {
+        Assert.Equal(5, CrossAssemblyAnchors.Length); // keep the typeof anchors emitted
+        // The default sibling resolver cannot find corelib beside the test assembly,
+        // so use the trusted-platform resolver (as the other cross-assembly tests do).
+        using var source = MetadataSource.Open(
+            typeof(TypeShapeClassificationTests).Assembly.Location,
+            null,
+            TestAssemblyReferenceResolvers.TrustedPlatformAssemblies());
+        Assert.Equal(expected, ClassifyReference(source, fullName));
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/TypeShapeClassificationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeShapeClassificationTests.cs
@@ -1,4 +1,6 @@
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Metadata;
 
@@ -7,6 +9,14 @@ namespace ILInspector.Decompiler.Tests;
 public class TypeShapeClassificationTests
 {
     static string CoreLibPath => typeof(object).Assembly.Location;
+
+    // A TypeSpec-parented constructor (newobj Nullable<int>::.ctor): the local
+    // signature carries ELEMENT_TYPE_VALUETYPE, exercising the hint fallback when
+    // the definition cannot be resolved cross-assembly.
+    static class NullableCtorFixture
+    {
+        public static int? Make() => new int?(1);
+    }
 
     // typeof(...) emits TypeReference rows into THIS test assembly, so opening it
     // and classifying those references exercises the cross-assembly resolution path.
@@ -61,5 +71,47 @@ public class TypeShapeClassificationTests
             null,
             TestAssemblyReferenceResolvers.TrustedPlatformAssemblies());
         Assert.Equal(expected, ClassifyReference(source, fullName));
+    }
+
+    [Fact]
+    public void ClassifyConstructedType_TypeSpecValueType_UsesLocalHintWithoutResolver()
+    {
+        // GPT-5.5 review probe: new int?(1) constructs Nullable<int> via a TypeSpec-parented
+        // ctor token. With no platform resolver the corelib definition cannot be located, so the
+        // classifier must fall back to the local ELEMENT_TYPE_VALUETYPE hint rather than Unknown.
+        string path = typeof(TypeShapeClassificationTests).Assembly.Location;
+        using var source = MetadataSource.Open(path, null, TestAssemblyReferenceResolvers.None);
+        using var pe = new PEReader(File.OpenRead(path));
+        var reader = pe.GetMetadataReader();
+
+        int token = FindNewobjToken(reader, pe, nameof(NullableCtorFixture), nameof(NullableCtorFixture.Make));
+        Assert.Equal(TypeShapeKind.Struct, source.ClassifyConstructedType(token));
+    }
+
+    static int FindNewobjToken(MetadataReader reader, PEReader pe, string typeName, string methodName)
+    {
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            if (reader.GetString(typeDef.Name) != typeName)
+                continue;
+            foreach (var methodHandle in typeDef.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (reader.GetString(method.Name) != methodName || method.RelativeVirtualAddress == 0)
+                    continue;
+                var il = pe.GetMethodBody(method.RelativeVirtualAddress).GetILReader();
+                var bytes = il.ReadBytes(il.Length);
+                for (int i = 0; i + 4 < bytes.Length; i++)
+                {
+                    if (bytes[i] != 0x73) // newobj
+                        continue;
+                    int candidate = BitConverter.ToInt32(bytes, i + 1);
+                    if (MetadataTokens.EntityHandle(candidate).Kind is HandleKind.MemberReference or HandleKind.MethodDefinition)
+                        return candidate;
+                }
+            }
+        }
+        throw new InvalidOperationException($"newobj token not found in {typeName}.{methodName}.");
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
@@ -466,6 +466,45 @@ internal sealed class CrossAssemblyTypeResolver
         }
     }
 
+    /// <summary>
+    /// The full <see cref="TypeShapeKind"/> of a cross-assembly type, read from
+    /// its located definition (base type + interface flag). Mirrors
+    /// <see cref="ReadValueTypeHint"/> but preserves the enum/delegate/interface
+    /// distinctions the coarse <see cref="ValueTypeHint"/> folds away. Returns
+    /// <see cref="TypeShapeKind.Unknown"/> when the definition cannot be located.
+    /// </summary>
+    public TypeShapeKind ClassifyShape(TypeRef type)
+    {
+        try
+        {
+            if (Locate(type) is not { } location
+                || _context.Open(location) is not { } assembly
+                || !assembly.TryGetType(location.FullTypeName, out var handle))
+            {
+                return TypeShapeKind.Unknown;
+            }
+
+            var typeDef = assembly.Reader.GetTypeDefinition(handle);
+            if ((typeDef.Attributes & System.Reflection.TypeAttributes.Interface) != 0)
+                return TypeShapeKind.Interface;
+
+            // A struct's base is System.ValueType (System.Enum for an enum), a
+            // delegate's is System.MulticastDelegate; a nil/TypeSpec base (object
+            // or a generic class base) reads as null and is a reference class.
+            return BaseTypeName(assembly.Reader, typeDef.BaseType) switch
+            {
+                "System.Enum" => TypeShapeKind.Enum,
+                "System.ValueType" => TypeShapeKind.Struct,
+                "System.MulticastDelegate" or "System.Delegate" => TypeShapeKind.Delegate,
+                _ => TypeShapeKind.Class,
+            };
+        }
+        catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException)
+        {
+            return TypeShapeKind.Unknown;
+        }
+    }
+
     ValueTypeHint ResolveValueTypeHint(TypeRef type)
     {
         if (_valueTypeCache.TryGetValue(type, out var cached))

--- a/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
@@ -12,6 +12,18 @@ public enum StackFamily { I4, I8, F, I, O }
 public enum TypeShape { Unknown, Reference, ValueType, Enum }
 
 /// <summary>
+/// The complete C#-relevant classification of a type — richer than
+/// <see cref="TypeShape"/>, which folds interface and delegate into
+/// <see cref="TypeShape.Reference"/> because the pipeline's evaluation-stack
+/// purposes never need that distinction. This is the consumer-facing projection
+/// (<see cref="MetadataSource.ClassifyType(TypeRef)"/>) built from the same
+/// base-type reads as <see cref="TypeShape"/> — not a parallel resolver.
+/// <see cref="Unknown"/> covers the unresolved cases: a cross-assembly type with
+/// no locatable definition, or a non-type handle.
+/// </summary>
+public enum TypeShapeKind { Unknown, Class, Struct, Enum, Interface, Delegate }
+
+/// <summary>
 /// The single home for type-family classification (review consolidation:
 /// this knowledge previously lived in the importer's slot merging, the
 /// structuring pass's float detection, and three printer spellings). When

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -293,6 +293,28 @@ public sealed class MetadataSource : IDisposable
     {
         if (type.Kind is TypeRefKind.SzArray or TypeRefKind.Array)
             return TypeShapeKind.Class;
+
+        var resolved = ResolveShapeKind(type);
+        if (resolved != TypeShapeKind.Unknown)
+            return resolved;
+
+        // Resolution fails for a cross-assembly type outside the reference closure
+        // (e.g. a TypeSpec-constructed Nullable<int> opened with no platform
+        // resolver). Fall back to the local signature hint the decoded TypeRef
+        // carries — the ELEMENT_TYPE_VALUETYPE/CLASS byte — so this stays at least
+        // as faithful as the legacy single-assembly newobj classifier it replaces.
+        // The byte cannot distinguish enum from struct, so a value-type hint reports
+        // Struct (constructed types are never enums).
+        return type.DeclaredValueTypeHint switch
+        {
+            ValueTypeHint.ValueType => TypeShapeKind.Struct,
+            ValueTypeHint.ReferenceType => TypeShapeKind.Class,
+            _ => TypeShapeKind.Unknown,
+        };
+    }
+
+    TypeShapeKind ResolveShapeKind(TypeRef type)
+    {
         if (NamedDefinition(type) is not { } definition || string.IsNullOrEmpty(definition.Assembly))
             return TypeShapeKind.Unknown;
 

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using ILInspector.Metadata;
 
@@ -260,6 +261,7 @@ public sealed class MetadataSource : IDisposable
     HashSet<TypeRef>? _interfaces;
     Dictionary<TypeRef, ImmutableArray<TypeRef>>? _interfaceImpls;
     HashSet<TypeRef>? _unionTypes;
+    HashSet<TypeRef>? _delegates;
 
     /// <summary>
     /// The C# shape of a type defined in THIS assembly — enum, struct, or
@@ -275,6 +277,76 @@ public sealed class MetadataSource : IDisposable
             return TypeShape.Unknown;
         EnsureTypeMaps();
         return _shapes!.GetValueOrDefault(type, TypeShape.Unknown);
+    }
+
+    /// <summary>
+    /// The full <see cref="TypeShapeKind"/> of a type — class, struct, enum,
+    /// interface, or delegate — resolved same-assembly from the type maps or,
+    /// cross-assembly, through the metadata context. <see cref="TypeShapeKind.Unknown"/>
+    /// when no definition resolves (e.g. a cross-assembly type outside the loaded
+    /// reference closure) or the type is not a named definition. The single product
+    /// entry point that replaces per-consumer base-chain re-derivation; a richer
+    /// projection over the same reads as <see cref="ResolveShape"/>, not a parallel
+    /// resolver.
+    /// </summary>
+    public TypeShapeKind ClassifyType(TypeRef type)
+    {
+        if (type.Kind is TypeRefKind.SzArray or TypeRefKind.Array)
+            return TypeShapeKind.Class;
+        if (NamedDefinition(type) is not { } definition || string.IsNullOrEmpty(definition.Assembly))
+            return TypeShapeKind.Unknown;
+
+        if (definition.Assembly == TypeRefDecoder.Canonical(AssemblyName))
+        {
+            EnsureTypeMaps();
+            if (_delegates!.Contains(definition))
+                return TypeShapeKind.Delegate;
+            if (_interfaces!.Contains(definition))
+                return TypeShapeKind.Interface;
+            return _shapes!.GetValueOrDefault(definition, TypeShape.Unknown) switch
+            {
+                TypeShape.Enum => TypeShapeKind.Enum,
+                TypeShape.ValueType => TypeShapeKind.Struct,
+                TypeShape.Reference => TypeShapeKind.Class,
+                _ => TypeShapeKind.Unknown,
+            };
+        }
+
+        return CrossAssembly.ClassifyShape(definition);
+    }
+
+    /// <summary>
+    /// <see cref="ClassifyType(TypeRef)"/> for a raw type handle
+    /// (<c>TypeDefinition</c>/<c>TypeReference</c>/<c>TypeSpecification</c>).
+    /// </summary>
+    public TypeShapeKind ClassifyType(EntityHandle handle)
+    {
+        TypeRef? type = handle.Kind switch
+        {
+            HandleKind.TypeDefinition => TypeRefDecoder.Instance.GetTypeFromDefinition(Reader, (TypeDefinitionHandle)handle, 0),
+            HandleKind.TypeReference => TypeRefDecoder.Instance.GetTypeFromReference(Reader, (TypeReferenceHandle)handle, 0),
+            HandleKind.TypeSpecification => TypeRefDecoder.Instance.GetTypeFromSpecification(Reader, new GenericScope([], []), (TypeSpecificationHandle)handle, 0),
+            _ => null,
+        };
+        return type is null ? TypeShapeKind.Unknown : ClassifyType(type);
+    }
+
+    /// <summary>
+    /// The <see cref="TypeShapeKind"/> of the type constructed/referenced by a
+    /// constructor token: the declaring type of a <c>MethodDefinition</c> or
+    /// <c>MemberReference</c> token (a <c>newobj</c> target).
+    /// <see cref="TypeShapeKind.Unknown"/> for any other token kind.
+    /// </summary>
+    public TypeShapeKind ClassifyConstructedType(int metadataToken)
+    {
+        var handle = MetadataTokens.EntityHandle(metadataToken);
+        EntityHandle typeHandle = handle.Kind switch
+        {
+            HandleKind.MethodDefinition => Reader.GetMethodDefinition((MethodDefinitionHandle)handle).GetDeclaringType(),
+            HandleKind.MemberReference => Reader.GetMemberReference((MemberReferenceHandle)handle).Parent,
+            _ => default,
+        };
+        return typeHandle.IsNil ? TypeShapeKind.Unknown : ClassifyType(typeHandle);
     }
 
     internal bool IsUnionType(TypeRef type)
@@ -322,6 +394,7 @@ public sealed class MetadataSource : IDisposable
         var interfaces = new HashSet<TypeRef>();
         var interfaceImpls = new Dictionary<TypeRef, ImmutableArray<TypeRef>>();
         var unionTypes = new HashSet<TypeRef>();
+        var delegates = new HashSet<TypeRef>();
         foreach (var handle in Reader.TypeDefinitions)
         {
             var typeDef = Reader.GetTypeDefinition(handle);
@@ -338,6 +411,9 @@ public sealed class MetadataSource : IDisposable
             bases[key] = DecodeBaseType(typeDef.BaseType, scope);
             if ((typeDef.Attributes & System.Reflection.TypeAttributes.Interface) != 0)
                 interfaces.Add(key);
+            if (!typeDef.BaseType.IsNil
+                && BaseName(typeDef.BaseType) is ("System", "MulticastDelegate") or ("System", "Delegate"))
+                delegates.Add(key);
             var impls = DecodeInterfaces(typeDef, scope);
             if (MethodDefinitionFacts.HasUnionAttribute(Reader, typeDef)
                 && impls.Any(IsUnionInterface))
@@ -356,6 +432,7 @@ public sealed class MetadataSource : IDisposable
         _interfaces = interfaces;
         _interfaceImpls = interfaceImpls;
         _unionTypes = unionTypes;
+        _delegates = delegates;
         _shapes = shapes;   // assign last: ResolveShape gates on _shapes
         }
     }

--- a/tools/DecompilerHarness/NotMyTypeCensus.cs
+++ b/tools/DecompilerHarness/NotMyTypeCensus.cs
@@ -1,0 +1,408 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Text.Json;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
+using Markout;
+using Markout.Formatting;
+
+namespace ILInspector.DecompilerHarness;
+
+// "Not My Type" (NMT) type-shape equivalence census: does the product type-shape oracle
+// (MetadataSource.ClassifyType) agree with the legacy base-name/interface classifier that
+// the harness sites (ReturnToSender.IsSupported*, FidelityCheck.ShapeOf, AnnotationCheck)
+// each re-derive?
+//   Axis A (agreement): over same-assembly TypeDefinitions the oracle and the legacy
+//     classifier read the same local base type, so they must agree. Divergence is a real
+//     discrepancy to fix BEFORE a producer is retired (the Return Address landing pattern).
+//   Axis B (recovery): over cross-assembly TypeReferences the single-assembly legacy walk
+//     can only answer Unknown (it cannot open the other PE — the documented AnnotationCheck
+//     value-type gap). "Recovered" counts the refs the corpus-aware oracle resolves to a
+//     definite kind, quantifying the gap the oracle closes.
+// A thin observer: it embeds no shape knowledge beyond the legacy base-name rule it exists
+// to retire, and compares product-produced classifications.
+
+internal enum NmtCensusFormat { Markdown, Tsv, Jsonl }
+
+internal sealed record NmtCensusExample(string Type, string Oracle, string Legacy);
+
+internal sealed record NmtCensusAssembly(
+    string Name,
+    bool Opened,
+    int Definitions,
+    int Agree,
+    int Diverge,
+    int CrossRefs,
+    int Recovered,
+    IReadOnlyList<NmtCensusExample> Examples);
+
+internal sealed record NmtCensusReport(IReadOnlyList<NmtCensusAssembly> Assemblies);
+
+// Committed-baseline snapshot for the drift gate (mirrors ReturnAddressCensus): the same-assembly
+// agree rate is a floor that must stay at/above baseline; refresh upward when it legitimately improves.
+internal sealed record NmtCensusSnapshot(
+    int SchemaVersion,
+    string Description,
+    DateTimeOffset GeneratedUtc,
+    NmtCensusTolerances? Tolerances,
+    int Definitions,
+    int Agree,
+    int Diverge,
+    int CrossRefs,
+    int Recovered,
+    int AgreeBasisPoints,
+    IReadOnlyList<NmtCensusAssemblySnapshot> Assemblies);
+
+internal sealed record NmtCensusAssemblySnapshot(string Assembly, int Definitions, int Agree, int Diverge, int AgreeBasisPoints);
+
+internal sealed record NmtCensusTolerances(int AgreeRateDropBasisPoints)
+{
+    // Same-assembly the oracle and legacy classifier read the same base, so the floor is a hard
+    // 100%: any drop (>0 bps) is a real regression, not corpus-composition drift.
+    public static readonly NmtCensusTolerances Default = new(AgreeRateDropBasisPoints: 0);
+}
+
+internal static class NotMyTypeCensus
+{
+    public static int Run(
+        IReadOnlyList<string> assemblies,
+        int maxExamples,
+        NmtCensusFormat format,
+        string? emitSnapshot = null,
+        string? diffBaseline = null)
+    {
+        var report = Measure(assemblies, maxExamples);
+        Console.Write(Format(report, maxExamples, format));
+
+        if (emitSnapshot is null && diffBaseline is null)
+            return 0;
+
+        var snapshot = BuildSnapshot(report);
+
+        if (emitSnapshot is not null)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(emitSnapshot)) ?? ".");
+            File.WriteAllText(emitSnapshot, JsonSerializer.Serialize(snapshot, JsonOptions()));
+            Console.Error.WriteLine($"Wrote not-my-type baseline: {emitSnapshot}");
+        }
+
+        if (diffBaseline is null)
+            return 0;
+
+        var baseline = JsonSerializer.Deserialize<NmtCensusSnapshot>(File.ReadAllText(diffBaseline), JsonOptions())
+            ?? throw new InvalidOperationException($"Could not read not-my-type baseline '{diffBaseline}'.");
+        var regressions = Compare(baseline, snapshot);
+        if (regressions.Count == 0)
+        {
+            Console.Error.WriteLine($"Not-my-type census matched baseline: {diffBaseline}");
+            return 0;
+        }
+
+        Console.Error.WriteLine("Not-my-type census regressions:");
+        foreach (var regression in regressions)
+            Console.Error.WriteLine($"- {regression}");
+        return 1;
+    }
+
+    static NmtCensusReport Measure(IReadOnlyList<string> assemblies, int maxExamples)
+    {
+        // One shared corpus context so cross-assembly references (CoreLib, corpus siblings)
+        // resolve for the oracle's cross-assembly path.
+        using var context = CorpusMetadata.Create(assemblies);
+        var rows = new List<NmtCensusAssembly>(assemblies.Count);
+        foreach (var path in assemblies)
+            rows.Add(MeasureOne(path, context, maxExamples));
+        return new NmtCensusReport(rows);
+    }
+
+    static NmtCensusAssembly MeasureOne(string path, MetadataContext context, int maxExamples)
+    {
+        var name = Path.GetFileName(path);
+        try
+        {
+            using var pe = new PEReader(File.OpenRead(path));
+            if (!pe.HasMetadata)
+                return new NmtCensusAssembly(name, Opened: false, 0, 0, 0, 0, 0, []);
+            var reader = pe.GetMetadataReader();
+            using var source = MetadataSource.Open(path, context: context);
+
+            int definitions = 0, agree = 0, diverge = 0;
+            var examples = new List<NmtCensusExample>();
+
+            // Axis A: same-assembly definitions — oracle must agree with the legacy classifier.
+            foreach (var handle in reader.TypeDefinitions)
+            {
+                var typeDef = reader.GetTypeDefinition(handle);
+                TypeShapeKind oracle, legacy;
+                try
+                {
+                    oracle = source.ClassifyType((EntityHandle)handle);
+                    legacy = LegacyClassify(reader, typeDef);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                definitions++;
+                if (oracle == legacy)
+                {
+                    agree++;
+                }
+                else
+                {
+                    diverge++;
+                    if (examples.Count < maxExamples)
+                        examples.Add(new NmtCensusExample(reader.GetFullTypeName(typeDef), oracle.ToString(), legacy.ToString()));
+                }
+            }
+
+            // Axis B: cross-assembly references — the single-assembly legacy walk answers Unknown;
+            // count the refs the corpus-aware oracle recovers to a definite kind.
+            int crossRefs = 0, recovered = 0;
+            foreach (var refHandle in reader.TypeReferences)
+            {
+                if (reader.GetTypeReference(refHandle).ResolutionScope.Kind is not (HandleKind.AssemblyReference or HandleKind.TypeReference))
+                    continue;
+                crossRefs++;
+                try
+                {
+                    if (source.ClassifyType((EntityHandle)refHandle) != TypeShapeKind.Unknown)
+                        recovered++;
+                }
+                catch
+                {
+                    // A malformed ref never crashes the sweep; it simply counts as unrecovered.
+                }
+            }
+
+            return new NmtCensusAssembly(name, Opened: true, definitions, agree, diverge, crossRefs, recovered, examples);
+        }
+        catch (Exception)
+        {
+            return new NmtCensusAssembly(name, Opened: false, 0, 0, 0, 0, 0, []);
+        }
+    }
+
+    /// <summary>
+    /// The legacy base-name/interface classifier that <c>ReturnToSender.IsSupported*</c>,
+    /// <c>FidelityCheck.ShapeOf</c>, and <c>AnnotationCheck</c> each re-derive — the producer
+    /// this census exists to retire. Same-assembly only: a cross-assembly base (or any TypeSpec
+    /// base) reads as <see cref="TypeShapeKind.Class"/> here, exactly the imprecision the oracle removes.
+    /// </summary>
+    static TypeShapeKind LegacyClassify(MetadataReader reader, TypeDefinition typeDef)
+    {
+        if ((typeDef.Attributes & TypeAttributes.Interface) != 0)
+            return TypeShapeKind.Interface;
+        if (typeDef.BaseType.IsNil)
+            return TypeShapeKind.Class;
+        string baseName = typeDef.BaseType.Kind switch
+        {
+            HandleKind.TypeReference => reader.GetFullTypeName(reader.GetTypeReference((TypeReferenceHandle)typeDef.BaseType)),
+            HandleKind.TypeDefinition => reader.GetFullTypeName(reader.GetTypeDefinition((TypeDefinitionHandle)typeDef.BaseType)),
+            _ => "",
+        };
+        return baseName switch
+        {
+            "System.Enum" => TypeShapeKind.Enum,
+            "System.ValueType" => TypeShapeKind.Struct,
+            "System.MulticastDelegate" or "System.Delegate" => TypeShapeKind.Delegate,
+            _ => TypeShapeKind.Class,
+        };
+    }
+
+    static string Format(NmtCensusReport report, int maxExamples, NmtCensusFormat format)
+    {
+        var output = new StringWriter();
+        if (format == NmtCensusFormat.Markdown)
+        {
+            MarkoutSerializer.Serialize(
+                BuildMarkdownView(report, maxExamples),
+                output,
+                new MarkdownFormatter(),
+                NmtCensusViewContext.Default,
+                new MarkoutWriterOptions());
+        }
+        else
+        {
+            MarkoutSerializer.Serialize(
+                BuildTableView(report, maxExamples),
+                output,
+                new TableFormatter(showHeader: true),
+                NmtCensusViewContext.Default,
+                format == NmtCensusFormat.Tsv
+                    ? new MarkoutWriterOptions { TableMode = MarkoutTableMode.Tsv }
+                    : new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl });
+        }
+
+        string rendered = output.ToString();
+        return format == NmtCensusFormat.Jsonl
+            ? string.Join(Environment.NewLine, rendered.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries)) + Environment.NewLine
+            : rendered;
+    }
+
+    static int TotalDefinitions(NmtCensusReport report) => report.Assemblies.Sum(a => a.Definitions);
+    static int TotalAgree(NmtCensusReport report) => report.Assemblies.Sum(a => a.Agree);
+    static int TotalDiverge(NmtCensusReport report) => report.Assemblies.Sum(a => a.Diverge);
+    static int TotalCrossRefs(NmtCensusReport report) => report.Assemblies.Sum(a => a.CrossRefs);
+    static int TotalRecovered(NmtCensusReport report) => report.Assemblies.Sum(a => a.Recovered);
+
+    static string Pct(int n, int total) => total == 0 ? "n/a" : $"{100.0 * n / total:0.00}%";
+
+    static NmtCensusSnapshot BuildSnapshot(NmtCensusReport report)
+    {
+        int definitions = TotalDefinitions(report), agree = TotalAgree(report), diverge = TotalDiverge(report);
+        return new NmtCensusSnapshot(
+            SchemaVersion: 1,
+            Description: "#2548 Not My Type type-shape equivalence census: same-assembly agreement between "
+                + "the product oracle (MetadataSource.ClassifyType) and the legacy base-name classifier the "
+                + "harness sites re-derive, plus cross-assembly reference recovery. Same-assembly agreement is a "
+                + "hard 100% floor; recovery is informational.",
+            GeneratedUtc: DateTimeOffset.UtcNow,
+            Tolerances: NmtCensusTolerances.Default,
+            Definitions: definitions,
+            Agree: agree,
+            Diverge: diverge,
+            CrossRefs: TotalCrossRefs(report),
+            Recovered: TotalRecovered(report),
+            AgreeBasisPoints: RateBasisPoints(agree, definitions),
+            Assemblies: report.Assemblies
+                .Where(a => a.Opened)
+                .OrderBy(a => a.Name, StringComparer.Ordinal)
+                .Select(a => new NmtCensusAssemblySnapshot(a.Name, a.Definitions, a.Agree, a.Diverge, RateBasisPoints(a.Agree, a.Definitions)))
+                .ToList());
+    }
+
+    static IReadOnlyList<string> Compare(NmtCensusSnapshot baseline, NmtCensusSnapshot current)
+    {
+        var regressions = new List<string>();
+        int tolerance = baseline.Tolerances?.AgreeRateDropBasisPoints ?? NmtCensusTolerances.Default.AgreeRateDropBasisPoints;
+
+        int drop = baseline.AgreeBasisPoints - current.AgreeBasisPoints;
+        if (drop > tolerance)
+            regressions.Add(
+                $"same-assembly agree rate dropped {FormatBps(drop)} ({FormatBps(baseline.AgreeBasisPoints)} -> "
+                + $"{FormatBps(current.AgreeBasisPoints)}), tolerance {FormatBps(tolerance)}");
+
+        return regressions;
+    }
+
+    static int RateBasisPoints(int part, int whole)
+        => whole <= 0 ? 0 : (int)Math.Round(10_000.0 * part / whole, MidpointRounding.AwayFromZero);
+
+    static string FormatBps(int basisPoints) => $"{basisPoints / 100.0:F2}%";
+
+    static JsonSerializerOptions JsonOptions()
+        => new() { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    static IReadOnlyList<(string Metric, string Value)> SummaryRows(NmtCensusReport report)
+    {
+        int definitions = TotalDefinitions(report), agree = TotalAgree(report), crossRefs = TotalCrossRefs(report);
+        return new (string, string)[]
+        {
+            ("assemblies", report.Assemblies.Count.ToString()),
+            ("opened", report.Assemblies.Count(a => a.Opened).ToString()),
+            ("definitions", definitions.ToString()),
+            ("agree", agree.ToString()),
+            ("agree rate", Pct(agree, definitions)),
+            ("diverge", TotalDiverge(report).ToString()),
+            ("cross-assembly refs", crossRefs.ToString()),
+            ("recovered", TotalRecovered(report).ToString()),
+            ("recovery rate", Pct(TotalRecovered(report), crossRefs)),
+        };
+    }
+
+    static NmtCensusMarkdownView BuildMarkdownView(NmtCensusReport report, int maxExamples)
+        => new()
+        {
+            Summary = SummaryRows(report).Select(r => new NmtCensusMetricRow(r.Metric, r.Value)).ToList(),
+            PerAssembly = report.Assemblies
+                .Where(a => a.Opened)
+                .Select(a => new NmtCensusAssemblyRow(a.Name, a.Definitions, a.Agree, a.Diverge, Pct(a.Agree, a.Definitions), a.CrossRefs, a.Recovered))
+                .ToList(),
+            Divergences = report.Assemblies
+                .SelectMany(a => a.Examples)
+                .Take(maxExamples)
+                .Select(e => new NmtCensusDivergenceRow(e.Type, e.Oracle, e.Legacy))
+                .ToList(),
+        };
+
+    static NmtCensusTableView BuildTableView(NmtCensusReport report, int maxExamples)
+        => new()
+        {
+            Summary = SummaryRows(report).Select(r => new NmtCensusSectionMetricRow("Summary", r.Metric, r.Value)).ToList(),
+            PerAssembly = report.Assemblies
+                .Where(a => a.Opened)
+                .Select(a => new NmtCensusSectionAssemblyRow("Per assembly", a.Name, a.Definitions, a.Agree, a.Diverge, Pct(a.Agree, a.Definitions), a.CrossRefs, a.Recovered))
+                .ToList(),
+            Divergences = report.Assemblies
+                .SelectMany(a => a.Examples)
+                .Take(maxExamples)
+                .Select(e => new NmtCensusSectionDivergenceRow("Divergences", e.Type, e.Oracle, e.Legacy))
+                .ToList(),
+        };
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
+internal sealed class NmtCensusMarkdownView
+{
+    [MarkoutIgnore]
+    public string Title => "Not My Type type-shape census";
+
+    [MarkoutSection(Name = "Summary")]
+    public List<NmtCensusMetricRow>? Summary { get; init; }
+
+    [MarkoutSection(Name = "Per assembly", EmptyText = "None")]
+    public List<NmtCensusAssemblyRow>? PerAssembly { get; init; }
+
+    [MarkoutSection(Name = "Divergences", EmptyText = "None - the oracle agrees with the legacy classifier on every same-assembly definition.")]
+    public List<NmtCensusDivergenceRow>? Divergences { get; init; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
+internal sealed class NmtCensusTableView
+{
+    [MarkoutIgnore]
+    public string Title => "Not My Type type-shape census";
+
+    [MarkoutSection(Name = "Summary")]
+    public List<NmtCensusSectionMetricRow>? Summary { get; init; }
+
+    [MarkoutSection(Name = "Per assembly")]
+    public List<NmtCensusSectionAssemblyRow>? PerAssembly { get; init; }
+
+    [MarkoutSection(Name = "Divergences")]
+    public List<NmtCensusSectionDivergenceRow>? Divergences { get; init; }
+}
+
+[MarkoutSerializable]
+internal sealed record NmtCensusMetricRow(string Metric, string Value);
+
+[MarkoutSerializable]
+internal sealed record NmtCensusSectionMetricRow(string Section, string Metric, string Value);
+
+[MarkoutSerializable]
+internal sealed record NmtCensusAssemblyRow(string Assembly, int Definitions, int Agree, int Diverge, [property: MarkoutPropertyName("Agree rate")] string AgreeRate, [property: MarkoutPropertyName("Cross refs")] int CrossRefs, int Recovered);
+
+[MarkoutSerializable]
+internal sealed record NmtCensusSectionAssemblyRow(string Section, string Assembly, int Definitions, int Agree, int Diverge, [property: MarkoutPropertyName("Agree rate")] string AgreeRate, [property: MarkoutPropertyName("Cross refs")] int CrossRefs, int Recovered);
+
+[MarkoutSerializable]
+internal sealed record NmtCensusDivergenceRow(string Type, string Oracle, string Legacy);
+
+[MarkoutSerializable]
+internal sealed record NmtCensusSectionDivergenceRow(string Section, string Type, string Oracle, string Legacy);
+
+[MarkoutContextOptions(SuppressTableWarnings = true)]
+[MarkoutContext(typeof(NmtCensusMarkdownView))]
+[MarkoutContext(typeof(NmtCensusTableView))]
+[MarkoutContext(typeof(NmtCensusMetricRow))]
+[MarkoutContext(typeof(NmtCensusSectionMetricRow))]
+[MarkoutContext(typeof(NmtCensusAssemblyRow))]
+[MarkoutContext(typeof(NmtCensusSectionAssemblyRow))]
+[MarkoutContext(typeof(NmtCensusDivergenceRow))]
+[MarkoutContext(typeof(NmtCensusSectionDivergenceRow))]
+internal sealed partial class NmtCensusViewContext : MarkoutSerializerContext
+{
+}

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -57,6 +57,9 @@ static class Program
         bool returnAddress = false;
         string? emitReturnAddressSnapshot = null;
         string? diffReturnAddressBaseline = null;
+        bool notMyType = false;
+        string? emitNotMyTypeSnapshot = null;
+        string? diffNotMyTypeBaseline = null;
         bool censusTsv = false;
         bool censusJsonl = false;
         bool returnToSenderAb = false;
@@ -153,6 +156,13 @@ static class Program
                 case "--diff-return-address-baseline":
                     if (i + 1 >= args.Length) return Fail("--diff-return-address-baseline requires <file>.");
                     diffReturnAddressBaseline = args[++i]; returnAddress = true; break;
+                case "--not-my-type": notMyType = true; break;
+                case "--emit-not-my-type-snapshot":
+                    if (i + 1 >= args.Length) return Fail("--emit-not-my-type-snapshot requires <file>.");
+                    emitNotMyTypeSnapshot = args[++i]; notMyType = true; break;
+                case "--diff-not-my-type-baseline":
+                    if (i + 1 >= args.Length) return Fail("--diff-not-my-type-baseline requires <file>.");
+                    diffNotMyTypeBaseline = args[++i]; notMyType = true; break;
                 case "--tsv": censusTsv = true; break;
                 case "--jsonl": censusJsonl = true; break;
                 case "--return-to-sender-ab": returnToSenderAb = true; break;
@@ -325,6 +335,16 @@ static class Program
                     : RaCensusFormat.Markdown,
                 emitReturnAddressSnapshot,
                 diffReturnAddressBaseline);
+
+        if (notMyType)
+            return NotMyTypeCensus.Run(
+                assemblies,
+                maxExamples,
+                censusJsonl || json ? NmtCensusFormat.Jsonl
+                    : censusTsv ? NmtCensusFormat.Tsv
+                    : NmtCensusFormat.Markdown,
+                emitNotMyTypeSnapshot,
+                diffNotMyTypeBaseline);
 
         if (returnToSenderAb)
             return ReturnToSender.RunComparison(assemblies, cap, maxExamples);
@@ -1582,6 +1602,20 @@ static class Program
                                 the agree rate regressed below baseline <f> beyond
                                 its tolerance (implies --return-address). The Deep
                                 Inspect census lane runs this as a drift gate.
+          --not-my-type           type-shape equivalence census: compare the product
+                                type-shape oracle (MetadataSource.ClassifyType) with
+                                the legacy base-name classifier the harness sites
+                                re-derive. Reports same-assembly agreement (a hard
+                                100% floor) plus cross-assembly reference recovery.
+                                Thin observer; --tsv/--jsonl select the format,
+                                --max-examples caps divergence rows. See #2548.
+          --emit-not-my-type-snapshot <f>
+                                run the not-my-type census and write a JSON baseline
+                                snapshot to <f> (implies --not-my-type).
+          --diff-not-my-type-baseline <f>
+                                run the not-my-type census and fail (exit 1) if the
+                                same-assembly agree rate regressed below baseline <f>
+                                (implies --not-my-type).
           --return-to-sender-ab   compare current compile-back and ReturnToSender
                                 over the same ReturnToSender property-getter targets.
           --return-to-sender-source-probe

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -354,7 +354,7 @@ static class ReturnToSender
                 || typeName == "<Module>"
                 || typeName.Contains('<', StringComparison.Ordinal)
                 || typeName.Contains('`', StringComparison.Ordinal)
-                || !IsSupportedClass(reader, typeDef))
+                || !IsSupportedClass(source, typeHandle))
             {
                 continue;
             }
@@ -434,7 +434,7 @@ static class ReturnToSender
             string typeName = reader.GetString(typeDef.Name);
             if (typeName == "<Module>"
                 || typeName.Contains('<', StringComparison.Ordinal)
-                || !IsSupportedTargetType(reader, typeDef))
+                || !IsSupportedTargetType(source, typeHandle))
             {
                 continue;
             }
@@ -1228,36 +1228,11 @@ static class ReturnToSender
         return overload;
     }
 
-    static bool IsSupportedClass(MetadataReader reader, TypeDefinition typeDef)
-    {
-        if ((typeDef.Attributes & TypeAttributes.Interface) != 0)
-            return false;
+    static bool IsSupportedClass(MetadataSource source, TypeDefinitionHandle handle)
+        => source.ClassifyType((EntityHandle)handle) == TypeShapeKind.Class;
 
-        string baseName = typeDef.BaseType.Kind switch
-        {
-            HandleKind.TypeReference => FullName(reader, reader.GetTypeReference((TypeReferenceHandle)typeDef.BaseType)),
-            HandleKind.TypeDefinition => FullName(reader, reader.GetTypeDefinition((TypeDefinitionHandle)typeDef.BaseType)),
-            _ => "",
-        };
-
-        return baseName is not "System.Enum" and not "System.ValueType"
-            and not "System.MulticastDelegate" and not "System.Delegate";
-    }
-
-    static bool IsSupportedTargetType(MetadataReader reader, TypeDefinition typeDef)
-    {
-        if ((typeDef.Attributes & TypeAttributes.Interface) != 0)
-            return false;
-
-        string baseName = typeDef.BaseType.Kind switch
-        {
-            HandleKind.TypeReference => FullName(reader, reader.GetTypeReference((TypeReferenceHandle)typeDef.BaseType)),
-            HandleKind.TypeDefinition => FullName(reader, reader.GetTypeDefinition((TypeDefinitionHandle)typeDef.BaseType)),
-            _ => "",
-        };
-
-        return baseName is not "System.Enum" and not "System.MulticastDelegate" and not "System.Delegate";
-    }
+    static bool IsSupportedTargetType(MetadataSource source, TypeDefinitionHandle handle)
+        => source.ClassifyType((EntityHandle)handle) is TypeShapeKind.Class or TypeShapeKind.Struct;
 
     static bool IsSupportedClosureRoot(MetadataReader reader, TypeDefinition typeDef)
     {


### PR DESCRIPTION
Implements **finding #1 of #2548**: a corpus-aware, product-owned type-shape
oracle that replaces the ≥6 harness re-derivations of "is this type a
value/ref/enum/delegate/interface", plus the **Not My Type** equivalence census
(the RA-census landing pattern) and the first pure-policy migration.

## What changed

**Product (`ILInspector.Decompiler`)**
- `TypeShapeKind {Unknown, Class, Struct, Enum, Interface, Delegate}` — the
  consumer-facing projection over the **same base-type reads** as the pipeline's
  coarse `TypeShape` (which deliberately folds interface/delegate into
  `Reference`). Not a parallel resolver.
- `MetadataSource.ClassifyType(TypeRef)` / `ClassifyType(EntityHandle)` /
  `ClassifyConstructedType(int token)` — same-assembly via the type maps (a new
  `_delegates` set alongside `_interfaces`/`_shapes`), cross-assembly via a new
  `CrossAssemblyTypeResolver.ClassifyShape` (mirrors the existing
  `ReadValueTypeHint` but preserves the enum/delegate/interface distinctions
  `ValueTypeHint` folds away).

**Harness (`tools/DecompilerHarness`)**
- `NotMyTypeCensus.cs` (`--not-my-type`), mirroring `ReturnAddressCensus`. Two
  axes: same-assembly **agreement** (oracle vs the legacy base-name classifier
  the harness sites re-derive — a hard 100% floor) and cross-assembly
  **recovery** (TypeReferences the corpus-aware oracle resolves where the
  single-assembly legacy walk answers `Unknown` — the documented AnnotationCheck
  value-type gap). Markdown/tsv/jsonl + snapshot/baseline drift gate.
- `ReturnToSender.IsSupportedClass`/`IsSupportedTargetType` now call the oracle
  (`source` already in scope; behavior-preserving same-assembly).

## Evidence (corelib + 4 product DLLs)

```
| Metric              | Value   |
| ------------------- | ------- |
| definitions         | 4215    |
| agree               | 4215    |
| agree rate          | 100.00% |
| diverge             | 0       |
| cross-assembly refs | 1114    |
| recovered           | 1087    |
| recovery rate       | 97.58%  |
```

- **100.00% same-assembly agreement** (4215/4215, 0 divergences) — proves the
  oracle reproduces the legacy classifier exactly, so the RTS migration is
  behavior-preserving.
- **97.58% cross-assembly recovery** (1087/1114) — quantifies the gap the oracle
  closes. The ~2.4% unrecovered are refs outside the passed reference closure.

## Test status

- `TypeShapeClassificationTests` — 10/10 pass (all five kinds, both same-assembly
  corelib defs and cross-assembly corelib refs).
- `ReturnToSenderPrototypeTests` — **8 pre-existing** compile-back fidelity
  failures (`Exact` vs `RecompileFail`) in this SDK 11 preview environment.
  Confirmed **pre-existing** by A/B: reverting only `ReturnToSender.cs` to the
  merge-base (`45a77828`) reproduces the identical 8 failures. This migration
  adds zero failures.
- Full `dotnet-inspect.slnx` build: 0 errors.

## Scope / deferrals (census-guarded)

- `FidelityCheck.ShapeOf` (same 5-kind classifier, ~10 sites in a 3.5k-line file)
  and `AnnotationCheck` (deliberately **independent** to grade the importer)
  are **not** migrated here. `ShapeOf` is same-assembly-equivalent to the oracle;
  threading `MetadataSource` through it is high-churn/low-value, and the census
  keeps both honest against the oracle. Tracked as follow-ups on #2548.

## Review

Per the Adversarial Review policy this needs **two** reviewers from a different
model family than the author (Claude Opus 4.8): requesting **GPT-5.5** and
**Gemini 3.1 Pro**. Attack points: (1) is the public `TypeShapeKind` a hidden
parallel representation vs a projection? (2) cross-assembly `ClassifyShape`
correctness for facades/forwarders/nil-base/TypeSpec-base; (3) RTS
`IsSupported*` semantic equivalence (`Class` vs `Class|Struct`); (4) census
Axis-B honesty (is "recovery" measuring what it claims?).

Refs #2548.
