### PR TITLE
Bound IL findings before ordered matching

### DIFF
--- a/src/ILInspector.Findings/FindingMatcher.cs
+++ b/src/ILInspector.Findings/FindingMatcher.cs
@@ -99,7 +99,8 @@ public static class FindingMatcher
     // would otherwise silently attempt a multi-gigabyte allocation. Guard the matrix with a documented
     // cell cap and fail loudly instead of OOMing. Large/unordered streams belong on the identity-set
     // committer (hash bijection, no matrix) — see issue #2585.
-    const long MaxOrderedMatchCells = 64_000_000;
+    /// <summary>The maximum dynamic-programming matrix cells accepted by ordered matching.</summary>
+    public const long MaxOrderedMatchCells = 64_000_000;
 
     public static FindingMatch Match(
         IEnumerable<FindingKey> oldStream,

--- a/src/ILInspector.Findings/FindingMatcher.cs
+++ b/src/ILInspector.Findings/FindingMatcher.cs
@@ -100,7 +100,7 @@ public static class FindingMatcher
     // cell cap and fail loudly instead of OOMing. Large/unordered streams belong on the identity-set
     // committer (hash bijection, no matrix) — see issue #2585.
     /// <summary>The maximum dynamic-programming matrix cells accepted by ordered matching.</summary>
-    public const long MaxOrderedMatchCells = 64_000_000;
+    public static readonly long MaxOrderedMatchCells = 64_000_000;
 
     public static FindingMatch Match(
         IEnumerable<FindingKey> oldStream,

--- a/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
@@ -584,20 +584,72 @@ public class FindingPilotTests
     static MethodInstructions Body(params byte[] il)
         => MethodInstructions.Decode(il, il.Length, Array.Empty<ExceptionRegion>());
 
+    static MethodInstructions OverLimitBody()
+    {
+        var il = new byte[IlFindings.MaxCanonicalOperations + 1];
+        il[^1] = Ret;
+        return Body(il);
+    }
+
     const byte Ldc0 = 0x16, Ldc1 = 0x17, Ldc2 = 0x18, Ldc3 = 0x19, Ldc4 = 0x1A, Ldc5 = 0x1B, Ldc6 = 0x1C, Ret = 0x2A;
     const byte BrS = 0x2B, Nop = 0x00;
 
     static readonly FindingSubject IlSubject = new("M", "M");
 
     [Fact]
-    public void IlFindings_PathologicallyLargeBody_PropagatesMatcherContractViolation()
+    public void IlFindings_Inspect_OverLimitBodyFailsBeforeMatching()
     {
-        var il = new byte[9000];
-        il[^1] = Ret;
-        var body = Body(il);
+        var inspection = IlFindings.Inspect(OverLimitBody(), null, IlSubject);
 
-        Assert.Throws<ArgumentException>(
-            () => IlFindings.Compare(body, null, body, null, IlSubject));
+        var failed = inspection switch
+        {
+            FindingInspection<CanonicalIlOperation>.Failed value => value,
+            _ => throw new InvalidOperationException("Expected a failed IL inspection."),
+        };
+        Assert.Equal(IlFindings.InspectionDescriptor, failed.Error.Descriptor);
+        Assert.Contains("limit", failed.Error.Reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void IlFindings_Compare_OneSidedOverLimitFailsWithoutAddRemovePairs()
+    {
+        var result = IlFindings.Compare(
+            OverLimitBody(),
+            null,
+            Body(Ret),
+            null,
+            IlSubject);
+
+        var failed = result switch
+        {
+            FindingComparison<CanonicalIlOperation>.Failed value => value,
+            _ => throw new InvalidOperationException("Expected a failed IL comparison."),
+        };
+        Assert.True(failed.OldInspection is FindingInspection<CanonicalIlOperation>.Failed);
+        Assert.True(failed.NewInspection is FindingInspection<CanonicalIlOperation>.Complete);
+        Assert.Contains("old:", failed.Failure, StringComparison.Ordinal);
+        Assert.DoesNotContain("new:", failed.Failure, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void IlFindings_Compare_TwoSidedOverLimitFailsWithoutMatcherException()
+    {
+        var result = IlFindings.Compare(
+            OverLimitBody(),
+            null,
+            OverLimitBody(),
+            null,
+            IlSubject);
+
+        var failed = result switch
+        {
+            FindingComparison<CanonicalIlOperation>.Failed value => value,
+            _ => throw new InvalidOperationException("Expected a failed IL comparison."),
+        };
+        Assert.True(failed.OldInspection is FindingInspection<CanonicalIlOperation>.Failed);
+        Assert.True(failed.NewInspection is FindingInspection<CanonicalIlOperation>.Failed);
+        Assert.Contains("old:", failed.Failure, StringComparison.Ordinal);
+        Assert.Contains("new:", failed.Failure, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/ILInspector.Instructions/IlFindings.cs
+++ b/src/ILInspector.Instructions/IlFindings.cs
@@ -23,6 +23,14 @@ public static class IlFindings
     public static readonly FindingDescriptor InspectionDescriptor = new("il.inspect", "IL inspection");
 
     /// <summary>
+    /// The maximum canonical IL operations a single inspection accepts. The ordered matcher matrix
+    /// is <c>(oldCount + 1) * (newCount + 1)</c>, so two inspections at this same limit remain within
+    /// <see cref="FindingMatcher.MaxOrderedMatchCells"/>.
+    /// </summary>
+    public static readonly int MaxCanonicalOperations =
+        (int)Math.Sqrt(FindingMatcher.MaxOrderedMatchCells) - 1;
+
+    /// <summary>
     /// Inspects one method body into a complete census, an absent-body state, or a canonicalization
     /// failure. A null body represents a method with no IL body, such as an abstract or extern method.
     /// </summary>
@@ -35,6 +43,16 @@ public static class IlFindings
 
         if (body is null)
             return new FindingInspection<CanonicalIlOperation>.Absent("Method has no IL body.");
+        if (body.IsComplete && body.Instructions.Length > MaxCanonicalOperations)
+        {
+            return new FindingInspection<CanonicalIlOperation>.Failed(
+                new InspectionError(
+                    subject,
+                    InspectionDescriptor,
+                    $"IL inspection skipped: body has {body.Instructions.Length:N0} canonical operations; " +
+                    $"limit is {MaxCanonicalOperations:N0}."));
+        }
+
         if (!IlBodyDiff.TryCanonicalize(body, reader, out var operations, out var failure))
         {
             return new FindingInspection<CanonicalIlOperation>.Failed(


### PR DESCRIPTION
Closes #2608.

## Change

**Conclusion: PASS** — IL findings now fail closed before ordered matching for oversized method bodies.

- Expose `FindingMatcher.MaxOrderedMatchCells` as the documented ordered-matcher matrix cap.
- Add `IlFindings.MaxCanonicalOperations`, derived from that cap so two same-limit IL inspections still fit the ordered matcher matrix.
- Make `IlFindings.Inspect` return `FindingInspection<CanonicalIlOperation>.Failed` with an `InspectionError` when a complete decoded body exceeds the IL operation limit.
- Replace the old pathologic IL test that expected a matcher exception with one- and two-sided failed-comparison coverage.
- Keep direct oversized ordered matcher usage as a leaf contract exception.

## Validation

```bash
dotnet build src/ILInspector.Instructions.Tests/ILInspector.Instructions.Tests.csproj -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Instructions.Tests -c Release --no-build -- -class "*FindingPilotTests"
dotnet run --project src/ILInspector.Instructions.Tests -c Release --no-build
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config
```

Solution build passed with the existing Metadata nullable warnings in `ApiDiffAnalyzerTests.cs` and `DefaultValueRenderingTests.cs`.
