### PR TITLE
Add Performance Analysis baselines doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Output Shapes](design/output-shapes.md) | The Document → Table → Vector → Scalar shape ladder, how Markout produces it, and how the output flags select a shape. |
 | [Graph Signal Annotations](design/graph-signal-annotations.md) | Projecting analysis signals (alloc/copy/unsafe, and exception-risk follow-ups) onto call-graph nodes via `--fields`. |
 | [Allocation Triage Pre-Filters](design/allocation-triage-prefilters.md) | Which allocation candidates Performance Triage surfaces, why the pre-filters prune cold-by-construction shapes, and what realized cost the static side cannot predict. |
+| [Performance Analysis Baselines](analysis-baselines.md) | Internal baselines of what each analysis type finds over a fixed corpus, with effectiveness ratings for the one-stop-shop Performance Analysis view. |
 | [Dynamic Leak-Watch](design/dynamic-leak-watch.md) | The retention axis: how `runfaster leak-watch` separates a managed leak from a churn storm from native/committed growth, and why static triage and the allocation-tick join cannot. |
 | [Rendering Model](design/rendering-model.md) | Historical/current rendering model notes; prefer [Progressive Disclosure](design/progressive-disclosure.md) for current agent-facing behavior. |
 | [Section Model](design/section-model.md) | Section selection design notes; use with [Progressive Disclosure](design/progressive-disclosure.md). |

