### PR TITLE
Harden IL-diff / canonical-IL TypeReference climbs against StackOverflow (#2578)

### DIFF
--- a/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
@@ -373,6 +373,102 @@ public class IlBodyDiffTests
         _ = SingleTokenOperand(diff, IlDiffKind.Add, "call", "[Dep, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null]N.T::M(");
     }
 
+    // Malformed metadata can encode a TypeReference resolution scope or a nested-type chain that
+    // points back at itself. The IL-diff operand/signature name climbs would then recurse until an
+    // *uncatchable* StackOverflowException — which MetadataOperandResolver's try/catch cannot
+    // intercept — so these assert the climbs terminate instead of overflowing the test runner.
+    [Fact]
+    public void Compare_SelfReferentialTypeReferenceOperand_DoesNotStackOverflow()
+    {
+        var image = BuildSyntheticEntryImage(
+            SyntheticTokenInstruction.LdToken,
+            (metadata, _) => metadata.AddTypeReference(
+                // ResolutionScope points at this very TypeReference row (token 1) -> a cycle.
+                MetadataTokens.TypeReferenceHandle(1),
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("Loop")));
+
+        var diff = SyntheticEntryDiff(image, image);
+
+        Assert.True(diff.IsExact);
+    }
+
+    [Fact]
+    public void Compare_SelfNestedTypeDefinitionOperand_DoesNotStackOverflow()
+    {
+        var image = BuildSyntheticEntryImage(
+            SyntheticTokenInstruction.LdToken,
+            (metadata, _) =>
+            {
+                var loop = metadata.AddTypeDefinition(
+                    TypeAttributes.NestedPublic,
+                    metadata.GetOrAddString("N"),
+                    metadata.GetOrAddString("Loop"),
+                    baseType: default,
+                    fieldList: MetadataTokens.FieldDefinitionHandle(1),
+                    methodList: MetadataTokens.MethodDefinitionHandle(1));
+                // Declares the type as nested inside itself -> GetDeclaringType() cycles.
+                metadata.AddNestedType(loop, loop);
+                return loop;
+            });
+
+        var diff = SyntheticEntryDiff(image, image);
+
+        Assert.True(diff.IsExact);
+    }
+
+    [Fact]
+    public void Compare_SelfReferentialTypeReferenceInTypeSpec_DoesNotStackOverflow()
+    {
+        var image = BuildSyntheticEntryImage(
+            SyntheticTokenInstruction.LdToken,
+            (metadata, _) =>
+            {
+                metadata.AddTypeReference(
+                    MetadataTokens.TypeReferenceHandle(1),
+                    metadata.GetOrAddString("N"),
+                    metadata.GetOrAddString("Loop"));
+                // ELEMENT_TYPE_CLASS (0x12) of the cyclic TypeRef (TypeDefOrRef coded token
+                // (row 1 << 2) | tag 1 = 0x05) -> the signature provider climbs the same cycle.
+                var spec = new BlobBuilder();
+                spec.WriteByte(0x12);
+                spec.WriteByte(0x05);
+                return metadata.AddTypeSpecification(metadata.GetOrAddBlob(spec));
+            });
+
+        var diff = SyntheticEntryDiff(image, image);
+
+        Assert.True(diff.IsExact);
+    }
+
+    [Fact]
+    public void Compare_SelfNestedTypeDefinitionInTypeSpec_DoesNotStackOverflow()
+    {
+        var image = BuildSyntheticEntryImage(
+            SyntheticTokenInstruction.LdToken,
+            (metadata, _) =>
+            {
+                var loop = metadata.AddTypeDefinition(
+                    TypeAttributes.NestedPublic,
+                    metadata.GetOrAddString("N"),
+                    metadata.GetOrAddString("Loop"),
+                    baseType: default,
+                    fieldList: MetadataTokens.FieldDefinitionHandle(1),
+                    methodList: MetadataTokens.MethodDefinitionHandle(1));
+                metadata.AddNestedType(loop, loop);
+                // ELEMENT_TYPE_CLASS (0x12) of the self-nested TypeDef (coded token
+                // (row 2 << 2) | tag 0 = 0x08).
+                var spec = new BlobBuilder();
+                spec.WriteByte(0x12);
+                spec.WriteByte(0x08);
+                return metadata.AddTypeSpecification(metadata.GetOrAddBlob(spec));
+            });
+
+        var diff = SyntheticEntryDiff(image, image);
+
+        Assert.True(diff.IsExact);
+    }
+
     [Fact]
     public void Compare_CompiledFixtureSwitchRetarget_ReportsChangedSwitch()
     {

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -440,6 +440,14 @@ public static class IlBodyDiff
 
     sealed class MetadataOperandResolver(MetadataReader reader)
     {
+        // Malformed metadata can make a declaring type or resolution-scope chain cyclic,
+        // so the type-name climbs below would recurse until an uncatchable
+        // StackOverflowException (which TryResolve's catch cannot intercept). Cap the climb
+        // ([ThreadStatic] for thread safety) and degrade to the leaf name past the cap.
+        [ThreadStatic]
+        static int s_climbDepth;
+        const int MaxClimbDepth = 256;
+
         public bool TryResolve(DecodedInstruction instruction, out IlOperandIdentity? operand, out string? failure)
         {
             try
@@ -620,9 +628,17 @@ public static class IlBodyDiff
             var type = reader.GetTypeDefinition(handle);
             string name = reader.GetString(type.Name);
             var declaring = type.GetDeclaringType();
-            string fullName = declaring.IsNil
-                ? Dotted(reader.GetString(type.Namespace), name)
-                : $"{FormatTypeDefinition(declaring)}+{name}";
+            string fullName;
+            if (!declaring.IsNil && s_climbDepth < MaxClimbDepth)
+            {
+                s_climbDepth++;
+                try { fullName = $"{FormatTypeDefinition(declaring)}+{name}"; }
+                finally { s_climbDepth--; }
+            }
+            else
+            {
+                fullName = Dotted(reader.GetString(type.Namespace), name);
+            }
             return $"[{CurrentAssemblyName()}]{fullName}";
         }
 
@@ -631,14 +647,15 @@ public static class IlBodyDiff
             var type = reader.GetTypeReference(handle);
             string name = reader.GetString(type.Name);
             string fullName = Dotted(reader.GetString(type.Namespace), name);
-            return type.ResolutionScope.Kind switch
+            if (type.ResolutionScope.Kind == HandleKind.AssemblyReference)
+                return $"[{AssemblyReferenceIdentity(reader, (AssemblyReferenceHandle)type.ResolutionScope)}]{fullName}";
+            if (type.ResolutionScope.Kind == HandleKind.TypeReference && s_climbDepth < MaxClimbDepth)
             {
-                HandleKind.AssemblyReference =>
-                    $"[{AssemblyReferenceIdentity(reader, (AssemblyReferenceHandle)type.ResolutionScope)}]{fullName}",
-                HandleKind.TypeReference =>
-                    $"{FormatTypeReference((TypeReferenceHandle)type.ResolutionScope)}+{fullName}",
-                _ => $"[{CurrentAssemblyName()}]{fullName}",
-            };
+                s_climbDepth++;
+                try { return $"{FormatTypeReference((TypeReferenceHandle)type.ResolutionScope)}+{fullName}"; }
+                finally { s_climbDepth--; }
+            }
+            return $"[{CurrentAssemblyName()}]{fullName}";
         }
 
         string CurrentAssemblyName()
