### PR TITLE
Guard SignatureDecoder composer decode sites (#2490 increment 3)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GuardedSignatureTextTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GuardedSignatureTextTests.cs
@@ -1,0 +1,43 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using ILInspector.Decompiler;
+
+namespace ILInspector.Decompiler.Tests;
+
+// GuardedSignatureText routes the compile-back / type-source composers' string-producing signature
+// decodes through SignatureBlobGuard, so a malformed deeply-nested signature degrades to a
+// placeholder type instead of overflowing the native stack inside SRM.
+public class GuardedSignatureTextTests
+{
+    [Fact]
+    public void DeepFieldSignature_DegradesToPlaceholder()
+    {
+        // FIELD header then a 600-deep array (over the 512 guard limit).
+        var sig = new BlobBuilder();
+        sig.WriteByte(0x06); // FIELD
+        for (int i = 0; i < 600; i++)
+            sig.WriteByte(0x1d); // SZARRAY
+        sig.WriteByte(0x08);     // I4
+
+        var (reader, handle) = BuildField(sig);
+        var text = GuardedSignatureText.FieldText(reader, reader.GetFieldDefinition(handle), context: null);
+
+        Assert.Equal("object", text);
+    }
+
+    static (MetadataReader Reader, FieldDefinitionHandle Handle) BuildField(BlobBuilder sig)
+    {
+        var md = new MetadataBuilder();
+        md.AddModule(0, md.GetOrAddString("m.dll"), md.GetOrAddGuid(Guid.NewGuid()), default, default);
+        md.AddAssembly(md.GetOrAddString("m"), new Version(1, 0, 0, 0), default, default, default, default);
+        var field = md.AddFieldDefinition(System.Reflection.FieldAttributes.Public, md.GetOrAddString("f"), md.GetOrAddBlob(sig));
+        md.AddTypeDefinition(default, default, md.GetOrAddString("<Module>"), default,
+            MetadataTokens.FieldDefinitionHandle(1), MetadataTokens.MethodDefinitionHandle(1));
+        var root = new MetadataRootBuilder(md, suppressValidation: true);
+        var image = new BlobBuilder();
+        root.Serialize(image, 0, 0);
+        var reader = MetadataReaderProvider.FromMetadataImage(ImmutableArray.Create(image.ToArray())).GetMetadataReader();
+        return (reader, field);
+    }
+}

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -391,8 +391,8 @@ public static class CompileBackSourceComposer
         var targetTypeDef = reader.GetTypeDefinition(targetType);
         var property = reader.GetPropertyDefinition(targetProperty);
         var getter = reader.GetMethodDefinition(targetGetter);
-        var signature = property.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForType(reader, targetTypeDef));
-        var getterSignature = getter.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, targetTypeDef, getter));
+        var signature = GuardedSignatureText.PropertyText(reader, property, GenericContext.ForType(reader, targetTypeDef));
+        var getterSignature = GuardedSignatureText.MethodText(reader, getter, GenericContext.ForMethod(reader, targetTypeDef, getter));
         var propertyDeclaration = MetadataDeclarationQuery.GetProperty(reader, targetTypeDef, property);
         var accessors = property.GetAccessors();
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
@@ -567,7 +567,7 @@ public static class CompileBackSourceComposer
         var targetTypeDef = reader.GetTypeDefinition(targetType);
         var property = reader.GetPropertyDefinition(targetProperty);
         var setter = reader.GetMethodDefinition(targetSetter);
-        var propertySignature = property.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForType(reader, targetTypeDef));
+        var propertySignature = GuardedSignatureText.PropertyText(reader, property, GenericContext.ForType(reader, targetTypeDef));
         var propertyDeclaration = MetadataDeclarationQuery.GetProperty(reader, targetTypeDef, property);
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
         string propertyName = Identifier(reader.GetString(property.Name));
@@ -665,7 +665,7 @@ public static class CompileBackSourceComposer
     {
         var targetTypeDef = reader.GetTypeDefinition(targetType);
         var method = reader.GetMethodDefinition(targetMethod);
-        var signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, targetTypeDef, method));
+        var signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, targetTypeDef, method));
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
         string targetMethodName = Identifier(methodName);
         bool isConstructor = function.MethodKind is IrMethodKind.Constructor or IrMethodKind.StaticConstructor;
