### PR TITLE
Add classified method Finding producers

### DIFF
--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -4,6 +4,26 @@ using ILInspector.MetadataPrimitives;
 
 namespace ILInspector.Metadata;
 
+public sealed record MethodAnchorInfo(
+    MemberAnchor Anchor,
+    string ReturnType)
+{
+    MemberAnchor _anchor = Anchor ?? throw new ArgumentNullException(nameof(Anchor));
+    string _returnType = ReturnType ?? throw new ArgumentNullException(nameof(ReturnType));
+
+    public MemberAnchor Anchor
+    {
+        get => _anchor;
+        init => _anchor = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    public string ReturnType
+    {
+        get => _returnType;
+        init => _returnType = value ?? throw new ArgumentNullException(nameof(value));
+    }
+}
+
 /// <summary>
 /// Metadata-owned API identity helpers for durable member selectors. These
 /// helpers compose identity strings from queryable metadata facts, not from C#
@@ -155,6 +175,13 @@ public static class ApiMemberIdentity
         TypeDefinitionHandle typeHandle,
         MethodDefinition method,
         bool isExtensionMethod = false)
+        => CreateMethodAnchorInfo(reader, typeHandle, method, isExtensionMethod).Anchor;
+
+    public static MethodAnchorInfo CreateMethodAnchorInfo(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        MethodDefinition method,
+        bool isExtensionMethod = false)
     {
         var type = reader.GetTypeDefinition(typeHandle);
         string methodName = reader.GetString(method.Name);
@@ -171,7 +198,9 @@ public static class ApiMemberIdentity
             signature.ParameterTypes,
             IsConversionOperator(methodName) ? signature.ReturnType : null);
         string selectorName = GetMemberSelectorName(methodName, isExtensionMethod);
-        return CreateAnchor(typeFullName, selectorName, memberName, canonicalSignature);
+        return new MethodAnchorInfo(
+            CreateAnchor(typeFullName, selectorName, memberName, canonicalSignature),
+            signature.ReturnType);
     }
 
     public static MemberAnchor CreateAnchor(ApiType type, ApiMember member, string canonicalSignature)

--- a/src/ILInspector.Metadata/MetadataFindings.Methods.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.Methods.cs
@@ -13,11 +13,20 @@ public sealed record ClassifiedMethodObservation(
     string ReturnType,
     string? ModuleName = null)
 {
-    public MemberAnchor Anchor { get; }
-        = Anchor ?? throw new ArgumentNullException(nameof(Anchor));
+    MemberAnchor _anchor = Anchor ?? throw new ArgumentNullException(nameof(Anchor));
+    string _returnType = ReturnType ?? throw new ArgumentNullException(nameof(ReturnType));
 
-    public string ReturnType { get; }
-        = ReturnType ?? throw new ArgumentNullException(nameof(ReturnType));
+    public MemberAnchor Anchor
+    {
+        get => _anchor;
+        init => _anchor = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    public string ReturnType
+    {
+        get => _returnType;
+        init => _returnType = value ?? throw new ArgumentNullException(nameof(value));
+    }
 }
 
 public static partial class MetadataFindings

--- a/src/ILInspector.Metadata/MetadataFindings.Methods.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.Methods.cs
@@ -1,0 +1,86 @@
+using ILInspector.Findings;
+using ILInspector.MetadataPrimitives;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// A notable method classification bound to Metadata's stable member identity.
+/// Rendered declaration text remains outside the Finding payload.
+/// </summary>
+public sealed record ClassifiedMethodObservation(
+    MemberAnchor Anchor,
+    MethodClassification Classification,
+    string? ModuleName = null)
+{
+    public MemberAnchor Anchor { get; }
+        = Anchor ?? throw new ArgumentNullException(nameof(Anchor));
+}
+
+public static partial class MetadataFindings
+{
+    public static readonly FindingDescriptor ClassifiedMethodDescriptor =
+        new("metadata.classified-method", "Classified method");
+
+    public static FindingInspection<ClassifiedMethodObservation> InspectClassifiedMethods(
+        IEnumerable<ClassifiedMethodInfo> methods,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(methods);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return InspectClassifiedMethodsCore(methods, subject, nameof(methods));
+    }
+
+    static FindingInspection<ClassifiedMethodObservation> InspectClassifiedMethodsCore(
+        IEnumerable<ClassifiedMethodInfo> methods,
+        FindingSubject subject,
+        string parameterName)
+    {
+        var materialized = methods
+            .Select(method => method is null
+                ? throw new ArgumentException(
+                    "Classified method inventory cannot contain null observations.",
+                    parameterName)
+                : method)
+            .ToArray();
+
+        if (materialized.Any(static method => method.Anchor is null))
+        {
+            return new FindingInspection<ClassifiedMethodObservation>.Failed(
+                new InspectionError(
+                    subject,
+                    ClassifiedMethodDescriptor,
+                    "One or more classified methods do not have structured member identity."));
+        }
+
+        return InspectInventory(
+            materialized.Select(static method => new ClassifiedMethodObservation(
+                method.Anchor!,
+                method.Classification,
+                method.ModuleName)),
+            subject,
+            ClassifiedMethodDescriptor,
+            static method => JoinSortKey(
+                method.Anchor.CanonicalSignature,
+                method.Classification.ToString()),
+            static method => JoinSortKey(
+                method.Anchor.CanonicalSignature,
+                method.Classification.ToString(),
+                method.ModuleName),
+            parameterName);
+    }
+
+    public static FindingComparison<ClassifiedMethodObservation> CompareClassifiedMethods(
+        IEnumerable<ClassifiedMethodInfo> oldMethods,
+        IEnumerable<ClassifiedMethodInfo> newMethods,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(oldMethods);
+        ArgumentNullException.ThrowIfNull(newMethods);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return CompareInventory(
+            InspectClassifiedMethodsCore(oldMethods, subject, nameof(oldMethods)),
+            InspectClassifiedMethodsCore(newMethods, subject, nameof(newMethods)));
+    }
+}

--- a/src/ILInspector.Metadata/MetadataFindings.Methods.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.Methods.cs
@@ -10,10 +10,14 @@ namespace ILInspector.Metadata;
 public sealed record ClassifiedMethodObservation(
     MemberAnchor Anchor,
     MethodClassification Classification,
+    string ReturnType,
     string? ModuleName = null)
 {
     public MemberAnchor Anchor { get; }
         = Anchor ?? throw new ArgumentNullException(nameof(Anchor));
+
+    public string ReturnType { get; }
+        = ReturnType ?? throw new ArgumentNullException(nameof(ReturnType));
 }
 
 public static partial class MetadataFindings
@@ -44,19 +48,20 @@ public static partial class MetadataFindings
                 : method)
             .ToArray();
 
