### PR TITLE
Add caller-driven package Finding onset

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,9 @@ dotnet-inspect library System.Text.Json -S "Signals,SourceLink Availability,Sour
 dotnet-inspect library System.Text.Json -S "SourceLink Integrity"
 dotnet-inspect package System.Text.Json -S Signals
 dotnet-inspect package System.Text.Json --versions
+dotnet-inspect package System.Text.Json@8.0.0..8.0.5 --versions
+dotnet-inspect type JsonSerializer --package System.Text.Json@8.0.0..8.0.5 --at '#4'
+dotnet-inspect member JsonSerializer Serialize --package System.Text.Json@8.0.0..8.0.5 --at 8.0.5
 dotnet-inspect type Command --project ./src/App
 dotnet-inspect member Command --project ./src/App --show-index
 dotnet-inspect project ./src/App -S Grounding

--- a/docs/design/finding-nomenclature.md
+++ b/docs/design/finding-nomenclature.md
@@ -66,7 +66,7 @@ Information types are durable values:
 | --- | --- | --- |
 | `Finding<T>` | One | One observation with a typed payload. |
 | `PairFinding<T>` | Two | One classified transition composed from observations. |
-| Future correlation type | More than two | A version-labelled timeline, if the product later needs one. |
+| `CorrelatedFinding<T>` | More than two | Durable occurrences of one exact identity, labelled with their evaluated version addresses. |
 
 Operation outcomes describe one invocation:
 
@@ -75,6 +75,7 @@ Operation outcomes describe one invocation:
 | Match | `FindingMatch` | Alignment edges and fringe candidates. |
 | Inspect | `FindingInspection<T>` | `Complete(Finding<T>[])`, `Absent`, or `Failed(InspectionError)`. |
 | Compare | `FindingComparison<T>` | Completed pairs/match/inspections, or the failed inspections that prevented matching. |
+| Correlate | `FindingCorrelation<T>` | A sparse, ordered timeline assembled from caller-supplied version-labelled inspections. |
 
 Outcome types carry information types; information types do not depend on
 outcome envelopes. Use the nominalized operation name instead of generic
@@ -96,6 +97,33 @@ The governing invariant is:
 
 > An empty match is evidence of a trivial alignment; a manufactured match is a
 > costume.
+
+## Sparse correlation and onset
+
+`FindingCorrelation<T>` does not traverse a version range. The caller chooses
+which addresses to inspect and supplies each `FindingInspection<T>` with a
+stable `FindingVersion`. This keeps bisect, backward scanning, retry, and probe
+limits in the agent or calling workflow rather than hiding an unbounded search
+inside the Finding layer.
+
+For one exact `FindingCorrelationKey`, an evaluated address has one of four
+states:
+
+- `Present`: a completed census contains the identity;
+- `Missing`: a completed census does not contain the identity;
+- `SubjectAbsent`: the producer had no applicable subject input;
+- `Failed`: inspection did not complete.
+
+Unevaluated addresses do not appear in the correlation. They are not
+manufactured as missing, absent, or failed. `CorrelatedFinding<T>` retains only
+the durable version-labelled occurrences; the correlation timeline retains the
+operation outcomes. Any two evaluated cells can be projected through the
+existing `FindingComparison.Compare` operation.
+
+This supports the current-onset question, "when was this not there?", without
+assuming monotonic history. A caller may scan backward until the first
+successful missing census for exact recurrence-safe onset, or use a bounded
+bracket/binary strategy only when its predicate is known to be monotonic.
 
 ## Research composition
 

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -4,7 +4,7 @@ dotnet-inspect uses Docker-style version tags to balance freshness against
 latency. Version discovery is cached briefly; package contents are cached
 permanently by exact version.
 
-## Three modes
+## Four modes
 
 | Syntax | Behavior | Network I/O |
 | --- | --- | --- |
@@ -12,6 +12,7 @@ permanently by exact version.
 | `Name` | **Latest stable** — resolve the latest stable version, then use/download that exact package | Only on version-cache miss |
 | `Name --preview` | **Latest prerelease** — resolve the latest version including prerelease/preview versions | Only on version-cache miss |
 | `Name@latest` | **Always check** — query NuGet for the latest version every time | Always |
+| `Name@A..B` | **Addressable vector** — resolve the inclusive published-version range without downloading package payloads | Only on version-list cache miss |
 
 ### Pinned (`Name@version`)
 
@@ -46,6 +47,31 @@ Forces a full network refresh. Bypasses the disk scan, version cache, and
 metadata cache. Useful when you want to verify you have the absolute latest
 version or check for newly published security advisories.
 
+### Addressable vector (`Name@A..B`)
+
+A package range names an immutable, inclusive vector of published versions. The
+vector follows the caller's direction: `1.0.0..2.0.0` is oldest-to-newest and
+`2.0.0..1.0.0` is newest-to-oldest. Both endpoints must exist.
+
+```bash
+dotnet-inspect package System.Text.Json@8.0.0..8.0.5 --versions
+dotnet-inspect type JsonSerializer \
+  --package System.Text.Json@8.0.0..8.0.5 --at '#4'
+dotnet-inspect member JsonSerializer Serialize \
+  --package System.Text.Json@8.0.0..8.0.5 --at 8.0.5
+```
+
+`package --versions` enumerates the vector. Range-capable API commands require
+`--at` with an exact version, a one-based `#N` address, `first`, or `last`.
+Resolving the vector reads version metadata only. The command downloads or
+opens a package only after the caller selects an address, so an agent can probe
+previous, midpoint, or adjacent versions without triggering an unbounded scan.
+
+Stable endpoints exclude prereleases by default. A prerelease endpoint or
+`--preview` on `package --versions` includes prereleases within the range.
+Existing `diff --package Name@A..B` remains the two-endpoint projection of the
+same familiar range syntax.
+
 ## Cache locations
 
 | Cache | Location | TTL | Written by |
@@ -70,6 +96,7 @@ offline mode, and unsupported local feed URLs are not cached as misses.
 | Bare package version resolution | Uses the version-resolution cache with a 1-hour TTL, then NuGet; package caches are used only after the version is resolved. |
 | Bare package `--preview` resolution | Uses a separate prerelease-aware version-resolution cache with a 1-hour TTL, then NuGet. |
 | Wildcard version resolution | Uses the same version-list cache as `--versions` with a 1-hour TTL for nuget.org-backed sources. |
+| Addressable package range | Uses the version-list cache to resolve the vector; package caches are consulted only after a caller selects a cell. |
 | `@latest` package resolution | Always checks NuGet and bypasses version/metadata caches. |
 | Package index scan | Cached permanently for extracted package contents. |
 | Package metadata | Cached for 1 hour in the metadata cache. |

