### PR TITLE
Harden Finding comparison and identity contracts

### DIFF
--- a/src/ILInspector.Decompiler/CSharpFindings.cs
+++ b/src/ILInspector.Decompiler/CSharpFindings.cs
@@ -79,36 +79,10 @@ public static class CSharpFindings
         FindingInspection<CSharpCanonicalLine> oldInspection,
         FindingInspection<CSharpCanonicalLine> newInspection,
         int acceptanceThreshold)
-    {
-        if (oldInspection is FindingInspection<CSharpCanonicalLine>.Failed
-            || newInspection is FindingInspection<CSharpCanonicalLine>.Failed)
-        {
-            return new FindingComparison<CSharpCanonicalLine>.Failed(
-                oldInspection,
-                newInspection);
-        }
-
-        var oldAtoms = InspectionAtoms(oldInspection);
-        var newAtoms = InspectionAtoms(newInspection);
-
-        var match = FindingMatcher.Match(oldAtoms.Keys(), newAtoms.Keys());
-        var pairs = FindingFold.ToPairs(match, oldAtoms, newAtoms, acceptanceThreshold);
-        return new FindingComparison<CSharpCanonicalLine>.Complete(
-            pairs,
-            match,
+        => FindingComparison.Compare(
             oldInspection,
-            newInspection);
-    }
-
-    internal static ImmutableArray<Finding<CSharpCanonicalLine>> InspectionAtoms(
-        FindingInspection<CSharpCanonicalLine> inspection)
-        => inspection switch
-        {
-            FindingInspection<CSharpCanonicalLine>.Complete complete => complete.Findings,
-            FindingInspection<CSharpCanonicalLine>.Absent => [],
-            FindingInspection<CSharpCanonicalLine>.Failed => throw new InvalidOperationException(
-                "A failed inspection cannot be matched."),
-        };
+            newInspection,
+            acceptanceThreshold: acceptanceThreshold);
 
     static InspectionError CreateInspectionError(FindingSubject subject, string reason)
         => new(subject, InspectionDescriptor, reason);

--- a/src/ILInspector.Findings/Finding.cs
+++ b/src/ILInspector.Findings/Finding.cs
@@ -7,7 +7,22 @@ namespace ILInspector.Findings;
 /// Domain-free: <see cref="Key"/> is an opaque stable string the producing layer chooses;
 /// <see cref="Display"/> is a human label.
 /// </summary>
-public sealed record FindingSubject(string Key, string Display);
+public sealed record FindingSubject
+{
+    public FindingSubject(string Key, string Display)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(Key);
+        ArgumentException.ThrowIfNullOrWhiteSpace(Display);
+        this.Key = Key;
+        this.Display = Display;
+    }
+
+    public string Key { get; }
+    public string Display { get; }
+
+    public void Deconstruct(out string key, out string display)
+        => (key, display) = (Key, Display);
+}
 
 /// <summary>
 /// A typed, reorder-stable vocabulary entry for a finding, following the Roslyn
@@ -15,7 +30,22 @@ public sealed record FindingSubject(string Key, string Display);
 /// (e.g. <c>il.op</c>, <c>alloc.box</c>); the absence of a numeric code is deliberate so
 /// descriptors can be added and reordered without renumbering.
 /// </summary>
-public sealed record FindingDescriptor(string Id, string Title);
+public sealed record FindingDescriptor
+{
+    public FindingDescriptor(string Id, string Title)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(Id);
+        ArgumentException.ThrowIfNullOrWhiteSpace(Title);
+        this.Id = Id;
+        this.Title = Title;
+    }
+
+    public string Id { get; }
+    public string Title { get; }
+
+    public void Deconstruct(out string id, out string title)
+        => (id, title) = (Id, Title);
+}
 
 /// <summary>
 /// How an old/new pair of findings relates across two versions. This is a <em>transition</em>
@@ -83,14 +113,49 @@ public interface IFinding<T> : IFinding
 /// than <c>object?</c>, so a value-typed payload is not boxed and consumers read it without a
 /// cast; absence is expressed by choosing <see cref="IFinding"/>, not by a null payload.
 /// </summary>
