### PR TITLE
Add Metadata inventory Finding producers

### DIFF
--- a/src/ILInspector.Metadata/MetadataFindings.Inventory.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.Inventory.cs
@@ -1,4 +1,6 @@
 using System.Collections.Immutable;
+using System.Globalization;
+using System.Text;
 using ILInspector.Findings;
 
 namespace ILInspector.Metadata;
@@ -201,9 +203,17 @@ public static partial class MetadataFindings
             : throw new InvalidOperationException("An in-memory inventory inspection must complete.");
 
     static string JoinSortKey(params object?[] parts)
-        => string.Join(
-            '\u001F',
-            parts.Select(static part => part?.ToString() ?? ""));
+    {
+        var builder = new StringBuilder();
+        foreach (var part in parts)
+        {
+            string value = Convert.ToString(part, CultureInfo.InvariantCulture) ?? "";
+            builder.Append(value.Length);
+            builder.Append(':');
+            builder.Append(value);
+        }
+        return builder.ToString();
+    }
 
     sealed record InventoryObservation<T>(
         T Payload,

--- a/src/ILInspector.Metadata/MetadataFindings.Inventory.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.Inventory.cs
@@ -23,11 +23,6 @@ public static partial class MetadataFindings
     public static readonly FindingDescriptor AssemblyAttributeDescriptor =
         new("metadata.assembly-attribute", "Assembly or module attribute");
 
-    static readonly FindingMatchOptions InventoryMatchOptions = new()
-    {
-        MatchMode = FindingMatchMode.IdentitySet,
-    };
-
     public static FindingInspection<AssemblyReference> InspectAssemblyReferences(
         IEnumerable<AssemblyReference> references,
         FindingSubject subject)
@@ -78,9 +73,9 @@ public static partial class MetadataFindings
             static resource => resource.Name,
             static resource => JoinSortKey(
                 resource.Name,
-                resource.IsPublic,
-                resource.IsEmbedded,
-                resource.Size));
+                resource.IsPublic ? "1" : "0",
+                resource.IsEmbedded ? "1" : "0",
+                resource.Size.ToString(CultureInfo.InvariantCulture)));
 
     public static FindingComparison<ManifestResourceInfo> CompareResources(
         IEnumerable<ManifestResourceInfo> oldResources,
@@ -97,7 +92,7 @@ public static partial class MetadataFindings
             attributes,
             subject,
             AssemblyAttributeDescriptor,
-            static attribute => JoinSortKey(attribute.Target, attribute.Name),
+            static attribute => JoinSortKey(attribute.Target, attribute.Name, attribute.Value),
             static attribute => JoinSortKey(attribute.Target, attribute.Name, attribute.Value));
 
     public static FindingComparison<AssemblyAttributeInfo> CompareAssemblyAttributes(
@@ -153,12 +148,12 @@ public static partial class MetadataFindings
         FindingInspection<T> newInspection)
         where T : notnull
     {
-        var oldFindings = CompleteFindings(oldInspection);
-        var newFindings = CompleteFindings(newInspection);
+        var oldFindings = InspectionFindings(oldInspection);
+        var newFindings = InspectionFindings(newInspection);
         var match = FindingMatcher.Match(
             oldFindings.Keys(),
             newFindings.Keys(),
-            InventoryMatchOptions);
+            IdentitySetOptions);
         var pairs = FindingFold.ToPairs(match, oldFindings, newFindings);
         pairs = PromoteChangedPayloads(pairs);
 
@@ -195,24 +190,39 @@ public static partial class MetadataFindings
         return builder.MoveToImmutable();
     }
 
