### PR TITLE
Clarify Finding coordinate semantics

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,7 +128,9 @@ The shared Finding model names one-version occurrences as observations
 (`PairFinding<T>`). Evidence is the role those and other producer-owned values
 play in supporting a conclusion, not a parallel row hierarchy. See
 [Finding Nomenclature](design/finding-nomenclature.md) and
-[Finding Producer Design](design/finding-producers.md).
+[Finding Producer Design](design/finding-producers.md). Finding subject identity,
+cross-version correspondence, optional producer order, and typed provenance are
+separate axes; see [Finding Coordinates](design/finding-coordinates.md).
 
 - **R1** is the lower, metadata/IL representation. `ILInspector.Analysis` reads
   assemblies with `System.Reflection.Metadata`, builds whole-assembly indexes,

--- a/docs/design/finding-coordinates.md
+++ b/docs/design/finding-coordinates.md
@@ -1,0 +1,60 @@
+# Finding Coordinates
+
+Finding keeps correspondence, ordering, and provenance separate. They answer
+different questions and do not share one generic string slot.
+
+## Coordinate axes
+
+| Axis | Contract | Meaning |
+| --- | --- | --- |
+| Subject | `FindingSubject.Key` | The stable thing being inspected, such as one method, member, or document. Sibling producers agree here when Research joins their results. |
+| Correspondence | `FindingKey.IdentityKey` | The exact cross-version candidate identity within one producer stream. |
+| Corroboration | `FindingKey.ScopeKey` | Optional structural evidence used to strengthen an otherwise ambiguous correspondence. It is not identity or provenance. |
+| Producer order | `Finding<T>.Ordinal` | Optional zero-based location retained by an ordered producer for presentation and producer-owned follow-up work. |
+| Provenance | Typed producer payload | Domain coordinates such as `AllocationOccurrence.ILOffset` or `MemberAnchor` retain their native semantics and validation. |
+
+`FindingMatcher` uses the enumeration order of the collections it receives.
+`Ordinal` does not control alignment or move classification. It lets an ordered
+producer retain the source-stream location after observations have been paired,
+materialized, or projected. Ordered IL, C#, and text observations populate it;
+Metadata identity sets leave it null.
+
+This distinction is intentional:
+
+- an API member does not gain semantic position because its inventory was
+  sorted for deterministic output;
+- an IL operation's ordinal is an operation-array index, not its IL offset;
+- a text line's ordinal is a logical line index, not a cross-document identity;
+- changing retained ordinals does not turn an order-preserving match into a
+  move.
+
+## Why there is no generic anchor
+
+The current anchors do not share one semantic contract:
+
+- Metadata's `MemberAnchor` is stable member identity and selector data;
+- an allocation's IL offset identifies one lower-representation occurrence
+  within a method;
+- `AnnotationAnchor` is a range-based projection algorithm from IL offsets to
+  raised statements;
+- C# and text line ordinals are representation-local locations.
+
+Flattening these into `FindingAnchor(string)` would discard type, coordinate
+space, and authority while duplicating data already owned by producer payloads.
+Member-level cross-producer joins use `FindingSubject.Key`; occurrence-level
+cross-stream joins should retain an explicit typed provenance relation when a
+producer needs one. A shared anchor belongs on the leaf only after at least two
+producers require the same validated semantics.
+
+## Soft-matching prerequisite
+
+Soft matching extends correspondence, not coordinates. Its design must add:
+
+- structured producer-owned identity projections;
+- typed facet or similarity deltas;
+- explicit match-tier provenance;
+- deterministic tie resolution from input order or a producer's stable sort.
+
+Hard matches remain authoritative and run first. A generic anchor is not a
+substitute for structured identity, and cross-stream provenance must not be
+scored as though it were fuzzy cross-version correspondence.

--- a/docs/design/finding-nomenclature.md
+++ b/docs/design/finding-nomenclature.md
@@ -113,11 +113,19 @@ This is a migration boundary, not authorization for a second universal spine:
 - Research must not wrap those values in a parallel generic `EvidenceRow`
   hierarchy solely to make them look uniform.
 