-public sealed record Finding<T>(
-    FindingSubject Subject,
-    FindingDescriptor Descriptor,
-    FindingKey Key,
-    int Position,
-    T Payload,
-    string? Detail = null) : IFinding<T>
-    where T : notnull;
+public sealed record Finding<T> : IFinding<T>
+    where T : notnull
+{
+    public Finding(
+        FindingSubject Subject,
+        FindingDescriptor Descriptor,
+        FindingKey Key,
+        int Position,
+        T Payload,
+        string? Detail = null)
+    {
+        this.Subject = Subject ?? throw new ArgumentNullException(nameof(Subject));
+        this.Descriptor = Descriptor ?? throw new ArgumentNullException(nameof(Descriptor));
+        if (Key.IdentityKey is null)
+            throw new ArgumentException("Finding key must be initialized.", nameof(Key));
+        if (Position < 0)
+            throw new ArgumentOutOfRangeException(nameof(Position), Position, "Position must be non-negative.");
+        if (Payload is null)
+            throw new ArgumentNullException(nameof(Payload));
+
+        this.Key = Key;
+        this.Position = Position;
+        this.Payload = Payload;
+        this.Detail = Detail;
+    }
+
+    public FindingSubject Subject { get; }
+    public FindingDescriptor Descriptor { get; }
+    public FindingKey Key { get; }
+    public int Position { get; }
+    public T Payload { get; }
+    public string? Detail { get; }
+
+    public void Deconstruct(
+        out FindingSubject subject,
+        out FindingDescriptor descriptor,
+        out FindingKey key,
+        out int position,
+        out T payload,
+        out string? detail)
+        => (subject, descriptor, key, position, payload, detail)
+            = (Subject, Descriptor, Key, Position, Payload, Detail);
+}
 
 /// <summary>
 /// The domain-free skeleton of a transition: an old/new pair classified by <see cref="Kind"/> and

--- a/src/ILInspector.Findings/FindingComparison.cs
+++ b/src/ILInspector.Findings/FindingComparison.cs
@@ -45,12 +45,37 @@ public sealed record FindingComparison<T> where T : notnull
     public bool IsExact => this is Complete { IsExact: true };
 
     /// <summary>
