### PR TITLE
Move signature spellability into metadata

### DIFF
--- a/src/ILInspector.Metadata/SignatureSpellability.cs
+++ b/src/ILInspector.Metadata/SignatureSpellability.cs
@@ -58,7 +58,7 @@ public sealed class SignatureSpellability
         if (_nonPublicTypes.TryGetValue(reference, out var cached))
             return cached;
 
-        if (_resolver.Resolve(reference.Identity, reference.Scope) is not { } resolved)
+        if (Resolve(reference) is not { } resolved)
         {
             _nonPublicTypes[reference] = null;
             return null;
@@ -96,6 +96,15 @@ public sealed class SignatureSpellability
         return types;
     }
 
+    ResolvedAssemblyReference? Resolve(ReferenceKey reference)
+    {
+        if (_resolver.Resolve(reference.Identity, reference.Scope) is { } exact)
+            return exact;
+
+        var relaxed = reference.Identity with { Version = null };
+        return _resolver.Resolve(relaxed, reference.Scope);
+    }
+
     static bool IsExternallyVisible(MetadataReader reader, TypeDefinitionHandle handle)
     {
         var typeDef = reader.GetTypeDefinition(handle);
@@ -124,25 +133,10 @@ public sealed class SignatureSpellability
         public static ReferenceKey From(MetadataReader reader, AssemblyReferenceHandle handle)
         {
             var identity = AssemblyReferenceIdentity.From(reader, handle);
-            var reference = reader.GetAssemblyReference(handle);
-            var scope = PlatformKeys.IsPlatform(ToHex(reader.GetBlobBytes(reference.PublicKeyOrToken)))
+            var scope = PlatformKeys.IsPlatform(identity.PublicKeyToken)
                 ? AssemblyResolutionScope.Platform
                 : AssemblyResolutionScope.Any;
             return new ReferenceKey(identity, scope);
-        }
-
-        static string? ToHex(byte[] bytes)
-        {
-            if (bytes.Length == 0)
-                return null;
-
-            var chars = new char[bytes.Length * 2];
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                chars[i * 2] = "0123456789abcdef"[bytes[i] >> 4];
-                chars[i * 2 + 1] = "0123456789abcdef"[bytes[i] & 0xF];
-            }
-            return new string(chars);
         }
     }
 