+## Coordinates
+
+Subject identity, cross-version correspondence, producer order, and typed
+provenance are independent axes. `Finding<T>.Ordinal` is optional retained
+observation metadata; collection order controls matching. Identity-set
+observations do not fabricate ordinals, and producer-specific structural
+coordinates remain typed in their payloads. See
+[Finding Coordinates](finding-coordinates.md).
+
 ## Open evolution points
 
 These require explicit design before dependent producers rely on them:
 
-- separate ordered-stream position from a stable structural anchor;
 - define structured soft-match projections, typed deltas, and match-tier
   provenance;
 - define value equality for envelopes containing `ImmutableArray` or

--- a/docs/design/finding-producers.md
+++ b/docs/design/finding-producers.md
@@ -47,8 +47,8 @@ as a namespace.
 - subject;
 - descriptor;
 - identity and scope keys;
-- position;
 - typed payload;
+- optional ordered-stream ordinal;
 - optional detail.
 
 Add a domain payload only for typed properties not already represented by the
@@ -96,16 +96,19 @@ The producer owns stable observation identity:
 - `FindingDescriptor` identifies the observation vocabulary entry.
 - `FindingKey.IdentityKey` identifies correspondence candidates.
 - `FindingKey.ScopeKey` constrains correspondence when the domain requires it.
-- `Position` records the producer ordinal. It is correspondence-significant only
-  for an ordered stream; identity-set producers may assign a deterministic
-  ordinal without making it part of identity.
+- `Ordinal` optionally retains the producer's source-stream index. Ordered
+  producers populate it when consumers need the source location after matching;
+  identity-set producers leave it null.
 
-Use `FindingMatchMode.Ordered` when position is semantic, such as IL, C#, or
-text. Use `FindingMatchMode.IdentitySet` when order is not semantic, such as API
-members.
+Use `FindingMatchMode.Ordered` when enumeration order is semantic, such as IL,
+C#, or text. Use `FindingMatchMode.IdentitySet` when order is not semantic, such
+as API members. The matcher uses collection order, not `Ordinal`, as its
+alignment authority.
 
-Do not overload ordinal position as a future Research join anchor. Stable
-structural anchors are a separate design axis.
+Do not overload an ordinal as a Research join anchor. Keep domain coordinates
+and provenance typed in producer payloads until multiple producers demonstrate
+one shared semantic contract. See
+[Finding Coordinates](finding-coordinates.md).
 
 ## 6. Keep generic comparison generic
 
@@ -151,7 +154,7 @@ Before approving a producer, answer:
 - Which product layer is its sole authority?
 - Which existing payload type represents it?
 - What stable descriptor and identity does it use?
-- Is position semantic?
+- Is enumeration order semantic, and must the observation retain its ordinal?
 - Is empty a complete result, or must absence and failure remain distinct?
 - Which two or more consumers need the same census?
 - Is any proposed field actually a downstream fact, verdict, or presentation?

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -45,6 +45,7 @@ Agents working in this repo should preserve these principles:
 - [IL Diff canonicalization](design/il-diff-canonicalization.md): current `CanonicalIlOperation` guarantees, boundaries, and extension points.
 - [Finding nomenclature](design/finding-nomenclature.md): observation/change semantics, operation outcomes, and Research composition boundaries.
 - [Finding producer design](design/finding-producers.md): how to choose owners, payloads, identities, result shapes, and matching modes.
+- [Finding coordinates](design/finding-coordinates.md): separation of subject identity, correspondence, optional producer order, and typed provenance.
 - [Implementation Diff](design/implementation-diff.md): product C# + IL/body diff projection shared by future CLI surfaces, RTS, and harnesses.
 - [Fixture governance](fixture-governance.md): fixture catalog, project-boundary, and semantic-axis rules.
 - [Integrations](design/integrations.md): library ecosystem integration roll-ups and focused API currency.

--- a/src/ILInspector.Decompiler.Tests/CSharpFindingsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpFindingsTests.cs
@@ -138,7 +138,9 @@ public class CSharpFindingsTests
         Assert.Contains(census, finding => finding.Descriptor.Id == "csharp.line");
         var list = census.ToList();
         Assert.NotEmpty(list);
-        Assert.Equal(Enumerable.Range(0, list.Count), list.Select(finding => finding.Position));
+        Assert.Equal<int?>(
+            Enumerable.Range(0, list.Count).Select(static ordinal => (int?)ordinal),
+            list.Select(finding => finding.Ordinal));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/CSharpFindings.cs
+++ b/src/ILInspector.Decompiler/CSharpFindings.cs
@@ -98,8 +98,8 @@ public static class CSharpFindings
                 subject,
                 LineDescriptor,
                 new FindingKey(lines[i].IdentityKey),
