### PR TITLE
Expose RTS source-probe opcode evidence

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -430,6 +430,24 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_ProjectsOpcodeDiffEvidence()
+    {
+        var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+            FixtureCatalog.DecompilerLadderRung9.AssemblyPath(),
+            [
+                new ReturnToSender.RequestedTarget("LadderRung9.DynamicAndExpressionTrees", "DynamicAdd", Overload: 0),
+            ]));
+
+        Assert.Equal(ReturnToSenderSourceOutcome.ValidDifferent, result.Outcome);
+        Assert.Equal(FidelityCheck.CompileBackStatus.OpcodeDiff, result.CompileBackStatus);
+        Assert.Equal("valid_different.semantic_opcode_diff.syntax", result.Reason);
+        Assert.False(string.IsNullOrWhiteSpace(result.OriginalOpcodes));
+        Assert.False(string.IsNullOrWhiteSpace(result.RecompiledOpcodes));
+        Assert.NotEmpty(result.IlDiffLines ?? []);
+        Assert.Contains(result.IlDiffLines!, line => line.StartsWith("h", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_CompilesGeneratedDynamicDelegateCallSites()
     {
         var targets = new[]

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -174,6 +174,10 @@ frontier and compile-back status, for example
 `valid_different.compiler_lowering.iterator.opcode_diff`,
 `valid_different.known_compiler_option.checked_context`, or
 `valid_different.semantic_opcode_diff.unsafe_residual`.
+For rows whose compile-back status is `OpcodeDiff`, text examples and JSON rows
+also include the original/recompiled opcode streams plus unified IL diff lines,
+so semantic-difference buckets can be triaged without rerunning a member-specific
+probe.
 Rows may carry two independent expectations: a Roslyn `SyntaxKind` shape verdict
 for the intended C# idiom, and a compile-back opcode verdict for semantic
 fidelity. A row can therefore be opcode-exact while still exposing a shape

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 
 using DotnetInspector.Fixtures;
 using ILInspector.Decompiler;
+using ILInspector.Instructions;
 using ILInspector.Metadata;
 
 using Microsoft.CodeAnalysis;
@@ -31,7 +32,10 @@ sealed record ReturnToSenderSourceProbeResult(
     string? Detail,
     string? SourcePath,
     string? ExpectedBody,
-    string? ActualBody)
+    string? ActualBody,
+    string? OriginalOpcodes = null,
+    string? RecompiledOpcodes = null,
+    IReadOnlyList<string>? IlDiffLines = null)
 {
     public bool Passed => Outcome == ReturnToSenderSourceOutcome.ValidMatch;
     public bool Different => Outcome == ReturnToSenderSourceOutcome.ValidDifferent;
@@ -96,6 +100,20 @@ static class ReturnToSenderSourceProbe
                     Console.WriteLine($"      detail: {example.Detail}");
                 if (!string.IsNullOrWhiteSpace(example.SourcePath))
                     Console.WriteLine($"      source: {example.SourcePath}");
+                if (example.CompileBackStatus == FidelityCheck.CompileBackStatus.OpcodeDiff)
+                {
+                    if (example.IlDiffLines is { Count: > 0 } diffLines)
+                    {
+                        Console.WriteLine("      il-diff:");
+                        foreach (var line in diffLines.Take(3))
+                            Console.WriteLine($"        {line}");
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(example.OriginalOpcodes))
+                        Console.WriteLine($"      original-opcodes  : {example.OriginalOpcodes}");
+                    if (!string.IsNullOrWhiteSpace(example.RecompiledOpcodes))
+                        Console.WriteLine($"      recompiled-opcodes: {example.RecompiledOpcodes}");
+                }
             }
         }
 
@@ -265,6 +283,7 @@ static class ReturnToSenderSourceProbe
                 result.Status,
                 result.Decisions ?? [],
                 out var classificationDetail);
+            var opcodeEvidence = OpcodeEvidence(result);
             results.Add(new ReturnToSenderSourceProbeResult(
                 target,
                 ReturnToSenderSourceOutcome.ValidDifferent,
@@ -273,11 +292,36 @@ static class ReturnToSenderSourceProbe
                 Detail: classificationDetail,
                 sourceMember.SourcePath,
                 expected,
-                actual));
+                actual,
+                OriginalOpcodes: opcodeEvidence?.OriginalOpcodes,
+                RecompiledOpcodes: opcodeEvidence?.RecompiledOpcodes,
+                IlDiffLines: opcodeEvidence?.IlDiffLines));
         }
 
         return results;
     }
+
+    static OpcodeDiffEvidence? OpcodeEvidence(ReturnToSender.Result result)
+    {
+        if (result.Status != FidelityCheck.CompileBackStatus.OpcodeDiff)
+            return null;
+
+        IReadOnlyList<string> diffLines = result.IlDiffDiagnostic is null
+            ? Array.Empty<string>()
+            : IlDiffPrinter.ToUnifiedLines(result.IlDiffDiagnostic);
+        return new OpcodeDiffEvidence(
+            NullIfWhiteSpace(result.OriginalOpcodes),
+            NullIfWhiteSpace(result.RecompiledOpcodes),
+            diffLines);
+    }
+
+    static string? NullIfWhiteSpace(string value)
+        => string.IsNullOrWhiteSpace(value) ? null : value;
+
+    sealed record OpcodeDiffEvidence(
+        string? OriginalOpcodes,
+        string? RecompiledOpcodes,
+        IReadOnlyList<string> IlDiffLines);
 
     static void WriteJson(
         IReadOnlyList<ReturnToSenderSourceProbeResult> results,
@@ -322,6 +366,9 @@ static class ReturnToSenderSourceProbe
                 source_path = result.SourcePath,
                 expected_body = result.ExpectedBody,
                 actual_body = result.ActualBody,
+                original_opcodes = result.OriginalOpcodes,
+                recompiled_opcodes = result.RecompiledOpcodes,
+                il_diff = result.IlDiffLines,
             }),
         };
         Console.WriteLine(JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));


### PR DESCRIPTION
## Summary

Adds opcode evidence to ReturnToSender source-probe rows whose compile-back status is `OpcodeDiff`:

- text examples print bounded unified IL diff lines plus original/recompiled opcode streams;
- JSON rows include `original_opcodes`, `recompiled_opcodes`, and `il_diff`.

This is a harness-only measurement slice for triaging `valid_different.semantic_opcode_diff.*` buckets. Product decompiler output is unchanged.

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --nologo -v:minimal`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/ReturnToSenderFixtureCatalogTests/ReturnToSenderSourceProbe_ProjectsOpcodeDiffEvidence"`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures decompiler --return-to-sender-source-probe --cap 10000 --max-examples 20`
  - `ValidMatch: 97`
  - `ValidDifferent: 107`
  - `Invalid: 0`
  - `valid_different.semantic_opcode_diff.syntax: 18`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures decompiler --return-to-sender-source-probe --cap 10000 --max-examples 1 --json > /tmp/rts-source-probe-semantic-syntax.json`
- `dotnet run /tmp/check-rts-json.cs`
- `npx markdownlint-cli --fix tools/DecompilerHarness/README.md && npx markdownlint-cli tools/DecompilerHarness/README.md`

## Notes

This does not reclassify or fix the 18 semantic syntax rows; it makes their opcode evidence directly visible for the next triage/fix slice.
