### PR TITLE
Rename Evidence spine leaf to Findings

### DIFF
--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -28,7 +28,7 @@
     <Project Path="src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj" />
     <Project Path="src/ILInspector.Analysis/ILInspector.Analysis.csproj" />
     <Project Path="src/ILInspector.ControlFlow/ILInspector.ControlFlow.csproj" />
-    <Project Path="src/ILInspector.Evidence/ILInspector.Evidence.csproj" />
+    <Project Path="src/ILInspector.Findings/ILInspector.Findings.csproj" />
     <Project Path="src/ILInspector.Decompiler.Fixtures.CheckedArithmetic/ILInspector.Decompiler.Fixtures.CheckedArithmetic.csproj" />
     <Project Path="src/ILInspector.Decompiler.Fixtures.ClassicAsync/ILInspector.Decompiler.Fixtures.ClassicAsync.csproj" />
     <Project Path="src/ILInspector.Decompiler.Fixtures.Ladder/ILInspector.Decompiler.Fixtures.Ladder.csproj" />

--- a/src/ILInspector.Findings/Finding.cs
+++ b/src/ILInspector.Findings/Finding.cs
@@ -67,7 +67,7 @@ public enum FindingDifferenceKind
 
 /// <summary>
 /// A domain-free identity/location bundle for an occurrence. <see cref="IdentityKey"/>
-/// is the canonical content fingerprint (the correspondence match key); the positions
+/// is the canonical content fingerprint (the alignment key); the positions
 /// and <see cref="ScopeKey"/> are the structural signals a Fold reads to classify a
 /// change (e.g. a move that crossed a scope boundary).
 /// </summary>

--- a/src/ILInspector.Findings/Finding.cs
+++ b/src/ILInspector.Findings/Finding.cs
@@ -1,14 +1,14 @@
 namespace ILInspector.Findings;
 
 /// <summary>
-/// The thing an finding row is about (a member, an occurrence within a body, an
+/// The thing a finding row is about (a member, an occurrence within a body, an
 /// API surface element). Domain-free: <see cref="Key"/> is an opaque stable string
 /// the producing layer chooses; <see cref="Display"/> is a human label.
 /// </summary>
 public sealed record FindingSubject(string Key, string Display);
 
 /// <summary>
-/// A typed, reorder-stable vocabulary entry for an finding row, following the
+/// A typed, reorder-stable vocabulary entry for a finding row, following the
 /// Roslyn <c>DiagnosticDescriptor</c> precedent. <see cref="Id"/> is a
 /// <c>family.kind</c> const string (e.g. <c>il.op</c>, <c>il.op.moved</c>); the
 /// absence of a numeric code is deliberate so descriptors can be added and
@@ -17,7 +17,7 @@ public sealed record FindingSubject(string Key, string Display);
 public sealed record FindingDescriptor(string Id, string Title);
 
 /// <summary>
-/// Whether an finding row asserts presence or a diff transition. A move is
+/// Whether a finding row asserts presence or a diff transition. A move is
 /// deliberately <em>not</em> a polarity: a moved occurrence keeps
 /// <see cref="Present"/> polarity (its content is unchanged) and carries the move
 /// on the orthogonal <see cref="FindingDifferenceKind"/> facet.

--- a/src/ILInspector.Findings/Finding.cs
+++ b/src/ILInspector.Findings/Finding.cs
@@ -1,28 +1,28 @@
-namespace ILInspector.Evidence;
+namespace ILInspector.Findings;
 
 /// <summary>
-/// The thing an evidence row is about (a member, an occurrence within a body, an
+/// The thing an finding row is about (a member, an occurrence within a body, an
 /// API surface element). Domain-free: <see cref="Key"/> is an opaque stable string
 /// the producing layer chooses; <see cref="Display"/> is a human label.
 /// </summary>
-public sealed record EvidenceSubject(string Key, string Display);
+public sealed record FindingSubject(string Key, string Display);
 
 /// <summary>
-/// A typed, reorder-stable vocabulary entry for an evidence row, following the
+/// A typed, reorder-stable vocabulary entry for an finding row, following the
 /// Roslyn <c>DiagnosticDescriptor</c> precedent. <see cref="Id"/> is a
 /// <c>family.kind</c> const string (e.g. <c>il.op</c>, <c>il.op.moved</c>); the
 /// absence of a numeric code is deliberate so descriptors can be added and
 /// reordered without renumbering.
 /// </summary>
-public sealed record EvidenceDescriptor(string Id, string Title);
+public sealed record FindingDescriptor(string Id, string Title);
 
 /// <summary>
-/// Whether an evidence row asserts presence or a diff transition. A move is
+/// Whether an finding row asserts presence or a diff transition. A move is
 /// deliberately <em>not</em> a polarity: a moved occurrence keeps
 /// <see cref="Present"/> polarity (its content is unchanged) and carries the move
-/// on the orthogonal <see cref="EvidenceDifferenceKind"/> facet.
+/// on the orthogonal <see cref="FindingDifferenceKind"/> facet.
 /// </summary>
