### PR TITLE
Add malformed-metadata signature fuzzer (#2499)

### DIFF
--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -138,6 +138,18 @@ jobs:
             --max-examples 10 \
             2>&1 | tee artifacts/deep-inspect/return-address-census.txt
 
+      - name: Run signature fuzzer
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p artifacts/deep-inspect
+          # Self-contained: generates adversarial signature blobs and drives them through
+          # SignatureBlobGuard + a real SRM decode. A guard gap aborts the process; finishing is
+          # the pass. Deterministic per seed, so a crash reproduces with --fuzz-seed.
+          dotnet run --project tools/DecompilerHarness -c Release -- \
+            --fuzz-signatures --fuzz-iterations 1000000 --fuzz-seed 1 --fuzz-log-every 50000 \
+            2>&1 | tee artifacts/deep-inspect/signature-fuzz.txt
+
       - name: Run validity predicate scan
         shell: bash
         run: |

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -54,6 +54,11 @@ static class Program
         string? diffValidityDefects = null;
         bool fidelityCheck = false;
         bool returnToSender = false;
+        bool fuzzSignatures = false;
+        bool fuzzUnguarded = false;
+        int fuzzIterations = 100_000;
+        int fuzzSeed = 1;
+        int fuzzLogEvery = 1;
         bool returnAddress = false;
         string? emitReturnAddressSnapshot = null;
         string? diffReturnAddressBaseline = null;
@@ -150,6 +155,11 @@ static class Program
                 case "--fidelity-check": fidelityCheck = true; break;
                 case "--return-to-sender": returnToSender = true; break;
                 case "--return-address": returnAddress = true; break;
+                case "--fuzz-signatures": fuzzSignatures = true; break;
+                case "--fuzz-unguarded": fuzzSignatures = true; fuzzUnguarded = true; break;
+                case "--fuzz-iterations": fuzzIterations = int.Parse(args[++i]); break;
+                case "--fuzz-seed": fuzzSeed = int.Parse(args[++i]); break;
+                case "--fuzz-log-every": fuzzLogEvery = int.Parse(args[++i]); break;
                 case "--emit-return-address-snapshot":
                     if (i + 1 >= args.Length) return Fail("--emit-return-address-snapshot requires <file>.");
                     emitReturnAddressSnapshot = args[++i]; returnAddress = true; break;
@@ -251,6 +261,13 @@ static class Program
             if (inputs.Count > 0)
                 return Fail("--generated-fixtures generates its own temporary input assembly; do not pass assembly paths.");
             return GeneratedFixtures(generatedFixtureSelector, keepGeneratedFixtures, json);
+        }
+
+        if (fuzzSignatures)
+        {
+            if (inputs.Count > 0)
+                return Fail("--fuzz-signatures generates its own signature blobs; do not pass assembly paths.");
+            return SignatureFuzzer.Run(fuzzIterations, fuzzSeed, fuzzLogEvery, fuzzUnguarded);
         }
 
         if (returnToSenderCatalog)
@@ -1602,6 +1619,20 @@ static class Program
                                 the agree rate regressed below baseline <f> beyond
                                 its tolerance (implies --return-address). The Deep
                                 Inspect census lane runs this as a drift gate.
