### PR TITLE
Clarify Finding semantic contracts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,8 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Output Shapes](design/output-shapes.md) | The Document → Table → Vector → Scalar shape ladder, how Markout produces it, and how the output flags select a shape. |
 | [Graph Signal Annotations](design/graph-signal-annotations.md) | Projecting analysis signals (alloc/copy/unsafe, and exception-risk follow-ups) onto call-graph nodes via `--fields`. |
 | [Allocation Triage Pre-Filters](design/allocation-triage-prefilters.md) | Which allocation candidates Performance Triage surfaces, why the pre-filters prune cold-by-construction shapes, and what realized cost the static side cannot predict. |
+| [Finding Nomenclature](design/finding-nomenclature.md) | Canonical observation/change vocabulary, arity ladder, operation outcomes, and Research composition boundary. |
+| [Finding Producer Design](design/finding-producers.md) | Choosing producer ownership, payloads, identities, result shapes, matching modes, and higher-rung boundaries. |
 | [Performance Analysis Baselines](analysis-baselines.md) | Internal baselines of what each analysis type finds over a fixed corpus, with effectiveness ratings for the one-stop-shop Performance Analysis view. |
 | [Dynamic Leak-Watch](design/dynamic-leak-watch.md) | The retention axis: how `runfaster leak-watch` separates a managed leak from a churn storm from native/committed growth, and why static triage and the allocation-tick join cannot. |
 | [Rendering Model](design/rendering-model.md) | Historical/current rendering model notes; prefer [Progressive Disclosure](design/progressive-disclosure.md) for current agent-facing behavior. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -123,6 +123,13 @@ Run `dotnet-inspect skill` to print the embedded SKILL.md.
 Method-body evidence is split by representation altitude, then joined by a
 single overlay layer:
 
+The shared Finding model names one-version occurrences as observations
+(`Finding<T>`) and classified old/new relationships as transitions
+(`PairFinding<T>`). Evidence is the role those and other producer-owned values
+play in supporting a conclusion, not a parallel row hierarchy. See
+[Finding Nomenclature](design/finding-nomenclature.md) and
+[Finding Producer Design](design/finding-producers.md).
+
 - **R1** is the lower, metadata/IL representation. `ILInspector.Analysis` reads
   assemblies with `System.Reflection.Metadata`, builds whole-assembly indexes,
   and produces method signals, direct-call evidence, allocation occurrences, and
@@ -588,3 +595,5 @@ src/ILInspector.Research/       # Registered fact overlay and annotated views
 9. **Deliberate metadata duplication — `ILInspector.Analysis` is a standalone product** — The whole-assembly memory-safety analyzer (`ILInspector.Analysis`: `LibraryBodyIndex`, `CallTree`, the `Hollow`/`Opaque`/`UnsafeLeverage` classifications) keeps **zero project references** and re-derives its own `TypeRef` / `TypeRefDecoder` / `MemberResolver` rather than sharing the codebase's other type-identity layers (`ILInspector.Metadata`, `ILInspector.MetadataPrimitives`, and the decompiler's `Pipeline/TypeRef`). This is a committed product boundary, not drift: the three `TypeRef` models answer different questions (display string, evidence matching, codegen IR), and `Analysis`'s SRM-direct independence is load-bearing — it ships and evolves as an independent memory-safety deliverable. The full rationale, the rejected consolidation path, and the single trip-wire that would reopen it are in [docs/metadata-primitives.md](metadata-primitives.md) ("Decision (2026-06): stop after step 3").
 
 10. **Research seam for R1/R2 overlays** — `ILInspector.Research` is the accepted bridge above Analysis (R1 lower representation) and Decompiler (R2 projection/recovery representation). Research owns the `ResearchFactRegistry`, annotation producers, and fact-overlay presenters, so new facts flow through one offset-keyed overlay instead of direct `Analysis <-> Decompiler` edges or bypass renderers.
+
+11. **Finding arity is semantic** — `Finding<T>` is a one-version observation and `PairFinding<T>` is a two-version transition. `IFinding` and `IPairFinding` provide separate heterogeneous collection contracts; repeated subject/descriptor/detail projections do not justify a misleading shared hierarchy. Research composes producer-owned observations, transitions, native structural diffs, failures, and provenance as evidence without wrapping them in a second universal row model. See [Finding Nomenclature](design/finding-nomenclature.md).

