### PR TITLE
Unqualify self-type static member calls

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CSharpBodyDiffTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpBodyDiffTests.cs
@@ -204,10 +204,10 @@ public class CSharpBodyDiffTests
             .OrderBy(row => row.Line)
             .ToArray();
         Assert.Equal(2, rows.Length);
-        Assert.Equal("DiffSample.Sink(value)", rows[0].OldValue);
-        Assert.Equal("DiffSample.MaybeThrow(value)", rows[0].NewValue);
-        Assert.Equal("DiffSample.Sink(value + 1)", rows[1].OldValue);
-        Assert.Equal("DiffSample.MaybeThrow(value + 1)", rows[1].NewValue);
+        Assert.Equal("Sink(value)", rows[0].OldValue);
+        Assert.Equal("MaybeThrow(value)", rows[0].NewValue);
+        Assert.Equal("Sink(value + 1)", rows[1].OldValue);
+        Assert.Equal("MaybeThrow(value + 1)", rows[1].NewValue);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/CSharpPrinterReceiverTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpPrinterReceiverTests.cs
@@ -133,6 +133,39 @@ public sealed class CSharpPrinterReceiverTests
             """);
     }
 
+    [Fact]
+    public void StaticCall_OnCurrentType_IsUnqualified()
+    {
+        // #2497: a static call to a member of the current type needs no type
+        // qualifier — Helper(1), not Holder.Helper(1) — matching the this-receiver
+        // instance form and same-type method groups.
+        var self = TypeRef.Definition("synthetic", "", "Holder");
+        var call = new Call(
+            new MethodRef(self, "Helper", Int32Type, [Int32Type], HasThis: false),
+            isVirtual: false,
+            [new Constant(1, Int32Type)]);
+
+        string body = RenderReturn(call, Int32Type);
+
+        Assert.Contains("return Helper(1);", body);
+        Assert.DoesNotContain("Holder.Helper", body);
+    }
+
+    [Fact]
+    public void StaticCall_OnCrossType_StaysQualified()
+    {
+        // Near-miss: a static call to another type's member must remain qualified.
+        var other = TypeRef.Definition("synthetic", "", "Other");
+        var call = new Call(
+            new MethodRef(other, "Helper", Int32Type, [Int32Type], HasThis: false),
+            isVirtual: false,
+            [new Constant(1, Int32Type)]);
+
+        string body = RenderReturn(call, Int32Type);
+
+        Assert.Contains("return Other.Helper(1);", body);
+    }
+
     static MethodRef Extension(string name, TypeRef receiverType)
         => new(
             TypeRef.Definition("synthetic", "", "Extensions"),

--- a/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
@@ -881,7 +881,7 @@ public class CoerceChokePointTests
         AssertCompiles(
             "public static unsafe void M()",
             body,
-            "public static unsafe class Holder { public static void Consume(byte* p) { } public static void Consume(int* p) { } }");
+            "using static Holder; public static unsafe class Holder { public static void Consume(byte* p) { } public static void Consume(int* p) { } }");
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
@@ -343,7 +343,7 @@ public class ForeachStatementPassTests
 
     [Theory]
     [InlineData(nameof(CfgSampleClass.ForeachStringField), "CfgSampleClass.s_text")]
-    [InlineData(nameof(CfgSampleClass.ForeachStringMethodResult), "CfgSampleClass.GetText()")]
+    [InlineData(nameof(CfgSampleClass.ForeachStringMethodResult), "GetText()")]
     [InlineData(nameof(CfgSampleClass.ForeachStringLiteral), "\"literal\"")]
     public void StringForeach_OverNonLocalReceiver_RaisesWithReceiverRestored(string method, string receiver)
     {

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1603,7 +1603,7 @@ public class CSharpPrinterTests
             [new Parameter("a", uintType)], HasThis: false, GenericParameterCount: 0);
         var function = new IrFunction("F", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
 
-        Assert.Contains("T.M((int)a);", CSharpPrinter.Print(function).Output!);
+        Assert.Contains("M((int)a);", CSharpPrinter.Print(function).Output!);
     }
 
     [Fact]
@@ -1926,7 +1926,7 @@ public class CSharpPrinterTests
         string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").TrimEnd();
 
         Assert.Contains("ReadOnlySpan<char> V_0 = MemoryExtensions.Trim(item);", output);
-        Assert.Contains("T.GetItems()[i] = V_0.ToString();", output);
+        Assert.Contains("GetItems()[i] = V_0.ToString();", output);
     }
 
     [Fact]
@@ -1961,7 +1961,7 @@ public class CSharpPrinterTests
 
         string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").TrimEnd();
 
-        Assert.Contains("ReadOnlySpan<char> V_0 = T.Next(i);", output);
+        Assert.Contains("ReadOnlySpan<char> V_0 = Next(i);", output);
         Assert.Contains("items[i] = V_0.ToString();", output);
     }
 
@@ -2525,7 +2525,7 @@ public class RaisingPassTests
 
         Assert.Equal(1, output.Split("RecordIndex()", StringSplitOptions.None).Length - 1);
         Assert.Contains("ref int", output);
-        Assert.Contains("= ref a[CfgSampleClass.RecordIndex()];", output);
+        Assert.Contains("= ref a[RecordIndex()];", output);
         Assert.Contains("+ v;", output);
     }
 
@@ -2878,9 +2878,9 @@ public class RaisingPassTests
         var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [refInt], container);
 
         string output = CSharpPrinter.Print(function).Output!;
-        Assert.Contains("ref int V_0 = ref T.A();", output);
-        Assert.Contains("V_0 = ref T.B();", output);
-        Assert.DoesNotContain("V_0 = T.A();", output);
+        Assert.Contains("ref int V_0 = ref A();", output);
+        Assert.Contains("V_0 = ref B();", output);
+        Assert.DoesNotContain("V_0 = A();", output);
     }
 
     [Fact]
@@ -2911,7 +2911,7 @@ public class RaisingPassTests
         var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [refInt], container);
 
         string output = CSharpPrinter.Print(function).Output!;
-        Assert.Contains("ref int V_0 = ref T.A();", output);
+        Assert.Contains("ref int V_0 = ref A();", output);
         Assert.DoesNotContain("Unsafe.NullRef", output);
         AssertRefLocalBodyCompiles(output);
     }
@@ -2946,7 +2946,7 @@ public class RaisingPassTests
 
         string output = CSharpPrinter.Print(function).Output!;
         Assert.Contains("ref int V_0 = ref System.Runtime.CompilerServices.Unsafe.NullRef<int>();", output);
-        Assert.Contains("V_0 = ref T.A();", output);
+        Assert.Contains("V_0 = ref A();", output);
         AssertRefLocalBodyCompiles(output);
     }
 
@@ -2978,7 +2978,7 @@ public class RaisingPassTests
 
         string output = CSharpPrinter.Print(function).Output!;
         Assert.Contains("ref int V_0 = ref System.Runtime.CompilerServices.Unsafe.NullRef<int>();", output);
-        Assert.Contains("V_0 = ref T.A();", output);
+        Assert.Contains("V_0 = ref A();", output);
         AssertRefLocalBodyCompiles(output);
     }
 
@@ -3004,7 +3004,7 @@ public class RaisingPassTests
 
         string output = CSharpPrinter.Print(function).Output!;
         Assert.Contains("ref int V_0 = ref System.Runtime.CompilerServices.Unsafe.NullRef<int>();", output);
-        Assert.Contains("V_0 = ref T.A(ref V_0);", output);
+        Assert.Contains("V_0 = ref A(ref V_0);", output);
         AssertRefLocalBodyCompiles(output);
     }
 
@@ -3950,7 +3950,7 @@ public class RaisingPassTests
         Assert.DoesNotContain("goto", output);
         Assert.DoesNotContain(function.Descendants.OfType<ConditionalBranch>(), _ => true);
         Assert.Contains("if (node is Call c)", output);
-        Assert.Contains("return c.Callee.RequiresUnsafe ? true : CSharpPrinter.SignatureRequiresUnsafe(c.Callee);", output);
+        Assert.Contains("return c.Callee.RequiresUnsafe ? true : SignatureRequiresUnsafe(c.Callee);", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/KeywordIdentifierTests.cs
+++ b/src/ILInspector.Decompiler.Tests/KeywordIdentifierTests.cs
@@ -45,7 +45,7 @@ public class KeywordIdentifierTests
     {
         var output = Render(nameof(CfgSampleClass.CallsKeywordStaticMethod));
 
-        Assert.Contains("CfgSampleClass.@return(value)", output);
+        Assert.Contains("@return(value)", output);
         Assert.DoesNotContain("CfgSampleClass.return(value)", output);
     }
 

--- a/src/ILInspector.Decompiler.Tests/LadderRung4GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung4GateTests.cs
@@ -108,7 +108,7 @@ public class LadderRung4GateTests
 
         var refLocal = Body("RefLocalUpdate");
         Assert.Contains("ref int ", refLocal);
-        Assert.Contains(" = ref CSharp7LocalSyntax.SelectRef(useLeft, ref left, ref right);", refLocal);
+        Assert.Contains(" = ref SelectRef(useLeft, ref left, ref right);", refLocal);
         Assert.Contains("+ 10;", refLocal);
 
         var refReturn = Body("SelectRef");

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -132,7 +132,7 @@ public class LadderRung6GateTests
         Assert.Contains("*(int*)(&value)", NewBody("DerefPointer"));
         Assert.Contains("ConsumePointer((int*)(&value))", NewBody("PassAddress"));
         Assert.Contains("callback(x);", FirstUnsafeBlockBody(NewBody("InvokeFunctionPointer")));
-        Assert.Contains("UnsafeFixtures.Risky()", FirstUnsafeBlockBody(NewBody("CallRisky")));
+        Assert.Contains("Risky()", FirstUnsafeBlockBody(NewBody("CallRisky")));
         Assert.Contains("NativeMemory.Free(p);", FirstUnsafeBlockBody(NewBody("FreePointer")));
 
         var skipInit = NewBody("StackAllocSkipInit");
@@ -168,10 +168,14 @@ public class LadderRung6GateTests
         var derefBody = members.Single(m => m.Name == "DerefPointer").Body;
         var passAddressBody = members.Single(m => m.Name == "PassAddress").Body;
 
-        var derefDiagnostics = RecompileNewRules("static int M(int value)", derefBody);
+        var derefDiagnostics = RecompileNewRules(
+            "static int M(int value)",
+            derefBody,
+            $"using static {NewUnsafeType};");
         var passAddressDiagnostics = RecompileNewRules(
             "static int M(int value)",
             passAddressBody,
+            $"using static {NewUnsafeType};",
             MetadataReference.CreateFromFile(NewUnsafePath));
 
         AssertNoErrors(derefDiagnostics, derefBody);

--- a/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
@@ -107,7 +107,7 @@ public class NullCoalescingAssignmentPassTests
         var output = CSharpPrinter.Print(function).Output;
 
         Assert.NotNull(output);
-        Assert.Contains("return value.GetValueOrDefault(CfgSampleClass.NullableFallbackWithSideEffect());", output);
+        Assert.Contains("return value.GetValueOrDefault(NullableFallbackWithSideEffect());", output);
         Assert.DoesNotContain("??", output);
     }
 

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerContiguityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerContiguityTests.cs
@@ -56,7 +56,7 @@ public class ObjectInitializerContiguityTests
         Assert.Empty(function.Descendants.OfType<StoreProperty>());
 
         var output = CSharpPrinter.Print(function).Output!;
-        Assert.Contains("new InitTarget { X = Owner.Log() }", output);
+        Assert.Contains("new InitTarget { X = Log() }", output);
         Assert.True(
             output.IndexOf("new InitTarget { X = Owner.Log() }", StringComparison.Ordinal)
                 < output.IndexOf("Other();", StringComparison.Ordinal),

--- a/src/ILInspector.Decompiler.Tests/SelfQualifyPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SelfQualifyPrinterTests.cs
@@ -64,6 +64,18 @@ public class SelfQualifyPrinterTests
         Assert.DoesNotContain("=> Op(Op)", body);
     }
 
+    [Fact]
+    public void OuterScopeShadowedStaticCall_InsideNestedLambda_StaysQualified()
+    {
+        // A lambda with its own locals renders through a nested printer; an outer
+        // parameter that shadows the static method name must still keep the call
+        // qualified (the nested printer inherits outer scope names).
+        string body = RenderAnyFidelity(typeof(SelfQualifyOuterShadow), nameof(SelfQualifyOuterShadow.Uses));
+
+        Assert.Contains("SelfQualifyOuterShadow.M()", body);
+        Assert.DoesNotContain("int x = M();", body);
+    }
+
     static string RenderFixture(System.Type type, string methodName)
     {
         var (function, source) = Import(type, methodName);
@@ -147,5 +159,16 @@ public class SelfQualifyLambdaShadow
     {
         System.Func<int, int> f = Op => SelfQualifyLambdaShadow.Op(Op);
         return f(seed);
+    }
+}
+
+public class SelfQualifyOuterShadow
+{
+    public static int M() => 1;
+
+    public int Uses(int M)
+    {
+        System.Func<int, int> f = seed => { int x = SelfQualifyOuterShadow.M(); return seed + x; };
+        return f(M);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/SelfQualifyPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SelfQualifyPrinterTests.cs
@@ -76,6 +76,16 @@ public class SelfQualifyPrinterTests
         Assert.DoesNotContain("int x = M();", body);
     }
 
+    [Fact]
+    public void SyntheticLocalShadowedStaticCall_StaysQualified()
+    {
+        // A static method whose name collides with a printer-synthetic local (a
+        // stack slot S_n) keeps the qualifier so the call does not bind to the local.
+        string body = RenderAnyFidelity(typeof(SelfQualifySyntheticShadow), nameof(SelfQualifySyntheticShadow.Uses));
+
+        Assert.Contains("SelfQualifySyntheticShadow.S_0()", body);
+    }
+
     static string RenderFixture(System.Type type, string methodName)
     {
         var (function, source) = Import(type, methodName);
@@ -171,4 +181,11 @@ public class SelfQualifyOuterShadow
         System.Func<int, int> f = seed => { int x = SelfQualifyOuterShadow.M(); return seed + x; };
         return f(M);
     }
+}
+
+public class SelfQualifySyntheticShadow
+{
+    public static int S_0() => 2;
+
+    public static int Uses(int a, int b) => S_0() + (a > b ? a : b);
 }

--- a/src/ILInspector.Decompiler.Tests/SelfQualifyPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SelfQualifyPrinterTests.cs
@@ -86,6 +86,18 @@ public class SelfQualifyPrinterTests
         Assert.Contains("SelfQualifySyntheticShadow.S_0()", body);
     }
 
+    [Fact]
+    public void MethodGenericParameterShadowedStaticCall_StaysQualified()
+    {
+        // A method type parameter shares the declaration space with the declaring
+        // type's members, so it shadows a same-named static member; the call must
+        // stay qualified or it binds to the type parameter (CS0119).
+        string body = RenderAnyFidelity(typeof(SelfQualifyGenericParamShadow), nameof(SelfQualifyGenericParamShadow.G));
+
+        Assert.Contains("SelfQualifyGenericParamShadow.M()", body);
+        Assert.DoesNotContain("return M();", body);
+    }
+
     static string RenderFixture(System.Type type, string methodName)
     {
         var (function, source) = Import(type, methodName);
@@ -188,4 +200,11 @@ public class SelfQualifySyntheticShadow
     public static int S_0() => 2;
 
     public static int Uses(int a, int b) => S_0() + (a > b ? a : b);
+}
+
+public class SelfQualifyGenericParamShadow
+{
+    public static int M() => 1;
+
+    public static int G<M>() => SelfQualifyGenericParamShadow.M();
 }

--- a/src/ILInspector.Decompiler.Tests/SelfQualifyPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SelfQualifyPrinterTests.cs
@@ -4,27 +4,49 @@ namespace ILInspector.Decompiler.Tests;
 
 // Issue #2497: calls to a static member declared on the current type were
 // over-qualified with the declaring type name (SelfType.M(...)) instead of the
-// source-faithful unqualified form M(...). Cross-type static calls must stay
-// qualified.
+// source-faithful unqualified form M(...). Cross-type static calls, a different
+// instantiation of the enclosing generic type, and names shadowed by a local or
+// parameter must stay qualified so the call cannot rebind.
 public class SelfQualifyPrinterTests
 {
     [Fact]
     public void SelfTypeStaticCall_RendersUnqualified_CrossTypeStaysQualified()
     {
-        string body = RenderFixture(nameof(SelfQualifySamples.CallsSelfAndCross));
+        string body = RenderFixture(typeof(SelfQualifySamples), nameof(SelfQualifySamples.CallsSelfAndCross));
 
-        // Self-type static call is unqualified.
         Assert.Contains("Helper(", body);
         Assert.DoesNotContain("SelfQualifySamples.Helper", body);
-
-        // Near-miss: a call to another type's static member stays qualified.
         Assert.Contains("SelfQualifyOther.External(", body);
     }
 
-    static string RenderFixture(string methodName)
+    [Fact]
+    public void GenericSelfInstantiation_Unqualified_DifferentInstantiationStaysQualified()
     {
-        using var source = MetadataSource.Open(typeof(SelfQualifySamples).Assembly.Location);
-        var function = IrImporter.Import(source, typeof(SelfQualifySamples).FullName!, methodName);
+        // A call to the enclosing generic type at its own instantiation is
+        // unqualified; a call to a different instantiation (C<string> from C<T>)
+        // must stay qualified or it rebinds to C<T>'s method.
+        Assert.Contains("return Helper(x);", RenderFixture(typeof(SelfQualifyGeneric<>), nameof(SelfQualifyGeneric<int>.SelfCall)));
+
+        string cross = RenderFixture(typeof(SelfQualifyGeneric<>), nameof(SelfQualifyGeneric<int>.CrossInstantiation));
+        Assert.Contains("SelfQualifyGeneric<string>.Tagged(x)", cross);
+        Assert.DoesNotContain("return Tagged(x);", cross);
+    }
+
+    [Fact]
+    public void ShadowedStaticCall_StaysQualified()
+    {
+        // A local that shadows the static method name means an unqualified call
+        // would bind to the local, so the type qualifier is retained.
+        string body = RenderFixture(typeof(SelfQualifyShadow), nameof(SelfQualifyShadow.CallsShadowed));
+
+        Assert.Contains("SelfQualifyShadow.Ping(Ping)", body);
+        Assert.DoesNotContain("return Ping(Ping)", body);
+    }
+
+    static string RenderFixture(System.Type type, string methodName)
+    {
+        using var source = MetadataSource.Open(type.Assembly.Location);
+        var function = IrImporter.Import(source, type.FullName!, methodName);
         Assert.NotNull(function);
         Assert.Equal(DecompilationFidelity.Full, function!.Fidelity);
         var result = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
@@ -48,4 +70,22 @@ public static class SelfQualifySamples
 public static class SelfQualifyOther
 {
     public static int External(int x) => x * 2;
+}
+
+public class SelfQualifyGeneric<T>
+{
+    public static int Helper(int x) => x + 1;
+    public static int Tagged(int x) => typeof(T) == typeof(string) ? x + 100 : x;
+    public int SelfCall(int x) => Helper(x);
+    public int CrossInstantiation(int x) => SelfQualifyGeneric<string>.Tagged(x);
+}
+
+public class SelfQualifyShadow
+{
+    public static int Ping(int value) => value + 1;
+
+    // The parameter name shadows the static method name, so an unqualified
+    // Ping(...) would be CS0149 (or bind to the parameter); the type qualifier
+    // must be retained.
+    public int CallsShadowed(int Ping) => SelfQualifyShadow.Ping(Ping);
 }

--- a/src/ILInspector.Decompiler.Tests/SelfQualifyPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SelfQualifyPrinterTests.cs
@@ -1,0 +1,51 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Issue #2497: calls to a static member declared on the current type were
+// over-qualified with the declaring type name (SelfType.M(...)) instead of the
+// source-faithful unqualified form M(...). Cross-type static calls must stay
+// qualified.
+public class SelfQualifyPrinterTests
+{
+    [Fact]
+    public void SelfTypeStaticCall_RendersUnqualified_CrossTypeStaysQualified()
+    {
+        string body = RenderFixture(nameof(SelfQualifySamples.CallsSelfAndCross));
+
+        // Self-type static call is unqualified.
+        Assert.Contains("Helper(", body);
+        Assert.DoesNotContain("SelfQualifySamples.Helper", body);
+
+        // Near-miss: a call to another type's static member stays qualified.
+        Assert.Contains("SelfQualifyOther.External(", body);
+    }
+
+    static string RenderFixture(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(SelfQualifySamples).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(SelfQualifySamples).FullName!, methodName);
+        Assert.NotNull(function);
+        Assert.Equal(DecompilationFidelity.Full, function!.Fidelity);
+        var result = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
+        Assert.NotNull(result.Output);
+        return result.Output!;
+    }
+}
+
+public static class SelfQualifySamples
+{
+    public static int Helper(int x) => x + 1;
+
+    public static int CallsSelfAndCross(int x)
+    {
+        int a = Helper(x);
+        int b = SelfQualifyOther.External(a);
+        return a + b;
+    }
+}
+
+public static class SelfQualifyOther
+{
+    public static int External(int x) => x * 2;
+}

--- a/src/ILInspector.Decompiler.Tests/SelfQualifyPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SelfQualifyPrinterTests.cs
@@ -35,20 +35,62 @@ public class SelfQualifyPrinterTests
     [Fact]
     public void ShadowedStaticCall_StaysQualified()
     {
-        // A local that shadows the static method name means an unqualified call
-        // would bind to the local, so the type qualifier is retained.
+        // A local/parameter that shadows the static method name means an
+        // unqualified call would bind to it, so the type qualifier is retained.
         string body = RenderFixture(typeof(SelfQualifyShadow), nameof(SelfQualifyShadow.CallsShadowed));
 
         Assert.Contains("SelfQualifyShadow.Ping(Ping)", body);
         Assert.DoesNotContain("return Ping(Ping)", body);
     }
 
+    [Fact]
+    public void KeywordShadowedStaticCall_StaysQualified()
+    {
+        // The shadowing check compares escaped C# spellings, so a keyword-named
+        // parameter (@event) still shadows the same-named static method.
+        string body = RenderFixture(typeof(SelfQualifyKeywordShadow), nameof(SelfQualifyKeywordShadow.Call));
+
+        Assert.Contains("SelfQualifyKeywordShadow.@event(@event)", body);
+    }
+
+    [Fact]
+    public void LambdaParameterShadowedStaticCall_StaysQualified()
+    {
+        // A nested lambda parameter that shadows the static method name keeps the
+        // call qualified (the shadow scope includes nested lambda parameters).
+        string body = RenderAnyFidelity(typeof(SelfQualifyLambdaShadow), nameof(SelfQualifyLambdaShadow.Uses));
+
+        Assert.Contains("SelfQualifyLambdaShadow.Op(Op)", body);
+        Assert.DoesNotContain("=> Op(Op)", body);
+    }
+
     static string RenderFixture(System.Type type, string methodName)
     {
-        using var source = MetadataSource.Open(type.Assembly.Location);
+        var (function, source) = Import(type, methodName);
+        using (source)
+        {
+            Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+            return Render(function, source);
+        }
+    }
+
+    static string RenderAnyFidelity(System.Type type, string methodName)
+    {
+        var (function, source) = Import(type, methodName);
+        using (source)
+            return Render(function, source);
+    }
+
+    static (IrFunction Function, MetadataSource Source) Import(System.Type type, string methodName)
+    {
+        var source = MetadataSource.Open(type.Assembly.Location);
         var function = IrImporter.Import(source, type.FullName!, methodName);
         Assert.NotNull(function);
-        Assert.Equal(DecompilationFidelity.Full, function!.Fidelity);
+        return (function!, source);
+    }
+
+    static string Render(IrFunction function, MetadataSource source)
+    {
         var result = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
         Assert.NotNull(result.Output);
         return result.Output!;
@@ -88,4 +130,22 @@ public class SelfQualifyShadow
     // Ping(...) would be CS0149 (or bind to the parameter); the type qualifier
     // must be retained.
     public int CallsShadowed(int Ping) => SelfQualifyShadow.Ping(Ping);
+}
+
+public class SelfQualifyKeywordShadow
+{
+    public static int @event(int value) => value + 1;
+
+    public int Call(int @event) => SelfQualifyKeywordShadow.@event(@event);
+}
+
+public class SelfQualifyLambdaShadow
+{
+    public static int Op(int x) => x + 1;
+
+    public int Uses(int seed)
+    {
+        System.Func<int, int> f = Op => SelfQualifyLambdaShadow.Op(Op);
+        return f(seed);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/TupleBinaryOperatorPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TupleBinaryOperatorPassTests.cs
@@ -191,7 +191,7 @@ public class TupleBinaryOperatorPassTests
         var output = CSharpPrinter.Print(function).Output;
         // Elements stay in source order; the fidelity gate proves the spill order
         // round-trips (a reorder would recompile to a different opcode stream).
-        Assert.Contains("Tick(a), CfgSampleClass.Tick(b)) == (CfgSampleClass.Tick(c), CfgSampleClass.Tick(d)", output);
+        Assert.Contains("Tick(a), Tick(b)) == (Tick(c), Tick(d)", output);
     }
 
     [Fact]
@@ -292,7 +292,7 @@ public class TupleBinaryOperatorPassTests
         var tupleBinary = Assert.Single(function.Descendants.OfType<TupleBinaryExpression>());
         Assert.Equal(2, ((TupleExpression)tupleBinary.Left).Elements.Count);
         var output = CSharpPrinter.Print(function).Output;
-        Assert.Contains("if (TupleBinaryAdversarialSamples.SideEffect(e) == TupleBinaryAdversarialSamples.SideEffect(f))", output);
+        Assert.Contains("if (SideEffect(e) == SideEffect(f))", output);
         Assert.Contains("return (a, b) == (c, d);", output);
         Assert.DoesNotContain("(e, (a, b))", output);
         Assert.DoesNotContain("(f, (c, d))", output);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -157,6 +157,33 @@ public sealed partial class CSharpPrinter
         return !Equals(Definition(memberDeclaringType), Definition(_function.DeclaringType));
     }
 
+    /// <summary>
+    /// True when a static-call target is the current type at its own
+    /// instantiation: the same non-generic type, or the enclosing generic type
+    /// instantiated with its own generic parameters in order
+    /// (<c>C&lt;T0, T1, …&gt;</c>). A different instantiation (<c>C&lt;string&gt;</c>)
+    /// or a method-type-parameter instantiation (<c>C&lt;!!0&gt;</c>) is a distinct
+    /// type whose static member must stay qualified — an unqualified call would
+    /// rebind to the enclosing instantiation and change which method runs.
+    /// </summary>
+    bool IsCurrentStaticScope(TypeRef calleeDeclaringType)
+    {
+        var scope = _function.DeclaringType;
+        var scopeDefinition = scope is { Kind: TypeRefKind.GenericInstance, ElementType: { } sd } ? sd : scope;
+        if (Equals(calleeDeclaringType, scope) || Equals(calleeDeclaringType, scopeDefinition))
+            return true;
+        if (calleeDeclaringType is not { Kind: TypeRefKind.GenericInstance, ElementType: { } definition }
+            || !Equals(definition, scopeDefinition))
+            return false;
+        var arguments = calleeDeclaringType.TypeArguments;
+        for (int i = 0; i < arguments.Length; i++)
+        {
+            if (arguments[i].Kind != TypeRefKind.GenericParameter || arguments[i].GenericParameterIndex != i)
+                return false;
+        }
+        return true;
+    }
+
     /// <summary>Member-access receivers: value-type receivers arrive by address in IL; C# spells the place itself, not its address.</summary>
     string ReceiverText(IrExpression receiver) => receiver switch
     {
@@ -265,12 +292,26 @@ public sealed partial class CSharpPrinter
             // qualifier — `M(args)`, not `SelfType.M(args)` — just as a this-
             // receiver instance call drops `this.` and a same-type static method
             // group drops its qualifier (see AddressOfMethodText). Cross-type
-            // (incl. base-declared/inherited) static calls stay qualified.
-            string staticName = $"{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}";
+            // (incl. base-declared/inherited) static calls stay qualified. The
+            // comparison is exact (including generic instantiation): a call to a
+            // different instantiation of the current open type — e.g. `C<string>.M`
+            // from within `C<T>` — must stay qualified so it does not silently
+            // rebind to `C<T>.M`.
+            // A static call to a member of the current type needs no type
+            // qualifier — `M(args)`, not `SelfType.M(args)` — just as a this-
+            // receiver instance call drops `this.` and a same-type static method
+            // group drops its qualifier (see AddressOfMethodText). It stays
+            // qualified when the target is a different type (incl. base-declared/
+            // inherited members and a different instantiation of the enclosing
+            // generic type), or when a local/parameter shadows the name — the type
+            // qualifier is the only disambiguator for a static call (there is no
+            // `this.`), so an unqualified call would bind to the local.
+            string sourceName = CSharpNaming.SourceMethodName(call.Callee.Name);
+            string staticName = $"{sourceName}{typeArguments}";
             string staticArgs = Arguments(arguments, call.Callee.ParameterTypes, call.Callee.ParameterRefKinds);
-            return IsCrossType(call.Callee.DeclaringType)
-                ? $"{TypeText(call.Callee.DeclaringType)}.{staticName}({staticArgs})"
-                : $"{staticName}({staticArgs})";
+            return IsCurrentStaticScope(call.Callee.DeclaringType) && !IsShadowedByLocal(sourceName)
+                ? $"{staticName}({staticArgs})"
+                : $"{TypeText(call.Callee.DeclaringType)}.{staticName}({staticArgs})";
         }
         var receiver = arguments[0];
         string rest = Arguments(arguments.Skip(1), call.Callee.ParameterTypes, call.Callee.ParameterRefKinds);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -309,7 +309,7 @@ public sealed partial class CSharpPrinter
             string sourceName = CSharpNaming.SourceMethodName(call.Callee.Name);
             string staticName = $"{sourceName}{typeArguments}";
             string staticArgs = Arguments(arguments, call.Callee.ParameterTypes, call.Callee.ParameterRefKinds);
-            return IsCurrentStaticScope(call.Callee.DeclaringType) && !IsShadowedByLocal(sourceName)
+            return IsCurrentStaticScope(call.Callee.DeclaringType) && !IsStaticCallNameShadowed(sourceName)
                 ? $"{staticName}({staticArgs})"
                 : $"{TypeText(call.Callee.DeclaringType)}.{staticName}({staticArgs})";
         }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -261,7 +261,16 @@ public sealed partial class CSharpPrinter
             // receiver, and the spelling recompiles to the same constrained call.
             if (call.ConstrainedTo is { } staticReceiver)
                 return $"{TypeText(staticReceiver)}.{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({Arguments(arguments, call.Callee.ParameterTypes, call.Callee.ParameterRefKinds)})";
-            return $"{TypeText(call.Callee.DeclaringType)}.{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({Arguments(arguments, call.Callee.ParameterTypes, call.Callee.ParameterRefKinds)})";
+            // A static call to a member of the current type needs no type
+            // qualifier — `M(args)`, not `SelfType.M(args)` — just as a this-
+            // receiver instance call drops `this.` and a same-type static method
+            // group drops its qualifier (see AddressOfMethodText). Cross-type
+            // (incl. base-declared/inherited) static calls stay qualified.
+            string staticName = $"{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}";
+            string staticArgs = Arguments(arguments, call.Callee.ParameterTypes, call.Callee.ParameterRefKinds);
+            return IsCrossType(call.Callee.DeclaringType)
+                ? $"{TypeText(call.Callee.DeclaringType)}.{staticName}({staticArgs})"
+                : $"{staticName}({staticArgs})";
         }
         var receiver = arguments[0];
         string rest = Arguments(arguments.Skip(1), call.Callee.ParameterTypes, call.Callee.ParameterRefKinds);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -3553,26 +3553,18 @@ public sealed partial class CSharpPrinter
         if (_staticScopeShadowNames is null)
         {
             _staticScopeShadowNames = new HashSet<string>(StringComparer.Ordinal);
-            // Names inherited from an enclosing printer (this printer renders a
-            // lambda/local-function body with its own scope): the outer parameters
-            // and locals are in scope here too, so an outer shadow must still keep
-            // the call qualified. _reservedScopeNames mixes raw and escaped names;
-            // EscapeIdentifier is idempotent, so normalize all to escaped form.
-            foreach (var inherited in _reservedScopeNames)
-                _staticScopeShadowNames.Add(CSharpNaming.EscapeIdentifier(inherited));
-            foreach (var parameter in _function.Signature.Parameters)
-                _staticScopeShadowNames.Add(CSharpNaming.EscapeIdentifier(parameter.Name));
-            for (int i = 0; i < _function.Locals.Length; i++)
-                _staticScopeShadowNames.Add(LocalName(i));
-            foreach (var lambda in _function.Descendants.OfType<Lambda>())
-                foreach (var parameter in lambda.Parameters)
-                    _staticScopeShadowNames.Add(CSharpNaming.EscapeIdentifier(parameter.Name));
-            foreach (var localFunction in _function.Descendants.OfType<LocalFunctionStatement>())
-            {
-                _staticScopeShadowNames.Add(CSharpNaming.EscapeIdentifier(localFunction.Name));
-                foreach (var parameter in localFunction.Parameters)
-                    _staticScopeShadowNames.Add(CSharpNaming.EscapeIdentifier(parameter.Name));
-            }
+            // CurrentScopeNames aggregates every binder in scope for this printer:
+            // the enclosing method's parameters and locals, names inherited from an
+            // enclosing printer (when this renders a lambda/local-function body with
+            // its own scope), nested lambda/local-function parameters, and the
+            // printer's own synthetic locals (stack slots S_n, switch temps). It
+            // mixes raw and escaped names; EscapeIdentifier is idempotent, so
+            // normalize all to the escaped spelling the rendered call name uses.
+            foreach (var name in CurrentScopeNames())
+                _staticScopeShadowNames.Add(CSharpNaming.EscapeIdentifier(name));
+            // FreshSyntheticLocalName("__stackalloc") does not flow through
+            // CurrentScopeNames; add it explicitly.
+            _staticScopeShadowNames.Add("__stackalloc");
         }
         return _staticScopeShadowNames.Contains(escapedName);
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -3534,10 +3534,19 @@ public sealed partial class CSharpPrinter
 
     /// <summary>
     /// True when the escaped source spelling of a static-call name is captured by
-    /// a parameter or local in scope — including nested lambda and local-function
-    /// parameters — so an unqualified call would bind to that local rather than the
-    /// static method. Names are compared in their escaped C# spelling (a keyword
-    /// carries the leading <c>@</c>), matching the rendered call name.
+    /// a parameter or local in scope — the enclosing method's parameters and
+    /// locals, names inherited from an enclosing printer, and nested lambda /
+    /// local-function parameters — so an unqualified call would bind to that local
+    /// rather than the static method. Names are compared in their escaped C#
+    /// spelling (a keyword carries the leading <c>@</c>), matching the rendered
+    /// call name.
+    ///
+    /// This is a deliberate over-approximation of lexical scope: it treats every
+    /// parameter/local anywhere in the method (including sibling lambdas) as a
+    /// shadow, so a rare sibling-lambda name collision keeps a call qualified that
+    /// could in principle be bare. That only costs fidelity (the qualified form is
+    /// always valid), whereas missing a real shadow would rebind the call and
+    /// produce wrong or uncompilable C#; the guard errs toward qualifying.
     /// </summary>
     bool IsStaticCallNameShadowed(string escapedName)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -3530,6 +3530,37 @@ public sealed partial class CSharpPrinter
         return _localScopeNames.Contains(fieldName);
     }
 
+    HashSet<string>? _staticScopeShadowNames;
+
+    /// <summary>
+    /// True when the escaped source spelling of a static-call name is captured by
+    /// a parameter or local in scope — including nested lambda and local-function
+    /// parameters — so an unqualified call would bind to that local rather than the
+    /// static method. Names are compared in their escaped C# spelling (a keyword
+    /// carries the leading <c>@</c>), matching the rendered call name.
+    /// </summary>
+    bool IsStaticCallNameShadowed(string escapedName)
+    {
+        if (_staticScopeShadowNames is null)
+        {
+            _staticScopeShadowNames = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var parameter in _function.Signature.Parameters)
+                _staticScopeShadowNames.Add(CSharpNaming.EscapeIdentifier(parameter.Name));
+            for (int i = 0; i < _function.Locals.Length; i++)
+                _staticScopeShadowNames.Add(LocalName(i));
+            foreach (var lambda in _function.Descendants.OfType<Lambda>())
+                foreach (var parameter in lambda.Parameters)
+                    _staticScopeShadowNames.Add(CSharpNaming.EscapeIdentifier(parameter.Name));
+            foreach (var localFunction in _function.Descendants.OfType<LocalFunctionStatement>())
+            {
+                _staticScopeShadowNames.Add(CSharpNaming.EscapeIdentifier(localFunction.Name));
+                foreach (var parameter in localFunction.Parameters)
+                    _staticScopeShadowNames.Add(CSharpNaming.EscapeIdentifier(parameter.Name));
+            }
+        }
+        return _staticScopeShadowNames.Contains(escapedName);
+    }
+
     string IncrementDecrementText(IncrementDecrement id)
     {
         string op = id.IsIncrement ? "++" : "--";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -3544,6 +3544,13 @@ public sealed partial class CSharpPrinter
         if (_staticScopeShadowNames is null)
         {
             _staticScopeShadowNames = new HashSet<string>(StringComparer.Ordinal);
+            // Names inherited from an enclosing printer (this printer renders a
+            // lambda/local-function body with its own scope): the outer parameters
+            // and locals are in scope here too, so an outer shadow must still keep
+            // the call qualified. _reservedScopeNames mixes raw and escaped names;
+            // EscapeIdentifier is idempotent, so normalize all to escaped form.
+            foreach (var inherited in _reservedScopeNames)
+                _staticScopeShadowNames.Add(CSharpNaming.EscapeIdentifier(inherited));
             foreach (var parameter in _function.Signature.Parameters)
                 _staticScopeShadowNames.Add(CSharpNaming.EscapeIdentifier(parameter.Name));
             for (int i = 0; i < _function.Locals.Length; i++)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2868,14 +2868,23 @@ public sealed partial class CSharpPrinter
             _function.Signature.Parameters.Select(p => p.Name)
                 .Concat(_function.LocalNames.Where(name => !string.IsNullOrWhiteSpace(name)).Select(name => name!)),
             StringComparer.Ordinal);
-        if (!used.Contains(baseName))
-            return baseName;
-        for (int i = 0; ; i++)
+        string chosen = baseName;
+        if (used.Contains(baseName))
         {
-            string candidate = $"{baseName}{i}";
-            if (!used.Contains(candidate))
-                return candidate;
+            for (int i = 0; ; i++)
+            {
+                string candidate = $"{baseName}{i}";
+                if (!used.Contains(candidate))
+                {
+                    chosen = candidate;
+                    break;
+                }
+            }
         }
+        // Record every generated synthetic local so a self-static call whose name
+        // collides with it (e.g. a suffixed `__stackalloc0`) stays qualified.
+        _syntheticLocalNames.Add(chosen);
+        return chosen;
     }
 
     static bool IsNativeInteger(TypeRef? type)
@@ -3531,6 +3540,7 @@ public sealed partial class CSharpPrinter
     }
 
     HashSet<string>? _staticScopeShadowNames;
+    readonly HashSet<string> _syntheticLocalNames = new(StringComparer.Ordinal);
 
     /// <summary>
     /// True when the escaped source spelling of a static-call name is captured by
@@ -3550,6 +3560,11 @@ public sealed partial class CSharpPrinter
     /// </summary>
     bool IsStaticCallNameShadowed(string escapedName)
     {
+        // Synthetic locals are generated during rendering; check the live set so a
+        // name emitted before this call (regardless of the cache below) is seen.
+        // These names are never keywords, so their spelling equals escapedName.
+        if (_syntheticLocalNames.Contains(escapedName))
+            return true;
         if (_staticScopeShadowNames is null)
         {
             _staticScopeShadowNames = new HashSet<string>(StringComparer.Ordinal);
@@ -3562,9 +3577,6 @@ public sealed partial class CSharpPrinter
             // normalize all to the escaped spelling the rendered call name uses.
             foreach (var name in CurrentScopeNames())
                 _staticScopeShadowNames.Add(CSharpNaming.EscapeIdentifier(name));
-            // FreshSyntheticLocalName("__stackalloc") does not flow through
-            // CurrentScopeNames; add it explicitly.
-            _staticScopeShadowNames.Add("__stackalloc");
         }
         return _staticScopeShadowNames.Contains(escapedName);
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1003,6 +1003,8 @@ public sealed partial class CSharpPrinter
         var names = new HashSet<string>(_reservedScopeNames, StringComparer.Ordinal);
         foreach (var parameter in _function.Signature.Parameters)
             names.Add(parameter.Name);
+        foreach (var genericParameter in _function.Signature.GenericParameterNames)
+            names.Add(genericParameter);
         foreach (var nested in _function.Descendants.OfType<Lambda>())
             foreach (var parameter in nested.Parameters)
                 names.Add(parameter.Name);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -991,6 +991,10 @@ public sealed partial class CSharpPrinter
             names.Add(name);
         foreach (var name in _switchTemps.Values)
             names.Add(name);
+        // Synthetic locals (e.g. __stackalloc) are in scope for this body and for
+        // any nested lambda/local-function printer built from these names.
+        foreach (var name in _syntheticLocalNames)
+            names.Add(name);
         return names;
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/MethodBody.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodBody.cs
@@ -34,7 +34,16 @@ public sealed record MethodSignature(
     TypeRef ReturnType,
     ImmutableArray<Parameter> Parameters,
     bool HasThis,
-    int GenericParameterCount);
+    int GenericParameterCount)
+{
+    /// <summary>
+    /// The method's own generic parameter names (e.g. <c>T</c>), when known; empty
+    /// otherwise. A method type parameter shares the declaration space with the
+    /// declaring type's members, so it shadows a same-named static member — an
+    /// unqualified call to that member would bind to the type parameter (CS0119).
+    /// </summary>
+    public ImmutableArray<string> GenericParameterNames { get; init; } = [];
+}
 
 /// <summary>
 /// The importer's output: declaring type, name, signature, and body — all

--- a/src/ILInspector.Decompiler/Pipeline/MethodImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodImporter.cs
@@ -51,9 +51,10 @@ public static class MethodImporter
         var typeDef = reader.GetTypeDefinition(typeDefHandle);
         var method = reader.GetMethodDefinition(methodHandle);
 
+        var methodGenericParameterNames = ParameterNames(reader, method.GetGenericParameters());
         var scope = new GenericScope(
             ParameterNames(reader, typeDef.GetGenericParameters()),
-            ParameterNames(reader, method.GetGenericParameters()));
+            methodGenericParameterNames);
 
         var declaringType = TypeRefDecoder.Instance.GetTypeFromDefinition(reader, typeDefHandle, 0);
         var decoded = GuardedDecode.MethodSignature(reader, method, scope);
@@ -80,7 +81,10 @@ public static class MethodImporter
             decoded.ReturnType,
             parameters.MoveToImmutable(),
             decoded.Header.IsInstance,
-            decoded.GenericParameterCount);
+            decoded.GenericParameterCount)
+        {
+            GenericParameterNames = methodGenericParameterNames,
+        };
 
         var body = source.Pe.GetMethodBody(method.RelativeVirtualAddress);
 


### PR DESCRIPTION
Fixes #2497. Base: latest `origin/main` (rebased).

## Change

**Conclusion:** **PASS** — a static call to a member of the *current type* now renders source-faithfully unqualified (`M(args)`), not over-qualified (`SelfType.M(args)`), mirroring the this-receiver instance form and the existing `AddressOfMethodText` (`&Method`) precedent.

Before → after (real corpus example, `ApiDiffAnalyzer.Compare` calling its own static helper):

```diff
-Dictionary<string, ApiType> oldTypes = ApiDiffAnalyzer.BuildTypeLookup(oldSurface);
+Dictionary<string, ApiType> oldTypes = BuildTypeLookup(oldSurface);
```

## Predicate (correctness-critical)

Unqualify **only** when the callee's declaring type is the current type *at its own instantiation*, and the name is not shadowed:

- `IsCurrentStaticScope` — exact type match for non-generic types; for a generic enclosing type, the callee must be `C<T0,T1,…>` instantiated with the type's **own** generic parameters. A *different* instantiation (`C<string>` from within `C<T>`) or a method-type-parameter instantiation (`C<!!0>`) stays qualified, so an unqualified call cannot silently rebind to `C<T>.M`.
- `IsStaticCallNameShadowed` — keeps the qualifier when a parameter or local (including **nested lambda / local-function** parameters) shadows the name, compared in escaped C# spelling (so `@event` matches a keyword-named parameter). The type qualifier is a static call's only disambiguator (there is no `this.`).

Operator, extension-method, and constrained (`ConstrainedTo`) calls are unchanged (handled by earlier branches).

## Evidence

| Check | Result |
| --- | --- |
| Render-text A/B vs merge-base (`origin/main`, corpus-method-cap 250) | **valid→invalid: 0**; 245 valid→valid (self-static calls unqualified, still compile); 45 pre-existing invalid→invalid |
| RTS source-probe (`rts.candidates`) | **Invalid 0**; ValidMatch 61 / ValidDifferent 41 (+9 exact source matches vs the pre-rebase baseline of 52/50 — over-qualification was a valid-different delta) |
| Affected + printer test classes | 494/494 pass, incl. new `SelfQualifyPrinterTests` (cross-type, generic self/cross-instantiation, plain/keyword/lambda shadowing) |
| Full `ILInspector.Decompiler.Tests` | Only pre-existing/environment failures (8 RTS `RecompileFail` + 2 fidelity-gate diffs for `PointerStoreUsesOriginalAddress`, a method with **no** static call that this change provably cannot affect) — 0 new failures |

## Test / harness updates

- ~19 test expectations that hard-coded the old over-qualified self-type static form updated to the unqualified form.
- Two foreign-`__Gate` recompile tests (`Rung6NewRulesPointerAddressOf_RecompilesInSafeMethodShell`, `CoerceChokePointTests.PointerArgument_NativeZero_RendersTypedNull`) add `using static <SelfType>` — they relocate a method body into a foreign class, unlike the product's full-type compile-back shells (where unqualified self-calls resolve; RTS Invalid stays 0). Test-harness artifacts, not product regressions.

## Scope boundary

`MethodGroupText` (delegate-creation static method groups, e.g. `new D(SelfType.Method)`) still qualifies self-type method groups. Deferred as a follow-up: it is a distinct construct from member calls (this issue's scope) and would need the same generic/shadowing guards and its own A/B pass.

## Review

This change had two adversarial pre-review passes from Gemini 3.1 Pro, which caught two real rebinding bugs the Roslyn-validity A/B structurally cannot detect (generic-instantiation rebinding; local/parameter shadowing incl. keyword-escaping and nested scopes); both are fixed with dedicated regression tests. Requesting the two-reviewer adversarial review on this head per policy.

## Validation

```bash
dotnet build src/ILInspector.Decompiler.Tests -c Release --configfile nuget.config
DOTNET_ROLL_FORWARD=LatestMajor dotnet artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll -class "*SelfQualifyPrinterTests"
# render A/B (fresh origin/main base) and RTS source probe
dotnet run --project tools/DecompilerHarness -c Release --no-build -- <corpus> --corpus-method-cap 250 --render-ab base.renderab --max-examples 0
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures rts.candidates --return-to-sender-source-probe --cap 10000 --max-examples 0
```

> This box runs SDK 11 preview.5, not the repo .NET 11 daily; the 10 full-suite failures reproduce as environment noise (RTS `RecompileFail`; `PointerStoreUsesOriginalAddress` has no static call so is untouched here). CI on the correct SDK is authoritative.
