### PR TITLE
Add Analysis allocation Findings

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,7 +135,9 @@ separate axes; see [Finding Coordinates](design/finding-coordinates.md).
 - **R1** is the lower, metadata/IL representation. `ILInspector.Analysis` reads
   assemblies with `System.Reflection.Metadata`, builds whole-assembly indexes,
   and produces method signals, direct-call evidence, allocation occurrences, and
-  leverage data without depending on the decompiler IR.
+  leverage data without depending on the decompiler IR. `AnalysisFindings`
+  projects allocation occurrences into one typed, IL-ordered census used by
+  both single-version and two-version consumers.
 - **R2** is the higher decompiler representation. `ILInspector.Decompiler`
   imports one method into IR, raises/lowers it for C# printing, projects raw or
   annotated IL, and supplies IR anchors for source-line placement.
@@ -148,6 +150,10 @@ separate axes; see [Finding Coordinates](design/finding-coordinates.md).
   computed as a view rather than stored as duplicate state. API comparisons
   retain Metadata's `ApiFindingComparison` (type/member `FindingComparison<T>`
   envelopes plus the classified `ApiDiff`) alongside the Research projection.
+  Allocation changes retain Analysis's
+  `FindingComparison<AllocationOccurrence>` on their Research projection;
+  count, hot/cold, and ranking fields are derived from that comparison rather
+  than from a separate count-only diff.
 
 `ResearchFactRegistry` is the dogfooded analyzer registry for the overlay.
 Producers implement `IResearchFactProducer` with a stable name, produced fact
@@ -158,7 +164,7 @@ includes:
 
 | Producer | Source | Facts |
 | -------- | ------ | ----- |
-| `AllocationOccurrenceFactProducer` | `ILInspector.Analysis` `LibraryBodyIndex` allocation occurrences | `alloc.box`, `alloc.array`, `alloc.new`, `alloc.closure`, `alloc.statemachine`, `alloc.delegate`, `alloc.enumerator` |
+| `AllocationOccurrenceFactProducer` | `ILInspector.Analysis` allocation Finding census | `alloc.box`, `alloc.array`, `alloc.new`, `alloc.closure`, `alloc.statemachine`, `alloc.delegate`, `alloc.enumerator` |
 | `DecompilerHiddenFactProducer` | existing decompiler annotation classifier | `unsafe.*`, `lifetime.*` |
 
 The important boundary is that Analysis remains SRM-only, NativeAOT-friendly,

--- a/docs/design/finding-coordinates.md
+++ b/docs/design/finding-coordinates.md
@@ -17,13 +17,16 @@ different questions and do not share one generic string slot.
 `Ordinal` does not control alignment or move classification. It lets an ordered
 producer retain the source-stream location after observations have been paired,
 materialized, or projected. Ordered IL, C#, and text observations populate it;
-Metadata identity sets leave it null.
+allocation observations also populate it after ordering by IL offset. Metadata
+identity sets leave it null.
 
 This distinction is intentional:
 
 - an API member does not gain semantic position because its inventory was
   sorted for deterministic output;
 - an IL operation's ordinal is an operation-array index, not its IL offset;
+- an allocation's ordinal is its position in the allocation census, while its
+  IL offset remains typed payload provenance;
 - a text line's ordinal is a logical line index, not a cross-document identity;
 - changing retained ordinals does not turn an order-preserving match into a
   move.

--- a/docs/design/finding-producers.md
+++ b/docs/design/finding-producers.md
@@ -161,6 +161,7 @@ Before approving a producer, answer:
 - Does comparison reuse the shared matcher and fold?
 - Which bespoke producer, adapter, or comparison path will this replace?
 
-The first end-to-end Analysis proof should use one allocation census for both
-single-version audit and old/new comparison, replacing the count-only Research
-allocation path rather than adding another adapter.
+The first end-to-end Analysis proof uses one allocation census for both
+single-version audit and old/new comparison. Research retains the typed
+allocation comparison and derives its compatibility count/hotness projection
+from it; there is no separate count-only allocation diff path.

--- a/src/ILInspector.Analysis.Tests/AnalysisFindingsTests.cs
+++ b/src/ILInspector.Analysis.Tests/AnalysisFindingsTests.cs
@@ -16,9 +16,8 @@ public class AnalysisFindingsTests
 
         var inspection = AnalysisFindings.InspectAllocations([later, earlier], Subject);
 
