### PR TITLE
Evidence spine: Metadata/API producer (MetadataEvidence)

### DIFF
--- a/src/ILInspector.Evidence/EvidenceFold.cs
+++ b/src/ILInspector.Evidence/EvidenceFold.cs
@@ -98,6 +98,7 @@ public static class EvidenceFold
                     EvidenceRowKind.Present,
                     new EvidenceAnchor(oldOcc.IdentityKey, link.OldIndex, link.NewIndex, oldOcc.ScopeKey),
                     EvidenceDifferenceKind.None,
+                    Confidence: link.Confidence,
                     Payload: newOcc.Payload);
             }
 
@@ -112,6 +113,7 @@ public static class EvidenceFold
                     EvidenceRowKind.Present,
                     new EvidenceAnchor(oldOcc.IdentityKey, link.OldIndex, link.NewIndex, oldOcc.ScopeKey),
                     EvidenceDifferenceKind.Moved,
+                    Confidence: link.Confidence,
                     Detail: $"moved {delta:+#;-#;0}",
                     Payload: newOcc.Payload);
             }
@@ -125,6 +127,7 @@ public static class EvidenceFold
                     EvidenceRowKind.Added,
                     new EvidenceAnchor(newOcc.IdentityKey, -1, link.NewIndex, newOcc.ScopeKey),
                     EvidenceDifferenceKind.None,
+                    Confidence: link.Confidence,
                     Payload: newOcc.Payload);
             }
 
@@ -137,6 +140,7 @@ public static class EvidenceFold
                     EvidenceRowKind.Removed,
                     new EvidenceAnchor(oldOcc.IdentityKey, link.OldIndex, -1, oldOcc.ScopeKey),
                     EvidenceDifferenceKind.None,
+                    Confidence: link.Confidence,
                     Payload: oldOcc.Payload);
             }
 

--- a/src/ILInspector.Evidence/EvidenceMatcher.cs
+++ b/src/ILInspector.Evidence/EvidenceMatcher.cs
@@ -46,23 +46,43 @@ public sealed record EvidenceMatch(
     ImmutableArray<EvidenceMatchEntry> Entries,
     ImmutableArray<EvidenceMoveCandidate> MoveCandidates);
 
+/// <summary>
+/// Whether a stream's order is semantic. <see cref="Ordered"/> (IL instructions, C# statements) uses
+/// the LCS + move committer. <see cref="IdentitySet"/> (an unordered set such as a type's members)
+/// bypasses order entirely and commits an identity-key bijection. The choice is per match invocation
+/// and per occurrence level — the same producer can be ordered at one level and a set at another
+/// (C# statements vs a type's member list).
+/// </summary>
+public enum EvidenceStreamKind
+{
+    /// <summary>Order is semantic; use the LCS committer + move pass.</summary>
+    Ordered,
+
+    /// <summary>Order is not semantic; commit an identity-key bijection (hash buckets, O(N)).</summary>
+    IdentitySet,
+}
+
 /// <summary>Tunables for <see cref="EvidenceMatcher.Match"/>.</summary>
+/// <param name="StreamKind">Whether the streams are ordered or an unordered identity set.</param>
 /// <param name="MinMoveRunLength">
 /// The minimum length of a common contiguous residual run to commit as a move. Runs shorter
 /// than this are left to the fringe, which is what gives the conservative default its
 /// mismatch resistance (a lone content-equal occurrence is not silently treated as a move).
+/// Applies only to <see cref="EvidenceStreamKind.Ordered"/> matching.
 /// </param>
-public sealed record EvidenceMatchOptions(int MinMoveRunLength = 2)
+public sealed record EvidenceMatchOptions(
+    EvidenceStreamKind StreamKind = EvidenceStreamKind.Ordered,
+    int MinMoveRunLength = 2)
 {
     public static readonly EvidenceMatchOptions Default = new();
 }
 
 /// <summary>