-                i,
-                lines[i]));
+                lines[i],
+                Ordinal: i));
         }
 
         return builder.MoveToImmutable();

--- a/src/ILInspector.Findings/Finding.cs
+++ b/src/ILInspector.Findings/Finding.cs
@@ -78,7 +78,7 @@ public enum FindingDifferenceKind
     /// <summary>No observable difference for this pair.</summary>
     None,
 
-    /// <summary>Same content, different location (a matched pair with a position delta).</summary>
+    /// <summary>Same content, different location in the compared streams.</summary>
     Moved,
 }
 
@@ -97,11 +97,13 @@ public interface IFinding
 /// <summary>
 /// The atom: a single observation projected from a domain node (an IL op, an allocation, an API
 /// member). A single-version query is just a <c>Finding&lt;T&gt;[]</c> census — no matcher, no
-/// diff. It carries its content <see cref="Key"/> and a single <see cref="Position"/> in its own
-/// stream; the transition concepts (add/remove/change, an old-vs-new delta) belong to
-/// <see cref="PairFinding{T}"/>, never here. The payload is non-null and a type parameter rather
-/// than <c>object?</c>, so a value-typed payload is not boxed and consumers read it without a
-/// cast; heterogeneous consumers use <see cref="IFinding"/> and pattern-match the concrete
+/// diff. It carries its content <see cref="Key"/> and may retain its <see cref="Ordinal"/> in an
+/// ordered producer stream. The ordinal is observation metadata, not matching authority:
+/// <see cref="FindingMatcher"/> uses the order of the collections it receives. Identity-set
+/// observations leave it null. Transition concepts (add/remove/change, an old-vs-new delta) belong
+/// to <see cref="PairFinding{T}"/>, never here. The payload is non-null and a type parameter rather
+/// than <c>object?</c>, so a value-typed payload is not boxed and consumers read it without a cast;
+/// heterogeneous consumers use <see cref="IFinding"/> and pattern-match the concrete
 /// <c>Finding&lt;T&gt;</c> when they need its payload.
 /// </summary>
 public sealed record Finding<T> : IFinding
@@ -111,41 +113,41 @@ public sealed record Finding<T> : IFinding
         FindingSubject Subject,
         FindingDescriptor Descriptor,
         FindingKey Key,
-        int Position,
         T Payload,
+        int? Ordinal = null,
         string? Detail = null)
     {
         this.Subject = Subject ?? throw new ArgumentNullException(nameof(Subject));
         this.Descriptor = Descriptor ?? throw new ArgumentNullException(nameof(Descriptor));
         if (Key.IdentityKey is null)
             throw new ArgumentException("Finding key must be initialized.", nameof(Key));
-        if (Position < 0)
-            throw new ArgumentOutOfRangeException(nameof(Position), Position, "Position must be non-negative.");
         if (Payload is null)
             throw new ArgumentNullException(nameof(Payload));
+        if (Ordinal is < 0)
+            throw new ArgumentOutOfRangeException(nameof(Ordinal), Ordinal, "Ordinal must be non-negative.");
 
         this.Key = Key;
-        this.Position = Position;
         this.Payload = Payload;
+        this.Ordinal = Ordinal;
         this.Detail = Detail;
     }
 
     public FindingSubject Subject { get; }
     public FindingDescriptor Descriptor { get; }
     public FindingKey Key { get; }
-    public int Position { get; }
     public T Payload { get; }
+    public int? Ordinal { get; }
     public string? Detail { get; }
 
     public void Deconstruct(
         out FindingSubject subject,
         out FindingDescriptor descriptor,
         out FindingKey key,
-        out int position,
         out T payload,
+        out int? ordinal,
         out string? detail)
-        => (subject, descriptor, key, position, payload, detail)
-            = (Subject, Descriptor, Key, Position, Payload, Detail);
+        => (subject, descriptor, key, payload, ordinal, detail)
+            = (Subject, Descriptor, Key, Payload, Ordinal, Detail);
 }
 
 /// <summary>