-        var complete = CompleteInspection(inspection);
         Assert.Collection(
-            complete.Findings,
+            inspection,
             finding =>
             {
                 Assert.Same(earlier, finding.Payload);
@@ -37,8 +36,7 @@ public class AnalysisFindingsTests
     {
         var inspection = AnalysisFindings.InspectAllocations([], Subject);
 
-        var complete = CompleteInspection(inspection);
-        Assert.Empty(complete.Findings);
+        Assert.Empty(inspection);
     }
 
     [Fact]
@@ -105,14 +103,6 @@ public class AnalysisFindingsTests
         Assert.Contains(complete.Pairs, pair => pair is PairFinding<AllocationOccurrence>.Added);
         Assert.DoesNotContain(complete.Pairs, pair => pair is PairFinding<AllocationOccurrence>.Present);
     }
-
-    static FindingInspection<AllocationOccurrence>.Complete CompleteInspection(
-        FindingInspection<AllocationOccurrence> inspection)
-        => inspection switch
-        {
-            FindingInspection<AllocationOccurrence>.Complete complete => complete,
-            _ => throw new InvalidOperationException("Expected a complete allocation inspection."),
-        };
 
     static FindingComparison<AllocationOccurrence>.Complete CompleteComparison(
         FindingComparison<AllocationOccurrence> comparison)

--- a/src/ILInspector.Analysis.Tests/AnalysisFindingsTests.cs
+++ b/src/ILInspector.Analysis.Tests/AnalysisFindingsTests.cs
@@ -1,0 +1,152 @@
+using System.Collections.Immutable;
+
+using ILInspector.Findings;
+
+namespace ILInspector.Analysis.Tests;
+
+public class AnalysisFindingsTests
+{
+    static readonly FindingSubject Subject = new("method:test", "Test.Method()");
+
+    [Fact]
+    public void InspectAllocations_ProducesCompleteIlOrderedCensus()
+    {
+        var later = Occurrence(12, AllocationKind.Box, TypeRef.CoreLib("System", "Int32"));
+        var earlier = Occurrence(4, AllocationKind.Object, TypeRef.CoreLib("System", "Object"));
+
+        var inspection = AnalysisFindings.InspectAllocations([later, earlier], Subject);
+
+        var complete = CompleteInspection(inspection);
+        Assert.Collection(
+            complete.Findings,
+            finding =>
+            {
+                Assert.Same(earlier, finding.Payload);
+                Assert.Equal(0, finding.Ordinal);
+                Assert.Equal(AnalysisFindings.AllocationDescriptor, finding.Descriptor);
+            },
+            finding =>
+            {
+                Assert.Same(later, finding.Payload);
+                Assert.Equal(1, finding.Ordinal);
+            });
+    }
+
+    [Fact]
+    public void InspectAllocations_EmptySequence_IsComplete()
+    {
+        var inspection = AnalysisFindings.InspectAllocations([], Subject);
+
+        var complete = CompleteInspection(inspection);
+        Assert.Empty(complete.Findings);
+    }
+
+    [Fact]
+    public void CompareAllocations_IgnoresVersionLocalProvenance()
+    {
+        var oldOccurrence = Occurrence(4, AllocationKind.Object, TypeRef.CoreLib("System", "Object"));
+        var newOccurrence = oldOccurrence with
+        {
+            Method = oldOccurrence.Method with
+            {
+                ModuleVersionId = Guid.Parse("22222222-2222-2222-2222-222222222222"),
+                MetadataToken = 0x06000002,
+            },
+            ILOffset = 20,
+            OperandToken = 0x0A000002,
+        };
+
+        var comparison = AnalysisFindings.CompareAllocations([oldOccurrence], [newOccurrence], Subject);
+
+        var complete = CompleteComparison(comparison);
+        var present = Assert.Single(complete.Pairs) switch
+        {
+            PairFinding<AllocationOccurrence>.Present value => value,
+            _ => throw new InvalidOperationException("Expected a present allocation."),
+        };
+        Assert.Equal(PairKind.Present, present.Kind);
+        Assert.Equal(FindingDifferenceKind.None, present.Difference);
+    }
+
+    [Fact]
+    public void CompareAllocations_ClassifiesSemanticFacetChange()
+    {
+        var oldOccurrence = Occurrence(4, AllocationKind.Object, TypeRef.CoreLib("System", "Object"));
+        var newOccurrence = oldOccurrence with
+        {
+            ILOffset = 8,
+            InLoop = true,
+            PathContext = AllocationPathContext.LoopBody,
+            Multiplicity = AllocationMultiplicity.Loop,
+        };
+
+        var comparison = AnalysisFindings.CompareAllocations([oldOccurrence], [newOccurrence], Subject);
+
+        var complete = CompleteComparison(comparison);
+        var changed = Assert.Single(complete.Pairs) switch
+        {
+            PairFinding<AllocationOccurrence>.Changed value => value,
+            _ => throw new InvalidOperationException("Expected a changed allocation."),
+        };
+        Assert.Contains("in loop: False -> True", changed.Detail);
+        Assert.Contains("multiplicity: Unknown -> Loop", changed.Detail);
+    }
+
+    [Fact]
+    public void CompareAllocations_EqualCountsWithDifferentIdentity_AreRemovedAndAdded()
+    {
+        var oldOccurrence = Occurrence(4, AllocationKind.Object, TypeRef.CoreLib("System", "Object"));
+        var newOccurrence = Occurrence(4, AllocationKind.Array, TypeRef.SzArray(TypeRef.CoreLib("System", "Byte")));
+
+        var comparison = AnalysisFindings.CompareAllocations([oldOccurrence], [newOccurrence], Subject);
+
+        var complete = CompleteComparison(comparison);
+        Assert.Contains(complete.Pairs, pair => pair is PairFinding<AllocationOccurrence>.Removed);
+        Assert.Contains(complete.Pairs, pair => pair is PairFinding<AllocationOccurrence>.Added);
+        Assert.DoesNotContain(complete.Pairs, pair => pair is PairFinding<AllocationOccurrence>.Present);
+    }
+
+    static FindingInspection<AllocationOccurrence>.Complete CompleteInspection(
+        FindingInspection<AllocationOccurrence> inspection)
+        => inspection switch
+        {
+            FindingInspection<AllocationOccurrence>.Complete complete => complete,
+            _ => throw new InvalidOperationException("Expected a complete allocation inspection."),
+        };
+
+    static FindingComparison<AllocationOccurrence>.Complete CompleteComparison(
+        FindingComparison<AllocationOccurrence> comparison)
+        => comparison switch
+        {
+            FindingComparison<AllocationOccurrence>.Complete complete => complete,
+            _ => throw new InvalidOperationException("Expected a complete allocation comparison."),
+        };
+
+    static AllocationOccurrence Occurrence(int offset, AllocationKind kind, TypeRef type)
+        => new(
+            new MethodIdentity(
+                "TestAssembly",
+                Guid.Parse("11111111-1111-1111-1111-111111111111"),
+                TypeRef.CoreLib("Test", "Fixture"),
+                "Method",
+                ImmutableArray<TypeRef>.Empty,
+                TypeRef.CoreLib("System", "Void"),
+                0x06000001,
+                IsStatic: true),
+            offset,
+            0x0A000001,
+            kind,
+            type,
+            type.ToDisplayString(),
+            CountsAsHeapAllocation: true,
+            AllocationFrequency.Always,
+            InLoop: false,
+            AllocationEscape.Unknown,
+            kind switch
+            {
+                AllocationKind.Array => AllocationFactSource.Newarr,
+                AllocationKind.Box => AllocationFactSource.Box,
+                AllocationKind.Enumerator => AllocationFactSource.GetEnumeratorCall,
+                _ => AllocationFactSource.Newobj,
+            });
+}

--- a/src/ILInspector.Analysis/AllocationOccurrence.cs
+++ b/src/ILInspector.Analysis/AllocationOccurrence.cs
@@ -96,8 +96,9 @@ public enum AllocationMultiplicity
 }
 
 /// <summary>