--- a/docs/design/finding-nomenclature.md
+++ b/docs/design/finding-nomenclature.md
@@ -1,0 +1,127 @@
+# Finding Nomenclature
+
+The Finding model separates durable information from operation outcomes and
+separates one-version observations from two-version transitions. These are
+semantic boundaries, not naming preferences.
+
+## Canonical distinction
+
+The primary distinction is:
+
+> **Observation versus change**
+
+The type model expresses that distinction as:
+
+> **`Finding<T>` versus `PairFinding<T>`**
+
+A `Finding<T>` is one independently identifiable occurrence in one version. A
+`PairFinding<T>` is the classified relationship between old and new
+observations. An unchanged pair is still a transition even though it carries no
+difference.
+
+The non-generic interfaces preserve heterogeneous collections without merging
+the concepts:
+
+- `IFinding` carries observations with different payload types.
+- `IPairFinding` carries transitions with different payload types.
+
+Neither inspection failures nor transitions implement `IFinding`. Repeated
+properties such as subject, descriptor, or detail do not create an `is-a`
+relationship. Shared value objects and algorithms should be reused; divergent
+meanings should retain separate contracts.
+
+## Two independent axes
+
+Arity and content are independent:
+
+| Content | One version | Two versions |
+| --- | --- | --- |
+| Structural: API member, IL operation, C# line, text line | Observation / `Finding<T>` | Change / `PairFinding<T>` |
+| Semantic/body: allocation, call site, unsafety, lifetime | Observation / `Finding<T>` | Change / `PairFinding<T>` |
+
+An allocation is an observation. Comparing allocation observations produces
+changes. The same is true for API members and IL operations. Rich structural
+diff engines may retain native payloads for fidelity, but that does not create a
+second semantic axis.
+
+## Vocabulary
+
+| Term | Canonical meaning | Guidance |
+| --- | --- | --- |
+| **Observation** | One independently identifiable occurrence about one subject at one version. | The semantic meaning of `Finding<T>`. |
+| **Change** / **transition** | The classified old/new relationship between observations. | The semantic meaning of `PairFinding<T>`. Prefer **transition** for topology and **change** in user-facing prose. |
+| **Difference** | A non-equivalence class or delta carried by a transition, such as moved or encoding-only. | Do not use it for every pair; an unchanged pair has no difference. |
+| **Diff** | A comparison operation, artifact, report, or presentation containing changes. | Appropriate for `ApiDiff`, `IlBodyDiff`, unified diff text, and CLI `diff`; not for one-version observations. |
+| **Evidence** | Information used to support a conclusion. | A Finding, transition, structural diff, failure, or provenance record may serve as evidence. Do not create a parallel `Evidence*` row hierarchy merely to rename the Finding model. |
+| **Detail** | Explanatory payload or rendered elaboration. | A field or presentation concept, not a model family. |
+| **Census** | The complete observation collection from a successful inspection. | A documentation concept, not a competing API type family. |
+| **Fact** | A curated or interpreted statement derived from observations where the product intentionally distinguishes that rung. | Do not use it as a synonym for every raw observation. |
+| **Triage** | Downstream prioritization or judgment over observations, changes, and facts. | Never present it as raw producer currency. |
+
+## Information types and operation outcomes
+
+Information types are durable values:
+
+| Type | Arity | Meaning |
+| --- | --- | --- |
+| `Finding<T>` | One | One observation with a typed payload. |
+| `PairFinding<T>` | Two | One classified transition composed from observations. |
+| Future correlation type | More than two | A version-labelled timeline, if the product later needs one. |
+
+Operation outcomes describe one invocation:
+
+| Verb | Outcome | Carries |
+| --- | --- | --- |
+| Match | `FindingMatch` | Alignment edges and fringe candidates. |
+| Inspect | `FindingInspection<T>` | `Complete(Finding<T>[])`, `Absent`, or `Failed(InspectionError)`. |
+| Compare | `FindingComparison<T>` | Completed pairs/match/inspections, or the failed inspections that prevented matching. |
+
+Outcome types carry information types; information types do not depend on
+outcome envelopes. Use the nominalized operation name instead of generic
+suffixes such as `Result`, `Engine`, or `Manager` when the operation supplies a
+precise noun.
+
+## Inspection and comparison semantics
+
+- `Complete([])` is a successful empty census.
+- `Absent` means the subject has no applicable producer input.
+- `Failed` means the census is unknown because inspection did not complete.
+- A removed observation comes from two successful inspections; it is not
+  another spelling of subject absence.
+- `FindingComparison<T>.Complete` means matching ran and exposes the real match.
+- `FindingComparison<T>.Failed` means matching never ran and must not expose a
+  success-shaped placeholder.
+
+The governing invariant is:
+
+> An empty match is evidence of a trivial alignment; a manufactured match is a
+> costume.
+
+## Research composition
+
+Research is the join layer for sibling producers. It may retain a producer's
+native structural diff when flattening would lose information. Until a
+mechanism exposes honest old/new Finding censuses, `ResearchChange` is a
+Research-owned projection rather than a fabricated `PairFinding<T>`.
+
+This is a migration boundary, not authorization for a second universal spine:
+
+- producers that own stable observations should emit `Finding<T>`;
+- their old/new comparison should produce `PairFinding<T>`;
+- Research may compose Findings, transitions, native structural diffs,
+  inspection failures, and provenance as evidence;
+- Research must not wrap those values in a parallel generic `EvidenceRow`
+  hierarchy solely to make them look uniform.
+
+## Open evolution points
+
+These require explicit design before dependent producers rely on them:
+
+- separate ordered-stream position from a stable structural anchor;
+- define structured soft-match projections, typed deltas, and match-tier
+  provenance;
+- define value equality for envelopes containing `ImmutableArray` or
+  `ImmutableHashSet` before using them as cache keys or change detectors.
+
+Source compatibility is not a veto while this API is young. A source break is
+appropriate when it produces a more ergonomic or capable semantic shape.

