### PR TITLE
Require explicit custom attribute JSON order

### DIFF
--- a/src/dotnet-inspect.Tests/LibraryFindingConsumerTests.cs
+++ b/src/dotnet-inspect.Tests/LibraryFindingConsumerTests.cs
@@ -63,9 +63,6 @@ public class LibraryFindingConsumerTests
             ResourceInspection = MetadataFindings.InspectResources(
                 resources,
                 FindingTestData.Subject),
-            AssemblyAttributeInspection = MetadataFindings.InspectAssemblyAttributes(
-                attributes,
-                FindingTestData.Subject),
             TypeForwarderInspection = MetadataFindings.InspectTypeForwarders(
                 [new TypeForwarderInfo("Test.Forwarded", "Test.Target")],
                 FindingTestData.Subject),
@@ -83,7 +80,9 @@ public class LibraryFindingConsumerTests
                 FindingTestData.Subject),
         };
         inspection.SetAssemblyAttributeInspection(
-            inspection.AssemblyAttributeInspection!,
+            MetadataFindings.InspectAssemblyAttributes(
+                attributes,
+                FindingTestData.Subject),
             attributes);
 
         var json = JsonSerializer.Serialize(inspection, JsonContext.Default.LibraryInspection);
@@ -108,6 +107,16 @@ public class LibraryFindingConsumerTests
         Assert.Equal("Test.ChatClient", root.GetProperty("ai")[0].GetProperty("name").GetString());
         Assert.Equal("Test.ActivitySource", root.GetProperty("open_telemetry")[0].GetProperty("name").GetString());
         Assert.DoesNotContain("inspection", json, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void AssemblyAttributeInspection_RequiresExplicitJsonOrder()
+    {
+        var property = typeof(LibraryInspection).GetProperty(
+            nameof(LibraryInspection.AssemblyAttributeInspection));
+
+        Assert.NotNull(property);
+        Assert.False(property.CanWrite);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -1194,13 +1194,15 @@ public class OutputFormatterTests
     public void SingleAudit_CustomAttributes_AreSortedByName()
     {
         var inspection = CreateTestAudit("Test.dll", "net9.0");
-        inspection.AssemblyAttributeInspection = MetadataFindings.InspectAssemblyAttributes(
-            [
-                new AssemblyAttributeInfo("NeutralResourcesLanguage", "Assembly", "en-US"),
-                new AssemblyAttributeInfo("AssemblyMetadata(Serviceable)", "Assembly", "True"),
-                new AssemblyAttributeInfo("AssemblyDefaultAlias", "Assembly", "Test"),
-            ],
-            FindingTestData.Subject);
+        inspection.SetAssemblyAttributeInspection(
+            MetadataFindings.InspectAssemblyAttributes(
+                [
+                    new AssemblyAttributeInfo("NeutralResourcesLanguage", "Assembly", "en-US"),
+                    new AssemblyAttributeInfo("AssemblyMetadata(Serviceable)", "Assembly", "True"),
+                    new AssemblyAttributeInfo("AssemblyDefaultAlias", "Assembly", "Test"),
+                ],
+                FindingTestData.Subject),
+            jsonOrder: null);
 
         var output = Serialize(inspection);
 

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1463,9 +1463,6 @@ public class SectionPipelineTests
             ResourceInspection = MetadataFindings.InspectResources(
                 [new ManifestResourceInfo("res", IsPublic: true, IsEmbedded: true, Size: 1)],
                 FindingTestData.Subject),
-            AssemblyAttributeInspection = MetadataFindings.InspectAssemblyAttributes(
-                [new AssemblyAttributeInfo("Attr", "Assembly", null)],
-                FindingTestData.Subject),
             TypeForwarderInspection = MetadataFindings.InspectTypeForwarders(
                 [new TypeForwarderInfo("T", "Other")],
                 FindingTestData.Subject),
@@ -1491,6 +1488,11 @@ public class SectionPipelineTests
                 [new OpenTelemetrySignalInfo("T", "M")],
                 FindingTestData.Subject),
         };
+        library.SetAssemblyAttributeInspection(
+            MetadataFindings.InspectAssemblyAttributes(
+                [new AssemblyAttributeInfo("Attr", "Assembly", null)],
+                FindingTestData.Subject),
+            jsonOrder: null);
         yield return DiscoverableCase("library", libraryPipeline, library);
 
         var packagePipeline = PackageSectionDescriptors.CreatePipeline();

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -164,8 +164,13 @@ internal static class LibraryMetadataService
                         path, MetadataFindings.ClassifiedMethodDescriptor, ex);
                     inspection.ResourceInspection ??= FailedInspection<MetadataResource>(
                         path, MetadataFindings.ResourceDescriptor, ex);