--- a/skills/compatibility/SKILL.md
+++ b/skills/compatibility/SKILL.md
@@ -61,3 +61,18 @@ Version resolution is cache-first (local cache in milliseconds; nuget.org
 `Foo --latest-version` for the newest on nuget.org, and `Foo --versions [N]`
 (add `--preview`) to list published versions. Pin with `@`: `Foo@9.0.0`,
 `Foo@latest`.
+
+For caller-driven onset or bisect work, resolve an inclusive addressable vector,
+then probe only the cells you choose:
+
+```bash
+dnx dotnet-inspect -y -- package Foo@1.0.0..2.0.0 --versions
+dnx dotnet-inspect -y -- type TargetType --package Foo@1.0.0..2.0.0 --at '#5'
+dnx dotnet-inspect -y -- member TargetType TargetMember --package Foo@1.0.0..2.0.0 --at 1.6.0
+```
+
+`--at` accepts an exact version, one-based `#N`, `first`, or `last`. Vector
+resolution does not download every package; only the selected probe is
+acquired. The agent owns the search policy and bound. For recurrence-safe
+current onset, walk backward from the bad version until the first successful
+absence; use binary search only for a predicate known to be monotonic.

--- a/src/DotnetInspector.Packages/DotnetInspector.Packages.csproj
+++ b/src/DotnetInspector.Packages/DotnetInspector.Packages.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\DotnetInspector.Core\DotnetInspector.Core.csproj" />
     <PackageReference Include="NuGetFetch" />
+    <PackageReference Include="NuGet.Versioning" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DotnetInspector.Packages/PackageVersionVector.cs
+++ b/src/DotnetInspector.Packages/PackageVersionVector.cs
@@ -1,0 +1,243 @@
+using System.Collections.Immutable;
+using DotnetInspector.Core;
+using NuGet.Versioning;
+
+namespace DotnetInspector.Packages;
+
+/// <summary>
+/// An inclusive package-version range supplied in the familiar <c>Package@A..B</c> form.
+/// </summary>
+public sealed record PackageVersionRange
+{
+    PackageVersionRange(string packageId, NuGetVersion start, NuGetVersion end)
+    {
+        PackageId = packageId;
+        Start = start;
+        End = end;
+    }
+
+    public string PackageId { get; }
+    public NuGetVersion Start { get; }
+    public NuGetVersion End { get; }
+    public bool IncludesPrerelease => Start.IsPrerelease || End.IsPrerelease;
+
+    /// <summary>
+    /// Parses a package range. A false result with no error means the reference is not a range.
+    /// </summary>
+    public static bool TryParse(
+        string packageReference,
+        out PackageVersionRange? range,
+        out string? error)
+    {
+        range = null;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(packageReference))
+            return false;
+
+        int atIndex = packageReference.LastIndexOf('@');
+        if (atIndex < 0 || !packageReference[(atIndex + 1)..].Contains("..", StringComparison.Ordinal))
+            return false;
+
+        string packageId = packageReference[..atIndex];
+        string versionRange = packageReference[(atIndex + 1)..];
+        int separatorIndex = versionRange.IndexOf("..", StringComparison.Ordinal);
+
+        if (string.IsNullOrWhiteSpace(packageId)
+            || separatorIndex <= 0
+            || separatorIndex + 2 >= versionRange.Length
+            || versionRange.IndexOf("..", separatorIndex + 2, StringComparison.Ordinal) >= 0)
+        {
+            error = $"Error: Invalid package version range '{packageReference}'. Expected Package@A..B.";
+            return false;
+        }
+
+        string startText = versionRange[..separatorIndex];
+        string endText = versionRange[(separatorIndex + 2)..];
+        if (!NuGetVersion.TryParse(startText, out var start))
+        {
+            error = $"Error: Invalid package version '{startText}' in range '{packageReference}'.";
+            return false;
+        }
+
+        if (!NuGetVersion.TryParse(endText, out var end))
+        {
+            error = $"Error: Invalid package version '{endText}' in range '{packageReference}'.";
+            return false;
+        }
+
+        range = new PackageVersionRange(packageId, start, end);
+        return true;
+    }
+}
+
+/// <summary>
+/// One stable address in an ordered package-version vector.
+/// </summary>
+public sealed record PackageVersionAddress
+{
+    internal PackageVersionAddress(int position, NuGetVersion version)
+    {
+        Position = position;
+        Version = version;
+    }
+
+    public int Position { get; }
+    public int Ordinal => Position + 1;
+    public string Selector => $"#{Ordinal}";
+    public NuGetVersion Version { get; }
+}
+
+/// <summary>
+/// An immutable, ordered vector resolved from a package-version range. Resolving the vector
+/// enumerates version metadata only; package payload acquisition remains caller-driven and lazy.
+/// </summary>
+public sealed class PackageVersionVector
+{
+    static readonly IVersionComparer VersionComparer = NuGet.Versioning.VersionComparer.VersionReleaseMetadata;
+    static readonly IComparer<NuGetVersion> SortComparer
+        = Comparer<NuGetVersion>.Create(VersionComparer.Compare);
+
+    PackageVersionVector(
+        string packageId,
+        NuGetVersion start,
+        NuGetVersion end,
+        ImmutableArray<PackageVersionAddress> addresses)
+    {
+        PackageId = packageId;
+        Start = start;
+        End = end;
+        Addresses = addresses;
+    }
+
+    public string PackageId { get; }
+    public NuGetVersion Start { get; }
+    public NuGetVersion End { get; }
+    public ImmutableArray<PackageVersionAddress> Addresses { get; }
+
+    public static async Task<PackageVersionVector> ResolveAsync(
+        HttpClient client,
+        PackageVersionRange range,
+        NuGetSourceOptions? sourceOptions = null,
+        Action<string>? log = null,
+        bool includePrerelease = false)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentNullException.ThrowIfNull(range);
+
+        var versions = await PackageExtractor.GetVersionsAsync(
+            client,
+            range.PackageId,
+            range.IncludesPrerelease || includePrerelease,
+            int.MaxValue,
+            log,
+            sourceOptions);
+
+        if (versions is null)
+            throw new InvalidOperationException($"Could not retrieve versions for package '{range.PackageId}'.");
+
+        return Create(range, versions, includePrerelease);
+    }
+
+    public static PackageVersionVector Create(
+        PackageVersionRange range,
+        IEnumerable<string> availableVersions,
+        bool includePrerelease = false)
+    {
+        ArgumentNullException.ThrowIfNull(range);
+        ArgumentNullException.ThrowIfNull(availableVersions);
+
+        var parsedVersions = availableVersions
+            .Select(version =>
+            {
+                if (!NuGetVersion.TryParse(version, out var parsed))
+                    throw new ArgumentException($"Available version '{version}' is not a valid NuGet version.", nameof(availableVersions));
+                return parsed;
+            })
+            .ToArray();
+        var versions = parsedVersions
+            .Where((version, index) => !parsedVersions
+                .Take(index)
+                .Any(previous => VersionComparer.Equals(previous, version)))
+            .ToArray();
+
+        if (!versions.Any(version => VersionComparer.Equals(version, range.Start)))
+            throw new ArgumentException($"Package '{range.PackageId}' does not contain range endpoint {range.Start}.", nameof(range));
+        if (!versions.Any(version => VersionComparer.Equals(version, range.End)))
+            throw new ArgumentException($"Package '{range.PackageId}' does not contain range endpoint {range.End}.", nameof(range));
+
+        int direction = VersionComparer.Compare(range.Start, range.End);
+        var minimum = direction <= 0 ? range.Start : range.End;
+        var maximum = direction <= 0 ? range.End : range.Start;
+
+        IEnumerable<NuGetVersion> ordered = versions
+            .Where(version =>
+                VersionComparer.Compare(version, minimum) >= 0
+                && VersionComparer.Compare(version, maximum) <= 0
+                && (range.IncludesPrerelease || includePrerelease || !version.IsPrerelease))
+            .OrderBy(version => version, SortComparer);
+
+        if (direction > 0)
+            ordered = ordered.Reverse();
+
+        var addresses = ordered
+            .Select((version, position) => new PackageVersionAddress(position, version))
+            .ToImmutableArray();
+
+        return new PackageVersionVector(range.PackageId, range.Start, range.End, addresses);
+    }
+
+    /// <summary>
+    /// Resolves an exact version, one-based <c>#N</c> index, or endpoint alias.
+    /// </summary>
+    public bool TrySelect(string selector, out PackageVersionAddress? address, out string? error)
+    {
+        address = null;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(selector))
+        {
+            error = "A package range address is required.";
+            return false;
+        }
+
+        if (selector.Equals("first", StringComparison.OrdinalIgnoreCase))
+        {
+            address = Addresses[0];
+            return true;
+        }
+
+        if (selector.Equals("last", StringComparison.OrdinalIgnoreCase))
+        {
+            address = Addresses[^1];
+            return true;
+        }
+
+        if (selector[0] == '#')
+        {
+            if (!int.TryParse(selector.AsSpan(1), out int ordinal) || ordinal < 1 || ordinal > Addresses.Length)
+            {
+                error = $"Range address '{selector}' is outside #1..#{Addresses.Length}.";
+                return false;
+            }
+
+            address = Addresses[ordinal - 1];
+            return true;
+        }
+
+        if (!NuGetVersion.TryParse(selector, out var version))
+        {
+            error = $"Range address '{selector}' must be an exact version, #N, first, or last.";
+            return false;
+        }
+
+        address = Addresses.FirstOrDefault(candidate => VersionComparer.Equals(candidate.Version, version));
+        if (address is null)
+        {
+            error = $"Version '{selector}' is not in range {Start}..{End}.";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/ILInspector.Findings/FindingCorrelation.cs
+++ b/src/ILInspector.Findings/FindingCorrelation.cs
@@ -1,0 +1,305 @@
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+
+namespace ILInspector.Findings;
+
+/// <summary>
+/// A stable caller-supplied address in an ordered inspection history.
+/// </summary>
+public sealed record FindingVersion
+{
+    public FindingVersion(string key, string display, int position)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ArgumentException.ThrowIfNullOrWhiteSpace(display);
+        ArgumentOutOfRangeException.ThrowIfNegative(position);
+        Key = key;
+        Display = display;
+        Position = position;
+    }
+
+    public string Key { get; }
+    public string Display { get; }
+    public int Position { get; }
+}
+
+/// <summary>
+/// One evaluated address and its complete inspection outcome.
+/// </summary>
+public sealed record VersionedFindingInspection<T>(
+    FindingVersion Version,
+    FindingInspection<T> Inspection)
+    where T : notnull
+{
+    public FindingVersion Version { get; }
+        = Version ?? throw new ArgumentNullException(nameof(Version));
+
+    public FindingInspection<T> Inspection { get; }
+        = Inspection ?? throw new ArgumentNullException(nameof(Inspection));
+}
+
+/// <summary>
+/// One occurrence labelled with the address where it was observed.
+/// </summary>
+public sealed record VersionedFinding<T>(
+    FindingVersion Version,
+    Finding<T> Finding)
+    where T : notnull
+{
+    public FindingVersion Version { get; }
+        = Version ?? throw new ArgumentNullException(nameof(Version));
+
+    public Finding<T> Finding { get; }
+        = Finding ?? throw new ArgumentNullException(nameof(Finding));
+}
+
+/// <summary>
+/// The exact identity selected for correlation.
+/// </summary>
+public sealed record FindingCorrelationKey(
+    FindingSubject Subject,
+    FindingDescriptor Descriptor,
+    FindingKey Key)
+{
+    public FindingSubject Subject { get; }
+        = Subject ?? throw new ArgumentNullException(nameof(Subject));
+
+    public FindingDescriptor Descriptor { get; }
+        = Descriptor ?? throw new ArgumentNullException(nameof(Descriptor));
+
+    public FindingKey Key { get; }
+        = Key.IdentityKey is null
+            ? throw new ArgumentException("Finding key must be initialized.", nameof(Key))
+            : Key;
+
+    public static FindingCorrelationKey From<T>(Finding<T> finding)
+        where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(finding);
+        return new(finding.Subject, finding.Descriptor, finding.Key);
+    }
+
+    internal bool Matches<T>(Finding<T> finding)
+        where T : notnull
+        => Subject.Key == finding.Subject.Key
+            && Descriptor.Id == finding.Descriptor.Id
+            && Key == finding.Key;
+}
+
+/// <summary>
+/// Durable N-address history for one exact finding identity. Only observed occurrences belong
+/// here; missing, absent, failed, and unevaluated addresses are not findings.
+/// </summary>
+public sealed record CorrelatedFinding<T>
+    where T : notnull
+{
+    public CorrelatedFinding(
+        FindingCorrelationKey key,
+        ImmutableArray<VersionedFinding<T>> occurrences)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        if (occurrences.IsDefault)
+            throw new ArgumentException("Occurrences must be initialized.", nameof(occurrences));
+        if (occurrences.Any(occurrence => occurrence is null))
+            throw new ArgumentException("Occurrences must not contain null values.", nameof(occurrences));
+
+        for (int i = 0; i < occurrences.Length; i++)
+        {
+            if (!key.Matches(occurrences[i].Finding))
+                throw new ArgumentException("Every occurrence must match the correlated identity.", nameof(occurrences));
+            if (i > 0 && occurrences[i - 1].Version.Position >= occurrences[i].Version.Position)
+                throw new ArgumentException("Occurrences must have unique ascending positions.", nameof(occurrences));
+            if (occurrences.Take(i).Any(previous => previous.Version.Key == occurrences[i].Version.Key))
+                throw new ArgumentException($"Version key '{occurrences[i].Version.Key}' is duplicated.", nameof(occurrences));
+        }
+
+        Key = key;
+        Occurrences = occurrences;
+    }
+
+    public FindingCorrelationKey Key { get; }
+    public ImmutableArray<VersionedFinding<T>> Occurrences { get; }
+}
+
+/// <summary>
+/// The presence of one correlated identity at an evaluated address. Missing means a successful
+/// census did not contain the identity; subject absence and inspection failure remain distinct.
+/// </summary>
+[Union]
+public sealed record FindingCorrelationPoint<T>
+    where T : notnull
+{
+    public FindingCorrelationPoint(Present value) => Value = Guard(value);
+    public FindingCorrelationPoint(Missing value) => Value = Guard(value);
+    public FindingCorrelationPoint(SubjectAbsent value) => Value = Guard(value);
+    public FindingCorrelationPoint(Failed value) => Value = Guard(value);
+
+    static object Guard(object value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return value;
+    }
+
+    public object? Value { get; }
+
+    public sealed record Present
+    {
+        public Present(FindingVersion version, Finding<T> finding)
+        {
+            Version = version ?? throw new ArgumentNullException(nameof(version));
+            Finding = finding ?? throw new ArgumentNullException(nameof(finding));
+        }
+
+        public FindingVersion Version { get; }
+        public Finding<T> Finding { get; }
+    }
+
+    public sealed record Missing
+    {
+        public Missing(FindingVersion version)
+            => Version = version ?? throw new ArgumentNullException(nameof(version));
+
+        public FindingVersion Version { get; }
+    }
+
+    public sealed record SubjectAbsent
+    {
+        public SubjectAbsent(FindingVersion version, string? detail)
+        {
+            Version = version ?? throw new ArgumentNullException(nameof(version));
+            Detail = detail;
+        }
+
+        public FindingVersion Version { get; }
+        public string? Detail { get; }
+    }
+
+    public sealed record Failed
+    {
+        public Failed(FindingVersion version, InspectionError error)
+        {
+            Version = version ?? throw new ArgumentNullException(nameof(version));
+            Error = error ?? throw new ArgumentNullException(nameof(error));
+        }
+
+        public FindingVersion Version { get; }
+        public InspectionError Error { get; }
+    }
+}
+
+/// <summary>
+/// A caller-assembled sparse correlation. It performs no probing or search: callers choose which
+/// addresses to inspect and may project any two evaluated cells through the existing pair fold.
+/// </summary>
+public sealed class FindingCorrelation<T>
+    where T : notnull
+{
+    readonly ImmutableDictionary<string, FindingInspection<T>> _inspections;
+
+    FindingCorrelation(
+        FindingCorrelationKey key,
+        ImmutableArray<VersionedFindingInspection<T>> inspections,
+        ImmutableArray<FindingCorrelationPoint<T>> timeline,
+        CorrelatedFinding<T> finding)
+    {
+        Key = key;
+        Inspections = inspections;
+        Timeline = timeline;
+        Finding = finding;
+        _inspections = inspections.ToImmutableDictionary(item => item.Version.Key, item => item.Inspection);
+    }
+
+    public FindingCorrelationKey Key { get; }
+    public ImmutableArray<VersionedFindingInspection<T>> Inspections { get; }
+    public ImmutableArray<FindingCorrelationPoint<T>> Timeline { get; }
+    public CorrelatedFinding<T> Finding { get; }
+
+    public static FindingCorrelation<T> Create(
+        FindingCorrelationKey key,
+        IEnumerable<VersionedFindingInspection<T>> inspections)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(inspections);
+
+        var evaluated = inspections.ToImmutableArray();
+        if (evaluated.Any(item => item is null))
+            throw new ArgumentException("Inspections must not contain null values.", nameof(inspections));
+
+        var duplicateKey = evaluated
+            .GroupBy(item => item.Version.Key, StringComparer.Ordinal)
+            .FirstOrDefault(group => group.Count() > 1);
+        if (duplicateKey is not null)
+            throw new ArgumentException($"Version key '{duplicateKey.Key}' is duplicated.", nameof(inspections));
+
+        var duplicatePosition = evaluated
+            .GroupBy(item => item.Version.Position)
+            .FirstOrDefault(group => group.Count() > 1);
+        if (duplicatePosition is not null)
+            throw new ArgumentException($"Version position {duplicatePosition.Key} is duplicated.", nameof(inspections));
+
+        var ordered = evaluated.OrderBy(item => item.Version.Position).ToImmutableArray();
+        var timeline = ImmutableArray.CreateBuilder<FindingCorrelationPoint<T>>(ordered.Length);
+        var occurrences = ImmutableArray.CreateBuilder<VersionedFinding<T>>();
+
+        foreach (var item in ordered)
+        {
+            switch (item.Inspection)
+            {
+                case FindingInspection<T>.Complete complete:
+                    var matches = complete.Findings.Where(key.Matches).Take(2).ToArray();
+                    if (matches.Length > 1)
+                    {
+                        throw new ArgumentException(
+                            $"Inspection '{item.Version.Key}' contains duplicate occurrences for the correlated identity.",
+                            nameof(inspections));
+                    }
+
+                    if (matches.Length == 1)
+                    {
+                        occurrences.Add(new(item.Version, matches[0]));
+                        timeline.Add(new FindingCorrelationPoint<T>.Present(item.Version, matches[0]));
+                    }
+                    else
+                    {
+                        timeline.Add(new FindingCorrelationPoint<T>.Missing(item.Version));
+                    }
+                    break;
+
+                case FindingInspection<T>.Absent absent:
+                    timeline.Add(new FindingCorrelationPoint<T>.SubjectAbsent(item.Version, absent.Detail));
+                    break;
+
+                case FindingInspection<T>.Failed failed:
+                    timeline.Add(new FindingCorrelationPoint<T>.Failed(item.Version, failed.Error));
+                    break;
+            }
+        }
+
+        return new FindingCorrelation<T>(
+            key,
+            ordered,
+            timeline.MoveToImmutable(),
+            new CorrelatedFinding<T>(key, occurrences.ToImmutable()));
+    }
+
+    public FindingComparison<T> Compare(
+        string oldVersionKey,
+        string newVersionKey,
+        FindingMatchOptions? matchOptions = null,
+        int acceptanceThreshold = 100)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(oldVersionKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(newVersionKey);
+
+        if (!_inspections.TryGetValue(oldVersionKey, out var oldInspection))
+            throw new ArgumentException($"Version '{oldVersionKey}' has not been evaluated.", nameof(oldVersionKey));
+        if (!_inspections.TryGetValue(newVersionKey, out var newInspection))
+            throw new ArgumentException($"Version '{newVersionKey}' has not been evaluated.", nameof(newVersionKey));
+
+        return FindingComparison.Compare(
+            oldInspection,
+            newInspection,
+            matchOptions,
+            acceptanceThreshold);
+    }
+}

