### PR TITLE
Add extension member Finding producers

### DIFF
--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -230,45 +230,7 @@ public static class ApiMemberIdentity
             shape.ParameterTypes[0]);
     }
 
-    public static ExtensionMemberAnchorInfo CreateExtensionPropertyAnchorInfo(
-        MetadataReader reader,
-        TypeDefinitionHandle typeHandle,
-        MethodDefinition accessor,
-        string propertyName)
-    {
-        var type = reader.GetTypeDefinition(typeHandle);
-        string accessorName = reader.GetString(accessor.Name);
-        var signature = accessor.DecodeSignature(
-            AnchorSignatureTypeProvider.Instance,
-            GenericContext.ForMethod(reader, type, accessor));
-        if (signature.ParameterTypes.Length == 0)
-            throw new BadImageFormatException("An extension property must have a receiver parameter.");
-
-        string typeFullName = FormatDefinitionName(reader, typeHandle);
-        string extendedType = signature.ParameterTypes[0];
-        bool isSetter = accessorName.StartsWith("set_", StringComparison.Ordinal);
-        if (isSetter && signature.ParameterTypes.Length < 2)
-            throw new BadImageFormatException("An extension property setter must have a value parameter.");
-
-        string returnType = isSetter ? signature.ParameterTypes[^1] : signature.ReturnType;
-        IReadOnlyList<string> identityParameters = isSetter
-            ? signature.ParameterTypes.Take(signature.ParameterTypes.Length - 1).ToArray()
-            : signature.ParameterTypes;
-        string canonicalSignature = MemberCanonicalSignature.BuildExtensionProperty(
-            typeFullName,
-            propertyName,
-            identityParameters);
-        return new ExtensionMemberAnchorInfo(
-            CreateAnchor(
-                typeFullName,
-                $"extension:{propertyName}",
-                propertyName,
-                canonicalSignature),
-            returnType,
-            extendedType);
-    }
-
-    internal static string CreateExtensionPropertyDeclarationCanonicalSignature(
+    internal static ExtensionMemberAnchorInfo CreateExtensionPropertyDeclarationAnchorInfo(
         MetadataReader reader,
         TypeDefinitionHandle extensionClassHandle,
         TypeDefinition markerType,
@@ -283,10 +245,19 @@ public static class ApiMemberIdentity
         var propertySignature = property.DecodeSignature(AnchorSignatureTypeProvider.Instance, context);
         string propertyName = reader.GetString(property.Name);
         string typeFullName = FormatDefinitionName(reader, extensionClassHandle);
-        return MemberCanonicalSignature.BuildExtensionProperty(
+        string extendedType = markerSignature.ParameterTypes[0];
+        string canonicalSignature = MemberCanonicalSignature.BuildExtensionProperty(
             typeFullName,
             propertyName,
             markerSignature.ParameterTypes.AddRange(propertySignature.ParameterTypes));
+        return new ExtensionMemberAnchorInfo(
+            CreateAnchor(
+                typeFullName,
+                $"extension:{propertyName}",
+                propertyName,
+                canonicalSignature),
+            propertySignature.ReturnType,
+            extendedType);
     }
 
     static (MemberAnchor Anchor, string ReturnType, ImmutableArray<string> ParameterTypes) CreateMethodAnchorShape(

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -24,6 +24,34 @@ public sealed record MethodAnchorInfo(
     }
 }
 
+public sealed record ExtensionMemberAnchorInfo(
+    MemberAnchor Anchor,
+    string ReturnType,
+    string ExtendedType)
+{
+    MemberAnchor _anchor = Anchor ?? throw new ArgumentNullException(nameof(Anchor));
+    string _returnType = ReturnType ?? throw new ArgumentNullException(nameof(ReturnType));
+    string _extendedType = ExtendedType ?? throw new ArgumentNullException(nameof(ExtendedType));
+
+    public MemberAnchor Anchor
+    {
+        get => _anchor;
+        init => _anchor = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    public string ReturnType
+    {
+        get => _returnType;
+        init => _returnType = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    public string ExtendedType
+    {
+        get => _extendedType;
+        init => _extendedType = value ?? throw new ArgumentNullException(nameof(value));
+    }
+}
+
 /// <summary>
 /// Metadata-owned API identity helpers for durable member selectors. These
 /// helpers compose identity strings from queryable metadata facts, not from C#
@@ -71,7 +99,7 @@ public static class ApiMemberIdentity
         public string GetSZArrayType(string elementType) => $"{elementType}[]";
 
         public string GetArrayType(string elementType, ArrayShape shape)
-            => $"{elementType}[{(shape.Rank == 1 ? "*" : new string(',', shape.Rank - 1))}]";
+            => $"{elementType}[{(shape.Rank <= 1 ? "*" : new string(',', shape.Rank - 1))}]";
 
         public string GetByReferenceType(string elementType) => $"{elementType}&";
 
@@ -90,7 +118,7 @@ public static class ApiMemberIdentity
         public string GetGenericMethodParameter(GenericContext? context, int index)
             => context is not null && index >= 0 && index < context.MethodParameters.Count
                 ? context.MethodParameters[index]
-                : $"!{index}";
+                : $"!!{index}";
 
         public string GetFunctionPointerType(MethodSignature<string> signature)
             => $"delegate*<{string.Join(",", signature.ParameterTypes.Append(signature.ReturnType))}>";
@@ -183,9 +211,74 @@ public static class ApiMemberIdentity
         MethodDefinition method,
         bool isExtensionMethod = false)
     {
+        var shape = CreateMethodAnchorShape(reader, typeHandle, method, isExtensionMethod);
+        return new MethodAnchorInfo(shape.Anchor, shape.ReturnType);
+    }
+
+    public static ExtensionMemberAnchorInfo CreateExtensionMethodAnchorInfo(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        MethodDefinition method)
+    {
+        var shape = CreateMethodAnchorShape(reader, typeHandle, method, isExtensionMethod: true);
+        if (shape.ParameterTypes.Length == 0)
+            throw new BadImageFormatException("An extension method must have a receiver parameter.");
+
+        return new ExtensionMemberAnchorInfo(
+            shape.Anchor,
+            shape.ReturnType,
+            shape.ParameterTypes[0]);
+    }
+
+    public static ExtensionMemberAnchorInfo CreateExtensionPropertyAnchorInfo(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        MethodDefinition accessor,
+        string propertyName)
+    {
+        var type = reader.GetTypeDefinition(typeHandle);
+        string accessorName = reader.GetString(accessor.Name);
+        var signature = accessor.DecodeSignature(
+            AnchorSignatureTypeProvider.Instance,
+            GenericContext.ForMethod(reader, type, accessor));
+        if (signature.ParameterTypes.Length == 0)
+            throw new BadImageFormatException("An extension property must have a receiver parameter.");
+
+        string typeFullName = FormatDefinitionName(reader, typeHandle);
+        string extendedType = signature.ParameterTypes[0];
+        bool isSetter = accessorName.StartsWith("set_", StringComparison.Ordinal);
+        if (isSetter && signature.ParameterTypes.Length < 2)
+            throw new BadImageFormatException("An extension property setter must have a value parameter.");
+
+        string returnType = isSetter ? signature.ParameterTypes[^1] : signature.ReturnType;
+        IReadOnlyList<string> identityParameters = isSetter
+            ? signature.ParameterTypes.Take(signature.ParameterTypes.Length - 1).ToArray()
+            : signature.ParameterTypes;
+        string canonicalSignature = MemberCanonicalSignature.BuildExtensionProperty(
+            typeFullName,
+            propertyName,
+            identityParameters);
+        return new ExtensionMemberAnchorInfo(
+            CreateAnchor(
+                typeFullName,
+                $"extension:{propertyName}",
+                propertyName,
+                canonicalSignature),
+            returnType,
+            extendedType);
+    }
+
+    static (MemberAnchor Anchor, string ReturnType, ImmutableArray<string> ParameterTypes) CreateMethodAnchorShape(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        MethodDefinition method,
+        bool isExtensionMethod)
+    {
         var type = reader.GetTypeDefinition(typeHandle);
         string methodName = reader.GetString(method.Name);
-        var signature = method.DecodeSignature(AnchorSignatureTypeProvider.Instance, GenericContext.ForMethod(reader, type, method));
+        var signature = method.DecodeSignature(
+            AnchorSignatureTypeProvider.Instance,
+            GenericContext.ForMethod(reader, type, method));
         string typeFullName = FormatDefinitionName(reader, typeHandle);
         string memberName = MethodMemberName(reader, methodName, method);
         // Route the SRM-direct producer through the single full-name grammar core so it
@@ -198,9 +291,10 @@ public static class ApiMemberIdentity
             signature.ParameterTypes,
             IsConversionOperator(methodName) ? signature.ReturnType : null);
         string selectorName = GetMemberSelectorName(methodName, isExtensionMethod);
-        return new MethodAnchorInfo(
+        return (
             CreateAnchor(typeFullName, selectorName, memberName, canonicalSignature),
-            signature.ReturnType);
+            signature.ReturnType,
+            signature.ParameterTypes);
     }
 
     public static MemberAnchor CreateAnchor(ApiType type, ApiMember member, string canonicalSignature)

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -268,6 +268,27 @@ public static class ApiMemberIdentity
             extendedType);
     }
 