@@ -1312,7 +1312,7 @@ public static class CompileBackSourceComposer
                 continue;
             }
 
-            var signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method));
+            var signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, typeDef, method));
             if (!OperatorSignaturesMatch(targetSignature, signature))
                 continue;
 
@@ -1358,7 +1358,7 @@ public static class CompileBackSourceComposer
             if (reader.GetString(method.Name) != siblingName)
                 continue;
 
-            var signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method));
+            var signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, typeDef, method));
             if (!OperatorSignaturesMatch(targetSignature, signature))
                 continue;
 
@@ -1452,7 +1452,7 @@ public static class CompileBackSourceComposer
             IReadOnlyList<TypeRef> parameterTypes;
             try
             {
-                signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method));
+                signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, typeDef, method));
                 parameterTypes = MethodParameterTypes(reader, typeDef, method);
             }
             catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
@@ -1495,7 +1495,7 @@ public static class CompileBackSourceComposer
             IReadOnlyList<TypeRef> parameterTypes;
             try
             {
-                signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method));
+                signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, typeDef, method));
                 parameterTypes = MethodParameterTypes(reader, typeDef, method);
             }
             catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
@@ -1636,7 +1636,7 @@ public static class CompileBackSourceComposer
         {
             HandleKind.TypeDefinition => CompileBackTypeIdentity.FromDefinition(reader, reader.GetTypeDefinition((TypeDefinitionHandle)handle)).FullName,
             HandleKind.TypeReference => FullName(reader, reader.GetTypeReference((TypeReferenceHandle)handle)),
-            HandleKind.TypeSpecification => reader.GetTypeSpecification((TypeSpecificationHandle)handle).DecodeSignature(SignatureDecoder.Instance, context),
+            HandleKind.TypeSpecification => GuardedSignatureText.TypeSpecText(reader, (TypeSpecificationHandle)handle, context),
             _ => null,
         };
 
@@ -1699,7 +1699,7 @@ public static class CompileBackSourceComposer
             string fieldType;
             try
             {
-                fieldType = field.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForType(reader, declaringType));
+                fieldType = GuardedSignatureText.FieldText(reader, field, GenericContext.ForType(reader, declaringType));
             }
             catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
             {
@@ -1730,7 +1730,7 @@ public static class CompileBackSourceComposer
         if (!RenderedBodyMatchesPrimaryConstructorInitializers(renderedBody, initializerTexts))
             return null;
 
-        var parameters = MethodParameters(reader, method, method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, declaringType, method)));
+        var parameters = MethodParameters(reader, method, GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, declaringType, method)));
         return new CompileBackPrimaryConstructor(
             string.Join(", ", parameters.Select(RenderParameter)),
             parameters,
@@ -1762,7 +1762,7 @@ public static class CompileBackSourceComposer
             string fieldType;
             try
             {
-                fieldType = field.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForType(reader, typeDef));
+                fieldType = GuardedSignatureText.FieldText(reader, field, GenericContext.ForType(reader, typeDef));
             }
             catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
             {
@@ -1941,7 +1941,7 @@ public static class CompileBackSourceComposer
             string fieldType;
             try
             {
-                fieldType = field.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForType(reader, typeDef));
+                fieldType = GuardedSignatureText.FieldText(reader, field, GenericContext.ForType(reader, typeDef));
             }
             catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
             {
@@ -2007,7 +2007,7 @@ public static class CompileBackSourceComposer
             string fieldType;
             try
             {
-                fieldType = field.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForType(reader, typeDef));
+                fieldType = GuardedSignatureText.FieldText(reader, field, GenericContext.ForType(reader, typeDef));
             }
             catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
             {
@@ -2085,7 +2085,7 @@ public static class CompileBackSourceComposer
                 return false;
             try
             {
-                return CompileBackTypeSignature.Display(field.DecodeSignature(SignatureDecoder.Instance, context)).DisplayName == propertyType;
+                return CompileBackTypeSignature.Display(GuardedSignatureText.FieldText(reader, field, context)).DisplayName == propertyType;
             }
             catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
             {
@@ -2126,7 +2126,7 @@ public static class CompileBackSourceComposer
                 return false;
             try
             {
-                return CompileBackTypeSignature.Display(field.DecodeSignature(SignatureDecoder.Instance, context)).DisplayName == propertyType;
+                return CompileBackTypeSignature.Display(GuardedSignatureText.FieldText(reader, field, context)).DisplayName == propertyType;
             }
             catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
             {
@@ -2313,7 +2313,7 @@ public static class CompileBackSourceComposer
             string fieldType;
             try
             {
-                fieldType = field.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForType(reader, typeDef));
+                fieldType = GuardedSignatureText.FieldText(reader, field, GenericContext.ForType(reader, typeDef));
             }
             catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
             {
@@ -2540,7 +2540,7 @@ public static class CompileBackSourceComposer
             MethodSignature<string> signature;
             try
             {
-                signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method));
+                signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, typeDef, method));
             }
             catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
             {
@@ -2657,7 +2657,7 @@ public static class CompileBackSourceComposer
                 if (reader.GetString(method.Name) != "Invoke")
                     continue;
 
-                var signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method));
+                var signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, typeDef, method));
                 return new CompileBackMemberDeclaration(
                     new CompileBackMethodIdentity(typeIdentity.FullName, "Invoke", 0, MethodSignatureText("Invoke", signature)),
                     CompileBackMemberKind.Method,
@@ -2872,7 +2872,7 @@ public static class CompileBackSourceComposer
                 string fieldType;
                 try
                 {
-                    fieldType = field.DecodeSignature(SignatureDecoder.Instance, typeContext);
+                    fieldType = GuardedSignatureText.FieldText(reader, field, typeContext);
                 }
                 catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
                 {
@@ -3008,7 +3008,7 @@ public static class CompileBackSourceComposer
                 MethodSignature<string> signature;
                 try
                 {
-                    signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method));
+                    signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, typeDef, method));
                 }
                 catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
                 {
@@ -3228,7 +3228,7 @@ public static class CompileBackSourceComposer
 
                 try
                 {
-                    var signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method));
+                    var signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, typeDef, method));
                     if (signature.ParameterTypes.Length == 0)
                         return true;
                 }

