### PR TITLE
Add lightweight C# type printer boundary

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -523,6 +523,10 @@ Research overlay bridge, and the application layer:
 │  PackageExtractor, NuGetCache, TfmResolver                  │
 │  DependencyGroup, PackageDependency                         │
 ├─────────────────────────────────────────────────────────────┤
+│  ILInspector.CSharp (C# type views)                         │
+│                                                             │
+│  CSharpTypePrinter, namespace/type skeleton composition      │
+├─────────────────────────────────────────────────────────────┤
 │  ILInspector.Metadata (Domain provider — PE/Assembly)       │
 │                                                             │
 │  AssemblyReader, ApiSurface models, PdbReader                │
@@ -533,6 +537,7 @@ Research overlay bridge, and the application layer:
 
 - **Domain providers** are application-agnostic. They know about NuGet packages and PE files, not about dotnet-inspect.
 - **Services** return DTOs (`NuspecData`, `DepsJsonData`, `PackageMetadata`), never mutate app types. They use `Action<string>?` for logging instead of app-specific logger types.
+- **CSharp** owns C# spelling and body-independent type views over Metadata models. It does not depend on Decompiler or Research.
 - **Analysis** owns R1 whole-assembly evidence and must not depend on the decompiler IR, Roslyn, or inspected-assembly loading.
 - **Decompiler** owns R2 method projection and rendering evidence, not whole-assembly analysis indexes.
 - **Research** is the only bridge between Analysis and Decompiler evidence. New overlay facts register as producers; presenters consume the merged offset-keyed overlay.
@@ -568,6 +573,7 @@ src/dotnet-inspect/
 src/DotnetInspector.Services/   # Shared, app-agnostic services
 src/DotnetInspector.Packages/   # NuGet domain provider
 src/ILInspector.Metadata/       # PE/assembly domain provider
+src/ILInspector.CSharp/         # C# spelling and namespace/type views
 src/ILInspector.ControlFlow/    # Shared control-flow/dataflow kernels
 src/ILInspector.Analysis/       # R1 whole-assembly method-body evidence
 src/ILInspector.Decompiler/     # R2 per-method IR and source/IL projection

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -8,6 +8,7 @@ It is built for both humans and agents. Markdown is the default output because h
 
 - `src/dotnet-inspect/` contains the CLI, command routing, parsers, options, output views, section descriptors, and inspectors.
 - `src/ILInspector.Metadata/` reads PE metadata, API surfaces, SourceLink/PDB data, method classification, and assembly details. `MetadataFindings` projects API type/member observations and comparisons onto the shared Finding spine while retaining compatibility classification through `ApiDiff`.
+- `src/ILInspector.CSharp/` is the lightweight C# spelling and type-view layer over Metadata shapes. It composes body-independent namespace/type skeletons without taking a Decompiler or Research dependency.
 - `src/ILInspector.Analysis/` indexes IL method-body evidence such as direct call sites, allocation occurrences, method signals, and whole-assembly leverage without decompiling to C#.
 - `src/ILInspector.Analysis.App/` is a temporary console harness for exercising Analysis queries until CLI wiring exists.
 - `src/ILInspector.ControlFlow/` contains shared block-edge, dominance, and dataflow kernels used below Analysis and Decompiler without depending on either.

--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -27,6 +27,8 @@
     <Project Path="src/ILInspector.Analysis.SpoofRuntimeFixtures/ILInspector.Analysis.SpoofRuntimeFixtures.csproj" />
     <Project Path="src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj" />
     <Project Path="src/ILInspector.Analysis/ILInspector.Analysis.csproj" />
+    <Project Path="src/ILInspector.CSharp.Tests/ILInspector.CSharp.Tests.csproj" />
+    <Project Path="src/ILInspector.CSharp/ILInspector.CSharp.csproj" />
     <Project Path="src/ILInspector.ControlFlow/ILInspector.ControlFlow.csproj" />
     <Project Path="src/ILInspector.Findings/ILInspector.Findings.csproj" />
     <Project Path="src/ILInspector.Decompiler.Fixtures.CheckedArithmetic/ILInspector.Decompiler.Fixtures.CheckedArithmetic.csproj" />

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -79,7 +79,7 @@ public sealed class CSharpTypePrinterTests
             new CSharpTypePrintRequest(CreateEmptyType("Samples", "Second"))
         };
 
-        var result = _printer.Print(requests);
+        var result = _printer.PrintBatch(requests);
 
         Assert.Collection(
             result.Units,
@@ -245,9 +245,58 @@ public sealed class CSharpTypePrinterTests
             new CSharpTypePrintRequest(type)
         };
 
