### PR TITLE
Unify Research change results on the Finding spine

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,7 +133,10 @@ single overlay layer:
 - **Research** is the bridge. `ILInspector.Research` depends on both Analysis
   and Decompiler; neither depends back on Research or on each other. It owns the
   offset-keyed fact overlay for `Annotated Source`, annotated IL, and the
-  structured `Facts` rows.
+  structured `Facts` rows. For two-version operations, it also owns
+  `ResearchComparison`: one flat collection of `ResearchChange` values from API,
+  body-signal, IL/body, C#, and round-trip mechanisms, with subject grouping
+  computed as a view rather than stored as duplicate state.
 
 `ResearchFactRegistry` is the dogfooded analyzer registry for the overlay.
 Producers implement `IResearchFactProducer` with a stable name, produced fact

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,7 +136,9 @@ single overlay layer:
   structured `Facts` rows. For two-version operations, it also owns
   `ResearchComparison`: one flat collection of `ResearchChange` values from API,
   body-signal, IL/body, C#, and round-trip mechanisms, with subject grouping
-  computed as a view rather than stored as duplicate state.
+  computed as a view rather than stored as duplicate state. API comparisons
+  retain Metadata's `ApiFindingComparison` (type/member `FindingComparison<T>`
+  envelopes plus the classified `ApiDiff`) alongside the Research projection.
 
 `ResearchFactRegistry` is the dogfooded analyzer registry for the overlay.
 Producers implement `IResearchFactProducer` with a stable name, produced fact

--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -3,7 +3,7 @@
 `ImplementationDiff` is the product-side C# + IL/body diff projection in
 `ILInspector.Research`. It is the reusable implementation-diff component for
 future CLI sections, ReturnToSender, harnesses, and other consumers that need one
-member-centric evidence model instead of separate C# and IL renderers.
+member-centric change model instead of separate C# and IL renderers.
 
 ## Ownership
 
@@ -12,33 +12,52 @@ member-centric evidence model instead of separate C# and IL renderers.
 - `ILInspector.Instructions` owns IL/body diff production and display rows
   through `IlBodyDiff`, `IlAssemblyDiff`, and `IlDiffPrinter`.
 - `ILInspector.Research` owns the join. `ImplementationDiff` compares assemblies
-  with C# and IL/body mechanisms, groups evidence by `ResearchSubjectKey`, and
+  with C# and IL/body mechanisms, groups changes by `ResearchSubjectKey`, and
   exposes typed display rows and unified lines without reformatting producer
   wording.
+
+## Research comparison model
+
+`ResearchDiff` is the operation facade. It returns one `ResearchComparison`
+containing a flat `Changes` collection. `BySubject()` computes member- and
+type-centric groups from that collection; grouped and flat consumers therefore
+cannot observe divergent copies of the same result.
+
+Each `ResearchChange` carries one mechanism, a `FindingDescriptor`, an
+added/removed/changed classification, its subject, and any native producer
+payload needed for typed presentation. It is deliberately not a
+`PairFinding<T>`. API, C#, IL/body, body-signal, and ReturnToSender producers do
+not all expose genuine old/new `Finding<T>` censuses yet, so Research must not
+manufacture Finding atoms or misuse `PairKind`. A producer can migrate to
+`PairFinding<T>` when it owns both observations and their matching policy.
 
 ## Consumer contract
 
 Use `ImplementationDiff.CompareAssemblies` or `ImplementationDiff.Compare` when
 the input is a pair of assemblies or `ResearchDiffInput` values. The result is a
-list of changed implementation members. Each member can carry C# evidence, IL
-evidence, or both; exact members are omitted.
+list of changed implementation members. Each member can carry C# changes, IL
+changes, or both; exact members are omitted.
 
 Use `ImplementationDiff.CompareMembers` when the caller already resolved exact
 old/new `MethodDefinitionHandle` values in live `MetadataSource` instances. The
 member result keeps the typed C# diff, typed IL diff, joined implementation
-evidence, and a single `ResearchSubjectKey`; exact members return an empty
-evidence list with `IsExact` set.
+changes, and a single `ResearchSubjectKey`; exact members return an empty
+change list with `IsExact` set.
 
-Use `ImplementationDiff.ToIlEvidence` when a caller already has a scoped
+Use `ImplementationDiff.ToIlChanges` when a caller already has a scoped
 `IlMemberDiffResult`, such as ReturnToSender comparing one original method to a
-recompiled artifact method. This preserves typed IL diff evidence and projects
-the same `ResearchDiffEvidence` rows used by assembly-wide Research diffs. Exact
-typed diffs produce no IL evidence rows, but callers may still retain the typed
+recompiled artifact method. This preserves typed IL diff data and projects the
+same `ResearchChange` model used by assembly-wide Research diffs. Exact typed
+diffs produce no IL changes, but callers may still retain the typed
 diff in their own result model when exact proof matters.
+
+Use `ImplementationDiff.UnifiedLines(change)` only at presentation boundaries.
+The durable model keeps the producer-owned typed display rows rather than a
+third implementation-specific row family.
 
 The component is intentionally not a CLI section yet. CLI wiring should be a
 separate usability change that chooses section names, verbosity, table schema,
-and row limits without changing the product evidence primitive.
+and row limits without changing the product change primitive.
 
 ## Non-goals
 

--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -26,10 +26,11 @@ cannot observe divergent copies of the same result.
 Each `ResearchChange` carries one mechanism, a `FindingDescriptor`, an
 added/removed/changed classification, its subject, and any native producer
 payload needed for typed presentation. It is deliberately not a
-`PairFinding<T>`. API, C#, IL/body, body-signal, and ReturnToSender producers do
-not all expose genuine old/new `Finding<T>` censuses yet, so Research must not
-manufacture Finding atoms or misuse `PairKind`. A producer can migrate to
-`PairFinding<T>` when it owns both observations and their matching policy.
+`PairFinding<T>`. Metadata now exposes genuine API type/member comparisons and
+`ResearchComparison.ApiComparison` retains that producer-owned envelope. C#,
+IL/body, body-signal, and ReturnToSender mechanisms do not all expose equivalent
+old/new Finding censuses yet, so the cross-mechanism `ResearchChange` projection
+must not manufacture Finding atoms or misuse `PairKind`.
 
 ## Consumer contract
 
@@ -63,7 +64,8 @@ and row limits without changing the product change primitive.
 
 - It does not prove semantic equivalence; IL/body rows are evidence, not a
   verifier.
-- It does not own API compatibility rows. API diff remains a separate Research
-  mechanism that can be joined by callers when needed.
+- It does not own API compatibility rows. Metadata owns API observations,
+  matching, and compatibility classification; Research retains and projects
+  that comparison separately from `ImplementationDiff`.
 - It does not compile source artifacts or plan closure. ReturnToSender and other
   harnesses own artifact requests and compilation.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,7 +7,7 @@ It is built for both humans and agents. Markdown is the default output because h
 ## Core architecture
 
 - `src/dotnet-inspect/` contains the CLI, command routing, parsers, options, output views, section descriptors, and inspectors.
-- `src/ILInspector.Metadata/` reads PE metadata, API surfaces, SourceLink/PDB data, method classification, and assembly details.
+- `src/ILInspector.Metadata/` reads PE metadata, API surfaces, SourceLink/PDB data, method classification, and assembly details. `MetadataFindings` projects API type/member observations and comparisons onto the shared Finding spine while retaining compatibility classification through `ApiDiff`.
 - `src/ILInspector.Analysis/` indexes IL method-body evidence such as direct call sites, allocation occurrences, method signals, and whole-assembly leverage without decompiling to C#.
 - `src/ILInspector.Analysis.App/` is a temporary console harness for exercising Analysis queries until CLI wiring exists.
 - `src/ILInspector.ControlFlow/` contains shared block-edge, dominance, and dataflow kernels used below Analysis and Decompiler without depending on either.

--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -1100,9 +1100,8 @@ public class GeneratedFixtureCatalogTests
             result => result.GetProperty("Method").GetString() == "get_Method1"
                 && result.GetProperty("MemberAnchor").GetProperty("StableSelector").GetString()!.StartsWith("Method1~", StringComparison.Ordinal));
         var researchDiff = document.RootElement.GetProperty("ResearchDiff");
-        Assert.Contains(researchDiff.GetProperty("Subjects").EnumerateArray(),
-            subject => subject.GetProperty("Evidence").EnumerateArray()
-                .Any(evidence => evidence.GetProperty("ChangeId").GetString() == "rts.status.pass"));
+        Assert.Contains(researchDiff.GetProperty("Changes").EnumerateArray(),
+            change => change.GetProperty("DescriptorId").GetString() == "rts.status.pass");
         Assert.DoesNotContain(document.RootElement.GetProperty("Results").EnumerateArray(),
             result => result.GetProperty("Reason").GetString() == "constructor-target");
     }

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderEvidenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderEvidenceTests.cs
@@ -11,7 +11,7 @@ public class ReturnToSenderEvidenceTests
     [Fact]
     public void FromCatalog_PreservesExactRtsStatusAndMemberAnchor()
     {
-        Assert.True(ResearchDiffMechanism.AllAvailable.HasFlag(ResearchDiffMechanism.ReturnToSender));
+        Assert.True(ResearchChangeMechanism.AllAvailable.HasFlag(ResearchChangeMechanism.ReturnToSender));
 
         var run = GeneratedFixtureRunner.RunReturnToSenderCatalog(
             [GeneratedFixtureCatalog.MinimalPropertyLiteral]);
@@ -28,17 +28,17 @@ public class ReturnToSenderEvidenceTests
         Assert.True(row.IlDiff.Diff.IsExact);
         Assert.Equal(row.IlDiff.Old.Identity, row.IlDiff.New.Identity);
 
-        var research = ReturnToSenderEvidence.ToResearchDiff(evidence);
+        var research = ReturnToSenderEvidence.ToResearchComparison(evidence);
         var subject = Assert.Single(research.MembersWhere(member => member.Subject.Id == row.Anchor.StableSelector));
-        Assert.Contains(subject.Evidence, item =>
-            item.Mechanism == ResearchDiffMechanism.ReturnToSender
-            && item.ChangeId == "rts.status.pass"
-            && item.Category == ResearchDiffChangeCategory.RoundTrip);
-        Assert.DoesNotContain(subject.Evidence, item => item.Mechanism == ResearchDiffMechanism.IlBody);
+        Assert.Contains(subject.Changes, item =>
+            item.Mechanism == ResearchChangeMechanism.ReturnToSender
+            && item.Descriptor.Id == "rts.status.pass"
+            && item.Category == ResearchChangeCategory.RoundTrip);
+        Assert.DoesNotContain(subject.Changes, item => item.Mechanism == ResearchChangeMechanism.IlBody);
     }
 
     [Fact]
-    public void ToResearchDiff_ProjectsStructuredIlDiffRowsWithoutReportTextParsing()
+    public void ToResearchComparison_ProjectsStructuredIlDiffRowsWithoutReportTextParsing()
     {
         var anchor = new MemberAnchor(
             "Method1~abcdef1234",
@@ -82,37 +82,37 @@ public class ReturnToSenderEvidenceTests
             IlDiffDiagnostic: null,
             IlDiff: typedDiff);
 
-        var research = ReturnToSenderEvidence.ToResearchDiff([evidence]);
+        var research = ReturnToSenderEvidence.ToResearchComparison([evidence]);
 
-        var subject = Assert.Single(research.Subjects);
+        var subject = Assert.Single(research.BySubject());
         Assert.Equal(anchor.StableSelector, subject.Subject.Id);
         Assert.Equal("TestType.Method1", subject.Subject.Display);
         Assert.Equal("TestType", subject.Subject.TypeName);
         Assert.Equal("Method1", subject.Subject.MemberName);
-        Assert.Contains(subject.Evidence, item =>
-            item.Mechanism == ResearchDiffMechanism.ReturnToSender
-            && item.ChangeId == "rts.status.fail");
-        Assert.Contains(subject.Evidence, item =>
-            item.Mechanism == ResearchDiffMechanism.IlBody
-            && item.ChangeId == "il.operation.removed"
+        Assert.Contains(subject.Changes, item =>
+            item.Mechanism == ResearchChangeMechanism.ReturnToSender
+            && item.Descriptor.Id == "rts.status.fail");
+        Assert.Contains(subject.Changes, item =>
+            item.Mechanism == ResearchChangeMechanism.IlBody
+            && item.Descriptor.Id == "il.operation.removed"
             && item.OldValue == "ldc.i4 1"
             && item.OldIlOffset == 1
             && item.IlMemberDiff == typedDiff
             && item.IlDisplayRows.Length == 1
             && item.IlDisplayRows[0].UnifiedLine == "h1 - IL_0001 ldc.i4 1");
-        Assert.Contains(subject.Evidence, item =>
-            item.Mechanism == ResearchDiffMechanism.IlBody
-            && item.ChangeId == "il.operation.added"
+        Assert.Contains(subject.Changes, item =>
+            item.Mechanism == ResearchChangeMechanism.IlBody
+            && item.Descriptor.Id == "il.operation.added"
             && item.NewValue == "ldc.i4 2"
             && item.NewIlOffset == 1
             && item.IlMemberDiff == typedDiff
             && item.IlDisplayRows.Length == 1
             && item.IlDisplayRows[0].UnifiedLine == "h1 + IL_0001 ldc.i4 2");
-        Assert.DoesNotContain(subject.Evidence, item => item.ChangeId == "il.operation.context");
+        Assert.DoesNotContain(subject.Changes, item => item.Descriptor.Id == "il.operation.context");
     }
 
     [Fact]
-    public void ToResearchDiff_ProjectsStructuredIlDiffFailureRows()
+    public void ToResearchComparison_ProjectsStructuredIlDiffFailureRows()
     {
         var anchor = new MemberAnchor(
             "Method1~abcdef1234",
@@ -140,11 +140,13 @@ public class ReturnToSenderEvidenceTests
                 FailureRows: [failure]),
             IlDiff: null);
 
-        var research = ReturnToSenderEvidence.ToResearchDiff([evidence]);
+        var research = ReturnToSenderEvidence.ToResearchComparison([evidence]);
 
-        var subject = Assert.Single(research.Subjects);
-        var ilFailure = Assert.Single(subject.Evidence, item => item.ChangeId == "il.diff.new-body-missing");
-        Assert.Equal(ResearchDiffMechanism.IlBody, ilFailure.Mechanism);
+        var subject = Assert.Single(research.BySubject());
+        var ilFailure = Assert.Single(
+            subject.Changes,
+            item => item.Descriptor.Id == "il.diff.new-body-missing");
+        Assert.Equal(ResearchChangeMechanism.IlBody, ilFailure.Mechanism);
         Assert.Equal("method has no body", ilFailure.Detail);
         Assert.Same(failure, ilFailure.IlDisplayFailureRow);
     }

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -324,8 +324,8 @@ public class ReturnToSenderFixtureCatalogTests
             ImplementationDiffMechanism.All);
 
         Assert.NotNull(diff);
-        Assert.True(diff!.HasCSharpEvidence);
-        Assert.True(diff.HasIlEvidence);
+        Assert.True(diff!.HasCSharpChanges);
+        Assert.True(diff.HasIlChanges);
         Assert.NotNull(diff.IlDiff);
         Assert.False(diff.IlDiff.Diff.IsExact);
     }

--- a/src/ILInspector.Metadata/ILInspector.Metadata.csproj
+++ b/src/ILInspector.Metadata/ILInspector.Metadata.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ILInspector.Findings\ILInspector.Findings.csproj" />
     <ProjectReference Include="..\ILInspector.Instructions\ILInspector.Instructions.csproj" />
     <ProjectReference Include="..\ILInspector.MetadataPrimitives\ILInspector.MetadataPrimitives.csproj" />
   </ItemGroup>