--- a/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
@@ -47,6 +47,69 @@ public class FindingPilotTests
     }
 
     [Fact]
+    public void FindingCorrelation_PreservesMissingAbsentAndFailedAddresses()
+    {
+        var present = Atoms("target")[0];
+        var key = FindingCorrelationKey.From(present);
+        var error = new InspectionError(Subject, Descriptor, "declined");
+        var correlation = FindingCorrelation<string>.Create(
+            key,
+            [
+                new(new FindingVersion("v1", "1.0.0", 0), new FindingInspection<string>.Complete([])),
+                new(new FindingVersion("v2", "2.0.0", 1), new FindingInspection<string>.Absent("no body")),
+                new(new FindingVersion("v3", "3.0.0", 2), new FindingInspection<string>.Failed(error)),
+                new(new FindingVersion("v4", "4.0.0", 3), new FindingInspection<string>.Complete([present])),
+            ]);
+
+        Assert.True(correlation.Timeline[0] is FindingCorrelationPoint<string>.Missing);
+        Assert.True(correlation.Timeline[1] is FindingCorrelationPoint<string>.SubjectAbsent);
+        Assert.True(correlation.Timeline[2] is FindingCorrelationPoint<string>.Failed);
+        Assert.True(correlation.Timeline[3] is FindingCorrelationPoint<string>.Present);
+        var occurrence = Assert.Single(correlation.Finding.Occurrences);
+        Assert.Equal("v4", occurrence.Version.Key);
+        Assert.Same(present, occurrence.Finding);
+    }
+
+    [Fact]
+    public void FindingCorrelation_ProjectsAnyEvaluatedPairThroughTheSharedFold()
+    {
+        var present = Atoms("target")[0];
+        var correlation = FindingCorrelation<string>.Create(
+            FindingCorrelationKey.From(present),
+            [
+                new(new FindingVersion("old", "1.0.0", 0), new FindingInspection<string>.Complete([])),
+                new(new FindingVersion("new", "3.0.0", 2), new FindingInspection<string>.Complete([present])),
+            ]);
+
+        var comparison = correlation.Compare("old", "new") switch
+        {
+            FindingComparison<string>.Complete value => value,
+            FindingComparison<string>.Failed failed => throw new Xunit.Sdk.XunitException(failed.Failure),
+        };
+        Assert.Equal(PairKind.Added, Assert.Single(comparison.Pairs).Kind);
+        Assert.Throws<ArgumentException>(() => correlation.Compare("unevaluated", "new"));
+    }
+
+    [Fact]
+    public void FindingCorrelation_RejectsAmbiguousOrDuplicateAddresses()
+    {
+        var present = Atoms("target")[0];
+        var key = FindingCorrelationKey.From(present);
+
+        Assert.Throws<ArgumentException>(() => FindingCorrelation<string>.Create(
+            key,
+            [
+                new(new FindingVersion("same", "1.0.0", 0), new FindingInspection<string>.Complete([])),
+                new(new FindingVersion("same", "2.0.0", 1), new FindingInspection<string>.Complete([])),
+            ]));
+        Assert.Throws<ArgumentException>(() => FindingCorrelation<string>.Create(
+            key,
+            [
+                new(new FindingVersion("v1", "1.0.0", 0), new FindingInspection<string>.Complete([present, present])),
+            ]));
+    }
+
+    [Fact]
     public void FindingContracts_KeepObservationsTransitionsAndFailuresDistinct()
     {
         var stringFinding = Atoms("a")[0];

--- a/src/dotnet-inspect.Tests/PackageVersionTests.cs
+++ b/src/dotnet-inspect.Tests/PackageVersionTests.cs
@@ -76,6 +76,59 @@ public class PackageVersionTests
     }
 
     [Fact]
