### PR TITLE
Unify Finding comparison envelopes

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CSharpFindingsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpFindingsTests.cs
@@ -22,9 +22,9 @@ public class CSharpFindingsTests
             "    Sink(value);",
             "    return value;");
 
-        var result = CSharpFindings.CompareCanonicalized(body, body, Subject);
+        var result = CompleteComparison(
+            CSharpFindings.CompareCanonicalized(body, body, Subject));
 
-        Assert.Null(result.Failure);
         Assert.True(result.IsExact);
         Assert.All(result.Pairs, pair => Assert.Equal(PairKind.Present, pair.Kind));
     }
@@ -38,9 +38,9 @@ public class CSharpFindingsTests
         var newMethod = FindMethod(newSource, "DiffFixtureSample.DiffSample", "ConstantValue");
 
         var classic = CSharpBodyDiff.CompareMembers(oldSource, oldMethod, newSource, newMethod);
-        var findings = CSharpFindings.Compare(oldSource, oldMethod, newSource, newMethod, Subject);
+        var findings = CompleteComparison(
+            CSharpFindings.Compare(oldSource, oldMethod, newSource, newMethod, Subject));
 
-        Assert.Null(findings.Failure);
         Assert.False(findings.IsExact);
         AssertRemovedAddedLineTextAgree(classic, findings);
     }
@@ -61,9 +61,9 @@ public class CSharpFindingsTests
             "    int second = value + 2;",
             "    return first + second;");
 
-        var result = CSharpFindings.CompareCanonicalized(old, @new, Subject);
+        var result = CompleteComparison(
+            CSharpFindings.CompareCanonicalized(old, @new, Subject));
 
-        Assert.Null(result.Failure);
         Assert.False(result.IsExact);
         Assert.Equal(2, result.Pairs.Count(pair => pair.Difference == FindingDifferenceKind.Moved));
         Assert.Equal(0, result.Pairs.Count(pair => pair.Kind is PairKind.Added or PairKind.Removed));
@@ -83,9 +83,9 @@ public class CSharpFindingsTests
         var newMethod = FindMethod(newSource, "DiffFixtureSample.DiffSample", methodName);
 
         var classic = CSharpBodyDiff.CompareMembers(oldSource, oldMethod, newSource, newMethod);
-        var findings = CSharpFindings.Compare(oldSource, oldMethod, newSource, newMethod, Subject);
+        var findings = CompleteComparison(
+            CSharpFindings.Compare(oldSource, oldMethod, newSource, newMethod, Subject));
 
-        Assert.Null(findings.Failure);
         Assert.Equal(classic.IsExact, findings.IsExact);
     }
 
@@ -98,9 +98,9 @@ public class CSharpFindingsTests
         var newMethod = FindMethod(newSource, "DiffFixtureSample.DiffSample", "MultipleHunks");
 
         var classic = CSharpBodyDiff.CompareMembers(oldSource, oldMethod, newSource, newMethod);
-        var findings = CSharpFindings.Compare(oldSource, oldMethod, newSource, newMethod, Subject);
+        var findings = CompleteComparison(
+            CSharpFindings.Compare(oldSource, oldMethod, newSource, newMethod, Subject));
 
-        Assert.Null(findings.Failure);
         Assert.Equal(0, findings.Pairs.Count(pair => pair.Difference == FindingDifferenceKind.Moved));
         AssertRemovedAddedLineTextAgree(classic, findings);
     }
@@ -117,7 +117,8 @@ public class CSharpFindingsTests
             "    Third();",
             "    First();");
 
-        var result = CSharpFindings.CompareCanonicalized(old, @new, Subject);
+        var result = CompleteComparison(
+            CSharpFindings.CompareCanonicalized(old, @new, Subject));
 
         Assert.Equal(0, result.Pairs.Count(pair => pair.Difference == FindingDifferenceKind.Moved));
         Assert.Equal(1, result.Pairs.Count(pair => pair.Kind == PairKind.Added));
@@ -171,10 +172,9 @@ public class CSharpFindingsTests
         var oldMethod = FindMethod(oldSource, "DiffFixtureSample.BodyStateSample", "BodyState");
         var newMethod = FindMethod(newSource, "DiffFixtureSample.BodyStateSample", "BodyState");
 
-        var result = CSharpFindings.Compare(
-            oldSource, oldMethod, newSource, newMethod, Subject);
+        var result = CompleteComparison(CSharpFindings.Compare(
+            oldSource, oldMethod, newSource, newMethod, Subject));
 
-        Assert.Null(result.Failure);
         Assert.True(result.OldInspection is FindingInspection<CSharpCanonicalLine>.Absent);
         Assert.True(result.NewInspection is FindingInspection<CSharpCanonicalLine>.Complete);
         Assert.False(result.IsExact);
@@ -191,10 +191,9 @@ public class CSharpFindingsTests
         var absentMethod = FindMethod(
             absentSource, "DiffFixtureSample.BodyStateSample", "BodyState");
 
-        var result = CSharpFindings.Compare(
-            bodySource, bodyMethod, absentSource, absentMethod, Subject);
+        var result = CompleteComparison(CSharpFindings.Compare(
+            bodySource, bodyMethod, absentSource, absentMethod, Subject));
 
-        Assert.Null(result.Failure);
         Assert.True(result.OldInspection is FindingInspection<CSharpCanonicalLine>.Complete);
         Assert.True(result.NewInspection is FindingInspection<CSharpCanonicalLine>.Absent);
         Assert.Empty(result.Pairs);
@@ -207,50 +206,13 @@ public class CSharpFindingsTests
         using var source = MetadataSource.OpenWithoutSymbols(FixtureCatalog.DiffPair.OldAssemblyPath());
         var method = FindMethod(source, "DiffFixtureSample.BodyStateSample", "BodyState");
 
-        var result = CSharpFindings.Compare(
-            source, method, source, method, Subject);
+        var result = CompleteComparison(CSharpFindings.Compare(
+            source, method, source, method, Subject));
 
-        Assert.Null(result.Failure);
         Assert.True(result.OldInspection is FindingInspection<CSharpCanonicalLine>.Absent);
         Assert.True(result.NewInspection is FindingInspection<CSharpCanonicalLine>.Absent);
         Assert.Empty(result.Pairs);
         Assert.True(result.IsExact);
-    }
-
-    [Fact]
-    public void CSharpFindingsResult_RejectsInvalidPublicStates()
-    {
-        FindingInspection<CSharpCanonicalLine> body
-            = new FindingInspection<CSharpCanonicalLine>.Complete([]);
-        var match = new FindingMatch([], []);
-
-        Assert.Throws<ArgumentException>(
-            () => new CSharpFindingsResult(default, match, body, body));
-        Assert.Throws<ArgumentNullException>(
-            () => new CSharpFindingsResult([], null!, body, body));
-        Assert.Throws<ArgumentException>(
-            () => CSharpFindingsResult.Failed(body, body));
-    }
-
-    [Fact]
-    public void CSharpFindingsResult_DerivesFailureFromCensusErrors()
-    {
-        FindingInspection<CSharpCanonicalLine> body
-            = new FindingInspection<CSharpCanonicalLine>.Complete([]);
-        FindingInspection<CSharpCanonicalLine> oldFailed
-            = new FindingInspection<CSharpCanonicalLine>.Failed(
-                new CensusError(Subject, CSharpFindings.InspectionDescriptor, "old failure"));
-        FindingInspection<CSharpCanonicalLine> newFailed
-            = new FindingInspection<CSharpCanonicalLine>.Failed(
-                new CensusError(Subject, CSharpFindings.InspectionDescriptor, "new failure"));
-
-        var oldOnly = CSharpFindingsResult.Failed(oldFailed, body);
-        var both = CSharpFindingsResult.Failed(oldFailed, newFailed);
-
-        Assert.Equal("old: old failure", oldOnly.Failure);
-        Assert.Equal("old: old failure; new: new failure", both.Failure);
-        Assert.False(oldOnly.IsExact);
-        Assert.False(both.IsExact);
     }
 
     [Theory]