--- a/src/ILInspector.Metadata/MetadataFindings.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.cs
@@ -1,0 +1,410 @@
+using System.Collections.Immutable;
+using ILInspector.Findings;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// API-surface observations and comparisons over the domain-free Finding substrate.
+/// Types and members are unordered identity sets; compatibility classification remains
+/// the responsibility of <see cref="ApiDiffAnalyzer"/>.
+/// </summary>
+public static class MetadataFindings
+{
+    public static readonly FindingDescriptor TypeDescriptor = new("api.type", "API type");
+    public static readonly FindingDescriptor MemberDescriptor = new("api.member", "API member");
+
+    static readonly FindingMatchOptions IdentitySetOptions = new()
+    {
+        MatchMode = FindingMatchMode.IdentitySet,
+    };
+
+    public static FindingInspection<ApiTypeHandle> InspectApiTypes(
+        ApiSurface surface,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(surface);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return new FindingInspection<ApiTypeHandle>.Complete(
+        [
+            .. surface.Types.Select((type, position) => new Finding<ApiTypeHandle>(
+                subject,
+                TypeDescriptor,
+                new FindingKey(type.FullName),
+                position,
+                new ApiTypeHandle(type))),
+        ]);
+    }
+
+    public static FindingInspection<ApiMemberHandle> InspectApiMembers(
+        ApiSurface surface,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(surface);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return new FindingInspection<ApiMemberHandle>.Complete(
+        [
+            .. EnumerateMembers(surface).Select((item, position) =>
+            {
+                var handle = ApiMemberIdentity.CreateHandle(item.Type, item.Member);
+                return new Finding<ApiMemberHandle>(
+                    subject,
+                    MemberDescriptor,
+                    new FindingKey(
+                        handle.CanonicalSignature ?? handle.Identity,
+                        item.Type.FullName),
+                    position,
+                    handle);
+            }),
+        ]);
+    }
+
+    public static FindingComparison<ApiTypeHandle> CompareApiTypes(
+        ApiSurface oldSurface,
+        ApiSurface newSurface,
+        FindingSubject subject,
+        ApiDiffOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(oldSurface);
+        ArgumentNullException.ThrowIfNull(newSurface);
+        ArgumentNullException.ThrowIfNull(subject);
+        options ??= ApiDiffOptions.Default;
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface, options);
+        return CompareApiTypes(oldSurface, newSurface, subject, options, diff);
+    }
+
+    public static FindingComparison<ApiMemberHandle> CompareApiMembers(
+        ApiSurface oldSurface,
+        ApiSurface newSurface,
+        FindingSubject subject,
+        ApiDiffOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(oldSurface);
+        ArgumentNullException.ThrowIfNull(newSurface);
+        ArgumentNullException.ThrowIfNull(subject);
+        options ??= ApiDiffOptions.Default;
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface, options);
+        return CompareApiMembers(oldSurface, newSurface, subject, options, diff);
+    }
+
+    public static ApiFindingComparison CompareApi(
+        ApiSurface oldSurface,
+        ApiSurface newSurface,
+        FindingSubject subject,
+        ApiDiffOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(oldSurface);
+        ArgumentNullException.ThrowIfNull(newSurface);
+        ArgumentNullException.ThrowIfNull(subject);
+        options ??= ApiDiffOptions.Default;
+
+        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface, options);
+        return new ApiFindingComparison(
+            CompareApiTypes(oldSurface, newSurface, subject, options, diff),
+            CompareApiMembers(oldSurface, newSurface, subject, options, diff),
+            diff);
+    }
+
+    static FindingComparison<ApiTypeHandle> CompareApiTypes(
+        ApiSurface oldSurface,
+        ApiSurface newSurface,
+        FindingSubject subject,
+        ApiDiffOptions options,
+        ApiDiff diff)
+    {
+        var oldInspection = InspectApiTypes(oldSurface, subject);
+        var newInspection = InspectApiTypes(newSurface, subject);
+        var oldFindings = InspectionFindings(oldInspection);
+        var newFindings = InspectionFindings(newInspection);
+        var match = FindingMatcher.Match(oldFindings.Keys(), newFindings.Keys(), IdentitySetOptions);
+        var pairs = FindingFold.ToPairs(match, oldFindings, newFindings);
+        pairs = ApplyTypeFacetChanges(pairs, diff, options.Scope);
+
+        return new FindingComparison<ApiTypeHandle>.Complete(
+            pairs,
+            match,
+            oldInspection,
+            newInspection);
+    }
+
+    static FindingComparison<ApiMemberHandle> CompareApiMembers(
+        ApiSurface oldSurface,
+        ApiSurface newSurface,
+        FindingSubject subject,
+        ApiDiffOptions options,
+        ApiDiff diff)
+    {
+        var oldInspection = InspectApiMembers(oldSurface, subject);
+        var newInspection = InspectApiMembers(newSurface, subject);
+        var oldFindings = InspectionFindings(oldInspection);
+        var newFindings = InspectionFindings(newInspection);
+        var match = FindingMatcher.Match(oldFindings.Keys(), newFindings.Keys(), IdentitySetOptions);
+        var pairs = FindingFold.ToPairs(match, oldFindings, newFindings);
+        pairs = ApplyMemberFacetChanges(pairs, diff, options.Scope);
+
+        return new FindingComparison<ApiMemberHandle>.Complete(
+            pairs,
+            match,
+            oldInspection,
+            newInspection);
+    }
+
+    static ImmutableArray<PairFinding<ApiTypeHandle>> ApplyTypeFacetChanges(
+        ImmutableArray<PairFinding<ApiTypeHandle>> pairs,
+        ApiDiff diff,
+        ApiDiffScope scope)
+    {
+        var changesByKey = BuildTypeChangeMap(diff);
+        var builder = ImmutableArray.CreateBuilder<PairFinding<ApiTypeHandle>>(pairs.Length);
+        foreach (var pair in pairs)
+        {
+            if (pair is not PairFinding<ApiTypeHandle>.Present present)
+            {
+                builder.Add(pair);
+                continue;
+            }
+
+            var details = new List<string>();
+            if (changesByKey.TryGetValue(present.New.Payload.TypeFullName, out var changes))
+                details.AddRange(changes.Select(FormatApiChange));
+            AddTypeFacetDetails(present.Old.Payload.Type, present.New.Payload.Type, scope, details);
+
+            builder.Add(details.Count == 0
+                ? pair
+                : new PairFinding<ApiTypeHandle>.Changed(
+                    present.Old,
+                    present.New,
+                    present.Difference,
+                    string.Join("; ", details.Distinct(StringComparer.Ordinal))));
+        }
+
+        return builder.ToImmutable();
+    }
+
+    static ImmutableArray<PairFinding<ApiMemberHandle>> ApplyMemberFacetChanges(
+        ImmutableArray<PairFinding<ApiMemberHandle>> pairs,
+        ApiDiff diff,
+        ApiDiffScope scope)
+    {
+        var changesByKey = BuildMemberChangeMap(diff);
+        var builder = ImmutableArray.CreateBuilder<PairFinding<ApiMemberHandle>>(pairs.Length);
+        foreach (var pair in pairs)
+        {
+            if (pair is not PairFinding<ApiMemberHandle>.Present present)
+            {
+                builder.Add(pair);
+                continue;
+            }
+
+            string key = present.New.Key.IdentityKey;
+            var details = new List<string>();
+            if (changesByKey.TryGetValue(key, out var changes))
+                details.AddRange(changes.Select(FormatApiChange));
+            AddMemberFacetDetails(present.Old.Payload.Member, present.New.Payload.Member, scope, details);
+
+            builder.Add(details.Count == 0
+                ? pair
+                : new PairFinding<ApiMemberHandle>.Changed(
+                    present.Old,
+                    present.New,
+                    present.Difference,
+                    string.Join("; ", details.Distinct(StringComparer.Ordinal))));
+        }
+
+        return builder.ToImmutable();
+    }
+
+    static Dictionary<string, List<ApiChange>> BuildTypeChangeMap(ApiDiff diff)
+    {
+        var changesByKey = new Dictionary<string, List<ApiChange>>(StringComparer.Ordinal);
+        foreach (var change in diff.TypeDiffs.SelectMany(typeDiff => typeDiff.Changes))
+        {
+            if (change.Subject is not
+                {
+                    Kind: ApiChangeSubjectKind.Type,
+                    OldType: not null,
+                    NewType: not null,
+                } subject
+                || !string.Equals(subject.OldType.TypeFullName, subject.NewType.TypeFullName, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            AddChange(changesByKey, subject.NewType.TypeFullName, change);
+        }
+
+        return changesByKey;
+    }
+
+    static Dictionary<string, List<ApiChange>> BuildMemberChangeMap(ApiDiff diff)
+    {
+        var changesByKey = new Dictionary<string, List<ApiChange>>(StringComparer.Ordinal);
+        foreach (var change in diff.TypeDiffs.SelectMany(typeDiff => typeDiff.Changes))
+        {
+            if (change.Subject is not
+                {
+                    Kind: ApiChangeSubjectKind.Member,
+                    OldMember.CanonicalSignature: not null,
+                    NewMember.CanonicalSignature: not null,
+                } subject
+                || !string.Equals(
+                    subject.OldMember.CanonicalSignature,
+                    subject.NewMember.CanonicalSignature,
+                    StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            AddChange(changesByKey, subject.NewMember.CanonicalSignature, change);
+        }
+
+        return changesByKey;
+    }
+
+    static void AddChange(Dictionary<string, List<ApiChange>> changesByKey, string key, ApiChange change)
+    {
+        if (!changesByKey.TryGetValue(key, out var changes))
+            changesByKey.Add(key, changes = []);
+        changes.Add(change);
+    }
+
+    static void AddTypeFacetDetails(ApiType oldType, ApiType newType, ApiDiffScope scope, List<string> details)
+    {
+        if (scope.HasFlag(ApiDiffScope.Signature))
+        {
+            AddFacetDetail(details, "kind", oldType.Kind, newType.Kind);
+            AddFacetDetail(details, "enum underlying type", oldType.EnumUnderlyingType, newType.EnumUnderlyingType);
+            AddFacetDetail(details, "sealed", oldType.IsSealed, newType.IsSealed);
+            AddFacetDetail(details, "abstract", oldType.IsAbstract, newType.IsAbstract);
+            AddFacetDetail(details, "static", oldType.IsStatic, newType.IsStatic);
+            AddFacetDetail(details, "byref-like", oldType.IsByRefLike, newType.IsByRefLike);
+            AddFacetDetail(details, "readonly", oldType.IsReadOnly, newType.IsReadOnly);
+            AddFacetDetail(details, "base type", oldType.BaseType, newType.BaseType);
+            AddFacetDetail(details, "interfaces", FormatSet(oldType.Interfaces), FormatSet(newType.Interfaces));
+            AddFacetDetail(
+                details,
+                "type parameters",
+                FormatTypeParameters(oldType.TypeParameters),
+                FormatTypeParameters(newType.TypeParameters));
+        }
+
+        if (scope.HasFlag(ApiDiffScope.Attributes))
+            AddFacetDetail(details, "attributes", FormatSet(oldType.Attributes), FormatSet(newType.Attributes));
+    }
+
+    static void AddMemberFacetDetails(ApiMember oldMember, ApiMember newMember, ApiDiffScope scope, List<string> details)
+    {
+        if (scope.HasFlag(ApiDiffScope.Signature))
+        {
+            AddFacetDetail(details, "signature", oldMember.Signature, newMember.Signature);
+            AddFacetDetail(details, "return type", oldMember.ReturnType, newMember.ReturnType);
+            AddFacetDetail(
+                details,
+                "accessibility",
+                NormalizeAccessibility(oldMember.Accessibility),
+                NormalizeAccessibility(newMember.Accessibility));
+            AddFacetDetail(details, "static", oldMember.IsStatic, newMember.IsStatic);
+            AddFacetDetail(details, "virtual", oldMember.IsVirtual, newMember.IsVirtual);
+            AddFacetDetail(details, "abstract", oldMember.IsAbstract, newMember.IsAbstract);
+            AddFacetDetail(details, "override", oldMember.IsOverride, newMember.IsOverride);
+            AddFacetDetail(details, "sealed", oldMember.IsSealed, newMember.IsSealed);
+            AddFacetDetail(details, "readonly", oldMember.IsReadOnly, newMember.IsReadOnly);
+            AddFacetDetail(details, "const", oldMember.IsConst, newMember.IsConst);
+            AddFacetDetail(details, "unsafe", oldMember.IsUnsafe, newMember.IsUnsafe);
+            AddFacetDetail(details, "extension", oldMember.IsExtension, newMember.IsExtension);
+            AddFacetDetail(details, "extended type", oldMember.ExtendedType, newMember.ExtendedType);
+            AddFacetDetail(details, "enum value", FormatEnumValue(oldMember), FormatEnumValue(newMember));
+        }
+
+        if (scope.HasFlag(ApiDiffScope.Attributes))
+        {
+            AddFacetDetail(details, "attributes", FormatSet(oldMember.Attributes), FormatSet(newMember.Attributes));
+            AddFacetDetail(details, "obsolete", oldMember.IsObsolete, newMember.IsObsolete);
+            AddFacetDetail(details, "obsolete message", oldMember.ObsoleteMessage, newMember.ObsoleteMessage);
+        }
+    }
+
+    static void AddFacetDetail(List<string> details, string name, bool oldValue, bool newValue)
+    {
+        if (oldValue != newValue)
+            details.Add($"{name}: {oldValue.ToString().ToLowerInvariant()} -> {newValue.ToString().ToLowerInvariant()}");
+    }
+
+    static void AddFacetDetail(List<string> details, string name, string? oldValue, string? newValue)
+    {
+        if (!string.Equals(oldValue, newValue, StringComparison.Ordinal))
+            details.Add($"{name}: {FormatValue(oldValue)} -> {FormatValue(newValue)}");
+    }
+
+    static string FormatApiChange(ApiChange change)
+    {
+        string detail = $"{change.Category}: {change.Kind}";
+        if (!string.IsNullOrEmpty(change.OldValue) || !string.IsNullOrEmpty(change.NewValue))
+            detail += $" ({FormatValue(change.OldValue)} -> {FormatValue(change.NewValue)})";
+        return detail;
+    }
+
+    static string FormatSet(IEnumerable<string> values)
+        => string.Join(", ", values.Order(StringComparer.Ordinal));
+
+    static string FormatTypeParameters(IEnumerable<TypeParameter> parameters)
+        => string.Join(
+            "; ",
+            parameters.Select(parameter =>
+                $"{parameter.Variance ?? ""} {parameter.Name}: {FormatSet(parameter.Constraints)}".Trim()));
+
+    static string NormalizeAccessibility(string? accessibility)
+        => string.IsNullOrWhiteSpace(accessibility) ? "public" : accessibility;
+
+    static string? FormatEnumValue(ApiMember member)
+        => member.EnumValueLiteral ?? member.EnumValue?.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+    static string FormatValue(string? value)
+        => string.IsNullOrEmpty(value) ? "none" : value;
+
+    static ImmutableArray<Finding<T>> InspectionFindings<T>(FindingInspection<T> inspection)
+        where T : notnull
+        => inspection is FindingInspection<T>.Complete complete
+            ? complete.Findings
+            : throw new InvalidOperationException("API-surface inspection unexpectedly failed.");
+
+    static IEnumerable<(ApiType Type, ApiMember Member)> EnumerateMembers(ApiSurface surface)
+    {
+        foreach (var type in surface.Types)
+        {
+            foreach (var member in type.Members)
+                yield return (type, member);
+        }
+    }
+}
+
+/// <summary>
+/// One API comparison operation: generic type/member transitions plus Metadata-owned
+/// compatibility classifications over the same two surfaces.
+/// </summary>
+public sealed record ApiFindingComparison
+{
+    public ApiFindingComparison(
+        FindingComparison<ApiTypeHandle> types,
+        FindingComparison<ApiMemberHandle> members,
+        ApiDiff apiDiff)
+    {
+        Types = types ?? throw new ArgumentNullException(nameof(types));
+        Members = members ?? throw new ArgumentNullException(nameof(members));
+        ApiDiff = apiDiff ?? throw new ArgumentNullException(nameof(apiDiff));
+    }
+
+    public FindingComparison<ApiTypeHandle> Types { get; }
+    public FindingComparison<ApiMemberHandle> Members { get; }
+    public ApiDiff ApiDiff { get; }
+
+    public bool IsExact
+        => Types is FindingComparison<ApiTypeHandle>.Complete typeComparison
+        && Members is FindingComparison<ApiMemberHandle>.Complete memberComparison
+        && ApiDiff.IsEmpty
+        && FindingEquivalence.Exact.IsEquivalent(typeComparison.Pairs)
+        && FindingEquivalence.Exact.IsEquivalent(memberComparison.Pairs);
+}

--- a/src/ILInspector.Metadata/MetadataFindings.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.cs
@@ -161,24 +161,25 @@ public static class MetadataFindings
         var builder = ImmutableArray.CreateBuilder<PairFinding<ApiTypeHandle>>(pairs.Length);
         foreach (var pair in pairs)
         {
-            if (pair is not PairFinding<ApiTypeHandle>.Present present)
+            if (pair is PairFinding<ApiTypeHandle>.Present present)
+            {
+                var details = new List<string>();
+                if (changesByKey.TryGetValue(present.New.Payload.TypeFullName, out var changes))
+                    details.AddRange(changes.Select(FormatApiChange));
+                AddTypeFacetDetails(present.Old.Payload.Type, present.New.Payload.Type, scope, details);
+
+                builder.Add(details.Count == 0
+                    ? pair
+                    : new PairFinding<ApiTypeHandle>.Changed(
+                        present.Old,
+                        present.New,
+                        present.Difference,
+                        string.Join("; ", details.Distinct(StringComparer.Ordinal))));
+            }
+            else
             {
                 builder.Add(pair);
-                continue;
             }
-
-            var details = new List<string>();
-            if (changesByKey.TryGetValue(present.New.Payload.TypeFullName, out var changes))
-                details.AddRange(changes.Select(FormatApiChange));
-            AddTypeFacetDetails(present.Old.Payload.Type, present.New.Payload.Type, scope, details);
-
-            builder.Add(details.Count == 0
-                ? pair
-                : new PairFinding<ApiTypeHandle>.Changed(
-                    present.Old,
-                    present.New,
-                    present.Difference,
-                    string.Join("; ", details.Distinct(StringComparer.Ordinal))));
         }
 
         return builder.ToImmutable();
@@ -193,25 +194,26 @@ public static class MetadataFindings
         var builder = ImmutableArray.CreateBuilder<PairFinding<ApiMemberHandle>>(pairs.Length);
         foreach (var pair in pairs)
         {
-            if (pair is not PairFinding<ApiMemberHandle>.Present present)
+            if (pair is PairFinding<ApiMemberHandle>.Present present)
+            {
+                string key = present.New.Key.IdentityKey;
+                var details = new List<string>();
+                if (changesByKey.TryGetValue(key, out var changes))
+                    details.AddRange(changes.Select(FormatApiChange));
+                AddMemberFacetDetails(present.Old.Payload.Member, present.New.Payload.Member, scope, details);
+
+                builder.Add(details.Count == 0
+                    ? pair
+                    : new PairFinding<ApiMemberHandle>.Changed(
+                        present.Old,
+                        present.New,
+                        present.Difference,
+                        string.Join("; ", details.Distinct(StringComparer.Ordinal))));
+            }
+            else
             {
                 builder.Add(pair);
-                continue;
             }
-
-            string key = present.New.Key.IdentityKey;
-            var details = new List<string>();
-            if (changesByKey.TryGetValue(key, out var changes))
-                details.AddRange(changes.Select(FormatApiChange));
-            AddMemberFacetDetails(present.Old.Payload.Member, present.New.Payload.Member, scope, details);
-
-            builder.Add(details.Count == 0
-                ? pair
-                : new PairFinding<ApiMemberHandle>.Changed(
-                    present.Old,
-                    present.New,
-                    present.Difference,
-                    string.Join("; ", details.Distinct(StringComparer.Ordinal))));
         }
 
         return builder.ToImmutable();

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -180,6 +180,15 @@ public class ResearchDiffTests
 
         var diff = ResearchDiff.CompareApiSurfaces(oldSurface, newSurface);
 
+        var apiComparison = Assert.IsType<ApiFindingComparison>(diff.ApiComparison);
+        var memberComparison = apiComparison.Members switch
+        {
+            FindingComparison<ApiMemberHandle>.Complete complete => complete,
+            _ => throw new Xunit.Sdk.XunitException("Expected a complete API member comparison."),
+        };
+        Assert.Contains(memberComparison.Pairs, pair =>
+            pair is PairFinding<ApiMemberHandle>.Added added
+            && added.New.Payload.MemberName == "Added");
         var changed = Assert.Single(diff.MembersWhere(member => member.ApiChanged));
         Assert.Equal("Added", changed.Subject.MemberName);
         Assert.True(changed.HasChange("api.member-added"));
@@ -378,7 +387,38 @@ public class ResearchDiffTests
         var combined = ResearchDiff.Combine(apiResult, ilResult);
 
         Assert.Same(api, combined.ApiDiff);
+        Assert.Null(combined.ApiComparison);
         Assert.Single(combined.Changes);
+    }
+
+    [Fact]
+    public void Combine_PreservesStructuredApiComparison()
+    {
+        var oldSurface = Surface("Widget", Member("Existing"));
+        var newSurface = Surface("Widget", Member("Existing"), Member("Added"));
+        var apiResult = ResearchDiff.CompareApiSurfaces(oldSurface, newSurface);
+        var ilResult = ResearchDiff.FromIlBodyDiff(new IlBodyDiffResult(IsExact: true, Failure: null, []));
+
+        var combined = ResearchDiff.Combine(apiResult, ilResult);
+
+        Assert.Same(apiResult.ApiComparison, combined.ApiComparison);
+        Assert.Same(apiResult.ApiDiff, combined.ApiDiff);
+    }
+
+    [Fact]
+    public void Combine_PrefersStructuredApiComparisonOverEarlierLegacyApiDiff()
+    {
+        var legacySurface = Surface("Legacy", Member("Existing"));
+        var legacyResult = ResearchDiff.FromApiDiff(
+            ApiDiffAnalyzer.Compare(legacySurface, Surface("Legacy", Member("Added"))));
+        var oldSurface = Surface("Widget", Member("Existing"));
+        var newSurface = Surface("Widget", Member("Existing"), Member("Added"));
+        var structuredResult = ResearchDiff.CompareApiSurfaces(oldSurface, newSurface);
+
+        var combined = ResearchDiff.Combine(legacyResult, structuredResult);
+
+        Assert.Same(structuredResult.ApiComparison, combined.ApiComparison);
+        Assert.Same(structuredResult.ApiDiff, combined.ApiDiff);
     }
 
     [Fact]

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -3,6 +3,7 @@ using System.Reflection.PortableExecutable;
 using DotnetInspector.Fixtures;
 using ILInspector.Analysis;
 using ILInspector.Decompiler;
+using ILInspector.Findings;
 using ILInspector.Metadata;
 using ILInspector.MetadataPrimitives;
 using ILInspector.Instructions;
@@ -12,6 +13,52 @@ namespace ILInspector.Research.Tests;
 
 public class ResearchDiffTests
 {
+    [Fact]
+    public void ResearchComparison_StoresChangesOnceAndComputesSubjectGroups()
+    {
+        var subject = new ResearchSubjectKey(
+            ResearchSubjectKind.Member,
+            "M~1234567890",
+            "Sample.Widget.M()");
+        var first = new ResearchChange(
+            subject,
+            ResearchChangeMechanism.CSharp,
+            new FindingDescriptor("csharp.line.added", "C# line"),
+            ResearchChangeKind.Added);
+        var second = new ResearchChange(
+            subject,
+            ResearchChangeMechanism.IlBody,
+            new FindingDescriptor("il.operation.added", "IL operation"),
+            ResearchChangeKind.Added);
+        var comparison = new ResearchComparison([first, second]);
+
+        var group = Assert.Single(comparison.BySubject());
+
+        Assert.Equal(subject, group.Subject);
+        Assert.Equal(2, comparison.Changes.Length);
+        Assert.Contains(first, group.Changes);
+        Assert.Contains(second, group.Changes);
+    }
+
+    [Fact]
+    public void ResearchComparison_RejectsDefaultChanges()
+        => Assert.Throws<ArgumentException>(() => new ResearchComparison(default));
+
+    [Fact]
+    public void ResearchChange_RejectsCompositeMechanism()
+    {
+        var subject = new ResearchSubjectKey(
+            ResearchSubjectKind.Member,
+            "M~1234567890",
+            "Sample.Widget.M()");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ResearchChange(
+            subject,
+            ResearchChangeMechanism.CSharp | ResearchChangeMechanism.IlBody,
+            new FindingDescriptor("implementation.changed", "Implementation"),
+            ResearchChangeKind.Changed));
+    }
+
     [Fact]
     public void ResearchMemberIdentity_SubjectFromAnchor_PreservesAnchorIdentityAndDisplay()
     {
@@ -24,7 +71,7 @@ public class ResearchDiffTests
 
         var subject = ResearchMemberIdentity.SubjectFromAnchor(anchor, "Sample.Widget.M(System.Int32)");
 
-        Assert.Equal(ResearchDiffSubjectKind.Member, subject.Kind);
+        Assert.Equal(ResearchSubjectKind.Member, subject.Kind);
         Assert.Equal(anchor.StableSelector, subject.Id);
         Assert.Equal("Sample.Widget.M(System.Int32)", subject.Display);
         Assert.Equal(anchor.TypeFullName, subject.TypeName);
@@ -182,10 +229,10 @@ public class ResearchDiffTests
 
         var diff = ResearchDiff.FromApiDiff(api);
 
-        var row = Assert.Single(diff.Rows);
-        Assert.Equal("api.member-added", row.ChangeId);
-        Assert.Equal(ResearchDiffEvidenceKind.MetadataApi, row.EvidenceKind);
-        Assert.Equal("Member 'Added' was added", row.Message);
+        var row = Assert.Single(diff.Changes);
+        Assert.Equal("api.member-added", row.Descriptor.Id);
+        Assert.Equal(ResearchChangeMechanism.Api, row.Mechanism);
+        Assert.Equal("Member 'Added' was added", row.Detail);
         Assert.Same(Assert.Single(Assert.Single(api.TypeDiffs).Changes), row.ApiChange);
     }
 
@@ -201,18 +248,18 @@ public class ResearchDiffTests
 
         var diff = ResearchDiff.FromIlBodyDiff(il);
 
-        var row = Assert.Single(diff.Rows);
-        Assert.Equal("il.operation.added", row.ChangeId);
-        Assert.Equal(ilRow.Message, row.Message);
+        var row = Assert.Single(diff.Changes);
+        Assert.Equal("il.operation.added", row.Descriptor.Id);
+        Assert.Equal(ilRow.Message, row.Detail);
         Assert.Same(ilRow, row.IlRow);
-        Assert.NotNull(row.IlDisplayRow);
-        Assert.Equal(3, row.IlDisplayRow.HunkId);
-        Assert.Equal("+", row.IlDisplayRow.Marker);
-        Assert.Equal("IL_0000", row.IlDisplayRow.Offset);
-        Assert.Equal("ldc.i4", row.IlDisplayRow.OpcodeFamily);
-        Assert.Equal(IlOperandIdentityKind.Immediate, row.IlDisplayRow.OperandKind);
-        Assert.Equal("2", row.IlDisplayRow.OperandValue);
-        Assert.Equal("h3 + IL_0000 ldc.i4 2", row.IlDisplayRow.UnifiedLine);
+        var displayRow = Assert.Single(row.IlDisplayRows);
+        Assert.Equal(3, displayRow.HunkId);
+        Assert.Equal("+", displayRow.Marker);
+        Assert.Equal("IL_0000", displayRow.Offset);
+        Assert.Equal("ldc.i4", displayRow.OpcodeFamily);
+        Assert.Equal(IlOperandIdentityKind.Immediate, displayRow.OperandKind);
+        Assert.Equal("2", displayRow.OperandValue);
+        Assert.Equal("h3 + IL_0000 ldc.i4 2", displayRow.UnifiedLine);
     }
 
     [Fact]
@@ -222,10 +269,10 @@ public class ResearchDiffTests
 
         var diff = ResearchDiff.FromIlBodyDiff(il);
 
-        var row = Assert.Single(diff.Rows);
-        Assert.Equal("il.diff.new-body-missing", row.ChangeId);
-        Assert.Equal(ResearchDiffEvidenceKind.IlBody, row.EvidenceKind);
-        Assert.Equal("new body missing", row.Message);
+        var row = Assert.Single(diff.Changes);
+        Assert.Equal("il.diff.new-body-missing", row.Descriptor.Id);
+        Assert.Equal(ResearchChangeMechanism.IlBody, row.Mechanism);
+        Assert.Equal("new body missing", row.Detail);
         var failure = Assert.IsType<IlDiffFailureRow>(row.IlFailureRow);
         Assert.Equal(IlDiffFailureKind.NewBodyMissing, failure.Kind);
         Assert.Equal("new", failure.Side);
@@ -254,19 +301,18 @@ public class ResearchDiffTests
         var diff = ResearchDiff.FromIlBodyDiff(il);
 
         Assert.Collection(
-            diff.Rows,
+            diff.Changes,
             failure =>
             {
-                Assert.Equal("il.diff.unsupported-boundary", failure.ChangeId);
+                Assert.Equal("il.diff.unsupported-boundary", failure.Descriptor.Id);
                 Assert.NotNull(failure.IlFailureRow);
                 Assert.Null(failure.IlRow);
             },
             operationRow =>
             {
-                Assert.Equal("il.operation.removed", operationRow.ChangeId);
+                Assert.Equal("il.operation.removed", operationRow.Descriptor.Id);
                 Assert.Same(ilRow, operationRow.IlRow);
-                Assert.NotNull(operationRow.IlDisplayRow);
-                Assert.Equal("h0 - IL_0000 nop", operationRow.IlDisplayRow.UnifiedLine);
+                Assert.Equal("h0 - IL_0000 nop", Assert.Single(operationRow.IlDisplayRows).UnifiedLine);
                 Assert.Null(operationRow.IlFailureRow);
             });
     }
@@ -282,17 +328,17 @@ public class ResearchDiffTests
 
         var diff = ResearchDiff.FromCSharpBodyDiff(new CSharpBodyDiffResult([csharpRow]));
 
