### PR TITLE
Add the identity-set committer to the finding matcher (#2585)

### DIFF
--- a/src/ILInspector.Findings/FindingMatcher.cs
+++ b/src/ILInspector.Findings/FindingMatcher.cs
@@ -46,23 +46,46 @@ public sealed record FindingMatch(
     ImmutableArray<FindingEdge> Edges,
     ImmutableArray<FindingMoveCandidate> MoveCandidates);
 
+/// <summary>
+/// Whether a finding stream's order carries meaning. The choice is per <see cref="FindingMatcher.Match"/>
+/// invocation and per occurrence level — the same producer can be ordered at one level and a set at another.
+/// </summary>
+public enum FindingStreamKind
+{
+    /// <summary>Order is semantic (an IL/C# body); use the LCS committer plus the scored move pass.</summary>
+    Ordered,
+
+    /// <summary>
+    /// Order is not semantic (an unordered set such as a type's members or an API surface); commit an
+    /// identity-key bijection by multiset (hash buckets, O(N), no matrix). A set has no position, so
+    /// there are no moves and no scored fringe.
+    /// </summary>
+    IdentitySet,
+}
+
 /// <summary>Tunables for <see cref="FindingMatcher.Match"/>.</summary>
 /// <param name="MinMoveRunLength">
 /// The minimum length of a common contiguous residual run to commit as a move. Runs shorter
 /// than this are left to the fringe, which is what gives the conservative default its
 /// mismatch resistance (a lone content-equal occurrence is not silently treated as a move).
+/// Applies only to <see cref="FindingStreamKind.Ordered"/> matching.
 /// </param>
-public sealed record FindingMatchOptions(int MinMoveRunLength = 2)
+/// <param name="StreamKind">Whether the streams are ordered or an unordered identity set.</param>
+public sealed record FindingMatchOptions(
+    int MinMoveRunLength = 2,
+    FindingStreamKind StreamKind = FindingStreamKind.Ordered)
 {
     public static readonly FindingMatchOptions Default = new();
 }
 
 /// <summary>
-/// The single, domain-free matcher every finding stream shares. It commits an
-/// order-preserving LCS core (which reproduces a classic sequence diff when there are no moves)
-/// and then recovers relocations as a scored move pass over the residual. It never inspects a payload and never decides
-/// equivalence: it emits a classified alignment (a set of edges), and a consumer <see cref="FindingFold"/>
-/// folds it.
+/// The single, domain-free matcher every finding stream shares. For <see cref="FindingStreamKind.Ordered"/>
+/// streams it commits an order-preserving LCS core (which reproduces a classic sequence diff when there are
+/// no moves) and then recovers relocations as a scored move pass over the residual; for
+/// <see cref="FindingStreamKind.IdentitySet"/> streams it commits an identity-key bijection by multiset with
+/// no notion of order (and no matrix, so it scales past the ordered cell cap). It never inspects a payload and
+/// never decides equivalence: it emits a classified alignment (a set of edges), and a consumer
+/// <see cref="FindingFold"/> folds it.
 /// </summary>
 public static class FindingMatcher
 {
@@ -82,20 +105,67 @@ public static class FindingMatcher
         ArgumentNullException.ThrowIfNull(newStream);
         options ??= FindingMatchOptions.Default;
 
-        // The ordered committer needs random access and two passes, so materialize once to a
-        // concrete FindingKey[] — the LCS hot loop then indexes an array directly (no interface
-        // dispatch). A streaming set committer (issue #2585) can instead consume the IEnumerable
-        // straight into its dictionary without this array.
+        // Both committers need the counts and (for ordered) two-pass random access, so materialize
+        // once to a concrete FindingKey[]: the ordered LCS hot loop then indexes an array directly
+        // (no interface dispatch), and the set committer streams it into its buckets.
         var oldKeys = oldStream as FindingKey[] ?? oldStream.ToArray();
         var newKeys = newStream as FindingKey[] ?? newStream.ToArray();
 
+        return options.StreamKind == FindingStreamKind.IdentitySet
+            ? MatchIdentitySet(oldKeys, newKeys)
+            : MatchOrdered(oldKeys, newKeys, options);
+    }
+
+    // Order-free committer: pair occurrences by identity-key equality via hash buckets, deterministic
+    // by stream order (the i-th occurrence of a key on the old side pairs with the i-th on the new).
+    // A set has no position, so there are no moves and no scored fringe — and no O(N*M) matrix, so it
+    // needs no cell cap and scales to assembly-size member/API-surface sets. A relocation only appears
+    // at this rung once a soft tier drops a facet (e.g. declaring type) from the identity key (#2585).
+    static FindingMatch MatchIdentitySet(FindingKey[] oldKeys, FindingKey[] newKeys)
+    {
+        var newByKey = new Dictionary<string, Queue<int>>(StringComparer.Ordinal);
+        for (int j = 0; j < newKeys.Length; j++)
+        {
+            if (!newByKey.TryGetValue(newKeys[j].IdentityKey, out var queue))
+                newByKey[newKeys[j].IdentityKey] = queue = new Queue<int>();
+            queue.Enqueue(j);
+        }
+
+        var matchedNew = new bool[newKeys.Length];
+        var edges = ImmutableArray.CreateBuilder<FindingEdge>();
+
+        for (int i = 0; i < oldKeys.Length; i++)
+        {
+            if (newByKey.TryGetValue(oldKeys[i].IdentityKey, out var queue) && queue.Count > 0)
+            {
+                int j = queue.Dequeue();
+                matchedNew[j] = true;
+                edges.Add(new FindingEdge(FindingEdgeKind.Matched, i, j, 100));
+            }
+            else
+            {
+                edges.Add(new FindingEdge(FindingEdgeKind.Removed, i, -1, 100));
+            }
+        }
+
+        for (int j = 0; j < newKeys.Length; j++)
+        {
+            if (!matchedNew[j])
+                edges.Add(new FindingEdge(FindingEdgeKind.Added, -1, j, 100));
+        }
+
+        return new FindingMatch(edges.ToImmutable(), ImmutableArray<FindingMoveCandidate>.Empty);
+    }
+
+    static FindingMatch MatchOrdered(FindingKey[] oldKeys, FindingKey[] newKeys, FindingMatchOptions options)
+    {
         long cells = ((long)oldKeys.Length + 1) * ((long)newKeys.Length + 1);
         if (cells > MaxOrderedMatchCells)
         {
             throw new ArgumentException(
                 $"Ordered matching is bounded to {MaxOrderedMatchCells:N0} matrix cells " +
                 $"({oldKeys.Length}x{newKeys.Length} requested). Streams this large need the " +
-                "identity-set committer, not the ordered LCS (see issue #2585).");
+                "identity-set committer (FindingStreamKind.IdentitySet), not the ordered LCS (see issue #2585).");
         }
 
         var matchedOld = new bool[oldKeys.Length];

--- a/src/ILInspector.Findings/FindingMatcher.cs
+++ b/src/ILInspector.Findings/FindingMatcher.cs
@@ -50,7 +50,7 @@ public sealed record FindingMatch(
 /// Whether a finding stream's order carries meaning. The choice is per <see cref="FindingMatcher.Match"/>
 /// invocation and per occurrence level — the same producer can be ordered at one level and a set at another.
 /// </summary>
-public enum FindingStreamKind
+public enum FindingMatchMode
 {
     /// <summary>Order is semantic (an IL/C# body); use the LCS committer plus the scored move pass.</summary>
     Ordered,
@@ -69,7 +69,7 @@ public enum FindingStreamKind
 /// The minimum length of a common contiguous residual run to commit as a move. Runs shorter
 /// than this are left to the fringe, which is what gives the conservative default its
 /// mismatch resistance (a lone content-equal occurrence is not silently treated as a move).
-/// Applies only to <see cref="FindingStreamKind.Ordered"/> matching.
+/// Applies only to <see cref="FindingMatchMode.Ordered"/> matching.
 /// </param>
 public sealed record FindingMatchOptions(int MinMoveRunLength = 2)
 {
@@ -78,16 +78,16 @@ public sealed record FindingMatchOptions(int MinMoveRunLength = 2)
     /// second positional parameter) so adding it keeps the record's <c>(int)</c> constructor and
     /// <c>Deconstruct</c> — no source or binary break for existing callers.
     /// </summary>
-    public FindingStreamKind StreamKind { get; init; } = FindingStreamKind.Ordered;
+    public FindingMatchMode MatchMode { get; init; } = FindingMatchMode.Ordered;
 
     public static readonly FindingMatchOptions Default = new();
 }
 
 /// <summary>
-/// The single, domain-free matcher every finding stream shares. For <see cref="FindingStreamKind.Ordered"/>
+/// The single, domain-free matcher every finding stream shares. For <see cref="FindingMatchMode.Ordered"/>
 /// streams it commits an order-preserving LCS core (which reproduces a classic sequence diff when there are
 /// no moves) and then recovers relocations as a scored move pass over the residual; for
-/// <see cref="FindingStreamKind.IdentitySet"/> streams it commits an identity-key bijection by multiset with
+/// <see cref="FindingMatchMode.IdentitySet"/> streams it commits an identity-key bijection by multiset with
 /// no notion of order (and no matrix, so it scales past the ordered cell cap). It never inspects a payload and
 /// never decides equivalence: it emits a classified alignment (a set of edges), and a consumer
 /// <see cref="FindingFold"/> folds it.
@@ -116,7 +116,7 @@ public static class FindingMatcher
         var oldKeys = oldStream as FindingKey[] ?? oldStream.ToArray();
         var newKeys = newStream as FindingKey[] ?? newStream.ToArray();
 
-        return options.StreamKind == FindingStreamKind.IdentitySet
+        return options.MatchMode == FindingMatchMode.IdentitySet
             ? MatchIdentitySet(oldKeys, newKeys)
             : MatchOrdered(oldKeys, newKeys, options);
     }
@@ -184,7 +184,7 @@ public static class FindingMatcher
             throw new ArgumentException(
                 $"Ordered matching is bounded to {MaxOrderedMatchCells:N0} matrix cells " +
                 $"({oldKeys.Length}x{newKeys.Length} requested). Streams this large need the " +
-                "identity-set committer (FindingStreamKind.IdentitySet), not the ordered LCS (see issue #2585).");
+                "identity-set committer (FindingMatchMode.IdentitySet), not the ordered LCS (see issue #2585).");
         }
 
         var matchedOld = new bool[oldKeys.Length];