--- a/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
@@ -21,12 +21,12 @@ public class FindingPilotTests
     // Matcher-only tests need just the alignment keys.
     static FindingKey[] Keys(params string[] keys) => [.. keys.Select(k => new FindingKey(k))];
 
-    // Fold tests need atoms: payload is the key string, position is the stream index.
+    // Fold tests need atoms: payload is the key string, ordinal is retained observation metadata.
     static ImmutableArray<Finding<string>> Atoms(params string[] keys)
     {
         var builder = ImmutableArray.CreateBuilder<Finding<string>>(keys.Length);
         for (int i = 0; i < keys.Length; i++)
-            builder.Add(new Finding<string>(Subject, Descriptor, new FindingKey(keys[i]), i, keys[i]));
+            builder.Add(new Finding<string>(Subject, Descriptor, new FindingKey(keys[i]), keys[i], Ordinal: i));
         return builder.MoveToImmutable();
     }
 
@@ -54,8 +54,8 @@ public class FindingPilotTests
             Subject,
             Descriptor,
             new FindingKey("1"),
-            0,
-            1);
+            1,
+            Ordinal: 0);
         IFinding[] observations = [stringFinding, intFinding];
         IPairFinding[] transitions =
         [
@@ -98,18 +98,32 @@ public class FindingPilotTests
         Assert.Throws<ArgumentNullException>(() => new FindingDescriptor("test.item", null!));
         Assert.Throws<ArgumentNullException>(() => new FindingKey(null!));
         Assert.Throws<ArgumentNullException>(
-            () => new Finding<string>(null!, Descriptor, new FindingKey("k"), 0, "k"));
+            () => new Finding<string>(null!, Descriptor, new FindingKey("k"), "k"));
         Assert.Throws<ArgumentNullException>(
-            () => new Finding<string>(Subject, null!, new FindingKey("k"), 0, "k"));
+            () => new Finding<string>(Subject, null!, new FindingKey("k"), "k"));
         Assert.Throws<ArgumentException>(
-            () => new Finding<string>(Subject, Descriptor, default, 0, "k"));
+            () => new Finding<string>(Subject, Descriptor, default, "k"));
         Assert.Throws<ArgumentOutOfRangeException>(
-            () => new Finding<string>(Subject, Descriptor, new FindingKey("k"), -1, "k"));
+            () => new Finding<string>(Subject, Descriptor, new FindingKey("k"), "k", Ordinal: -1));
         Assert.Throws<ArgumentNullException>(
-            () => new Finding<string>(Subject, Descriptor, new FindingKey("k"), 0, null!));
+            () => new Finding<string>(Subject, Descriptor, new FindingKey("k"), null!));
+        Assert.Throws<ArgumentNullException>(
+            () => new Finding<string>(
+                Subject,
+                Descriptor,
+                new FindingKey("k"),
+                null!,
+                Ordinal: -1));
 
         // Empty content is a valid identity for an empty logical text line.
         Assert.Equal("", new FindingKey("").IdentityKey);
+
+        var identitySetFinding = new Finding<string>(
+            Subject,
+            Descriptor,
+            new FindingKey("k"),
+            "k");
+        Assert.Null(identitySetFinding.Ordinal);
     }
 
     [Fact]
@@ -286,6 +300,23 @@ public class FindingPilotTests
 
         Assert.False(FindingEquivalence.Exact.IsEquivalent(pairs));
         Assert.True(FindingEquivalence.Multiset.IsEquivalent(pairs));
+    }
+
+    [Fact]
+    public void OrderedMatching_UsesCollectionOrderNotRetainedOrdinal()
+    {
+        var old = ImmutableArray.Create(
+            new Finding<string>(Subject, Descriptor, new FindingKey("same"), "old", Ordinal: 40));
+        var @new = ImmutableArray.Create(
+            new Finding<string>(Subject, Descriptor, new FindingKey("same"), "new", Ordinal: 7));
+
+        var match = FindingMatcher.Match(old.Keys(), @new.Keys());
+        var present = Assert.IsType<PairFinding<string>.Present>(
+            Assert.Single(FindingFold.ToPairs(match, old, @new)).Value);
+
+        Assert.Equal(FindingDifferenceKind.None, present.Difference);
+        Assert.Equal(40, present.Old.Ordinal);
+        Assert.Equal(7, present.New.Ordinal);
     }
 
     [Fact]