+    /// Applies producer-owned classification to a completed comparison while preserving the
+    /// alignment's atoms and order. Failed comparisons pass through unchanged.
+    /// </summary>
+    public FindingComparison<T> TransformPairs(
+        Func<ImmutableArray<PairFinding<T>>, ImmutableArray<PairFinding<T>>> transform)
+    {
+        ArgumentNullException.ThrowIfNull(transform);
+        var complete = this switch
+        {
+            Complete value => value,
+            Failed => null,
+        };
+        if (complete is null)
+            return this;
+
+        var transformed = transform(complete.Pairs);
+        ValidateTransformation(complete.Pairs, transformed);
+        return new Complete(
+            transformed,
+            complete.Match,
+            complete.OldInspection,
+            complete.NewInspection);
+    }
+
+    /// <summary>
     /// Matching ran. An empty match is valid evidence of a trivial alignment, including
     /// <c>Absent</c> versus <c>Absent</c>.
     /// </summary>
     public sealed record Complete
     {
-        public Complete(
+        internal Complete(
             ImmutableArray<PairFinding<T>> pairs,
             FindingMatch match,
             FindingInspection<T> oldInspection,
@@ -78,8 +103,8 @@ public sealed record FindingComparison<T> where T : notnull
         public FindingMatch Match { get; }
         public FindingInspection<T> OldInspection { get; }
         public FindingInspection<T> NewInspection { get; }
-        public ImmutableArray<Finding<T>> OldAtoms => InspectionAtoms(OldInspection);
-        public ImmutableArray<Finding<T>> NewAtoms => InspectionAtoms(NewInspection);
+        public ImmutableArray<Finding<T>> OldAtoms => FindingComparison.InspectionAtoms(OldInspection);
+        public ImmutableArray<Finding<T>> NewAtoms => FindingComparison.InspectionAtoms(NewInspection);
 
         public bool IsExact =>
             SameInspectionState(OldInspection, NewInspection)
@@ -89,7 +114,7 @@ public sealed record FindingComparison<T> where T : notnull
     /// <summary>Matching never ran because at least one inspection failed.</summary>
     public sealed record Failed
     {
-        public Failed(
+        internal Failed(
             FindingInspection<T> oldInspection,
             FindingInspection<T> newInspection)
         {
@@ -124,15 +149,6 @@ public sealed record FindingComparison<T> where T : notnull
         }
     }
 
-    static ImmutableArray<Finding<T>> InspectionAtoms(FindingInspection<T> inspection)
-        => inspection switch
-        {
-            FindingInspection<T>.Complete complete => complete.Findings,
-            FindingInspection<T>.Absent => [],
-            FindingInspection<T>.Failed => throw new InvalidOperationException(
-                "A completed comparison cannot contain a failed inspection."),
-        };
-
     static bool SameInspectionState(
         FindingInspection<T> oldInspection,
         FindingInspection<T> newInspection)
@@ -141,5 +157,77 @@ public sealed record FindingComparison<T> where T : notnull
             (FindingInspection<T>.Complete, FindingInspection<T>.Complete) => true,
             (FindingInspection<T>.Absent, FindingInspection<T>.Absent) => true,
             _ => false,
+        };
+
+    static void ValidateTransformation(
+        ImmutableArray<PairFinding<T>> original,
+        ImmutableArray<PairFinding<T>> transformed)
+    {
+        if (transformed.IsDefault)
+            throw new ArgumentException("Transformed pairs must be initialized.", nameof(transformed));
+        if (transformed.Length != original.Length)
+        {
+            throw new ArgumentException(
+                "Pair classification must preserve the alignment length.",
+                nameof(transformed));
+        }
+
+        for (int i = 0; i < original.Length; i++)
+        {
+            var before = (IPairFinding)original[i];
+            var after = transformed[i] as IPairFinding
+                ?? throw new ArgumentException(
+                    $"Transformed pair {i} must not be null.",
+                    nameof(transformed));
+            if (!ReferenceEquals(before.Old, after.Old)
+                || !ReferenceEquals(before.New, after.New))
+            {
+                throw new ArgumentException(
+                    $"Transformed pair {i} must preserve its old and new atoms.",
+                    nameof(transformed));
+            }
+        }
+    }
+}
+
+/// <summary>Runs the shared inspect-to-match-to-fold comparison operation.</summary>
+public static class FindingComparison
+{
+    public static FindingComparison<T> Compare<T>(
+        FindingInspection<T> oldInspection,
+        FindingInspection<T> newInspection,
+        FindingMatchOptions? matchOptions = null,
+        int acceptanceThreshold = 100)
+        where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(oldInspection);
+        ArgumentNullException.ThrowIfNull(newInspection);
+
+        if (oldInspection is FindingInspection<T>.Failed
+            || newInspection is FindingInspection<T>.Failed)
+        {
+            return new FindingComparison<T>.Failed(oldInspection, newInspection);
+        }
+
+        var oldAtoms = InspectionAtoms(oldInspection);
+        var newAtoms = InspectionAtoms(newInspection);
+        var match = FindingMatcher.Match(oldAtoms.Keys(), newAtoms.Keys(), matchOptions);
+        var pairs = FindingFold.ToPairs(match, oldAtoms, newAtoms, acceptanceThreshold);
+        return new FindingComparison<T>.Complete(
+            pairs,
+            match,
+            oldInspection,
+            newInspection);
+    }
+
+    internal static ImmutableArray<Finding<T>> InspectionAtoms<T>(
+        FindingInspection<T> inspection)
+        where T : notnull
+        => inspection switch
+        {
+            FindingInspection<T>.Complete complete => complete.Findings,
+            FindingInspection<T>.Absent => [],
+            FindingInspection<T>.Failed => throw new InvalidOperationException(
+                "A failed inspection cannot be matched."),
         };
 }

--- a/src/ILInspector.Findings/FindingInspection.cs
+++ b/src/ILInspector.Findings/FindingInspection.cs
@@ -53,9 +53,24 @@ public sealed record FindingInspection<T>
         ImmutableArray<Finding<T>> Findings)
     {
         public ImmutableArray<Finding<T>> Findings { get; }
-            = Findings.IsDefault
-                ? throw new ArgumentException("Findings must be initialized.", nameof(Findings))
-                : Findings;
+            = Validate(Findings);
+
+        static ImmutableArray<Finding<T>> Validate(ImmutableArray<Finding<T>> findings)
+        {
+            if (findings.IsDefault)
+                throw new ArgumentException("Findings must be initialized.", nameof(Findings));
+            for (int i = 0; i < findings.Length; i++)
+            {
+                if (findings[i] is null)
+                {
+                    throw new ArgumentException(
+                        $"Finding at index {i} must not be null.",
+                        nameof(Findings));
+                }
+            }
+
+            return findings;
+        }
     }
 
     /// <summary>The subject has no applicable input for this producer.</summary>