-        var row = Assert.Single(diff.Rows);
-        Assert.Equal(csharpRow.ChangeId, row.ChangeId);
-        Assert.Equal(ResearchDiffEvidenceKind.CSharp, row.EvidenceKind);
-        Assert.Equal(csharpRow.Message, row.Message);
+        var row = Assert.Single(diff.Changes);
+        Assert.Equal(csharpRow.ChangeId, row.Descriptor.Id);
+        Assert.Equal(ResearchChangeMechanism.CSharp, row.Mechanism);
+        Assert.Equal(csharpRow.Message, row.Detail);
         Assert.Same(csharpRow, row.CSharpRow);
-        Assert.NotNull(row.CSharpDisplayRow);
-        Assert.Equal(csharpRow.HunkId, row.CSharpDisplayRow.HunkId);
-        Assert.Equal("-", row.CSharpDisplayRow.Marker);
-        Assert.Equal(CSharpDiffOperationKind.Line, row.CSharpDisplayRow.OperationKind);
-        Assert.Equal(csharpRow.Text, row.CSharpDisplayRow.Operation);
-        Assert.Contains(csharpRow.Text, row.CSharpDisplayRow.UnifiedLine, StringComparison.Ordinal);
+        var displayRow = Assert.Single(row.CSharpDisplayRows);
+        Assert.Equal(csharpRow.HunkId, displayRow.HunkId);
+        Assert.Equal("-", displayRow.Marker);
+        Assert.Equal(CSharpDiffOperationKind.Line, displayRow.OperationKind);
+        Assert.Equal(csharpRow.Text, displayRow.Operation);
+        Assert.Contains(csharpRow.Text, displayRow.UnifiedLine, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -306,16 +352,18 @@ public class ResearchDiffTests
 
         var diff = ResearchDiff.FromCSharpBodyDiff(csharp);
 
-        var row = Assert.Single(diff.Rows, row => row.CSharpFailureRow is not null);
-        Assert.Equal("csharp.diff.old-body-missing", row.ChangeId);
-        Assert.Equal(ResearchDiffEvidenceKind.CSharp, row.EvidenceKind);
-        Assert.Equal(failureRow.Message, row.Message);
+        var row = Assert.Single(diff.Changes, row => row.CSharpFailureRow is not null);
+        Assert.Equal("csharp.diff.old-body-missing", row.Descriptor.Id);
+        Assert.Equal(ResearchChangeMechanism.CSharp, row.Mechanism);
+        Assert.Equal(failureRow.Message, row.Detail);
         Assert.Same(failureRow, row.CSharpFailureRow);
         Assert.NotNull(row.CSharpDisplayFailureRow);
         Assert.Equal(CSharpDiffFailureKind.OldBodyMissing, row.CSharpDisplayFailureRow.Kind);
         Assert.Equal("old", row.CSharpDisplayFailureRow.Side);
         Assert.Equal("C# diff failed: Old method has no C# body.", row.CSharpDisplayFailureRow.UnifiedLine);
-        Assert.Contains(diff.Rows, row => row.CSharpRow is not null && row.ChangeId == "csharp.method.body-added");
+        Assert.Contains(diff.Changes, row =>
+            row.CSharpRow is not null
+            && row.Descriptor.Id == "csharp.method.body-added");
     }
 
     [Fact]
@@ -330,7 +378,7 @@ public class ResearchDiffTests
         var combined = ResearchDiff.Combine(apiResult, ilResult);
 
         Assert.Same(api, combined.ApiDiff);
-        Assert.Single(combined.Rows);
+        Assert.Single(combined.Changes);
     }
 
     [Fact]
@@ -342,7 +390,7 @@ public class ResearchDiffTests
         var diff = ResearchDiff.Compare(
             ResearchDiffInput.FromApiSurface(oldSurface),
             ResearchDiffInput.FromApiSurface(newSurface),
-            new ResearchDiffOptions(ResearchDiffMechanism.Api, ApiScope: ApiDiffScope.Attributes));
+            new ResearchDiffOptions(ResearchChangeMechanism.Api, ApiScope: ApiDiffScope.Attributes));
 
         var changed = Assert.Single(diff.MembersWhere(member => member.ApiAttributeChanged));
         Assert.Equal("Existing", changed.Subject.MemberName);
@@ -361,7 +409,7 @@ public class ResearchDiffTests
         var diff = ResearchDiff.Compare(
             ResearchDiffInput.FromApiSurface(oldSurface),
             ResearchDiffInput.FromApiSurface(newSurface),
-            new ResearchDiffOptions(ResearchDiffMechanism.Api, ApiScope: ApiDiffScope.All));
+            new ResearchDiffOptions(ResearchChangeMechanism.Api, ApiScope: ApiDiffScope.All));
 
         Assert.Single(diff.MembersWhere(member => member.ApiSignatureChanged && member.Subject.MemberName == "Added"));
         Assert.Single(diff.MembersWhere(member => member.ApiAttributeChanged && member.Subject.MemberName == "Existing"));
@@ -373,7 +421,7 @@ public class ResearchDiffTests
         var diff = ResearchDiff.CompareAssemblies(
             FixtureCatalog.DiffPair.OldAssemblyPath(),
             FixtureCatalog.DiffPair.NewAssemblyPath(),
-            new ResearchDiffOptions(ResearchDiffMechanism.BodySignals));
+            new ResearchDiffOptions(ResearchChangeMechanism.BodySignals));
 
         var unsafeMembers = diff.MembersWhere(member => member.HasChange("unsafe.stackalloc.added"));
 
@@ -389,7 +437,7 @@ public class ResearchDiffTests
         var unfiltered = ResearchDiff.CompareAssemblies(
             FixtureCatalog.DiffPair.OldAssemblyPath(),
             FixtureCatalog.DiffPair.NewAssemblyPath(),
-            new ResearchDiffOptions(ResearchDiffMechanism.BodySignals));
+            new ResearchDiffOptions(ResearchChangeMechanism.BodySignals));
         var targetId = Assert.Single(unfiltered.MembersWhere(member =>
             member.Subject.Display.Contains("AddsUnsafe", StringComparison.Ordinal)
             && member.HasChange("unsafe.stackalloc.added"))).Subject.Id;
@@ -398,7 +446,7 @@ public class ResearchDiffTests
             FixtureCatalog.DiffPair.OldAssemblyPath(),
             FixtureCatalog.DiffPair.NewAssemblyPath(),
             new ResearchDiffOptions(
-                ResearchDiffMechanism.BodySignals,
+                ResearchChangeMechanism.BodySignals,
                 MemberTargetIdentities: new HashSet<string>(StringComparer.Ordinal) { targetId }));
 
         var changed = Assert.Single(filtered.MembersWhere(member => member.HasChange("unsafe.stackalloc.added")));
@@ -413,7 +461,7 @@ public class ResearchDiffTests
             FixtureCatalog.DiffPair.OldAssemblyPath(),
             FixtureCatalog.DiffPair.NewAssemblyPath(),
             new ResearchDiffOptions(
-                ResearchDiffMechanism.BodySignals,
+                ResearchChangeMechanism.BodySignals,
                 TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "NoSuchType" }));
 
         Assert.Empty(diff.MembersWhere(member => member.HasChange("unsafe.stackalloc.added")));
@@ -439,7 +487,7 @@ public class ResearchDiffTests
         var diff = ResearchDiff.Compare(
             ResearchDiffInput.FromAssembly("old.dll", bodyIndex: oldIndex),
             ResearchDiffInput.FromAssembly("new.dll", bodyIndex: newIndex),
-            new ResearchDiffOptions(ResearchDiffMechanism.BodySignals));
+            new ResearchDiffOptions(ResearchChangeMechanism.BodySignals));
 
         Assert.Empty(diff.MembersWhere(member => member.HasChange("unsafe.stackalloc.added")));
     }
@@ -450,7 +498,7 @@ public class ResearchDiffTests
         var diff = ResearchDiff.CompareAssemblies(
             FixtureCatalog.DiffPair.OldAssemblyPath(),
             FixtureCatalog.DiffPair.NewAssemblyPath(),
-            new ResearchDiffOptions(ResearchDiffMechanism.IlBody));
+            new ResearchDiffOptions(ResearchChangeMechanism.IlBody));
 
         var changedMembers = diff.MembersWhere(member => member.ImplementationChanged);
 
@@ -462,9 +510,11 @@ public class ResearchDiffTests
 
         var constantValue = Assert.Single(changedMembers, member =>
             member.Subject.Display.Contains("ConstantValue", StringComparison.Ordinal));
-        var ilEvidence = Assert.Single(constantValue.Evidence, evidence => evidence.ChangeId == "il.hunk.changed");
-        Assert.NotEmpty(ilEvidence.IlDisplayRows);
-        Assert.Contains(ilEvidence.IlDisplayRows, row =>
+        var ilChange = Assert.Single(
+            constantValue.Changes,
+            change => change.Descriptor.Id == "il.hunk.changed");
+        Assert.NotEmpty(ilChange.IlDisplayRows);
+        Assert.Contains(ilChange.IlDisplayRows, row =>
             row.Kind == IlDiffKind.Remove
             && row.Marker == "-"
             && row.OpcodeFamily == "ldc.i4"
@@ -479,7 +529,7 @@ public class ResearchDiffTests
         var diff = ResearchDiff.CompareAssemblies(
             FixtureCatalog.DiffPair.OldAssemblyPath(),
             FixtureCatalog.DiffPair.NewAssemblyPath(),
-            new ResearchDiffOptions(ResearchDiffMechanism.CSharp, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" }));
+            new ResearchDiffOptions(ResearchChangeMechanism.CSharp, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" }));
 
         var changedMembers = diff.MembersWhere(member => member.ImplementationChanged);
 
@@ -499,16 +549,18 @@ public class ResearchDiffTests
         var diff = ResearchDiff.CompareAssemblies(
             FixtureCatalog.DiffPair.OldAssemblyPath(),
             FixtureCatalog.DiffPair.NewAssemblyPath(),
-            new ResearchDiffOptions(ResearchDiffMechanism.CSharp, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" }));
+            new ResearchDiffOptions(ResearchChangeMechanism.CSharp, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" }));
 
         var changed = Assert.Single(diff.MembersWhere(member =>
             member.Subject.Display.Contains("SemanticReturnExpression", StringComparison.Ordinal)
             && member.HasChange("csharp.return-expression.changed")));
         Assert.Contains("SemanticReturnExpression(System.Int32)", changed.Subject.Display, StringComparison.Ordinal);
-        var evidence = Assert.Single(changed.Evidence, evidence => evidence.ChangeId == "csharp.return-expression.changed");
-        Assert.Equal("value + 1", evidence.OldValue);
-        Assert.Equal("value + 2", evidence.NewValue);
-        var displayRow = Assert.Single(evidence.CSharpDisplayRows);
+        var change = Assert.Single(
+            changed.Changes,
+            change => change.Descriptor.Id == "csharp.return-expression.changed");
+        Assert.Equal("value + 1", change.OldValue);
+        Assert.Equal("value + 2", change.NewValue);
+        var displayRow = Assert.Single(change.CSharpDisplayRows);
         Assert.Equal("~", displayRow.Marker);
         Assert.Equal(CSharpDiffOperationKind.ReturnExpression, displayRow.OperationKind);
         Assert.Equal("return value + 1 => return value + 2", displayRow.Operation);
@@ -521,19 +573,21 @@ public class ResearchDiffTests
         var diff = ResearchDiff.CompareAssemblies(
             FixtureCatalog.DiffPair.OldAssemblyPath(),
             FixtureCatalog.DiffPair.NewAssemblyPath(),
-            new ResearchDiffOptions(ResearchDiffMechanism.CSharp, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "BodyStateSample" }));
+            new ResearchDiffOptions(ResearchChangeMechanism.CSharp, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "BodyStateSample" }));
 
         var changed = Assert.Single(diff.MembersWhere(member =>
             member.Subject.Display.Contains("BodyStateSample", StringComparison.Ordinal)
             && member.HasChange("csharp.diff.old-body-missing")));
         Assert.Contains("BodyStateSample.BodyState()", changed.Subject.Display, StringComparison.Ordinal);
-        var evidence = Assert.Single(changed.Evidence, evidence => evidence.ChangeId == "csharp.diff.old-body-missing");
-        Assert.Equal(ResearchDiffDirection.Added, evidence.Direction);
-        Assert.NotNull(evidence.CSharpDisplayFailureRow);
-        Assert.Equal(CSharpDiffFailureKind.OldBodyMissing, evidence.CSharpDisplayFailureRow.Kind);
-        Assert.Equal("old", evidence.CSharpDisplayFailureRow.Side);
-        Assert.Equal("C# diff failed: Old method has no C# body.", evidence.CSharpDisplayFailureRow.UnifiedLine);
-        Assert.Contains(changed.Evidence, evidence => evidence.ChangeId == "csharp.method.body-added");
+        var change = Assert.Single(
+            changed.Changes,
+            change => change.Descriptor.Id == "csharp.diff.old-body-missing");
+        Assert.Equal(ResearchChangeKind.Added, change.Kind);
+        Assert.NotNull(change.CSharpDisplayFailureRow);
+        Assert.Equal(CSharpDiffFailureKind.OldBodyMissing, change.CSharpDisplayFailureRow.Kind);
+        Assert.Equal("old", change.CSharpDisplayFailureRow.Side);
+        Assert.Equal("C# diff failed: Old method has no C# body.", change.CSharpDisplayFailureRow.UnifiedLine);
+        Assert.Contains(changed.Changes, change => change.Descriptor.Id == "csharp.method.body-added");
     }
 
     [Fact]
@@ -542,12 +596,12 @@ public class ResearchDiffTests
         var diff = ResearchDiff.CompareAssemblies(
             FixtureCatalog.DiffPair.OldAssemblyPath(),
             FixtureCatalog.DiffPair.NewAssemblyPath(),
-            new ResearchDiffOptions(ResearchDiffMechanism.Api | ResearchDiffMechanism.CSharp, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MethodRemovalSample" }));
+            new ResearchDiffOptions(ResearchChangeMechanism.Api | ResearchChangeMechanism.CSharp, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MethodRemovalSample" }));
 
         var changed = Assert.Single(diff.MembersWhere(member =>
             member.Subject.MemberName == "Removed"
-            && member.HasMechanism(ResearchDiffMechanism.Api)
-            && member.HasMechanism(ResearchDiffMechanism.CSharp)));
+            && member.HasMechanism(ResearchChangeMechanism.Api)
+            && member.HasMechanism(ResearchChangeMechanism.CSharp)));
 
         Assert.StartsWith("Removed~", changed.Subject.Id, StringComparison.Ordinal);
     }
@@ -558,14 +612,16 @@ public class ResearchDiffTests
         var diff = ResearchDiff.CompareAssemblies(
             FixtureCatalog.DiffPair.OldAssemblyPath(),
             FixtureCatalog.DiffPair.NewAssemblyPath(),
-            new ResearchDiffOptions(ResearchDiffMechanism.Api | ResearchDiffMechanism.CSharp, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MethodRemovalSample" }));
+            new ResearchDiffOptions(ResearchChangeMechanism.Api | ResearchChangeMechanism.CSharp, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MethodRemovalSample" }));
 
         Assert.Contains(diff.MembersWhere(member =>
             member.Subject.MemberName == "Removed"
-            && member.HasMechanism(ResearchDiffMechanism.Api)
-            && member.HasMechanism(ResearchDiffMechanism.CSharp)), member =>
+            && member.HasMechanism(ResearchChangeMechanism.Api)
+            && member.HasMechanism(ResearchChangeMechanism.CSharp)), member =>
             member.Subject.Id.StartsWith("Removed~", StringComparison.Ordinal)
-            && member.Evidence.Any(evidence => evidence.Mechanism == ResearchDiffMechanism.CSharp && evidence.OldValue?.Contains("method removed", StringComparison.Ordinal) == true));
+            && member.Changes.Any(change =>
+                change.Mechanism == ResearchChangeMechanism.CSharp
+                && change.OldValue?.Contains("method removed", StringComparison.Ordinal) == true));
     }
 
     [Fact]
@@ -574,12 +630,12 @@ public class ResearchDiffTests
         var diff = ResearchDiff.CompareAssemblies(
             FixtureCatalog.DiffPair.OldAssemblyPath(),
             FixtureCatalog.DiffPair.NewAssemblyPath(),
-            new ResearchDiffOptions(ResearchDiffMechanism.Api | ResearchDiffMechanism.CSharp, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ConstructorRemovalSample" }));
+            new ResearchDiffOptions(ResearchChangeMechanism.Api | ResearchChangeMechanism.CSharp, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ConstructorRemovalSample" }));
 
         var changed = Assert.Single(diff.MembersWhere(member =>
             member.Subject.MemberName == ".ctor"
-            && member.HasMechanism(ResearchDiffMechanism.Api)
-            && member.HasMechanism(ResearchDiffMechanism.CSharp)));
+            && member.HasMechanism(ResearchChangeMechanism.Api)
+            && member.HasMechanism(ResearchChangeMechanism.CSharp)));
 
         Assert.StartsWith(".ctor~", changed.Subject.Id, StringComparison.Ordinal);
     }
@@ -590,12 +646,12 @@ public class ResearchDiffTests
         var diff = ResearchDiff.CompareAssemblies(
             FixtureCatalog.DiffPair.OldAssemblyPath(),
             FixtureCatalog.DiffPair.NewAssemblyPath(),
-            new ResearchDiffOptions(ResearchDiffMechanism.CSharp | ResearchDiffMechanism.IlBody, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "OperatorSample" }));
+            new ResearchDiffOptions(ResearchChangeMechanism.CSharp | ResearchChangeMechanism.IlBody, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "OperatorSample" }));
 
         var changed = Assert.Single(diff.MembersWhere(member =>
             member.Subject.MemberName == "op_Addition"
-            && member.HasMechanism(ResearchDiffMechanism.CSharp)
-            && member.HasMechanism(ResearchDiffMechanism.IlBody)));
+            && member.HasMechanism(ResearchChangeMechanism.CSharp)
+            && member.HasMechanism(ResearchChangeMechanism.IlBody)));
 
         Assert.StartsWith("operator:op_Addition~", changed.Subject.Id, StringComparison.Ordinal);
     }
@@ -606,12 +662,12 @@ public class ResearchDiffTests
         var diff = ResearchDiff.CompareAssemblies(
             FixtureCatalog.DiffPair.OldAssemblyPath(),
             FixtureCatalog.DiffPair.NewAssemblyPath(),
-            new ResearchDiffOptions(ResearchDiffMechanism.CSharp | ResearchDiffMechanism.IlBody, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ConversionSample" }));
+            new ResearchDiffOptions(ResearchChangeMechanism.CSharp | ResearchChangeMechanism.IlBody, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ConversionSample" }));
 
         var changed = Assert.Single(diff.MembersWhere(member =>
             member.Subject.MemberName == "op_Implicit"
-            && member.HasMechanism(ResearchDiffMechanism.CSharp)
-            && member.HasMechanism(ResearchDiffMechanism.IlBody)));
+            && member.HasMechanism(ResearchChangeMechanism.CSharp)
+            && member.HasMechanism(ResearchChangeMechanism.IlBody)));
 
         Assert.StartsWith("operator:op_Implicit~", changed.Subject.Id, StringComparison.Ordinal);
     }
@@ -622,12 +678,12 @@ public class ResearchDiffTests
         var diff = ResearchDiff.CompareAssemblies(
             FixtureCatalog.DiffPair.OldAssemblyPath(),
             FixtureCatalog.DiffPair.NewAssemblyPath(),
-            new ResearchDiffOptions(ResearchDiffMechanism.CSharp | ResearchDiffMechanism.IlBody, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" }));
+            new ResearchDiffOptions(ResearchChangeMechanism.CSharp | ResearchChangeMechanism.IlBody, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" }));
 
         var changed = Assert.Single(diff.MembersWhere(member =>
             member.Subject.MemberName == "GenericParamBody"
-            && member.HasMechanism(ResearchDiffMechanism.CSharp)
-            && member.HasMechanism(ResearchDiffMechanism.IlBody)));
+            && member.HasMechanism(ResearchChangeMechanism.CSharp)
+            && member.HasMechanism(ResearchChangeMechanism.IlBody)));
 
         Assert.StartsWith("GenericParamBody~", changed.Subject.Id, StringComparison.Ordinal);
     }
@@ -638,12 +694,12 @@ public class ResearchDiffTests
         var diff = ResearchDiff.CompareAssemblies(
             FixtureCatalog.DiffPair.OldAssemblyPath(),
             FixtureCatalog.DiffPair.NewAssemblyPath(),
-            new ResearchDiffOptions(ResearchDiffMechanism.CSharp | ResearchDiffMechanism.IlBody, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ExtensionSample" }));
+            new ResearchDiffOptions(ResearchChangeMechanism.CSharp | ResearchChangeMechanism.IlBody, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ExtensionSample" }));
 
         var changed = Assert.Single(diff.MembersWhere(member =>
             member.Subject.MemberName == "Twice"
-            && member.HasMechanism(ResearchDiffMechanism.CSharp)
-            && member.HasMechanism(ResearchDiffMechanism.IlBody)));
+            && member.HasMechanism(ResearchChangeMechanism.CSharp)
+            && member.HasMechanism(ResearchChangeMechanism.IlBody)));
 
         Assert.StartsWith("extension:Twice~", changed.Subject.Id, StringComparison.Ordinal);
     }
@@ -654,12 +710,12 @@ public class ResearchDiffTests
         var diff = ResearchDiff.CompareAssemblies(
             FixtureCatalog.DiffPair.OldAssemblyPath(),
             FixtureCatalog.DiffPair.NewAssemblyPath(),
-            new ResearchDiffOptions(ResearchDiffMechanism.CSharp | ResearchDiffMechanism.IlBody, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ExplicitSurface" }));
+            new ResearchDiffOptions(ResearchChangeMechanism.CSharp | ResearchChangeMechanism.IlBody, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ExplicitSurface" }));
 
         var changed = Assert.Single(diff.MembersWhere(member =>
             member.Subject.MemberName == "DiffFixtureSample.IExplicitSurface.Get"
-            && member.HasMechanism(ResearchDiffMechanism.CSharp)
-            && member.HasMechanism(ResearchDiffMechanism.IlBody)));
+            && member.HasMechanism(ResearchChangeMechanism.CSharp)
+            && member.HasMechanism(ResearchChangeMechanism.IlBody)));
 
         Assert.StartsWith("explicit:DiffFixtureSample.IExplicitSurface.Get~", changed.Subject.Id, StringComparison.Ordinal);
     }
@@ -673,7 +729,7 @@ public class ResearchDiffTests
 
         Assert.Contains(diff.MembersWhere(member => member.ImplementationChanged), member =>
             member.Subject.Display.Contains("ConstantValue", StringComparison.Ordinal)
-            && member.HasMechanism(ResearchDiffMechanism.CSharp));
+            && member.HasMechanism(ResearchChangeMechanism.CSharp));
     }
 
     [Fact]
@@ -685,8 +741,8 @@ public class ResearchDiffTests
 
         var changed = Assert.Single(diff.MembersWhere(member =>
             member.Subject.MemberName == "ConstantValue"
-            && member.HasMechanism(ResearchDiffMechanism.CSharp)
-            && member.HasMechanism(ResearchDiffMechanism.IlBody)));
+            && member.HasMechanism(ResearchChangeMechanism.CSharp)
+            && member.HasMechanism(ResearchChangeMechanism.IlBody)));
 
         Assert.StartsWith("ConstantValue~", changed.Subject.Id, StringComparison.Ordinal);
     }