@@ -272,13 +234,14 @@ public class CSharpFindingsTests
 
             var token = MetadataTokens.GetToken(handle).ToString(CultureInfo.InvariantCulture);
             var subject = new FindingSubject(token, "m");
-            var findings = CSharpFindings.Compare(source, handle, source, handle, subject);
-            if (findings.Failure is not null)
+            var comparison = CSharpFindings.Compare(source, handle, source, handle, subject);
+            if (comparison is FindingComparison<CSharpCanonicalLine>.Failed)
             {
                 declined++;
                 continue;
             }
 
+            var findings = CompleteComparison(comparison);
             Assert.True(findings.IsExact, $"CSharpFindings self-compare not exact for token {token}");
             Assert.All(findings.Pairs, pair => Assert.Equal(PairKind.Present, pair.Kind));
             canonicalized++;
@@ -319,7 +282,9 @@ public class CSharpFindingsTests
         throw new InvalidOperationException($"Could not find {typeName}.{methodName}.");
     }
 
-    static void AssertRemovedAddedLineTextAgree(CSharpBodyDiffResult classic, CSharpFindingsResult findings)
+    static void AssertRemovedAddedLineTextAgree(
+        CSharpBodyDiffResult classic,
+        FindingComparison<CSharpCanonicalLine>.Complete findings)
     {
         Assert.Equal(ClassicLineTexts(classic, CSharpDiffKind.Remove), FindingTexts(findings, PairKind.Removed));
         Assert.Equal(ClassicLineTexts(classic, CSharpDiffKind.Add), FindingTexts(findings, PairKind.Added));
@@ -333,7 +298,9 @@ public class CSharpFindingsTests
             .OrderBy(text => text, StringComparer.Ordinal)
             .ToArray();
 
-    static string[] FindingTexts(CSharpFindingsResult findings, PairKind kind)
+    static string[] FindingTexts(
+        FindingComparison<CSharpCanonicalLine>.Complete findings,
+        PairKind kind)
         => findings.Pairs
             .Where(pair => pair.Kind == kind)
             .Select(pair => AtomForKind(pair, kind).Payload.Text)
@@ -348,5 +315,14 @@ public class CSharpFindingsTests
             (PairFinding<CSharpCanonicalLine>.Present present, PairKind.Present) => present.New,
             (PairFinding<CSharpCanonicalLine>.Changed changed, PairKind.Changed) => changed.New,
             _ => throw new ArgumentException("Pair kind does not match the requested atom side.", nameof(pair)),
+        };
+
+    static FindingComparison<CSharpCanonicalLine>.Complete CompleteComparison(
+        FindingComparison<CSharpCanonicalLine> comparison)
+        => comparison switch
+        {
+            FindingComparison<CSharpCanonicalLine>.Complete complete => complete,
+            FindingComparison<CSharpCanonicalLine>.Failed failed => throw new InvalidOperationException(
+                $"Expected a completed C# comparison: {failed.Failure}"),
         };
 }

--- a/src/ILInspector.Decompiler/CSharpFindings.cs
+++ b/src/ILInspector.Decompiler/CSharpFindings.cs
@@ -44,11 +44,11 @@ public static class CSharpFindings
                 new FindingInspection<CSharpCanonicalLine>.Absent(absent.Detail),
             CSharpCanonicalization.Failed failed =>
                 new FindingInspection<CSharpCanonicalLine>.Failed(
-                    InspectionError(subject, failed.Reason)),
+                    CreateInspectionError(subject, failed.Reason)),
         };
     }
 
