### PR TITLE
Filter hidden extension accessors independently

### DIFF
--- a/src/ILInspector.Metadata/ExtensionMethodScanner.cs
+++ b/src/ILInspector.Metadata/ExtensionMethodScanner.cs
@@ -460,11 +460,19 @@ public static class ExtensionMethodScanner
                     continue;
 
                 if (!includeAll
-                    && (AttributeReader.HasHiddenAttribute(reader, property.GetCustomAttributes())
-                        || includeGetter && IsHiddenAccessor(reader, accessors.Getter)
-                        || includeSetter && IsHiddenAccessor(reader, accessors.Setter)))
+                    && AttributeReader.HasHiddenAttribute(reader, property.GetCustomAttributes()))
                 {
                     continue;
+                }
+
+                if (!includeAll)
+                {
+                    if (includeGetter && IsHiddenAccessor(reader, accessors.Getter))
+                        includeGetter = false;
+                    if (includeSetter && IsHiddenAccessor(reader, accessors.Setter))
+                        includeSetter = false;
+                    if (!includeGetter && !includeSetter)
+                        continue;
                 }
 
                 var markerMethod = reader.GetMethodDefinition(markerMethodHandle);

--- a/tests/ILInspector.Metadata.Tests/MetadataExtensionFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataExtensionFindingsTests.cs
@@ -100,6 +100,11 @@ public sealed class MetadataExtensionFindingsTests
             static member => member.MethodName == "MixedVisibility");
         Assert.Contains("get;", defaultMixed.Signature, StringComparison.Ordinal);
         Assert.DoesNotContain("set;", defaultMixed.Signature, StringComparison.Ordinal);
+        var defaultPartiallyHidden = Assert.Single(
+            members,
+            static member => member.MethodName == "PartiallyHidden");
+        Assert.Contains("get;", defaultPartiallyHidden.Signature, StringComparison.Ordinal);
+        Assert.DoesNotContain("set;", defaultPartiallyHidden.Signature, StringComparison.Ordinal);
 
         using var allStream = File.OpenRead(typeof(MetadataExtensionFindingsTests).Assembly.Location);
         var allMembers = ExtensionMethodScanner.FindAllExtensions(
@@ -114,6 +119,10 @@ public sealed class MetadataExtensionFindingsTests
             allMembers,
             static member => member.MethodName == "MixedVisibility");
         Assert.Contains("get; set;", allMixed.Signature, StringComparison.Ordinal);
+        var allPartiallyHidden = Assert.Single(
+            allMembers,
+            static member => member.MethodName == "PartiallyHidden");
+        Assert.Contains("get; set;", allPartiallyHidden.Signature, StringComparison.Ordinal);
 
         using var targetedStream = File.OpenRead(typeof(MetadataExtensionFindingsTests).Assembly.Location);
         var stringExtensions = ExtensionMethodScanner.FindExtensions(
@@ -293,6 +302,12 @@ public static class ExtensionPropertyIdentityFixture
         {
             get => number;
             internal set { }
+        }
+        public int PartiallyHidden
+        {
+            get => number;
+            [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+            set { }
         }
     }
 


### PR DESCRIPTION
## Summary

Preserve visible C# 14 extension-property accessors when a sibling accessor is hidden. Property-level hiding still suppresses the full declaration; `includeAll` still returns every accessor.

Follow-up to #2627 and its post-merge review feedback.

## Validation

- `ILInspector.Metadata.Tests`: 450 passed
- focused extension command tests: 16 passed
- Release solution build succeeded

## Adversarial review

- Claude Opus 4.8: CLEAN on exact head `2f5c3cda`
- Gemini 3.1 Pro: CLEAN on exact head `2f5c3cda`
- Reviewers agreed the property-level precedence, per-accessor filtering, null-handle guards, `includeAll` behavior, and compiler-emitted fixture coverage are correct. No findings required follow-up commits or non-actions.