### PR TITLE
Gate Not My Type census in Deep Inspect

### DIFF
--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -138,6 +138,18 @@ jobs:
             --max-examples 10 \
             2>&1 | tee artifacts/deep-inspect/return-address-census.txt
 
+      - name: Run not-my-type equivalence census
+        shell: bash
+        run: |
+          set -o pipefail
+          mapfile -t assemblies < corpus-assemblies.txt
+          mkdir -p artifacts/deep-inspect
+          dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
+            --emit-not-my-type-snapshot artifacts/deep-inspect/not-my-type-snapshot.json \
+            --diff-not-my-type-baseline tools/DecompilerHarness/corpus/not-my-type-baseline.json \
+            --max-examples 10 \
+            2>&1 | tee artifacts/deep-inspect/not-my-type-census.txt
+
       - name: Run validity predicate scan
         shell: bash
         run: |

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -691,7 +691,7 @@ or API-filtered) that have no ApiSurface member, so they are counted for coverag
 but never miscompared. The sweep never crashes on unreadable file inputs — a bad
 path is reported as an unopened assembly.
 
-#### Baseline drift gate (Deep Inspect)
+#### Return Address baseline drift gate (Deep Inspect)
 
 The census runs in the Deep Inspect **census lane** as a committed-baseline drift
 gate, mirroring the real-world corpus sensor:
