### PR TITLE
Evidence spine: C# producer (CSharpEvidence)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CSharpEvidenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpEvidenceTests.cs
@@ -1,0 +1,200 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+using DotnetInspector.Fixtures;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Evidence;
+using ILInspector.Metadata;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class CSharpEvidenceTests
+{
+    static readonly EvidenceSubject Subject = new("M", "M");
+
+    [Fact]
+    public void CSharpEvidence_SameBody_IsExact()
+    {
+        var body = Statements(
+            "    int value = 1;",
+            "    Sink(value);",
+            "    return value;");
+
+        var result = CSharpEvidence.CompareCanonicalized(body, body, Subject);
+
+        Assert.Null(result.Failure);
+        Assert.True(result.IsExact);
+        Assert.All(result.Rows, row => Assert.Equal(EvidenceRowKind.Present, row.Kind));
+    }
+
+    [Fact]
+    public void CSharpEvidence_ChangedStatement_AgreesWithCSharpBodyDiff()
+    {
+        using var oldSource = MetadataSource.OpenWithoutSymbols(FixtureCatalog.DiffPair.OldAssemblyPath());
+        using var newSource = MetadataSource.OpenWithoutSymbols(FixtureCatalog.DiffPair.NewAssemblyPath());
+        var oldMethod = FindMethod(oldSource, "DiffFixtureSample.DiffSample", "ConstantValue");
+        var newMethod = FindMethod(newSource, "DiffFixtureSample.DiffSample", "ConstantValue");
+
+        var classic = CSharpBodyDiff.CompareMembers(oldSource, oldMethod, newSource, newMethod);
+        var evidence = CSharpEvidence.Compare(oldSource, oldMethod, newSource, newMethod, Subject);
+
+        Assert.Null(evidence.Failure);
+        Assert.False(evidence.IsExact);
+        AssertRemovedAddedLineTextAgree(classic, evidence);
+    }
+
+    [Fact]
+    public void CSharpEvidence_RelocatedBlock_IsDetectedAsMoved()
+    {
+        var old = Statements(
+            "    int first = value + 1;",
+            "    int second = value + 2;",
+            "    Sink(10);",
+            "    Sink(20);",
+            "    return first + second;");
+        var @new = Statements(
+            "    Sink(10);",
+            "    Sink(20);",
+            "    int first = value + 1;",
+            "    int second = value + 2;",
+            "    return first + second;");
+
+        var result = CSharpEvidence.CompareCanonicalized(old, @new, Subject);
+
+        Assert.Null(result.Failure);
+        Assert.False(result.IsExact);
+        Assert.Equal(2, result.Rows.Count(row => row.DifferenceKind == EvidenceDifferenceKind.Moved));
+        Assert.Equal(0, result.Rows.Count(row => row.Kind is EvidenceRowKind.Added or EvidenceRowKind.Removed));
+        Assert.True(EvidenceEquivalence.Multiset.IsEquivalent(result.Rows));
+    }
+
+    [Theory]
+    [InlineData("Stable")]
+    [InlineData("ConstantValue")]
+    [InlineData("MultipleHunks")]
+    [InlineData("StringToken")]
+    public void CSharpEvidence_Exactness_AgreesWithCSharpBodyDiff_AcrossFixtures(string methodName)
+    {
+        using var oldSource = MetadataSource.OpenWithoutSymbols(FixtureCatalog.DiffPair.OldAssemblyPath());
+        using var newSource = MetadataSource.OpenWithoutSymbols(FixtureCatalog.DiffPair.NewAssemblyPath());
+        var oldMethod = FindMethod(oldSource, "DiffFixtureSample.DiffSample", methodName);
+        var newMethod = FindMethod(newSource, "DiffFixtureSample.DiffSample", methodName);
+
+        var classic = CSharpBodyDiff.CompareMembers(oldSource, oldMethod, newSource, newMethod);
+        var evidence = CSharpEvidence.Compare(oldSource, oldMethod, newSource, newMethod, Subject);
+
+        Assert.Null(evidence.Failure);
+        Assert.Equal(classic.IsExact, evidence.IsExact);
+    }
+
+    [Fact]
+    public void CSharpEvidence_CommittedCore_ReproducesCSharpBodyDiffResidual()
+    {
+        using var oldSource = MetadataSource.OpenWithoutSymbols(FixtureCatalog.DiffPair.OldAssemblyPath());
+        using var newSource = MetadataSource.OpenWithoutSymbols(FixtureCatalog.DiffPair.NewAssemblyPath());
+        var oldMethod = FindMethod(oldSource, "DiffFixtureSample.DiffSample", "MultipleHunks");
+        var newMethod = FindMethod(newSource, "DiffFixtureSample.DiffSample", "MultipleHunks");
+
+        var classic = CSharpBodyDiff.CompareMembers(oldSource, oldMethod, newSource, newMethod);
+        var evidence = CSharpEvidence.Compare(oldSource, oldMethod, newSource, newMethod, Subject);
+
+        Assert.Null(evidence.Failure);
+        Assert.Equal(0, evidence.Rows.Count(row => row.DifferenceKind == EvidenceDifferenceKind.Moved));
+        AssertRemovedAddedLineTextAgree(classic, evidence);
+    }
+
+    [Fact]
+    public void CSharpEvidence_TriviaOnlyMatchedLine_IsEncodingOnly()
+    {
+        var old = Statements("    return value;");
+        var @new = Statements("        return value;   ");
+
+        var result = CSharpEvidence.CompareCanonicalized(old, @new, Subject);
+
+        var row = Assert.Single(result.Rows);
+        Assert.Equal(EvidenceRowKind.Present, row.Kind);
+        Assert.Equal(EvidenceDifferenceKind.EncodingOnly, row.DifferenceKind);
+        Assert.True(result.IsExact);
+    }
+
+    [Theory]
+    [InlineData(typeof(CSharpBodyDiff))]
+    [InlineData(typeof(CSharpEvidenceTests))]
+    [InlineData(typeof(System.Linq.Enumerable))]
+    public void CSharpEvidence_SelfCompare_IsExactAcrossWholeAssembly(Type anchorType)
+    {
+        using var source = MetadataSource.OpenWithoutSymbols(anchorType.Assembly.Location);
+        var reader = source.Reader;
+
+        int canonicalized = 0;
+        int declined = 0;
+        foreach (var handle in reader.MethodDefinitions)
+        {
+            var method = reader.GetMethodDefinition(handle);
+            if (method.RelativeVirtualAddress == 0)
+                continue;
+
+            var token = MetadataTokens.GetToken(handle).ToString(CultureInfo.InvariantCulture);
+            var subject = new EvidenceSubject(token, "m");
+            var evidence = CSharpEvidence.Compare(source, handle, source, handle, subject);
+            if (evidence.Failure is not null)
+            {
+                declined++;
+                continue;
+            }
+
+            Assert.True(evidence.IsExact, $"CSharpEvidence self-compare not exact for token {token}");
+            Assert.All(evidence.Rows, row => Assert.Equal(EvidenceRowKind.Present, row.Kind));
+            canonicalized++;
+        }
+
+        Assert.True(canonicalized > 50, $"expected a substantial corpus; canonicalized={canonicalized} declined={declined}");
+        Assert.True(declined <= canonicalized / 10, $"too many canonicalization declines: canonicalized={canonicalized} declined={declined}");
+    }
+
+    static ImmutableArray<CSharpCanonicalStatement> Statements(params string[] lines)
+        => CSharpBodyDiff.CanonicalizeRenderedLines(lines);
+
+    static MethodDefinitionHandle FindMethod(MetadataSource source, string typeName, string methodName)
+    {
+        var reader = source.Reader;
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var type = reader.GetTypeDefinition(typeHandle);
+            if (reader.GetFullTypeName(type) != typeName)
+                continue;
+
+            foreach (var methodHandle in type.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (reader.GetString(method.Name) == methodName)
+                    return methodHandle;
+            }
+        }
+
+        throw new InvalidOperationException($"Could not find {typeName}.{methodName}.");
+    }
+
+    static void AssertRemovedAddedLineTextAgree(CSharpBodyDiffResult classic, CSharpEvidenceResult evidence)
+    {
+        Assert.Equal(ClassicLineTexts(classic, CSharpDiffKind.Remove), EvidenceTexts(evidence, EvidenceRowKind.Removed));
+        Assert.Equal(ClassicLineTexts(classic, CSharpDiffKind.Add), EvidenceTexts(evidence, EvidenceRowKind.Added));
+    }
+
+    static string[] ClassicLineTexts(CSharpBodyDiffResult classic, CSharpDiffKind kind)
+        => classic.Rows
+            .Select(row => kind == CSharpDiffKind.Remove ? row.OldOperation : row.NewOperation)
+            .Where(operation => operation?.Kind == CSharpDiffOperationKind.Line)
+            .Select(operation => operation!.Value)
+            .OrderBy(text => text, StringComparer.Ordinal)
+            .ToArray();
+
+    static string[] EvidenceTexts(CSharpEvidenceResult evidence, EvidenceRowKind kind)
+        => evidence.Rows
+            .Where(row => row.Kind == kind)
+            .Select(row => Assert.IsType<CSharpDiffOperation>(row.Payload).Value)
+            .OrderBy(text => text, StringComparer.Ordinal)
+            .ToArray();
+}