-/// One static heap-allocation occurrence, keyed by IL offset. Presentation layers
-/// project this into hidden-fact annotations, method signals, and triage rows.
+/// One static heap-allocation occurrence, located by IL offset within its method. The offset is
+/// version-local provenance, not cross-version correspondence identity. Presentation layers project
+/// this into Findings, hidden-fact annotations, method signals, and triage rows.
 /// </summary>
 public sealed record AllocationOccurrence(
     MethodIdentity Method,

--- a/src/ILInspector.Analysis/AnalysisFindings.cs
+++ b/src/ILInspector.Analysis/AnalysisFindings.cs
@@ -1,0 +1,139 @@
+using System.Collections.Immutable;
+
+using ILInspector.Findings;
+
+namespace ILInspector.Analysis;
+
+/// <summary>Analysis observations and comparisons over the Finding substrate.</summary>
+public static class AnalysisFindings
+{
+    public static readonly FindingDescriptor AllocationDescriptor =
+        new("analysis.allocation", "Allocation occurrence");
+
+    /// <summary>
+    /// Projects one method's allocation occurrences into IL order. An empty occurrence sequence is
+    /// a complete empty census; acquisition failures belong to the caller that builds the body index.
+    /// </summary>
+    public static FindingInspection<AllocationOccurrence> InspectAllocations(
+        IEnumerable<AllocationOccurrence> occurrences,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(occurrences);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        var ordered = occurrences
+            .OrderBy(static occurrence => occurrence.ILOffset)
+            .ThenBy(GetAllocationIdentityKey, StringComparer.Ordinal)
+            .ToImmutableArray();
+        var findings = ImmutableArray.CreateBuilder<Finding<AllocationOccurrence>>(ordered.Length);
+        for (int i = 0; i < ordered.Length; i++)
+        {
+            AllocationOccurrence occurrence = ordered[i];
+            findings.Add(new Finding<AllocationOccurrence>(
+                subject,
+                AllocationDescriptor,
+                new FindingKey(GetAllocationIdentityKey(occurrence)),
+                occurrence,
+                Ordinal: i,
+                Detail: occurrence.Detail));
+        }
+
+        return new FindingInspection<AllocationOccurrence>.Complete(findings.MoveToImmutable());
+    }
+
+    /// <summary>
+    /// Compares two allocation censuses conservatively. Hard correspondence requires the same
+    /// allocation source, kind, and allocated type; version-local IL coordinates never establish
+    /// cross-version identity.
+    /// </summary>
+    public static FindingComparison<AllocationOccurrence> CompareAllocations(
+        IEnumerable<AllocationOccurrence> oldOccurrences,
+        IEnumerable<AllocationOccurrence> newOccurrences,
+        FindingSubject subject,
+        int acceptanceThreshold = 100)
+    {
+        ArgumentNullException.ThrowIfNull(oldOccurrences);
+        ArgumentNullException.ThrowIfNull(newOccurrences);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return FindingComparison.Compare(
+                InspectAllocations(oldOccurrences, subject),
+                InspectAllocations(newOccurrences, subject),
+                acceptanceThreshold: acceptanceThreshold)
+            .TransformPairs(ClassifyFacetChanges);
+    }
+
+    public static string GetAllocationIdentityKey(AllocationOccurrence occurrence)
+    {
+        ArgumentNullException.ThrowIfNull(occurrence);
+        string allocatedType = occurrence.AllocatedType?.ToQualifiedDisplayString()
+            ?? occurrence.RuntimeAllocationType
+            ?? occurrence.Detail
+            ?? "?";
+        return $"{(int)occurrence.Source}:{(int)occurrence.Kind}:{allocatedType}";
+    }
+
+    static ImmutableArray<PairFinding<AllocationOccurrence>> ClassifyFacetChanges(
+        ImmutableArray<PairFinding<AllocationOccurrence>> pairs)
+    {
+        var builder = ImmutableArray.CreateBuilder<PairFinding<AllocationOccurrence>>(pairs.Length);
+        foreach (var pair in pairs)
+        {
+            if (pair is PairFinding<AllocationOccurrence>.Present present
+                && !SameSemanticFacets(present.Old.Payload, present.New.Payload))
+            {
+                builder.Add(new PairFinding<AllocationOccurrence>.Changed(
+                    present.Old,
+                    present.New,
+                    present.Difference,
+                    DescribeFacetChanges(present.Old.Payload, present.New.Payload)));
+            }
+            else
+            {
+                builder.Add(pair);
+            }
+        }
+
+        return builder.MoveToImmutable();
+    }
+
+    static bool SameSemanticFacets(AllocationOccurrence oldOccurrence, AllocationOccurrence newOccurrence)
+        => oldOccurrence with
+        {
+            Method = newOccurrence.Method,
+            ILOffset = newOccurrence.ILOffset,
+            OperandToken = newOccurrence.OperandToken,
+        } == newOccurrence;
+
+    static string DescribeFacetChanges(
+        AllocationOccurrence oldOccurrence,
+        AllocationOccurrence newOccurrence)
+    {
+        var changes = new List<string>();
+        AddChange(changes, "detail", oldOccurrence.Detail, newOccurrence.Detail);
+        AddChange(changes, "heap allocation", oldOccurrence.CountsAsHeapAllocation, newOccurrence.CountsAsHeapAllocation);
+        AddChange(changes, "frequency", oldOccurrence.Frequency, newOccurrence.Frequency);
+        AddChange(changes, "in loop", oldOccurrence.InLoop, newOccurrence.InLoop);
+        AddChange(changes, "escape", oldOccurrence.Escape, newOccurrence.Escape);
+        AddChange(changes, "runtime type", oldOccurrence.RuntimeAllocationType, newOccurrence.RuntimeAllocationType);
+        AddChange(changes, "path", oldOccurrence.PathContext, newOccurrence.PathContext);
+        AddChange(changes, "path confidence", oldOccurrence.PathConfidence, newOccurrence.PathConfidence);
+        AddChange(changes, "estimated size", oldOccurrence.EstimatedSizeBytes, newOccurrence.EstimatedSizeBytes);
+        AddChange(changes, "size tier", oldOccurrence.SizeTier, newOccurrence.SizeTier);
+        AddChange(changes, "post-dominance", oldOccurrence.PostDominance, newOccurrence.PostDominance);
+        AddChange(changes, "escape kind", oldOccurrence.EscapeKind, newOccurrence.EscapeKind);
+        AddChange(changes, "multiplicity", oldOccurrence.Multiplicity, newOccurrence.Multiplicity);
+        AddChange(changes, "churned type", oldOccurrence.ChurnedType, newOccurrence.ChurnedType);
+        return string.Join("; ", changes);
+    }
+
+    static void AddChange<T>(List<string> changes, string name, T oldValue, T newValue)
+    {
+        if (EqualityComparer<T>.Default.Equals(oldValue, newValue))
+            return;
+
+        changes.Add($"{name}: {Format(oldValue)} -> {Format(newValue)}");
+    }
+
+    static string Format<T>(T value) => value?.ToString() ?? "none";
+}

--- a/src/ILInspector.Analysis/AnalysisFindings.cs
+++ b/src/ILInspector.Analysis/AnalysisFindings.cs
@@ -72,6 +72,10 @@ public static class AnalysisFindings
     public static string GetAllocationIdentityKey(AllocationOccurrence occurrence)
     {
         ArgumentNullException.ThrowIfNull(occurrence);
+        // Analysis observations are heuristic evidence and may lack a resolved TypeRef. Keep the
+        // census usable by falling back through the producer's remaining type evidence. Unknown
+        // candidates remain conservatively aligned by stream order, and any non-provenance payload
+        // difference is still classified as Changed.
         string allocatedType = occurrence.AllocatedType?.ToQualifiedDisplayString()
             ?? occurrence.RuntimeAllocationType
             ?? occurrence.Detail
@@ -130,7 +134,7 @@ public static class AnalysisFindings
         AddChange(changes, "escape kind", oldOccurrence.EscapeKind, newOccurrence.EscapeKind);
         AddChange(changes, "multiplicity", oldOccurrence.Multiplicity, newOccurrence.Multiplicity);
         AddChange(changes, "churned type", oldOccurrence.ChurnedType, newOccurrence.ChurnedType);
-        return string.Join("; ", changes);
+        return changes.Count == 0 ? "other facets changed" : string.Join("; ", changes);
     }
 
     static void AddChange<T>(List<string> changes, string name, T oldValue, T newValue)

--- a/src/ILInspector.Analysis/AnalysisFindings.cs
+++ b/src/ILInspector.Analysis/AnalysisFindings.cs
@@ -14,7 +14,7 @@ public static class AnalysisFindings
     /// Projects one method's allocation occurrences into IL order. An empty occurrence sequence is
     /// a complete empty census; acquisition failures belong to the caller that builds the body index.
     /// </summary>
-    public static FindingInspection<AllocationOccurrence> InspectAllocations(
+    public static ImmutableArray<Finding<AllocationOccurrence>> InspectAllocations(
         IEnumerable<AllocationOccurrence> occurrences,
         FindingSubject subject)
     {
@@ -38,7 +38,7 @@ public static class AnalysisFindings
                 Detail: occurrence.Detail));
         }
 