@@ -474,8 +505,8 @@ public class FindingPilotTests
     [Fact]
     public void PairFinding_CasesFixTheirKind_AndBothNullIsUnrepresentable()
     {
-        var a = new Finding<string>(Subject, Descriptor, new FindingKey("k"), 0, "k");
-        var b = new Finding<string>(Subject, Descriptor, new FindingKey("k"), 1, "k");
+        var a = new Finding<string>(Subject, Descriptor, new FindingKey("k"), "k", Ordinal: 0);
+        var b = new Finding<string>(Subject, Descriptor, new FindingKey("k"), "k", Ordinal: 1);
 
         // Each union case fixes its own polarity; there is no Kind field to set out of step with the
         // sides. The cases convert implicitly to the union.
@@ -496,7 +527,7 @@ public class FindingPilotTests
     [Fact]
     public void PairFinding_Cases_RejectNullAtoms_FailClosed()
     {
-        var a = new Finding<string>(Subject, Descriptor, new FindingKey("k"), 0, "k");
+        var a = new Finding<string>(Subject, Descriptor, new FindingKey("k"), "k", Ordinal: 0);
 
         // A plain null literal is already a compile error under the non-null annotations; a
         // null-forgiving caller is caught at construction so a case can never hold a missing side.
@@ -540,7 +571,8 @@ public class FindingPilotTests
         // Pairs fabricated as if from an arbitrary (non-IL) stream: the consumer does not care.
         var subject = new FindingSubject("s", "s");
         var descriptor = new FindingDescriptor("any.kind", "any");
-        Finding<string> Atom(string key, int position) => new(subject, descriptor, new FindingKey(key), position, key);
+        Finding<string> Atom(string key, int ordinal) =>
+            new(subject, descriptor, new FindingKey(key), key, Ordinal: ordinal);
 
         IPairFinding[] pairs =
         [
@@ -584,9 +616,9 @@ public class FindingPilotTests
         var failed = IlFindings.Inspect(malformed, null, IlSubject);
 
         Assert.Contains(complete.Findings, f => f.Descriptor.Id == "il.op");
-        Assert.Equal(
-            Enumerable.Range(0, complete.Findings.Length),
-            complete.Findings.Select(f => f.Position));
+        Assert.Equal<int?>(
+            Enumerable.Range(0, complete.Findings.Length).Select(static ordinal => (int?)ordinal),
+            complete.Findings.Select(f => f.Ordinal));
         Assert.True(absent is FindingInspection<CanonicalIlOperation>.Absent);
         Assert.True(failed is FindingInspection<CanonicalIlOperation>.Failed);
     }

--- a/src/ILInspector.Instructions/IlFindings.cs
+++ b/src/ILInspector.Instructions/IlFindings.cs
@@ -117,14 +117,19 @@ public static class IlFindings
         foreach (var pair in pairs)
         {
             if (pair is PairFinding<CanonicalIlOperation>.Present { Difference: FindingDifferenceKind.Moved } moved)
-                alignment[moved.Old.Position] = moved.New.Position;
+                alignment[RequiredOrdinal(moved.Old)] = RequiredOrdinal(moved.New);
         }
 
         var builder = ImmutableArray.CreateBuilder<PairFinding<CanonicalIlOperation>>(pairs.Length);
         foreach (var pair in pairs)
         {
             if (pair is PairFinding<CanonicalIlOperation>.Present present
-                && !IlBodyDiff.BranchTargetsMatch(oldInstructions, present.Old.Position, newInstructions, present.New.Position, alignment))
+                && !IlBodyDiff.BranchTargetsMatch(
+                    oldInstructions,
+                    RequiredOrdinal(present.Old),
+                    newInstructions,
+                    RequiredOrdinal(present.New),
+                    alignment))
             {
                 // A moved-and-retargeted operation keeps its move Detail; append the retarget so
                 // neither the distance nor the retarget note is lost. Promoting the Present case to
@@ -144,7 +149,11 @@ public static class IlFindings
         return builder.ToImmutable();
     }
 
-    // One Finding per operation, carrying its content key and stream position. Private:
+    static int RequiredOrdinal(Finding<CanonicalIlOperation> finding)
+        => finding.Ordinal
+            ?? throw new InvalidOperationException("An IL operation finding must retain its stream ordinal.");
+
+    // One Finding per operation, carrying its content key and stream ordinal. Private:
     // canonicalized operations remain an internal shape.
     static IEnumerable<Finding<CanonicalIlOperation>> ProjectAtoms(
         ImmutableArray<CanonicalIlOperation> operations,
@@ -158,8 +167,8 @@ public static class IlFindings
                 subject,
                 OperationDescriptor,
                 new FindingKey(GetIdentityKey(operations[i])),
-                i,
-                operations[i]);
+                operations[i],
+                Ordinal: i);
         }
     }
 