--- a/src/ILInspector.Decompiler/CSharpBodyDiff.cs
+++ b/src/ILInspector.Decompiler/CSharpBodyDiff.cs
@@ -42,6 +42,14 @@ public sealed record CSharpDiffOperation(CSharpDiffOperationKind Kind, string Va
     };
 }
 
+public sealed record CSharpCanonicalStatement(
+    int Line,
+    string Text,
+    string IdentityKey)
+{
+    public CSharpDiffOperation Operation => new(CSharpDiffOperationKind.Line, Text);
+}
+
 public sealed record CSharpDiffRow(
     string AssemblyIdentity,
     string StableMemberKey,
@@ -201,6 +209,51 @@ public static class CSharpBodyDiff
         int hunkId = 0;
         AddLineDiffRows(rows, failureRows, oldEntry, Decompile(oldEntry, oldSource), Decompile(newEntry, newSource), ref hunkId);
         return new CSharpBodyDiffResult(rows.ToImmutable(), failureRows.ToImmutable());
+    }
+
+    /// <summary>
+    /// Canonicalizes a decompiled method body into the rendered statement stream the C# body diff
+    /// aligns over. Exposed so the evidence adapter can reuse the decompiler render and statement
+    /// identity normalization instead of independently reconstructing C# text.
+    /// </summary>
+    public static bool TryCanonicalize(
+        MetadataSource source,
+        MethodDefinitionHandle method,
+        out ImmutableArray<CSharpCanonicalStatement> statements,
+        out string? failure)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        if (method.IsNil)
+            throw new ArgumentException("Method handle must not be nil.", nameof(method));
+
+        try
+        {
+            var entry = CreateMethodEntry(source, source.Reader.GetMethodDefinition(method).GetDeclaringType(), method, StableAssemblyKey(source));
+            var render = Decompile(entry, source);
+            if (render.State != CSharpMethodRenderState.Body)
+            {
+                statements = [];
+                failure = render.Lines.Length == 0 ? $"method render state was {render.State}" : render.Lines[0];
+                return false;
+            }
+
+            if (render.Lines.Length > MaxLcsLines)
+            {
+                statements = [];
+                failure = $"C# body has {render.Lines.Length} lines; limit is {MaxLcsLines}";
+                return false;
+            }
+
+            statements = CanonicalizeRenderedLines(render.Lines);
+            failure = null;
+            return true;
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or NotSupportedException)
+        {
+            statements = [];
+            failure = ex.Message;
+            return false;
+        }
     }
 
     public static CSharpBodyDiffResult CompareAssemblies(IReadOnlyList<string> oldPaths, IReadOnlyList<string> newPaths, bool includeNonPublic = false, IReadOnlySet<string>? typeFilters = null)