-    public static CSharpFindingsResult Compare(
+    public static FindingComparison<CSharpCanonicalLine> Compare(
         MetadataSource oldSource,
         MethodDefinitionHandle oldMethod,
         MetadataSource newSource,
@@ -62,14 +62,10 @@ public static class CSharpFindings
 
         var oldInspection = Inspect(oldSource, oldMethod, subject);
         var newInspection = Inspect(newSource, newMethod, subject);
-        if (oldInspection is FindingInspection<CSharpCanonicalLine>.Failed
-            || newInspection is FindingInspection<CSharpCanonicalLine>.Failed)
-            return CSharpFindingsResult.Failed(oldInspection, newInspection);
-
         return CompareInspections(oldInspection, newInspection, acceptanceThreshold);
     }
 
-    internal static CSharpFindingsResult CompareCanonicalized(
+    internal static FindingComparison<CSharpCanonicalLine> CompareCanonicalized(
         ImmutableArray<CSharpCanonicalLine> oldLines,
         ImmutableArray<CSharpCanonicalLine> newLines,
         FindingSubject subject,
@@ -79,17 +75,25 @@ public static class CSharpFindings
             new FindingInspection<CSharpCanonicalLine>.Complete(ProjectAtoms(newLines, subject)),
             acceptanceThreshold);
 
-    static CSharpFindingsResult CompareInspections(
+    static FindingComparison<CSharpCanonicalLine> CompareInspections(
         FindingInspection<CSharpCanonicalLine> oldInspection,
         FindingInspection<CSharpCanonicalLine> newInspection,
         int acceptanceThreshold)
     {
+        if (oldInspection is FindingInspection<CSharpCanonicalLine>.Failed
+            || newInspection is FindingInspection<CSharpCanonicalLine>.Failed)
+        {
+            return new FindingComparison<CSharpCanonicalLine>.Failed(
+                oldInspection,
+                newInspection);
+        }
+
         var oldAtoms = InspectionAtoms(oldInspection);
         var newAtoms = InspectionAtoms(newInspection);
 
         var match = FindingMatcher.Match(oldAtoms.Keys(), newAtoms.Keys());
         var pairs = FindingFold.ToPairs(match, oldAtoms, newAtoms, acceptanceThreshold);
-        return new CSharpFindingsResult(
+        return new FindingComparison<CSharpCanonicalLine>.Complete(
             pairs,
             match,
             oldInspection,
@@ -102,10 +106,11 @@ public static class CSharpFindings
         {
             FindingInspection<CSharpCanonicalLine>.Complete complete => complete.Findings,
             FindingInspection<CSharpCanonicalLine>.Absent => [],
-            FindingInspection<CSharpCanonicalLine>.Failed => [],
+            FindingInspection<CSharpCanonicalLine>.Failed => throw new InvalidOperationException(
+                "A failed inspection cannot be matched."),
         };
 
-    static CensusError InspectionError(FindingSubject subject, string reason)
+    static InspectionError CreateInspectionError(FindingSubject subject, string reason)
         => new(subject, InspectionDescriptor, reason);
 
     static ImmutableArray<Finding<CSharpCanonicalLine>> ProjectAtoms(
@@ -125,84 +130,4 @@ public static class CSharpFindings
 
         return builder.MoveToImmutable();
     }
-}
-
-/// <summary>The outcome of a <see cref="CSharpFindings.Compare"/> call.</summary>
-public sealed record CSharpFindingsResult(
-    ImmutableArray<PairFinding<CSharpCanonicalLine>> Pairs,
-    FindingMatch Match,
-    FindingInspection<CSharpCanonicalLine> OldInspection,
-    FindingInspection<CSharpCanonicalLine> NewInspection)
-{
-    public ImmutableArray<PairFinding<CSharpCanonicalLine>> Pairs { get; }
-        = Pairs.IsDefault
-            ? throw new ArgumentException("Pairs must be initialized.", nameof(Pairs))
-            : Pairs;
-
-    public FindingMatch Match { get; }
-        = Match ?? throw new ArgumentNullException(nameof(Match));
-
-    public FindingInspection<CSharpCanonicalLine> OldInspection { get; }
-        = OldInspection ?? throw new ArgumentNullException(nameof(OldInspection));
-
-    public FindingInspection<CSharpCanonicalLine> NewInspection { get; }
-        = NewInspection ?? throw new ArgumentNullException(nameof(NewInspection));
-
-    public ImmutableArray<Finding<CSharpCanonicalLine>> OldAtoms
-        => CSharpFindings.InspectionAtoms(OldInspection);
-
-    public ImmutableArray<Finding<CSharpCanonicalLine>> NewAtoms
-        => CSharpFindings.InspectionAtoms(NewInspection);
-
-    public string? Failure
-        => (OldInspection, NewInspection) switch
-        {
-            (FindingInspection<CSharpCanonicalLine>.Failed oldFailed,
-                FindingInspection<CSharpCanonicalLine>.Failed newFailed) =>
-                $"old: {oldFailed.Error.Reason}; new: {newFailed.Error.Reason}",
-            (FindingInspection<CSharpCanonicalLine>.Failed oldFailed, _) =>
-                $"old: {oldFailed.Error.Reason}",
-            (_, FindingInspection<CSharpCanonicalLine>.Failed newFailed) =>
-                $"new: {newFailed.Error.Reason}",
-            _ => null,
-        };
-
-    /// <summary>
-    /// True when both methods have the same body-presence state and their lines are exact under the
-    /// fidelity fold (no adds/removes/moves).
-    /// </summary>
-    public bool IsExact
-        => Failure is null
-           && SameBodyState(OldInspection, NewInspection)
-           && FindingEquivalence.Exact.IsEquivalent(Pairs);
-
-    internal static CSharpFindingsResult Failed(
-        FindingInspection<CSharpCanonicalLine> oldInspection,
-        FindingInspection<CSharpCanonicalLine> newInspection)
-    {
-        if (oldInspection is not FindingInspection<CSharpCanonicalLine>.Failed
-            && newInspection is not FindingInspection<CSharpCanonicalLine>.Failed)
-        {
-            throw new ArgumentException("At least one inspection must have failed.");
-        }
-
-        return new(
-            [],
-            new FindingMatch([], []),
-            oldInspection,
-            newInspection);
-    }
-
-    static bool SameBodyState(
-        FindingInspection<CSharpCanonicalLine> oldInspection,
-        FindingInspection<CSharpCanonicalLine> newInspection)
-        => (oldInspection, newInspection) switch
-        {
-            (FindingInspection<CSharpCanonicalLine>.Complete,
-                FindingInspection<CSharpCanonicalLine>.Complete) => true,
-            (FindingInspection<CSharpCanonicalLine>.Absent,
-                FindingInspection<CSharpCanonicalLine>.Absent) => true,
-            _ => false,
-        };
-
 }

--- a/src/ILInspector.Findings/FindingComparison.cs
+++ b/src/ILInspector.Findings/FindingComparison.cs
@@ -1,0 +1,147 @@
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+
+namespace ILInspector.Findings;
+
+/// <summary>
+/// The outcome of comparing two finding inspections. A completed comparison carries the alignment;
+/// a failed comparison carries only the inspections that prevented matching from running.
+/// </summary>
+[Union]
+public sealed record FindingComparison<T> where T : notnull
+{
+    public FindingComparison(Complete value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        Value = value;
+    }
+
+    public FindingComparison(Failed value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        Value = value;
+    }
+
+    public object Value { get; }
+
+    public FindingInspection<T> OldInspection => this switch
+    {
+        Complete complete => complete.OldInspection,
+        Failed failed => failed.OldInspection,
+    };
+
+    public FindingInspection<T> NewInspection => this switch
+    {
+        Complete complete => complete.NewInspection,
+        Failed failed => failed.NewInspection,
+    };
+
+    public string? Failure => this switch
+    {
+        Complete => null,
+        Failed failed => failed.Failure,
+    };
+
+    public bool IsExact => this is Complete { IsExact: true };
+
+    /// <summary>
+    /// Matching ran. An empty match is valid evidence of a trivial alignment, including
+    /// <c>Absent</c> versus <c>Absent</c>.
+    /// </summary>
+    public sealed record Complete
+    {
+        public Complete(
+            ImmutableArray<PairFinding<T>> pairs,
+            FindingMatch match,
+            FindingInspection<T> oldInspection,
+            FindingInspection<T> newInspection)
+        {
+            if (pairs.IsDefault)
+                throw new ArgumentException("Pairs must be initialized.", nameof(pairs));
+            ArgumentNullException.ThrowIfNull(match);
+            if (match.Edges.IsDefault || match.MoveCandidates.IsDefault)
+                throw new ArgumentException("Match arrays must be initialized.", nameof(match));
+            ArgumentNullException.ThrowIfNull(oldInspection);
+            ArgumentNullException.ThrowIfNull(newInspection);
+            if (oldInspection is FindingInspection<T>.Failed)
+                throw new ArgumentException("A completed comparison cannot contain a failed old inspection.", nameof(oldInspection));
+            if (newInspection is FindingInspection<T>.Failed)
+                throw new ArgumentException("A completed comparison cannot contain a failed new inspection.", nameof(newInspection));
+
+            Pairs = pairs;
+            Match = match;
+            OldInspection = oldInspection;
+            NewInspection = newInspection;
+        }
+
+        public ImmutableArray<PairFinding<T>> Pairs { get; }
+        public FindingMatch Match { get; }
+        public FindingInspection<T> OldInspection { get; }
+        public FindingInspection<T> NewInspection { get; }
+        public ImmutableArray<Finding<T>> OldAtoms => InspectionAtoms(OldInspection);
+        public ImmutableArray<Finding<T>> NewAtoms => InspectionAtoms(NewInspection);
+
+        public bool IsExact =>
+            SameInspectionState(OldInspection, NewInspection)
+            && Pairs.All(static pair =>
+                pair.Kind == PairKind.Present
+                && pair.Difference == FindingDifferenceKind.None);
+    }
+
+    /// <summary>Matching never ran because at least one inspection failed.</summary>
+    public sealed record Failed
+    {
+        public Failed(
+            FindingInspection<T> oldInspection,
+            FindingInspection<T> newInspection)
+        {
+            ArgumentNullException.ThrowIfNull(oldInspection);
+            ArgumentNullException.ThrowIfNull(newInspection);
+            if (oldInspection is not FindingInspection<T>.Failed
+                && newInspection is not FindingInspection<T>.Failed)
+            {
+                throw new ArgumentException(
+                    "A failed comparison requires at least one failed inspection.",
+                    nameof(oldInspection));
+            }
+
+            OldInspection = oldInspection;
+            NewInspection = newInspection;
+        }
+
+        public FindingInspection<T> OldInspection { get; }
+        public FindingInspection<T> NewInspection { get; }
+
+        public string Failure
+        {
+            get
+            {
+                var failures = new List<string>(2);
+                if (OldInspection is FindingInspection<T>.Failed oldFailed)
+                    failures.Add($"old: {oldFailed.Error.Detail}");
+                if (NewInspection is FindingInspection<T>.Failed newFailed)
+                    failures.Add($"new: {newFailed.Error.Detail}");
+                return string.Join("; ", failures);
+            }
+        }
+    }
+
+    static ImmutableArray<Finding<T>> InspectionAtoms(FindingInspection<T> inspection)
+        => inspection switch
+        {
+            FindingInspection<T>.Complete complete => complete.Findings,
+            FindingInspection<T>.Absent => [],
+            FindingInspection<T>.Failed => throw new InvalidOperationException(
+                "A completed comparison cannot contain a failed inspection."),
+        };
+
+    static bool SameInspectionState(
+        FindingInspection<T> oldInspection,
+        FindingInspection<T> newInspection)
+        => (oldInspection, newInspection) switch
+        {
+            (FindingInspection<T>.Complete, FindingInspection<T>.Complete) => true,
+            (FindingInspection<T>.Absent, FindingInspection<T>.Absent) => true,
+            _ => false,
+        };
+}

--- a/src/ILInspector.Findings/FindingComparison.cs
+++ b/src/ILInspector.Findings/FindingComparison.cs
@@ -83,9 +83,7 @@ public sealed record FindingComparison<T> where T : notnull
 
         public bool IsExact =>
             SameInspectionState(OldInspection, NewInspection)
-            && Pairs.All(static pair =>
-                pair.Kind == PairKind.Present
-                && pair.Difference == FindingDifferenceKind.None);
+            && FindingEquivalence.Exact.IsEquivalent(Pairs);
     }
 
     /// <summary>Matching never ran because at least one inspection failed.</summary>

--- a/src/ILInspector.Findings/FindingInspection.cs
+++ b/src/ILInspector.Findings/FindingInspection.cs
@@ -5,10 +5,10 @@ namespace ILInspector.Findings;
 
 /// <summary>
 /// A whole-census inspection failure on the non-generic finding skeleton. This is not a
-/// <c>Finding&lt;CensusError&gt;</c>: there is no diffable domain occurrence, only a failure to
+/// <c>Finding&lt;InspectionError&gt;</c>: there is no diffable domain occurrence, only a failure to
 /// produce the requested census.
 /// </summary>
-public sealed record CensusError(
+public sealed record InspectionError(
     FindingSubject Subject,
     FindingDescriptor Descriptor,
     string Reason) : IFinding
@@ -29,7 +29,7 @@ public sealed record CensusError(
 /// The explicit outcome of inspecting one subject for a stream of findings. This replaces a
 /// <c>TryInspect(..., out findings)</c> contract when absence and failure are distinct states:
 /// <see cref="Complete"/> may contain an empty census, <see cref="Absent"/> means the subject has
-/// no applicable producer input, and <see cref="Failed"/> carries a <see cref="CensusError"/>.
+/// no applicable producer input, and <see cref="Failed"/> carries an <see cref="InspectionError"/>.
 /// </summary>
 [Union]
 public sealed record FindingInspection<T>
@@ -62,9 +62,9 @@ public sealed record FindingInspection<T>
     public sealed record Absent(string? Detail = null);
 
     /// <summary>The producer could not complete the inspection.</summary>
-    public sealed record Failed(CensusError Error)
+    public sealed record Failed(InspectionError Error)
     {
-        public CensusError Error { get; }
+        public InspectionError Error { get; }
             = Error ?? throw new ArgumentNullException(nameof(Error));
     }
 }

--- a/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
@@ -37,7 +37,7 @@ public class FindingPilotTests
     {
         FindingInspection<string> complete = new FindingInspection<string>.Complete([]);
         FindingInspection<string> absent = new FindingInspection<string>.Absent();
-        var error = new CensusError(Subject, Descriptor, "declined");
+        var error = new InspectionError(Subject, Descriptor, "declined");
         FindingInspection<string> failed = new FindingInspection<string>.Failed(error);
 
         Assert.True(complete is FindingInspection<string>.Complete);
@@ -55,11 +55,88 @@ public class FindingPilotTests
         Assert.Throws<ArgumentNullException>(
             () => new FindingInspection<string>.Failed(null!));
         Assert.Throws<ArgumentNullException>(
-            () => new CensusError(null!, Descriptor, "declined"));
+            () => new InspectionError(null!, Descriptor, "declined"));
         Assert.Throws<ArgumentNullException>(
-            () => new CensusError(Subject, null!, "declined"));
+            () => new InspectionError(Subject, null!, "declined"));
         Assert.Throws<ArgumentNullException>(
-            () => new CensusError(Subject, Descriptor, null!));
+            () => new InspectionError(Subject, Descriptor, null!));
+    }
+
+    [Fact]
+    public void FindingComparison_CasesEnforceRanVersusNeverRan()
+    {
+        FindingInspection<string> completeInspection =
+            new FindingInspection<string>.Complete([]);
+        FindingInspection<string> absentInspection =
+            new FindingInspection<string>.Absent();
+        FindingInspection<string> failedInspection =
+            new FindingInspection<string>.Failed(
+                new InspectionError(Subject, Descriptor, "declined"));
+        var emptyMatch = new FindingMatch([], []);
+
+        FindingComparison<string> complete =
+            new FindingComparison<string>.Complete(
+                [],
+                emptyMatch,
+                absentInspection,
+                absentInspection);
+        FindingComparison<string> failed =
+            new FindingComparison<string>.Failed(
+                failedInspection,
+                completeInspection);
+
+        Assert.True(complete is FindingComparison<string>.Complete);
+        Assert.True(complete.IsExact);
+        Assert.Null(complete.Failure);
+        Assert.True(failed is FindingComparison<string>.Failed);
+        Assert.False(failed.IsExact);
+        Assert.Equal("old: declined", failed.Failure);
+    }
+
+    [Fact]
+    public void FindingComparison_CasesRejectInvalidPublicStates()
+    {
+        FindingInspection<string> complete =
+            new FindingInspection<string>.Complete([]);
+        FindingInspection<string> failed =
+            new FindingInspection<string>.Failed(
+                new InspectionError(Subject, Descriptor, "declined"));
+        var match = new FindingMatch([], []);
+
+        Assert.Throws<ArgumentException>(
+            () => new FindingComparison<string>.Complete(default, match, complete, complete));
+        Assert.Throws<ArgumentNullException>(
+            () => new FindingComparison<string>.Complete([], null!, complete, complete));
+        Assert.Throws<ArgumentException>(
+            () => new FindingComparison<string>.Complete(
+                [],
+                new FindingMatch(default, []),
+                complete,
+                complete));
+        Assert.Throws<ArgumentException>(
+            () => new FindingComparison<string>.Complete([], match, failed, complete));
+        Assert.Throws<ArgumentException>(
+            () => new FindingComparison<string>.Complete([], match, complete, failed));
+        Assert.Throws<ArgumentException>(
+            () => new FindingComparison<string>.Failed(complete, complete));
+        Assert.Throws<ArgumentNullException>(
+            () => new FindingComparison<string>.Failed(null!, failed));
+    }
+
+    [Fact]
+    public void FindingComparison_FailedDerivesBothInspectionErrors()
+    {
+        FindingInspection<string> oldFailed =
+            new FindingInspection<string>.Failed(
+                new InspectionError(Subject, Descriptor, "old failure"));
+        FindingInspection<string> newFailed =
+            new FindingInspection<string>.Failed(
+                new InspectionError(Subject, Descriptor, "new failure"));
+
+        FindingComparison<string> comparison =
+            new FindingComparison<string>.Failed(oldFailed, newFailed);
+
+        Assert.Equal("old: old failure; new: new failure", comparison.Failure);
     }
 
     [Fact]
@@ -396,18 +473,21 @@ public class FindingPilotTests
         // A stream-agnostic consumer: it reads only the pair skeleton, so the same pairs could have
         // come from IL, C#, or a fact producer. Here we drive it from the IL adapter.
         var identical = Body(Ldc0, Ldc1, Ret);
-        var identicalPairs = IlFindings.Compare(identical, null, identical, null, IlSubject).Pairs;
+        var identicalPairs = CompleteComparison(
+            IlFindings.Compare(identical, null, identical, null, IlSubject)).Pairs;
         Assert.Equal(DiffShape.Identical, FindingSummary.Summarize(identicalPairs).Shape);
 
         var old = Body(Ldc0, Ldc1, Ldc2, Ldc3, Ldc4, Ldc5, Ldc6, Ret);
         var reordered = Body(Ldc3, Ldc4, Ldc0, Ldc1, Ldc2, Ldc5, Ldc6, Ret);
-        var reorderPairs = IlFindings.Compare(old, null, reordered, null, IlSubject).Pairs;
+        var reorderPairs = CompleteComparison(
+            IlFindings.Compare(old, null, reordered, null, IlSubject)).Pairs;
         var reorderSummary = FindingSummary.Summarize(reorderPairs);
         Assert.Equal(DiffShape.ReorderOnly, reorderSummary.Shape);
         Assert.Equal(2, reorderSummary.Moved);
 
         var changed = Body(Ldc0, Ldc2, Ldc3, Ret);
-        var changedPairs = IlFindings.Compare(old, null, changed, null, IlSubject).Pairs;
+        var changedPairs = CompleteComparison(
+            IlFindings.Compare(old, null, changed, null, IlSubject)).Pairs;
         Assert.Equal(DiffShape.Structural, FindingSummary.Summarize(changedPairs).Shape);
     }
 
@@ -444,20 +524,59 @@ public class FindingPilotTests
     }
 
     [Fact]
