### PR TITLE
Enforce Research change payload ownership

### DIFF
--- a/docs/design/finding-producers.md
+++ b/docs/design/finding-producers.md
@@ -137,6 +137,12 @@ Some useful product concepts are intentionally not one raw Finding stream:
 Evidence is a role those values may play; it is not a reason to flatten them
 into a parallel generic row.
 
+While `ResearchChange` remains a migration projection, every populated native
+payload must belong to its declared mechanism. A payload may be absent for a
+status- or failure-only row, but an API-tagged change cannot carry an IL, C#, or
+body-signal payload. This construction invariant retires with the projection
+fields as mechanisms adopt honest observations and transitions.
+
 ## Review checklist
 
 Before approving a producer, answer:

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -59,6 +59,90 @@ public class ResearchDiffTests
             ResearchChangeKind.Changed));
     }
 
+    [Theory]
+    [InlineData(ResearchChangeMechanism.Api)]
+    [InlineData(ResearchChangeMechanism.IlBody)]
+    [InlineData(ResearchChangeMechanism.CSharp)]
+    [InlineData(ResearchChangeMechanism.ReturnToSender)]
+    public void ResearchChange_RejectsPayloadFromAnotherMechanism(
+        ResearchChangeMechanism mechanism)
+    {
+        var subject = new ResearchSubjectKey(
+            ResearchSubjectKind.Member,
+            "M~1234567890",
+            "Sample.Widget.M()");
+        var row = new BodySignalDiffRow(
+            BodySignalDiffKind.Added,
+            "allocation",
+            "Sample.Widget.M()",
+            "newobj",
+            0,
+            "newobj Sample.Widget");
+
+        var error = Assert.Throws<ArgumentException>(() => new ResearchChange(
+            subject,
+            mechanism,
+            new FindingDescriptor("analysis.signal.added", "Body signal"),
+            ResearchChangeKind.Added,
+            bodySignalRow: row));
+
+        Assert.Equal("bodySignalRow", error.ParamName);
+    }
+
+    [Fact]
+    public void ResearchChange_RejectsIlPayloadForApiMechanism()
+    {
+        var subject = new ResearchSubjectKey(
+            ResearchSubjectKind.Member,
+            "M~1234567890",
+            "Sample.Widget.M()");
+        var row = new IlDiffRow(
+            0,
+            IlDiffKind.Add,
+            new CanonicalIlOperation(0, "nop", Operand: null),
+            "Added IL operation 'nop'");
+
+        var error = Assert.Throws<ArgumentException>(() => new ResearchChange(
+            subject,
+            ResearchChangeMechanism.Api,
+            new FindingDescriptor("api.member-added", "API member"),
+            ResearchChangeKind.Added,
+            ilRow: row));
+
+        Assert.Equal("ilRow", error.ParamName);
+    }
+
+    [Fact]
+    public void ResearchChange_AllowsMatchingOrAbsentNativePayload()
+    {
+        var subject = new ResearchSubjectKey(
+            ResearchSubjectKind.Member,
+            "M~1234567890",
+            "Sample.Widget.M()");
+        var row = new BodySignalDiffRow(
+            BodySignalDiffKind.Added,
+            "allocation",
+            "Sample.Widget.M()",
+            "newobj",
+            0,
+            "newobj Sample.Widget");
+
+        var bodySignal = new ResearchChange(
+            subject,
+            ResearchChangeMechanism.BodySignals,
+            new FindingDescriptor("analysis.signal.added", "Body signal"),
+            ResearchChangeKind.Added,
+            bodySignalRow: row);
+        var statusOnly = new ResearchChange(
+            subject,
+            ResearchChangeMechanism.ReturnToSender,
+            new FindingDescriptor("rts.status.pass", "Return to sender status"),
+            ResearchChangeKind.Changed);
+
+        Assert.Same(row, bodySignal.BodySignalRow);
+        Assert.Equal(ResearchChangeMechanism.ReturnToSender, statusOnly.Mechanism);
+    }
+
     [Fact]
     public void ResearchMemberIdentity_SubjectFromAnchor_PreservesAnchorIdentityAndDisplay()
     {

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -113,6 +113,29 @@ public class ResearchDiffTests
     }
 
     [Fact]