@@ -1681,6 +1734,26 @@ public static class CSharpBodyDiff
         while (normalized.EndsWith('\n'))
             normalized = normalized[..^1];
         return normalized.Length == 0 ? [] : normalized.Split('\n');
+    }
+
+    internal static ImmutableArray<CSharpCanonicalStatement> CanonicalizeRenderedLines(IReadOnlyList<string> lines)
+    {
+        ArgumentNullException.ThrowIfNull(lines);
+
+        var builder = ImmutableArray.CreateBuilder<CSharpCanonicalStatement>(lines.Count);
+        for (int i = 0; i < lines.Count; i++)
+        {
+            string text = lines[i];
+            builder.Add(new CSharpCanonicalStatement(i + 1, text, GetStatementIdentityKey(text)));
+        }
+
+        return builder.MoveToImmutable();
+    }
+
+    public static string GetStatementIdentityKey(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        return text.Trim();
     }
 
     sealed record CSharpMethodEntry(

--- a/src/ILInspector.Decompiler/CSharpEvidence.cs
+++ b/src/ILInspector.Decompiler/CSharpEvidence.cs
@@ -1,0 +1,136 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Evidence;
+
+namespace ILInspector.Decompiler;
+
+/// <summary>
+/// Adapts decompiled C# method bodies onto the domain-free evidence substrate. It reuses
+/// <see cref="CSharpBodyDiff"/> to render and canonicalize a method into ordered C# statement
+/// occurrences, runs the shared <see cref="EvidenceMatcher"/>, folds the correspondence into
+/// <see cref="EvidenceRow"/>s, and classifies trivia-only matched text changes as encoding-only.
+/// </summary>
+public static class CSharpEvidence
+{
+    /// <summary>The evidence descriptor for a single decompiled C# statement occurrence.</summary>
+    public static readonly EvidenceDescriptor StatementDescriptor = new("csharp.stmt", "C# statement");
+
+    public static CSharpEvidenceResult Compare(
+        MetadataSource oldSource,
+        MethodDefinitionHandle oldMethod,
+        MetadataSource newSource,
+        MethodDefinitionHandle newMethod,
+        EvidenceSubject subject,
+        int acceptanceThreshold = 100)
+    {
+        ArgumentNullException.ThrowIfNull(oldSource);
+        ArgumentNullException.ThrowIfNull(newSource);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        try
+        {
+            if (!CSharpBodyDiff.TryCanonicalize(oldSource, oldMethod, out var oldStatements, out var oldFailure))
+                return CSharpEvidenceResult.Failed(oldFailure ?? "old body canonicalization failed");
+            if (!CSharpBodyDiff.TryCanonicalize(newSource, newMethod, out var newStatements, out var newFailure))
+                return CSharpEvidenceResult.Failed(newFailure ?? "new body canonicalization failed");
+
+            return CompareCanonicalized(oldStatements, newStatements, subject, acceptanceThreshold);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or NotSupportedException)
+        {
+            return CSharpEvidenceResult.Failed(ex.Message);
+        }
+    }
+
+    internal static CSharpEvidenceResult CompareCanonicalized(
+        ImmutableArray<CSharpCanonicalStatement> oldStatements,
+        ImmutableArray<CSharpCanonicalStatement> newStatements,
+        EvidenceSubject subject,
+        int acceptanceThreshold = 100)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+
+        var oldStream = BuildOccurrences(oldStatements);
+        var newStream = BuildOccurrences(newStatements);
+
+        EvidenceMatch correspondence;
+        try
+        {
+            correspondence = EvidenceMatcher.Match(oldStream, newStream);
+        }
+        catch (ArgumentException ex)
+        {
+            return CSharpEvidenceResult.Failed(ex.Message);
+        }
+
+        var rows = EvidenceFold.ToRows(correspondence, oldStream, newStream, subject, StatementDescriptor, acceptanceThreshold);
+        rows = ApplyTriviaOnlyClassification(rows, oldStatements, newStatements);
+        return new CSharpEvidenceResult(rows, correspondence, oldStream, newStream, Failure: null);
+    }
+
+    static ImmutableArray<EvidenceOccurrence> BuildOccurrences(ImmutableArray<CSharpCanonicalStatement> statements)
+    {
+        var builder = ImmutableArray.CreateBuilder<EvidenceOccurrence>(statements.Length);
+        foreach (var statement in statements)
+        {
+            // ScopeKey is left null for rung 0: CSharpBodyDiff aligns rendered lines without block
+            // identity, and C# scope-aware equivalence belongs to the future soft tier (#2585).
+            builder.Add(new EvidenceOccurrence(GetIdentityKey(statement), ScopeKey: null, Payload: statement.Operation));
+        }
+
+        return builder.MoveToImmutable();
+    }
+
+    static ImmutableArray<EvidenceRow> ApplyTriviaOnlyClassification(
+        ImmutableArray<EvidenceRow> rows,
+        ImmutableArray<CSharpCanonicalStatement> oldStatements,
+        ImmutableArray<CSharpCanonicalStatement> newStatements)
+    {
+        var builder = ImmutableArray.CreateBuilder<EvidenceRow>(rows.Length);
+        foreach (var row in rows)
+        {
+            if (row.Kind == EvidenceRowKind.Present
+                && row.DifferenceKind == EvidenceDifferenceKind.None
+                && row.Anchor.OldIndex >= 0
+                && row.Anchor.NewIndex >= 0
+                && !string.Equals(oldStatements[row.Anchor.OldIndex].Text, newStatements[row.Anchor.NewIndex].Text, StringComparison.Ordinal))
+            {
+                builder.Add(row with { DifferenceKind = EvidenceDifferenceKind.EncodingOnly, Detail = "trivia-only" });
+            }
+            else
+            {
+                builder.Add(row);
+            }
+        }
+
+        return builder.MoveToImmutable();
+    }
+
+    /// <summary>
+    /// The canonical content key for a rendered C# statement. The key is produced by
+    /// <see cref="CSharpBodyDiff"/> so evidence matching stays anchored to the existing body-diff
+    /// render/canonicalization path.
+    /// </summary>
+    public static string GetIdentityKey(CSharpCanonicalStatement statement)
+    {
+        ArgumentNullException.ThrowIfNull(statement);
+        return statement.IdentityKey;
+    }
+}
+
+/// <summary>The outcome of a <see cref="CSharpEvidence.Compare"/> call.</summary>
+public sealed record CSharpEvidenceResult(
+    ImmutableArray<EvidenceRow> Rows,
+    EvidenceMatch Match,
+    ImmutableArray<EvidenceOccurrence> OldOccurrences,
+    ImmutableArray<EvidenceOccurrence> NewOccurrences,
+    string? Failure)
+{
+    /// <summary>True when the bodies are exact under the fidelity fold (no adds/removes/moves).</summary>
+    public bool IsExact => Failure is null && EvidenceEquivalence.Exact.IsEquivalent(Rows);
+
+    public static CSharpEvidenceResult Failed(string failure)
+        => new([], new EvidenceMatch([], []), [], [], failure);
+}