--- a/src/ILInspector.Findings/FindingKey.cs
+++ b/src/ILInspector.Findings/FindingKey.cs
@@ -19,4 +19,18 @@ namespace ILInspector.Findings;
 /// An optional structural scope tag (enclosing loop/try/region); a corroborating signal for move
 /// detection. Null when unknown or not modeled.
 /// </param>
-public readonly record struct FindingKey(string IdentityKey, string? ScopeKey = null);
+public readonly record struct FindingKey
+{
+    public FindingKey(string IdentityKey, string? ScopeKey = null)
+    {
+        ArgumentNullException.ThrowIfNull(IdentityKey);
+        this.IdentityKey = IdentityKey;
+        this.ScopeKey = ScopeKey;
+    }
+
+    public string IdentityKey { get; }
+    public string? ScopeKey { get; }
+
+    public void Deconstruct(out string identityKey, out string? scopeKey)
+        => (identityKey, scopeKey) = (IdentityKey, ScopeKey);
+}

--- a/src/ILInspector.Findings/FindingMatcher.cs
+++ b/src/ILInspector.Findings/FindingMatcher.cs
@@ -116,10 +116,25 @@ public static class FindingMatcher
         // (no interface dispatch), and the set committer streams it into its buckets.
         var oldKeys = oldStream as FindingKey[] ?? oldStream.ToArray();
         var newKeys = newStream as FindingKey[] ?? newStream.ToArray();
+        ValidateKeys(oldKeys, nameof(oldStream));
+        ValidateKeys(newKeys, nameof(newStream));
 
         return options.MatchMode == FindingMatchMode.IdentitySet
             ? MatchIdentitySet(oldKeys, newKeys)
             : MatchOrdered(oldKeys, newKeys, options);
+    }
+
+    static void ValidateKeys(FindingKey[] keys, string parameterName)
+    {
+        for (int i = 0; i < keys.Length; i++)
+        {
+            if (keys[i].IdentityKey is null)
+            {
+                throw new ArgumentException(
+                    $"Finding key at index {i} must be initialized.",
+                    parameterName);
+            }
+        }
     }
 
     // Order-free committer: pair occurrences by identity-key equality via hash buckets, deterministic