--- a/src/ILInspector.Metadata/MetadataFindings.Inventory.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.Inventory.cs
@@ -205,14 +205,12 @@ public static partial class MetadataFindings
             .ToArray();
 
         var findings = ImmutableArray.CreateBuilder<Finding<T>>(projected.Length);
-        for (int position = 0; position < projected.Length; position++)
+        foreach (var observation in projected)
         {
-            var observation = projected[position];
             findings.Add(new Finding<T>(
                 subject,
                 descriptor,
                 new FindingKey(observation.Identity),
-                position,
                 observation.Payload));
         }
 

--- a/src/ILInspector.Metadata/MetadataFindings.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.cs
@@ -27,11 +27,10 @@ public static partial class MetadataFindings
 
         return new FindingInspection<ApiTypeHandle>.Complete(
         [
-            .. surface.Types.Select((type, position) => new Finding<ApiTypeHandle>(
+            .. surface.Types.Select(type => new Finding<ApiTypeHandle>(
                 subject,
                 TypeDescriptor,
                 new FindingKey(type.FullName),
-                position,
                 new ApiTypeHandle(type))),
         ]);
     }
@@ -45,7 +44,7 @@ public static partial class MetadataFindings
 
         return new FindingInspection<ApiMemberHandle>.Complete(
         [
-            .. EnumerateMembers(surface).Select((item, position) =>
+            .. EnumerateMembers(surface).Select(item =>
             {
                 var handle = ApiMemberIdentity.CreateHandle(item.Type, item.Member);
                 return new Finding<ApiMemberHandle>(
@@ -54,7 +53,6 @@ public static partial class MetadataFindings
                     new FindingKey(
                         handle.CanonicalSignature ?? handle.Identity,
                         item.Type.FullName),
-                    position,
                     handle);
             }),
         ]);

--- a/src/ILInspector.Text.Tests/TextFindingsTests.cs
+++ b/src/ILInspector.Text.Tests/TextFindingsTests.cs
@@ -12,7 +12,7 @@ public class TextFindingsTests
         var findings = TextFindings.Inspect("first\r\n second\nthird", Subject).ToArray();
 
         Assert.Equal(["first", " second", "third"], findings.Select(f => f.Payload));
-        Assert.Equal([0, 1, 2], findings.Select(f => f.Position));
+        Assert.Equal([0, 1, 2], findings.Select(f => f.Ordinal));
         Assert.All(findings, finding =>
         {
             Assert.Same(Subject, finding.Subject);
@@ -38,7 +38,7 @@ public class TextFindingsTests
 
         var whitespace = Assert.Single(TextFindings.Inspect(" \t", Subject));
         Assert.Equal(" \t", whitespace.Payload);
-        Assert.Equal(0, whitespace.Position);
+        Assert.Equal(0, whitespace.Ordinal);
     }
 
     [Fact]

--- a/src/ILInspector.Text/TextFindings.cs
+++ b/src/ILInspector.Text/TextFindings.cs
@@ -12,7 +12,7 @@ public static class TextFindings
 
     /// <summary>
     /// Lazily yields an exact line census. Each string payload is the line content and
-    /// <see cref="Finding{T}.Position"/> is its zero-based position in the logical line stream.
+    /// <see cref="Finding{T}.Ordinal"/> is its zero-based position in the logical line stream.
     /// CRLF, CR, and LF are equivalent boundaries.
     /// Empty text has zero lines. A terminating boundary produces a final empty line, preserving
     /// the distinction between a document with and without a final newline.
@@ -82,8 +82,8 @@ public static class TextFindings
                 subject,
                 LineDescriptor,
                 new FindingKey(content),
-                position++,
-                content);
+                content,
+                Ordinal: position++);
         }
     }
 }