-        if (materialized.Any(static method => method.Anchor is null))
+        if (materialized.Any(static method => method.Anchor is null || method.ReturnType is null))
         {
             return new FindingInspection<ClassifiedMethodObservation>.Failed(
                 new InspectionError(
                     subject,
                     ClassifiedMethodDescriptor,
-                    "One or more classified methods do not have structured member identity."));
+                    "One or more classified methods do not have structured method shape."));
         }
 
         return InspectInventory(
             materialized.Select(static method => new ClassifiedMethodObservation(
                 method.Anchor!,
                 method.Classification,
+                method.ReturnType!,
                 method.ModuleName)),
             subject,
             ClassifiedMethodDescriptor,
@@ -66,6 +71,7 @@ public static partial class MetadataFindings
             static method => JoinSortKey(
                 method.Anchor.CanonicalSignature,
                 method.Classification.ToString(),
+                method.ReturnType,
                 method.ModuleName),
             parameterName);
     }

--- a/src/ILInspector.Metadata/MethodClassificationScanner.cs
+++ b/src/ILInspector.Metadata/MethodClassificationScanner.cs
@@ -14,8 +14,11 @@ public record ClassifiedMethodInfo(
     string? Namespace,
     string Signature,
     MethodClassification Classification,
-    string? ModuleName = null,
-    MemberAnchor? Anchor = null);
+    string? ModuleName = null)
+{
+    public MemberAnchor? Anchor { get; init; }
+    public string? ReturnType { get; init; }
+}
 
 /// <summary>
 /// Classification of a method based on its metadata characteristics.
@@ -108,10 +111,14 @@ public static class MethodClassificationScanner
                 if ((method.Attributes & MethodAttributes.PinvokeImpl) != 0)
                 {
                     string? moduleName = GetPInvokeModuleName(reader, methodHandle);
-                    var signature = FormatSignature(reader, typeDef, method);
+                    var (signature, returnType) = FormatSignature(reader, typeDef, method);
                     results.Add(new ClassifiedMethodInfo(
                         methodName, fullTypeName, ns, signature,
-                        MethodClassification.PInvoke, moduleName, GetAnchor()));
+                        MethodClassification.PInvoke, moduleName)
+                    {
+                        Anchor = GetAnchor(),
+                        ReturnType = returnType,
+                    });
                     continue; // P/Invoke methods are also "unsafe" but classify as P/Invoke
                 }
 
@@ -119,10 +126,13 @@ public static class MethodClassificationScanner
                 var asyncClassification = ClassifyAsyncMethod(reader, method);
                 if (asyncClassification is { } asyncKind)
                 {
-                    var signature = FormatSignature(reader, typeDef, method);
+                    var (signature, returnType) = FormatSignature(reader, typeDef, method);
                     results.Add(new ClassifiedMethodInfo(
-                        methodName, fullTypeName, ns, signature, asyncKind,
-                        Anchor: GetAnchor()));
+                        methodName, fullTypeName, ns, signature, asyncKind)
+                    {
+                        Anchor = GetAnchor(),
+                        ReturnType = returnType,
+                    });
                 }
 
                 // Check unsafe (pointer types in signature)