@@ -701,14 +757,14 @@ public class ResearchDiffTests
 
         var changed = Assert.Single(diff.Members, member => member.Subject.MemberName == "ConstantValue");
 
-        Assert.True(changed.HasCSharpEvidence);
-        Assert.True(changed.HasIlEvidence);
-        Assert.Contains(changed.Evidence, evidence =>
-            evidence.Kind == ImplementationDiffEvidenceKind.CSharp
-            && evidence.UnifiedLines.Any(line => line.Contains("return 1", StringComparison.Ordinal)));
-        Assert.Contains(changed.Evidence, evidence =>
-            evidence.Kind == ImplementationDiffEvidenceKind.IlBody
-            && evidence.UnifiedLines.Any(line => line.Contains("ldc.i4 1", StringComparison.Ordinal)));
+        Assert.True(changed.HasCSharpChanges);
+        Assert.True(changed.HasIlChanges);
+        Assert.Contains(changed.Changes, change =>
+            change.Mechanism == ResearchChangeMechanism.CSharp
+            && ImplementationDiff.UnifiedLines(change).Any(line => line.Contains("return 1", StringComparison.Ordinal)));
+        Assert.Contains(changed.Changes, change =>
+            change.Mechanism == ResearchChangeMechanism.IlBody
+            && ImplementationDiff.UnifiedLines(change).Any(line => line.Contains("ldc.i4 1", StringComparison.Ordinal)));
     }
 
     [Fact]
@@ -723,8 +779,8 @@ public class ResearchDiffTests
             string.Equals(member.Subject.MemberName, "ConstantValue", StringComparison.Ordinal));
         Assert.Contains(diff.Members, member =>
             string.Equals(member.Subject.MemberName, "op_Addition", StringComparison.Ordinal)
-            && member.HasCSharpEvidence
-            && member.HasIlEvidence);
+            && member.HasCSharpChanges
+            && member.HasIlChanges);
     }
 
     [Fact]
@@ -743,12 +799,12 @@ public class ResearchDiffTests
                 TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" },
                 MemberTargetIdentities: new HashSet<string>(StringComparer.Ordinal) { targetId }));
 
-        var researchMembers = scoped.ResearchDiff.MembersWhere(member => member.ImplementationChanged);
+        var researchMembers = scoped.Research.MembersWhere(member => member.ImplementationChanged);
         Assert.All(researchMembers, member => Assert.Equal(targetId, member.Subject.Id));
         var member = Assert.Single(scoped.Members);
         Assert.Equal(targetId, member.Subject.Id);
-        Assert.True(member.HasCSharpEvidence);
-        Assert.True(member.HasIlEvidence);
+        Assert.True(member.HasCSharpChanges);
+        Assert.True(member.HasIlChanges);
     }
 
     [Fact]
@@ -765,7 +821,7 @@ public class ResearchDiffTests
         Assert.True(diff.CSharpDiff.IsExact);
         Assert.NotNull(diff.IlDiff);
         Assert.True(diff.IlDiff.Diff.IsExact);
-        Assert.Empty(diff.Evidence);
+        Assert.Empty(diff.Changes);
     }
 
     [Fact]
@@ -780,18 +836,18 @@ public class ResearchDiffTests
 
         Assert.False(diff.IsExact);
         Assert.Equal("ConstantValue", diff.Subject.MemberName);
-        Assert.True(diff.HasCSharpEvidence);
-        Assert.True(diff.HasIlEvidence);
-        Assert.Contains(diff.Evidence, evidence =>
-            evidence.Kind == ImplementationDiffEvidenceKind.CSharp
-            && evidence.UnifiedLines.Any(line => line.Contains("return 1", StringComparison.Ordinal)));
-        Assert.Contains(diff.Evidence, evidence =>
-            evidence.Kind == ImplementationDiffEvidenceKind.IlBody
-            && evidence.UnifiedLines.Any(line => line.Contains("ldc.i4 1", StringComparison.Ordinal)));
+        Assert.True(diff.HasCSharpChanges);
+        Assert.True(diff.HasIlChanges);
+        Assert.Contains(diff.Changes, change =>
+            change.Mechanism == ResearchChangeMechanism.CSharp
+            && ImplementationDiff.UnifiedLines(change).Any(line => line.Contains("return 1", StringComparison.Ordinal)));
+        Assert.Contains(diff.Changes, change =>
+            change.Mechanism == ResearchChangeMechanism.IlBody
+            && ImplementationDiff.UnifiedLines(change).Any(line => line.Contains("ldc.i4 1", StringComparison.Ordinal)));
     }
 
     [Fact]
-    public void ImplementationDiff_ToIlEvidence_ProjectsTypedMemberDiffRows()
+    public void ImplementationDiff_ToIlChanges_ProjectsTypedMemberDiffRows()
     {
         var typedDiff = new IlMemberDiffResult(
             new IlMemberDiffSubject("old-id", "old-label"),
@@ -818,17 +874,17 @@ public class ResearchDiffTests
                         "Added IL operation 'ldc.i4 2'"),
                 ]));
 
-        var evidence = ImplementationDiff.ToIlEvidence(typedDiff);
+        var changes = ImplementationDiff.ToIlChanges(typedDiff);
 
-        Assert.DoesNotContain(evidence, item => item.ChangeId == "il.operation.context");
-        Assert.Contains(evidence, item =>
-            item.ChangeId == "il.operation.removed"
+        Assert.DoesNotContain(changes, item => item.Descriptor.Id == "il.operation.context");
+        Assert.Contains(changes, item =>
+            item.Descriptor.Id == "il.operation.removed"
             && item.OldValue == "ldc.i4 1"
             && item.OldIlOffset == 1
             && item.IlMemberDiff == typedDiff
             && item.IlDisplayRows.Single().UnifiedLine == "h1 - IL_0001 ldc.i4 1");
-        Assert.Contains(evidence, item =>
-            item.ChangeId == "il.operation.added"
+        Assert.Contains(changes, item =>
+            item.Descriptor.Id == "il.operation.added"
             && item.NewValue == "ldc.i4 2"
             && item.NewIlOffset == 1
             && item.IlMemberDiff == typedDiff
@@ -836,7 +892,7 @@ public class ResearchDiffTests
     }
 
     [Fact]
-    public void ImplementationDiff_ToIlEvidence_FallsBackWhenTypedDiffHasNoRows()
+    public void ImplementationDiff_ToIlChanges_FallsBackWhenTypedDiffHasNoRows()
     {
         var typedDiff = new IlMemberDiffResult(
             new IlMemberDiffSubject("old-id", "old-label"),
@@ -855,10 +911,12 @@ public class ResearchDiffTests
             Rows: [],
             FailureRows: [failure]);
 
-        var evidence = ImplementationDiff.ToIlEvidence(typedDiff, fallback);
+        var changes = ImplementationDiff.ToIlChanges(
+            typedDiff,
+            fallbackDisplay: fallback);
 
-        var row = Assert.Single(evidence);
-        Assert.Equal("il.diff.new-body-missing", row.ChangeId);
+        var row = Assert.Single(changes);
+        Assert.Equal("il.diff.new-body-missing", row.Descriptor.Id);
         Assert.Equal("method has no body", row.Detail);
         Assert.Same(failure, row.IlDisplayFailureRow);
         Assert.Null(row.IlMemberDiff);

--- a/src/ILInspector.Research/ILInspector.Research.csproj
+++ b/src/ILInspector.Research/ILInspector.Research.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler\ILInspector.Decompiler.csproj" />
+    <ProjectReference Include="..\ILInspector.Findings\ILInspector.Findings.csproj" />
     <ProjectReference Include="..\ILInspector.Instructions\ILInspector.Instructions.csproj" />
     <ProjectReference Include="..\ILInspector.Metadata\ILInspector.Metadata.csproj" />
   </ItemGroup>

--- a/src/ILInspector.Research/ImplementationDiff.cs
+++ b/src/ILInspector.Research/ImplementationDiff.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
+using ILInspector.Findings;
 using ILInspector.Instructions;
 using ILInspector.Metadata;
 using ILInspector.MetadataPrimitives;
@@ -18,12 +19,6 @@ public enum ImplementationDiffMechanism
     All = CSharp | IlBody,
 }
 
-public enum ImplementationDiffEvidenceKind
-{
-    CSharp,
-    IlBody,
-}
-
 public sealed record ImplementationDiffOptions(
     ImplementationDiffMechanism Mechanisms = ImplementationDiffMechanism.All,
     IReadOnlySet<string>? TypeFilters = null,
@@ -31,69 +26,43 @@ public sealed record ImplementationDiffOptions(
 
 public sealed record ImplementationDiffResult(
     IReadOnlyList<ImplementationDiffMember> Members,
-    ResearchDiffResult ResearchDiff)
+    ResearchComparison Research)
 {
     public bool IsEmpty => Members.Count == 0;
 }
 
 public sealed record ImplementationDiffMember(
     ResearchSubjectKey Subject,
-    IReadOnlyList<ImplementationDiffEvidence> Evidence)
+    IReadOnlyList<ResearchChange> Changes)
 {
-    public bool HasCSharpEvidence => Evidence.Any(evidence => evidence.Kind == ImplementationDiffEvidenceKind.CSharp);
-    public bool HasIlEvidence => Evidence.Any(evidence => evidence.Kind == ImplementationDiffEvidenceKind.IlBody);
+    public bool HasCSharpChanges
+        => Changes.Any(change => change.Mechanism == ResearchChangeMechanism.CSharp);
+
+    public bool HasIlChanges
+        => Changes.Any(change => change.Mechanism == ResearchChangeMechanism.IlBody);
 }
 
 public sealed record ImplementationMemberDiffResult(
     ResearchSubjectKey Subject,
     CSharpBodyDiffResult? CSharpDiff,
     IlMemberDiffResult? IlDiff,
-    IReadOnlyList<ImplementationDiffEvidence> Evidence)
+    IReadOnlyList<ResearchChange> Changes)
 {
-    public bool HasCSharpEvidence => Evidence.Any(evidence => evidence.Kind == ImplementationDiffEvidenceKind.CSharp);
-    public bool HasIlEvidence => Evidence.Any(evidence => evidence.Kind == ImplementationDiffEvidenceKind.IlBody);
+    public bool HasCSharpChanges
+        => Changes.Any(change => change.Mechanism == ResearchChangeMechanism.CSharp);
+
+    public bool HasIlChanges
+        => Changes.Any(change => change.Mechanism == ResearchChangeMechanism.IlBody);
+
     public bool IsExact
-        => Evidence.Count == 0
+        => Changes.Count == 0
            && (CSharpDiff is null || CSharpDiff.IsExact)
            && (IlDiff is null || IlDiff.Diff.IsExact);
 }
 
-public sealed record ImplementationDiffEvidence(
-    ImplementationDiffEvidenceKind Kind,
-    string ChangeId,
-    ResearchDiffDirection Direction,
-    string? OldValue = null,
-    string? NewValue = null,
-    string? Detail = null,
-    int? OldIlOffset = null,
-    int? NewIlOffset = null,
-    ImmutableArray<CSharpDiffDisplayRow> CSharpDisplayRows = default,
-    CSharpDiffDisplayFailureRow? CSharpDisplayFailureRow = null,
-    ImmutableArray<IlDiffDisplayRow> IlDisplayRows = default,
-    IlDiffDisplayFailureRow? IlDisplayFailureRow = null,
-    IlMemberDiffResult? IlMemberDiff = null)
-{
-    public ImmutableArray<string> UnifiedLines
-    {
-        get
-        {
-            var lines = ImmutableArray.CreateBuilder<string>();
-            if (CSharpDisplayFailureRow is not null)
-                lines.Add(CSharpDisplayFailureRow.UnifiedLine);
-            if (!CSharpDisplayRows.IsDefaultOrEmpty)
-                lines.AddRange(CSharpDisplayRows.Select(row => row.UnifiedLine));
-            if (IlDisplayFailureRow is not null)
-                lines.Add(IlDisplayFailureRow.UnifiedLine);
-            if (!IlDisplayRows.IsDefaultOrEmpty)
-                lines.AddRange(IlDisplayRows.Select(row => row.UnifiedLine));
-            return lines.ToImmutable();
-        }
-    }
-}
-
 /// <summary>
 /// Product-owned implementation diff projection that joins C# source-shape and
-/// IL/body evidence by Research member identity.
+/// IL/body changes by Research member identity.
 /// </summary>
 public static class ImplementationDiff
 {
@@ -128,12 +97,12 @@ public static class ImplementationDiff
         subject ??= SubjectFromMethod(oldSource, oldMethod);
         CSharpBodyDiffResult? csharpDiff = null;
         IlMemberDiffResult? ilDiff = null;
-        var evidence = ImmutableArray.CreateBuilder<ImplementationDiffEvidence>();
+        var changes = ImmutableArray.CreateBuilder<ResearchChange>();
 
         if (mechanisms.HasFlag(ImplementationDiffMechanism.CSharp))
         {
             csharpDiff = CSharpBodyDiff.CompareMembers(oldSource, oldMethod, newSource, newMethod);
-            evidence.AddRange(ToCSharpImplementationEvidence(csharpDiff));
+            changes.AddRange(ToCSharpChanges(csharpDiff, subject));
         }
 
         if (mechanisms.HasFlag(ImplementationDiffMechanism.IlBody))
@@ -150,10 +119,10 @@ public static class ImplementationDiff
                 newMethod,
                 oldLabel: label,
                 newLabel: label);
-            evidence.AddRange(ToIlEvidence(ilDiff).Select(item => ToImplementationEvidence(item)!));
+            changes.AddRange(ToIlChanges(ilDiff, subject));
         }
 
-        return new ImplementationMemberDiffResult(subject, csharpDiff, ilDiff, evidence.ToImmutable());
+        return new ImplementationMemberDiffResult(subject, csharpDiff, ilDiff, changes.ToImmutable());
     }
 
     public static ImplementationDiffResult Compare(
@@ -169,11 +138,11 @@ public static class ImplementationDiff
             ToResearchMechanisms(options.Mechanisms),
             TypeFilters: options.TypeFilters,
             MemberTargetIdentities: options.MemberTargetIdentities));
-        return FromResearchDiff(research, options);
+        return FromResearchComparison(research, options);
     }
 
-    public static ImplementationDiffResult FromResearchDiff(
-        ResearchDiffResult research,
+    public static ImplementationDiffResult FromResearchComparison(
+        ResearchComparison research,
         ImplementationDiffOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(research);
@@ -182,8 +151,10 @@ public static class ImplementationDiff
         var members = research.MembersWhere(member => member.ImplementationChanged)
             .Select(member => new ImplementationDiffMember(
                 member.Subject,
-                [.. member.Evidence.Select(ToImplementationEvidence).Where(evidence => evidence is not null).Select(evidence => evidence!)]))
-            .Where(member => member.Evidence.Count > 0)
+                [.. member.Changes.Where(change =>
+                    change.Mechanism is ResearchChangeMechanism.CSharp
+                        or ResearchChangeMechanism.IlBody)]))
+            .Where(member => member.Changes.Count > 0)
             .Where(member => ResearchDiff.MatchesTypeFilters(member.Subject.TypeName ?? "", options.TypeFilters))
             .Where(member => MatchesMemberTargets(member.Subject, options.MemberTargetIdentities))
             .ToArray();
@@ -191,21 +162,29 @@ public static class ImplementationDiff
         return new ImplementationDiffResult(members, research);
     }
 
