### PR TITLE
Genericize finding payload: IFinding / IFinding<T> / Finding<T>

### DIFF
--- a/src/ILInspector.Findings/Finding.cs
+++ b/src/ILInspector.Findings/Finding.cs
@@ -83,16 +83,44 @@ public sealed record FindingAnchor(
 }
 
 /// <summary>
-/// One finding row: the shared envelope every stream (IL diff, C# diff, semantic
-/// fact) projects into so cross-stream consumers query a single skeleton. Rich,
-/// stream-specific detail rides as an opaque <see cref="Payload"/> for display and is
-/// never required to interpret the row.
+/// The domain-free skeleton of a finding row: everything a cross-stream consumer needs to
+/// classify and align a row without knowing which producer emitted it or what the payload is.
+/// Cross-stream code (Performance Triage, <see cref="FindingSummary"/>, <see cref="FindingEquivalence"/>)
+/// is written against this interface; <see cref="IFinding{T}"/> adds the typed payload for
+/// same-domain consumers.
 /// </summary>
-public sealed record Finding(
+public interface IFinding
+{
+    FindingSubject Subject { get; }
+    FindingDescriptor Descriptor { get; }
+    FindingKind Kind { get; }
+    FindingAnchor Anchor { get; }
+    FindingDifferenceKind DifferenceKind { get; }
+    string? Detail { get; }
+}
+
+/// <summary>
+/// A finding row with its typed payload. Same-domain consumers take this; the substrate matcher
+/// and fold never do (the payload is opaque to them). Non-variant on <typeparamref name="T"/>: a
+/// payload may be a value type, and CLR variance is reference-only.
+/// </summary>
+public interface IFinding<T> : IFinding
+{
+    T? Payload { get; }
+}
+
+/// <summary>
+/// One finding row: the shared envelope every stream (IL diff, C# diff, semantic fact) projects
+/// into so cross-stream consumers query a single skeleton (<see cref="IFinding"/>). Rich,
+/// stream-specific detail rides as a typed <see cref="Payload"/> for display and is never
+/// required to interpret the row. The payload is a type parameter rather than <c>object?</c> so a
+/// value-typed payload is not boxed and same-domain consumers read it without a cast.
+/// </summary>
+public sealed record Finding<T>(
     FindingSubject Subject,
     FindingDescriptor Descriptor,
     FindingKind Kind,
     FindingAnchor Anchor,
     FindingDifferenceKind DifferenceKind = FindingDifferenceKind.None,
     string? Detail = null,
-    object? Payload = null);
+    T? Payload = default) : IFinding<T>;

