### PR TITLE
Matcher foundation: row confidence + identity-set mode (#2585)

### DIFF
--- a/src/ILInspector.Evidence/EvidenceFold.cs
+++ b/src/ILInspector.Evidence/EvidenceFold.cs
@@ -98,6 +98,7 @@ public static class EvidenceFold
                     EvidenceRowKind.Present,
                     new EvidenceAnchor(oldOcc.IdentityKey, link.OldIndex, link.NewIndex, oldOcc.ScopeKey),
                     EvidenceDifferenceKind.None,
+                    Confidence: link.Confidence,
                     Payload: newOcc.Payload);
             }
 
@@ -112,6 +113,7 @@ public static class EvidenceFold
                     EvidenceRowKind.Present,
                     new EvidenceAnchor(oldOcc.IdentityKey, link.OldIndex, link.NewIndex, oldOcc.ScopeKey),
                     EvidenceDifferenceKind.Moved,
+                    Confidence: link.Confidence,
                     Detail: $"moved {delta:+#;-#;0}",
                     Payload: newOcc.Payload);
             }
@@ -125,6 +127,7 @@ public static class EvidenceFold
                     EvidenceRowKind.Added,
                     new EvidenceAnchor(newOcc.IdentityKey, -1, link.NewIndex, newOcc.ScopeKey),
                     EvidenceDifferenceKind.None,
+                    Confidence: link.Confidence,
                     Payload: newOcc.Payload);
             }
 
@@ -137,6 +140,7 @@ public static class EvidenceFold
                     EvidenceRowKind.Removed,
                     new EvidenceAnchor(oldOcc.IdentityKey, link.OldIndex, -1, oldOcc.ScopeKey),
                     EvidenceDifferenceKind.None,
+                    Confidence: link.Confidence,
                     Payload: oldOcc.Payload);
             }
 

--- a/src/ILInspector.Evidence/EvidenceMatcher.cs
+++ b/src/ILInspector.Evidence/EvidenceMatcher.cs
@@ -46,23 +46,43 @@ public sealed record EvidenceMatch(
     ImmutableArray<EvidenceMatchEntry> Entries,
     ImmutableArray<EvidenceMoveCandidate> MoveCandidates);
 
+/// <summary>
+/// Whether a stream's order is semantic. <see cref="Ordered"/> (IL instructions, C# statements) uses
+/// the LCS + move committer. <see cref="IdentitySet"/> (an unordered set such as a type's members)
+/// bypasses order entirely and commits an identity-key bijection. The choice is per match invocation
+/// and per occurrence level — the same producer can be ordered at one level and a set at another
+/// (C# statements vs a type's member list).
+/// </summary>
+public enum EvidenceStreamKind
+{
+    /// <summary>Order is semantic; use the LCS committer + move pass.</summary>
+    Ordered,
+
+    /// <summary>Order is not semantic; commit an identity-key bijection (hash buckets, O(N)).</summary>
+    IdentitySet,
+}
+
 /// <summary>Tunables for <see cref="EvidenceMatcher.Match"/>.</summary>
+/// <param name="StreamKind">Whether the streams are ordered or an unordered identity set.</param>
 /// <param name="MinMoveRunLength">
 /// The minimum length of a common contiguous residual run to commit as a move. Runs shorter
 /// than this are left to the fringe, which is what gives the conservative default its
 /// mismatch resistance (a lone content-equal occurrence is not silently treated as a move).
+/// Applies only to <see cref="EvidenceStreamKind.Ordered"/> matching.
 /// </param>
-public sealed record EvidenceMatchOptions(int MinMoveRunLength = 2)
+public sealed record EvidenceMatchOptions(
+    EvidenceStreamKind StreamKind = EvidenceStreamKind.Ordered,
+    int MinMoveRunLength = 2)
 {
     public static readonly EvidenceMatchOptions Default = new();
 }
 
 /// <summary>