+    internal static string CreateExtensionPropertyDeclarationCanonicalSignature(
+        MetadataReader reader,
+        TypeDefinitionHandle extensionClassHandle,
+        TypeDefinition markerType,
+        MethodDefinition markerMethod,
+        PropertyDefinition property)
+    {
+        var context = GenericContext.ForType(reader, markerType);
+        var markerSignature = markerMethod.DecodeSignature(AnchorSignatureTypeProvider.Instance, context);
+        if (markerSignature.ParameterTypes.Length != 1)
+            throw new BadImageFormatException("An extension marker must have exactly one receiver parameter.");
+
+        var propertySignature = property.DecodeSignature(AnchorSignatureTypeProvider.Instance, context);
+        string propertyName = reader.GetString(property.Name);
+        string typeFullName = FormatDefinitionName(reader, extensionClassHandle);
+        return MemberCanonicalSignature.BuildExtensionProperty(
+            typeFullName,
+            propertyName,
+            markerSignature.ParameterTypes.AddRange(propertySignature.ParameterTypes));
+    }
+
     static (MemberAnchor Anchor, string ReturnType, ImmutableArray<string> ParameterTypes) CreateMethodAnchorShape(
         MetadataReader reader,
         TypeDefinitionHandle typeHandle,

--- a/src/ILInspector.Metadata/AttributeReader.cs
+++ b/src/ILInspector.Metadata/AttributeReader.cs
@@ -11,6 +11,8 @@ namespace ILInspector.Metadata;
 public static class AttributeReader
 {
     private const string EditorBrowsableAttributeName = "System.ComponentModel.EditorBrowsableAttribute";
+    private const string ExtensionMarkerAttributeName = "System.Runtime.CompilerServices.ExtensionMarkerAttribute";
+    private const string ExtensionMarkerNameAttributeName = "System.Runtime.CompilerServices.ExtensionMarkerNameAttribute";
     private const string ObsoleteAttributeName = "System.ObsoleteAttribute";
     private const string RequiredMembersFeatureName = "RequiredMembers";
     private const string RequiredMembersConstructorObsoleteMessage =
@@ -31,6 +33,37 @@ public static class AttributeReader
             if (attrTypeName == KnownAttributeNames.ExtensionAttribute)
                 return true;
         }
+        return false;
+    }
+
+    public static bool TryGetExtensionMarkerName(
+        MetadataReader reader,
+        CustomAttributeHandleCollection attributes,
+        out string? markerName)
+    {
+        foreach (var attrHandle in attributes)
+        {
+            var attr = reader.GetCustomAttribute(attrHandle);
+            var attrTypeName = GetAttributeTypeName(reader, attr.Constructor);
+            if (attrTypeName is not (ExtensionMarkerAttributeName or ExtensionMarkerNameAttributeName))
+                continue;
+
+            try
+            {
+                var blob = reader.GetBlobReader(attr.Value);
+                if (blob.ReadUInt16() != 1)
+                    break;
+
+                markerName = blob.ReadSerializedString();
+                return !string.IsNullOrEmpty(markerName);
+            }
+            catch (BadImageFormatException)
+            {
+                break;
+            }
+        }
+
+        markerName = null;
         return false;
     }
 

--- a/src/ILInspector.Metadata/ExtensionMethodScanner.cs
+++ b/src/ILInspector.Metadata/ExtensionMethodScanner.cs
@@ -89,6 +89,10 @@ public static class ExtensionMethodScanner
 
             // Track property accessors seen (for deduplication of get_/set_ pairs)
             var seenProperties = new HashSet<string>(StringComparer.Ordinal);