-                    inspection.AssemblyAttributeInspection ??= FailedInspection<AssemblyAttributeInfo>(
-                        path, MetadataFindings.AssemblyAttributeDescriptor, ex);
+                    if (inspection.AssemblyAttributeInspection is null)
+                    {
+                        inspection.SetAssemblyAttributeInspection(
+                            FailedInspection<AssemblyAttributeInfo>(
+                                path, MetadataFindings.AssemblyAttributeDescriptor, ex),
+                            jsonOrder: null);
+                    }
                     inspection.UnionTypeInspection ??= FailedInspection<UnionTypeInfo>(
                         path, MetadataFindings.UnionTypeDescriptor, ex);
                     inspection.TypeForwarderInspection ??= FailedInspection<TypeForwarderInfo>(
@@ -1157,8 +1162,13 @@ internal static class LibraryMetadataService
                 path, MetadataFindings.ClassifiedMethodDescriptor, ex);
             inspection.ResourceInspection ??= FailedInspection<MetadataResource>(
                 path, MetadataFindings.ResourceDescriptor, ex);
-            inspection.AssemblyAttributeInspection ??= FailedInspection<AssemblyAttributeInfo>(
-                path, MetadataFindings.AssemblyAttributeDescriptor, ex);
+            if (inspection.AssemblyAttributeInspection is null)
+            {
+                inspection.SetAssemblyAttributeInspection(
+                    FailedInspection<AssemblyAttributeInfo>(
+                        path, MetadataFindings.AssemblyAttributeDescriptor, ex),
+                    jsonOrder: null);
+            }
             inspection.TypeForwarderInspection ??= FailedInspection<TypeForwarderInfo>(
                 path, MetadataFindings.TypeForwarderDescriptor, ex);
         }
@@ -1252,8 +1262,10 @@ internal static class LibraryMetadataService
         catch (Exception ex)
         {
             logger.Log($"Warning: Error scanning custom attributes in {path}: {ex.Message}");
-            inspection.AssemblyAttributeInspection = FailedInspection<AssemblyAttributeInfo>(
-                path, MetadataFindings.AssemblyAttributeDescriptor, ex);
+            inspection.SetAssemblyAttributeInspection(
+                FailedInspection<AssemblyAttributeInfo>(
+                    path, MetadataFindings.AssemblyAttributeDescriptor, ex),
+                jsonOrder: null);
         }
     }
 
@@ -1271,8 +1283,10 @@ internal static class LibraryMetadataService
         catch (Exception ex)
         {
             logger.Log($"Warning: Error scanning custom attributes in {path}: {ex.Message}");
-            inspection.AssemblyAttributeInspection = FailedInspection<AssemblyAttributeInfo>(
-                path, MetadataFindings.AssemblyAttributeDescriptor, ex);
+            inspection.SetAssemblyAttributeInspection(
+                FailedInspection<AssemblyAttributeInfo>(
+                    path, MetadataFindings.AssemblyAttributeDescriptor, ex),
+                jsonOrder: null);
         }
     }
 

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -381,26 +381,17 @@ public class LibraryInspection
     }
 
     [JsonIgnore]
-    public FindingInspection<AssemblyAttributeInfo>? AssemblyAttributeInspection
-    {
-        get => _assemblyAttributeInspection;
-        set
-        {
-            _assemblyAttributeInspection = value;
-            _assemblyAttributeJsonOrder = null;
-            ResetFindingProjectionCaches();
-        }
-    }
+    public FindingInspection<AssemblyAttributeInfo>? AssemblyAttributeInspection =>
+        _assemblyAttributeInspection;
 
     internal void SetAssemblyAttributeInspection(
         FindingInspection<AssemblyAttributeInfo> inspection,
-        IReadOnlyList<AssemblyAttributeInfo> jsonOrder)
+        IReadOnlyList<AssemblyAttributeInfo>? jsonOrder)
     {
         ArgumentNullException.ThrowIfNull(inspection);
-        ArgumentNullException.ThrowIfNull(jsonOrder);
 
         _assemblyAttributeInspection = inspection;
-        _assemblyAttributeJsonOrder = jsonOrder.ToArray();
+        _assemblyAttributeJsonOrder = jsonOrder?.ToArray();
         ResetFindingProjectionCaches();
     }
 


### PR DESCRIPTION
## Summary

- make `AssemblyAttributeInspection` read-only so callers cannot silently discard retained JSON order
- route every success and failure assignment through one internal method with a required `jsonOrder` argument
- pin the no-public-setter contract and preserve existing Finding, Markdown, failure, and raw JSON behavior

Follow-up to the non-blocking footgun identified on #2628.

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- -class '*LibraryFindingConsumerTests*'` — 9 passed
- focused custom-attribute Markdown and console-capture reruns passed
- raw `library ... --json -v:d --references` output is byte-identical to #2628 for the same assembly

This is a low-risk contract-only change; no product behavior changes and no adversarial review required.