+    public async Task Versions_WithRange_ListsTheInclusiveAddressVector()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+        var args = new[] { "package", "System.Text.Json@8.0.0..8.0.5", "--versions" };
+
+        var (exit, output, _) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(root.Parse(args).InvokeAsync().Result));
+
+        Assert.Equal(0, exit);
+        Assert.Equal(
+            ["8.0.0", "8.0.1", "8.0.2", "8.0.3", "8.0.4", "8.0.5"],
+            output.Trim().Split('\n', StringSplitOptions.RemoveEmptyEntries));
+    }
+
+    [Fact]
+    public async Task Type_WithRange_RequiresAnExplicitAddress()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+        var args = new[]
+        {
+            "type", "JsonSerializer",
+            "--package", "System.Text.Json@8.0.0..8.0.5",
+        };
+
+        var (exit, _, error) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(root.Parse(args).InvokeAsync().Result));
+
+        Assert.Equal(1, exit);
+        Assert.Contains("requires --at <version|#N|first|last>", error);
+        Assert.Contains("package System.Text.Json@8.0.0..8.0.5 --versions", error);
+    }
+
+    [Fact]
+    public async Task Type_WithRangeAddress_InspectsOnlyTheSelectedVersion()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+        var args = new[]
+        {
+            "type", "JsonSerializer",
+            "--package", "System.Text.Json@8.0.0..8.0.5",
+            "--at", "#6",
+            "--verbose",
+        };
+
+        var (exit, output, error) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(root.Parse(args).InvokeAsync().Result));
+
+        Assert.Equal(0, exit);
+        Assert.Contains("JsonSerializer", output);
+        Assert.Contains("to 8.0.5 (#6 of #6)", error);
+    }
+
+    [Fact]
     public async Task Version_Bare_MatchesRouterBehavior()
     {
         await EnsurePackageCached("System.CommandLine");

--- a/src/dotnet-inspect.Tests/PackageVersionTests.cs
+++ b/src/dotnet-inspect.Tests/PackageVersionTests.cs
@@ -129,6 +129,27 @@ public class PackageVersionTests
     }
 
     [Fact]