@@ -654,6 +671,14 @@ public static class IlBodyDiff
     sealed class SignatureIdentityProvider : ISignatureTypeProvider<string, object?>
     {
         public static SignatureIdentityProvider Instance { get; } = new();
+
+        // Malformed metadata can make a declaring type or resolution-scope chain cyclic, so
+        // the TypeName climbs below would recurse until an uncatchable StackOverflowException.
+        // Cap the climb ([ThreadStatic] so the shared Instance stays thread-safe) and degrade
+        // to the leaf name past the cap.
+        [ThreadStatic]
+        static int s_climbDepth;
+        const int MaxClimbDepth = 256;
 
         public string GetPrimitiveType(PrimitiveTypeCode typeCode)
             => typeCode switch
@@ -710,8 +735,12 @@ public static class IlBodyDiff
             var type = reader.GetTypeDefinition(handle);
             string name = reader.GetString(type.Name);
             var declaring = type.GetDeclaringType();
-            if (!declaring.IsNil)
-                return $"{TypeName(reader, declaring)}+{name}";
+            if (!declaring.IsNil && s_climbDepth < MaxClimbDepth)
+            {
+                s_climbDepth++;
+                try { return $"{TypeName(reader, declaring)}+{name}"; }
+                finally { s_climbDepth--; }
+            }
             string ns = reader.GetString(type.Namespace);
             string assembly = reader.IsAssembly ? reader.GetString(reader.GetAssemblyDefinition().Name) : "";
             return $"[{assembly}]{(ns.Length == 0 ? name : $"{ns}.{name}")}";
@@ -723,14 +752,15 @@ public static class IlBodyDiff
             string name = reader.GetString(type.Name);
             string ns = reader.GetString(type.Namespace);
             string fullName = ns.Length == 0 ? name : $"{ns}.{name}";
-            return type.ResolutionScope.Kind switch
+            if (type.ResolutionScope.Kind == HandleKind.AssemblyReference)
+                return $"[{AssemblyReferenceIdentity(reader, (AssemblyReferenceHandle)type.ResolutionScope)}]{fullName}";
+            if (type.ResolutionScope.Kind == HandleKind.TypeReference && s_climbDepth < MaxClimbDepth)
             {
-                HandleKind.AssemblyReference =>
-                    $"[{AssemblyReferenceIdentity(reader, (AssemblyReferenceHandle)type.ResolutionScope)}]{fullName}",
-                HandleKind.TypeReference =>
-                    $"{TypeName(reader, (TypeReferenceHandle)type.ResolutionScope)}+{fullName}",
-                _ => fullName,
-            };
+                s_climbDepth++;
+                try { return $"{TypeName(reader, (TypeReferenceHandle)type.ResolutionScope)}+{fullName}"; }
+                finally { s_climbDepth--; }
+            }
+            return fullName;
         }
     }
 