-        var exception = Assert.Throws<ArgumentException>(() => _printer.Print(requests));
+        var exception = Assert.Throws<ArgumentException>(() => _printer.PrintBatch(requests));
 
         Assert.Contains("duplicate C# type 'Samples.Widget'", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CanonicalMetadataIdentityRejectsDuplicateGenericDeclarations()
+    {
+        var first = CreateEmptyType("Samples", "Converter<T>");
+        first.MetadataName = "Converter`1";
+        var second = CreateEmptyType("Samples", "Converter<U>");
+        second.MetadataName = "Converter`1";
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => _printer.PrintBatch(
+            [
+                new CSharpTypePrintRequest(first),
+                new CSharpTypePrintRequest(second)
+            ]));
+
+        Assert.Contains("duplicate C# type", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MalformedTypeNameFailsExplicitly()
+    {
+        var type = CreateEmptyType("Samples", "Widget");
+        type.Name = null!;
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => _printer.Print(new CSharpTypePrintRequest(type)));
+
+        Assert.Contains("non-empty type name", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MalformedMemberCollectionFailsExplicitly()
+    {
+        var type = CreateEmptyType("Samples", "Widget");
+        type.Members = null!;
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => _printer.Print(new CSharpTypePrintRequest(type)));
+
+        Assert.Contains("null member collection", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NullCallsResolveToExplicitArgumentFailures()
+    {
+        Assert.Throws<ArgumentNullException>(() => _printer.Print(null!));
+        Assert.Throws<ArgumentNullException>(() => _printer.PrintBatch(null!));
     }
 
     static ApiType CreateEmptyType(string? @namespace, string name)

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -131,7 +131,8 @@ public sealed class CSharpTypePrinterTests
         var type = new ApiType
         {
             Namespace = "Samples",
-            Name = "Converter<T>",
+            Name = "Converter`1",
+            MetadataName = "Converter`1",
             Kind = "class",
             TypeParameters = [new TypeParameter { Name = "T" }],
             Members =
@@ -155,9 +156,14 @@ public sealed class CSharpTypePrinterTests
         var result = _printer.Print(new CSharpTypePrintRequest(type));
 
         Assert.Contains(
+            "public class Converter<T>",
+            result.Units[0].Source,
+            StringComparison.Ordinal);
+        Assert.Contains(
             "public TResult Convert<TResult>(T value) where TResult : class;",
             result.Units[0].Source,
             StringComparison.Ordinal);
+        Assert.DoesNotContain("Converter<T><T>", result.Units[0].Source, StringComparison.Ordinal);
         Assert.DoesNotContain("broken compatibility signature", result.Units[0].Source, StringComparison.Ordinal);
     }
 
@@ -253,10 +259,12 @@ public sealed class CSharpTypePrinterTests
     [Fact]
     public void CanonicalMetadataIdentityRejectsDuplicateGenericDeclarations()
     {
-        var first = CreateEmptyType("Samples", "Converter<T>");
+        var first = CreateEmptyType("Samples", "Converter`1");
         first.MetadataName = "Converter`1";
-        var second = CreateEmptyType("Samples", "Converter<U>");
+        first.TypeParameters = [new TypeParameter { Name = "T" }];
+        var second = CreateEmptyType("Samples", "Other`1");
         second.MetadataName = "Converter`1";
+        second.TypeParameters = [new TypeParameter { Name = "U" }];
 
         var exception = Assert.Throws<ArgumentException>(
             () => _printer.PrintBatch(
@@ -266,6 +274,40 @@ public sealed class CSharpTypePrinterTests
             ]));
 
         Assert.Contains("duplicate C# type", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CSharpSpelledGenericTypeNameFailsExplicitly()
+    {
+        var type = CreateEmptyType("Samples", "Converter<T>");
+        type.TypeParameters = [new TypeParameter { Name = "T" }];
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => _printer.Print(new CSharpTypePrintRequest(type)));
+
+        Assert.Contains("must use a metadata name", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("Converter", 1)]
+    [InlineData("Converter`2", 1)]
+    [InlineData("Converter`x", 1)]
+    public void InconsistentGenericMetadataArityFailsExplicitly(string name, int parameterCount)
+    {
+        var type = CreateEmptyType("Samples", name);
+        type.TypeParameters = Enumerable.Range(0, parameterCount)
+            .Select(index => new TypeParameter { Name = $"T{index}" })
+            .ToList();
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => _printer.Print(new CSharpTypePrintRequest(type)));
+
+        Assert.Contains(
+            name.Contains('`', StringComparison.Ordinal)
+                ? "inconsistent metadata arity"
+                : "requires metadata arity",
+            exception.Message,
+            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -202,13 +202,80 @@ public sealed class CSharpTypePrinterTests
     [Fact]
     public void NonSkeletonPolicyFailsInsteadOfDroppingBodies()
     {
-        var request = new CSharpTypePrintRequest(
-            CreateEmptyType("Samples", "Widget"),
-            CSharpTypeBodyPolicy.Full);
+        var type = CreateEmptyType("Samples", "Widget");
+        type.Members.Add(CreateMethod("Run"));
+        var request = new CSharpTypePrintRequest(type, CSharpBodyPolicy.Full);
 
         var exception = Assert.Throws<NotSupportedException>(() => _printer.Print(request));
 
         Assert.Contains("requires a body provider", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MemberPolicyOverridesTypeDefault()
+    {
+        var type = CreateEmptyType("Samples", "Widget");
+        var member = CreateMethod("Run");
+        type.Members.Add(member);
+        var request = new CSharpTypePrintRequest(
+            type,
+            CSharpBodyPolicy.Full,
+            memberPolicyOverrides: [new CSharpMemberPolicy(member, CSharpBodyPolicy.Skeleton)]);
+
+        var result = _printer.Print(request);
+
+        Assert.Contains("public void Run();", result.Units[0].Source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NonSkeletonMemberPolicyFailsInsteadOfDroppingBody()
+    {
+        var type = CreateEmptyType("Samples", "Widget");
+        var member = CreateMethod("Run");
+        type.Members.Add(member);
+        var request = new CSharpTypePrintRequest(
+            type,
+            memberPolicyOverrides: [new CSharpMemberPolicy(member, CSharpBodyPolicy.Full)]);
+
+        var exception = Assert.Throws<NotSupportedException>(() => _printer.Print(request));
+
+        Assert.Contains("'Full' for 'Run' requires a body provider", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MemberPolicyMustTargetSelectedMember()
+    {
+        var type = CreateEmptyType("Samples", "Widget");
+        var selected = CreateMethod("Selected");
+        var omitted = CreateMethod("Omitted");
+        type.Members.AddRange([selected, omitted]);
+        var request = new CSharpTypePrintRequest(
+            type,
+            members: [selected],
+            memberPolicyOverrides: [new CSharpMemberPolicy(omitted, CSharpBodyPolicy.Skeleton)]);
+
+        var exception = Assert.Throws<ArgumentException>(() => _printer.Print(request));
+
+        Assert.Contains("is not in the selected member set", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MemberPolicyOverridesMustBeUnique()
+    {
+        var type = CreateEmptyType("Samples", "Widget");
+        var member = CreateMethod("Run");
+        type.Members.Add(member);
+        var request = new CSharpTypePrintRequest(
+            type,
+            memberPolicyOverrides:
+            [
+                new CSharpMemberPolicy(member, CSharpBodyPolicy.Skeleton),
+                new CSharpMemberPolicy(member, CSharpBodyPolicy.Skeleton)
+            ]);
+
+        var exception = Assert.Throws<ArgumentException>(() => _printer.Print(request));
+
+        Assert.Contains("multiple policy overrides", exception.Message, StringComparison.Ordinal);
     }
 
     [Theory]
@@ -347,5 +414,17 @@ public sealed class CSharpTypePrinterTests
             Namespace = @namespace,
             Name = name,
             Kind = "class"
+        };
+
+    static ApiMember CreateMethod(string name)
+        => new()
+        {
+            Name = name,
+            Kind = "method",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "void",
+                MemberName = name
+            }
         };
 }

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -430,6 +430,114 @@ public sealed class CSharpTypePrinterTests
     }
 
     [Fact]
+    public void RenderingSnapshotDoesNotRetainMutableMetadataAliases()
+    {
+        var typeParameter = new TypeParameter
+        {
+            Name = "T",
+            Constraints = ["System.IDisposable"]
+        };
+        var parameter = new ApiParameter
+        {
+            Attributes = ["ParamMarker"],
+            Name = "value",
+            Type = "T"
+        };
+        var accessor = new ApiAccessor
+        {
+            Kind = "get",
+            ReturnAttributes = ["AccessorMarker"]
+        };
+        var method = new ApiMember
+        {
+            Name = "Transform",
+            Kind = "method",
+            Attributes = ["MemberMarker"],
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "T",
+                ReturnAttributes = ["ReturnMarker"],
+                MemberName = "Transform",
+                Parameters = [parameter]
+            }
+        };
+        var property = new ApiMember
+        {
+            Name = "Value",
+            Kind = "property",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "string",
+                MemberName = "Value",
+                IsRequired = true,
+                Accessors = [accessor]
+            }
+        };
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Container`1",
+            MetadataName = "Container`1",
+            Kind = "class",
+            Attributes = ["TypeMarker"],
+            BaseType = "Samples.BaseType",
+            Interfaces = ["Samples.IContract"],
+            TypeParameters = [typeParameter],
+            Members = [method, property]
+        };
+
+        var snapshot = CSharpTypePrinter.SnapshotTypeForRendering(type, type.Members);
+
+        type.Namespace = "Mutated";
+        type.Name = "Mutated";
+        type.MetadataName = "Mutated";
+        type.Kind = "enum";
+        type.Attributes[0] = "Mutated";
+        type.BaseType = "Mutated";
+        type.Interfaces[0] = "Mutated";
+        typeParameter.Name = "Mutated";
+        typeParameter.Constraints[0] = "Mutated";
+        method.Name = "Mutated";
+        method.Kind = "field";
+        method.Attributes[0] = "Mutated";
+        method.SignatureModel!.ReturnType = "Mutated";
+        method.SignatureModel.ReturnAttributes[0] = "Mutated";
+        method.SignatureModel.MemberName = "Mutated";
+        parameter.Attributes[0] = "Mutated";
+        parameter.Name = "Mutated";
+        parameter.Type = "Mutated";
+        property.SignatureModel!.ReturnType = "Mutated";
+        property.SignatureModel.MemberName = "Mutated";
+        property.SignatureModel.IsRequired = false;
+        accessor.Kind = "set";
+        accessor.ReturnAttributes[0] = "Mutated";
+
+        var rendered = CSharpDeclarationWriter.RenderTypeUnit(
+            snapshot,
+            snapshot.Members,
+            new CSharpDeclarationOptions
+            {
+                TypeNameMode = CSharpTypeNameMode.ContextualShort,
+                NamespaceMode = CSharpNamespaceMode.Omit,
+                IncludeCustomAttributes = true
+            });
+
+        Assert.Contains(
+            "[TypeMarker] public class Container<T> : Samples.BaseType, Samples.IContract where T : System.IDisposable",
+            rendered.Source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "[MemberMarker] [return: ReturnMarker] public T Transform([ParamMarker] T value);",
+            rendered.Source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "public required string Value { [return: AccessorMarker] get; }",
+            rendered.Source,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("Mutated", rendered.Source, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void NullCallsResolveToExplicitArgumentFailures()
     {
         Assert.Throws<ArgumentNullException>(() => _printer.Print(null!));

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -205,6 +205,51 @@ public sealed class CSharpTypePrinterTests
         Assert.Contains("requires a body provider", exception.Message, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData("enum")]
+    [InlineData("delegate")]
+    public void UnsupportedTypeKindFailsInsteadOfEmittingInvalidSkeleton(string kind)
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Shape",
+            Kind = kind
+        };
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => _printer.Print(new CSharpTypePrintRequest(type)));
+
+        Assert.Contains($"type kind '{kind}'", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NestedTypeFailsWithoutItsDeclaringType()
+    {
+        var type = CreateEmptyType("Samples", "Outer.Inner");
+        type.MetadataName = "Outer+Inner";
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => _printer.Print(new CSharpTypePrintRequest(type)));
+
+        Assert.Contains("requires its declaring type", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DuplicateTypeRequestsFailInsteadOfEmittingDuplicateDeclarations()
+    {
+        var type = CreateEmptyType("Samples", "Widget");
+        var requests = new[]
+        {
+            new CSharpTypePrintRequest(type),
+            new CSharpTypePrintRequest(type)
+        };
+
+        var exception = Assert.Throws<ArgumentException>(() => _printer.Print(requests));
+
+        Assert.Contains("duplicate C# type 'Samples.Widget'", exception.Message, StringComparison.Ordinal);
+    }
+
     static ApiType CreateEmptyType(string? @namespace, string name)
         => new()
         {

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -278,6 +278,34 @@ public sealed class CSharpTypePrinterTests
         Assert.Contains("multiple policy overrides", exception.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void RequestSnapshotsMembersBeforeValidation()
+    {
+        var member = CreateMethod("Run");
+        var changingMembers = new DifferentEachEnumerationList<ApiMember>(member, null!);
+
+        var request = new CSharpTypePrintRequest(
+            CreateEmptyType("Samples", "Widget"),
+            members: changingMembers);
+
+        Assert.Same(member, Assert.Single(request.Members!));
+    }
+
+    [Fact]
+    public void RequestSnapshotsMemberPoliciesBeforeValidation()
+    {
+        var member = CreateMethod("Run");
+        var policy = new CSharpMemberPolicy(member, CSharpBodyPolicy.Skeleton);
+        var changingPolicies = new DifferentEachEnumerationList<CSharpMemberPolicy>(policy, null!);
+
+        var request = new CSharpTypePrintRequest(
+            CreateEmptyType("Samples", "Widget"),
+            members: [member],
+            memberPolicyOverrides: changingPolicies);
+
+        Assert.Same(policy, Assert.Single(request.MemberPolicyOverrides));
+    }
+
     [Theory]
     [InlineData("enum")]
     [InlineData("delegate")]
@@ -427,4 +455,21 @@ public sealed class CSharpTypePrinterTests
                 MemberName = name
             }
         };
+
+    sealed class DifferentEachEnumerationList<T>(T first, T later) : IReadOnlyList<T>
+    {
+        int _enumerationCount;
+
+        public int Count => 1;
+
+        public T this[int index] => index == 0 ? first : throw new ArgumentOutOfRangeException(nameof(index));
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            yield return _enumerationCount++ == 0 ? first : later;
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+            => GetEnumerator();
+    }
 }

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -1,0 +1,215 @@
+using ILInspector.Metadata;
+
+namespace ILInspector.CSharp.Tests;
+
+public sealed class CSharpTypePrinterTests
+{
+    readonly CSharpTypePrinter _printer = new();
+
+    [Fact]
+    public void SkeletonPrintsApiProposalStyleSource()
+    {
+        var type = new ApiType
+        {
+            Namespace = "System.Text",
+            Name = "StringBuilder",
+            Kind = "class",
+            IsSealed = true,
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = ".ctor",
+                    Kind = "constructor",
+                    Signature = "this text must not be used",
+                    SignatureModel = new ApiSignature()
+                },
+                new ApiMember
+                {
+                    Name = "Append",
+                    Kind = "method",
+                    Signature = "this text must not be used",
+                    SignatureModel = new ApiSignature
+                    {
+                        ReturnType = "System.Text.StringBuilder",
+                        MemberName = "Append",
+                        Parameters = [new ApiParameter { Type = "string?", Name = "value" }]
+                    }
+                },
+                new ApiMember
+                {
+                    Name = "ToString",
+                    Kind = "method",
+                    IsOverride = true,
+                    SignatureModel = new ApiSignature
+                    {
+                        ReturnType = "string",
+                        MemberName = "ToString"
+                    }
+                }
+            ]
+        };
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        var unit = Assert.Single(result.Units);
+        Assert.Equal("System.Text", unit.Namespace);
+        Assert.Equal(
+            """
+            namespace System.Text;
+
+            public sealed class StringBuilder
+            {
+                public StringBuilder();
+                public StringBuilder Append(string? value);
+                public override string ToString();
+            }
+            """,
+            unit.Source);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void BatchGroupsTypesIntoNamespaceSourceUnits()
+    {
+        var requests = new[]
+        {
+            new CSharpTypePrintRequest(CreateEmptyType("Samples", "First")),
+            new CSharpTypePrintRequest(CreateEmptyType("Other", "Third")),
+            new CSharpTypePrintRequest(CreateEmptyType("Samples", "Second"))
+        };
+
+        var result = _printer.Print(requests);
+
+        Assert.Collection(
+            result.Units,
+            unit =>
+            {
+                Assert.Equal("Samples", unit.Namespace);
+                Assert.Equal(
+                    """
+                    namespace Samples;
+
+                    public class First
+                    {
+                    }
+
+                    public class Second
+                    {
+                    }
+                    """,
+                    unit.Source);
+            },
+            unit =>
+            {
+                Assert.Equal("Other", unit.Namespace);
+                Assert.Contains("public class Third", unit.Source, StringComparison.Ordinal);
+            });
+    }
+
+    [Fact]
+    public void GlobalNamespaceOmitsNamespaceDeclaration()
+    {
+        var type = CreateEmptyType(null, "GlobalType");
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        var unit = Assert.Single(result.Units);
+        Assert.Null(unit.Namespace);
+        Assert.Equal(
+            """
+            public class GlobalType
+            {
+            }
+            """,
+            unit.Source);
+    }
+
+    [Fact]
+    public void SkeletonPrefersStructuredGenericSignature()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Converter<T>",
+            Kind = "class",
+            TypeParameters = [new TypeParameter { Name = "T" }],
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = "Convert",
+                    Kind = "method",
+                    Signature = "broken compatibility signature",
+                    SignatureModel = new ApiSignature
+                    {
+                        ReturnType = "TResult",
+                        MemberName = "Convert<TResult>",
+                        TypeParameters = [new TypeParameter { Name = "TResult", Constraints = ["class"] }],
+                        Parameters = [new ApiParameter { Type = "T", Name = "value" }]
+                    }
+                }
+            ]
+        };
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.Contains(
+            "public TResult Convert<TResult>(T value) where TResult : class;",
+            result.Units[0].Source,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("broken compatibility signature", result.Units[0].Source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SkeletonMatchesMetadataDeclarationWriter()
+    {
+        var type = CreateEmptyType("Samples", "Widget");
+        type.Members.Add(new ApiMember
+        {
+            Name = "Create",
+            Kind = "method",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "Samples.Widget",
+                MemberName = "Create"
+            }
+        });
+        var declarationOptions = new CSharpDeclarationOptions
+        {
+            TypeNameMode = CSharpTypeNameMode.ContextualShort,
+            ContainingNamespace = "Samples",
+            NamespaceMode = CSharpNamespaceMode.Omit,
+            TerminateMemberDeclaration = true
+        };
+        var expectedDeclaration = CSharpDeclarationWriter.RenderTypeUnit(
+            type,
+            type.Members,
+            declarationOptions);
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.Equal($"namespace Samples;\n\n{expectedDeclaration.Source}", result.Units[0].Source);
+        Assert.Equal(expectedDeclaration.Diagnostics, result.Diagnostics.Select(diagnostic => diagnostic.Message));
+    }
+
+    [Fact]
+    public void NonSkeletonPolicyFailsInsteadOfDroppingBodies()
+    {
+        var request = new CSharpTypePrintRequest(
+            CreateEmptyType("Samples", "Widget"),
+            CSharpTypeBodyPolicy.Full);
+
+        var exception = Assert.Throws<NotSupportedException>(() => _printer.Print(request));
+
+        Assert.Contains("requires a body provider", exception.Message, StringComparison.Ordinal);
+    }
+
+    static ApiType CreateEmptyType(string? @namespace, string name)
+        => new()
+        {
+            Namespace = @namespace,
+            Name = name,
+            Kind = "class"
+        };
+}

--- a/src/ILInspector.CSharp.Tests/ILInspector.CSharp.Tests.csproj
+++ b/src/ILInspector.CSharp.Tests/ILInspector.CSharp.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit.v3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ILInspector.CSharp\ILInspector.CSharp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ILInspector.CSharp/CSharpTypePrintContracts.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrintContracts.cs
@@ -1,0 +1,48 @@
+using System.Collections.Immutable;
+using ILInspector.Metadata;
+
+namespace ILInspector.CSharp;
+
+public enum CSharpTypeBodyPolicy
+{
+    Skeleton,
+    Full,
+    Mixed,
+    Stubs
+}
+
+public sealed record CSharpTypePrintRequest
+{
+    public CSharpTypePrintRequest(
+        ApiType type,
+        CSharpTypeBodyPolicy bodyPolicy = CSharpTypeBodyPolicy.Skeleton,
+        IReadOnlyList<ApiMember>? members = null)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        if (!Enum.IsDefined(bodyPolicy))
+            throw new ArgumentOutOfRangeException(nameof(bodyPolicy));
+
+        Type = type;
+        BodyPolicy = bodyPolicy;
+        Members = members?.ToArray();
+    }
+
+    public ApiType Type { get; }
+
+    public CSharpTypeBodyPolicy BodyPolicy { get; }
+
+    public IReadOnlyList<ApiMember>? Members { get; }
+}
+
+public sealed record CSharpTypePrintOptions
+{
+    public bool IncludeCustomAttributes { get; init; }
+}
+
+public sealed record CSharpTypeSourceUnit(string? Namespace, string Source);
+
+public sealed record CSharpTypePrintDiagnostic(string TypeName, string Message);
+
+public sealed record CSharpTypePrintResult(
+    ImmutableArray<CSharpTypeSourceUnit> Units,
+    ImmutableArray<CSharpTypePrintDiagnostic> Diagnostics);

--- a/src/ILInspector.CSharp/CSharpTypePrintContracts.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrintContracts.cs
@@ -10,24 +10,9 @@ public enum CSharpBodyPolicy
     Stub
 }
 
-public sealed record CSharpMemberPolicy
-{
-    public CSharpMemberPolicy(ApiMember member, CSharpBodyPolicy bodyPolicy)
-    {
-        ArgumentNullException.ThrowIfNull(member);
-        if (!Enum.IsDefined(bodyPolicy))
-            throw new ArgumentOutOfRangeException(nameof(bodyPolicy));
+public sealed record CSharpMemberPolicy(ApiMember Member, CSharpBodyPolicy BodyPolicy);
 
-        Member = member;
-        BodyPolicy = bodyPolicy;
-    }
-
-    public ApiMember Member { get; }
-
-    public CSharpBodyPolicy BodyPolicy { get; }
-}
-
-public sealed record CSharpTypePrintRequest
+public sealed class CSharpTypePrintRequest
 {
     public CSharpTypePrintRequest(
         ApiType type,
@@ -38,19 +23,39 @@ public sealed record CSharpTypePrintRequest
         ArgumentNullException.ThrowIfNull(type);
         if (!Enum.IsDefined(bodyPolicy))
             throw new ArgumentOutOfRangeException(nameof(bodyPolicy));
-        if (members?.Any(member => member is null) == true)
+
+        var memberArray = members?.ToArray();
+        if (memberArray?.Any(member => member is null) == true)
             throw new ArgumentException("Type print members cannot contain null entries.", nameof(members));
-        if (memberPolicyOverrides?.Any(policy => policy is null) == true)
+
+        var memberPolicyArray = memberPolicyOverrides?.ToArray() ?? [];
+        if (memberPolicyArray.Any(policy => policy is null))
         {
             throw new ArgumentException(
                 "Member policy overrides cannot contain null entries.",
                 nameof(memberPolicyOverrides));
         }
+        foreach (var policy in memberPolicyArray)
+        {
+            if (policy.Member is null)
+            {
+                throw new ArgumentException(
+                    "Member policy overrides require a member.",
+                    nameof(memberPolicyOverrides));
+            }
+            if (!Enum.IsDefined(policy.BodyPolicy))
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(memberPolicyOverrides),
+                    policy.BodyPolicy,
+                    "Member policy overrides require a defined body policy.");
+            }
+        }
 
         Type = type;
         BodyPolicy = bodyPolicy;
-        Members = members?.ToArray();
-        MemberPolicyOverrides = memberPolicyOverrides?.ToArray() ?? [];
+        Members = memberArray;
+        MemberPolicyOverrides = memberPolicyArray;
     }
 
     public ApiType Type { get; }

--- a/src/ILInspector.CSharp/CSharpTypePrintContracts.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrintContracts.cs
@@ -3,37 +3,63 @@ using ILInspector.Metadata;
 
 namespace ILInspector.CSharp;
 
-public enum CSharpTypeBodyPolicy
+public enum CSharpBodyPolicy
 {
     Skeleton,
     Full,
-    Mixed,
-    Stubs
+    Stub
+}
+
+public sealed record CSharpMemberPolicy
+{
+    public CSharpMemberPolicy(ApiMember member, CSharpBodyPolicy bodyPolicy)
+    {
+        ArgumentNullException.ThrowIfNull(member);
+        if (!Enum.IsDefined(bodyPolicy))
+            throw new ArgumentOutOfRangeException(nameof(bodyPolicy));
+
+        Member = member;
+        BodyPolicy = bodyPolicy;
+    }
+
+    public ApiMember Member { get; }
+
+    public CSharpBodyPolicy BodyPolicy { get; }
 }
 
 public sealed record CSharpTypePrintRequest
 {
     public CSharpTypePrintRequest(
         ApiType type,
-        CSharpTypeBodyPolicy bodyPolicy = CSharpTypeBodyPolicy.Skeleton,
-        IReadOnlyList<ApiMember>? members = null)
+        CSharpBodyPolicy bodyPolicy = CSharpBodyPolicy.Skeleton,
+        IReadOnlyList<ApiMember>? members = null,
+        IReadOnlyList<CSharpMemberPolicy>? memberPolicyOverrides = null)
     {
         ArgumentNullException.ThrowIfNull(type);
         if (!Enum.IsDefined(bodyPolicy))
             throw new ArgumentOutOfRangeException(nameof(bodyPolicy));
         if (members?.Any(member => member is null) == true)
             throw new ArgumentException("Type print members cannot contain null entries.", nameof(members));
+        if (memberPolicyOverrides?.Any(policy => policy is null) == true)
+        {
+            throw new ArgumentException(
+                "Member policy overrides cannot contain null entries.",
+                nameof(memberPolicyOverrides));
+        }
 
         Type = type;
         BodyPolicy = bodyPolicy;
         Members = members?.ToArray();
+        MemberPolicyOverrides = memberPolicyOverrides?.ToArray() ?? [];
     }
 
     public ApiType Type { get; }
 
-    public CSharpTypeBodyPolicy BodyPolicy { get; }
+    public CSharpBodyPolicy BodyPolicy { get; }
 
     public IReadOnlyList<ApiMember>? Members { get; }
+
+    public IReadOnlyList<CSharpMemberPolicy> MemberPolicyOverrides { get; }
 }
 
 public sealed record CSharpTypePrintOptions

--- a/src/ILInspector.CSharp/CSharpTypePrintContracts.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrintContracts.cs
@@ -21,6 +21,8 @@ public sealed record CSharpTypePrintRequest
         ArgumentNullException.ThrowIfNull(type);
         if (!Enum.IsDefined(bodyPolicy))
             throw new ArgumentOutOfRangeException(nameof(bodyPolicy));
+        if (members?.Any(member => member is null) == true)
+            throw new ArgumentException("Type print members cannot contain null entries.", nameof(members));
 
         Type = type;
         BodyPolicy = bodyPolicy;

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -1,0 +1,85 @@
+using System.Collections.Immutable;
+using ILInspector.Metadata;
+
+namespace ILInspector.CSharp;
+
+public sealed class CSharpTypePrinter
+{
+    public CSharpTypePrintResult Print(
+        CSharpTypePrintRequest request,
+        CSharpTypePrintOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return Print([request], options);
+    }
+
+    public CSharpTypePrintResult Print(
+        IEnumerable<CSharpTypePrintRequest> requests,
+        CSharpTypePrintOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(requests);
+        options ??= new CSharpTypePrintOptions();
+
+        var requestList = requests.ToArray();
+        if (requestList.Any(request => request is null))
+            throw new ArgumentException("Type print requests cannot contain null entries.", nameof(requests));
+
+        foreach (var request in requestList)
+        {
+            if (request.BodyPolicy != CSharpTypeBodyPolicy.Skeleton)
+            {
+                throw new NotSupportedException(
+                    $"C# type body policy '{request.BodyPolicy}' requires a body provider; "
+                    + "this printer currently supports skeleton requests.");
+            }
+        }
+
+        var units = ImmutableArray.CreateBuilder<CSharpTypeSourceUnit>();
+        var diagnostics = ImmutableArray.CreateBuilder<CSharpTypePrintDiagnostic>();
+
+        foreach (var group in requestList.GroupBy(
+                     request => NormalizeNamespace(request.Type.Namespace),
+                     StringComparer.Ordinal))
+        {
+            var containingNamespace = group.Key.Length == 0 ? null : group.Key;
+            var declarationOptions = new CSharpDeclarationOptions
+            {
+                TypeNameMode = CSharpTypeNameMode.ContextualShort,
+                ContainingNamespace = containingNamespace,
+                NamespaceMode = CSharpNamespaceMode.Omit,
+                TerminateMemberDeclaration = true,
+                IncludeCustomAttributes = options.IncludeCustomAttributes
+            };
+
+            var typeSources = new List<string>();
+            foreach (var request in group)
+            {
+                var rendered = CSharpDeclarationWriter.RenderTypeUnit(
+                    request.Type,
+                    request.Members ?? request.Type.Members,
+                    declarationOptions);
+
+                if (rendered.Usings.Count > 0)
+                {
+                    throw new InvalidOperationException(
+                        "Namespace-batched type source cannot contain declaration-local using directives.");
+                }
+
+                typeSources.Add(rendered.Source);
+                diagnostics.AddRange(rendered.Diagnostics.Select(
+                    diagnostic => new CSharpTypePrintDiagnostic(request.Type.FullName, diagnostic)));
+            }
+
+            var source = string.Join("\n\n", typeSources);
+            if (containingNamespace is not null)
+                source = $"namespace {containingNamespace};\n\n{source}";
+
+            units.Add(new CSharpTypeSourceUnit(containingNamespace, source));
+        }
+
+        return new CSharpTypePrintResult(units.ToImmutable(), diagnostics.ToImmutable());
+    }
+
+    static string NormalizeNamespace(string? value)
+        => string.IsNullOrWhiteSpace(value) ? "" : value;
+}

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -59,17 +59,17 @@ public sealed class CSharpTypePrinter
                 IncludeCustomAttributes = options.IncludeCustomAttributes
             };
 
-            var members = request.Members ?? request.Type.Members
+            var memberArray = (request.Members ?? request.Type.Members
                 ?? throw new ArgumentException(
                     $"Type '{request.Type.FullName}' has a null member collection.",
-                    nameof(requests));
-            if (members.Any(member => member is null))
+                    nameof(requests)))
+                .ToArray();
+            if (memberArray.Any(member => member is null))
             {
                 throw new ArgumentException(
                     $"Type '{request.Type.FullName}' has a null member entry.",
                     nameof(requests));
             }
-            var memberArray = members.ToArray();
             ValidateResolvedBodyPolicies(request, memberArray, nameof(requests));
 
             var rendered = CSharpDeclarationWriter.RenderTypeUnit(

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -30,13 +30,6 @@ public sealed class CSharpTypePrinter
         var diagnostics = ImmutableArray.CreateBuilder<CSharpTypePrintDiagnostic>();
         foreach (var request in requestList)
         {
-            if (request.BodyPolicy != CSharpTypeBodyPolicy.Skeleton)
-            {
-                throw new NotSupportedException(
-                    $"C# type body policy '{request.BodyPolicy}' requires a body provider; "
-                    + "this printer currently supports skeleton requests.");
-            }
-
             ValidateRequiredShape(request.Type);
             ValidateTopLevelSkeletonType(request.Type);
 
@@ -76,10 +69,12 @@ public sealed class CSharpTypePrinter
                     $"Type '{request.Type.FullName}' has a null member entry.",
                     nameof(requests));
             }
+            var memberArray = members.ToArray();
+            ValidateResolvedBodyPolicies(request, memberArray, nameof(requests));
 
             var rendered = CSharpDeclarationWriter.RenderTypeUnit(
                 request.Type,
-                members.ToArray(),
+                memberArray,
                 declarationOptions);
 
             if (rendered.Usings.Count > 0)
@@ -159,6 +154,43 @@ public sealed class CSharpTypePrinter
         {
             throw new NotSupportedException(
                 $"C# skeleton printing does not yet support type kind '{type.Kind}' for '{type.FullName}'.");
+        }
+    }
+
+    static void ValidateResolvedBodyPolicies(
+        CSharpTypePrintRequest request,
+        IReadOnlyList<ApiMember> members,
+        string parameterName)
+    {
+        var selectedMembers = new HashSet<ApiMember>(members, ReferenceEqualityComparer.Instance);
+        var overrides = new Dictionary<ApiMember, CSharpBodyPolicy>(ReferenceEqualityComparer.Instance);
+        foreach (var policy in request.MemberPolicyOverrides)
+        {
+            if (!selectedMembers.Contains(policy.Member))
+            {
+                throw new ArgumentException(
+                    $"Member policy override '{policy.Member.Name}' is not in the selected member set.",
+                    parameterName);
+            }
+            if (!overrides.TryAdd(policy.Member, policy.BodyPolicy))
+            {
+                throw new ArgumentException(
+                    $"Member '{policy.Member.Name}' has multiple policy overrides.",
+                    parameterName);
+            }
+        }
+
+        foreach (var member in members)
+        {
+            var bodyPolicy = overrides.TryGetValue(member, out var memberPolicy)
+                ? memberPolicy
+                : request.BodyPolicy;
+            if (bodyPolicy != CSharpBodyPolicy.Skeleton)
+            {
+                throw new NotSupportedException(
+                    $"C# member body policy '{bodyPolicy}' for '{member.Name}' requires a body provider; "
+                    + "this printer currently supports skeleton requests.");
+            }
         }
     }
 

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -30,23 +30,37 @@ public sealed class CSharpTypePrinter
         var diagnostics = ImmutableArray.CreateBuilder<CSharpTypePrintDiagnostic>();
         foreach (var request in requestList)
         {
-            ValidateRequiredShape(request.Type);
-            ValidateTopLevelSkeletonType(request.Type);
+            var memberArray = (request.Members ?? request.Type.Members
+                ?? throw new ArgumentException(
+                    $"Type '{request.Type.FullName}' has a null member collection.",
+                    nameof(requests)))
+                .ToArray();
+            if (memberArray.Any(member => member is null))
+            {
+                throw new ArgumentException(
+                    $"Type '{request.Type.FullName}' has a null member entry.",
+                    nameof(requests));
+            }
 
-            var containingNamespace = NormalizeNamespace(request.Type.Namespace);
+            var type = SnapshotTypeForRendering(request.Type, memberArray);
+            ValidateRequiredShape(type);
+            ValidateTopLevelSkeletonType(type);
+            ValidateResolvedBodyPolicies(request, memberArray, nameof(requests));
+
+            var containingNamespace = NormalizeNamespace(type.Namespace);
             var canonicalIdentity = new TypeOutputIdentity(
                 containingNamespace,
-                string.IsNullOrWhiteSpace(request.Type.MetadataName)
-                    ? request.Type.Name
-                    : request.Type.MetadataName);
+                string.IsNullOrWhiteSpace(type.MetadataName)
+                    ? type.Name
+                    : type.MetadataName);
             var outputIdentity = new TypeOutputIdentity(
                 containingNamespace,
-                request.Type.Name);
+                type.Name);
             if (!canonicalIdentities.Add(canonicalIdentity)
                 || !outputIdentities.Add(outputIdentity))
             {
                 throw new ArgumentException(
-                    $"Type print requests contain duplicate C# type '{request.Type.FullName}'.",
+                    $"Type print requests contain duplicate C# type '{type.FullName}'.",
                     nameof(requests));
             }
 