--- a/docs/analysis-baselines.md
+++ b/docs/analysis-baselines.md
@@ -1,0 +1,123 @@
+# Performance Analysis baselines
+
+`dotnet-inspect` ships a lot of low-level analysis tools (metadata, IL, decompile, caller graph,
+allocation triage, leak triage). **Performance Analysis is the one-stop shop**: run one view over a
+library and see whether there is something interesting worth a closer look — without first knowing
+which low-level tool to reach for. This doc is the internal baseline of *what each analysis type
+finds* over a fixed corpus, plus an **effectiveness rating** so we know which lanes are worthy of
+leading the one-stop-shop view. Everything is **static** (nothing is executed) and every row has a
+re-runnable receipt.
+
+## Corpus
+
+44 assemblies, all resolved from NuGet / the shared framework:
+
+- **Apps**: `Aspire.Dashboard` 9.0.0.
+- **Serialization / wire**: Newtonsoft.Json, MessagePack, protobuf-net, Google.Protobuf, YamlDotNet,
+  CsvHelper, MongoDB.Bson.
+- **Networking / data**: Npgsql, StackExchange.Redis, RabbitMQ.Client, Grpc.Net.Client,
+  Confluent.Kafka, Pipelines.Sockets.Unofficial, MongoDB.Driver, RestSharp, Flurl.Http, Refit,
+  AWSSDK.Core.
+- **Text / parsing**: MimeKit, Markdig, AngleSharp, HtmlAgilityPack, Humanizer, Microsoft.CodeAnalysis(.CSharp).
+- **Infra / util**: Serilog, NLog, AutoMapper, MediatR, Dapper, FluentValidation, Polly, NodaTime,
+  Bogus, SharpCompress, K4os.LZ4, SixLabors.ImageSharp, prometheus-net, ZLinq, CliWrap.
+
+The leak/MemoryPool lanes were also baselined over the .NET 9.0.14 shared framework (308 asm).
+
+## The one-stop-shop funnel (Performance Triage, all 44 assemblies)
+
+| Cut | Rows | What it is |
+| --- | ---- | ---------- |
+| Raw `Performance Triage` | 13,598 | every allocation/scan site — too much to read |
+| Ranked (`--loop --min-confidence medium`) | 943 | in a hot loop, non-trivial confidence |
+| Sharp (`--loop --min-confidence high`) | 318 | the "read these first" set |
+| Algorithmic shapes (scan/linq/string-build in loop) | 155 | quadratic / hot-loop hotspots — the headline |
+
+The takeaway: **the raw dump is noise; the value is the ranking.** Root-Reach + Loop + Confidence +
+Post-Dominance columns turn 13.6k rows into a few hundred worth a look, and the algorithmic shapes
+are the cheapest "found something interesting" wins.
+
+## Effectiveness matrix
+
+| # | Analysis type | Command | Volume (44 asm) | Precision | Actionability | Verdict |
+| - | ------------- | ------- | --------------- | --------- | ------------- | ------- |
+| 1 | Algorithmic scan-in-loop | `Performance Triage` (`scan-method-in-loop-call`, `linq-scan-in-loop`, `string-build-in-loop`, `allocation-hotspot`) | 155 | High | **Very high** (quadratic) | **Headline** |
+| 2 | Leak-after-exception | harness `--leak-triage` + `--leak-actionability` | 5 actionable | **Very high (9/9 confirmed)** | High (`try/finally`) | **Headline** |
+| 3 | Delegate allocation | `Performance Triage` (`instance-method-group-delegate`, `capturing-delegate`) | 3,327 raw / 128 hot | High (real) / High in loops | High in loops | **Worthy w/ ranking** |
+| 4 | Enumerator allocation | `Performance Triage` (`enumerator-allocation`) | 121 / 117 hot | High | Med–High | **Worthy** |
+| 5 | Reach / leverage | `Top Leverage` | ranking | — | Impact multiplier for 1,3,4 | **Worthy as a lens** |
+| 6 | Boxing | `Performance Triage` (`box-value-type`) | 2,478 / 136 hot | High | Low–Med (mostly cold `ThrowHelper`) | **Only when loop + reach** |
+| 7 | Small-array | `Performance Triage` (`small-array`) | 7,466 / 446 hot | High | Low (often non-escaping / cold) | **Defer** |
+| 8 | MemoryPool lifecycle | harness `--memorypool-lifecycle` | 8 sites / 0 leaks | High (0 false) | Low so far | **Census, not a bug-finder** |
+
+## Per-type baselines
+
+### 1. Algorithmic scan-in-loop — the headline allocation-lane shape
+
+Flags a **linear scan invoked on every iteration of a caller's loop** — the quadratic shape. 155
+across the corpus, concentrated in text/serialization/reflection-heavy libs: Humanizer (20),
+Microsoft.CodeAnalysis.CSharp (14), Newtonsoft.Json (10), AWSSDK.Core (9), MimeKit / AngleSharp (8),
+MongoDB.Bson / HtmlAgilityPack / Confluent.Kafka / Aspire.Dashboard (7). Low volume, very high
+impact, clean "build an index / hoist the scan" fix.
+
+```bash
+dotnet-inspect library <asm> -S "Performance Triage" --triage-shape scan-method-in-loop-call,linq-scan-in-loop
+```
+
+Example (Aspire): `OtlpTrace.AddSpan` → `Enumerable.Any` invoked inside a loop by
+`TelemetryRepository::AddTracesCore`; and the gist's `CalculateMaxDepth` (`Spans.Max(CalculateDepth)`
+where each `CalculateDepth` step re-scans all spans) — the O(N·D·N) waterfall rebuild.
+
+### 2. Leak-after-exception — highest-precision lane
+
+Pooled-buffer leak on the exception path (see catalog issue #2572 and #2439). Harness sensors classify
+the exception-path `ArrayPool` candidates by whether the throwing boundary consumes external input.
+
+- Broadened packages (44 asm): 12 exception-path candidates → **5 untrusted-actionable, all confirmed**
+  (MessagePack `ReadStringSlow`, MimeKit `Rfc2047.DecodePhrase`/`DecodeText`, Npgsql
+  `TextConverter.GetChars`, Pipelines.Sockets `AsyncPipeStream.ReadByte`).
+- Framework (308 asm): 4 untrusted-actionable, all confirmed.
+- **9/9 confirmed real leaks**, IL-verified. Lowest volume, highest precision, clean `try/finally` fix.
+
+### 3–4. Delegate & enumerator allocation
+
+`instance-method-group-delegate` / `capturing-delegate`: a `Func`/closure allocated per call, hot when
+in a loop or reached by many roots. `enumerator-allocation`: `foreach` over an interface-typed
+sequence allocates a reference-type enumerator per pass. The two hand-found Aspire.Dashboard gist
+finds reproduce on current `main`: `OtlpSpan.GetParentSpan()`/`GetChildSpans()` and
+`ColorGenerator.GetColorIndex` all surface as `instance-method-group-delegate`. Worthy **with**
+Root-Reach/Loop/Confidence ranking — the unfiltered list is dominated by cold straight-line delegates.
+
+### 5. Reach / leverage — `Top Leverage`
+
+Ranks members by `Callers`, `Root Reach`, `Fanout`, `Depth`, `Loop Calls`, `Visibility`, `Stable`. Not
+a finding on its own — it is the **multiplier** that decides whether an allocation or scan matters (a
+micro-alloc reached by 92 roots vs one on a cold path). It gates lanes 1, 3, 4.
+
+### 6–7. Boxing & small-array — high volume, low actionability
+
+`box-value-type` (2,478) and `small-array` (7,466) dominate the raw count but are mostly `low` weight:
+boxing in cold `ThrowHelper`s post-dominated by `return`, or small non-escaping arrays. Only worth
+surfacing when `--loop` + high Root-Reach. Defer small-array; gate boxing.
+
+### 8. MemoryPool lifecycle — census
+
+Every `MemoryPool<T>.Rent` → `IMemoryOwner<T>` site across framework + packages is
+`ownership-transfer` (segments / pools / async state-machine fields): **0 leak candidates, 0 false
+positives.** Precision-first census holds but has found no real leaks. Keep as a census / regression
+guard; do not lead with it.
+
+## Recommendation for the one-stop-shop view
+
+Lead with high precision + high impact, gated by the reach lens:
+
+1. **Leak-after-exception** and **algorithmic scan-in-loop** — headline finds; low volume, high
+   confidence, clean fixes.
+2. **Delegate / enumerator allocation in loops** — worthy with ranking.
+3. **Top Leverage** — the impact lens that ranks 1–2.
+
+De-emphasize small-array and cold boxing (surface only under loop + high reach), and treat MemoryPool
+as a census.
+
+Follow-ups: add a "confirmed vs candidate" verification step to the allocation lanes (as the leak lane
+has); carry the caller-graph receipt into the algorithmic finding row; keep widening the app corpus.


### PR DESCRIPTION
## What

Adds `docs/analysis-baselines.md` — an internal baseline of what each **static** analysis type
`dotnet-inspect` can run finds over a fixed corpus, with an effectiveness rating per lane so we can
decide what is worthy of leading the **one-stop-shop Performance Analysis** view (the idea: the tool
ships many low-level tools; Performance Analysis is where you look to find something interesting
cheaply, without knowing which tool to reach for).

## Corpus

44 assemblies (`Aspire.Dashboard` 9.0.0 + 43 popular libraries: Newtonsoft.Json, MessagePack,
Roslyn, Npgsql, MimeKit, AngleSharp, Serilog, MongoDB.Driver, AWSSDK.Core, …), plus the .NET 9.0.14
shared framework (308 asm) for the leak/MemoryPool lanes.

## Key findings

- **The raw Performance Triage list is noise** (13,598 rows across the corpus). The value is the
  ranking columns: `--loop --min-confidence medium` → ~943, `high` → ~318, and the **algorithmic**
  scan-in-loop shapes → ~155 quadratic/hot-loop hotspots (the cheapest "found something
  interesting" wins).
- **Headline lanes**: leak-after-exception (9/9 IL-confirmed real leaks, harness) and algorithmic
  scan-in-loop.
- **Worthy with ranking**: delegate / enumerator allocation in loops.
- **High-volume / low-actionability**: boxing and small-array (mostly cold `ThrowHelper` / non-escaping).
- **Census, not a bug-finder**: MemoryPool lifecycle (0 real leaks found; precise).
- Reproduces the by-hand `Aspire.Dashboard` gist finds on current `main`
  (`OtlpSpan.GetParentSpan()`/`GetChildSpans()`, `ColorGenerator.GetColorIndex` →
  `instance-method-group-delegate`) — validating the shipping capability.

## Validation

- Docs-only; no product/analyzer behavior change. **markdownlint** clean. Linked from `docs/README.md`.
- Low-risk per the docs-only PR policy; no adversarial review requested.

Relates to the Performance analysis findings program (#2572, #2439).