+    public void ResearchChange_ValidatesRequiredFieldsBeforePayloadOwnership()
+    {
+        var subject = new ResearchSubjectKey(
+            ResearchSubjectKind.Member,
+            "M~1234567890",
+            "Sample.Widget.M()");
+        var row = new IlDiffRow(
+            0,
+            IlDiffKind.Add,
+            new CanonicalIlOperation(0, "nop", Operand: null),
+            "Added IL operation 'nop'");
+
+        var error = Assert.Throws<ArgumentNullException>(() => new ResearchChange(
+            subject,
+            ResearchChangeMechanism.Api,
+            null!,
+            ResearchChangeKind.Added,
+            ilRow: row));
+
+        Assert.Equal("descriptor", error.ParamName);
+    }
+
+    [Fact]
     public void ResearchChange_AllowsMatchingOrAbsentNativePayload()
     {
         var subject = new ResearchSubjectKey(

--- a/src/ILInspector.Research/ResearchChanges.cs
+++ b/src/ILInspector.Research/ResearchChanges.cs
@@ -124,6 +124,7 @@ public sealed record ResearchChange
             throw new ArgumentOutOfRangeException(nameof(kind));
         if (!Enum.IsDefined(category))
             throw new ArgumentOutOfRangeException(nameof(category));
+        ArgumentNullException.ThrowIfNull(descriptor);
 
         ValidatePayloadMechanism(
             apiChange is not null,
@@ -182,7 +183,7 @@ public sealed record ResearchChange
             nameof(cSharpDisplayFailureRow));
 
         Mechanism = mechanism;
-        Descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
+        Descriptor = descriptor;
         Kind = kind;
         OldValue = oldValue;
         NewValue = newValue;

--- a/src/ILInspector.Research/ResearchChanges.cs
+++ b/src/ILInspector.Research/ResearchChanges.cs
@@ -75,7 +75,8 @@ public sealed record ResearchSubjectKey
 /// One Research-level change projected from a two-version mechanism. This is not a
 /// <see cref="PairFinding{T}"/>: mechanisms that do not yet expose old/new Finding censuses cannot
 /// honestly manufacture Finding atoms. The native producer payload remains attached for typed
-/// presentation and future producer migration.
+/// presentation and future producer migration. Common-field-only status and failure rows are valid;
+/// any populated native payload must belong to <see cref="Mechanism"/>.
 /// </summary>
 public sealed record ResearchChange
 {
@@ -124,6 +125,62 @@ public sealed record ResearchChange
         if (!Enum.IsDefined(category))
             throw new ArgumentOutOfRangeException(nameof(category));
 
+        ValidatePayloadMechanism(
+            apiChange is not null,
+            mechanism,
+            ResearchChangeMechanism.Api,
+            nameof(apiChange));
+        ValidatePayloadMechanism(
+            ilRow is not null,
+            mechanism,
+            ResearchChangeMechanism.IlBody,
+            nameof(ilRow));
+        ValidatePayloadMechanism(
+            ilFailureRow is not null,
+            mechanism,
+            ResearchChangeMechanism.IlBody,
+            nameof(ilFailureRow));
+        ValidatePayloadMechanism(
+            bodySignalRow is not null,
+            mechanism,
+            ResearchChangeMechanism.BodySignals,
+            nameof(bodySignalRow));
+        ValidatePayloadMechanism(
+            cSharpRow is not null,
+            mechanism,
+            ResearchChangeMechanism.CSharp,
+            nameof(cSharpRow));
+        ValidatePayloadMechanism(
+            cSharpFailureRow is not null,
+            mechanism,
+            ResearchChangeMechanism.CSharp,
+            nameof(cSharpFailureRow));
+        ValidatePayloadMechanism(
+            !ilDisplayRows.IsDefaultOrEmpty,
+            mechanism,
+            ResearchChangeMechanism.IlBody,
+            nameof(ilDisplayRows));
+        ValidatePayloadMechanism(
+            ilDisplayFailureRow is not null,
+            mechanism,
+            ResearchChangeMechanism.IlBody,
+            nameof(ilDisplayFailureRow));
+        ValidatePayloadMechanism(
+            ilMemberDiff is not null,
+            mechanism,
+            ResearchChangeMechanism.IlBody,
+            nameof(ilMemberDiff));
+        ValidatePayloadMechanism(
+            !cSharpDisplayRows.IsDefaultOrEmpty,
+            mechanism,
+            ResearchChangeMechanism.CSharp,
+            nameof(cSharpDisplayRows));
+        ValidatePayloadMechanism(
+            cSharpDisplayFailureRow is not null,
+            mechanism,
+            ResearchChangeMechanism.CSharp,
+            nameof(cSharpDisplayFailureRow));
+
         Mechanism = mechanism;
         Descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
         Kind = kind;
@@ -151,6 +208,20 @@ public sealed record ResearchChange
         IlMemberDiff = ilMemberDiff;
         CSharpDisplayRows = cSharpDisplayRows.IsDefault ? [] : cSharpDisplayRows;
         CSharpDisplayFailureRow = cSharpDisplayFailureRow;
+    }
+
+    static void ValidatePayloadMechanism(
+        bool populated,
+        ResearchChangeMechanism actual,
+        ResearchChangeMechanism expected,
+        string parameterName)
+    {
+        if (populated && actual != expected)
+        {
+            throw new ArgumentException(
+                $"{parameterName} is valid only for the {expected} mechanism.",
+                parameterName);
+        }
     }
 
     public ResearchSubjectKey Subject { get; }


### PR DESCRIPTION
## Conclusion

**PASS** — `ResearchChange` now rejects native payloads that disagree with its declared mechanism, closing the interim tagged-slot hazard without turning the migration projection into a permanent union.

Follow-up to #2620 and its architecture review. Advances #2614 and #2564.

## Change

- Validate every API, body-signal, IL, and C# native payload slot against `ResearchChangeMechanism`.
- Reject mixed-family construction such as an API-tagged change carrying an IL row.
- Preserve common-field-only status, failure, and aggregate rows, including ReturnToSender status and IL failure-string rows.
- Treat default or empty display arrays as no payload; constrain nonempty arrays to their native family.
- Document the invariant as temporary and retiring with the projection fields.

## Validation

```text
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config

ILInspector.Research.Tests: 77 passed
ReturnToSenderEvidenceTests: 3 passed
Total: 80 passed

markdownlint: clean
```

The solution build retains three pre-existing nullable warnings in Metadata tests.

## Adversarial review

Claude Opus 4.8 and Gemini 3.1 Pro are reviewing `5f2839d3` in separate clean worktrees. Results will be reconciled in a PR comment.