@@ -59,22 +73,9 @@ public sealed class CSharpTypePrinter
                 IncludeCustomAttributes = options.IncludeCustomAttributes
             };
 
-            var memberArray = (request.Members ?? request.Type.Members
-                ?? throw new ArgumentException(
-                    $"Type '{request.Type.FullName}' has a null member collection.",
-                    nameof(requests)))
-                .ToArray();
-            if (memberArray.Any(member => member is null))
-            {
-                throw new ArgumentException(
-                    $"Type '{request.Type.FullName}' has a null member entry.",
-                    nameof(requests));
-            }
-            ValidateResolvedBodyPolicies(request, memberArray, nameof(requests));
-
             var rendered = CSharpDeclarationWriter.RenderTypeUnit(
-                request.Type,
-                memberArray,
+                type,
+                type.Members,
                 declarationOptions);
 
             if (rendered.Usings.Count > 0)
@@ -83,7 +84,7 @@ public sealed class CSharpTypePrinter
                     "Namespace-batched type source cannot contain declaration-local using directives.");
             }
 
-            var typeName = request.Type.FullName;
+            var typeName = type.FullName;
             preparedTypes.Add(new PreparedTypeSource(containingNamespace, rendered.Source));
             diagnostics.AddRange(rendered.Diagnostics.Select(
                 diagnostic => new CSharpTypePrintDiagnostic(typeName, diagnostic)));