+            var declaredPropertyAccessors = GetDeclaredPropertyAccessors(reader, typeDef);
+            var hiddenExtensionProperties = includeAll
+                ? null
+                : GetHiddenExtensionPropertyCanonicals(reader, typeDefHandle);
 
             foreach (var methodHandle in typeDef.GetMethods())
             {
@@ -104,6 +108,9 @@ public static class ExtensionMethodScanner
                     (methodName.StartsWith("get_", StringComparison.Ordinal) ||
                      methodName.StartsWith("set_", StringComparison.Ordinal)))
                 {
+                    if (declaredPropertyAccessors.Contains(methodHandle))
+                        continue;
+
                     // Skip hidden methods unless includeAll
                     if (!includeAll && AttributeReader.HasHiddenAttribute(reader, method.GetCustomAttributes()))
                         continue;
@@ -122,6 +129,8 @@ public static class ExtensionMethodScanner
                         string propertyName = methodName.Substring(4); // strip get_ or set_
                         var anchorInfo = ApiMemberIdentity.CreateExtensionPropertyAnchorInfo(
                             reader, typeDefHandle, method, propertyName);
+                        if (hiddenExtensionProperties?.Contains(anchorInfo.Anchor.CanonicalSignature) == true)
+                            continue;
                         if (!seenProperties.Add(anchorInfo.Anchor.CanonicalSignature)) continue;
 
                         var propSignature = FormatPropertySignature(signature, extendedType, propertyName);
@@ -217,6 +226,10 @@ public static class ExtensionMethodScanner
             string fullClassName = TypeResolver.FormatDisplayName(reader.GetFullTypeName(typeDef));
 
             var seenProperties = new HashSet<string>(StringComparer.Ordinal);
+            var declaredPropertyAccessors = GetDeclaredPropertyAccessors(reader, typeDef);
+            var hiddenExtensionProperties = includeAll
+                ? null
+                : GetHiddenExtensionPropertyCanonicals(reader, typeDefHandle);
 
             foreach (var methodHandle in typeDef.GetMethods())
             {
@@ -231,6 +244,9 @@ public static class ExtensionMethodScanner
                     (methodName.StartsWith("get_", StringComparison.Ordinal) ||
                      methodName.StartsWith("set_", StringComparison.Ordinal)))
                 {
+                    if (declaredPropertyAccessors.Contains(methodHandle))
+                        continue;
+
                     if (!includeAll && AttributeReader.HasHiddenAttribute(reader, method.GetCustomAttributes()))
                         continue;
 
@@ -242,6 +258,8 @@ public static class ExtensionMethodScanner
                     string propertyName = methodName.Substring(4);
                     var anchorInfo = ApiMemberIdentity.CreateExtensionPropertyAnchorInfo(
                         reader, typeDefHandle, method, propertyName);
+                    if (hiddenExtensionProperties?.Contains(anchorInfo.Anchor.CanonicalSignature) == true)
+                        continue;
                     if (!seenProperties.Add(anchorInfo.Anchor.CanonicalSignature)) continue;
 
                     var propSignature = FormatPropertySignature(signature, extendedType, propertyName);
@@ -463,10 +481,83 @@ public static class ExtensionMethodScanner
         var returnType = signature.ReturnType;
         if (returnType == "void" && signature.ParameterTypes.Length >= 2)
         {
-            // This is a setter — the property type is the second parameter
-            returnType = signature.ParameterTypes[1];
+            // This is a setter — the property value is always the final parameter.
+            returnType = signature.ParameterTypes[^1];
         }
         return $"{returnType} {propertyName} {{ get; }}";
+    }
+
+    private static HashSet<MethodDefinitionHandle> GetDeclaredPropertyAccessors(
+        MetadataReader reader,
+        TypeDefinition type)
+    {
+        var accessors = new HashSet<MethodDefinitionHandle>();
+        foreach (var propertyHandle in type.GetProperties())
+        {
+            var propertyAccessors = reader.GetPropertyDefinition(propertyHandle).GetAccessors();
+            if (!propertyAccessors.Getter.IsNil)
+                accessors.Add(propertyAccessors.Getter);
+            if (!propertyAccessors.Setter.IsNil)
+                accessors.Add(propertyAccessors.Setter);
+            foreach (var accessor in propertyAccessors.Others)
+                accessors.Add(accessor);
+        }
+
+        return accessors;
+    }
+
+    private static HashSet<string> GetHiddenExtensionPropertyCanonicals(
+        MetadataReader reader,
+        TypeDefinitionHandle extensionClassHandle)
+    {
+        var nestedTypes = reader.TypeDefinitions
+            .Where(handle => reader.GetTypeDefinition(handle).GetDeclaringType() == extensionClassHandle)
+            .ToArray();
+        var hiddenProperties = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var groupingTypeHandle in nestedTypes)
+        {
+            var groupingType = reader.GetTypeDefinition(groupingTypeHandle);
+            foreach (var propertyHandle in groupingType.GetProperties())
+            {
+                var property = reader.GetPropertyDefinition(propertyHandle);
+                if (!AttributeReader.HasHiddenAttribute(reader, property.GetCustomAttributes())
+                    || !AttributeReader.TryGetExtensionMarkerName(
+                        reader,
+                        property.GetCustomAttributes(),
+                        out var markerName))
+                {
+                    continue;
+                }
+
+                var markerTypeHandle = reader.TypeDefinitions.FirstOrDefault(handle =>
+                {
+                    var candidate = reader.GetTypeDefinition(handle);
+                    return candidate.GetDeclaringType() == groupingTypeHandle
+                        && reader.StringComparer.Equals(candidate.Name, markerName!);
+                });
+                if (markerTypeHandle.IsNil)
+                    continue;
+
+                var markerType = reader.GetTypeDefinition(markerTypeHandle);
+                var markerMethodHandle = markerType.GetMethods().FirstOrDefault(handle =>
+                    reader.StringComparer.Equals(
+                        reader.GetMethodDefinition(handle).Name,
+                        "<Extension>$"));
+                if (markerMethodHandle.IsNil)
+                    continue;
+
+                hiddenProperties.Add(
+                    ApiMemberIdentity.CreateExtensionPropertyDeclarationCanonicalSignature(
+                        reader,
+                        extensionClassHandle,
+                        markerType,
+                        reader.GetMethodDefinition(markerMethodHandle),
+                        property));
+            }
+        }
+
+        return hiddenProperties;
     }
 
     private static string FormatMethodSignature(

--- a/src/ILInspector.Metadata/ExtensionMethodScanner.cs
+++ b/src/ILInspector.Metadata/ExtensionMethodScanner.cs
@@ -87,12 +87,21 @@ public static class ExtensionMethodScanner
             string classNs = reader.GetString(typeDef.Namespace);
             string fullClassName = TypeResolver.FormatDisplayName(reader.GetFullTypeName(typeDef));
 
-            // Track property accessors seen (for deduplication of get_/set_ pairs)
-            var seenProperties = new HashSet<string>(StringComparer.Ordinal);
-            var declaredPropertyAccessors = GetDeclaredPropertyAccessors(reader, typeDef);
-            var hiddenExtensionProperties = includeAll
-                ? null
-                : GetHiddenExtensionPropertyCanonicals(reader, typeDefHandle);
+            foreach (var property in FindDeclaredExtensionProperties(
+                reader,
+                typeDefHandle,
+                typeDef,
+                fullClassName,
+                classNs,
+                includeAll))
+            {
+                if (TypeMatcher.Matches(
+                    TypeMatcher.Normalize(property.ExtendedType),
+                    normalizedTarget))
+                {
+                    yield return property;
+                }
+            }
 
             foreach (var methodHandle in typeDef.GetMethods())
             {
@@ -102,59 +111,7 @@ public static class ExtensionMethodScanner
 
                 string methodName = reader.GetString(method.Name);
 
-                // C# 14 extension properties: get_/set_ accessors without [Extension] on the method
                 bool hasExtension = AttributeReader.HasExtensionAttribute(reader, method.GetCustomAttributes());
-                if (!hasExtension &&
-                    (methodName.StartsWith("get_", StringComparison.Ordinal) ||
-                     methodName.StartsWith("set_", StringComparison.Ordinal)))
-                {
-                    if (declaredPropertyAccessors.Contains(methodHandle))
-                        continue;
-
-                    // Skip hidden methods unless includeAll
-                    if (!includeAll && AttributeReader.HasHiddenAttribute(reader, method.GetCustomAttributes()))
-                        continue;
-
-                    var context = GenericContext.ForMethod(reader, typeDef, method);
-                    var signature = method.DecodeSignature(SignatureDecoder.Instance, context);
-
-                    // Must have at least one parameter (the receiver); skip static extension properties (no receiver)
-                    if (signature.ParameterTypes.Length == 0
-                        || methodName.StartsWith("set_", StringComparison.Ordinal)
-                        && signature.ParameterTypes.Length < 2)
-                    {
-                        continue;
-                    }
-
-                    var extendedType = signature.ParameterTypes[0];
-                    var normalizedExtended = TypeMatcher.Normalize(extendedType);
-
-                    if (TypeMatcher.Matches(normalizedExtended, normalizedTarget))
-                    {
-                        string propertyName = methodName.Substring(4); // strip get_ or set_
-                        var anchorInfo = ApiMemberIdentity.CreateExtensionPropertyAnchorInfo(
-                            reader, typeDefHandle, method, propertyName);
-                        if (hiddenExtensionProperties?.Contains(anchorInfo.Anchor.CanonicalSignature) == true)
-                            continue;
-                        if (!seenProperties.Add(anchorInfo.Anchor.CanonicalSignature)) continue;
-
-                        var propSignature = FormatPropertySignature(signature, extendedType, propertyName);
-                        yield return new ExtensionMethodInfo(
-                            MethodName: propertyName,
-                            ExtensionClass: fullClassName,
-                            Namespace: classNs,
-                            ExtendedType: extendedType,
-                            Signature: propSignature,
-                            Kind: "property")
-                        {
-                            Anchor = anchorInfo.Anchor,
-                            ReturnType = anchorInfo.ReturnType,
-                            CanonicalExtendedType = anchorInfo.ExtendedType,
-                        };
-                    }
-                    continue;
-                }
-
                 if (!hasExtension) continue;
 
                 // Skip hidden methods unless includeAll
@@ -230,11 +187,16 @@ public static class ExtensionMethodScanner
             string classNs = reader.GetString(typeDef.Namespace);
             string fullClassName = TypeResolver.FormatDisplayName(reader.GetFullTypeName(typeDef));
 
-            var seenProperties = new HashSet<string>(StringComparer.Ordinal);
-            var declaredPropertyAccessors = GetDeclaredPropertyAccessors(reader, typeDef);
-            var hiddenExtensionProperties = includeAll
-                ? null
-                : GetHiddenExtensionPropertyCanonicals(reader, typeDefHandle);
+            foreach (var property in FindDeclaredExtensionProperties(
+                reader,
+                typeDefHandle,
+                typeDef,
+                fullClassName,
+                classNs,
+                includeAll))
+            {
+                yield return property;
+            }
 
             foreach (var methodHandle in typeDef.GetMethods())
             {
@@ -245,49 +207,6 @@ public static class ExtensionMethodScanner
                 string methodName = reader.GetString(method.Name);
 
                 bool hasExtension = AttributeReader.HasExtensionAttribute(reader, method.GetCustomAttributes());
-                if (!hasExtension &&
-                    (methodName.StartsWith("get_", StringComparison.Ordinal) ||
-                     methodName.StartsWith("set_", StringComparison.Ordinal)))
-                {
-                    if (declaredPropertyAccessors.Contains(methodHandle))
-                        continue;
-
-                    if (!includeAll && AttributeReader.HasHiddenAttribute(reader, method.GetCustomAttributes()))
-                        continue;
-
-                    var context = GenericContext.ForMethod(reader, typeDef, method);
-                    var signature = method.DecodeSignature(SignatureDecoder.Instance, context);
-                    if (signature.ParameterTypes.Length == 0
-                        || methodName.StartsWith("set_", StringComparison.Ordinal)
-                        && signature.ParameterTypes.Length < 2)
-                    {
-                        continue;
-                    }
-
-                    var extendedType = signature.ParameterTypes[0];
-                    string propertyName = methodName.Substring(4);
-                    var anchorInfo = ApiMemberIdentity.CreateExtensionPropertyAnchorInfo(
-                        reader, typeDefHandle, method, propertyName);
-                    if (hiddenExtensionProperties?.Contains(anchorInfo.Anchor.CanonicalSignature) == true)
-                        continue;
-                    if (!seenProperties.Add(anchorInfo.Anchor.CanonicalSignature)) continue;
-
-                    var propSignature = FormatPropertySignature(signature, extendedType, propertyName);
-                    yield return new ExtensionMethodInfo(
-                        MethodName: propertyName,
-                        ExtensionClass: fullClassName,
-                        Namespace: classNs,
-                        ExtendedType: extendedType,
-                        Signature: propSignature,
-                        Kind: "property")
-                    {
-                        Anchor = anchorInfo.Anchor,
-                        ReturnType = anchorInfo.ReturnType,
-                        CanonicalExtendedType = anchorInfo.ExtendedType,
-                    };
-                    continue;
-                }
-
                 if (!hasExtension) continue;
 
                 if (!includeAll && AttributeReader.HasHiddenAttribute(reader, method.GetCustomAttributes()))
@@ -483,56 +402,35 @@ public static class ExtensionMethodScanner
         _ => false
     };
 
-    private static string FormatPropertySignature(
-        MethodSignature<string> signature, string extendedType, string propertyName)
-    {
-        // For a getter: ReturnType PropertyName { get; } — receiver is the first param
-        // For a setter: void PropertyName { set; } — receiver is the first param, value is the second
-        var returnType = signature.ReturnType;
-        if (returnType == "void" && signature.ParameterTypes.Length >= 2)
-        {
-            // This is a setter — the property value is always the final parameter.
-            returnType = signature.ParameterTypes[^1];
-        }
-        return $"{returnType} {propertyName} {{ get; }}";
-    }
-
-    private static HashSet<MethodDefinitionHandle> GetDeclaredPropertyAccessors(
+    private static IEnumerable<ExtensionMethodInfo> FindDeclaredExtensionProperties(
         MetadataReader reader,
-        TypeDefinition type)
+        TypeDefinitionHandle extensionClassHandle,
+        TypeDefinition extensionClass,
+        string extensionClassName,
+        string? extensionClassNamespace,
+        bool includeAll)
     {
-        var accessors = new HashSet<MethodDefinitionHandle>();
-        foreach (var propertyHandle in type.GetProperties())
-        {
-            var propertyAccessors = reader.GetPropertyDefinition(propertyHandle).GetAccessors();
-            if (!propertyAccessors.Getter.IsNil)
-                accessors.Add(propertyAccessors.Getter);
-            if (!propertyAccessors.Setter.IsNil)
-                accessors.Add(propertyAccessors.Setter);
-            foreach (var accessor in propertyAccessors.Others)
-                accessors.Add(accessor);
-        }
-
-        return accessors;
-    }
-
-    private static HashSet<string> GetHiddenExtensionPropertyCanonicals(
-        MetadataReader reader,
-        TypeDefinitionHandle extensionClassHandle)
-    {
-        var extensionClass = reader.GetTypeDefinition(extensionClassHandle);
-        var hiddenProperties = new HashSet<string>(StringComparer.Ordinal);
+        var seenProperties = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (var groupingTypeHandle in extensionClass.GetNestedTypes())
         {
             var groupingType = reader.GetTypeDefinition(groupingTypeHandle);
+            if (!AttributeReader.HasExtensionAttribute(reader, groupingType.GetCustomAttributes()))
+                continue;
+
             foreach (var propertyHandle in groupingType.GetProperties())
             {
                 var property = reader.GetPropertyDefinition(propertyHandle);
-                if (!AttributeReader.HasHiddenAttribute(reader, property.GetCustomAttributes())
-                    || !AttributeReader.TryGetExtensionMarkerName(
+                var accessors = property.GetAccessors();
+                bool hasPublicGetter = IsPublicAccessor(reader, accessors.Getter);
+                bool hasPublicSetter = IsPublicAccessor(reader, accessors.Setter);
+                if (!hasPublicGetter && !hasPublicSetter)
+                    continue;
+
+                if (!TryGetExtensionMarkerName(
                         reader,
-                        property.GetCustomAttributes(),
+                        property,
+                        accessors,
                         out var markerName))
                 {
                     continue;
@@ -553,18 +451,89 @@ public static class ExtensionMethodScanner
                 if (markerMethodHandle.IsNil)
                     continue;
 
-                hiddenProperties.Add(
-                    ApiMemberIdentity.CreateExtensionPropertyDeclarationCanonicalSignature(
+                if (!includeAll
+                    && (AttributeReader.HasHiddenAttribute(reader, property.GetCustomAttributes())
+                        || hasPublicGetter && IsHiddenAccessor(reader, accessors.Getter)
+                        || hasPublicSetter && IsHiddenAccessor(reader, accessors.Setter)))
+                {
+                    continue;
+                }
+
+                var markerMethod = reader.GetMethodDefinition(markerMethodHandle);
+                var anchorInfo =
+                    ApiMemberIdentity.CreateExtensionPropertyDeclarationAnchorInfo(
                         reader,
                         extensionClassHandle,
                         markerType,
-                        reader.GetMethodDefinition(markerMethodHandle),
-                        property));
+                        markerMethod,
+                        property);
+                if (!seenProperties.Add(anchorInfo.Anchor.CanonicalSignature))
+                    continue;
+
+                var displayContext = GenericContext.ForType(reader, markerType);
+                var markerSignature = markerMethod.DecodeSignature(
+                    SignatureDecoder.Instance,
+                    displayContext);
+                if (markerSignature.ParameterTypes.Length != 1)
+                    throw new BadImageFormatException(
+                        "An extension marker must have exactly one receiver parameter.");
+
+                var propertySignature = property.DecodeSignature(
+                    SignatureDecoder.Instance,
+                    displayContext);
+                string propertyName = reader.GetString(property.Name);
+                string accessorText = hasPublicGetter && hasPublicSetter
+                    ? "get; set;"
+                    : hasPublicGetter ? "get;" : "set;";
+                yield return new ExtensionMethodInfo(
+                    MethodName: propertyName,
+                    ExtensionClass: extensionClassName,
+                    Namespace: extensionClassNamespace,
+                    ExtendedType: markerSignature.ParameterTypes[0],
+                    Signature: $"{propertySignature.ReturnType} {propertyName} {{ {accessorText} }}",
+                    Kind: "property")
+                {
+                    Anchor = anchorInfo.Anchor,
+                    ReturnType = anchorInfo.ReturnType,
+                    CanonicalExtendedType = anchorInfo.ExtendedType,
+                };
             }
         }
-
-        return hiddenProperties;
     }
+
+    private static bool IsPublicAccessor(
+        MetadataReader reader,
+        MethodDefinitionHandle accessorHandle)
+        => !accessorHandle.IsNil
+        && (reader.GetMethodDefinition(accessorHandle).Attributes
+            & MethodAttributes.MemberAccessMask) == MethodAttributes.Public;
+
+    private static bool IsHiddenAccessor(
+        MetadataReader reader,
+        MethodDefinitionHandle accessorHandle)
+        => AttributeReader.HasHiddenAttribute(
+            reader,
+            reader.GetMethodDefinition(accessorHandle).GetCustomAttributes());
+
+    private static bool TryGetExtensionMarkerName(
+        MetadataReader reader,
+        PropertyDefinition property,
+        PropertyAccessors accessors,
+        out string? markerName)
+        => AttributeReader.TryGetExtensionMarkerName(
+                reader,
+                property.GetCustomAttributes(),
+                out markerName)
+            || !accessors.Getter.IsNil
+            && AttributeReader.TryGetExtensionMarkerName(
+                reader,
+                reader.GetMethodDefinition(accessors.Getter).GetCustomAttributes(),
+                out markerName)
+            || !accessors.Setter.IsNil
+            && AttributeReader.TryGetExtensionMarkerName(
+                reader,
+                reader.GetMethodDefinition(accessors.Setter).GetCustomAttributes(),
+                out markerName);
 
     private static string FormatMethodSignature(
         MetadataReader reader,

--- a/src/ILInspector.Metadata/ExtensionMethodScanner.cs
+++ b/src/ILInspector.Metadata/ExtensionMethodScanner.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using ILInspector.MetadataPrimitives;
 
 namespace ILInspector.Metadata;
 
@@ -14,7 +15,40 @@ public record ExtensionMethodInfo(
     string ExtendedType,
     string Signature,
     string? Assembly = null,
-    string Kind = "method");
+    string Kind = "method")
+{
+    public MemberAnchor? Anchor { get; init; }
+    public string? ReturnType { get; init; }
+    public string? CanonicalExtendedType { get; init; }
+
+    // Preserve the original seven-field record contract. The structured fields
+    // are derived from the same metadata and intentionally do not affect equality.
+    public virtual bool Equals(ExtensionMethodInfo? other)
+        => ReferenceEquals(this, other)
+        || other is not null
+        && EqualityContract == other.EqualityContract
+        && string.Equals(MethodName, other.MethodName, StringComparison.Ordinal)
+        && string.Equals(ExtensionClass, other.ExtensionClass, StringComparison.Ordinal)
+        && string.Equals(Namespace, other.Namespace, StringComparison.Ordinal)
+        && string.Equals(ExtendedType, other.ExtendedType, StringComparison.Ordinal)
+        && string.Equals(Signature, other.Signature, StringComparison.Ordinal)
+        && string.Equals(Assembly, other.Assembly, StringComparison.Ordinal)
+        && string.Equals(Kind, other.Kind, StringComparison.Ordinal);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(EqualityContract);
+        hash.Add(MethodName, StringComparer.Ordinal);
+        hash.Add(ExtensionClass, StringComparer.Ordinal);
+        hash.Add(Namespace, StringComparer.Ordinal);
+        hash.Add(ExtendedType, StringComparer.Ordinal);
+        hash.Add(Signature, StringComparer.Ordinal);
+        hash.Add(Assembly, StringComparer.Ordinal);
+        hash.Add(Kind, StringComparer.Ordinal);
+        return hash.ToHashCode();
+    }
+}
 
 /// <summary>
 /// Scans assemblies for extension methods targeting a specific type.
@@ -54,7 +88,7 @@ public static class ExtensionMethodScanner
             string fullClassName = TypeResolver.FormatDisplayName(reader.GetFullTypeName(typeDef));
 
             // Track property accessors seen (for deduplication of get_/set_ pairs)
-            var seenPropertyNames = new HashSet<string>(StringComparer.Ordinal);
+            var seenProperties = new HashSet<string>(StringComparer.Ordinal);
 
             foreach (var methodHandle in typeDef.GetMethods())
             {
@@ -86,7 +120,9 @@ public static class ExtensionMethodScanner
                     if (TypeMatcher.Matches(normalizedExtended, normalizedTarget))
                     {
                         string propertyName = methodName.Substring(4); // strip get_ or set_
-                        if (!seenPropertyNames.Add(propertyName)) continue; // deduplicate
+                        var anchorInfo = ApiMemberIdentity.CreateExtensionPropertyAnchorInfo(
+                            reader, typeDefHandle, method, propertyName);
+                        if (!seenProperties.Add(anchorInfo.Anchor.CanonicalSignature)) continue;
 
                         var propSignature = FormatPropertySignature(signature, extendedType, propertyName);
                         yield return new ExtensionMethodInfo(
@@ -95,7 +131,12 @@ public static class ExtensionMethodScanner
                             Namespace: classNs,
                             ExtendedType: extendedType,
                             Signature: propSignature,
-                            Kind: "property");
+                            Kind: "property")
+                        {
+                            Anchor = anchorInfo.Anchor,
+                            ReturnType = anchorInfo.ReturnType,
+                            CanonicalExtendedType = anchorInfo.ExtendedType,
+                        };
                     }
                     continue;
                 }
@@ -118,12 +159,19 @@ public static class ExtensionMethodScanner
                     // Match against target
                     if (TypeMatcher.Matches(normalizedExtended, normalizedTarget))
                     {
+                        var anchorInfo = ApiMemberIdentity.CreateExtensionMethodAnchorInfo(
+                            reader, typeDefHandle, method);
                         yield return new ExtensionMethodInfo(
                             MethodName: methodName,
                             ExtensionClass: fullClassName,
                             Namespace: classNs,
                             ExtendedType: extendedType,
-                            Signature: FormatMethodSignature(reader, typeDef, method, context));
+                            Signature: FormatMethodSignature(reader, typeDef, method, context))
+                        {
+                            Anchor = anchorInfo.Anchor,
+                            ReturnType = anchorInfo.ReturnType,
+                            CanonicalExtendedType = anchorInfo.ExtendedType,
+                        };
                     }
                 }
             }