-        return new FindingInspection<AllocationOccurrence>.Complete(findings.MoveToImmutable());
+        return findings.MoveToImmutable();
     }
 
     /// <summary>
@@ -56,9 +56,15 @@ public static class AnalysisFindings
         ArgumentNullException.ThrowIfNull(newOccurrences);
         ArgumentNullException.ThrowIfNull(subject);
 
+        FindingInspection<AllocationOccurrence> oldInspection =
+            new FindingInspection<AllocationOccurrence>.Complete(
+                InspectAllocations(oldOccurrences, subject));
+        FindingInspection<AllocationOccurrence> newInspection =
+            new FindingInspection<AllocationOccurrence>.Complete(
+                InspectAllocations(newOccurrences, subject));
         return FindingComparison.Compare(
-                InspectAllocations(oldOccurrences, subject),
-                InspectAllocations(newOccurrences, subject),
+                oldInspection,
+                newInspection,
                 acceptanceThreshold: acceptanceThreshold)
             .TransformPairs(ClassifyFacetChanges);
     }

--- a/src/ILInspector.Analysis/ILInspector.Analysis.csproj
+++ b/src/ILInspector.Analysis/ILInspector.Analysis.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ILInspector.ControlFlow\ILInspector.ControlFlow.csproj" />
+    <ProjectReference Include="..\ILInspector.Findings\ILInspector.Findings.csproj" />
     <ProjectReference Include="..\ILInspector.Instructions\ILInspector.Instructions.csproj" />
     <ProjectReference Include="..\ILInspector.Metadata\ILInspector.Metadata.csproj" />
   </ItemGroup>

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -739,7 +739,8 @@ public sealed class LibraryBodyIndex
 
     internal static LibraryBodyIndex FromEvidence(
         ImmutableArray<MethodIdentity> methods,
-        ImmutableArray<UnsafeEvidence> unsafeEvidence)
+        ImmutableArray<UnsafeEvidence> unsafeEvidence,
+        IReadOnlyDictionary<int, ImmutableArray<AllocationOccurrence>>? allocationOccurrences = null)
         => new(
             path: "",
             methods,
@@ -754,7 +755,8 @@ public sealed class LibraryBodyIndex
                 methods.Count(method => method.CallerUnsafeMode == CallerUnsafeMode.Implicit),
                 methods.Count(method => method.CallerUnsafeMode == CallerUnsafeMode.Explicit)),
             bodySignals: new Dictionary<int, BodySignals>(),