-    public void Inspect_IsALazyCensus_QueriedWithLinq()
+    public void IlFindings_Inspect_DistinguishesCompleteAbsentAndFailed()
     {
-        // The single-version shape: Inspect is the census — canonicalizes the body internally and
-        // returns a lazy IEnumerable<Finding<T>>. A consumer asks existence/count/filter with LINQ
-        // over the stream (it short-circuits on a hit and never allocates a list itself); one
-        // Finding per op, positions 0..N.
         var body = Body(Ldc0, Ldc1, Ldc2, Ret);
+        var malformed = MethodInstructions.Decode(
+            [],
+            ilLength: 1,
+            Array.Empty<ExceptionRegion>());
 
-        IEnumerable<Finding<CanonicalIlOperation>> census = IlFindings.Inspect(body, null, IlSubject);
+        var complete = IlFindings.Inspect(body, null, IlSubject) switch
+        {
+            FindingInspection<CanonicalIlOperation>.Complete value => value,
+            _ => throw new InvalidOperationException("Expected a complete IL inspection."),
+        };
+        var absent = IlFindings.Inspect(null, null, IlSubject);
+        var failed = IlFindings.Inspect(malformed, null, IlSubject);
 
-        Assert.Contains(census, f => f.Descriptor.Id == "il.op");
-        var list = census.ToList();
-        Assert.NotEmpty(list);
-        Assert.Equal(Enumerable.Range(0, list.Count), list.Select(f => f.Position));
+        Assert.Contains(complete.Findings, f => f.Descriptor.Id == "il.op");
+        Assert.Equal(
+            Enumerable.Range(0, complete.Findings.Length),
+            complete.Findings.Select(f => f.Position));
+        Assert.True(absent is FindingInspection<CanonicalIlOperation>.Absent);
+        Assert.True(failed is FindingInspection<CanonicalIlOperation>.Failed);
+    }
+
+    [Fact]
+    public void IlFindings_Compare_AbsentBodiesIsAnExactCompletedComparison()
+    {
+        var result = CompleteComparison(
+            IlFindings.Compare(null, null, null, null, IlSubject));
+
+        Assert.True(result.OldInspection is FindingInspection<CanonicalIlOperation>.Absent);
+        Assert.True(result.NewInspection is FindingInspection<CanonicalIlOperation>.Absent);
+        Assert.Empty(result.Pairs);
+        Assert.True(result.IsExact);
+    }
+
+    [Fact]
+    public void IlFindings_Compare_InspectionFailureDoesNotManufactureAMatch()
+    {
+        var malformed = MethodInstructions.Decode(
+            [],
+            ilLength: 1,
+            Array.Empty<ExceptionRegion>());
+
+        var result = IlFindings.Compare(
+            malformed,
+            null,
+            Body(Ret),
+            null,
+            IlSubject);
+
+        Assert.True(result is FindingComparison<CanonicalIlOperation>.Failed);
+        Assert.NotNull(result.Failure);
     }
 
     // ---- IL adapter: real decode + raw-byte fixtures -----------------------------------------
