### PR TITLE
Source shell where-clauses from product declaration facts (#2548 finding #4)

### DIFF
--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -363,12 +363,27 @@ public static class MetadataDeclarationQuery
     {
         var clauses = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach (var parameter in TypeParameters(reader, typeDef.GetGenericParameters(), GenericContext.ForType(reader, typeDef)))
-            if (parameter.ConstraintsSummary is { } summary)
-                clauses[parameter.Name] = summary;
+            if (SpellableConstraintClause(parameter) is { } clause)
+                clauses[parameter.Name] = clause;
         foreach (var parameter in MethodTypeParameters(reader, typeDef, method))
-            if (parameter.ConstraintsSummary is { } summary)
-                clauses.TryAdd(parameter.Name, summary);
+            if (SpellableConstraintClause(parameter) is { } clause)
+                clauses.TryAdd(parameter.Name, clause);
         return clauses;
+    }
+
+    /// <summary>
+    /// The spellable <c>where</c> clause body for a parameter, or null when nothing
+    /// remains to spell. C# forbids an explicit <c>System.Object</c> constraint
+    /// (<c>CS0702: Constraint cannot be special class 'object'</c>) — and it is
+    /// semantically vacuous — so it is dropped. Non-C# compilers can emit it even
+    /// though Roslyn does not.
+    /// </summary>
+    internal static string? SpellableConstraintClause(TypeParameter parameter)
+    {
+        var spellable = parameter.Constraints
+            .Where(constraint => constraint is not ("System.Object" or "Object" or "object"))
+            .ToList();
+        return spellable.Count > 0 ? string.Join(", ", spellable) : null;
     }
 
     public static string SelfTypeSignature(MetadataReader reader, TypeDefinition typeDef)

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -344,6 +344,33 @@ public static class MetadataDeclarationQuery
             RenderMemberAttributes(reader, field.GetCustomAttributes()));
     }
 
+    /// <summary>
+    /// The C# generic-constraint clause body for each in-scope generic parameter of
+    /// <paramref name="method"/> — its own parameters and its declaring type's —
+    /// keyed by parameter name (for example <c>"TOther"</c> to
+    /// <c>"INumberBase&lt;TOther&gt;"</c>). Each body already honors the C# ordering
+    /// and redundancy rules (<c>class</c>/<c>struct</c>, then base/interface
+    /// constraints, then <c>new()</c>; <c>struct</c> implies <c>new()</c> and drops
+    /// the <c>ValueType</c> base). Type parameters win over method parameters on a
+    /// name clash, since both share one scope inside a method shell. A parameter with
+    /// no constraints is omitted. This is the product-owned source of constraint
+    /// declaration facts, so consumers do not re-derive the C# rules from metadata.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> GetGenericConstraintClauses(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        MethodDefinition method)
+    {
+        var clauses = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var parameter in TypeParameters(reader, typeDef.GetGenericParameters(), GenericContext.ForType(reader, typeDef)))
+            if (parameter.ConstraintsSummary is { } summary)
+                clauses[parameter.Name] = summary;
+        foreach (var parameter in MethodTypeParameters(reader, typeDef, method))
+            if (parameter.ConstraintsSummary is { } summary)
+                clauses.TryAdd(parameter.Name, summary);
+        return clauses;
+    }
+
     public static string SelfTypeSignature(MetadataReader reader, TypeDefinition typeDef)
     {
         var metadataFullName = TypeResolver.GetFullName(reader, typeDef);

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -131,6 +131,33 @@ public sealed class MetadataDeclarationQueryTests
         Assert.Equal("ILInspector.Metadata.Tests.MetadataDeclarationQueryFixtures.Container<T>.Row<U>", signature);
     }
 