@@ -105,6 +106,114 @@ public sealed class CSharpTypePrinter
 
     static string NormalizeNamespace(string? value)
         => string.IsNullOrWhiteSpace(value) ? "" : value;
+
+    internal static ApiType SnapshotTypeForRendering(
+        ApiType type,
+        IReadOnlyList<ApiMember> members)
+    {
+        var attributes = type.Attributes;
+        var interfaces = type.Interfaces;
+        var typeParameters = type.TypeParameters;
+        return new ApiType
+        {
+            Namespace = type.Namespace,
+            Name = type.Name,
+            MetadataName = type.MetadataName,
+            Kind = type.Kind,
+            Attributes = attributes?.ToList()!,
+            EnumUnderlyingType = type.EnumUnderlyingType,
+            IsSealed = type.IsSealed,
+            IsAbstract = type.IsAbstract,
+            IsStatic = type.IsStatic,
+            IsByRefLike = type.IsByRefLike,
+            IsReadOnly = type.IsReadOnly,
+            BaseType = type.BaseType,
+            Interfaces = interfaces?.ToList()!,
+            TypeParameters = typeParameters?.Select(SnapshotTypeParameter).ToList()!,
+            Members = members.Select(SnapshotMember).ToList()
+        };
+    }
+
+    static ApiMember SnapshotMember(ApiMember member)
+    {
+        var attributes = member.Attributes;
+        var signatureModel = member.SignatureModel;
+        return new ApiMember
+        {
+            Name = member.Name,
+            Kind = member.Kind,
+            Attributes = attributes?.ToList()!,
+            ReturnType = member.ReturnType,
+            Signature = member.Signature,
+            SignatureModel = signatureModel is null ? null : SnapshotSignature(signatureModel),
+            IsStatic = member.IsStatic,
+            IsVirtual = member.IsVirtual,
+            IsAbstract = member.IsAbstract,
+            IsOverride = member.IsOverride,
+            IsSealed = member.IsSealed,
+            IsReadOnly = member.IsReadOnly,
+            IsConst = member.IsConst,
+            IsUnsafe = member.IsUnsafe,
+            Accessibility = member.Accessibility,
+            IsExtension = member.IsExtension,
+            IsObsolete = member.IsObsolete,
+            ObsoleteMessage = member.ObsoleteMessage
+        };
+    }
+
+    static ApiSignature SnapshotSignature(ApiSignature signature)
+    {
+        var returnAttributes = signature.ReturnAttributes;
+        var typeParameters = signature.TypeParameters;
+        var parameters = signature.Parameters;
+        var accessors = signature.Accessors;
+        return new ApiSignature
+        {
+            ReturnType = signature.ReturnType,
+            ReturnAttributes = returnAttributes?.ToList()!,
+            MemberName = signature.MemberName,
+            IsRequired = signature.IsRequired,
+            TypeParameters = typeParameters?.Select(SnapshotTypeParameter).ToList()!,
+            Parameters = parameters?.Select(SnapshotParameter).ToList()!,
+            Accessors = accessors?.Select(SnapshotAccessor).ToList()!
+        };
+    }
+
+    static TypeParameter SnapshotTypeParameter(TypeParameter parameter)
+    {
+        var constraints = parameter.Constraints;
+        return new TypeParameter
+        {
+            Name = parameter.Name,
+            Variance = parameter.Variance,
+            Constraints = constraints?.ToList()!
+        };
+    }
+
+    static ApiParameter SnapshotParameter(ApiParameter parameter)
+    {
+        var attributes = parameter.Attributes;
+        return new ApiParameter
+        {
+            Attributes = attributes?.ToList()!,
+            Name = parameter.Name,
+            Type = parameter.Type,
+            Modifier = parameter.Modifier,
+            HasDefault = parameter.HasDefault,
+            DefaultValueText = parameter.DefaultValueText
+        };
+    }
+
+    static ApiAccessor SnapshotAccessor(ApiAccessor accessor)
+    {
+        var returnAttributes = accessor.ReturnAttributes;
+        return new ApiAccessor
+        {
+            Kind = accessor.Kind,
+            Accessibility = accessor.Accessibility,
+            ReturnAttributes = returnAttributes?.ToList()!
+        };
+    }
 
     static void ValidateRequiredShape(ApiType type)
     {

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -115,6 +115,34 @@ public sealed class CSharpTypePrinter
     {
         if (string.IsNullOrWhiteSpace(type.Name))
             throw new ArgumentException("Type print requests require a non-empty type name.");
+        if (type.TypeParameters is null)
+            throw new ArgumentException($"Type '{type.FullName}' has a null type-parameter collection.");
+        if (type.Name.Contains('<', StringComparison.Ordinal)
+            || type.Name.Contains('>', StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"Type '{type.FullName}' must use a metadata name rather than C# type-argument spelling.");
+        }
+
+        var tick = type.Name.LastIndexOf('`');
+        if (tick < 0)
+        {
+            if (type.TypeParameters.Count > 0)
+            {
+                throw new ArgumentException(
+                    $"Generic type '{type.FullName}' requires metadata arity in its name.");
+            }
+
+            return;
+        }
+
+        if (!int.TryParse(type.Name.AsSpan(tick + 1), out var arity)
+            || arity <= 0
+            || arity != type.TypeParameters.Count)
+        {
+            throw new ArgumentException(
+                $"Type '{type.FullName}' has inconsistent metadata arity and type parameters.");
+        }
     }
 
     static void ValidateTopLevelSkeletonType(ApiType type)

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -10,10 +10,10 @@ public sealed class CSharpTypePrinter
         CSharpTypePrintOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(request);
-        return Print([request], options);
+        return PrintBatch([request], options);
     }
 