--- a/src/ILInspector.Decompiler/ILInspector.Decompiler.csproj
+++ b/src/ILInspector.Decompiler/ILInspector.Decompiler.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\ILInspector.Metadata\ILInspector.Metadata.csproj" />
     <ProjectReference Include="..\ILInspector.MetadataPrimitives\ILInspector.MetadataPrimitives.csproj" />
     <ProjectReference Include="..\ILInspector.Instructions\ILInspector.Instructions.csproj" />
+    <ProjectReference Include="..\ILInspector.Evidence\ILInspector.Evidence.csproj" />
     <ProjectReference Include="..\ILInspector.ControlFlow\ILInspector.ControlFlow.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Refs #2564 #2585

## Summary
- Adds `CSharpEvidence`, the C# evidence producer that projects decompiled C# body diffs into the shared `EvidenceRow` stream.
- Adds a `CSharpBodyDiff.TryCanonicalize(...)` entry point so the producer reuses the existing decompile/render path rather than reconstructing C# text.
- Covers exact, changed, moved, trivia-only, CSharpBodyDiff reproduction, exactness-agreement, and real-assembly self-compare gates.

## Shape
`CSharpEvidence.Compare(...)` canonicalizes old/new methods through `CSharpBodyDiff`, builds ordered `EvidenceOccurrence` streams, runs `EvidenceMatcher.Match(...)`, folds via `EvidenceFold.ToRows(...)`, then applies a C# attach pass for trivia-only matched text differences.