@@ -135,8 +145,11 @@ public static class MethodClassificationScanner
                         var signature = SignatureRenderer.RenderDecodedSignature(reader, method, methodName, sig);
                         results.Add(new ClassifiedMethodInfo(
                             methodName, fullTypeName, ns, signature,
-                            MethodClassification.Unsafe,
-                            Anchor: GetAnchor()));
+                            MethodClassification.Unsafe)
+                        {
+                            Anchor = GetAnchor(),
+                            ReturnType = sig.ReturnType,
+                        });
                     }
                 }
                 catch
@@ -208,18 +221,23 @@ public static class MethodClassificationScanner
         }
     }
 
-    private static string FormatSignature(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)
+    private static (string Signature, string? ReturnType) FormatSignature(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        MethodDefinition method)
     {
         try
         {
             var context = GenericContext.ForMethod(reader, typeDef, method);
             var sig = method.DecodeSignature(SignatureDecoder.Instance, context);
             string methodName = reader.GetString(method.Name);
-            return SignatureRenderer.RenderDecodedSignature(reader, method, methodName, sig);
+            return (
+                SignatureRenderer.RenderDecodedSignature(reader, method, methodName, sig),
+                sig.ReturnType);
         }
         catch
         {
-            return reader.GetString(method.Name) + "(...)";
+            return (reader.GetString(method.Name) + "(...)", null);
         }
     }
 }

--- a/src/ILInspector.Metadata/MethodClassificationScanner.cs
+++ b/src/ILInspector.Metadata/MethodClassificationScanner.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using ILInspector.MetadataPrimitives;
 
 namespace ILInspector.Metadata;
 
@@ -13,7 +14,8 @@ public record ClassifiedMethodInfo(
     string? Namespace,
     string Signature,
     MethodClassification Classification,
-    string? ModuleName = null);
+    string? ModuleName = null,
+    MemberAnchor? Anchor = null);
 
 /// <summary>
 /// Classification of a method based on its metadata characteristics.
@@ -81,6 +83,19 @@ public static class MethodClassificationScanner
                     continue;
 
                 string methodName = reader.GetString(method.Name);
+                MemberAnchor? anchor = null;
+                bool anchorAttempted = false;
+
+                MemberAnchor? GetAnchor()
+                {
+                    if (!anchorAttempted)
+                    {
+                        anchor = TryCreateAnchor(reader, typeDefHandle, method);
+                        anchorAttempted = true;
+                    }
+
+                    return anchor;
+                }
 
                 // Skip accessors and constructors
                 if (methodName.StartsWith("get_", StringComparison.Ordinal) ||
@@ -96,7 +111,7 @@ public static class MethodClassificationScanner
                     var signature = FormatSignature(reader, typeDef, method);
                     results.Add(new ClassifiedMethodInfo(
                         methodName, fullTypeName, ns, signature,
-                        MethodClassification.PInvoke, moduleName));
+                        MethodClassification.PInvoke, moduleName, GetAnchor()));
                     continue; // P/Invoke methods are also "unsafe" but classify as P/Invoke
                 }
 
@@ -106,7 +121,8 @@ public static class MethodClassificationScanner
                 {
                     var signature = FormatSignature(reader, typeDef, method);
                     results.Add(new ClassifiedMethodInfo(
-                        methodName, fullTypeName, ns, signature, asyncKind));
+                        methodName, fullTypeName, ns, signature, asyncKind,
+                        Anchor: GetAnchor()));
                 }
 
                 // Check unsafe (pointer types in signature)
@@ -119,7 +135,8 @@ public static class MethodClassificationScanner
                         var signature = SignatureRenderer.RenderDecodedSignature(reader, method, methodName, sig);
                         results.Add(new ClassifiedMethodInfo(
                             methodName, fullTypeName, ns, signature,
-                            MethodClassification.Unsafe));
+                            MethodClassification.Unsafe,
+                            Anchor: GetAnchor()));
                     }
                 }
                 catch
@@ -174,6 +191,21 @@ public static class MethodClassificationScanner
 
         var moduleRef = reader.GetModuleReference(import.Module);
         return reader.GetString(moduleRef.Name);
+    }
+
+    private static MemberAnchor? TryCreateAnchor(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        MethodDefinition method)
+    {
+        try
+        {
+            return ApiMemberIdentity.CreateMethodAnchor(reader, typeHandle, method);
+        }
+        catch (BadImageFormatException)
+        {
+            return null;
+        }
     }
 
     private static string FormatSignature(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)