--- a/docs/design/finding-producers.md
+++ b/docs/design/finding-producers.md
@@ -68,13 +68,14 @@ capability.
 API inventory is the positive Metadata example:
 
 ```csharp
-Finding<ApiType>
-Finding<ApiMember>
+Finding<ApiTypeHandle>
+Finding<ApiMemberHandle>
 ```
 
 Metadata owns the structured shape, canonical identities, and compatibility
-classification. Research may project those observations and transitions into a
-product view, but it does not become their source of truth.
+classification. The handles retain the underlying API value together with its
+canonical identity and anchor. Research may project those observations and
+transitions into a product view, but it does not become their source of truth.
 
 ## 4. Choose the result shape
 

--- a/docs/design/finding-producers.md
+++ b/docs/design/finding-producers.md
@@ -1,0 +1,156 @@
+# Finding Producer Design
+
+Start with a stable raw observation, not a new `*Findings` class name. A Finding
+producer should add reusable product capability while keeping matching,
+interpretation, and presentation at their proper layers.
+
+See [Finding Nomenclature](finding-nomenclature.md) for the observation/change
+model and canonical vocabulary.
+
+## 1. Decide whether the value is an observation
+
+A Finding is a concrete, single-version occurrence that can be independently
+identified and consumed by more than one product surface. It is not:
+
+- a boolean answer;
+- an old/new correspondence;
+- an equivalence verdict;
+- oracle agreement;
+- a compatibility classification;
+- triage priority.
+
+Those values belong to transitions, equivalence folds, Research composition, or
+triage layers.
+
+## 2. Choose the owner before the name
+
+Prefer one broad facade per product domain and methods for observation families:
+
+```csharp
+AnalysisFindings.InspectAllocations(...)
+AnalysisFindings.InspectCallSites(...)
+AnalysisFindings.InspectUnsafety(...)
+MetadataFindings.InspectApiMembers(...)
+MetadataFindings.InspectApiTypes(...)
+DecompilerFindings.InspectDiagnostics(...)
+```
+
+Do not create `AllocationFindings`, `CallSiteFindings`, or
+`DecompilerDiagnosticFindings` classes merely to name queries. A narrower type
+is justified only when it owns independent state or behavior rather than acting
+as a namespace.
+
+## 3. Reuse or add the payload
+
+`Finding<T>` already owns:
+
+- subject;
+- descriptor;
+- identity and scope keys;
+- position;
+- typed payload;
+- optional detail.
+
+Add a domain payload only for typed properties not already represented by the
+Finding contract.
+
+Allocation is the positive Analysis example:
+
+```csharp
+Finding<AllocationOccurrence>
+```
+
+`AllocationOccurrence` already carries allocation kind, allocated type,
+frequency, loop/path context, multiplicity, size, and escape information. An
+`AllocationFinding` wrapper would duplicate the generic contract without adding
+capability.
+
+API inventory is the positive Metadata example:
+
+```csharp
+Finding<ApiType>
+Finding<ApiMember>
+```
+
+Metadata owns the structured shape, canonical identities, and compatibility
+classification. Research may project those observations and transitions into a
+product view, but it does not become their source of truth.
+
+## 4. Choose the result shape
+
+- Return a Finding collection when the producer is total and an empty collection
+  is a complete census.
+- Use `FindingInspection<T>` when `Complete([])`, `Absent`, and
+  `Failed(InspectionError)` have materially different meanings.
+- Keep caller-owned acquisition failures outside a pure in-memory producer when
+  the producer cannot own that failure.
+
+An inspection failure is an operation outcome, not an observation. Do not wrap
+it in `Finding<InspectionError>` or make it implement `IFinding`.
+
+## 5. Choose identity and ordering semantics
+
+The producer owns stable observation identity:
+
+- `FindingDescriptor` identifies the observation vocabulary entry.
+- `FindingKey.IdentityKey` identifies correspondence candidates.
+- `FindingKey.ScopeKey` constrains correspondence when the domain requires it.
+- `Position` records the producer ordinal. It is correspondence-significant only
+  for an ordered stream; identity-set producers may assign a deterministic
+  ordinal without making it part of identity.
+
+Use `FindingMatchMode.Ordered` when position is semantic, such as IL, C#, or
+text. Use `FindingMatchMode.IdentitySet` when order is not semantic, such as API
+members.
+
+Do not overload ordinal position as a future Research join anchor. Stable
+structural anchors are a separate design axis.
+
+## 6. Keep generic comparison generic
+
+Producers project observations and stable keys. They reuse
+`FindingComparison.Compare` for inspection projection, matching, folding, and
+outcome construction.
+
+Producer-owned classification may use `TransformPairs`, which preserves the
+matcher's pair count, order, and exact old/new atom references. Producers do not
+implement private matchers, folds, summaries, or equivalence policy.
+
+Consumers select equivalence from the emitted transitions. The producer does
+not collapse a rich transition stream into one universal verdict.
+
+## 7. Keep higher rungs separate
+
+Some useful product concepts are intentionally not one raw Finding stream:
+
+- **ReturnToSender:** compile validity, compiler diagnostics, C# differences,
+  and opcode fidelity are heterogeneous outputs. Compose existing producer
+  results and add a diagnostic producer only where a stable raw occurrence
+  exists.
+- **Oracle agreement:** agreement is a comparison or verdict. Productize the
+  underlying observations first.
+- **Dependencies:** package dependencies, assembly references, type forwarders,
+  and network vulnerability advisories have different owners, subjects, and
+  availability contracts. Split them into concrete queries.
+
+Evidence is a role those values may play; it is not a reason to flatten them
+into a parallel generic row.
+
+## Review checklist
+
+Before approving a producer, answer:
+
+- What is the raw occurrence?
+- Which product layer is its sole authority?
+- Which existing payload type represents it?
+- What stable descriptor and identity does it use?
+- Is position semantic?
+- Is empty a complete result, or must absence and failure remain distinct?
+- Which two or more consumers need the same census?
+- Is any proposed field actually a downstream fact, verdict, or presentation?
+- Does comparison reuse the shared matcher and fold?
+- Which bespoke producer, adapter, or comparison path will this replace?
+
+The first end-to-end Analysis proof should use one allocation census for both
+single-version audit and old/new comparison, replacing the count-only Research
+allocation path rather than adding another adapter.