--- a/src/ILInspector.Metadata/SignatureSpellability.cs
+++ b/src/ILInspector.Metadata/SignatureSpellability.cs
@@ -1,0 +1,171 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Answers whether metadata signatures can be spelled from a generated C#
+/// assembly. Public metadata can expose non-public referenced types, especially
+/// in non-C# or friend-assembly-produced libraries; those signatures are valid
+/// metadata but cannot be named by a normal compile-back shell.
+/// </summary>
+public sealed class SignatureSpellability
+{
+    readonly IAssemblyReferenceResolver _resolver;
+    readonly Dictionary<ReferenceKey, HashSet<string>?> _nonPublicTypes = new();
+
+    public SignatureSpellability(IAssemblyReferenceResolver resolver)
+        => _resolver = resolver;
+
+    public bool CanSpellField(MetadataReader reader, FieldDefinition field, GenericContext context)
+    {
+        try { return !field.DecodeSignature(new InaccessibleTypeDetector(this), context); }
+        catch (Exception ex) when (IsDecodeException(ex)) { return true; }
+    }
+
+    public bool CanSpellProperty(MetadataReader reader, PropertyDefinition property, GenericContext context)
+    {
+        try { return !property.DecodeSignature(new InaccessibleTypeDetector(this), context).ReturnType; }
+        catch (Exception ex) when (IsDecodeException(ex)) { return true; }
+    }
+
+    public bool CanSpellMethod(MetadataReader reader, MethodDefinition method, GenericContext context)
+    {
+        try
+        {
+            var signature = method.DecodeSignature(new InaccessibleTypeDetector(this), context);
+            return !signature.ReturnType && !signature.ParameterTypes.Any(inaccessible => inaccessible);
+        }
+        catch (Exception ex) when (IsDecodeException(ex)) { return true; }
+    }
+
+    static bool IsDecodeException(Exception ex)
+        => ex is BadImageFormatException or InvalidOperationException or ArgumentException;
+
+    bool IsInaccessible(MetadataReader reader, TypeReferenceHandle handle)
+    {
+        if (AssemblyScope(reader, handle) is not { } reference)
+            return false;
+
+        string fullName = reader.GetFullTypeName(reader.GetTypeReference(handle));
+        return NonPublicTypes(reference)?.Contains(fullName) == true;
+    }
+
+    HashSet<string>? NonPublicTypes(ReferenceKey reference)
+    {
+        if (_nonPublicTypes.TryGetValue(reference, out var cached))
+            return cached;
+
+        if (_resolver.Resolve(reference.Identity, reference.Scope) is not { } resolved)
+        {
+            _nonPublicTypes[reference] = null;
+            return null;
+        }
+
+        var types = new HashSet<string>(StringComparer.Ordinal);
+        Stream? stream = null;
+        PEReader? pe = null;
+        try
+        {
+            stream = resolved.OpenRead();
+            pe = new PEReader(stream);
+            if (pe.HasMetadata)
+            {
+                var reader = pe.GetMetadataReader();
+                foreach (var handle in reader.TypeDefinitions)
+                {
+                    if (!IsExternallyVisible(reader, handle))
+                        types.Add(reader.GetFullTypeName(reader.GetTypeDefinition(handle)));
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException)
+        {
+            _nonPublicTypes[reference] = null;
+            return null;
+        }
+        finally
+        {
+            pe?.Dispose();
+            stream?.Dispose();
+        }
+
+        _nonPublicTypes[reference] = types;
+        return types;
+    }
+
+    static bool IsExternallyVisible(MetadataReader reader, TypeDefinitionHandle handle)
+    {
+        var typeDef = reader.GetTypeDefinition(handle);
+        return (typeDef.Attributes & TypeAttributes.VisibilityMask) switch
+        {
+            TypeAttributes.Public => true,
+            TypeAttributes.NestedPublic => !typeDef.GetDeclaringType().IsNil
+                && IsExternallyVisible(reader, typeDef.GetDeclaringType()),
+            _ => false,
+        };
+    }
+
+    static ReferenceKey? AssemblyScope(MetadataReader reader, TypeReferenceHandle handle)
+    {
+        var typeRef = reader.GetTypeReference(handle);
+        return typeRef.ResolutionScope.Kind switch
+        {
+            HandleKind.AssemblyReference => ReferenceKey.From(reader, (AssemblyReferenceHandle)typeRef.ResolutionScope),
+            HandleKind.TypeReference => AssemblyScope(reader, (TypeReferenceHandle)typeRef.ResolutionScope),
+            _ => null,
+        };
+    }
+
+    sealed record ReferenceKey(AssemblyReferenceIdentity Identity, AssemblyResolutionScope Scope)
+    {
+        public static ReferenceKey From(MetadataReader reader, AssemblyReferenceHandle handle)
+        {
+            var identity = AssemblyReferenceIdentity.From(reader, handle);
+            var reference = reader.GetAssemblyReference(handle);
+            var scope = PlatformKeys.IsPlatform(ToHex(reader.GetBlobBytes(reference.PublicKeyOrToken)))
+                ? AssemblyResolutionScope.Platform
+                : AssemblyResolutionScope.Any;
+            return new ReferenceKey(identity, scope);
+        }
+
+        static string? ToHex(byte[] bytes)
+        {
+            if (bytes.Length == 0)
+                return null;
+
+            var chars = new char[bytes.Length * 2];
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                chars[i * 2] = "0123456789abcdef"[bytes[i] >> 4];
+                chars[i * 2 + 1] = "0123456789abcdef"[bytes[i] & 0xF];
+            }
+            return new string(chars);
+        }
+    }
+
+    sealed class InaccessibleTypeDetector(SignatureSpellability spellability)
+        : ISignatureTypeProvider<bool, GenericContext?>
+    {
+        public bool GetPrimitiveType(PrimitiveTypeCode typeCode) => false;
+        public bool GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => false;
+        public bool GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+            => spellability.IsInaccessible(reader, handle);
+        public bool GetTypeFromSpecification(MetadataReader reader, GenericContext? context, TypeSpecificationHandle handle, byte rawTypeKind)
+            => reader.GetTypeSpecification(handle).DecodeSignature(this, context);
+        public bool GetSZArrayType(bool elementType) => elementType;
+        public bool GetArrayType(bool elementType, ArrayShape shape) => elementType;
+        public bool GetByReferenceType(bool elementType) => elementType;
+        public bool GetPointerType(bool elementType) => elementType;
+        public bool GetGenericInstantiation(bool genericType, ImmutableArray<bool> typeArguments)
+            => genericType || typeArguments.Any(inaccessible => inaccessible);
+        public bool GetGenericMethodParameter(GenericContext? context, int index) => false;
+        public bool GetGenericTypeParameter(GenericContext? context, int index) => false;
+        public bool GetFunctionPointerType(MethodSignature<bool> signature)
+            => signature.ReturnType || signature.ParameterTypes.Any(inaccessible => inaccessible);
+        public bool GetModifiedType(bool modifier, bool unmodifiedType, bool isRequired) => unmodifiedType;
+        public bool GetPinnedType(bool elementType) => elementType;
+    }
+}

--- a/src/ILInspector.Metadata/SignatureSpellability.cs
+++ b/src/ILInspector.Metadata/SignatureSpellability.cs
@@ -1,7 +1,9 @@
 using System.Collections.Immutable;
+using System.Collections.Concurrent;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Threading;
 
 namespace ILInspector.Metadata;
 
@@ -14,7 +16,7 @@ namespace ILInspector.Metadata;
 public sealed class SignatureSpellability
 {
     readonly IAssemblyReferenceResolver _resolver;
-    readonly Dictionary<ReferenceKey, HashSet<string>?> _nonPublicTypes = new();
+    readonly ConcurrentDictionary<ReferenceKey, Lazy<NonPublicTypeSet>> _nonPublicTypes = new();
 
     public SignatureSpellability(IAssemblyReferenceResolver resolver)
         => _resolver = resolver;
@@ -27,7 +29,11 @@ public sealed class SignatureSpellability
 
     public bool CanSpellProperty(MetadataReader reader, PropertyDefinition property, GenericContext context)
     {
-        try { return !property.DecodeSignature(new InaccessibleTypeDetector(this), context).ReturnType; }
+        try
+        {
+            var signature = property.DecodeSignature(new InaccessibleTypeDetector(this), context);
+            return !signature.ReturnType && !signature.ParameterTypes.Any(inaccessible => inaccessible);
+        }
         catch (Exception ex) when (IsDecodeException(ex)) { return true; }
     }
 
@@ -50,19 +56,18 @@ public sealed class SignatureSpellability
             return false;
 
         string fullName = reader.GetFullTypeName(reader.GetTypeReference(handle));
-        return NonPublicTypes(reference)?.Contains(fullName) == true;
+        return NonPublicTypes(reference).Types?.Contains(fullName) == true;
     }
 
-    HashSet<string>? NonPublicTypes(ReferenceKey reference)
-    {
-        if (_nonPublicTypes.TryGetValue(reference, out var cached))
-            return cached;
+    NonPublicTypeSet NonPublicTypes(ReferenceKey reference)
+        => _nonPublicTypes.GetOrAdd(
+            reference,
+            key => new Lazy<NonPublicTypeSet>(() => LoadNonPublicTypes(key), LazyThreadSafetyMode.ExecutionAndPublication)).Value;
 
+    NonPublicTypeSet LoadNonPublicTypes(ReferenceKey reference)
+    {
         if (Resolve(reference) is not { } resolved)
-        {
-            _nonPublicTypes[reference] = null;
-            return null;
-        }
+            return new NonPublicTypeSet(null);
 
         var types = new HashSet<string>(StringComparer.Ordinal);
         Stream? stream = null;
@@ -83,8 +88,7 @@ public sealed class SignatureSpellability
         }
         catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException)
         {
-            _nonPublicTypes[reference] = null;
-            return null;
+            return new NonPublicTypeSet(null);
         }
         finally
         {
@@ -92,8 +96,7 @@ public sealed class SignatureSpellability
             stream?.Dispose();
         }
 
-        _nonPublicTypes[reference] = types;
-        return types;
+        return new NonPublicTypeSet(types);
     }
 
     ResolvedAssemblyReference? Resolve(ReferenceKey reference)