+    [Fact]
+    public void GetGenericConstraintClauses_RendersSpecialConstraints()
+    {
+        var type = GetTypeDefinition(typeof(MetadataDeclarationQueryFixtures));
+
+        var structClauses = MetadataDeclarationQuery.GetGenericConstraintClauses(
+            Reader, type, GetMethod(type, nameof(MetadataDeclarationQueryFixtures.StructConstraint)));
+        Assert.Equal("struct", Assert.Contains("T", structClauses));
+
+        var classClauses = MetadataDeclarationQuery.GetGenericConstraintClauses(
+            Reader, type, GetMethod(type, nameof(MetadataDeclarationQueryFixtures.ClassNewConstraint)));
+        Assert.Equal("class, new()", Assert.Contains("T", classClauses));
+    }
+
+    [Fact]
+    public void SpellableConstraintClause_DropsExplicitObjectConstraint()
+    {
+        // C# forbids `where T : object` (CS0702); it must be dropped even though
+        // Roslyn never emits it (non-C# compilers can).
+        Assert.Null(MetadataDeclarationQuery.SpellableConstraintClause(
+            new TypeParameter { Name = "T", Constraints = { "System.Object" } }));
+        Assert.Equal("System.IComparable", MetadataDeclarationQuery.SpellableConstraintClause(
+            new TypeParameter { Name = "T", Constraints = { "System.Object", "System.IComparable" } }));
+        Assert.Equal("class, new()", MetadataDeclarationQuery.SpellableConstraintClause(
+            new TypeParameter { Name = "T", Constraints = { "class", "new()" } }));
+    }
+
     static TypeDefinition GetTypeDefinition(Type type)
         => Reader.GetTypeDefinition(GetTypeDefinitionHandle(type));
 
@@ -206,6 +233,10 @@ public class MetadataDeclarationQueryFixtures
     public int @while { get; set; }
 
     public int @event = 1;
