### PR TITLE
Enforce stdout=data / stderr=diagnostics in DecompilerHarness (#2500)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -48,6 +48,8 @@
   -->
   <ItemGroup>
     <Compile Include="..\..\tools\DecompilerHarness\InverseLedger.cs" Link="InverseArchitecture\InverseLedger.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\HarnessLog.cs"
+             Link="HarnessLog.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\CorpusMetadata.cs"
              Link="CorpusMetadata.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\CorpusMethodIdentity.cs"

--- a/tools/DecompilerHarness/AssertionScan.cs
+++ b/tools/DecompilerHarness/AssertionScan.cs
@@ -858,7 +858,7 @@ internal static class AssertionScan
         var snapshot = AssertionViolationSnapshot.FromResult(result);
         File.WriteAllText(path, JsonSerializer.Serialize(snapshot, JsonOptions()));
         Console.WriteLine();
-        Console.WriteLine($"Wrote assertion-violation map for {snapshot.Methods.Count} methods to {path}");
+        HarnessLog.Status($"Wrote assertion-violation map for {snapshot.Methods.Count} methods to {path}");
     }
 
     static void DiffViolations(string baselinePath, Result result)

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -68,7 +68,7 @@ internal static class CorpusSensor
             if (!qualityDiffCard)
             {
                 Console.WriteLine();
-                Console.WriteLine($"Wrote corpus baseline: {emitBaseline}");
+                HarnessLog.Status($"Wrote corpus baseline: {emitBaseline}");
             }
         }
 
@@ -84,7 +84,7 @@ internal static class CorpusSensor
             if (!qualityDiffCard)
             {
                 Console.WriteLine();
-                Console.WriteLine($"Wrote per-method corpus delta: {emitDelta}");
+                HarnessLog.Status($"Wrote per-method corpus delta: {emitDelta}");
             }
         }
         if (qualityDiffCard)

--- a/tools/DecompilerHarness/HarnessLog.cs
+++ b/tools/DecompilerHarness/HarnessLog.cs
@@ -1,0 +1,15 @@
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// Output discipline for the harness: stdout carries a sensor's data (reports,
+/// cards, and <c>--json</c>/<c>--jsonl</c>/<c>--tsv</c> payloads); stderr carries
+/// status, progress, and gate diagnostics. Routing status messages through
+/// <see cref="Status(string)"/> keeps structured stdout parseable — for example a
+/// <c>--jsonl</c> stream stays valid and a teed quality card stays free of stray
+/// "Wrote …" lines.
+/// </summary>
+static class HarnessLog
+{
+    /// <summary>Writes a status, progress, or gate diagnostic to stderr.</summary>
+    public static void Status(string message) => Console.Error.WriteLine(message);
+}

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -303,7 +303,7 @@ static class Program
         if (emitInverseLedger is not null)
         {
             File.WriteAllText(emitInverseLedger, ILInspector.Decompiler.Tests.InverseArchitecture.InverseLedger.RenderMarkdown(typeof(IrFunction).Assembly));
-            Console.WriteLine($"Wrote inverse ledger to {emitInverseLedger}");
+            HarnessLog.Status($"Wrote inverse ledger to {emitInverseLedger}");
             return 0;
         }
 

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -2,6 +2,10 @@
 
 The diagnostic harness from [docs/decompiler.md](../../docs/decompiler.md) — the asmdiffs analog for the decompiler. It inventories the pipeline's health, scores the real-gap completeness, validates output two ways, and dumps a single method through every pipeline stage. This is the invocation reference for the modes; the strategy they serve — which check proves what, what gates CI, the corpus-sweep plan — is [docs/decompiler-quality.md](../../docs/decompiler-quality.md).
 
+## Output discipline
+
+**stdout = data, stderr = diagnostics.** A sensor's data — reports, cards, and `--json`/`--jsonl`/`--tsv` payloads — goes to stdout; status, progress, gate, and emit-confirmation messages (e.g. "Wrote …: `<path>`") go to stderr. This keeps structured stdout parseable (a `--jsonl` stream stays valid; a teed quality card stays free of stray status lines). Route status through `HarnessLog.Status(...)` rather than `Console.WriteLine` so new sensors follow the convention by default.
+
 ## Modes
 
 **Inverse ledger regeneration** (`--emit-inverse-ledger <path>`): evaluates `[InverseOf]` and `[NotInverted]` attributes on the decompiler's node schema and renders the Markdown representation to the specified path. Use this command to update the single-source-of-truth document at `docs/design/inverse-ledger.generated.md` after adding or changing inverse annotations in the IR types. A drift-gate test enforces that the committed file matches this command's output.