-    public static ImmutableArray<ResearchDiffEvidence> ToIlEvidence(
+    public static ImmutableArray<ResearchChange> ToIlChanges(
         IlMemberDiffResult? diff,
+        ResearchSubjectKey? subject = null,
         IlDiffDisplayResult? fallbackDisplay = null)
     {
+        subject ??= diff is { } typedDiff
+            ? new ResearchSubjectKey(
+                ResearchSubjectKind.Member,
+                typedDiff.New.Identity,
+                typedDiff.New.Label)
+            : new ResearchSubjectKey(ResearchSubjectKind.Member, "member:il-body", "il-body");
         if (diff is not { } typed)
-            return fallbackDisplay is null ? [] : ToIlEvidence(fallbackDisplay);
+            return fallbackDisplay is null ? [] : ToIlChanges(fallbackDisplay, subject);
 
-        var typedEvidence = ToIlEvidence(IlDiffPrinter.ToDisplayResult(typed.Diff), typed);
-        return typedEvidence.IsEmpty && fallbackDisplay is not null
-            ? ToIlEvidence(fallbackDisplay)
-            : typedEvidence;
+        var typedChanges = ToIlChanges(IlDiffPrinter.ToDisplayResult(typed.Diff), subject, typed);
+        return typedChanges.IsEmpty && fallbackDisplay is not null
+            ? ToIlChanges(fallbackDisplay, subject)
+            : typedChanges;
     }
 
-    public static ImmutableArray<ResearchDiffEvidence> ToIlEvidence(
+    public static ImmutableArray<ResearchChange> ToIlChanges(
         IlDiffDisplayResult display,
+        ResearchSubjectKey subject,
         IlMemberDiffResult? diff = null)
     {
         ArgumentNullException.ThrowIfNull(display);
@@ -213,29 +192,32 @@ public static class ImplementationDiff
         if (display.IsEmpty)
             return [];
 
-        var evidence = ImmutableArray.CreateBuilder<ResearchDiffEvidence>();
+        var changes = ImmutableArray.CreateBuilder<ResearchChange>();
         var failureRows = display.FailureRows.IsDefault ? [] : display.FailureRows;
         foreach (var failureRow in failureRows)
         {
-            evidence.Add(new ResearchDiffEvidence(
-                ResearchDiffMechanism.IlBody,
-                $"il.diff.{ResearchDiff.ToChangeIdPart(failureRow.Kind.ToString())}",
-                ResearchDiffDirection.Changed,
-                Detail: failureRow.Detail ?? failureRow.Message,
-                Category: ResearchDiffChangeCategory.IlBody,
-                IlDisplayFailureRow: failureRow,
-                IlMemberDiff: diff));
+            string descriptorId = $"il.diff.{ResearchDiff.ToChangeIdPart(failureRow.Kind.ToString())}";
+            changes.Add(new ResearchChange(
+                subject,
+                ResearchChangeMechanism.IlBody,
+                new FindingDescriptor(descriptorId, failureRow.Kind.ToString()),
+                ResearchChangeKind.Changed,
+                detail: failureRow.Detail ?? failureRow.Message,
+                category: ResearchChangeCategory.IlBody,
+                ilDisplayFailureRow: failureRow,
+                ilMemberDiff: diff));
         }
 
         if (failureRows.IsDefaultOrEmpty && display.Failure is { Length: > 0 } failure)
         {
-            evidence.Add(new ResearchDiffEvidence(
-                ResearchDiffMechanism.IlBody,
-                "il.diff.failed",
-                ResearchDiffDirection.Changed,
-                Detail: failure,
-                Category: ResearchDiffChangeCategory.IlBody,
-                IlMemberDiff: diff));
+            changes.Add(new ResearchChange(
+                subject,
+                ResearchChangeMechanism.IlBody,
+                new FindingDescriptor("il.diff.failed", "IL diff failed"),
+                ResearchChangeKind.Changed,
+                detail: failure,
+                category: ResearchChangeCategory.IlBody,
+                ilMemberDiff: diff));
         }
 
         var displayRows = display.Rows.IsDefault ? [] : display.Rows;
@@ -244,108 +226,111 @@ public static class ImplementationDiff
             if (displayRow.Kind == IlDiffKind.Context)
                 continue;
 
-            var direction = displayRow.Kind == IlDiffKind.Add
-                ? ResearchDiffDirection.Added
-                : ResearchDiffDirection.Removed;
-            evidence.Add(new ResearchDiffEvidence(
-                ResearchDiffMechanism.IlBody,
-                displayRow.Kind == IlDiffKind.Add ? "il.operation.added" : "il.operation.removed",
-                direction,
-                OldValue: displayRow.Kind == IlDiffKind.Remove ? displayRow.Operation : null,
-                NewValue: displayRow.Kind == IlDiffKind.Add ? displayRow.Operation : null,
-                OldIlOffset: displayRow.Kind == IlDiffKind.Remove ? displayRow.RawOffset : null,
-                NewIlOffset: displayRow.Kind == IlDiffKind.Add ? displayRow.RawOffset : null,
-                Detail: displayRow.Message,
-                Category: ResearchDiffChangeCategory.IlBody,
-                IlDisplayRows: [displayRow],
-                IlMemberDiff: diff));
+            var kind = displayRow.Kind == IlDiffKind.Add
+                ? ResearchChangeKind.Added
+                : ResearchChangeKind.Removed;
+            string descriptorId = displayRow.Kind == IlDiffKind.Add
+                ? "il.operation.added"
+                : "il.operation.removed";
+            changes.Add(new ResearchChange(
+                subject,
+                ResearchChangeMechanism.IlBody,
+                new FindingDescriptor(descriptorId, "IL operation"),
+                kind,
+                oldValue: displayRow.Kind == IlDiffKind.Remove ? displayRow.Operation : null,
+                newValue: displayRow.Kind == IlDiffKind.Add ? displayRow.Operation : null,
+                oldIlOffset: displayRow.Kind == IlDiffKind.Remove ? displayRow.RawOffset : null,
+                newIlOffset: displayRow.Kind == IlDiffKind.Add ? displayRow.RawOffset : null,
+                detail: displayRow.Message,
+                category: ResearchChangeCategory.IlBody,
+                ilDisplayRows: [displayRow],
+                ilMemberDiff: diff));
         }
 
-        return evidence.ToImmutable();
+        return changes.ToImmutable();
     }
 
-    static ImmutableArray<ImplementationDiffEvidence> ToCSharpImplementationEvidence(CSharpBodyDiffResult diff)
+    public static ImmutableArray<string> UnifiedLines(ResearchChange change)
+    {
+        ArgumentNullException.ThrowIfNull(change);
+        var lines = ImmutableArray.CreateBuilder<string>();
+        if (change.CSharpDisplayFailureRow is not null)
+            lines.Add(change.CSharpDisplayFailureRow.UnifiedLine);
+        if (!change.CSharpDisplayRows.IsDefaultOrEmpty)
+            lines.AddRange(change.CSharpDisplayRows.Select(row => row.UnifiedLine));
+        if (change.IlDisplayFailureRow is not null)
+            lines.Add(change.IlDisplayFailureRow.UnifiedLine);
+        if (!change.IlDisplayRows.IsDefaultOrEmpty)
+            lines.AddRange(change.IlDisplayRows.Select(row => row.UnifiedLine));
+        return lines.ToImmutable();
+    }
+
+    static ImmutableArray<ResearchChange> ToCSharpChanges(
+        CSharpBodyDiffResult diff,
+        ResearchSubjectKey subject)
     {
         ArgumentNullException.ThrowIfNull(diff);
         if (diff.IsExact)
             return [];
 
-        var evidence = ImmutableArray.CreateBuilder<ImplementationDiffEvidence>();
+        var changes = ImmutableArray.CreateBuilder<ResearchChange>();
         foreach (var failure in diff.FailureRows.IsDefault ? [] : diff.FailureRows)
         {
-            var direction = failure.Kind switch
+            var kind = failure.Kind switch
             {
-                CSharpDiffFailureKind.OldBodyMissing => ResearchDiffDirection.Added,
-                CSharpDiffFailureKind.NewBodyMissing => ResearchDiffDirection.Removed,
-                _ => ResearchDiffDirection.Changed,
+                CSharpDiffFailureKind.OldBodyMissing => ResearchChangeKind.Added,
+                CSharpDiffFailureKind.NewBodyMissing => ResearchChangeKind.Removed,
+                _ => ResearchChangeKind.Changed,
             };
-            evidence.Add(new ImplementationDiffEvidence(
-                ImplementationDiffEvidenceKind.CSharp,
-                $"csharp.diff.{ResearchDiff.ToChangeIdPart(failure.Kind.ToString())}",
-                direction,
-                OldValue: failure.Side == "old" ? failure.Detail ?? failure.Message : null,
-                NewValue: failure.Side == "new" ? failure.Detail ?? failure.Message : null,
-                Detail: failure.Detail ?? failure.Message,
-                CSharpDisplayFailureRow: CSharpDiffPrinter.ToDisplayFailureRow(failure)));
+            string descriptorId = $"csharp.diff.{ResearchDiff.ToChangeIdPart(failure.Kind.ToString())}";
+            changes.Add(new ResearchChange(
+                subject,
+                ResearchChangeMechanism.CSharp,
+                new FindingDescriptor(descriptorId, failure.Kind.ToString()),
+                kind,
+                oldValue: failure.Side == "old" ? failure.Detail ?? failure.Message : null,
+                newValue: failure.Side == "new" ? failure.Detail ?? failure.Message : null,
+                detail: failure.Detail ?? failure.Message,
+                category: ResearchChangeCategory.CSharp,
+                cSharpDisplayFailureRow: CSharpDiffPrinter.ToDisplayFailureRow(failure)));
         }
 
         foreach (var row in diff.Rows.IsDefault ? [] : diff.Rows)
         {
-            var direction = row.Kind switch
+            var kind = row.Kind switch
             {
-                CSharpDiffKind.Add => ResearchDiffDirection.Added,
-                CSharpDiffKind.Remove => ResearchDiffDirection.Removed,
-                _ => ResearchDiffDirection.Changed,
+                CSharpDiffKind.Add => ResearchChangeKind.Added,
+                CSharpDiffKind.Remove => ResearchChangeKind.Removed,
+                _ => ResearchChangeKind.Changed,
             };
-            evidence.Add(new ImplementationDiffEvidence(
-                ImplementationDiffEvidenceKind.CSharp,
-                row.ChangeId,
-                direction,
-                OldValue: row.OldOperation?.Value ?? row.OldValue ?? (direction == ResearchDiffDirection.Removed ? row.Text : null),
-                NewValue: row.NewOperation?.Value ?? row.NewValue ?? (direction == ResearchDiffDirection.Added ? row.Text : null),
-                Detail: row.Message,
-                CSharpDisplayRows: [CSharpDiffPrinter.ToDisplayRow(row)]));
+            changes.Add(new ResearchChange(
+                subject,
+                ResearchChangeMechanism.CSharp,
+                new FindingDescriptor(row.ChangeId, row.ChangeId),
+                kind,
+                oldValue: row.OldOperation?.Value
+                    ?? row.OldValue
+                    ?? (kind == ResearchChangeKind.Removed ? row.Text : null),
+                newValue: row.NewOperation?.Value
+                    ?? row.NewValue
+                    ?? (kind == ResearchChangeKind.Added ? row.Text : null),
+                detail: row.Message,
+                category: ResearchChangeCategory.CSharp,
+                cSharpDisplayRows: [CSharpDiffPrinter.ToDisplayRow(row)]));
         }
 
-        return evidence.ToImmutable();
+        return changes.ToImmutable();
     }
 
-    static ResearchDiffMechanism ToResearchMechanisms(ImplementationDiffMechanism mechanisms)
+    static ResearchChangeMechanism ToResearchMechanisms(ImplementationDiffMechanism mechanisms)
     {
-        var research = ResearchDiffMechanism.None;
+        var research = ResearchChangeMechanism.None;
         if (mechanisms.HasFlag(ImplementationDiffMechanism.CSharp))
-            research |= ResearchDiffMechanism.CSharp;
+            research |= ResearchChangeMechanism.CSharp;
         if (mechanisms.HasFlag(ImplementationDiffMechanism.IlBody))
-            research |= ResearchDiffMechanism.IlBody;
+            research |= ResearchChangeMechanism.IlBody;
         return research;
     }
-
-    static ImplementationDiffEvidence? ToImplementationEvidence(ResearchDiffEvidence evidence)
-        => evidence.Mechanism switch
-        {
-            ResearchDiffMechanism.CSharp => new ImplementationDiffEvidence(
-                ImplementationDiffEvidenceKind.CSharp,
-                evidence.ChangeId,
-                evidence.Direction,
-                evidence.OldValue,
-                evidence.NewValue,
-                evidence.Detail,
-                CSharpDisplayRows: evidence.CSharpDisplayRows.IsDefault ? [] : evidence.CSharpDisplayRows,
-                CSharpDisplayFailureRow: evidence.CSharpDisplayFailureRow),
-            ResearchDiffMechanism.IlBody => new ImplementationDiffEvidence(
-                ImplementationDiffEvidenceKind.IlBody,
-                evidence.ChangeId,
-                evidence.Direction,
-                evidence.OldValue,
-                evidence.NewValue,
-                evidence.Detail,
-                evidence.OldIlOffset,
-                evidence.NewIlOffset,
-                IlDisplayRows: evidence.IlDisplayRows.IsDefault ? [] : evidence.IlDisplayRows,
-                IlDisplayFailureRow: evidence.IlDisplayFailureRow,
-                IlMemberDiff: evidence.IlMemberDiff),
-            _ => null,
-        };
 
     static bool MatchesMemberTargets(ResearchSubjectKey subject, IReadOnlySet<string>? memberTargetIdentities)
         => memberTargetIdentities is null

--- a/src/ILInspector.Research/ResearchChanges.cs
+++ b/src/ILInspector.Research/ResearchChanges.cs
@@ -1,0 +1,296 @@
+using System.Collections.Immutable;
+using ILInspector.Analysis;
+using ILInspector.Decompiler;
+using ILInspector.Findings;
+using ILInspector.Instructions;
+using ILInspector.Metadata;
+
+namespace ILInspector.Research;
+
+[Flags]
+public enum ResearchChangeMechanism
+{
+    None = 0,
+    Api = 1,
+    BodySignals = 2,
+    IlBody = 4,
+    CSharp = 8,
+    ReturnToSender = 16,
+    AllAvailable = Api | BodySignals | IlBody | CSharp | ReturnToSender,
+}
+
+public enum ResearchSubjectKind
+{
+    Type,
+    Member,
+}
+
+public enum ResearchChangeKind
+{
+    Added,
+    Removed,
+    Changed,
+}
+
+public enum ResearchChangeCategory
+{
+    Unknown,
+    Signature,
+    Attribute,
+    BodySignal,
+    IlBody,
+    CSharp,
+    RoundTrip,
+}
+
+public sealed record ResearchSubjectKey
+{
+    public ResearchSubjectKey(
+        ResearchSubjectKind kind,
+        string id,
+        string display,
+        string? typeName = null,
+        string? memberName = null)
+    {
+        if (!Enum.IsDefined(kind))
+            throw new ArgumentOutOfRangeException(nameof(kind));
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        ArgumentException.ThrowIfNullOrWhiteSpace(display);
+
+        Kind = kind;
+        Id = id;
+        Display = display;
+        TypeName = typeName;
+        MemberName = memberName;
+    }
+
+    public ResearchSubjectKind Kind { get; }
+    public string Id { get; }
+    public string Display { get; }
+    public string? TypeName { get; }
+    public string? MemberName { get; }
+}
+
+/// <summary>
+/// One Research-level change projected from a two-version mechanism. This is not a
+/// <see cref="PairFinding{T}"/>: mechanisms that do not yet expose old/new Finding censuses cannot
+/// honestly manufacture Finding atoms. The native producer payload remains attached for typed
+/// presentation and future producer migration.
+/// </summary>
+public sealed record ResearchChange
+{
+    public ResearchChange(
+        ResearchSubjectKey subject,
+        ResearchChangeMechanism mechanism,
+        FindingDescriptor descriptor,
+        ResearchChangeKind kind,
+        string? oldValue = null,
+        string? newValue = null,
+        string? delta = null,
+        int? oldIlOffset = null,
+        int? newIlOffset = null,
+        string? detail = null,
+        ResearchChangeCategory category = ResearchChangeCategory.Unknown,
+        string? signal = null,
+        string? shape = null,
+        int? magnitude = null,
+        int directionScore = 0,
+        bool subjectInBoth = true,
+        bool inLoop = false,
+        ApiChange? apiChange = null,
+        IlDiffRow? ilRow = null,
+        IlDiffFailureRow? ilFailureRow = null,
+        BodySignalDiffRow? bodySignalRow = null,
+        CSharpDiffRow? cSharpRow = null,
+        CSharpDiffFailureRow? cSharpFailureRow = null,
+        ImmutableArray<IlDiffDisplayRow> ilDisplayRows = default,
+        IlDiffDisplayFailureRow? ilDisplayFailureRow = null,
+        IlMemberDiffResult? ilMemberDiff = null,
+        ImmutableArray<CSharpDiffDisplayRow> cSharpDisplayRows = default,
+        CSharpDiffDisplayFailureRow? cSharpDisplayFailureRow = null)
+    {
+        Subject = subject ?? throw new ArgumentNullException(nameof(subject));
+        int mechanismValue = (int)mechanism;
+        if (mechanism == ResearchChangeMechanism.None
+            || (mechanism & ~ResearchChangeMechanism.AllAvailable) != 0
+            || (mechanismValue & (mechanismValue - 1)) != 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(mechanism),
+                "A Research change must have exactly one known mechanism.");
+        }
+        if (!Enum.IsDefined(kind))
+            throw new ArgumentOutOfRangeException(nameof(kind));
+        if (!Enum.IsDefined(category))
+            throw new ArgumentOutOfRangeException(nameof(category));
+
+        Mechanism = mechanism;
+        Descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
+        Kind = kind;
+        OldValue = oldValue;
+        NewValue = newValue;
+        Delta = delta;
+        OldIlOffset = oldIlOffset;
+        NewIlOffset = newIlOffset;
+        Detail = detail;
+        Category = category;
+        Signal = signal;
+        Shape = shape;
+        Magnitude = magnitude;
+        DirectionScore = directionScore;
+        SubjectInBoth = subjectInBoth;
+        InLoop = inLoop;
+        ApiChange = apiChange;
+        IlRow = ilRow;
+        IlFailureRow = ilFailureRow;
+        BodySignalRow = bodySignalRow;
+        CSharpRow = cSharpRow;
+        CSharpFailureRow = cSharpFailureRow;
+        IlDisplayRows = ilDisplayRows.IsDefault ? [] : ilDisplayRows;
+        IlDisplayFailureRow = ilDisplayFailureRow;
+        IlMemberDiff = ilMemberDiff;
+        CSharpDisplayRows = cSharpDisplayRows.IsDefault ? [] : cSharpDisplayRows;
+        CSharpDisplayFailureRow = cSharpDisplayFailureRow;
+    }
+
+    public ResearchSubjectKey Subject { get; }
+    public ResearchChangeMechanism Mechanism { get; }
+    public FindingDescriptor Descriptor { get; }
+    public ResearchChangeKind Kind { get; }
+    public string? OldValue { get; }
+    public string? NewValue { get; }
+    public string? Delta { get; }
+    public int? OldIlOffset { get; }
+    public int? NewIlOffset { get; }
+    public string? Detail { get; }
+    public ResearchChangeCategory Category { get; }
+    public string? Signal { get; }
+    public string? Shape { get; }
+    public int? Magnitude { get; }
+    public int DirectionScore { get; }
+    public bool SubjectInBoth { get; }
+    public bool InLoop { get; }
+    public ApiChange? ApiChange { get; }
+    public IlDiffRow? IlRow { get; }
+    public IlDiffFailureRow? IlFailureRow { get; }
+    public BodySignalDiffRow? BodySignalRow { get; }
+    public CSharpDiffRow? CSharpRow { get; }
+    public CSharpDiffFailureRow? CSharpFailureRow { get; }
+    public ImmutableArray<IlDiffDisplayRow> IlDisplayRows { get; }
+    public IlDiffDisplayFailureRow? IlDisplayFailureRow { get; }
+    public IlMemberDiffResult? IlMemberDiff { get; }
+    public ImmutableArray<CSharpDiffDisplayRow> CSharpDisplayRows { get; }
+    public CSharpDiffDisplayFailureRow? CSharpDisplayFailureRow { get; }
+}
+
+public sealed record ResearchSubjectChanges
+{
+    public ResearchSubjectChanges(
+        ResearchSubjectKey subject,
+        ImmutableArray<ResearchChange> changes)
+    {
+        Subject = subject ?? throw new ArgumentNullException(nameof(subject));
+        if (changes.IsDefault)
+            throw new ArgumentException("Changes must be initialized.", nameof(changes));
+        if (changes.Any(change => change is null))
+            throw new ArgumentException("Changes cannot contain null entries.", nameof(changes));
+
+        Changes = changes;
+    }
+
+    public ResearchSubjectKey Subject { get; }
+    public ImmutableArray<ResearchChange> Changes { get; }
+
+    public bool ApiChanged
+        => Changes.Any(change => change.Mechanism == ResearchChangeMechanism.Api);
+
+    public bool ApiSignatureChanged
+        => Changes.Any(change =>
+            change.Mechanism == ResearchChangeMechanism.Api
+            && change.Category == ResearchChangeCategory.Signature);
+
+    public bool ApiAttributeChanged
+        => Changes.Any(change =>
+            change.Mechanism == ResearchChangeMechanism.Api
+            && change.Category == ResearchChangeCategory.Attribute);
+
+    public bool ImplementationChanged
+        => Changes.Any(change =>
+            change.Mechanism is ResearchChangeMechanism.BodySignals
+                or ResearchChangeMechanism.IlBody
+                or ResearchChangeMechanism.CSharp);
+
+    public bool HasMechanism(ResearchChangeMechanism mechanism)
+        => Changes.Any(change => change.Mechanism == mechanism);
+
+    public bool HasChange(string descriptorId)
+        => Changes.Any(change =>
+            string.Equals(change.Descriptor.Id, descriptorId, StringComparison.Ordinal));
+
+    public bool HasChangePrefix(string descriptorIdPrefix)
+        => Changes.Any(change =>
+            change.Descriptor.Id.StartsWith(descriptorIdPrefix, StringComparison.Ordinal));
+
+    public bool HasChangeCategory(ResearchChangeCategory category)
+        => Changes.Any(change => change.Category == category);
+}
+
+/// <summary>
+/// Outcome of one Research diff operation. Changes are stored once; subject grouping is a
+/// projection so flat and grouped consumers cannot observe divergent state.
+/// </summary>
+public sealed record ResearchComparison
+{
+    public ResearchComparison(
+        ImmutableArray<ResearchChange> changes,
+        ApiDiff? apiDiff = null)
+    {
+        if (changes.IsDefault)
+            throw new ArgumentException("Changes must be initialized.", nameof(changes));
+        if (changes.Any(change => change is null))
+            throw new ArgumentException("Changes cannot contain null entries.", nameof(changes));
+        Changes = changes;
+        ApiDiff = apiDiff;
+    }
+
+    public ImmutableArray<ResearchChange> Changes { get; }
+    public ApiDiff? ApiDiff { get; }
+    public bool IsEmpty => Changes.IsEmpty;
+
+    public IReadOnlyList<ResearchSubjectChanges> BySubject()
+        => [.. Changes
+            .GroupBy(change => change.Subject, ResearchSubjectKeyIdentityComparer.Instance)
+            .OrderBy(group => group.Key.Kind)
+            .ThenBy(group => group.Key.Id, StringComparer.Ordinal)
+            .Select(group => new ResearchSubjectChanges(
+                group.Key,
+                [.. group
+                    .OrderBy(change => change.Mechanism)
+                    .ThenBy(change => change.Descriptor.Id, StringComparer.Ordinal)
+                    .ThenBy(change => change.OldIlOffset)
+                    .ThenBy(change => change.NewIlOffset)]))];
+
+    public IReadOnlyList<ResearchSubjectChanges> MembersWhere(
+        Func<ResearchSubjectChanges, bool> predicate)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        return [.. BySubject().Where(subject =>
+            subject.Subject.Kind == ResearchSubjectKind.Member
+            && predicate(subject))];
+    }
+
+    sealed class ResearchSubjectKeyIdentityComparer : IEqualityComparer<ResearchSubjectKey>
+    {
+        public static ResearchSubjectKeyIdentityComparer Instance { get; } = new();
+
+        public bool Equals(ResearchSubjectKey? x, ResearchSubjectKey? y)
+            => ReferenceEquals(x, y)
+               || (x is not null
+                   && y is not null
+                   && x.Kind == y.Kind
+                   && string.Equals(x.Id, y.Id, StringComparison.Ordinal));
+
+        public int GetHashCode(ResearchSubjectKey obj)
+            => HashCode.Combine(obj.Kind, StringComparer.Ordinal.GetHashCode(obj.Id));
+    }
+}

--- a/src/ILInspector.Research/ResearchChanges.cs
+++ b/src/ILInspector.Research/ResearchChanges.cs
@@ -243,18 +243,29 @@ public sealed record ResearchComparison
 {
     public ResearchComparison(
         ImmutableArray<ResearchChange> changes,
-        ApiDiff? apiDiff = null)
+        ApiDiff? apiDiff = null,
+        ApiFindingComparison? apiComparison = null)
     {
         if (changes.IsDefault)
             throw new ArgumentException("Changes must be initialized.", nameof(changes));
         if (changes.Any(change => change is null))
             throw new ArgumentException("Changes cannot contain null entries.", nameof(changes));
+        if (apiDiff is not null
+            && apiComparison is not null
+            && !ReferenceEquals(apiDiff, apiComparison.ApiDiff))
+        {
+            throw new ArgumentException(
+                "The API diff must be the diff carried by the API Finding comparison.",
+                nameof(apiDiff));
+        }
         Changes = changes;
-        ApiDiff = apiDiff;
+        ApiComparison = apiComparison;
+        ApiDiff = apiComparison?.ApiDiff ?? apiDiff;
     }
 
     public ImmutableArray<ResearchChange> Changes { get; }
     public ApiDiff? ApiDiff { get; }
+    public ApiFindingComparison? ApiComparison { get; }
     public bool IsEmpty => Changes.IsEmpty;
 
     public IReadOnlyList<ResearchSubjectChanges> BySubject()

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -4,75 +4,15 @@ using System.Reflection.PortableExecutable;
 using System.Collections.Immutable;
 using ILInspector.Analysis;
 using ILInspector.Decompiler;
+using ILInspector.Findings;
 using ILInspector.Instructions;
 using ILInspector.Metadata;
 using ILInspector.MetadataPrimitives;
 
 namespace ILInspector.Research;
 