@@ -129,22 +144,17 @@ public static class FindingMatcher
     // at this rung once a soft tier drops a facet (e.g. declaring type) from the identity key (#2585).
     static FindingMatch MatchIdentitySet(FindingKey[] oldKeys, FindingKey[] newKeys)
     {
-        // Bucket new occurrences by identity key. IdentityKey is non-null by contract, but the ordered
-        // committer tolerates a null key (null == null matches), so keep parity via a dedicated null
-        // bucket instead of crashing in Dictionary (which rejects a null key) on a degenerate
-        // default(FindingKey).
         var newByKey = new Dictionary<string, Queue<int>>(StringComparer.Ordinal);
-        var newNull = new Queue<int>();
         for (int j = 0; j < newKeys.Length; j++)
-            Bucket(newByKey, newNull, newKeys[j].IdentityKey).Enqueue(j);
+            Bucket(newByKey, newKeys[j].IdentityKey).Enqueue(j);
 
         var matchedNew = new bool[newKeys.Length];
         var edges = ImmutableArray.CreateBuilder<FindingEdge>();
 
         for (int i = 0; i < oldKeys.Length; i++)
         {
-            string? key = oldKeys[i].IdentityKey;
-            var queue = key is null ? newNull : (newByKey.TryGetValue(key, out var q) ? q : null);
+            string key = oldKeys[i].IdentityKey;
+            var queue = newByKey.TryGetValue(key, out var q) ? q : null;
             if (queue is { Count: > 0 })
             {
                 int j = queue.Dequeue();
@@ -165,12 +175,8 @@ public static class FindingMatcher
 
         return new FindingMatch(edges.ToImmutable(), ImmutableArray<FindingMoveCandidate>.Empty);
 
-        // Route a null identity key to a dedicated bucket (Dictionary rejects null keys); real keys
-        // bucket by ordinal equality.
-        static Queue<int> Bucket(Dictionary<string, Queue<int>> byKey, Queue<int> nullBucket, string? key)
+        static Queue<int> Bucket(Dictionary<string, Queue<int>> byKey, string key)
         {
-            if (key is null)
-                return nullBucket;
             if (!byKey.TryGetValue(key, out var queue))
                 byKey[key] = queue = new Queue<int>();
             return queue;

--- a/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
@@ -52,6 +52,8 @@ public class FindingPilotTests
     {
         Assert.Throws<ArgumentException>(
             () => new FindingInspection<string>.Complete(default));
+        Assert.Throws<ArgumentException>(
+            () => new FindingInspection<string>.Complete([null!]));
         Assert.Throws<ArgumentNullException>(
             () => new FindingInspection<string>.Failed(null!));
         Assert.Throws<ArgumentNullException>(
@@ -60,6 +62,31 @@ public class FindingPilotTests
             () => new InspectionError(Subject, null!, "declined"));
         Assert.Throws<ArgumentNullException>(
             () => new InspectionError(Subject, Descriptor, null!));
+    }
+
+    [Fact]
+    public void FindingPrimitives_RejectInvalidIdentityAndPayloadStates()
+    {
+        Assert.Throws<ArgumentNullException>(() => new FindingSubject(null!, "subject"));
+        Assert.Throws<ArgumentException>(() => new FindingSubject("", "subject"));
+        Assert.Throws<ArgumentNullException>(() => new FindingSubject("subject", null!));
+        Assert.Throws<ArgumentNullException>(() => new FindingDescriptor(null!, "item"));
+        Assert.Throws<ArgumentException>(() => new FindingDescriptor("", "item"));
+        Assert.Throws<ArgumentNullException>(() => new FindingDescriptor("test.item", null!));
+        Assert.Throws<ArgumentNullException>(() => new FindingKey(null!));
+        Assert.Throws<ArgumentNullException>(
+            () => new Finding<string>(null!, Descriptor, new FindingKey("k"), 0, "k"));
+        Assert.Throws<ArgumentNullException>(
+            () => new Finding<string>(Subject, null!, new FindingKey("k"), 0, "k"));
+        Assert.Throws<ArgumentException>(
+            () => new Finding<string>(Subject, Descriptor, default, 0, "k"));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new Finding<string>(Subject, Descriptor, new FindingKey("k"), -1, "k"));
+        Assert.Throws<ArgumentNullException>(
+            () => new Finding<string>(Subject, Descriptor, new FindingKey("k"), 0, null!));
+
+        // Empty content is a valid identity for an empty logical text line.
+        Assert.Equal("", new FindingKey("").IdentityKey);
     }
 
     [Fact]
@@ -72,18 +99,11 @@ public class FindingPilotTests
         FindingInspection<string> failedInspection =
             new FindingInspection<string>.Failed(
                 new InspectionError(Subject, Descriptor, "declined"));
-        var emptyMatch = new FindingMatch([], []);
 
         FindingComparison<string> complete =
-            new FindingComparison<string>.Complete(
-                [],
-                emptyMatch,
-                absentInspection,
-                absentInspection);
+            FindingComparison.Compare(absentInspection, absentInspection);
         FindingComparison<string> failed =
-            new FindingComparison<string>.Failed(
-                failedInspection,
-                completeInspection);
+            FindingComparison.Compare(failedInspection, completeInspection);
 
         Assert.True(complete is FindingComparison<string>.Complete);
         Assert.True(complete.IsExact);
@@ -94,33 +114,40 @@ public class FindingPilotTests
     }
 
     [Fact]
-    public void FindingComparison_CasesRejectInvalidPublicStates()
+    public void FindingComparison_DifferentCensusesCannotReportExact()
     {
-        FindingInspection<string> complete =
-            new FindingInspection<string>.Complete([]);
-        FindingInspection<string> failed =
-            new FindingInspection<string>.Failed(
-                new InspectionError(Subject, Descriptor, "declined"));
-        var match = new FindingMatch([], []);
+        FindingInspection<string> oldInspection =
+            new FindingInspection<string>.Complete(Atoms("old"));
+        FindingInspection<string> newInspection =
+            new FindingInspection<string>.Complete(Atoms("new"));
 
-        Assert.Throws<ArgumentException>(
-            () => new FindingComparison<string>.Complete(default, match, complete, complete));
-        Assert.Throws<ArgumentNullException>(
-            () => new FindingComparison<string>.Complete([], null!, complete, complete));
-        Assert.Throws<ArgumentException>(
-            () => new FindingComparison<string>.Complete(
-                [],
-                new FindingMatch(default, []),
-                complete,
-                complete));
-        Assert.Throws<ArgumentException>(
-            () => new FindingComparison<string>.Complete([], match, failed, complete));
-        Assert.Throws<ArgumentException>(
-            () => new FindingComparison<string>.Complete([], match, complete, failed));
-        Assert.Throws<ArgumentException>(
-            () => new FindingComparison<string>.Failed(complete, complete));
-        Assert.Throws<ArgumentNullException>(
-            () => new FindingComparison<string>.Failed(null!, failed));
+        var comparison = FindingComparison.Compare(oldInspection, newInspection);
+
+        Assert.False(comparison.IsExact);
+        var complete = comparison switch
+        {
+            FindingComparison<string>.Complete value => value,
+            FindingComparison<string>.Failed failed => throw new Xunit.Sdk.XunitException(failed.Failure),
+        };
+        Assert.Equal(1, complete.Pairs.Count(pair => pair.Kind == PairKind.Added));
+        Assert.Equal(1, complete.Pairs.Count(pair => pair.Kind == PairKind.Removed));
+    }
+
+    [Fact]
+    public void FindingComparison_TransformationMustPreserveAlignmentAtoms()
+    {
+        FindingInspection<string> inspection =
+            new FindingInspection<string>.Complete(Atoms("same"));
+        var comparison = FindingComparison.Compare(inspection, inspection);
+
+        Assert.Throws<ArgumentException>(() => comparison.TransformPairs(_ => []));
+        Assert.Throws<ArgumentException>(() => comparison.TransformPairs(
+            pairs =>
+            [
+                new PairFinding<string>.Present(
+                    Atoms("replacement")[0],
+                    Atoms("replacement")[0]),
+            ]));
     }
 
     [Fact]
@@ -134,7 +161,7 @@ public class FindingPilotTests
                 new InspectionError(Subject, Descriptor, "new failure"));
 
         FindingComparison<string> comparison =
-            new FindingComparison<string>.Failed(oldFailed, newFailed);
+            FindingComparison.Compare(oldFailed, newFailed);
 
         Assert.Equal("old: old failure; new: new failure", comparison.Failure);
     }