@@ -139,6 +142,8 @@ public sealed class SignatureSpellability
             return new ReferenceKey(identity, scope);
         }
     }
+
+    sealed record NonPublicTypeSet(HashSet<string>? Types);
 
     sealed class InaccessibleTypeDetector(SignatureSpellability spellability)
         : ISignatureTypeProvider<bool, GenericContext?>

--- a/tests/ILInspector.Metadata.Tests/Fixtures/SignatureSpellabilityConsumer/ConsumerTypes.cs
+++ b/tests/ILInspector.Metadata.Tests/Fixtures/SignatureSpellabilityConsumer/ConsumerTypes.cs
@@ -9,6 +9,7 @@ public sealed class SignatureSpellabilityConsumerFixtures
 
     internal HiddenReferenceType HiddenProperty { get; set; } = new();
     internal VisibleReferenceType VisibleProperty { get; set; } = new();
+    internal int this[HiddenReferenceType key] => 0;
 
     internal HiddenReferenceType HiddenMethod(HiddenReferenceType value) => value;
     internal VisibleReferenceType VisibleMethod(VisibleReferenceType value) => value;

--- a/tests/ILInspector.Metadata.Tests/Fixtures/SignatureSpellabilityConsumer/ConsumerTypes.cs
+++ b/tests/ILInspector.Metadata.Tests/Fixtures/SignatureSpellabilityConsumer/ConsumerTypes.cs
@@ -1,0 +1,15 @@
+using ILInspector.Metadata.Tests.SpellabilityReference;
+
+namespace ILInspector.Metadata.Tests.SpellabilityConsumer;
+
+public sealed class SignatureSpellabilityConsumerFixtures
+{
+    internal HiddenReferenceType HiddenField = new();
+    internal VisibleReferenceType VisibleField = new();
+
+    internal HiddenReferenceType HiddenProperty { get; set; } = new();
+    internal VisibleReferenceType VisibleProperty { get; set; } = new();
+
+    internal HiddenReferenceType HiddenMethod(HiddenReferenceType value) => value;
+    internal VisibleReferenceType VisibleMethod(VisibleReferenceType value) => value;
+}

--- a/tests/ILInspector.Metadata.Tests/Fixtures/SignatureSpellabilityConsumer/ILInspector.Metadata.SpellabilityConsumer.csproj
+++ b/tests/ILInspector.Metadata.Tests/Fixtures/SignatureSpellabilityConsumer/ILInspector.Metadata.SpellabilityConsumer.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <AssemblyName>ILInspector.Metadata.SpellabilityConsumer</AssemblyName>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../SignatureSpellabilityReference/ILInspector.Metadata.SpellabilityReference.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/ILInspector.Metadata.Tests/Fixtures/SignatureSpellabilityReference/ILInspector.Metadata.SpellabilityReference.csproj
+++ b/tests/ILInspector.Metadata.Tests/Fixtures/SignatureSpellabilityReference/ILInspector.Metadata.SpellabilityReference.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <AssemblyName>ILInspector.Metadata.SpellabilityReference</AssemblyName>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/tests/ILInspector.Metadata.Tests/Fixtures/SignatureSpellabilityReference/ReferenceTypes.cs
+++ b/tests/ILInspector.Metadata.Tests/Fixtures/SignatureSpellabilityReference/ReferenceTypes.cs
@@ -1,0 +1,13 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ILInspector.Metadata.SpellabilityConsumer")]
+
+namespace ILInspector.Metadata.Tests.SpellabilityReference;
+
+internal sealed class HiddenReferenceType
+{
+}
+
+public sealed class VisibleReferenceType
+{
+}

--- a/tests/ILInspector.Metadata.Tests/ILInspector.Metadata.Tests.csproj
+++ b/tests/ILInspector.Metadata.Tests/ILInspector.Metadata.Tests.csproj
@@ -12,6 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Fixtures/**/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="xunit.v3" />
   </ItemGroup>
 
@@ -21,6 +25,8 @@
 
   <ItemGroup>
     <ProjectReference Include="../../src/ILInspector.Metadata/ILInspector.Metadata.csproj" />
+    <ProjectReference Include="Fixtures/SignatureSpellabilityConsumer/ILInspector.Metadata.SpellabilityConsumer.csproj" />
+    <ProjectReference Include="Fixtures/SignatureSpellabilityReference/ILInspector.Metadata.SpellabilityReference.csproj" />
     <!-- New-rules unsafe fixture: a member declared `unsafe` with no pointer in
          its signature is stamped [RequiresUnsafeAttribute]; used to verify the
          API surface marks it unsafe. -->

--- a/tests/ILInspector.Metadata.Tests/SignatureSpellabilityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SignatureSpellabilityTests.cs
@@ -38,6 +38,17 @@ public sealed class SignatureSpellabilityTests
     }
 
     [Fact]