--- a/src/ILInspector.Metadata/MethodClassificationScanner.cs
+++ b/src/ILInspector.Metadata/MethodClassificationScanner.cs
@@ -18,6 +18,30 @@ public record ClassifiedMethodInfo(
 {
     public MemberAnchor? Anchor { get; init; }
     public string? ReturnType { get; init; }
+
+    public virtual bool Equals(ClassifiedMethodInfo? other)
+        => ReferenceEquals(this, other)
+        || other is not null
+        && EqualityContract == other.EqualityContract
+        && string.Equals(MethodName, other.MethodName, StringComparison.Ordinal)
+        && string.Equals(DeclaringType, other.DeclaringType, StringComparison.Ordinal)
+        && string.Equals(Namespace, other.Namespace, StringComparison.Ordinal)
+        && string.Equals(Signature, other.Signature, StringComparison.Ordinal)
+        && Classification == other.Classification
+        && string.Equals(ModuleName, other.ModuleName, StringComparison.Ordinal);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(EqualityContract);
+        hash.Add(MethodName, StringComparer.Ordinal);
+        hash.Add(DeclaringType, StringComparer.Ordinal);
+        hash.Add(Namespace, StringComparer.Ordinal);
+        hash.Add(Signature, StringComparer.Ordinal);
+        hash.Add(Classification);
+        hash.Add(ModuleName, StringComparer.Ordinal);
+        return hash.ToHashCode();
+    }
 }
 
 /// <summary>
@@ -86,18 +110,18 @@ public static class MethodClassificationScanner
                     continue;
 
                 string methodName = reader.GetString(method.Name);
-                MemberAnchor? anchor = null;
-                bool anchorAttempted = false;
+                MethodAnchorInfo? methodIdentity = null;
+                bool identityAttempted = false;
 
-                MemberAnchor? GetAnchor()
+                MethodAnchorInfo? GetMethodIdentity()
                 {
-                    if (!anchorAttempted)
+                    if (!identityAttempted)
                     {
-                        anchor = TryCreateAnchor(reader, typeDefHandle, method);
-                        anchorAttempted = true;
+                        methodIdentity = TryCreateMethodIdentity(reader, typeDefHandle, method);
+                        identityAttempted = true;
                     }
 
-                    return anchor;
+                    return methodIdentity;
                 }
 
                 // Skip accessors and constructors
@@ -111,13 +135,13 @@ public static class MethodClassificationScanner
                 if ((method.Attributes & MethodAttributes.PinvokeImpl) != 0)
                 {
                     string? moduleName = GetPInvokeModuleName(reader, methodHandle);
-                    var (signature, returnType) = FormatSignature(reader, typeDef, method);
+                    var signature = FormatSignature(reader, typeDef, method);
                     results.Add(new ClassifiedMethodInfo(
                         methodName, fullTypeName, ns, signature,
                         MethodClassification.PInvoke, moduleName)
                     {
-                        Anchor = GetAnchor(),
-                        ReturnType = returnType,
+                        Anchor = GetMethodIdentity()?.Anchor,
+                        ReturnType = GetMethodIdentity()?.ReturnType,
                     });
                     continue; // P/Invoke methods are also "unsafe" but classify as P/Invoke
                 }
@@ -126,12 +150,12 @@ public static class MethodClassificationScanner
                 var asyncClassification = ClassifyAsyncMethod(reader, method);
                 if (asyncClassification is { } asyncKind)
                 {
-                    var (signature, returnType) = FormatSignature(reader, typeDef, method);
+                    var signature = FormatSignature(reader, typeDef, method);
                     results.Add(new ClassifiedMethodInfo(
                         methodName, fullTypeName, ns, signature, asyncKind)
                     {
-                        Anchor = GetAnchor(),
-                        ReturnType = returnType,
+                        Anchor = GetMethodIdentity()?.Anchor,
+                        ReturnType = GetMethodIdentity()?.ReturnType,
                     });
                 }
 
@@ -147,8 +171,8 @@ public static class MethodClassificationScanner
                             methodName, fullTypeName, ns, signature,
                             MethodClassification.Unsafe)
                         {
-                            Anchor = GetAnchor(),
-                            ReturnType = sig.ReturnType,
+                            Anchor = GetMethodIdentity()?.Anchor,
+                            ReturnType = GetMethodIdentity()?.ReturnType,
                         });
                     }
                 }
@@ -206,14 +230,14 @@ public static class MethodClassificationScanner
         return reader.GetString(moduleRef.Name);
     }
 