@@ -393,19 +420,12 @@ public class FindingPilotTests
     }
 
     [Fact]
-    public void IdentitySet_NullIdentityKeys_MatchLikeOrdered_NoCrash()
+    public void UninitializedIdentityKeys_AreRejectedByBothMatchers()
     {
-        // default(FindingKey) has a null IdentityKey. The ordered committer treats null == null as a
-        // match; the set committer keeps parity (dedicated null bucket) rather than crashing in
-        // Dictionary, so a degenerate stream behaves the same on both rungs.
         var stream = new FindingKey[] { default, default };
 
-        var set = FindingMatcher.Match(stream, stream, IdentitySet);
-        Assert.Equal(2, Count(set, FindingEdgeKind.Matched));
-        Assert.Equal(0, Count(set, FindingEdgeKind.Added));
-        Assert.Equal(0, Count(set, FindingEdgeKind.Removed));
-
-        Assert.Equal(2, Count(FindingMatcher.Match(stream, stream), FindingEdgeKind.Matched));
+        Assert.Throws<ArgumentException>(() => FindingMatcher.Match(stream, stream, IdentitySet));
+        Assert.Throws<ArgumentException>(() => FindingMatcher.Match(stream, stream));
     }
 
     [Fact]

--- a/src/ILInspector.Instructions/IlFindings.cs
+++ b/src/ILInspector.Instructions/IlFindings.cs
@@ -78,33 +78,26 @@ public static class IlFindings
 
         var oldInspection = Inspect(oldBody, oldReader, subject);
         var newInspection = Inspect(newBody, newReader, subject);
