### PR TITLE
Invert the SourceLink index cache to remove the engine→tool reference (#2579)

### DIFF
--- a/src/DotnetInspector.Services.Tests/CoreSourceLinkIndexCacheTests.cs
+++ b/src/DotnetInspector.Services.Tests/CoreSourceLinkIndexCacheTests.cs
@@ -1,0 +1,38 @@
+using DotnetInspector.Core;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Services.Tests;
+
+/// <summary>
+/// Locks the tool side of the SourceLink cache dependency-inversion seam (#2579):
+/// <see cref="CoreSourceLinkIndexCache"/> must round-trip the engine's index through
+/// <see cref="CoreCache"/> under the expected category. The engine's integration paths
+/// bypass tool startup, so this is where the adapter's category/key mapping is exercised.
+/// </summary>
+[Collection(CoreCacheCollection.Name)]
+public class CoreSourceLinkIndexCacheTests : IDisposable
+{
+    private const string Category = "sourcelink-index";
+
+    public CoreSourceLinkIndexCacheTests()
+    {
+        CoreCache.Initialize("dotnet-inspect-test");
+        CoreCache.Clear(Category);
+    }
+
+    public void Dispose() => CoreCache.Clear(Category);
+
+    [Fact]
+    public void RoundTripsIndexThroughCoreCacheUnderExpectedCategory()
+    {
+        ISourceLinkIndexCache cache = CoreSourceLinkIndexCache.Instance;
+        const string key = "commit-abc123";
+        const string content = "{\"N.T\":[\"src/T.cs\"]}";
+
+        Assert.Null(cache.TryGet(key));           // miss before set
+        cache.Set(key, content);
+        Assert.Equal(content, cache.TryGet(key)); // hit after set
+        // Stored under the category the engine's SourceLink index expects.
+        Assert.Equal(content, CoreCache.TryGet(Category, key));
+    }
+}

--- a/src/DotnetInspector.Services/CoreSourceLinkIndexCache.cs
+++ b/src/DotnetInspector.Services/CoreSourceLinkIndexCache.cs
@@ -1,0 +1,22 @@
+using DotnetInspector.Core;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Services;
+
+/// <summary>
+/// Tool-tier implementation of the engine's <see cref="ISourceLinkIndexCache"/> seam,
+/// backed by the shared <see cref="CoreCache"/> disk cache. Wiring this into
+/// <see cref="SourceLinkService.DefaultCache"/> at startup lets the engine persist its
+/// SourceLink index without the engine referencing the tool tier (dependency inversion).
+/// </summary>
+public sealed class CoreSourceLinkIndexCache : ISourceLinkIndexCache
+{
+    private const string Category = "sourcelink-index";
+
+    /// <summary>Shared instance; the cache itself is stateless over <see cref="CoreCache"/>.</summary>
+    public static CoreSourceLinkIndexCache Instance { get; } = new();
+
+    public string? TryGet(string key) => CoreCache.TryGet(Category, key);
+
+    public void Set(string key, string content) => CoreCache.Set(Category, key, content);
+}

--- a/src/DotnetInspector.Services/DotnetInspector.Services.csproj
+++ b/src/DotnetInspector.Services/DotnetInspector.Services.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../ILInspector.Metadata/ILInspector.Metadata.csproj" />
+    <ProjectReference Include="../DotnetInspector.Core/DotnetInspector.Core.csproj" />
     <ProjectReference Include="../DotnetInspector.Packages/DotnetInspector.Packages.csproj" />
   </ItemGroup>
 

--- a/src/ILInspector.Metadata/ILInspector.Metadata.csproj
+++ b/src/ILInspector.Metadata/ILInspector.Metadata.csproj
@@ -20,7 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\DotnetInspector.Core\DotnetInspector.Core.csproj" />
     <ProjectReference Include="..\ILInspector.Instructions\ILInspector.Instructions.csproj" />
     <ProjectReference Include="..\ILInspector.MetadataPrimitives\ILInspector.MetadataPrimitives.csproj" />
   </ItemGroup>

--- a/src/ILInspector.Metadata/ISourceLinkIndexCache.cs
+++ b/src/ILInspector.Metadata/ISourceLinkIndexCache.cs
@@ -1,0 +1,18 @@
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Persistent-cache seam for the SourceLink type→file index, keyed by an assembly's
+/// commit hash. This is the engine side of a dependency-inversion boundary:
+/// <see cref="SourceLinkService"/> builds the index from PDB data (engine work) but
+/// must not depend on the tool tier's concrete disk cache. The engine declares the
+/// shape it needs here; the tool tier supplies the implementation and wires it into
+/// <see cref="SourceLinkService.DefaultCache"/> at startup.
+/// </summary>
+public interface ISourceLinkIndexCache
+{
+    /// <summary>Returns the cached index content for <paramref name="key"/>, or null on miss.</summary>
+    string? TryGet(string key);
+
+    /// <summary>Stores index <paramref name="content"/> under <paramref name="key"/> (best-effort).</summary>
+    void Set(string key, string content);
+}

--- a/src/ILInspector.Metadata/SourceLinkService.cs
+++ b/src/ILInspector.Metadata/SourceLinkService.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using DotnetInspector.Core;
 
 namespace ILInspector.Metadata;
 
@@ -13,23 +12,38 @@ internal partial class SourceLinkJsonContext : JsonSerializerContext;
 /// </summary>
 public class SourceLinkService : IDisposable
 {
+    /// <summary>
+    /// Process-wide cache implementation for the SourceLink type→file index, wired by
+    /// the tool tier at startup. This is the dependency-inversion seam that keeps the
+    /// engine free of a tool-tier cache dependency: the engine defines the cache shape
+    /// it needs (<see cref="ISourceLinkIndexCache"/>); the tool supplies it. Null means
+    /// no persistence — the index is rebuilt from PDB data on each open.
+    /// </summary>
+    public static ISourceLinkIndexCache? DefaultCache { get; set; }
+
     private readonly PdbContext _context;
+    private readonly ISourceLinkIndexCache? _cache;
     private IReadOnlyList<SourceDocument>? _trackedFiles;
     private Dictionary<string, string[]>? _typeFileIndex;
 
-    private SourceLinkService(PdbContext context)
+    private SourceLinkService(PdbContext context, ISourceLinkIndexCache? cache)
     {
         _context = context;
+        _cache = cache;
     }
 
     /// <summary>
     /// Opens an assembly and probes for PDB (embedded, then standalone adjacent).
     /// After return, check <see cref="NeedsPdb"/> to see if the caller should download a PDB.
     /// </summary>
-    public static SourceLinkService Open(string assemblyPath, Action<string>? log = null)
+    /// <param name="cache">
+    /// Optional index cache; when null, <see cref="DefaultCache"/> is used. Pass an
+    /// explicit instance in tests to avoid the process-wide default.
+    /// </param>
+    public static SourceLinkService Open(string assemblyPath, Action<string>? log = null, ISourceLinkIndexCache? cache = null)
     {
         var context = PdbContext.Open(assemblyPath, log);
-        return new SourceLinkService(context);
+        return new SourceLinkService(context, cache ?? DefaultCache);
     }
 
     /// <summary>
@@ -163,7 +177,7 @@ public class SourceLinkService : IDisposable
         var commitHash = CommitHash;
         if (commitHash != null)
         {
-            var cached = CoreCache.TryGet("sourcelink-index", commitHash);
+            var cached = _cache?.TryGet(commitHash);
             if (cached != null)
             {
                 try
@@ -187,7 +201,7 @@ public class SourceLinkService : IDisposable
             try
             {
                 var json = JsonSerializer.Serialize(_typeFileIndex, SourceLinkJsonContext.Default.DictionaryStringStringArray);
-                CoreCache.Set("sourcelink-index", commitHash, json);
+                _cache?.Set(commitHash, json);
             }
             catch
             {

--- a/src/ILInspector.Metadata/SourceLinkService.cs
+++ b/src/ILInspector.Metadata/SourceLinkService.cs
@@ -36,11 +36,15 @@ public class SourceLinkService : IDisposable
     /// Opens an assembly and probes for PDB (embedded, then standalone adjacent).
     /// After return, check <see cref="NeedsPdb"/> to see if the caller should download a PDB.
     /// </summary>
-    /// <param name="cache">
-    /// Optional index cache; when null, <see cref="DefaultCache"/> is used. Pass an
-    /// explicit instance in tests to avoid the process-wide default.
-    /// </param>
-    public static SourceLinkService Open(string assemblyPath, Action<string>? log = null, ISourceLinkIndexCache? cache = null)
+    public static SourceLinkService Open(string assemblyPath, Action<string>? log = null)
+        => Open(assemblyPath, log, cache: null);
+
+    /// <summary>
+    /// Opens an assembly with an explicit index cache. Prefer passing a cache in tests to
+    /// avoid the process-wide <see cref="DefaultCache"/>; when <paramref name="cache"/> is
+    /// null, <see cref="DefaultCache"/> is used.
+    /// </summary>
+    public static SourceLinkService Open(string assemblyPath, Action<string>? log, ISourceLinkIndexCache? cache)
     {
         var context = PdbContext.Open(assemblyPath, log);
         return new SourceLinkService(context, cache ?? DefaultCache);

--- a/src/dotnet-inspect/Program.cs
+++ b/src/dotnet-inspect/Program.cs
@@ -57,6 +57,8 @@ if (isolated && cacheBasePath == null)
 // Initialize library configuration
 DotnetInspector.Core.HttpClientFactory.Initialize(offline);
 NuGetCache.Initialize("dotnet-inspect", basePath: cacheBasePath, skipNuGetCache: noNuGetCache);
+// Wire the tool-tier SourceLink index cache into the engine's dependency-inversion seam.
+ILInspector.Metadata.SourceLinkService.DefaultCache = DotnetInspector.Services.CoreSourceLinkIndexCache.Instance;
 
 // Start info tracking (installs counting writer on Console.Out)
 if (showInfo)

--- a/tests/ILInspector.Metadata.Tests/EngineToolBoundaryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/EngineToolBoundaryTests.cs
@@ -1,0 +1,59 @@
+using System.Text.RegularExpressions;
+
+namespace ILInspector.Metadata.Tests;
+
+/// <summary>
+/// Architecture guardrail for the engine/tool boundary (#2568, #2579): a production
+/// <c>ILInspector.*</c> (engine) project must never reference a <c>DotnetInspector.*</c>
+/// (tool) project. The dependency arrow points tool → engine only. Test projects are
+/// intentionally excluded — pulling shared fixtures/services into a test is normal and
+/// is a separate policy call from the production boundary.
+/// </summary>
+public class EngineToolBoundaryTests
+{
+    [Fact]
+    public void NoProductionEngineProjectReferencesTheToolTier()
+    {
+        var srcDir = Path.Combine(FindRepoRoot(), "src");
+        var violations = new List<string>();
+
+        foreach (var csproj in Directory.EnumerateFiles(srcDir, "ILInspector.*.csproj", SearchOption.AllDirectories))
+        {
+            var projectName = Path.GetFileNameWithoutExtension(csproj);
+            if (projectName.EndsWith(".Tests", StringComparison.Ordinal))
+                continue;
+
+            foreach (var reference in ReadProjectReferences(csproj))
+            {
+                // csproj Include paths use either separator (the repo mixes `..\` and
+                // `../`); normalize so the leaf name is extracted on any OS.
+                var referenceName = Path.GetFileNameWithoutExtension(reference.Replace('\\', '/'));
+                if (referenceName.StartsWith("DotnetInspector.", StringComparison.Ordinal))
+                    violations.Add($"{projectName} -> {referenceName}");
+            }
+        }
+
+        Assert.True(
+            violations.Count == 0,
+            "Production ILInspector.* (engine) projects must not reference DotnetInspector.* (tool); "
+            + "the arrow points tool -> engine only. Violations:\n  "
+            + string.Join("\n  ", violations));
+    }
+
+    static IEnumerable<string> ReadProjectReferences(string csprojPath)
+    {
+        var text = File.ReadAllText(csprojPath);
+        foreach (Match match in Regex.Matches(text, "<ProjectReference\\s+Include=\"([^\"]+)\""))
+            yield return match.Groups[1].Value;
+    }
+
+    static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "dotnet-inspect.slnx")))
+            dir = dir.Parent;
+
+        Assert.True(dir != null, "Could not locate the repository root (dotnet-inspect.slnx) from the test output directory.");
+        return dir!.FullName;
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/EngineToolBoundaryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/EngineToolBoundaryTests.cs
@@ -1,4 +1,4 @@
-using System.Text.RegularExpressions;
+using System.Xml.Linq;
 
 namespace ILInspector.Metadata.Tests;
 
@@ -42,9 +42,16 @@ public class EngineToolBoundaryTests
 
     static IEnumerable<string> ReadProjectReferences(string csprojPath)
     {
-        var text = File.ReadAllText(csprojPath);
-        foreach (Match match in Regex.Matches(text, "<ProjectReference\\s+Include=\"([^\"]+)\""))
-            yield return match.Groups[1].Value;
+        // Parse the XML rather than pattern-match text, so attribute order/extra
+        // attributes (e.g. a Condition before Include) can't slip a reference past the
+        // guardrail. Match by local name to tolerate any MSBuild XML namespace.
+        var doc = XDocument.Load(csprojPath);
+        foreach (var element in doc.Descendants().Where(e => e.Name.LocalName == "ProjectReference"))
+        {
+            var include = element.Attribute("Include")?.Value;
+            if (!string.IsNullOrEmpty(include))
+                yield return include;
+        }
     }
 
     static string FindRepoRoot()


### PR DESCRIPTION
Fixes #2579.

## The violation

`ILInspector.Metadata` (engine) referenced `DotnetInspector.Core` (tool) — the exact inversion #2568's engine/tool boundary forbids (the arrow points tool → engine only). The sole edge: `SourceLinkService.GetOrBuildTypeFileIndex` called `CoreCache.TryGet/Set` to persist its type→file index.

## Why dependency inversion (not "move the service up")

The issue floated moving `SourceLinkService` into the tool tier. Reading the code rules that out: the service uses **`internal`** members of `PdbContext` (`Log`, `GetResolver`, `GetPdbReader`, `GetMetadataReader`), so it genuinely belongs in the engine — moving it up would force those internals public or an `InternalsVisibleTo` engine→tool (itself a boundary smell). The misplaced concern is the **cache**, so invert that dependency:

- **`ILInspector.Metadata`** declares `ISourceLinkIndexCache` (the cache shape the engine needs) and a `SourceLinkService.DefaultCache` seam; the two `CoreCache` calls become `_cache?.TryGet/Set`. `Open(...)` also takes an optional `cache` for tests.
- **`DotnetInspector.Services`** provides `CoreSourceLinkIndexCache` (backed by `CoreCache`, category `sourcelink-index`).
- **The CLI** wires `SourceLinkService.DefaultCache = CoreSourceLinkIndexCache.Instance` at startup, next to `CoreCache`/`HttpClientFactory` init.
- The `DotnetInspector.Core` project reference is dropped from `ILInspector.Metadata`.

No behavior change: same cache category/key, same best-effort semantics; the engine simply no longer names the tool.

## Guardrail

New production-scoped boundary test in `ILInspector.Metadata.Tests`: no production `ILInspector.*` project may reference `DotnetInspector.*` (test projects excluded, per the issue's policy call — pulling shared fixtures/services into tests is normal). **Verified in both directions**: it fails on the edge (reporting `ILInspector.Metadata -> DotnetInspector.Core`) and passes once unwound. (The negative check caught a real bug in the test itself — csproj `Include` paths use `\` separators that don't split via `Path.GetFileNameWithoutExtension` on macOS/Linux; fixed by normalizing separators.)

## Validation

- Full `dotnet-inspect.slnx` builds (Release).
- `ILInspector.Metadata.Tests`: 401 pass (incl. the new boundary test).
- SourceLink source-location path smoke-tested through the CLI (the `DefaultCache` wiring resolves; no NRE).

## Note on scope

The evolved fix is a small **design change** (an inversion seam + a static `DefaultCache` provider), not the mechanical move first envisioned — so I'm requesting adversarial review despite the small diff. The `static DefaultCache` mirrors the codebase's existing `CoreCache.Initialize` startup-wiring pattern; the optional `Open(cache:)` param keeps it testable without global state.