-public enum EvidenceRowKind
+public enum FindingKind
 {
     /// <summary>Present on both sides (or a single-stream audit fact).</summary>
     Present,
@@ -39,13 +39,13 @@ public enum EvidenceRowKind
 
 /// <summary>
 /// The kind of difference a Fold observed for a matched pair, orthogonal to
-/// <see cref="EvidenceRowKind"/> and to the content-kind carried by
-/// <see cref="EvidenceDescriptor"/>. Consumers select an equivalence by allow-listing
-/// classes (see <see cref="EvidenceEquivalence"/>), which is why this is a
+/// <see cref="FindingKind"/> and to the content-kind carried by
+/// <see cref="FindingDescriptor"/>. Consumers select an equivalence by allow-listing
+/// classes (see <see cref="FindingEquivalence"/>), which is why this is a
 /// separate axis: the same class is folded away by one consumer and is the salient
 /// signal for another.
 /// </summary>
-public enum EvidenceDifferenceKind
+public enum FindingDifferenceKind
 {
     /// <summary>No observable difference for this pair.</summary>
     None,
@@ -71,7 +71,7 @@ public enum EvidenceDifferenceKind
 /// and <see cref="ScopeKey"/> are the structural signals a Fold reads to classify a
 /// change (e.g. a move that crossed a scope boundary).
 /// </summary>
-public sealed record EvidenceAnchor(
+public sealed record FindingAnchor(
     string IdentityKey,
     int OldIndex = -1,
     int NewIndex = -1,
@@ -83,16 +83,16 @@ public sealed record EvidenceAnchor(
 }
 
 /// <summary>
-/// One evidence row: the shared envelope every stream (IL diff, C# diff, semantic
+/// One finding row: the shared envelope every stream (IL diff, C# diff, semantic
 /// fact) projects into so cross-stream consumers query a single skeleton. Rich,
 /// stream-specific detail rides as an opaque <see cref="Payload"/> for display and is
 /// never required to interpret the row.
 /// </summary>
-public sealed record EvidenceRow(
-    EvidenceSubject Subject,
-    EvidenceDescriptor Descriptor,
-    EvidenceRowKind Kind,
-    EvidenceAnchor Anchor,
-    EvidenceDifferenceKind DifferenceKind = EvidenceDifferenceKind.None,
+public sealed record Finding(
+    FindingSubject Subject,
+    FindingDescriptor Descriptor,
+    FindingKind Kind,
+    FindingAnchor Anchor,
+    FindingDifferenceKind DifferenceKind = FindingDifferenceKind.None,
     string? Detail = null,
     object? Payload = null);

--- a/src/ILInspector.Findings/FindingEquivalence.cs
+++ b/src/ILInspector.Findings/FindingEquivalence.cs
@@ -1,6 +1,6 @@
 using System.Collections.Immutable;
 
-namespace ILInspector.Evidence;
+namespace ILInspector.Findings;
 
 /// <summary>
 /// A consumer-selected equivalence relation over a diff, expressed as data (an allow-list of
@@ -9,11 +9,11 @@ namespace ILInspector.Evidence;
 /// mechanism behind "equivalence is a fold": the differ emits classified rows once, and each
 /// consumer picks which classes it forgives.
 /// </summary>
-public sealed record EvidenceEquivalence(
-    ImmutableHashSet<EvidenceRowKind> AllowedRowKinds,
-    ImmutableHashSet<EvidenceDifferenceKind> AllowedDifferenceKinds)
+public sealed record FindingEquivalence(
+    ImmutableHashSet<FindingKind> AllowedRowKinds,
+    ImmutableHashSet<FindingDifferenceKind> AllowedDifferenceKinds)
 {
-    public bool IsEquivalent(IReadOnlyList<EvidenceRow> rows)
+    public bool IsEquivalent(IReadOnlyList<Finding> rows)
     {
         ArgumentNullException.ThrowIfNull(rows);
         foreach (var row in rows)
@@ -32,15 +32,15 @@ public sealed record EvidenceEquivalence(
     /// encoding is folded. A move is a real difference (order is semantic for IL), so a
     /// reordered body is not exact.
     /// </summary>
-    public static readonly EvidenceEquivalence Exact = new(
-        [EvidenceRowKind.Present],
-        [EvidenceDifferenceKind.None, EvidenceDifferenceKind.EncodingOnly]);
+    public static readonly FindingEquivalence Exact = new(
+        [FindingKind.Present],
+        [FindingDifferenceKind.None, FindingDifferenceKind.EncodingOnly]);
 
     /// <summary>
     /// "Same operations, order aside": moves are forgiven, but additions and removals are not.
     /// Appropriate for a consumer that only cares whether the multiset of operations changed.
     /// </summary>
-    public static readonly EvidenceEquivalence Multiset = new(
-        [EvidenceRowKind.Present],
-        [EvidenceDifferenceKind.None, EvidenceDifferenceKind.EncodingOnly, EvidenceDifferenceKind.Moved]);
+    public static readonly FindingEquivalence Multiset = new(
+        [FindingKind.Present],
+        [FindingDifferenceKind.None, FindingDifferenceKind.EncodingOnly, FindingDifferenceKind.Moved]);
 }

--- a/src/ILInspector.Findings/FindingFold.cs
+++ b/src/ILInspector.Findings/FindingFold.cs
@@ -12,36 +12,36 @@ namespace ILInspector.Findings;
 public static class FindingFold
 {
     public static ImmutableArray<Finding> ToRows(
-        FindingMatch correspondence,
+        FindingMatch match,
         IReadOnlyList<FindingOccurrence> oldStream,
         IReadOnlyList<FindingOccurrence> newStream,
         FindingSubject subject,
         FindingDescriptor descriptor,
         int acceptanceThreshold = 100)
     {
-        ArgumentNullException.ThrowIfNull(correspondence);
+        ArgumentNullException.ThrowIfNull(match);
         ArgumentNullException.ThrowIfNull(oldStream);
         ArgumentNullException.ThrowIfNull(newStream);
         ArgumentNullException.ThrowIfNull(subject);
         ArgumentNullException.ThrowIfNull(descriptor);
 
-        var links = ApplyAcceptance(correspondence, acceptanceThreshold);
-        var rows = ImmutableArray.CreateBuilder<Finding>(links.Length);
-        foreach (var link in links)
-            rows.Add(ToRow(link, oldStream, newStream, subject, descriptor));
+        var edges = ApplyAcceptance(match, acceptanceThreshold);
+        var rows = ImmutableArray.CreateBuilder<Finding>(edges.Length);
+        foreach (var edge in edges)
+            rows.Add(ToRow(edge, oldStream, newStream, subject, descriptor));
 
         return rows.ToImmutable();
     }
 
-    static ImmutableArray<FindingMatchEntry> ApplyAcceptance(FindingMatch correspondence, int threshold)
+    static ImmutableArray<FindingEdge> ApplyAcceptance(FindingMatch match, int threshold)
     {
-        if (threshold > 99 || correspondence.MoveCandidates.IsDefaultOrEmpty)
-            return correspondence.Entries;
+        if (threshold > 99 || match.MoveCandidates.IsDefaultOrEmpty)
+            return match.Edges;
 
         var usedOld = new HashSet<int>();
         var usedNew = new HashSet<int>();
         var accepted = new List<FindingMoveCandidate>();
-        foreach (var candidate in correspondence.MoveCandidates
+        foreach (var candidate in match.MoveCandidates
             .OrderByDescending(c => c.Confidence)
             .ThenBy(c => c.OldIndex)
             .ThenBy(c => c.NewIndex))
@@ -60,88 +60,88 @@ public static class FindingFold
         }
 
         if (accepted.Count == 0)
-            return correspondence.Entries;
+            return match.Edges;
 
-        var result = ImmutableArray.CreateBuilder<FindingMatchEntry>();
-        foreach (var link in correspondence.Entries)
+        var result = ImmutableArray.CreateBuilder<FindingEdge>();
+        foreach (var edge in match.Edges)
         {
-            if (link.Kind == FindingMatchKind.Removed && usedOld.Contains(link.OldIndex))
+            if (edge.Kind == FindingEdgeKind.Removed && usedOld.Contains(edge.OldIndex))
                 continue;
-            if (link.Kind == FindingMatchKind.Added && usedNew.Contains(link.NewIndex))
+            if (edge.Kind == FindingEdgeKind.Added && usedNew.Contains(edge.NewIndex))
                 continue;
 
-            result.Add(link);
+            result.Add(edge);
         }
 
         foreach (var candidate in accepted)
-            result.Add(new FindingMatchEntry(FindingMatchKind.Moved, candidate.OldIndex, candidate.NewIndex, candidate.Confidence));
+            result.Add(new FindingEdge(FindingEdgeKind.Moved, candidate.OldIndex, candidate.NewIndex, candidate.Confidence));
 
         return result.ToImmutable();
     }
 
     static Finding ToRow(
-        FindingMatchEntry link,
+        FindingEdge edge,
         IReadOnlyList<FindingOccurrence> oldStream,
         IReadOnlyList<FindingOccurrence> newStream,
         FindingSubject subject,
         FindingDescriptor descriptor)
     {
-        switch (link.Kind)
+        switch (edge.Kind)
         {
-            case FindingMatchKind.Matched:
+            case FindingEdgeKind.Matched:
             {
-                var oldOcc = oldStream[link.OldIndex];
-                var newOcc = newStream[link.NewIndex];
+                var oldOcc = oldStream[edge.OldIndex];
+                var newOcc = newStream[edge.NewIndex];
                 return new Finding(
                     subject,
                     descriptor,
                     FindingKind.Present,
-                    new FindingAnchor(oldOcc.IdentityKey, link.OldIndex, link.NewIndex, oldOcc.ScopeKey),
+                    new FindingAnchor(oldOcc.IdentityKey, edge.OldIndex, edge.NewIndex, oldOcc.ScopeKey),
                     FindingDifferenceKind.None,
                     Payload: newOcc.Payload);
             }
 
-            case FindingMatchKind.Moved:
+            case FindingEdgeKind.Moved:
             {
-                var oldOcc = oldStream[link.OldIndex];
-                var newOcc = newStream[link.NewIndex];
-                int delta = link.NewIndex - link.OldIndex;
+                var oldOcc = oldStream[edge.OldIndex];
+                var newOcc = newStream[edge.NewIndex];
+                int delta = edge.NewIndex - edge.OldIndex;
                 return new Finding(
                     subject,
                     descriptor,
                     FindingKind.Present,
-                    new FindingAnchor(oldOcc.IdentityKey, link.OldIndex, link.NewIndex, oldOcc.ScopeKey),
+                    new FindingAnchor(oldOcc.IdentityKey, edge.OldIndex, edge.NewIndex, oldOcc.ScopeKey),
                     FindingDifferenceKind.Moved,
                     Detail: $"moved {delta:+#;-#;0}",
                     Payload: newOcc.Payload);
             }
 
-            case FindingMatchKind.Added:
+            case FindingEdgeKind.Added:
             {
-                var newOcc = newStream[link.NewIndex];
+                var newOcc = newStream[edge.NewIndex];
                 return new Finding(
                     subject,
                     descriptor,
                     FindingKind.Added,
-                    new FindingAnchor(newOcc.IdentityKey, -1, link.NewIndex, newOcc.ScopeKey),
+                    new FindingAnchor(newOcc.IdentityKey, -1, edge.NewIndex, newOcc.ScopeKey),
                     FindingDifferenceKind.None,
                     Payload: newOcc.Payload);
             }
 
-            case FindingMatchKind.Removed:
+            case FindingEdgeKind.Removed:
             {
-                var oldOcc = oldStream[link.OldIndex];
+                var oldOcc = oldStream[edge.OldIndex];
                 return new Finding(
                     subject,
                     descriptor,
                     FindingKind.Removed,
-                    new FindingAnchor(oldOcc.IdentityKey, link.OldIndex, -1, oldOcc.ScopeKey),
+                    new FindingAnchor(oldOcc.IdentityKey, edge.OldIndex, -1, oldOcc.ScopeKey),
                     FindingDifferenceKind.None,
                     Payload: oldOcc.Payload);
             }
 
             default:
-                throw new ArgumentOutOfRangeException(nameof(link), link.Kind, "Unknown link kind.");
+                throw new ArgumentOutOfRangeException(nameof(edge), edge.Kind, "Unknown edge kind.");
         }
     }
 }

--- a/src/ILInspector.Findings/FindingFold.cs
+++ b/src/ILInspector.Findings/FindingFold.cs
@@ -1,22 +1,22 @@
 using System.Collections.Immutable;
 
-namespace ILInspector.Evidence;
+namespace ILInspector.Findings;
 
 /// <summary>
-/// Projects a <see cref="EvidenceMatch"/> into evidence rows. This is the generic diff Fold:
+/// Projects a <see cref="FindingMatch"/> into finding rows. This is the generic diff Fold:
 /// it never decides equivalence, it materializes classified rows (Present / Added / Removed,
-/// with a <see cref="EvidenceDifferenceKind"/> facet). Move <em>acceptance</em> is itself a
+/// with a <see cref="FindingDifferenceKind"/> facet). Move <em>acceptance</em> is itself a
 /// fold: the default threshold (100) commits nothing from the fringe, while a recall-hungry
 /// consumer can lower it to promote scored candidates into moves.
 /// </summary>
-public static class EvidenceFold
+public static class FindingFold
 {
-    public static ImmutableArray<EvidenceRow> ToRows(
-        EvidenceMatch correspondence,
-        IReadOnlyList<EvidenceOccurrence> oldStream,
-        IReadOnlyList<EvidenceOccurrence> newStream,
-        EvidenceSubject subject,
-        EvidenceDescriptor descriptor,
+    public static ImmutableArray<Finding> ToRows(
+        FindingMatch correspondence,
+        IReadOnlyList<FindingOccurrence> oldStream,
+        IReadOnlyList<FindingOccurrence> newStream,
+        FindingSubject subject,
+        FindingDescriptor descriptor,
         int acceptanceThreshold = 100)
     {
         ArgumentNullException.ThrowIfNull(correspondence);
@@ -26,21 +26,21 @@ public static class EvidenceFold
         ArgumentNullException.ThrowIfNull(descriptor);
 
         var links = ApplyAcceptance(correspondence, acceptanceThreshold);
-        var rows = ImmutableArray.CreateBuilder<EvidenceRow>(links.Length);
+        var rows = ImmutableArray.CreateBuilder<Finding>(links.Length);
         foreach (var link in links)
             rows.Add(ToRow(link, oldStream, newStream, subject, descriptor));
 
         return rows.ToImmutable();
     }
 
-    static ImmutableArray<EvidenceMatchEntry> ApplyAcceptance(EvidenceMatch correspondence, int threshold)
+    static ImmutableArray<FindingMatchEntry> ApplyAcceptance(FindingMatch correspondence, int threshold)
     {
         if (threshold > 99 || correspondence.MoveCandidates.IsDefaultOrEmpty)
             return correspondence.Entries;
 
         var usedOld = new HashSet<int>();
         var usedNew = new HashSet<int>();
-        var accepted = new List<EvidenceMoveCandidate>();
+        var accepted = new List<FindingMoveCandidate>();
         foreach (var candidate in correspondence.MoveCandidates
             .OrderByDescending(c => c.Confidence)
             .ThenBy(c => c.OldIndex)
@@ -62,81 +62,81 @@ public static class EvidenceFold
         if (accepted.Count == 0)
             return correspondence.Entries;
 
-        var result = ImmutableArray.CreateBuilder<EvidenceMatchEntry>();
+        var result = ImmutableArray.CreateBuilder<FindingMatchEntry>();
         foreach (var link in correspondence.Entries)
         {
-            if (link.Kind == EvidenceMatchKind.Removed && usedOld.Contains(link.OldIndex))
+            if (link.Kind == FindingMatchKind.Removed && usedOld.Contains(link.OldIndex))
                 continue;
-            if (link.Kind == EvidenceMatchKind.Added && usedNew.Contains(link.NewIndex))
+            if (link.Kind == FindingMatchKind.Added && usedNew.Contains(link.NewIndex))
                 continue;
 
             result.Add(link);
         }
 
         foreach (var candidate in accepted)
-            result.Add(new EvidenceMatchEntry(EvidenceMatchKind.Moved, candidate.OldIndex, candidate.NewIndex, candidate.Confidence));
+            result.Add(new FindingMatchEntry(FindingMatchKind.Moved, candidate.OldIndex, candidate.NewIndex, candidate.Confidence));
 
         return result.ToImmutable();
     }
 
-    static EvidenceRow ToRow(
-        EvidenceMatchEntry link,
-        IReadOnlyList<EvidenceOccurrence> oldStream,
-        IReadOnlyList<EvidenceOccurrence> newStream,
-        EvidenceSubject subject,
-        EvidenceDescriptor descriptor)
+    static Finding ToRow(
+        FindingMatchEntry link,
+        IReadOnlyList<FindingOccurrence> oldStream,
+        IReadOnlyList<FindingOccurrence> newStream,
+        FindingSubject subject,
+        FindingDescriptor descriptor)
     {
         switch (link.Kind)
         {
-            case EvidenceMatchKind.Matched:
+            case FindingMatchKind.Matched:
             {
                 var oldOcc = oldStream[link.OldIndex];
                 var newOcc = newStream[link.NewIndex];
-                return new EvidenceRow(
+                return new Finding(
                     subject,
                     descriptor,
-                    EvidenceRowKind.Present,
-                    new EvidenceAnchor(oldOcc.IdentityKey, link.OldIndex, link.NewIndex, oldOcc.ScopeKey),
-                    EvidenceDifferenceKind.None,
+                    FindingKind.Present,
+                    new FindingAnchor(oldOcc.IdentityKey, link.OldIndex, link.NewIndex, oldOcc.ScopeKey),
+                    FindingDifferenceKind.None,
                     Payload: newOcc.Payload);
             }
 
-            case EvidenceMatchKind.Moved:
+            case FindingMatchKind.Moved:
             {
                 var oldOcc = oldStream[link.OldIndex];
                 var newOcc = newStream[link.NewIndex];
                 int delta = link.NewIndex - link.OldIndex;
-                return new EvidenceRow(
+                return new Finding(
                     subject,
                     descriptor,
-                    EvidenceRowKind.Present,
-                    new EvidenceAnchor(oldOcc.IdentityKey, link.OldIndex, link.NewIndex, oldOcc.ScopeKey),
-                    EvidenceDifferenceKind.Moved,
+                    FindingKind.Present,
+                    new FindingAnchor(oldOcc.IdentityKey, link.OldIndex, link.NewIndex, oldOcc.ScopeKey),
+                    FindingDifferenceKind.Moved,
                     Detail: $"moved {delta:+#;-#;0}",
                     Payload: newOcc.Payload);
             }
 
-            case EvidenceMatchKind.Added:
+            case FindingMatchKind.Added:
             {
                 var newOcc = newStream[link.NewIndex];
-                return new EvidenceRow(
+                return new Finding(
                     subject,
                     descriptor,
-                    EvidenceRowKind.Added,
-                    new EvidenceAnchor(newOcc.IdentityKey, -1, link.NewIndex, newOcc.ScopeKey),
-                    EvidenceDifferenceKind.None,
+                    FindingKind.Added,
+                    new FindingAnchor(newOcc.IdentityKey, -1, link.NewIndex, newOcc.ScopeKey),
+                    FindingDifferenceKind.None,
                     Payload: newOcc.Payload);
             }
 
-            case EvidenceMatchKind.Removed:
+            case FindingMatchKind.Removed:
             {
                 var oldOcc = oldStream[link.OldIndex];
-                return new EvidenceRow(
+                return new Finding(
                     subject,
                     descriptor,
-                    EvidenceRowKind.Removed,
-                    new EvidenceAnchor(oldOcc.IdentityKey, link.OldIndex, -1, oldOcc.ScopeKey),
-                    EvidenceDifferenceKind.None,
+                    FindingKind.Removed,
+                    new FindingAnchor(oldOcc.IdentityKey, link.OldIndex, -1, oldOcc.ScopeKey),
+                    FindingDifferenceKind.None,
                     Payload: oldOcc.Payload);
             }
 

--- a/src/ILInspector.Findings/FindingMatcher.cs
+++ b/src/ILInspector.Findings/FindingMatcher.cs
@@ -1,9 +1,9 @@
 using System.Collections.Immutable;
 
-namespace ILInspector.Evidence;
+namespace ILInspector.Findings;
 
 /// <summary>How an old/new occurrence pair (or singleton) is related across versions.</summary>
-public enum EvidenceMatchKind
+public enum FindingMatchKind
 {
     /// <summary>Order-preserving content match found by the committed LCS core.</summary>
     Matched,
@@ -19,19 +19,19 @@ public enum EvidenceMatchKind
 }
 
 /// <summary>
-/// One correspondence edge. <see cref="OldIndex"/> is -1 for <see cref="EvidenceMatchKind.Added"/>;
-/// <see cref="NewIndex"/> is -1 for <see cref="EvidenceMatchKind.Removed"/>. <see cref="Confidence"/>
+/// One correspondence edge. <see cref="OldIndex"/> is -1 for <see cref="FindingMatchKind.Added"/>;
+/// <see cref="NewIndex"/> is -1 for <see cref="FindingMatchKind.Removed"/>. <see cref="Confidence"/>
 /// is 100 for the committed matching; lower values are reserved for accepted fringe.
 /// </summary>
-public sealed record EvidenceMatchEntry(EvidenceMatchKind Kind, int OldIndex, int NewIndex, int Confidence);
+public sealed record FindingMatchEntry(FindingMatchKind Kind, int OldIndex, int NewIndex, int Confidence);
 
 /// <summary>
 /// A deferred, ambiguous correspondence the committed core did not commit (a content-equal
 /// singleton that lacks a corroborating run). Acceptance is a <em>consumer</em> decision:
-/// <see cref="EvidenceFold"/> promotes candidates whose <see cref="Confidence"/> meets a caller
+/// <see cref="FindingFold"/> promotes candidates whose <see cref="Confidence"/> meets a caller
 /// threshold. The default (100) accepts none, so these stay Added+Removed.
 /// </summary>
-public sealed record EvidenceMoveCandidate(int OldIndex, int NewIndex, int Confidence, string Reason);
+public sealed record FindingMoveCandidate(int OldIndex, int NewIndex, int Confidence, string Reason);
 
 /// <summary>The result of matching two occurrence streams.</summary>
 /// <param name="Entries">
@@ -42,29 +42,29 @@ public sealed record EvidenceMoveCandidate(int OldIndex, int NewIndex, int Confi
 /// Scored move candidates a recall-hungry consumer may accept to reclassify an Added+Removed
 /// pair into a move. Empty when nothing is ambiguous.
 /// </param>
-public sealed record EvidenceMatch(
-    ImmutableArray<EvidenceMatchEntry> Entries,
-    ImmutableArray<EvidenceMoveCandidate> MoveCandidates);
+public sealed record FindingMatch(
+    ImmutableArray<FindingMatchEntry> Entries,
+    ImmutableArray<FindingMoveCandidate> MoveCandidates);
 
-/// <summary>Tunables for <see cref="EvidenceMatcher.Match"/>.</summary>
+/// <summary>Tunables for <see cref="FindingMatcher.Match"/>.</summary>
 /// <param name="MinMoveRunLength">
 /// The minimum length of a common contiguous residual run to commit as a move. Runs shorter
 /// than this are left to the fringe, which is what gives the conservative default its
 /// mismatch resistance (a lone content-equal occurrence is not silently treated as a move).
 /// </param>
-public sealed record EvidenceMatchOptions(int MinMoveRunLength = 2)
+public sealed record FindingMatchOptions(int MinMoveRunLength = 2)
 {
-    public static readonly EvidenceMatchOptions Default = new();
+    public static readonly FindingMatchOptions Default = new();
 }
 
 /// <summary>
-/// The single, domain-free matcher every evidence stream shares. It commits an
+/// The single, domain-free matcher every finding stream shares. It commits an
 /// order-preserving LCS core (which reproduces a classic sequence diff when there are no moves)
 /// and then recovers relocations as a scored move pass over the residual. It never decides
-/// equivalence: it emits classified correspondence, and a consumer <see cref="EvidenceFold"/>
+/// equivalence: it emits classified correspondence, and a consumer <see cref="FindingFold"/>
 /// folds it.
 /// </summary>
-public static class EvidenceMatcher
+public static class FindingMatcher
 {
     // The ordered committer is a full-matrix LCS (O(N*M) space). That is ample for method-body-scale
     // ordered streams (the only thing shipped today), but a caller feeding assembly-scale streams
@@ -73,14 +73,14 @@ public static class EvidenceMatcher
     // committer (hash bijection, no matrix) — see issue #2585.
     const long MaxOrderedMatchCells = 64_000_000;
 
-    public static EvidenceMatch Match(
-        IReadOnlyList<EvidenceOccurrence> oldStream,
-        IReadOnlyList<EvidenceOccurrence> newStream,
-        EvidenceMatchOptions? options = null)
+    public static FindingMatch Match(
+        IReadOnlyList<FindingOccurrence> oldStream,
+        IReadOnlyList<FindingOccurrence> newStream,
+        FindingMatchOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(oldStream);
         ArgumentNullException.ThrowIfNull(newStream);
-        options ??= EvidenceMatchOptions.Default;
+        options ??= FindingMatchOptions.Default;
 
         long cells = ((long)oldStream.Count + 1) * ((long)newStream.Count + 1);
         if (cells > MaxOrderedMatchCells)
@@ -93,14 +93,14 @@ public static class EvidenceMatcher
 
         var matchedOld = new bool[oldStream.Count];
         var matchedNew = new bool[newStream.Count];
-        var links = ImmutableArray.CreateBuilder<EvidenceMatchEntry>();
+        var links = ImmutableArray.CreateBuilder<FindingMatchEntry>();
 
         // 1. Committed core: order-preserving LCS over content keys.
         foreach (var (oldIndex, newIndex) in LongestCommonSubsequence(oldStream, newStream))
         {
             matchedOld[oldIndex] = true;
             matchedNew[newIndex] = true;
-            links.Add(new EvidenceMatchEntry(EvidenceMatchKind.Matched, oldIndex, newIndex, 100));
+            links.Add(new FindingMatchEntry(FindingMatchKind.Matched, oldIndex, newIndex, 100));
         }
 
         // 2. Residual (what the order-preserving core could not match).
@@ -118,16 +118,16 @@ public static class EvidenceMatcher
         foreach (var (localIndex, oldIndex) in Indexed(residualOld))
         {
             if (!committedOld[localIndex])
-                links.Add(new EvidenceMatchEntry(EvidenceMatchKind.Removed, oldIndex, -1, 100));
+                links.Add(new FindingMatchEntry(FindingMatchKind.Removed, oldIndex, -1, 100));
         }
 
         foreach (var (localIndex, newIndex) in Indexed(residualNew))
         {
             if (!committedNew[localIndex])
-                links.Add(new EvidenceMatchEntry(EvidenceMatchKind.Added, -1, newIndex, 100));
+                links.Add(new FindingMatchEntry(FindingMatchKind.Added, -1, newIndex, 100));
         }
 
-        return new EvidenceMatch(links.ToImmutable(), fringe);
+        return new FindingMatch(links.ToImmutable(), fringe);
     }
 
     static int[] ResidualIndices(bool[] matched)
@@ -149,14 +149,14 @@ public static class EvidenceMatcher
     }
 
     static void DetectMoveRuns(
-        IReadOnlyList<EvidenceOccurrence> oldStream,
-        IReadOnlyList<EvidenceOccurrence> newStream,
+        IReadOnlyList<FindingOccurrence> oldStream,
+        IReadOnlyList<FindingOccurrence> newStream,
         int[] residualOld,
         int[] residualNew,
         bool[] committedOld,
         bool[] committedNew,
         int minRun,
-        ImmutableArray<EvidenceMatchEntry>.Builder links)
+        ImmutableArray<FindingMatchEntry>.Builder links)
     {
         // A committed move is a run of >= minRun operations that is contiguous in BOTH original
         // streams (a relocated block), not merely adjacent in the residual arrays. Requiring
@@ -214,25 +214,25 @@ public static class EvidenceMatcher
             {
                 committedOld[bestA + k] = true;
                 committedNew[bestB + k] = true;
-                links.Add(new EvidenceMatchEntry(EvidenceMatchKind.Moved, residualOld[bestA + k], residualNew[bestB + k], 100));
+                links.Add(new FindingMatchEntry(FindingMatchKind.Moved, residualOld[bestA + k], residualNew[bestB + k], 100));
             }
         }
     }
 
     // Emit the FULL scored candidate graph: every content-equal pair of still-uncommitted residual
-    // occurrences. Deferring the actual one-to-one resolution to EvidenceFold.ApplyAcceptance (which
+    // occurrences. Deferring the actual one-to-one resolution to FindingFold.ApplyAcceptance (which
     // sorts by score and enforces the matching constraint) is deliberate — it lets scope-corroborated
     // (higher-scored) pairings win over incidental index-order pairings. This is the "scored fringe"
     // half of committed-core-plus-scored-fringe.
-    static ImmutableArray<EvidenceMoveCandidate> BuildFringe(
-        IReadOnlyList<EvidenceOccurrence> oldStream,
-        IReadOnlyList<EvidenceOccurrence> newStream,
+    static ImmutableArray<FindingMoveCandidate> BuildFringe(
+        IReadOnlyList<FindingOccurrence> oldStream,
+        IReadOnlyList<FindingOccurrence> newStream,
         int[] residualOld,
         int[] residualNew,
         bool[] committedOld,
         bool[] committedNew)
     {
-        var fringe = ImmutableArray.CreateBuilder<EvidenceMoveCandidate>();
+        var fringe = ImmutableArray.CreateBuilder<FindingMoveCandidate>();
 
         for (int a = 0; a < residualOld.Length; a++)
         {
@@ -252,7 +252,7 @@ public static class EvidenceMatcher
                 int score = scopeCorroborates ? 75 : 50;
                 string reason = scopeCorroborates ? "content+scope" : "content-only";
 
-                fringe.Add(new EvidenceMoveCandidate(residualOld[a], residualNew[b], score, reason));
+                fringe.Add(new FindingMoveCandidate(residualOld[a], residualNew[b], score, reason));
             }
         }
 
@@ -262,8 +262,8 @@ public static class EvidenceMatcher
     // Same construction and tiebreak as ILInspector.Instructions.IlBodyDiff so the committed
     // core reproduces the existing IL sequence diff exactly on move-free inputs.
     static List<(int OldIndex, int NewIndex)> LongestCommonSubsequence(
-        IReadOnlyList<EvidenceOccurrence> oldStream,
-        IReadOnlyList<EvidenceOccurrence> newStream)
+        IReadOnlyList<FindingOccurrence> oldStream,
+        IReadOnlyList<FindingOccurrence> newStream)
     {
         int oldLength = oldStream.Count;
         int newLength = newStream.Count;

--- a/src/ILInspector.Findings/FindingMatcher.cs
+++ b/src/ILInspector.Findings/FindingMatcher.cs
@@ -3,7 +3,7 @@ using System.Collections.Immutable;
 namespace ILInspector.Findings;
 
 /// <summary>How an old/new occurrence pair (or singleton) is related across versions.</summary>
-public enum FindingMatchKind
+public enum FindingEdgeKind
 {
     /// <summary>Order-preserving content match found by the committed LCS core.</summary>
     Matched,
@@ -19,14 +19,14 @@ public enum FindingMatchKind
 }
 
 /// <summary>
-/// One correspondence edge. <see cref="OldIndex"/> is -1 for <see cref="FindingMatchKind.Added"/>;
-/// <see cref="NewIndex"/> is -1 for <see cref="FindingMatchKind.Removed"/>. <see cref="Confidence"/>
+/// One alignment edge. <see cref="OldIndex"/> is -1 for <see cref="FindingEdgeKind.Added"/>;
+/// <see cref="NewIndex"/> is -1 for <see cref="FindingEdgeKind.Removed"/>. <see cref="Confidence"/>
 /// is 100 for the committed matching; lower values are reserved for accepted fringe.
 /// </summary>
-public sealed record FindingMatchEntry(FindingMatchKind Kind, int OldIndex, int NewIndex, int Confidence);
+public sealed record FindingEdge(FindingEdgeKind Kind, int OldIndex, int NewIndex, int Confidence);
 
 /// <summary>
-/// A deferred, ambiguous correspondence the committed core did not commit (a content-equal
+/// A deferred, ambiguous match the committed core did not commit (a content-equal
 /// singleton that lacks a corroborating run). Acceptance is a <em>consumer</em> decision:
 /// <see cref="FindingFold"/> promotes candidates whose <see cref="Confidence"/> meets a caller
 /// threshold. The default (100) accepts none, so these stay Added+Removed.
@@ -34,7 +34,7 @@ public sealed record FindingMatchEntry(FindingMatchKind Kind, int OldIndex, int 
 public sealed record FindingMoveCandidate(int OldIndex, int NewIndex, int Confidence, string Reason);
 
 /// <summary>The result of matching two occurrence streams.</summary>
-/// <param name="Entries">
+/// <param name="Edges">
 /// The committed, conservative interpretation: order-preserving matches, committed moves,
 /// and Added/Removed for everything else (including the endpoints of every fringe candidate).
 /// </param>
@@ -43,7 +43,7 @@ public sealed record FindingMoveCandidate(int OldIndex, int NewIndex, int Confid
 /// pair into a move. Empty when nothing is ambiguous.
 /// </param>
 public sealed record FindingMatch(
-    ImmutableArray<FindingMatchEntry> Entries,
+    ImmutableArray<FindingEdge> Edges,
     ImmutableArray<FindingMoveCandidate> MoveCandidates);
 
 /// <summary>Tunables for <see cref="FindingMatcher.Match"/>.</summary>
@@ -61,7 +61,7 @@ public sealed record FindingMatchOptions(int MinMoveRunLength = 2)
 /// The single, domain-free matcher every finding stream shares. It commits an
 /// order-preserving LCS core (which reproduces a classic sequence diff when there are no moves)
 /// and then recovers relocations as a scored move pass over the residual. It never decides
-/// equivalence: it emits classified correspondence, and a consumer <see cref="FindingFold"/>
+/// equivalence: it emits a classified alignment (a set of edges), and a consumer <see cref="FindingFold"/>
 /// folds it.
 /// </summary>
 public static class FindingMatcher
@@ -93,14 +93,14 @@ public static class FindingMatcher
 
         var matchedOld = new bool[oldStream.Count];
         var matchedNew = new bool[newStream.Count];
-        var links = ImmutableArray.CreateBuilder<FindingMatchEntry>();
+        var edges = ImmutableArray.CreateBuilder<FindingEdge>();
 
         // 1. Committed core: order-preserving LCS over content keys.
         foreach (var (oldIndex, newIndex) in LongestCommonSubsequence(oldStream, newStream))
         {
             matchedOld[oldIndex] = true;
             matchedNew[newIndex] = true;
-            links.Add(new FindingMatchEntry(FindingMatchKind.Matched, oldIndex, newIndex, 100));
+            edges.Add(new FindingEdge(FindingEdgeKind.Matched, oldIndex, newIndex, 100));
         }
 
         // 2. Residual (what the order-preserving core could not match).
@@ -110,7 +110,7 @@ public static class FindingMatcher
         // 3. Move pass: commit maximal common contiguous residual runs (>= MinMoveRunLength).
         var committedOld = new bool[residualOld.Length];
         var committedNew = new bool[residualNew.Length];
-        DetectMoveRuns(oldStream, newStream, residualOld, residualNew, committedOld, committedNew, options.MinMoveRunLength, links);
+        DetectMoveRuns(oldStream, newStream, residualOld, residualNew, committedOld, committedNew, options.MinMoveRunLength, edges);
 
         // 4. Leftover residual: score singleton content matches as fringe, emit the rest as add/remove.
         var fringe = BuildFringe(oldStream, newStream, residualOld, residualNew, committedOld, committedNew);
@@ -118,16 +118,16 @@ public static class FindingMatcher
         foreach (var (localIndex, oldIndex) in Indexed(residualOld))
         {
             if (!committedOld[localIndex])
-                links.Add(new FindingMatchEntry(FindingMatchKind.Removed, oldIndex, -1, 100));
+                edges.Add(new FindingEdge(FindingEdgeKind.Removed, oldIndex, -1, 100));
         }
 
         foreach (var (localIndex, newIndex) in Indexed(residualNew))
         {
             if (!committedNew[localIndex])
-                links.Add(new FindingMatchEntry(FindingMatchKind.Added, -1, newIndex, 100));
+                edges.Add(new FindingEdge(FindingEdgeKind.Added, -1, newIndex, 100));
         }
 
-        return new FindingMatch(links.ToImmutable(), fringe);
+        return new FindingMatch(edges.ToImmutable(), fringe);
     }
 
     static int[] ResidualIndices(bool[] matched)
@@ -156,7 +156,7 @@ public static class FindingMatcher
         bool[] committedOld,
         bool[] committedNew,
         int minRun,
-        ImmutableArray<FindingMatchEntry>.Builder links)
+        ImmutableArray<FindingEdge>.Builder edges)
     {
         // A committed move is a run of >= minRun operations that is contiguous in BOTH original
         // streams (a relocated block), not merely adjacent in the residual arrays. Requiring
@@ -214,7 +214,7 @@ public static class FindingMatcher
             {
                 committedOld[bestA + k] = true;
                 committedNew[bestB + k] = true;
-                links.Add(new FindingMatchEntry(FindingMatchKind.Moved, residualOld[bestA + k], residualNew[bestB + k], 100));
+                edges.Add(new FindingEdge(FindingEdgeKind.Moved, residualOld[bestA + k], residualNew[bestB + k], 100));
             }
         }
     }

--- a/src/ILInspector.Findings/FindingOccurrence.cs
+++ b/src/ILInspector.Findings/FindingOccurrence.cs
@@ -1,8 +1,8 @@
-namespace ILInspector.Evidence;
+namespace ILInspector.Findings;
 
 /// <summary>
 /// A single domain-free item within an ordered stream, presented to the
-/// <see cref="EvidenceMatcher"/> for cross-version matching. Domain producers
+/// <see cref="FindingMatcher"/> for cross-version matching. Domain producers
 /// project their nodes (IL operations, IR nodes, API members) into this shape.
 /// </summary>
 /// <param name="IdentityKey">
@@ -16,10 +16,10 @@ namespace ILInspector.Evidence;
 /// when unknown or not modeled.
 /// </param>
 /// <param name="Payload">
-/// Opaque domain detail carried onto the produced <see cref="EvidenceRow"/> for
+/// Opaque domain detail carried onto the produced <see cref="Finding"/> for
 /// display. Never inspected by the matcher.
 /// </param>
-public sealed record EvidenceOccurrence(
+public sealed record FindingOccurrence(
     string IdentityKey,
     string? ScopeKey = null,
     object? Payload = null);

--- a/src/ILInspector.Findings/FindingSummary.cs
+++ b/src/ILInspector.Findings/FindingSummary.cs
@@ -1,7 +1,7 @@
-namespace ILInspector.Evidence;
+namespace ILInspector.Findings;
 
 /// <summary>A coarse, stream-agnostic classification of a diff read from the skeleton alone.</summary>
-public enum EvidenceFinding
+public enum DiffShape
 {
     /// <summary>No differences at all.</summary>
     Identical,
@@ -14,22 +14,22 @@ public enum EvidenceFinding
 }
 
 /// <summary>
-/// A minimal, stream-agnostic consumer of evidence rows. It reads only the skeleton
-/// (<see cref="EvidenceRowKind"/> and <see cref="EvidenceDifferenceKind"/>) — never the opaque
+/// A minimal, stream-agnostic consumer of finding rows. It reads only the skeleton
+/// (<see cref="FindingKind"/> and <see cref="FindingDifferenceKind"/>) — never the opaque
 /// payload — so the same code summarizes an IL diff, a C# diff, or a semantic-fact stream. This
 /// is the shape a cross-stream consumer (e.g. Performance Triage) is built from: uniform queries
 /// over one row envelope, regardless of which producer emitted the rows.
 /// </summary>
-public sealed record EvidenceDiffSummary(
+public sealed record FindingSummary(
     int Total,
     int Present,
     int Added,
     int Removed,
     int Changed,
     int Moved,
-    EvidenceFinding Finding)
+    DiffShape Shape)
 {
-    public static EvidenceDiffSummary Summarize(IReadOnlyList<EvidenceRow> rows)
+    public static FindingSummary Summarize(IReadOnlyList<Finding> rows)
     {
         ArgumentNullException.ThrowIfNull(rows);
 
@@ -43,29 +43,29 @@ public sealed record EvidenceDiffSummary(
         {
             switch (row.Kind)
             {
-                case EvidenceRowKind.Present:
+                case FindingKind.Present:
                     present++;
                     break;
-                case EvidenceRowKind.Added:
+                case FindingKind.Added:
                     added++;
                     break;
-                case EvidenceRowKind.Removed:
+                case FindingKind.Removed:
                     removed++;
                     break;
-                case EvidenceRowKind.Changed:
+                case FindingKind.Changed:
                     changed++;
                     break;
             }
 
-            if (row.DifferenceKind == EvidenceDifferenceKind.Moved)
+            if (row.DifferenceKind == FindingDifferenceKind.Moved)
                 moved++;
         }
 
         bool structural = added > 0 || removed > 0 || changed > 0;
         var verdict = structural
-            ? EvidenceFinding.Structural
-            : moved > 0 ? EvidenceFinding.ReorderOnly : EvidenceFinding.Identical;
+            ? DiffShape.Structural
+            : moved > 0 ? DiffShape.ReorderOnly : DiffShape.Identical;
 
-        return new EvidenceDiffSummary(rows.Count, present, added, removed, changed, moved, verdict);
+        return new FindingSummary(rows.Count, present, added, removed, changed, moved, verdict);
     }
 }

--- a/src/ILInspector.Findings/ILInspector.Findings.csproj
+++ b/src/ILInspector.Findings/ILInspector.Findings.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <Authors>Richard Lander</Authors>
-    <Description>Domain-free finding substrate (leaf): the occurrence-correspondence engine (committed LCS core plus a scored move fringe) and the generic diff Fold that every finding stream shares. Records and pure logic only; no SRM, no IrNode, no C#, no inspected-assembly loading. See issue #2564.</Description>
+    <Description>Domain-free finding substrate (leaf): the occurrence-alignment engine (committed LCS core plus a scored move fringe) and the generic diff Fold that every finding stream shares. Records and pure logic only; no SRM, no IrNode, no C#, no inspected-assembly loading. See issue #2564.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/src/ILInspector.Findings/ILInspector.Findings.csproj
+++ b/src/ILInspector.Findings/ILInspector.Findings.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <Authors>Richard Lander</Authors>
-    <Description>Domain-free evidence substrate (leaf): the occurrence-correspondence engine (committed LCS core plus a scored move fringe) and the generic diff Fold that every evidence stream shares. Records and pure logic only; no SRM, no IrNode, no C#, no inspected-assembly loading. See issue #2564.</Description>
+    <Description>Domain-free finding substrate (leaf): the occurrence-correspondence engine (committed LCS core plus a scored move fringe) and the generic diff Fold that every finding stream shares. Records and pure logic only; no SRM, no IrNode, no C#, no inspected-assembly loading. See issue #2564.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
@@ -6,7 +6,7 @@ using ILInspector.Findings;
 namespace ILInspector.Instructions.Tests;
 
 /// <summary>
-/// Pilot gates for the finding spine (#2564): the domain-free correspondence engine plus the IL
+/// Pilot gates for the finding spine (#2564): the domain-free alignment engine plus the IL
 /// adapter. The engine's committed core is an LCS (so it reproduces the existing IL sequence
 /// diff on move-free inputs); the move pass recovers relocations; equivalence is a consumer fold.
 /// </summary>
@@ -20,8 +20,8 @@ public class FindingPilotTests
     static readonly FindingSubject Subject = new("test", "test");
     static readonly FindingDescriptor Descriptor = new("test.item", "item");
 
-    static int Count(FindingMatch c, FindingMatchKind kind)
-        => c.Entries.Count(l => l.Kind == kind);
+    static int Count(FindingMatch c, FindingEdgeKind kind)
+        => c.Edges.Count(l => l.Kind == kind);
 
     [Fact]
     public void CommittedCore_IsAnOptimalLcs_OnManyShapes()
@@ -40,8 +40,8 @@ public class FindingPilotTests
 
         foreach (var (old, @new) in cases)
         {
-            var correspondence = FindingMatcher.Match(Stream(old), Stream(@new));
-            var matched = correspondence.Entries.Where(l => l.Kind == FindingMatchKind.Matched).ToArray();
+            var match = FindingMatcher.Match(Stream(old), Stream(@new));
+            var matched = match.Edges.Where(l => l.Kind == FindingEdgeKind.Matched).ToArray();
 
             // Optimality: as long as a classic LCS.
             Assert.Equal(ReferenceLcsLength(old, @new), matched.Length);
@@ -53,8 +53,8 @@ public class FindingPilotTests
                 Assert.True(matched[i].NewIndex > matched[i - 1].NewIndex);
             }
 
-            foreach (var link in matched)
-                Assert.Equal(old[link.OldIndex], @new[link.NewIndex]);
+            foreach (var edge in matched)
+                Assert.Equal(old[edge.OldIndex], @new[edge.NewIndex]);
         }
     }
 
@@ -66,11 +66,11 @@ public class FindingPilotTests
         var old = Stream("A", "B", "C", "m1", "m2", "D", "E");
         var @new = Stream("m1", "m2", "A", "B", "C", "D", "E");
 
-        var correspondence = FindingMatcher.Match(old, @new);
+        var match = FindingMatcher.Match(old, @new);
 
-        Assert.Equal(2, Count(correspondence, FindingMatchKind.Moved));
-        Assert.Equal(0, Count(correspondence, FindingMatchKind.Added));
-        Assert.Equal(0, Count(correspondence, FindingMatchKind.Removed));
+        Assert.Equal(2, Count(match, FindingEdgeKind.Moved));
+        Assert.Equal(0, Count(match, FindingEdgeKind.Added));
+        Assert.Equal(0, Count(match, FindingEdgeKind.Removed));
     }
 
     [Fact]
@@ -80,12 +80,12 @@ public class FindingPilotTests
         var old = Stream("c0", "c1", "c2");
         var @new = Stream("c1", "c2", "c0");
 
-        var correspondence = FindingMatcher.Match(old, @new);
+        var match = FindingMatcher.Match(old, @new);
 
-        Assert.Equal(0, Count(correspondence, FindingMatchKind.Moved));
-        Assert.Equal(1, Count(correspondence, FindingMatchKind.Added));
-        Assert.Equal(1, Count(correspondence, FindingMatchKind.Removed));
-        var candidate = Assert.Single(correspondence.MoveCandidates);
+        Assert.Equal(0, Count(match, FindingEdgeKind.Moved));
+        Assert.Equal(1, Count(match, FindingEdgeKind.Added));
+        Assert.Equal(1, Count(match, FindingEdgeKind.Removed));
+        var candidate = Assert.Single(match.MoveCandidates);
         Assert.Equal(50, candidate.Confidence);
     }
 
@@ -94,14 +94,14 @@ public class FindingPilotTests
     {
         var old = Stream("c0", "c1", "c2");
         var @new = Stream("c1", "c2", "c0");
-        var correspondence = FindingMatcher.Match(old, @new);
+        var match = FindingMatcher.Match(old, @new);
 
-        var strict = FindingFold.ToRows(correspondence, old, @new, Subject, Descriptor);
+        var strict = FindingFold.ToRows(match, old, @new, Subject, Descriptor);
         Assert.Equal(0, strict.Count(r => r.DifferenceKind == FindingDifferenceKind.Moved));
         Assert.Equal(1, strict.Count(r => r.Kind == FindingKind.Added));
         Assert.Equal(1, strict.Count(r => r.Kind == FindingKind.Removed));
 
-        var recall = FindingFold.ToRows(correspondence, old, @new, Subject, Descriptor, acceptanceThreshold: 50);
+        var recall = FindingFold.ToRows(match, old, @new, Subject, Descriptor, acceptanceThreshold: 50);
         Assert.Equal(1, recall.Count(r => r.DifferenceKind == FindingDifferenceKind.Moved));
         Assert.Equal(0, recall.Count(r => r.Kind == FindingKind.Added));
         Assert.Equal(0, recall.Count(r => r.Kind == FindingKind.Removed));
@@ -119,8 +119,8 @@ public class FindingPilotTests
             new FindingOccurrence("c2"),
             new FindingOccurrence("c0", ScopeKey: "loop1"));
 
-        var correspondence = FindingMatcher.Match(old, @new);
-        var candidate = Assert.Single(correspondence.MoveCandidates);
+        var match = FindingMatcher.Match(old, @new);
+        var candidate = Assert.Single(match.MoveCandidates);
         Assert.Equal(75, candidate.Confidence);
         Assert.Equal("content+scope", candidate.Reason);
     }
@@ -130,8 +130,8 @@ public class FindingPilotTests
     {
         var old = Stream("A", "B", "C", "m1", "m2", "D", "E");
         var @new = Stream("m1", "m2", "A", "B", "C", "D", "E");
-        var correspondence = FindingMatcher.Match(old, @new);
-        var rows = FindingFold.ToRows(correspondence, old, @new, Subject, Descriptor);
+        var match = FindingMatcher.Match(old, @new);
+        var rows = FindingFold.ToRows(match, old, @new, Subject, Descriptor);
 
         // Order is semantic under the fidelity fold: a reorder is a real difference.
         Assert.False(FindingEquivalence.Exact.IsEquivalent(rows));
@@ -143,8 +143,8 @@ public class FindingPilotTests
     public void IdenticalStreams_AreExact()
     {
         var stream = Stream("a", "b", "c", "d");
-        var correspondence = FindingMatcher.Match(stream, stream);
-        var rows = FindingFold.ToRows(correspondence, stream, stream, Subject, Descriptor);
+        var match = FindingMatcher.Match(stream, stream);
+        var rows = FindingFold.ToRows(match, stream, stream, Subject, Descriptor);
 
         Assert.All(rows, r => Assert.Equal(FindingKind.Present, r.Kind));
         Assert.True(FindingEquivalence.Exact.IsEquivalent(rows));
@@ -158,11 +158,11 @@ public class FindingPilotTests
         var old = Stream("M1", "A", "M2", "B");
         var @new = Stream("A", "B", "M1", "M2");
 
-        var correspondence = FindingMatcher.Match(old, @new);
+        var match = FindingMatcher.Match(old, @new);
 
-        Assert.Equal(0, Count(correspondence, FindingMatchKind.Moved));
-        Assert.Equal(2, Count(correspondence, FindingMatchKind.Added));
-        Assert.Equal(2, Count(correspondence, FindingMatchKind.Removed));
+        Assert.Equal(0, Count(match, FindingEdgeKind.Moved));
+        Assert.Equal(2, Count(match, FindingEdgeKind.Added));
+        Assert.Equal(2, Count(match, FindingEdgeKind.Removed));
     }
 
     [Fact]
@@ -173,11 +173,11 @@ public class FindingPilotTests
         var old = Stream("A", "B");
         var @new = Stream("B", "A", "A");
 
-        var correspondence = FindingMatcher.Match(old, @new);
+        var match = FindingMatcher.Match(old, @new);
 
-        Assert.Equal(2, correspondence.MoveCandidates.Length);
-        Assert.All(correspondence.MoveCandidates, c => Assert.Equal("A", old[c.OldIndex].IdentityKey));
-        Assert.All(correspondence.MoveCandidates, c => Assert.Equal("A", @new[c.NewIndex].IdentityKey));
+        Assert.Equal(2, match.MoveCandidates.Length);
+        Assert.All(match.MoveCandidates, c => Assert.Equal("A", old[c.OldIndex].IdentityKey));
+        Assert.All(match.MoveCandidates, c => Assert.Equal("A", @new[c.NewIndex].IdentityKey));
     }
 
     [Fact]
@@ -189,7 +189,7 @@ public class FindingPilotTests
         var first = FindingMatcher.Match(old, @new);
         var second = FindingMatcher.Match(old, @new);
 
-        Assert.Equal(first.Entries, second.Entries);
+        Assert.Equal(first.Edges, second.Edges);
         Assert.Equal(first.MoveCandidates, second.MoveCandidates);
     }
 

--- a/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
@@ -1,26 +1,26 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
 
-using ILInspector.Evidence;
+using ILInspector.Findings;
 
 namespace ILInspector.Instructions.Tests;
 
 /// <summary>
-/// Pilot gates for the evidence spine (#2564): the domain-free correspondence engine plus the IL
+/// Pilot gates for the finding spine (#2564): the domain-free correspondence engine plus the IL
 /// adapter. The engine's committed core is an LCS (so it reproduces the existing IL sequence
 /// diff on move-free inputs); the move pass recovers relocations; equivalence is a consumer fold.
 /// </summary>
-public class EvidencePilotTests
+public class FindingPilotTests
 {
     // ---- Leaf engine: synthetic occurrence streams -------------------------------------------
 
-    static ImmutableArray<EvidenceOccurrence> Stream(params string[] keys)
-        => [.. keys.Select(k => new EvidenceOccurrence(k))];
+    static ImmutableArray<FindingOccurrence> Stream(params string[] keys)
+        => [.. keys.Select(k => new FindingOccurrence(k))];
 
-    static readonly EvidenceSubject Subject = new("test", "test");
-    static readonly EvidenceDescriptor Descriptor = new("test.item", "item");
+    static readonly FindingSubject Subject = new("test", "test");
+    static readonly FindingDescriptor Descriptor = new("test.item", "item");
 
-    static int Count(EvidenceMatch c, EvidenceMatchKind kind)
+    static int Count(FindingMatch c, FindingMatchKind kind)
         => c.Entries.Count(l => l.Kind == kind);
 
     [Fact]
@@ -40,8 +40,8 @@ public class EvidencePilotTests
 
         foreach (var (old, @new) in cases)
         {
-            var correspondence = EvidenceMatcher.Match(Stream(old), Stream(@new));
-            var matched = correspondence.Entries.Where(l => l.Kind == EvidenceMatchKind.Matched).ToArray();
+            var correspondence = FindingMatcher.Match(Stream(old), Stream(@new));
+            var matched = correspondence.Entries.Where(l => l.Kind == FindingMatchKind.Matched).ToArray();
 
             // Optimality: as long as a classic LCS.
             Assert.Equal(ReferenceLcsLength(old, @new), matched.Length);
@@ -66,11 +66,11 @@ public class EvidencePilotTests
         var old = Stream("A", "B", "C", "m1", "m2", "D", "E");
         var @new = Stream("m1", "m2", "A", "B", "C", "D", "E");
 
-        var correspondence = EvidenceMatcher.Match(old, @new);
+        var correspondence = FindingMatcher.Match(old, @new);
 
-        Assert.Equal(2, Count(correspondence, EvidenceMatchKind.Moved));
-        Assert.Equal(0, Count(correspondence, EvidenceMatchKind.Added));
-        Assert.Equal(0, Count(correspondence, EvidenceMatchKind.Removed));
+        Assert.Equal(2, Count(correspondence, FindingMatchKind.Moved));
+        Assert.Equal(0, Count(correspondence, FindingMatchKind.Added));
+        Assert.Equal(0, Count(correspondence, FindingMatchKind.Removed));
     }
 
     [Fact]
@@ -80,11 +80,11 @@ public class EvidencePilotTests
         var old = Stream("c0", "c1", "c2");
         var @new = Stream("c1", "c2", "c0");
 
-        var correspondence = EvidenceMatcher.Match(old, @new);
+        var correspondence = FindingMatcher.Match(old, @new);
 
-        Assert.Equal(0, Count(correspondence, EvidenceMatchKind.Moved));
-        Assert.Equal(1, Count(correspondence, EvidenceMatchKind.Added));
-        Assert.Equal(1, Count(correspondence, EvidenceMatchKind.Removed));
+        Assert.Equal(0, Count(correspondence, FindingMatchKind.Moved));
+        Assert.Equal(1, Count(correspondence, FindingMatchKind.Added));
+        Assert.Equal(1, Count(correspondence, FindingMatchKind.Removed));
         var candidate = Assert.Single(correspondence.MoveCandidates);
         Assert.Equal(50, candidate.Confidence);
     }
@@ -94,32 +94,32 @@ public class EvidencePilotTests
     {
         var old = Stream("c0", "c1", "c2");
         var @new = Stream("c1", "c2", "c0");
-        var correspondence = EvidenceMatcher.Match(old, @new);
+        var correspondence = FindingMatcher.Match(old, @new);
 
-        var strict = EvidenceFold.ToRows(correspondence, old, @new, Subject, Descriptor);
-        Assert.Equal(0, strict.Count(r => r.DifferenceKind == EvidenceDifferenceKind.Moved));
-        Assert.Equal(1, strict.Count(r => r.Kind == EvidenceRowKind.Added));
-        Assert.Equal(1, strict.Count(r => r.Kind == EvidenceRowKind.Removed));
+        var strict = FindingFold.ToRows(correspondence, old, @new, Subject, Descriptor);
+        Assert.Equal(0, strict.Count(r => r.DifferenceKind == FindingDifferenceKind.Moved));
+        Assert.Equal(1, strict.Count(r => r.Kind == FindingKind.Added));
+        Assert.Equal(1, strict.Count(r => r.Kind == FindingKind.Removed));
 
-        var recall = EvidenceFold.ToRows(correspondence, old, @new, Subject, Descriptor, acceptanceThreshold: 50);
-        Assert.Equal(1, recall.Count(r => r.DifferenceKind == EvidenceDifferenceKind.Moved));
-        Assert.Equal(0, recall.Count(r => r.Kind == EvidenceRowKind.Added));
-        Assert.Equal(0, recall.Count(r => r.Kind == EvidenceRowKind.Removed));
+        var recall = FindingFold.ToRows(correspondence, old, @new, Subject, Descriptor, acceptanceThreshold: 50);
+        Assert.Equal(1, recall.Count(r => r.DifferenceKind == FindingDifferenceKind.Moved));
+        Assert.Equal(0, recall.Count(r => r.Kind == FindingKind.Added));
+        Assert.Equal(0, recall.Count(r => r.Kind == FindingKind.Removed));
     }
 
     [Fact]
     public void ScopeCorroboration_RaisesFringeScore()
     {
         var old = ImmutableArray.Create(
-            new EvidenceOccurrence("c0", ScopeKey: "loop1"),
-            new EvidenceOccurrence("c1"),
-            new EvidenceOccurrence("c2"));
+            new FindingOccurrence("c0", ScopeKey: "loop1"),
+            new FindingOccurrence("c1"),
+            new FindingOccurrence("c2"));
         var @new = ImmutableArray.Create(
-            new EvidenceOccurrence("c1"),
-            new EvidenceOccurrence("c2"),
-            new EvidenceOccurrence("c0", ScopeKey: "loop1"));
+            new FindingOccurrence("c1"),
+            new FindingOccurrence("c2"),
+            new FindingOccurrence("c0", ScopeKey: "loop1"));
 
-        var correspondence = EvidenceMatcher.Match(old, @new);
+        var correspondence = FindingMatcher.Match(old, @new);
         var candidate = Assert.Single(correspondence.MoveCandidates);
         Assert.Equal(75, candidate.Confidence);
         Assert.Equal("content+scope", candidate.Reason);
@@ -130,24 +130,24 @@ public class EvidencePilotTests
     {
         var old = Stream("A", "B", "C", "m1", "m2", "D", "E");
         var @new = Stream("m1", "m2", "A", "B", "C", "D", "E");
-        var correspondence = EvidenceMatcher.Match(old, @new);
-        var rows = EvidenceFold.ToRows(correspondence, old, @new, Subject, Descriptor);
+        var correspondence = FindingMatcher.Match(old, @new);
+        var rows = FindingFold.ToRows(correspondence, old, @new, Subject, Descriptor);
 
         // Order is semantic under the fidelity fold: a reorder is a real difference.
-        Assert.False(EvidenceEquivalence.Exact.IsEquivalent(rows));
+        Assert.False(FindingEquivalence.Exact.IsEquivalent(rows));
         // The multiset of operations is unchanged: a reorder is forgiven.
-        Assert.True(EvidenceEquivalence.Multiset.IsEquivalent(rows));
+        Assert.True(FindingEquivalence.Multiset.IsEquivalent(rows));
     }
 
     [Fact]
     public void IdenticalStreams_AreExact()
     {
         var stream = Stream("a", "b", "c", "d");
-        var correspondence = EvidenceMatcher.Match(stream, stream);
-        var rows = EvidenceFold.ToRows(correspondence, stream, stream, Subject, Descriptor);
+        var correspondence = FindingMatcher.Match(stream, stream);
+        var rows = FindingFold.ToRows(correspondence, stream, stream, Subject, Descriptor);
 
-        Assert.All(rows, r => Assert.Equal(EvidenceRowKind.Present, r.Kind));
-        Assert.True(EvidenceEquivalence.Exact.IsEquivalent(rows));
+        Assert.All(rows, r => Assert.Equal(FindingKind.Present, r.Kind));
+        Assert.True(FindingEquivalence.Exact.IsEquivalent(rows));
     }
 
     [Fact]
@@ -158,11 +158,11 @@ public class EvidencePilotTests
         var old = Stream("M1", "A", "M2", "B");
         var @new = Stream("A", "B", "M1", "M2");
 
-        var correspondence = EvidenceMatcher.Match(old, @new);
+        var correspondence = FindingMatcher.Match(old, @new);
 
-        Assert.Equal(0, Count(correspondence, EvidenceMatchKind.Moved));
-        Assert.Equal(2, Count(correspondence, EvidenceMatchKind.Added));
-        Assert.Equal(2, Count(correspondence, EvidenceMatchKind.Removed));
+        Assert.Equal(0, Count(correspondence, FindingMatchKind.Moved));
+        Assert.Equal(2, Count(correspondence, FindingMatchKind.Added));
+        Assert.Equal(2, Count(correspondence, FindingMatchKind.Removed));
     }
 
     [Fact]
@@ -173,7 +173,7 @@ public class EvidencePilotTests
         var old = Stream("A", "B");
         var @new = Stream("B", "A", "A");
 
-        var correspondence = EvidenceMatcher.Match(old, @new);
+        var correspondence = FindingMatcher.Match(old, @new);
 
         Assert.Equal(2, correspondence.MoveCandidates.Length);
         Assert.All(correspondence.MoveCandidates, c => Assert.Equal("A", old[c.OldIndex].IdentityKey));
@@ -186,8 +186,8 @@ public class EvidencePilotTests
         var old = Stream("x", "a", "y", "a", "z", "a");
         var @new = Stream("a", "z", "a", "x", "a", "y");
 
-        var first = EvidenceMatcher.Match(old, @new);
-        var second = EvidenceMatcher.Match(old, @new);
+        var first = FindingMatcher.Match(old, @new);
+        var second = FindingMatcher.Match(old, @new);
 
         Assert.Equal(first.Entries, second.Entries);
         Assert.Equal(first.MoveCandidates, second.MoveCandidates);
@@ -199,10 +199,10 @@ public class EvidencePilotTests
         // The ordered LCS matrix is O(N*M); guard it so an assembly-scale stream fails loudly
         // instead of attempting a multi-gigabyte allocation (issue #2585).
         var big = Enumerable.Range(0, 8000)
-            .Select(i => new EvidenceOccurrence(i.ToString(System.Globalization.CultureInfo.InvariantCulture)))
+            .Select(i => new FindingOccurrence(i.ToString(System.Globalization.CultureInfo.InvariantCulture)))
             .ToArray();
 
-        var ex = Assert.Throws<ArgumentException>(() => EvidenceMatcher.Match(big, big));
+        var ex = Assert.Throws<ArgumentException>(() => FindingMatcher.Match(big, big));
         Assert.Contains("identity-set", ex.Message, StringComparison.Ordinal);
     }
 
@@ -212,35 +212,35 @@ public class EvidencePilotTests
         // A stream-agnostic consumer: it reads only the skeleton, so the same rows could have
         // come from IL, C#, or a fact producer. Here we drive it from the IL adapter.
         var identical = Body(Ldc0, Ldc1, Ret);
-        var identicalRows = IlEvidence.Compare(identical, null, identical, null, IlSubject).Rows;
-        Assert.Equal(EvidenceFinding.Identical, EvidenceDiffSummary.Summarize(identicalRows).Finding);
+        var identicalRows = IlFindings.Compare(identical, null, identical, null, IlSubject).Rows;
+        Assert.Equal(DiffShape.Identical, FindingSummary.Summarize(identicalRows).Shape);
 
         var old = Body(Ldc0, Ldc1, Ldc2, Ldc3, Ldc4, Ldc5, Ldc6, Ret);
         var reordered = Body(Ldc3, Ldc4, Ldc0, Ldc1, Ldc2, Ldc5, Ldc6, Ret);
-        var reorderRows = IlEvidence.Compare(old, null, reordered, null, IlSubject).Rows;
-        var reorderSummary = EvidenceDiffSummary.Summarize(reorderRows);
-        Assert.Equal(EvidenceFinding.ReorderOnly, reorderSummary.Finding);
+        var reorderRows = IlFindings.Compare(old, null, reordered, null, IlSubject).Rows;
+        var reorderSummary = FindingSummary.Summarize(reorderRows);
+        Assert.Equal(DiffShape.ReorderOnly, reorderSummary.Shape);
         Assert.Equal(2, reorderSummary.Moved);
 
         var changed = Body(Ldc0, Ldc2, Ldc3, Ret);
-        var changedRows = IlEvidence.Compare(old, null, changed, null, IlSubject).Rows;
-        Assert.Equal(EvidenceFinding.Structural, EvidenceDiffSummary.Summarize(changedRows).Finding);
+        var changedRows = IlFindings.Compare(old, null, changed, null, IlSubject).Rows;
+        Assert.Equal(DiffShape.Structural, FindingSummary.Summarize(changedRows).Shape);
     }
 
     [Fact]
     public void SkeletonConsumer_IsStreamAgnostic_OverHandBuiltRows()
     {
         // Rows fabricated as if from an arbitrary (non-IL) stream: the consumer does not care.
-        var subject = new EvidenceSubject("s", "s");
-        var descriptor = new EvidenceDescriptor("any.kind", "any");
-        EvidenceRow[] rows =
+        var subject = new FindingSubject("s", "s");
+        var descriptor = new FindingDescriptor("any.kind", "any");
+        Finding[] rows =
         [
-            new(subject, descriptor, EvidenceRowKind.Present, new EvidenceAnchor("k0", 0, 0)),
-            new(subject, descriptor, EvidenceRowKind.Added, new EvidenceAnchor("k1", -1, 1)),
+            new(subject, descriptor, FindingKind.Present, new FindingAnchor("k0", 0, 0)),
+            new(subject, descriptor, FindingKind.Added, new FindingAnchor("k1", -1, 1)),
         ];
 
-        var summary = EvidenceDiffSummary.Summarize(rows);
-        Assert.Equal(EvidenceFinding.Structural, summary.Finding);
+        var summary = FindingSummary.Summarize(rows);
+        Assert.Equal(DiffShape.Structural, summary.Shape);
         Assert.Equal(1, summary.Added);
         Assert.Equal(1, summary.Present);
     }
@@ -266,10 +266,10 @@ public class EvidencePilotTests
     const byte Ldc0 = 0x16, Ldc1 = 0x17, Ldc2 = 0x18, Ldc3 = 0x19, Ldc4 = 0x1A, Ldc5 = 0x1B, Ldc6 = 0x1C, Ret = 0x2A;
     const byte BrS = 0x2B, Nop = 0x00;
 
-    static readonly EvidenceSubject IlSubject = new("M", "M");
+    static readonly FindingSubject IlSubject = new("M", "M");
 
     [Fact]
-    public void IlEvidence_PathologicallyLargeBody_FailsClosed()
+    public void IlFindings_PathologicallyLargeBody_FailsClosed()
     {
         // A body large enough to exceed the ordered matcher's cell guard must fail closed
         // (return a failure result), not throw at the caller — consistent with the decode path.
@@ -277,14 +277,14 @@ public class EvidencePilotTests
         il[^1] = Ret; // 8999 nops + ret
         var body = Body(il);
 
-        var result = IlEvidence.Compare(body, null, body, null, IlSubject);
+        var result = IlFindings.Compare(body, null, body, null, IlSubject);
 
         Assert.NotNull(result.Failure);
         Assert.False(result.IsExact);
     }
 
     [Fact]
-    public void IlEvidence_BranchRetarget_IsChangedNotExact()
+    public void IlFindings_BranchRetarget_IsChangedNotExact()
     {
         // br.s to IL_0005 (second ret) vs br.s to IL_0003 (first ret): a real control-flow retarget.
         // The branch operation's content key ignores its target, so without target validation this
@@ -292,34 +292,34 @@ public class EvidencePilotTests
         var old = Body(BrS, 0x03, Nop, Ret, Nop, Ret);
         var @new = Body(BrS, 0x01, Nop, Ret, Nop, Ret);
 
-        var result = IlEvidence.Compare(old, null, @new, null, IlSubject);
+        var result = IlFindings.Compare(old, null, @new, null, IlSubject);
 
         Assert.Null(result.Failure);
         Assert.False(result.IsExact);
-        Assert.Contains(result.Rows, r => r.Kind == EvidenceRowKind.Changed);
+        Assert.Contains(result.Rows, r => r.Kind == FindingKind.Changed);
         Assert.False(IlBodyDiff.Compare(old, @new).IsExact);
     }
 
     [Fact]
-    public void IlEvidence_BranchInsideMovedBlock_IsReorderNotRetarget()
+    public void IlFindings_BranchInsideMovedBlock_IsReorderNotRetarget()
     {
         // The [ldc.i4.0, br.s] block (branch targets the ldc just before it) relocates ahead of the
         // NOP spine. The branch is byte-identical and still targets its (moved) ldc, so it must read
-        // as a move, not a retarget. Requires overlaying the evidence Moved mappings onto the
+        // as a move, not a retarget. Requires overlaying the finding Moved mappings onto the
         // IlBodyDiff alignment map (which is move-blind).
         var old = Body(Nop, Nop, Nop, Ldc0, BrS, 0xFD, Ret);
         var @new = Body(Ldc0, BrS, 0xFD, Nop, Nop, Nop, Ret);
 
-        var result = IlEvidence.Compare(old, null, @new, null, IlSubject);
+        var result = IlFindings.Compare(old, null, @new, null, IlSubject);
 
         Assert.Null(result.Failure);
-        Assert.DoesNotContain(result.Rows, r => r.Kind == EvidenceRowKind.Changed);
-        Assert.Equal(2, result.Rows.Count(r => r.DifferenceKind == EvidenceDifferenceKind.Moved));
-        Assert.True(EvidenceEquivalence.Multiset.IsEquivalent(result.Rows));
+        Assert.DoesNotContain(result.Rows, r => r.Kind == FindingKind.Changed);
+        Assert.Equal(2, result.Rows.Count(r => r.DifferenceKind == FindingDifferenceKind.Moved));
+        Assert.True(FindingEquivalence.Multiset.IsEquivalent(result.Rows));
     }
 
     [Fact]
-    public void IlEvidence_Exactness_AgreesWithIlBodyDiff_AcrossFixtures()
+    public void IlFindings_Exactness_AgreesWithIlBodyDiff_AcrossFixtures()
     {
         (byte[] Old, byte[] New)[] pairs =
         [
@@ -334,14 +334,14 @@ public class EvidencePilotTests
         {
             var old = Body(oldBytes);
             var @new = Body(newBytes);
-            bool evidenceExact = IlEvidence.Compare(old, null, @new, null, IlSubject).IsExact;
+            bool findingExact = IlFindings.Compare(old, null, @new, null, IlSubject).IsExact;
             bool classicExact = IlBodyDiff.Compare(old, @new).IsExact;
-            Assert.Equal(classicExact, evidenceExact);
+            Assert.Equal(classicExact, findingExact);
         }
     }
 
     [Fact]
-    public void IlEvidence_BranchTargetContentChangedButSlotStable_BranchIsNotRetargeted()
+    public void IlFindings_BranchTargetContentChangedButSlotStable_BranchIsNotRetargeted()
     {
         // br.s targets the instruction right after it; that instruction's content changes
         // (ldc.i4.0 -> ldc.i4.1) but stays in the same slot. IlBodyDiff's equal-size gap-pair
@@ -349,96 +349,96 @@ public class EvidencePilotTests
         var old = Body(BrS, 0x00, Ldc0, Ret);
         var @new = Body(BrS, 0x00, Ldc1, Ret);
 
-        var result = IlEvidence.Compare(old, null, @new, null, IlSubject);
+        var result = IlFindings.Compare(old, null, @new, null, IlSubject);
 
         Assert.Null(result.Failure);
-        Assert.DoesNotContain(result.Rows, r => r.Kind == EvidenceRowKind.Changed);
-        Assert.Equal(1, result.Rows.Count(r => r.Kind == EvidenceRowKind.Added));
-        Assert.Equal(1, result.Rows.Count(r => r.Kind == EvidenceRowKind.Removed));
+        Assert.DoesNotContain(result.Rows, r => r.Kind == FindingKind.Changed);
+        Assert.Equal(1, result.Rows.Count(r => r.Kind == FindingKind.Added));
+        Assert.Equal(1, result.Rows.Count(r => r.Kind == FindingKind.Removed));
     }
 
     [Fact]
-    public void IlEvidence_SameBranch_IsExact()
+    public void IlFindings_SameBranch_IsExact()
     {
         // Branch validation must not false-positive: an identical body with a branch is exact.
         var body = Body(BrS, 0x01, Nop, Ret, Nop, Ret);
-        var result = IlEvidence.Compare(body, null, body, null, IlSubject);
+        var result = IlFindings.Compare(body, null, body, null, IlSubject);
 
         Assert.Null(result.Failure);
         Assert.True(result.IsExact);
     }
 
     [Fact]
-    public void IlEvidence_SameBody_IsExact()
+    public void IlFindings_SameBody_IsExact()
     {
         var body = Body(Ldc0, Ldc1, Ldc2, Ret);
-        var result = IlEvidence.Compare(body, null, body, null, IlSubject);
+        var result = IlFindings.Compare(body, null, body, null, IlSubject);
 
         Assert.Null(result.Failure);
         Assert.True(result.IsExact);
-        Assert.All(result.Rows, r => Assert.Equal(EvidenceRowKind.Present, r.Kind));
+        Assert.All(result.Rows, r => Assert.Equal(FindingKind.Present, r.Kind));
     }
 
     [Fact]
-    public void IlEvidence_RelocatedBlock_IsDetectedAsMoved()
+    public void IlFindings_RelocatedBlock_IsDetectedAsMoved()
     {
         // old: c0 c1 c2 c3 c4 c5 c6 ret ; new moves the [c3,c4] block to the front.
         var old = Body(Ldc0, Ldc1, Ldc2, Ldc3, Ldc4, Ldc5, Ldc6, Ret);
         var @new = Body(Ldc3, Ldc4, Ldc0, Ldc1, Ldc2, Ldc5, Ldc6, Ret);
 
-        var result = IlEvidence.Compare(old, null, @new, null, IlSubject);
+        var result = IlFindings.Compare(old, null, @new, null, IlSubject);
 
         Assert.Null(result.Failure);
-        Assert.Equal(2, result.Rows.Count(r => r.DifferenceKind == EvidenceDifferenceKind.Moved));
-        Assert.Equal(0, result.Rows.Count(r => r.Kind is EvidenceRowKind.Added or EvidenceRowKind.Removed));
+        Assert.Equal(2, result.Rows.Count(r => r.DifferenceKind == FindingDifferenceKind.Moved));
+        Assert.Equal(0, result.Rows.Count(r => r.Kind is FindingKind.Added or FindingKind.Removed));
         Assert.False(result.IsExact);
-        Assert.True(EvidenceEquivalence.Multiset.IsEquivalent(result.Rows));
+        Assert.True(FindingEquivalence.Multiset.IsEquivalent(result.Rows));
     }
 
     [Fact]
-    public void IlEvidence_CommittedCore_ReproducesIlBodyDiffResidual()
+    public void IlFindings_CommittedCore_ReproducesIlBodyDiffResidual()
     {
-        // A body pair with no moves: pure insert/delete. The evidence adapter's Added/Removed
+        // A body pair with no moves: pure insert/delete. The finding adapter's Added/Removed
         // operations must match IlBodyDiff's Add/Remove rows (the committed core is the LCS).
         var old = Body(Ldc0, Ldc1, Ldc2, Ret);
         var @new = Body(Ldc0, Ldc2, Ldc3, Ret);
 
         var classic = IlBodyDiff.Compare(old, @new);
-        var evidence = IlEvidence.Compare(old, null, @new, null, IlSubject);
+        var finding = IlFindings.Compare(old, null, @new, null, IlSubject);
 
-        Assert.Equal(0, evidence.Rows.Count(r => r.DifferenceKind == EvidenceDifferenceKind.Moved));
+        Assert.Equal(0, finding.Rows.Count(r => r.DifferenceKind == FindingDifferenceKind.Moved));
 
         var classicRemoved = classic.Rows
             .Where(r => r.Kind == IlDiffKind.Remove)
-            .Select(r => IlEvidence.GetIdentityKey(r.Operation))
+            .Select(r => IlFindings.GetIdentityKey(r.Operation))
             .OrderBy(k => k, StringComparer.Ordinal)
             .ToArray();
-        var evidenceRemoved = ResidualKeys(evidence, EvidenceRowKind.Removed);
-        Assert.Equal(classicRemoved, evidenceRemoved);
+        var findingRemoved = ResidualKeys(finding, FindingKind.Removed);
+        Assert.Equal(classicRemoved, findingRemoved);
 
         var classicAdded = classic.Rows
             .Where(r => r.Kind == IlDiffKind.Add)
-            .Select(r => IlEvidence.GetIdentityKey(r.Operation))
+            .Select(r => IlFindings.GetIdentityKey(r.Operation))
             .OrderBy(k => k, StringComparer.Ordinal)
             .ToArray();
-        var evidenceAdded = ResidualKeys(evidence, EvidenceRowKind.Added);
-        Assert.Equal(classicAdded, evidenceAdded);
+        var findingAdded = ResidualKeys(finding, FindingKind.Added);
+        Assert.Equal(classicAdded, findingAdded);
     }
 
     [Fact]
-    public void IlEvidence_MismatchResistance_SingletonStaysAddedRemoved()
+    public void IlFindings_MismatchResistance_SingletonStaysAddedRemoved()
     {
         var old = Body(Ldc0, Ldc1, Ldc2, Ret);
         var @new = Body(Ldc1, Ldc2, Ldc0, Ret);
 
-        var result = IlEvidence.Compare(old, null, @new, null, IlSubject);
+        var result = IlFindings.Compare(old, null, @new, null, IlSubject);
 
-        Assert.Equal(0, result.Rows.Count(r => r.DifferenceKind == EvidenceDifferenceKind.Moved));
-        Assert.Equal(1, result.Rows.Count(r => r.Kind == EvidenceRowKind.Added));
-        Assert.Equal(1, result.Rows.Count(r => r.Kind == EvidenceRowKind.Removed));
+        Assert.Equal(0, result.Rows.Count(r => r.DifferenceKind == FindingDifferenceKind.Moved));
+        Assert.Equal(1, result.Rows.Count(r => r.Kind == FindingKind.Added));
+        Assert.Equal(1, result.Rows.Count(r => r.Kind == FindingKind.Removed));
     }
 
-    static string[] ResidualKeys(IlEvidenceResult result, EvidenceRowKind polarity)
+    static string[] ResidualKeys(IlFindingsResult result, FindingKind polarity)
         => result.Rows
             .Where(r => r.Kind == polarity)
             .Select(r => r.Anchor.IdentityKey)
@@ -449,9 +449,9 @@ public class EvidencePilotTests
 
     [Theory]
     [InlineData(typeof(IlBodyDiff))]                    // ILInspector.Instructions: diverse real IL.
-    [InlineData(typeof(EvidencePilotTests))]            // the test assembly itself.
+    [InlineData(typeof(FindingPilotTests))]            // the test assembly itself.
     [InlineData(typeof(System.Linq.Enumerable))]        // System.Linq: a larger BCL corpus.
-    public void IlEvidence_SelfCompare_IsExactAcrossWholeAssembly(Type anchorType)
+    public void IlFindings_SelfCompare_IsExactAcrossWholeAssembly(Type anchorType)
     {
         using var stream = File.OpenRead(anchorType.Assembly.Location);
         using var pe = new System.Reflection.PortableExecutable.PEReader(stream);
@@ -478,16 +478,16 @@ public class EvidencePilotTests
             if (!body.IsComplete)
                 continue;
 
-            var subject = new EvidenceSubject(handle.GetHashCode().ToString(System.Globalization.CultureInfo.InvariantCulture), "m");
-            var evidence = IlEvidence.Compare(body, reader, body, reader, subject);
-            if (evidence.Failure is not null)
+            var subject = new FindingSubject(handle.GetHashCode().ToString(System.Globalization.CultureInfo.InvariantCulture), "m");
+            var finding = IlFindings.Compare(body, reader, body, reader, subject);
+            if (finding.Failure is not null)
             {
                 declined++; // rare token-resolution edge cases; tracked, not asserted.
                 continue;
             }
 
             // A body compared to itself must be exact: all Present, no moves, no add/remove.
-            Assert.True(evidence.IsExact, $"IlEvidence self-compare not exact for RVA {method.RelativeVirtualAddress}");
+            Assert.True(finding.IsExact, $"IlFindings self-compare not exact for RVA {method.RelativeVirtualAddress}");
             canonicalized++;
         }
 

--- a/src/ILInspector.Instructions/ILInspector.Instructions.csproj
+++ b/src/ILInspector.Instructions/ILInspector.Instructions.csproj
@@ -16,7 +16,7 @@
   <!-- System.Reflection.Metadata is part of the BCL -->
 
   <ItemGroup>
-    <ProjectReference Include="..\ILInspector.Evidence\ILInspector.Evidence.csproj" />
+    <ProjectReference Include="..\ILInspector.Findings\ILInspector.Findings.csproj" />
     <ProjectReference Include="..\ILInspector.ControlFlow\ILInspector.ControlFlow.csproj" />
   </ItemGroup>
 

--- a/src/ILInspector.Instructions/IlFindings.cs
+++ b/src/ILInspector.Instructions/IlFindings.cs
@@ -9,7 +9,7 @@ namespace ILInspector.Instructions;
 /// Adapts IL method bodies onto the domain-free finding substrate: it canonicalizes each body
 /// (reusing <see cref="IlBodyDiff"/> exactly), projects operations into
 /// <see cref="FindingOccurrence"/>s, runs the shared <see cref="FindingMatcher"/>, and
-/// folds the correspondence into <see cref="Finding"/>s. This is the "IL as finding" pilot:
+/// folds the alignment into <see cref="Finding"/>s. This is the "IL as finding" pilot:
 /// the committed LCS core reproduces <see cref="IlBodyDiff"/> on move-free bodies, and the move
 /// pass recovers relocations that the order-preserving diff cannot.
 /// </summary>
@@ -38,10 +38,10 @@ public static class IlFindings
         var oldStream = BuildOccurrences(oldOps);
         var newStream = BuildOccurrences(newOps);
 
-        FindingMatch correspondence;
+        FindingMatch match;
         try
         {
-            correspondence = FindingMatcher.Match(oldStream, newStream);
+            match = FindingMatcher.Match(oldStream, newStream);
         }
         catch (ArgumentException ex)
         {
@@ -50,9 +50,9 @@ public static class IlFindings
             return IlFindingsResult.Failed(ex.Message);
         }
 
-        var rows = FindingFold.ToRows(correspondence, oldStream, newStream, subject, OperationDescriptor, acceptanceThreshold);
+        var rows = FindingFold.ToRows(match, oldStream, newStream, subject, OperationDescriptor, acceptanceThreshold);
         rows = ApplyBranchTargetValidation(rows, oldBody.Instructions, oldOps, newBody.Instructions, newOps);
-        return new IlFindingsResult(rows, correspondence, oldStream, newStream, Failure: null);
+        return new IlFindingsResult(rows, match, oldStream, newStream, Failure: null);
     }
 
     // IdentityKey deliberately ignores a branch/switch operation's targets (matching CanonicalEquals),

--- a/src/ILInspector.Instructions/IlFindings.cs
+++ b/src/ILInspector.Instructions/IlFindings.cs
@@ -1,29 +1,29 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
 
-using ILInspector.Evidence;
+using ILInspector.Findings;
 
 namespace ILInspector.Instructions;
 
 /// <summary>
-/// Adapts IL method bodies onto the domain-free evidence substrate: it canonicalizes each body
+/// Adapts IL method bodies onto the domain-free finding substrate: it canonicalizes each body
 /// (reusing <see cref="IlBodyDiff"/> exactly), projects operations into
-/// <see cref="EvidenceOccurrence"/>s, runs the shared <see cref="EvidenceMatcher"/>, and
-/// folds the correspondence into <see cref="EvidenceRow"/>s. This is the "IL as evidence" pilot:
+/// <see cref="FindingOccurrence"/>s, runs the shared <see cref="FindingMatcher"/>, and
+/// folds the correspondence into <see cref="Finding"/>s. This is the "IL as finding" pilot:
 /// the committed LCS core reproduces <see cref="IlBodyDiff"/> on move-free bodies, and the move
 /// pass recovers relocations that the order-preserving diff cannot.
 /// </summary>
-public static class IlEvidence
+public static class IlFindings
 {
-    /// <summary>The evidence descriptor for a single IL operation occurrence.</summary>
-    public static readonly EvidenceDescriptor OperationDescriptor = new("il.op", "IL operation");
+    /// <summary>The finding descriptor for a single IL operation occurrence.</summary>
+    public static readonly FindingDescriptor OperationDescriptor = new("il.op", "IL operation");
 
-    public static IlEvidenceResult Compare(
+    public static IlFindingsResult Compare(
         MethodInstructions oldBody,
         MetadataReader? oldReader,
         MethodInstructions newBody,
         MetadataReader? newReader,
-        EvidenceSubject subject,
+        FindingSubject subject,
         int acceptanceThreshold = 100)
     {
         ArgumentNullException.ThrowIfNull(oldBody);
@@ -31,38 +31,38 @@ public static class IlEvidence
         ArgumentNullException.ThrowIfNull(subject);
 
         if (!IlBodyDiff.TryCanonicalize(oldBody, oldReader, out var oldOps, out var oldFailure))
-            return IlEvidenceResult.Failed(oldFailure ?? "old body canonicalization failed");
+            return IlFindingsResult.Failed(oldFailure ?? "old body canonicalization failed");
         if (!IlBodyDiff.TryCanonicalize(newBody, newReader, out var newOps, out var newFailure))
-            return IlEvidenceResult.Failed(newFailure ?? "new body canonicalization failed");
+            return IlFindingsResult.Failed(newFailure ?? "new body canonicalization failed");
 
         var oldStream = BuildOccurrences(oldOps);
         var newStream = BuildOccurrences(newOps);
 
-        EvidenceMatch correspondence;
+        FindingMatch correspondence;
         try
         {
-            correspondence = EvidenceMatcher.Match(oldStream, newStream);
+            correspondence = FindingMatcher.Match(oldStream, newStream);
         }
         catch (ArgumentException ex)
         {
             // Fail closed like the canonicalization path: a pathological body that exceeds the
             // ordered matcher's size guard returns a failure result instead of throwing at the caller.
-            return IlEvidenceResult.Failed(ex.Message);
+            return IlFindingsResult.Failed(ex.Message);
         }
 
-        var rows = EvidenceFold.ToRows(correspondence, oldStream, newStream, subject, OperationDescriptor, acceptanceThreshold);
+        var rows = FindingFold.ToRows(correspondence, oldStream, newStream, subject, OperationDescriptor, acceptanceThreshold);
         rows = ApplyBranchTargetValidation(rows, oldBody.Instructions, oldOps, newBody.Instructions, newOps);
-        return new IlEvidenceResult(rows, correspondence, oldStream, newStream, Failure: null);
+        return new IlFindingsResult(rows, correspondence, oldStream, newStream, Failure: null);
     }
 
     // IdentityKey deliberately ignores a branch/switch operation's targets (matching CanonicalEquals),
     // so a matched branch whose target was retargeted would otherwise read as unchanged. Reuse
     // IlBodyDiff's own alignment map and branch-target decision verbatim (not a reimplementation),
-    // then overlay the evidence Moved mappings so a branch that targets a relocated instruction is
-    // judged in the evidence frame (its target moved with it) rather than being falsely retargeted.
+    // then overlay the finding Moved mappings so a branch that targets a relocated instruction is
+    // judged in the finding frame (its target moved with it) rather than being falsely retargeted.
     // On move-free inputs there are no Moved rows, so the map is exactly IlBodyDiff's.
-    static ImmutableArray<EvidenceRow> ApplyBranchTargetValidation(
-        ImmutableArray<EvidenceRow> rows,
+    static ImmutableArray<Finding> ApplyBranchTargetValidation(
+        ImmutableArray<Finding> rows,
         ImmutableArray<DecodedInstruction> oldInstructions,
         ImmutableArray<CanonicalIlOperation> oldOps,
         ImmutableArray<DecodedInstruction> newInstructions,
@@ -71,7 +71,7 @@ public static class IlEvidence
         var alignment = new Dictionary<int, int>(IlBodyDiff.BuildAlignmentMap(oldOps, newOps));
         foreach (var row in rows)
         {
-            if (row.DifferenceKind == EvidenceDifferenceKind.Moved
+            if (row.DifferenceKind == FindingDifferenceKind.Moved
                 && row.Anchor.OldIndex >= 0
                 && row.Anchor.NewIndex >= 0)
             {
@@ -79,15 +79,15 @@ public static class IlEvidence
             }
         }
 
-        var builder = ImmutableArray.CreateBuilder<EvidenceRow>(rows.Length);
+        var builder = ImmutableArray.CreateBuilder<Finding>(rows.Length);
         foreach (var row in rows)
         {
-            if (row.Kind == EvidenceRowKind.Present
+            if (row.Kind == FindingKind.Present
                 && row.Anchor.OldIndex >= 0
                 && row.Anchor.NewIndex >= 0
                 && !IlBodyDiff.BranchTargetsMatch(oldInstructions, row.Anchor.OldIndex, newInstructions, row.Anchor.NewIndex, alignment))
             {
-                builder.Add(row with { Kind = EvidenceRowKind.Changed, Detail = "branch retargeted" });
+                builder.Add(row with { Kind = FindingKind.Changed, Detail = "branch retargeted" });
             }
             else
             {
@@ -98,14 +98,14 @@ public static class IlEvidence
         return builder.ToImmutable();
     }
 
-    static ImmutableArray<EvidenceOccurrence> BuildOccurrences(ImmutableArray<CanonicalIlOperation> operations)
+    static ImmutableArray<FindingOccurrence> BuildOccurrences(ImmutableArray<CanonicalIlOperation> operations)
     {
-        var builder = ImmutableArray.CreateBuilder<EvidenceOccurrence>(operations.Length);
+        var builder = ImmutableArray.CreateBuilder<FindingOccurrence>(operations.Length);
         foreach (var operation in operations)
         {
             // ScopeKey is left null in the pilot: move detection is corroborated by run
             // contiguity, and EH/loop-region scope is the Attach layer's concern (issue #2564).
-            builder.Add(new EvidenceOccurrence(GetIdentityKey(operation), ScopeKey: null, Payload: operation));
+            builder.Add(new FindingOccurrence(GetIdentityKey(operation), ScopeKey: null, Payload: operation));
         }
 
         return builder.MoveToImmutable();
@@ -131,17 +131,17 @@ public static class IlEvidence
     }
 }
 
-/// <summary>The outcome of an <see cref="IlEvidence.Compare"/> call.</summary>
-public sealed record IlEvidenceResult(
-    ImmutableArray<EvidenceRow> Rows,
-    EvidenceMatch Match,
-    ImmutableArray<EvidenceOccurrence> OldOccurrences,
-    ImmutableArray<EvidenceOccurrence> NewOccurrences,
+/// <summary>The outcome of an <see cref="IlFindings.Compare"/> call.</summary>
+public sealed record IlFindingsResult(
+    ImmutableArray<Finding> Rows,
+    FindingMatch Match,
+    ImmutableArray<FindingOccurrence> OldOccurrences,
+    ImmutableArray<FindingOccurrence> NewOccurrences,
     string? Failure)
 {
     /// <summary>True when the bodies are exact under the fidelity fold (no adds/removes/moves).</summary>
-    public bool IsExact => Failure is null && EvidenceEquivalence.Exact.IsEquivalent(Rows);
+    public bool IsExact => Failure is null && FindingEquivalence.Exact.IsEquivalent(Rows);
 
-    public static IlEvidenceResult Failed(string failure)
-        => new([], new EvidenceMatch([], []), [], [], failure);
+    public static IlFindingsResult Failed(string failure)
+        => new([], new FindingMatch([], []), [], [], failure);
 }


### PR DESCRIPTION
## What

Surface rename of the merged `ILInspector.Evidence` leaf (the IL evidence-spine pilot, #2584) to `ILInspector.Findings`. **No behavior change** — pure rename + file/project moves.

## Why

"Evidence" is already heavily overloaded in this codebase as **"proof"**: `UnsafeEvidence`, `ReturnToSenderEvidence`, `ConsumedMemberEvidence`, `ResearchDiffEvidence`, `ImplementationDiffEvidence`, the RTS `subject.IlEvidence` report property, and more. Reusing it for the diff/fact-row substrate invites confusion.

"**Finding**" is the codebase's real word for a producer/analyzer output and is a natural **consolidation target** for the existing `*Finding` types (`LeakTriageFinding`, `BaselineFinding`). This rename establishes the vocabulary before the C#/Metadata/Analysis producers (#2586/#2588/#2589) and the matcher (#2587) stack on top.

## Mapping

| before | after |
| --- | --- |
| `ILInspector.Evidence` (project + namespace) | `ILInspector.Findings` |
| `EvidenceRow` (the atom) | `Finding` |
| `EvidenceRowKind` | `FindingKind` |
| `EvidenceDifferenceKind` | `FindingDifferenceKind` |
| `EvidenceAnchor/Subject/Descriptor/Occurrence/Fold/Equivalence` | `Finding*` |
| `EvidenceMatcher` / `EvidenceMatch` / `EvidenceMatchOptions` / `EvidenceMoveCandidate` | `FindingMatcher` / `FindingMatch` / `FindingMatchOptions` / `FindingMoveCandidate` |
| `EvidenceMatchEntry` (an alignment edge) | `FindingEdge` |
| `EvidenceMatchKind` | `FindingEdgeKind` |
| `FindingMatch.Entries` | `.Edges` |
| `EvidenceDiffSummary` | `FindingSummary` |
| `EvidenceFinding {Identical,ReorderOnly,Structural}` (rollup enum) | `DiffShape` |
| `FindingSummary.Finding` field | `.Shape` |
| `IlEvidence` / `IlEvidenceResult` (IL producer) | `IlFindings` / `IlFindingsResult` |

The `DiffShape` / `.Shape` split avoids a `FindingSummary.Finding`-of-type-`Finding` stutter.

## Not touched (separate concept)

The unrelated proof-"Evidence" types — `ReturnToSenderEvidence`, the RTS `subject.IlEvidence` report/JSON property, `ConsumedMemberEvidence`, `UnsafeEvidence`, `ResearchDiffEvidence`, etc. — are a different concept (proof, not diff rows) and are intentionally left as-is. They may later *consolidate into* the Finding model, but that is not this PR.

## Validation

- Full `dotnet-inspect.slnx` build clean (0 errors; the 3 warnings are pre-existing in `ILInspector.Metadata.Tests`).
- 26 `FindingPilotTests` green (renamed from `EvidencePilotTests`).

This is the foundation the in-flight spine PRs (#2586/#2587/#2588/#2589) rebase onto. Low-risk mechanical rename; adversarial review will follow once the producer PRs are re-based on it.

> **Review follow-up (commit `0feb24f4`):** `FindingMatchEntry`/`FindingMatchKind` landed as `FindingEdge`/`FindingEdgeKind` (the entries are one-sided-capable bipartite-alignment edges, not matches), `.Entries` -> `.Edges`, and the vestigial `correspondence` token was scrubbed to `alignment`/`match`. `FindingMatch`/`FindingMatcher`/`FindingMatchOptions` keep their names.