@@ -168,7 +216,7 @@ public static class ExtensionMethodScanner
             string classNs = reader.GetString(typeDef.Namespace);
             string fullClassName = TypeResolver.FormatDisplayName(reader.GetFullTypeName(typeDef));
 
-            var seenPropertyNames = new HashSet<string>(StringComparer.Ordinal);
+            var seenProperties = new HashSet<string>(StringComparer.Ordinal);
 
             foreach (var methodHandle in typeDef.GetMethods())
             {
@@ -192,7 +240,9 @@ public static class ExtensionMethodScanner
 
                     var extendedType = signature.ParameterTypes[0];
                     string propertyName = methodName.Substring(4);
-                    if (!seenPropertyNames.Add(propertyName)) continue;
+                    var anchorInfo = ApiMemberIdentity.CreateExtensionPropertyAnchorInfo(
+                        reader, typeDefHandle, method, propertyName);
+                    if (!seenProperties.Add(anchorInfo.Anchor.CanonicalSignature)) continue;
 
                     var propSignature = FormatPropertySignature(signature, extendedType, propertyName);
                     yield return new ExtensionMethodInfo(
@@ -201,7 +251,12 @@ public static class ExtensionMethodScanner
                         Namespace: classNs,
                         ExtendedType: extendedType,
                         Signature: propSignature,
-                        Kind: "property");
+                        Kind: "property")
+                    {
+                        Anchor = anchorInfo.Anchor,
+                        ReturnType = anchorInfo.ReturnType,
+                        CanonicalExtendedType = anchorInfo.ExtendedType,
+                    };
                     continue;
                 }
 