--- a/src/ILInspector.Metadata/CanonicalIL.cs
+++ b/src/ILInspector.Metadata/CanonicalIL.cs
@@ -238,13 +238,26 @@ public static class CanonicalIL
         => dotted.Contains('.') ? string.Join(".", dotted.Split('.').Select(QuoteName)) : QuoteName(dotted);
 
     /// <summary>Dotted (and slash-nested) name for a type definition — no assembly qualifier.</summary>
+    // Malformed metadata can make a TypeDefinition declaring type or a TypeReference
+    // resolution scope self-referential or cyclic, so the name climbs below would recurse
+    // until an uncatchable StackOverflowException. Cap the climb ([ThreadStatic] so these
+    // static helpers stay thread-safe) and degrade to the leaf name past the cap — mirrors
+    // the TypeResolver / TypeRefDecoder resolution-scope guards from #2490.
+    [ThreadStatic]
+    static int s_climbDepth;
+    const int MaxClimbDepth = 256;
+
     internal static string QualifiedName(MetadataReader reader, TypeDefinitionHandle handle)
     {
         var td = reader.GetTypeDefinition(handle);
         string name = QuoteName(reader.GetString(td.Name));
         var declaring = td.GetDeclaringType();
-        if (!declaring.IsNil)
-            return $"{QualifiedName(reader, declaring)}/{name}";
+        if (!declaring.IsNil && s_climbDepth < MaxClimbDepth)
+        {
+            s_climbDepth++;
+            try { return $"{QualifiedName(reader, declaring)}/{name}"; }
+            finally { s_climbDepth--; }
+        }
         string ns = QuoteDottedName(reader.GetString(td.Namespace));
         return ns.Length > 0 ? $"{ns}.{name}" : name;
     }
