### PR TITLE
Add CSharp formatter seam

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -536,7 +536,7 @@ Research overlay bridge, and the application layer:
 ├─────────────────────────────────────────────────────────────┤
 │  ILInspector.CSharp (C# type views)                         │
 │                                                             │
-│  CSharpTypePrinter, namespace/type skeleton composition      │
+│  CSharpFormatter, CSharpTypePrinter, type-view composition   │
 ├─────────────────────────────────────────────────────────────┤
 │  ILInspector.Metadata (Domain provider — PE/Assembly)       │
 │                                                             │
@@ -548,7 +548,7 @@ Research overlay bridge, and the application layer:
 
 - **Domain providers** are application-agnostic. They know about NuGet packages and PE files, not about dotnet-inspect.
 - **Services** return DTOs (`NuspecData`, `DepsJsonData`, `PackageMetadata`), never mutate app types. They use `Action<string>?` for logging instead of app-specific logger types.
-- **CSharp** owns C# spelling and body-independent type views over Metadata models. It does not depend on Decompiler or Research.
+- **CSharp** owns C# spelling and body-independent type views over Metadata models. Consumers retain API selection, grouping, and output rendering, then use `CSharpFormatter` for declaration text. `CSharpTypePrinter` composes those declarations into namespace/type units. CSharp does not depend on Decompiler or Research. The formatter temporarily delegates to Metadata's compatibility declaration writer while structured spelling primitives move to their owning layer.
 - **Analysis** owns R1 whole-assembly evidence and must not depend on the decompiler IR, Roslyn, or inspected-assembly loading.
 - **Decompiler** owns R2 method projection and rendering evidence, not whole-assembly analysis indexes.
 - **Research** is the only bridge between Analysis and Decompiler evidence. New overlay facts register as producers; presenters consume the merged offset-keyed overlay.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -550,7 +550,7 @@ Research overlay bridge, and the application layer:
 - **Services** return DTOs (`NuspecData`, `DepsJsonData`, `PackageMetadata`), never mutate app types. They use `Action<string>?` for logging instead of app-specific logger types.
 - **CSharp** owns C# spelling and body-independent type views over Metadata models. Consumers retain API selection, grouping, and output rendering, then use `CSharpFormatter` for declaration text. `CSharpTypePrinter` composes those declarations into namespace/type units. CSharp does not depend on Decompiler or Research. The formatter temporarily delegates to Metadata's compatibility declaration writer while structured spelling primitives move to their owning layer.
 - **Analysis** owns R1 whole-assembly evidence and must not depend on the decompiler IR, Roslyn, or inspected-assembly loading.
-- **Decompiler** owns R2 method projection and rendering evidence, not whole-assembly analysis indexes.
+- **Decompiler** owns R2 method projection and rendering evidence, not whole-assembly analysis indexes. It consumes CSharp for body-independent declaration spelling and combines those declarations with reconstructed bodies.
 - **Research** is the only bridge between Analysis and Decompiler evidence. New overlay facts register as producers; presenters consume the merged offset-keyed overlay.
 - **Models** are pure data with no Markout references. JSON conditional attributes (`[JsonIgnore(Condition = ...)]`) are acceptable since they control data serialization, not presentation.
 - **Views** wrap models and own all Markout attributes, sections, field builders, and computed display properties. They are the only types registered in `MarkoutContext`.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -8,7 +8,7 @@ It is built for both humans and agents. Markdown is the default output because h
 
 - `src/dotnet-inspect/` contains the CLI, command routing, parsers, options, output views, section descriptors, and inspectors.
 - `src/ILInspector.Metadata/` reads PE metadata, API surfaces, SourceLink/PDB data, method classification, and assembly details. `MetadataFindings` projects API type/member observations and comparisons onto the shared Finding spine while retaining compatibility classification through `ApiDiff`.
-- `src/ILInspector.CSharp/` is the lightweight C# spelling and type-view layer over Metadata shapes. It composes body-independent namespace/type skeletons without taking a Decompiler or Research dependency.
+- `src/ILInspector.CSharp/` is the lightweight C# spelling and type-view layer over Metadata shapes. `CSharpFormatter` projects selected Metadata declarations into C# text; `CSharpTypePrinter` composes body-independent namespace/type skeletons. The layer does not select APIs or take a Decompiler or Research dependency. During migration, the facade delegates to Metadata's compatibility declaration writer.
 - `src/ILInspector.Analysis/` indexes IL method-body evidence such as direct call sites, allocation occurrences, method signals, and whole-assembly leverage without decompiling to C#.
 - `src/ILInspector.Analysis.App/` is a temporary console harness for exercising Analysis queries until CLI wiring exists.
 - `src/ILInspector.ControlFlow/` contains shared block-edge, dominance, and dataflow kernels used below Analysis and Decompiler without depending on either.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -17,7 +17,7 @@ It is built for both humans and agents. Markdown is the default output because h
 - `src/ILInspector.Text/` provides the reusable `TextFindings` API for exact, ordered line inspection and generic text comparison on the shared Finding spine.
 - `src/DotnetInspector.Packages/` handles NuGet package extraction, package/source caches, feeds, symbol package acquisition, and version resolution.
 - `src/DotnetInspector.Services/` contains shared services such as platform/package resolution, dependency resolution, signatures, source fetching, and nuspec parsing.
-- `src/ILInspector.Decompiler/` emits lowered C#, raw IL, and structural annotated IL from method bodies.
+- `src/ILInspector.Decompiler/` emits lowered C#, raw IL, and structural annotated IL from method bodies. It consumes `ILInspector.CSharp` for body-independent type and member declaration spelling.
 - `src/ILInspector.Research/` owns the offset-keyed fact overlay above Analysis and Decompiler: its registry orders fact producers, joins R1 analysis occurrences with R2 decompiler projections, and projects facts into the Annotated Source, annotated IL, and Facts views used by `member`.
 
 ## Agent contract

--- a/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
@@ -1,0 +1,95 @@
+using ILInspector.Metadata;
+
+namespace ILInspector.CSharp.Tests;
+
+public sealed class CSharpFormatterTests
+{
+    [Fact]
+    public void FormatsStructuredMemberDeclaration()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Container`1",
+            Kind = "class",
+            TypeParameters = [new TypeParameter { Name = "T" }]
+        };
+        var member = new ApiMember
+        {
+            Name = "Map",
+            Kind = "method",
+            Signature = "compatibility text",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "TResult",
+                MemberName = "Map<TResult>",
+                TypeParameters = [new TypeParameter { Name = "TResult", Constraints = ["class"] }],
+                Parameters = [new ApiParameter { Type = "T", Name = "value" }]
+            }
+        };
+
+        var declaration = new CSharpFormatter().FormatMember(type, member);
+
+        Assert.Equal(
+            "public TResult Map<TResult>(T value) where TResult : class",
+            declaration);
+    }
+
+    [Fact]
+    public void FormatsContextualTypeUnit()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Widget",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = "Create",
+                    Kind = "method",
+                    SignatureModel = new ApiSignature
+                    {
+                        ReturnType = "Samples.Widget",
+                        MemberName = "Create"
+                    }
+                }
+            ]
+        };
+        var formatter = new CSharpFormatter(new CSharpFormatOptions
+        {
+            TypeNamePolicy = CSharpTypeNamePolicy.ContextualShort,
+            ContainingNamespace = "Samples",
+            TerminateMemberDeclaration = true
+        });
+
+        var declaration = formatter.FormatTypeUnit(type, type.Members);
+
+        Assert.Equal(
+            """
+            public class Widget
+            {
+                public Widget Create();
+            }
+            """,
+            declaration.Text);
+        Assert.Empty(declaration.Usings);
+        Assert.Empty(declaration.Diagnostics);
+    }
+
+    [Fact]
+    public void RejectsUndefinedPolicies()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new CSharpFormatter(new CSharpFormatOptions
+            {
+                TypeNamePolicy = (CSharpTypeNamePolicy)42
+            }));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new CSharpFormatter(new CSharpFormatOptions
+            {
+                NamespacePolicy = (CSharpNamespacePolicy)42
+            }));
+    }
+}

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -168,7 +168,7 @@ public sealed class CSharpTypePrinterTests
     }
 
     [Fact]
-    public void SkeletonMatchesMetadataDeclarationWriter()
+    public void SkeletonMatchesCSharpFormatter()
     {
         var type = CreateEmptyType("Samples", "Widget");
         type.Members.Add(new ApiMember
@@ -181,21 +181,20 @@ public sealed class CSharpTypePrinterTests
                 MemberName = "Create"
             }
         });
-        var declarationOptions = new CSharpDeclarationOptions
+        var formatter = new CSharpFormatter(new CSharpFormatOptions
         {
-            TypeNameMode = CSharpTypeNameMode.ContextualShort,
+            TypeNamePolicy = CSharpTypeNamePolicy.ContextualShort,
             ContainingNamespace = "Samples",
-            NamespaceMode = CSharpNamespaceMode.Omit,
+            NamespacePolicy = CSharpNamespacePolicy.Omit,
             TerminateMemberDeclaration = true
-        };
-        var expectedDeclaration = CSharpDeclarationWriter.RenderTypeUnit(
+        });
+        var expectedDeclaration = formatter.FormatTypeUnit(
             type,
-            type.Members,
-            declarationOptions);
+            type.Members);
 
         var result = _printer.Print(new CSharpTypePrintRequest(type));
 
-        Assert.Equal($"namespace Samples;\n\n{expectedDeclaration.Source}", result.Units[0].Source);
+        Assert.Equal($"namespace Samples;\n\n{expectedDeclaration.Text}", result.Units[0].Source);
         Assert.Equal(expectedDeclaration.Diagnostics, result.Diagnostics.Select(diagnostic => diagnostic.Message));
     }
 

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -188,9 +188,7 @@ public sealed class CSharpTypePrinterTests
             NamespacePolicy = CSharpNamespacePolicy.Omit,
             TerminateMemberDeclaration = true
         });
-        var expectedDeclaration = formatter.FormatTypeUnit(
-            type,
-            type.Members);
+        var expectedDeclaration = formatter.FormatTypeUnit(type);
 
         var result = _printer.Print(new CSharpTypePrintRequest(type));
 

--- a/src/ILInspector.CSharp/CSharpFormatter.cs
+++ b/src/ILInspector.CSharp/CSharpFormatter.cs
@@ -1,0 +1,134 @@
+using ILInspector.Metadata;
+
+namespace ILInspector.CSharp;
+
+public enum CSharpTypeNamePolicy
+{
+    Qualified,
+    ShortWithUsings,
+    ContextualShort
+}
+
+public enum CSharpNamespacePolicy
+{
+    Omit,
+    FileScoped
+}
+
+public sealed record CSharpFormatOptions
+{
+    public CSharpTypeNamePolicy TypeNamePolicy { get; init; } = CSharpTypeNamePolicy.Qualified;
+    public string? ContainingNamespace { get; init; }
+    public IReadOnlyCollection<string> Usings { get; init; } = [];
+    public CSharpNamespacePolicy NamespacePolicy { get; init; } = CSharpNamespacePolicy.Omit;
+    public bool AbbreviateSignature { get; init; }
+    public bool TerminateMemberDeclaration { get; init; }
+    public bool ForceAsync { get; init; }
+    public bool ForceUnsafe { get; init; }
+    public bool IncludeCustomAttributes { get; init; } = true;
+    public bool IncludeObsoleteAttribute { get; init; } = true;
+    public bool OmitInterfaceMemberModifiers { get; init; }
+}
+
+public sealed record CSharpFormattedDeclaration(
+    string Text,
+    IReadOnlyList<string> Usings,
+    IReadOnlyList<string> Diagnostics);
+
+/// <summary>
+/// Formats Metadata declaration shapes as C# without selecting or grouping APIs.
+/// </summary>
+public sealed class CSharpFormatter
+{
+    readonly CSharpFormatOptions _options;
+
+    public CSharpFormatter(CSharpFormatOptions? options = null)
+    {
+        options ??= new CSharpFormatOptions();
+        if (!Enum.IsDefined(options.TypeNamePolicy))
+            throw new ArgumentOutOfRangeException(nameof(options), options.TypeNamePolicy, "C# type-name policy must be defined.");
+        if (!Enum.IsDefined(options.NamespacePolicy))
+            throw new ArgumentOutOfRangeException(nameof(options), options.NamespacePolicy, "C# namespace policy must be defined.");
+        _options = options with
+        {
+            Usings = options.Usings?.ToArray()
+                ?? throw new ArgumentException("C# formatter usings cannot be null.", nameof(options))
+        };
+    }
+
+    public string FormatMember(
+        ApiType type,
+        ApiMember member,
+        IReadOnlyList<string>? methodParameters = null)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        ArgumentNullException.ThrowIfNull(member);
+        return CSharpDeclarationWriter.RenderMemberDeclaration(
+            type,
+            member,
+            ToMetadataOptions(),
+            methodParameters);
+    }
+
+    public CSharpFormattedDeclaration FormatMemberUnit(
+        ApiType type,
+        ApiMember member,
+        IReadOnlyList<string>? methodParameters = null)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        ArgumentNullException.ThrowIfNull(member);
+        return ToFormattedDeclaration(CSharpDeclarationWriter.RenderMemberUnit(
+            type,
+            member,
+            ToMetadataOptions(),
+            methodParameters));
+    }
+
+    public string FormatTypeDeclaration(ApiType type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        return CSharpDeclarationWriter.RenderTypeDeclaration(type, ToMetadataOptions());
+    }
+
+    public CSharpFormattedDeclaration FormatTypeUnit(
+        ApiType type,
+        IEnumerable<ApiMember>? members = null)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        var memberArray = members?.ToArray();
+        return ToFormattedDeclaration(CSharpDeclarationWriter.RenderTypeUnit(
+            type,
+            memberArray,
+            ToMetadataOptions()));
+    }
+
+    CSharpDeclarationOptions ToMetadataOptions()
+        => new()
+        {
+            TypeNameMode = _options.TypeNamePolicy switch
+            {
+                CSharpTypeNamePolicy.Qualified => CSharpTypeNameMode.Qualified,
+                CSharpTypeNamePolicy.ShortWithUsings => CSharpTypeNameMode.ShortWithUsings,
+                CSharpTypeNamePolicy.ContextualShort => CSharpTypeNameMode.ContextualShort,
+                _ => throw new InvalidOperationException()
+            },
+            ContainingNamespace = _options.ContainingNamespace,
+            Usings = _options.Usings,
+            NamespaceMode = _options.NamespacePolicy switch
+            {
+                CSharpNamespacePolicy.Omit => CSharpNamespaceMode.Omit,
+                CSharpNamespacePolicy.FileScoped => CSharpNamespaceMode.FileScoped,
+                _ => throw new InvalidOperationException()
+            },
+            AbbreviateSignature = _options.AbbreviateSignature,
+            TerminateMemberDeclaration = _options.TerminateMemberDeclaration,
+            ForceAsync = _options.ForceAsync,
+            ForceUnsafe = _options.ForceUnsafe,
+            IncludeCustomAttributes = _options.IncludeCustomAttributes,
+            IncludeObsoleteAttribute = _options.IncludeObsoleteAttribute,
+            OmitInterfaceMemberModifiers = _options.OmitInterfaceMemberModifiers
+        };
+
+    static CSharpFormattedDeclaration ToFormattedDeclaration(CSharpRenderedDeclaration declaration)
+        => new(declaration.Source, declaration.Usings.ToArray(), declaration.Diagnostics.ToArray());
+}

--- a/src/ILInspector.CSharp/CSharpFormatter.cs
+++ b/src/ILInspector.CSharp/CSharpFormatter.cs
@@ -40,7 +40,7 @@ public sealed record CSharpFormattedDeclaration(
 /// </summary>
 public sealed class CSharpFormatter
 {
-    readonly CSharpFormatOptions _options;
+    readonly CSharpDeclarationOptions _metadataOptions;
 
     public CSharpFormatter(CSharpFormatOptions? options = null)
     {
@@ -49,11 +49,9 @@ public sealed class CSharpFormatter
             throw new ArgumentOutOfRangeException(nameof(options), options.TypeNamePolicy, "C# type-name policy must be defined.");
         if (!Enum.IsDefined(options.NamespacePolicy))
             throw new ArgumentOutOfRangeException(nameof(options), options.NamespacePolicy, "C# namespace policy must be defined.");
-        _options = options with
-        {
-            Usings = options.Usings?.ToArray()
-                ?? throw new ArgumentException("C# formatter usings cannot be null.", nameof(options))
-        };
+        var usings = options.Usings?.ToArray()
+            ?? throw new ArgumentException("C# formatter usings cannot be null.", nameof(options));
+        _metadataOptions = ToMetadataOptions(options, usings);
     }
 
     public string FormatMember(
@@ -66,7 +64,7 @@ public sealed class CSharpFormatter
         return CSharpDeclarationWriter.RenderMemberDeclaration(
             type,
             member,
-            ToMetadataOptions(),
+            _metadataOptions,
             methodParameters);
     }
 
@@ -80,14 +78,14 @@ public sealed class CSharpFormatter
         return ToFormattedDeclaration(CSharpDeclarationWriter.RenderMemberUnit(
             type,
             member,
-            ToMetadataOptions(),
+            _metadataOptions,
             methodParameters));
     }
 
     public string FormatTypeDeclaration(ApiType type)
     {
         ArgumentNullException.ThrowIfNull(type);
-        return CSharpDeclarationWriter.RenderTypeDeclaration(type, ToMetadataOptions());
+        return CSharpDeclarationWriter.RenderTypeDeclaration(type, _metadataOptions);
     }
 
     public CSharpFormattedDeclaration FormatTypeUnit(
@@ -95,38 +93,39 @@ public sealed class CSharpFormatter
         IEnumerable<ApiMember>? members = null)
     {
         ArgumentNullException.ThrowIfNull(type);
-        var memberArray = members?.ToArray();
         return ToFormattedDeclaration(CSharpDeclarationWriter.RenderTypeUnit(
             type,
-            memberArray,
-            ToMetadataOptions()));
+            members,
+            _metadataOptions));
     }
 
-    CSharpDeclarationOptions ToMetadataOptions()
+    static CSharpDeclarationOptions ToMetadataOptions(
+        CSharpFormatOptions options,
+        IReadOnlyCollection<string> usings)
         => new()
         {
-            TypeNameMode = _options.TypeNamePolicy switch
+            TypeNameMode = options.TypeNamePolicy switch
             {
                 CSharpTypeNamePolicy.Qualified => CSharpTypeNameMode.Qualified,
                 CSharpTypeNamePolicy.ShortWithUsings => CSharpTypeNameMode.ShortWithUsings,
                 CSharpTypeNamePolicy.ContextualShort => CSharpTypeNameMode.ContextualShort,
                 _ => throw new InvalidOperationException()
             },
-            ContainingNamespace = _options.ContainingNamespace,
-            Usings = _options.Usings,
-            NamespaceMode = _options.NamespacePolicy switch
+            ContainingNamespace = options.ContainingNamespace,
+            Usings = usings,
+            NamespaceMode = options.NamespacePolicy switch
             {
                 CSharpNamespacePolicy.Omit => CSharpNamespaceMode.Omit,
                 CSharpNamespacePolicy.FileScoped => CSharpNamespaceMode.FileScoped,
                 _ => throw new InvalidOperationException()
             },
-            AbbreviateSignature = _options.AbbreviateSignature,
-            TerminateMemberDeclaration = _options.TerminateMemberDeclaration,
-            ForceAsync = _options.ForceAsync,
-            ForceUnsafe = _options.ForceUnsafe,
-            IncludeCustomAttributes = _options.IncludeCustomAttributes,
-            IncludeObsoleteAttribute = _options.IncludeObsoleteAttribute,
-            OmitInterfaceMemberModifiers = _options.OmitInterfaceMemberModifiers
+            AbbreviateSignature = options.AbbreviateSignature,
+            TerminateMemberDeclaration = options.TerminateMemberDeclaration,
+            ForceAsync = options.ForceAsync,
+            ForceUnsafe = options.ForceUnsafe,
+            IncludeCustomAttributes = options.IncludeCustomAttributes,
+            IncludeObsoleteAttribute = options.IncludeObsoleteAttribute,
+            OmitInterfaceMemberModifiers = options.OmitInterfaceMemberModifiers
         };
 
     static CSharpFormattedDeclaration ToFormattedDeclaration(CSharpRenderedDeclaration declaration)

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -28,6 +28,7 @@ public sealed class CSharpTypePrinter
         var canonicalIdentities = new HashSet<TypeOutputIdentity>();
         var outputIdentities = new HashSet<TypeOutputIdentity>();
         var diagnostics = ImmutableArray.CreateBuilder<CSharpTypePrintDiagnostic>();
+        var formatters = new Dictionary<string, CSharpFormatter>(StringComparer.Ordinal);
         foreach (var request in requestList)
         {
             var memberArray = (request.Members ?? request.Type.Members
@@ -64,18 +65,20 @@ public sealed class CSharpTypePrinter
                     nameof(requests));
             }
 
-            var formatter = new CSharpFormatter(new CSharpFormatOptions
+            if (!formatters.TryGetValue(containingNamespace, out var formatter))
             {
-                TypeNamePolicy = CSharpTypeNamePolicy.ContextualShort,
-                ContainingNamespace = containingNamespace.Length == 0 ? null : containingNamespace,
-                NamespacePolicy = CSharpNamespacePolicy.Omit,
-                TerminateMemberDeclaration = true,
-                IncludeCustomAttributes = options.IncludeCustomAttributes
-            });
+                formatter = new CSharpFormatter(new CSharpFormatOptions
+                {
+                    TypeNamePolicy = CSharpTypeNamePolicy.ContextualShort,
+                    ContainingNamespace = containingNamespace.Length == 0 ? null : containingNamespace,
+                    NamespacePolicy = CSharpNamespacePolicy.Omit,
+                    TerminateMemberDeclaration = true,
+                    IncludeCustomAttributes = options.IncludeCustomAttributes
+                });
+                formatters.Add(containingNamespace, formatter);
+            }
 
-            var rendered = formatter.FormatTypeUnit(
-                type,
-                type.Members);
+            var rendered = formatter.FormatTypeUnit(type);
 
             if (rendered.Usings.Count > 0)
             {

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -64,19 +64,18 @@ public sealed class CSharpTypePrinter
                     nameof(requests));
             }
 
-            var declarationOptions = new CSharpDeclarationOptions
+            var formatter = new CSharpFormatter(new CSharpFormatOptions
             {
-                TypeNameMode = CSharpTypeNameMode.ContextualShort,
+                TypeNamePolicy = CSharpTypeNamePolicy.ContextualShort,
                 ContainingNamespace = containingNamespace.Length == 0 ? null : containingNamespace,
-                NamespaceMode = CSharpNamespaceMode.Omit,
+                NamespacePolicy = CSharpNamespacePolicy.Omit,
                 TerminateMemberDeclaration = true,
                 IncludeCustomAttributes = options.IncludeCustomAttributes
-            };
+            });
 
-            var rendered = CSharpDeclarationWriter.RenderTypeUnit(
+            var rendered = formatter.FormatTypeUnit(
                 type,
-                type.Members,
-                declarationOptions);
+                type.Members);
 
             if (rendered.Usings.Count > 0)
             {
@@ -85,7 +84,7 @@ public sealed class CSharpTypePrinter
             }
 
             var typeName = type.FullName;
-            preparedTypes.Add(new PreparedTypeSource(containingNamespace, rendered.Source));
+            preparedTypes.Add(new PreparedTypeSource(containingNamespace, rendered.Text));
             diagnostics.AddRange(rendered.Diagnostics.Select(
                 diagnostic => new CSharpTypePrintDiagnostic(typeName, diagnostic)));
         }

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Text;
+using ILInspector.CSharp;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Metadata;
 
@@ -360,6 +361,10 @@ public sealed record CompileBackPlanningDiagnostic(string Layer, string Reason, 
 
 public static class CompileBackSourceComposer
 {
+    static readonly CSharpFormatter DefaultDeclarationFormatter = new();
+    static readonly CSharpFormatter AsyncDeclarationFormatter = new(
+        new CSharpFormatOptions { ForceAsync = true });
+
     public static CompileBackMemberRequirement? TryCreateClosureMemberRequirement(
         MetadataReader reader,
         TypeDefinitionHandle typeHandle,
@@ -894,7 +899,7 @@ public static class CompileBackSourceComposer
             return;
         }
 
-        var declaration = CSharpDeclarationWriter.RenderTypeDeclaration(ToApiType(type));
+        var declaration = DefaultDeclarationFormatter.FormatTypeDeclaration(ToApiType(type));
         if (type.PrimaryConstructorParameters is { Length: > 0 } parameters)
             declaration = AddPrimaryConstructorParameters(declaration, parameters);
         sb.AppendLine($"{pad}{declaration}");
@@ -941,10 +946,9 @@ public static class CompileBackSourceComposer
 
         var apiType = ToApiType(type);
         var apiMember = ToApiMember(type, member);
-        string declaration = CSharpDeclarationWriter.RenderMemberDeclaration(
-            apiType,
-            apiMember,
-            new CSharpDeclarationOptions { ForceAsync = member.IsAsync });
+        string declaration = (member.IsAsync
+            ? AsyncDeclarationFormatter
+            : DefaultDeclarationFormatter).FormatMember(apiType, apiMember);
         switch (member.Kind)
         {
             case CompileBackMemberKind.PropertyGet:

--- a/src/ILInspector.Decompiler/ILInspector.Decompiler.csproj
+++ b/src/ILInspector.Decompiler/ILInspector.Decompiler.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <Compile Include="..\UnionPolyfill.cs" Link="UnionPolyfill.cs" />
+    <ProjectReference Include="..\ILInspector.CSharp\ILInspector.CSharp.csproj" />
     <ProjectReference Include="..\ILInspector.Findings\ILInspector.Findings.csproj" />
     <ProjectReference Include="..\ILInspector.Metadata\ILInspector.Metadata.csproj" />
     <ProjectReference Include="..\ILInspector.MetadataPrimitives\ILInspector.MetadataPrimitives.csproj" />

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -3,6 +3,7 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Text;
+using ILInspector.CSharp;
 using ILInspector.Metadata;
 
 namespace ILInspector.Decompiler;
@@ -17,6 +18,12 @@ namespace ILInspector.Decompiler;
 /// </summary>
 public static class TypeSourceComposer
 {
+    static readonly CSharpFormatter DefaultDeclarationFormatter = CreateDeclarationFormatter();
+    static readonly CSharpFormatter UnsafeDeclarationFormatter = CreateDeclarationFormatter(forceUnsafe: true);
+    static readonly CSharpFormatter AsyncDeclarationFormatter = CreateDeclarationFormatter(forceAsync: true);
+    static readonly CSharpFormatter AsyncUnsafeDeclarationFormatter = CreateDeclarationFormatter(forceUnsafe: true, forceAsync: true);
+    static readonly CSharpFormatter TerminatedDeclarationFormatter = CreateDeclarationFormatter(terminateMemberDeclaration: true);
+
     /// <summary>
     /// Legacy path-only entry point. Prefer the <see cref="IAssemblyReferenceResolver"/>
     /// overload for new product and harness code.
@@ -174,17 +181,31 @@ public static class TypeSourceComposer
             return sb.ToString();
         }
 
-        return CSharpDeclarationWriter.RenderTypeDeclaration(type, DeclarationOptions());
+        return DefaultDeclarationFormatter.FormatTypeDeclaration(type);
     }
 
-    static CSharpDeclarationOptions DeclarationOptions(bool forceUnsafe = false, bool forceAsync = false) => new()
-    {
-        ForceAsync = forceAsync,
-        ForceUnsafe = forceUnsafe,
-        IncludeCustomAttributes = false,
-        IncludeObsoleteAttribute = false,
-        OmitInterfaceMemberModifiers = true
-    };
+    static CSharpFormatter CreateDeclarationFormatter(
+        bool forceUnsafe = false,
+        bool forceAsync = false,
+        bool terminateMemberDeclaration = false)
+        => new(new CSharpFormatOptions
+        {
+            ForceAsync = forceAsync,
+            ForceUnsafe = forceUnsafe,
+            IncludeCustomAttributes = false,
+            IncludeObsoleteAttribute = false,
+            OmitInterfaceMemberModifiers = true,
+            TerminateMemberDeclaration = terminateMemberDeclaration
+        });
+
+    static CSharpFormatter DeclarationFormatter(bool forceUnsafe, bool forceAsync)
+        => (forceUnsafe, forceAsync) switch
+        {
+            (false, false) => DefaultDeclarationFormatter,
+            (true, false) => UnsafeDeclarationFormatter,
+            (false, true) => AsyncDeclarationFormatter,
+            (true, true) => AsyncUnsafeDeclarationFormatter
+        };
 
     static string DisplayName(ApiType type)
     {
@@ -437,10 +458,8 @@ public static class TypeSourceComposer
                         break;
                     }
 
-                    var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(
-                        type,
-                        member,
-                        DeclarationOptions(requiresUnsafeContext, requiresAsync));
+                    var declaration = DeclarationFormatter(requiresUnsafeContext, requiresAsync)
+                        .FormatMember(type, member);
                     AppendMember(sb, declaration, body, constructorChain);
                     break;
                 }
@@ -465,10 +484,7 @@ public static class TypeSourceComposer
                     foreach (var attribute in AttributeReader.RenderEventAttributes(
                         reader, typeHandle, member.Name, bodyNamespaces))
                         sb.AppendLine($"    [{attribute}]");
-                    string declaration = CSharpDeclarationWriter.RenderMemberDeclaration(
-                        type,
-                        member,
-                        DeclarationOptions() with { TerminateMemberDeclaration = true });
+                    string declaration = TerminatedDeclarationFormatter.FormatMember(type, member);
                     sb.AppendLine($"    {declaration}");
                     break;
                 }
@@ -742,7 +758,7 @@ public static class TypeSourceComposer
         SortedSet<string> bodyNamespaces)
     {
         string typeFullName = type.FullName;
-        string signature = CSharpDeclarationWriter.RenderMemberDeclaration(type, member, DeclarationOptions());
+        string signature = DefaultDeclarationFormatter.FormatMember(type, member);
         int accessorList = signature.IndexOf('{');
         string head = accessorList >= 0 ? signature[..accessorList].TrimEnd() : signature;
         bool requiresUnsafeContext = member.IsUnsafe || signature.Contains('*', StringComparison.Ordinal);
@@ -761,7 +777,7 @@ public static class TypeSourceComposer
 
         if (!requiresUnsafeContext && accessors.Any(a => a.RequiresUnsafeContext))
         {
-            signature = CSharpDeclarationWriter.RenderMemberDeclaration(type, member, DeclarationOptions(forceUnsafe: true));
+            signature = UnsafeDeclarationFormatter.FormatMember(type, member);
             accessorList = signature.IndexOf('{');
             head = accessorList >= 0 ? signature[..accessorList].TrimEnd() : signature;
         }

--- a/src/dotnet-inspect.Tests/CSharpDeclarationFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/CSharpDeclarationFormatterTests.cs
@@ -7,7 +7,7 @@ namespace DotnetInspector.Tests;
 public sealed class CSharpDeclarationFormatterTests
 {
     [Fact]
-    public void MemberSignatureSection_UsesSharedCSharpDeclarationWriter()
+    public void MemberSignatureSection_UsesCSharpFormatter()
     {
         var type = new ApiType
         {

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1,6 +1,7 @@
 using DotnetInspector.Inspectors;
 using DotnetInspector.Commands;
 using DotnetInspector.Core;
+using ILInspector.CSharp;
 using ILInspector.Metadata;
 using ILInspector.MetadataPrimitives;
 using System.Text;
@@ -20,6 +21,12 @@ namespace DotnetInspector.Output;
 /// </summary>
 public static class ApiOutputFormatter
 {
+    static readonly CSharpFormatter DefaultCSharpFormatter = new();
+    static readonly CSharpFormatter AbbreviatedCSharpFormatter = new(
+        new CSharpFormatOptions { AbbreviateSignature = true });
+    static readonly CSharpFormatter CSharpFormatterWithoutObsolete = new(
+        new CSharpFormatOptions { IncludeObsoleteAttribute = false });
+
     static IAssemblyReferenceResolver AnalysisReferenceResolver(string dllPath, ApiOptions? options = null)
         => ApiCommand.PlatformAssemblyResolver(dllPath, options?.ProjectAssetsPath, options?.Tfm);
 
@@ -1095,10 +1102,9 @@ public static class ApiOutputFormatter
         {
             if (HasKeywordGenericIdentifier(type, signature))
             {
-                var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(
+                var declaration = CSharpFormatterWithoutObsolete.FormatMember(
                     type,
-                    constructor,
-                    new CSharpDeclarationOptions { IncludeObsoleteAttribute = false });
+                    constructor);
                 if (!string.IsNullOrWhiteSpace(declaration))
                     return ConstructorCallFromDeclaration(declaration);
             }
@@ -2170,16 +2176,17 @@ public static class ApiOutputFormatter
         IReadOnlyList<string>? methodParameters = null,
         bool forceAsync = false,
         bool forceUnsafe = false)
-        => CSharpDeclarationWriter.RenderMemberDeclaration(
-            type,
-            member,
-            new CSharpDeclarationOptions
+    {
+        var formatter = !forceAsync && !forceUnsafe
+            ? abbreviate ? AbbreviatedCSharpFormatter : DefaultCSharpFormatter
+            : new CSharpFormatter(new CSharpFormatOptions
             {
                 AbbreviateSignature = abbreviate,
                 ForceAsync = forceAsync,
                 ForceUnsafe = forceUnsafe
-            },
-            methodParameters);
+            });
+        return formatter.FormatMember(type, member, methodParameters);
+    }
 
     // ===== Helper Methods =====
 

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -62,6 +62,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />
+    <ProjectReference Include="..\ILInspector.CSharp\ILInspector.CSharp.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler\ILInspector.Decompiler.csproj" />
     <ProjectReference Include="..\ILInspector.Findings\ILInspector.Findings.csproj" />
     <ProjectReference Include="..\ILInspector.Research\ILInspector.Research.csproj" />


### PR DESCRIPTION
## Summary

- add a concrete, immutable `CSharpFormatter` facade in `ILInspector.CSharp` for member, type, and declaration-unit formatting over Metadata shapes
- route `CSharpTypePrinter`, dotnet-inspect API declaration rows, and Decompiler's body-independent declaration spelling through the facade
- cache translated Metadata options and formatter variants, reuse type-printer formatters by namespace, and avoid redundant member-list materialization
- keep Metadata's existing declaration writer as the compatibility implementation during the structured-spelling migration

## Design

This establishes the composition boundary without changing Metadata producers while #2574 is still hardening that surface:

```text
Metadata shapes
    -> consumer-owned API/body selection
        -> CSharpFormatter for declaration text
            -> consumer-owned source/Markout composition
```

`CSharpFormatter` does not query or group APIs, render Markdown, depend on Decompiler/Research, or own body policy. `CSharpTypePrinter` remains the higher namespace/type composition layer. Decompiler combines formatter-produced declarations with reconstructed bodies.

The facade intentionally omits a public identifier-spelling API: Metadata's current helper is signature-text-specific, so exposing it as a general qualified-name formatter would create the wrong primitive contract.

## Compatibility

- `type StringBuilder --markdown -v:n --tips q` is byte-identical before/after on the same SDK/runtime.
- Final-head render A/B against merge base `11198494` evaluated 89,065 methods: 0 changed, 0 added, 0 removed.
- Existing Metadata C# compatibility APIs remain available.
- The default `--shape` compatibility path is unchanged.

## Validation

- `ILInspector.CSharp.Tests`: 28 passed
- `dotnet-inspect.Tests`: 1,710 passed, 10 tool-dependent skips
- `TypeSourceCheckTests`: 33 passed
- `TypeBindCheckTests`: 5 passed
- Release solution build: passed
- targeted net10 CSharp build: passed with zero warnings/errors
- markdownlint: passed

The exhaustive Decompiler run has reported four failures that each reproduce at clean `origin/main`; they are tracked in #2629, #2630, #2631, and #2632.

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity compiled 350 methods (compile-cap 25; per-sample, not corpus-wide); fidelity sampled 36 / 89,065 (0.04%)

| Metric | Change | Count delta |
| ------ | ------ | ----------- |
| Fully raised (+) | 78,406 (88.03%) → 78,406 (88.03%) (neutral) | 0 |
| Conditional-branch residual (-) | 2,401 (2.70%) → 2,401 (2.70%) (neutral) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) → 2,286 (2.57%) (neutral) | 0 |
| Full malformed (-) | 0 → 0 (neutral) | 0 |
| Semantic defects (-) | 54 (0.21%) → 0 (0.00%) (good) | -54 |
| Fidelity opcode diffs (-) | 4 (11.11%) → 4 (11.11%) (neutral) | 0 |
| Fidelity exact (+) | 32 (88.89%) → 32 (88.89%) (neutral) | 0 |
| Fidelity recompile failures (-) | 0 (0.00%) → 0 (0.00%) (neutral) | 0 |
| Fidelity context failures (-) | 0 (0.00%) → 0 (0.00%) (neutral) | 0 |
| Fidelity check coverage (+) | 36 (0.04%) → 36 (0.04%) (neutral) | 0 |
| Pass bugs (-) | 0 → 0 (neutral) | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 88.03% -> 88.03% (0 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); opcode diffs 4 -> 4 (0).

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- validity cap lower than baseline (baseline 4000, current 25)
- semantic checked methods lower than baseline (baseline 25183, current 350)

The generated card's warning is solely the documented sampling-cap mismatch; raised/residual/malformed/opcode/fidelity counts are neutral, and the uncapped render A/B has zero changed methods.

## Review status

Gemini's initial Decompiler-routing and allocation findings were fixed in `8dc46ada`; its type-printer allocation follow-ups were fixed in `5215b2d6`. Fresh exact-head Opus and Gemini reviews are pending. This PR is not ready to merge until both are clean and CI is green.