+
+    public void StructConstraint<T>() where T : struct { }
+
+    public void ClassNewConstraint<T>() where T : class, new() { }
 
     public abstract class AbstractBase
     {

--- a/tools/DecompilerHarness/ShellConstraints.cs
+++ b/tools/DecompilerHarness/ShellConstraints.cs
@@ -1,7 +1,4 @@
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Reflection;
-using System.Reflection.Metadata;
 using System.Text;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
@@ -10,13 +7,14 @@ using ILInspector.Metadata;
 namespace ILInspector.DecompilerHarness;
 
 /// <summary>
-/// Reconstructs the generic-parameter <c>where</c> clauses for the validity-check
+/// Supplies the generic-parameter <c>where</c> clauses for the validity-check
 /// method shell. The shell declares a body's generic parameters (<c>__M&lt;TOther&gt;</c>)
 /// but, with no constraints, a constrained call — <c>byte.TryConvertFromTruncating&lt;TOther&gt;</c>
 /// needs <c>where TOther : INumberBase&lt;TOther&gt;</c> — spuriously fails CS0314, which
-/// is a shell limitation, not a decompiler defect. Reading the real constraints from
-/// metadata (type- and method-level) lets the shell bind the same code the runtime
-/// accepts, so genuine defects are not drowned by ~100 phantom CS0314s.
+/// is a shell limitation, not a decompiler defect. The constraint clause bodies come
+/// from the product (<see cref="MetadataDeclarationQuery.GetGenericConstraintClauses"/>),
+/// so the harness carries no C# constraint-ordering or redundancy knowledge — it only
+/// keys the product facts by the shell's identity and renders the clauses.
 /// </summary>
 internal static class ShellConstraints
 {
@@ -34,22 +32,22 @@ internal static class ShellConstraints
         {
             var typeDef = reader.GetTypeDefinition(typeHandle);
             string typeName = reader.GetFullTypeName(typeDef);
-            var typeParams = typeDef.GetGenericParameters();
+            bool typeIsGeneric = typeDef.GetGenericParameters().Count > 0;
             foreach (var methodHandle in typeDef.GetMethods())
             {
                 var method = reader.GetMethodDefinition(methodHandle);
-                var methodParams = method.GetGenericParameters();
-                if (typeParams.Count == 0 && methodParams.Count == 0)
+                int methodArity = method.GetGenericParameters().Count;
+                if (!typeIsGeneric && methodArity == 0)
                     continue;
 
-                // The decoder resolves a constraint's `!N`/`!!N` references against the
-                // type's and method's parameter names — the same scope the importer uses.
-                var scope = new GenericScope(Names(reader, typeParams), Names(reader, methodParams));
-                string key = $"{typeName}::{reader.GetString(method.Name)}::{methodParams.Count}";
+                string key = $"{typeName}::{reader.GetString(method.Name)}::{methodArity}";
                 if (!map.TryGetValue(key, out var clauses))
                     map[key] = clauses = new Dictionary<string, string>(StringComparer.Ordinal);
-                AddClauses(reader, scope, typeParams, clauses);
-                AddClauses(reader, scope, methodParams, clauses);
+                // Overloads sharing the key can declare different generic parameter
+                // names; accumulate the union, keeping the first clause seen per name
+                // (constraints are stable across overloads that share a name).
+                foreach (var (name, clause) in MetadataDeclarationQuery.GetGenericConstraintClauses(reader, typeDef, method))
+                    clauses.TryAdd(name, clause);
             }
         }
         return map;
@@ -68,79 +66,5 @@ internal static class ShellConstraints
             if (clauses.TryGetValue(name, out var clause))
                 sb.Append(" where ").Append(name).Append(" : ").Append(clause);
         return sb.ToString();
-    }
-
-    static ImmutableArray<string> Names(MetadataReader reader, GenericParameterHandleCollection handles)
-    {
-        var builder = ImmutableArray.CreateBuilder<string>(handles.Count);
-        foreach (var handle in handles)
-            builder.Add(reader.GetString(reader.GetGenericParameter(handle).Name));
-        return builder.MoveToImmutable();
-    }
-
-    static void AddClauses(MetadataReader reader, GenericScope scope,
-        GenericParameterHandleCollection handles, Dictionary<string, string> clauses)
-    {
-        foreach (var handle in handles)
-        {
-            var gp = reader.GetGenericParameter(handle);
-            string name = reader.GetString(gp.Name);
-            if (clauses.ContainsKey(name))
-                continue;
-            if (Clause(reader, scope, gp) is { } clause)
-                clauses[name] = clause;
-        }
-    }
-
-    static string? Clause(MetadataReader reader, GenericScope scope, GenericParameter gp)
-    {
-        var attributes = gp.Attributes;
-        bool isClass = (attributes & GenericParameterAttributes.ReferenceTypeConstraint) != 0;
-        bool isStruct = (attributes & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0;
-        bool hasNew = (attributes & GenericParameterAttributes.DefaultConstructorConstraint) != 0;
-
-        // C# ordering: class/struct, then base/interface constraints, then new().
-        var parts = new List<string>();
-        if (isClass)
-            parts.Add("class");
-        if (isStruct)
-            parts.Add("struct");
-
-        foreach (var constraintHandle in gp.GetConstraints())
-        {
-            var constraint = reader.GetGenericParameterConstraint(constraintHandle);
-            if (Decode(reader, scope, constraint.Type) is not { } type)
-                continue;
-            // Implicit/redundant constraints C# forbids spelling: every type satisfies
-            // object, and `struct` already implies the System.ValueType base.
-            if (IsCoreType(type, "Object") || (isStruct && IsCoreType(type, "ValueType")))
-                continue;
-            if (Render(type) is { } text)
-                parts.Add(text);
-        }
-
-        // `struct` already implies a public parameterless constructor.
-        if (hasNew && !isStruct)
-            parts.Add("new()");
-
-        return parts.Count > 0 ? string.Join(", ", parts) : null;
-    }
-
-    static TypeRef? Decode(MetadataReader reader, GenericScope scope, EntityHandle handle) => handle.Kind switch
-    {
-        HandleKind.TypeDefinition => TypeRefDecoder.Instance.GetTypeFromDefinition(reader, (TypeDefinitionHandle)handle, 0),
-        HandleKind.TypeReference => TypeRefDecoder.Instance.GetTypeFromReference(reader, (TypeReferenceHandle)handle, 0),
-        HandleKind.TypeSpecification => TypeRefDecoder.Instance.GetTypeFromSpecification(reader, scope, (TypeSpecificationHandle)handle, 0),
-        _ => null,
-    };
-
-    static bool IsCoreType(TypeRef type, string name)
-        => type.Kind == TypeRefKind.Definition && type.Namespace == "System" && type.Name == name;
-
-    /// <summary>Renders a constraint type, or null when it does not resolve to a spellable name (an unresolved `!` slot — better skipped than emitted as the illegal `where T : object`).</summary>
-    static string? Render(TypeRef type)
-    {
-        string text = type.ToDisplayString();
-        return string.IsNullOrWhiteSpace(text) || text.Contains('!') ? null : text;
     }
 }


### PR DESCRIPTION
Implements **finding #4 of #2548**: move generic-constraint `where`-clause
knowledge out of the `ShellConstraints` harness and onto the product declaration
facts it duplicated.

## Problem

`ShellConstraints` read SRM directly *and* re-encoded the C# constraint
ordering/redundancy rules (class/struct, then base/interface, then `new()`;
`struct` implies `new()` and drops the `ValueType` base) — a near-total duplicate
of the product's `MetadataDeclarationQuery.TypeParameters`, which already computes
these facts and is the source of truth for real C# declaration output
(`CSharpDeclarationWriter`).

## What changed

- **Product**: new public `MetadataDeclarationQuery.GetGenericConstraintClauses(reader, typeDef, method)`
  — the constraint clause body per in-scope generic parameter (the method's own and
  its declaring type's), built from the existing constraint facts. It also resolves
  `!N`/`!!N` references to parameter names via `GenericContext`, which
  `ShellConstraints` previously could not (it dropped `'!'`-containing constraints).
- **Harness**: `ShellConstraints` drops all constraint knowledge (**146 → 68 lines**).
  It now only keys the product clauses by shell identity (`type::method::arity`) and
  renders them, preserving the union-accumulation across same-key overloads the shell
  relies on.

## Validation — validity-defect A/B (compile-all)

Constraint clauses directly drive validity (a wrong/missing `where` → CS0314), so
`--emit-validity-defects` / `--diff-validity-defects` is a purpose-built A/B.

| Corpus | Methods compared | Regressed | Improved |
| --- | --- | --- | --- |
| System.Collections.Immutable + System.Linq | 2185 | 0 | 0 |
| System.Private.CoreLib | 23650 | 0 | 0 |

The A/B earned its keep: an earlier cut used a per-key keep-first-overload map, which
dropped an arity-shared overload's `TAccumulator` constraint and produced a phantom
CS0314 on `Enumerable.Sum`. Fixed by restoring union-accumulation (keep first clause
per name across same-key overloads); the tables above are the fixed head.

Full `dotnet-inspect.slnx` build: 0 errors.

## Review

Per the Adversarial Review policy this needs **two** reviewers from a different
model family than the author (Claude Opus 4.8): requesting **GPT-5.5** and
**Gemini 3.1 Pro**. Attack points: (1) does `GetGenericConstraintClauses` ever
produce a clause that differs semantically from the old `ShellConstraints`
rendering in a way the corpus A/B missed (e.g., nested/generic constraints,
type-vs-method param name clashes, `!`-resolution)? (2) is the union-accumulation
across same-key overloads correct and complete? (3) any assembly where a constraint
is now dropped or over-qualified such that a shell stops/starts compiling?

Refs #2548.