@@ -256,14 +269,15 @@ public static class CanonicalIL
         string name = QuoteName(reader.GetString(tr.Name));
         string ns = QuoteDottedName(reader.GetString(tr.Namespace));
         string dotted = ns.Length > 0 ? $"{ns}.{name}" : name;
-        return tr.ResolutionScope.Kind switch
+        if (tr.ResolutionScope.Kind == HandleKind.AssemblyReference)
+            return $"[{QuoteDottedName(reader.GetString(reader.GetAssemblyReference((AssemblyReferenceHandle)tr.ResolutionScope).Name))}]{dotted}";
+        if (tr.ResolutionScope.Kind == HandleKind.TypeReference && s_climbDepth < MaxClimbDepth)
         {
-            HandleKind.AssemblyReference =>
-                $"[{QuoteDottedName(reader.GetString(reader.GetAssemblyReference((AssemblyReferenceHandle)tr.ResolutionScope).Name))}]{dotted}",
-            HandleKind.TypeReference =>
-                $"{QualifiedName(reader, (TypeReferenceHandle)tr.ResolutionScope)}/{dotted}",
-            _ => dotted
-        };
+            s_climbDepth++;
+            try { return $"{QualifiedName(reader, (TypeReferenceHandle)tr.ResolutionScope)}/{dotted}"; }
+            finally { s_climbDepth--; }
+        }
+        return dotted;
     }
 
     static string FormatMethodDef(MetadataReader reader, MethodDefinitionHandle handle)