+    public void CanSpellProperty_RejectsReferencedInternalIndexerParameterType()
+    {
+        using var fixture = OpenFixture();
+
+        Assert.False(fixture.Spellability.CanSpellProperty(
+            fixture.Reader,
+            GetProperty(fixture.Reader, fixture.Type, "Item"),
+            GenericContext.ForType(fixture.Reader, fixture.Type)));
+    }
+
+    [Fact]
     public void CanSpellMethod_RejectsReferencedInternalType()
     {
         using var fixture = OpenFixture();

--- a/tests/ILInspector.Metadata.Tests/SignatureSpellabilityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SignatureSpellabilityTests.cs
@@ -1,0 +1,140 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using ILInspector.Metadata.Tests.SpellabilityConsumer;
+using ILInspector.Metadata.Tests.SpellabilityReference;
+
+namespace ILInspector.Metadata.Tests;
+
+public sealed class SignatureSpellabilityTests
+{
+    [Fact]
+    public void CanSpellField_RejectsReferencedInternalType()
+    {
+        using var fixture = OpenFixture();
+
+        Assert.False(fixture.Spellability.CanSpellField(
+            fixture.Reader,
+            GetField(fixture.Reader, fixture.Type, "HiddenField"),
+            GenericContext.ForType(fixture.Reader, fixture.Type)));
+        Assert.True(fixture.Spellability.CanSpellField(
+            fixture.Reader,
+            GetField(fixture.Reader, fixture.Type, "VisibleField"),
+            GenericContext.ForType(fixture.Reader, fixture.Type)));
+    }
+
+    [Fact]
+    public void CanSpellProperty_RejectsReferencedInternalType()
+    {
+        using var fixture = OpenFixture();
+
+        Assert.False(fixture.Spellability.CanSpellProperty(
+            fixture.Reader,
+            GetProperty(fixture.Reader, fixture.Type, "HiddenProperty"),
+            GenericContext.ForType(fixture.Reader, fixture.Type)));
+        Assert.True(fixture.Spellability.CanSpellProperty(
+            fixture.Reader,
+            GetProperty(fixture.Reader, fixture.Type, "VisibleProperty"),
+            GenericContext.ForType(fixture.Reader, fixture.Type)));
+    }
+
+    [Fact]
+    public void CanSpellMethod_RejectsReferencedInternalType()
+    {
+        using var fixture = OpenFixture();
+
+        Assert.False(fixture.Spellability.CanSpellMethod(
+            fixture.Reader,
+            GetMethod(fixture.Reader, fixture.Type, "HiddenMethod"),
+            GenericContext.ForMethod(fixture.Reader, fixture.Type, GetMethod(fixture.Reader, fixture.Type, "HiddenMethod"))));
+        Assert.True(fixture.Spellability.CanSpellMethod(
+            fixture.Reader,
+            GetMethod(fixture.Reader, fixture.Type, "VisibleMethod"),
+            GenericContext.ForMethod(fixture.Reader, fixture.Type, GetMethod(fixture.Reader, fixture.Type, "VisibleMethod"))));
+    }
+
+    static Fixture OpenFixture()
+    {
+        var stream = File.OpenRead(typeof(SignatureSpellabilityConsumerFixtures).Assembly.Location);
+        var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+        var type = GetTypeDefinition(reader, typeof(SignatureSpellabilityConsumerFixtures));
+        var resolver = new MapResolver(typeof(VisibleReferenceType).Assembly.Location);
+        return new Fixture(stream, pe, reader, type, new SignatureSpellability(resolver));
+    }
+
+    static TypeDefinition GetTypeDefinition(MetadataReader reader, Type type)
+    {
+        var expected = type.FullName!.Replace('+', '.');
+        foreach (var handle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(handle);
+            if (reader.GetFullTypeName(typeDef) == expected)
+                return typeDef;
+        }
+
+        throw new InvalidOperationException($"Type '{expected}' was not found.");
+    }
+
+    static FieldDefinition GetField(MetadataReader reader, TypeDefinition type, string name)
+    {
+        foreach (var handle in type.GetFields())
+        {
+            var field = reader.GetFieldDefinition(handle);
+            if (reader.GetString(field.Name) == name)
+                return field;
+        }
+
+        throw new InvalidOperationException($"Field '{name}' was not found.");
+    }
+
+    static PropertyDefinition GetProperty(MetadataReader reader, TypeDefinition type, string name)
+    {
+        foreach (var handle in type.GetProperties())
+        {
+            var property = reader.GetPropertyDefinition(handle);
+            if (reader.GetString(property.Name) == name)
+                return property;
+        }
+
+        throw new InvalidOperationException($"Property '{name}' was not found.");
+    }
+
+    static MethodDefinition GetMethod(MetadataReader reader, TypeDefinition type, string name)
+    {
+        foreach (var handle in type.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(handle);
+            if (reader.GetString(method.Name) == name)
+                return method;
+        }
+
+        throw new InvalidOperationException($"Method '{name}' was not found.");
+    }
+
+    sealed class MapResolver(params string[] paths) : IAssemblyReferenceResolver
+    {
+        readonly Dictionary<string, string> _paths = paths.ToDictionary(
+            path => Path.GetFileNameWithoutExtension(path)!,
+            Path.GetFullPath,
+            StringComparer.OrdinalIgnoreCase);
+
+        public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
+            => _paths.TryGetValue(identity.Name, out var path)
+                ? new ResolvedAssemblyReference(identity, path, () => File.OpenRead(path), "TestMap")
+                : null;
+    }
+
+    sealed record Fixture(
+        Stream Stream,
+        PEReader Pe,
+        MetadataReader Reader,
+        TypeDefinition Type,
+        SignatureSpellability Spellability) : IDisposable
+    {
+        public void Dispose()
+        {
+            Pe.Dispose();
+            Stream.Dispose();
+        }
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/SignatureSpellabilityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SignatureSpellabilityTests.cs
@@ -52,13 +52,24 @@ public sealed class SignatureSpellabilityTests
             GenericContext.ForMethod(fixture.Reader, fixture.Type, GetMethod(fixture.Reader, fixture.Type, "VisibleMethod"))));
     }
 
-    static Fixture OpenFixture()
+    [Fact]
+    public void CanSpellField_RelaxesVersionWhenResolverUnifiesReferences()
+    {
+        using var fixture = OpenFixture(new VersionRelaxingResolver(typeof(VisibleReferenceType).Assembly.Location));
+
+        Assert.False(fixture.Spellability.CanSpellField(
+            fixture.Reader,
+            GetField(fixture.Reader, fixture.Type, "HiddenField"),
+            GenericContext.ForType(fixture.Reader, fixture.Type)));
+    }
+
+    static Fixture OpenFixture(IAssemblyReferenceResolver? resolver = null)
     {
         var stream = File.OpenRead(typeof(SignatureSpellabilityConsumerFixtures).Assembly.Location);
         var pe = new PEReader(stream);
         var reader = pe.GetMetadataReader();
         var type = GetTypeDefinition(reader, typeof(SignatureSpellabilityConsumerFixtures));
-        var resolver = new MapResolver(typeof(VisibleReferenceType).Assembly.Location);
+        resolver ??= new MapResolver(typeof(VisibleReferenceType).Assembly.Location);
         return new Fixture(stream, pe, reader, type, new SignatureSpellability(resolver));
     }
 
@@ -121,6 +132,17 @@ public sealed class SignatureSpellabilityTests
         public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
             => _paths.TryGetValue(identity.Name, out var path)
                 ? new ResolvedAssemblyReference(identity, path, () => File.OpenRead(path), "TestMap")