@@ -471,16 +590,14 @@ public class FindingPilotTests
     static readonly FindingSubject IlSubject = new("M", "M");
 
     [Fact]
-    public void IlFindings_PathologicallyLargeBody_FailsClosed()
+    public void IlFindings_PathologicallyLargeBody_PropagatesMatcherContractViolation()
     {
         var il = new byte[9000];
         il[^1] = Ret;
         var body = Body(il);
 
-        var result = IlFindings.Compare(body, null, body, null, IlSubject);
-
-        Assert.NotNull(result.Failure);
-        Assert.False(result.IsExact);
+        Assert.Throws<ArgumentException>(
+            () => IlFindings.Compare(body, null, body, null, IlSubject));
     }
 
     [Fact]
@@ -489,9 +606,9 @@ public class FindingPilotTests
         var old = Body(BrS, 0x03, Nop, Ret, Nop, Ret);
         var @new = Body(BrS, 0x01, Nop, Ret, Nop, Ret);
 
-        var result = IlFindings.Compare(old, null, @new, null, IlSubject);
+        var result = CompleteComparison(
+            IlFindings.Compare(old, null, @new, null, IlSubject));
 
-        Assert.Null(result.Failure);
         Assert.False(result.IsExact);
         Assert.Contains(result.Pairs, p => p.Kind == PairKind.Changed);
         Assert.False(IlBodyDiff.Compare(old, @new).IsExact);
@@ -503,9 +620,9 @@ public class FindingPilotTests
         var old = Body(Nop, Nop, Nop, Ldc0, BrS, 0xFD, Ret);
         var @new = Body(Ldc0, BrS, 0xFD, Nop, Nop, Nop, Ret);
 
-        var result = IlFindings.Compare(old, null, @new, null, IlSubject);
+        var result = CompleteComparison(
+            IlFindings.Compare(old, null, @new, null, IlSubject));
 
-        Assert.Null(result.Failure);
         Assert.DoesNotContain(result.Pairs, p => p.Kind == PairKind.Changed);
         Assert.Equal(2, result.Pairs.Count(p => p.Difference == FindingDifferenceKind.Moved));
         Assert.True(FindingEquivalence.Multiset.IsEquivalent(result.Pairs));
@@ -539,9 +656,9 @@ public class FindingPilotTests
         var old = Body(BrS, 0x00, Ldc0, Ret);
         var @new = Body(BrS, 0x00, Ldc1, Ret);
 
-        var result = IlFindings.Compare(old, null, @new, null, IlSubject);
+        var result = CompleteComparison(
+            IlFindings.Compare(old, null, @new, null, IlSubject));
 
-        Assert.Null(result.Failure);
         Assert.DoesNotContain(result.Pairs, p => p.Kind == PairKind.Changed);
         Assert.Equal(1, result.Pairs.Count(p => p.Kind == PairKind.Added));
         Assert.Equal(1, result.Pairs.Count(p => p.Kind == PairKind.Removed));
@@ -551,9 +668,9 @@ public class FindingPilotTests
     public void IlFindings_SameBranch_IsExact()
     {
         var body = Body(BrS, 0x01, Nop, Ret, Nop, Ret);
-        var result = IlFindings.Compare(body, null, body, null, IlSubject);
+        var result = CompleteComparison(
+            IlFindings.Compare(body, null, body, null, IlSubject));
 
-        Assert.Null(result.Failure);
         Assert.True(result.IsExact);
     }
 
@@ -561,9 +678,9 @@ public class FindingPilotTests
     public void IlFindings_SameBody_IsExact()
     {
         var body = Body(Ldc0, Ldc1, Ldc2, Ret);
-        var result = IlFindings.Compare(body, null, body, null, IlSubject);
+        var result = CompleteComparison(
+            IlFindings.Compare(body, null, body, null, IlSubject));
 
-        Assert.Null(result.Failure);
         Assert.True(result.IsExact);
         Assert.All(result.Pairs, p => Assert.Equal(PairKind.Present, p.Kind));
     }
@@ -574,9 +691,9 @@ public class FindingPilotTests
         var old = Body(Ldc0, Ldc1, Ldc2, Ldc3, Ldc4, Ldc5, Ldc6, Ret);
         var @new = Body(Ldc3, Ldc4, Ldc0, Ldc1, Ldc2, Ldc5, Ldc6, Ret);
 
-        var result = IlFindings.Compare(old, null, @new, null, IlSubject);
+        var result = CompleteComparison(
+            IlFindings.Compare(old, null, @new, null, IlSubject));
 