-    public CSharpTypePrintResult Print(
+    public CSharpTypePrintResult PrintBatch(
         IEnumerable<CSharpTypePrintRequest> requests,
         CSharpTypePrintOptions? options = null)
     {
@@ -24,7 +24,10 @@ public sealed class CSharpTypePrinter
         if (requestList.Any(request => request is null))
             throw new ArgumentException("Type print requests cannot contain null entries.", nameof(requests));
 
+        var preparedTypes = new List<PreparedTypeSource>();
+        var canonicalIdentities = new HashSet<TypeOutputIdentity>();
         var outputIdentities = new HashSet<TypeOutputIdentity>();
+        var diagnostics = ImmutableArray.CreateBuilder<CSharpTypePrintDiagnostic>();
         foreach (var request in requestList)
         {
             if (request.BodyPolicy != CSharpTypeBodyPolicy.Skeleton)
@@ -34,56 +37,68 @@ public sealed class CSharpTypePrinter
                     + "this printer currently supports skeleton requests.");
             }
 
+            ValidateRequiredShape(request.Type);
             ValidateTopLevelSkeletonType(request.Type);
 
+            var containingNamespace = NormalizeNamespace(request.Type.Namespace);
+            var canonicalIdentity = new TypeOutputIdentity(
+                containingNamespace,
+                string.IsNullOrWhiteSpace(request.Type.MetadataName)
+                    ? request.Type.Name
+                    : request.Type.MetadataName);
             var outputIdentity = new TypeOutputIdentity(
-                NormalizeNamespace(request.Type.Namespace),
+                containingNamespace,
                 request.Type.Name);
-            if (!outputIdentities.Add(outputIdentity))
+            if (!canonicalIdentities.Add(canonicalIdentity)
+                || !outputIdentities.Add(outputIdentity))
             {
                 throw new ArgumentException(
                     $"Type print requests contain duplicate C# type '{request.Type.FullName}'.",
                     nameof(requests));
             }
-        }
 