-            allocationOccurrences: new Dictionary<int, ImmutableArray<AllocationOccurrence>>(),
+            allocationOccurrences: allocationOccurrences
+                ?? new Dictionary<int, ImmutableArray<AllocationOccurrence>>(),
             unsafetyOccurrences: new Dictionary<int, ImmutableArray<UnsafetyOccurrence>>(),
             inAssemblyTypeIsException: new Dictionary<(string Namespace, string Name), bool>(),
             suppressedOpportunityTokens: new HashSet<int>(),

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using DotnetInspector.Fixtures;
@@ -164,6 +165,33 @@ public class ResearchDiffTests
 
         Assert.Same(row, bodySignal.BodySignalRow);
         Assert.Equal(ResearchChangeMechanism.ReturnToSender, statusOnly.Mechanism);
+    }
+
+    [Fact]
+    public void ResearchChange_RejectsAllocationComparisonFromAnotherMechanism()
+    {
+        var occurrence = AllocationOccurrence(
+            Method("Asm", Guid.Empty, 0x06000001),
+            0,
+            AllocationKind.Object,
+            TypeRef.CoreLib("System", "Object"));
+        var comparison = AnalysisFindings.CompareAllocations(
+            [occurrence],
+            [occurrence],
+            new FindingSubject("method:test", "Test.Method()"));
+        var subject = new ResearchSubjectKey(
+            ResearchSubjectKind.Member,
+            "M~1234567890",
+            "Sample.Widget.M()");
+
+        var error = Assert.Throws<ArgumentException>(() => new ResearchChange(
+            subject,
+            ResearchChangeMechanism.Api,
+            AnalysisFindings.AllocationDescriptor,
+            ResearchChangeKind.Changed,
+            allocationComparison: comparison));
+
+        Assert.Equal("allocationComparison", error.ParamName);
     }
 
     [Fact]
@@ -640,6 +668,65 @@ public class ResearchDiffTests
     }
 
     [Fact]
+    public void CompareAssemblies_BodySignals_EqualAllocationCountsRetainOccurrenceChanges()
+    {
+        var oldMethod = Method(
+            "Asm",
+            Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            0x06000001);
+        var newMethod = Method(
+            "Asm",
+            Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            0x06000002);
+        var oldOccurrence = AllocationOccurrence(
+            oldMethod,
+            4,
+            AllocationKind.Object,
+            TypeRef.CoreLib("System", "Object"));
+        var newOccurrence = AllocationOccurrence(
+            newMethod,
+            4,
+            AllocationKind.Array,
+            TypeRef.SzArray(TypeRef.CoreLib("System", "Byte")));
+        var oldIndex = LibraryBodyIndex.FromEvidence(
+            [oldMethod],
+            [],
+            new Dictionary<int, ImmutableArray<AllocationOccurrence>>
+            {
+                [oldMethod.MetadataToken] = [oldOccurrence],
+            });
+        var newIndex = LibraryBodyIndex.FromEvidence(
+            [newMethod],
+            [],
+            new Dictionary<int, ImmutableArray<AllocationOccurrence>>
+            {
+                [newMethod.MetadataToken] = [newOccurrence],
+            });
+
+        var diff = ResearchDiff.Compare(
+            ResearchDiffInput.FromAssembly("old.dll", bodyIndex: oldIndex),
+            ResearchDiffInput.FromAssembly("new.dll", bodyIndex: newIndex),
+            new ResearchDiffOptions(ResearchChangeMechanism.BodySignals));
+
+        var change = Assert.Single(diff.Changes, change =>
+            change.Descriptor == AnalysisFindings.AllocationDescriptor);
+        Assert.Equal("1", change.OldValue);
+        Assert.Equal("1", change.NewValue);
+        Assert.Equal("changed", change.Delta);
+        Assert.Equal(0, change.DirectionScore);
+        Assert.NotNull(change.AllocationComparison);
+        var comparison = change.AllocationComparison switch
+        {
+            FindingComparison<AllocationOccurrence>.Complete complete => complete,
+            _ => throw new InvalidOperationException("Expected a complete allocation comparison."),
+        };
+        Assert.Contains(comparison.Pairs, pair => pair is PairFinding<AllocationOccurrence>.Removed);
+        Assert.Contains(comparison.Pairs, pair => pair is PairFinding<AllocationOccurrence>.Added);
+        Assert.DoesNotContain(diff.Changes, change =>
+            change.Descriptor.Id == "analysis.signal.allocations");
+    }
+
+    [Fact]
     public void CompareAssemblies_IlBody_QueryImplementationChanges()
     {
         var diff = ResearchDiff.CompareAssemblies(
@@ -1068,6 +1155,37 @@ public class ResearchDiffTests
         Assert.Same(failure, row.IlDisplayFailureRow);
         Assert.Null(row.IlMemberDiff);
     }
+
+    static MethodIdentity Method(string assemblyName, Guid moduleVersionId, int metadataToken)
+        => new(
+            assemblyName,
+            moduleVersionId,
+            TypeRef.Definition(assemblyName, "Sample", "Widget"),
+            "Allocate",
+            [],
+            TypeRef.CoreLib("System", "Void"),
+            metadataToken,
+            IsStatic: true);
+
+    static AllocationOccurrence AllocationOccurrence(
+        MethodIdentity method,
+        int ilOffset,
+        AllocationKind kind,
+        TypeRef allocatedType)
+        => new(
+            method,
+            ilOffset,
+            OperandToken: 0x0A000001,
+            kind,
+            allocatedType,
+            allocatedType.ToDisplayString(),
+            CountsAsHeapAllocation: true,
+            AllocationFrequency.Always,
+            InLoop: false,
+            AllocationEscape.Unknown,
+            kind == AllocationKind.Array
+                ? AllocationFactSource.Newarr
+                : AllocationFactSource.Newobj);
 
     static ApiSurface Surface(string typeName, params ApiMember[] members)
         => new()

--- a/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
@@ -63,6 +63,21 @@ public class ResearchFactRegistryTests
     }
 
     [Fact]