-    private static MemberAnchor? TryCreateAnchor(
+    private static MethodAnchorInfo? TryCreateMethodIdentity(
         MetadataReader reader,
         TypeDefinitionHandle typeHandle,
         MethodDefinition method)
     {
         try
         {
-            return ApiMemberIdentity.CreateMethodAnchor(reader, typeHandle, method);
+            return ApiMemberIdentity.CreateMethodAnchorInfo(reader, typeHandle, method);
         }
         catch (BadImageFormatException)
         {
@@ -221,7 +245,7 @@ public static class MethodClassificationScanner
         }
     }
 
-    private static (string Signature, string? ReturnType) FormatSignature(
+    private static string FormatSignature(
         MetadataReader reader,
         TypeDefinition typeDef,
         MethodDefinition method)
@@ -231,13 +255,11 @@ public static class MethodClassificationScanner
             var context = GenericContext.ForMethod(reader, typeDef, method);
             var sig = method.DecodeSignature(SignatureDecoder.Instance, context);
             string methodName = reader.GetString(method.Name);
-            return (
-                SignatureRenderer.RenderDecodedSignature(reader, method, methodName, sig),
-                sig.ReturnType);
+            return SignatureRenderer.RenderDecodedSignature(reader, method, methodName, sig);
         }
         catch
         {
-            return (reader.GetString(method.Name) + "(...)", null);
+            return reader.GetString(method.Name) + "(...)";
         }
     }
 }

--- a/src/dotnet-inspect.Tests/MethodClassificationScannerTests.cs
+++ b/src/dotnet-inspect.Tests/MethodClassificationScannerTests.cs
@@ -28,6 +28,7 @@ public class MethodClassificationScannerTests
         var pointerMethod = unsafe_.First(m => m.MethodName == "UnsafePointerMethod");
         Assert.Equal("DotnetInspector.Tests.SampleUnsafeClass", pointerMethod.DeclaringType);
         Assert.Contains("*", pointerMethod.Signature);
+        Assert.NotNull(pointerMethod.Anchor);
     }
 
     [Fact]
@@ -44,6 +45,7 @@ public class MethodClassificationScannerTests
         var method = pinvoke.First(m => m.MethodName == "GetCurrentProcessId");
         Assert.Equal("DotnetInspector.Tests.SamplePInvokeClass", method.DeclaringType);
         Assert.Equal("kernel32.dll", method.ModuleName);
+        Assert.NotNull(method.Anchor);
     }
 
     [Fact]
@@ -82,6 +84,7 @@ public class MethodClassificationScannerTests
         var method = results.FirstOrDefault(m => m.MethodName == "FakeRuntimeAsync");
         Assert.NotNull(method);
         Assert.Equal(MethodClassification.RuntimeAsync, method.Classification);
+        Assert.NotNull(method.Anchor);
     }
 
     [Fact]
@@ -97,6 +100,7 @@ public class MethodClassificationScannerTests
         var method = results.FirstOrDefault(m => m.MethodName == "AttributedStateMachineAsync");
         Assert.NotNull(method);
         Assert.Equal(MethodClassification.StateMachineAsync, method.Classification);
+        Assert.NotNull(method.Anchor);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/MethodClassificationScannerTests.cs
+++ b/src/dotnet-inspect.Tests/MethodClassificationScannerTests.cs
@@ -29,6 +29,7 @@ public class MethodClassificationScannerTests
         Assert.Equal("DotnetInspector.Tests.SampleUnsafeClass", pointerMethod.DeclaringType);
         Assert.Contains("*", pointerMethod.Signature);
         Assert.NotNull(pointerMethod.Anchor);
+        Assert.Equal("int", pointerMethod.ReturnType);
     }
 
     [Fact]
@@ -46,6 +47,7 @@ public class MethodClassificationScannerTests
         Assert.Equal("DotnetInspector.Tests.SamplePInvokeClass", method.DeclaringType);
         Assert.Equal("kernel32.dll", method.ModuleName);
         Assert.NotNull(method.Anchor);
+        Assert.Equal("int", method.ReturnType);
     }
 
     [Fact]
@@ -85,6 +87,7 @@ public class MethodClassificationScannerTests
         Assert.NotNull(method);
         Assert.Equal(MethodClassification.RuntimeAsync, method.Classification);
         Assert.NotNull(method.Anchor);
+        Assert.Equal("System.Threading.Tasks.Task<int>", method.ReturnType);
     }
 
     [Fact]
@@ -101,6 +104,7 @@ public class MethodClassificationScannerTests
         Assert.NotNull(method);
         Assert.Equal(MethodClassification.StateMachineAsync, method.Classification);
         Assert.NotNull(method.Anchor);
+        Assert.Equal("System.Threading.Tasks.Task<int>", method.ReturnType);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/MethodClassificationScannerTests.cs
+++ b/src/dotnet-inspect.Tests/MethodClassificationScannerTests.cs
@@ -29,7 +29,7 @@ public class MethodClassificationScannerTests
         Assert.Equal("DotnetInspector.Tests.SampleUnsafeClass", pointerMethod.DeclaringType);
         Assert.Contains("*", pointerMethod.Signature);
         Assert.NotNull(pointerMethod.Anchor);