--- a/src/dotnet-inspect/Output/SourceTextDiffRenderer.cs
+++ b/src/dotnet-inspect/Output/SourceTextDiffRenderer.cs
@@ -49,7 +49,11 @@ internal static class SourceTextDiffRenderer
                 {
                     Difference: FindingDifferenceKind.None
                 } present)
-                anchors.Add((present.Old.Position, present.New.Position));
+            {
+                anchors.Add((
+                    RequiredOrdinal(present.Old),
+                    RequiredOrdinal(present.New)));
+            }
         }
 
         anchors.Sort(static (left, right) => left.OldPosition.CompareTo(right.OldPosition));
@@ -77,4 +81,8 @@ internal static class SourceTextDiffRenderer
 
         return lines;
     }
+
+    static int RequiredOrdinal(Finding<string> finding)
+        => finding.Ordinal
+            ?? throw new InvalidOperationException("A text-line finding must retain its stream ordinal.");
 }

--- a/tests/ILInspector.Metadata.Tests/MetadataFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataFindingsTests.cs
@@ -143,6 +143,20 @@ public class MetadataFindingsTests
     }
 
     [Fact]
+    public void ApiIdentitySetFindings_DoNotFabricateOrdinals()
+    {
+        var surface = Surface(Type("Widget", members: [Method("Run", "void Run()")]));
+
+        var type = Assert.IsType<FindingInspection<ApiTypeHandle>.Complete>(
+            MetadataFindings.InspectApiTypes(surface, Subject).Value);
+        var member = Assert.IsType<FindingInspection<ApiMemberHandle>.Complete>(
+            MetadataFindings.InspectApiMembers(surface, Subject).Value);
+
+        Assert.Null(Assert.Single(type.Findings).Ordinal);
+        Assert.Null(Assert.Single(member.Findings).Ordinal);
+    }
+
+    [Fact]
     public void SignatureChangesRemainConservativeAddRemovePairs()
     {
         var oldSurface = Surface(Type("Widget", members: [Method("Run", "void Run(int value)")]));

--- a/tests/ILInspector.Metadata.Tests/MetadataInventoryFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataInventoryFindingsTests.cs
@@ -21,6 +21,16 @@ public sealed class MetadataInventoryFindingsTests
     }
 
     [Fact]
+    public void IdentitySetInventory_DoesNotFabricateOrdinals()
+    {
+        var findings = Findings(MetadataFindings.InspectResources(
+            [new ManifestResourceInfo("data.json", IsPublic: true, IsEmbedded: true, Size: 10)],
+            Subject));
+
+        Assert.Null(Assert.Single(findings).Ordinal);
+    }
+
+    [Fact]
     public void AssemblyReferences_IgnoreOrderAndPromoteVersionChanges()
     {
         AssemblyReference systemRuntimeV1 = new(


### PR DESCRIPTION
## Summary

- replace required, ambiguous `Finding<T>.Position` with optional `Ordinal` observation metadata and move the required payload before it
- keep collection order as the sole matcher/fold authority while retaining ordinals for ordered IL, C#, and text consumers
- stop Metadata/API identity-set producers from fabricating positions
- document why member anchors, IL offsets, rendered lines, and annotation ranges remain typed producer coordinates instead of one opaque `FindingAnchor`

## Design decision

The coordinate model now separates subject identity, exact correspondence, scope corroboration, producer order, and provenance. No current consumer demonstrates one shared structural-anchor contract, so the leaf does not gain a speculative string slot. Soft matching (#2585) should add structured identity projections, typed deltas, and match-tier provenance rather than overload order or provenance.

This intentionally breaks positional `Finding<T>` construction, `.Position` reads, and old deconstruction order while the API is young. Identity-set construction becomes the common ergonomic form: `(subject, descriptor, key, payload)`.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `ILInspector.Instructions.Tests`: 101 passed
- `ILInspector.Metadata.Tests`: 442 passed
- `ILInspector.Research.Tests`: 78 passed
- focused C# Finding tests: 18 passed
- `ILInspector.Text.Tests`: 13 passed
- focused source-text renderer tests: 5 passed
- markdownlint on all changed Markdown

Refs #2614. Coordinate design is the prerequisite for #2585 soft matching.