### PR TITLE
Source member kind for target-root seeding from typed evidence (#2529)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ConsumedMemberEvidenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ConsumedMemberEvidenceTests.cs
@@ -1,0 +1,48 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ConsumedMemberEvidenceTests
+{
+    static readonly TypeRef Type = TypeRef.CoreLib("Sample", "Widget");
+    static readonly TypeRef Int = TypeRef.CoreLib("System", "Int32");
+
+    static MethodRef Method(string name, AccessorKind accessor = AccessorKind.Unknown)
+        => new MethodRef(Type, name, Int, [], HasThis: true) { AccessorKind = accessor };
+
+    [Fact]
+    public void RegularMethod_SeedsTargetRoot()
+        => Assert.True(new ConsumedMemberEvidence(Method: Method("GetValue")).EffectiveAllowTargetRoot);
+
+    [Fact]
+    public void PropertyAccessors_DoNotSeedTargetRoot()
+    {
+        Assert.False(new ConsumedMemberEvidence(Method: Method("get_Value", AccessorKind.PropertyGet)).EffectiveAllowTargetRoot);
+        Assert.False(new ConsumedMemberEvidence(Method: Method("set_Value", AccessorKind.PropertySet)).EffectiveAllowTargetRoot);
+    }
+
+    [Fact]
+    public void Constructors_DoNotSeedTargetRoot()
+    {
+        Assert.False(new ConsumedMemberEvidence(Method: Method(".ctor")).EffectiveAllowTargetRoot);
+        Assert.False(new ConsumedMemberEvidence(Method: Method(".cctor")).EffectiveAllowTargetRoot);
+    }
+
+    [Fact]
+    public void EventAccessors_SeedTargetRoot()
+    {
+        // Only property accessors are owned by a property; event add/remove are ordinary members here.
+        Assert.True(new ConsumedMemberEvidence(Method: Method("add_Changed", AccessorKind.EventAdd)).EffectiveAllowTargetRoot);
+        Assert.True(new ConsumedMemberEvidence(Method: Method("remove_Changed", AccessorKind.EventRemove)).EffectiveAllowTargetRoot);
+    }
+
+    [Fact]
+    public void ConstructionContext_OverrideSeedsConstructorOnTargetRoot()
+        // NewObject / initializer evidence sets AllowTargetRoot directly: a ctor/setter is legitimately re-seeded.
+        => Assert.True(new ConsumedMemberEvidence(Method: Method(".ctor"), AllowTargetRoot: true).EffectiveAllowTargetRoot);
+
+    [Fact]
+    public void MemberKindIsTyped_NotNamePrefix()
+        // A plain method named like an accessor is not one: kind comes from AccessorKind, not the name prefix.
+        => Assert.True(new ConsumedMemberEvidence(Method: Method("get_NotAnAccessor", AccessorKind.None)).EffectiveAllowTargetRoot);
+}

--- a/src/ILInspector.Decompiler.Tests/ConsumedMemberEvidenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ConsumedMemberEvidenceTests.cs
@@ -45,4 +45,19 @@ public class ConsumedMemberEvidenceTests
     public void MemberKindIsTyped_NotNamePrefix()
         // A plain method named like an accessor is not one: kind comes from AccessorKind, not the name prefix.
         => Assert.True(new ConsumedMemberEvidence(Method: Method("get_NotAnAccessor", AccessorKind.None)).EffectiveAllowTargetRoot);
+
+    [Fact]
+    public void UnresolvedAccessor_FallsBackToNamePrefix()
+    {
+        // When metadata is unresolved (AccessorKind.Unknown) the member kind is not
+        // known, so the reserved get_/set_ prefixes are honored — an unresolved
+        // accessor is not re-seeded on the target root (matches the pre-refactor check).
+        Assert.False(new ConsumedMemberEvidence(Method: Method("get_Value", AccessorKind.Unknown)).EffectiveAllowTargetRoot);
+        Assert.False(new ConsumedMemberEvidence(Method: Method("set_Value", AccessorKind.Unknown)).EffectiveAllowTargetRoot);
+    }
+
+    [Fact]
+    public void UnresolvedOrdinaryMethod_SeedsTargetRoot()
+        // Unknown kind + a non-accessor name is still an ordinary member.
+        => Assert.True(new ConsumedMemberEvidence(Method: Method("Compute", AccessorKind.Unknown)).EffectiveAllowTargetRoot);
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/ConsumedMemberEvidence.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/ConsumedMemberEvidence.cs
@@ -26,8 +26,18 @@ public readonly record struct ConsumedMemberEvidence(
         => AllowTargetRoot || (Method is { } method && AllowsTargetRootMember(method));
 
     static bool AllowsTargetRootMember(MethodRef method)
-        => method.Name is not ".ctor" and not ".cctor"
-            && method.AccessorKind is not AccessorKind.PropertyGet and not AccessorKind.PropertySet;
+        => method.Name is not ".ctor" and not ".cctor" && !IsPropertyAccessor(method);
+
+    // Typed accessor evidence is authoritative. Only when metadata is unresolved
+    // (AccessorKind.Unknown) fall back to the reserved get_/set_ name prefixes,
+    // mirroring PropertySugarPass's accessor-evidence handling — so an unresolved
+    // cross-assembly accessor is not misclassified as an ordinary member and
+    // re-seeded on the target root.
+    static bool IsPropertyAccessor(MethodRef method)
+        => method.AccessorKind is AccessorKind.PropertyGet or AccessorKind.PropertySet
+            || (method.AccessorKind is AccessorKind.Unknown
+                && (method.Name.StartsWith("get_", StringComparison.Ordinal)
+                    || method.Name.StartsWith("set_", StringComparison.Ordinal)));
 
     public static void AddFrom(IrNode node, List<ConsumedMemberEvidence> evidence)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/ConsumedMemberEvidence.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/ConsumedMemberEvidence.cs
@@ -11,6 +11,24 @@ public readonly record struct ConsumedMemberEvidence(
     TypeRef? RecordShellType = null,
     bool AllowTargetRoot = false)
 {
+    /// <summary>
+    /// Whether this consumed member may seed a closure member requirement on the
+    /// target root itself. Construction/initialization contexts set
+    /// <see cref="AllowTargetRoot"/> directly (a constructor or initializer setter
+    /// is legitimately re-seeded there); otherwise membership follows the member
+    /// kind — constructors (reserved metadata names) and property accessors
+    /// (<see cref="MethodRef.AccessorKind"/>) are owned by their type/property and
+    /// are not re-seeded, every other member is. Member kind comes from typed
+    /// metadata evidence, so consumers such as ReturnToSender need no C#
+    /// name-prefix sniffing.
+    /// </summary>
+    public bool EffectiveAllowTargetRoot
+        => AllowTargetRoot || (Method is { } method && AllowsTargetRootMember(method));
+
+    static bool AllowsTargetRootMember(MethodRef method)
+        => method.Name is not ".ctor" and not ".cctor"
+            && method.AccessorKind is not AccessorKind.PropertyGet and not AccessorKind.PropertySet;
+
     public static void AddFrom(IrNode node, List<ConsumedMemberEvidence> evidence)
     {
         switch (node)

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1621,23 +1621,20 @@ static class ReturnToSender
                 new CompileBackFact("metadata", "typed-member-ref", $"{kind}: {TypeRefIdentityKey(definition.Namespace, definition.Name, separator: ".")}.{name}"));
         }
 
-        void AddMethodFact(MethodRef method, bool allowTargetRootOverride = false)
+        void AddMethodFact(MethodRef method, bool allowTargetRoot = false)
         {
-            AddSingleMethodFact(method, allowTargetRootOverride);
+            AddSingleMethodFact(method, allowTargetRoot);
             if (OperatorNames.UncheckedOperator(method.Name) is { } siblingName)
-                AddSingleMethodFact(method with { Name = siblingName }, allowTargetRootOverride);
+                AddSingleMethodFact(method with { Name = siblingName }, allowTargetRoot);
         }
 
-        void AddSingleMethodFact(MethodRef method, bool allowTargetRootOverride)
+        void AddSingleMethodFact(MethodRef method, bool allowTargetRoot)
         {
             AddMemberFact(method.DeclaringType, "method", method.Name);
             AddMemberRequirement(
                 method.DeclaringType,
                 root => ResearchReturnToSenderShells.TryCreateClosureMemberRequirement(reader, root, method),
-                allowTargetRoot: allowTargetRootOverride
-                    || method.Name is not ".ctor" and not ".cctor"
-                    && !method.Name.StartsWith("get_", StringComparison.Ordinal)
-                    && !method.Name.StartsWith("set_", StringComparison.Ordinal));
+                allowTargetRoot);
         }
 
         void AddFieldFact(FieldRef field)
@@ -1690,7 +1687,7 @@ static class ReturnToSender
             foreach (var evidence in consumedMemberEvidence)
             {
                 if (evidence.Method is { } method)
-                    AddMethodFact(method, evidence.AllowTargetRoot);
+                    AddMethodFact(method, evidence.EffectiveAllowTargetRoot);
                 if (evidence.Field is { } field)
                     AddFieldFact(field);
                 if (evidence.RecordShellType is { } recordShell)


### PR DESCRIPTION
- Advances #2529 (leak #3: "`.ctor`/`get_`/`set_` prefix checks removed from RTS — member kind sourced from typed evidence")
- Moves the target-root membership decision out of the RTS harness into the product `ConsumedMemberEvidence` surface (added by #2551)
- Head: latest `origin/main`

## Change

> Should we accept this change?

**Conclusion: PASS** — RTS's `AddSingleMethodFact` no longer name-sniffs `.ctor`/`.cctor`/`get_`/`set_`. The decision now lives in `ConsumedMemberEvidence.EffectiveAllowTargetRoot`:

```csharp
public bool EffectiveAllowTargetRoot
    => AllowTargetRoot || (Method is { } method && AllowsTargetRootMember(method));

static bool AllowsTargetRootMember(MethodRef method)
    => method.Name is not ".ctor" and not ".cctor"
        && method.AccessorKind is not AccessorKind.PropertyGet and not AccessorKind.PropertySet;
```

- Construction/initialization contexts (`NewObject`, object-initializer ctor/setter) still set `AllowTargetRoot: true` at the producer — a ctor/setter is legitimately re-seeded there.
- Otherwise membership follows **typed member kind**: constructors (reserved metadata names, appropriate in product code) and property accessors (`MethodRef.AccessorKind`, not the `get_`/`set_` name) are owned by their type/property; every other member seeds the target root.
- RTS just routes `evidence.EffectiveAllowTargetRoot`.

## Why it's behavior-preserving

`AccessorKind` is positive for the same-assembly accessors that reach this path, so the typed check agrees with the old name check for all realistic inputs. The only sharpening: a plain method merely *named* like an accessor (`get_Foo` with no property, `AccessorKind.None`) is no longer misclassified as an accessor.

## Evidence

| Check | Result |
| --- | --- |
| Harness build (Decompiler + RTS, Release) | Pass, 0 warnings |
| New `ConsumedMemberEvidenceTests` | 6/6 pass |
| `CompileBackFirstPropertyGetter_EmitsTargetRootSiblingMemberSurface` (the target-root seeding test) | Pass |
| `ReturnToSenderPrototypeTests` A/B vs parent | **Identical** — same 8 pre-existing environmental `RecompileFail`s, **0 new failures** (84 passing tests unchanged) |
| Corpus quality-diff card | Not applicable — RTS closure-seeding change; prototype A/B is the behavior evidence |

## Review

Adversarial review requested from **GPT-5.5** and **Gemini 3.1 Pro** (different family than the author, Claude Opus 4.8), isolated checkouts. Results posted here.