--- a/src/ILInspector.Findings/FindingEquivalence.cs
+++ b/src/ILInspector.Findings/FindingEquivalence.cs
@@ -13,7 +13,7 @@ public sealed record FindingEquivalence(
     ImmutableHashSet<FindingKind> AllowedRowKinds,
     ImmutableHashSet<FindingDifferenceKind> AllowedDifferenceKinds)
 {
-    public bool IsEquivalent(IReadOnlyList<Finding> rows)
+    public bool IsEquivalent(IReadOnlyList<IFinding> rows)
     {
         ArgumentNullException.ThrowIfNull(rows);
         foreach (var row in rows)

--- a/src/ILInspector.Findings/FindingFold.cs
+++ b/src/ILInspector.Findings/FindingFold.cs
@@ -11,10 +11,10 @@ namespace ILInspector.Findings;
 /// </summary>
 public static class FindingFold
 {
-    public static ImmutableArray<Finding> ToRows(
+    public static ImmutableArray<Finding<T>> ToRows<T>(
         FindingMatch match,
-        IReadOnlyList<FindingOccurrence> oldStream,
-        IReadOnlyList<FindingOccurrence> newStream,
+        IReadOnlyList<FindingOccurrence<T>> oldStream,
+        IReadOnlyList<FindingOccurrence<T>> newStream,
         FindingSubject subject,
         FindingDescriptor descriptor,
         int acceptanceThreshold = 100)
@@ -26,7 +26,7 @@ public static class FindingFold
         ArgumentNullException.ThrowIfNull(descriptor);
 
         var edges = ApplyAcceptance(match, acceptanceThreshold);
-        var rows = ImmutableArray.CreateBuilder<Finding>(edges.Length);
+        var rows = ImmutableArray.CreateBuilder<Finding<T>>(edges.Length);
         foreach (var edge in edges)
             rows.Add(ToRow(edge, oldStream, newStream, subject, descriptor));
 
@@ -79,10 +79,10 @@ public static class FindingFold
         return result.ToImmutable();
     }
 
-    static Finding ToRow(
+    static Finding<T> ToRow<T>(
         FindingEdge edge,
-        IReadOnlyList<FindingOccurrence> oldStream,
-        IReadOnlyList<FindingOccurrence> newStream,
+        IReadOnlyList<FindingOccurrence<T>> oldStream,
+        IReadOnlyList<FindingOccurrence<T>> newStream,
         FindingSubject subject,
         FindingDescriptor descriptor)
     {
@@ -92,7 +92,7 @@ public static class FindingFold
             {
                 var oldOcc = oldStream[edge.OldIndex];
                 var newOcc = newStream[edge.NewIndex];
-                return new Finding(
+                return new Finding<T>(
                     subject,
                     descriptor,
                     FindingKind.Present,
@@ -106,7 +106,7 @@ public static class FindingFold
                 var oldOcc = oldStream[edge.OldIndex];
                 var newOcc = newStream[edge.NewIndex];
                 int delta = edge.NewIndex - edge.OldIndex;
-                return new Finding(
+                return new Finding<T>(
                     subject,
                     descriptor,
                     FindingKind.Present,
@@ -119,7 +119,7 @@ public static class FindingFold
             case FindingEdgeKind.Added:
             {
                 var newOcc = newStream[edge.NewIndex];
-                return new Finding(
+                return new Finding<T>(
                     subject,
                     descriptor,
                     FindingKind.Added,
@@ -131,7 +131,7 @@ public static class FindingFold
             case FindingEdgeKind.Removed:
             {
                 var oldOcc = oldStream[edge.OldIndex];
-                return new Finding(
+                return new Finding<T>(
                     subject,
                     descriptor,
                     FindingKind.Removed,

--- a/src/ILInspector.Findings/FindingKey.cs
+++ b/src/ILInspector.Findings/FindingKey.cs
@@ -4,8 +4,10 @@ namespace ILInspector.Findings;
 /// The domain-free alignment key the <see cref="FindingMatcher"/> operates on: a content
 /// fingerprint plus an optional structural scope tag. Deliberately a value type carrying no
 /// payload — the matcher never needs the domain detail, so keeping the payload out of the core
-/// keeps the matcher monomorphic (no generic instantiation, no boxing, no interface dispatch in
-/// the hot loop). A producer feeds keys projected from its typed
+/// keeps the matcher monomorphic (no generic instantiation, no boxing). Because the matcher
+/// consumes the keys as a concrete <see cref="System.Collections.Immutable.ImmutableArray{T}"/>
+/// of <see cref="FindingKey"/>, the LCS hot loop indexes a struct directly rather than through an
+/// interface. A producer feeds keys projected from its typed
 /// <see cref="FindingOccurrence{T}"/> stream (see <c>ToKeys</c>).
 /// </summary>
 /// <param name="IdentityKey">

--- a/src/ILInspector.Findings/FindingKey.cs
+++ b/src/ILInspector.Findings/FindingKey.cs
@@ -1,0 +1,20 @@
+namespace ILInspector.Findings;
+
+/// <summary>
+/// The domain-free alignment key the <see cref="FindingMatcher"/> operates on: a content
+/// fingerprint plus an optional structural scope tag. Deliberately a value type carrying no
+/// payload — the matcher never needs the domain detail, so keeping the payload out of the core
+/// keeps the matcher monomorphic (no generic instantiation, no boxing, no interface dispatch in
+/// the hot loop). A producer feeds keys projected from its typed
+/// <see cref="FindingOccurrence{T}"/> stream (see <c>ToKeys</c>).
+/// </summary>
+/// <param name="IdentityKey">
+/// The canonical content fingerprint. Two occurrences are candidate "same thing" matches iff
+/// their identity keys are equal, so the producing layer must fold all incidental encoding
+/// (short/long form, register renumbering) into this key.
+/// </param>
+/// <param name="ScopeKey">
+/// An optional structural scope tag (enclosing loop/try/region); a corroborating signal for move
+/// detection. Null when unknown or not modeled.
+/// </param>
+public readonly record struct FindingKey(string IdentityKey, string? ScopeKey = null);

--- a/src/ILInspector.Findings/FindingMatcher.cs
+++ b/src/ILInspector.Findings/FindingMatcher.cs
@@ -33,7 +33,7 @@ public sealed record FindingEdge(FindingEdgeKind Kind, int OldIndex, int NewInde
 /// </summary>
 public sealed record FindingMoveCandidate(int OldIndex, int NewIndex, int Confidence, string Reason);
 
-/// <summary>The result of matching two occurrence streams.</summary>
+/// <summary>The result of matching two key streams (see FindingKey).</summary>
 /// <param name="Edges">
 /// The committed, conservative interpretation: order-preserving matches, committed moves,
 /// and Added/Removed for everything else (including the endpoints of every fringe candidate).
@@ -60,7 +60,7 @@ public sealed record FindingMatchOptions(int MinMoveRunLength = 2)
 /// <summary>
 /// The single, domain-free matcher every finding stream shares. It commits an
 /// order-preserving LCS core (which reproduces a classic sequence diff when there are no moves)
-/// and then recovers relocations as a scored move pass over the residual. It never decides
+/// and then recovers relocations as a scored move pass over the residual. It never inspects a payload and never decides
 /// equivalence: it emits a classified alignment (a set of edges), and a consumer <see cref="FindingFold"/>
 /// folds it.
 /// </summary>
@@ -74,8 +74,8 @@ public static class FindingMatcher
     const long MaxOrderedMatchCells = 64_000_000;
 
     public static FindingMatch Match(
-        IReadOnlyList<FindingOccurrence> oldStream,
-        IReadOnlyList<FindingOccurrence> newStream,
+        IReadOnlyList<FindingKey> oldStream,
+        IReadOnlyList<FindingKey> newStream,
         FindingMatchOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(oldStream);
@@ -149,8 +149,8 @@ public static class FindingMatcher
     }
 
     static void DetectMoveRuns(
-        IReadOnlyList<FindingOccurrence> oldStream,
-        IReadOnlyList<FindingOccurrence> newStream,
+        IReadOnlyList<FindingKey> oldStream,
+        IReadOnlyList<FindingKey> newStream,
         int[] residualOld,
         int[] residualNew,
         bool[] committedOld,
@@ -225,8 +225,8 @@ public static class FindingMatcher
     // (higher-scored) pairings win over incidental index-order pairings. This is the "scored fringe"
     // half of committed-core-plus-scored-fringe.
     static ImmutableArray<FindingMoveCandidate> BuildFringe(
-        IReadOnlyList<FindingOccurrence> oldStream,
-        IReadOnlyList<FindingOccurrence> newStream,
+        IReadOnlyList<FindingKey> oldStream,
+        IReadOnlyList<FindingKey> newStream,
         int[] residualOld,
         int[] residualNew,
         bool[] committedOld,
@@ -262,8 +262,8 @@ public static class FindingMatcher
     // Same construction and tiebreak as ILInspector.Instructions.IlBodyDiff so the committed
     // core reproduces the existing IL sequence diff exactly on move-free inputs.
     static List<(int OldIndex, int NewIndex)> LongestCommonSubsequence(
-        IReadOnlyList<FindingOccurrence> oldStream,
-        IReadOnlyList<FindingOccurrence> newStream)
+        IReadOnlyList<FindingKey> oldStream,
+        IReadOnlyList<FindingKey> newStream)
     {
         int oldLength = oldStream.Count;
         int newLength = newStream.Count;

--- a/src/ILInspector.Findings/FindingMatcher.cs
+++ b/src/ILInspector.Findings/FindingMatcher.cs
@@ -74,25 +74,27 @@ public static class FindingMatcher
     const long MaxOrderedMatchCells = 64_000_000;
 
     public static FindingMatch Match(
-        IReadOnlyList<FindingKey> oldStream,
-        IReadOnlyList<FindingKey> newStream,
+        ImmutableArray<FindingKey> oldStream,
+        ImmutableArray<FindingKey> newStream,
         FindingMatchOptions? options = null)
     {
-        ArgumentNullException.ThrowIfNull(oldStream);
-        ArgumentNullException.ThrowIfNull(newStream);
+        if (oldStream.IsDefault)
+            oldStream = ImmutableArray<FindingKey>.Empty;
+        if (newStream.IsDefault)
+            newStream = ImmutableArray<FindingKey>.Empty;
         options ??= FindingMatchOptions.Default;
 
-        long cells = ((long)oldStream.Count + 1) * ((long)newStream.Count + 1);
+        long cells = ((long)oldStream.Length + 1) * ((long)newStream.Length + 1);
         if (cells > MaxOrderedMatchCells)
         {
             throw new ArgumentException(
                 $"Ordered matching is bounded to {MaxOrderedMatchCells:N0} matrix cells " +
-                $"({oldStream.Count}x{newStream.Count} requested). Streams this large need the " +
+                $"({oldStream.Length}x{newStream.Length} requested). Streams this large need the " +
                 "identity-set committer, not the ordered LCS (see issue #2585).");
         }
 
-        var matchedOld = new bool[oldStream.Count];
-        var matchedNew = new bool[newStream.Count];
+        var matchedOld = new bool[oldStream.Length];
+        var matchedNew = new bool[newStream.Length];
         var edges = ImmutableArray.CreateBuilder<FindingEdge>();
 
         // 1. Committed core: order-preserving LCS over content keys.
@@ -149,8 +151,8 @@ public static class FindingMatcher
     }
 
     static void DetectMoveRuns(
-        IReadOnlyList<FindingKey> oldStream,
-        IReadOnlyList<FindingKey> newStream,
+        ImmutableArray<FindingKey> oldStream,
+        ImmutableArray<FindingKey> newStream,
         int[] residualOld,
         int[] residualNew,
         bool[] committedOld,
@@ -225,8 +227,8 @@ public static class FindingMatcher
     // (higher-scored) pairings win over incidental index-order pairings. This is the "scored fringe"
     // half of committed-core-plus-scored-fringe.
     static ImmutableArray<FindingMoveCandidate> BuildFringe(
-        IReadOnlyList<FindingKey> oldStream,
-        IReadOnlyList<FindingKey> newStream,
+        ImmutableArray<FindingKey> oldStream,
+        ImmutableArray<FindingKey> newStream,
         int[] residualOld,
         int[] residualNew,
         bool[] committedOld,
@@ -262,11 +264,11 @@ public static class FindingMatcher
     // Same construction and tiebreak as ILInspector.Instructions.IlBodyDiff so the committed
     // core reproduces the existing IL sequence diff exactly on move-free inputs.
     static List<(int OldIndex, int NewIndex)> LongestCommonSubsequence(
-        IReadOnlyList<FindingKey> oldStream,
-        IReadOnlyList<FindingKey> newStream)
+        ImmutableArray<FindingKey> oldStream,
+        ImmutableArray<FindingKey> newStream)
     {
-        int oldLength = oldStream.Count;
-        int newLength = newStream.Count;
+        int oldLength = oldStream.Length;
+        int newLength = newStream.Length;
         var lengths = new int[oldLength + 1, newLength + 1];
         for (int oldIndex = oldLength - 1; oldIndex >= 0; oldIndex--)
         {

--- a/src/ILInspector.Findings/FindingOccurrence.cs
+++ b/src/ILInspector.Findings/FindingOccurrence.cs
@@ -45,6 +45,9 @@ public static class FindingOccurrenceExtensions
     /// </summary>
     public static ImmutableArray<FindingKey> ToKeys<T>(this ImmutableArray<FindingOccurrence<T>> occurrences)
     {
+        if (occurrences.IsDefaultOrEmpty)
+            return ImmutableArray<FindingKey>.Empty;
+
         var builder = ImmutableArray.CreateBuilder<FindingKey>(occurrences.Length);
         foreach (var occurrence in occurrences)
             builder.Add(occurrence.Key);

--- a/src/ILInspector.Findings/FindingOccurrence.cs
+++ b/src/ILInspector.Findings/FindingOccurrence.cs
@@ -1,25 +1,54 @@
+using System.Collections.Immutable;
+
 namespace ILInspector.Findings;
 
 /// <summary>
-/// A single domain-free item within an ordered stream, presented to the
-/// <see cref="FindingMatcher"/> for cross-version matching. Domain producers
-/// project their nodes (IL operations, IR nodes, API members) into this shape.
+/// A single domain-free item within an ordered stream, presented as an alignment
+/// <see cref="Key"/> to the <see cref="FindingMatcher"/> for cross-version matching, and (with
+/// its typed <see cref="Payload"/>) to <see cref="FindingFold"/>. Domain producers project their
+/// nodes (IL operations, IR nodes, API members) into this shape, choosing the payload type they
+/// want carried onto the produced <see cref="Finding{T}"/>.
 /// </summary>
-/// <param name="IdentityKey">
-/// The canonical content fingerprint. Two occurrences are candidate "same thing"
-/// matches iff their content keys are equal, so the producing layer must fold all
-/// incidental encoding (short/long form, register renumbering) into this key.
-/// </param>
-/// <param name="ScopeKey">
-/// An optional structural scope tag (enclosing loop/try/region). A corroborating
-/// signal for move detection and the raw material for scope-transition folds; null
-/// when unknown or not modeled.
-/// </param>
+/// <param name="IdentityKey">The canonical content fingerprint (see <see cref="FindingKey"/>).</param>
+/// <param name="ScopeKey">Optional structural scope tag; null when unknown or not modeled.</param>
 /// <param name="Payload">
-/// Opaque domain detail carried onto the produced <see cref="Finding"/> for
-/// display. Never inspected by the matcher.
+/// Typed domain detail carried onto the produced <see cref="Finding{T}"/> for display. Never
+/// inspected by the matcher, which sees only <see cref="Key"/>.
 /// </param>
-public sealed record FindingOccurrence(
+public sealed record FindingOccurrence<T>(
     string IdentityKey,
     string? ScopeKey = null,
-    object? Payload = null);
+    T? Payload = default)
+{
+    /// <summary>The alignment key the matcher consumes.</summary>
+    public FindingKey Key => new(IdentityKey, ScopeKey);
+}
+
+/// <summary>Helpers for projecting a typed occurrence stream onto the matcher's key view.</summary>
+public static class FindingOccurrenceExtensions
+{
+    /// <summary>Projects a typed occurrence stream onto the alignment keys the matcher consumes.</summary>
+    public static ImmutableArray<FindingKey> ToKeys<T>(this IReadOnlyList<FindingOccurrence<T>> occurrences)
+    {
+        ArgumentNullException.ThrowIfNull(occurrences);
+        var builder = ImmutableArray.CreateBuilder<FindingKey>(occurrences.Count);
+        foreach (var occurrence in occurrences)
+            builder.Add(occurrence.Key);
+
+        return builder.MoveToImmutable();
+    }
+
+    /// <summary>
+    /// Projects a typed occurrence stream onto the alignment keys the matcher consumes. This
+    /// overload takes <see cref="ImmutableArray{T}"/> directly so the product path does not box
+    /// the struct to <see cref="IReadOnlyList{T}"/> or enumerate through the boxed interface.
+    /// </summary>
+    public static ImmutableArray<FindingKey> ToKeys<T>(this ImmutableArray<FindingOccurrence<T>> occurrences)
+    {
+        var builder = ImmutableArray.CreateBuilder<FindingKey>(occurrences.Length);
+        foreach (var occurrence in occurrences)
+            builder.Add(occurrence.Key);
+
+        return builder.MoveToImmutable();
+    }
+}

--- a/src/ILInspector.Findings/FindingSummary.cs
+++ b/src/ILInspector.Findings/FindingSummary.cs
@@ -29,7 +29,7 @@ public sealed record FindingSummary(
     int Moved,
     DiffShape Shape)
 {
-    public static FindingSummary Summarize(IReadOnlyList<Finding> rows)
+    public static FindingSummary Summarize(IReadOnlyList<IFinding> rows)
     {
         ArgumentNullException.ThrowIfNull(rows);
 

--- a/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
@@ -14,8 +14,8 @@ public class FindingPilotTests
 {
     // ---- Leaf engine: synthetic occurrence streams -------------------------------------------
 
-    static ImmutableArray<FindingOccurrence> Stream(params string[] keys)
-        => [.. keys.Select(k => new FindingOccurrence(k))];
+    static ImmutableArray<FindingOccurrence<string>> Stream(params string[] keys)
+        => [.. keys.Select(k => new FindingOccurrence<string>(k))];
 
     static readonly FindingSubject Subject = new("test", "test");
     static readonly FindingDescriptor Descriptor = new("test.item", "item");
@@ -40,7 +40,7 @@ public class FindingPilotTests
 
         foreach (var (old, @new) in cases)
         {
-            var match = FindingMatcher.Match(Stream(old), Stream(@new));
+            var match = FindingMatcher.Match(Stream(old).ToKeys(), Stream(@new).ToKeys());
             var matched = match.Edges.Where(l => l.Kind == FindingEdgeKind.Matched).ToArray();
 
             // Optimality: as long as a classic LCS.
@@ -66,7 +66,7 @@ public class FindingPilotTests
         var old = Stream("A", "B", "C", "m1", "m2", "D", "E");
         var @new = Stream("m1", "m2", "A", "B", "C", "D", "E");
 
-        var match = FindingMatcher.Match(old, @new);
+        var match = FindingMatcher.Match(old.ToKeys(), @new.ToKeys());
 
         Assert.Equal(2, Count(match, FindingEdgeKind.Moved));
         Assert.Equal(0, Count(match, FindingEdgeKind.Added));
@@ -80,7 +80,7 @@ public class FindingPilotTests
         var old = Stream("c0", "c1", "c2");
         var @new = Stream("c1", "c2", "c0");
 
-        var match = FindingMatcher.Match(old, @new);
+        var match = FindingMatcher.Match(old.ToKeys(), @new.ToKeys());
 
         Assert.Equal(0, Count(match, FindingEdgeKind.Moved));
         Assert.Equal(1, Count(match, FindingEdgeKind.Added));
@@ -94,7 +94,7 @@ public class FindingPilotTests
     {
         var old = Stream("c0", "c1", "c2");
         var @new = Stream("c1", "c2", "c0");
-        var match = FindingMatcher.Match(old, @new);
+        var match = FindingMatcher.Match(old.ToKeys(), @new.ToKeys());
 
         var strict = FindingFold.ToRows(match, old, @new, Subject, Descriptor);
         Assert.Equal(0, strict.Count(r => r.DifferenceKind == FindingDifferenceKind.Moved));
@@ -111,15 +111,15 @@ public class FindingPilotTests
     public void ScopeCorroboration_RaisesFringeScore()
     {
         var old = ImmutableArray.Create(
-            new FindingOccurrence("c0", ScopeKey: "loop1"),
-            new FindingOccurrence("c1"),
-            new FindingOccurrence("c2"));
+            new FindingOccurrence<string>("c0", ScopeKey: "loop1"),
+            new FindingOccurrence<string>("c1"),
+            new FindingOccurrence<string>("c2"));
         var @new = ImmutableArray.Create(
-            new FindingOccurrence("c1"),
-            new FindingOccurrence("c2"),
-            new FindingOccurrence("c0", ScopeKey: "loop1"));
+            new FindingOccurrence<string>("c1"),
+            new FindingOccurrence<string>("c2"),
+            new FindingOccurrence<string>("c0", ScopeKey: "loop1"));
 
-        var match = FindingMatcher.Match(old, @new);
+        var match = FindingMatcher.Match(old.ToKeys(), @new.ToKeys());
         var candidate = Assert.Single(match.MoveCandidates);
         Assert.Equal(75, candidate.Confidence);
         Assert.Equal("content+scope", candidate.Reason);
@@ -130,7 +130,7 @@ public class FindingPilotTests
     {
         var old = Stream("A", "B", "C", "m1", "m2", "D", "E");
         var @new = Stream("m1", "m2", "A", "B", "C", "D", "E");
-        var match = FindingMatcher.Match(old, @new);
+        var match = FindingMatcher.Match(old.ToKeys(), @new.ToKeys());
         var rows = FindingFold.ToRows(match, old, @new, Subject, Descriptor);
 
         // Order is semantic under the fidelity fold: a reorder is a real difference.
@@ -143,7 +143,7 @@ public class FindingPilotTests
     public void IdenticalStreams_AreExact()
     {
         var stream = Stream("a", "b", "c", "d");
-        var match = FindingMatcher.Match(stream, stream);
+        var match = FindingMatcher.Match(stream.ToKeys(), stream.ToKeys());
         var rows = FindingFold.ToRows(match, stream, stream, Subject, Descriptor);
 
         Assert.All(rows, r => Assert.Equal(FindingKind.Present, r.Kind));
@@ -158,7 +158,7 @@ public class FindingPilotTests
         var old = Stream("M1", "A", "M2", "B");
         var @new = Stream("A", "B", "M1", "M2");
 
-        var match = FindingMatcher.Match(old, @new);
+        var match = FindingMatcher.Match(old.ToKeys(), @new.ToKeys());
 
         Assert.Equal(0, Count(match, FindingEdgeKind.Moved));
         Assert.Equal(2, Count(match, FindingEdgeKind.Added));
@@ -173,7 +173,7 @@ public class FindingPilotTests
         var old = Stream("A", "B");
         var @new = Stream("B", "A", "A");
 
-        var match = FindingMatcher.Match(old, @new);
+        var match = FindingMatcher.Match(old.ToKeys(), @new.ToKeys());
 
         Assert.Equal(2, match.MoveCandidates.Length);
         Assert.All(match.MoveCandidates, c => Assert.Equal("A", old[c.OldIndex].IdentityKey));
@@ -186,8 +186,8 @@ public class FindingPilotTests
         var old = Stream("x", "a", "y", "a", "z", "a");
         var @new = Stream("a", "z", "a", "x", "a", "y");
 
-        var first = FindingMatcher.Match(old, @new);
-        var second = FindingMatcher.Match(old, @new);
+        var first = FindingMatcher.Match(old.ToKeys(), @new.ToKeys());
+        var second = FindingMatcher.Match(old.ToKeys(), @new.ToKeys());
 
         Assert.Equal(first.Edges, second.Edges);
         Assert.Equal(first.MoveCandidates, second.MoveCandidates);
@@ -199,10 +199,10 @@ public class FindingPilotTests
         // The ordered LCS matrix is O(N*M); guard it so an assembly-scale stream fails loudly
         // instead of attempting a multi-gigabyte allocation (issue #2585).
         var big = Enumerable.Range(0, 8000)
-            .Select(i => new FindingOccurrence(i.ToString(System.Globalization.CultureInfo.InvariantCulture)))
+            .Select(i => new FindingOccurrence<string>(i.ToString(System.Globalization.CultureInfo.InvariantCulture)))
             .ToArray();
 
-        var ex = Assert.Throws<ArgumentException>(() => FindingMatcher.Match(big, big));
+        var ex = Assert.Throws<ArgumentException>(() => FindingMatcher.Match(big.ToKeys(), big.ToKeys()));
         Assert.Contains("identity-set", ex.Message, StringComparison.Ordinal);
     }
 
@@ -233,7 +233,7 @@ public class FindingPilotTests
         // Rows fabricated as if from an arbitrary (non-IL) stream: the consumer does not care.
         var subject = new FindingSubject("s", "s");
         var descriptor = new FindingDescriptor("any.kind", "any");
-        Finding[] rows =
+        Finding<string>[] rows =
         [
             new(subject, descriptor, FindingKind.Present, new FindingAnchor("k0", 0, 0)),
             new(subject, descriptor, FindingKind.Added, new FindingAnchor("k1", -1, 1)),

--- a/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
@@ -207,6 +207,25 @@ public class FindingPilotTests
     }
 
     [Fact]
+    public void ToKeys_OnDefaultOrEmptyArray_IsEmpty_NotNullReference()
+    {
+        // A default (uninitialized) ImmutableArray has a null backing array; ToKeys must not
+        // read .Length off it. Guarded to return Empty, consistent with the IReadOnlyList overload.
+        ImmutableArray<FindingOccurrence<string>> uninitialized = default;
+        Assert.True(uninitialized.ToKeys().IsEmpty);
+        Assert.True(ImmutableArray<FindingOccurrence<string>>.Empty.ToKeys().IsEmpty);
+    }
+
+    [Fact]
+    public void Match_OnDefaultStreams_IsAnEmptyMatch_NotNullReference()
+    {
+        // Default streams normalize to empty rather than throwing an NRE on .Length.
+        var match = FindingMatcher.Match(default, default);
+        Assert.True(match.Edges.IsEmpty);
+        Assert.True(match.MoveCandidates.IsEmpty);
+    }
+
+    [Fact]
     public void SkeletonConsumer_ClassifiesFromPolarityAndDifferenceAlone()
     {
         // A stream-agnostic consumer: it reads only the skeleton, so the same rows could have

--- a/src/ILInspector.Instructions/IlFindings.cs
+++ b/src/ILInspector.Instructions/IlFindings.cs
@@ -8,8 +8,8 @@ namespace ILInspector.Instructions;
 /// <summary>
 /// Adapts IL method bodies onto the domain-free finding substrate: it canonicalizes each body
 /// (reusing <see cref="IlBodyDiff"/> exactly), projects operations into
-/// <see cref="FindingOccurrence"/>s, runs the shared <see cref="FindingMatcher"/>, and
-/// folds the alignment into <see cref="Finding"/>s. This is the "IL as finding" pilot:
+/// <see cref="FindingOccurrence{T}"/>s, runs the shared <see cref="FindingMatcher"/>, and
+/// folds the alignment into <see cref="Finding{T}"/>s. This is the "IL as finding" pilot:
 /// the committed LCS core reproduces <see cref="IlBodyDiff"/> on move-free bodies, and the move
 /// pass recovers relocations that the order-preserving diff cannot.
 /// </summary>
@@ -41,7 +41,7 @@ public static class IlFindings
         FindingMatch match;
         try
         {
-            match = FindingMatcher.Match(oldStream, newStream);
+            match = FindingMatcher.Match(oldStream.ToKeys(), newStream.ToKeys());
         }
         catch (ArgumentException ex)
         {
@@ -61,8 +61,8 @@ public static class IlFindings
     // then overlay the finding Moved mappings so a branch that targets a relocated instruction is
     // judged in the finding frame (its target moved with it) rather than being falsely retargeted.
     // On move-free inputs there are no Moved rows, so the map is exactly IlBodyDiff's.
-    static ImmutableArray<Finding> ApplyBranchTargetValidation(
-        ImmutableArray<Finding> rows,
+    static ImmutableArray<Finding<CanonicalIlOperation>> ApplyBranchTargetValidation(
+        ImmutableArray<Finding<CanonicalIlOperation>> rows,
         ImmutableArray<DecodedInstruction> oldInstructions,
         ImmutableArray<CanonicalIlOperation> oldOps,
         ImmutableArray<DecodedInstruction> newInstructions,
@@ -79,7 +79,7 @@ public static class IlFindings
             }
         }
 
-        var builder = ImmutableArray.CreateBuilder<Finding>(rows.Length);
+        var builder = ImmutableArray.CreateBuilder<Finding<CanonicalIlOperation>>(rows.Length);
         foreach (var row in rows)
         {
             if (row.Kind == FindingKind.Present
@@ -98,14 +98,14 @@ public static class IlFindings
         return builder.ToImmutable();
     }
 
-    static ImmutableArray<FindingOccurrence> BuildOccurrences(ImmutableArray<CanonicalIlOperation> operations)
+    static ImmutableArray<FindingOccurrence<CanonicalIlOperation>> BuildOccurrences(ImmutableArray<CanonicalIlOperation> operations)
     {
-        var builder = ImmutableArray.CreateBuilder<FindingOccurrence>(operations.Length);
+        var builder = ImmutableArray.CreateBuilder<FindingOccurrence<CanonicalIlOperation>>(operations.Length);
         foreach (var operation in operations)
         {
             // ScopeKey is left null in the pilot: move detection is corroborated by run
             // contiguity, and EH/loop-region scope is the Attach layer's concern (issue #2564).
-            builder.Add(new FindingOccurrence(GetIdentityKey(operation), ScopeKey: null, Payload: operation));
+            builder.Add(new FindingOccurrence<CanonicalIlOperation>(GetIdentityKey(operation), ScopeKey: null, Payload: operation));
         }
 
         return builder.MoveToImmutable();
@@ -133,10 +133,10 @@ public static class IlFindings
 
 /// <summary>The outcome of an <see cref="IlFindings.Compare"/> call.</summary>
 public sealed record IlFindingsResult(
-    ImmutableArray<Finding> Rows,
+    ImmutableArray<Finding<CanonicalIlOperation>> Rows,
     FindingMatch Match,
-    ImmutableArray<FindingOccurrence> OldOccurrences,
-    ImmutableArray<FindingOccurrence> NewOccurrences,
+    ImmutableArray<FindingOccurrence<CanonicalIlOperation>> OldOccurrences,
+    ImmutableArray<FindingOccurrence<CanonicalIlOperation>> NewOccurrences,
     string? Failure)
 {
     /// <summary>True when the bodies are exact under the fidelity fold (no adds/removes/moves).</summary>


### PR DESCRIPTION
## What

Replaces the leaf's `object? Payload` with a typed triad:

- **`IFinding`** — the domain-free **skeleton** (`Subject`, `Descriptor`, `Kind`, `Anchor`, `DifferenceKind`, `Detail`). Cross-stream consumers and the skeleton folds (`FindingSummary`, `FindingEquivalence`) are written against this.
- **`IFinding<T> : IFinding`** — adds the typed `Payload` for **same-domain** consumers. Non-variant (a payload may be a value type; CLR variance is reference-only).
- **`Finding<T> : IFinding<T>`** — the concrete row producers/folds instantiate. Payload is a typed field: **no boxing for a struct `T`, no cast on read.**

## Why

`object?` is a poor NativeAOT shape: value-typed payloads box, and the erased type defeats trimmer/AOT reasoning and forces a cast on every read. A bounded, statically-known set of payload instantiations is exactly the generic pattern AOT *likes*.

## Monomorphic core, generic seam

- The **matcher stays payload-free and T-free**: it now aligns two `IReadOnlyList<FindingKey>` streams — a new value-type `FindingKey(IdentityKey, ScopeKey)` — so there is no interface dispatch on payloads, no `T`, and no boxing in the LCS hot loop. There is still exactly **one matcher**.
- **`FindingFold.ToRows<T>`** is the single generic seam. It is called once per stream pair, and a stream is single-domain, so `T` is uniform per call (bounded monomorphization).
- Producers project their typed occurrence stream to keys via **`ToKeys()`** (with an `ImmutableArray<FindingOccurrence<T>>` overload to avoid boxing on the product path).

## Ergonomics (verified)

`ImmutableArray<Finding<T>>` flows into `IReadOnlyList<IFinding>` skeleton parameters **directly** — the compiler chains the boxing + `IReadOnlyList<out T>` covariance conversion, so callers need no `CastUp`.

## Scope

`FindingOccurrence` → `FindingOccurrence<T>`; `IlFindings` binds `T = CanonicalIlOperation`. Only the pilot producer and its tests consume the leaf, so the change is contained to the leaf + `IlFindings` + `FindingPilotTests`.

## Follow-on (not in this PR)

Aggregated consumers (Research) hold heterogeneous `IFinding` and cannot statically know `T`. Reaching a payload from that context requires a **descriptor→(tier, projector) registry** — the same registry that will carry the Finding/Fact/Triage tier — where producers register a `T`-aware projector. This PR is the producer/same-domain shape that the registry builds on; the registry is a separate design piece.

## Validation

- Full `dotnet-inspect.slnx` build clean (3 pre-existing `ILInspector.Metadata.Tests` warnings).
- 26 `FindingPilotTests` green.

Foundation for the four in-flight spine PRs (#2586/#2587/#2588/#2589), which rebase onto this before adopting `Finding<T>`.