-        var units = ImmutableArray.CreateBuilder<CSharpTypeSourceUnit>();
-        var diagnostics = ImmutableArray.CreateBuilder<CSharpTypePrintDiagnostic>();
-
-        foreach (var group in requestList.GroupBy(
-                     request => NormalizeNamespace(request.Type.Namespace),
-                     StringComparer.Ordinal))
-        {
-            var containingNamespace = group.Key.Length == 0 ? null : group.Key;
             var declarationOptions = new CSharpDeclarationOptions
             {
                 TypeNameMode = CSharpTypeNameMode.ContextualShort,
-                ContainingNamespace = containingNamespace,
+                ContainingNamespace = containingNamespace.Length == 0 ? null : containingNamespace,
                 NamespaceMode = CSharpNamespaceMode.Omit,
                 TerminateMemberDeclaration = true,
                 IncludeCustomAttributes = options.IncludeCustomAttributes
             };
 
-            var typeSources = new List<string>();
-            foreach (var request in group)
+            var members = request.Members ?? request.Type.Members
+                ?? throw new ArgumentException(
+                    $"Type '{request.Type.FullName}' has a null member collection.",
+                    nameof(requests));
+            if (members.Any(member => member is null))
             {
-                var rendered = CSharpDeclarationWriter.RenderTypeUnit(
-                    request.Type,
-                    request.Members ?? request.Type.Members,
-                    declarationOptions);
-
-                if (rendered.Usings.Count > 0)
-                {
-                    throw new InvalidOperationException(
-                        "Namespace-batched type source cannot contain declaration-local using directives.");
-                }
-
-                typeSources.Add(rendered.Source);
-                diagnostics.AddRange(rendered.Diagnostics.Select(
-                    diagnostic => new CSharpTypePrintDiagnostic(request.Type.FullName, diagnostic)));
+                throw new ArgumentException(
+                    $"Type '{request.Type.FullName}' has a null member entry.",
+                    nameof(requests));
             }
 
-            var source = string.Join("\n\n", typeSources);
+            var rendered = CSharpDeclarationWriter.RenderTypeUnit(
+                request.Type,
+                members.ToArray(),
+                declarationOptions);
+
+            if (rendered.Usings.Count > 0)
+            {
+                throw new InvalidOperationException(
+                    "Namespace-batched type source cannot contain declaration-local using directives.");
+            }
+
+            var typeName = request.Type.FullName;
+            preparedTypes.Add(new PreparedTypeSource(containingNamespace, rendered.Source));
+            diagnostics.AddRange(rendered.Diagnostics.Select(
+                diagnostic => new CSharpTypePrintDiagnostic(typeName, diagnostic)));
+        }
+
+        var units = ImmutableArray.CreateBuilder<CSharpTypeSourceUnit>();
+        foreach (var group in preparedTypes.GroupBy(type => type.Namespace, StringComparer.Ordinal))
+        {
+            var containingNamespace = group.Key.Length == 0 ? null : group.Key;
+            var source = string.Join("\n\n", group.Select(type => type.Source));
             if (containingNamespace is not null)
                 source = $"namespace {containingNamespace};\n\n{source}";
 
@@ -95,6 +110,12 @@ public sealed class CSharpTypePrinter
 
     static string NormalizeNamespace(string? value)
         => string.IsNullOrWhiteSpace(value) ? "" : value;
+
+    static void ValidateRequiredShape(ApiType type)
+    {
+        if (string.IsNullOrWhiteSpace(type.Name))
+            throw new ArgumentException("Type print requests require a non-empty type name.");
+    }
 
     static void ValidateTopLevelSkeletonType(ApiType type)
     {
@@ -112,6 +133,8 @@ public sealed class CSharpTypePrinter
                 $"C# skeleton printing does not yet support type kind '{type.Kind}' for '{type.FullName}'.");
         }
     }