--- a/tools/DecompilerHarness/RenderAbSensor.cs
+++ b/tools/DecompilerHarness/RenderAbSensor.cs
@@ -33,7 +33,7 @@ internal static class RenderAbSensor
         {
             var json = JsonSerializer.Serialize(ToBodyDictionary(current), new JsonSerializerOptions { WriteIndented = true });
             File.WriteAllText(emitPath, json);
-            Console.WriteLine($"Wrote baseline to {emitPath} ({current.Count} methods).");
+            HarnessLog.Status($"Wrote baseline to {emitPath} ({current.Count} methods).");
             if (diffPath is null)
                 return 0;
         }

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -332,7 +332,7 @@ static class ValidityCheck
         foreach (var (method, codes) in map.OrderBy(kv => kv.Key, StringComparer.Ordinal))
             writer.WriteLine($"{method}\t{string.Join(",", codes)}");
         Console.WriteLine();
-        Console.WriteLine($"Wrote per-method defects for {map.Count} methods to {path}");
+        HarnessLog.Status($"Wrote per-method defects for {map.Count} methods to {path}");
     }
 
     /// <summary>


### PR DESCRIPTION
- Fixes #2500
- Establishes a `stdout = data, stderr = diagnostics` discipline in DecompilerHarness and moves the remaining stdout emit-confirmation messages to stderr.
- Dev-tooling only; no product/decompiler behavior change.

## Problem

While landing #2491, review found the return-address census wrote status to
**stdout**, corrupting `--jsonl`/`--tsv` output. The same latent pattern remained in
other sensors: emit-confirmation lines (`Wrote …: <path>`) were written to stdout via
`Console.WriteLine`. Most visibly, the CI quality-diff-card is produced by teeing the
corpus sensor's **stdout**, so a stray `Wrote corpus baseline: …` line lands in the
card artifact; any future structured mode on those sensors would break parsing.

## Change

- Add `HarnessLog.Status(...)` → stderr as the single seam for status/progress/gate
  diagnostics, and document the convention in `tools/DecompilerHarness/README.md`.
- Route the remaining stdout emit-confirmations through it: corpus baseline/delta
  (`CorpusSensor`), inverse ledger (`Program`), render-ab baseline (`RenderAbSensor`),
  per-method validity defects (`ValidityCheck`), assertion-violation map (`AssertionScan`).

Structured-output sensors (`--json`/`--jsonl`/`--tsv`) already early-return before
their human-readable report (verified for `ReturnToSenderSourceProbe`, `Dec0009Classifier`,
`LibraryReport`), and `ReturnAddressCensus`/`NotMyTypeCensus` already route status to
stderr — so those stay clean. This closes the emit-message gap and gives new sensors a
default to follow.

## Evidence

```text
$ decompiler-harness --emit-inverse-ledger /tmp/l.md   → stdout: (empty)   stderr: Wrote inverse ledger to /tmp/l.md
$ decompiler-harness --emit-corpus-snapshot /tmp/s.json --corpus-method-cap 3 --compile-cap 0 --corpus-fidelity-cap 0
      → stdout has 'Wrote corpus': 0   stderr has 'Wrote corpus': 1
```

| Check | Result |
| --- | --- |
| Harness build | Pass |
| Decompiler tests build (links `HarnessLog.cs`) | Pass |
| `markdownlint` (README) | Clean |
| Emit messages on stderr, stdout clean | Verified (`--emit-inverse-ledger`, `--emit-corpus-snapshot`) |

No test or CI/eng script asserts these messages on stdout (checked); the CI corpus
step takes its pass/fail from the sensor exit code and only *benefits* from a cleaner
teed card.

## Risk

Low — dev tooling, stream-only change (message content unchanged). No decompiler
raise/structuring/printer semantics change, so no corpus/A-B applies. Per AGENTS.md
this is a low-risk change and does not require the two-model adversarial review.