--- a/docs/design/hidden-fact-annotations.md
+++ b/docs/design/hidden-fact-annotations.md
@@ -13,6 +13,12 @@ decompiler-side correctness oracle this layer's validation is modelled on, and
 ("render what the IL does, not what the source probably said") that this layer
 extends.
 
+Terminology follows [Finding Nomenclature](finding-nomenclature.md). A raw
+single-version occurrence is an observation; **Fact** in this document names a
+curated Research overlay statement and the existing `Facts` product view. It is
+not a synonym for every `Finding<T>` and does not define a parallel evidence
+model.
+
 ## The model
 
 Modelled on Roslyn analyzers — a registry of independent producers, a

--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -5,6 +5,11 @@
 future CLI sections, ReturnToSender, harnesses, and other consumers that need one
 member-centric change model instead of separate C# and IL renderers.
 
+Terminology follows [Finding Nomenclature](finding-nomenclature.md):
+`Finding<T>` is a one-version observation, `PairFinding<T>` is a two-version
+transition, and evidence is the role either may play rather than a competing row
+family.
+
 ## Ownership
 
 - `ILInspector.Decompiler` owns C# body diff production and display rows through
@@ -30,7 +35,11 @@ payload needed for typed presentation. It is deliberately not a
 `ResearchComparison.ApiComparison` retains that producer-owned envelope. C#,
 IL/body, body-signal, and ReturnToSender mechanisms do not all expose equivalent
 old/new Finding censuses yet, so the cross-mechanism `ResearchChange` projection