+
+    readonly record struct PreparedTypeSource(string Namespace, string Source);
 
     readonly record struct TypeOutputIdentity(string Namespace, string Name);
 }

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -24,6 +24,7 @@ public sealed class CSharpTypePrinter
         if (requestList.Any(request => request is null))
             throw new ArgumentException("Type print requests cannot contain null entries.", nameof(requests));
 
+        var outputIdentities = new HashSet<TypeOutputIdentity>();
         foreach (var request in requestList)
         {
             if (request.BodyPolicy != CSharpTypeBodyPolicy.Skeleton)
@@ -31,6 +32,18 @@ public sealed class CSharpTypePrinter
                 throw new NotSupportedException(
                     $"C# type body policy '{request.BodyPolicy}' requires a body provider; "
                     + "this printer currently supports skeleton requests.");
+            }
+
+            ValidateTopLevelSkeletonType(request.Type);
+
+            var outputIdentity = new TypeOutputIdentity(
+                NormalizeNamespace(request.Type.Namespace),
+                request.Type.Name);
+            if (!outputIdentities.Add(outputIdentity))
+            {
+                throw new ArgumentException(
+                    $"Type print requests contain duplicate C# type '{request.Type.FullName}'.",
+                    nameof(requests));
             }
         }
 
@@ -82,4 +95,23 @@ public sealed class CSharpTypePrinter
 
     static string NormalizeNamespace(string? value)
         => string.IsNullOrWhiteSpace(value) ? "" : value;