-        Assert.Null(result.Failure);
         Assert.Equal(2, result.Pairs.Count(p => p.Difference == FindingDifferenceKind.Moved));
         Assert.Equal(0, result.Pairs.Count(p => p.Kind is PairKind.Added or PairKind.Removed));
         Assert.False(result.IsExact);
@@ -590,7 +707,8 @@ public class FindingPilotTests
         var @new = Body(Ldc0, Ldc2, Ldc3, Ret);
 
         var classic = IlBodyDiff.Compare(old, @new);
-        var finding = IlFindings.Compare(old, null, @new, null, IlSubject);
+        var finding = CompleteComparison(
+            IlFindings.Compare(old, null, @new, null, IlSubject));
 
         Assert.Equal(0, finding.Pairs.Count(p => p.Difference == FindingDifferenceKind.Moved));
 
@@ -615,19 +733,31 @@ public class FindingPilotTests
         var old = Body(Ldc0, Ldc1, Ldc2, Ret);
         var @new = Body(Ldc1, Ldc2, Ldc0, Ret);
 
-        var result = IlFindings.Compare(old, null, @new, null, IlSubject);
+        var result = CompleteComparison(
+            IlFindings.Compare(old, null, @new, null, IlSubject));
 
         Assert.Equal(0, result.Pairs.Count(p => p.Difference == FindingDifferenceKind.Moved));
         Assert.Equal(1, result.Pairs.Count(p => p.Kind == PairKind.Added));
         Assert.Equal(1, result.Pairs.Count(p => p.Kind == PairKind.Removed));
     }
 
-    static string[] ResidualKeys(IlFindingsResult result, PairKind polarity)
+    static string[] ResidualKeys(
+        FindingComparison<CanonicalIlOperation>.Complete result,
+        PairKind polarity)
         => result.Pairs
             .Where(p => p.Kind == polarity)
             .Select(p => CurrentAtom(p).Key.IdentityKey)
             .OrderBy(k => k, StringComparer.Ordinal)
             .ToArray();
+
+    static FindingComparison<CanonicalIlOperation>.Complete CompleteComparison(
+        FindingComparison<CanonicalIlOperation> comparison)
+        => comparison switch
+        {
+            FindingComparison<CanonicalIlOperation>.Complete complete => complete,
+            FindingComparison<CanonicalIlOperation>.Failed failed => throw new InvalidOperationException(
+                $"Expected a completed IL comparison: {failed.Failure}"),
+        };
 
     // The representative atom of a pair (new side if present, else old), recovered by matching the
     // union directly (`pair switch`, not `pair.Value switch`) so the compiler enforces exhaustiveness:
@@ -674,13 +804,14 @@ public class FindingPilotTests
                 continue;
 
             var subject = new FindingSubject(handle.GetHashCode().ToString(System.Globalization.CultureInfo.InvariantCulture), "m");
-            var finding = IlFindings.Compare(body, reader, body, reader, subject);
-            if (finding.Failure is not null)
+            var comparison = IlFindings.Compare(body, reader, body, reader, subject);
+            if (comparison is FindingComparison<CanonicalIlOperation>.Failed)
             {
                 declined++;
                 continue;
             }
 
+            var finding = CompleteComparison(comparison);
             Assert.True(finding.IsExact, $"IlFindings self-compare not exact for RVA {method.RelativeVirtualAddress}");
             canonicalized++;
         }

--- a/src/ILInspector.Instructions/IlFindings.cs
+++ b/src/ILInspector.Instructions/IlFindings.cs
@@ -19,69 +19,74 @@ public static class IlFindings
     /// <summary>The finding descriptor for a single IL operation occurrence.</summary>
     public static readonly FindingDescriptor OperationDescriptor = new("il.op", "IL operation");
 
+    /// <summary>The descriptor used when an IL inspection cannot produce a census.</summary>
+    public static readonly FindingDescriptor InspectionDescriptor = new("il.inspect", "IL inspection");
+
     /// <summary>
-    /// The census (one feed): inspects a single method body and lazily yields one
-    /// <see cref="Finding{T}"/> per operation — the complete, unjudged raw view, in the spirit of
-    /// <c>docker inspect</c>. Paired with <see cref="Compare"/> (two feeds). Like
-    /// <see cref="Compare"/> it canonicalizes the body internally (reusing <see cref="IlBodyDiff"/>)
-    /// and fails closed — an uninspectable body yields an empty census — so a caller never touches
-    /// <see cref="IlBodyDiff"/>. Existence/filter/count are LINQ over the returned stream
-    /// (<c>Any</c>/<c>Where</c>/<c>Count</c>), short-circuiting without allocating a list.
+    /// Inspects one method body into a complete census, an absent-body state, or a canonicalization
+    /// failure. A null body represents a method with no IL body, such as an abstract or extern method.
     /// </summary>
-    public static IEnumerable<Finding<CanonicalIlOperation>> Inspect(
-        MethodInstructions body,
+    public static FindingInspection<CanonicalIlOperation> Inspect(
+        MethodInstructions? body,
         MetadataReader? reader,
         FindingSubject subject)
     {
-        ArgumentNullException.ThrowIfNull(body);
         ArgumentNullException.ThrowIfNull(subject);
 
-        // Fail closed: an uninspectable body is an empty census, not an exception through a query.
-        if (!IlBodyDiff.TryCanonicalize(body, reader, out var operations, out _))
-            return [];
+        if (body is null)
+            return new FindingInspection<CanonicalIlOperation>.Absent("Method has no IL body.");
+        if (!IlBodyDiff.TryCanonicalize(body, reader, out var operations, out var failure))
+        {
+            return new FindingInspection<CanonicalIlOperation>.Failed(
+                new InspectionError(
+                    subject,
+                    InspectionDescriptor,
+                    failure ?? "IL canonicalization failed."));
+        }
 
-        return ProjectAtoms(operations, subject);
+        return new FindingInspection<CanonicalIlOperation>.Complete(
+            [.. ProjectAtoms(operations, subject)]);
     }
 
-    public static IlFindingsResult Compare(
-        MethodInstructions oldBody,
+    public static FindingComparison<CanonicalIlOperation> Compare(
+        MethodInstructions? oldBody,
         MetadataReader? oldReader,
-        MethodInstructions newBody,
+        MethodInstructions? newBody,
         MetadataReader? newReader,
         FindingSubject subject,
         int acceptanceThreshold = 100)
     {
-        ArgumentNullException.ThrowIfNull(oldBody);
-        ArgumentNullException.ThrowIfNull(newBody);
         ArgumentNullException.ThrowIfNull(subject);
 
-        if (!IlBodyDiff.TryCanonicalize(oldBody, oldReader, out var oldOps, out var oldFailure))
-            return IlFindingsResult.Failed(oldFailure ?? "old body canonicalization failed");
-        if (!IlBodyDiff.TryCanonicalize(newBody, newReader, out var newOps, out var newFailure))
-            return IlFindingsResult.Failed(newFailure ?? "new body canonicalization failed");
-
-        // The projection is lazy; the diff enumerates each side more than once (keys for Match,
-        // atoms for ToPairs, and again on the result), so materialize both once here. That is the
-        // "materialize iff you enumerate more than once" rule: a single-version census consumer
-        // (see Inspect) stays lazy, the diff pays one array per side at this boundary.
-        var oldAtoms = ProjectAtoms(oldOps, subject).ToImmutableArray();
-        var newAtoms = ProjectAtoms(newOps, subject).ToImmutableArray();
-
-        FindingMatch match;
-        try
+        var oldInspection = Inspect(oldBody, oldReader, subject);
+        var newInspection = Inspect(newBody, newReader, subject);
+        if (oldInspection is FindingInspection<CanonicalIlOperation>.Failed
+            || newInspection is FindingInspection<CanonicalIlOperation>.Failed)
         {
-            match = FindingMatcher.Match(oldAtoms.Keys(), newAtoms.Keys());
-        }
-        catch (ArgumentException ex)
-        {
-            // Fail closed like the canonicalization path: a pathological body that exceeds the
-            // ordered matcher's size guard returns a failure result instead of throwing at the caller.
-            return IlFindingsResult.Failed(ex.Message);
+            return new FindingComparison<CanonicalIlOperation>.Failed(
+                oldInspection,
+                newInspection);
         }
 
+        var oldAtoms = InspectionAtoms(oldInspection);
+        var newAtoms = InspectionAtoms(newInspection);
+        var match = FindingMatcher.Match(oldAtoms.Keys(), newAtoms.Keys());
         var pairs = FindingFold.ToPairs(match, oldAtoms, newAtoms, acceptanceThreshold);
-        pairs = ApplyBranchTargetValidation(pairs, oldBody.Instructions, oldOps, newBody.Instructions, newOps);
-        return new IlFindingsResult(pairs, match, oldAtoms, newAtoms, Failure: null);
+        if (oldBody is not null && newBody is not null)
+        {
+            pairs = ApplyBranchTargetValidation(
+                pairs,
+                oldBody.Instructions,
+                [.. oldAtoms.Select(static atom => atom.Payload)],
+                newBody.Instructions,
+                [.. newAtoms.Select(static atom => atom.Payload)]);
+        }
+
+        return new FindingComparison<CanonicalIlOperation>.Complete(
+            pairs,
+            match,
+            oldInspection,
+            newInspection);
     }
 
     // IdentityKey deliberately ignores a branch/switch operation's targets (matching CanonicalEquals),
@@ -128,10 +133,8 @@ public static class IlFindings
         return builder.ToImmutable();
     }
 
-    // The shared ops->findings projection used by Inspect (lazy) and Compare (materialized). One
-    // Finding per operation, carrying its content key and stream position. Private: canonicalized
-    // ops are an internal shape; callers reach findings through Inspect or Compare, which own
-    // canonicalization. Both callers guard their arguments before reaching here.
+    // One Finding per operation, carrying its content key and stream position. Private:
+    // canonicalized operations remain an internal shape.
     static IEnumerable<Finding<CanonicalIlOperation>> ProjectAtoms(
         ImmutableArray<CanonicalIlOperation> operations,
         FindingSubject subject)
@@ -148,6 +151,16 @@ public static class IlFindings
                 operations[i]);
         }
     }
