### PR TITLE
Model PairFinding as a native discriminated union (#2585)

### DIFF
--- a/src/ILInspector.Findings/Finding.cs
+++ b/src/ILInspector.Findings/Finding.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace ILInspector.Findings;
 
 /// <summary>
@@ -97,8 +99,9 @@ public sealed record Finding<T>(
 /// The domain-free skeleton of a transition: an old/new pair classified by <see cref="Kind"/> and
 /// <see cref="Difference"/>. Extends <see cref="IFinding"/> so a cross-stream fold
 /// (<see cref="FindingSummary"/>, <see cref="FindingEquivalence"/>) reads it without knowing the
-/// payload type. <see cref="Old"/>/<see cref="New"/> expose each side as a skeleton; polarity is
-/// read from their nullability (<see cref="Old"/> is null ⟹ added).
+/// payload type. Each concrete case (<see cref="Added{T}"/>, <see cref="Removed{T}"/>,
+/// <see cref="Present{T}"/>, <see cref="Changed{T}"/>) fixes its own <see cref="Kind"/> and exposes
+/// exactly the sides it has via <see cref="Old"/>/<see cref="New"/>.
 /// </summary>
 public interface IPairFinding : IFinding
 {
@@ -108,77 +111,95 @@ public interface IPairFinding : IFinding
     IFinding? New { get; }
 }
 
-/// <summary>
-/// A classified transition between two <see cref="Finding{T}"/> atoms — the diff row. Composed of
-/// findings: <see cref="Old"/> and <see cref="New"/>, one of which is null for a one-sided
-/// add/remove. Implements <see cref="IFinding{T}"/> with a "current" payload projection
-/// (<see cref="New"/> if present, else <see cref="Old"/>); both sides remain reachable via
-/// <see cref="Old"/>/<see cref="New"/> for consumers that need the change.
-/// <para>
-/// The type makes an inconsistent pair unrepresentable. <see cref="Kind"/> is <em>derived</em>
-/// from the sides (one side ⟹ Added/Removed; both ⟹ Changed when <see cref="ContentChanged"/>,
-/// else Present), so there is no polarity to set out of step with them. <see cref="Old"/> and
-/// <see cref="New"/> are get-only — a <c>with</c> expression cannot null them out — and the
-/// constructor rejects the one remaining degenerate case (neither side present). Only the
-/// non-structural facets (<see cref="Difference"/>, <see cref="ContentChanged"/>,
-/// <see cref="Detail"/>) remain <c>init</c>-settable for <c>with</c>.
-/// </para>
-/// </summary>
-public sealed record PairFinding<T> : IPairFinding, IFinding<T>
+/// <summary>A transition present only on the new side: a one-sided addition.</summary>
+public sealed record Added<T>(Finding<T> New, string? Detail = null) : IPairFinding
     where T : notnull
 {
-    public PairFinding(
-        Finding<T>? old,
-        Finding<T>? @new,
-        FindingDifferenceKind difference = FindingDifferenceKind.None,
-        bool contentChanged = false,
-        string? detail = null)
-    {
-        if (old is null && @new is null)
-            throw new ArgumentException("A PairFinding must have a non-null Old or New side.", nameof(old));
+    public PairKind Kind => PairKind.Added;
+    public FindingDifferenceKind Difference => FindingDifferenceKind.None;
+    public FindingSubject Subject => New.Subject;
+    public FindingDescriptor Descriptor => New.Descriptor;
+    IFinding? IPairFinding.Old => null;
+    IFinding? IPairFinding.New => New;
+}
 
-        Old = old;
-        New = @new;
-        Difference = difference;
-        ContentChanged = contentChanged;
-        Detail = detail;
-    }
+/// <summary>A transition present only on the old side: a one-sided removal.</summary>
+public sealed record Removed<T>(Finding<T> Old, string? Detail = null) : IPairFinding
+    where T : notnull
+{
+    public PairKind Kind => PairKind.Removed;
+    public FindingDifferenceKind Difference => FindingDifferenceKind.None;
+    public FindingSubject Subject => Old.Subject;
+    public FindingDescriptor Descriptor => Old.Descriptor;
+    IFinding? IPairFinding.Old => Old;
+    IFinding? IPairFinding.New => null;
+}
 
-    /// <summary>The old-side atom, or null when this pair is an addition. Set only at construction.</summary>
-    public Finding<T>? Old { get; }
-
-    /// <summary>The new-side atom, or null when this pair is a removal. Set only at construction.</summary>
-    public Finding<T>? New { get; }
-
-    public FindingDifferenceKind Difference { get; init; }
-
-    /// <summary>Marks a both-sides pair as a content change, deriving <see cref="Kind"/> = Changed.</summary>
-    public bool ContentChanged { get; init; }
-
-    public string? Detail { get; init; }
-
-    /// <summary>
-    /// The transition polarity, derived from the sides (and <see cref="ContentChanged"/> for the
-    /// both-present case) so it is always consistent with them.
-    /// </summary>
-    public PairKind Kind => Old is null
-        ? PairKind.Added
-        : New is null
-            ? PairKind.Removed
-            : ContentChanged ? PairKind.Changed : PairKind.Present;
-
-    private Finding<T> Current => New ?? Old
-        ?? throw new InvalidOperationException("A PairFinding has neither an Old nor a New side.");
-
-    public FindingSubject Subject => Current.Subject;
-    public FindingDescriptor Descriptor => Current.Descriptor;
-    public T Payload => Current.Payload;
-
+/// <summary>
+/// A matched pair whose content is unchanged. May still carry a non-structural
+/// <see cref="Difference"/> (e.g. <see cref="FindingDifferenceKind.Moved"/>): a move keeps Present
+/// polarity because the content is the same, only the location differs.
+/// </summary>
+public sealed record Present<T>(
+    Finding<T> Old,
+    Finding<T> New,
+    FindingDifferenceKind Difference = FindingDifferenceKind.None,
+    string? Detail = null) : IPairFinding
+    where T : notnull
+{
+    public PairKind Kind => PairKind.Present;
+    public FindingSubject Subject => New.Subject;
+    public FindingDescriptor Descriptor => New.Descriptor;
     IFinding? IPairFinding.Old => Old;
     IFinding? IPairFinding.New => New;
+}
 
-    /// <summary>The signed position delta for a matched pair, or null if one-sided.</summary>
-    public int? PositionDelta => Old is not null && New is not null ? New.Position - Old.Position : null;
+/// <summary>A matched pair whose content changed across the two sides.</summary>
+public sealed record Changed<T>(
+    Finding<T> Old,
+    Finding<T> New,
+    FindingDifferenceKind Difference = FindingDifferenceKind.None,
+    string? Detail = null) : IPairFinding
+    where T : notnull
+{
+    public PairKind Kind => PairKind.Changed;
+    public FindingSubject Subject => New.Subject;
+    public FindingDescriptor Descriptor => New.Descriptor;
+    IFinding? IPairFinding.Old => Old;
+    IFinding? IPairFinding.New => New;
+}
+
+/// <summary>
+/// A classified transition between two <see cref="Finding{T}"/> atoms — the diff row, modeled as a
+/// discriminated union (.NET 11 <c>[Union]</c>) over its four cases. Because each case carries
+/// exactly the atoms it has, an inconsistent transition — a polarity that disagrees with its sides,
+/// or a pair with neither side — is <em>unrepresentable by construction</em>. There is no invariant
+/// to enforce and nothing a <c>with</c> expression can desync: the closed set of cases is the
+/// invariant. A reference union (a <c>record class</c>, not the struct sugar) so there is no
+/// <c>default</c>/empty state to guard and no boxing when a case is viewed as <see cref="IPairFinding"/>.
+/// Pattern-match <see cref="Value"/> to recover a case and its typed atoms.
+/// </summary>
+[Union]
+public sealed record PairFinding<T> : IPairFinding
+    where T : notnull
+{
+    public PairFinding(Added<T> value) => Value = value;
+    public PairFinding(Removed<T> value) => Value = value;
+    public PairFinding(Present<T> value) => Value = value;
+    public PairFinding(Changed<T> value) => Value = value;
+
+    /// <summary>The active case: <see cref="Added{T}"/>, <see cref="Removed{T}"/>, <see cref="Present{T}"/>, or <see cref="Changed{T}"/>.</summary>
+    public object? Value { get; }
+
+    private IPairFinding Case => (IPairFinding)Value!;
+
+    public PairKind Kind => Case.Kind;
+    public FindingDifferenceKind Difference => Case.Difference;
+    public FindingSubject Subject => Case.Subject;
+    public FindingDescriptor Descriptor => Case.Descriptor;
+    public string? Detail => Case.Detail;
+    IFinding? IPairFinding.Old => Case.Old;
+    IFinding? IPairFinding.New => Case.New;
 }
 
 /// <summary>Projections over finding streams shared by producers and the matcher seam.</summary>

--- a/src/ILInspector.Findings/Finding.cs
+++ b/src/ILInspector.Findings/Finding.cs
@@ -111,95 +111,31 @@ public interface IPairFinding : IFinding
     IFinding? New { get; }
 }
 
-/// <summary>A transition present only on the new side: a one-sided addition.</summary>
-public sealed record Added<T>(Finding<T> New, string? Detail = null) : IPairFinding
-    where T : notnull
-{
-    // A null-forgiving (`null!`) caller could otherwise slip a missing atom past the non-null
-    // annotation and reintroduce a case with no side; guard the required atom at construction.
-    public Finding<T> New { get; } = New ?? throw new ArgumentNullException(nameof(New));
-
-    public PairKind Kind => PairKind.Added;
-    public FindingDifferenceKind Difference => FindingDifferenceKind.None;
-    public FindingSubject Subject => New.Subject;
-    public FindingDescriptor Descriptor => New.Descriptor;
-    IFinding? IPairFinding.Old => null;
-    IFinding? IPairFinding.New => New;
-}
-
-/// <summary>A transition present only on the old side: a one-sided removal.</summary>
-public sealed record Removed<T>(Finding<T> Old, string? Detail = null) : IPairFinding
-    where T : notnull
-{
-    public Finding<T> Old { get; } = Old ?? throw new ArgumentNullException(nameof(Old));
-
-    public PairKind Kind => PairKind.Removed;
-    public FindingDifferenceKind Difference => FindingDifferenceKind.None;
-    public FindingSubject Subject => Old.Subject;
-    public FindingDescriptor Descriptor => Old.Descriptor;
-    IFinding? IPairFinding.Old => Old;
-    IFinding? IPairFinding.New => null;
-}
-
-/// <summary>
-/// A matched pair whose content is unchanged. May still carry a non-structural
-/// <see cref="Difference"/> (e.g. <see cref="FindingDifferenceKind.Moved"/>): a move keeps Present
-/// polarity because the content is the same, only the location differs.
-/// </summary>
-public sealed record Present<T>(
-    Finding<T> Old,
-    Finding<T> New,
-    FindingDifferenceKind Difference = FindingDifferenceKind.None,
-    string? Detail = null) : IPairFinding
-    where T : notnull
-{
-    public Finding<T> Old { get; } = Old ?? throw new ArgumentNullException(nameof(Old));
-    public Finding<T> New { get; } = New ?? throw new ArgumentNullException(nameof(New));
-
-    public PairKind Kind => PairKind.Present;
-    public FindingSubject Subject => New.Subject;
-    public FindingDescriptor Descriptor => New.Descriptor;
-    IFinding? IPairFinding.Old => Old;
-    IFinding? IPairFinding.New => New;
-}
-
-/// <summary>A matched pair whose content changed across the two sides.</summary>
-public sealed record Changed<T>(
-    Finding<T> Old,
-    Finding<T> New,
-    FindingDifferenceKind Difference = FindingDifferenceKind.None,
-    string? Detail = null) : IPairFinding
-    where T : notnull
-{
-    public Finding<T> Old { get; } = Old ?? throw new ArgumentNullException(nameof(Old));
-    public Finding<T> New { get; } = New ?? throw new ArgumentNullException(nameof(New));
-
-    public PairKind Kind => PairKind.Changed;
-    public FindingSubject Subject => New.Subject;
-    public FindingDescriptor Descriptor => New.Descriptor;
-    IFinding? IPairFinding.Old => Old;
-    IFinding? IPairFinding.New => New;
-}
-
 /// <summary>
 /// A classified transition between two <see cref="Finding{T}"/> atoms — the diff row, modeled as a
-/// discriminated union (.NET 11 <c>[Union]</c>) over its four cases. Because each case carries
+/// discriminated union (.NET 11 <c>[Union]</c>) over four nested cases (<see cref="Added"/>,
+/// <see cref="Removed"/>, <see cref="Present"/>, <see cref="Changed"/>). Because each case carries
 /// exactly the atoms it has, an inconsistent transition — a polarity that disagrees with its sides,
 /// or a pair with neither side — is <em>unrepresentable by construction</em>. There is no invariant
 /// to enforce and nothing a <c>with</c> expression can desync: the closed set of cases is the
 /// invariant. A reference union (a <c>record class</c>, not the struct sugar) so there is no
 /// <c>default</c>/empty state to guard and no boxing when a case is viewed as <see cref="IPairFinding"/>.
-/// Pattern-match the union itself (<c>pair switch { Added&lt;T&gt; … }</c>, not <c>pair.Value switch</c>)
-/// to recover a case and its typed atoms with compiler-checked exhaustiveness.
+/// <para>
+/// The cases are <em>nested</em> so their four otherwise-generic names stay scoped to the union
+/// (<c>PairFinding&lt;T&gt;.Present</c>) rather than claiming the producer-facing namespace, and each
+/// inherits <typeparamref name="T"/> from the enclosing union. Pattern-match the union itself
+/// (<c>pair switch { PairFinding&lt;T&gt;.Added … }</c>, not <c>pair.Value switch</c>) for
+/// compiler-checked exhaustiveness; a fifth case then breaks the build rather than falling through.
+/// </para>
 /// </summary>
 [Union]
 public sealed record PairFinding<T> : IPairFinding
     where T : notnull
 {
-    public PairFinding(Added<T> value) => Value = Guard(value);
-    public PairFinding(Removed<T> value) => Value = Guard(value);
-    public PairFinding(Present<T> value) => Value = Guard(value);
-    public PairFinding(Changed<T> value) => Value = Guard(value);
+    public PairFinding(Added value) => Value = Guard(value);
+    public PairFinding(Removed value) => Value = Guard(value);
+    public PairFinding(Present value) => Value = Guard(value);
+    public PairFinding(Changed value) => Value = Guard(value);
 
     // A constructed wrapper always holds a case. (A `default`/null PairFinding<T> reference is a
     // separate, NRT-visible concern inherent to any reference type, not an empty union state.)
@@ -209,7 +145,7 @@ public sealed record PairFinding<T> : IPairFinding
         return value;
     }
 
-    /// <summary>The active case: <see cref="Added{T}"/>, <see cref="Removed{T}"/>, <see cref="Present{T}"/>, or <see cref="Changed{T}"/>.</summary>
+    /// <summary>The active case: <see cref="Added"/>, <see cref="Removed"/>, <see cref="Present"/>, or <see cref="Changed"/>.</summary>
     public object? Value { get; }
 
     private IPairFinding Case => (IPairFinding)Value!;
@@ -221,6 +157,72 @@ public sealed record PairFinding<T> : IPairFinding
     public string? Detail => Case.Detail;
     IFinding? IPairFinding.Old => Case.Old;
     IFinding? IPairFinding.New => Case.New;
+
+    /// <summary>A transition present only on the new side: a one-sided addition.</summary>
+    public sealed record Added(Finding<T> New, string? Detail = null) : IPairFinding
+    {
+        // A null-forgiving (`null!`) caller could otherwise slip a missing atom past the non-null
+        // annotation and reintroduce a case with no side; guard the required atom at construction.
+        public Finding<T> New { get; } = New ?? throw new ArgumentNullException(nameof(New));
+
+        public PairKind Kind => PairKind.Added;
+        public FindingDifferenceKind Difference => FindingDifferenceKind.None;
+        public FindingSubject Subject => New.Subject;
+        public FindingDescriptor Descriptor => New.Descriptor;
+        IFinding? IPairFinding.Old => null;
+        IFinding? IPairFinding.New => New;
+    }
+
+    /// <summary>A transition present only on the old side: a one-sided removal.</summary>
+    public sealed record Removed(Finding<T> Old, string? Detail = null) : IPairFinding
+    {
+        public Finding<T> Old { get; } = Old ?? throw new ArgumentNullException(nameof(Old));
+
+        public PairKind Kind => PairKind.Removed;
+        public FindingDifferenceKind Difference => FindingDifferenceKind.None;
+        public FindingSubject Subject => Old.Subject;
+        public FindingDescriptor Descriptor => Old.Descriptor;
+        IFinding? IPairFinding.Old => Old;
+        IFinding? IPairFinding.New => null;
+    }
+
+    /// <summary>
+    /// A matched pair whose content is unchanged. May still carry a non-structural
+    /// <see cref="Difference"/> (e.g. <see cref="FindingDifferenceKind.Moved"/>): a move keeps Present
+    /// polarity because the content is the same, only the location differs.
+    /// </summary>
+    public sealed record Present(
+        Finding<T> Old,
+        Finding<T> New,
+        FindingDifferenceKind Difference = FindingDifferenceKind.None,
+        string? Detail = null) : IPairFinding
+    {
+        public Finding<T> Old { get; } = Old ?? throw new ArgumentNullException(nameof(Old));
+        public Finding<T> New { get; } = New ?? throw new ArgumentNullException(nameof(New));
+
+        public PairKind Kind => PairKind.Present;
+        public FindingSubject Subject => New.Subject;
+        public FindingDescriptor Descriptor => New.Descriptor;
+        IFinding? IPairFinding.Old => Old;
+        IFinding? IPairFinding.New => New;
+    }
+
+    /// <summary>A matched pair whose content changed across the two sides.</summary>
+    public sealed record Changed(
+        Finding<T> Old,
+        Finding<T> New,
+        FindingDifferenceKind Difference = FindingDifferenceKind.None,
+        string? Detail = null) : IPairFinding
+    {
+        public Finding<T> Old { get; } = Old ?? throw new ArgumentNullException(nameof(Old));
+        public Finding<T> New { get; } = New ?? throw new ArgumentNullException(nameof(New));
+
+        public PairKind Kind => PairKind.Changed;
+        public FindingSubject Subject => New.Subject;
+        public FindingDescriptor Descriptor => New.Descriptor;
+        IFinding? IPairFinding.Old => Old;
+        IFinding? IPairFinding.New => New;
+    }
 }
 
 /// <summary>Projections over finding streams shared by producers and the matcher seam.</summary>

