### PR TITLE
Restore faithful record ToString/PrintMembers compile-back shell (#2599)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -2862,6 +2862,38 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_RecordSurfaceHelperKeepsGenericSameNameOverload()
+    {
+        // A user generic `PrintMembers<T>` overload called by a custom ToString must survive
+        // the record-surface stub removal: the removal must match only the exact synthesized
+        // `bool PrintMembers(StringBuilder)` shape, not every member named PrintMembers (the
+        // surface enumeration cannot re-emit the generic overload).
+        var assemblyPath = CompileFixture("""
+            public record Row(string Name)
+            {
+                public override string ToString() => PrintMembers<int>(7).ToString();
+
+                public bool PrintMembers<T>(int x) => x == 7;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Row", "ToString", 0)]));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("PrintMembers<T>", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_UsesFieldShellForRecordGeneratedFieldReadHelpers()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -2830,6 +2830,38 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_RecordSurfaceHelperKeepsGenericDependency()
+    {
+        // A record with a custom ToString that calls a generic same-type helper: the record
+        // surface path reconstructs the faithful member surface, but the metadata surface
+        // enumeration skips generic methods — so the IR-gathered generic dependency must still
+        // be carried (via AddRequiredMembers) or compile-back regresses to a non-Exact floor.
+        var assemblyPath = CompileFixture("""
+            public record Row(string Name, string Value)
+            {
+                public override string ToString() => Render<int>();
+
+                private string Render<T>() => Name + Value;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Row", "ToString", 0)]));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("Render", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_UsesFieldShellForRecordGeneratedFieldReadHelpers()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -2865,13 +2865,20 @@ public class ReturnToSenderPrototypeTests
     public void CompileBackTargets_RecordSurfaceHelperKeepsGenericSameNameOverload()
     {
         // A user generic `PrintMembers<T>` overload called by a custom ToString must survive
-        // the record-surface stub removal: the removal must match only the exact synthesized
-        // `bool PrintMembers(StringBuilder)` shape, not every member named PrintMembers (the
-        // surface enumeration cannot re-emit the generic overload).
+        // the record-surface stub removal, and the synthesized `PrintMembers(StringBuilder)`
+        // it also calls must still be present: the removal must not leave the synthesized shape
+        // unre-emitted when a same-name overload shadows it in the name-based surface dedup.
         var assemblyPath = CompileFixture("""
+            using System.Text;
             public record Row(string Name)
             {
-                public override string ToString() => PrintMembers<int>(7).ToString();
+                public override string ToString()
+                {
+                    var b = new StringBuilder();
+                    PrintMembers<int>(7);
+                    PrintMembers(b);
+                    return b.ToString();
+                }
 
                 public bool PrintMembers<T>(int x) => x == 7;
             }
@@ -2886,6 +2893,7 @@ public class ReturnToSenderPrototypeTests
                 result.Status == FidelityCheck.CompileBackStatus.Exact,
                 $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
             Assert.Contains("PrintMembers<T>", result.Source);
+            Assert.Contains("PrintMembers(System.Text.StringBuilder", result.Source);
         }
         finally
         {

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -704,11 +704,21 @@ public static class CompileBackSourceComposer
                 IsSealed: false,
                 IsAsync: !isConstructor && function.RequiresAsyncBodyModifier)
         ];
+        bool includeRecordSurface = false;
         if (!isConstructor && IsRecordGeneratedFieldReadHelper(reader, targetTypeDef, targetIdentity, methodName, signature, function))
         {
             if (TypeProducer.TryCreateRecordEqualityContractRequirement(reader, targetType) is { } equalityContract)
                 targetMembers.Add(equalityContract);
             targetMembers.AddRange(TargetBackingFieldReadMembers(reader, targetTypeDef, targetIdentity, function));
+        }
+        else if (!isConstructor && IsRecordGeneratedSurfaceHelper(reader, targetTypeDef, targetIdentity, methodName, signature))
+        {
+            // ToString / PrintMembers delegate to the record's other synthesized members
+            // rather than reading backing fields directly, so reconstruct the full record
+            // member surface (faithful `protected virtual` helpers, EqualityContract, and the
+            // record properties) via the closure-member surface path instead of field shells.
+            targetFacts.Add(new CompileBackFact("metadata", "closure-member", "record-generated-helper"));
+            includeRecordSurface = true;
         }
         if (isConstructor && primaryConstructor is null)
             targetMembers.AddRange(TargetBackingFieldWriteMembers(reader, targetTypeDef, targetIdentity, function, allowStaticStores: false));
@@ -729,7 +739,8 @@ public static class CompileBackSourceComposer
         {
             targetMembers.Add(typedEqualsSibling);
         }
-        AddRequiredMembers(targetMembers, closureMemberRequirements, targetType, primaryConstructor);
+        if (!includeRecordSurface)
+            AddRequiredMembers(targetMembers, closureMemberRequirements, targetType, primaryConstructor);
 
         var requirements = new List<CompileBackTypeRequirement>
         {
@@ -1405,6 +1416,27 @@ public static class CompileBackSourceComposer
             && signature.ReturnType == "bool"
             && function.Signature.Parameters is [{ Type: var parameterType }]
             && IsSelfType(parameterType, typeIdentity);
+    }
+
+    // ToString / PrintMembers are record-generated helpers that delegate to the record's
+    // other synthesized members rather than reading backing fields directly, so they need
+    // the full record surface (see IsRecordGeneratedFieldReadHelper for the field-read helpers).
+    static bool IsRecordGeneratedSurfaceHelper(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        CompileBackTypeIdentity typeIdentity,
+        string methodName,
+        MethodSignature<string> signature)
+    {
+        if (!HasRecordHelperShell(reader, typeDef, typeIdentity))
+            return false;
+
+        return (methodName == "ToString"
+                && signature.ReturnType == "string"
+                && signature.ParameterTypes.Length == 0)
+            || (methodName == "PrintMembers"
+                && signature.ReturnType == "bool"
+                && signature.ParameterTypes.Length == 1);
     }
 
     static bool HasRecordHelperShell(MetadataReader reader, TypeDefinition typeDef, CompileBackTypeIdentity typeIdentity)

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -742,16 +742,21 @@ public static class CompileBackSourceComposer
         AddRequiredMembers(targetMembers, closureMemberRequirements, targetType, primaryConstructor);
         if (includeRecordSurface)
         {
-            // AddRequiredMembers above preserves every IR-gathered dependency (including a
-            // user generic `PrintMembers<T>` overload the surface enumeration would skip).
-            // Drop only the *synthesized* record-helper stubs — the exact-shape
-            // `bool PrintMembers(StringBuilder)` (no type parameters) and the EqualityContract
-            // property — so AddClosureMemberSurface re-emits them with faithful
-            // `protected virtual` accessibility. The target body (StubBody == TargetBody) and
-            // any differently-shaped same-name member are never removed.
+            // AddRequiredMembers above preserves every IR-gathered dependency (including a user
+            // generic `PrintMembers<T>` overload the surface enumeration would skip). Drop the
+            // synthesized record-helper stubs so AddClosureMemberSurface re-emits them with
+            // faithful `protected virtual` accessibility — but only when no differently-shaped
+            // same-name member remains: the surface dedups methods by name, so removing a stub
+            // shadowed by a same-name overload would leave the synthesized shape unre-emitted.
+            // In that (pathological) case the public stub is kept, still yielding an Exact build.
+            var shadowedHelpers = targetMembers
+                .Where(member => !IsSynthesizedRecordHelperStub(member))
+                .Select(member => (member.Kind, member.Identity.Method))
+                .ToHashSet();
             targetMembers.RemoveAll(member =>
                 member.StubBody != CompileBackStubBodyKind.TargetBody
-                && IsSynthesizedRecordHelperStub(member));
+                && IsSynthesizedRecordHelperStub(member)
+                && !shadowedHelpers.Contains((member.Kind, member.Identity.Method)));
         }
 
         var requirements = new List<CompileBackTypeRequirement>

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -742,14 +742,16 @@ public static class CompileBackSourceComposer
         AddRequiredMembers(targetMembers, closureMemberRequirements, targetType, primaryConstructor);
         if (includeRecordSurface)
         {
-            // AddRequiredMembers above preserves every IR-gathered dependency (e.g. generic
-            // same-type helpers the metadata surface enumeration filters out). Drop only the
-            // loosely-typed PrintMembers/EqualityContract *stubs* so AddClosureMemberSurface
-            // can re-emit them with faithful `protected virtual` accessibility. The target
-            // body itself (StubBody == TargetBody) is never removed.
+            // AddRequiredMembers above preserves every IR-gathered dependency (including a
+            // user generic `PrintMembers<T>` overload the surface enumeration would skip).
+            // Drop only the *synthesized* record-helper stubs — the exact-shape
+            // `bool PrintMembers(StringBuilder)` (no type parameters) and the EqualityContract
+            // property — so AddClosureMemberSurface re-emits them with faithful
+            // `protected virtual` accessibility. The target body (StubBody == TargetBody) and
+            // any differently-shaped same-name member are never removed.
             targetMembers.RemoveAll(member =>
                 member.StubBody != CompileBackStubBodyKind.TargetBody
-                && member.Identity.Method is "PrintMembers" or "EqualityContract" or "get_EqualityContract");
+                && IsSynthesizedRecordHelperStub(member));
         }
 
         var requirements = new List<CompileBackTypeRequirement>
@@ -1448,6 +1450,17 @@ public static class CompileBackSourceComposer
                 && signature.ReturnType == "bool"
                 && signature.ParameterTypes is ["System.Text.StringBuilder"]);
     }
+
+    // Matches only the exact compiler-synthesized record-helper stubs so the record surface
+    // path can replace them with faithful `protected virtual` declarations without deleting a
+    // differently-shaped same-name member (e.g. a user generic `PrintMembers<T>` overload).
+    static bool IsSynthesizedRecordHelperStub(CompileBackMemberRequirement member)
+        => (member.Kind == CompileBackMemberKind.PropertyGet
+                && member.Identity.Method == "EqualityContract")
+            || (member.Kind == CompileBackMemberKind.Method
+                && member.Identity.Method == "PrintMembers"
+                && member.TypeParameters.Count == 0
+                && member.Parameters is [{ Type.DisplayName: "System.Text.StringBuilder" }]);
 
     static bool HasRecordHelperShell(MetadataReader reader, TypeDefinition typeDef, CompileBackTypeIdentity typeIdentity)
     {

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -739,8 +739,18 @@ public static class CompileBackSourceComposer
         {
             targetMembers.Add(typedEqualsSibling);
         }
-        if (!includeRecordSurface)
-            AddRequiredMembers(targetMembers, closureMemberRequirements, targetType, primaryConstructor);
+        AddRequiredMembers(targetMembers, closureMemberRequirements, targetType, primaryConstructor);
+        if (includeRecordSurface)
+        {
+            // AddRequiredMembers above preserves every IR-gathered dependency (e.g. generic
+            // same-type helpers the metadata surface enumeration filters out). Drop only the
+            // loosely-typed PrintMembers/EqualityContract *stubs* so AddClosureMemberSurface
+            // can re-emit them with faithful `protected virtual` accessibility. The target
+            // body itself (StubBody == TargetBody) is never removed.
+            targetMembers.RemoveAll(member =>
+                member.StubBody != CompileBackStubBodyKind.TargetBody
+                && member.Identity.Method is "PrintMembers" or "EqualityContract" or "get_EqualityContract");
+        }
 
         var requirements = new List<CompileBackTypeRequirement>
         {
@@ -1436,7 +1446,7 @@ public static class CompileBackSourceComposer
                 && signature.ParameterTypes.Length == 0)
             || (methodName == "PrintMembers"
                 && signature.ReturnType == "bool"
-                && signature.ParameterTypes.Length == 1);
+                && signature.ParameterTypes is ["System.Text.StringBuilder"]);
     }
 
     static bool HasRecordHelperShell(MetadataReader reader, TypeDefinition typeDef, CompileBackTypeIdentity typeIdentity)


### PR DESCRIPTION
- Fixes #2599
- Restores the faithful record-generated `ToString`/`PrintMembers` compile-back shell that #2504 silently regressed.
- Decompiler-shell change; per-target source-probe census unchanged.

## Root cause (bisected)

First bad commit: **#2504 "Expand RTS fixture source coverage" (60a796be)**. It narrowed record-member emission to the field-read helpers (`GetHashCode` / typed `Equals`) via `IsRecordGeneratedFieldReadHelper`, so `ToString`/`PrintMembers` lost the full record surface. Compile-back stayed `Exact`, so only the unfiltered decompiler suite caught it — #2504's filtered CI missed it.

For `record Row(string Name, string Value)`, target `ToString`:

**Before #2504 (faithful):**

```csharp
public class Row
{
    public string ToString() { /* calls PrintMembers */ }
    protected virtual System.Type EqualityContract { get { throw null; } }
    public string Name { get; set; }
    public string Value { get; set; }
    protected virtual bool PrintMembers(System.Text.StringBuilder builder) { throw null; }
    public int GetHashCode() { throw null; }
    public bool Equals(object obj) { throw null; }
    public void Deconstruct(out string Name, out string Value) { throw null; }
    public Row() { throw null; }
}
```

**Regressed (post-#2504):** minimal + wrong accessibility —

```csharp
public class Row
{
    public string ToString() { /* calls PrintMembers */ }
    public virtual bool PrintMembers(System.Text.StringBuilder builder) { throw null; }
}
```

## Fix

`ToString`/`PrintMembers` delegate to the record's other synthesized members rather than reading backing fields directly, so they need the full record surface — not field shells. Add `IsRecordGeneratedSurfaceHelper` and, for those targets, seed the target type requirement with a `closure-member` fact so the **existing** `AddClosureMemberSurface` path reconstructs the faithful surface (with correct metadata `protected` accessibility from `MethodAccessibility`). Skip the redundant seeded-member pull for that target so the faithful surface member wins over the leftover `public` `PrintMembers` stub. The field-read-helper path (`public string Name;` field shells) is unchanged.

34-line change, reusing existing machinery.

## Evidence

| Check | Result |
| --- | --- |
| `CompileBackTargets_UsesFieldShellForRecordGeneratedFieldReadHelpers` (#2599) | Pass (was fail) |
| `CompileBackTargets_PreservesRecordGeneratedVirtualHelperShells` | Pass (was fail) |
| RTS prototype suite | 2 fixed, **0 regressions** (2 remaining failures — `AddsSameAssemblyReturnTypeClosureRoot`, `EscapesKeywordNamespacesInClosureRoots` — are pre-existing, unrelated property-getter tests, confirmed failing on origin/main) |
| RTS fixture catalog | 80/0 |
| Per-target source-probe census (`--return-to-sender-fixtures decompiler`, 204 targets) | **Identical** to origin/main |

Bisect: known-good `db8d2fa6` (#2234, test added and green) → `git bisect run` → first bad `60a796be` (#2504).

## Risk

Scoped to record-generated `ToString`/`PrintMembers` targets (via `IsRecordGeneratedSurfaceHelper`); non-record and field-read-helper paths untouched. Census-neutral. Adversarial review (two models, isolated worktrees) requested; will reconcile on the PR before ready-to-merge.