+    public async Task Member_WithRangeAddress_UsesSelectedVersionForSourceAcquisition()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+        var args = new[]
+        {
+            "member", "Serilog.Core.Logger", "Write:1",
+            "--package", "Serilog@4.0.0..4.2.0",
+            "--at", "4.2.0",
+            "-S", "Original Source",
+            "--print",
+        };
+
+        var (exit, output, error) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(root.Parse(args).InvokeAsync().Result));
+
+        Assert.Equal(0, exit);
+        Assert.Contains("public void Write(LogEvent logEvent)", output);
+        Assert.DoesNotContain("Invalid package version", error);
+    }
+
+    [Fact]
     public async Task Version_Bare_MatchesRouterBehavior()
     {
         await EnsurePackageCached("System.CommandLine");

--- a/src/dotnet-inspect.Tests/PackageVersionVectorTests.cs
+++ b/src/dotnet-inspect.Tests/PackageVersionVectorTests.cs
@@ -1,0 +1,112 @@
+using DotnetInspector.Packages;
+
+namespace DotnetInspector.Tests;
+
+public class PackageVersionVectorTests
+{
+    static readonly string[] Versions =
+    [
+        "1.0.0",
+        "1.1.0-alpha.1",
+        "1.1.0",
+        "1.2.0-preview.1",
+        "1.2.0",
+        "2.0.0",
+    ];
+
+    [Fact]
+    public void Create_ResolvesAnInclusiveVectorInCallerDirection()
+    {
+        Assert.True(PackageVersionRange.TryParse("Example@1.0.0..1.2.0", out var range, out var error));
+        Assert.Null(error);
+
+        var ascending = PackageVersionVector.Create(range!, Versions);
+        Assert.Equal(["1.0.0", "1.1.0", "1.2.0"], ascending.Addresses.Select(address => address.Version.ToString()));
+
+        Assert.True(PackageVersionRange.TryParse("Example@1.2.0..1.0.0", out range, out error));
+        var descending = PackageVersionVector.Create(range!, Versions);
+        Assert.Equal(["1.2.0", "1.1.0", "1.0.0"], descending.Addresses.Select(address => address.Version.ToString()));
+    }
+
+    [Fact]
+    public void Create_IncludesPrereleasesOnlyWhenAnEndpointRequiresThem()
+    {
+        Assert.True(PackageVersionRange.TryParse("Example@1.1.0-alpha.1..1.2.0", out var range, out _));
+
+        var vector = PackageVersionVector.Create(range!, Versions);
+
+        Assert.Equal(
+            ["1.1.0-alpha.1", "1.1.0", "1.2.0-preview.1", "1.2.0"],
+            vector.Addresses.Select(address => address.Version.ToString()));
+    }
+
+    [Fact]
+    public void Create_CanExplicitlyIncludePrereleasesBetweenStableEndpoints()
+    {
+        PackageVersionRange.TryParse("Example@1.0.0..1.2.0", out var range, out _);
+
+        var vector = PackageVersionVector.Create(range!, Versions, includePrerelease: true);
+
+        Assert.Equal(
+            ["1.0.0", "1.1.0-alpha.1", "1.1.0", "1.2.0-preview.1", "1.2.0"],
+            vector.Addresses.Select(address => address.Version.ToString()));
+    }
+
+    [Theory]
+    [InlineData("#1", "1.0.0")]
+    [InlineData("#3", "1.2.0")]
+    [InlineData("first", "1.0.0")]
+    [InlineData("last", "1.2.0")]
+    [InlineData("1.1.0", "1.1.0")]
+    public void TrySelect_ResolvesStableAddresses(string selector, string expectedVersion)
+    {
+        PackageVersionRange.TryParse("Example@1.0.0..1.2.0", out var range, out _);
+        var vector = PackageVersionVector.Create(range!, Versions);
+
+        Assert.True(vector.TrySelect(selector, out var address, out var error));
+        Assert.Null(error);
+        Assert.Equal(expectedVersion, address!.Version.ToString());
+    }
+
+    [Fact]
+    public void TrySelect_RejectsAddressesOutsideTheVector()
+    {
+        PackageVersionRange.TryParse("Example@1.0.0..1.2.0", out var range, out _);
+        var vector = PackageVersionVector.Create(range!, Versions);
+
+        Assert.False(vector.TrySelect("#4", out _, out var indexError));
+        Assert.Contains("#1..#3", indexError);
+        Assert.False(vector.TrySelect("2.0.0", out _, out var versionError));
+        Assert.Contains("not in range", versionError);
+    }
+
+    [Fact]
+    public void Create_RequiresPublishedEndpoints()
+    {
+        PackageVersionRange.TryParse("Example@1.0.1..1.2.0", out var range, out _);
+
+        var error = Assert.Throws<ArgumentException>(
+            () => PackageVersionVector.Create(range!, Versions));
+
+        Assert.Contains("does not contain range endpoint 1.0.1", error.Message);
+    }
+
+    [Theory]
+    [InlineData("Example@1.0.0", false, null)]
+    [InlineData("Example@1.0.0..", false, "Expected Package@A..B")]
+    [InlineData("Example@bad..2.0.0", false, "Invalid package version 'bad'")]
+    public void TryParse_DistinguishesNonRangesFromInvalidRanges(
+        string value,
+        bool expectedResult,
+        string? expectedError)
+    {
+        bool result = PackageVersionRange.TryParse(value, out var range, out var error);
+
+        Assert.Equal(expectedResult, result);
+        Assert.Null(range);
+        if (expectedError is null)
+            Assert.Null(error);
+        else
+            Assert.Contains(expectedError, error);
+    }
+}

--- a/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
@@ -24,6 +24,7 @@ public class MemberOptionsParserTests
 
         var argsArg = new Argument<string[]>("args") { Arity = ArgumentArity.ZeroOrMore };
         var packageOption = new Option<string?>("--package");
+        var atOption = new Option<string?>("--at");
         var assemblyOption = new Option<string?>("--library");
         var platformOption = new Option<string?>("--platform");
         var frameworkOption = new Option<string?>("--framework");
@@ -45,6 +46,7 @@ public class MemberOptionsParserTests
 
         memberCommand.Arguments.Add(argsArg);
         memberCommand.Options.Add(packageOption);
+        memberCommand.Options.Add(atOption);
         memberCommand.Options.Add(assemblyOption);
         memberCommand.Options.Add(platformOption);
         memberCommand.Options.Add(frameworkOption);
@@ -76,7 +78,7 @@ public class MemberOptionsParserTests
             argsArg, packageOption, assemblyOption, platformOption, frameworkOption, tfmOption,
             allOption, memberOption, ctorOption, compactOption, opts.OneLine, opts.NoHeaders,
             unsafeOption, indexOption, selectOption, kindOption,
-            binOption, callerProjectOption, callerPackageOption);
+            binOption, callerProjectOption, callerPackageOption, atOption);
 
         return (root, opts, args);
     }