--- a/tests/ILInspector.Metadata.Tests/CanonicalILRecursionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/CanonicalILRecursionTests.cs
@@ -1,0 +1,89 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+namespace ILInspector.Metadata.Tests;
+
+// Malformed metadata can encode a TypeReference resolution scope or a nested-type chain that
+// points back at itself. The canonical-IL name climbs would then recurse until an *uncatchable*
+// StackOverflowException takes down the process. These tests craft those cycles and assert the
+// climb terminates (degrading to the leaf name) instead of overflowing.
+//
+// WARNING: if the climb-depth guard in CanonicalIL is removed, these tests do not fail — they
+// StackOverflow and take down the whole test runner.
+public class CanonicalILRecursionTests
+{
+    [Fact]
+    public void SelfReferentialResolutionScope_DoesNotStackOverflow()
+    {
+        var reader = BuildMetadata(metadata =>
+            metadata.AddTypeReference(
+                // ResolutionScope points at this very TypeReference row (token 1) -> a cycle.
+                MetadataTokens.TypeReferenceHandle(1),
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("Loop")));
+
+        string name = CanonicalIL.QualifiedName(reader, MetadataTokens.TypeReferenceHandle(1));
+
+        // Reaching this assertion at all proves the climb terminated instead of overflowing.
+        Assert.EndsWith("N.Loop", name, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SelfNestedTypeDefinition_DoesNotStackOverflow()
+    {
+        TypeDefinitionHandle typeHandle = default;
+        var reader = BuildMetadata(metadata =>
+        {
+            typeHandle = metadata.AddTypeDefinition(
+                TypeAttributes.NestedPublic,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("Loop"),
+                baseType: default,
+                fieldList: MetadataTokens.FieldDefinitionHandle(1),
+                methodList: MetadataTokens.MethodDefinitionHandle(1));
+            // Declares the type as nested inside itself -> GetDeclaringType() returns it -> a cycle.
+            metadata.AddNestedType(typeHandle, typeHandle);
+            return default(EntityHandle);
+        });
+
+        string name = CanonicalIL.QualifiedName(reader, typeHandle);
+
+        Assert.EndsWith("Loop", name, StringComparison.Ordinal);
+    }
+
+    static MetadataReader BuildMetadata(Func<MetadataBuilder, EntityHandle> addMalformedRow)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("Synthetic.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Synthetic"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        // The module (<Module>) pseudo-type must be row 1; the malformed rows come after it.
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        addMalformedRow(metadata);
+
+        var rootBuilder = new MetadataRootBuilder(metadata, suppressValidation: true);
+        var image = new BlobBuilder();
+        rootBuilder.Serialize(image, methodBodyStreamRva: 0, mappedFieldDataStreamRva: 0);
+        var provider = MetadataReaderProvider.FromMetadataImage(ImmutableArray.Create(image.ToArray()));
+        return provider.GetMetadataReader();
+    }
+}


### PR DESCRIPTION
## Why

Follow-up to #2574. During review of the `SignatureDecoder` string-decode surface, three unguarded recursive `TypeReference.ResolutionScope` climbs were fixed in `TypeResolver` / `MetadataReaderExtensions`. Two **sibling** climbs on the **IL-diff / canonical-IL surface** have the same unbounded-recursion bug but a different output format (assembly-qualified, slash/plus-nested), so they can't delegate to the guarded `TypeResolver`:

1. `CanonicalIL.QualifiedName(TypeReferenceHandle)` — recurses on the `TypeReference` resolution-scope arm.
2. `IlBodyDiff` — `MetadataOperandResolver.FormatTypeReference` and `SignatureIdentityProvider.TypeName(TypeReferenceHandle)` recurse on the same arm.

A self-scoped / cyclic `TypeReference` reached while IL-diffing or canonical-IL rendering malformed metadata recurses until an **uncatchable** `StackOverflowException` (exit 134). `MetadataOperandResolver.TryResolve` catches `BadImageFormatException` but **not** `StackOverflowException`, so the guard — not the catch — is what prevents the crash.

## What

Guard each resolution-scope climb with a `[ThreadStatic]` climb-depth cap (`256`), degrading to the leaf name past the cap — mirrors the `TypeResolver` / `TypeRefDecoder` guards from #2490:

- `CanonicalIL.QualifiedName(TypeReferenceHandle)`
- `IlBodyDiff.MetadataOperandResolver.FormatTypeReference`
- `IlBodyDiff.SignatureIdentityProvider.TypeName(TypeReferenceHandle)`

The **adjacent `TypeDefinition` declaring-type climbs** in the same three helpers have the identical shape via a cyclic `NestedClass` table, so they are guarded with the same field (avoids shipping an incomplete fix):

- `CanonicalIL.QualifiedName(TypeDefinitionHandle)`
- `IlBodyDiff.MetadataOperandResolver.FormatTypeDefinition`
- `IlBodyDiff.SignatureIdentityProvider.TypeName(TypeDefinitionHandle)`

Both `ISignatureTypeProvider`s in these files delegate their `GetTypeFromDefinition`/`GetTypeFromReference` to the guarded name methods, so guarding the six climbs covers the providers too.

## Deliberately out of scope (same as #2574)

The nested-`TypeSpec` signature-**blob** depth vector reachable from these providers' `GetTypeFromSpecification` is the `SignatureBlobGuard` domain (#2574 / its follow-ups), not a resolution-scope climb. Not expanded here.

## Tests

`CanonicalILRecursionTests` (2) call `QualifiedName` directly on a self-scoped `TypeReference` and a self-nested `TypeDefinition`. `IlBodyDiffTests` (+4) drive the public `IlBodyDiff.Compare(reader, body, …)` over a synthetic PE whose entry body `ldtoken`s a self-scoped TypeRef, a self-nested TypeDef, and both wrapped in a `CLASS` `TypeSpec` (exercising `SignatureIdentityProvider`). Each asserts the climb terminates.

**These tests are non-vacuous:** removing a guard makes the corresponding test StackOverflow the test runner (verified locally — deep native stack dump, process abort).

## Validation

- `ILInspector.Metadata.Tests`: 407/0 (+2).
- `ILInspector.Instructions.Tests`: 49/0.
- `ILInspector.Analysis.Tests` `IlBodyDiffTests`: 35/0 (+4).
- Guard only trips on malformed input, so real-assembly IL-diff / canonical-IL output is unchanged.

Part of #2490. Adversarial review (two models, isolated worktrees) requested; will reconcile on the PR. Not ready to merge until two clean confirmatory reviews on the fixed head.