-        Assert.Equal("int", pointerMethod.ReturnType);
+        Assert.Equal("System.Int32", pointerMethod.ReturnType);
     }
 
     [Fact]
@@ -47,7 +47,7 @@ public class MethodClassificationScannerTests
         Assert.Equal("DotnetInspector.Tests.SamplePInvokeClass", method.DeclaringType);
         Assert.Equal("kernel32.dll", method.ModuleName);
         Assert.NotNull(method.Anchor);
-        Assert.Equal("int", method.ReturnType);
+        Assert.Equal("System.Int32", method.ReturnType);
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public class MethodClassificationScannerTests
         Assert.NotNull(method);
         Assert.Equal(MethodClassification.RuntimeAsync, method.Classification);
         Assert.NotNull(method.Anchor);
-        Assert.Equal("System.Threading.Tasks.Task<int>", method.ReturnType);
+        Assert.Equal("System.Threading.Tasks.Task`1<System.Int32>", method.ReturnType);
     }
 
     [Fact]
@@ -104,7 +104,7 @@ public class MethodClassificationScannerTests
         Assert.NotNull(method);
         Assert.Equal(MethodClassification.StateMachineAsync, method.Classification);
         Assert.NotNull(method.Anchor);
-        Assert.Equal("System.Threading.Tasks.Task<int>", method.ReturnType);
+        Assert.Equal("System.Threading.Tasks.Task`1<System.Int32>", method.ReturnType);
     }
 
     [Fact]

--- a/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
@@ -39,6 +39,22 @@ public class ApiMemberIdentityTests
     }
 
     [Fact]