@@ -104,6 +106,18 @@ public class MemberOptionsParserTests
         Assert.Equal("System.Text.Json", options.PackagePath);
         Assert.Null(options.PlatformAssembly);
         Assert.Null(options.AssemblyPath);
+    }
+
+    [Fact]
+    public async Task PackageRangeAddress_IsPreservedForLazyResolution()
+    {
+        var options = await ParseSuccessAsync(
+            "member", "JsonSerializer",
+            "--package", "System.Text.Json@8.0.0..9.0.0",
+            "--at", "8.0.5");
+
+        Assert.Equal("System.Text.Json@8.0.0..9.0.0", options.PackagePath);
+        Assert.Equal("8.0.5", options.PackageRangeAddress);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/Parsers/TypeOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/TypeOptionsParserTests.cs
@@ -15,6 +15,7 @@ public class TypeOptionsParserTests
 
         var argsArg = new Argument<string[]>("args") { Arity = ArgumentArity.ZeroOrMore };
         var packageOption = new Option<string?>("--package");
+        var atOption = new Option<string?>("--at");
         var assemblyOption = new Option<string?>("--library");
         var platformOption = new Option<string?>("--platform");
         var projectOption = new Option<string?>("--project");
@@ -30,6 +31,7 @@ public class TypeOptionsParserTests
 
         typeCommand.Arguments.Add(argsArg);
         typeCommand.Options.Add(packageOption);
+        typeCommand.Options.Add(atOption);
         typeCommand.Options.Add(assemblyOption);
         typeCommand.Options.Add(platformOption);
         typeCommand.Options.Add(projectOption);
@@ -56,7 +58,7 @@ public class TypeOptionsParserTests
         var args = new TypeOptionsParser.TypeCommandArgs(
             argsArg, packageOption, assemblyOption, platformOption, projectOption, frameworkOption, tfmOption,
             allOption, typeFilterOption, compactOption, opts.OneLine, opts.NoHeaders,
-            shapeOption, unsafeOption, memberOption, kindOption);
+            shapeOption, unsafeOption, memberOption, kindOption, atOption);
 
         return (root, opts, args);
     }
