### PR TITLE
Use signature-based target identity for RTS source probes (#2507)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -70,6 +70,8 @@
              Link="ReturnToSenderSourceProbe.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\CSharpSourceIdentity.cs"
              Link="CSharpSourceIdentity.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\SignatureIdentity.cs"
+             Link="SignatureIdentity.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\ReturnToSenderCatalogReport.cs"
              Link="ReturnToSenderCatalogReport.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\GeneratedFixtures.cs"

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1546,6 +1546,92 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_ResolvesBySignatureOverridingOrdinal()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public int Pick(int value) => value + 1;
+
+                public int Pick(string value) => value.Length;
+            }
+            """);
+        try
+        {
+            // Ordinal 0 is Pick(int) in count-all metadata order; the signature must win
+            // and select Pick(string) instead, proving identity no longer depends on the
+            // ordinal position of same-name members.
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", "Pick", Overload: 0, Signature: "`0(string)")]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Equal(1, result.Plan.TargetMethod.Overload);
+            Assert.Contains("public int Pick(string value)", result.Source);
+            Assert.DoesNotContain("public int Pick(int value)", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_MatchesSourceBySignatureWhenDeclarationOrderDiffers()
+    {
+        // The compiled assembly declares Pick(int) before Pick(string); the source slice
+        // reverses that order. Ordinal correlation would pair Pick(int)'s decompiled body
+        // with Pick(string)'s source (a false ValidDifferent); the normalized signature
+        // pairs them correctly.
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public int Pick(int value) => value + 1;
+
+                public int Pick(string value) => value.Length;
+            }
+            """);
+        var sourceDirectory = Path.Combine(Path.GetTempPath(), $"rts-signature-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(sourceDirectory);
+        var sourcePath = Path.Combine(sourceDirectory, "ReversedOrder.cs");
+        File.WriteAllText(sourcePath, """
+            public class Class1
+            {
+                public int Pick(string value) => value.Length;
+
+                public int Pick(int value) => value + 1;
+            }
+            """);
+        try
+        {
+            var withSignature = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", "Pick", Overload: 0, Signature: "`0(int)")],
+                [sourcePath]));
+
+            Assert.Equal(ReturnToSenderSourceOutcome.ValidMatch, withSignature.Outcome);
+
+            var ordinalOnly = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", "Pick", Overload: 0)],
+                [sourcePath]));
+
+            Assert.Equal(ReturnToSenderSourceOutcome.ValidDifferent, ordinalOnly.Outcome);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+            try
+            {
+                Directory.Delete(sourceDirectory, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_EmitsNestedTargetMemberRequirement()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1632,6 +1632,132 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void DiscoverTargets_DropsSignatureWhenNormalizationIsAmbiguous()
+    {
+        // A user type named Nullable<T> normalizes to the same `int?` token as
+        // System.Nullable<int> in metadata. The round-trip guard must drop that
+        // ambiguous signature so correlation cannot mis-select the sibling overload.
+        var assemblyPath = CompileFixture("""
+            namespace Sample { public readonly struct Nullable<T> { } }
+
+            public class Class1
+            {
+                public int Pick(Sample.Nullable<int> value) => 1;
+
+                public int Pick(int? value) => 2;
+            }
+            """);
+        try
+        {
+            var pickTargets = ReturnToSenderSourceProbe.DiscoverTargets(assemblyPath, int.MaxValue)
+                .Where(target => target.Target is { Type: "Class1", Method: "Pick" })
+                .ToArray();
+
+            Assert.Equal(2, pickTargets.Length);
+            Assert.All(pickTargets, target => Assert.Null(target.Target.Signature));
+
+            // With the signature dropped, correlation falls back to the ordinal and each
+            // overload still pairs with its own source body (no false ValidDifferent).
+            var results = ReturnToSenderSourceProbe.EvaluateTargets(
+                assemblyPath,
+                pickTargets.Select(target => target.Target).ToArray(),
+                [WriteTempSource(
+                    "NullableCollision.cs",
+                    """
+                    namespace Sample { public readonly struct Nullable<T> { } }
+
+                    public class Class1
+                    {
+                        public int Pick(Sample.Nullable<int> value) => 1;
+
+                        public int Pick(int? value) => 2;
+                    }
+                    """,
+                    out var sourceDirectory)]);
+
+            try
+            {
+                Assert.All(results, result => Assert.Equal(ReturnToSenderSourceOutcome.ValidMatch, result.Outcome));
+            }
+            finally
+            {
+                TryDeleteDirectory(sourceDirectory);
+            }
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_MatchesMixedRankArrayOverloadsBySignature()
+    {
+        // int[][,] and int[,][] must not cross-match: source lists ranks outer-to-inner
+        // while metadata builds them inner-to-outer. With the source slice in reversed
+        // declaration order, only a rank-consistent signature pairs each overload with
+        // its own body.
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public int Rank(int[][,] value) => value.Length + 1;
+
+                public int Rank(int[,][] value) => value.Length + 2;
+            }
+            """);
+        var reversedSource = WriteTempSource(
+            "MixedRankArrays.cs",
+            """
+            public class Class1
+            {
+                public int Rank(int[,][] value) => value.Length + 2;
+
+                public int Rank(int[][,] value) => value.Length + 1;
+            }
+            """,
+            out var sourceDirectory);
+        try
+        {
+            var targets = ReturnToSenderSourceProbe.DiscoverTargets(assemblyPath, int.MaxValue)
+                .Where(target => target.Target is { Type: "Class1", Method: "Rank" })
+                .Select(target => target.Target)
+                .ToArray();
+
+            Assert.Equal(2, targets.Length);
+            Assert.All(targets, target => Assert.NotNull(target.Signature));
+
+            var results = ReturnToSenderSourceProbe.EvaluateTargets(assemblyPath, targets, [reversedSource]);
+
+            Assert.All(results, result => Assert.Equal(ReturnToSenderSourceOutcome.ValidMatch, result.Outcome));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+            TryDeleteDirectory(sourceDirectory);
+        }
+    }
+
+    static string WriteTempSource(string fileName, string source, out string directory)
+    {
+        directory = Path.Combine(Path.GetTempPath(), $"rts-signature-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, fileName);
+        File.WriteAllText(path, source);
+        return path;
+    }
+
+    static void TryDeleteDirectory(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_EmitsNestedTargetMemberRequirement()
     {
         var assemblyPath = CompileFixture("""

--- a/tools/DecompilerHarness/CSharpSourceIdentity.cs
+++ b/tools/DecompilerHarness/CSharpSourceIdentity.cs
@@ -6,6 +6,7 @@ namespace ILInspector.DecompilerHarness;
 
 internal sealed record CSharpSourceMemberIdentity(
     string MetadataName,
+    string Signature,
     string? Body,
     IReadOnlyList<string> Evidence);
 
@@ -62,6 +63,7 @@ internal sealed class CSharpSourceIdentityContext
         [
             new CSharpSourceMemberIdentity(
                 method.Identifier.ValueText,
+                SignatureIdentity.ForSourceMethod(method),
                 BodyText(method),
                 MethodEvidence(method).ToArray()),
         ];
@@ -71,7 +73,11 @@ internal sealed class CSharpSourceIdentityContext
     {
         var members = new List<CSharpSourceMemberIdentity>();
         if (HasPrimaryConstructor(type))
-            members.Add(new CSharpSourceMemberIdentity(".ctor", Body: null, Evidence: ["primary-constructor"]));
+            members.Add(new CSharpSourceMemberIdentity(
+                ".ctor",
+                SignatureIdentity.ForSourceConstructor(type.ParameterList),
+                Body: null,
+                Evidence: ["primary-constructor"]));
         return members;
     }
 
@@ -82,6 +88,7 @@ internal sealed class CSharpSourceIdentityContext
         [
             new CSharpSourceMemberIdentity(
                 methodName,
+                SignatureIdentity.ForSourceConstructor(constructor.ParameterList),
                 BodyText(constructor),
                 ConstructorEvidence(constructor).ToArray()),
         ];
@@ -92,6 +99,7 @@ internal sealed class CSharpSourceIdentityContext
         [
             new CSharpSourceMemberIdentity(
                 OperatorMetadataName(op),
+                SignatureIdentity.ForSourceOperator(op),
                 BodyText(op),
                 ["operator"]),
         ];
@@ -111,6 +119,7 @@ internal sealed class CSharpSourceIdentityContext
         [
             new CSharpSourceMemberIdentity(
                 methodName,
+                SignatureIdentity.ForSourceConversion(conversion),
                 BodyText(conversion),
                 ["conversion-operator"]),
         ];
@@ -124,9 +133,17 @@ internal sealed class CSharpSourceIdentityContext
         var evidence = PropertyEvidence(property).ToArray();
         var members = new List<CSharpSourceMemberIdentity>(2);
         if (HasGetter(property))
-            members.Add(new CSharpSourceMemberIdentity($"get_{property.Identifier.ValueText}", GetterBodyText(property), evidence));
+            members.Add(new CSharpSourceMemberIdentity(
+                $"get_{property.Identifier.ValueText}",
+                SignatureIdentity.ForSourcePropertyGetter(),
+                GetterBodyText(property),
+                evidence));
         if (HasSetter(property))
-            members.Add(new CSharpSourceMemberIdentity($"set_{property.Identifier.ValueText}", SetterBodyText(property), evidence));
+            members.Add(new CSharpSourceMemberIdentity(
+                $"set_{property.Identifier.ValueText}",
+                SignatureIdentity.ForSourcePropertySetter(property.Type),
+                SetterBodyText(property),
+                evidence));
         return members;
     }
 
@@ -139,9 +156,17 @@ internal sealed class CSharpSourceIdentityContext
         var evidence = IndexerEvidence(indexer, metadataName).ToArray();
         var members = new List<CSharpSourceMemberIdentity>(2);
         if (HasGetter(indexer))
-            members.Add(new CSharpSourceMemberIdentity($"get_{metadataName}", GetterBodyText(indexer), evidence));
+            members.Add(new CSharpSourceMemberIdentity(
+                $"get_{metadataName}",
+                SignatureIdentity.ForSourceIndexerGetter(indexer.ParameterList),
+                GetterBodyText(indexer),
+                evidence));
         if (HasSetter(indexer))
-            members.Add(new CSharpSourceMemberIdentity($"set_{metadataName}", SetterBodyText(indexer), evidence));
+            members.Add(new CSharpSourceMemberIdentity(
+                $"set_{metadataName}",
+                SignatureIdentity.ForSourceIndexerSetter(indexer.ParameterList, indexer.Type),
+                SetterBodyText(indexer),
+                evidence));
         return members;
     }
 

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -36,7 +36,7 @@ static class ReturnToSender
         MemberAnchor? MemberAnchor = null,
         IReadOnlyList<DecompilerDecision>? Decisions = null);
 
-    public sealed record RequestedTarget(string Type, string Method, int Overload);
+    public sealed record RequestedTarget(string Type, string Method, int Overload, string? Signature = null);
 
     sealed class NoSupportedReturnToSenderTargetsException(string message) : InvalidOperationException(message);
 
@@ -439,7 +439,7 @@ static class ReturnToSender
                 continue;
             }
 
-            if (TryFindPropertyGetter(reader, typeDef, target.Method, target.Overload) is { } propertyTarget)
+            if (TryFindPropertyGetter(reader, typeDef, target) is { } propertyTarget)
             {
                 results.Add(CompileBackPropertyGetterOrContextFail(
                     assemblyPath,
@@ -453,7 +453,7 @@ static class ReturnToSender
                 continue;
             }
 
-            if (TryFindPropertySetter(reader, typeDef, target.Method, target.Overload) is { } setterTarget)
+            if (TryFindPropertySetter(reader, typeDef, target) is { } setterTarget)
             {
                 results.Add(CompileBackPropertySetterOrContextFail(
                     assemblyPath,
@@ -467,7 +467,7 @@ static class ReturnToSender
                 continue;
             }
 
-            if (TryFindMethod(reader, typeDef, target.Method, target.Overload) is { } methodHandle)
+            if (TryFindMethod(reader, typeDef, target) is { } methodHandle)
             {
                 results.Add(CompileBackMethodOrContextFail(
                     assemblyPath,
@@ -486,8 +486,7 @@ static class ReturnToSender
     static (PropertyDefinitionHandle Property, MethodDefinitionHandle Getter)? TryFindPropertyGetter(
         MetadataReader reader,
         TypeDefinition typeDef,
-        string methodName,
-        int overload)
+        RequestedTarget target)
     {
         var getterToProperty = new Dictionary<MethodDefinitionHandle, PropertyDefinitionHandle>();
         foreach (var propertyHandle in typeDef.GetProperties())
@@ -498,7 +497,7 @@ static class ReturnToSender
                 getterToProperty[accessors.Getter] = propertyHandle;
         }
 
-        if (TryFindMethod(reader, typeDef, methodName, overload) is { } getterHandle
+        if (TryFindMethod(reader, typeDef, target) is { } getterHandle
             && getterToProperty.TryGetValue(getterHandle, out var foundPropertyHandle))
         {
             return (foundPropertyHandle, getterHandle);
@@ -510,8 +509,7 @@ static class ReturnToSender
     static (PropertyDefinitionHandle Property, MethodDefinitionHandle Setter)? TryFindPropertySetter(
         MetadataReader reader,
         TypeDefinition typeDef,
-        string methodName,
-        int overload)
+        RequestedTarget target)
     {
         var setterToProperty = new Dictionary<MethodDefinitionHandle, PropertyDefinitionHandle>();
         foreach (var propertyHandle in typeDef.GetProperties())
@@ -522,13 +520,57 @@ static class ReturnToSender
                 setterToProperty[accessors.Setter] = propertyHandle;
         }
 
-        if (TryFindMethod(reader, typeDef, methodName, overload) is { } setterHandle
+        if (TryFindMethod(reader, typeDef, target) is { } setterHandle
             && setterToProperty.TryGetValue(setterHandle, out var foundPropertyHandle))
         {
             return (foundPropertyHandle, setterHandle);
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Resolves the target metadata method by normalized signature when the target
+    /// carries one (ordinal-independent), falling back to the count-all overload
+    /// ordinal when no signature is supplied or the signature is missing/ambiguous.
+    /// </summary>
+    static MethodDefinitionHandle? TryFindMethod(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        RequestedTarget target)
+    {
+        if (target.Signature is { } signature
+            && TryFindMethodBySignature(reader, typeDef, target.Method, signature) is { } bySignature)
+        {
+            return bySignature;
+        }
+
+        return TryFindMethod(reader, typeDef, target.Method, target.Overload);
+    }
+
+    static MethodDefinitionHandle? TryFindMethodBySignature(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        string methodName,
+        string signature)
+    {
+        MethodDefinitionHandle? found = null;
+        foreach (var methodHandle in typeDef.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (reader.GetString(method.Name) != methodName
+                || method.RelativeVirtualAddress == 0
+                || SignatureIdentity.ForMetadataMethod(reader, typeDef, methodHandle) != signature)
+            {
+                continue;
+            }
+
+            if (found is not null)
+                return null;
+            found = methodHandle;
+        }
+
+        return found;
     }
 
     static MethodDefinitionHandle? TryFindMethod(

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -573,6 +573,20 @@ static class ReturnToSender
         return found;
     }
 
+    /// <summary>
+    /// True when <paramref name="signature"/> resolves to exactly <paramref name="expected"/>
+    /// among body-bearing same-name methods. Target discovery uses this to only attach a
+    /// signature that unambiguously round-trips, so a lossy/ambiguous normalized signature
+    /// is dropped and both metadata and source correlation fall back to the ordinal.
+    /// </summary>
+    internal static bool ResolvesUniquelyBySignature(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        string methodName,
+        string signature,
+        MethodDefinitionHandle expected)
+        => TryFindMethodBySignature(reader, typeDef, methodName, signature) == expected;
+
     static MethodDefinitionHandle? TryFindMethod(
         MetadataReader reader,
         TypeDefinition typeDef,

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -345,22 +345,32 @@ static class ReturnToSenderSourceProbe
             ActualBody: result.TargetBody));
     }
 
-    sealed record SourceMember(string Type, string Method, int Overload, string SourcePath, string? Body);
+    sealed record SourceMember(string Type, string Method, int Overload, string Signature, string SourcePath, string? Body);
 
     sealed class FixtureSourceIndex
     {
         readonly Dictionary<string, SourceMember> _members;
+        readonly Dictionary<string, SourceMember> _membersBySignature;
+        readonly HashSet<string> _ambiguousSignatures;
         readonly Dictionary<string, RecordSourceInfo> _recordSources;
 
-        FixtureSourceIndex(Dictionary<string, SourceMember> members, Dictionary<string, RecordSourceInfo> recordSources)
+        FixtureSourceIndex(
+            Dictionary<string, SourceMember> members,
+            Dictionary<string, SourceMember> membersBySignature,
+            HashSet<string> ambiguousSignatures,
+            Dictionary<string, RecordSourceInfo> recordSources)
         {
             _members = members;
+            _membersBySignature = membersBySignature;
+            _ambiguousSignatures = ambiguousSignatures;
             _recordSources = recordSources;
         }
 
         public static FixtureSourceIndex? TryCreate(IReadOnlyList<string> sourcePaths)
         {
             var members = new Dictionary<string, SourceMember>(StringComparer.Ordinal);
+            var membersBySignature = new Dictionary<string, SourceMember>(StringComparer.Ordinal);
+            var ambiguousSignatures = new HashSet<string>(StringComparer.Ordinal);
             var recordSources = new Dictionary<string, RecordSourceInfo>(StringComparer.Ordinal);
             var overloads = new Dictionary<string, Dictionary<string, int>>(StringComparer.Ordinal);
             var sourceFiles = new List<(string Path, CompilationUnitSyntax Root)>();
@@ -373,9 +383,9 @@ static class ReturnToSenderSourceProbe
 
             var sourceIdentity = CSharpSourceIdentityContext.Create(sourceFiles.Select(file => file.Root));
             foreach (var sourceFile in sourceFiles)
-                AddSourceFile(members, recordSources, overloads, sourceFile.Path, sourceFile.Root, sourceIdentity);
+                AddSourceFile(members, membersBySignature, ambiguousSignatures, recordSources, overloads, sourceFile.Path, sourceFile.Root, sourceIdentity);
 
-            return new FixtureSourceIndex(members, recordSources);
+            return new FixtureSourceIndex(members, membersBySignature, ambiguousSignatures, recordSources);
         }
 
         public static FixtureSourceIndex? TryCreate(string assemblyPath)
@@ -431,7 +441,19 @@ static class ReturnToSenderSourceProbe
         }
 
         public bool TryFind(ReturnToSender.RequestedTarget target, out SourceMember member)
-            => _members.TryGetValue(Key(target.Type, target.Method, target.Overload), out member!);
+        {
+            if (target.Signature is { } signature)
+            {
+                var signatureKey = SigKey(target.Type, target.Method, signature);
+                if (!_ambiguousSignatures.Contains(signatureKey)
+                    && _membersBySignature.TryGetValue(signatureKey, out member!))
+                {
+                    return true;
+                }
+            }
+
+            return _members.TryGetValue(Key(target.Type, target.Method, target.Overload), out member!);
+        }
 
         public bool TryFindRecordSynthesizedMember(ReturnToSender.RequestedTarget target, out string sourcePath)
         {
@@ -466,6 +488,8 @@ static class ReturnToSenderSourceProbe
 
         static void AddSourceFile(
             Dictionary<string, SourceMember> members,
+            Dictionary<string, SourceMember> membersBySignature,
+            HashSet<string> ambiguousSignatures,
             Dictionary<string, RecordSourceInfo> recordSources,
             Dictionary<string, Dictionary<string, int>> overloads,
             string sourcePath,
@@ -473,7 +497,18 @@ static class ReturnToSenderSourceProbe
             CSharpSourceIdentityContext sourceIdentity)
         {
             foreach (var member in SourceMembers(root, sourcePath, recordSources, overloads, sourceIdentity))
+            {
                 members.TryAdd(Key(member.Type, member.Method, member.Overload), member);
+
+                var signatureKey = SigKey(member.Type, member.Method, member.Signature);
+                if (ambiguousSignatures.Contains(signatureKey))
+                    continue;
+                if (!membersBySignature.TryAdd(signatureKey, member))
+                {
+                    membersBySignature.Remove(signatureKey);
+                    ambiguousSignatures.Add(signatureKey);
+                }
+            }
         }
 
         static IEnumerable<SourceMember> SourceMembers(
@@ -541,7 +576,7 @@ static class ReturnToSenderSourceProbe
                 foreach (var sourceMember in sourceIdentity.TypeMembers(type, fullType))
                 {
                     int overload = NextOverload(overloads, sourceMember.MetadataName);
-                    yield return new SourceMember(fullType, sourceMember.MetadataName, overload, path, sourceMember.Body);
+                    yield return new SourceMember(fullType, sourceMember.MetadataName, overload, sourceMember.Signature, path, sourceMember.Body);
                 }
             }
 
@@ -630,12 +665,13 @@ static class ReturnToSenderSourceProbe
                 }
 
                 var overload = OverloadIndex(reader, type, methodHandle, methodName);
+                var signature = SignatureIdentity.ForMetadataMethod(reader, type, methodHandle);
                 var fragments = new List<string>();
                 fragments.AddRange(typeFragments);
                 fragments.AddRange(AttributeReader.RenderAttributes(reader, method.GetCustomAttributes(), qualifyNames: true)
                     .Select(attribute => $"[{attribute}]"));
                 AddReturnAndParameterFragments(reader, method.GetParameters(), fragments);
-                targets.Add(new ProbeTarget(new ReturnToSender.RequestedTarget(fullType, methodName, overload), fragments.Distinct(StringComparer.Ordinal).ToArray()));
+                targets.Add(new ProbeTarget(new ReturnToSender.RequestedTarget(fullType, methodName, overload, signature), fragments.Distinct(StringComparer.Ordinal).ToArray()));
             }
 
             foreach (var propertyHandle in type.GetProperties())
@@ -657,12 +693,13 @@ static class ReturnToSenderSourceProbe
 
                 var methodName = reader.GetString(getter.Name);
                 var overload = OverloadIndex(reader, type, accessors.Getter, methodName);
+                var signature = SignatureIdentity.ForMetadataMethod(reader, type, accessors.Getter);
                 var fragments = new List<string>();
                 fragments.AddRange(typeFragments);
                 fragments.AddRange(AttributeReader.RenderAttributes(reader, property.GetCustomAttributes(), qualifyNames: true)
                     .Select(attribute => $"[{attribute}]"));
                 AddReturnAndParameterFragments(reader, getter.GetParameters(), fragments);
-                targets.Add(new ProbeTarget(new ReturnToSender.RequestedTarget(fullType, methodName, overload), fragments.Distinct(StringComparer.Ordinal).ToArray()));
+                targets.Add(new ProbeTarget(new ReturnToSender.RequestedTarget(fullType, methodName, overload, signature), fragments.Distinct(StringComparer.Ordinal).ToArray()));
             }
         }
 
@@ -694,6 +731,8 @@ static class ReturnToSenderSourceProbe
     }
 
     static string Key(string type, string method, int overload) => $"{type}::{method}#{overload}";
+
+    static string SigKey(string type, string method, string signature) => $"{type}::{method}{signature}";
 
     static string OutcomeId(ReturnToSenderSourceOutcome outcome)
         => outcome switch

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -665,7 +665,7 @@ static class ReturnToSenderSourceProbe
                 }
 
                 var overload = OverloadIndex(reader, type, methodHandle, methodName);
-                var signature = SignatureIdentity.ForMetadataMethod(reader, type, methodHandle);
+                var signature = UniqueTargetSignature(reader, type, methodName, methodHandle);
                 var fragments = new List<string>();
                 fragments.AddRange(typeFragments);
                 fragments.AddRange(AttributeReader.RenderAttributes(reader, method.GetCustomAttributes(), qualifyNames: true)
@@ -693,7 +693,7 @@ static class ReturnToSenderSourceProbe
 
                 var methodName = reader.GetString(getter.Name);
                 var overload = OverloadIndex(reader, type, accessors.Getter, methodName);
-                var signature = SignatureIdentity.ForMetadataMethod(reader, type, accessors.Getter);
+                var signature = UniqueTargetSignature(reader, type, methodName, accessors.Getter);
                 var fragments = new List<string>();
                 fragments.AddRange(typeFragments);
                 fragments.AddRange(AttributeReader.RenderAttributes(reader, property.GetCustomAttributes(), qualifyNames: true)
@@ -733,6 +733,19 @@ static class ReturnToSenderSourceProbe
     static string Key(string type, string method, int overload) => $"{type}::{method}#{overload}";
 
     static string SigKey(string type, string method, string signature) => $"{type}::{method}{signature}";
+
+    // Only carry a signature identity that unambiguously round-trips to this exact
+    // metadata member. A lossy or ambiguous normalized signature is dropped so both
+    // metadata resolution and source correlation fall back to the ordinal.
+    static string? UniqueTargetSignature(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        string methodName,
+        MethodDefinitionHandle handle)
+        => SignatureIdentity.ForMetadataMethod(reader, typeDef, handle) is { } signature
+            && ReturnToSender.ResolvesUniquelyBySignature(reader, typeDef, methodName, signature, handle)
+                ? signature
+                : null;
 
     static string OutcomeId(ReturnToSenderSourceOutcome outcome)
         => outcome switch

--- a/tools/DecompilerHarness/SignatureIdentity.cs
+++ b/tools/DecompilerHarness/SignatureIdentity.cs
@@ -27,15 +27,24 @@ static class SignatureIdentity
 {
     static readonly Provider s_provider = new();
 
-    public static string ForMetadataMethod(MetadataReader reader, TypeDefinition typeDef, MethodDefinitionHandle handle)
+    public static string? ForMetadataMethod(MetadataReader reader, TypeDefinition typeDef, MethodDefinitionHandle handle)
     {
         var method = reader.GetMethodDefinition(handle);
         string name = reader.GetString(method.Name);
-        var signature = method.DecodeSignature(s_provider, GenericContext.ForMethod(reader, typeDef, method));
-        return Format(
-            signature.GenericParameterCount,
-            signature.ParameterTypes,
-            IsConversionOperator(name) ? signature.ReturnType : null);
+        try
+        {
+            var signature = method.DecodeSignature(s_provider, GenericContext.ForMethod(reader, typeDef, method));
+            return Format(
+                signature.GenericParameterCount,
+                signature.ParameterTypes,
+                IsConversionOperator(name) ? signature.ReturnType : null);
+        }
+        catch (BadImageFormatException)
+        {
+            // A signature we cannot decode simply yields no signature identity, so the
+            // caller falls back to ordinal resolution rather than failing the probe.
+            return null;
+        }
     }
 
     public static string ForSourceMethod(MethodDeclarationSyntax method)

--- a/tools/DecompilerHarness/SignatureIdentity.cs
+++ b/tools/DecompilerHarness/SignatureIdentity.cs
@@ -107,7 +107,7 @@ static class SignatureIdentity
         AliasQualifiedNameSyntax alias => SourceTypeToken(alias.Name),
         ArrayTypeSyntax array =>
             SourceTypeToken(array.ElementType)
-                + string.Concat(array.RankSpecifiers.Select(rank => $"[{new string(',', rank.Rank - 1)}]")),
+                + string.Concat(array.RankSpecifiers.Reverse().Select(rank => $"[{new string(',', rank.Rank - 1)}]")),
         PointerTypeSyntax pointer => $"{SourceTypeToken(pointer.ElementType)}*",
         NullableTypeSyntax nullable => $"{SourceTypeToken(nullable.ElementType)}?",
         RefTypeSyntax reference => $"ref {SourceTypeToken(reference.Type)}",

--- a/tools/DecompilerHarness/SignatureIdentity.cs
+++ b/tools/DecompilerHarness/SignatureIdentity.cs
@@ -1,0 +1,181 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+using ILInspector.Metadata;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// Ordinal-independent method signature identity used to correlate RTS metadata
+/// targets with fixture source members. The same normalization is applied to
+/// metadata (via a custom <see cref="ISignatureTypeProvider{TType, TGenericContext}"/>)
+/// and to C# source syntax so that a target's metadata-derived signature matches its
+/// source declaration without depending on hidden/non-public same-name member ordering.
+///
+/// Format: <c>`{genericArity}(p0,p1,...)</c>, with <c>:{returnType}</c> appended for
+/// conversion operators (which overload on return type). Named types are reduced to
+/// their simple (arity-stripped) name, generic parameters to their declared name, and
+/// primitives to C# keywords, so both sides agree for the common overload-set cases.
+/// Cases the normalization cannot reconcile fall back to ordinal matching at the call
+/// site, so a lossy token never mis-selects a member.
+/// </summary>
+static class SignatureIdentity
+{
+    static readonly Provider s_provider = new();
+
+    public static string ForMetadataMethod(MetadataReader reader, TypeDefinition typeDef, MethodDefinitionHandle handle)
+    {
+        var method = reader.GetMethodDefinition(handle);
+        string name = reader.GetString(method.Name);
+        var signature = method.DecodeSignature(s_provider, GenericContext.ForMethod(reader, typeDef, method));
+        return Format(
+            signature.GenericParameterCount,
+            signature.ParameterTypes,
+            IsConversionOperator(name) ? signature.ReturnType : null);
+    }
+
+    public static string ForSourceMethod(MethodDeclarationSyntax method)
+        => Format(method.TypeParameterList?.Parameters.Count ?? 0, ParameterTokens(method.ParameterList.Parameters), returnType: null);
+
+    public static string ForSourceConstructor(ParameterListSyntax? parameters)
+        => Format(0, ParameterTokens(parameters?.Parameters ?? default), returnType: null);
+
+    public static string ForSourceOperator(OperatorDeclarationSyntax op)
+        => Format(0, ParameterTokens(op.ParameterList.Parameters), returnType: null);
+
+    public static string ForSourceConversion(ConversionOperatorDeclarationSyntax conversion)
+        => Format(0, ParameterTokens(conversion.ParameterList.Parameters), SourceTypeToken(conversion.Type));
+
+    public static string ForSourcePropertyGetter()
+        => Format(0, [], returnType: null);
+
+    public static string ForSourcePropertySetter(TypeSyntax propertyType)
+        => Format(0, [SourceTypeToken(propertyType)], returnType: null);
+
+    public static string ForSourceIndexerGetter(BracketedParameterListSyntax parameters)
+        => Format(0, ParameterTokens(parameters.Parameters), returnType: null);
+
+    public static string ForSourceIndexerSetter(BracketedParameterListSyntax parameters, TypeSyntax indexerType)
+        => Format(0, [.. ParameterTokens(parameters.Parameters), SourceTypeToken(indexerType)], returnType: null);
+
+    static string Format(int genericArity, IReadOnlyList<string> parameterTokens, string? returnType)
+    {
+        string signature = $"`{genericArity}({string.Join(",", parameterTokens)})";
+        return returnType is null ? signature : $"{signature}:{returnType}";
+    }
+
+    static bool IsConversionOperator(string name)
+        => name is "op_Implicit" or "op_Explicit" or "op_CheckedImplicit" or "op_CheckedExplicit";
+
+    static IReadOnlyList<string> ParameterTokens(SeparatedSyntaxList<ParameterSyntax> parameters)
+    {
+        var tokens = new List<string>(parameters.Count);
+        foreach (var parameter in parameters)
+        {
+            if (parameter.Type is not { } type)
+                continue;
+            bool byRef = parameter.Modifiers.Any(modifier =>
+                modifier.IsKind(SyntaxKind.RefKeyword)
+                || modifier.IsKind(SyntaxKind.OutKeyword)
+                || modifier.IsKind(SyntaxKind.InKeyword));
+            tokens.Add(byRef ? $"ref {SourceTypeToken(type)}" : SourceTypeToken(type));
+        }
+
+        return tokens;
+    }
+
+    static string SourceTypeToken(TypeSyntax type) => type switch
+    {
+        PredefinedTypeSyntax predefined => predefined.Keyword.ValueText,
+        IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
+        GenericNameSyntax generic =>
+            $"{generic.Identifier.ValueText}<{string.Join(",", generic.TypeArgumentList.Arguments.Select(SourceTypeToken))}>",
+        QualifiedNameSyntax qualified => SourceTypeToken(qualified.Right),
+        AliasQualifiedNameSyntax alias => SourceTypeToken(alias.Name),
+        ArrayTypeSyntax array =>
+            SourceTypeToken(array.ElementType)
+                + string.Concat(array.RankSpecifiers.Select(rank => $"[{new string(',', rank.Rank - 1)}]")),
+        PointerTypeSyntax pointer => $"{SourceTypeToken(pointer.ElementType)}*",
+        NullableTypeSyntax nullable => $"{SourceTypeToken(nullable.ElementType)}?",
+        RefTypeSyntax reference => $"ref {SourceTypeToken(reference.Type)}",
+        TupleTypeSyntax tuple =>
+            $"ValueTuple<{string.Join(",", tuple.Elements.Select(element => SourceTypeToken(element.Type)))}>",
+        _ => type.ToString(),
+    };
+
+    sealed class Provider : ISignatureTypeProvider<string, GenericContext?>
+    {
+        public string GetPrimitiveType(PrimitiveTypeCode typeCode) => typeCode switch
+        {
+            PrimitiveTypeCode.Void => "void",
+            PrimitiveTypeCode.Boolean => "bool",
+            PrimitiveTypeCode.Char => "char",
+            PrimitiveTypeCode.SByte => "sbyte",
+            PrimitiveTypeCode.Byte => "byte",
+            PrimitiveTypeCode.Int16 => "short",
+            PrimitiveTypeCode.UInt16 => "ushort",
+            PrimitiveTypeCode.Int32 => "int",
+            PrimitiveTypeCode.UInt32 => "uint",
+            PrimitiveTypeCode.Int64 => "long",
+            PrimitiveTypeCode.UInt64 => "ulong",
+            PrimitiveTypeCode.Single => "float",
+            PrimitiveTypeCode.Double => "double",
+            PrimitiveTypeCode.String => "string",
+            PrimitiveTypeCode.Object => "object",
+            PrimitiveTypeCode.IntPtr => "nint",
+            PrimitiveTypeCode.UIntPtr => "nuint",
+            PrimitiveTypeCode.TypedReference => "TypedReference",
+            _ => typeCode.ToString(),
+        };
+
+        public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
+            => SimpleName(reader.GetString(reader.GetTypeDefinition(handle).Name));
+
+        public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+            => SimpleName(reader.GetString(reader.GetTypeReference(handle).Name));
+
+        public string GetTypeFromSpecification(MetadataReader reader, GenericContext? context, TypeSpecificationHandle handle, byte rawTypeKind)
+            => reader.GetTypeSpecification(handle).DecodeSignature(this, context);
+
+        public string GetSZArrayType(string elementType) => $"{elementType}[]";
+
+        public string GetArrayType(string elementType, ArrayShape shape)
+            => $"{elementType}[{new string(',', shape.Rank - 1)}]";
+
+        public string GetByReferenceType(string elementType) => $"ref {elementType}";
+
+        public string GetPointerType(string elementType) => $"{elementType}*";
+
+        public string GetGenericInstantiation(string genericType, ImmutableArray<string> typeArguments)
+            => genericType == "Nullable" && typeArguments.Length == 1
+                ? $"{typeArguments[0]}?"
+                : $"{genericType}<{string.Join(",", typeArguments)}>";
+
+        public string GetGenericMethodParameter(GenericContext? context, int index)
+            => context is not null && index < context.MethodParameters.Count
+                ? context.MethodParameters[index]
+                : $"!!{index}";
+
+        public string GetGenericTypeParameter(GenericContext? context, int index)
+            => context is not null && index < context.TypeParameters.Count
+                ? context.TypeParameters[index]
+                : $"!{index}";
+
+        public string GetFunctionPointerType(MethodSignature<string> signature)
+            => $"delegate*<{string.Join(",", signature.ParameterTypes.Append(signature.ReturnType))}>";
+
+        public string GetModifiedType(string modifier, string unmodifiedType, bool isRequired) => unmodifiedType;
+
+        public string GetPinnedType(string elementType) => elementType;
+
+        static string SimpleName(string name)
+        {
+            int backtick = name.IndexOf('`');
+            return backtick < 0 ? name : name[..backtick];
+        }
+    }
+}


### PR DESCRIPTION
- Fixes #2507
- Changes RTS target identity from a count-all overload ordinal to a normalized, ordinal-independent method signature (with ordinal fallback).
- No change to decompiler raising/structuring/printer output; source-probe outcomes unchanged.

## Change

> Should we accept this change?

**Conclusion:** **PASS** — target identity no longer depends on the ordinal position of hidden/non-public same-name members, and the decompiler-group source probe is unchanged (204: 97/107/0/0/0, per-target identical to base).

RTS identity was `(Type, Method, Overload)` where `Overload` is a count-all metadata
ordinal, mirrored by a parallel source-declaration ordinal in the fixture source
index. That couples identity to the ordering of hidden/non-public same-name members
(the fragility #2504 called out).

This PR introduces a normalized signature identity used consistently across target
discovery, metadata resolution, and source correlation:

- **`SignatureIdentity`** (new) produces a normalized signature string —
  `` `arity(params) `` with `:ret` appended for conversion operators — from both
  metadata (a custom `ISignatureTypeProvider`) and C# source syntax. Named types are
  reduced to their simple name, primitives to C# keywords, and generic parameters to
  their declared names, so both sides agree for the common overload-set cases.
- **`RequestedTarget`** gains an optional `Signature`. `DiscoverTargets` populates it
  **only when the signature uniquely round-trips to that exact metadata member**, so a
  lossy/ambiguous normalized signature is dropped and correlation falls back to ordinal.
- **`ReturnToSender`** resolves the metadata method by signature (methods and
  property/indexer accessors), falling back to the overload ordinal when no signature
  is supplied or the signature is missing/ambiguous.
- **`FixtureSourceIndex`** correlates source members by signature first, then ordinal,
  so a target matches its source declaration regardless of hidden same-name members or
  declaration order.

The design is additive: every existing positional `RequestedTarget(Type, Method, Overload)`
call site keeps ordinal semantics, and any signature that cannot be reconciled falls
back to the prior ordinal behavior — so a lossy token can never mis-select a member.

## Evidence

| Check | Result |
| --- | --- |
| Harness build (`tools/DecompilerHarness`) | Pass |
| Decompiler tests build | Pass |
| `ReturnToSenderFixtureCatalogTests` | 68/68 pass |
| `ReturnToSenderPrototypeTests` | 4 new tests pass; 8 failures are pre-existing on base `c780cc6f` (base 88 / branch 92; identical failure set) |
| `NullCoalescingAssignmentPassTests` + `ReturnToSenderEvidenceTests` | 39/39 pass |
| RTS source probe (`--return-to-sender-fixtures decompiler`) | Unchanged: 204 → 97 ValidMatch / 107 ValidDifferent / 0 Invalid / 0 SourceUnavailable / 0 UnsupportedTarget |
| Per-target census A/B (base `c780cc6f` vs head) | **Identical** (204/204 targets, same outcome/reason/source) |

New tests:

- `CompileBackTargets_ResolvesBySignatureOverridingOrdinal` — a signature-bearing
  target selects the intended overload even when the passed ordinal points elsewhere.
- `ReturnToSenderSourceProbe_MatchesSourceBySignatureWhenDeclarationOrderDiffers` —
  reversed source-vs-metadata declaration order: ordinal yields a false `ValidDifferent`,
  signature yields the correct `ValidMatch`.
- `DiscoverTargets_DropsSignatureWhenNormalizationIsAmbiguous` — a user `Nullable<T>`
  colliding with `System.Nullable<int>` drops the ambiguous signature (round-trip guard).
- `ReturnToSenderSourceProbe_MatchesMixedRankArrayOverloadsBySignature` — `int[][,]` vs
  `int[,][]` no longer cross-match (array rank ordering symmetry).

## Decompiler quality

**Conclusion:** **N/A** — this change does not touch raising, structuring, validity,
fidelity, or printer semantics. It only changes how RTS correlates a target with its
metadata member and fixture source slice. The per-target source-probe census over the
decompiler fixture group is identical to base, so there is no corpus raise delta and no
render-text A/B to run.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| GPT-5.5 | Clean (round 2) | Round-1 Nullable-collision finding resolved; verified build, 4/4 new tests, catalog 68/68, probe baseline |
| Gemini 3.1 Pro | Clean (round 2) | Round-1 Nullable + mixed-rank-array findings resolved; confirmed reversal direction and round-trip guard |

**Review conclusion:** **PASS** — two independent clean reviews (neither the author model). Round-1 findings (Nullable-name collision, mixed-rank array cross-match) fixed in `a6174597` with regression tests; see PR comments for the full reconciliation.

## Validation

```bash
dotnet build tools/DecompilerHarness -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "ILInspector.Decompiler.Tests.ReturnToSenderFixtureCatalogTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "ILInspector.Decompiler.Tests.ReturnToSenderPrototypeTests"
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll --return-to-sender-source-probe --return-to-sender-fixtures decompiler
```