--- a/src/ILInspector.Decompiler/GuardedSignatureText.cs
+++ b/src/ILInspector.Decompiler/GuardedSignatureText.cs
@@ -1,0 +1,48 @@
+using System.Reflection.Metadata;
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+
+namespace ILInspector.Decompiler;
+
+/// <summary>
+/// Guarded wrappers around the string-producing <see cref="SignatureDecoder"/> used by the
+/// compile-back / type-source composers.
+///
+/// These composers decode signatures of the inspected (untrusted) assembly, so a malformed
+/// deeply-nested or huge-count signature would overflow the native stack inside SRM's
+/// <c>SignatureDecoder</c> (an uncatchable <c>StackOverflowException</c>) or trigger a
+/// multi-gigabyte pre-allocation. <see cref="SignatureBlobGuard"/> detects both before decoding,
+/// so these helpers fail closed to an unresolved placeholder type (a parseable <c>object</c>)
+/// instead of crashing. Real signatures are shallow, so the guard only trips on malformed input.
+/// </summary>
+internal static class GuardedSignatureText
+{
+    // A degraded but syntactically valid C# type keeps composed source parseable; a member whose
+    // signature could not be decoded is already un-reconstructable, so its exact text is moot.
+    const string Unresolved = "object";
+
+    public static MethodSignature<string> MethodText(MetadataReader reader, MethodDefinition method, GenericContext? context)
+        => SignatureBlobGuard.IsSafeToDecode(reader, method.Signature, SignatureBlobGuard.Kind.Method)
+            ? method.DecodeSignature(SignatureDecoder.Instance, context)
+            : UnresolvedMethod;
+
+    public static MethodSignature<string> PropertyText(MetadataReader reader, PropertyDefinition property, GenericContext? context)
+        => SignatureBlobGuard.IsSafeToDecode(reader, property.Signature, SignatureBlobGuard.Kind.Method)
+            ? property.DecodeSignature(SignatureDecoder.Instance, context)
+            : UnresolvedMethod;
+
+    public static string FieldText(MetadataReader reader, FieldDefinition field, GenericContext? context)
+        => SignatureBlobGuard.IsSafeToDecode(reader, field.Signature, SignatureBlobGuard.Kind.Field)
+            ? field.DecodeSignature(SignatureDecoder.Instance, context)
+            : Unresolved;
+
+    public static string TypeSpecText(MetadataReader reader, TypeSpecificationHandle handle, GenericContext? context)
+    {
+        var spec = reader.GetTypeSpecification(handle);
+        return SignatureBlobGuard.IsSafeToDecode(reader, spec.Signature, SignatureBlobGuard.Kind.TypeSpecification)
+            ? spec.DecodeSignature(SignatureDecoder.Instance, context)
+            : Unresolved;
+    }
+
+    static readonly MethodSignature<string> UnresolvedMethod = new(default, Unresolved, 0, 0, []);
+}

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -286,7 +286,7 @@ public static class TypeSourceComposer
             string fieldType;
             try
             {
-                fieldType = field.DecodeSignature(SignatureDecoder.Instance, genericContext);
+                fieldType = GuardedSignatureText.FieldText(reader, field, genericContext);
             }
             catch (Exception ex)
             {
@@ -509,7 +509,7 @@ public static class TypeSourceComposer
 
             try
             {
-                var signature = property.DecodeSignature(SignatureDecoder.Instance, genericContext);
+                var signature = GuardedSignatureText.PropertyText(reader, property, genericContext);
                 hasObjectValueGetter = signature.ReturnType is "object" or "System.Object";
             }
             catch
@@ -538,7 +538,7 @@ public static class TypeSourceComposer
             MethodSignature<string> signature;
             try
             {
-                signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method));
+                signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, typeDef, method));
             }
             catch
             {


### PR DESCRIPTION
Increment 3 of #2490 — completes the tool-wide signature-decode hardening.

## Problem

#2503 (Analysis) and #2550 (Decompiler `TypeRefDecoder`) closed the uncatchable-`StackOverflow` / count-driven-OOM decode surface for one provider. The **last unguarded provider** is `SignatureDecoder` (`ISignatureTypeProvider<string, GenericContext?>`), used by `CompileBackSourceComposer` and `TypeSourceComposer` to render C# type text from the inspected (untrusted) assembly's signatures — still exposed to the same crash on malformed metadata.

## This increment

- **`GuardedSignatureText`** — guarded wrappers (method / property / field / type-spec) that run `SignatureBlobGuard` before `SignatureDecoder` and fail closed to a **parseable placeholder type (`object`)** on trip (a member whose signature can't be decoded is already un-reconstructable, so its exact text is moot; `object` keeps composed source parseable).
- **Routed all 25 `SignatureDecoder.Instance` decode sites** in `CompileBackSourceComposer` (24) and `TypeSourceComposer` (1) through it. `grep` confirms no `SignatureDecoder.Instance` decode remains outside `GuardedSignatureText`.

The property/method sites use `Kind.Method` (a property signature is structurally header + count + return + params, which `SeedMethodRoots` handles); the field and type-spec sites use `Kind.Field` / `Kind.TypeSpecification`.

## Evidence

- **No behavior change on real code** — the guard never trips on valid signatures (0 false-positives across 53k+ CoreLib signatures, established in #2503). `ILInspector.Decompiler.Tests` **2198/0**; full `dotnet-inspect.slnx` build clean.
- New **`GuardedSignatureTextTests`**: a 600-deep field signature degrades to the `object` placeholder (no crash).

## Review

Mechanical application of the merged, fuzzer-validated guard via a small tested helper, but it touches the compile-back/type-source composers → requesting two-model adversarial review (GPT-5.5 + Gemini 3.1 Pro) with a confirmatory pass. Reviewers: please (a) confirm no `SignatureDecoder.Instance` decode was missed, (b) verify the `Kind` mapping (esp. property → `Kind.Method`) and the `object`/`UnresolvedMethod` fallbacks are safe for the composers, and (c) run a compile-back / type-source A/B on CoreLib to confirm byte-identical composed output. The `--fuzz-signatures` harness (merged #2557) validates the underlying guard end-to-end.

## #2490 status

With this, all three providers are guarded — Analysis decode sites (#2503), Decompiler `TypeRefDecoder` (#2550), and Decompiler `SignatureDecoder` (this PR). #2490 can close once this merges.