+
+    static ImmutableArray<Finding<CanonicalIlOperation>> InspectionAtoms(
+        FindingInspection<CanonicalIlOperation> inspection)
+        => inspection switch
+        {
+            FindingInspection<CanonicalIlOperation>.Complete complete => complete.Findings,
+            FindingInspection<CanonicalIlOperation>.Absent => [],
+            FindingInspection<CanonicalIlOperation>.Failed => throw new InvalidOperationException(
+                "A failed inspection cannot be matched."),
+        };
 
     /// <summary>
     /// The canonical content key for an operation, defined so that key equality is exactly the
@@ -167,19 +180,4 @@ public static class IlFindings
             _ => $"{operation.OpcodeFamily}|{operation.Operand.Kind}:{operation.Operand.Value}",
         };
     }
-}
-
-/// <summary>The outcome of an <see cref="IlFindings.Compare"/> call.</summary>
-public sealed record IlFindingsResult(
-    ImmutableArray<PairFinding<CanonicalIlOperation>> Pairs,
-    FindingMatch Match,
-    ImmutableArray<Finding<CanonicalIlOperation>> OldAtoms,
-    ImmutableArray<Finding<CanonicalIlOperation>> NewAtoms,
-    string? Failure)
-{
-    /// <summary>True when the bodies are exact under the fidelity fold (no adds/removes/moves).</summary>
-    public bool IsExact => Failure is null && FindingEquivalence.Exact.IsEquivalent(Pairs);
-
-    public static IlFindingsResult Failed(string failure)
-        => new([], new FindingMatch([], []), [], [], failure);
 }

--- a/src/ILInspector.Text.Tests/TextFindingsTests.cs
+++ b/src/ILInspector.Text.Tests/TextFindingsTests.cs
@@ -50,13 +50,13 @@ public class TextFindingsTests
         Assert.Equal(
             expected.Select(f => f.Payload),
             actual.Select(f => f.Payload));
