### PR TITLE
Restore RTS compile-back floor

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -103,6 +103,9 @@ public class ReturnToSenderPrototypeTests
             Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.CompileBackFloor.Status);
             Assert.Contains("compile-back-floor", result.Detail);
             Assert.Contains("CS0641", result.Detail);
+            Assert.Contains("return true;", result.TargetBody);
+            Assert.Contains("return true;", result.Source);
+            Assert.NotNull(result.MemberAnchor);
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -78,6 +78,39 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackFirstPropertyGetter_FallsBackToCompileBackFloorForAttributeShellStall()
+    {
+        var assemblyPath = CompileFixture("""
+            using System;
+
+            public abstract class BaseMarkerAttribute : Attribute
+            {
+            }
+
+            [AttributeUsage(AttributeTargets.Class)]
+            public sealed class MarkerAttribute : BaseMarkerAttribute
+            {
+                public bool Flag => true;
+            }
+            """);
+        try
+        {
+            var result = ReturnToSender.CompileBackFirstPropertyGetter(assemblyPath);
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.True(result.UsedCompileBackFloor, result.Detail);
+            Assert.NotNull(result.CompileBackFloor);
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.CompileBackFloor.Status);
+            Assert.Contains("compile-back-floor", result.Detail);
+            Assert.Contains("CS0641", result.Detail);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_UsesDependencyReferencesAndNamespaces()
     {
         var directory = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -828,7 +828,10 @@ static class ReturnToSender
                     FidelityCheck.CompileBackStatus.ContextFail,
                     string.Join(" ", originalOps),
                     "",
-                    $"{identityDiagnostic.Reason}: {identityDiagnostic.Detail}");
+                    $"{identityDiagnostic.Reason}: {identityDiagnostic.Detail}",
+                    TargetBody: printed.Output,
+                    MemberAnchor: memberAnchor,
+                    Decisions: printed.Decisions);
             }
 
             string unit = sourceResult.Source;
@@ -856,7 +859,10 @@ static class ReturnToSender
                         FidelityCheck.CompileBackStatus.ContextFail,
                         string.Join(" ", originalOps),
                         "",
-                        "method-not-found");
+                        "method-not-found",
+                        TargetBody: printed.Output,
+                        MemberAnchor: memberAnchor,
+                        Decisions: printed.Decisions);
                 }
 
                 return new Result(
@@ -888,7 +894,10 @@ static class ReturnToSender
                     FidelityCheck.CompileBackStatus.RecompileFail,
                     string.Join(" ", originalOps),
                     "",
-                    $"{reason}: {FormatDiagnostic(error)}");
+                    $"{reason}: {FormatDiagnostic(error)}",
+                    TargetBody: printed.Output,
+                    MemberAnchor: memberAnchor,
+                    Decisions: printed.Decisions);
             }
         }
 
@@ -915,7 +924,10 @@ static class ReturnToSender
                 FidelityCheck.CompileBackStatus.RecompileFail,
                 string.Join(" ", originalOps),
                 "",
-                $"closure-iteration-budget: {FormatDiagnostic(firstError)}");
+                $"closure-iteration-budget: {FormatDiagnostic(firstError)}",
+                TargetBody: printed.Output,
+                MemberAnchor: memberAnchor,
+                Decisions: printed.Decisions);
         }
     }
 
@@ -990,7 +1002,10 @@ static class ReturnToSender
                     FidelityCheck.CompileBackStatus.ContextFail,
                     string.Join(" ", originalOps),
                     "",
-                    $"{identityDiagnostic.Reason}: {identityDiagnostic.Detail}");
+                    $"{identityDiagnostic.Reason}: {identityDiagnostic.Detail}",
+                    TargetBody: printed.Output,
+                    MemberAnchor: memberAnchor,
+                    Decisions: printed.Decisions);
             }
 
             string unit = sourceResult.Source;
@@ -1018,7 +1033,10 @@ static class ReturnToSender
                         FidelityCheck.CompileBackStatus.ContextFail,
                         string.Join(" ", originalOps),
                         "",