@@ -217,12 +272,19 @@ public static class ExtensionMethodScanner
 
                     var extendedType = signature.ParameterTypes[0];
 
+                    var anchorInfo = ApiMemberIdentity.CreateExtensionMethodAnchorInfo(
+                        reader, typeDefHandle, method);
                     yield return new ExtensionMethodInfo(
                         MethodName: methodName,
                         ExtensionClass: fullClassName,
                         Namespace: classNs,
                         ExtendedType: extendedType,
-                        Signature: FormatMethodSignature(reader, typeDef, method, context));
+                        Signature: FormatMethodSignature(reader, typeDef, method, context))
+                    {
+                        Anchor = anchorInfo.Anchor,
+                        ReturnType = anchorInfo.ReturnType,
+                        CanonicalExtendedType = anchorInfo.ExtendedType,
+                    };
                 }
             }
         }

--- a/src/ILInspector.Metadata/ExtensionMethodScanner.cs
+++ b/src/ILInspector.Metadata/ExtensionMethodScanner.cs
@@ -119,7 +119,12 @@ public static class ExtensionMethodScanner
                     var signature = method.DecodeSignature(SignatureDecoder.Instance, context);
 
                     // Must have at least one parameter (the receiver); skip static extension properties (no receiver)
-                    if (signature.ParameterTypes.Length == 0) continue;
+                    if (signature.ParameterTypes.Length == 0
+                        || methodName.StartsWith("set_", StringComparison.Ordinal)
+                        && signature.ParameterTypes.Length < 2)
+                    {
+                        continue;
+                    }
 
                     var extendedType = signature.ParameterTypes[0];
                     var normalizedExtended = TypeMatcher.Normalize(extendedType);
@@ -252,7 +257,12 @@ public static class ExtensionMethodScanner
 
                     var context = GenericContext.ForMethod(reader, typeDef, method);
                     var signature = method.DecodeSignature(SignatureDecoder.Instance, context);
-                    if (signature.ParameterTypes.Length == 0) continue;
+                    if (signature.ParameterTypes.Length == 0
+                        || methodName.StartsWith("set_", StringComparison.Ordinal)
+                        && signature.ParameterTypes.Length < 2)
+                    {
+                        continue;
+                    }
 
                     var extendedType = signature.ParameterTypes[0];
                     string propertyName = methodName.Substring(4);