+    public void CreateMethodAnchorInfo_IncludesCanonicalReturnType()
+    {
+        using var stream = File.OpenRead(typeof(ApiMemberIdentityTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (typeHandle, method) = FindFixtureMethod(reader);
+
+        var identity = ApiMemberIdentity.CreateMethodAnchorInfo(reader, typeHandle, method);
+
+        Assert.Equal("System.Void", identity.ReturnType);
+        Assert.Equal(
+            ApiMemberIdentity.CreateMethodAnchor(reader, typeHandle, method),
+            identity.Anchor);
+    }
+
+    [Fact]
     public void GetMemberAnchor_DisambiguatesConversionOperatorsByReturnType()
     {
         using var stream = File.OpenRead(typeof(ApiMemberIdentityTests).Assembly.Location);

--- a/tests/ILInspector.Metadata.Tests/MetadataMethodFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataMethodFindingsTests.cs
@@ -25,7 +25,7 @@ public sealed class MetadataMethodFindingsTests
             method.Anchor.CanonicalSignature,
             StringComparison.Ordinal);
         Assert.Contains("System.Int32*", method.Anchor.CanonicalSignature, StringComparison.Ordinal);
-        Assert.Equal("int*", method.ReturnType);
+        Assert.Equal("System.Int32*", method.ReturnType);
     }
 
     [Fact]
@@ -58,6 +58,60 @@ public sealed class MetadataMethodFindingsTests
             "int M",
             present.New.Payload.Anchor.CanonicalSignature,
             StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LegacyRecordEqualityAndDeconstructionIgnoreAdditiveShape()
+    {
+        var anchor = CreateAnchor("M:Sample.Native.M()");
+        ClassifiedMethodInfo enriched = new(
+            "M",
+            "Sample.Native",
+            "Sample",
+            "void M()",
+            MethodClassification.PInvoke,
+            "native")
+        {
+            Anchor = anchor,
+            ReturnType = "System.Void",
+        };
+        ClassifiedMethodInfo legacy = new(
+            "M",
+            "Sample.Native",
+            "Sample",
+            "void M()",
+            MethodClassification.PInvoke,
+            "native");
+
+        var (methodName, declaringType, @namespace, signature, classification, moduleName) = enriched;
+
+        Assert.Equal(legacy, enriched);
+        Assert.Equal(legacy.GetHashCode(), enriched.GetHashCode());
+        Assert.Equal("M", methodName);
+        Assert.Equal("Sample.Native", declaringType);
+        Assert.Equal("Sample", @namespace);
+        Assert.Equal("void M()", signature);
+        Assert.Equal(MethodClassification.PInvoke, classification);
+        Assert.Equal("native", moduleName);
+    }
+
+    [Fact]
+    public void ObservationWithExpressionPreservesRecordSemantics()
+    {
+        var observation = new ClassifiedMethodObservation(
+            CreateAnchor("M:Sample.Native.M()"),
+            MethodClassification.PInvoke,
+            "System.Void",
+            "old");
+
+        var changed = observation with
+        {
+            ReturnType = "System.Int32",
+            ModuleName = "new",
+        };
+
+        Assert.Equal("System.Int32", changed.ReturnType);
+        Assert.Equal("new", changed.ModuleName);
     }
 
     [Fact]

--- a/tests/ILInspector.Metadata.Tests/MetadataMethodFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataMethodFindingsTests.cs
@@ -1,0 +1,145 @@
+using System.Collections.Immutable;
+using System.Reflection.PortableExecutable;
+using ILInspector.Findings;
+using ILInspector.MetadataPrimitives;
+
+namespace ILInspector.Metadata.Tests;
+
+public sealed class MetadataMethodFindingsTests
+{
+    static readonly FindingSubject Subject = new("assembly", "Test assembly");
+
+    [Fact]
+    public void ScannerBindsClassifiedMethodsToCanonicalIdentity()
+    {
+        using var stream = File.OpenRead(typeof(MetadataMethodFindingsTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+
+        var method = Assert.Single(
+            MethodClassificationScanner.Scan(peReader),
+            static method => method.MethodName == nameof(ClassifiedPointerMethod));
+
+        Assert.NotNull(method.Anchor);
+        Assert.Contains(
+            $"{nameof(MetadataMethodFindingsTests)}.{nameof(ClassifiedPointerMethod)}",
+            method.Anchor.CanonicalSignature,
+            StringComparison.Ordinal);
+        Assert.Contains("System.Int32*", method.Anchor.CanonicalSignature, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DisplaySignatureChangesDoNotChangeMethodObservations()
+    {
+        var anchor = CreateAnchor("M:Sample.Native.M(System.Int32)");
+        ClassifiedMethodInfo oldMethod = new(
+            "M",
+            "Sample.Native",
+            "Sample",
+            "int M(int value)",
+            MethodClassification.PInvoke,
+            "native",
+            anchor);
+        ClassifiedMethodInfo newMethod = oldMethod with
+        {
+            Signature = "System.Int32 M(System.Int32 value)",
+        };
+
+        var pair = Assert.Single(Pairs(MetadataFindings.CompareClassifiedMethods(
+            [oldMethod],
+            [newMethod],
+            Subject)));
+
+        var present = Assert.IsType<PairFinding<ClassifiedMethodObservation>.Present>(pair.Value);
+        Assert.DoesNotContain(
+            "int M",
+            present.New.Payload.Anchor.CanonicalSignature,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ModuleChangesAreChangedButClassificationChangesAreExactTransitions()
+    {
+        var anchor = CreateAnchor("M:Sample.Native.M()");
+        ClassifiedMethodInfo pinvoke = new(
+            "M",
+            "Sample.Native",
+            "Sample",
+            "void M()",
+            MethodClassification.PInvoke,
+            "old",
+            anchor);
+
+        var moduleChange = MetadataFindings.CompareClassifiedMethods(
+            [pinvoke],
+            [pinvoke with { ModuleName = "new" }],
+            Subject);
+        var classificationChange = MetadataFindings.CompareClassifiedMethods(
+            [pinvoke],
+            [pinvoke with { Classification = MethodClassification.Unsafe, ModuleName = null }],
+            Subject);
+
+        var changed = Assert.Single(Pairs(moduleChange));
+        Assert.Equal(PairKind.Changed, changed.Kind);
+        Assert.Null(changed.Detail);
+        Assert.Equal(1, Pairs(classificationChange).Count(static pair => pair.Kind == PairKind.Added));
+        Assert.Equal(1, Pairs(classificationChange).Count(static pair => pair.Kind == PairKind.Removed));
+    }
+
+    [Fact]
+    public void MissingStructuredIdentityFailsTheWholeCensus()
+    {
+        ClassifiedMethodInfo unbound = new(
+            "M",
+            "Sample.Native",
+            "Sample",
+            "void M()",
+            MethodClassification.PInvoke);
+
+        var inspection = MetadataFindings.InspectClassifiedMethods([unbound], Subject);
+        var comparison = MetadataFindings.CompareClassifiedMethods([unbound], [], Subject);
+
+        var failedInspection = Assert.IsType<FindingInspection<ClassifiedMethodObservation>.Failed>(inspection.Value);
+        Assert.Contains("structured member identity", failedInspection.Error.Reason, StringComparison.Ordinal);
+        var failedComparison = Assert.IsType<FindingComparison<ClassifiedMethodObservation>.Failed>(comparison.Value);
+        Assert.Contains("old:", failedComparison.Failure, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RealScannerOutputProjectsWithoutChangingTheCensus()
+    {
+        using var stream = File.OpenRead(typeof(MetadataMethodFindingsTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var methods = MethodClassificationScanner.Scan(peReader);
+
+        var inspection = MetadataFindings.InspectClassifiedMethods(methods, Subject);
+
+        Assert.Equal(methods.Count, Findings(inspection).Length);
+        Assert.All(methods, static method => Assert.NotNull(method.Anchor));
+        Assert.NotEmpty(methods);
+    }
+
+    public static unsafe int* ClassifiedPointerMethod(int* value) => value;
+
+    static MemberAnchor CreateAnchor(string canonicalSignature)
+    {
+        string fingerprint = MemberAnchor.ComputeFingerprint(canonicalSignature);
+        return new MemberAnchor(
+            $"M~{fingerprint}",
+            canonicalSignature,
+            fingerprint,
+            "Sample.Native",
+            "M");
+    }
+
+    static ImmutableArray<Finding<T>> Findings<T>(FindingInspection<T> inspection)
+        where T : notnull
+        => inspection is FindingInspection<T>.Complete complete
+            ? complete.Findings
+            : throw new Xunit.Sdk.XunitException($"Expected complete inspection: {inspection}");
+
+    static ImmutableArray<PairFinding<T>> Pairs<T>(FindingComparison<T> comparison)
+        where T : notnull
+        => comparison is FindingComparison<T>.Complete complete
+            ? complete.Pairs
+            : throw new Xunit.Sdk.XunitException($"Expected complete comparison: {comparison.Failure}");
+}

--- a/tests/ILInspector.Metadata.Tests/MetadataMethodFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataMethodFindingsTests.cs
@@ -25,6 +25,7 @@ public sealed class MetadataMethodFindingsTests
             method.Anchor.CanonicalSignature,
             StringComparison.Ordinal);
         Assert.Contains("System.Int32*", method.Anchor.CanonicalSignature, StringComparison.Ordinal);
+        Assert.Equal("int*", method.ReturnType);
     }
 
     [Fact]
@@ -37,8 +38,11 @@ public sealed class MetadataMethodFindingsTests
             "Sample",
             "int M(int value)",
             MethodClassification.PInvoke,
-            "native",
-            anchor);
+            "native")
+        {
+            Anchor = anchor,
+            ReturnType = "int",
+        };
         ClassifiedMethodInfo newMethod = oldMethod with
         {
             Signature = "System.Int32 M(System.Int32 value)",
@@ -66,12 +70,19 @@ public sealed class MetadataMethodFindingsTests
             "Sample",
             "void M()",
             MethodClassification.PInvoke,
-            "old",
-            anchor);
+            "old")
+        {
+            Anchor = anchor,
+            ReturnType = "void",
+        };
 
         var moduleChange = MetadataFindings.CompareClassifiedMethods(
             [pinvoke],
             [pinvoke with { ModuleName = "new" }],
+            Subject);
+        var returnChange = MetadataFindings.CompareClassifiedMethods(
+            [pinvoke],
+            [pinvoke with { ReturnType = "nint" }],
             Subject);
         var classificationChange = MetadataFindings.CompareClassifiedMethods(
             [pinvoke],
@@ -81,6 +92,7 @@ public sealed class MetadataMethodFindingsTests
         var changed = Assert.Single(Pairs(moduleChange));
         Assert.Equal(PairKind.Changed, changed.Kind);
         Assert.Null(changed.Detail);
+        Assert.Equal(PairKind.Changed, Assert.Single(Pairs(returnChange)).Kind);
         Assert.Equal(1, Pairs(classificationChange).Count(static pair => pair.Kind == PairKind.Added));
         Assert.Equal(1, Pairs(classificationChange).Count(static pair => pair.Kind == PairKind.Removed));
     }
@@ -99,7 +111,7 @@ public sealed class MetadataMethodFindingsTests
         var comparison = MetadataFindings.CompareClassifiedMethods([unbound], [], Subject);
 
         var failedInspection = Assert.IsType<FindingInspection<ClassifiedMethodObservation>.Failed>(inspection.Value);
-        Assert.Contains("structured member identity", failedInspection.Error.Reason, StringComparison.Ordinal);
+        Assert.Contains("structured method shape", failedInspection.Error.Reason, StringComparison.Ordinal);
         var failedComparison = Assert.IsType<FindingComparison<ClassifiedMethodObservation>.Failed>(comparison.Value);
         Assert.Contains("old:", failedComparison.Failure, StringComparison.Ordinal);
     }


### PR DESCRIPTION
Binds classified-method scanner rows to Metadata-owned `MemberAnchor` identity and adds typed, presentation-free Finding inspection/comparison. Existing rendered signatures remain available to current consumers but are excluded from Finding keys and payloads.

Method identity is canonical signature plus classification. P/Invoke module changes become typed `Changed` pairs; classification transitions remain exact add/remove observations. A scanner row without structured identity fails the whole Finding census rather than silently falling back to rendered text.

Validation:
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release --no-restore` (432 passed)
- focused `MethodClassificationScannerTests` (9 passed)
- `dotnet build dotnet-inspect.slnx -c Release --no-restore --nologo`

Final adversarial reviews are in progress with Claude Opus 4.8 and Gemini 3.1 Pro.