-must not manufacture Finding atoms or misuse `PairKind`.
+must not manufacture Finding atoms or misuse `PairKind`. `ResearchChange` is a
+Research-owned migration projection, not the seed of a parallel generic
+`EvidenceRow` spine. As each mechanism gains honest observations and
+transitions, Research should retain those producer-owned values and retire the
+corresponding projection fields.
 
 ## Consumer contract
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -11,6 +11,7 @@ It is built for both humans and agents. Markdown is the default output because h
 - `src/ILInspector.Analysis/` indexes IL method-body evidence such as direct call sites, allocation occurrences, method signals, and whole-assembly leverage without decompiling to C#.
 - `src/ILInspector.Analysis.App/` is a temporary console harness for exercising Analysis queries until CLI wiring exists.
 - `src/ILInspector.ControlFlow/` contains shared block-edge, dominance, and dataflow kernels used below Analysis and Decompiler without depending on either.
+- `src/ILInspector.Findings/` contains the domain-free observation, inspection, matching, transition, and comparison contracts shared by product producers.
 - `src/ILInspector.Instructions/` is the shared IL decode + EH-aware basic-block substrate (one decoder the analyzer and decompiler converge onto); see [instruction substrate](design/instruction-substrate.md).
 - `src/ILInspector.Text/` provides the reusable `TextFindings` API for exact, ordered line inspection and generic text comparison on the shared Finding spine.
 - `src/DotnetInspector.Packages/` handles NuGet package extraction, package/source caches, feeds, symbol package acquisition, and version resolution.
@@ -41,6 +42,8 @@ Agents working in this repo should preserve these principles:
 - [Analysis UX scopes](design/analysis-ux-scopes.md): shared analysis vocabulary across offset, member, type, and library scopes.
 - [IL coordinate workflows](design/il-coordinate-workflows.md): prototype workflows for explaining sparse runtime coordinates from debugger, profiler, or analyzer artifacts.
 - [IL Diff canonicalization](design/il-diff-canonicalization.md): current `CanonicalIlOperation` guarantees, boundaries, and extension points.
+- [Finding nomenclature](design/finding-nomenclature.md): observation/change semantics, operation outcomes, and Research composition boundaries.
+- [Finding producer design](design/finding-producers.md): how to choose owners, payloads, identities, result shapes, and matching modes.
 - [Implementation Diff](design/implementation-diff.md): product C# + IL/body diff projection shared by future CLI surfaces, RTS, and harnesses.
 - [Fixture governance](fixture-governance.md): fixture catalog, project-boundary, and semantic-axis rules.
 - [Integrations](design/integrations.md): library ecosystem integration roll-ups and focused API currency.