## Design decisions
- Occurrence granularity: rendered C# line/statement, matching the unit `CSharpBodyDiff` aligns with its LCS.
- Identity key: `CSharpBodyDiff.GetStatementIdentityKey(...)` currently trims leading/trailing trivia from the rendered statement while preserving interior text, keeping rung-0 exact and conservative.
- Scope key: null for rung 0; block/scope-aware matching is left for the future soft tier.
- Payload: `CSharpDiffOperation(Line, renderedText)`.
- Attach classification: matched statements with equal identity but different rendered text are `EncodingOnly`/`trivia-only`; no sugar, paren, or rename equivalence is attempted.
- Failure behavior: canonicalization failures and matcher size guards return `CSharpEvidenceResult.Failed(...)` rather than throwing.

## Validation
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*CSharpEvidenceTests"` (12 passed)
- Corpus self-compare counts from the same gate: `ILInspector.Decompiler` 7810/0 canonicalized/declined; `ILInspector.Decompiler.Tests` 10710/0; `System.Linq` 1440/0.

## Open questions
- Whether `csharp.stmt` should remain rendered-line based or move to a later syntax/IR statement unit when soft-tier C# equivalence lands.
- Whether the rung-0 identity should trim only edge trivia (current behavior) or fold broader whitespace once CSharpBodyDiff itself has an explicit formatting-equivalence contract.
- Whether/when C# scope keys should be populated from block structure to corroborate moves across loops/try/catch regions.
