### PR TITLE
Match the union, not .Value, in the PairFinding consumer

### DIFF
--- a/src/ILInspector.Instructions/IlFindings.cs
+++ b/src/ILInspector.Instructions/IlFindings.cs
@@ -100,14 +100,14 @@ public static class IlFindings
         var alignment = new Dictionary<int, int>(IlBodyDiff.BuildAlignmentMap(oldOps, newOps));
         foreach (var pair in pairs)
         {
-            if (pair.Value is PairFinding<CanonicalIlOperation>.Present { Difference: FindingDifferenceKind.Moved } moved)
+            if (pair is PairFinding<CanonicalIlOperation>.Present { Difference: FindingDifferenceKind.Moved } moved)
                 alignment[moved.Old.Position] = moved.New.Position;
         }
 
         var builder = ImmutableArray.CreateBuilder<PairFinding<CanonicalIlOperation>>(pairs.Length);
         foreach (var pair in pairs)
         {
-            if (pair.Value is PairFinding<CanonicalIlOperation>.Present present
+            if (pair is PairFinding<CanonicalIlOperation>.Present present
                 && !IlBodyDiff.BranchTargetsMatch(oldInstructions, present.Old.Position, newInstructions, present.New.Position, alignment))
             {
                 // A moved-and-retargeted operation keeps its move Detail; append the retarget so


### PR DESCRIPTION
## What

Follow-up to the review nit on #2593. `IlFindings.ApplyBranchTargetValidation` — the **first in-repo `PairFinding` consumer**, and the snippet others will copy — matched `pair.Value is PairFinding<T>.Present`, reaching into the union's `object? Value`, while `PairFinding<T>`'s own doc steers consumers to match the union itself (`pair switch { PairFinding<T>.Added … }`).

Both `is`-test sites now match `pair` directly.

## Why it's low-risk

For a single-case `is` test, `pair is Case` and `pair.Value is Case` are semantically identical (exhaustiveness only matters in a `switch`). This is exemplar/style consistency, not a correctness change — but as the canonical consumer, it's the pattern people copy, so it should model matching the union rather than its backing field.

## Validation

- `ILInspector.Instructions.Tests` builds clean; 32 `FindingPilotTests` green.
- Behaviour unchanged (verified `pair is PairFinding<T>.Present { Difference: Moved } moved` and the plain bind compile clean under `TreatWarningsAsErrors`).

Low-risk cosmetic alignment — no adversarial review requested per the `AGENTS.md` simple-PR carve-out.