@@ -716,6 +716,50 @@ that ratchets toward 100% as identity consolidation (#2440) lands — improvemen
 never fail; re-emit the baseline to raise the floor. `matched`/`unmatched` counts
 drift with corpus composition (framework/NuGet version bumps), so they are
 reported in the card for triage but not gated.
+
+### Not My Type equivalence census (`--not-my-type`)
+
+`--not-my-type` runs the Not My Type (NMT) type-shape equivalence census. It
+compares the product type-shape oracle (`MetadataSource.ClassifyType`) with the
+legacy base-name classifier that the harness sites used to re-derive locally.
+It reports two axes:
+
+- **same-assembly agreement** over type definitions, where the oracle and legacy
+  classifier read the same local metadata and therefore must agree; and
+- **cross-assembly reference recovery**, where the corpus-aware product oracle
+  can resolve shapes that a single-assembly legacy walk leaves `Unknown`.
+
+```bash
+dotnet run --project tools/DecompilerHarness -c Release -- <assemblies> --not-my-type
+```
+
+Output is a Markout card (Markdown by default; `--tsv` and `--jsonl` select the
+tabular and JSONL renderings). `--max-examples N` caps same-assembly divergence
+rows. The recovery rate is informational; it quantifies the cross-assembly gap
+the product oracle closes.
+
+#### Not My Type baseline drift gate (Deep Inspect)
+
+The census runs in the Deep Inspect **census lane** as a committed-baseline drift
+gate, matching the Return Address pattern:
+
+```bash
+# Refresh the committed baseline (run when the agree rate legitimately improves):
+dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
+  --emit-not-my-type-snapshot tools/DecompilerHarness/corpus/not-my-type-baseline.json
+
+# Gate against the committed baseline (fails with exit 1 on regression):
+dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
+  --diff-not-my-type-baseline tools/DecompilerHarness/corpus/not-my-type-baseline.json \
+  --max-examples 10
+```
+
+The baseline is the pinned real-world corpus (`eng/prepare-decompiler-corpus.sh`).
+The gate compares only the **global same-assembly agree rate** (stored in basis
+points). This floor is intentionally hard (`agreeRateDropBasisPoints` defaults to
+0) because same-assembly agreement should be 100%; a drop is a real oracle or
+legacy-classifier divergence, not corpus drift. Re-emit the baseline only when
+the floor legitimately improves or the pinned corpus changes deliberately.
 
 ## Usage
 

--- a/tools/DecompilerHarness/corpus/not-my-type-baseline.json
+++ b/tools/DecompilerHarness/corpus/not-my-type-baseline.json
@@ -1,0 +1,114 @@
+{
+  "schemaVersion": 1,
+  "description": "#2548 Not My Type type-shape equivalence census: same-assembly agreement between the product oracle (MetadataSource.ClassifyType) and the legacy base-name classifier the harness sites re-derive, plus cross-assembly reference recovery. Same-assembly agreement is a hard 100% floor; recovery is informational.",
+  "generatedUtc": "2026-07-08T22:06:57.4282544+00:00",
+  "tolerances": {
+    "agreeRateDropBasisPoints": 0
+  },
+  "definitions": 8472,
+  "agree": 8472,
+  "diverge": 0,
+  "crossRefs": 4660,
+  "recovered": 4587,
+  "agreeBasisPoints": 10000,
+  "assemblies": [
+    {
+      "assembly": "DotnetInspector.Core.dll",
+      "definitions": 41,
+      "agree": 41,
+      "diverge": 0,
+      "agreeBasisPoints": 10000
+    },
+    {
+      "assembly": "DotnetInspector.Packages.dll",
+      "definitions": 58,
+      "agree": 58,
+      "diverge": 0,
+      "agreeBasisPoints": 10000
+    },
+    {
+      "assembly": "DotnetInspector.Services.dll",
+      "definitions": 79,
+      "agree": 79,
+      "diverge": 0,
+      "agreeBasisPoints": 10000
+    },
+    {
+      "assembly": "ILInspector.Analysis.dll",
+      "definitions": 66,
+      "agree": 66,
+      "diverge": 0,
+      "agreeBasisPoints": 10000
+    },
+    {
+      "assembly": "ILInspector.Decompiler.dll",
+      "definitions": 654,
+      "agree": 654,
+      "diverge": 0,
+      "agreeBasisPoints": 10000
+    },
+    {
+      "assembly": "ILInspector.Metadata.dll",
+      "definitions": 164,
+      "agree": 164,
+      "diverge": 0,
+      "agreeBasisPoints": 10000
+    },
+    {
+      "assembly": "ILInspector.MetadataPrimitives.dll",
+      "definitions": 9,
+      "agree": 9,
+      "diverge": 0,
+      "agreeBasisPoints": 10000
+    },
+    {
+      "assembly": "Microsoft.ApplicationInsights.dll",
+      "definitions": 379,
+      "agree": 379,
+      "diverge": 0,
+      "agreeBasisPoints": 10000
+    },
+    {
+      "assembly": "Microsoft.CodeAnalysis.CSharp.dll",
+      "definitions": 2752,
+      "agree": 2752,
+      "diverge": 0,
+      "agreeBasisPoints": 10000
+    },
+    {
+      "assembly": "Microsoft.CodeAnalysis.dll",
+      "definitions": 2371,
+      "agree": 2371,
+      "diverge": 0,
+      "agreeBasisPoints": 10000
+    },
+    {
+      "assembly": "Newtonsoft.Json.dll",
+      "definitions": 501,
+      "agree": 501,
+      "diverge": 0,
+      "agreeBasisPoints": 10000
+    },
+    {
+      "assembly": "NuGet.Versioning.dll",
+      "definitions": 41,
+      "agree": 41,
+      "diverge": 0,
+      "agreeBasisPoints": 10000
+    },
+    {
+      "assembly": "System.CommandLine.dll",
+      "definitions": 149,
+      "agree": 149,
+      "diverge": 0,
+      "agreeBasisPoints": 10000
+    },
+    {
+      "assembly": "dotnet-inspect.dll",
+      "definitions": 1208,
+      "agree": 1208,
+      "diverge": 0,
+      "agreeBasisPoints": 10000
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Part of #2548.

- Add the committed `not-my-type-baseline.json` for the existing Not My Type type-shape census.
- Run `--diff-not-my-type-baseline` in the Deep Inspect census lane and publish the emitted snapshot/card artifacts.
- Document the Not My Type census refresh/gate workflow next to Return Address.

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "*TypeShapeClassificationTests"`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- "${assemblies[@]}" --diff-not-my-type-baseline tools/DecompilerHarness/corpus/not-my-type-baseline.json --max-examples 10`
- `npx markdownlint-cli tools/DecompilerHarness/README.md`

## Notes

NMT baseline: 8,472/8,472 same-assembly definitions agree (100.00%); 4,587/4,660 cross-assembly references recover a concrete shape (98.43%).

Low-risk harness/CI/docs baseline wiring only; no decompiler behavior change.