-[Flags]
-public enum ResearchDiffMechanism
-{
-    None = 0,
-    Api = 1,
-    BodySignals = 2,
-    IlBody = 4,
-    CSharp = 8,
-    ReturnToSender = 16,
-    AllAvailable = Api | BodySignals | IlBody | CSharp | ReturnToSender,
-}
-
-public enum ResearchDiffSubjectKind
-{
-    Type,
-    Member,
-}
-
-public enum ResearchDiffDirection
-{
-    Added,
-    Removed,
-    Changed,
-}
-
-public enum ResearchDiffChangeCategory
-{
-    Unknown,
-    Signature,
-    Attribute,
-    BodySignal,
-    IlBody,
-    CSharp,
-    RoundTrip,
-}
-
-public enum ResearchDiffEvidenceKind
-{
-    MetadataApi,
-    IlBody,
-    BodySignal,
-    CSharp,
-}
-
-public sealed record ResearchDiffRow(
-    string ChangeId,
-    ResearchDiffEvidenceKind EvidenceKind,
-    string Message,
-    ApiChange? ApiChange = null,
-    IlDiffRow? IlRow = null,
-    IlDiffFailureRow? IlFailureRow = null,
-    IlDiffDisplayRow? IlDisplayRow = null,
-    IlDiffDisplayFailureRow? IlDisplayFailureRow = null,
-    BodySignalDiffRow? BodySignalRow = null,
-    CSharpDiffRow? CSharpRow = null,
-    CSharpDiffFailureRow? CSharpFailureRow = null,
-    CSharpDiffDisplayFailureRow? CSharpDisplayFailureRow = null)
-{
-    public CSharpDiffDisplayRow? CSharpDisplayRow { get; init; }
-}
-
 public sealed record ResearchDiffOptions(
-    ResearchDiffMechanism Mechanisms = ResearchDiffMechanism.AllAvailable,
+    ResearchChangeMechanism Mechanisms = ResearchChangeMechanism.AllAvailable,
     bool IncludeAllApi = false,
     ApiDiffScope ApiScope = ApiDiffScope.Signature,
     IReadOnlySet<string>? TypeFilters = null,
@@ -93,193 +33,189 @@ public sealed record ResearchDiffInput(
         => new([], apiSurface);
 }
 
-public sealed record ResearchSubjectKey(
-    ResearchDiffSubjectKind Kind,
-    string Id,
-    string Display,
-    string? TypeName = null,
-    string? MemberName = null);
-
-public sealed record ResearchDiffEvidence(
-    ResearchDiffMechanism Mechanism,
-    string ChangeId,
-    ResearchDiffDirection Direction,
-    string? OldValue = null,
-    string? NewValue = null,
-    string? Delta = null,
-    int? OldIlOffset = null,
-    int? NewIlOffset = null,
-    string? Detail = null,
-    ResearchDiffChangeCategory Category = ResearchDiffChangeCategory.Unknown,
-    string? Signal = null,
-    string? Shape = null,
-    int? Magnitude = null,
-    int DirectionScore = 0,
-    bool SubjectInBoth = true,
-    bool InLoop = false,
-    ImmutableArray<IlDiffDisplayRow> IlDisplayRows = default,
-    IlDiffDisplayFailureRow? IlDisplayFailureRow = null,
-    IlMemberDiffResult? IlMemberDiff = null,
-    CSharpDiffDisplayFailureRow? CSharpDisplayFailureRow = null)
-{
-    public ImmutableArray<CSharpDiffDisplayRow> CSharpDisplayRows { get; init; } = default;
-}
-
-public sealed record ResearchSubjectDiff(
-    ResearchSubjectKey Subject,
-    IReadOnlyList<ResearchDiffEvidence> Evidence)
-{
-    public bool ApiChanged => Evidence.Any(evidence => evidence.Mechanism == ResearchDiffMechanism.Api);
-
-    public bool ApiSignatureChanged
-        => Evidence.Any(evidence => evidence.Mechanism == ResearchDiffMechanism.Api && evidence.Category == ResearchDiffChangeCategory.Signature);
-
-    public bool ApiAttributeChanged
-        => Evidence.Any(evidence => evidence.Mechanism == ResearchDiffMechanism.Api && evidence.Category == ResearchDiffChangeCategory.Attribute);
-
-    public bool ImplementationChanged
-        => Evidence.Any(evidence => evidence.Mechanism is ResearchDiffMechanism.BodySignals or ResearchDiffMechanism.IlBody or ResearchDiffMechanism.CSharp);
-
-    public bool HasMechanism(ResearchDiffMechanism mechanism)
-        => Evidence.Any(evidence => evidence.Mechanism == mechanism);
-
-    public bool HasChange(string changeId)
-        => Evidence.Any(evidence => string.Equals(evidence.ChangeId, changeId, StringComparison.Ordinal));
-
-    public bool HasChangePrefix(string changeIdPrefix)
-        => Evidence.Any(evidence => evidence.ChangeId.StartsWith(changeIdPrefix, StringComparison.Ordinal));
-
-    public bool HasChangeCategory(ResearchDiffChangeCategory category)
-        => Evidence.Any(evidence => evidence.Category == category);
-}
-
-public sealed record ResearchDiffResult(
-    IReadOnlyList<ResearchSubjectDiff> Subjects,
-    ApiDiff? ApiDiff = null,
-    ImmutableArray<ResearchDiffRow> Rows = default)
-{
-    public bool IsEmpty => Subjects.Count == 0 && Rows.IsDefaultOrEmpty;
-
-    public IReadOnlyList<ResearchSubjectDiff> MembersWhere(Func<ResearchSubjectDiff, bool> predicate)
-        => [.. Subjects.Where(subject => subject.Subject.Kind == ResearchDiffSubjectKind.Member && predicate(subject))];
-}
-
 public static class ResearchDiff
 {
     public static string ToChangeIdPart(string value)
         => ToKebabCase(value);
 
-    public static ResearchDiffResult FromApiDiff(ApiDiff diff)
+    static FindingDescriptor Descriptor(string id, string title)
+        => new(id, title);
+
+    public static ResearchComparison FromApiDiff(ApiDiff diff)
     {
         ArgumentNullException.ThrowIfNull(diff);
-        var rows = ImmutableArray.CreateBuilder<ResearchDiffRow>();
+        var changes = ImmutableArray.CreateBuilder<ResearchChange>();
         foreach (var typeDiff in diff.TypeDiffs)
         {
             foreach (var change in typeDiff.Changes)
             {
-                rows.Add(new ResearchDiffRow(
-                    $"api.{ToKebabCase(change.Kind.ToString())}",
-                    ResearchDiffEvidenceKind.MetadataApi,
-                    change.Message,
-                    ApiChange: change));
+                string descriptorId = $"api.{ToKebabCase(change.Kind.ToString())}";
+                changes.Add(new ResearchChange(
+                    ApiSubject(typeDiff.TypeFullName, change),
+                    ResearchChangeMechanism.Api,
+                    Descriptor(descriptorId, change.Kind.ToString()),
+                    Direction(change.Kind),
+                    oldValue: change.OldValue,
+                    newValue: change.NewValue,
+                    detail: change.Message,
+                    category: ToResearchCategory(change.Category),
+                    apiChange: change));
             }
         }
 
-        return new ResearchDiffResult([], diff, rows.ToImmutable());
+        return new ResearchComparison(changes.ToImmutable(), diff);
     }
 
-    public static ResearchDiffResult FromIlBodyDiff(IlBodyDiffResult diff)
+    public static ResearchComparison FromIlBodyDiff(IlBodyDiffResult diff)
     {
         ArgumentNullException.ThrowIfNull(diff);
-        var rows = ImmutableArray.CreateBuilder<ResearchDiffRow>();
+        var changes = ImmutableArray.CreateBuilder<ResearchChange>();
+        var subject = UnknownMemberSubject("il-body");
         if (!diff.FailureRows.IsDefaultOrEmpty)
         {
-            rows.AddRange(diff.FailureRows.Select(row => new ResearchDiffRow(
-                $"il.diff.{ToKebabCase(row.Kind.ToString())}",
-                ResearchDiffEvidenceKind.IlBody,
-                row.Message,
-                IlFailureRow: row,
-                IlDisplayFailureRow: IlDiffPrinter.ToDisplayFailureRow(row))));
+            changes.AddRange(diff.FailureRows.Select(row =>
+            {
+                string descriptorId = $"il.diff.{ToKebabCase(row.Kind.ToString())}";
+                return new ResearchChange(
+                    subject,
+                    ResearchChangeMechanism.IlBody,
+                    Descriptor(descriptorId, row.Kind.ToString()),
+                    Direction(row.Kind),
+                    detail: row.Message,
+                    category: ResearchChangeCategory.IlBody,
+                    ilFailureRow: row,
+                    ilDisplayFailureRow: IlDiffPrinter.ToDisplayFailureRow(row));
+            }));
         }
         else if (diff.Failure is { Length: > 0 } failure)
         {
-            rows.Add(new ResearchDiffRow("il.diff.failed", ResearchDiffEvidenceKind.IlBody, failure));
+            changes.Add(new ResearchChange(
+                subject,
+                ResearchChangeMechanism.IlBody,
+                Descriptor("il.diff.failed", "IL diff failed"),
+                ResearchChangeKind.Changed,
+                detail: failure,
+                category: ResearchChangeCategory.IlBody));
         }
 
         if (!diff.Rows.IsDefaultOrEmpty)
         {
-            rows.AddRange(diff.Rows.Select(row => new ResearchDiffRow(
-                $"il.operation.{ChangeIdSuffix(row.Kind)}",
-                ResearchDiffEvidenceKind.IlBody,
-                row.Message,
-                IlRow: row,
-                IlDisplayRow: IlDiffPrinter.ToDisplayRow(row))));
+            changes.AddRange(diff.Rows
+                .Where(row => row.Kind != IlDiffKind.Context)
+                .Select(row =>
+                {
+                    string descriptorId = $"il.operation.{ChangeIdSuffix(row.Kind)}";
+                    return new ResearchChange(
+                        subject,
+                        ResearchChangeMechanism.IlBody,
+                        Descriptor(descriptorId, "IL operation"),
+                        Direction(row.Kind),
+                        oldValue: row.Kind == IlDiffKind.Remove ? row.Operation.Display : null,
+                        newValue: row.Kind == IlDiffKind.Add ? row.Operation.Display : null,
+                        oldIlOffset: row.Kind == IlDiffKind.Remove ? row.Operation.Offset : null,
+                        newIlOffset: row.Kind == IlDiffKind.Add ? row.Operation.Offset : null,
+                        detail: row.Message,
+                        category: ResearchChangeCategory.IlBody,
+                        ilRow: row,
+                        ilDisplayRows: [IlDiffPrinter.ToDisplayRow(row)]);
+                }));
         }
 
-        return new ResearchDiffResult([], Rows: rows.ToImmutable());
+        return new ResearchComparison(changes.ToImmutable());
     }
 
-    public static ResearchDiffResult FromBodySignalDiff(BodySignalDiffResult diff)
+    public static ResearchComparison FromBodySignalDiff(BodySignalDiffResult diff)
     {
         ArgumentNullException.ThrowIfNull(diff);
-        return new ResearchDiffResult(
-            [],
-            Rows:
-            [
-                .. diff.Rows.Select(row => new ResearchDiffRow(
-                    $"unsafe.{ToKebabCase(row.Signal)}.{ToKebabCase(row.Kind.ToString())}",
-                    ResearchDiffEvidenceKind.BodySignal,
-                    $"{row.Kind} {row.Signal}: {row.Operation}",
-                    BodySignalRow: row))
-            ]);
+        return new ResearchComparison(
+        [
+            .. diff.Rows.Select(row =>
+            {
+                string descriptorId =
+                    $"unsafe.{ToKebabCase(row.Signal)}.{ToKebabCase(row.Kind.ToString())}";
+                var kind = row.Kind == BodySignalDiffKind.Added
+                    ? ResearchChangeKind.Added
+                    : ResearchChangeKind.Removed;
+                return new ResearchChange(
+                    UnknownMemberSubject(row.Member),
+                    ResearchChangeMechanism.BodySignals,
+                    Descriptor(descriptorId, row.Signal),
+                    kind,
+                    oldIlOffset: kind == ResearchChangeKind.Removed ? row.ILOffset : null,
+                    newIlOffset: kind == ResearchChangeKind.Added ? row.ILOffset : null,
+                    detail: $"{row.Operation}: {row.Evidence}",
+                    category: ResearchChangeCategory.BodySignal,
+                    signal: row.Signal,
+                    bodySignalRow: row);
+            })
+        ]);
     }
 
-    public static ResearchDiffResult FromCSharpBodyDiff(CSharpBodyDiffResult diff)
+    public static ResearchComparison FromCSharpBodyDiff(CSharpBodyDiffResult diff)
     {
         ArgumentNullException.ThrowIfNull(diff);
-        var rows = ImmutableArray.CreateBuilder<ResearchDiffRow>();
+        var changes = ImmutableArray.CreateBuilder<ResearchChange>();
         if (!diff.FailureRows.IsDefaultOrEmpty)
         {
-            rows.AddRange(diff.FailureRows.Select(row => new ResearchDiffRow(
-                $"csharp.diff.{ToKebabCase(row.Kind.ToString())}",
-                ResearchDiffEvidenceKind.CSharp,
-                row.Message,
-                CSharpFailureRow: row,
-                CSharpDisplayFailureRow: CSharpDiffPrinter.ToDisplayFailureRow(row))));
-        }
-
-        if (!diff.Rows.IsDefaultOrEmpty)
-        {
-            rows.AddRange(diff.Rows.Select(row => new ResearchDiffRow(
-                row.ChangeId,
-                ResearchDiffEvidenceKind.CSharp,
-                row.Message,
-                CSharpRow: row)
+            changes.AddRange(diff.FailureRows.Select(row =>
             {
-                CSharpDisplayRow = CSharpDiffPrinter.ToDisplayRow(row)
+                string descriptorId = $"csharp.diff.{ToKebabCase(row.Kind.ToString())}";
+                return new ResearchChange(
+                    ResearchMemberIdentity.SubjectFromAnchor(row.Anchor, row.Member),
+                    ResearchChangeMechanism.CSharp,
+                    Descriptor(descriptorId, row.Kind.ToString()),
+                    Direction(row.Kind),
+                    oldValue: row.Side == "old" ? row.Detail ?? row.Message : null,
+                    newValue: row.Side == "new" ? row.Detail ?? row.Message : null,
+                    detail: row.Message,
+                    category: ResearchChangeCategory.CSharp,
+                    cSharpFailureRow: row,
+                    cSharpDisplayFailureRow: CSharpDiffPrinter.ToDisplayFailureRow(row));
             }));
         }
 
-        return new ResearchDiffResult([], Rows: rows.ToImmutable());
+        if (!diff.Rows.IsDefaultOrEmpty)
+        {
+            changes.AddRange(diff.Rows.Select(row =>
+            {
+                var kind = Direction(row.Kind);
+                return new ResearchChange(
+                    ResearchMemberIdentity.SubjectFromAnchor(row.Anchor, row.Member),
+                    ResearchChangeMechanism.CSharp,
+                    Descriptor(row.ChangeId, row.Kind.ToString()),
+                    kind,
+                    oldValue: row.OldOperation?.Value ?? row.OldValue
+                        ?? (kind == ResearchChangeKind.Removed ? row.Text : null),
+                    newValue: row.NewOperation?.Value ?? row.NewValue
+                        ?? (kind == ResearchChangeKind.Added ? row.Text : null),
+                    detail: row.Message,
+                    category: ResearchChangeCategory.CSharp,
+                    cSharpRow: row,
+                    cSharpDisplayRows: [CSharpDiffPrinter.ToDisplayRow(row)]);
+            }));
+        }
+
+        return new ResearchComparison(changes.ToImmutable());
     }
 
-    public static ResearchDiffResult Combine(params ResearchDiffResult[] results)
+    public static ResearchComparison Combine(params ResearchComparison[] results)
     {
         ArgumentNullException.ThrowIfNull(results);
-        return new ResearchDiffResult(
-            [.. results.SelectMany(result => result.Subjects)],
-            results.FirstOrDefault(result => result.ApiDiff is not null)?.ApiDiff,
-            Rows: [.. results.SelectMany(result => result.Rows.IsDefault ? [] : result.Rows)]);
+        if (results.Any(result => result is null))
+            throw new ArgumentException("Results cannot contain null entries.", nameof(results));
+        return new ResearchComparison(
+            [.. results.SelectMany(result => result.Changes)],
+            results.FirstOrDefault(result => result.ApiDiff is not null)?.ApiDiff);
     }
 
-    public static ResearchDiffResult CompareAssemblies(string oldAssemblyPath, string newAssemblyPath, ResearchDiffOptions? options = null)
+    public static ResearchComparison CompareAssemblies(string oldAssemblyPath, string newAssemblyPath, ResearchDiffOptions? options = null)
         => Compare(ResearchDiffInput.FromAssembly(oldAssemblyPath), ResearchDiffInput.FromAssembly(newAssemblyPath), options);
 
-    public static ResearchDiffResult CompareApiSurfaces(ApiSurface oldSurface, ApiSurface newSurface)
+    public static ResearchComparison CompareApiSurfaces(ApiSurface oldSurface, ApiSurface newSurface)
         => Compare(ResearchDiffInput.FromApiSurface(oldSurface), ResearchDiffInput.FromApiSurface(newSurface),
-            new ResearchDiffOptions(ResearchDiffMechanism.Api));
+            new ResearchDiffOptions(ResearchChangeMechanism.Api));
 
-    public static ResearchDiffResult Compare(ResearchDiffInput oldInput, ResearchDiffInput newInput, ResearchDiffOptions? options = null)
+    public static ResearchComparison Compare(ResearchDiffInput oldInput, ResearchDiffInput newInput, ResearchDiffOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(oldInput);
         ArgumentNullException.ThrowIfNull(newInput);
@@ -287,16 +223,16 @@ public static class ResearchDiff
         options ??= new ResearchDiffOptions();
         var builder = new ResultBuilder();
 
-        if (options.Mechanisms.HasFlag(ResearchDiffMechanism.Api))
+        if (options.Mechanisms.HasFlag(ResearchChangeMechanism.Api))
             AddApiDiff(builder, oldInput, newInput, options.IncludeAllApi, options.ApiScope);
 
-        if (options.Mechanisms.HasFlag(ResearchDiffMechanism.BodySignals))
+        if (options.Mechanisms.HasFlag(ResearchChangeMechanism.BodySignals))
             AddBodySignalDiff(builder, oldInput, newInput, options.TypeFilters, options.MemberTargetIdentities);
 
-        if (options.Mechanisms.HasFlag(ResearchDiffMechanism.IlBody))
+        if (options.Mechanisms.HasFlag(ResearchChangeMechanism.IlBody))
             AddIlBodyDiff(builder, oldInput, newInput, options.TypeFilters, options.MemberTargetIdentities);
 
-        if (options.Mechanisms.HasFlag(ResearchDiffMechanism.CSharp))
+        if (options.Mechanisms.HasFlag(ResearchChangeMechanism.CSharp))
             AddCSharpDiff(builder, oldInput, newInput, options.TypeFilters, options.MemberTargetIdentities);
 
         return builder.ToResult();
@@ -315,15 +251,18 @@ public static class ResearchDiff
         {
             foreach (var change in typeDiff.Changes)
             {
-                var subject = ApiSubject(oldSurface, newSurface, typeDiff.TypeFullName, change);
-                builder.Add(subject, new ResearchDiffEvidence(
-                    ResearchDiffMechanism.Api,
-                    $"api.{ToKebabCase(change.Kind.ToString())}",
+                var subject = ApiSubject(typeDiff.TypeFullName, change);
+                string descriptorId = $"api.{ToKebabCase(change.Kind.ToString())}";
+                builder.Add(new ResearchChange(
+                    subject,
+                    ResearchChangeMechanism.Api,
+                    Descriptor(descriptorId, change.Kind.ToString()),
                     Direction(change.Kind),
                     change.OldValue,
                     change.NewValue,
-                    Detail: $"{change.Classification}: {change.Message}",
-                    Category: ToResearchCategory(change.Category)));
+                    detail: $"{change.Classification}: {change.Message}",
+                    category: ToResearchCategory(change.Category),
+                    apiChange: change));
             }
         }
     }
@@ -348,16 +287,22 @@ public static class ResearchDiff
                     continue;
                 if (!MatchesMemberTargets(subject, memberTargetIdentities))
                     continue;
-                var direction = row.Kind == BodySignalDiffKind.Added ? ResearchDiffDirection.Added : ResearchDiffDirection.Removed;
-                var suffix = direction == ResearchDiffDirection.Added ? "added" : "removed";
-                builder.Add(subject, new ResearchDiffEvidence(
-                    ResearchDiffMechanism.BodySignals,
-                    $"unsafe.{NormalizeChangePart(row.Signal)}.{suffix}",
-                    direction,
-                    OldIlOffset: direction == ResearchDiffDirection.Removed ? row.ILOffset : null,
-                    NewIlOffset: direction == ResearchDiffDirection.Added ? row.ILOffset : null,
-                    Detail: $"{row.Operation}: {row.Evidence}",
-                    Category: ResearchDiffChangeCategory.BodySignal));
+                var kind = row.Kind == BodySignalDiffKind.Added
+                    ? ResearchChangeKind.Added
+                    : ResearchChangeKind.Removed;
+                var suffix = kind == ResearchChangeKind.Added ? "added" : "removed";
+                string descriptorId = $"unsafe.{NormalizeChangePart(row.Signal)}.{suffix}";
+                builder.Add(new ResearchChange(
+                    subject,
+                    ResearchChangeMechanism.BodySignals,
+                    Descriptor(descriptorId, row.Signal),
+                    kind,
+                    oldIlOffset: kind == ResearchChangeKind.Removed ? row.ILOffset : null,
+                    newIlOffset: kind == ResearchChangeKind.Added ? row.ILOffset : null,
+                    detail: $"{row.Operation}: {row.Evidence}",
+                    category: ResearchChangeCategory.BodySignal,
+                    signal: row.Signal,
+                    bodySignalRow: row));
             }
         }
 
@@ -552,21 +497,22 @@ public static class ResearchDiff
             int directionScore,
             bool inBoth,
             bool inLoop)
-            => builder.Add(subject, new ResearchDiffEvidence(
-                ResearchDiffMechanism.BodySignals,
-                changeId,
-                ResearchDiffDirection.Changed,
+            => builder.Add(new ResearchChange(
+                subject,
+                ResearchChangeMechanism.BodySignals,
+                Descriptor(changeId, signal),
+                ResearchChangeKind.Changed,
                 oldValue,
                 newValue,
-                Delta: delta,
-                Detail: detail,
-                Category: ResearchDiffChangeCategory.BodySignal,
-                Signal: signal,
-                Shape: shape,
-                Magnitude: magnitude,
-                DirectionScore: directionScore,
-                SubjectInBoth: inBoth,
-                InLoop: inLoop));
+                delta: delta,
+                detail: detail,
+                category: ResearchChangeCategory.BodySignal,
+                signal: signal,
+                shape: shape,
+                magnitude: magnitude,
+                directionScore: directionScore,
+                subjectInBoth: inBoth,
+                inLoop: inLoop));
     }
 
     static void AddIlBodyDiff(
@@ -634,26 +580,28 @@ public static class ResearchDiff
                     var removed = hunk.Where(row => row.Kind == IlDiffKind.Remove).ToArray();
                     var added = hunk.Where(row => row.Kind == IlDiffKind.Add).ToArray();
                     var displayRows = hunk.Select(IlDiffPrinter.ToDisplayRow).ToImmutableArray();
-                    var direction = removed.Length == 0
-                        ? ResearchDiffDirection.Added
+                    var kind = removed.Length == 0
+                        ? ResearchChangeKind.Added
                         : added.Length == 0
-                            ? ResearchDiffDirection.Removed
-                            : ResearchDiffDirection.Changed;
-                    builder.Add(subject, new ResearchDiffEvidence(
-                        ResearchDiffMechanism.IlBody,
-                        direction switch
+                            ? ResearchChangeKind.Removed
+                            : ResearchChangeKind.Changed;
+                    string descriptorId = kind switch
                         {
-                            ResearchDiffDirection.Added => "il.operation.added",
-                            ResearchDiffDirection.Removed => "il.operation.removed",
+                            ResearchChangeKind.Added => "il.operation.added",
+                            ResearchChangeKind.Removed => "il.operation.removed",
                             _ => "il.hunk.changed",
-                        },
-                        direction,
-                        OldValue: FormatOperations(removed),
-                        NewValue: FormatOperations(added),
-                        OldIlOffset: removed.Select(row => (int?)row.Operation.Offset).FirstOrDefault(offset => offset is not null),
-                        NewIlOffset: added.Select(row => (int?)row.Operation.Offset).FirstOrDefault(offset => offset is not null),
-                        Category: ResearchDiffChangeCategory.IlBody,
-                        IlDisplayRows: displayRows));
+                        };
+                    builder.Add(new ResearchChange(
+                        subject,
+                        ResearchChangeMechanism.IlBody,
+                        Descriptor(descriptorId, "IL body"),
+                        kind,
+                        oldValue: FormatOperations(removed),
+                        newValue: FormatOperations(added),
+                        oldIlOffset: removed.Select(row => (int?)row.Operation.Offset).FirstOrDefault(offset => offset is not null),
+                        newIlOffset: added.Select(row => (int?)row.Operation.Offset).FirstOrDefault(offset => offset is not null),
+                        category: ResearchChangeCategory.IlBody,
+                        ilDisplayRows: displayRows));
                 }
             }
         }