--- a/src/ILInspector.Findings/FindingMatcher.cs
+++ b/src/ILInspector.Findings/FindingMatcher.cs
@@ -58,7 +58,8 @@ public enum FindingStreamKind
     /// <summary>
     /// Order is not semantic (an unordered set such as a type's members or an API surface); commit an
     /// identity-key bijection by multiset (hash buckets, O(N), no matrix). A set has no position, so
-    /// there are no moves and no scored fringe.
+    /// there are no moves and no scored fringe. Matching considers <see cref="FindingKey.IdentityKey"/>
+    /// only; <see cref="FindingKey.ScopeKey"/> is not consulted at this rung.
     /// </summary>
     IdentitySet,
 }
@@ -70,11 +71,15 @@ public enum FindingStreamKind
 /// mismatch resistance (a lone content-equal occurrence is not silently treated as a move).
 /// Applies only to <see cref="FindingStreamKind.Ordered"/> matching.
 /// </param>
-/// <param name="StreamKind">Whether the streams are ordered or an unordered identity set.</param>
-public sealed record FindingMatchOptions(
-    int MinMoveRunLength = 2,
-    FindingStreamKind StreamKind = FindingStreamKind.Ordered)
+public sealed record FindingMatchOptions(int MinMoveRunLength = 2)
 {
+    /// <summary>
+    /// Whether the streams are ordered or an unordered identity set. An <c>init</c> property (not a
+    /// second positional parameter) so adding it keeps the record's <c>(int)</c> constructor and
+    /// <c>Deconstruct</c> — no source or binary break for existing callers.
+    /// </summary>
+    public FindingStreamKind StreamKind { get; init; } = FindingStreamKind.Ordered;
+
     public static readonly FindingMatchOptions Default = new();
 }
 