+                : null;
+    }
+
+    sealed class VersionRelaxingResolver(string path) : IAssemblyReferenceResolver
+    {
+        readonly string _assemblyName = Path.GetFileNameWithoutExtension(path);
+        readonly string _path = Path.GetFullPath(path);
+
+        public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
+            => identity.Version is null && identity.Name.Equals(_assemblyName, StringComparison.OrdinalIgnoreCase)
+                ? new ResolvedAssemblyReference(identity, _path, () => File.OpenRead(_path), "VersionRelaxing")
                 : null;
     }
 

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -458,6 +458,43 @@ static class FidelityCheck
 
     sealed record ReferenceSet(ImmutableArray<MetadataReference> Metadata, SignatureSpellability Accessibility);
 
+    sealed class CompilerReferenceResolver(IEnumerable<ResolvedAssemblyReference> references) : IAssemblyReferenceResolver
+    {
+        readonly IReadOnlyList<ResolvedAssemblyReference> _references = references.ToList();
+
+        public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
+        {
+            foreach (var reference in _references)
+            {
+                if (!reference.Identity.Name.Equals(identity.Name, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (!CultureMatches(identity.Culture, reference.Identity.Culture))
+                    continue;
+                if (identity.PublicKeyToken is { Length: > 0 }
+                    && !string.Equals(identity.PublicKeyToken, reference.Identity.PublicKeyToken, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (identity.Version is not null && reference.Identity.Version != identity.Version)
+                    continue;
+                return reference;
+            }
+
+            return null;
+        }
+
+        static bool CultureMatches(string? expected, string? actual)
+        {
+            if (string.IsNullOrEmpty(expected))
+                return true;
+
+            static string Normalize(string? culture)
+                => string.IsNullOrEmpty(culture) || culture.Equals("neutral", StringComparison.OrdinalIgnoreCase)
+                    ? ""
+                    : culture;
+
+            return Normalize(expected).Equals(Normalize(actual), StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
     internal sealed class ZeroSignalGuard
     {
         readonly int _probeCount;
@@ -3349,6 +3386,7 @@ static class FidelityCheck
     static ReferenceSet RuntimeReferences(string targetPath, IReadOnlyList<string>? corpusAssemblies = null)
     {
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var resolvedReferences = new List<ResolvedAssemblyReference>();
         var builder = ImmutableArray.CreateBuilder<MetadataReference>();
 
         void Add(string path)
@@ -3367,6 +3405,8 @@ static class FidelityCheck
                 if (seen.Add(simple))
                 {
                     builder.Add(reference);
+                    if (TryReadAssemblyIdentity(fullPath) is { } identity)
+                        resolvedReferences.Add(new ResolvedAssemblyReference(identity, fullPath, () => File.OpenRead(fullPath), "CompilerReference"));
                 }
             }
             catch (IOException) { }
@@ -3383,7 +3423,39 @@ static class FidelityCheck
         foreach (var dependency in resolver.ResolveAll())
             Add(dependency.Path);
 
-        return new ReferenceSet(builder.ToImmutable(), new SignatureSpellability(resolver));
+        return new ReferenceSet(builder.ToImmutable(), new SignatureSpellability(new CompilerReferenceResolver(resolvedReferences)));
+    }
+
+    static AssemblyReferenceIdentity? TryReadAssemblyIdentity(string path)
+    {
+        try
+        {
+            var name = AssemblyName.GetAssemblyName(path);
+            string? token = ToHex(name.GetPublicKeyToken());
+            return new AssemblyReferenceIdentity(
+                name.Name ?? Path.GetFileNameWithoutExtension(path),
+                name.Version,
+                name.CultureName,
+                token);
+        }
+        catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    static string? ToHex(byte[]? bytes)
+    {
+        if (bytes is null || bytes.Length == 0)
+            return null;
+
+        var chars = new char[bytes.Length * 2];
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            chars[i * 2] = "0123456789abcdef"[bytes[i] >> 4];
+            chars[i * 2 + 1] = "0123456789abcdef"[bytes[i] & 0xF];
+        }
+        return new string(chars);
     }
 
 }

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -456,7 +456,7 @@ static class FidelityCheck
 
     sealed record TargetedCompileBackResult(MethodTarget Target, CompileBackResult Result);
 
-    sealed record ReferenceSet(ImmutableArray<MetadataReference> Metadata, SignatureAccessibility Accessibility);
+    sealed record ReferenceSet(ImmutableArray<MetadataReference> Metadata, SignatureSpellability Accessibility);
 
     internal sealed class ZeroSignalGuard
     {
@@ -567,144 +567,6 @@ static class FidelityCheck
             Console.WriteLine($"  compilation create         : {Ms(_compilationCreateTicks)}");
             Console.WriteLine($"  emit                       : {Ms(_emitTicks)}");
             Console.WriteLine($"  opcode compare             : {Ms(_opcodeCompareTicks)}");
-        }
-    }
-
-    /// <summary>
-    /// Some metadata-valid public members expose internal types from referenced
-    /// assemblies (Roslyn has several). C# cannot spell those signatures from the
-    /// compile-back assembly, so sibling stubs with such signatures are skipped
-    /// instead of poisoning unrelated target methods with CS0122.
-    /// </summary>
-    sealed class SignatureAccessibility
-    {
-        readonly IReadOnlyDictionary<string, string> _referencePaths;
-        readonly Dictionary<string, HashSet<string>?> _nonPublicTypes = new(StringComparer.OrdinalIgnoreCase);
-
-        public SignatureAccessibility(IReadOnlyDictionary<string, string> referencePaths)
-            => _referencePaths = referencePaths;
-
-        public bool CanEmitField(MetadataReader reader, FieldDefinition field, GenericContext context)
-        {
-            try { return !field.DecodeSignature(new InaccessibleTypeDetector(this), context); }
-            catch (Exception ex) when (IsDecodeException(ex)) { return true; }
-        }
-
-        public bool CanEmitProperty(MetadataReader reader, PropertyDefinition property, GenericContext context)
-        {
-            try { return !property.DecodeSignature(new InaccessibleTypeDetector(this), context).ReturnType; }
-            catch (Exception ex) when (IsDecodeException(ex)) { return true; }
-        }
-
-        public bool CanEmitMethod(MetadataReader reader, MethodDefinition method, GenericContext context)
-        {
-            try
-            {
-                var signature = method.DecodeSignature(new InaccessibleTypeDetector(this), context);
-                return !signature.ReturnType && !signature.ParameterTypes.Any(inaccessible => inaccessible);
-            }
-            catch (Exception ex) when (IsDecodeException(ex)) { return true; }
-        }
-
-        static bool IsDecodeException(Exception ex)
-            => ex is BadImageFormatException or InvalidOperationException or ArgumentException;
-
-        bool IsInaccessible(MetadataReader reader, TypeReferenceHandle handle)
-        {
-            if (AssemblyScope(reader, handle) is not { Length: > 0 } assemblyName)
-                return false;
-
-            string fullName = reader.GetFullTypeName(reader.GetTypeReference(handle));
-            return NonPublicTypes(assemblyName)?.Contains(fullName) == true;
-        }
-
-        HashSet<string>? NonPublicTypes(string assemblyName)
-        {
-            if (_nonPublicTypes.TryGetValue(assemblyName, out var cached))
-                return cached;
-
-            if (!_referencePaths.TryGetValue(assemblyName, out var path))
-            {
-                _nonPublicTypes[assemblyName] = null;
-                return null;
-            }
-
-            var types = new HashSet<string>(StringComparer.Ordinal);
-            FileStream? stream = null;
-            PEReader? pe = null;
-            try
-            {
-                stream = File.OpenRead(path);
-                pe = new PEReader(stream);
-                if (pe.HasMetadata)
-                {
-                    var reader = pe.GetMetadataReader();
-                    foreach (var handle in reader.TypeDefinitions)
-                    {
-                        if (!IsExternallyVisible(reader, handle))
-                            types.Add(reader.GetFullTypeName(reader.GetTypeDefinition(handle)));
-                    }
-                }
-            }
-            catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException)
-            {
-                _nonPublicTypes[assemblyName] = null;
-                return null;
-            }
-            finally
-            {
-                pe?.Dispose();
-                stream?.Dispose();
-            }
-
-            _nonPublicTypes[assemblyName] = types;
-            return types;
-        }
-
-        static bool IsExternallyVisible(MetadataReader reader, TypeDefinitionHandle handle)
-        {
-            var typeDef = reader.GetTypeDefinition(handle);
-            return (typeDef.Attributes & TypeAttributes.VisibilityMask) switch
-            {
-                TypeAttributes.Public => true,
-                TypeAttributes.NestedPublic => !typeDef.GetDeclaringType().IsNil
-                    && IsExternallyVisible(reader, typeDef.GetDeclaringType()),
-                _ => false,
-            };
-        }
-
-        static string? AssemblyScope(MetadataReader reader, TypeReferenceHandle handle)
-        {
-            var typeRef = reader.GetTypeReference(handle);
-            return typeRef.ResolutionScope.Kind switch
-            {
-                HandleKind.AssemblyReference => reader.GetString(reader.GetAssemblyReference((AssemblyReferenceHandle)typeRef.ResolutionScope).Name),
-                HandleKind.TypeReference => AssemblyScope(reader, (TypeReferenceHandle)typeRef.ResolutionScope),
-                _ => null,
-            };
-        }
-
-        sealed class InaccessibleTypeDetector(SignatureAccessibility accessibility)
-            : ISignatureTypeProvider<bool, GenericContext?>
-        {
-            public bool GetPrimitiveType(PrimitiveTypeCode typeCode) => false;
-            public bool GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => false;
-            public bool GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
-                => accessibility.IsInaccessible(reader, handle);
-            public bool GetTypeFromSpecification(MetadataReader reader, GenericContext? context, TypeSpecificationHandle handle, byte rawTypeKind)
-                => reader.GetTypeSpecification(handle).DecodeSignature(this, context);
-            public bool GetSZArrayType(bool elementType) => elementType;
-            public bool GetArrayType(bool elementType, ArrayShape shape) => elementType;
-            public bool GetByReferenceType(bool elementType) => elementType;
-            public bool GetPointerType(bool elementType) => elementType;
-            public bool GetGenericInstantiation(bool genericType, ImmutableArray<bool> typeArguments)
-                => genericType || typeArguments.Any(inaccessible => inaccessible);
-            public bool GetGenericMethodParameter(GenericContext? context, int index) => false;
-            public bool GetGenericTypeParameter(GenericContext? context, int index) => false;
-            public bool GetFunctionPointerType(MethodSignature<bool> signature)
-                => signature.ReturnType || signature.ParameterTypes.Any(inaccessible => inaccessible);
-            public bool GetModifiedType(bool modifier, bool unmodifiedType, bool isRequired) => unmodifiedType;
-            public bool GetPinnedType(bool elementType) => elementType;
         }
     }
 
@@ -1919,7 +1781,7 @@ static class FidelityCheck
         bool targetRequiresAsync,
         PrimaryConstructorShape? targetPrimaryConstructor,
         IReadOnlyList<(string Field, string Value)> targetFieldInits,
-        SignatureAccessibility accessibility,
+        SignatureSpellability accessibility,
         IReadOnlySet<string>? requiredNamespaces = null,
         IReadOnlySet<TypeDefinitionHandle>? includeRoots = null)
     {
@@ -1940,7 +1802,7 @@ static class FidelityCheck
     /// </summary>
     static string BuildUnit(MetadataReader reader, IReadOnlyDictionary<MethodDefinitionHandle, TargetBody> targets,
         IReadOnlyList<(string Field, string Value)> fieldInits, TypeDefinitionHandle fieldInitType,
-        SignatureAccessibility accessibility, IReadOnlySet<TypeDefinitionHandle>? includeRoots = null,
+        SignatureSpellability accessibility, IReadOnlySet<TypeDefinitionHandle>? includeRoots = null,
         IReadOnlySet<string>? isolatedTargetNamespaces = null)
     {
         var sb = new StringBuilder();
@@ -2055,7 +1917,7 @@ static class FidelityCheck
            || (type.ElementType is { } element && ContainsUnsupportedType(element))
            || type.TypeArguments.Any(ContainsUnsupportedType);
 
-    static string InterfaceClause(MetadataReader reader, TypeDefinition typeDef, TypeKind kind, SignatureAccessibility accessibility)
+    static string InterfaceClause(MetadataReader reader, TypeDefinition typeDef, TypeKind kind, SignatureSpellability accessibility)
     {
         if (kind != TypeKind.Class)
             return "";
@@ -2189,7 +2051,7 @@ static class FidelityCheck
         return $"{qualified}<{string.Join(", ", type.TypeArguments.Select(FullyQualifiedTypeName))}>";
     }
 
-    static bool InterfaceMembersSatisfied(MetadataReader reader, TypeDefinition typeDef, EntityHandle interfaceHandle, SignatureAccessibility accessibility)
+    static bool InterfaceMembersSatisfied(MetadataReader reader, TypeDefinition typeDef, EntityHandle interfaceHandle, SignatureSpellability accessibility)
     {
         if (interfaceHandle.Kind != HandleKind.TypeDefinition)
             return false;
@@ -2204,7 +2066,7 @@ static class FidelityCheck
         foreach (var propertyHandle in interfaceDef.GetProperties())
         {
             var property = reader.GetPropertyDefinition(propertyHandle);
-            if (!accessibility.CanEmitProperty(reader, property, GenericContext.ForType(reader, interfaceDef)))
+            if (!accessibility.CanSpellProperty(reader, property, GenericContext.ForType(reader, interfaceDef)))
                 continue;
             if (!HierarchyHasProperty(reader, typeDef, reader.GetString(property.Name)))
                 return false;
@@ -2217,7 +2079,7 @@ static class FidelityCheck
             string name = reader.GetString(method.Name);
             if (accessorNames.Contains(name))
                 continue;
-            if (!accessibility.CanEmitMethod(reader, method, GenericContext.ForMethod(reader, interfaceDef, method)))
+            if (!accessibility.CanSpellMethod(reader, method, GenericContext.ForMethod(reader, interfaceDef, method)))
                 continue;
             if (name.Contains('.') || !HierarchyHasMethod(reader, typeDef, name))
                 return false;
@@ -2269,7 +2131,7 @@ static class FidelityCheck
     static void EmitType(MetadataReader reader, TypeDefinitionHandle typeHandle,
         IReadOnlyDictionary<MethodDefinitionHandle, TargetBody> targets,
         IReadOnlyList<(string Field, string Value)> fieldInits, TypeDefinitionHandle fieldInitType,
-        SignatureAccessibility accessibility, StringBuilder sb, int indent)
+        SignatureSpellability accessibility, StringBuilder sb, int indent)
     {
         var typeDef = reader.GetTypeDefinition(typeHandle);
         var kind = ShapeOf(reader, typeDef);
@@ -2439,7 +2301,7 @@ static class FidelityCheck
     /// without bodies or accessibility, as the interface form requires.
     /// </summary>
     static void EmitInterface(MetadataReader reader, TypeDefinitionHandle typeHandle,
-        string name, string genParams, string whereClauses, SignatureAccessibility accessibility, StringBuilder sb, string pad, int indent)
+        string name, string genParams, string whereClauses, SignatureSpellability accessibility, StringBuilder sb, string pad, int indent)
     {
         var typeDef = reader.GetTypeDefinition(typeHandle);
         string interfaceBaseClause = InterfaceBaseClause(reader, typeDef);
@@ -2459,7 +2321,7 @@ static class FidelityCheck
                 continue; // indexer / explicit impl — skip
             try
             {
-                if (!accessibility.CanEmitProperty(reader, prop, GenericContext.ForType(reader, typeDef)))
+                if (!accessibility.CanSpellProperty(reader, prop, GenericContext.ForType(reader, typeDef)))
                     continue;
                 var sig = prop.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForType(reader, typeDef));
                 string body = (!pa.Getter.IsNil ? " get;" : "") + (!pa.Setter.IsNil ? " set;" : "");
@@ -2475,7 +2337,7 @@ static class FidelityCheck
             if (mn.Contains('<') || mn.Contains('.') || accessors.Contains(mn))
                 continue; // accessor, static-abstract op, or explicit impl
             var context = GenericContext.ForMethod(reader, typeDef, method);
-            if (!accessibility.CanEmitMethod(reader, method, context))
+            if (!accessibility.CanSpellMethod(reader, method, context))
                 continue;
             MethodSignature<string> sig;
             try { sig = method.DecodeSignature(SignatureDecoder.Instance, context); }
@@ -2534,7 +2396,7 @@ static class FidelityCheck
     /// </summary>
     static void EmitStubProperties(MetadataReader reader, TypeDefinition typeDef,
         IReadOnlyDictionary<MethodDefinitionHandle, TargetBody> targets,
-        SignatureAccessibility accessibility, IReadOnlyList<(string Field, string Value)> fieldInits,
+        SignatureSpellability accessibility, IReadOnlyList<(string Field, string Value)> fieldInits,
         HashSet<MethodDefinitionHandle> skipAccessors, StringBuilder sb, string pad,
         bool requireAutoProperty = false)
     {
@@ -2548,7 +2410,7 @@ static class FidelityCheck
                 continue; // compiler-generated / explicit interface impl
             try
             {
-                if (!accessibility.CanEmitProperty(reader, prop, typeContext))
+                if (!accessibility.CanSpellProperty(reader, prop, typeContext))
                     continue;
                 var sig = prop.DecodeSignature(SignatureDecoder.Instance, typeContext);
                 if (sig.ParameterTypes.Length > 0)
@@ -2667,10 +2529,10 @@ static class FidelityCheck
         return false;
     }
 
-    static bool CanEmitAccessor(MetadataReader reader, TypeDefinition typeDef, MethodDefinitionHandle handle, SignatureAccessibility accessibility)
+    static bool CanEmitAccessor(MetadataReader reader, TypeDefinition typeDef, MethodDefinitionHandle handle, SignatureSpellability accessibility)
     {
         var method = reader.GetMethodDefinition(handle);
-        return accessibility.CanEmitMethod(reader, method, GenericContext.ForMethod(reader, typeDef, method));
+        return accessibility.CanSpellMethod(reader, method, GenericContext.ForMethod(reader, typeDef, method));
     }
 
 
@@ -2732,7 +2594,7 @@ static class FidelityCheck
     }
 
     static void EmitField(MetadataReader reader, FieldDefinitionHandle fh, GenericContext context,
-        IReadOnlyList<(string Field, string Value)> fieldInits, SignatureAccessibility accessibility, StringBuilder sb, string pad)
+        IReadOnlyList<(string Field, string Value)> fieldInits, SignatureSpellability accessibility, StringBuilder sb, string pad)
     {
         var field = reader.GetFieldDefinition(fh);
         string name = reader.GetString(field.Name);
@@ -2741,7 +2603,7 @@ static class FidelityCheck
         string type;
         try { type = field.DecodeSignature(SignatureDecoder.Instance, context); }
         catch { return; }
-        if (!accessibility.CanEmitField(reader, field, context)
+        if (!accessibility.CanSpellField(reader, field, context)
             && !fieldInits.Any(init => string.Equals(init.Field, name, StringComparison.Ordinal)))
             return;
         if (type.Contains(">e__FixedBuffer", StringComparison.Ordinal))
@@ -2777,7 +2639,7 @@ static class FidelityCheck
 
     static void EmitMethod(MetadataReader reader, TypeDefinitionHandle typeHandle,
         MethodDefinitionHandle mh, string? realBody, string? realChain, bool realRequiresAsync,
-        SignatureAccessibility accessibility, StringBuilder sb, string pad)
+        SignatureSpellability accessibility, StringBuilder sb, string pad)
     {
         var typeDef = reader.GetTypeDefinition(typeHandle);
         var method = reader.GetMethodDefinition(mh);
@@ -2794,7 +2656,7 @@ static class FidelityCheck
         if (realBody is null && name.Contains('.') && name is not ".ctor" and not ".cctor")
             return;
         var context = GenericContext.ForMethod(reader, typeDef, method);
-        if (realBody is null && !accessibility.CanEmitMethod(reader, method, context))
+        if (realBody is null && !accessibility.CanSpellMethod(reader, method, context))
             return;
         MethodSignature<string> sig;
         try { sig = method.DecodeSignature(SignatureDecoder.Instance, context); }
@@ -3487,7 +3349,6 @@ static class FidelityCheck
     static ReferenceSet RuntimeReferences(string targetPath, IReadOnlyList<string>? corpusAssemblies = null)
     {
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var referencePaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         var builder = ImmutableArray.CreateBuilder<MetadataReference>();
 
         void Add(string path)
@@ -3506,7 +3367,6 @@ static class FidelityCheck
                 if (seen.Add(simple))
                 {
                     builder.Add(reference);
-                    referencePaths[simple] = fullPath;
                 }
             }
             catch (IOException) { }
@@ -3523,7 +3383,7 @@ static class FidelityCheck
         foreach (var dependency in resolver.ResolveAll())
             Add(dependency.Path);
 
-        return new ReferenceSet(builder.ToImmutable(), new SignatureAccessibility(referencePaths));
+        return new ReferenceSet(builder.ToImmutable(), new SignatureSpellability(resolver));
     }
 
 }

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -458,14 +458,20 @@ static class FidelityCheck
 
     sealed record ReferenceSet(ImmutableArray<MetadataReference> Metadata, SignatureSpellability Accessibility);
 
-    sealed class CompilerReferenceResolver(IEnumerable<ResolvedAssemblyReference> references) : IAssemblyReferenceResolver
+    sealed record CompilerReference(ResolvedAssemblyReference Reference, bool PlatformTrusted);
+
+    sealed class CompilerReferenceResolver(IEnumerable<CompilerReference> references) : IAssemblyReferenceResolver
     {
-        readonly IReadOnlyList<ResolvedAssemblyReference> _references = references.ToList();
+        readonly IReadOnlyList<CompilerReference> _references = references.ToList();
 
         public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
         {
-            foreach (var reference in _references)
+            foreach (var candidate in _references)
             {
+                if (scope == AssemblyResolutionScope.Platform && !candidate.PlatformTrusted)
+                    continue;
+
+                var reference = candidate.Reference;
                 if (!reference.Identity.Name.Equals(identity.Name, StringComparison.OrdinalIgnoreCase))
                     continue;
                 if (!CultureMatches(identity.Culture, reference.Identity.Culture))
@@ -3386,10 +3392,10 @@ static class FidelityCheck
     static ReferenceSet RuntimeReferences(string targetPath, IReadOnlyList<string>? corpusAssemblies = null)
     {
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var resolvedReferences = new List<ResolvedAssemblyReference>();
+        var resolvedReferences = new List<CompilerReference>();
         var builder = ImmutableArray.CreateBuilder<MetadataReference>();
 
-        void Add(string path)
+        void Add(string path, AssemblyDependencyProvenance? provenance)
         {
             if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
                 return;
@@ -3406,7 +3412,10 @@ static class FidelityCheck
                 {
                     builder.Add(reference);
                     if (TryReadAssemblyIdentity(fullPath) is { } identity)
-                        resolvedReferences.Add(new ResolvedAssemblyReference(identity, fullPath, () => File.OpenRead(fullPath), "CompilerReference"));
+                        resolvedReferences.Add(new CompilerReference(
+                            new ResolvedAssemblyReference(identity, fullPath, () => File.OpenRead(fullPath), provenance?.ToString() ?? "CompilerReference"),
+                            PlatformTrusted: provenance is AssemblyDependencyProvenance.TrustedPlatformAssembly
+                                or AssemblyDependencyProvenance.SharedFramework));
                 }
             }
             catch (IOException) { }
@@ -3421,7 +3430,7 @@ static class FidelityCheck
             ExcludeTargetAssembly = true,
         });
         foreach (var dependency in resolver.ResolveAll())
-            Add(dependency.Path);
+            Add(dependency.Path, dependency.Provenance);
 
         return new ReferenceSet(builder.ToImmutable(), new SignatureSpellability(new CompilerReferenceResolver(resolvedReferences)));
     }


### PR DESCRIPTION
## Summary

Part of #2548 Finding #3.

- Add product `SignatureSpellability` over `IAssemblyReferenceResolver` to detect signatures that expose inaccessible referenced types.
- Migrate `FidelityCheck` from its harness-local `SignatureAccessibility` / `InaccessibleTypeDetector` to the product API.
- Add fixture-backed metadata tests for field, property, and method signatures using a friend assembly that references an internal type.

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release --no-build`
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release -- -class "*SignatureSpellabilityTests"`
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release -- -class "*MetadataDeclarationQueryTests"`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- artifacts/bin/ILInspector.Metadata/release/ILInspector.Metadata.dll --fidelity-check --compile-cap 5 --max-examples 2`

## Notes

Low-risk product extraction for compile-back shell filtering; no decompiler output behavior change.