-                        "method-not-found");
+                        "method-not-found",
+                        TargetBody: printed.Output,
+                        MemberAnchor: memberAnchor,
+                        Decisions: printed.Decisions);
                 }
 
                 return new Result(
@@ -1050,7 +1068,10 @@ static class ReturnToSender
                     FidelityCheck.CompileBackStatus.RecompileFail,
                     string.Join(" ", originalOps),
                     "",
-                    $"{reason}: {FormatDiagnostic(error)}");
+                    $"{reason}: {FormatDiagnostic(error)}",
+                    TargetBody: printed.Output,
+                    MemberAnchor: memberAnchor,
+                    Decisions: printed.Decisions);
             }
         }
 
@@ -1076,7 +1097,10 @@ static class ReturnToSender
                 FidelityCheck.CompileBackStatus.RecompileFail,
                 string.Join(" ", originalOps),
                 "",
-                $"closure-iteration-budget: {FormatDiagnostic(firstError)}");
+                $"closure-iteration-budget: {FormatDiagnostic(firstError)}",
+                TargetBody: printed.Output,
+                MemberAnchor: memberAnchor,
+                Decisions: printed.Decisions);
         }
     }
 
@@ -1153,7 +1177,10 @@ static class ReturnToSender
                     FidelityCheck.CompileBackStatus.ContextFail,
                     string.Join(" ", originalOps),
                     "",
-                    $"{identityDiagnostic.Reason}: {identityDiagnostic.Detail}");
+                    $"{identityDiagnostic.Reason}: {identityDiagnostic.Detail}",
+                    TargetBody: printed.Output,
+                    MemberAnchor: memberAnchor,
+                    Decisions: printed.Decisions);
             }
 
             string unit = sourceResult.Source;
@@ -1181,7 +1208,10 @@ static class ReturnToSender
                         FidelityCheck.CompileBackStatus.ContextFail,
                         string.Join(" ", originalOps),
                         "",
-                        "method-not-found");
+                        "method-not-found",
+                        TargetBody: printed.Output,
+                        MemberAnchor: memberAnchor,
+                        Decisions: printed.Decisions);
                 }
 
                 return new Result(
@@ -1213,7 +1243,10 @@ static class ReturnToSender
                     FidelityCheck.CompileBackStatus.RecompileFail,
                     string.Join(" ", originalOps),
                     "",
-                    $"{reason}: {FormatDiagnostic(error)}");
+                    $"{reason}: {FormatDiagnostic(error)}",
+                    TargetBody: printed.Output,
+                    MemberAnchor: memberAnchor,
+                    Decisions: printed.Decisions);
             }
         }
 
@@ -1240,7 +1273,10 @@ static class ReturnToSender
                 FidelityCheck.CompileBackStatus.RecompileFail,
                 string.Join(" ", originalOps),
                 "",
-                $"closure-iteration-budget: {FormatDiagnostic(firstError)}");
+                $"closure-iteration-budget: {FormatDiagnostic(firstError)}",
+                TargetBody: printed.Output,
+                MemberAnchor: memberAnchor,
+                Decisions: printed.Decisions);
         }
     }
 

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -544,7 +544,12 @@ static class ReturnToSender
     }
 
     static bool NeedsCompileBackFloor(Result result)
-        => result.Status is FidelityCheck.CompileBackStatus.RecompileFail or FidelityCheck.CompileBackStatus.ContextFail;
+        => result.Status is FidelityCheck.CompileBackStatus.RecompileFail or FidelityCheck.CompileBackStatus.ContextFail
+           && HasUsableFloorPayload(result);
+
+    static bool HasUsableFloorPayload(Result result)
+        => !string.IsNullOrWhiteSpace(result.Source)
+           && !string.IsNullOrWhiteSpace(result.TargetBody);
 
     static Result WithCompileBackFloor(Result result, FidelityCheck.CompileBackResult floor)
     {

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -34,7 +34,11 @@ static class ReturnToSender
         IlDiffDisplayResult? IlDiffDiagnostic = null,
         IlMemberDiffResult? IlDiff = null,
         MemberAnchor? MemberAnchor = null,
-        IReadOnlyList<DecompilerDecision>? Decisions = null);
+        IReadOnlyList<DecompilerDecision>? Decisions = null,
+        FidelityCheck.CompileBackResult? CompileBackFloor = null)
+    {
+        public bool UsedCompileBackFloor => CompileBackFloor is not null;
+    }
 
     public sealed record RequestedTarget(string Type, string Method, int Overload, string? Signature = null);
 