+
+    static void ValidateTopLevelSkeletonType(ApiType type)
+    {
+        if (type.MetadataName?.Contains('+', StringComparison.Ordinal) == true
+            || type.Name.Contains('.', StringComparison.Ordinal)
+            || type.Name.Contains('+', StringComparison.Ordinal))
+        {
+            throw new NotSupportedException(
+                $"C# skeleton printing for nested type '{type.FullName}' requires its declaring type.");
+        }
+
+        if (type.Kind is not ("class" or "struct" or "interface" or "record"))
+        {
+            throw new NotSupportedException(
+                $"C# skeleton printing does not yet support type kind '{type.Kind}' for '{type.FullName}'.");
+        }
+    }
+
+    readonly record struct TypeOutputIdentity(string Namespace, string Name);
 }

--- a/src/ILInspector.CSharp/ILInspector.CSharp.csproj
+++ b/src/ILInspector.CSharp/ILInspector.CSharp.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAotCompatible>true</IsAotCompatible>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <Description>C# spelling and type view composition over ILInspector metadata</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ILInspector.Metadata\ILInspector.Metadata.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ILInspector.CSharp/ILInspector.CSharp.csproj
+++ b/src/ILInspector.CSharp/ILInspector.CSharp.csproj
@@ -14,4 +14,8 @@
     <ProjectReference Include="..\ILInspector.Metadata\ILInspector.Metadata.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="ILInspector.CSharp.Tests" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

- add a lightweight `ILInspector.CSharp` layer that depends only on Metadata
- introduce request, default body-policy, per-member override, source-unit,
  result, and diagnostic contracts
- compose API-proposal-style skeletons from structured Metadata shapes, grouped
  into deterministic file-scoped namespace units
- derive mixed output from resolved member policies rather than encoding it as
  a type-level policy
- keep unsupported full/stub policies explicit until body providers land

This reflects the design refinement after #2613 was written: Metadata remains
the structured producer and canonical identity source, `ILInspector.CSharp`
owns C# declaration/type-view composition, Decompiler supplies reconstructed
bodies, and Research remains the aggregate.

## Validation

- `dotnet run --project src/ILInspector.CSharp.Tests -c Release --no-restore`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --no-restore`
- `dotnet build src/ILInspector.CSharp.Tests/ILInspector.CSharp.Tests.csproj -c Release --configfile nuget.config -p:DefaultTargetFramework=net10.0 --no-restore`
- `npx markdownlint-cli docs/overview.md docs/architecture.md`

Part of #2613.