-/// The single, domain-free matcher every evidence stream shares. It commits an
-/// order-preserving LCS core (which reproduces a classic sequence diff when there are no moves)
-/// and then recovers relocations as a scored move pass over the residual. It never decides
-/// equivalence: it emits classified correspondence, and a consumer <see cref="EvidenceFold"/>
-/// folds it.
+/// The single, domain-free matcher every evidence stream shares. For <see cref="EvidenceStreamKind.Ordered"/>
+/// streams it commits an order-preserving LCS core (reproducing a classic sequence diff when there are no
+/// moves) and recovers relocations with a scored move pass; for <see cref="EvidenceStreamKind.IdentitySet"/>
+/// streams it commits an identity-key bijection with no notion of order. It never decides equivalence: it
+/// emits classified correspondence, and a consumer <see cref="EvidenceFold"/> folds it.
 /// </summary>
 public static class EvidenceMatcher
 {
@@ -82,6 +102,59 @@ public static class EvidenceMatcher
         ArgumentNullException.ThrowIfNull(newStream);
         options ??= EvidenceMatchOptions.Default;
 
+        return options.StreamKind == EvidenceStreamKind.IdentitySet
+            ? MatchIdentitySet(oldStream, newStream)
+            : MatchOrdered(oldStream, newStream, options);
+    }
+
+    // Order-free committer: pair occurrences by identity-key equality (hash buckets, deterministic by
+    // index within a bucket), leftover old -> Removed, leftover new -> Added. O(N) time and space, so
+    // it needs no matrix cell cap and scales to assembly-size member sets. There is no positional move
+    // at this rung — a set has no position; a relocation only appears once a soft tier drops a facet
+    // (e.g. declaring type) from the identity key (see #2585).
+    static EvidenceMatch MatchIdentitySet(
+        IReadOnlyList<EvidenceOccurrence> oldStream,
+        IReadOnlyList<EvidenceOccurrence> newStream)
+    {
+        var newByKey = new Dictionary<string, Queue<int>>();
+        for (int j = 0; j < newStream.Count; j++)
+        {
+            if (!newByKey.TryGetValue(newStream[j].IdentityKey, out var queue))
+                newByKey[newStream[j].IdentityKey] = queue = new Queue<int>();
+            queue.Enqueue(j);
+        }
+
+        var matchedNew = new bool[newStream.Count];
+        var links = ImmutableArray.CreateBuilder<EvidenceMatchEntry>();
+
+        for (int i = 0; i < oldStream.Count; i++)
+        {
+            if (newByKey.TryGetValue(oldStream[i].IdentityKey, out var queue) && queue.Count > 0)
+            {
+                int j = queue.Dequeue();
+                matchedNew[j] = true;
+                links.Add(new EvidenceMatchEntry(EvidenceMatchKind.Matched, i, j, 100));
+            }
+            else
+            {
+                links.Add(new EvidenceMatchEntry(EvidenceMatchKind.Removed, i, -1, 100));
+            }
+        }
+
+        for (int j = 0; j < newStream.Count; j++)
+        {
+            if (!matchedNew[j])
+                links.Add(new EvidenceMatchEntry(EvidenceMatchKind.Added, -1, j, 100));
+        }
+
+        return new EvidenceMatch(links.ToImmutable(), ImmutableArray<EvidenceMoveCandidate>.Empty);
+    }
+
+    static EvidenceMatch MatchOrdered(
+        IReadOnlyList<EvidenceOccurrence> oldStream,
+        IReadOnlyList<EvidenceOccurrence> newStream,
+        EvidenceMatchOptions options)
+    {
         long cells = ((long)oldStream.Count + 1) * ((long)newStream.Count + 1);
         if (cells > MaxOrderedMatchCells)
         {

--- a/src/ILInspector.Evidence/EvidenceRow.cs
+++ b/src/ILInspector.Evidence/EvidenceRow.cs
@@ -88,11 +88,19 @@ public sealed record EvidenceAnchor(
 /// stream-specific detail rides as an opaque <see cref="Payload"/> for display and is
 /// never required to interpret the row.
 /// </summary>
+/// <param name="Confidence">
+/// How confident the match behind this row is, carried from the correspondence entry: 100 for a
+/// committed (exact-identity) match, and lower for a match accepted from the scored fringe. It is on
+/// the row — not just the internal match entry — so a consumer can tell a definite change from a
+/// low-confidence guess once soft matching lands (a hard <see cref="EvidenceRowKind.Changed"/> and a
+/// future fuzzy one would otherwise render identically).
+/// </param>
 public sealed record EvidenceRow(
     EvidenceSubject Subject,
     EvidenceDescriptor Descriptor,
     EvidenceRowKind Kind,
     EvidenceAnchor Anchor,
     EvidenceDifferenceKind DifferenceKind = EvidenceDifferenceKind.None,
+    int Confidence = 100,
     string? Detail = null,
     object? Payload = null);

--- a/src/ILInspector.Instructions.Tests/EvidencePilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/EvidencePilotTests.cs
@@ -108,6 +108,25 @@ public class EvidencePilotTests
     }
 
     [Fact]
+    public void AcceptedFringeMove_CarriesItsConfidenceOntoTheRow()
+    {
+        // The match entry's Confidence must survive onto the row, so a consumer can tell a committed
+        // match (100) from a lower-confidence fringe-accepted one — the basis for distinguishing a
+        // hard Changed from a future fuzzy Changed.
+        var old = Stream("c0", "c1", "c2");
+        var @new = Stream("c1", "c2", "c0");
+        var correspondence = EvidenceMatcher.Match(old, @new);
+
+        var rows = EvidenceFold.ToRows(correspondence, old, @new, Subject, Descriptor, acceptanceThreshold: 50);
+
+        var moved = Assert.Single(rows.Where(r => r.DifferenceKind == EvidenceDifferenceKind.Moved));
+        Assert.Equal(50, moved.Confidence);
+        Assert.All(
+            rows.Where(r => r.DifferenceKind == EvidenceDifferenceKind.None && r.Kind == EvidenceRowKind.Present),
+            r => Assert.Equal(100, r.Confidence));
+    }
+
+    [Fact]
     public void ScopeCorroboration_RaisesFringeScore()
     {
         var old = ImmutableArray.Create(

--- a/src/ILInspector.Instructions.Tests/EvidencePilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/EvidencePilotTests.cs
@@ -213,6 +213,57 @@ public class EvidencePilotTests
     }
 
     [Fact]
+    public void IdentitySet_PermutationIsAllMatched_NoAddRemove()
+    {
+        // Order is not semantic for a set: a permutation is a non-event, unlike the ordered matcher
+        // (which would report it as add/remove). Every element matches by identity key.
+        var old = Stream("A", "B", "C", "D");
+        var @new = Stream("D", "C", "B", "A");
+        var options = new EvidenceMatchOptions(EvidenceStreamKind.IdentitySet);
+
+        var correspondence = EvidenceMatcher.Match(old, @new, options);
+
+        Assert.Equal(4, Count(correspondence, EvidenceMatchKind.Matched));
+        Assert.Equal(0, Count(correspondence, EvidenceMatchKind.Added));
+        Assert.Equal(0, Count(correspondence, EvidenceMatchKind.Removed));
+        Assert.Equal(0, Count(correspondence, EvidenceMatchKind.Moved));
+    }
+
+    [Fact]
+    public void IdentitySet_DistinctMultisets_AreAddRemove()
+    {
+        var old = Stream("A", "B", "B", "C");
+        var @new = Stream("B", "C", "D");
+        var options = new EvidenceMatchOptions(EvidenceStreamKind.IdentitySet);
+
+        var correspondence = EvidenceMatcher.Match(old, @new, options);
+
+        // multiset intersection {B, C} matched; old {A, B} removed; new {D} added.
+        Assert.Equal(2, Count(correspondence, EvidenceMatchKind.Matched));
+        Assert.Equal(2, Count(correspondence, EvidenceMatchKind.Removed));
+        Assert.Equal(1, Count(correspondence, EvidenceMatchKind.Added));
+    }
+
+    [Fact]
+    public void IdentitySet_IsDeterministic_AndScalesPastTheOrderedGuard()
+    {
+        // No O(N*M) matrix, so the identity-set committer handles a stream far larger than the ordered
+        // cell cap without allocating or throwing.
+        var big = Enumerable.Range(0, 20000)
+            .Select(i => new EvidenceOccurrence(i.ToString(System.Globalization.CultureInfo.InvariantCulture)))
+            .ToArray();
+        var options = new EvidenceMatchOptions(EvidenceStreamKind.IdentitySet);
+
+        var first = EvidenceMatcher.Match(big, big, options);
+        var second = EvidenceMatcher.Match(big, big, options);
+
+        Assert.Equal(20000, Count(first, EvidenceMatchKind.Matched));
+        Assert.Equal(0, Count(first, EvidenceMatchKind.Added));
+        Assert.Equal(0, Count(first, EvidenceMatchKind.Removed));
+        Assert.Equal(first.Entries, second.Entries);
+    }
+
+    [Fact]
     public void Match_RejectsStreamsTooLargeForOrderedMatrix()
     {
         // The ordered LCS matrix is O(N*M); guard it so an assembly-scale stream fails loudly


### PR DESCRIPTION
## Matcher foundation for the ladder (#2585 rung-1 prep)

Two backward-compatible, foundational additions to the shared matcher/leaf, ahead of the hard→soft
ladder. Both came out of the #2585 review.

### 1. Confidence on the row (`daa5f7f3`) — blocker 1

`EvidenceMatchEntry.Confidence` already existed but `EvidenceFold.ToRow` dropped it, so a
fringe-accepted `Moved` row (lowered acceptance threshold) already lost its 50/75. `EvidenceRow` now
carries `Confidence` (default 100, backward-compatible), propagated through the fold. A committed match
reads 100; a fringe-accepted one reads its score — the basis for telling a hard `Changed` (100) from a
future fuzzy `Changed` once soft tiers land.

### 2. `EvidenceStreamKind.IdentitySet` set-mode committer (`f465f606`)

The ordered matcher assumes order is semantic. A set (a type's member list, API surface) has none, so a
permutation must be a non-event. `EvidenceMatchOptions.StreamKind {Ordered, IdentitySet}` (per-invocation
/ per-occurrence-level — C# is ordered at statement level, set-like at member level) selects a
`MatchIdentitySet` committer: an identity-key bijection over hash buckets, deterministic by index within a
bucket. **O(N)** — no matrix, no cell cap, scales to assembly-size sets (the ordered guard's OOM path is
not taken). No positional move at this rung; a relocation appears only once a soft tier drops a facet
(e.g. declaring type). **This unblocks the Metadata/API producer.**

### Validation
- 30 pilot tests green (incl. permutation-is-all-matched, distinct-multisets, determinism + 20k-element scale).
- Both changes are additive/backward-compatible; the merged IL pilot is untouched behaviorally.

Rung-2 (soft tiers, LSH blocking, tier/delta on the row, structured-identity ladder) tracked in #2585.

Refs #2564, #2585.