@@ -57,7 +61,7 @@ static class ReturnToSender
     public static int Run(IReadOnlyList<string> assemblies, int cap, int maxExamples)
     {
         int total = 0, exact = 0, opcodeDiff = 0, recompileFail = 0, contextFail = 0;
-        int closureRoots = 0, closureMembers = 0;
+        int closureRoots = 0, closureMembers = 0, compileBackFloor = 0;
         var planningDiagnostics = new SortedDictionary<string, int>(StringComparer.Ordinal);
         var examples = new List<string>();
 
@@ -94,6 +98,8 @@ static class ReturnToSender
                 closureMembers += result.Plan.Types
                     .Skip(1)
                     .Sum(type => type.Members.Count);
+                if (result.UsedCompileBackFloor)
+                    compileBackFloor++;
                 foreach (var diagnostic in result.Plan.Diagnostics)
                 {
                     string key = $"{diagnostic.Layer}/{diagnostic.Reason}";
@@ -139,6 +145,7 @@ static class ReturnToSender
         Console.WriteLine("Plan layers:");
         Console.WriteLine($"  closure roots   : {closureRoots}");
         Console.WriteLine($"  closure members : {closureMembers}");
+        Console.WriteLine($"  compile-back floor: {compileBackFloor}");
         if (planningDiagnostics.Count == 0)
         {
             Console.WriteLine("  diagnostics     : 0");
@@ -174,7 +181,7 @@ static class ReturnToSender
             IReadOnlyList<Result> rtsResults;
             try
             {
-                rtsResults = CompileBackPropertyGetters(assemblyPath, cap - total);
+                rtsResults = CompileBackPropertyGetters(assemblyPath, cap - total, applyCompileBackFloor: false);
             }
             catch (NoSupportedReturnToSenderTargetsException)
             {
@@ -204,6 +211,7 @@ static class ReturnToSender
                 current = FidelityCheck.EvaluateTargets([assemblyPath], currentTargets)
                     .GroupBy(CurrentKey, StringComparer.Ordinal)
                     .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+                rtsResults = ApplyCompileBackFloor(assemblyPath, rtsResults, current.Values);
             }
             catch (Exception ex) when (ex is IOException or BadImageFormatException or InvalidOperationException or UnauthorizedAccessException)
             {
@@ -279,6 +287,12 @@ static class ReturnToSender
     static string ReturnToSenderKey(Result result)
         => $"{result.Plan.TargetMethod.Type}::{result.Plan.TargetMethod.Method}::{result.Plan.TargetMethod.Overload}";
 
+    static string FloorKey(FidelityCheck.CompileBackResult result)
+        => $"{result.Type}::{result.Method}::{result.Overload}::{result.Signature}";
+
+    static string FloorKey(Result result)
+        => $"{result.Plan.TargetMethod.Type}::{result.Plan.TargetMethod.Method}::{result.Plan.TargetMethod.Overload}::{result.Plan.TargetMethod.Signature}";
+
     static ComparisonDelta ClassifyDelta(FidelityCheck.CompileBackResult? current, Result rts)
     {
         if (current is null)
@@ -319,6 +333,8 @@ static class ReturnToSender
 
     static (string Layer, string Detail) ExampleLayerAndDetail(Result result)
     {
+        if (result.UsedCompileBackFloor)
+            return ("compile-back floor", result.Detail ?? result.CompileBackFloor!.Status.ToString());
         if (result.Plan.Diagnostics.FirstOrDefault() is { } diagnostic)
             return (diagnostic.Layer, $"{diagnostic.Reason}: {diagnostic.Detail}");
         if (!string.IsNullOrWhiteSpace(result.Detail))
@@ -332,6 +348,9 @@ static class ReturnToSender
         => CompileBackPropertyGetters(assemblyPath, maxTargets: 1).First();
 
     public static IReadOnlyList<Result> CompileBackPropertyGetters(string assemblyPath, int maxTargets = int.MaxValue)
+        => CompileBackPropertyGetters(assemblyPath, maxTargets, applyCompileBackFloor: true);
+
+    static IReadOnlyList<Result> CompileBackPropertyGetters(string assemblyPath, int maxTargets, bool applyCompileBackFloor)
     {
         if (maxTargets <= 0)
             return [];
@@ -396,13 +415,13 @@ static class ReturnToSender
                     accessors.Getter,
                     MemberAnchorFor(memberAnchors, accessors.Getter)));
                 if (results.Count >= maxTargets)
-                    return results;
+                    return applyCompileBackFloor ? ApplyCompileBackFloor(assemblyPath, results) : results;
             }
         }
 
         if (results.Count == 0)
             throw new NoSupportedReturnToSenderTargetsException("No supported property getter with a method body was found.");
-        return results;
+        return applyCompileBackFloor ? ApplyCompileBackFloor(assemblyPath, results) : results;
     }
 
     public static IReadOnlyList<Result> CompileBackTargets(string assemblyPath, IReadOnlyList<RequestedTarget> targets)
@@ -480,7 +499,69 @@ static class ReturnToSender
             }
         }
 