--- a/src/ILInspector.Findings/Finding.cs
+++ b/src/ILInspector.Findings/Finding.cs
@@ -115,6 +115,10 @@ public interface IPairFinding : IFinding
 public sealed record Added<T>(Finding<T> New, string? Detail = null) : IPairFinding
     where T : notnull
 {
+    // A null-forgiving (`null!`) caller could otherwise slip a missing atom past the non-null
+    // annotation and reintroduce a case with no side; guard the required atom at construction.
+    public Finding<T> New { get; } = New ?? throw new ArgumentNullException(nameof(New));
+
     public PairKind Kind => PairKind.Added;
     public FindingDifferenceKind Difference => FindingDifferenceKind.None;
     public FindingSubject Subject => New.Subject;
@@ -127,6 +131,8 @@ public sealed record Added<T>(Finding<T> New, string? Detail = null) : IPairFind
 public sealed record Removed<T>(Finding<T> Old, string? Detail = null) : IPairFinding
     where T : notnull
 {
+    public Finding<T> Old { get; } = Old ?? throw new ArgumentNullException(nameof(Old));
+
     public PairKind Kind => PairKind.Removed;
     public FindingDifferenceKind Difference => FindingDifferenceKind.None;
     public FindingSubject Subject => Old.Subject;
@@ -147,6 +153,9 @@ public sealed record Present<T>(
     string? Detail = null) : IPairFinding
     where T : notnull
 {
+    public Finding<T> Old { get; } = Old ?? throw new ArgumentNullException(nameof(Old));
+    public Finding<T> New { get; } = New ?? throw new ArgumentNullException(nameof(New));
+
     public PairKind Kind => PairKind.Present;
     public FindingSubject Subject => New.Subject;
     public FindingDescriptor Descriptor => New.Descriptor;
@@ -162,6 +171,9 @@ public sealed record Changed<T>(
     string? Detail = null) : IPairFinding
     where T : notnull
 {
+    public Finding<T> Old { get; } = Old ?? throw new ArgumentNullException(nameof(Old));
+    public Finding<T> New { get; } = New ?? throw new ArgumentNullException(nameof(New));
+
     public PairKind Kind => PairKind.Changed;
     public FindingSubject Subject => New.Subject;
     public FindingDescriptor Descriptor => New.Descriptor;
@@ -177,16 +189,25 @@ public sealed record Changed<T>(
 /// to enforce and nothing a <c>with</c> expression can desync: the closed set of cases is the
 /// invariant. A reference union (a <c>record class</c>, not the struct sugar) so there is no
 /// <c>default</c>/empty state to guard and no boxing when a case is viewed as <see cref="IPairFinding"/>.
-/// Pattern-match <see cref="Value"/> to recover a case and its typed atoms.
+/// Pattern-match the union itself (<c>pair switch { Added&lt;T&gt; … }</c>, not <c>pair.Value switch</c>)
+/// to recover a case and its typed atoms with compiler-checked exhaustiveness.
 /// </summary>
 [Union]
 public sealed record PairFinding<T> : IPairFinding
     where T : notnull
 {
-    public PairFinding(Added<T> value) => Value = value;
-    public PairFinding(Removed<T> value) => Value = value;
-    public PairFinding(Present<T> value) => Value = value;
-    public PairFinding(Changed<T> value) => Value = value;
+    public PairFinding(Added<T> value) => Value = Guard(value);
+    public PairFinding(Removed<T> value) => Value = Guard(value);
+    public PairFinding(Present<T> value) => Value = Guard(value);
+    public PairFinding(Changed<T> value) => Value = Guard(value);
+
+    // A constructed wrapper always holds a case. (A `default`/null PairFinding<T> reference is a
+    // separate, NRT-visible concern inherent to any reference type, not an empty union state.)
+    static IPairFinding Guard(IPairFinding value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return value;
+    }
 
     /// <summary>The active case: <see cref="Added{T}"/>, <see cref="Removed{T}"/>, <see cref="Present{T}"/>, or <see cref="Changed{T}"/>.</summary>
     public object? Value { get; }

--- a/src/ILInspector.Findings/FindingFold.cs
+++ b/src/ILInspector.Findings/FindingFold.cs
@@ -87,23 +87,23 @@ public static class FindingFold
         switch (edge.Kind)
         {
             case FindingEdgeKind.Matched:
-                return new PairFinding<T>(oldStream[edge.OldIndex], newStream[edge.NewIndex]);
+                return new Present<T>(oldStream[edge.OldIndex], newStream[edge.NewIndex]);
 
             case FindingEdgeKind.Moved:
             {
                 int delta = edge.NewIndex - edge.OldIndex;
-                return new PairFinding<T>(
+                return new Present<T>(
                     oldStream[edge.OldIndex],
                     newStream[edge.NewIndex],
                     FindingDifferenceKind.Moved,
-                    detail: $"moved {delta:+#;-#;0}");
+                    Detail: $"moved {delta:+#;-#;0}");
             }
 
             case FindingEdgeKind.Added:
-                return new PairFinding<T>(null, newStream[edge.NewIndex]);
+                return new Added<T>(newStream[edge.NewIndex]);
 
             case FindingEdgeKind.Removed:
-                return new PairFinding<T>(oldStream[edge.OldIndex], null);
+                return new Removed<T>(oldStream[edge.OldIndex]);
 
             default:
                 throw new ArgumentOutOfRangeException(nameof(edge), edge.Kind, "Unknown edge kind.");

--- a/src/ILInspector.Findings/FindingFold.cs
+++ b/src/ILInspector.Findings/FindingFold.cs
@@ -87,12 +87,12 @@ public static class FindingFold
         switch (edge.Kind)
         {
             case FindingEdgeKind.Matched:
-                return new Present<T>(oldStream[edge.OldIndex], newStream[edge.NewIndex]);
+                return new PairFinding<T>.Present(oldStream[edge.OldIndex], newStream[edge.NewIndex]);
 
             case FindingEdgeKind.Moved:
             {
                 int delta = edge.NewIndex - edge.OldIndex;
-                return new Present<T>(
+                return new PairFinding<T>.Present(
                     oldStream[edge.OldIndex],
                     newStream[edge.NewIndex],
                     FindingDifferenceKind.Moved,
@@ -100,10 +100,10 @@ public static class FindingFold
             }
 
             case FindingEdgeKind.Added:
-                return new Added<T>(newStream[edge.NewIndex]);
+                return new PairFinding<T>.Added(newStream[edge.NewIndex]);
 
             case FindingEdgeKind.Removed:
-                return new Removed<T>(oldStream[edge.OldIndex]);
+                return new PairFinding<T>.Removed(oldStream[edge.OldIndex]);
 
             default:
                 throw new ArgumentOutOfRangeException(nameof(edge), edge.Kind, "Unknown edge kind.");

--- a/src/ILInspector.Findings/UnionPolyfill.cs
+++ b/src/ILInspector.Findings/UnionPolyfill.cs
@@ -1,0 +1,16 @@
+// The native discriminated-union feature (used by PairFinding<T>) is purely compiler-lowered: the
+// compiler recognizes [Union] by well-known name and generates the case conversions and pattern-
+// matching itself. Only the marker types live in the runtime, and only on net11+. The official
+// non-AOT "any" fallback package targets the net10.0 LTS floor (see Directory.Build.props), so on
+// that floor we supply the marker shapes ourselves — the same polyfill pattern used for
+// IsExternalInit/RequiredMember on older frameworks. Guarded to below-net11 so it never conflicts
+// with the real System.Private.CoreLib types on net11+ (which would be a CS0436 under
+// TreatWarningsAsErrors). Kept internal so it stays off the package's public API surface.
+#if !NET11_0_OR_GREATER
+namespace System.Runtime.CompilerServices;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
+internal sealed class UnionAttribute : Attribute;
+
+internal interface IUnion;
+#endif

--- a/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
@@ -214,20 +214,25 @@ public class FindingPilotTests
         => Assert.Throws<ArgumentNullException>(() => FindingMatcher.Match(null!, Keys("a")));
 
     [Fact]
-    public void PairFinding_DerivesKindFromSides_AndRejectsBothNull()
+    public void PairFinding_CasesFixTheirKind_AndBothNullIsUnrepresentable()
     {
         var a = new Finding<string>(Subject, Descriptor, new FindingKey("k"), 0, "k");
         var b = new Finding<string>(Subject, Descriptor, new FindingKey("k"), 1, "k");
 
-        // Kind is derived from the sides — there is no Kind to set out of step with them.
-        Assert.Equal(PairKind.Present, new PairFinding<string>(a, b).Kind);
-        Assert.Equal(PairKind.Changed, new PairFinding<string>(a, b, contentChanged: true).Kind);
-        Assert.Equal(PairKind.Added, new PairFinding<string>(null, b).Kind);
-        Assert.Equal(PairKind.Removed, new PairFinding<string>(a, null).Kind);
+        // Each union case fixes its own polarity; there is no Kind field to set out of step with the
+        // sides. The cases convert implicitly to the union.
+        Assert.Equal(PairKind.Present, ((PairFinding<string>)new Present<string>(a, b)).Kind);
+        Assert.Equal(PairKind.Changed, ((PairFinding<string>)new Changed<string>(a, b)).Kind);
+        Assert.Equal(PairKind.Added, ((PairFinding<string>)new Added<string>(b)).Kind);
+        Assert.Equal(PairKind.Removed, ((PairFinding<string>)new Removed<string>(a)).Kind);
 
-        // A with-expression cannot desync polarity from the sides (Kind is derived) nor null a side
-        // out (Old/New are get-only); the only rejected case is both-null at construction.
-        Assert.Throws<ArgumentException>(() => new PairFinding<string>(null, null));
+        // A both-null pair is not a runtime error to reject — it is unrepresentable: every case
+        // requires the atom(s) it carries, so there is no constructor that takes neither side.
+        // (Uncommenting the next line would be a compile error, which is the point.)
+        //   _ = new PairFinding<string>(null, null);
+
+        // Value equality holds across the union (record class over its case).
+        Assert.Equal((PairFinding<string>)new Present<string>(a, b), new Present<string>(a, b));
     }
 
     [Fact]
@@ -261,8 +266,8 @@ public class FindingPilotTests
 
         IPairFinding[] pairs =
         [
-            new PairFinding<string>(Atom("k0", 0), Atom("k0", 0)),
-            new PairFinding<string>(null, Atom("k1", 1)),
+            new Present<string>(Atom("k0", 0), Atom("k0", 0)),
+            new Added<string>(Atom("k1", 1)),
         ];
 
         var summary = FindingSummary.Summarize(pairs);
@@ -465,9 +470,20 @@ public class FindingPilotTests
     static string[] ResidualKeys(IlFindingsResult result, PairKind polarity)
         => result.Pairs
             .Where(p => p.Kind == polarity)
-            .Select(p => (p.New ?? p.Old)!.Key.IdentityKey)
+            .Select(p => CurrentAtom(p).Key.IdentityKey)
             .OrderBy(k => k, StringComparer.Ordinal)
             .ToArray();
+
+    // The representative atom of a pair (new side if present, else old), recovered by matching the
+    // union's closed set of cases — a consumer that wants the typed payload must handle each case.
+    static Finding<CanonicalIlOperation> CurrentAtom(PairFinding<CanonicalIlOperation> pair) => pair.Value switch
+    {
+        Added<CanonicalIlOperation> a => a.New,
+        Removed<CanonicalIlOperation> r => r.Old,
+        Present<CanonicalIlOperation> p => p.New,
+        Changed<CanonicalIlOperation> c => c.New,
+        _ => throw new InvalidOperationException("PairFinding has no case."),
+    };
 
     // ---- IL adapter: real-assembly corpus ----------------------------------------------------
 

--- a/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
@@ -236,6 +236,23 @@ public class FindingPilotTests
     }
 
     [Fact]
+    public void PairFinding_Cases_RejectNullAtoms_FailClosed()
+    {
+        var a = new Finding<string>(Subject, Descriptor, new FindingKey("k"), 0, "k");
+
+        // A plain null literal is already a compile error under the non-null annotations; a
+        // null-forgiving caller is caught at construction so a case can never hold a missing side.
+        Assert.Throws<ArgumentNullException>(() => new Added<string>(null!));
+        Assert.Throws<ArgumentNullException>(() => new Removed<string>(null!));
+        Assert.Throws<ArgumentNullException>(() => new Present<string>(a, null!));
+        Assert.Throws<ArgumentNullException>(() => new Present<string>(null!, a));
+        Assert.Throws<ArgumentNullException>(() => new Changed<string>(a, null!));
+
+        // The union wrapper likewise never holds a null case.
+        Assert.Throws<ArgumentNullException>(() => new PairFinding<string>((Added<string>)null!));
+    }
+
+    [Fact]
     public void SkeletonConsumer_ClassifiesFromPolarityAndDifferenceAlone()
     {
         // A stream-agnostic consumer: it reads only the pair skeleton, so the same pairs could have
@@ -475,14 +492,14 @@ public class FindingPilotTests
             .ToArray();
 
     // The representative atom of a pair (new side if present, else old), recovered by matching the
-    // union's closed set of cases — a consumer that wants the typed payload must handle each case.
-    static Finding<CanonicalIlOperation> CurrentAtom(PairFinding<CanonicalIlOperation> pair) => pair.Value switch
+    // union directly (`pair switch`, not `pair.Value switch`) so the compiler enforces exhaustiveness:
+    // adding a fifth case makes this fail to build rather than fall through at runtime.
+    static Finding<CanonicalIlOperation> CurrentAtom(PairFinding<CanonicalIlOperation> pair) => pair switch
     {
         Added<CanonicalIlOperation> a => a.New,
         Removed<CanonicalIlOperation> r => r.Old,
         Present<CanonicalIlOperation> p => p.New,
         Changed<CanonicalIlOperation> c => c.New,
-        _ => throw new InvalidOperationException("PairFinding has no case."),
     };
 
     // ---- IL adapter: real-assembly corpus ----------------------------------------------------

--- a/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
@@ -221,10 +221,10 @@ public class FindingPilotTests
 
         // Each union case fixes its own polarity; there is no Kind field to set out of step with the
         // sides. The cases convert implicitly to the union.
-        Assert.Equal(PairKind.Present, ((PairFinding<string>)new Present<string>(a, b)).Kind);
-        Assert.Equal(PairKind.Changed, ((PairFinding<string>)new Changed<string>(a, b)).Kind);
-        Assert.Equal(PairKind.Added, ((PairFinding<string>)new Added<string>(b)).Kind);
-        Assert.Equal(PairKind.Removed, ((PairFinding<string>)new Removed<string>(a)).Kind);
+        Assert.Equal(PairKind.Present, ((PairFinding<string>)new PairFinding<string>.Present(a, b)).Kind);
+        Assert.Equal(PairKind.Changed, ((PairFinding<string>)new PairFinding<string>.Changed(a, b)).Kind);
+        Assert.Equal(PairKind.Added, ((PairFinding<string>)new PairFinding<string>.Added(b)).Kind);
+        Assert.Equal(PairKind.Removed, ((PairFinding<string>)new PairFinding<string>.Removed(a)).Kind);
 
         // A both-null pair is not a runtime error to reject — it is unrepresentable: every case
         // requires the atom(s) it carries, so there is no constructor that takes neither side.
@@ -232,7 +232,7 @@ public class FindingPilotTests
         //   _ = new PairFinding<string>(null, null);
 
         // Value equality holds across the union (record class over its case).
-        Assert.Equal((PairFinding<string>)new Present<string>(a, b), new Present<string>(a, b));
+        Assert.Equal((PairFinding<string>)new PairFinding<string>.Present(a, b), new PairFinding<string>.Present(a, b));
     }
 
     [Fact]
@@ -242,14 +242,14 @@ public class FindingPilotTests
 
         // A plain null literal is already a compile error under the non-null annotations; a
         // null-forgiving caller is caught at construction so a case can never hold a missing side.
-        Assert.Throws<ArgumentNullException>(() => new Added<string>(null!));
-        Assert.Throws<ArgumentNullException>(() => new Removed<string>(null!));
-        Assert.Throws<ArgumentNullException>(() => new Present<string>(a, null!));
-        Assert.Throws<ArgumentNullException>(() => new Present<string>(null!, a));
-        Assert.Throws<ArgumentNullException>(() => new Changed<string>(a, null!));
+        Assert.Throws<ArgumentNullException>(() => new PairFinding<string>.Added(null!));
+        Assert.Throws<ArgumentNullException>(() => new PairFinding<string>.Removed(null!));
+        Assert.Throws<ArgumentNullException>(() => new PairFinding<string>.Present(a, null!));
+        Assert.Throws<ArgumentNullException>(() => new PairFinding<string>.Present(null!, a));
+        Assert.Throws<ArgumentNullException>(() => new PairFinding<string>.Changed(a, null!));
 
         // The union wrapper likewise never holds a null case.
-        Assert.Throws<ArgumentNullException>(() => new PairFinding<string>((Added<string>)null!));
+        Assert.Throws<ArgumentNullException>(() => new PairFinding<string>((PairFinding<string>.Added)null!));
     }
 
     [Fact]
@@ -283,8 +283,8 @@ public class FindingPilotTests
 
         IPairFinding[] pairs =
         [
-            new Present<string>(Atom("k0", 0), Atom("k0", 0)),
-            new Added<string>(Atom("k1", 1)),
+            new PairFinding<string>.Present(Atom("k0", 0), Atom("k0", 0)),
+            new PairFinding<string>.Added(Atom("k1", 1)),
         ];
 
         var summary = FindingSummary.Summarize(pairs);
@@ -496,10 +496,10 @@ public class FindingPilotTests
     // adding a fifth case makes this fail to build rather than fall through at runtime.
     static Finding<CanonicalIlOperation> CurrentAtom(PairFinding<CanonicalIlOperation> pair) => pair switch
     {
-        Added<CanonicalIlOperation> a => a.New,
-        Removed<CanonicalIlOperation> r => r.Old,
-        Present<CanonicalIlOperation> p => p.New,
-        Changed<CanonicalIlOperation> c => c.New,
+        PairFinding<CanonicalIlOperation>.Added a => a.New,
+        PairFinding<CanonicalIlOperation>.Removed r => r.Old,
+        PairFinding<CanonicalIlOperation>.Present p => p.New,
+        PairFinding<CanonicalIlOperation>.Changed c => c.New,
     };
 
     // ---- IL adapter: real-assembly corpus ----------------------------------------------------

--- a/src/ILInspector.Instructions/IlFindings.cs
+++ b/src/ILInspector.Instructions/IlFindings.cs
@@ -100,20 +100,20 @@ public static class IlFindings
         var alignment = new Dictionary<int, int>(IlBodyDiff.BuildAlignmentMap(oldOps, newOps));
         foreach (var pair in pairs)
         {
-            if (pair.Value is Present<CanonicalIlOperation> { Difference: FindingDifferenceKind.Moved } moved)
+            if (pair.Value is PairFinding<CanonicalIlOperation>.Present { Difference: FindingDifferenceKind.Moved } moved)
                 alignment[moved.Old.Position] = moved.New.Position;
         }
 
         var builder = ImmutableArray.CreateBuilder<PairFinding<CanonicalIlOperation>>(pairs.Length);
         foreach (var pair in pairs)
         {
-            if (pair.Value is Present<CanonicalIlOperation> present
+            if (pair.Value is PairFinding<CanonicalIlOperation>.Present present
                 && !IlBodyDiff.BranchTargetsMatch(oldInstructions, present.Old.Position, newInstructions, present.New.Position, alignment))
             {
                 // A moved-and-retargeted operation keeps its move Detail; append the retarget so
                 // neither the distance nor the retarget note is lost. Promoting the Present case to
                 // Changed keeps both sides while flipping the polarity.
-                builder.Add(new Changed<CanonicalIlOperation>(
+                builder.Add(new PairFinding<CanonicalIlOperation>.Changed(
                     present.Old,
                     present.New,
                     present.Difference,

--- a/src/ILInspector.Instructions/IlFindings.cs
+++ b/src/ILInspector.Instructions/IlFindings.cs
@@ -100,26 +100,24 @@ public static class IlFindings
         var alignment = new Dictionary<int, int>(IlBodyDiff.BuildAlignmentMap(oldOps, newOps));
         foreach (var pair in pairs)
         {
-            if (pair.Difference == FindingDifferenceKind.Moved && pair.Old is not null && pair.New is not null)
-                alignment[pair.Old.Position] = pair.New.Position;
+            if (pair.Value is Present<CanonicalIlOperation> { Difference: FindingDifferenceKind.Moved } moved)
+                alignment[moved.Old.Position] = moved.New.Position;
         }
 
         var builder = ImmutableArray.CreateBuilder<PairFinding<CanonicalIlOperation>>(pairs.Length);
         foreach (var pair in pairs)
         {
-            if (pair.Kind == PairKind.Present
-                && pair.Old is not null
-                && pair.New is not null
-                && !IlBodyDiff.BranchTargetsMatch(oldInstructions, pair.Old.Position, newInstructions, pair.New.Position, alignment))
+            if (pair.Value is Present<CanonicalIlOperation> present
+                && !IlBodyDiff.BranchTargetsMatch(oldInstructions, present.Old.Position, newInstructions, present.New.Position, alignment))
             {
                 // A moved-and-retargeted operation keeps its move Detail; append the retarget so
-                // neither the distance nor the retarget note is lost. ContentChanged flips the
-                // derived Kind from Present to Changed while keeping both sides.
-                builder.Add(pair with
-                {
-                    ContentChanged = true,
-                    Detail = pair.Detail is null ? "branch retargeted" : $"{pair.Detail}; branch retargeted",
-                });
+                // neither the distance nor the retarget note is lost. Promoting the Present case to
+                // Changed keeps both sides while flipping the polarity.
+                builder.Add(new Changed<CanonicalIlOperation>(
+                    present.Old,
+                    present.New,
+                    present.Difference,
+                    present.Detail is null ? "branch retargeted" : $"{present.Detail}; branch retargeted"));
             }
             else
             {


### PR DESCRIPTION
## What

Reshape `PairFinding<T>` from a nullable-pair record into a **native .NET 11 discriminated union** (`[Union]`) over four case records — `Added<T>`, `Removed<T>`, `Present<T>`, `Changed<T>`.

Follow-on to #2592 (the atom/pair split). Same behavior, stronger type.

## Why

#2592 landed `PairFinding<T>` as a `sealed record` with nullable `Old?`/`New?`, a `Kind` *derived* from the sides, a `ContentChanged` flag, and a constructor that rejected the both-null case. Getting that invariant airtight took **five review rounds** across GPT-5.5 / Gemini 3.1 Pro / MAI-Code-1-Flash / Claude Code: ctor-validate → derive `Kind` → get-only sides → reject both-null. Each round closed one more way to hand-build an inconsistent pair.

A discriminated union makes the whole class of bug **unrepresentable** instead of *rejected*:

- Each case carries exactly the atoms it has (`Added` has only a new side, `Removed` only an old side, `Present`/`Changed` both). There is no nullable side to get wrong and no both-null pair to construct.
- `Kind` is a property of the case, not a value derived from mutable state — nothing a `with` expression can desync.
- The closed set of four cases *is* the invariant. No runtime guard, no invariant test.

This dogfoods the .NET 11 union feature the product decompiler already uses.

## Shape

- **Reference union** (`[Union] sealed record class`, not the struct sugar): the struct form's `default` is itself an illegal state (`Value == null`, neither case — the exact hazard we just eliminated) and boxes when viewed as `IPairFinding`. The record-class form has no `default`/empty state (a null *reference*, NRT-visible) and no boxing.
- `PairFinding<T>` keeps `IPairFinding` (`Kind`/`Difference`/`Old`/`New`) by delegating to the active case. It **no longer implements `IFinding<T>`** — the "current payload" projection had no consumers.
- Cases implement `IPairFinding` directly, so a producer can emit a case without wrapping it in the union.
- Value equality preserved (record class over its `Value` case).

## Changes

- `Finding.cs`: four case records + `[Union]` `PairFinding<T>`; drop the nullable-pair ctor, `ContentChanged`, `PositionDelta` (unused), `IFinding<T>`.
- `FindingFold.ToPair`: constructs cases (implicit case→union conversion).
- `IlFindings` branch-target validation: pattern-matches the `Present` case and constructs `Changed<T>`, replacing the `with { ContentChanged = true }` mutation.
- Tests: construct cases; the derive-Kind/reject-both-null test becomes a case→`Kind` mapping + a note that both-null is now a compile error; a residual-key helper dogfoods the `Value switch` over the closed case set.

## Validation

- Full `dotnet-inspect.slnx` builds clean (`-c Release --configfile nuget.config`).
- 31 `FindingPilotTests` green.
- AOT-safe: union lowering is `isinst` type tests, no reflection.

## Review

Behavior-preserving reshape of a merged type with subtle correctness history → adversarial review by two roster models (per `AGENTS.md`). Attack points: union `default`/null handling, exhaustiveness / `CS8509` under `TreatWarningsAsErrors`, behavior parity vs merged `PairFinding` (esp. branch-retarget → Changed), boxing via `IPairFinding`, value equality, AOT.