-/// The single, domain-free matcher every evidence stream shares. It commits an
-/// order-preserving LCS core (which reproduces a classic sequence diff when there are no moves)
-/// and then recovers relocations as a scored move pass over the residual. It never decides
-/// equivalence: it emits classified correspondence, and a consumer <see cref="EvidenceFold"/>
-/// folds it.
+/// The single, domain-free matcher every evidence stream shares. For <see cref="EvidenceStreamKind.Ordered"/>
+/// streams it commits an order-preserving LCS core (reproducing a classic sequence diff when there are no
+/// moves) and recovers relocations with a scored move pass; for <see cref="EvidenceStreamKind.IdentitySet"/>
+/// streams it commits an identity-key bijection with no notion of order. It never decides equivalence: it
+/// emits classified correspondence, and a consumer <see cref="EvidenceFold"/> folds it.
 /// </summary>
 public static class EvidenceMatcher
 {
@@ -82,6 +102,59 @@ public static class EvidenceMatcher
         ArgumentNullException.ThrowIfNull(newStream);
         options ??= EvidenceMatchOptions.Default;
 
+        return options.StreamKind == EvidenceStreamKind.IdentitySet
+            ? MatchIdentitySet(oldStream, newStream)
+            : MatchOrdered(oldStream, newStream, options);
+    }
+
+    // Order-free committer: pair occurrences by identity-key equality (hash buckets, deterministic by
+    // index within a bucket), leftover old -> Removed, leftover new -> Added. O(N) time and space, so
+    // it needs no matrix cell cap and scales to assembly-size member sets. There is no positional move
+    // at this rung — a set has no position; a relocation only appears once a soft tier drops a facet
+    // (e.g. declaring type) from the identity key (see #2585).
+    static EvidenceMatch MatchIdentitySet(
+        IReadOnlyList<EvidenceOccurrence> oldStream,
+        IReadOnlyList<EvidenceOccurrence> newStream)
+    {
+        var newByKey = new Dictionary<string, Queue<int>>();
+        for (int j = 0; j < newStream.Count; j++)
+        {
+            if (!newByKey.TryGetValue(newStream[j].IdentityKey, out var queue))
+                newByKey[newStream[j].IdentityKey] = queue = new Queue<int>();
+            queue.Enqueue(j);
+        }
+
+        var matchedNew = new bool[newStream.Count];
+        var links = ImmutableArray.CreateBuilder<EvidenceMatchEntry>();
+
+        for (int i = 0; i < oldStream.Count; i++)
+        {
+            if (newByKey.TryGetValue(oldStream[i].IdentityKey, out var queue) && queue.Count > 0)
+            {
+                int j = queue.Dequeue();
+                matchedNew[j] = true;
+                links.Add(new EvidenceMatchEntry(EvidenceMatchKind.Matched, i, j, 100));
+            }
+            else
+            {
+                links.Add(new EvidenceMatchEntry(EvidenceMatchKind.Removed, i, -1, 100));
+            }
+        }
+
+        for (int j = 0; j < newStream.Count; j++)
+        {
+            if (!matchedNew[j])
+                links.Add(new EvidenceMatchEntry(EvidenceMatchKind.Added, -1, j, 100));
+        }
+
+        return new EvidenceMatch(links.ToImmutable(), ImmutableArray<EvidenceMoveCandidate>.Empty);
+    }
+
+    static EvidenceMatch MatchOrdered(
+        IReadOnlyList<EvidenceOccurrence> oldStream,
+        IReadOnlyList<EvidenceOccurrence> newStream,
+        EvidenceMatchOptions options)
+    {
         long cells = ((long)oldStream.Count + 1) * ((long)newStream.Count + 1);
         if (cells > MaxOrderedMatchCells)
         {

--- a/src/ILInspector.Evidence/EvidenceRow.cs
+++ b/src/ILInspector.Evidence/EvidenceRow.cs
@@ -88,11 +88,19 @@ public sealed record EvidenceAnchor(
 /// stream-specific detail rides as an opaque <see cref="Payload"/> for display and is
 /// never required to interpret the row.
 /// </summary>
+/// <param name="Confidence">
+/// How confident the match behind this row is, carried from the correspondence entry: 100 for a
+/// committed (exact-identity) match, and lower for a match accepted from the scored fringe. It is on
+/// the row — not just the internal match entry — so a consumer can tell a definite change from a
+/// low-confidence guess once soft matching lands (a hard <see cref="EvidenceRowKind.Changed"/> and a
+/// future fuzzy one would otherwise render identically).
+/// </param>
 public sealed record EvidenceRow(
     EvidenceSubject Subject,
     EvidenceDescriptor Descriptor,
     EvidenceRowKind Kind,
     EvidenceAnchor Anchor,
     EvidenceDifferenceKind DifferenceKind = EvidenceDifferenceKind.None,
+    int Confidence = 100,
     string? Detail = null,
     object? Payload = null);

--- a/src/ILInspector.Instructions.Tests/EvidencePilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/EvidencePilotTests.cs
@@ -108,6 +108,25 @@ public class EvidencePilotTests
     }
 
     [Fact]
+    public void AcceptedFringeMove_CarriesItsConfidenceOntoTheRow()
+    {
+        // The match entry's Confidence must survive onto the row, so a consumer can tell a committed
+        // match (100) from a lower-confidence fringe-accepted one — the basis for distinguishing a
+        // hard Changed from a future fuzzy Changed.
+        var old = Stream("c0", "c1", "c2");
+        var @new = Stream("c1", "c2", "c0");
+        var correspondence = EvidenceMatcher.Match(old, @new);
+
+        var rows = EvidenceFold.ToRows(correspondence, old, @new, Subject, Descriptor, acceptanceThreshold: 50);
+
+        var moved = Assert.Single(rows.Where(r => r.DifferenceKind == EvidenceDifferenceKind.Moved));
+        Assert.Equal(50, moved.Confidence);
+        Assert.All(
+            rows.Where(r => r.DifferenceKind == EvidenceDifferenceKind.None && r.Kind == EvidenceRowKind.Present),
+            r => Assert.Equal(100, r.Confidence));
+    }
+
+    [Fact]
     public void ScopeCorroboration_RaisesFringeScore()
     {
         var old = ImmutableArray.Create(

--- a/src/ILInspector.Instructions.Tests/EvidencePilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/EvidencePilotTests.cs
@@ -213,6 +213,57 @@ public class EvidencePilotTests
     }
 
     [Fact]
+    public void IdentitySet_PermutationIsAllMatched_NoAddRemove()
+    {
+        // Order is not semantic for a set: a permutation is a non-event, unlike the ordered matcher
+        // (which would report it as add/remove). Every element matches by identity key.
+        var old = Stream("A", "B", "C", "D");
+        var @new = Stream("D", "C", "B", "A");
+        var options = new EvidenceMatchOptions(EvidenceStreamKind.IdentitySet);
+
+        var correspondence = EvidenceMatcher.Match(old, @new, options);
+
+        Assert.Equal(4, Count(correspondence, EvidenceMatchKind.Matched));
+        Assert.Equal(0, Count(correspondence, EvidenceMatchKind.Added));
+        Assert.Equal(0, Count(correspondence, EvidenceMatchKind.Removed));
+        Assert.Equal(0, Count(correspondence, EvidenceMatchKind.Moved));
+    }
+
+    [Fact]
+    public void IdentitySet_DistinctMultisets_AreAddRemove()
+    {
+        var old = Stream("A", "B", "B", "C");
+        var @new = Stream("B", "C", "D");
+        var options = new EvidenceMatchOptions(EvidenceStreamKind.IdentitySet);
+
+        var correspondence = EvidenceMatcher.Match(old, @new, options);
+
+        // multiset intersection {B, C} matched; old {A, B} removed; new {D} added.
+        Assert.Equal(2, Count(correspondence, EvidenceMatchKind.Matched));
+        Assert.Equal(2, Count(correspondence, EvidenceMatchKind.Removed));
+        Assert.Equal(1, Count(correspondence, EvidenceMatchKind.Added));
+    }
+
+    [Fact]
+    public void IdentitySet_IsDeterministic_AndScalesPastTheOrderedGuard()
+    {
+        // No O(N*M) matrix, so the identity-set committer handles a stream far larger than the ordered
+        // cell cap without allocating or throwing.
+        var big = Enumerable.Range(0, 20000)
+            .Select(i => new EvidenceOccurrence(i.ToString(System.Globalization.CultureInfo.InvariantCulture)))
+            .ToArray();
+        var options = new EvidenceMatchOptions(EvidenceStreamKind.IdentitySet);
+
+        var first = EvidenceMatcher.Match(big, big, options);
+        var second = EvidenceMatcher.Match(big, big, options);
+
+        Assert.Equal(20000, Count(first, EvidenceMatchKind.Matched));
+        Assert.Equal(0, Count(first, EvidenceMatchKind.Added));
+        Assert.Equal(0, Count(first, EvidenceMatchKind.Removed));
+        Assert.Equal(first.Entries, second.Entries);
+    }
+
+    [Fact]
     public void Match_RejectsStreamsTooLargeForOrderedMatrix()
     {
         // The ordered LCS matrix is O(N*M); guard it so an assembly-scale stream fails loudly

--- a/src/ILInspector.Metadata/ILInspector.Metadata.csproj
+++ b/src/ILInspector.Metadata/ILInspector.Metadata.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ILInspector.Evidence\ILInspector.Evidence.csproj" />
     <ProjectReference Include="..\ILInspector.Instructions\ILInspector.Instructions.csproj" />
     <ProjectReference Include="..\ILInspector.MetadataPrimitives\ILInspector.MetadataPrimitives.csproj" />
   </ItemGroup>

--- a/src/ILInspector.Metadata/MetadataEvidence.cs
+++ b/src/ILInspector.Metadata/MetadataEvidence.cs
@@ -1,0 +1,217 @@
+using System.Collections.Immutable;
+
+using ILInspector.Evidence;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Adapts an API surface onto the domain-free evidence substrate. The rung-0 occurrence unit is a
+/// member declaration, matched as an unordered identity set by the canonical metadata member
+/// signature; matched members are then checked for API facets outside that identity.
+/// </summary>
+public static class MetadataEvidence
+{
+    /// <summary>The evidence descriptor for a single API member occurrence.</summary>
+    public static readonly EvidenceDescriptor MemberDescriptor = new("api.member", "API member");
+
+    static readonly EvidenceMatchOptions MemberSetOptions = new(EvidenceStreamKind.IdentitySet);
+    static readonly ApiDiffOptions DiffOptions = new(ApiDiffScope.All);
+
+    public static MetadataEvidenceResult Compare(
+        ApiSurface oldSurface,
+        ApiSurface newSurface,
+        EvidenceSubject subject,
+        int acceptanceThreshold = 100)
+    {
+        if (oldSurface is null)
+            return MetadataEvidenceResult.Failed("old API surface is null");
+        if (newSurface is null)
+            return MetadataEvidenceResult.Failed("new API surface is null");
+        if (subject is null)
+            return MetadataEvidenceResult.Failed("evidence subject is null");
+
+        ImmutableArray<EvidenceOccurrence> oldStream;
+        ImmutableArray<EvidenceOccurrence> newStream;
+        ApiDiff apiDiff;
+        EvidenceMatch correspondence;
+
+        try
+        {
+            oldStream = BuildOccurrences(oldSurface);
+            newStream = BuildOccurrences(newSurface);
+            apiDiff = ApiDiffAnalyzer.Compare(oldSurface, newSurface, DiffOptions);
+            correspondence = EvidenceMatcher.Match(oldStream, newStream, MemberSetOptions);
+        }
+        catch (ArgumentException ex)
+        {
+            return MetadataEvidenceResult.Failed(ex.Message);
+        }
+
+        var rows = EvidenceFold.ToRows(correspondence, oldStream, newStream, subject, MemberDescriptor, acceptanceThreshold);
+        rows = ApplyApiFacetChanges(rows, oldStream, newStream, apiDiff);
+        return new MetadataEvidenceResult(rows, correspondence, oldStream, newStream, apiDiff, Failure: null);
+    }
+
+    static ImmutableArray<EvidenceOccurrence> BuildOccurrences(ApiSurface surface)
+    {
+        var builder = ImmutableArray.CreateBuilder<EvidenceOccurrence>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var (type, member) in EnumerateMembers(surface))
+        {
+            var handle = ApiMemberIdentity.CreateHandle(type, member);
+            var key = handle.CanonicalSignature ?? handle.Identity;
+            if (!seen.Add(key))
+                continue;
+
+            builder.Add(new EvidenceOccurrence(
+                key,
+                ScopeKey: MetadataTypeNameFormatter.FormatFullName(type),
+                Payload: handle));
+        }
+
+        return builder.ToImmutable();
+    }
+
+    static IEnumerable<(ApiType Type, ApiMember Member)> EnumerateMembers(ApiSurface surface)
+    {
+        foreach (var type in surface.Types)
+        {
+            foreach (var member in type.Members)
+            {
+                if (!MemberFilters.IsCompilerGenerated(member.Name))
+                    yield return (type, member);
+            }
+        }
+    }
+
+    static ImmutableArray<EvidenceRow> ApplyApiFacetChanges(
+        ImmutableArray<EvidenceRow> rows,
+        IReadOnlyList<EvidenceOccurrence> oldStream,
+        IReadOnlyList<EvidenceOccurrence> newStream,
+        ApiDiff apiDiff)
+    {
+        var apiChangesByKey = BuildApiChangeMap(apiDiff);
+        var builder = ImmutableArray.CreateBuilder<EvidenceRow>(rows.Length);
+        foreach (var row in rows)
+        {
+            if (row.Kind != EvidenceRowKind.Present || row.Anchor.OldIndex < 0 || row.Anchor.NewIndex < 0)
+            {
+                builder.Add(row);
+                continue;
+            }
+
+            var oldHandle = (ApiMemberHandle?)oldStream[row.Anchor.OldIndex].Payload;
+            var newHandle = (ApiMemberHandle?)newStream[row.Anchor.NewIndex].Payload;
+            if (oldHandle is null || newHandle is null)
+            {
+                builder.Add(row);
+                continue;
+            }
+
+            var details = new List<string>();
+            if (apiChangesByKey.TryGetValue(row.Anchor.IdentityKey, out var apiChanges))
+                details.AddRange(apiChanges.Select(FormatApiChange));
+            AddFacetDetails(oldHandle.Member, newHandle.Member, details);
+
+            if (details.Count == 0)
+            {
+                builder.Add(row);
+                continue;
+            }
+
+            builder.Add(row with
+            {
+                Kind = EvidenceRowKind.Changed,
+                Detail = string.Join("; ", details.Distinct(StringComparer.Ordinal))
+            });
+        }
+
+        return builder.MoveToImmutable();
+    }
+
+    static Dictionary<string, List<ApiChange>> BuildApiChangeMap(ApiDiff apiDiff)
+    {
+        var changesByKey = new Dictionary<string, List<ApiChange>>(StringComparer.Ordinal);
+        foreach (var change in apiDiff.TypeDiffs.SelectMany(typeDiff => typeDiff.Changes))
+        {
+            if (change.Subject?.Kind != ApiChangeSubjectKind.Member)
+                continue;
+
+            var oldKey = change.Subject.OldMember?.CanonicalSignature;
+            var newKey = change.Subject.NewMember?.CanonicalSignature;
+            if (oldKey is null || newKey is null || oldKey != newKey)
+                continue;
+
+            if (!changesByKey.TryGetValue(newKey, out var changes))
+            {
+                changes = [];
+                changesByKey.Add(newKey, changes);
+            }
+
+            changes.Add(change);
+        }
+
+        return changesByKey;
+    }
+
+    static string FormatApiChange(ApiChange change)
+    {
+        var detail = $"{change.Category}: {change.Kind}";
+        if (!string.IsNullOrEmpty(change.OldValue) || !string.IsNullOrEmpty(change.NewValue))
+            detail += $" ({FormatValue(change.OldValue)} -> {FormatValue(change.NewValue)})";
+        return detail;
+    }
+
+    static void AddFacetDetails(ApiMember oldMember, ApiMember newMember, List<string> details)
+    {
+        AddFacetDetail(details, "signature", oldMember.Signature, newMember.Signature);
+        AddFacetDetail(details, "return type", oldMember.ReturnType, newMember.ReturnType);
+        AddFacetDetail(details, "accessibility", NormalizeAccessibility(oldMember.Accessibility), NormalizeAccessibility(newMember.Accessibility));
+        AddFacetDetail(details, "static", oldMember.IsStatic ? "static" : "instance", newMember.IsStatic ? "static" : "instance");
+        AddFacetDetail(details, "virtual", oldMember.IsVirtual, newMember.IsVirtual);
+        AddFacetDetail(details, "abstract", oldMember.IsAbstract, newMember.IsAbstract);
+        AddFacetDetail(details, "override", oldMember.IsOverride, newMember.IsOverride);
+        AddFacetDetail(details, "sealed", oldMember.IsSealed, newMember.IsSealed);
+        AddFacetDetail(details, "readonly", oldMember.IsReadOnly, newMember.IsReadOnly);
+        AddFacetDetail(details, "const", oldMember.IsConst, newMember.IsConst);
+        AddFacetDetail(details, "unsafe", oldMember.IsUnsafe, newMember.IsUnsafe);
+        AddFacetDetail(details, "extension", oldMember.IsExtension, newMember.IsExtension);
+        AddFacetDetail(details, "extended type", oldMember.ExtendedType, newMember.ExtendedType);
+        AddFacetDetail(details, "obsolete", oldMember.IsObsolete, newMember.IsObsolete);
+        AddFacetDetail(details, "obsolete message", oldMember.ObsoleteMessage, newMember.ObsoleteMessage);
+    }
+
+    static void AddFacetDetail(List<string> details, string name, bool oldValue, bool newValue)
+    {
+        if (oldValue != newValue)
+            details.Add($"{name}: {oldValue.ToString().ToLowerInvariant()} -> {newValue.ToString().ToLowerInvariant()}");
+    }
+
+    static void AddFacetDetail(List<string> details, string name, string? oldValue, string? newValue)
+    {
+        if (!string.Equals(oldValue, newValue, StringComparison.Ordinal))
+            details.Add($"{name}: {FormatValue(oldValue)} -> {FormatValue(newValue)}");
+    }
+
+    static string NormalizeAccessibility(string? accessibility)
+        => string.IsNullOrWhiteSpace(accessibility) ? "public" : accessibility!;
+
+    static string FormatValue(string? value)
+        => string.IsNullOrEmpty(value) ? "none" : value;
+}
+
+/// <summary>The outcome of a <see cref="MetadataEvidence.Compare"/> call.</summary>
+public sealed record MetadataEvidenceResult(
+    ImmutableArray<EvidenceRow> Rows,
+    EvidenceMatch Match,
+    ImmutableArray<EvidenceOccurrence> OldOccurrences,
+    ImmutableArray<EvidenceOccurrence> NewOccurrences,
+    ApiDiff ApiDiff,
+    string? Failure)
+{
+    /// <summary>True when the member set is exact under the fidelity fold.</summary>
+    public bool IsExact => Failure is null && EvidenceEquivalence.Exact.IsEquivalent(Rows);
+
+    public static MetadataEvidenceResult Failed(string failure)
+        => new([], new EvidenceMatch([], []), [], [], new ApiDiff(), failure);
+}

--- a/tests/ILInspector.Metadata.Tests/MetadataEvidenceTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataEvidenceTests.cs
@@ -1,0 +1,248 @@
+using System.Collections.Immutable;
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Evidence;
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests;
+
+public class MetadataEvidenceTests
+{
+    static readonly EvidenceSubject Subject = new("api", "API");
+
+    [Fact]
+    public void SameSurface_IsExactAndAllPresent()
+    {
+        var surface = Surface(Type("Widget", members:
+        [
+            Method("Get", "int Get()"),
+            Property("Name", "string Name { get; }")
+        ]));
+
+        var result = MetadataEvidence.Compare(surface, surface, Subject);
+
+        Assert.Null(result.Failure);
+        Assert.True(result.IsExact);
+        Assert.All(result.Rows, row => Assert.Equal(EvidenceRowKind.Present, row.Kind));
+        Assert.All(result.Rows, row => Assert.Equal(EvidenceDifferenceKind.None, row.DifferenceKind));
+    }
+
+    [Fact]
+    public void AddedAndRemovedMembers_AgreeWithApiDiffAnalyzer()
+    {
+        var oldSurface = Surface(Type("Widget", members:
+        [
+            Method("Keep", "void Keep()"),
+            Method("Removed", "void Removed()")
+        ]));
+        var newSurface = Surface(Type("Widget", members:
+        [
+            Method("Keep", "void Keep()"),
+            Method("Added", "void Added()")
+        ]));
+
+        var result = MetadataEvidence.Compare(oldSurface, newSurface, Subject);
+        var expected = ExpectedFromApiDiff(oldSurface, newSurface);
+
+        Assert.Null(result.Failure);
+        Assert.Equal(expected.Added, RowKeys(result.Rows, EvidenceRowKind.Added));
+        Assert.Equal(expected.Removed, RowKeys(result.Rows, EvidenceRowKind.Removed));
+        Assert.Empty(RowKeys(result.Rows, EvidenceRowKind.Changed));
+    }
+
+    [Fact]
+    public void MatchedMemberFacetChanges_AreChangedRows()
+    {
+        var oldSurface = Surface(Type("Widget", members:
+        [
+            Method("Run", "void Run()")
+        ]));
+        var newSurface = Surface(Type("Widget", members:
+        [
+            Method("Run", "void Run()", accessibility: "protected", isObsolete: true, attributes: ["System.ObsoleteAttribute"])
+        ]));
+
+        var result = MetadataEvidence.Compare(oldSurface, newSurface, Subject);
+
+        var row = Assert.Single(result.Rows);
+        Assert.Equal(EvidenceRowKind.Changed, row.Kind);
+        Assert.Contains("accessibility: public -> protected", row.Detail ?? "", StringComparison.Ordinal);
+        Assert.Contains("obsolete: false -> true", row.Detail ?? "", StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReorderedMembers_AreAllPresentUnderIdentitySetMode()
+    {
+        var oldSurface = Surface(Type("Widget", members:
+        [
+            Method("A", "void A()"),
+            Method("B", "void B()"),
+            Method("C", "void C()")
+        ]));
+        var newSurface = Surface(Type("Widget", members:
+        [
+            Method("C", "void C()"),
+            Method("A", "void A()"),
+            Method("B", "void B()")
+        ]));
+
+        var result = MetadataEvidence.Compare(oldSurface, newSurface, Subject);
+
+        Assert.Null(result.Failure);
+        Assert.True(result.IsExact);
+        Assert.Equal(3, result.Rows.Length);
+        Assert.All(result.Rows, row => Assert.Equal(EvidenceRowKind.Present, row.Kind));
+        Assert.All(result.Rows, row => Assert.Equal(EvidenceDifferenceKind.None, row.DifferenceKind));
+        Assert.DoesNotContain(result.Rows, row => row.Kind is EvidenceRowKind.Added or EvidenceRowKind.Removed);
+    }
+
+    [Fact]
+    public void Exactness_AgreesWithApiDiffAnalyzer_AcrossFixtures()
+    {
+        (ApiSurface Old, ApiSurface New)[] pairs =
+        [
+            (
+                Surface(Type("Widget", members: [Method("A", "void A()")])),
+                Surface(Type("Widget", members: [Method("A", "void A()")]))
+            ),
+            (
+                Surface(Type("Widget", members: [Method("A", "void A()")])),
+                Surface(Type("Widget", members: [Method("A", "void A()"), Method("B", "void B()")]))
+            ),
+            (
+                Surface(Type("Widget", members: [Method("A", "void A()"), Method("B", "void B()")])),
+                Surface(Type("Widget", members: [Method("A", "void A()")]))
+            ),
+            (
+                Surface(Type("Widget", members: [Method("A", "void A()", isVirtual: true)])),
+                Surface(Type("Widget", members: [Method("A", "void A()")]))
+            ),
+            (
+                Surface(Type("Widget", members: [Method("A", "void A(int value)")])),
+                Surface(Type("Widget", members: [Method("A", "void A(string value)")]))
+            ),
+            (
+                Surface(Type("Widget", members: [Method("A", "int A()")])),
+                Surface(Type("Widget", members: [Method("A", "string A()")]))
+            ),
+            (
+                Surface(Type("Widget", members: [Method("A", "void A()")])),
+                Surface(Type("Widget", members: [Method("A", "void A()", isObsolete: true, attributes: ["System.ObsoleteAttribute"])]))
+            )
+        ];
+
+        foreach (var (oldSurface, newSurface) in pairs)
+        {
+            var result = MetadataEvidence.Compare(oldSurface, newSurface, Subject);
+            var expected = ExpectedFromApiDiff(oldSurface, newSurface);
+
+            Assert.Null(result.Failure);
+            Assert.Equal(expected.Added, RowKeys(result.Rows, EvidenceRowKind.Added));
+            Assert.Equal(expected.Removed, RowKeys(result.Rows, EvidenceRowKind.Removed));
+            Assert.Equal(expected.Changed, RowKeys(result.Rows, EvidenceRowKind.Changed));
+        }
+    }
+
+    [Fact]
+    public void RealAssemblySelfCompare_IsExact()
+    {
+        using var stream = File.OpenRead(typeof(ApiDiffAnalyzer).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        var result = MetadataEvidence.Compare(surface, surface, Subject);
+
+        Assert.Null(result.Failure);
+        Assert.True(result.IsExact);
+        Assert.True(result.Rows.Length > 50, $"expected a substantial real API member corpus; rows={result.Rows.Length}");
+        Assert.All(result.Rows, row => Assert.Equal(EvidenceRowKind.Present, row.Kind));
+    }
+
+    static ApiSurface Surface(params ApiType[] types)
+    {
+        var surface = new ApiSurface();
+        surface.Types.AddRange(types);
+        return surface;
+    }
+
+    static ApiType Type(string name, string kind = "class", string? ns = "TestNamespace", List<ApiMember>? members = null)
+        => new()
+        {
+            Name = name,
+            Kind = kind,
+            Namespace = ns,
+            Members = members ?? []
+        };
+
+    static ApiMember Method(
+        string name,
+        string signature,
+        bool isVirtual = false,
+        bool isObsolete = false,
+        string? accessibility = null,
+        IReadOnlyList<string>? attributes = null)
+        => new()
+        {
+            Name = name,
+            Kind = "method",
+            Signature = signature,
+            IsVirtual = isVirtual,
+            IsObsolete = isObsolete,
+            Accessibility = accessibility,
+            Attributes = attributes?.ToList() ?? []
+        };
+
+    static ApiMember Property(string name, string signature)
+        => new() { Name = name, Kind = "property", Signature = signature };
+
+    static string[] RowKeys(ImmutableArray<EvidenceRow> rows, EvidenceRowKind kind)
+        => rows
+            .Where(row => row.Kind == kind)
+            .Select(row => row.Anchor.IdentityKey)
+            .OrderBy(key => key, StringComparer.Ordinal)
+            .ToArray();
+
+    static ExpectedEvidence ExpectedFromApiDiff(ApiSurface oldSurface, ApiSurface newSurface)
+    {
+        var added = new List<string>();
+        var removed = new List<string>();
+        var changed = new List<string>();
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface, new ApiDiffOptions(ApiDiffScope.All));
+
+        foreach (var change in diff.TypeDiffs.SelectMany(typeDiff => typeDiff.Changes))
+        {
+            if (change.Subject?.Kind != ApiChangeSubjectKind.Member)
+                continue;
+
+            var oldKey = change.Subject.OldMember?.CanonicalSignature;
+            var newKey = change.Subject.NewMember?.CanonicalSignature;
+            switch (change.Kind)
+            {
+                case ChangeKind.MemberAdded when newKey is not null:
+                    added.Add(newKey);
+                    break;
+                case ChangeKind.MemberRemoved when oldKey is not null:
+                    removed.Add(oldKey);
+                    break;
+                case ChangeKind.MemberSignatureChanged when oldKey is not null && newKey is not null && oldKey != newKey:
+                    removed.Add(oldKey);
+                    added.Add(newKey);
+                    break;
+                case ChangeKind.MemberSignatureChanged when newKey is not null:
+                    changed.Add(newKey);
+                    break;
+                default:
+                    if (oldKey is not null && oldKey == newKey)
+                        changed.Add(oldKey);
+                    break;
+            }
+        }
+
+        return new ExpectedEvidence(
+            [.. added.Distinct(StringComparer.Ordinal).OrderBy(key => key, StringComparer.Ordinal)],
+            [.. removed.Distinct(StringComparer.Ordinal).OrderBy(key => key, StringComparer.Ordinal)],
+            [.. changed.Distinct(StringComparer.Ordinal).OrderBy(key => key, StringComparer.Ordinal)]);
+    }
+
+    sealed record ExpectedEvidence(string[] Added, string[] Removed, string[] Changed);
+}


### PR DESCRIPTION
## Summary

Refs #2564 #2585. Draft stacked on #2587 / `origin/feature/issue-2585-matcher-setmode`; this PR targets `main` and should be rebased after #2587 merges.

Adds `MetadataEvidence` in `ILInspector.Metadata` as the API-surface evidence producer:

- projects API members into `api.member` evidence occurrences
- uses `EvidenceStreamKind.IdentitySet` so member order permutations are non-events
- uses `ApiMemberIdentity` / `ApiMemberHandle.CanonicalSignature` as the identity key
- carries declaring type as `ScopeKey` for a future relocation tier
- folds matcher output into `EvidenceRow`s and marks matched members `Changed` when API facets outside identity differ

## Design decisions

- Occurrence granularity is member-only for rung 0; type-level evidence is left out to avoid mixing levels in the first API producer.
- Identity key includes the declaring type through the canonical member signature, so moving a member between types is exact `Removed` + `Added` for now.
- Attach classifies exact matched-member facet changes: signature/display facets, return type, accessibility, static/virtual/abstract/override/sealed/readonly/const/unsafe/extension, extended type, obsolete flag/message, plus member changes reported by `ApiDiffAnalyzer` with `ApiDiffScope.All`.
- No rename, relocation, or soft matching is attempted.

## Open questions

- Whether a future rung should add type occurrences alongside member occurrences, or keep type evidence as a separate producer.
- Which facts should graduate into identity versus remain Attach facets, especially property/field return type and accessibility/static changes.
- Whether `ApiDiffAnalyzer` should expose a first-class public member enumeration/identity helper for consumers beyond `ApiMemberIdentity.CreateHandle`.

## Validation

- `dotnet build tests/ILInspector.Metadata.Tests/ILInspector.Metadata.Tests.csproj -c Release --configfile nuget.config`
- `dotnet run --project tests/ILInspector.Metadata.Tests/ILInspector.Metadata.Tests.csproj -c Release -- -class "*MetadataEvidenceTests"`
- `dotnet run --project tests/ILInspector.Metadata.Tests/ILInspector.Metadata.Tests.csproj -c Release`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `dotnet build dotnet-inspect.slnx -c Release --no-restore -v:quiet`

Real-assembly self-compare corpus: `ILInspector.Metadata` surface with 179 types / 2,394 member rows; exact, 2,394 Present, 0 Added, 0 Removed, 0 Changed, 0 failures.

No adversarial review run here; requested separately/orchestrated externally.