+    public void DefaultAllocationProducer_ProjectsAnalysisFindingCensus()
+    {
+        using var source = MetadataSource.Open(typeof(ResearchFixture).Assembly.Location);
+
+        var facts = ResearchViews.CollectFacts(
+            source,
+            typeof(ResearchFixture).FullName!,
+            nameof(ResearchFixture.BoxInt));
+
+        var allocation = Assert.Single(facts, fact => fact.Descriptor.Id == "alloc.box");
+        Assert.True(allocation.SourceOffset >= 0);
+        Assert.Contains("System.Int32", allocation.Detail);
+    }
+
+    [Fact]
     public void CostOverlay_AnnotatesHighValueCalleeAtCallSite()
     {
         using var source = MetadataSource.Open(typeof(ResearchFixture).Assembly.Location);

--- a/src/ILInspector.Research/AllocationOccurrenceFactProducer.cs
+++ b/src/ILInspector.Research/AllocationOccurrenceFactProducer.cs
@@ -30,12 +30,11 @@ sealed class AllocationOccurrenceFactProducer : IResearchFactProducer
         FindingSubject subject = occurrences.IsEmpty
             ? new($"{path}|{function.MetadataToken:X8}", function.Name)
             : ToFindingSubject(occurrences[0].Method);
-        return AnalysisFindings.InspectAllocations(occurrences, subject) switch
-        {
-            FindingInspection<AllocationOccurrence>.Complete complete =>
-                [.. complete.Findings.Select(finding => ToAnnotation(finding.Payload))],
-            _ => [],
-        };
+        return
+        [
+            .. AnalysisFindings.InspectAllocations(occurrences, subject)
+                .Select(finding => ToAnnotation(finding.Payload)),
+        ];
     }
 
     static FindingSubject ToFindingSubject(MethodIdentity method)

--- a/src/ILInspector.Research/AllocationOccurrenceFactProducer.cs
+++ b/src/ILInspector.Research/AllocationOccurrenceFactProducer.cs
@@ -1,5 +1,6 @@
 using ILInspector.Analysis;
 using ILInspector.Decompiler.Annotations;
+using ILInspector.Findings;
 
 namespace ILInspector.Research;
 
@@ -22,10 +23,25 @@ sealed class AllocationOccurrenceFactProducer : IResearchFactProducer
         var function = context.Imported;
         if (function.AssemblyPath is not { Length: > 0 } path || function.MetadataToken == 0)
             return [];
-        var index = AnalysisIndexCache.ForPath(path);
+        var index = context.Assembly?.Index ?? AnalysisIndexCache.ForPath(path);
         if (!index.GetAllocationOccurrences().TryGetValue(function.MetadataToken, out var occurrences))
             return [];
-        return [.. occurrences.Select(ToAnnotation)];
+
+        FindingSubject subject = occurrences.IsEmpty
+            ? new($"{path}|{function.MetadataToken:X8}", function.Name)
+            : ToFindingSubject(occurrences[0].Method);
+        return AnalysisFindings.InspectAllocations(occurrences, subject) switch
+        {
+            FindingInspection<AllocationOccurrence>.Complete complete =>
+                [.. complete.Findings.Select(finding => ToAnnotation(finding.Payload))],
+            _ => [],
+        };
+    }
+
+    static FindingSubject ToFindingSubject(MethodIdentity method)
+    {
+        var subject = ResearchMemberIdentity.SubjectFromMethod(method);
+        return new FindingSubject(subject.Id, subject.Display);
     }
 
     static Annotation ToAnnotation(AllocationOccurrence occurrence)

--- a/src/ILInspector.Research/ResearchChanges.cs
+++ b/src/ILInspector.Research/ResearchChanges.cs
@@ -108,7 +108,8 @@ public sealed record ResearchChange
         IlDiffDisplayFailureRow? ilDisplayFailureRow = null,
         IlMemberDiffResult? ilMemberDiff = null,
         ImmutableArray<CSharpDiffDisplayRow> cSharpDisplayRows = default,