--- a/src/ILInspector.Findings/Finding.cs
+++ b/src/ILInspector.Findings/Finding.cs
@@ -83,9 +83,9 @@ public enum FindingDifferenceKind
 }
 
 /// <summary>
-/// The domain-free skeleton shared by an atom (<see cref="Finding{T}"/>) and a transition
-/// (<see cref="PairFinding{T}"/>): what a cross-stream consumer needs without knowing the payload
-/// type or which producer emitted it. <see cref="IFinding{T}"/> adds the typed payload.
+/// The non-generic observation contract. A heterogeneous census can carry
+/// <c>Finding&lt;T&gt;</c> values with different payload types while preserving the common
+/// subject, descriptor, and detail projection.
 /// </summary>
 public interface IFinding
 {
@@ -95,25 +95,16 @@ public interface IFinding
 }
 
 /// <summary>
-/// A finding with its typed payload. Non-variant on <typeparamref name="T"/>: a payload may be a
-/// value type, and CLR variance is reference-only.
-/// </summary>
-public interface IFinding<T> : IFinding
-    where T : notnull
-{
-    T Payload { get; }
-}
-
-/// <summary>
 /// The atom: a single observation projected from a domain node (an IL op, an allocation, an API
 /// member). A single-version query is just a <c>Finding&lt;T&gt;[]</c> census — no matcher, no
 /// diff. It carries its content <see cref="Key"/> and a single <see cref="Position"/> in its own
 /// stream; the transition concepts (add/remove/change, an old-vs-new delta) belong to
 /// <see cref="PairFinding{T}"/>, never here. The payload is non-null and a type parameter rather
 /// than <c>object?</c>, so a value-typed payload is not boxed and consumers read it without a
-/// cast; absence is expressed by choosing <see cref="IFinding"/>, not by a null payload.
+/// cast; heterogeneous consumers use <see cref="IFinding"/> and pattern-match the concrete
+/// <c>Finding&lt;T&gt;</c> when they need its payload.
 /// </summary>