-        Assert.True(TextFindings.Compare("one\ntwo\nthree\n", "one\r\ntwo\rthree\r", Subject).IsExact);
+        Assert.True(Compare("one\ntwo\nthree\n", "one\r\ntwo\rthree\r").IsExact);
     }
 
     [Fact]
     public void IdenticalText_IsAllPresentAndIdentical()
     {
-        var result = TextFindings.Compare("alpha\nbeta", "alpha\nbeta", Subject);
+        var result = Compare("alpha\nbeta", "alpha\nbeta");
 
         Assert.True(result.IsExact);
         Assert.All(result.Pairs, pair =>
@@ -70,7 +70,7 @@ public class TextFindingsTests
     [Fact]
     public void Compare_ReportsAddedAndRemovedLines()
     {
-        var result = TextFindings.Compare("shared\nremoved", "shared\nadded", Subject);
+        var result = Compare("shared\nremoved", "shared\nadded");
 
         Assert.False(result.IsExact);
         Assert.Equal(1, result.Pairs.Count(pair => pair is PairFinding<string>.Present));
@@ -96,7 +96,7 @@ public class TextFindingsTests
         const string oldText = "A\nB\nC\nmoved-one\nmoved-two\nD\nE";
         const string newText = "moved-one\nmoved-two\nA\nB\nC\nD\nE";
 
-        var result = TextFindings.Compare(oldText, newText, Subject);
+        var result = Compare(oldText, newText);
 
         Assert.Equal(2, result.Pairs.Count(pair => pair.Difference == FindingDifferenceKind.Moved));
         Assert.All(result.Pairs, pair => Assert.Equal(PairKind.Present, pair.Kind));
@@ -106,7 +106,7 @@ public class TextFindingsTests
     [Fact]
     public void WhitespaceDifference_IsStructuralText()
     {
-        var result = TextFindings.Compare("value ", "value", Subject);
+        var result = Compare("value ", "value");
 
         Assert.False(result.IsExact);
         Assert.Equal(1, result.Pairs.Count(pair => pair.Kind == PairKind.Added));
@@ -125,7 +125,7 @@ public class TextFindingsTests
         Assert.Equal(["value"], withoutNewline.Select(f => f.Payload));
         Assert.Equal(["value", ""], withNewline.Select(f => f.Payload));
 
-        var result = TextFindings.Compare("value", "value\n", Subject);
+        var result = Compare("value", "value\n");
         var added = Assert.Single(
             result.Pairs.Where(pair => pair is PairFinding<string>.Added)) switch
         {
@@ -146,7 +146,7 @@ public class TextFindingsTests
         "New summary")]
     public void Compare_IsDomainNeutral(string oldText, string newText, string expectedNewLine)
     {
-        var result = TextFindings.Compare(oldText, newText, Subject);
+        var result = Compare(oldText, newText);
 
         Assert.Equal(DiffShape.Structural, FindingSummary.Summarize(result.Pairs).Shape);
         Assert.Contains(
@@ -166,29 +166,27 @@ public class TextFindingsTests
     }
 
     [Fact]
-    public void Result_RejectsInvalidPublicStates()
+    public void Compare_NormalizesTotalCensusesToCompleteInspections()
     {
-        var valid = TextFindings.Compare("", "", Subject);
+        var comparison = TextFindings.Compare("", "", Subject);
+        var complete = CompleteComparison(comparison);
 
-        Assert.Throws<ArgumentException>(() =>
-            new TextFindingsResult(default, valid.Match, valid.OldAtoms, valid.NewAtoms));
-        Assert.Throws<ArgumentNullException>(() =>
-            new TextFindingsResult(valid.Pairs, null!, valid.OldAtoms, valid.NewAtoms));
-        Assert.Throws<ArgumentException>(() =>
-            new TextFindingsResult(
-                valid.Pairs,
-                new FindingMatch(default, []),
-                valid.OldAtoms,
-                valid.NewAtoms));
-        Assert.Throws<ArgumentException>(() =>
-            new TextFindingsResult(
-                valid.Pairs,
-                new FindingMatch([], default),
-                valid.OldAtoms,
-                valid.NewAtoms));
-        Assert.Throws<ArgumentException>(() =>
-            new TextFindingsResult(valid.Pairs, valid.Match, default, valid.NewAtoms));
-        Assert.Throws<ArgumentException>(() =>
-            new TextFindingsResult(valid.Pairs, valid.Match, valid.OldAtoms, default));
+        Assert.True(comparison is FindingComparison<string>.Complete);
+        Assert.True(complete.OldInspection is FindingInspection<string>.Complete);
+        Assert.True(complete.NewInspection is FindingInspection<string>.Complete);
+        Assert.Empty(complete.Pairs);
+        Assert.True(complete.IsExact);
     }
+
+    static FindingComparison<string>.Complete Compare(string oldText, string newText)
+        => CompleteComparison(TextFindings.Compare(oldText, newText, Subject));
+
+    static FindingComparison<string>.Complete CompleteComparison(
+        FindingComparison<string> comparison)
+        => comparison switch
+        {
+            FindingComparison<string>.Complete complete => complete,
+            FindingComparison<string>.Failed failed => throw new InvalidOperationException(
+                $"Expected a completed text comparison: {failed.Failure}"),
+        };
 }

--- a/src/ILInspector.Text/TextFindings.cs
+++ b/src/ILInspector.Text/TextFindings.cs
@@ -26,7 +26,7 @@ public static class TextFindings
     }
 
     /// <summary>Compares two non-null text documents with exact, ordered line identity.</summary>
-    public static TextFindingsResult Compare(
+    public static FindingComparison<string> Compare(
         string oldText,
         string newText,
         FindingSubject subject,
@@ -38,10 +38,18 @@ public static class TextFindings
 
         var oldAtoms = Inspect(oldText, subject).ToImmutableArray();
         var newAtoms = Inspect(newText, subject).ToImmutableArray();
+        FindingInspection<string> oldInspection =
+            new FindingInspection<string>.Complete(oldAtoms);
+        FindingInspection<string> newInspection =
+            new FindingInspection<string>.Complete(newAtoms);
         var match = FindingMatcher.Match(oldAtoms.Keys(), newAtoms.Keys());
         var pairs = FindingFold.ToPairs(match, oldAtoms, newAtoms, acceptanceThreshold);
 
-        return new TextFindingsResult(pairs, match, oldAtoms, newAtoms);
+        return new FindingComparison<string>.Complete(
+            pairs,
+            match,
+            oldInspection,
+            newInspection);
     }
 
     static IEnumerable<string> SplitLines(string text)
@@ -81,43 +89,5 @@ public static class TextFindings
                 position++,
                 content);
         }
-    }
-}
-
-/// <summary>The successful outcome of an in-memory text comparison.</summary>
-public sealed record TextFindingsResult(
-    ImmutableArray<PairFinding<string>> Pairs,
-    FindingMatch Match,
-    ImmutableArray<Finding<string>> OldAtoms,
-    ImmutableArray<Finding<string>> NewAtoms)
-{
-    public ImmutableArray<PairFinding<string>> Pairs { get; }
-        = Pairs.IsDefault
-            ? throw new ArgumentException("Pairs must be initialized.", nameof(Pairs))
-            : Pairs;
-
-    public FindingMatch Match { get; }
-        = ValidateMatch(Match);
-
-    public ImmutableArray<Finding<string>> OldAtoms { get; }
-        = OldAtoms.IsDefault
-            ? throw new ArgumentException("Old atoms must be initialized.", nameof(OldAtoms))
-            : OldAtoms;
-
-    public ImmutableArray<Finding<string>> NewAtoms { get; }
-        = NewAtoms.IsDefault
-            ? throw new ArgumentException("New atoms must be initialized.", nameof(NewAtoms))
-            : NewAtoms;
-
-    /// <summary>True when the documents have the same logical lines in the same order.</summary>
-    public bool IsExact => FindingEquivalence.Exact.IsEquivalent(Pairs);
-
-    static FindingMatch ValidateMatch(FindingMatch match)
-    {
-        ArgumentNullException.ThrowIfNull(match);
-        if (match.Edges.IsDefault || match.MoveCandidates.IsDefault)
-            throw new ArgumentException("Match arrays must be initialized.", nameof(match));
-
-        return match;
     }
 }

--- a/src/dotnet-inspect/Output/SourceTextDiffRenderer.cs
+++ b/src/dotnet-inspect/Output/SourceTextDiffRenderer.cs
@@ -16,7 +16,12 @@ internal static class SourceTextDiffRenderer
         if (after is null)
             return $"# {afterLabel} unavailable; source diff requires both {beforeLabel} and {afterLabel}.";
 
-        var comparison = TextFindings.Compare(before, after, Subject);
+        var comparison = TextFindings.Compare(before, after, Subject) switch
+        {
+            FindingComparison<string>.Complete complete => complete,
+            FindingComparison<string>.Failed failed => throw new InvalidOperationException(
+                $"The total text producer unexpectedly failed: {failed.Failure}"),
+        };
         if (comparison.IsExact)
             return $"# {beforeLabel} and {afterLabel} are identical.";
 
@@ -31,7 +36,8 @@ internal static class SourceTextDiffRenderer
         return string.Join(Environment.NewLine, output);
     }
 
-    static List<(char Prefix, string Text)> RenderLines(TextFindingsResult comparison)
+    static List<(char Prefix, string Text)> RenderLines(
+        FindingComparison<string>.Complete comparison)
     {
         // Unchanged Present pairs are the ordered anchors. Added, Removed, Changed, and Moved
         // pairs remain gaps, so a typed move renders conventionally as '-' at its old position


### PR DESCRIPTION
Closes #2604.

## Change

**Conclusion: PASS** — IL, C#, and text now share one product-owned comparison
envelope, with failed inspection distinguished from a completed empty alignment.

- Add the closed `FindingComparison<T>.Complete | Failed` union.
- Rename `CensusError` to `InspectionError`.
- Delete `IlFindingsResult`, `CSharpFindingsResult`, and `TextFindingsResult`.
- Migrate partial IL inspection to explicit `Complete`, `Absent`, and `Failed`
  states; `null` represents an abstract/extern method with no IL body.
- Keep ordered-matcher capacity violations as contract exceptions rather than
  misreporting a successful census as failed.
- Update the source-text renderer to consume only the completed case.

`Complete` exposes pairs and the real match because matching ran. `Failed`
exposes only the two inspections and requires at least one failed inspection;
it cannot manufacture an empty match.

## Evidence

| Check | Result |
| --- | --- |
| Product/test solution build | Pass |
| Findings + IL focused tests | 46 passed |
| C# findings focused tests | 18 passed |
| Text findings suite | 13 passed |
| Full Instructions suite | 95 passed |
| Source-text renderer tests | 5 passed |
| net10 product fallback build | Pass |
| Decompiler output/corpus | Not applicable; no raising, structuring, or printing behavior changed |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| GPT-5.5 | Clean | Final head `71dbd299`; isolated worktree |
| Gemini 3.1 Pro | Clean | Final head `71dbd299`; isolated worktree |

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Instructions.Tests -c Release --no-build
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "*CSharpFindingsTests"
dotnet run --project src/ILInspector.Text.Tests -c Release --no-build
dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- -class "*SourceTextDiffRendererTests"
dotnet build src/dotnet-inspect/dotnet-inspect.csproj -c Release --configfile nuget.config -p:DefaultTargetFramework=net10.0 -p:PublishAot=false
```
