### PR TITLE
Classify dynamic call-site source deltas

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -440,7 +440,7 @@ public class ReturnToSenderFixtureCatalogTests
 
         Assert.Equal(ReturnToSenderSourceOutcome.ValidDifferent, result.Outcome);
         Assert.Equal(FidelityCheck.CompileBackStatus.OpcodeDiff, result.CompileBackStatus);
-        Assert.Equal("valid_different.semantic_opcode_diff.syntax", result.Reason);
+        Assert.Equal("valid_different.compiler_lowering.dynamic_callsite.opcode_diff", result.Reason);
         Assert.False(string.IsNullOrWhiteSpace(result.OriginalOpcodes));
         Assert.False(string.IsNullOrWhiteSpace(result.RecompiledOpcodes));
         Assert.NotEmpty(result.IlDiffLines ?? []);

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -448,6 +448,43 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_ClassifiesDynamicCallSiteOpcodeDiffs()
+    {
+        var results = ReturnToSenderSourceProbe.EvaluateTargets(
+            FixtureCatalog.DecompilerLadderRung9.AssemblyPath(),
+            [
+                new ReturnToSender.RequestedTarget("LadderRung9.DynamicAndExpressionTrees", "DynamicAdd", Overload: 0),
+                new ReturnToSender.RequestedTarget("LadderRung9.DynamicAndExpressionTrees", "DynamicCompoundMember", Overload: 0),
+            ]);
+
+        Assert.All(results, result =>
+        {
+            Assert.Equal(ReturnToSenderSourceOutcome.ValidDifferent, result.Outcome);
+            Assert.Equal(FidelityCheck.CompileBackStatus.OpcodeDiff, result.CompileBackStatus);
+            Assert.Equal("valid_different.compiler_lowering.dynamic_callsite.opcode_diff", result.Reason);
+            Assert.Contains("compiler_lowering.dynamic_callsite", result.Detail);
+        });
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_DynamicCallSiteClassifierRequiresOpcodeDiff()
+    {
+        var reason = ReturnToSenderSourceProbe.ClassifyValidDifference(
+            "return left + right;",
+            """
+            CSharpArgumentInfo[] infos;
+            ___o__0.___p__0 = CallSite<Func<CallSite, object, object, object>>.Create(Binder.BinaryOperation((CSharpBinderFlags)0, ExpressionType.Add, typeof(C), infos));
+            return ___o__0.___p__0.Target.Invoke(___o__0.___p__0, left, right);
+            """,
+            FidelityCheck.CompileBackStatus.Exact,
+            decisions: [],
+            out var detail);
+
+        Assert.Equal("valid_different.source_shape_frontier.syntax.exact", reason);
+        Assert.DoesNotContain("dynamic_callsite", detail);
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_CompilesGeneratedDynamicDelegateCallSites()
     {
         var targets = new[]

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -484,6 +484,31 @@ public class ReturnToSenderFixtureCatalogTests
         Assert.DoesNotContain("dynamic_callsite", detail);
     }
 
+    [Theory]
+    [InlineData("yield return value;", "valid_different.compiler_lowering.iterator.opcode_diff")]
+    [InlineData("unsafe { int* p = null; return *p; }", "valid_different.semantic_opcode_diff.unsafe_residual")]
+    [InlineData("Func<int> next = () => value + 1; return next();", "valid_different.semantic_opcode_diff.closure")]
+    public void ReturnToSenderSourceProbe_DynamicCallSiteClassifierPreservesHigherPriorityShapes(
+        string expected,
+        string reason)
+    {
+        var actual = """
+            CSharpArgumentInfo[] infos;
+            ___o__0.___p__0 = CallSite<Func<CallSite, object, object, object>>.Create(Binder.BinaryOperation((CSharpBinderFlags)0, ExpressionType.Add, typeof(C), infos));
+            return ___o__0.___p__0.Target.Invoke(___o__0.___p__0, left, right);
+            """;
+
+        var actualReason = ReturnToSenderSourceProbe.ClassifyValidDifference(
+            expected,
+            actual,
+            FidelityCheck.CompileBackStatus.OpcodeDiff,
+            decisions: [],
+            out var detail);
+
+        Assert.Equal(reason, actualReason);
+        Assert.DoesNotContain("dynamic_callsite", detail);
+    }
+
     [Fact]
     public void ReturnToSenderSourceProbe_CompilesGeneratedDynamicDelegateCallSites()
     {

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -172,6 +172,7 @@ The source probe also supports `--json` for machine-readable census rows. The
 `reason` field classifies valid-but-different rows by the source-fidelity
 frontier and compile-back status, for example
 `valid_different.compiler_lowering.iterator.opcode_diff`,
+`valid_different.compiler_lowering.dynamic_callsite.opcode_diff`,
 `valid_different.known_compiler_option.checked_context`, or
 `valid_different.semantic_opcode_diff.unsafe_residual`.
 For rows whose compile-back status is `OpcodeDiff`, text examples and JSON rows

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -899,6 +899,7 @@ static class ReturnToSenderSourceProbe
                 ? "exact"
                 : status.ToString().ToLowerInvariant();
         if (status == FidelityCheck.CompileBackStatus.OpcodeDiff
+            && AllowsDynamicCallSiteClassification(shape)
             && IsDynamicCallSiteLowering(actual))
         {
             detail = "decompiled body is Roslyn-valid and compile-back opcode-different; classification=compiler_lowering.dynamic_callsite; compile-back=OpcodeDiff";
@@ -1044,6 +1045,12 @@ static class ReturnToSenderSourceProbe
         => actual.Contains("CallSite<", StringComparison.Ordinal)
             && actual.Contains("Binder.", StringComparison.Ordinal)
             && actual.Contains("CSharpArgumentInfo", StringComparison.Ordinal);
+
+    static bool AllowsDynamicCallSiteClassification(string shape)
+        => shape is
+            "source_shape_frontier.syntax" or
+            "source_shape_frontier.checked_context" or
+            "source_shape_frontier.dynamic";
 
     static string ShapeLeaf(string shape)
     {

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -898,6 +898,12 @@ static class ReturnToSenderSourceProbe
             : status == FidelityCheck.CompileBackStatus.Exact
                 ? "exact"
                 : status.ToString().ToLowerInvariant();
+        if (status == FidelityCheck.CompileBackStatus.OpcodeDiff
+            && IsDynamicCallSiteLowering(actual))
+        {
+            detail = "decompiled body is Roslyn-valid and compile-back opcode-different; classification=compiler_lowering.dynamic_callsite; compile-back=OpcodeDiff";
+            return "valid_different.compiler_lowering.dynamic_callsite.opcode_diff";
+        }
 
         string reason = shape.StartsWith("compiler_lowering.", StringComparison.Ordinal)
             ? $"valid_different.{shape}.{statusId}"
@@ -1033,6 +1039,11 @@ static class ReturnToSenderSourceProbe
 
     static bool ContainsDynamic(IReadOnlyList<SyntaxNode> nodes)
         => nodes.Any(node => node is IdentifierNameSyntax identifier && identifier.Identifier.ValueText == "dynamic");
+
+    static bool IsDynamicCallSiteLowering(string actual)
+        => actual.Contains("CallSite<", StringComparison.Ordinal)
+            && actual.Contains("Binder.", StringComparison.Ordinal)
+            && actual.Contains("CSharpArgumentInfo", StringComparison.Ordinal);
 
     static string ShapeLeaf(string shape)
     {


### PR DESCRIPTION
## Summary

Splits dynamic call-site ReturnToSender source-probe `OpcodeDiff` rows into a stable compiler-lowering bucket:

- `valid_different.compiler_lowering.dynamic_callsite.opcode_diff`

The classifier is gated by compile-back `OpcodeDiff` plus lowered body evidence (`CallSite<`, `Binder.`, and `CSharpArgumentInfo`). Product decompiler output is unchanged.

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --nologo -v:minimal`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/ReturnToSenderFixtureCatalogTests/*DynamicCallSite*"`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures decompiler --return-to-sender-source-probe --cap 10000 --max-examples 260 --json > /tmp/rts-source-probe-dynamic-classified-r2.json`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures decompiler --return-to-sender-source-probe --cap 10000 --max-examples 260`
  - `ValidMatch: 97`
  - `ValidDifferent: 107`
  - `Invalid: 0`
  - new bucket: `valid_different.compiler_lowering.dynamic_callsite.opcode_diff: 15`
  - `valid_different.semantic_opcode_diff.syntax` reduced from 18 to 9
- `dotnet run /tmp/check-rts-json.cs`
- `npx markdownlint-cli --fix tools/DecompilerHarness/README.md && npx markdownlint-cli tools/DecompilerHarness/README.md`

## Notes

This is a harness-only classification refinement. It does not fix or re-render dynamic source; it keeps the lowered call-site shape explicit and identifies the compiler-lowering bucket so the remaining semantic syntax rows are sharper.