-public sealed record Finding<T> : IFinding<T>
+public sealed record Finding<T> : IFinding
     where T : notnull
 {
     public Finding(
@@ -158,15 +149,18 @@ public sealed record Finding<T> : IFinding<T>
 }
 
 /// <summary>
-/// The domain-free skeleton of a transition: an old/new pair classified by <see cref="Kind"/> and
-/// <see cref="Difference"/>. Extends <see cref="IFinding"/> so a cross-stream fold
-/// (<see cref="FindingSummary"/>, <see cref="FindingEquivalence"/>) reads it without knowing the
-/// payload type. Each concrete case (<see cref="Added{T}"/>, <see cref="Removed{T}"/>,
+/// The non-generic transition contract: an old/new pair classified by <see cref="Kind"/> and
+/// <see cref="Difference"/>. A heterogeneous change stream can carry pair values with different
+/// payload types without treating a two-version transition as a one-version <see cref="IFinding"/>.
+/// Each concrete case (<see cref="Added{T}"/>, <see cref="Removed{T}"/>,
 /// <see cref="Present{T}"/>, <see cref="Changed{T}"/>) fixes its own <see cref="Kind"/> and exposes
-/// exactly the sides it has via <see cref="Old"/>/<see cref="New"/>.
+/// exactly the observation sides it has via <see cref="Old"/>/<see cref="New"/>.
 /// </summary>
-public interface IPairFinding : IFinding
+public interface IPairFinding
 {
+    FindingSubject Subject { get; }
+    FindingDescriptor Descriptor { get; }
+    string? Detail { get; }
     PairKind Kind { get; }
     FindingDifferenceKind Difference { get; }
     IFinding? Old { get; }

--- a/src/ILInspector.Findings/FindingComparison.cs
+++ b/src/ILInspector.Findings/FindingComparison.cs
@@ -141,9 +141,9 @@ public sealed record FindingComparison<T> where T : notnull
             {
                 var failures = new List<string>(2);
                 if (OldInspection is FindingInspection<T>.Failed oldFailed)
-                    failures.Add($"old: {oldFailed.Error.Detail}");
+                    failures.Add($"old: {oldFailed.Error.Reason}");
                 if (NewInspection is FindingInspection<T>.Failed newFailed)
-                    failures.Add($"new: {newFailed.Error.Detail}");
+                    failures.Add($"new: {newFailed.Error.Reason}");
                 return string.Join("; ", failures);
             }
         }

--- a/src/ILInspector.Findings/FindingInspection.cs
+++ b/src/ILInspector.Findings/FindingInspection.cs
@@ -11,7 +11,7 @@ namespace ILInspector.Findings;
 public sealed record InspectionError(
     FindingSubject Subject,
     FindingDescriptor Descriptor,
-    string Reason) : IFinding
+    string Reason)
 {
     public FindingSubject Subject { get; }
         = Subject ?? throw new ArgumentNullException(nameof(Subject));
@@ -21,8 +21,6 @@ public sealed record InspectionError(
 
     public string Reason { get; }
         = Reason ?? throw new ArgumentNullException(nameof(Reason));
-
-    public string? Detail => Reason;
 }
 
 /// <summary>

--- a/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
@@ -43,8 +43,31 @@ public class FindingPilotTests
         Assert.True(complete is FindingInspection<string>.Complete);
         Assert.True(absent is FindingInspection<string>.Absent);
         Assert.True(failed is FindingInspection<string>.Failed);
-        Assert.IsAssignableFrom<IFinding>(error);
-        Assert.Equal("declined", error.Detail);
+        Assert.Equal("declined", error.Reason);
+    }
+
+    [Fact]
+    public void FindingContracts_KeepObservationsTransitionsAndFailuresDistinct()
+    {
+        var stringFinding = Atoms("a")[0];
+        var intFinding = new Finding<int>(
+            Subject,
+            Descriptor,
+            new FindingKey("1"),
+            0,
+            1);
+        IFinding[] observations = [stringFinding, intFinding];
+        IPairFinding[] transitions =
+        [
+            new PairFinding<string>.Added(stringFinding),
+            new PairFinding<int>.Added(intFinding),
+        ];
+
+        Assert.Equal(2, observations.Length);
+        Assert.Equal(2, transitions.Length);
+        Assert.False(typeof(IFinding).IsAssignableFrom(typeof(PairFinding<string>)));
+        Assert.False(typeof(IFinding).IsAssignableFrom(typeof(PairFinding<string>.Added)));
+        Assert.False(typeof(IFinding).IsAssignableFrom(typeof(InspectionError)));
     }
 
     [Fact]


### PR DESCRIPTION
## Conclusion

**PASS** — the Finding spine now distinguishes observations, transitions, and inspection failures by meaning while retaining separate heterogeneous collection contracts for observations and transitions.

Closes #2603.
Closes #2609.
Closes #2577.
Advances #2614 and #2564.

## Change

- Make `IFinding` observation-only and `IPairFinding` an independent transition contract.
- Remove unused `IFinding<T>`; divergent payload types are carried through `IFinding`, while typed consumers use the sealed `Finding<T>` directly.
- Remove `InspectionError`'s observation inheritance and its redundant `Detail` alias; failure composition uses `Reason`.
- Add contract tests for heterogeneous observation/transition collections and the negative type relationships.
- Add canonical Finding nomenclature and producer-design guidance.
- Document `ResearchChange` as an honest migration projection, not a second generic `EvidenceRow` spine, while retaining producer-native structural diffs that cannot yet expose old/new Finding censuses.

## Validation

```text
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config

ILInspector.Instructions.Tests: 100 passed
ILInspector.Metadata.Tests: 427 passed
ILInspector.Research.Tests: 71 passed
ILInspector.Decompiler.Tests CSharpFindingsTests: 18 passed
Total: 616 passed

markdownlint: clean
```

The solution build retains three pre-existing nullable warnings in Metadata tests.

## Adversarial review

Claude Opus 4.8 and Gemini 3.1 Pro are reviewing `cafb42a9` in separate clean worktrees. Results will be reconciled in a PR comment.