@@ -123,20 +128,23 @@ public static class FindingMatcher
     // at this rung once a soft tier drops a facet (e.g. declaring type) from the identity key (#2585).
     static FindingMatch MatchIdentitySet(FindingKey[] oldKeys, FindingKey[] newKeys)
     {
+        // Bucket new occurrences by identity key. IdentityKey is non-null by contract, but the ordered
+        // committer tolerates a null key (null == null matches), so keep parity via a dedicated null
+        // bucket instead of crashing in Dictionary (which rejects a null key) on a degenerate
+        // default(FindingKey).
         var newByKey = new Dictionary<string, Queue<int>>(StringComparer.Ordinal);
+        var newNull = new Queue<int>();
         for (int j = 0; j < newKeys.Length; j++)
-        {
-            if (!newByKey.TryGetValue(newKeys[j].IdentityKey, out var queue))
-                newByKey[newKeys[j].IdentityKey] = queue = new Queue<int>();
-            queue.Enqueue(j);
-        }
+            Bucket(newByKey, newNull, newKeys[j].IdentityKey).Enqueue(j);
 
         var matchedNew = new bool[newKeys.Length];
         var edges = ImmutableArray.CreateBuilder<FindingEdge>();
 
         for (int i = 0; i < oldKeys.Length; i++)
         {
-            if (newByKey.TryGetValue(oldKeys[i].IdentityKey, out var queue) && queue.Count > 0)
+            string? key = oldKeys[i].IdentityKey;
+            var queue = key is null ? newNull : (newByKey.TryGetValue(key, out var q) ? q : null);
+            if (queue is { Count: > 0 })
             {
                 int j = queue.Dequeue();
                 matchedNew[j] = true;
@@ -155,6 +163,17 @@ public static class FindingMatcher
         }
 
         return new FindingMatch(edges.ToImmutable(), ImmutableArray<FindingMoveCandidate>.Empty);
+
+        // Route a null identity key to a dedicated bucket (Dictionary rejects null keys); real keys
+        // bucket by ordinal equality.
+        static Queue<int> Bucket(Dictionary<string, Queue<int>> byKey, Queue<int> nullBucket, string? key)
+        {
+            if (key is null)
+                return nullBucket;
+            if (!byKey.TryGetValue(key, out var queue))
+                byKey[key] = queue = new Queue<int>();
+            return queue;
+        }
     }
 
     static FindingMatch MatchOrdered(FindingKey[] oldKeys, FindingKey[] newKeys, FindingMatchOptions options)

--- a/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
@@ -213,7 +213,7 @@ public class FindingPilotTests
     public void Match_NullStream_Throws()
         => Assert.Throws<ArgumentNullException>(() => FindingMatcher.Match(null!, Keys("a")));
 
-    static readonly FindingMatchOptions IdentitySet = new(StreamKind: FindingStreamKind.IdentitySet);
+    static readonly FindingMatchOptions IdentitySet = new() { StreamKind = FindingStreamKind.IdentitySet };
 
     [Fact]
     public void IdentitySet_Permutation_IsAllMatched_NoAddRemoveOrMove()
@@ -283,6 +283,42 @@ public class FindingPilotTests
         // Deterministic: the same inputs yield the same edge sequence.
         var second = FindingMatcher.Match(big, big, IdentitySet);
         Assert.Equal(first.Edges, second.Edges);
+    }
+
+    [Fact]
+    public void IdentitySet_NullIdentityKeys_MatchLikeOrdered_NoCrash()
+    {
+        // default(FindingKey) has a null IdentityKey. The ordered committer treats null == null as a
+        // match; the set committer keeps parity (dedicated null bucket) rather than crashing in
+        // Dictionary, so a degenerate stream behaves the same on both rungs.
+        var stream = new FindingKey[] { default, default };
+
+        var set = FindingMatcher.Match(stream, stream, IdentitySet);
+        Assert.Equal(2, Count(set, FindingEdgeKind.Matched));
+        Assert.Equal(0, Count(set, FindingEdgeKind.Added));
+        Assert.Equal(0, Count(set, FindingEdgeKind.Removed));
+
+        Assert.Equal(2, Count(FindingMatcher.Match(stream, stream), FindingEdgeKind.Matched));
+    }
+
+    [Fact]
+    public void IdentitySet_FoldsThroughToSummary_EndToEnd()
+    {
+        // Locks the full set pipeline the Metadata/Analysis producers will build on:
+        // match -> FindingFold.ToPairs -> FindingSummary.
+        var old = Atoms("a", "b", "c", "d");
+        var permuted = Atoms("d", "a", "c", "b");
+        var permutedPairs = FindingFold.ToPairs(FindingMatcher.Match(old.Keys(), permuted.Keys(), IdentitySet), old, permuted);
+        Assert.All(permutedPairs, p => Assert.Equal(PairKind.Present, p.Kind));
+        // A permuted set is a non-event: the summary reads Identical (no moves, no add/remove).
+        Assert.Equal(DiffShape.Identical, FindingSummary.Summarize(permutedPairs).Shape);
+
+        var changedNew = Atoms("a", "c");
+        var oldSmall = Atoms("a", "b");
+        var changedPairs = FindingFold.ToPairs(FindingMatcher.Match(oldSmall.Keys(), changedNew.Keys(), IdentitySet), oldSmall, changedNew);
+        var summary = FindingSummary.Summarize(changedPairs);
+        Assert.Equal(1, summary.Added);
+        Assert.Equal(1, summary.Removed);
     }
 
     [Fact]