@@ -510,12 +520,10 @@ public static class ExtensionMethodScanner
         MetadataReader reader,
         TypeDefinitionHandle extensionClassHandle)
     {
-        var nestedTypes = reader.TypeDefinitions
-            .Where(handle => reader.GetTypeDefinition(handle).GetDeclaringType() == extensionClassHandle)
-            .ToArray();
+        var extensionClass = reader.GetTypeDefinition(extensionClassHandle);
         var hiddenProperties = new HashSet<string>(StringComparer.Ordinal);
 
-        foreach (var groupingTypeHandle in nestedTypes)
+        foreach (var groupingTypeHandle in extensionClass.GetNestedTypes())
         {
             var groupingType = reader.GetTypeDefinition(groupingTypeHandle);
             foreach (var propertyHandle in groupingType.GetProperties())
@@ -530,12 +538,10 @@ public static class ExtensionMethodScanner
                     continue;
                 }
 
-                var markerTypeHandle = reader.TypeDefinitions.FirstOrDefault(handle =>
-                {
-                    var candidate = reader.GetTypeDefinition(handle);
-                    return candidate.GetDeclaringType() == groupingTypeHandle
-                        && reader.StringComparer.Equals(candidate.Name, markerName!);
-                });
+                var markerTypeHandle = groupingType.GetNestedTypes().FirstOrDefault(handle =>
+                    reader.StringComparer.Equals(
+                        reader.GetTypeDefinition(handle).Name,
+                        markerName!));
                 if (markerTypeHandle.IsNil)
                     continue;
 

--- a/src/ILInspector.Metadata/ExtensionMethodScanner.cs
+++ b/src/ILInspector.Metadata/ExtensionMethodScanner.cs
@@ -106,7 +106,11 @@ public static class ExtensionMethodScanner
             foreach (var methodHandle in typeDef.GetMethods())
             {
                 var method = reader.GetMethodDefinition(methodHandle);
-                if ((method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public) continue;
+                if (!includeAll
+                    && (method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public)
+                {
+                    continue;
+                }
                 if ((method.Attributes & MethodAttributes.Static) == 0) continue;
 
                 string methodName = reader.GetString(method.Name);
@@ -201,7 +205,11 @@ public static class ExtensionMethodScanner
             foreach (var methodHandle in typeDef.GetMethods())
             {
                 var method = reader.GetMethodDefinition(methodHandle);
-                if ((method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public) continue;
+                if (!includeAll
+                    && (method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public)
+                {
+                    continue;
+                }
                 if ((method.Attributes & MethodAttributes.Static) == 0) continue;
 
                 string methodName = reader.GetString(method.Name);
@@ -422,9 +430,9 @@ public static class ExtensionMethodScanner
             {
                 var property = reader.GetPropertyDefinition(propertyHandle);
                 var accessors = property.GetAccessors();
-                bool hasPublicGetter = IsPublicAccessor(reader, accessors.Getter);
-                bool hasPublicSetter = IsPublicAccessor(reader, accessors.Setter);
-                if (!hasPublicGetter && !hasPublicSetter)
+                bool includeGetter = IsIncludedAccessor(reader, accessors.Getter, includeAll);
+                bool includeSetter = IsIncludedAccessor(reader, accessors.Setter, includeAll);
+                if (!includeGetter && !includeSetter)
                     continue;
 
                 if (!TryGetExtensionMarkerName(
@@ -453,8 +461,8 @@ public static class ExtensionMethodScanner
 
                 if (!includeAll
                     && (AttributeReader.HasHiddenAttribute(reader, property.GetCustomAttributes())
-                        || hasPublicGetter && IsHiddenAccessor(reader, accessors.Getter)
-                        || hasPublicSetter && IsHiddenAccessor(reader, accessors.Setter)))
+                        || includeGetter && IsHiddenAccessor(reader, accessors.Getter)
+                        || includeSetter && IsHiddenAccessor(reader, accessors.Setter)))
                 {
                     continue;
                 }
@@ -482,15 +490,18 @@ public static class ExtensionMethodScanner
                     SignatureDecoder.Instance,
                     displayContext);
                 string propertyName = reader.GetString(property.Name);
-                string accessorText = hasPublicGetter && hasPublicSetter
+                string parameterText = propertySignature.ParameterTypes.Length == 0
+                    ? ""
+                    : $"[{string.Join(", ", propertySignature.ParameterTypes)}]";
+                string accessorText = includeGetter && includeSetter
                     ? "get; set;"
-                    : hasPublicGetter ? "get;" : "set;";
+                    : includeGetter ? "get;" : "set;";
                 yield return new ExtensionMethodInfo(
                     MethodName: propertyName,
                     ExtensionClass: extensionClassName,
                     Namespace: extensionClassNamespace,
                     ExtendedType: markerSignature.ParameterTypes[0],
-                    Signature: $"{propertySignature.ReturnType} {propertyName} {{ {accessorText} }}",
+                    Signature: $"{propertySignature.ReturnType} {propertyName}{parameterText} {{ {accessorText} }}",
                     Kind: "property")
                 {
                     Anchor = anchorInfo.Anchor,
@@ -501,12 +512,14 @@ public static class ExtensionMethodScanner
         }
     }
 
-    private static bool IsPublicAccessor(
+    private static bool IsIncludedAccessor(
         MetadataReader reader,
-        MethodDefinitionHandle accessorHandle)
+        MethodDefinitionHandle accessorHandle,
+        bool includeAll)
         => !accessorHandle.IsNil
-        && (reader.GetMethodDefinition(accessorHandle).Attributes
-            & MethodAttributes.MemberAccessMask) == MethodAttributes.Public;
+        && (includeAll
+            || (reader.GetMethodDefinition(accessorHandle).Attributes
+                & MethodAttributes.MemberAccessMask) == MethodAttributes.Public);
 
     private static bool IsHiddenAccessor(
         MetadataReader reader,

--- a/src/ILInspector.Metadata/MemberCanonicalSignature.cs
+++ b/src/ILInspector.Metadata/MemberCanonicalSignature.cs
@@ -38,4 +38,14 @@ public static class MemberCanonicalSignature
             ? signature
             : $"{signature}~{conversionReturnType}";
     }
+
+    /// <summary>
+    /// Builds a canonical signature for a C# extension property. Unlike an
+    /// ordinary property, its receiver type is part of member identity.
+    /// </summary>
+    public static string BuildExtensionProperty(
+        string typeFullName,
+        string memberName,
+        IReadOnlyList<string> parameterTypeFullNames)
+        => $"P:{typeFullName}.{memberName}({string.Join(",", parameterTypeFullNames)})";
 }

--- a/src/ILInspector.Metadata/MetadataFindings.Extensions.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.Extensions.cs
@@ -1,0 +1,128 @@
+using ILInspector.Findings;
+using ILInspector.MetadataPrimitives;
+
+namespace ILInspector.Metadata;
+
+public enum ExtensionMemberKind
+{
+    Method,
+    Property,
+}
+
+/// <summary>
+/// An extension member bound to Metadata's stable member identity.
+/// Rendered declaration text remains outside the Finding payload.
+/// </summary>
+public sealed record ExtensionMemberObservation(
+    MemberAnchor Anchor,
+    ExtensionMemberKind Kind,
+    string ExtendedType,
+    string ReturnType,
+    string? Assembly = null)
+{
+    MemberAnchor _anchor = Anchor ?? throw new ArgumentNullException(nameof(Anchor));
+    string _extendedType = ExtendedType ?? throw new ArgumentNullException(nameof(ExtendedType));
+    string _returnType = ReturnType ?? throw new ArgumentNullException(nameof(ReturnType));
+
+    public MemberAnchor Anchor
+    {
+        get => _anchor;
+        init => _anchor = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    public string ExtendedType
+    {
+        get => _extendedType;
+        init => _extendedType = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    public string ReturnType
+    {
+        get => _returnType;
+        init => _returnType = value ?? throw new ArgumentNullException(nameof(value));
+    }
+}
+
+public static partial class MetadataFindings
+{
+    public static readonly FindingDescriptor ExtensionMemberDescriptor =
+        new("metadata.extension-member", "Extension member");
+
+    public static FindingInspection<ExtensionMemberObservation> InspectExtensionMembers(
+        IEnumerable<ExtensionMethodInfo> members,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(members);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return InspectExtensionMembersCore(members, subject, nameof(members));
+    }
+
+    static FindingInspection<ExtensionMemberObservation> InspectExtensionMembersCore(
+        IEnumerable<ExtensionMethodInfo> members,
+        FindingSubject subject,
+        string parameterName)
+    {
+        var materialized = members
+            .Select(member => member is null
+                ? throw new ArgumentException(
+                    "Extension member inventory cannot contain null observations.",
+                    parameterName)
+                : member)
+            .ToArray();
+
+        if (materialized.Any(static member =>
+                member.Anchor is null
+                || member.CanonicalExtendedType is null
+                || member.ReturnType is null))
+        {
+            return new FindingInspection<ExtensionMemberObservation>.Failed(
+                new InspectionError(
+                    subject,
+                    ExtensionMemberDescriptor,
+                    "One or more extension members do not have structured member shape."));
+        }
+
+        if (materialized.Any(static member => member.Kind is not ("method" or "property")))
+        {
+            return new FindingInspection<ExtensionMemberObservation>.Failed(
+                new InspectionError(
+                    subject,
+                    ExtensionMemberDescriptor,
+                    "One or more extension members have an unsupported member kind."));
+        }
+
+        return InspectInventory(
+            materialized.Select(static member => new ExtensionMemberObservation(
+                member.Anchor!,
+                member.Kind == "method" ? ExtensionMemberKind.Method : ExtensionMemberKind.Property,
+                member.CanonicalExtendedType!,
+                member.ReturnType!,
+                member.Assembly)),
+            subject,
+            ExtensionMemberDescriptor,
+            static member => JoinSortKey(
+                member.Anchor.CanonicalSignature,
+                member.Kind.ToString()),
+            static member => JoinSortKey(
+                member.Anchor.CanonicalSignature,
+                member.Kind.ToString(),
+                member.ExtendedType,
+                JoinSortKey(member.ReturnType, member.Assembly)),
+            parameterName);
+    }
+
+    public static FindingComparison<ExtensionMemberObservation> CompareExtensionMembers(
+        IEnumerable<ExtensionMethodInfo> oldMembers,
+        IEnumerable<ExtensionMethodInfo> newMembers,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(oldMembers);
+        ArgumentNullException.ThrowIfNull(newMembers);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return CompareInventory(
+            InspectExtensionMembersCore(oldMembers, subject, nameof(oldMembers)),
+            InspectExtensionMembersCore(newMembers, subject, nameof(newMembers)));
+    }
+}

--- a/src/ILInspector.Metadata/MethodClassificationScanner.cs
+++ b/src/ILInspector.Metadata/MethodClassificationScanner.cs
@@ -19,6 +19,8 @@ public record ClassifiedMethodInfo(
     public MemberAnchor? Anchor { get; init; }
     public string? ReturnType { get; init; }
 
+    // Preserve the original six-field record contract. Anchor and ReturnType are
+    // derived structured data and intentionally do not participate in equality.
     public virtual bool Equals(ClassifiedMethodInfo? other)
         => ReferenceEquals(this, other)
         || other is not null

--- a/tests/ILInspector.Metadata.Tests/MemberCanonicalSignatureTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MemberCanonicalSignatureTests.cs
@@ -50,4 +50,15 @@ public class MemberCanonicalSignatureTests
         // Parameter list is ignored for P/F/E even if provided.
         Assert.Equal(expected, MemberCanonicalSignature.Build(kind, typeName, memberName, ["System.Int32"]));
     }
+
+    [Fact]
+    public void BuildExtensionProperty_IncludesReceiverAndIndexerParameters()
+    {
+        Assert.Equal(
+            "P:Sample.Extensions.Item(System.String,System.Int32)",
+            MemberCanonicalSignature.BuildExtensionProperty(
+                "Sample.Extensions",
+                "Item",
+                ["System.String", "System.Int32"]));
+    }
 }

--- a/tests/ILInspector.Metadata.Tests/MetadataExtensionFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataExtensionFindingsTests.cs
@@ -85,6 +85,9 @@ public sealed class MetadataExtensionFindingsTests
             static member => member.MethodName == nameof(ExtensionPropertyIdentityFixture.Ordinary));
         Assert.DoesNotContain(
             members,
+            static member => member.MethodName == "Standalone");
+        Assert.DoesNotContain(
+            members,
             static member => member.MethodName == "Hidden");
 
         using var allStream = File.OpenRead(typeof(MetadataExtensionFindingsTests).Assembly.Location);
@@ -241,6 +244,7 @@ public sealed class MetadataExtensionFindingsTests
 public static class ExtensionPropertyIdentityFixture
 {
     public static int Ordinary { get; set; }
+    public static void set_Standalone(int value) { }
 
     extension(string value)
     {

--- a/tests/ILInspector.Metadata.Tests/MetadataExtensionFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataExtensionFindingsTests.cs
@@ -70,6 +70,27 @@ public sealed class MetadataExtensionFindingsTests
                 && member.MethodName == "Capacity");
         Assert.Equal("System.Text.StringBuilder", capacity.CanonicalExtendedType);
         Assert.Equal("System.Int32", capacity.ReturnType);
+        var indexer = Assert.Single(
+            members,
+            static member =>
+                member.ExtensionClass.EndsWith(
+                    nameof(ExtensionPropertyIdentityFixture),
+                    StringComparison.Ordinal)
+                && member.MethodName == "Item");
+        Assert.StartsWith("int Item", indexer.Signature, StringComparison.Ordinal);
+        Assert.Equal("System.Int32", indexer.ReturnType);
+        Assert.Contains("System.String", indexer.Anchor!.CanonicalSignature, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            members,
+            static member => member.MethodName == nameof(ExtensionPropertyIdentityFixture.Ordinary));
+        Assert.DoesNotContain(
+            members,
+            static member => member.MethodName == "Hidden");
+
+        using var allStream = File.OpenRead(typeof(MetadataExtensionFindingsTests).Assembly.Location);
+        Assert.Contains(
+            ExtensionMethodScanner.FindAllExtensions(allStream, includeAll: true),
+            static member => member.MethodName == "Hidden");
     }
 
     [Fact]
@@ -219,9 +240,14 @@ public sealed class MetadataExtensionFindingsTests
 
 public static class ExtensionPropertyIdentityFixture
 {
+    public static int Ordinary { get; set; }
+
     extension(string value)
     {
         public bool HasValue => value.Length > 0;
+
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        public bool Hidden => false;
     }
 
     extension(int value)
@@ -235,6 +261,11 @@ public static class ExtensionPropertyIdentityFixture
         {
             get => builder.Capacity;
             set => builder.Capacity = value;
+        }
+
+        public int this[string key]
+        {
+            set { }
         }
     }
 }

--- a/tests/ILInspector.Metadata.Tests/MetadataExtensionFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataExtensionFindingsTests.cs
@@ -89,11 +89,31 @@ public sealed class MetadataExtensionFindingsTests
         Assert.DoesNotContain(
             members,
             static member => member.MethodName == "Hidden");
+        Assert.DoesNotContain(
+            members,
+            static member => member.MethodName == "InternalValue");
+        Assert.DoesNotContain(
+            members,
+            static member => member.MethodName == "InternalClassic");
+        var defaultMixed = Assert.Single(
+            members,
+            static member => member.MethodName == "MixedVisibility");
+        Assert.Contains("get;", defaultMixed.Signature, StringComparison.Ordinal);
+        Assert.DoesNotContain("set;", defaultMixed.Signature, StringComparison.Ordinal);
 
         using var allStream = File.OpenRead(typeof(MetadataExtensionFindingsTests).Assembly.Location);
+        var allMembers = ExtensionMethodScanner.FindAllExtensions(
+            allStream,
+            includeAll: true).ToList();
         Assert.Contains(
-            ExtensionMethodScanner.FindAllExtensions(allStream, includeAll: true),
+            allMembers,
             static member => member.MethodName == "Hidden");
+        Assert.Contains(allMembers, static member => member.MethodName == "InternalValue");
+        Assert.Contains(allMembers, static member => member.MethodName == "InternalClassic");
+        var allMixed = Assert.Single(
+            allMembers,
+            static member => member.MethodName == "MixedVisibility");
+        Assert.Contains("get; set;", allMixed.Signature, StringComparison.Ordinal);
 
         using var targetedStream = File.OpenRead(typeof(MetadataExtensionFindingsTests).Assembly.Location);
         var stringExtensions = ExtensionMethodScanner.FindExtensions(
@@ -254,6 +274,7 @@ public static class ExtensionPropertyIdentityFixture
     public static int Ordinary { get; set; }
     public static int get_Standalone(string value) => value.Length;
     public static void set_Standalone(int value) { }
+    internal static int InternalClassic(this string value) => value.Length;
 
     extension(string value)
     {
@@ -264,9 +285,15 @@ public static class ExtensionPropertyIdentityFixture
         public bool Hidden => false;
     }
 
-    extension(int value)
+    extension(int number)
     {
-        public bool HasValue => value != 0;
+        public bool HasValue => number != 0;
+        internal bool InternalValue => false;
+        public int MixedVisibility
+        {
+            get => number;
+            internal set { }
+        }
     }
 
     extension(System.Text.StringBuilder builder)

--- a/tests/ILInspector.Metadata.Tests/MetadataExtensionFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataExtensionFindingsTests.cs
@@ -1,0 +1,240 @@
+using System.Collections.Immutable;
+using ILInspector.Findings;
+using ILInspector.MetadataPrimitives;
+
+namespace ILInspector.Metadata.Tests;
+
+public sealed class MetadataExtensionFindingsTests
+{
+    static readonly FindingSubject Subject = new("assembly", "Test assembly");
+
+    [Fact]
+    public void ScannerBindsMethodsAndPropertiesToCanonicalIdentity()
+    {
+        using var stream = File.OpenRead(typeof(MetadataFindings).Assembly.Location);
+        var members = ExtensionMethodScanner.FindAllExtensions(stream).ToList();
+
+        var methods = members
+            .Where(static member => member.MethodName == "GetFullTypeName")
+            .ToList();
+        var property = Assert.Single(
+            members,
+            static member => member.MethodName == "IsPublic" && member.Kind == "property");
+
+        Assert.Equal(3, methods.Count);
+        Assert.Equal(3, methods.Select(static method => method.Anchor).Distinct().Count());
+        Assert.All(methods, static method =>
+        {
+            Assert.NotNull(method.Anchor);
+            Assert.Equal("System.Reflection.Metadata.MetadataReader", method.CanonicalExtendedType);
+            Assert.False(string.IsNullOrEmpty(method.ReturnType));
+            Assert.StartsWith("M:", method.Anchor.CanonicalSignature, StringComparison.Ordinal);
+        });
+        Assert.Equal("System.Reflection.Metadata.TypeDefinition", property.CanonicalExtendedType);
+        Assert.Equal("System.Boolean", property.ReturnType);
+        Assert.StartsWith("P:", property.Anchor!.CanonicalSignature, StringComparison.Ordinal);
+        Assert.Contains(
+            "(System.Reflection.Metadata.TypeDefinition)",
+            property.Anchor.CanonicalSignature,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SamePropertyNameOnDifferentReceiversProducesDistinctMembers()
+    {
+        using var stream = File.OpenRead(typeof(MetadataExtensionFindingsTests).Assembly.Location);
+        var members = ExtensionMethodScanner.FindAllExtensions(stream).ToList();
+        var properties = members
+            .Where(static member =>
+                member.ExtensionClass.EndsWith(
+                    nameof(ExtensionPropertyIdentityFixture),
+                    StringComparison.Ordinal)
+                && member.MethodName == "HasValue")
+            .ToList();
+
+        Assert.Equal(2, properties.Count);
+        Assert.Equal(2, properties.Select(static property => property.Anchor).Distinct().Count());
+        Assert.Equal(
+            ["System.Int32", "System.String"],
+            properties
+                .Select(static property => property.CanonicalExtendedType!)
+                .Order(StringComparer.Ordinal)
+                .ToArray());
+
+        var capacity = Assert.Single(
+            members,
+            static member =>
+                member.ExtensionClass.EndsWith(
+                    nameof(ExtensionPropertyIdentityFixture),
+                    StringComparison.Ordinal)
+                && member.MethodName == "Capacity");
+        Assert.Equal("System.Text.StringBuilder", capacity.CanonicalExtendedType);
+        Assert.Equal("System.Int32", capacity.ReturnType);
+    }
+
+    [Fact]
+    public void DisplayChangesDoNotChangeExtensionObservations()
+    {
+        var member = CreateMember("M:Sample.Extensions.M(System.String)");
+        var comparison = MetadataFindings.CompareExtensionMembers(
+            [member],
+            [member with { Signature = "different display text" }],
+            Subject);
+
+        var pair = Assert.Single(Pairs(comparison));
+        var present = Assert.IsType<PairFinding<ExtensionMemberObservation>.Present>(pair.Value);
+        Assert.DoesNotContain(
+            "different display text",
+            present.New.Payload.Anchor.CanonicalSignature,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PayloadChangesAreChangedButReceiverChangesAreExactTransitions()
+    {
+        var member = CreateMember("M:Sample.Extensions.M(System.String)");
+        var returnChange = MetadataFindings.CompareExtensionMembers(
+            [member],
+            [member with { ReturnType = "System.Int64" }],
+            Subject);
+        var receiverChange = MetadataFindings.CompareExtensionMembers(
+            [member],
+            [CreateMember(
+                "M:Sample.Extensions.M(System.Object)",
+                canonicalExtendedType: "System.Object")],
+            Subject);
+
+        Assert.Equal(PairKind.Changed, Assert.Single(Pairs(returnChange)).Kind);
+        Assert.Equal(1, Pairs(receiverChange).Count(static pair => pair.Kind == PairKind.Added));
+        Assert.Equal(1, Pairs(receiverChange).Count(static pair => pair.Kind == PairKind.Removed));
+    }
+
+    [Fact]
+    public void MissingShapeOrUnknownKindFailsTheWholeCensus()
+    {
+        ExtensionMethodInfo unbound = new(
+            "M",
+            "Sample.Extensions",
+            "Sample",
+            "string",
+            "void M(this string value)");
+        var unknown = CreateMember("M:Sample.Extensions.M(System.String)") with
+        {
+            Kind = "event",
+        };
+
+        var missingShape = MetadataFindings.InspectExtensionMembers([unbound], Subject);
+        var unknownKind = MetadataFindings.CompareExtensionMembers([unknown], [], Subject);
+
+        var failedInspection =
+            Assert.IsType<FindingInspection<ExtensionMemberObservation>.Failed>(missingShape.Value);
+        Assert.Contains("structured member shape", failedInspection.Error.Reason, StringComparison.Ordinal);
+        var failedComparison =
+            Assert.IsType<FindingComparison<ExtensionMemberObservation>.Failed>(unknownKind.Value);
+        Assert.Contains("unsupported member kind", failedComparison.Failure, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LegacyRecordEqualityAndDeconstructionIgnoreAdditiveShape()
+    {
+        ExtensionMethodInfo enriched = CreateMember("M:Sample.Extensions.M(System.String)");
+        ExtensionMethodInfo legacy = new(
+            "M",
+            "Sample.Extensions",
+            "Sample",
+            "string",
+            "void M(this string value)",
+            "Sample",
+            "method");
+
+        var (name, extensionClass, @namespace, extendedType, signature, assembly, kind) = enriched;
+
+        Assert.Equal(legacy, enriched);
+        Assert.Equal(legacy.GetHashCode(), enriched.GetHashCode());
+        Assert.Equal("M", name);
+        Assert.Equal("Sample.Extensions", extensionClass);
+        Assert.Equal("Sample", @namespace);
+        Assert.Equal("string", extendedType);
+        Assert.Equal("void M(this string value)", signature);
+        Assert.Equal("Sample", assembly);
+        Assert.Equal("method", kind);
+    }
+
+    [Fact]
+    public void RealScannerOutputProjectsWithoutChangingTheCensus()
+    {
+        using var stream = File.OpenRead(typeof(MetadataFindings).Assembly.Location);
+        var members = ExtensionMethodScanner.FindAllExtensions(stream).ToList();
+
+        var inspection = MetadataFindings.InspectExtensionMembers(members, Subject);
+
+        Assert.Equal(members.Count, Findings(inspection).Length);
+        Assert.All(members, static member =>
+        {
+            Assert.NotNull(member.Anchor);
+            Assert.False(string.IsNullOrEmpty(member.CanonicalExtendedType));
+            Assert.False(string.IsNullOrEmpty(member.ReturnType));
+        });
+        Assert.NotEmpty(members);
+    }
+
+    static ExtensionMethodInfo CreateMember(
+        string canonicalSignature,
+        string canonicalExtendedType = "System.String")
+    {
+        string fingerprint = MemberAnchor.ComputeFingerprint(canonicalSignature);
+        var anchor = new MemberAnchor(
+            $"extension:M~{fingerprint}",
+            canonicalSignature,
+            fingerprint,
+            "Sample.Extensions",
+            "M");
+        return new ExtensionMethodInfo(
+            "M",
+            "Sample.Extensions",
+            "Sample",
+            "string",
+            "void M(this string value)",
+            "Sample",
+            "method")
+        {
+            Anchor = anchor,
+            ReturnType = "System.Void",
+            CanonicalExtendedType = canonicalExtendedType,
+        };
+    }
+
+    static ImmutableArray<Finding<T>> Findings<T>(FindingInspection<T> inspection)
+        where T : notnull
+        => inspection is FindingInspection<T>.Complete complete
+            ? complete.Findings
+            : throw new Xunit.Sdk.XunitException($"Expected complete inspection: {inspection}");
+
+    static ImmutableArray<PairFinding<T>> Pairs<T>(FindingComparison<T> comparison)
+        where T : notnull
+        => comparison is FindingComparison<T>.Complete complete
+            ? complete.Pairs
+            : throw new Xunit.Sdk.XunitException($"Expected complete comparison: {comparison.Failure}");
+}
+
+public static class ExtensionPropertyIdentityFixture
+{
+    extension(string value)
+    {
+        public bool HasValue => value.Length > 0;
+    }
+
+    extension(int value)
+    {
+        public bool HasValue => value != 0;
+    }
+
+    extension(System.Text.StringBuilder builder)
+    {
+        public int Capacity
+        {
+            get => builder.Capacity;
+            set => builder.Capacity = value;
+        }
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/MetadataExtensionFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataExtensionFindingsTests.cs
@@ -70,16 +70,6 @@ public sealed class MetadataExtensionFindingsTests
                 && member.MethodName == "Capacity");
         Assert.Equal("System.Text.StringBuilder", capacity.CanonicalExtendedType);
         Assert.Equal("System.Int32", capacity.ReturnType);
-        var indexer = Assert.Single(
-            members,
-            static member =>
-                member.ExtensionClass.EndsWith(
-                    nameof(ExtensionPropertyIdentityFixture),
-                    StringComparison.Ordinal)
-                && member.MethodName == "Item");
-        Assert.StartsWith("int Item", indexer.Signature, StringComparison.Ordinal);
-        Assert.Equal("System.Int32", indexer.ReturnType);
-        Assert.Contains("System.String", indexer.Anchor!.CanonicalSignature, StringComparison.Ordinal);
         Assert.DoesNotContain(
             members,
             static member => member.MethodName == nameof(ExtensionPropertyIdentityFixture.Ordinary));
@@ -265,11 +255,6 @@ public static class ExtensionPropertyIdentityFixture
         {
             get => builder.Capacity;
             set => builder.Capacity = value;
-        }
-
-        public int this[string key]
-        {
-            set { }
         }
     }
 }

--- a/tests/ILInspector.Metadata.Tests/MetadataExtensionFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataExtensionFindingsTests.cs
@@ -70,6 +70,16 @@ public sealed class MetadataExtensionFindingsTests
                 && member.MethodName == "Capacity");
         Assert.Equal("System.Text.StringBuilder", capacity.CanonicalExtendedType);
         Assert.Equal("System.Int32", capacity.ReturnType);
+        var staticValue = Assert.Single(
+            members,
+            static member =>
+                member.ExtensionClass.EndsWith(
+                    nameof(ExtensionPropertyIdentityFixture),
+                    StringComparison.Ordinal)
+                && member.MethodName == "StaticValue");
+        Assert.Equal("System.String", staticValue.CanonicalExtendedType);
+        Assert.Equal("System.Int32", staticValue.ReturnType);
+        Assert.StartsWith("P:", staticValue.Anchor!.CanonicalSignature, StringComparison.Ordinal);
         Assert.DoesNotContain(
             members,
             static member => member.MethodName == nameof(ExtensionPropertyIdentityFixture.Ordinary));
@@ -84,6 +94,14 @@ public sealed class MetadataExtensionFindingsTests
         Assert.Contains(
             ExtensionMethodScanner.FindAllExtensions(allStream, includeAll: true),
             static member => member.MethodName == "Hidden");
+
+        using var targetedStream = File.OpenRead(typeof(MetadataExtensionFindingsTests).Assembly.Location);
+        var stringExtensions = ExtensionMethodScanner.FindExtensions(
+            targetedStream,
+            "System.String",
+            includeAll: true);
+        Assert.Contains(stringExtensions, static member => member.MethodName == "StaticValue");
+        Assert.DoesNotContain(stringExtensions, static member => member.MethodName == "Standalone");
     }
 
     [Fact]
@@ -234,11 +252,13 @@ public sealed class MetadataExtensionFindingsTests
 public static class ExtensionPropertyIdentityFixture
 {
     public static int Ordinary { get; set; }
+    public static int get_Standalone(string value) => value.Length;
     public static void set_Standalone(int value) { }
 
     extension(string value)
     {
         public bool HasValue => value.Length > 0;
+        public static int StaticValue => 42;
 
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public bool Hidden => false;


### PR DESCRIPTION
Adds typed Metadata Finding producers for extension methods and C# 14 extension properties. Findings use canonical structured identity, preserve the legacy scanner record contract, fail the whole census when shape is unavailable, and keep rendered signatures out of payloads.

Extension-property identity includes receiver and index parameters, deduplicates getter/setter accessors, distinguishes same-named properties across receivers, filters hidden declaration metadata, and excludes ordinary property accessors and standalone `set_*` methods.

Also addresses late review findings from #2621: rank-zero array formatting cannot throw `ArgumentOutOfRangeException`, generic method fallback parameters use `!!`, and the intentional classified-method equality boundary is documented.

Validation: full solution build; 450 Metadata tests; 25 targeted product scanner tests. Final adversarial reviews on this exact rebased head are CLEAN from Claude Opus 4.8 and Gemini 3.1 Pro.