@@ -83,6 +85,18 @@ public class TypeOptionsParserTests
         Assert.Null(options.PackagePath);
         Assert.Null(options.AssemblyPath);
         Assert.Null(options.PlatformAssembly);
+    }
+
+    [Fact]
+    public async Task PackageRangeAddress_IsPreservedForLazyResolution()
+    {
+        var options = await ParseSuccessAsync(
+            "type", "JsonSerializer",
+            "--package", "System.Text.Json@8.0.0..9.0.0",
+            "--at", "#2");
+
+        Assert.Equal("System.Text.Json@8.0.0..9.0.0", options.PackagePath);
+        Assert.Equal("#2", options.PackageRangeAddress);
     }
 
     [Fact]

--- a/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
@@ -50,7 +50,8 @@ public static class ApiCommandDefinitions
             Arity = ArgumentArity.ZeroOrMore
         };
 
-        var packageOption = new Option<string?>("--package") { Description = "Source: package (file, name, or name@version)" };
+        var packageOption = new Option<string?>("--package") { Description = "Source: package (file, name, name@version, or name@A..B)" };
+        var atOption = new Option<string?>("--at") { Description = "Address in a package range: exact version, #N, first, or last" };
         var assemblyOption = new Option<string?>("--library") { Description = "Source: library path (local file, or relative within package)" };
         var platformOption = new Option<string?>("--platform") { Description = "Source: platform library (e.g., System.Text.Json)" };
         var projectOption = new Option<string?>("--project") { Description = "Source: restored project.assets.json context" };
@@ -77,6 +78,7 @@ public static class ApiCommandDefinitions
 
         typeCommand.Arguments.Add(argsArg);
         typeCommand.Options.Add(packageOption);
+        typeCommand.Options.Add(atOption);
         typeCommand.Options.Add(assemblyOption);
         typeCommand.Options.Add(platformOption);
         typeCommand.Options.Add(projectOption);
@@ -107,7 +109,7 @@ public static class ApiCommandDefinitions
         var commandArgs = new TypeOptionsParser.TypeCommandArgs(
             argsArg, packageOption, assemblyOption, platformOption, projectOption, frameworkOption, tfmOption,
             allOption, typeFilterOption, compactOption, opts.OneLine,
-            opts.NoHeaders, shapeOption, unsafeOption, memberOption, kindOption);
+            opts.NoHeaders, shapeOption, unsafeOption, memberOption, kindOption, atOption);
 
         typeCommand.SetAction(async (parseResult, ct) =>
         {
@@ -164,7 +166,8 @@ public static class ApiCommandDefinitions
             Arity = ArgumentArity.ZeroOrMore
         };
 
-        var packageOption = new Option<string?>("--package") { Description = "Source: package (file, name, or name@version)" };
+        var packageOption = new Option<string?>("--package") { Description = "Source: package (file, name, name@version, or name@A..B)" };
+        var atOption = new Option<string?>("--at") { Description = "Address in a package range: exact version, #N, first, or last" };
         var assemblyOption = new Option<string?>("--library") { Description = "Source: library path (local file, or relative within package)" };
         var platformOption = new Option<string?>("--platform") { Description = "Source: platform library (e.g., System.Text.Json)" };
         var frameworkOption = new Option<string?>("--framework") { Description = "Source: platform framework (runtime, aspnetcore, netstandard). @version for specific" };
@@ -206,6 +209,7 @@ public static class ApiCommandDefinitions
 
         memberCommand.Arguments.Add(argsArg);
         memberCommand.Options.Add(packageOption);
+        memberCommand.Options.Add(atOption);
         memberCommand.Options.Add(assemblyOption);
         memberCommand.Options.Add(platformOption);
         memberCommand.Options.Add(frameworkOption);
@@ -242,7 +246,7 @@ public static class ApiCommandDefinitions
             allOption, memberOption, ctorOption,
             compactOption, opts.OneLine, opts.NoHeaders,
             unsafeOption, indexOption, selectOption, kindOption,
-            binOption, callerProjectOption, callerPackageOption);
+            binOption, callerProjectOption, callerPackageOption, atOption);
 
         memberCommand.SetAction(async (parseResult, ct) =>
         {

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -35,7 +35,8 @@ public static class MemberOptionsParser
         Option<string[]> KindOption,
         Option<string[]> BinOption,
         Option<string[]> ProjectOption,
-        Option<string[]> CallerPackageOption);
+        Option<string[]> CallerPackageOption,
+        Option<string?> AtOption);
 
     /// <summary>
     /// Result of parsing member command options.
@@ -257,6 +258,7 @@ public static class MemberOptionsParser
         {
             TypeName = typeName,
             PackagePath = source.PackagePath,
+            PackageRangeAddress = parseResult.GetValue(args.AtOption),
             AssemblyPath = source.AssemblyPath,
             PlatformAssembly = source.PlatformAssembly,
             ProjectPath = projectSourcePath,

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -32,7 +32,8 @@ public static class TypeOptionsParser
         Option<bool> ShapeOption,
         Option<bool> UnsafeOption,
         Option<string[]> MemberOption,
-        Option<string[]> KindOption);
+        Option<string[]> KindOption,
+        Option<string?> AtOption);
 
     /// <summary>
     /// Result of parsing type command options.