+          --fuzz-signatures       malformed-metadata signature fuzzer (#2499):
+                                generate adversarial signature blobs and drive each
+                                through SignatureBlobGuard, then a real SRM decode
+                                when the guard reports it safe. A guard gap aborts
+                                the process (StackOverflow/OOM); finishing all
+                                iterations is the pass. Generates its own input.
+          --fuzz-unguarded        positive control: --fuzz-signatures but skip the
+                                guard, so a deep/huge blob decodes directly. Expected
+                                to abort — demonstrates the guard is necessary.
+          --fuzz-iterations <n>   fuzz iteration count (default 100000).
+          --fuzz-seed <n>         deterministic RNG seed (default 1); a crash is
+                                reproduced by re-running with the same seed.
+          --fuzz-log-every <n>    log a heartbeat blob to stderr every n iterations
+                                (default 1) so a process abort leaves the culprit.
           --not-my-type           type-shape equivalence census: compare the product
                                 type-shape oracle (MetadataSource.ClassifyType) with
                                 the legacy base-name classifier the harness sites

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -713,6 +713,39 @@ never fail; re-emit the baseline to raise the floor. `matched`/`unmatched` count
 drift with corpus composition (framework/NuGet version bumps), so they are
 reported in the card for triage but not gated.
 
+### Malformed-metadata signature fuzzer (`--fuzz-signatures`)
+
+`--fuzz-signatures` runs a self-contained fuzzer (#2499) over the signature-decode
+hardening. It generates adversarial signature blobs — deep wrapper chains, wide and
+huge declared counts, adversarial array shapes, function pointers, truncation, and
+random bytes — across all five `SignatureBlobGuard.Kind` shapes, and for each blob:
+
+1. runs `SignatureBlobGuard.IsSafeToDecode`, then
+2. when the guard reports the blob safe, runs a **real** SRM signature decode.
+
+The guard's contract is that a *safe* verdict implies SRM can decode the blob without
+an uncatchable `StackOverflowException` or an unbounded pre-allocation. A blob that
+violates that contract aborts the process — which is the fuzzing signal — so
+**finishing all iterations is the pass**. The decode uses a trivial provider because
+the StackOverflow (native `DecodeType` recursion) and the count-driven pre-allocation
+both live inside SRM's decoder, independent of the provider.
+
+```bash
+# Deterministic run; a crash reproduces with the same --fuzz-seed.
+dotnet run --project tools/DecompilerHarness -c Release -- \
+  --fuzz-signatures --fuzz-iterations 1000000 --fuzz-seed 1 --fuzz-log-every 50000
+
+# Positive control: skip the guard so a deep/huge blob decodes directly. Expected to
+# abort (StackOverflow/OOM) — this demonstrates the guard is necessary and the fuzzer
+# generates genuinely crashing inputs.
+dotnet run --project tools/DecompilerHarness -c Release -- --fuzz-unguarded
+```
+
+Each blob is logged to stderr (kind, iteration, hex) every `--fuzz-log-every` iterations
+so a process abort leaves the culprit as the last line; the run is deterministic given
+`--fuzz-seed`, so a crash is reproduced by re-running the same seed. A bounded run
+(1,000,000 iterations) runs in the opt-in Deep Inspect **census lane**.
+
 ## Usage
 
 ```bash

--- a/tools/DecompilerHarness/SignatureFuzzer.cs
+++ b/tools/DecompilerHarness/SignatureFuzzer.cs
@@ -213,7 +213,7 @@ internal static class SignatureFuzzer
             case 1: // GENERICINST with a huge or wide arg count
                 blob.Add(0x15);
                 blob.Add(0x12); // CLASS
-                blob.Add(0x06); // generic type token
+                blob.Add(0x05); // generic type token = TypeRef (SRM rejects a TypeSpec token here)
                 WriteCount(rng, blob);
                 blob.Add(0x08); // one concrete arg follows (rest are "declared but absent")
                 break;
@@ -234,7 +234,7 @@ internal static class SignatureFuzzer
             {
                 blob.Add(0x15);
                 blob.Add(0x12);
-                blob.Add(0x06);
+                blob.Add(0x05); // generic type token = TypeRef
                 int args = rng.Next(1, 100_000);
                 WriteCompressed(blob, args);
                 for (int i = 0; i < args; i++)
@@ -270,7 +270,7 @@ internal static class SignatureFuzzer
                 {
                     blob.Add(0x15); // GENERICINST
                     blob.Add(0x12); // CLASS
-                    blob.Add(0x06); // generic type token
+                    blob.Add(0x05); // generic type token = TypeRef (SRM rejects a TypeSpec token here)
                     blob.Add(0x01); // one argument, which continues the chain
                 }
                 blob.Add(0x08);
@@ -292,8 +292,8 @@ internal static class SignatureFuzzer
             }
             default: // a simple leaf
                 blob.Add((byte)new byte[] { 0x08, 0x0e, 0x1c, 0x02, 0x18, 0x11, 0x12 }[rng.Next(0, 7)]);
-                if (blob[^1] is 0x11 or 0x12) // VALUETYPE/CLASS carry a token
-                    blob.Add(0x06);
+                if (blob[^1] is 0x11 or 0x12) // VALUETYPE/CLASS carry a token (TypeRef; not TypeSpec)
+                    blob.Add(0x05);
                 break;
         }
         return blob;

--- a/tools/DecompilerHarness/SignatureFuzzer.cs
+++ b/tools/DecompilerHarness/SignatureFuzzer.cs
@@ -189,11 +189,13 @@ internal static class SignatureFuzzer
         }
     }
 
-    // Emits a Type blob. Iterative (no generator-side recursion), with adversarial strategies.
+    // Emits a Type blob. Iterative (no generator-side recursion), with adversarial strategies —
+    // including *recursively* nested shapes (deep inside FNPTR return / GENERICINST arg / ARRAY
+    // element), emitted as a flat byte sequence so the generator's own stack is never at risk.
     static List<byte> GenerateType(Random rng)
     {
         var blob = new List<byte>();
-        switch (rng.Next(0, 8))
+        switch (rng.Next(0, 11))
         {
             case 0: // deep wrapper chain (StackOverflow probe)
             {
@@ -247,6 +249,45 @@ internal static class SignatureFuzzer
                 int n = rng.Next(1, 4_000);
                 for (int i = 0; i < n; i++)
                     blob.Add((byte)rng.Next(0, 256));
+                break;
+            }
+            case 7: // deep FNPTR-return chain: FNPTR() -> FNPTR() -> ... -> I4
+            {
+                int depth = rng.Next(1, 60_000);
+                for (int i = 0; i < depth; i++)
+                {
+                    blob.Add(0x1b); // FNPTR
+                    blob.Add(0x00); // default calling convention
+                    blob.Add(0x00); // 0 parameters; the return type continues the chain
+                }
+                blob.Add(0x08); // I4 return type at the bottom
+                break;
+            }
+            case 8: // deep GENERICINST single-arg chain: G<G<...<I4>>>
+            {
+                int depth = rng.Next(1, 60_000);
+                for (int i = 0; i < depth; i++)
+                {
+                    blob.Add(0x15); // GENERICINST
+                    blob.Add(0x12); // CLASS
+                    blob.Add(0x06); // generic type token
+                    blob.Add(0x01); // one argument, which continues the chain
+                }
+                blob.Add(0x08);
+                break;
+            }
+            case 9: // deep ARRAY-element chain: I4[]...[] (shapes trail in the blob)
+            {
+                int depth = rng.Next(1, 60_000);
+                for (int i = 0; i < depth; i++)
+                    blob.Add(0x14); // ARRAY
+                blob.Add(0x08);     // innermost element I4
+                for (int i = 0; i < depth; i++)
+                {
+                    blob.Add(0x01); // rank 1
+                    blob.Add(0x00); // 0 sizes
+                    blob.Add(0x00); // 0 lower bounds
+                }
                 break;
             }
             default: // a simple leaf

--- a/tools/DecompilerHarness/SignatureFuzzer.cs
+++ b/tools/DecompilerHarness/SignatureFuzzer.cs
@@ -1,0 +1,300 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using ILInspector.Metadata;
+
+namespace ILInspector.DecompilerHarness;
+
+// Malformed-metadata signature fuzzer (#2499). It generates adversarial signature blobs — deep
+// nesting, wide/huge declared counts, prefix chains, truncation, random bytes — and drives each
+// through SignatureBlobGuard and (when the guard reports it safe) a real SRM signature decode.
+//
+// The guard's contract is: IsSafeToDecode == true implies SRM can decode the blob without an
+// *uncatchable* StackOverflowException or an unbounded pre-allocation. A generated blob that
+// violates that contract aborts the process — which is the fuzzing signal. Each blob is logged
+// (kind, seed, iteration, hex) *before* it is decoded, so the last line before an abort is the
+// reproducer. The run is deterministic given --seed, and finishing all iterations is the pass.
+//
+// The decode uses a trivial provider on purpose: the StackOverflow (native DecodeType recursion)
+// and the count-driven pre-allocation (e.g. array-shape sizes) both happen inside SRM's decoder,
+// independent of the provider, so this stays self-contained (no dependency on the product decoders).
+internal static class SignatureFuzzer
+{
+    public static int Run(int iterations, int seed, int? logEvery, bool unguarded = false)
+    {
+        Console.Error.WriteLine($"signature fuzzer: iterations={iterations} seed={seed}{(unguarded ? " UNGUARDED (positive control — expected to crash)" : "")}");
+        var rng = new Random(seed);
+
+        long guardSafe = 0, guardRejected = 0, decodeThrew = 0;
+        var provider = new FuzzProvider();
+
+        for (int i = 0; i < iterations; i++)
+        {
+            var kind = (SignatureBlobGuard.Kind)rng.Next(0, 5);
+            byte[] blob = GenerateSignature(rng, kind);
+
+            // Log before every decode so a process abort leaves the culprit as the last line.
+            if (logEvery is { } n && n > 0 && i % n == 0)
+                Console.Error.WriteLine($"[{i}] kind={kind} len={blob.Length} {Convert.ToHexString(blob.AsSpan(0, Math.Min(blob.Length, 48)))}");
+
+            MetadataReader reader;
+            BlobHandle sig;
+            try
+            {
+                (reader, sig) = BuildImage(kind, blob);
+            }
+            catch
+            {
+                // A blob the metadata writer itself rejects is not interesting; skip it.
+                continue;
+            }
+
+            if (!unguarded)
+            {
+                bool safe;
+                try
+                {
+                    safe = SignatureBlobGuard.IsSafeToDecode(reader, sig, kind);
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"GUARD THREW on kind={kind} len={blob.Length} {Convert.ToHexString(blob)}: {ex.GetType().Name}");
+                    return 1;
+                }
+
+                if (!safe)
+                {
+                    guardRejected++;
+                    continue;
+                }
+                guardSafe++;
+            }
+
+            // The guard promised this is safe: a real decode must terminate. If it StackOverflows or
+            // OOMs, the process aborts and the logged blob above is the reproducer. In --fuzz-unguarded
+            // mode the guard is skipped, so this is the positive control that demonstrates the guard is
+            // necessary — it is expected to abort on a deep/huge blob.
+            try
+            {
+                DecodeForContract(reader, sig, kind, provider);
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or NotSupportedException or OverflowException)
+            {
+                // A catchable malformed-signature exception is fine — the guard only promises no
+                // *uncatchable* crash, not that every "safe" blob is well-formed.
+                decodeThrew++;
+            }
+        }
+
+        Console.Error.WriteLine($"signature fuzzer: OK — {iterations} iterations, guard-safe={guardSafe} guard-rejected={guardRejected} decode-threw={decodeThrew}");
+        return 0;
+    }
+
+    static void DecodeForContract(MetadataReader reader, BlobHandle sig, SignatureBlobGuard.Kind kind, FuzzProvider provider)
+    {
+        var decoder = new SignatureDecoder<int, object?>(provider, reader, null);
+        var blob = reader.GetBlobReader(sig);
+        switch (kind)
+        {
+            case SignatureBlobGuard.Kind.TypeSpecification:
+                decoder.DecodeType(ref blob);
+                break;
+            case SignatureBlobGuard.Kind.Field:
+                decoder.DecodeFieldSignature(ref blob);
+                break;
+            case SignatureBlobGuard.Kind.LocalVariables:
+                decoder.DecodeLocalSignature(ref blob);
+                break;
+            case SignatureBlobGuard.Kind.MethodSpecification:
+                decoder.DecodeMethodSpecificationSignature(ref blob);
+                break;
+            default:
+                decoder.DecodeMethodSignature(ref blob);
+                break;
+        }
+    }
+
+    // --- Metadata image: one TypeSpec or StandaloneSignature per generated blob ---
+
+    static (MetadataReader Reader, BlobHandle Signature) BuildImage(SignatureBlobGuard.Kind kind, byte[] blob)
+    {
+        var md = new MetadataBuilder();
+        md.AddModule(0, md.GetOrAddString("f.dll"), md.GetOrAddGuid(Guid.NewGuid()), default, default);
+        md.AddAssembly(md.GetOrAddString("f"), new Version(1, 0, 0, 0), default, default, default, default);
+        md.AddTypeDefinition(default, default, md.GetOrAddString("<Module>"), default,
+            MetadataTokens.FieldDefinitionHandle(1), MetadataTokens.MethodDefinitionHandle(1));
+
+        var bb = new BlobBuilder();
+        bb.WriteBytes(blob);
+        BlobHandle blobHandle = md.GetOrAddBlob(bb);
+        EntityHandle handle = kind == SignatureBlobGuard.Kind.TypeSpecification
+            ? md.AddTypeSpecification(blobHandle)
+            : md.AddStandaloneSignature(blobHandle);
+
+        var root = new MetadataRootBuilder(md, suppressValidation: true);
+        var image = new BlobBuilder();
+        root.Serialize(image, 0, 0);
+        var reader = MetadataReaderProvider.FromMetadataImage(ImmutableArray.Create(image.ToArray())).GetMetadataReader();
+
+        BlobHandle signature = kind == SignatureBlobGuard.Kind.TypeSpecification
+            ? reader.GetTypeSpecification((TypeSpecificationHandle)handle).Signature
+            : reader.GetStandaloneSignature((StandaloneSignatureHandle)handle).Signature;
+        return (reader, signature);
+    }
+
+    // --- Adversarial signature generation ---
+
+    static byte[] GenerateSignature(Random rng, SignatureBlobGuard.Kind kind)
+    {
+        var type = GenerateType(rng);
+        var blob = new List<byte>();
+        switch (kind)
+        {
+            case SignatureBlobGuard.Kind.TypeSpecification:
+                blob.AddRange(type);
+                break;
+            case SignatureBlobGuard.Kind.Field:
+                blob.Add(0x06); // FIELD header
+                blob.AddRange(type);
+                break;
+            case SignatureBlobGuard.Kind.LocalVariables:
+                blob.Add(0x07); // LOCAL_SIG header
+                WriteCount(rng, blob);
+                blob.AddRange(type);
+                break;
+            case SignatureBlobGuard.Kind.MethodSpecification:
+                blob.Add(0x0a); // GENRICINST header
+                WriteCount(rng, blob);
+                blob.AddRange(type);
+                break;
+            default: // Method
+                blob.Add((byte)rng.Next(0, 0x40)); // calling convention (occasionally IsGeneric etc.)
+                WriteCount(rng, blob); // param count
+                blob.Add(0x01);        // return type VOID
+                blob.AddRange(type);   // one parameter
+                break;
+        }
+        return [.. blob];
+    }
+
+    // A count that is sometimes valid-small, sometimes a huge compressed integer (amplification).
+    static void WriteCount(Random rng, List<byte> blob)
+    {
+        switch (rng.Next(0, 4))
+        {
+            case 0: blob.Add(0x01); break;                                   // 1
+            case 1: blob.Add((byte)rng.Next(0, 0x7f)); break;               // small
+            case 2: blob.AddRange([0xdf, 0xff, 0xff, 0xff]); break;          // ~536M (huge)
+            default: blob.AddRange([0x81, (byte)rng.Next(0, 256)]); break;  // 2-byte compressed
+        }
+    }
+
+    // Emits a Type blob. Iterative (no generator-side recursion), with adversarial strategies.
+    static List<byte> GenerateType(Random rng)
+    {
+        var blob = new List<byte>();
+        switch (rng.Next(0, 8))
+        {
+            case 0: // deep wrapper chain (StackOverflow probe)
+            {
+                byte wrapper = PickWrapper(rng);
+                int depth = rng.Next(1, 200_000);
+                for (int i = 0; i < depth; i++)
+                {
+                    blob.Add(wrapper);
+                    if (wrapper is 0x1f or 0x20) // CMOD_REQD/OPT carry a token
+                        blob.Add(0x06);
+                }
+                blob.Add(0x08); // I4 leaf
+                break;
+            }
+            case 1: // GENERICINST with a huge or wide arg count
+                blob.Add(0x15);
+                blob.Add(0x12); // CLASS
+                blob.Add(0x06); // generic type token
+                WriteCount(rng, blob);
+                blob.Add(0x08); // one concrete arg follows (rest are "declared but absent")
+                break;
+            case 2: // general ARRAY with adversarial shape counts
+                blob.Add(0x14);
+                blob.Add(0x08); // element I4
+                blob.Add((byte)rng.Next(1, 4)); // rank
+                WriteCount(rng, blob);          // numSizes (sometimes huge)
+                WriteCount(rng, blob);          // numLoBounds (sometimes huge)
+                break;
+            case 3: // FNPTR with adversarial nested method sig
+                blob.Add(0x1b);
+                blob.Add(0x00);
+                WriteCount(rng, blob);
+                blob.Add(0x01);
+                break;
+            case 4: // wide GENERICINST with many real 1-byte args
+            {
+                blob.Add(0x15);
+                blob.Add(0x12);
+                blob.Add(0x06);
+                int args = rng.Next(1, 100_000);
+                WriteCompressed(blob, args);
+                for (int i = 0; i < args; i++)
+                    blob.Add(0x08);
+                break;
+            }
+            case 5: // truncated: a valid prefix then nothing
+                blob.Add(PickWrapper(rng));
+                break;
+            case 6: // random bytes
+            {
+                int n = rng.Next(1, 4_000);
+                for (int i = 0; i < n; i++)
+                    blob.Add((byte)rng.Next(0, 256));
+                break;
+            }
+            default: // a simple leaf
+                blob.Add((byte)new byte[] { 0x08, 0x0e, 0x1c, 0x02, 0x18, 0x11, 0x12 }[rng.Next(0, 7)]);
+                if (blob[^1] is 0x11 or 0x12) // VALUETYPE/CLASS carry a token
+                    blob.Add(0x06);
+                break;
+        }
+        return blob;
+    }
+
+    static byte PickWrapper(Random rng)
+        => new byte[] { 0x0f /*PTR*/, 0x1d /*SZARRAY*/, 0x10 /*BYREF*/, 0x45 /*PINNED*/, 0x1f /*CMOD_REQD*/, 0x20 /*CMOD_OPT*/ }[rng.Next(0, 6)];
+
+    static void WriteCompressed(List<byte> blob, int value)
+    {
+        if (value < 0x80)
+            blob.Add((byte)value);
+        else if (value < 0x4000)
+        {
+            blob.Add((byte)(0x80 | (value >> 8)));
+            blob.Add((byte)value);
+        }
+        else
+        {
+            blob.Add((byte)(0xc0 | (value >> 24)));
+            blob.Add((byte)(value >> 16));
+            blob.Add((byte)(value >> 8));
+            blob.Add((byte)value);
+        }
+    }
+
+    // Trivial provider: the SO / pre-allocation both live in SRM's decoder, so results are irrelevant.
+    sealed class FuzzProvider : ISignatureTypeProvider<int, object?>
+    {
+        public int GetPrimitiveType(PrimitiveTypeCode typeCode) => 0;
+        public int GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => 0;
+        public int GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) => 0;
+        public int GetTypeFromSpecification(MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind) => 0;
+        public int GetSZArrayType(int elementType) => 0;
+        public int GetArrayType(int elementType, ArrayShape shape) => 0;
+        public int GetByReferenceType(int elementType) => 0;
+        public int GetPointerType(int elementType) => 0;
+        public int GetPinnedType(int elementType) => 0;
+        public int GetGenericInstantiation(int genericType, ImmutableArray<int> typeArguments) => 0;
+        public int GetGenericTypeParameter(object? genericContext, int index) => 0;
+        public int GetGenericMethodParameter(object? genericContext, int index) => 0;
+        public int GetFunctionPointerType(MethodSignature<int> signature) => 0;
+        public int GetModifiedType(int modifier, int unmodifiedType, bool isRequired) => 0;
+    }
+}


### PR DESCRIPTION
Fixes #2499.

## Why

The `SignatureBlobGuard` hardening (#2503, #2550) was validated by hand-crafted fixtures one shape at a time, and adversarial review **repeatedly found vectors those fixtures missed** — across those two PRs, review caught seven real StackOverflow/OOM vectors, and in several rounds one strong reviewer missed a shape another caught (the cumulative-cycle and array-shape OOM among them). That is a fragile way to protect a tool whose job is inspecting untrusted assemblies. This adds an **automated fuzzer** so that whole class is exercised mechanically.

## What

`--fuzz-signatures` generates adversarial signature blobs — deep wrapper chains (`PTR`/`SZARRAY`/`BYREF`/`PINNED`/`CMOD`), wide and huge declared counts, adversarial `ARRAY` shapes, `FNPTR`, truncation, and random bytes — across all five `SignatureBlobGuard.Kind` shapes. For each blob it:

1. runs `SignatureBlobGuard.IsSafeToDecode`, then
2. when the guard reports it **safe**, runs a **real SRM signature decode**.

The guard's contract is: *safe ⟹ SRM decodes without an uncatchable `StackOverflowException` or unbounded pre-allocation*. A blob that violates it aborts the process — the fuzzing signal — so **finishing all iterations is the pass**. The decode uses a trivial `ISignatureTypeProvider` because both failure modes live inside SRM's `DecodeType`/array decoding, independent of the provider, keeping the fuzzer self-contained (no dependency on the product decoders).

**`--fuzz-unguarded`** is the positive control: it skips the guard and decodes directly. It is *expected to abort* on a deep/huge blob — demonstrating both that the fuzzer generates genuinely crashing inputs and that the guard is what prevents them.

Runs are deterministic per `--fuzz-seed` and log the culprit blob to stderr for repro. A bounded **1,000,000-iteration** run is wired into the opt-in **Deep Inspect** census lane (not PR CI).

## Evidence

- **Teeth (positive control):** `--fuzz-unguarded` aborts with **exit 134** — `StackOverflow` inside `System.Reflection.Metadata.Ecma335.SignatureDecoder.DecodeType` — on the first deep blob.
- **Guard holds:** guarded runs at seeds 1 (1,000,000 iterations) and 2/3/7 (50,000 each) — **>1.1M adversarial blobs** — all finish cleanly (exit 0). The guard rejects ~61% of the generated blobs (the deep/huge ones); the remaining "safe" ones decode with no uncatchable crash (~33% throw catchable `BadImageFormatException`, as expected for malformed-but-shallow input).
- Full `dotnet-inspect.slnx` build clean; README markdownlint clean; `deep-inspect.yml` YAML valid.

## Review

New adversarial-tooling with subtle invariants (guard-contract, self-contained decode, determinism) → requesting two-model adversarial review (GPT-5.5 + Gemini 3.1 Pro) with a confirmatory pass. Reviewers: please (a) confirm the fuzzer actually exercises the known vectors and would catch a guard regression (run `--fuzz-unguarded`), (b) check the generator/`BuildImage`/decode plumbing is sound and self-contained, and (c) try to find a guard gap the fuzzer misses (a shape it does not generate that the guard mishandles).