-        CSharpDiffDisplayFailureRow? cSharpDisplayFailureRow = null)
+        CSharpDiffDisplayFailureRow? cSharpDisplayFailureRow = null,
+        FindingComparison<AllocationOccurrence>? allocationComparison = null)
     {
         Subject = subject ?? throw new ArgumentNullException(nameof(subject));
         int mechanismValue = (int)mechanism;
@@ -181,6 +182,11 @@ public sealed record ResearchChange
             mechanism,
             ResearchChangeMechanism.CSharp,
             nameof(cSharpDisplayFailureRow));
+        ValidatePayloadMechanism(
+            allocationComparison is not null,
+            mechanism,
+            ResearchChangeMechanism.BodySignals,
+            nameof(allocationComparison));
 
         Mechanism = mechanism;
         Descriptor = descriptor;
@@ -209,6 +215,7 @@ public sealed record ResearchChange
         IlMemberDiff = ilMemberDiff;
         CSharpDisplayRows = cSharpDisplayRows.IsDefault ? [] : cSharpDisplayRows;
         CSharpDisplayFailureRow = cSharpDisplayFailureRow;
+        AllocationComparison = allocationComparison;
     }
 
     static void ValidatePayloadMechanism(
@@ -253,6 +260,7 @@ public sealed record ResearchChange
     public IlMemberDiffResult? IlMemberDiff { get; }
     public ImmutableArray<CSharpDiffDisplayRow> CSharpDisplayRows { get; }
     public CSharpDiffDisplayFailureRow? CSharpDisplayFailureRow { get; }
+    public FindingComparison<AllocationOccurrence>? AllocationComparison { get; }
 }
 
 public sealed record ResearchSubjectChanges

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -431,9 +431,11 @@ public static class ResearchDiff
             var complete = comparison switch
             {
                 FindingComparison<AllocationOccurrence>.Complete value => value,
-                FindingComparison<AllocationOccurrence>.Failed => null,
+                FindingComparison<AllocationOccurrence>.Failed failed =>
+                    throw new InvalidOperationException(
+                        $"A comparison of total allocation censuses cannot fail: {failed.Failure}"),
             };
-            if (complete is null || complete.IsExact)
+            if (complete.IsExact)
                 return;
 
             int oldValue = oldOccurrences.Count(static occurrence => occurrence.CountsAsHeapAllocation);

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -332,6 +332,13 @@ public static class ResearchDiff
                 newSnapshot.TryGetValue(key, out var newMethod);
                 var subject = newMethod?.Subject ?? oldMethod?.Subject ?? UnknownMemberSubject(key);
                 var inBoth = oldMethod is not null && newMethod is not null;
+                AddAllocationRow(
+                    builder,
+                    subject,
+                    inBoth,
+                    oldMethod?.Allocations ?? [],
+                    newMethod?.Allocations ?? [],
+                    Evidence(oldMethod?.Signals, newMethod?.Signals));
                 AddCountRows(builder, subject, inBoth, oldMethod?.Signals, newMethod?.Signals);
                 AddExceptionRow(builder, subject, inBoth, oldMethod?.Signals, newMethod?.Signals);
                 AddOptimizationRows(builder, subject, inBoth, oldMethod?.Opportunities, newMethod?.Opportunities);
@@ -346,6 +353,7 @@ public static class ResearchDiff
             var methods = new Dictionary<string, ResearchAnalysisMethod>(StringComparer.Ordinal);
             var generatedFrameworkTypes = index.GeneratedFrameworkTypeNames;
             var signalsByToken = index.GetMethodSignals();
+            var allocationsByToken = index.GetAllocationOccurrences();
             foreach (var method in index.Methods)
             {
                 if (IsGeneratedMethod(method, generatedFrameworkTypes))
@@ -356,15 +364,24 @@ public static class ResearchDiff
                 if (!MatchesMemberTargets(subject, memberTargetIdentities))
                     continue;
                 signalsByToken.TryGetValue(method.MetadataToken, out var signals);
+                allocationsByToken.TryGetValue(method.MetadataToken, out var allocations);
                 var key = BodySignalMethodKey(method);
                 if (!methods.TryGetValue(key, out var entry))
                 {
-                    entry = new ResearchAnalysisMethod(subject, signals ?? MethodSignals.None, []);
+                    entry = new ResearchAnalysisMethod(
+                        subject,
+                        signals ?? MethodSignals.None,
+                        allocations.IsDefault ? [] : allocations,
+                        []);
                     methods[key] = entry;
                 }
                 else
                 {
-                    methods[key] = entry with { Signals = signals ?? MethodSignals.None };
+                    methods[key] = entry with
+                    {
+                        Signals = signals ?? MethodSignals.None,
+                        Allocations = allocations.IsDefault ? [] : allocations,
+                    };
                 }
             }
 
@@ -380,7 +397,7 @@ public static class ResearchDiff
                 var key = BodySignalMethodKey(opportunity.Method);
                 if (!methods.TryGetValue(key, out var entry))
                 {
-                    entry = new ResearchAnalysisMethod(subject, MethodSignals.None, []);
+                    entry = new ResearchAnalysisMethod(subject, MethodSignals.None, [], []);
                     methods[key] = entry;
                 }
                 entry.Opportunities.Add(opportunity);