@@ -661,21 +609,24 @@ public static class ResearchDiff
 
     static void AddIlFailureEvidence(ResultBuilder builder, ResearchSubjectKey subject, IlDiffFailureRow failure)
     {
-        var direction = failure.Kind switch
+        var kind = failure.Kind switch
         {
-            IlDiffFailureKind.OldBodyMissing => ResearchDiffDirection.Added,
-            IlDiffFailureKind.NewBodyMissing => ResearchDiffDirection.Removed,
-            _ => ResearchDiffDirection.Changed,
+            IlDiffFailureKind.OldBodyMissing => ResearchChangeKind.Added,
+            IlDiffFailureKind.NewBodyMissing => ResearchChangeKind.Removed,
+            _ => ResearchChangeKind.Changed,
         };
-        builder.Add(subject, new ResearchDiffEvidence(
-            ResearchDiffMechanism.IlBody,
-            $"il.diff.{ToKebabCase(failure.Kind.ToString())}",
-            direction,
-            OldValue: failure.Side == "old" ? failure.Detail ?? failure.Message : null,
-            NewValue: failure.Side == "new" ? failure.Detail ?? failure.Message : null,
-            Detail: failure.Detail ?? failure.Message,
-            Category: ResearchDiffChangeCategory.IlBody,
-            IlDisplayFailureRow: IlDiffPrinter.ToDisplayFailureRow(failure)));
+        string descriptorId = $"il.diff.{ToKebabCase(failure.Kind.ToString())}";
+        builder.Add(new ResearchChange(
+            subject,
+            ResearchChangeMechanism.IlBody,
+            Descriptor(descriptorId, failure.Kind.ToString()),
+            kind,
+            oldValue: failure.Side == "old" ? failure.Detail ?? failure.Message : null,
+            newValue: failure.Side == "new" ? failure.Detail ?? failure.Message : null,
+            detail: failure.Detail ?? failure.Message,
+            category: ResearchChangeCategory.IlBody,
+            ilFailureRow: failure,
+            ilDisplayFailureRow: IlDiffPrinter.ToDisplayFailureRow(failure)));
     }
 
     static void AddCSharpDiff(
@@ -701,43 +652,48 @@ public static class ResearchDiff
             var subject = ResearchMemberIdentity.SubjectFromAnchor(row.Anchor, row.Member);
             if (!MatchesMemberTargets(subject, memberTargetIdentities))
                 continue;
-            var direction = row.Kind switch
+            var kind = row.Kind switch
             {
-                CSharpDiffKind.Add => ResearchDiffDirection.Added,
-                CSharpDiffKind.Remove => ResearchDiffDirection.Removed,
-                _ => ResearchDiffDirection.Changed,
+                CSharpDiffKind.Add => ResearchChangeKind.Added,
+                CSharpDiffKind.Remove => ResearchChangeKind.Removed,
+                _ => ResearchChangeKind.Changed,
             };
-            builder.Add(subject, new ResearchDiffEvidence(
-                ResearchDiffMechanism.CSharp,
-                row.ChangeId,
-                direction,
-                OldValue: row.OldOperation?.Value ?? row.OldValue ?? (direction == ResearchDiffDirection.Removed ? row.Text : null),
-                NewValue: row.NewOperation?.Value ?? row.NewValue ?? (direction == ResearchDiffDirection.Added ? row.Text : null),
-                Detail: row.Message,
-                Category: ResearchDiffChangeCategory.CSharp)
-            {
-                CSharpDisplayRows = [CSharpDiffPrinter.ToDisplayRow(row)]
-            });
+            builder.Add(new ResearchChange(
+                subject,
+                ResearchChangeMechanism.CSharp,
+                Descriptor(row.ChangeId, row.Kind.ToString()),
+                kind,
+                oldValue: row.OldOperation?.Value ?? row.OldValue
+                    ?? (kind == ResearchChangeKind.Removed ? row.Text : null),
+                newValue: row.NewOperation?.Value ?? row.NewValue
+                    ?? (kind == ResearchChangeKind.Added ? row.Text : null),
+                detail: row.Message,
+                category: ResearchChangeCategory.CSharp,
+                cSharpRow: row,
+                cSharpDisplayRows: [CSharpDiffPrinter.ToDisplayRow(row)]));
         }
     }
 
     static void AddCSharpFailureEvidence(ResultBuilder builder, ResearchSubjectKey subject, CSharpDiffFailureRow failure)
     {
-        var direction = failure.Kind switch
+        var kind = failure.Kind switch
         {
-            CSharpDiffFailureKind.OldBodyMissing => ResearchDiffDirection.Added,
-            CSharpDiffFailureKind.NewBodyMissing => ResearchDiffDirection.Removed,
-            _ => ResearchDiffDirection.Changed,
+            CSharpDiffFailureKind.OldBodyMissing => ResearchChangeKind.Added,
+            CSharpDiffFailureKind.NewBodyMissing => ResearchChangeKind.Removed,
+            _ => ResearchChangeKind.Changed,
         };
-        builder.Add(subject, new ResearchDiffEvidence(
-            ResearchDiffMechanism.CSharp,
-            $"csharp.diff.{ToKebabCase(failure.Kind.ToString())}",
-            direction,
-            OldValue: failure.Side == "old" ? failure.Detail ?? failure.Message : null,
-            NewValue: failure.Side == "new" ? failure.Detail ?? failure.Message : null,
-            Detail: failure.Detail ?? failure.Message,
-            Category: ResearchDiffChangeCategory.CSharp,
-            CSharpDisplayFailureRow: CSharpDiffPrinter.ToDisplayFailureRow(failure)));
+        string descriptorId = $"csharp.diff.{ToKebabCase(failure.Kind.ToString())}";
+        builder.Add(new ResearchChange(
+            subject,
+            ResearchChangeMechanism.CSharp,
+            Descriptor(descriptorId, failure.Kind.ToString()),
+            kind,
+            oldValue: failure.Side == "old" ? failure.Detail ?? failure.Message : null,
+            newValue: failure.Side == "new" ? failure.Detail ?? failure.Message : null,
+            detail: failure.Detail ?? failure.Message,
+            category: ResearchChangeCategory.CSharp,
+            cSharpFailureRow: failure,
+            cSharpDisplayFailureRow: CSharpDiffPrinter.ToDisplayFailureRow(failure)));
     }
 
     static ApiSurface? ResolveApiSurface(ResearchDiffInput input, bool includeAll)
@@ -808,13 +764,13 @@ public static class ResearchDiff
            || memberTargetIdentities.Count == 0
            || memberTargetIdentities.Contains(subject.Id);
 
-    static ResearchSubjectKey ApiSubject(ApiSurface oldSurface, ApiSurface newSurface, string typeName, ApiChange change)
+    static ResearchSubjectKey ApiSubject(string typeName, ApiChange change)
     {
         if (!IsMemberChange(change.Kind))
-            return new ResearchSubjectKey(ResearchDiffSubjectKind.Type, $"type:{typeName}", typeName, TypeName: typeName);
+            return new ResearchSubjectKey(ResearchSubjectKind.Type, $"type:{typeName}", typeName, typeName: typeName);
 
-        var direction = Direction(change.Kind);
-        var handle = direction == ResearchDiffDirection.Removed
+        var kind = Direction(change.Kind);
+        var handle = kind == ResearchChangeKind.Removed
             ? change.Subject?.OldMember
             : change.Subject?.NewMember ?? change.Subject?.OldMember;
         var memberName = handle?.MemberName ?? change.Subject?.MemberName;
@@ -828,14 +784,14 @@ public static class ResearchDiff
         }
         else
         {
-            var value = direction == ResearchDiffDirection.Removed
+            var value = kind == ResearchChangeKind.Removed
                 ? change.Subject?.OldIdentity ?? change.OldValue
                 : change.Subject?.NewIdentity ?? change.NewValue;
             memberId = $"member:{typeName}::{value ?? memberName ?? change.Kind.ToString()}";
             display = $"{typeName}.{memberName ?? value ?? change.Kind.ToString()}";
         }
 
-        return new ResearchSubjectKey(ResearchDiffSubjectKind.Member, memberId, display, typeName, memberName);
+        return new ResearchSubjectKey(ResearchSubjectKind.Member, memberId, display, typeName, memberName);
     }
 
     static ApiType? FindType(ApiSurface surface, string typeName)
@@ -858,21 +814,53 @@ public static class ResearchDiff
             or ChangeKind.VirtualRemoved or ChangeKind.AbstractMemberAdded or ChangeKind.EnumValueChanged
             or ChangeKind.MemberAttributeAdded or ChangeKind.MemberAttributeRemoved;
 
-    static ResearchDiffDirection Direction(ChangeKind kind)
+    static ResearchChangeKind Direction(ChangeKind kind)
         => kind switch
         {
             ChangeKind.TypeAdded or ChangeKind.MemberAdded or ChangeKind.InterfaceAdded
-                or ChangeKind.TypeAttributeAdded or ChangeKind.MemberAttributeAdded => ResearchDiffDirection.Added,
+                or ChangeKind.TypeAttributeAdded or ChangeKind.MemberAttributeAdded => ResearchChangeKind.Added,
             ChangeKind.TypeRemoved or ChangeKind.MemberRemoved or ChangeKind.InterfaceRemoved
-                or ChangeKind.TypeAttributeRemoved or ChangeKind.MemberAttributeRemoved => ResearchDiffDirection.Removed,
-            _ => ResearchDiffDirection.Changed,
+                or ChangeKind.TypeAttributeRemoved or ChangeKind.MemberAttributeRemoved => ResearchChangeKind.Removed,
+            _ => ResearchChangeKind.Changed,
         };
 
-    static ResearchDiffChangeCategory ToResearchCategory(ApiChangeCategory category)
+    static ResearchChangeKind Direction(IlDiffKind kind)
+        => kind switch
+        {
+            IlDiffKind.Add => ResearchChangeKind.Added,
+            IlDiffKind.Remove => ResearchChangeKind.Removed,
+            _ => ResearchChangeKind.Changed,
+        };
+
+    static ResearchChangeKind Direction(IlDiffFailureKind kind)
+        => kind switch
+        {
+            IlDiffFailureKind.OldBodyMissing => ResearchChangeKind.Added,
+            IlDiffFailureKind.NewBodyMissing => ResearchChangeKind.Removed,
+            _ => ResearchChangeKind.Changed,
+        };
+
+    static ResearchChangeKind Direction(CSharpDiffKind kind)
+        => kind switch
+        {
+            CSharpDiffKind.Add => ResearchChangeKind.Added,
+            CSharpDiffKind.Remove => ResearchChangeKind.Removed,
+            _ => ResearchChangeKind.Changed,
+        };
+
+    static ResearchChangeKind Direction(CSharpDiffFailureKind kind)
+        => kind switch
+        {
+            CSharpDiffFailureKind.OldBodyMissing => ResearchChangeKind.Added,
+            CSharpDiffFailureKind.NewBodyMissing => ResearchChangeKind.Removed,
+            _ => ResearchChangeKind.Changed,
+        };
+
+    static ResearchChangeCategory ToResearchCategory(ApiChangeCategory category)
         => category switch
         {
-            ApiChangeCategory.Attribute => ResearchDiffChangeCategory.Attribute,
-            _ => ResearchDiffChangeCategory.Signature,
+            ApiChangeCategory.Attribute => ResearchChangeCategory.Attribute,
+            _ => ResearchChangeCategory.Signature,
         };
 
     static ResearchSubjectKey SubjectFromMethod(MethodIdentity method)
@@ -882,7 +870,7 @@ public static class ResearchDiff
         => methodName is "op_Implicit" or "op_Explicit" or "op_CheckedExplicit";
 
     static ResearchSubjectKey UnknownMemberSubject(string key)
-        => new(ResearchDiffSubjectKind.Member, $"member:{key}", key);
+        => new(ResearchSubjectKind.Member, $"member:{key}", key);
 
     static string BodySignalMethodKey(MethodIdentity method)
         => $"{method.AssemblyName}|{GenericMemberIdentity.KeyFragment(method.DeclaringType)}|{method.Name}|{method.GenericArity}|{method.IsExtension}|{string.Join(",", method.ParameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(method.ReturnType)}";
@@ -1007,46 +995,14 @@ public static class ResearchDiff
 
     sealed class ResultBuilder
     {
-        readonly Dictionary<ResearchSubjectKey, List<ResearchDiffEvidence>> _rows = new(ResearchSubjectKeyIdentityComparer.Instance);
+        readonly List<ResearchChange> _changes = [];
 
         public ApiDiff? ApiDiff { get; set; }
 
-        public void Add(ResearchSubjectKey subject, ResearchDiffEvidence evidence)
-        {
-            if (!_rows.TryGetValue(subject, out var evidenceRows))
-            {
-                evidenceRows = [];
-                _rows.Add(subject, evidenceRows);
-            }
-            evidenceRows.Add(evidence);
-        }
+        public void Add(ResearchChange change) => _changes.Add(change);
 
-        public ResearchDiffResult ToResult()
-            => new([.. _rows
-                .OrderBy(pair => pair.Key.Kind)
-                .ThenBy(pair => pair.Key.Id, StringComparer.Ordinal)
-                .Select(pair => new ResearchSubjectDiff(pair.Key, [.. pair.Value
-                    .OrderBy(evidence => evidence.Mechanism)
-                    .ThenBy(evidence => evidence.ChangeId, StringComparer.Ordinal)
-                    .ThenBy(evidence => evidence.OldIlOffset)
-                    .ThenBy(evidence => evidence.NewIlOffset)]))],
-                ApiDiff,
-                Rows: []);
-    }
-
-    sealed class ResearchSubjectKeyIdentityComparer : IEqualityComparer<ResearchSubjectKey>
-    {
-        public static ResearchSubjectKeyIdentityComparer Instance { get; } = new();
-
-        public bool Equals(ResearchSubjectKey? x, ResearchSubjectKey? y)
-            => ReferenceEquals(x, y)
-               || (x is not null
-                   && y is not null
-                   && x.Kind == y.Kind
-                   && string.Equals(x.Id, y.Id, StringComparison.Ordinal));
-
-        public int GetHashCode(ResearchSubjectKey obj)
-            => HashCode.Combine(obj.Kind, StringComparer.Ordinal.GetHashCode(obj.Id));
+        public ResearchComparison ToResult()
+            => new([.. _changes], ApiDiff);
     }
 
     sealed class MethodBodyLookup : IDisposable

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -203,9 +203,15 @@ public static class ResearchDiff
         ArgumentNullException.ThrowIfNull(results);
         if (results.Any(result => result is null))
             throw new ArgumentException("Results cannot contain null entries.", nameof(results));
+        var apiComparison = results
+            .Select(result => result.ApiComparison)
+            .FirstOrDefault(comparison => comparison is not null);
+        var apiDiff = apiComparison?.ApiDiff
+            ?? results.FirstOrDefault(result => result.ApiDiff is not null)?.ApiDiff;
         return new ResearchComparison(
             [.. results.SelectMany(result => result.Changes)],
-            results.FirstOrDefault(result => result.ApiDiff is not null)?.ApiDiff);
+            apiDiff,
+            apiComparison);
     }
 
     public static ResearchComparison CompareAssemblies(string oldAssemblyPath, string newAssemblyPath, ResearchDiffOptions? options = null)
@@ -245,8 +251,13 @@ public static class ResearchDiff
         if (oldSurface is null || newSurface is null)
             return;
 
-        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface, new ApiDiffOptions(apiScope));
-        builder.ApiDiff = diff;
+        var findings = MetadataFindings.CompareApi(
+            oldSurface,
+            newSurface,
+            new FindingSubject("api", "API surface"),
+            new ApiDiffOptions(apiScope));
+        var diff = findings.ApiDiff;
+        builder.ApiComparison = findings;
         foreach (var typeDiff in diff.TypeDiffs)
         {
             foreach (var change in typeDiff.Changes)
@@ -997,12 +1008,12 @@ public static class ResearchDiff
     {
         readonly List<ResearchChange> _changes = [];
 
-        public ApiDiff? ApiDiff { get; set; }
+        public ApiFindingComparison? ApiComparison { get; set; }
 
         public void Add(ResearchChange change) => _changes.Add(change);
 
         public ResearchComparison ToResult()
-            => new([.. _changes], ApiDiff);
+            => new([.. _changes], apiComparison: ApiComparison);
     }
 
     sealed class MethodBodyLookup : IDisposable

--- a/src/ILInspector.Research/ResearchMemberIdentity.cs
+++ b/src/ILInspector.Research/ResearchMemberIdentity.cs
@@ -21,7 +21,7 @@ public static class ResearchMemberIdentity
 
     public static ResearchSubjectKey SubjectFromAnchor(MemberAnchor anchor, string display)
         => new(
-            ResearchDiffSubjectKind.Member,
+            ResearchSubjectKind.Member,
             anchor.StableSelector,
             display,
             anchor.TypeFullName,
@@ -32,7 +32,7 @@ public static class ResearchMemberIdentity
         var identity = BodyIdentityFromMethod(method);
         var displayParameters = string.Join(", ", method.ParameterTypes.Select(type => type.ToQualifiedDisplayString()));
         return new ResearchSubjectKey(
-            ResearchDiffSubjectKind.Member,
+            ResearchSubjectKind.Member,
             identity.StableSelector,
             $"{identity.TypeName}.{identity.MemberName}({displayParameters})",
             identity.TypeName,

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -380,27 +380,26 @@ public class DiffCommand
             ResearchDiffInput.FromAssemblies(fromPaths),
             ResearchDiffInput.FromAssemblies(toPaths),
             new ResearchDiffOptions(
-                ResearchDiffMechanism.BodySignals,
+                ResearchChangeMechanism.BodySignals,
                 TypeFilters: options.TypeFilter,
                 MemberTargetIdentities: memberTargetIdentities));
-        var ranked = research.Subjects
-            .SelectMany(subject => subject.Evidence.Select(evidence => (subject, evidence)))
-            .Where(entry => entry.evidence.Category == ResearchDiffChangeCategory.BodySignal
-                && entry.evidence.ChangeId.StartsWith("analysis.", StringComparison.Ordinal)
-                && entry.evidence.Signal is { Length: > 0 })
-            .Select(entry => new RankedAnalysisRow(
+        var ranked = research.Changes
+            .Where(change => change.Category == ResearchChangeCategory.BodySignal
+                && change.Descriptor.Id.StartsWith("analysis.", StringComparison.Ordinal)
+                && change.Signal is { Length: > 0 })
+            .Select(change => new RankedAnalysisRow(
                 new AnalysisDiffRow(
-                    MarkoutInline.Code(entry.subject.Subject.Display),
-                    entry.evidence.Signal!,
-                    entry.evidence.OldValue ?? "",
-                    entry.evidence.NewValue ?? "",
-                    entry.evidence.Delta ?? "changed",
-                    entry.evidence.Shape,
-                    entry.evidence.Detail),
-                entry.evidence.Magnitude ?? 1,
-                entry.evidence.DirectionScore,
-                entry.evidence.SubjectInBoth,
-                entry.evidence.InLoop))
+                    MarkoutInline.Code(change.Subject.Display),
+                    change.Signal!,
+                    change.OldValue ?? "",
+                    change.NewValue ?? "",
+                    change.Delta ?? "changed",
+                    change.Shape,
+                    change.Detail),
+                change.Magnitude ?? 1,
+                change.DirectionScore,
+                change.SubjectInBoth,
+                change.InLoop))
             .ToList();
 
         return RankAnalysisRows(ranked, options.ChangedOnly, options.AllocRegressionsOnly);
@@ -580,7 +579,7 @@ public class DiffCommand
                 ResearchDiffInput.FromApiSurface(fromSurface),
                 ResearchDiffInput.FromApiSurface(toSurface),
                 new ResearchDiffOptions(
-                    ResearchDiffMechanism.Api,
+                    ResearchChangeMechanism.Api,
                     IncludeAllApi: options.IncludeAll,
                     ApiScope: ApiDiffScope.Signature)).ApiDiff
             ?? new ApiDiff();