@@ -150,6 +151,7 @@ public static class TypeOptionsParser
         {
             TypeName = source.TypeName,
             PackagePath = source.PackagePath,
+            PackageRangeAddress = parseResult.GetValue(args.AtOption),
             AssemblyPath = source.AssemblyPath,
             PlatformAssembly = source.PlatformAssembly,
             ProjectPath = projectPath,

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -56,7 +56,12 @@ public static class MemberCommand
         var context = source.Context;
         var logger = context.Logger;
 
-        options = options with { ProjectAssetsPath = projectAssetsPath };
+        options = options with
+        {
+            PackagePath = source.ResolvedPackagePath,
+            PackageRangeAddress = null,
+            ProjectAssetsPath = projectAssetsPath,
+        };
 
         try
         {

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -147,6 +147,42 @@ public class PackageCommand
         // Handle --versions mode: list versions and exit early
         if (options.ListVersions)
         {
+            PackageVersionRange? range = null;
+            string? rangeError = null;
+            bool isRange = !File.Exists(packageArgs[0])
+                && PackageVersionRange.TryParse(packageArgs[0], out range, out rangeError);
+            if (rangeError is not null)
+            {
+                Console.Error.WriteLine(rangeError);
+                return 1;
+            }
+
+            if (isRange)
+            {
+                try
+                {
+                    var vector = await PackageVersionVector.ResolveAsync(
+                        context.HttpClient,
+                        range!,
+                        options.SourceOptions,
+                        logger.Log,
+                        options.IncludePrerelease);
+                    var rangeVersions = vector.Addresses
+                        .Take(options.Limit ?? int.MaxValue)
+                        .Select(address => address.Version.ToNormalizedString());
+                    OutputFormatter.WriteStringList(rangeVersions, "Version", "Version", options.Tsv, options.Jsonl, Console.Out);
+                    return 0;
+                }
+                catch (Exception ex) when (ex is HttpRequestException
+                    or IOException
+                    or InvalidOperationException
+                    or ArgumentException)
+                {
+                    Console.Error.WriteLine($"Error: {ex.Message}");
+                    return 1;
+                }
+            }
+
             var (versionQueryName, versionQueryPinned) = PackageExtractor.ParsePackageReference(packageArgs[0]);
             string normalizedName = versionQueryName.ToLowerInvariant();
             if (string.Equals(versionQueryPinned, "latest", StringComparison.OrdinalIgnoreCase))
@@ -230,6 +266,20 @@ public class PackageCommand
             OutputFormatter.WriteStringList(versions, "Version", "Version", options.Tsv, options.Jsonl, Console.Out);
 
             return 0;
+        }
+
+        string? packageRangeError = null;
+        if (!File.Exists(packageArgs[0])
+            && PackageVersionRange.TryParse(packageArgs[0], out _, out packageRangeError))
+        {
+            Console.Error.WriteLine(
+                $"Error: Package range '{packageArgs[0]}' requires --versions for package inspection.");
+            return 1;
+        }
+        if (packageRangeError is not null)
+        {
+            Console.Error.WriteLine(packageRangeError);
+            return 1;
         }
 
         var client = context.HttpClient;

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -67,7 +67,12 @@ public static class TypeCommand
         var context = source.Context;
         var logger = context.Logger;
 
-        options = options with { ProjectAssetsPath = projectAssetsPath };
+        options = options with
+        {
+            PackagePath = source.ResolvedPackagePath,
+            PackageRangeAddress = null,
+            ProjectAssetsPath = projectAssetsPath,
+        };
 
         try
         {

--- a/src/dotnet-inspect/Inspectors/ApiSourceResolver.cs
+++ b/src/dotnet-inspect/Inspectors/ApiSourceResolver.cs
@@ -37,10 +37,70 @@ internal static class ApiSourceResolver
         string? apiVersion = null;
         string? projectAssetsPath = null;
         var typeName = options.TypeName;
+        var packagePath = options.PackagePath;
 
-        if (!string.IsNullOrEmpty(options.PackagePath))
+        if (!string.IsNullOrEmpty(packagePath) && !File.Exists(packagePath))
         {
-            var outcome = await PackageExtractor.ExtractPackageAsync(context.HttpClient, options.PackagePath, context.Logger.Log, "inspect-api", options.SourceOptions);
+            bool isRange = PackageVersionRange.TryParse(packagePath, out var range, out var rangeError);
+            if (rangeError is not null)
+            {
+                Console.Error.WriteLine(rangeError);
+                return (null!, 1);
+            }
+
+            if (isRange)
+            {
+                if (string.IsNullOrWhiteSpace(options.PackageRangeAddress))
+                {
+                    Console.Error.WriteLine(
+                        $"Error: Package range '{packagePath}' requires --at <version|#N|first|last>.");
+                    Console.Error.WriteLine(
+                        $"List its addressable versions with 'dotnet-inspect package {packagePath} --versions'.");
+                    return (null!, 1);
+                }
+
+                try
+                {
+                    var vector = await PackageVersionVector.ResolveAsync(
+                        context.HttpClient,
+                        range!,
+                        options.SourceOptions,
+                        context.Logger.Log);
+                    if (!vector.TrySelect(options.PackageRangeAddress, out var address, out var addressError))
+                    {
+                        Console.Error.WriteLine($"Error: {addressError}");
+                        return (null!, 1);
+                    }
+
+                    packagePath = $"{range!.PackageId}@{address!.Version.ToNormalizedString()}";
+                    context.Logger.Log(
+                        $"Resolved {range.PackageId}@{range.Start}..{range.End} {options.PackageRangeAddress} "
+                        + $"to {address.Version} ({address.Selector} of #{vector.Addresses.Length})");
+                }
+                catch (Exception ex) when (ex is HttpRequestException
+                    or IOException
+                    or InvalidOperationException
+                    or ArgumentException)
+                {
+                    Console.Error.WriteLine($"Error: {ex.Message}");
+                    return (null!, 1);
+                }
+            }
+            else if (!string.IsNullOrWhiteSpace(options.PackageRangeAddress))
+            {
+                Console.Error.WriteLine("Error: --at requires a package version range such as Package@A..B.");
+                return (null!, 1);
+            }
+        }
+        else if (!string.IsNullOrWhiteSpace(options.PackageRangeAddress))
+        {
+            Console.Error.WriteLine("Error: --at requires --package Package@A..B.");
+            return (null!, 1);
+        }
+
+        if (!string.IsNullOrEmpty(packagePath))
+        {
+            var outcome = await PackageExtractor.ExtractPackageAsync(context.HttpClient, packagePath, context.Logger.Log, "inspect-api", options.SourceOptions);
             if (!outcome.IsSuccess)
             {
                 Console.Error.WriteLine($"Error: {outcome.ErrorMessage}");

--- a/src/dotnet-inspect/Inspectors/ApiSourceResolver.cs
+++ b/src/dotnet-inspect/Inspectors/ApiSourceResolver.cs
@@ -12,6 +12,7 @@ internal sealed record ApiSourceResult(
     string? RuntimeAssemblyPath,
     string? PackageName,
     string? PackageVersion,
+    string? ResolvedPackagePath,
     string? ApiSource,
     string? ApiVersion,
     string? SelectedTfm,
@@ -348,7 +349,7 @@ internal static class ApiSourceResolver
             }
         }
 
-        return (new ApiSourceResult(searchPath, runtimeAssemblyPath, packageName, packageVersion,
+        return (new ApiSourceResult(searchPath, runtimeAssemblyPath, packageName, packageVersion, packagePath,
             apiSource, apiVersion, selectedTfm, projectAssetsPath, tempDir, typeName, context), null);
     }
 }

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -16,6 +16,8 @@ public partial record ApiOptions
 
     // Source resolution
     public string? PackagePath { get; init; }
+    /// <summary>Explicit address within a package version range: version, #N, first, or last.</summary>
+    public string? PackageRangeAddress { get; init; }
     public string? AssemblyPath { get; init; }
     public string? PlatformAssembly { get; init; }
     public string? ProjectPath { get; init; }


### PR DESCRIPTION
## Summary

- resolve `Package@A..B` as an inclusive, caller-directed version vector without acquiring package payloads
- require an explicit `--at <version|#N|first|last>` cell for `type` and `member`, then acquire only that pinned package
- add sparse version-labelled Finding correlation with distinct present, missing, absent, failed, and unevaluated semantics
- document the agent-owned onset/bisect workflow

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `dotnet run --project src/ILInspector.Instructions.Tests -c Release --no-build` (103 passed)
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build` (1719 run; the sole dirty-source SourceLink mismatch passed after rebuilding the committed head)
- focused range/correlation/parser tests (179 passed across targeted runs)
- live `System.Text.Json@8.0.0..8.0.5` vector, type, and member probes
- markdownlint on all changed Markdown

## Review

Two isolated adversarial reviews completed cleanly: Claude Opus 4.8 and Gemini 3.1 Pro.