-    static ImmutableArray<Finding<T>> CompleteFindings<T>(
-        FindingInspection<T> inspection)
-        where T : notnull
-        => inspection is FindingInspection<T>.Complete complete
-            ? complete.Findings
-            : throw new InvalidOperationException("An in-memory inventory inspection must complete.");
-
-    static string JoinSortKey(params object?[] parts)
+    static string JoinSortKey(string? first, string? second)
     {
         var builder = new StringBuilder();
-        foreach (var part in parts)
-        {
-            string value = Convert.ToString(part, CultureInfo.InvariantCulture) ?? "";
-            builder.Append(value.Length);
-            builder.Append(':');
-            builder.Append(value);
-        }
+        AppendSortKeyPart(builder, first);
+        AppendSortKeyPart(builder, second);
         return builder.ToString();
+    }
+
+    static string JoinSortKey(string? first, string? second, string? third)
+    {
+        var builder = new StringBuilder();
+        AppendSortKeyPart(builder, first);
+        AppendSortKeyPart(builder, second);
+        AppendSortKeyPart(builder, third);
+        return builder.ToString();
+    }
+
+    static string JoinSortKey(string? first, string? second, string? third, string? fourth)
+    {
+        var builder = new StringBuilder();
+        AppendSortKeyPart(builder, first);
+        AppendSortKeyPart(builder, second);
+        AppendSortKeyPart(builder, third);
+        AppendSortKeyPart(builder, fourth);
+        return builder.ToString();
+    }
+
+    static void AppendSortKeyPart(StringBuilder builder, string? value)
+    {
+        value ??= "";
+        builder.Append(value.Length);
+        builder.Append(':');
+        builder.Append(value);
     }
 
     sealed record InventoryObservation<T>(

--- a/src/ILInspector.Metadata/MetadataFindings.Inventory.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.Inventory.cs
@@ -30,7 +30,14 @@ public static partial class MetadataFindings
         ArgumentNullException.ThrowIfNull(references);
         ArgumentNullException.ThrowIfNull(subject);
 
-        return InspectInventory(
+        return InspectAssemblyReferencesCore(references, subject, nameof(references));
+    }
+
+    static FindingInspection<AssemblyReference> InspectAssemblyReferencesCore(
+        IEnumerable<AssemblyReference> references,
+        FindingSubject subject,
+        string parameterName)
+        => InspectInventory(
             references,
             subject,
             AssemblyReferenceDescriptor,
@@ -39,8 +46,8 @@ public static partial class MetadataFindings
                 reference.Name.ToUpperInvariant(),
                 reference.Version,
                 reference.Culture,
-                reference.PublicKeyToken));
-    }
+                reference.PublicKeyToken),
+            parameterName);
 
     public static FindingComparison<AssemblyReference> CompareAssemblyReferences(
         IEnumerable<AssemblyReference> oldReferences,
@@ -52,8 +59,8 @@ public static partial class MetadataFindings
         ArgumentNullException.ThrowIfNull(subject);
 
         return CompareInventory(
-            InspectAssemblyReferences(oldReferences, subject),
-            InspectAssemblyReferences(newReferences, subject));
+            InspectAssemblyReferencesCore(oldReferences, subject, nameof(oldReferences)),
+            InspectAssemblyReferencesCore(newReferences, subject, nameof(newReferences)));
     }
 
     public static FindingInspection<TypeForwarderInfo> InspectTypeForwarders(
@@ -63,13 +70,20 @@ public static partial class MetadataFindings
         ArgumentNullException.ThrowIfNull(forwarders);
         ArgumentNullException.ThrowIfNull(subject);
 
-        return InspectInventory(
+        return InspectTypeForwardersCore(forwarders, subject, nameof(forwarders));
+    }
+
+    static FindingInspection<TypeForwarderInfo> InspectTypeForwardersCore(
+        IEnumerable<TypeForwarderInfo> forwarders,
+        FindingSubject subject,
+        string parameterName)
+        => InspectInventory(
             forwarders,
             subject,
             TypeForwarderDescriptor,
             static forwarder => forwarder.TypeName,
-            static forwarder => JoinSortKey(forwarder.TypeName, forwarder.TargetAssembly));
-    }
+            static forwarder => JoinSortKey(forwarder.TypeName, forwarder.TargetAssembly),
+            parameterName);
 
     public static FindingComparison<TypeForwarderInfo> CompareTypeForwarders(
         IEnumerable<TypeForwarderInfo> oldForwarders,
@@ -81,8 +95,8 @@ public static partial class MetadataFindings
         ArgumentNullException.ThrowIfNull(subject);
 
         return CompareInventory(
-            InspectTypeForwarders(oldForwarders, subject),
-            InspectTypeForwarders(newForwarders, subject));
+            InspectTypeForwardersCore(oldForwarders, subject, nameof(oldForwarders)),
+            InspectTypeForwardersCore(newForwarders, subject, nameof(newForwarders)));
     }
 
     public static FindingInspection<ManifestResourceInfo> InspectResources(
@@ -92,7 +106,14 @@ public static partial class MetadataFindings
         ArgumentNullException.ThrowIfNull(resources);
         ArgumentNullException.ThrowIfNull(subject);
 
-        return InspectInventory(
+        return InspectResourcesCore(resources, subject, nameof(resources));
+    }
+
+    static FindingInspection<ManifestResourceInfo> InspectResourcesCore(
+        IEnumerable<ManifestResourceInfo> resources,
+        FindingSubject subject,
+        string parameterName)
+        => InspectInventory(
             resources,
             subject,
             ResourceDescriptor,
@@ -101,8 +122,8 @@ public static partial class MetadataFindings
                 resource.Name,
                 resource.IsPublic ? "1" : "0",
                 resource.IsEmbedded ? "1" : "0",
-                resource.Size.ToString(CultureInfo.InvariantCulture)));
-    }
+                resource.Size.ToString(CultureInfo.InvariantCulture)),
+            parameterName);
 
     public static FindingComparison<ManifestResourceInfo> CompareResources(
         IEnumerable<ManifestResourceInfo> oldResources,
@@ -114,8 +135,8 @@ public static partial class MetadataFindings
         ArgumentNullException.ThrowIfNull(subject);
 
         return CompareInventory(
-            InspectResources(oldResources, subject),
-            InspectResources(newResources, subject));
+            InspectResourcesCore(oldResources, subject, nameof(oldResources)),
+            InspectResourcesCore(newResources, subject, nameof(newResources)));
     }
 
     public static FindingInspection<AssemblyAttributeInfo> InspectAssemblyAttributes(
@@ -125,13 +146,20 @@ public static partial class MetadataFindings
         ArgumentNullException.ThrowIfNull(attributes);
         ArgumentNullException.ThrowIfNull(subject);
 
-        return InspectInventory(
+        return InspectAssemblyAttributesCore(attributes, subject, nameof(attributes));
+    }
+
+    static FindingInspection<AssemblyAttributeInfo> InspectAssemblyAttributesCore(
+        IEnumerable<AssemblyAttributeInfo> attributes,
+        FindingSubject subject,
+        string parameterName)
+        => InspectInventory(
             attributes,
             subject,
             AssemblyAttributeDescriptor,
             static attribute => JoinSortKey(attribute.Target, attribute.Name, attribute.Value),
-            static attribute => JoinSortKey(attribute.Target, attribute.Name, attribute.Value));
-    }
+            static attribute => JoinSortKey(attribute.Target, attribute.Name, attribute.Value),
+            parameterName);
 
     public static FindingComparison<AssemblyAttributeInfo> CompareAssemblyAttributes(
         IEnumerable<AssemblyAttributeInfo> oldAttributes,
@@ -143,8 +171,8 @@ public static partial class MetadataFindings
         ArgumentNullException.ThrowIfNull(subject);
 
         return CompareInventory(
-            InspectAssemblyAttributes(oldAttributes, subject),
-            InspectAssemblyAttributes(newAttributes, subject));
+            InspectAssemblyAttributesCore(oldAttributes, subject, nameof(oldAttributes)),
+            InspectAssemblyAttributesCore(newAttributes, subject, nameof(newAttributes)));
     }
 
     static FindingInspection<T> InspectInventory<T>(
@@ -152,7 +180,8 @@ public static partial class MetadataFindings
         FindingSubject subject,
         FindingDescriptor descriptor,
         Func<T, string> identity,
-        Func<T, string> sortKey)
+        Func<T, string> sortKey,
+        string observationsParameterName)
         where T : notnull
     {
         ArgumentNullException.ThrowIfNull(observations);
@@ -160,10 +189,13 @@ public static partial class MetadataFindings
         ArgumentNullException.ThrowIfNull(descriptor);
         ArgumentNullException.ThrowIfNull(identity);
         ArgumentNullException.ThrowIfNull(sortKey);
+        ArgumentException.ThrowIfNullOrEmpty(observationsParameterName);
 
         var projected = observations
             .Select(observation => observation is null
-                ? throw new ArgumentException("Inventory cannot contain null observations.", nameof(observations))
+                ? throw new ArgumentException(
+                    "Inventory cannot contain null observations.",
+                    observationsParameterName)
                 : new InventoryObservation<T>(
                     observation,
                     identity(observation),

--- a/src/ILInspector.Metadata/MetadataFindings.Inventory.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.Inventory.cs
@@ -1,0 +1,213 @@
+using System.Collections.Immutable;
+using ILInspector.Findings;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Finding producers over typed Metadata inventories. These operations consume already-extracted
+/// data; acquisition and presentation remain outside the producer.
+/// </summary>
+public static partial class MetadataFindings
+{
+    public static readonly FindingDescriptor AssemblyReferenceDescriptor =
+        new("metadata.assembly-reference", "Assembly reference");
+
+    public static readonly FindingDescriptor TypeForwarderDescriptor =
+        new("metadata.type-forwarder", "Type forwarder");
+
+    public static readonly FindingDescriptor ResourceDescriptor =
+        new("metadata.resource", "Manifest resource");
+
+    public static readonly FindingDescriptor AssemblyAttributeDescriptor =
+        new("metadata.assembly-attribute", "Assembly or module attribute");
+
+    static readonly FindingMatchOptions InventoryMatchOptions = new()
+    {
+        MatchMode = FindingMatchMode.IdentitySet,
+    };
+
+    public static FindingInspection<AssemblyReference> InspectAssemblyReferences(
+        IEnumerable<AssemblyReference> references,
+        FindingSubject subject)
+        => InspectInventory(
+            references,
+            subject,
+            AssemblyReferenceDescriptor,
+            static reference => reference.Name.ToUpperInvariant(),
+            static reference => JoinSortKey(
+                reference.Name.ToUpperInvariant(),
+                reference.Version,
+                reference.Culture,
+                reference.PublicKeyToken));
+
+    public static FindingComparison<AssemblyReference> CompareAssemblyReferences(
+        IEnumerable<AssemblyReference> oldReferences,
+        IEnumerable<AssemblyReference> newReferences,
+        FindingSubject subject)
+        => CompareInventory(
+            InspectAssemblyReferences(oldReferences, subject),
+            InspectAssemblyReferences(newReferences, subject));
+
+    public static FindingInspection<TypeForwarderInfo> InspectTypeForwarders(
+        IEnumerable<TypeForwarderInfo> forwarders,
+        FindingSubject subject)
+        => InspectInventory(
+            forwarders,
+            subject,
+            TypeForwarderDescriptor,
+            static forwarder => forwarder.TypeName,
+            static forwarder => JoinSortKey(forwarder.TypeName, forwarder.TargetAssembly));
+
+    public static FindingComparison<TypeForwarderInfo> CompareTypeForwarders(
+        IEnumerable<TypeForwarderInfo> oldForwarders,
+        IEnumerable<TypeForwarderInfo> newForwarders,
+        FindingSubject subject)
+        => CompareInventory(
+            InspectTypeForwarders(oldForwarders, subject),
+            InspectTypeForwarders(newForwarders, subject));
+
+    public static FindingInspection<ManifestResourceInfo> InspectResources(
+        IEnumerable<ManifestResourceInfo> resources,
+        FindingSubject subject)
+        => InspectInventory(
+            resources,
+            subject,
+            ResourceDescriptor,
+            static resource => resource.Name,
+            static resource => JoinSortKey(
+                resource.Name,
+                resource.IsPublic,
+                resource.IsEmbedded,
+                resource.Size));
+
+    public static FindingComparison<ManifestResourceInfo> CompareResources(
+        IEnumerable<ManifestResourceInfo> oldResources,
+        IEnumerable<ManifestResourceInfo> newResources,
+        FindingSubject subject)
+        => CompareInventory(
+            InspectResources(oldResources, subject),
+            InspectResources(newResources, subject));
+
+    public static FindingInspection<AssemblyAttributeInfo> InspectAssemblyAttributes(
+        IEnumerable<AssemblyAttributeInfo> attributes,
+        FindingSubject subject)
+        => InspectInventory(
+            attributes,
+            subject,
+            AssemblyAttributeDescriptor,
+            static attribute => JoinSortKey(attribute.Target, attribute.Name),
+            static attribute => JoinSortKey(attribute.Target, attribute.Name, attribute.Value));
+
+    public static FindingComparison<AssemblyAttributeInfo> CompareAssemblyAttributes(
+        IEnumerable<AssemblyAttributeInfo> oldAttributes,
+        IEnumerable<AssemblyAttributeInfo> newAttributes,
+        FindingSubject subject)
+        => CompareInventory(
+            InspectAssemblyAttributes(oldAttributes, subject),
+            InspectAssemblyAttributes(newAttributes, subject));
+
+    static FindingInspection<T> InspectInventory<T>(
+        IEnumerable<T> observations,
+        FindingSubject subject,
+        FindingDescriptor descriptor,
+        Func<T, string> identity,
+        Func<T, string> sortKey)
+        where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(observations);
+        ArgumentNullException.ThrowIfNull(subject);
+        ArgumentNullException.ThrowIfNull(descriptor);
+        ArgumentNullException.ThrowIfNull(identity);
+        ArgumentNullException.ThrowIfNull(sortKey);
+
+        var projected = observations
+            .Select(observation => observation is null
+                ? throw new ArgumentException("Inventory cannot contain null observations.", nameof(observations))
+                : new InventoryObservation<T>(
+                    observation,
+                    identity(observation),
+                    sortKey(observation)))
+            .OrderBy(static observation => observation.Identity, StringComparer.Ordinal)
+            .ThenBy(static observation => observation.SortKey, StringComparer.Ordinal)
+            .ToArray();
+
+        var findings = ImmutableArray.CreateBuilder<Finding<T>>(projected.Length);
+        for (int position = 0; position < projected.Length; position++)
+        {
+            var observation = projected[position];
+            findings.Add(new Finding<T>(
+                subject,
+                descriptor,
+                new FindingKey(observation.Identity),
+                position,
+                observation.Payload));
+        }
+
+        return new FindingInspection<T>.Complete(findings.MoveToImmutable());
+    }
+
+    static FindingComparison<T> CompareInventory<T>(
+        FindingInspection<T> oldInspection,
+        FindingInspection<T> newInspection)
+        where T : notnull
+    {
+        var oldFindings = CompleteFindings(oldInspection);
+        var newFindings = CompleteFindings(newInspection);
+        var match = FindingMatcher.Match(
+            oldFindings.Keys(),
+            newFindings.Keys(),
+            InventoryMatchOptions);
+        var pairs = FindingFold.ToPairs(match, oldFindings, newFindings);
+        pairs = PromoteChangedPayloads(pairs);
+
+        return new FindingComparison<T>.Complete(
+            pairs,
+            match,
+            oldInspection,
+            newInspection);
+    }
+
+    static ImmutableArray<PairFinding<T>> PromoteChangedPayloads<T>(
+        ImmutableArray<PairFinding<T>> pairs)
+        where T : notnull
+    {
+        var builder = ImmutableArray.CreateBuilder<PairFinding<T>>(pairs.Length);
+        foreach (var pair in pairs)
+        {
+            if (pair is PairFinding<T>.Present present
+                && !EqualityComparer<T>.Default.Equals(
+                    present.Old.Payload,
+                    present.New.Payload))
+            {
+                builder.Add(new PairFinding<T>.Changed(
+                    present.Old,
+                    present.New,
+                    present.Difference));
+            }
+            else
+            {
+                builder.Add(pair);
+            }
+        }
+
+        return builder.MoveToImmutable();
+    }
+
+    static ImmutableArray<Finding<T>> CompleteFindings<T>(
+        FindingInspection<T> inspection)
+        where T : notnull
+        => inspection is FindingInspection<T>.Complete complete
+            ? complete.Findings
+            : throw new InvalidOperationException("An in-memory inventory inspection must complete.");
+
+    static string JoinSortKey(params object?[] parts)
+        => string.Join(
+            '\u001F',
+            parts.Select(static part => part?.ToString() ?? ""));
+
+    sealed record InventoryObservation<T>(
+        T Payload,
+        string Identity,
+        string SortKey)
+        where T : notnull;
+}

--- a/src/ILInspector.Metadata/MetadataFindings.Inventory.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.Inventory.cs
@@ -26,7 +26,11 @@ public static partial class MetadataFindings
     public static FindingInspection<AssemblyReference> InspectAssemblyReferences(
         IEnumerable<AssemblyReference> references,
         FindingSubject subject)
-        => InspectInventory(
+    {
+        ArgumentNullException.ThrowIfNull(references);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return InspectInventory(
             references,
             subject,
             AssemblyReferenceDescriptor,
@@ -36,37 +40,59 @@ public static partial class MetadataFindings
                 reference.Version,
                 reference.Culture,
                 reference.PublicKeyToken));
+    }
 
     public static FindingComparison<AssemblyReference> CompareAssemblyReferences(
         IEnumerable<AssemblyReference> oldReferences,
         IEnumerable<AssemblyReference> newReferences,
         FindingSubject subject)
-        => CompareInventory(
+    {
+        ArgumentNullException.ThrowIfNull(oldReferences);
+        ArgumentNullException.ThrowIfNull(newReferences);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return CompareInventory(
             InspectAssemblyReferences(oldReferences, subject),
             InspectAssemblyReferences(newReferences, subject));
+    }
 
     public static FindingInspection<TypeForwarderInfo> InspectTypeForwarders(
         IEnumerable<TypeForwarderInfo> forwarders,
         FindingSubject subject)
-        => InspectInventory(
+    {
+        ArgumentNullException.ThrowIfNull(forwarders);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return InspectInventory(
             forwarders,
             subject,
             TypeForwarderDescriptor,
             static forwarder => forwarder.TypeName,
             static forwarder => JoinSortKey(forwarder.TypeName, forwarder.TargetAssembly));
+    }
 
     public static FindingComparison<TypeForwarderInfo> CompareTypeForwarders(
         IEnumerable<TypeForwarderInfo> oldForwarders,
         IEnumerable<TypeForwarderInfo> newForwarders,
         FindingSubject subject)
-        => CompareInventory(
+    {
+        ArgumentNullException.ThrowIfNull(oldForwarders);
+        ArgumentNullException.ThrowIfNull(newForwarders);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return CompareInventory(
             InspectTypeForwarders(oldForwarders, subject),
             InspectTypeForwarders(newForwarders, subject));
+    }
 
     public static FindingInspection<ManifestResourceInfo> InspectResources(
         IEnumerable<ManifestResourceInfo> resources,
         FindingSubject subject)
-        => InspectInventory(
+    {
+        ArgumentNullException.ThrowIfNull(resources);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return InspectInventory(
             resources,
             subject,
             ResourceDescriptor,
@@ -76,32 +102,50 @@ public static partial class MetadataFindings
                 resource.IsPublic ? "1" : "0",
                 resource.IsEmbedded ? "1" : "0",
                 resource.Size.ToString(CultureInfo.InvariantCulture)));
+    }
 
     public static FindingComparison<ManifestResourceInfo> CompareResources(
         IEnumerable<ManifestResourceInfo> oldResources,
         IEnumerable<ManifestResourceInfo> newResources,
         FindingSubject subject)
-        => CompareInventory(
+    {
+        ArgumentNullException.ThrowIfNull(oldResources);
+        ArgumentNullException.ThrowIfNull(newResources);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return CompareInventory(
             InspectResources(oldResources, subject),
             InspectResources(newResources, subject));
+    }
 
     public static FindingInspection<AssemblyAttributeInfo> InspectAssemblyAttributes(
         IEnumerable<AssemblyAttributeInfo> attributes,
         FindingSubject subject)
-        => InspectInventory(
+    {
+        ArgumentNullException.ThrowIfNull(attributes);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return InspectInventory(
             attributes,
             subject,
             AssemblyAttributeDescriptor,
             static attribute => JoinSortKey(attribute.Target, attribute.Name, attribute.Value),
             static attribute => JoinSortKey(attribute.Target, attribute.Name, attribute.Value));
+    }
 
     public static FindingComparison<AssemblyAttributeInfo> CompareAssemblyAttributes(
         IEnumerable<AssemblyAttributeInfo> oldAttributes,
         IEnumerable<AssemblyAttributeInfo> newAttributes,
         FindingSubject subject)
-        => CompareInventory(
+    {
+        ArgumentNullException.ThrowIfNull(oldAttributes);
+        ArgumentNullException.ThrowIfNull(newAttributes);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return CompareInventory(
             InspectAssemblyAttributes(oldAttributes, subject),
             InspectAssemblyAttributes(newAttributes, subject));
+    }
 
     static FindingInspection<T> InspectInventory<T>(
         IEnumerable<T> observations,
@@ -219,7 +263,13 @@ public static partial class MetadataFindings
 
     static void AppendSortKeyPart(StringBuilder builder, string? value)
     {
-        value ??= "";
+        if (value is null)
+        {
+            builder.Append('N');
+            return;
+        }
+
+        builder.Append('S');
         builder.Append(value.Length);
         builder.Append(':');
         builder.Append(value);

--- a/src/ILInspector.Metadata/MetadataFindings.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.cs
@@ -8,7 +8,7 @@ namespace ILInspector.Metadata;
 /// Types and members are unordered identity sets; compatibility classification remains
 /// the responsibility of <see cref="ApiDiffAnalyzer"/>.
 /// </summary>
-public static class MetadataFindings
+public static partial class MetadataFindings
 {
     public static readonly FindingDescriptor TypeDescriptor = new("api.type", "API type");
     public static readonly FindingDescriptor MemberDescriptor = new("api.member", "API member");

--- a/src/ILInspector.Metadata/MetadataFindings.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.cs
@@ -371,7 +371,7 @@ public static partial class MetadataFindings
         where T : notnull
         => inspection is FindingInspection<T>.Complete complete
             ? complete.Findings
-            : throw new InvalidOperationException("API-surface inspection unexpectedly failed.");
+            : throw new InvalidOperationException("Metadata inspection unexpectedly failed.");
 
     static IEnumerable<(ApiType Type, ApiMember Member)> EnumerateMembers(ApiSurface surface)
     {

--- a/tests/ILInspector.Metadata.Tests/MetadataInventoryFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataInventoryFindingsTests.cs
@@ -97,23 +97,33 @@ public sealed class MetadataInventoryFindingsTests
     }
 
     [Fact]
-    public void DuplicateAttributes_AreMatchedDeterministicallyByValue()
+    public void DuplicateAttributes_UseValueAsExactIdentityWithoutShiftingExistingPairs()
     {
-        AssemblyAttributeInfo first = new("Tag", "Assembly", "A");
-        AssemblyAttributeInfo second = new("Tag", "Assembly", "B");
+        AssemblyAttributeInfo a = new("Tag", "Assembly", "A");
+        AssemblyAttributeInfo b = new("Tag", "Assembly", "B");
+        AssemblyAttributeInfo c = new("Tag", "Assembly", "C");
 
         var reordered = MetadataFindings.CompareAssemblyAttributes(
-            [first, second],
-            [second, first],
+            [b, c],
+            [c, b],
             Subject);
-        var changed = MetadataFindings.CompareAssemblyAttributes(
-            [first, second],
-            [first, second with { Value = "C" }],
+        var inserted = MetadataFindings.CompareAssemblyAttributes(
+            [b, c],
+            [a, b, c],
+            Subject);
+        var replaced = MetadataFindings.CompareAssemblyAttributes(
+            [a, b],
+            [a, c],
             Subject);
 
         Assert.All(Pairs(reordered), static pair => Assert.Equal(PairKind.Present, pair.Kind));
-        Assert.Equal(1, Pairs(changed).Count(static pair => pair.Kind == PairKind.Present));
-        Assert.Equal(1, Pairs(changed).Count(static pair => pair.Kind == PairKind.Changed));
+        Assert.Equal(2, Pairs(inserted).Count(static pair => pair.Kind == PairKind.Present));
+        Assert.Equal(1, Pairs(inserted).Count(static pair => pair.Kind == PairKind.Added));
+        Assert.Equal(1, Pairs(replaced).Count(static pair => pair.Kind == PairKind.Present));
+        Assert.Equal(1, Pairs(replaced).Count(static pair => pair.Kind == PairKind.Added));
+        Assert.Equal(1, Pairs(replaced).Count(static pair => pair.Kind == PairKind.Removed));
+        Assert.DoesNotContain(Pairs(inserted), static pair => pair.Kind == PairKind.Changed);
+        Assert.DoesNotContain(Pairs(replaced), static pair => pair.Kind == PairKind.Changed);
     }
 
     [Fact]

--- a/tests/ILInspector.Metadata.Tests/MetadataInventoryFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataInventoryFindingsTests.cs
@@ -127,6 +127,41 @@ public sealed class MetadataInventoryFindingsTests
     }
 
     [Fact]
+    public void AttributeIdentity_DistinguishesNullAndEmptyValues()
+    {
+        var comparison = MetadataFindings.CompareAssemblyAttributes(
+            [new AssemblyAttributeInfo("Tag", "Assembly", null)],
+            [new AssemblyAttributeInfo("Tag", "Assembly", "")],
+            Subject);
+
+        Assert.Equal(1, Pairs(comparison).Count(static pair => pair.Kind == PairKind.Added));
+        Assert.Equal(1, Pairs(comparison).Count(static pair => pair.Kind == PairKind.Removed));
+        Assert.DoesNotContain(Pairs(comparison), static pair => pair.Kind == PairKind.Changed);
+    }
+
+    [Fact]
+    public void CompareInventory_ValidatesPublicInputsBeforeEnumeration()
+    {
+        bool enumerated = false;
+        IEnumerable<AssemblyReference> oldReferences = Enumerate();
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => MetadataFindings.CompareAssemblyReferences(
+                oldReferences,
+                null!,
+                Subject));
+
+        Assert.Equal("newReferences", exception.ParamName);
+        Assert.False(enumerated);
+
+        IEnumerable<AssemblyReference> Enumerate()
+        {
+            enumerated = true;
+            yield break;
+        }
+    }
+
+    [Fact]
     public void RealScannerOutputs_ProjectWithoutChangingTheCensus()
     {
         using var stream = File.OpenRead(typeof(ApiSurfaceExtractor).Assembly.Location);

--- a/tests/ILInspector.Metadata.Tests/MetadataInventoryFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataInventoryFindingsTests.cs
@@ -1,0 +1,159 @@
+using System.Collections.Immutable;
+using System.Reflection.PortableExecutable;
+using ILInspector.Findings;
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests;
+
+public sealed class MetadataInventoryFindingsTests
+{
+    static readonly FindingSubject Subject = new("assembly", "Test assembly");
+
+    [Fact]
+    public void EmptyInventory_IsACompleteExactCensus()
+    {
+        var inspection = MetadataFindings.InspectResources([], Subject);
+        var comparison = MetadataFindings.CompareResources([], [], Subject);
+
+        Assert.Empty(Findings(inspection));
+        Assert.True(comparison.IsExact);
+        Assert.Empty(Pairs(comparison));
+    }
+
+    [Fact]
+    public void AssemblyReferences_IgnoreOrderAndPromoteVersionChanges()
+    {
+        AssemblyReference systemRuntimeV1 = new(
+            "System.Runtime",
+            "9.0.0.0",
+            Culture: null,
+            PublicKeyToken: "b03f5f7f11d50a3a");
+        AssemblyReference systemRuntimeV2 = systemRuntimeV1 with { Version = "10.0.0.0" };
+        AssemblyReference collections = new(
+            "System.Collections",
+            "9.0.0.0",
+            Culture: null,
+            PublicKeyToken: "b03f5f7f11d50a3a");
+
+        var comparison = MetadataFindings.CompareAssemblyReferences(
+            [systemRuntimeV1, collections],
+            [collections, systemRuntimeV2],
+            Subject);
+
+        Assert.Collection(
+            Pairs(comparison).OrderBy(static pair => pair.Subject.Display).ThenBy(static pair => pair.Kind),
+            pair => Assert.Equal(PairKind.Present, pair.Kind),
+            pair =>
+            {
+                Assert.Equal(PairKind.Changed, pair.Kind);
+                Assert.Null(pair.Detail);
+            });
+    }
+
+    [Fact]
+    public void AssemblyReferenceNames_AreCaseInsensitiveIdentities()
+    {
+        var comparison = MetadataFindings.CompareAssemblyReferences(
+            [new AssemblyReference("System.Runtime", "9.0.0.0", null, null)],
+            [new AssemblyReference("system.runtime", "9.0.0.0", null, null)],
+            Subject);
+
+        var pair = Assert.Single(Pairs(comparison));
+
+        Assert.Equal(PairKind.Changed, pair.Kind);
+    }
+
+    [Fact]
+    public void TypeForwarders_ReportAddedRemovedAndChangedTargets()
+    {
+        var comparison = MetadataFindings.CompareTypeForwarders(
+            [
+                new TypeForwarderInfo("Sample.Removed", "Old"),
+                new TypeForwarderInfo("Sample.Moved", "Old"),
+            ],
+            [
+                new TypeForwarderInfo("Sample.Moved", "New"),
+                new TypeForwarderInfo("Sample.Added", "New"),
+            ],
+            Subject);
+
+        Assert.Equal(1, Pairs(comparison).Count(static pair => pair.Kind == PairKind.Added));
+        Assert.Equal(1, Pairs(comparison).Count(static pair => pair.Kind == PairKind.Removed));
+        Assert.Equal(1, Pairs(comparison).Count(static pair => pair.Kind == PairKind.Changed));
+    }
+
+    [Fact]
+    public void Resources_PromoteVisibilityEmbeddingAndSizeChanges()
+    {
+        var comparison = MetadataFindings.CompareResources(
+            [new ManifestResourceInfo("data.json", IsPublic: true, IsEmbedded: true, Size: 10)],
+            [new ManifestResourceInfo("data.json", IsPublic: false, IsEmbedded: false, Size: 20)],
+            Subject);
+
+        var pair = Assert.Single(Pairs(comparison));
+
+        Assert.Equal(PairKind.Changed, pair.Kind);
+        Assert.Null(pair.Detail);
+    }
+
+    [Fact]
+    public void DuplicateAttributes_AreMatchedDeterministicallyByValue()
+    {
+        AssemblyAttributeInfo first = new("Tag", "Assembly", "A");
+        AssemblyAttributeInfo second = new("Tag", "Assembly", "B");
+
+        var reordered = MetadataFindings.CompareAssemblyAttributes(
+            [first, second],
+            [second, first],
+            Subject);
+        var changed = MetadataFindings.CompareAssemblyAttributes(
+            [first, second],
+            [first, second with { Value = "C" }],
+            Subject);
+
+        Assert.All(Pairs(reordered), static pair => Assert.Equal(PairKind.Present, pair.Kind));
+        Assert.Equal(1, Pairs(changed).Count(static pair => pair.Kind == PairKind.Present));
+        Assert.Equal(1, Pairs(changed).Count(static pair => pair.Kind == PairKind.Changed));
+    }
+
+    [Fact]
+    public void RealScannerOutputs_ProjectWithoutChangingTheCensus()
+    {
+        using var stream = File.OpenRead(typeof(ApiSurfaceExtractor).Assembly.Location);
+        using var peReader = new PEReader(stream);
+
+        var references = AssemblyInspector
+            .ExtractAssemblyInfo(peReader, includeReferences: true)
+            .References!;
+        var attributes = AssemblyDetailScanner.ScanCustomAttributes(peReader);
+        var forwarders = AssemblyDetailScanner.ScanTypeForwarders(peReader);
+        var resources = ResourceScanner.Scan(peReader);
+
+        Assert.Equal(
+            references.Count,
+            Findings(MetadataFindings.InspectAssemblyReferences(references, Subject)).Length);
+        Assert.Equal(
+            attributes.Count,
+            Findings(MetadataFindings.InspectAssemblyAttributes(attributes, Subject)).Length);
+        Assert.Equal(
+            forwarders.Count,
+            Findings(MetadataFindings.InspectTypeForwarders(forwarders, Subject)).Length);
+        Assert.Equal(
+            resources.Count,
+            Findings(MetadataFindings.InspectResources(resources, Subject)).Length);
+        Assert.NotEmpty(references);
+        Assert.NotEmpty(attributes);
+    }
+
+    static ImmutableArray<Finding<T>> Findings<T>(FindingInspection<T> inspection)
+        where T : notnull
+        => inspection is FindingInspection<T>.Complete complete
+            ? complete.Findings
+            : throw new Xunit.Sdk.XunitException("Expected a complete inventory inspection.");
+
+    static ImmutableArray<PairFinding<T>> Pairs<T>(FindingComparison<T> comparison)
+        where T : notnull
+        => comparison is FindingComparison<T>.Complete complete
+            ? complete.Pairs
+            : throw new Xunit.Sdk.XunitException($"Expected a complete comparison: {comparison.Failure}");
+}

--- a/tests/ILInspector.Metadata.Tests/MetadataInventoryFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataInventoryFindingsTests.cs
@@ -162,6 +162,24 @@ public sealed class MetadataInventoryFindingsTests
     }
 
     [Fact]
+    public void InventoryNullElements_ReportThePublicCollectionParameter()
+    {
+        AssemblyReference valid = new("System.Runtime", "9.0.0.0", null, null);
+        AssemblyReference[] containingNull = [null!];
+
+        var inspectException = Assert.Throws<ArgumentException>(
+            () => MetadataFindings.InspectAssemblyReferences(containingNull, Subject));
+        var oldException = Assert.Throws<ArgumentException>(
+            () => MetadataFindings.CompareAssemblyReferences(containingNull, [valid], Subject));
+        var newException = Assert.Throws<ArgumentException>(
+            () => MetadataFindings.CompareAssemblyReferences([valid], containingNull, Subject));
+
+        Assert.Equal("references", inspectException.ParamName);
+        Assert.Equal("oldReferences", oldException.ParamName);
+        Assert.Equal("newReferences", newException.ParamName);
+    }
+
+    [Fact]
     public void RealScannerOutputs_ProjectWithoutChangingTheCensus()
     {
         using var stream = File.OpenRead(typeof(ApiSurfaceExtractor).Assembly.Location);


### PR DESCRIPTION
Adds typed, presentation-free Finding producers for assembly references, type forwarders, manifest resources, and assembly/module attributes. Each inventory supports complete inspection and unordered identity-set comparison while preserving scanner-owned payloads.

Duplicate attributes use target, name, and value as their exact identity so cardinality changes cannot shift otherwise unchanged matches. Research remains responsible for rendering typed old/new payloads.

Validation:
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release --no-restore` (424 passed)
- `dotnet build dotnet-inspect.slnx -c Release --no-restore --nologo`

Final adversarial reviews are in progress with Claude Opus 4.8 and Gemini 3.1 Pro.