--- a/tests/ILInspector.Metadata.Tests/MetadataFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataFindingsTests.cs
@@ -1,0 +1,272 @@
+using System.Collections.Immutable;
+using System.Reflection.PortableExecutable;
+using ILInspector.Findings;
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests;
+
+public class MetadataFindingsTests
+{
+    static readonly FindingSubject Subject = new("api", "API");
+
+    [Fact]
+    public void SameSurface_IsExactAndAllPresent()
+    {
+        var oldSurface = Surface(Type("Widget", members:
+        [
+            Method("Get", "int Get()"),
+            Property("Name", "string Name { get; }"),
+        ]));
+        var newSurface = Surface(Type("Widget", members:
+        [
+            Method("Get", "int Get()"),
+            Property("Name", "string Name { get; }"),
+        ]));
+
+        var result = MetadataFindings.CompareApi(oldSurface, newSurface, Subject);
+
+        Assert.True(result.IsExact);
+        Assert.All(Pairs(result.Types), pair => Assert.Equal(PairKind.Present, pair.Kind));
+        Assert.All(Pairs(result.Members), pair => Assert.Equal(PairKind.Present, pair.Kind));
+    }
+
+    [Fact]
+    public void AddedAndRemovedMembers_AgreeWithApiDiffAnalyzer()
+    {
+        var oldSurface = Surface(Type("Widget", members:
+        [
+            Method("Keep", "void Keep()"),
+            Method("Removed", "void Removed()"),
+        ]));
+        var newSurface = Surface(Type("Widget", members:
+        [
+            Method("Keep", "void Keep()"),
+            Method("Added", "void Added()"),
+        ]));
+
+        var result = MetadataFindings.CompareApi(oldSurface, newSurface, Subject);
+        var expected = GetExpectedMembers(result.ApiDiff);
+
+        Assert.Equal(expected.Added, PairKeys(result.Members, PairKind.Added));
+        Assert.Equal(expected.Removed, PairKeys(result.Members, PairKind.Removed));
+        Assert.Empty(PairKeys(result.Members, PairKind.Changed));
+    }
+
+    [Fact]
+    public void MatchedMemberFacetChanges_AreChangedPairs()
+    {
+        var oldSurface = Surface(Type("Widget", members:
+        [
+            Method("Run", "void Run()"),
+        ]));
+        var newSurface = Surface(Type("Widget", members:
+        [
+            Method(
+                "Run",
+                "void Run()",
+                accessibility: "protected",
+                isObsolete: true,
+                attributes: ["System.ObsoleteAttribute"]),
+        ]));
+
+        var result = MetadataFindings.CompareApi(
+            oldSurface,
+            newSurface,
+            Subject,
+            new ApiDiffOptions(ApiDiffScope.All));
+
+        var pair = Assert.Single(Pairs(result.Members));
+        Assert.Equal(PairKind.Changed, pair.Kind);
+        Assert.Contains("accessibility: public -> protected", pair.Detail, StringComparison.Ordinal);
+        Assert.Contains("obsolete: false -> true", pair.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MatchedTypeFacetChanges_AreChangedPairs()
+    {
+        var oldSurface = Surface(Type("Widget"));
+        var newSurface = Surface(Type("Widget", isByRefLike: true));
+
+        var result = MetadataFindings.CompareApi(oldSurface, newSurface, Subject);
+
+        var pair = Assert.Single(Pairs(result.Types));
+        Assert.Equal(PairKind.Changed, pair.Kind);
+        Assert.Contains("byref-like: false -> true", pair.Detail, StringComparison.Ordinal);
+        Assert.False(result.IsExact);
+        Assert.True(result.ApiDiff.IsEmpty);
+    }
+
+    [Fact]
+    public void AddedAndRemovedTypes_AgreeWithApiDiffAnalyzer()
+    {
+        var oldSurface = Surface(Type("Keep"), Type("Removed"));
+        var newSurface = Surface(Type("Keep"), Type("Added"));
+
+        var result = MetadataFindings.CompareApi(oldSurface, newSurface, Subject);
+        var pairs = Pairs(result.Types);
+
+        Assert.Contains(pairs, pair =>
+            pair is PairFinding<ApiTypeHandle>.Added added
+            && added.New.Payload.TypeFullName == "TestNamespace.Added");
+        Assert.Contains(pairs, pair =>
+            pair is PairFinding<ApiTypeHandle>.Removed removed
+            && removed.Old.Payload.TypeFullName == "TestNamespace.Removed");
+        Assert.Contains(
+            result.ApiDiff.TypeDiffs.SelectMany(typeDiff => typeDiff.Changes),
+            change => change.Kind == ChangeKind.TypeAdded);
+        Assert.Contains(
+            result.ApiDiff.TypeDiffs.SelectMany(typeDiff => typeDiff.Changes),
+            change => change.Kind == ChangeKind.TypeRemoved);
+    }
+
+    [Fact]
+    public void ReorderedMembers_AreAllPresentUnderIdentitySetMode()
+    {
+        var oldSurface = Surface(Type("Widget", members:
+        [
+            Method("A", "void A()"),
+            Method("B", "void B()"),
+            Method("C", "void C()"),
+        ]));
+        var newSurface = Surface(Type("Widget", members:
+        [
+            Method("C", "void C()"),
+            Method("A", "void A()"),
+            Method("B", "void B()"),
+        ]));
+
+        var result = MetadataFindings.CompareApi(oldSurface, newSurface, Subject);
+
+        Assert.True(result.IsExact);
+        Assert.Equal(3, Pairs(result.Members).Length);
+        Assert.All(Pairs(result.Members), pair => Assert.Equal(PairKind.Present, pair.Kind));
+    }
+
+    [Fact]
+    public void SignatureChangesRemainConservativeAddRemovePairs()
+    {
+        var oldSurface = Surface(Type("Widget", members: [Method("Run", "void Run(int value)")]));
+        var newSurface = Surface(Type("Widget", members: [Method("Run", "void Run(string value)")]));
+
+        var result = MetadataFindings.CompareApi(oldSurface, newSurface, Subject);
+
+        Assert.Collection(
+            Pairs(result.Members).OrderBy(pair => pair.Kind),
+            pair => Assert.Equal(PairKind.Added, pair.Kind),
+            pair => Assert.Equal(PairKind.Removed, pair.Kind));
+        Assert.Contains(
+            result.ApiDiff.TypeDiffs.SelectMany(type => type.Changes),
+            change => change.Kind == ChangeKind.MemberSignatureChanged);
+    }
+
+    [Fact]
+    public void ApiSurfaceMembersAreNotFilteredByNameHeuristics()
+    {
+        var oldSurface = Surface(Type("Widget"));
+        var newSurface = Surface(Type("Widget", members: [Method("s_value", "void s_value()")]));
+
+        var result = MetadataFindings.CompareApi(oldSurface, newSurface, Subject);
+
+        var added = Assert.Single(Pairs(result.Members));
+        Assert.Equal(PairKind.Added, added.Kind);
+    }
+
+    [Fact]
+    public void RealAssemblySelfCompare_IsExact()
+    {
+        using var stream = File.OpenRead(typeof(ApiDiffAnalyzer).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        var result = MetadataFindings.CompareApi(surface, surface, Subject);
+
+        Assert.True(result.IsExact);
+        Assert.True(Pairs(result.Members).Length > 50);
+    }
+
+    static ImmutableArray<PairFinding<T>> Pairs<T>(FindingComparison<T> comparison)
+        where T : notnull
+        => comparison is FindingComparison<T>.Complete complete
+            ? complete.Pairs
+            : throw new Xunit.Sdk.XunitException($"Expected a complete comparison; failure: {comparison.Failure}");
+
+    static string[] PairKeys(
+        FindingComparison<ApiMemberHandle> comparison,
+        PairKind kind)
+        => Pairs(comparison)
+            .Where(pair => pair.Kind == kind)
+            .Select(pair => pair switch
+            {
+                PairFinding<ApiMemberHandle>.Added added => added.New.Key.IdentityKey,
+                PairFinding<ApiMemberHandle>.Removed removed => removed.Old.Key.IdentityKey,
+                PairFinding<ApiMemberHandle>.Changed changed => changed.New.Key.IdentityKey,
+                PairFinding<ApiMemberHandle>.Present present => present.New.Key.IdentityKey,
+                _ => throw new InvalidOperationException(),
+            })
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+    static ExpectedMembers GetExpectedMembers(ApiDiff diff)
+    {
+        var added = new List<string>();
+        var removed = new List<string>();
+        foreach (var change in diff.TypeDiffs.SelectMany(typeDiff => typeDiff.Changes))
+        {
+            if (change.Subject?.Kind != ApiChangeSubjectKind.Member)
+                continue;
+
+            switch (change.Kind)
+            {
+                case ChangeKind.MemberAdded when change.Subject.NewMember?.CanonicalSignature is { } newKey:
+                    added.Add(newKey);
+                    break;
+                case ChangeKind.MemberRemoved when change.Subject.OldMember?.CanonicalSignature is { } oldKey:
+                    removed.Add(oldKey);
+                    break;
+            }
+        }
+
+        return new ExpectedMembers(
+            [.. added.Order(StringComparer.Ordinal)],
+            [.. removed.Order(StringComparer.Ordinal)]);
+    }
+
+    static ApiSurface Surface(params ApiType[] types)
+        => new() { Types = [.. types] };
+
+    static ApiType Type(
+        string name,
+        string kind = "class",
+        string? ns = "TestNamespace",
+        bool isByRefLike = false,
+        List<ApiMember>? members = null)
+        => new()
+        {
+            Name = name,
+            Kind = kind,
+            Namespace = ns,
+            IsByRefLike = isByRefLike,
+            Members = members ?? [],
+        };
+
+    static ApiMember Method(
+        string name,
+        string signature,
+        bool isObsolete = false,
+        string? accessibility = null,
+        IReadOnlyList<string>? attributes = null)
+        => new()
+        {
+            Name = name,
+            Kind = "method",
+            Signature = signature,
+            IsObsolete = isObsolete,
+            Accessibility = accessibility,
+            Attributes = attributes?.ToList() ?? [],
+        };
+
+    static ApiMember Property(string name, string signature)
+        => new() { Name = name, Kind = "property", Signature = signature };
+
+    sealed record ExpectedMembers(string[] Added, string[] Removed);
+}

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -2341,13 +2341,13 @@ internal static class GeneratedFixtureRunner
 
     public static string FormatReturnToSenderCatalogJson(GeneratedFixtureReturnToSenderRunResult run)
     {
-        var research = ReturnToSenderEvidence.ToResearchDiff(ReturnToSenderEvidence.FromCatalog(run));
+        var research = ReturnToSenderEvidence.ToResearchComparison(ReturnToSenderEvidence.FromCatalog(run));
         var payload = new
         {
             ProjectDirectory = Directory.Exists(run.ProjectDirectory) ? run.ProjectDirectory : null,
             AssemblyPath = File.Exists(run.AssemblyPath) ? run.AssemblyPath : null,
             Results = run.Results.Select(SerializableReturnToSenderResult).ToArray(),
-            ResearchDiff = SerializableResearchDiff(research),
+            ResearchDiff = SerializableResearchComparison(research),
             ResearchSummary = ReturnToSenderEvidence.Summarize(research, int.MaxValue),
             RoslynFallbacks = ReturnToSenderCatalogReport.RoslynFallbackBuckets(run.Results),
             run.Passed,
@@ -2398,54 +2398,36 @@ internal static class GeneratedFixtureRunner
                 FailureRows = result.Diff.FailureRows.IsDefault ? Array.Empty<IlDiffFailureRow>() : result.Diff.FailureRows.ToArray(),
             };
 
-    static object SerializableResearchDiff(ResearchDiffResult research)
+    static object SerializableResearchComparison(ResearchComparison research)
         => new
         {
             research.ApiDiff,
-            Subjects = research.Subjects.Select(subject => new
-            {
-                subject.Subject,
-                Evidence = subject.Evidence.Select(SerializableEvidence).ToArray(),
-            }).ToArray(),
-            Rows = research.Rows.IsDefault
-                ? Array.Empty<object>()
-                : research.Rows.Select(row => (object)new
-                {
-                    row.ChangeId,
-                    row.EvidenceKind,
-                    row.Message,
-                    row.ApiChange,
-                    row.IlRow,
-                    row.IlFailureRow,
-                    row.IlDisplayRow,
-                    row.IlDisplayFailureRow,
-                    row.BodySignalRow,
-                    row.CSharpRow,
-                }).ToArray(),
+            Changes = research.Changes.Select(SerializableChange).ToArray(),
         };
 
-    static object SerializableEvidence(ResearchDiffEvidence evidence)
+    static object SerializableChange(ResearchChange change)
         => new
         {
-            evidence.Mechanism,
-            evidence.ChangeId,
-            evidence.Direction,
-            evidence.OldValue,
-            evidence.NewValue,
-            evidence.Delta,
-            evidence.OldIlOffset,
-            evidence.NewIlOffset,
-            evidence.Detail,
-            evidence.Category,
-            evidence.Signal,
-            evidence.Shape,
-            evidence.Magnitude,
-            evidence.DirectionScore,
-            evidence.SubjectInBoth,
-            evidence.InLoop,
-            IlDisplayRows = evidence.IlDisplayRows.IsDefault ? Array.Empty<IlDiffDisplayRow>() : evidence.IlDisplayRows.ToArray(),
-            evidence.IlDisplayFailureRow,
-            IlMemberDiff = SerializableIlMemberDiff(evidence.IlMemberDiff),
+            change.Subject,
+            change.Mechanism,
+            DescriptorId = change.Descriptor.Id,
+            change.Kind,
+            change.OldValue,
+            change.NewValue,
+            change.Delta,
+            change.OldIlOffset,
+            change.NewIlOffset,
+            change.Detail,
+            change.Category,
+            change.Signal,
+            change.Shape,
+            change.Magnitude,
+            change.DirectionScore,
+            change.SubjectInBoth,
+            change.InLoop,
+            IlDisplayRows = change.IlDisplayRows.IsDefault ? Array.Empty<IlDiffDisplayRow>() : change.IlDisplayRows.ToArray(),
+            change.IlDisplayFailureRow,
+            IlMemberDiff = SerializableIlMemberDiff(change.IlMemberDiff),
         };
 
     public static string FormatList(IReadOnlyList<GeneratedFixtureDefinition> fixtures)

--- a/tools/DecompilerHarness/ReturnToSenderCatalogReport.cs
+++ b/tools/DecompilerHarness/ReturnToSenderCatalogReport.cs
@@ -16,7 +16,7 @@ internal sealed record ReturnToSenderCatalogFixtureGroup(
     IReadOnlyList<GeneratedFixtureReturnToSenderResult> Rows);
 
 internal sealed record ReturnToSenderCatalogResearchSection(
-    ResearchDiffResult Diff,
+    ResearchComparison Comparison,
     ReturnToSenderResearchSummary Summary,
     IReadOnlyList<ReturnToSenderCatalogReportBucket> ChangeBuckets);
 
@@ -54,15 +54,15 @@ internal static class ReturnToSenderCatalogReport
             .OrderBy(row => row.FixtureId, StringComparer.Ordinal)
             .ToArray();
 
-        var research = ReturnToSenderEvidence.ToResearchDiff(ReturnToSenderEvidence.FromCatalog(run));
-        var researchEvidence = research.Subjects.SelectMany(subject => subject.Evidence).ToArray();
-        var researchSection = researchEvidence.Length == 0
+        var research = ReturnToSenderEvidence.ToResearchComparison(ReturnToSenderEvidence.FromCatalog(run));
+        var researchChanges = research.Changes;
+        var researchSection = researchChanges.Length == 0
             ? null
             : new ReturnToSenderCatalogResearchSection(
                 research,
                 ReturnToSenderEvidence.Summarize(research, maxExamples),
-                [.. researchEvidence
-                    .GroupBy(row => row.ChangeId, StringComparer.Ordinal)
+                [.. researchChanges
+                    .GroupBy(change => change.Descriptor.Id, StringComparer.Ordinal)
                     .OrderByDescending(group => group.Count())
                     .ThenBy(group => group.Key, StringComparer.Ordinal)
                     .Select(group => new ReturnToSenderCatalogReportBucket(group.Key, group.Count()))]);
@@ -139,9 +139,9 @@ internal static class ReturnToSenderCatalogReport
             ResearchEvidence = view.Research is null
                 ? null
                 : [
-                    new("Subjects", view.Research.Diff.Subjects.Count),
-                    new("RTS rows", view.Research.Diff.Subjects.SelectMany(subject => subject.Evidence).Count(row => row.Mechanism == ResearchDiffMechanism.ReturnToSender)),
-                    new("IL rows", view.Research.Diff.Subjects.SelectMany(subject => subject.Evidence).Count(row => row.Mechanism == ResearchDiffMechanism.IlBody)),
+                    new("Subjects", view.Research.Comparison.BySubject().Count),
+                    new("RTS rows", view.Research.Comparison.Changes.Count(change => change.Mechanism == ResearchChangeMechanism.ReturnToSender)),
+                    new("IL rows", view.Research.Comparison.Changes.Count(change => change.Mechanism == ResearchChangeMechanism.IlBody)),
                     .. view.Research.ChangeBuckets.Select(bucket => new ReturnToSenderResearchEvidenceRow(bucket.Key, bucket.Count)),
                 ],
             ActionableSubjects = view.Research?.Summary.ActionableSubjects.Count > 0
@@ -229,12 +229,12 @@ internal static class ReturnToSenderCatalogReport
         if (research is null)
             return;
 
-        var evidence = research.Diff.Subjects.SelectMany(subject => subject.Evidence).ToArray();
+        var changes = research.Comparison.Changes;
         sb.AppendLine();
         sb.AppendLine("Research evidence:");
-        sb.AppendLine($"  Subjects : {research.Diff.Subjects.Count}");
-        sb.AppendLine($"  RTS rows : {evidence.Count(row => row.Mechanism == ResearchDiffMechanism.ReturnToSender)}");
-        sb.AppendLine($"  IL rows  : {evidence.Count(row => row.Mechanism == ResearchDiffMechanism.IlBody)}");
+        sb.AppendLine($"  Subjects : {research.Comparison.BySubject().Count}");
+        sb.AppendLine($"  RTS rows : {changes.Count(change => change.Mechanism == ResearchChangeMechanism.ReturnToSender)}");
+        sb.AppendLine($"  IL rows  : {changes.Count(change => change.Mechanism == ResearchChangeMechanism.IlBody)}");
         foreach (var bucket in research.ChangeBuckets)
             sb.AppendLine($"  {bucket.Key}: {bucket.Count}");
     }

--- a/tools/DecompilerHarness/ReturnToSenderEvidence.cs
+++ b/tools/DecompilerHarness/ReturnToSenderEvidence.cs
@@ -1,4 +1,5 @@
 using ILInspector.Instructions;
+using ILInspector.Findings;
 using ILInspector.MetadataPrimitives;
 using ILInspector.Research;
 
@@ -27,7 +28,7 @@ internal sealed record ReturnToSenderResearchSummary(
     int OpcodeDiffMembers,
     int RecompileFailMembers,
     int ContextFailMembers,
-    int MembersWithIlEvidence,
+    int MembersWithIlChanges,
     IReadOnlyList<ReturnToSenderActionableSubject> ActionableSubjects);
 
 internal sealed record ReturnToSenderActionableSubject(
@@ -64,23 +65,21 @@ internal static class ReturnToSenderEvidence
             result.IlDiff))];
     }
 
-    public static ResearchDiffResult ToResearchDiff(IEnumerable<ReturnToSenderEvidenceRow> rows)
+    public static ResearchComparison ToResearchComparison(IEnumerable<ReturnToSenderEvidenceRow> rows)
     {
         ArgumentNullException.ThrowIfNull(rows);
 
-        var subjects = rows
-            .GroupBy(SubjectKey)
-            .Select(group => new ResearchSubjectDiff(group.Key, [.. group.SelectMany(Evidence)]))
-            .Where(subject => subject.Evidence.Count > 0)
-            .ToArray();
-        return new ResearchDiffResult(subjects, Rows: []);
+        return new ResearchComparison(
+        [
+            .. rows.SelectMany(row => Changes(row, SubjectKey(row)))
+        ]);
     }
 
-    public static ReturnToSenderResearchSummary Summarize(ResearchDiffResult research, int maxSubjects)
+    public static ReturnToSenderResearchSummary Summarize(ResearchComparison research, int maxSubjects)
     {
         ArgumentNullException.ThrowIfNull(research);
-        var subjects = research.Subjects;
-        var evidence = subjects.SelectMany(subject => subject.Evidence).ToArray();
+        var subjects = research.BySubject();
+        var changes = research.Changes;
         var actionable = subjects
             .Select(ActionableSubject)
             .Where(subject => subject is not null)
@@ -92,53 +91,55 @@ internal static class ReturnToSenderEvidence
 
         return new ReturnToSenderResearchSummary(
             subjects.Count,
-            evidence.Count(item => item.Mechanism == ResearchDiffMechanism.ReturnToSender),
-            evidence.Count(item => item.Mechanism == ResearchDiffMechanism.IlBody),
+            changes.Count(item => item.Mechanism == ResearchChangeMechanism.ReturnToSender),
+            changes.Count(item => item.Mechanism == ResearchChangeMechanism.IlBody),
             subjects.Count(subject => HasRtsStatus(subject, "rts.status.fail")),
             subjects.Count(subject => HasCompileBackStatus(subject, "OpcodeDiff")),
             subjects.Count(subject => HasCompileBackStatus(subject, "RecompileFail")),
             subjects.Count(subject => HasCompileBackStatus(subject, "ContextFail")),
-            subjects.Count(subject => subject.Evidence.Any(item => item.Mechanism == ResearchDiffMechanism.IlBody)),
+            subjects.Count(subject => subject.Changes.Any(item => item.Mechanism == ResearchChangeMechanism.IlBody)),
             actionable);
     }
 
-    static ReturnToSenderActionableSubject? ActionableSubject(ResearchSubjectDiff subject)
+    static ReturnToSenderActionableSubject? ActionableSubject(ResearchSubjectChanges subject)
     {
-        var rts = subject.Evidence.FirstOrDefault(item => item.Mechanism == ResearchDiffMechanism.ReturnToSender);
-        if (rts is null || rts.ChangeId == "rts.status.pass")
+        var rts = subject.Changes.FirstOrDefault(item => item.Mechanism == ResearchChangeMechanism.ReturnToSender);
+        if (rts is null || rts.Descriptor.Id == "rts.status.pass")
             return null;
 
-        var changeCounts = subject.Evidence
-            .Where(item => item.Mechanism != ResearchDiffMechanism.ReturnToSender)
-            .GroupBy(item => item.ChangeId, StringComparer.Ordinal)
+        var changeCounts = subject.Changes
+            .Where(item => item.Mechanism != ResearchChangeMechanism.ReturnToSender)
+            .GroupBy(item => item.Descriptor.Id, StringComparer.Ordinal)
             .OrderByDescending(group => group.Count())
             .ThenBy(group => group.Key, StringComparer.Ordinal)
             .Select(group => new ReturnToSenderChangeCount(group.Key, group.Count()))
             .ToArray();
-        var ilEvidence = subject.Evidence
-            .Where(item => item.Mechanism == ResearchDiffMechanism.IlBody
+        var ilEvidence = subject.Changes
+            .Where(item => item.Mechanism == ResearchChangeMechanism.IlBody
                 && (item.IlDisplayFailureRow is not null || !item.IlDisplayRows.IsDefaultOrEmpty))
             .Select(item => new ReturnToSenderIlEvidence(
-                item.ChangeId,
+                item.Descriptor.Id,
                 item.IlDisplayFailureRow,
                 item.IlDisplayRows.IsDefault ? [] : item.IlDisplayRows.ToArray()))
             .ToArray();
         return new ReturnToSenderActionableSubject(
             subject.Subject.Id,
             subject.Subject.Display,
-            rts.ChangeId,
+            rts.Descriptor.Id,
             rts.NewValue,
             rts.Detail,
             changeCounts,
             ilEvidence);
     }
 
-    static bool HasRtsStatus(ResearchSubjectDiff subject, string changeId)
-        => subject.Evidence.Any(item => item.Mechanism == ResearchDiffMechanism.ReturnToSender && item.ChangeId == changeId);
+    static bool HasRtsStatus(ResearchSubjectChanges subject, string descriptorId)
+        => subject.Changes.Any(item =>
+            item.Mechanism == ResearchChangeMechanism.ReturnToSender
+            && item.Descriptor.Id == descriptorId);
 
-    static bool HasCompileBackStatus(ResearchSubjectDiff subject, string status)
-        => subject.Evidence.Any(item =>
-            item.Mechanism == ResearchDiffMechanism.ReturnToSender
+    static bool HasCompileBackStatus(ResearchSubjectChanges subject, string status)
+        => subject.Changes.Any(item =>
+            item.Mechanism == ResearchChangeMechanism.ReturnToSender
             && string.Equals(item.NewValue, status, StringComparison.Ordinal));
 
     static int Rank(ReturnToSenderActionableSubject subject)
@@ -156,26 +157,29 @@ internal static class ReturnToSenderEvidence
             return ResearchMemberIdentity.SubjectFromAnchor(anchor, $"{anchor.TypeFullName}.{anchor.MemberName}");
 
         return new ResearchSubjectKey(
-            ResearchDiffSubjectKind.Member,
+            ResearchSubjectKind.Member,
             $"rts:{row.DisplayMember}",
             $"{row.Type}.{row.Method}",
             row.Type,
             row.Method);
     }
 
-    static IEnumerable<ResearchDiffEvidence> Evidence(ReturnToSenderEvidenceRow row)
+    static IEnumerable<ResearchChange> Changes(
+        ReturnToSenderEvidenceRow row,
+        ResearchSubjectKey subject)
     {
-        yield return new ResearchDiffEvidence(
-            ResearchDiffMechanism.ReturnToSender,
-            $"rts.status.{StatusId(row.Status)}",
-            ResearchDiffDirection.Changed,
-            OldValue: null,
-            NewValue: row.CompileBackStatus?.ToString(),
-            Detail: row.Detail ?? row.Reason,
-            Category: ResearchDiffChangeCategory.RoundTrip);
+        string descriptorId = $"rts.status.{StatusId(row.Status)}";
+        yield return new ResearchChange(
+            subject,
+            ResearchChangeMechanism.ReturnToSender,
+            new FindingDescriptor(descriptorId, "Return to sender status"),
+            ResearchChangeKind.Changed,
+            newValue: row.CompileBackStatus?.ToString(),
+            detail: row.Detail ?? row.Reason,
+            category: ResearchChangeCategory.RoundTrip);
 
-        foreach (var ilEvidence in ImplementationDiff.ToIlEvidence(row.IlDiff, row.IlDiffDiagnostic))
-            yield return ilEvidence;
+        foreach (var change in ImplementationDiff.ToIlChanges(row.IlDiff, subject, row.IlDiffDiagnostic))
+            yield return change;
     }
 
     static string StatusId(GeneratedFixtureReturnToSenderStatus status)


### PR DESCRIPTION
## Summary

- replace Research's parallel diff row/result families with one flat
  `ResearchChange` / `ResearchComparison` model and computed subject grouping
- add Metadata-owned API type/member Finding inspections and comparisons while
  retaining `ApiDiff` compatibility classification
- migrate CLI diff, ImplementationDiff, and ReturnToSender consumers to the
  unified Research result

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- `dotnet build src/dotnet-inspect -c Release
  -p:DefaultTargetFramework=net10.0 -p:PublishAot=false`
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release --no-build`
  (417 passed)
- `dotnet run --project src/ILInspector.Research.Tests -c Release --no-build`
  (71 passed)
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- -class
  '*DiffCommandTests*'` (61 passed)
- `npx markdownlint-cli docs/overview.md docs/architecture.md
  docs/design/implementation-diff.md`

The ReturnToSender class filter has two existing failures under the current
.NET 11 daily SDK; both reproduce unchanged on clean `origin/main`.

Refs #2564.
Refs #2577.