@@ -391,7 +408,6 @@ public static class ResearchDiff
 
         static void AddCountRows(ResultBuilder builder, ResearchSubjectKey subject, bool inBoth, MethodSignals? oldSignals, MethodSignals? newSignals)
         {
-            AddCountRow(builder, subject, inBoth, "allocations", oldSignals?.Allocations ?? 0, newSignals?.Allocations ?? 0, Evidence(oldSignals, newSignals), oldSignals?.AllocInLoop ?? false, newSignals?.AllocInLoop ?? false);
             AddCountRow(builder, subject, inBoth, "copies", oldSignals?.Copies ?? 0, newSignals?.Copies ?? 0, Evidence(oldSignals, newSignals));
             AddCountRow(builder, subject, inBoth, "reflection", oldSignals?.Reflection ?? 0, newSignals?.Reflection ?? 0, Evidence(oldSignals, newSignals));
             AddCountRow(builder, subject, inBoth, "throws", oldSignals?.Throws ?? 0, newSignals?.Throws ?? 0, Evidence(oldSignals, newSignals));
@@ -399,6 +415,89 @@ public static class ResearchDiff
             AddCountRow(builder, subject, inBoth, "finallys", oldSignals?.Finallys ?? 0, newSignals?.Finallys ?? 0, Evidence(oldSignals, newSignals));
             AddCountRow(builder, subject, inBoth, "unsafe", oldSignals?.Unsafe == true ? 1 : 0, newSignals?.Unsafe == true ? 1 : 0, Evidence(oldSignals, newSignals));
         }
+
+        static void AddAllocationRow(
+            ResultBuilder builder,
+            ResearchSubjectKey subject,
+            bool inBoth,
+            ImmutableArray<AllocationOccurrence> oldOccurrences,
+            ImmutableArray<AllocationOccurrence> newOccurrences,
+            string? evidence)
+        {
+            var comparison = AnalysisFindings.CompareAllocations(
+                oldOccurrences,
+                newOccurrences,
+                new FindingSubject(subject.Id, subject.Display));
+            var complete = comparison switch
+            {
+                FindingComparison<AllocationOccurrence>.Complete value => value,
+                FindingComparison<AllocationOccurrence>.Failed => null,
+            };
+            if (complete is null || complete.IsExact)
+                return;
+
+            int oldValue = oldOccurrences.Count(static occurrence => occurrence.CountsAsHeapAllocation);
+            int newValue = newOccurrences.Count(static occurrence => occurrence.CountsAsHeapAllocation);
+            bool oldInLoop = oldOccurrences.Any(IsHotAllocation);
+            bool newInLoop = newOccurrences.Any(IsHotAllocation);
+            int delta = newValue - oldValue;
+            string deltaText;
+            string? shape = null;
+            int magnitude;
+            int directionScore;
+            bool inLoop;
+
+            if (delta != 0)
+            {
+                deltaText = FormatDelta(delta);
+                magnitude = Math.Abs(delta);
+                directionScore = Math.Sign(delta);
+                inLoop = delta > 0 ? newInLoop : oldInLoop;
+                shape = inLoop ? "in-loop" : null;
+            }
+            else if (newValue > 0 && oldInLoop != newInLoop)
+            {
+                bool becameHot = newInLoop;
+                deltaText = becameHot ? "hot" : "cold";
+                shape = "in-loop";
+                magnitude = 1;
+                directionScore = becameHot ? 1 : -1;
+                inLoop = true;
+            }
+            else
+            {
+                deltaText = "changed";
+                magnitude = complete.Pairs.Count(static pair =>
+                    pair.Kind != PairKind.Present
+                    || pair.Difference != FindingDifferenceKind.None);
+                directionScore = 0;
+                inLoop = oldOccurrences.Any(static occurrence => occurrence.InLoop)
+                    || newOccurrences.Any(static occurrence => occurrence.InLoop);
+            }
+
+            builder.Add(new ResearchChange(
+                subject,
+                ResearchChangeMechanism.BodySignals,
+                AnalysisFindings.AllocationDescriptor,
+                ResearchChangeKind.Changed,
+                oldValue.ToString(),
+                newValue.ToString(),
+                delta: deltaText,
+                detail: evidence,
+                category: ResearchChangeCategory.BodySignal,
+                signal: "allocations",
+                shape: shape,
+                magnitude: magnitude,
+                directionScore: directionScore,
+                subjectInBoth: inBoth,
+                inLoop: inLoop,
+                allocationComparison: comparison));
+        }
+
+        static bool IsHotAllocation(AllocationOccurrence occurrence)
+            => occurrence.CountsAsHeapAllocation
+                && occurrence.InLoop
+                && occurrence.Escape != AllocationEscape.ThrowPath;
 
         static void AddCountRow(ResultBuilder builder, ResearchSubjectKey subject, bool inBoth, string signal, int oldValue, int newValue, string? evidence, bool oldAllocInLoop = false, bool newAllocInLoop = false)
         {
@@ -1002,7 +1101,11 @@ public static class ResearchDiff
 
     sealed record BodyIndexEntry(string Key, string Path, LibraryBodyIndex Index);
 
-    sealed record ResearchAnalysisMethod(ResearchSubjectKey Subject, MethodSignals Signals, List<OptimizationOpportunity> Opportunities);
+    sealed record ResearchAnalysisMethod(
+        ResearchSubjectKey Subject,
+        MethodSignals Signals,
+        ImmutableArray<AllocationOccurrence> Allocations,
+        List<OptimizationOpportunity> Opportunities);
 
     sealed class ResultBuilder
     {


### PR DESCRIPTION
Allocation occurrences now have one Analysis-owned Finding census for single-version facts and two-version changes.

- add total `AnalysisFindings.InspectAllocations` and conservative `CompareAllocations` correspondence over source, kind, and allocated type
- retain IL offsets and tokens as typed version-local provenance while classifying semantic facet changes
- project Research annotations from the census and retain the typed allocation comparison on `ResearchChange`
- replace the count-only allocation diff lane while preserving count and hot/cold DotnetInspector output
- surface equal-count remove/add replacements that were previously invisible

Validation: solution build; 416 Analysis tests; 81 Research tests; 1,730 DotnetInspector tests (10 expected ilasm/ildasm skips); markdownlint.

Advances #2564.