-        if (oldInspection is FindingInspection<CanonicalIlOperation>.Failed
-            || newInspection is FindingInspection<CanonicalIlOperation>.Failed)
-        {
-            return new FindingComparison<CanonicalIlOperation>.Failed(
-                oldInspection,
-                newInspection);
-        }
-
-        var oldAtoms = InspectionAtoms(oldInspection);
-        var newAtoms = InspectionAtoms(newInspection);
-        var match = FindingMatcher.Match(oldAtoms.Keys(), newAtoms.Keys());
-        var pairs = FindingFold.ToPairs(match, oldAtoms, newAtoms, acceptanceThreshold);
-        if (oldBody is not null && newBody is not null)
-        {
-            pairs = ApplyBranchTargetValidation(
-                pairs,
-                oldBody.Instructions,
-                [.. oldAtoms.Select(static atom => atom.Payload)],
-                newBody.Instructions,
-                [.. newAtoms.Select(static atom => atom.Payload)]);
-        }
-
-        return new FindingComparison<CanonicalIlOperation>.Complete(
-            pairs,
-            match,
+        var comparison = FindingComparison.Compare(
             oldInspection,
-            newInspection);
+            newInspection,
+            acceptanceThreshold: acceptanceThreshold);
+        var complete = comparison switch
+        {
+            FindingComparison<CanonicalIlOperation>.Complete value => value,
+            FindingComparison<CanonicalIlOperation>.Failed => null,
+        };
+        if (oldBody is null || newBody is null || complete is null)
+        {
+            return comparison;
+        }
+
+        return comparison.TransformPairs(pairs => ApplyBranchTargetValidation(
+            pairs,
+            oldBody.Instructions,
+            [.. complete.OldAtoms.Select(static atom => atom.Payload)],
+            newBody.Instructions,
+            [.. complete.NewAtoms.Select(static atom => atom.Payload)]));
     }
 
     // IdentityKey deliberately ignores a branch/switch operation's targets (matching CanonicalEquals),
@@ -169,16 +162,6 @@ public static class IlFindings
                 operations[i]);
         }
     }
-
-    static ImmutableArray<Finding<CanonicalIlOperation>> InspectionAtoms(
-        FindingInspection<CanonicalIlOperation> inspection)
-        => inspection switch
-        {
-            FindingInspection<CanonicalIlOperation>.Complete complete => complete.Findings,
-            FindingInspection<CanonicalIlOperation>.Absent => [],
-            FindingInspection<CanonicalIlOperation>.Failed => throw new InvalidOperationException(
-                "A failed inspection cannot be matched."),
-        };
 
     /// <summary>
     /// The canonical content key for an operation, defined so that key equality is exactly the

