### PR TITLE
Add Metadata semantic Finding producers

### DIFF
--- a/src/ILInspector.Metadata/MetadataFindings.Inventory.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.Inventory.cs
@@ -221,25 +221,30 @@ public static partial class MetadataFindings
 
     static FindingComparison<T> CompareInventory<T>(
         FindingInspection<T> oldInspection,
-        FindingInspection<T> newInspection)
+        FindingInspection<T> newInspection,
+        Func<T, T, bool>? payloadsEqual = null)
         where T : notnull
         => FindingComparison.Compare(
             oldInspection,
             newInspection,
             IdentitySetOptions)
-            .TransformPairs(PromoteChangedPayloads);
+            .TransformPairs(pairs => PromoteChangedPayloads(pairs, payloadsEqual));
 
     static ImmutableArray<PairFinding<T>> PromoteChangedPayloads<T>(
-        ImmutableArray<PairFinding<T>> pairs)
+        ImmutableArray<PairFinding<T>> pairs,
+        Func<T, T, bool>? payloadsEqual)
         where T : notnull
     {
         var builder = ImmutableArray.CreateBuilder<PairFinding<T>>(pairs.Length);
         foreach (var pair in pairs)
         {
             if (pair is PairFinding<T>.Present present
-                && !EqualityComparer<T>.Default.Equals(
-                    present.Old.Payload,
-                    present.New.Payload))
+                && !(payloadsEqual?.Invoke(
+                        present.Old.Payload,
+                        present.New.Payload)
+                    ?? EqualityComparer<T>.Default.Equals(
+                        present.Old.Payload,
+                        present.New.Payload)))
             {
                 builder.Add(new PairFinding<T>.Changed(
                     present.Old,
@@ -260,6 +265,16 @@ public static partial class MetadataFindings
         var builder = new StringBuilder();
         AppendSortKeyPart(builder, first);
         AppendSortKeyPart(builder, second);
+        return builder.ToString();
+    }
+
+    static string JoinSortKey(IEnumerable<string?> parts)
+    {
+        ArgumentNullException.ThrowIfNull(parts);
+
+        var builder = new StringBuilder();
+        foreach (var part in parts)
+            AppendSortKeyPart(builder, part);
         return builder.ToString();
     }
 

--- a/src/ILInspector.Metadata/MetadataFindings.Semantics.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.Semantics.cs
@@ -1,0 +1,194 @@
+using ILInspector.Findings;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Finding producers over typed semantic observations extracted from assembly metadata.
+/// </summary>
+public static partial class MetadataFindings
+{
+    public static readonly FindingDescriptor UnionTypeDescriptor =
+        new("metadata.union-type", "Union type");
+
+    public static readonly FindingDescriptor EcosystemIntegrationDescriptor =
+        new("metadata.ecosystem-integration", "Ecosystem integration");
+
+    public static readonly FindingDescriptor OpenTelemetrySignalDescriptor =
+        new("metadata.opentelemetry-signal", "OpenTelemetry signal");
+
+    public static readonly FindingDescriptor SwitchDescriptor =
+        new("metadata.switch", "Feature switch");
+
+    public static FindingInspection<UnionTypeInfo> InspectUnionTypes(
+        IEnumerable<UnionTypeInfo> unions,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(unions);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return InspectUnionTypesCore(unions, subject, nameof(unions));
+    }
+
+    static FindingInspection<UnionTypeInfo> InspectUnionTypesCore(
+        IEnumerable<UnionTypeInfo> unions,
+        FindingSubject subject,
+        string parameterName)
+        => InspectInventory(
+            unions,
+            subject,
+            UnionTypeDescriptor,
+            static union => union.TypeName,
+            static union => JoinSortKey(
+                union.TypeName,
+                union.Kind,
+                union.ImplementsIUnion ? "1" : "0",
+                JoinSortKey(union.CaseTypes.Order(StringComparer.Ordinal))),
+            parameterName);
+
+    public static FindingComparison<UnionTypeInfo> CompareUnionTypes(
+        IEnumerable<UnionTypeInfo> oldUnions,
+        IEnumerable<UnionTypeInfo> newUnions,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(oldUnions);
+        ArgumentNullException.ThrowIfNull(newUnions);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return CompareInventory(
+            InspectUnionTypesCore(oldUnions, subject, nameof(oldUnions)),
+            InspectUnionTypesCore(newUnions, subject, nameof(newUnions)),
+            UnionPayloadsEqual);
+    }
+
+    public static FindingInspection<EcosystemIntegrationSignalInfo> InspectEcosystemIntegrations(
+        IEnumerable<EcosystemIntegrationSignalInfo> integrations,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(integrations);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return InspectEcosystemIntegrationsCore(integrations, subject, nameof(integrations));
+    }
+
+    static FindingInspection<EcosystemIntegrationSignalInfo> InspectEcosystemIntegrationsCore(
+        IEnumerable<EcosystemIntegrationSignalInfo> integrations,
+        FindingSubject subject,
+        string parameterName)
+        => InspectInventory(
+            integrations,
+            subject,
+            EcosystemIntegrationDescriptor,
+            static integration => JoinSortKey(
+                integration.Integration,
+                integration.Kind,
+                integration.Shape,
+                integration.Name),
+            static integration => JoinSortKey(
+                integration.Integration,
+                integration.Kind,
+                integration.Shape,
+                integration.Name),
+            parameterName);
+
+    public static FindingComparison<EcosystemIntegrationSignalInfo> CompareEcosystemIntegrations(
+        IEnumerable<EcosystemIntegrationSignalInfo> oldIntegrations,
+        IEnumerable<EcosystemIntegrationSignalInfo> newIntegrations,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(oldIntegrations);
+        ArgumentNullException.ThrowIfNull(newIntegrations);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return CompareInventory(
+            InspectEcosystemIntegrationsCore(oldIntegrations, subject, nameof(oldIntegrations)),
+            InspectEcosystemIntegrationsCore(newIntegrations, subject, nameof(newIntegrations)));
+    }
+
+    public static FindingInspection<OpenTelemetrySignalInfo> InspectOpenTelemetrySignals(
+        IEnumerable<OpenTelemetrySignalInfo> signals,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(signals);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return InspectOpenTelemetrySignalsCore(signals, subject, nameof(signals));
+    }
+
+    static FindingInspection<OpenTelemetrySignalInfo> InspectOpenTelemetrySignalsCore(
+        IEnumerable<OpenTelemetrySignalInfo> signals,
+        FindingSubject subject,
+        string parameterName)
+        => InspectInventory(
+            signals,
+            subject,
+            OpenTelemetrySignalDescriptor,
+            static signal => JoinSortKey(signal.Kind, signal.Shape, signal.Name),
+            static signal => JoinSortKey(signal.Kind, signal.Shape, signal.Name),
+            parameterName);
+
+    public static FindingComparison<OpenTelemetrySignalInfo> CompareOpenTelemetrySignals(
+        IEnumerable<OpenTelemetrySignalInfo> oldSignals,
+        IEnumerable<OpenTelemetrySignalInfo> newSignals,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(oldSignals);
+        ArgumentNullException.ThrowIfNull(newSignals);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return CompareInventory(
+            InspectOpenTelemetrySignalsCore(oldSignals, subject, nameof(oldSignals)),
+            InspectOpenTelemetrySignalsCore(newSignals, subject, nameof(newSignals)));
+    }
+
+    public static FindingInspection<SwitchInfo> InspectSwitches(
+        IEnumerable<SwitchInfo> switches,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(switches);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return InspectSwitchesCore(switches, subject, nameof(switches));
+    }
+
+    static FindingInspection<SwitchInfo> InspectSwitchesCore(
+        IEnumerable<SwitchInfo> switches,
+        FindingSubject subject,
+        string parameterName)
+        => InspectInventory(
+            switches,
+            subject,
+            SwitchDescriptor,
+            static featureSwitch => JoinSortKey(
+                featureSwitch.Kind,
+                featureSwitch.Switch,
+                featureSwitch.Api),
+            static featureSwitch => JoinSortKey(
+                featureSwitch.Kind,
+                featureSwitch.Switch,
+                featureSwitch.Api),
+            parameterName);
+
+    public static FindingComparison<SwitchInfo> CompareSwitches(
+        IEnumerable<SwitchInfo> oldSwitches,
+        IEnumerable<SwitchInfo> newSwitches,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(oldSwitches);
+        ArgumentNullException.ThrowIfNull(newSwitches);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return CompareInventory(
+            InspectSwitchesCore(oldSwitches, subject, nameof(oldSwitches)),
+            InspectSwitchesCore(newSwitches, subject, nameof(newSwitches)));
+    }
+
+    static bool UnionPayloadsEqual(UnionTypeInfo oldUnion, UnionTypeInfo newUnion)
+        => string.Equals(oldUnion.TypeName, newUnion.TypeName, StringComparison.Ordinal)
+        && string.Equals(oldUnion.Kind, newUnion.Kind, StringComparison.Ordinal)
+        && oldUnion.ImplementsIUnion == newUnion.ImplementsIUnion
+        && oldUnion.CaseTypes
+            .Order(StringComparer.Ordinal)
+            .SequenceEqual(
+                newUnion.CaseTypes.Order(StringComparer.Ordinal),
+                StringComparer.Ordinal);
+}

--- a/tests/ILInspector.Metadata.Tests/MetadataSemanticFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataSemanticFindingsTests.cs
@@ -1,0 +1,160 @@
+using System.Collections.Immutable;
+using System.Reflection.PortableExecutable;
+using ILInspector.Findings;
+
+namespace ILInspector.Metadata.Tests;
+
+public sealed class MetadataSemanticFindingsTests
+{
+    static readonly FindingSubject Subject = new("assembly", "Test assembly");
+
+    [Fact]
+    public void UnionTypes_IgnoreCaseOrderAndPromoteShapeChanges()
+    {
+        UnionTypeInfo oldUnion = new(
+            "Sample.Result",
+            "struct",
+            ImplementsIUnion: true,
+            ["Sample.Success", "Sample.Error"]);
+        UnionTypeInfo reordered = oldUnion with
+        {
+            CaseTypes = ["Sample.Error", "Sample.Success"],
+        };
+        UnionTypeInfo expanded = oldUnion with
+        {
+            CaseTypes = ["Sample.Success", "Sample.Error", "Sample.Pending"],
+        };
+        UnionTypeInfo reclassified = oldUnion with
+        {
+            Kind = "class",
+            ImplementsIUnion = false,
+        };
+
+        var reorderedComparison = MetadataFindings.CompareUnionTypes(
+            [oldUnion],
+            [reordered],
+            Subject);
+        var expandedComparison = MetadataFindings.CompareUnionTypes(
+            [oldUnion],
+            [expanded],
+            Subject);
+        var reclassifiedComparison = MetadataFindings.CompareUnionTypes(
+            [oldUnion],
+            [reclassified],
+            Subject);
+
+        Assert.Equal(PairKind.Present, Assert.Single(Pairs(reorderedComparison)).Kind);
+        var expandedPair = Assert.Single(Pairs(expandedComparison));
+        Assert.Equal(PairKind.Changed, expandedPair.Kind);
+        Assert.Null(expandedPair.Detail);
+        Assert.Equal(PairKind.Changed, Assert.Single(Pairs(reclassifiedComparison)).Kind);
+    }
+
+    [Fact]
+    public void SemanticSignals_AreExactUnorderedOccurrences()
+    {
+        EcosystemIntegrationSignalInfo dependencyInjection = new(
+            "Dependency Injection",
+            "Builder",
+            "Sample.ServiceCollectionExtensions.AddSample(...)",
+            IntegrationSignalShape.Api);
+        EcosystemIntegrationSignalInfo logging = new(
+            "Logging",
+            "Provider",
+            "Sample.SampleLoggerProvider");
+
+        var ecosystemComparison = MetadataFindings.CompareEcosystemIntegrations(
+            [dependencyInjection],
+            [logging, dependencyInjection],
+            Subject);
+        var telemetryComparison = MetadataFindings.CompareOpenTelemetrySignals(
+            [new OpenTelemetrySignalInfo("Tracing", "Sample.ActivitySource")],
+            [new OpenTelemetrySignalInfo("Metrics", "Sample.Meter")],
+            Subject);
+        var switchComparison = MetadataFindings.CompareSwitches(
+            [new SwitchInfo("AppContext", "Sample.Switch", "Sample.Old(...)")],
+            [new SwitchInfo("AppContext", "Sample.Switch", "Sample.New(...)")],
+            Subject);
+
+        Assert.Equal(1, Pairs(ecosystemComparison).Count(static pair => pair.Kind == PairKind.Present));
+        Assert.Equal(1, Pairs(ecosystemComparison).Count(static pair => pair.Kind == PairKind.Added));
+        Assert.Equal(1, Pairs(telemetryComparison).Count(static pair => pair.Kind == PairKind.Added));
+        Assert.Equal(1, Pairs(telemetryComparison).Count(static pair => pair.Kind == PairKind.Removed));
+        Assert.Equal(1, Pairs(switchComparison).Count(static pair => pair.Kind == PairKind.Added));
+        Assert.Equal(1, Pairs(switchComparison).Count(static pair => pair.Kind == PairKind.Removed));
+        Assert.DoesNotContain(Pairs(ecosystemComparison), static pair => pair.Kind == PairKind.Changed);
+        Assert.DoesNotContain(Pairs(telemetryComparison), static pair => pair.Kind == PairKind.Changed);
+        Assert.DoesNotContain(Pairs(switchComparison), static pair => pair.Kind == PairKind.Changed);
+    }
+
+    [Fact]
+    public void SignalIdentities_AreCollisionSafe()
+    {
+        EcosystemIntegrationSignalInfo first = new("A", "B:C", "D");
+        EcosystemIntegrationSignalInfo second = new("A:B", "C", "D");
+
+        var comparison = MetadataFindings.CompareEcosystemIntegrations(
+            [first],
+            [second],
+            Subject);
+
+        Assert.Equal(1, Pairs(comparison).Count(static pair => pair.Kind == PairKind.Added));
+        Assert.Equal(1, Pairs(comparison).Count(static pair => pair.Kind == PairKind.Removed));
+    }
+
+    [Fact]
+    public void SemanticProducers_ReportPublicCollectionParameters()
+    {
+        UnionTypeInfo valid = new("Sample.Result", "struct", true, []);
+        UnionTypeInfo[] containingNull = [null!];
+
+        var inspectException = Assert.Throws<ArgumentException>(
+            () => MetadataFindings.InspectUnionTypes(containingNull, Subject));
+        var oldException = Assert.Throws<ArgumentException>(
+            () => MetadataFindings.CompareUnionTypes(containingNull, [valid], Subject));
+        var newException = Assert.Throws<ArgumentException>(
+            () => MetadataFindings.CompareUnionTypes([valid], containingNull, Subject));
+
+        Assert.Equal("unions", inspectException.ParamName);
+        Assert.Equal("oldUnions", oldException.ParamName);
+        Assert.Equal("newUnions", newException.ParamName);
+    }
+
+    [Fact]
+    public void RealScannerOutputs_ProjectWithoutChangingTheCensus()
+    {
+        using var stream = File.OpenRead(typeof(MetadataUnionFixture).Assembly.Location);
+        using var peReader = new PEReader(stream);
+
+        var unions = UnionTypeScanner.Scan(peReader);
+        var ecosystem = EcosystemIntegrationScanner.Scan(peReader);
+        var telemetry = OpenTelemetryScanner.Scan(peReader);
+        var switches = SwitchScanner.Scan(peReader);
+
+        Assert.Equal(
+            unions.Count,
+            Findings(MetadataFindings.InspectUnionTypes(unions, Subject)).Length);
+        Assert.Equal(
+            ecosystem.Count,
+            Findings(MetadataFindings.InspectEcosystemIntegrations(ecosystem, Subject)).Length);
+        Assert.Equal(
+            telemetry.Count,
+            Findings(MetadataFindings.InspectOpenTelemetrySignals(telemetry, Subject)).Length);
+        Assert.Equal(
+            switches.Count,
+            Findings(MetadataFindings.InspectSwitches(switches, Subject)).Length);
+        Assert.NotEmpty(unions);
+    }
+
+    static ImmutableArray<Finding<T>> Findings<T>(FindingInspection<T> inspection)
+        where T : notnull
+        => inspection is FindingInspection<T>.Complete complete
+            ? complete.Findings
+            : throw new Xunit.Sdk.XunitException("Expected a complete semantic inspection.");
+
+    static ImmutableArray<PairFinding<T>> Pairs<T>(FindingComparison<T> comparison)
+        where T : notnull
+        => comparison is FindingComparison<T>.Complete complete
+            ? complete.Pairs
+            : throw new Xunit.Sdk.XunitException($"Expected a complete comparison: {comparison.Failure}");
+}


### PR DESCRIPTION
Adds typed, presentation-free Finding producers for union shapes, ecosystem integration signals, OpenTelemetry signals, and feature switches. Each producer supports complete inspection and unordered identity-set comparison over existing Metadata scanner outputs.

Union types match by type identity and promote kind, `IUnion`, or case-set changes to typed `Changed` pairs; case declaration order is non-semantic. Signal and switch rows use exact occurrence identities and therefore report additions/removals without speculative pairing.

Validation:
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release --no-restore` (432 passed)
- `dotnet build dotnet-inspect.slnx -c Release --no-restore --nologo`

Final adversarial reviews are in progress with Claude Opus 4.8 and Gemini 3.1 Pro.