-        return results;
+        return ApplyCompileBackFloor(assemblyPath, results);
+    }
+
+    static IReadOnlyList<Result> ApplyCompileBackFloor(
+        string assemblyPath,
+        IReadOnlyList<Result> results,
+        IEnumerable<FidelityCheck.CompileBackResult>? compileBackResults = null)
+    {
+        if (results.Count == 0 || !results.Any(NeedsCompileBackFloor))
+            return results;
+
+        var floorRows = compileBackResults?.ToArray()
+            ?? FidelityCheck.EvaluateTargets(
+                [assemblyPath],
+                results
+                    .Where(NeedsCompileBackFloor)
+                    .Select(result => new FidelityCheck.CompileBackTarget(
+                        assemblyPath,
+                        result.Plan.TargetMethod.Type,
+                        result.Plan.TargetMethod.Method,
+                        result.Plan.TargetMethod.Overload,
+                        result.Plan.TargetMethod.Signature))
+                    .Distinct()
+                    .ToArray());
+        var floorByTarget = floorRows
+            .Where(row => row.Status is FidelityCheck.CompileBackStatus.Exact or FidelityCheck.CompileBackStatus.OpcodeDiff)
+            .GroupBy(FloorKey, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+        if (floorByTarget.Count == 0)
+            return results;
+
+        var adjusted = new Result[results.Count];
+        for (int i = 0; i < results.Count; i++)
+        {
+            var result = results[i];
+            adjusted[i] = NeedsCompileBackFloor(result)
+                && floorByTarget.TryGetValue(FloorKey(result), out var floor)
+                    ? WithCompileBackFloor(result, floor)
+                    : result;
+        }
+
+        return adjusted;
+    }
+
+    static bool NeedsCompileBackFloor(Result result)
+        => result.Status is FidelityCheck.CompileBackStatus.RecompileFail or FidelityCheck.CompileBackStatus.ContextFail;
+
+    static Result WithCompileBackFloor(Result result, FidelityCheck.CompileBackResult floor)
+    {
+        string originalFailure = string.IsNullOrWhiteSpace(result.Detail)
+            ? result.Status.ToString()
+            : $"{result.Status}: {result.Detail}";
+        string floorDetail = string.IsNullOrWhiteSpace(floor.Detail)
+            ? $"compile-back-floor: {originalFailure}"
+            : $"compile-back-floor: {floor.Detail}; rts: {originalFailure}";
+        return result with
+        {
+            Status = floor.Status,
+            OriginalOpcodes = floor.OriginalOpcodes,
+            RecompiledOpcodes = floor.RecompiledOpcodes,
+            Detail = floorDetail,
+            CompileBackFloor = floor,
+        };
     }
 
     static (PropertyDefinitionHandle Property, MethodDefinitionHandle Getter)? TryFindPropertyGetter(

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -824,7 +824,7 @@ static class ReturnToSender
             {
                 return new Result(
                     plan,
-                    "",
+                    sourceResult.Source,
                     FidelityCheck.CompileBackStatus.ContextFail,
                     string.Join(" ", originalOps),
                     "",
@@ -998,7 +998,7 @@ static class ReturnToSender
             {
                 return new Result(
                     plan,
-                    "",
+                    sourceResult.Source,
                     FidelityCheck.CompileBackStatus.ContextFail,
                     string.Join(" ", originalOps),
                     "",
@@ -1173,7 +1173,7 @@ static class ReturnToSender
             {
                 return new Result(
                     plan,
-                    "",
+                    sourceResult.Source,
                     FidelityCheck.CompileBackStatus.ContextFail,
                     string.Join(" ", originalOps),
                     "",


### PR DESCRIPTION
- Advances #2558
- Part of #2560 / #2280 RTS parity burndown
- Changes RTS harness behavior: failed typed-shell RTS rows now inherit the retained compile-back floor when the legacy path checks the same target as `Exact` or `OpcodeDiff`.
- Evidence revision: `74264ad3`

## Change

**Conclusion:** **PASS** — RTS no longer reports a worse fidelity result when its typed closure stalls but the retained compile-back path can check the same target.

Before, a transitive attribute-base shell could stall at `CS0641` and report RTS `RecompileFail` even when legacy compile-back was `Exact`. After, the row reports `Exact` with `compile-back-floor` provenance preserving the original RTS failure detail.

## Scope and safety

- **Root cause:** RTS reused the closure-membership loop without the legacy escalation/fallback floor, so closure stalls became direct `RecompileFail` rows.
- **Fix shape:** harness-only RTS orchestration change; apply the floor only for RTS `RecompileFail`/`ContextFail` rows and only when `FidelityCheck.EvaluateTargets` returns `Exact`/`OpcodeDiff` for the same type/method/overload/signature.
- **Product impact:** none; no product decompiler output changes.
- **Scope boundary:** this does not fix the underlying typed-shell gaps (`CS0641`, enum/member coercion, structured diagnostics); it restores the monotonic floor while those parity buckets are burned down.
- **RTS boundary:** RTS remains the harness orchestrator; the retained compile-back path is used only as the compatibility floor.

## ReturnToSender A/B

Run: fixed corpus from `eng/prepare-decompiler-corpus.sh`, cap 500, max examples 20.

```text
RETURNTOSENDER A/B over 500 property getters

  Rescued       : 1
  Same          : 499
  Changed       : 0
  Worse         : 0
  CurrentMissing: 0
```

Real witness for the visible floor:

```text
RETURNTOSENDER over 5 property getters

  Exact         : 5
  OpcodeDiff    : 0
  RecompileFail : 0
  ContextFail   : 0

Plan layers:
  closure roots   : 0
  closure members : 0
  compile-back floor: 1

Newtonsoft.Json.JsonArrayAttribute::get_AllowNullItems
  status: Exact
  layer : compile-back floor
  detail: compile-back-floor: RecompileFail: closure-stalled: CS0641: Attribute 'System.AttributeUsage' is only valid on classes derived from System.Attribute
```

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -method "*CompileBackFirstPropertyGetter_FallsBackToCompileBackFloorForAttributeShellStall*"
dotnet build tools/DecompilerHarness -c Release --no-restore --nologo --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- "${assemblies[@]}" --return-to-sender-ab --cap 500 --max-examples 20
dotnet run --project tools/DecompilerHarness -c Release --no-build -- "$newtonsoft" --return-to-sender --cap 5 --max-examples 5
dotnet build dotnet-inspect.slnx -c Release --no-restore --nologo --verbosity quiet
```

`dotnet build dotnet-inspect.slnx` passed with 3 existing nullable warnings in `tests/ILInspector.Metadata.Tests`.

`ReturnToSenderPrototypeTests` as a full class is baseline-red on clean `origin/main` (8 failures at `e7e1c0f7`); the PR branch had 4 failures in the same class. The focused new regression test passed.

## Review

Adversarial review is in progress in isolated worktrees:

| Reviewer | Result | Notes |
| --- | --- | --- |
| Gemini 3.1 Pro | Pending | `/home/rich/di-work/review-2558-gemini` |
| MAI-Code-1-Flash | Pending | `/home/rich/di-work/review-2558-mai` |

**Review conclusion:** **PENDING** — draft until both reviews are clean or findings are resolved and re-reviewed.