--- a/src/ILInspector.Metadata/MetadataFindings.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.cs
@@ -117,17 +117,11 @@ public static class MetadataFindings
     {
         var oldInspection = InspectApiTypes(oldSurface, subject);
         var newInspection = InspectApiTypes(newSurface, subject);
-        var oldFindings = InspectionFindings(oldInspection);
-        var newFindings = InspectionFindings(newInspection);
-        var match = FindingMatcher.Match(oldFindings.Keys(), newFindings.Keys(), IdentitySetOptions);
-        var pairs = FindingFold.ToPairs(match, oldFindings, newFindings);
-        pairs = ApplyTypeFacetChanges(pairs, diff, options.Scope);
-
-        return new FindingComparison<ApiTypeHandle>.Complete(
-            pairs,
-            match,
+        return FindingComparison.Compare(
             oldInspection,
-            newInspection);
+            newInspection,
+            IdentitySetOptions)
+            .TransformPairs(pairs => ApplyTypeFacetChanges(pairs, diff, options.Scope));
     }
 
     static FindingComparison<ApiMemberHandle> CompareApiMembers(
@@ -139,17 +133,11 @@ public static class MetadataFindings
     {
         var oldInspection = InspectApiMembers(oldSurface, subject);
         var newInspection = InspectApiMembers(newSurface, subject);
-        var oldFindings = InspectionFindings(oldInspection);
-        var newFindings = InspectionFindings(newInspection);
-        var match = FindingMatcher.Match(oldFindings.Keys(), newFindings.Keys(), IdentitySetOptions);
-        var pairs = FindingFold.ToPairs(match, oldFindings, newFindings);
-        pairs = ApplyMemberFacetChanges(pairs, diff, options.Scope);
-
-        return new FindingComparison<ApiMemberHandle>.Complete(
-            pairs,
-            match,
+        return FindingComparison.Compare(
             oldInspection,
-            newInspection);
+            newInspection,
+            IdentitySetOptions)
+            .TransformPairs(pairs => ApplyMemberFacetChanges(pairs, diff, options.Scope));
     }
 
     static ImmutableArray<PairFinding<ApiTypeHandle>> ApplyTypeFacetChanges(
@@ -366,12 +354,6 @@ public static class MetadataFindings
 
     static string FormatValue(string? value)
         => string.IsNullOrEmpty(value) ? "none" : value;
-
-    static ImmutableArray<Finding<T>> InspectionFindings<T>(FindingInspection<T> inspection)
-        where T : notnull
-        => inspection is FindingInspection<T>.Complete complete
-            ? complete.Findings
-            : throw new InvalidOperationException("API-surface inspection unexpectedly failed.");
 
     static IEnumerable<(ApiType Type, ApiMember Member)> EnumerateMembers(ApiSurface surface)
     {

--- a/src/ILInspector.Text/TextFindings.cs
+++ b/src/ILInspector.Text/TextFindings.cs
@@ -42,14 +42,10 @@ public static class TextFindings
             new FindingInspection<string>.Complete(oldAtoms);
         FindingInspection<string> newInspection =
             new FindingInspection<string>.Complete(newAtoms);
-        var match = FindingMatcher.Match(oldAtoms.Keys(), newAtoms.Keys());
-        var pairs = FindingFold.ToPairs(match, oldAtoms, newAtoms, acceptanceThreshold);
-
-        return new FindingComparison<string>.Complete(
-            pairs,
-            match,
+        return FindingComparison.Compare(
             oldInspection,
-            newInspection);
+            newInspection,
+            acceptanceThreshold: acceptanceThreshold);
     }
 
     static IEnumerable<string> SplitLines(string text)


### PR DESCRIPTION
## Conclusion

**PASS** — Finding comparisons can no longer be fabricated independently of their inspections and matcher output, and malformed identities now fail before matching.

Part of #2614.

## Change

- Add the shared `FindingComparison.Compare` operation for failure handling, inspection projection, matching, folding, and envelope construction.
- Make `FindingComparison<T>.Complete` / `Failed` case construction internal to the Finding leaf.
- Add `TransformPairs` for producer-owned classification, constrained to preserve pair count, order, and exact old/new atom references.
- Migrate IL, C#, text, and Metadata producers to the shared comparison operation.
- Validate Finding subjects, descriptors, keys, positions, payloads, and complete census entries.
- Reject `default(FindingKey)` before either ordered or identity-set matching; exact empty text-line identities remain valid.

## Validation

```text
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --no-restore

ILInspector.Instructions.Tests: 99 passed
ILInspector.Text.Tests: 13 passed
ILInspector.Metadata.Tests: 417 passed
ILInspector.Decompiler.Tests CSharpFindingsTests: 18 passed
ILInspector.Research.Tests: 71 passed
```

The solution build retains three existing nullable warnings in Metadata tests.

## Adversarial review

- Claude Opus 4.8: clean at `b593a2e1`; verified envelope non-forgeability, transform atom preservation, union accessibility, valid-edge handling, and Research integration.
- Gemini 3.1 Pro: clean at `b593a2e1`; verified substitution/reordering attacks, matcher validation, compatibility, all producer semantics, and targeted real runs.

No review guidance required a follow-up commit.