--- a/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
@@ -213,6 +213,78 @@ public class FindingPilotTests
     public void Match_NullStream_Throws()
         => Assert.Throws<ArgumentNullException>(() => FindingMatcher.Match(null!, Keys("a")));
 
+    static readonly FindingMatchOptions IdentitySet = new(StreamKind: FindingStreamKind.IdentitySet);
+
+    [Fact]
+    public void IdentitySet_Permutation_IsAllMatched_NoAddRemoveOrMove()
+    {
+        // Order is not semantic for a set: a permutation is a non-event, unlike the ordered matcher
+        // (which reports the relocation as moves or add/remove). Every element matches by identity key.
+        var old = Keys("a", "b", "c", "d");
+        var @new = Keys("d", "b", "a", "c");
+
+        var match = FindingMatcher.Match(old, @new, IdentitySet);
+
+        Assert.Equal(4, Count(match, FindingEdgeKind.Matched));
+        Assert.Equal(0, Count(match, FindingEdgeKind.Added));
+        Assert.Equal(0, Count(match, FindingEdgeKind.Removed));
+        Assert.Equal(0, Count(match, FindingEdgeKind.Moved));
+        Assert.True(match.MoveCandidates.IsEmpty);
+    }
+
+    [Fact]
+    public void IdentitySet_DistinctMultisets_AreMatchedByIntersection()
+    {
+        // old {A,B,C,C} vs new {C,C,D,B}: multiset intersection {B,C,C} matches; old-only {A} removed;
+        // new-only {D} added. Duplicates are matched by count, not collapsed.
+        var old = Keys("A", "B", "C", "C");
+        var @new = Keys("C", "C", "D", "B");
+
+        var match = FindingMatcher.Match(old, @new, IdentitySet);
+
+        Assert.Equal(3, Count(match, FindingEdgeKind.Matched));
+        Assert.Equal(1, Count(match, FindingEdgeKind.Removed));
+        Assert.Equal(1, Count(match, FindingEdgeKind.Added));
+        Assert.Equal(0, Count(match, FindingEdgeKind.Moved));
+    }
+
+    [Fact]
+    public void IdentitySet_DuplicateKeys_MatchByMultisetCount()
+    {
+        var match = FindingMatcher.Match(Keys("A", "A", "A"), Keys("A", "A"), IdentitySet);
+
+        Assert.Equal(2, Count(match, FindingEdgeKind.Matched));
+        Assert.Equal(1, Count(match, FindingEdgeKind.Removed));
+        Assert.Equal(0, Count(match, FindingEdgeKind.Added));
+    }
+
+    [Fact]
+    public void IdentitySet_EmptyAndOneSided_AreWhollyAddedOrRemoved()
+    {
+        Assert.Empty(FindingMatcher.Match(Keys(), Keys(), IdentitySet).Edges);
+        Assert.Equal(2, Count(FindingMatcher.Match(Keys(), Keys("a", "b"), IdentitySet), FindingEdgeKind.Added));
+        Assert.Equal(2, Count(FindingMatcher.Match(Keys("a", "b"), Keys(), IdentitySet), FindingEdgeKind.Removed));
+    }
+
+    [Fact]
+    public void IdentitySet_ScalesPastTheOrderedGuard_AndIsDeterministic()
+    {
+        // A stream large enough that the ordered committer's O(N*M) matrix trips its cell cap; the
+        // identity-set committer has no matrix, so it matches all of it.
+        var big = Keys([.. Enumerable.Range(0, 9000).Select(i => $"k{i}")]);
+
+        Assert.Throws<ArgumentException>(() => FindingMatcher.Match(big, big));
+
+        var first = FindingMatcher.Match(big, big, IdentitySet);
+        Assert.Equal(9000, Count(first, FindingEdgeKind.Matched));
+        Assert.Equal(0, Count(first, FindingEdgeKind.Added));
+        Assert.Equal(0, Count(first, FindingEdgeKind.Removed));
+
+        // Deterministic: the same inputs yield the same edge sequence.
+        var second = FindingMatcher.Match(big, big, IdentitySet);
+        Assert.Equal(first.Edges, second.Edges);
+    }
+
     [Fact]
     public void PairFinding_CasesFixTheirKind_AndBothNullIsUnrepresentable()
     {

--- a/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
@@ -213,7 +213,7 @@ public class FindingPilotTests
     public void Match_NullStream_Throws()
         => Assert.Throws<ArgumentNullException>(() => FindingMatcher.Match(null!, Keys("a")));
 
-    static readonly FindingMatchOptions IdentitySet = new() { StreamKind = FindingStreamKind.IdentitySet };
+    static readonly FindingMatchOptions IdentitySet = new() { MatchMode = FindingMatchMode.IdentitySet };
 
     [Fact]
     public void IdentitySet_Permutation_IsAllMatched_NoAddRemoveOrMove()


### PR DESCRIPTION
## What

Adds an **identity-set committer** to the shared `FindingMatcher`, alongside the
existing ordered LCS + move committer. A new `FindingMatchMode`
(`Ordered` | `IdentitySet`) on `FindingMatchOptions` selects it per invocation.

## Why

The matcher only had the ordered committer, which assumes position is meaning
(an IL/C# body). Unordered finding collections -- a type's members, an API
surface -- have no semantic order, so the ordered path both **mis-reports a
permutation as add/remove** and **trips its O(N*M) matrix cell cap** on
assembly-scale sets. This is the foundation the unordered producers
(Metadata/API #2589, Analysis #2588) need.

Re-implements the net-new half of the now-closed draft #2587 against the merged
Finding model (row confidence was already merged in the spine reshape).

## How

- `MatchIdentitySet` pairs occurrences by identity-key equality via hash-bucket
  `Queue<int>` instances: O(N), no matrix, no cell cap. It is deterministic by
  collection order -- the i-th occurrence of a key on the old side pairs with
  the i-th on the new. An identity set has no position, so it emits no moves or
  scored fringe.
- Null identity keys use a dedicated parity bucket, matching the ordered
  committer's `null == null` tolerance.
- Identity-set matching considers `IdentityKey` only; `ScopeKey` is not
  consulted at this rung.
- `Match` materializes both collections once and dispatches on `MatchMode`; the
  ordered body (and its cell-cap guard) moved verbatim into `MatchOrdered`, so
  the ordered path is behavior-identical.
- `FindingMatchOptions` retains its original primary constructor and
  `Deconstruct`; `MatchMode` is an `init` property to preserve source and binary
  compatibility.

## Tests

Seven new tests cover:

- Permutations as a non-event: all matched, with no add/remove/move.
- Distinct multisets matched by intersection and duplicates matched by count.
- Empty and one-sided collections.
- Null identity-key parity with the ordered path.
- Scaling beyond the ordered cell cap with a 9000-element collection.
- Deterministic edge sequences across repeated runs.
- Identity-set match through `FindingFold.ToPairs` and `FindingSummary`.

## Validation

- 39 `FindingPilotTests` green (was 32).
- Full `dotnet-inspect.slnx` builds clean on net11.
- `ILInspector.Findings` builds on the net10.0 fallback.
- Current PR CI is green.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| GPT-5.5 | Clean | Verified multiset correctness, determinism, ordered-path identity, fold/summary, and scale |
| Gemini 3.1 Pro | Clean after fixes | Binary compatibility and null-key handling resolved in `347bcec8` |
| Claude Code | Clean/non-blocking | Scope contract and end-to-end fold gate added; materialization retained deliberately |

The final matching-mode rename in `552e280b` was mechanical and made no logic
change. **Ready to merge.**
