### PR TITLE
Consolidate ILDisassembler/ILInstruction onto the Instructions substrate

### DIFF
--- a/docs/design/instruction-substrate.md
+++ b/docs/design/instruction-substrate.md
@@ -237,12 +237,52 @@ closed on numbers. Its credible future home is **memory-safety lifetime**
 territory), to be measured the same way. Until then the typed stack stays a
 minimal, opt-in Layer-1 model with its own fidelity gate, not a product dependency.
 
+## The Metadata cutover (done)
+
+`ILInspector.Metadata`'s `ILDisassembler`/`ILInstruction` were a second,
+independent decoded-body model: they called `InstructionDecoder.Decode` directly
+(the raw Layer 0 primitive) and built their own per-instruction display strings,
+duplicating the substrate's decode/format logic rather than projecting from it.
+Every consumer (`MemberCodeProvider`'s CLI IL section, `SwitchScanner`'s
+AppContext-switch heuristics, `PdbContext`'s display-name lookups,
+`DecompilerHarness`'s `FidelityCheck`/`ReturnToSender`, and the disassembler/emit
+test suites, plus `DotnetInspector.ILRoundtrip.Tests`' canonical-ilasm roundtrip
+via the vendored ILAssembler) has been migrated to a new `ILInstructionPrinter`
+(`ILInstructionText` projection) that decodes via `MethodInstructions.Decode` and
+throws `BadImageFormatException` (with the substrate's `IncompleteReason`) when
+the body is not `IsComplete` — the same fail-honest contract `ILDisassembler` had,
+now backed by the shared substrate instead of a second decode path.
+`ILDisassembler`/`ILInstruction` are deleted; `MethodInstructions`/
+`DecodedInstruction` are the sole decoded-body model.
+
+This cutover intentionally does **not** unify the three metadata-token-to-string
+traversals that sit downstream of the shared decode: `ILTokenResolver` (human
+display strings for the CLI/PdbContext), `CanonicalIL` (canonical ilasm-assembler
+syntax, quoting/`class`/`valuetype` prefixes, used by the ILRoundtrip corpus),
+and `IlBodyDiff`'s private `MetadataOperandResolver` (stable cross-version
+identity strings — `` `N `` generic arity, calling-convention prefixes, no
+quoting). These have genuinely different output policies (display vs.
+assembler-grammar vs. stable-identity), each with its own test/fixture coverage,
+and `MetadataOperandResolver` has no external callers to migrate. Consolidating
+them into one flag-heavy renderer would trade a well-understood, low-risk
+duplication for a higher-risk shared implementation whose three policies would
+have to be threaded through every future change. They remain separate,
+intentionally, per issue
+[#2612](https://github.com/richlander/dotnet-inspect/issues/2612)'s own
+"explicitly documented" escape hatch; unifying them is tracked as follow-up work,
+not attempted in that PR.
+
 ## Status
 
 - Layer 0 substrate: decoder on the ported `ILReader`; tiling, round-trip, and
   MaxStack fidelity gates over CoreLib; Layer 0/1 split with offset→block lookup.
-- De-dup: `ReachingDefinitions` cut over (done, validated). Remaining:
-  `LibraryBodyIndex` (the allocation/triage producer — convert its decode loop with
-  the full corpus baseline as guard) and the decompiler importer (with the
-  minimal-CFG refactor).
+- De-dup: `ReachingDefinitions` cut over (done, validated).
+  `ILInspector.Metadata`'s `ILDisassembler`/`ILInstruction` cut over to
+  `ILInstructionPrinter`/`ILInstructionText` over `MethodInstructions` (done,
+  validated; see "The Metadata cutover" above). Remaining: `LibraryBodyIndex`
+  (the allocation/triage producer — convert its decode loop with the full corpus
+  baseline as guard), the decompiler importer (with the minimal-CFG refactor),
+  and consolidating the three metadata-token-to-string traversals
+  (`ILTokenResolver`/`CanonicalIL`/`IlBodyDiff.MetadataOperandResolver`) if their
+  output policies are ever found to overlap enough to share code safely.
 - Typed stack: gated; no measured trigger; re-probe under memory-safety lifetime.

--- a/src/ILInspector.Metadata/AssemblyInspectionSession.cs
+++ b/src/ILInspector.Metadata/AssemblyInspectionSession.cs
@@ -25,7 +25,7 @@ public sealed class AssemblyInspectionSession : IDisposable
     /// <summary>Whether the image contains managed metadata (false for a native binary).</summary>
     public bool HasMetadata => _image.HasMetadata;
 
-    // The method-body / IL seam (the CLI's MemberCodeProvider + ILDisassembler) needs low-level
+    // The method-body / IL seam (the CLI's MemberCodeProvider + ILInstructionPrinter) needs low-level
     // reader access that the public facet API deliberately does not expose. These internal
     // accessors let that composition read through this owned image instead of opening its own raw
     // PEReader, so the single PE open stays owned here. The public contract ("callers never touch a

--- a/src/ILInspector.Metadata/CanonicalIL.cs
+++ b/src/ILInspector.Metadata/CanonicalIL.cs
@@ -5,22 +5,6 @@ using System.Reflection.Metadata.Ecma335;
 namespace ILInspector.Metadata;
 
 /// <summary>
-/// Selects how IL operands are rendered by <see cref="ILDisassembler"/>.
-/// </summary>
-public enum ILSyntax
-{
-    /// <summary>Human-readable C#-style names (the IL section's historical format).</summary>
-    Display,
-
-    /// <summary>
-    /// Canonical ilasm syntax — assembly-qualified type names, IL primitive names,
-    /// return types and calling conventions on member refs — suitable for feeding
-    /// back through an IL assembler.
-    /// </summary>
-    Canonical,
-}
-
-/// <summary>
 /// Renders signature types in IL assembler syntax: <c>int32</c>, <c>float64</c>,
 /// <c>class [asm]Ns.Type</c>, <c>valuetype [asm]Ns.E</c>, <c>!0</c>/<c>!!0</c>.
 /// Generic parameters are never substituted — canonical IL refers to them by index.

--- a/src/ILInspector.Metadata/ILInstructionPrinter.cs
+++ b/src/ILInspector.Metadata/ILInstructionPrinter.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -9,13 +8,32 @@ using ILInspector.Instructions;
 namespace ILInspector.Metadata;
 
 /// <summary>
-/// A single decoded IL instruction with its offset, opcode, and resolved operand.
+/// Selects how IL operands are rendered by <see cref="ILInstructionPrinter"/>.
 /// </summary>
-public record ILInstruction(int Offset, string OpCodeName, string? Operand = null)
+public enum ILSyntax
 {
+    /// <summary>Human-readable C#-style names (the IL section's historical format).</summary>
+    Display,
+
     /// <summary>
-    /// Formats the instruction as "IL_XXXX: opcode operand".
+    /// Canonical ilasm syntax — assembly-qualified type names, IL primitive names,
+    /// return types and calling conventions on member refs — suitable for feeding
+    /// back through an IL assembler.
     /// </summary>
+    Canonical,
+}
+
+/// <summary>
+/// A rendered projection of one decoded IL instruction: opcode display/canonical name plus
+/// formatted operand text. This is deliberately <b>not</b> a second decoded-instruction model —
+/// offset identity, opcode enum, operand kind/value, branch targets, and control-flow facts live
+/// solely on <see cref="DecodedInstruction"/> / <see cref="MethodInstructions"/>
+/// (<c>ILInspector.Instructions</c>). This record exists only so display/ilasm consumers can work
+/// with formatted text/fields without repeating metadata token/signature traversal themselves.
+/// </summary>
+public record ILInstructionText(int Offset, string OpCodeName, string? Operand = null)
+{
+    /// <summary>Formats the instruction as "IL_XXXX: opcode operand".</summary>
     public override string ToString()
     {
         return Operand is null
@@ -25,19 +43,43 @@ public record ILInstruction(int Offset, string OpCodeName, string? Operand = nul
 }
 
 /// <summary>
-/// Disassembles IL method bodies into human-readable instructions.
-/// Uses System.Reflection.Metadata to decode opcodes and resolve metadata tokens.
-/// Operand type classification uses a lookup table derived from ILSpy (MIT license).
+/// Renders decoded IL instructions (<see cref="MethodInstructions"/> — the sole decoded-body
+/// model, shared with <c>IlFindings</c>/<c>IlBodyDiff</c>) into human-readable or canonical ilasm
+/// text. Operand type classification uses a lookup table derived from ILSpy (MIT license).
 /// </summary>
-public static class ILDisassembler
+public static class ILInstructionPrinter
 {
     /// <summary>
-    /// Disassembles a method body into a list of IL instructions.
-    /// Returns null if the method has no IL body (abstract, extern, etc.).
+    /// Renders an already-decoded body. Throws <see cref="BadImageFormatException"/> when the
+    /// body failed to decode (malformed IL) — the same fail-closed contract
+    /// <see cref="MethodInstructions.Decode(MethodBodyBlock)"/> uses for its throwing callers.
+    /// </summary>
+    public static List<ILInstructionText> Render(MethodInstructions body, MetadataReader reader, ILSyntax syntax = ILSyntax.Display)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        ArgumentNullException.ThrowIfNull(reader);
+        if (!body.IsComplete)
+            throw new BadImageFormatException(body.Blocks.IncompleteReason ?? "IL body decode failed.");
+
+        var instructions = new List<ILInstructionText>(body.Instructions.Length);
+        foreach (var instruction in body.Instructions)
+        {
+            instructions.Add(new ILInstructionText(
+                instruction.Offset, GetDisplayName(instruction.OpCode), FormatOperand(instruction, reader, syntax)));
+        }
+
+        return instructions;
+    }
+
+    /// <summary>
+    /// Decodes and renders a method body. Returns null if the method has no IL body (abstract,
+    /// extern, etc.). Malformed IL that decodes to an incomplete body still throws
+    /// <see cref="BadImageFormatException"/> (via <see cref="Render"/>) — a null result is
+    /// reserved for the honest "no body" case, never a decode failure.
     /// <paramref name="syntax"/> selects display rendering (default) or canonical
     /// ilasm operand syntax (see <see cref="ILSyntax"/>).
     /// </summary>
-    public static List<ILInstruction>? Disassemble(PEReader peReader, MetadataReader reader, MethodDefinition method, ILSyntax syntax = ILSyntax.Display)
+    public static List<ILInstructionText>? Disassemble(PEReader peReader, MetadataReader reader, MethodDefinition method, ILSyntax syntax = ILSyntax.Display)
     {
         if (method.RelativeVirtualAddress == 0)
             return null;
@@ -52,27 +94,17 @@ public static class ILDisassembler
             return null;
         }
 
-        var ilBytes = body.GetILContent().ToArray();
-        var decoded = InstructionDecoder.Decode(ilBytes);
-
-        var instructions = new List<ILInstruction>(decoded.Length);
-        foreach (var instruction in decoded)
-        {
-            instructions.Add(new ILInstruction(
-                instruction.Offset, GetDisplayName(instruction.OpCode), FormatOperand(instruction, reader, syntax)));
-        }
-
-        return instructions;
+        return Render(MethodInstructions.Decode(body), reader, syntax);
     }
 
     /// <summary>
     /// Finds a method by name on a type and disassembles it.
     /// Returns null if the method is not found or has no IL body.
     /// </summary>
-    public static List<ILInstruction>? DisassembleMethod(PEReader peReader, string typeName, string methodName)
+    public static List<ILInstructionText>? DisassembleMethod(PEReader peReader, string typeName, string methodName)
         => DisassembleMethod(peReader, typeName, methodName, overloadIndex: 0);
 
-    public static List<ILInstruction>? DisassembleMethod(PEReader peReader, string typeName, string methodName, int overloadIndex, bool publicOnly = false)
+    public static List<ILInstructionText>? DisassembleMethod(PEReader peReader, string typeName, string methodName, int overloadIndex, bool publicOnly = false)
     {
         var reader = peReader.GetMetadataReader();
 
@@ -92,7 +124,7 @@ public static class ILDisassembler
     /// Overload for callers that have already resolved the declaring type handle, avoiding a repeated
     /// TypeDefinitions scan per method.
     /// </summary>
-    public static List<ILInstruction>? DisassembleMethod(
+    public static List<ILInstructionText>? DisassembleMethod(
         PEReader peReader, MetadataReader reader, TypeDefinitionHandle typeHandle, string methodName, int overloadIndex, bool publicOnly = false)
     {
         var typeDef = reader.GetTypeDefinition(typeHandle);

--- a/src/ILInspector.Metadata/ILTokenResolver.cs
+++ b/src/ILInspector.Metadata/ILTokenResolver.cs
@@ -5,9 +5,9 @@ namespace ILInspector.Metadata;
 
 /// <summary>
 /// Resolves IL operand metadata tokens (strings, types, methods, fields) to human-readable text.
-/// Shared by <see cref="ILDisassembler"/> (the IL section) and the decompiler's annotated-IL emitter
-/// so a given call/field/type operand renders identically in both — method operands always carry
-/// their full parameter list and generic type arguments.
+/// Shared by <see cref="ILInstructionPrinter"/> (the IL section) and the decompiler's annotated-IL
+/// emitter so a given call/field/type operand renders identically in both — method operands always
+/// carry their full parameter list and generic type arguments.
 ///
 /// Type resolution accepts an optional <see cref="GenericContext"/> so callers that have the
 /// enclosing method's generic parameters (the annotated emitter) can resolve <c>!0</c>/<c>!!0</c>

--- a/src/ILInspector.Metadata/PdbContext.cs
+++ b/src/ILInspector.Metadata/PdbContext.cs
@@ -372,7 +372,7 @@ public class PdbContext : IDisposable
             return new ILOffsetInstructionContextInfo(
                 ILOffset: ilOffset,
                 Boundary: "Exact",
-                Opcode: ILDisassembler.GetDisplayName(instruction.OpCode),
+                Opcode: ILInstructionPrinter.GetDisplayName(instruction.OpCode),
                 OperandKind: operand.Kind,
                 Operand: operand.Value,
                 OperandToken: operand.Token,
@@ -524,7 +524,7 @@ public class PdbContext : IDisposable
         var operand = ResolveInstructionOperand(reader!, instruction);
         return new ILOffsetCallsiteContextInfo(
             CallOffset: instruction.Offset,
-            Opcode: ILDisassembler.GetDisplayName(instruction.OpCode),
+            Opcode: ILInstructionPrinter.GetDisplayName(instruction.OpCode),
             CallKind: GetCallKind(instruction.OpCode),
             Callee: operand.Value ?? operand.Token ?? "",
             OperandToken: operand.Token,
@@ -552,7 +552,7 @@ public class PdbContext : IDisposable
         return new ILOffsetReturnAddressContextInfo(
             ILOffset: ilOffset,
             CallOffset: previous.Offset,
-            Opcode: ILDisassembler.GetDisplayName(previous.OpCode),
+            Opcode: ILInstructionPrinter.GetDisplayName(previous.OpCode),
             CallKind: GetCallKind(previous.OpCode),
             Callee: operand.Value ?? operand.Token ?? "",
             OperandToken: operand.Token);

--- a/src/ILInspector.Metadata/SwitchScanner.cs
+++ b/src/ILInspector.Metadata/SwitchScanner.cs
@@ -102,7 +102,7 @@ public static class SwitchScanner
             foreach (var methodHandle in type.GetMethods())
             {
                 var method = reader.GetMethodDefinition(methodHandle);
-                var instructions = ILDisassembler.Disassemble(peReader, reader, method);
+                var instructions = ILInstructionPrinter.Disassemble(peReader, reader, method);
                 if (instructions is not { Count: > 0 })
                     continue;
 

--- a/src/dotnet-inspect.Tests/ILDisassemblerComparisonTests.cs
+++ b/src/dotnet-inspect.Tests/ILDisassemblerComparisonTests.cs
@@ -174,11 +174,11 @@ public class ILDisassemblerComparisonTests
         _ => throw new ArgumentException($"Unknown assembly key: {key}")
     };
 
-    static List<ILInstruction>? DisassembleFrom(string assemblyPath, string typeName, string methodName)
+    static List<ILInstructionText>? DisassembleFrom(string assemblyPath, string typeName, string methodName)
     {
         using var stream = File.OpenRead(assemblyPath);
         using var peReader = new PEReader(stream);
-        return ILDisassembler.DisassembleMethod(peReader, typeName, methodName);
+        return ILInstructionPrinter.DisassembleMethod(peReader, typeName, methodName);
     }
 
     static int CountMethods(string assemblyPath)

--- a/src/dotnet-inspect.Tests/ILDisassemblerEmitTests.cs
+++ b/src/dotnet-inspect.Tests/ILDisassemblerEmitTests.cs
@@ -297,7 +297,7 @@ public class ILDisassemblerEmitTests : IDisposable
 
     // --- Helper: emit a method, save to disk, disassemble ---
 
-    List<ILInstruction> EmitAndDisassemble(
+    List<ILInstructionText> EmitAndDisassemble(
         string typeName,
         string methodName,
         Action<ILGenerator> emitBody,
@@ -331,7 +331,7 @@ public class ILDisassemblerEmitTests : IDisposable
 
         using var stream = File.OpenRead(dllPath);
         using var peReader = new PEReader(stream);
-        var result = ILDisassembler.DisassembleMethod(
+        var result = ILInstructionPrinter.DisassembleMethod(
             peReader, $"EmitTest.{typeName}", methodName);
 
         Assert.NotNull(result);

--- a/src/dotnet-inspect.Tests/ILDisassemblerTests.cs
+++ b/src/dotnet-inspect.Tests/ILDisassemblerTests.cs
@@ -122,7 +122,7 @@ public class ILDisassemblerTests
         using var stream = File.OpenRead(assemblyPath);
         using var peReader = new PEReader(stream);
 
-        var instructions = ILDisassembler.DisassembleMethod(
+        var instructions = ILInstructionPrinter.DisassembleMethod(
             peReader,
             "DotnetInspector.Tests.ILSampleClass",
             nameof(ILSampleClass.Add));
@@ -138,7 +138,7 @@ public class ILDisassemblerTests
         using var stream = File.OpenRead(assemblyPath);
         using var peReader = new PEReader(stream);
 
-        var instructions = ILDisassembler.DisassembleMethod(peReader, "NoSuch.Type", "Method");
+        var instructions = ILInstructionPrinter.DisassembleMethod(peReader, "NoSuch.Type", "Method");
 
         Assert.Null(instructions);
     }
@@ -150,7 +150,7 @@ public class ILDisassemblerTests
         using var stream = File.OpenRead(assemblyPath);
         using var peReader = new PEReader(stream);
 
-        var instructions = ILDisassembler.DisassembleMethod(
+        var instructions = ILInstructionPrinter.DisassembleMethod(
             peReader,
             "DotnetInspector.Tests.ILSampleClass",
             "NonexistentMethod");
@@ -159,28 +159,28 @@ public class ILDisassemblerTests
     }
 
     [Fact]
-    public void ILInstruction_ToString_FormatsCorrectly()
+    public void ILInstructionText_ToString_FormatsCorrectly()
     {
-        var instruction = new ILInstruction(0x0A, "call", "System.String::Concat");
+        var instruction = new ILInstructionText(0x0A, "call", "System.String::Concat");
         Assert.Equal("IL_000A: call         System.String::Concat", instruction.ToString());
     }
 
     [Fact]
-    public void ILInstruction_ToString_NoOperand_OmitsTrailingSpace()
+    public void ILInstructionText_ToString_NoOperand_OmitsTrailingSpace()
     {
-        var instruction = new ILInstruction(0x00, "nop");
+        var instruction = new ILInstructionText(0x00, "nop");
         Assert.Equal("IL_0000: nop", instruction.ToString());
     }
 
     // Helper to disassemble a method from the test assembly's ILSampleClass
-    static List<ILInstruction>? DisassembleTestMethod(string methodName, Type? declaringType = null)
+    static List<ILInstructionText>? DisassembleTestMethod(string methodName, Type? declaringType = null)
     {
         declaringType ??= typeof(ILSampleClass);
         var assemblyPath = declaringType.Assembly.Location;
         using var stream = File.OpenRead(assemblyPath);
         using var peReader = new PEReader(stream);
 
-        return ILDisassembler.DisassembleMethod(
+        return ILInstructionPrinter.DisassembleMethod(
             peReader,
             declaringType.FullName!,
             methodName);
@@ -506,7 +506,7 @@ public class ILDisassemblerTests
 
                     try
                     {
-                        var instructions = ILDisassembler.Disassemble(peReader, reader, method);
+                        var instructions = ILInstructionPrinter.Disassemble(peReader, reader, method);
                         if (instructions is not null)
                             totalInstructions += instructions.Count;
                     }
@@ -568,7 +568,7 @@ public class ILDisassemblerTests
 
                 try
                 {
-                    var instructions = ILDisassembler.Disassemble(peReader, reader, method);
+                    var instructions = ILInstructionPrinter.Disassemble(peReader, reader, method);
                     if (instructions is not null)
                         totalInstructions += instructions.Count;
                 }

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -175,7 +175,7 @@ internal static class MemberCodeProvider
             {
                 try
                 {
-                    var instructions = ILDisassembler.DisassembleMethod(
+                    var instructions = ILInstructionPrinter.DisassembleMethod(
                         peReader, reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
                     if (instructions is { Count: > 0 })
                         ilText = string.Join(Environment.NewLine, instructions.Select(i => i.ToString()));

--- a/tests/DotnetInspector.ILRoundtrip.Tests/ILAssemblerRoundtripTests.cs
+++ b/tests/DotnetInspector.ILRoundtrip.Tests/ILAssemblerRoundtripTests.cs
@@ -32,7 +32,7 @@ public class ILAssemblerRoundtripTests
         var reader = peReader.GetMetadataReader();
 
         var method = IlasmScaffold.FindMethod(reader, nameof(RoundtripFixtures), methodName);
-        var original = ILDisassembler.Disassemble(peReader, reader, method);
+        var original = ILInstructionPrinter.Disassemble(peReader, reader, method);
         Assert.NotNull(original);
 
         string il = IlasmScaffold.BuildCompilationUnit(peReader, reader, method);
@@ -292,7 +292,13 @@ public class ILAssemblerRoundtripTests
     }
 
     [Theory]
-    [InlineData("switch (12, 14)")]                 // integer offsets
+    // Switch targets are relative to the instruction *following* the switch
+    // (ECMA-335 III.3.66), and this switch has two entries (13-byte encoding:
+    // opcode + count + 2 x int32), so the real post-switch offset is 14, not
+    // the cosmetic IL_000A label. `2` and `4` are the relative offsets that
+    // land on IL_000C/IL_000E's actual assembled positions -- verified to
+    // produce byte-identical bytecode to the label-list form below.
+    [InlineData("switch (2, 4)")]                    // integer offsets
     [InlineData("switch (IL_000C, IL_000E)")]       // label list (vendor grammar fix)
     public void Switch_Assembles(string switchLine)
     {
@@ -418,7 +424,7 @@ public class ILAssemblerRoundtripTests
         var sourceImage = source.Image!;
         var reader = sourceImage.GetMetadataReader();
         var method = IlasmScaffold.FindMethod(reader, typeName, methodName);
-        var original = ILDisassembler.Disassemble(sourceImage, reader, method);
+        var original = ILInstructionPrinter.Disassemble(sourceImage, reader, method);
         Assert.NotNull(original);
         Assert.Equal(expectedOps, original.Select(i => i.OpCodeName).ToList());
 

--- a/tests/DotnetInspector.ILRoundtrip.Tests/ILSweepTests.cs
+++ b/tests/DotnetInspector.ILRoundtrip.Tests/ILSweepTests.cs
@@ -16,7 +16,7 @@ public class ILSweepTests
 {
     public static TheoryData<string> SweptAssemblies => new(
         typeof(ILSweepTests).Assembly.Location,        // this test assembly
-        typeof(ILDisassembler).Assembly.Location);     // ILInspector.Metadata
+        typeof(ILInstructionPrinter).Assembly.Location);     // ILInspector.Metadata
 
     [Theory]
     [MemberData(nameof(SweptAssemblies))]
@@ -51,7 +51,7 @@ public class ILSweepTests
                         continue;
                     }
 
-                    var original = ILDisassembler.Disassemble(peReader, reader, method)!;
+                    var original = ILInstructionPrinter.Disassemble(peReader, reader, method)!;
                     var roundtripped = IlasmScaffold.DisassembleByName(
                         result.Image!, reader.GetString(method.Name), typePath, IlasmScaffold.ParamTypes(method));
                     if (roundtripped is null)

--- a/tests/DotnetInspector.ILRoundtrip.Tests/IlasmScaffold.cs
+++ b/tests/DotnetInspector.ILRoundtrip.Tests/IlasmScaffold.cs
@@ -192,7 +192,7 @@ public static class IlasmScaffold
 
         if (isTarget)
         {
-            var instructions = ILDisassembler.Disassemble(peReader, reader, method, ILSyntax.Canonical)
+            var instructions = ILInstructionPrinter.Disassemble(peReader, reader, method, ILSyntax.Canonical)
                 ?? throw new InvalidOperationException($"No IL body for {name}");
             var body = peReader.GetMethodBody(method.RelativeVirtualAddress);
 
@@ -311,7 +311,7 @@ public static class IlasmScaffold
     /// (see <see cref="ParamTypes"/>) disambiguate within the full module
     /// skeleton (stubs share names with their originals elsewhere).
     /// </summary>
-    public static List<ILInstruction>? DisassembleByName(PEReader peReader, string methodName, string? typePath = null, string? paramTypes = null)
+    public static List<ILInstructionText>? DisassembleByName(PEReader peReader, string methodName, string? typePath = null, string? paramTypes = null)
     {
         var reader = peReader.GetMetadataReader();
         foreach (var tdh in reader.TypeDefinitions)
@@ -326,7 +326,7 @@ public static class IlasmScaffold
                     continue;
                 if (paramTypes is not null && ParamTypes(method) != paramTypes)
                     continue;
-                return ILDisassembler.Disassemble(peReader, reader, method);
+                return ILInstructionPrinter.Disassemble(peReader, reader, method);
             }
         }
         return null;

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -926,7 +926,7 @@ static class FidelityCheck
                 continue;
             var requiredNamespaces = RequiredNamespaces(function);
             PrimaryConstructorShape? primaryConstructor = PrimaryConstructorFromPrologue(reader, method, function, body);
-            var original = ILDisassembler.Disassemble(pe, reader, method);
+            var original = ILInstructionPrinter.Disassemble(pe, reader, method);
             if (original is null)
                 continue;
             var origOps = original.Select(i => CanonicalOpcode(i.OpCodeName)).ToList();
@@ -3349,7 +3349,7 @@ static class FidelityCheck
 
     static string Invariant(double d) => d.ToString("R", System.Globalization.CultureInfo.InvariantCulture);
 
-    static List<ILInstruction>? FindAndDisassemble(PEReader pe, string fullType, string name, int overload)
+    static List<ILInstructionText>? FindAndDisassemble(PEReader pe, string fullType, string name, int overload)
     {
         var reader = pe.GetMetadataReader();
         int seen = 0;
@@ -3371,7 +3371,7 @@ static class FidelityCheck
                 if (mn != match)
                     continue;
                 if (seen++ == overload)
-                    return ILDisassembler.Disassemble(pe, reader, m);
+                    return ILInstructionPrinter.Disassemble(pe, reader, m);
             }
         }
         return null;

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -780,7 +780,7 @@ static class ReturnToSender
         if (printed.Output is null)
             throw new InvalidOperationException($"Could not print {fullType}::{methodName}.");
 
-        var original = ILDisassembler.Disassemble(pe, reader, getter)
+        var original = ILInstructionPrinter.Disassemble(pe, reader, getter)
             ?? throw new InvalidOperationException($"Could not disassemble {fullType}::{methodName}.");
         var originalOps = original.Select(instruction => CanonicalOpcode(instruction.OpCodeName)).ToArray();
 
@@ -957,7 +957,7 @@ static class ReturnToSender
         if (printed.Output is null)
             throw new InvalidOperationException($"Could not print {fullType}::{methodName}.");
 
-        var original = ILDisassembler.Disassemble(pe, reader, method)
+        var original = ILInstructionPrinter.Disassemble(pe, reader, method)
             ?? throw new InvalidOperationException($"Could not disassemble {fullType}::{methodName}.");
         var originalOps = original.Select(instruction => CanonicalOpcode(instruction.OpCodeName)).ToArray();
 
@@ -1131,7 +1131,7 @@ static class ReturnToSender
         if (printed.Output is null)
             throw new InvalidOperationException($"Could not print {fullType}::{methodName}.");
 
-        var original = ILDisassembler.Disassemble(pe, reader, setter)
+        var original = ILInstructionPrinter.Disassemble(pe, reader, setter)
             ?? throw new InvalidOperationException($"Could not disassemble {fullType}::{methodName}.");
         var originalOps = original.Select(instruction => CanonicalOpcode(instruction.OpCodeName)).ToArray();
 
@@ -1449,13 +1449,13 @@ static class ReturnToSender
         return ns.Length == 0 ? name : $"{ns}.{name}";
     }
 
-    static IReadOnlyList<ILInstruction>? FindAndDisassemble(
+    static List<ILInstructionText>? FindAndDisassemble(
         PEReader pe,
         string fullType,
         string methodName,
         int overload)
         => FindMethodDefinition(pe, fullType, methodName, overload) is { } found
-            ? ILDisassembler.Disassemble(pe, found.Reader, found.Method)
+            ? ILInstructionPrinter.Disassemble(pe, found.Reader, found.Method)
             : null;
 
     static (MetadataReader Reader, MethodDefinitionHandle Handle, MethodDefinition Method)? FindMethodDefinition(


### PR DESCRIPTION
## Summary

Closes the first slice of #2612: consolidates `ILInspector.Metadata`'s
`ILDisassembler`/`ILInstruction` — a second, independent decoded-body model
built directly on `InstructionDecoder.Decode` — onto the shared
`ILInspector.Instructions` substrate (`MethodInstructions`/`DecodedInstruction`).
`MethodInstructions`/`DecodedInstruction` are now the sole decoded-body model;
`IlFindings`/`IlBodyDiff` were already the substrate's consumers, and every
`ILDisassembler` consumer now decodes through the same substrate.

## What changed

- **New**: `ILInspector.Metadata/ILInstructionPrinter.cs` — `ILInstructionPrinter`
  (static class: `Render`/`Disassemble`/`DisassembleMethod` overloads,
  `GetDisplayName`, `FormatOperand`, opcode display-name table) and
  `ILInstructionText` (rendered-instruction record), replacing
  `ILDisassembler`/`ILInstruction` 1:1 in shape (`List<T>?`, class-based record)
  to minimize call-site churn. This is deliberately a **rendering projection
  only** — offset identity, opcode enum, operand kind/value, and branch-target
  facts stay solely on `DecodedInstruction`/`MethodInstructions`; no second
  decoded-instruction model is introduced.
- `Render` decodes via `MethodInstructions.Decode` and throws
  `BadImageFormatException` (with the substrate's `IncompleteReason`) when the
  body isn't `IsComplete` — the same fail-honest contract the old
  `ILDisassembler.Disassemble` had (it called `InstructionDecoder.Decode`
  directly and let `BadImageFormatException` propagate on malformed IL), now
  surfaced via the shared substrate instead of a second raw decode path.
- **Deleted** `ILDisassembler.cs`; moved the `ILSyntax` enum out of
  `CanonicalIL.cs` into the new file (no more duplicate enum).
- **Migrated every call site**: `MemberCodeProvider` (CLI IL section),
  `SwitchScanner` (AppContext switch heuristics, still pattern-matches on
  display-syntax text), `PdbContext` (display-name lookups — it already decoded
  via `MethodInstructions`), `DecompilerHarness`'s `FidelityCheck` and
  `ReturnToSender`, and the `ILDisassembler{,Comparison,Emit}Tests` /
  `DotnetInspector.ILRoundtrip.Tests` suites (canonical ilasm roundtrip via the
  vendored ILAssembler).
- **Fixed a pre-existing test-data bug** surfaced by the stricter substrate:
  `ILAssemblerRoundtripTests.Switch_Assembles`'s integer-offset case used
  literal switch targets `(12, 14)` assuming the switch instruction consumes 9
  bytes, but a 2-entry switch needs 13 (`opcode + count + 2×int32`), so the
  vendored assembler emitted branch targets pointing outside the method body.
  The old lenient decode path never validated target bounds, so this went
  undetected (the assertion only checked `Contains("switch")`, never operand
  correctness). Corrected to the real relative offsets `(2, 4)`, verified
  byte-identical to the existing label-based case (`switch (IL_000C,
  IL_000E)`).
- **Documented the scope decision** in `docs/design/instruction-substrate.md`:
  `ILTokenResolver` (human display), `CanonicalIL` (canonical ilasm syntax), and
  `IlBodyDiff`'s private `MetadataOperandResolver` (stable cross-version
  identity) remain three intentionally separate metadata-token-to-string
  traversals downstream of the shared decode. Their output policies are
  genuinely different (display vs. assembler grammar vs. stable identity),
  `MetadataOperandResolver` has no external callers, and unifying them into one
  flag-heavy renderer would trade a well-understood low-risk duplication for a
  higher-risk shared implementation. Tracked as explicit follow-up per #2612's
  own "explicitly documented" escape hatch, not attempted in this PR.

## Behavior preserved

- No product behavior change for well-formed IL. `MemberCodeProvider` and
  `SwitchScanner` keep their existing collection/try-catch handling unchanged.
- Malformed IL / absent-body honesty preserved: `Disassemble`/`DisassembleMethod`
  still return `null` only for the honest "no IL body" case (RVA == 0 or the PE
  reader can't locate the body); malformed IL that decodes incomplete still
  throws `BadImageFormatException`.
- Attack points verified: generic MemberRef/MethodSpec, type/field tokens,
  strings, floating-point raw bits (`float32`/`float64` canonical forms vs.
  human decimal display), branch/switch targets, and unusual identifiers are
  all exercised by the existing `ILDisassembler*Tests` and
  `DotnetInspector.ILRoundtrip.Tests` suites, now passing through the shared
  substrate.
- No Metadata↔Instructions dependency cycle: `ILInspector.Metadata` depends on
  `ILInspector.Instructions` (pre-existing direction, e.g. `PdbContext`); no new
  reverse reference was introduced.

## Testing

All run via `dotnet run --project <path> -c Release` (xUnit v3 executable
runners — `dotnet test` silently produces no output for this repo).

| Suite | Result |
|---|---|
| `dotnet build dotnet-inspect.slnx -c Release` | 0 errors, 3 pre-existing warnings |
| `src/dotnet-inspect.Tests` | 1701 total, 0 failed, 10 skipped (ildasm/ilasm not installed — pre-existing environment limitation) |
| `src/ILInspector.Instructions.Tests` | 97 total, 0 failed |
| `tests/ILInspector.Metadata.Tests` | 417 total, 0 failed |
| `src/ILInspector.Analysis.Tests` | 411 total, 0 failed |
| `src/DotnetInspector.Services.Tests` | 242 total, 0 failed |
| `tests/DotnetInspector.ILRoundtrip.Tests` (full, incl. `Speed=Slow`) | 23 total, 0 failed |
| `src/ILInspector.Decompiler.Tests` (`-trait- "Speed=Slow"`, matches CI) | 2231 total, 2 failed |

The 2 `ILInspector.Decompiler.Tests` failures
(`LockSugarTests.CoreLibStaticFieldLock_PreservesCopiedReceiverLocal`,
`TypeSourceComposerUnionTests.ClassUnionSwitchExpression_RendersTypePatternArms`)
are pre-existing and unrelated to this change — reproduced identically against
a clean `origin/main` checkout (no reference to `ILDisassembler`/
`ILInstructionPrinter`/`ILInstructionText` in either test file; both assert on
specific CoreLib-derived decompiled C# shapes and drift with the installed
CoreLib build, consistent with this repo's documented .NET 11 daily-SDK
tracking).

## Follow-up (not in this PR)

- Unify or further document `ILTokenResolver`/`CanonicalIL`/
  `IlBodyDiff.MetadataOperandResolver` if their output policies are ever found
  to overlap enough to share code safely (see the new
  `docs/design/instruction-substrate.md` section).

Refs #2612.
