### PR TITLE
Replace project grounding with skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ the .NET 11 daily feed and nuget.org: most projects target the nightly
 | Source | Examples | Notes |
 | ------ | -------- | ----- |
 | NuGet packages | `package System.Text.Json`, `type --package Markout` | Supports versions, custom sources, `nuget.config`, TFMs, package layout, dependencies, and vulnerabilities. |
-| Restored projects | `type Command --project ./src/App`, `project ./src/App -S Grounding --print` | Uses an existing `project.assets.json` as restored-assets context for API lookup, relationship search, and package grounding; restore/build first if dependencies changed. No restore/build/MSBuild evaluation is run. |
+| Restored projects | `type Command --project ./src/App`, `project ./src/App -S Skills --print` | Uses an existing `project.assets.json` as restored-assets context for API lookup, relationship search, and dependency package skills; restore/build first if dependencies changed. No restore/build/MSBuild evaluation is run. |
 | Platform libraries | `library System.Private.CoreLib`, `library System.Text.Json --version 10.0.0`, `diff --platform System.Runtime@9.0.0..10.0.0` | Resolves installed SDK/runtime assemblies, including runtime-only implementation assemblies with no NuGet package. |
 | Local assets | `library ./bin/MyLib.dll`, `package ./pkg/MyLib.nupkg` | Useful for auditing builds before publishing. |
 
@@ -107,7 +107,7 @@ context for copied DLLs. A future `--deps` source can represent runtime
 | Capability | Commands | Highlights |
 | ---------- | -------- | ---------- |
 | Package inventory | `package` | Metadata, versions, TFMs, file layout, dependency tree, metadata audit, vulnerability data, custom feeds, NuGet config support. |
-| Project grounding | `project` | Direct dependency `Grounding` rows and printable best package docs from restored projects. |
+| Project skills | `project` | Direct dependency `Skills` rows from package `skills/**/SKILL.md` files, plus version-resolved package README/PROJECT docs from restored projects. |
 | Library audit | `library` | Assembly identity, public key token, trim/AOT metadata, unsafe/interoperability signals, OpenTelemetry support, symbols/PDBs, SourceLink and determinism audit, references, resources, async method classification. |
 | API discovery | `type`, `member`, `find` | Type search, member tables, docs, overload selection, generics, obsolete-member markers, direct calls and callers, source/decompiled/IL drill-in. Add `--project` to resolve type/member queries in the project's restored dependency context. |
 | API compatibility | `diff` | Version ranges, package or platform diffs, breaking/additive/potentially-breaking classification, type and member filters. |
@@ -122,7 +122,7 @@ context for copied DLLs. A future `--deps` source can represent runtime
 | Command | Purpose |
 | ------- | ------- |
 | `package X` | Inspect NuGet metadata, versions, dependencies, TFMs, layout, and vulnerabilities. |
-| `project [path]` | Inspect restored direct package references for grounding indexes and package docs. |
+| `project [path]` | Inspect restored direct package references for skill files and package docs. |
 | `library X` | Inspect assembly metadata, symbols, SourceLink, references, resources, and async methods. |
 | `type X` | Discover types or render a single type shape. |
 | `member X` | Inspect members, docs, overloads, decompiled/lowered C#, SourceLink-backed original source, and IL. |
@@ -259,9 +259,9 @@ dotnet-inspect package System.Text.Json --path @readme --content --frontmatter
 dotnet-inspect package Newtonsoft.Json -S "Package Info" --fields Version --value
 dotnet-inspect type Command --project ./src/App
 dotnet-inspect member Command --project ./src/App --show-index
-dotnet-inspect project ./src/App -S Grounding --jsonl
-dotnet-inspect project ./src/App -S Grounding --paths
-dotnet-inspect project ./src/App -S Grounding --print --row 1
+dotnet-inspect project ./src/App -S Skills --jsonl
+dotnet-inspect project ./src/App -S Skills --paths
+dotnet-inspect project ./src/App -S Skills --print --row 1
 dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files" --urls --json-array
 dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files" --print --row 1
 ```
@@ -284,8 +284,8 @@ dotnet-inspect type JsonSerializer --package System.Text.Json@8.0.0..8.0.5 --at 
 dotnet-inspect member JsonSerializer Serialize --package System.Text.Json@8.0.0..8.0.5 --at 8.0.5
 dotnet-inspect type Command --project ./src/App
 dotnet-inspect member Command --project ./src/App --show-index
-dotnet-inspect project ./src/App -S Grounding
-dotnet-inspect project ./src/App -S Grounding --print --row 1
+dotnet-inspect project ./src/App -S Skills
+dotnet-inspect project ./src/App -S Skills --print --row 1
 dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files" --print-all
 dotnet-inspect type string --shape
 dotnet-inspect type --package System.Text.Json --table

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,8 +63,8 @@ Inspects NuGet package metadata without extracting libraries:
 Inspects a restored project through `project.assets.json`:
 
 - Direct package references with resolved versions per selected TFM
-- Compact `AGENTS.md` frontmatter index for package grounding
-- Version-resolved best package docs for one direct dependency
+- Package `skills/**/SKILL.md` files from direct dependencies
+- Version-resolved README/PROJECT docs for one direct dependency
 
 ### library
 

--- a/docs/design/rendering-model.md
+++ b/docs/design/rendering-model.md
@@ -66,7 +66,7 @@ The `package` command inspects a NuGet package. Its default view is *package ide
 
 Each lens is self-contained. `--files` shows a file tree and exits. It does not also show metadata or dependencies -- those belong to the identity view.
 
-`Files`, `Grounding`, `Library Files`, and `Markdown Files` all expose package-relative paths and uncompressed byte sizes. `Files` is explicit-only and renders the full package depth; `Grounding` is explicit-only and returns the best grounding candidate (`AGENTS.md` > `README.md` > `PACKAGE.md` > declared readme); `Markdown Files` is explicit-only and renders all `.md` files; `Library Files` is the default library asset slice over the same schema. For `project`, `Grounding` renders one best-grounding row per direct dependency.
+`Files`, `Grounding`, `Library Files`, and `Markdown Files` all expose package-relative paths and uncompressed byte sizes. `Files` is explicit-only and renders the full package depth; package `Grounding` is explicit-only and returns the best grounding candidate (`AGENTS.md` > `README.md` > `PACKAGE.md` > declared readme); `Markdown Files` is explicit-only and renders all `.md` files; `Library Files` is the default library asset slice over the same schema. For `project`, `Skills` renders every direct dependency package `skills/**/SKILL.md` file.
 
 **Why Files is not in `-v:d`:** Files are structural layout data (what the package contains on disk), not identity metadata (what the package is). Mixing structural content into the identity view conflates two different concerns. The `--path`/`-S Files` file-resolution view is the correct entry point for structural exploration.
 
@@ -119,7 +119,7 @@ When a lens has multiple possible rendering modes, the default should be the mos
 | Command | Identity (verbosity) | Lenses (mode-switch flags) |
 | ------- | -------------------- | -------------------------- |
 | `package` | Package Info, Statistics, Dependencies, Vulnerabilities | `--files`, `-S Grounding --print`, `--readme`, `--versions`, `-S Signals` |
-| `project` | — | `-S Grounding`, `-S Grounding --print --row N`, `-S Grounding --print-all` |
+| `project` | — | `-S Skills`, `-S Skills --print --row N`, `-S Skills --print-all` |
 | `type`/`member` | Type/member identity and sectioned evidence | `-S "Source Files" --print --row N`, `-S "Source Locations" --print --row N`, `-S "Original Source" --print` |
 | `api` | Type fields, Members table | `--docs`, `--samples`, `--table`, `--tsv` |
 | `library` | Library info, PE headers | `--sourcelink`, `--references` |

--- a/docs/workflows/core/package-inspection.md
+++ b/docs/workflows/core/package-inspection.md
@@ -208,10 +208,10 @@ or body:
 dotnet-inspect package Markout -S "Grounding"
 dotnet-inspect package Markout -S "Package Info" --fields Version --value
 dotnet-inspect package Markout -S "Grounding" --print
-dotnet-inspect project ./src/App -S "Grounding"
-dotnet-inspect project ./src/App -S "Grounding" --paths
-dotnet-inspect project ./src/App -S "Grounding" --print --row 1
-dotnet-inspect project ./src/App -S "Grounding" --print-all --jsonl
+dotnet-inspect project ./src/App -S "Skills"
+dotnet-inspect project ./src/App -S "Skills" --paths
+dotnet-inspect project ./src/App -S "Skills" --print --row 1
+dotnet-inspect project ./src/App -S "Skills" --print-all --jsonl
 dotnet-inspect package Markout -S "Markdown Files"
 dotnet-inspect package Markout --path @agents --content --frontmatter
 dotnet-inspect package Markout Polly --path @agents --path @readme --match first --content --jsonl

--- a/src/DotnetInspector.Services.Tests/ProjectAssetsParserTests.cs
+++ b/src/DotnetInspector.Services.Tests/ProjectAssetsParserTests.cs
@@ -227,6 +227,145 @@ public class ProjectAssetsParserTests
     }
 
     [Fact]
+    public void ParsePackageFileEntries_ReturnsDirectPackageFilesMatchingPattern()
+    {
+        var packageRoot = Path.Combine(Path.GetTempPath(), $"pa-files-{Guid.NewGuid():N}");
+        var skillPath = Path.Combine(packageRoot, "skills", "query", "SKILL.md");
+        Directory.CreateDirectory(Path.GetDirectoryName(skillPath)!);
+        File.WriteAllText(skillPath, "# Skill");
+
+        var transitiveRoot = Path.Combine(Path.GetTempPath(), $"pa-files-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(transitiveRoot, "skills", "transitive"));
+
+        var json = $$"""
+        {
+            "targets": {
+                "net9.0": {
+                    "Direct.Package/2.1.0": {},
+                    "Transitive.Package/1.0.0": {},
+                    "ProjectRef/1.0.0": {}
+                }
+            },
+            "libraries": {
+                "Direct.Package/2.1.0": {
+                    "type": "package",
+                    "path": "{{packageRoot.Replace("\\", "/")}}",
+                    "files": [
+                        "README.md",
+                        "skills/query/SKILL.md"
+                    ]
+                },
+                "Transitive.Package/1.0.0": {
+                    "type": "package",
+                    "path": "{{transitiveRoot.Replace("\\", "/")}}",
+                    "files": [
+                        "skills/transitive/SKILL.md"
+                    ]
+                },
+                "ProjectRef/1.0.0": {
+                    "type": "project",
+                    "path": "../ProjectRef/ProjectRef.csproj"
+                }
+            },
+            "project": {
+                "frameworks": {
+                    "net9.0": {
+                        "dependencies": {
+                            "Direct.Package": {
+                                "target": "Package",
+                                "version": "[2.0.0, )"
+                            },
+                            "ProjectRef": {
+                                "target": "Project"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        """;
+
+        var assetsPath = WriteTempFile(json);
+        try
+        {
+            var result = ProjectAssetsParser.ParsePackageFileEntries(
+                assetsPath,
+                null,
+                ["skills/**/SKILL.md"],
+                null);
+
+            var entry = Assert.Single(result);
+            Assert.Equal("Direct.Package", entry.PackageName);
+            Assert.Equal("2.1.0", entry.Version);
+            Assert.Equal("skills/query/SKILL.md", entry.Path);
+            Assert.Equal("net9.0", entry.TargetFramework);
+            Assert.Equal(Path.GetFullPath(packageRoot), entry.PackagePath);
+            Assert.Equal(Path.GetFullPath(skillPath), entry.FullPath);
+            Assert.True(ProjectAssetsParser.HasPackageFileEntries(assetsPath, null, ["skills/**/SKILL.md"], null));
+        }
+        finally
+        {
+            File.Delete(assetsPath);
+            Directory.Delete(packageRoot, recursive: true);
+            Directory.Delete(transitiveRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ParsePackageFileEntries_ReturnsEmptyWhenPatternDoesNotMatch()
+    {
+        var json = """
+        {
+            "targets": {
+                "net9.0": {
+                    "Direct.Package/1.0.0": {}
+                }
+            },
+            "libraries": {
+                "Direct.Package/1.0.0": {
+                    "type": "package",
+                    "path": "direct.package/1.0.0",
+                    "files": [
+                        "README.md"
+                    ]
+                }
+            },
+            "project": {
+                "frameworks": {
+                    "net9.0": {
+                        "dependencies": {
+                            "Direct.Package": {
+                                "target": "Package",
+                                "version": "[1.0.0, )"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        """;
+
+        var assetsPath = WriteTempFile(json);
+        try
+        {
+            Assert.Empty(ProjectAssetsParser.ParsePackageFileEntries(
+                assetsPath,
+                null,
+                ["skills/**/SKILL.md"],
+                null));
+            Assert.False(ProjectAssetsParser.HasPackageFileEntries(
+                assetsPath,
+                null,
+                ["skills/**/SKILL.md"],
+                null));
+        }
+        finally
+        {
+            File.Delete(assetsPath);
+        }
+    }
+
+    [Fact]
     public void Parse_WithoutTfmFilter_SelectsHighestPriorityTfm()
     {
         var json = """

--- a/src/DotnetInspector.Services.Tests/ProjectAssetsParserTests.cs
+++ b/src/DotnetInspector.Services.Tests/ProjectAssetsParserTests.cs
@@ -251,6 +251,7 @@ public class ProjectAssetsParserTests
                     "type": "package",
                     "path": "{{packageRoot.Replace("\\", "/")}}",
                     "files": [
+                        42,
                         "README.md",
                         "skills/query/SKILL.md"
                     ]
@@ -308,6 +309,64 @@ public class ProjectAssetsParserTests
             File.Delete(assetsPath);
             Directory.Delete(packageRoot, recursive: true);
             Directory.Delete(transitiveRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ParsePackageFileEntries_CanMatchTopLevelSkillFile()
+    {
+        var packageRoot = Path.Combine(Path.GetTempPath(), $"pa-files-{Guid.NewGuid():N}");
+        var skillPath = Path.Combine(packageRoot, "skills", "SKILL.md");
+        Directory.CreateDirectory(Path.GetDirectoryName(skillPath)!);
+        File.WriteAllText(skillPath, "# Skill");
+
+        var json = $$"""
+        {
+            "targets": {
+                "net9.0": {
+                    "Direct.Package/1.0.0": {}
+                }
+            },
+            "libraries": {
+                "Direct.Package/1.0.0": {
+                    "type": "package",
+                    "path": "{{packageRoot.Replace("\\", "/")}}",
+                    "files": [
+                        "skills/SKILL.md"
+                    ]
+                }
+            },
+            "project": {
+                "frameworks": {
+                    "net9.0": {
+                        "dependencies": {
+                            "Direct.Package": {
+                                "target": "Package",
+                                "version": "[1.0.0, )"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        """;
+
+        var assetsPath = WriteTempFile(json);
+        try
+        {
+            var entry = Assert.Single(ProjectAssetsParser.ParsePackageFileEntries(
+                assetsPath,
+                null,
+                ["skills/SKILL.md", "skills/**/SKILL.md"],
+                null));
+
+            Assert.Equal("skills/SKILL.md", entry.Path);
+            Assert.Equal(Path.GetFullPath(skillPath), entry.FullPath);
+        }
+        finally
+        {
+            File.Delete(assetsPath);
+            Directory.Delete(packageRoot, recursive: true);
         }
     }
 

--- a/src/DotnetInspector.Services/ProjectAssetsParser.cs
+++ b/src/DotnetInspector.Services/ProjectAssetsParser.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.IO.Enumeration;
 using System.Text.Json;
 using DotnetInspector.Packages;
 using NuGetFetch;
@@ -9,6 +10,14 @@ public sealed record ProjectPackageReference(
     string PackageName,
     string Version,
     string? PackagePath,
+    string TargetFramework);
+
+public sealed record ProjectPackageFileEntry(
+    string PackageName,
+    string Version,
+    string Path,
+    string? PackagePath,
+    string? FullPath,
     string TargetFramework);
 
 /// <summary>
@@ -257,6 +266,102 @@ public static class ProjectAssetsParser
             .ToList();
     }
 
+    /// <summary>
+    /// Parses a project.assets.json file and returns direct dependency package files
+    /// whose package-relative paths match any supplied glob pattern.
+    /// </summary>
+    public static List<ProjectPackageFileEntry> ParsePackageFileEntries(
+        string assetsPath,
+        string? tfmFilter,
+        IEnumerable<string> patterns,
+        Action<string>? log)
+    {
+        var normalizedPatterns = patterns
+            .Where(pattern => !string.IsNullOrWhiteSpace(pattern))
+            .Select(NormalizeAssetPath)
+            .ToArray();
+        if (normalizedPatterns.Length == 0)
+            return [];
+
+        List<ProjectPackageFileEntry> results = [];
+
+        try
+        {
+            var json = File.ReadAllText(assetsPath);
+            using var doc = JsonDocument.Parse(json);
+
+            if (!doc.RootElement.TryGetProperty("targets", out var targets))
+                return results;
+            if (!doc.RootElement.TryGetProperty("libraries", out var libraries))
+                return results;
+
+            var selectedTfm = SelectTargetFramework(targets, tfmFilter);
+            if (selectedTfm == null)
+                return results;
+
+            log?.Invoke($"Using target framework: {selectedTfm}");
+            var baseTfm = GetBaseTfm(selectedTfm);
+            if (!TryGetFrameworkDependencies(doc.RootElement, baseTfm, out var frameworkDependencies))
+                return results;
+
+            var targetDependencies = targets.GetProperty(selectedTfm);
+            foreach (var dependency in frameworkDependencies.EnumerateObject())
+            {
+                if (IsProjectDependency(dependency.Value))
+                    continue;
+
+                if (!TryResolvePackage(
+                    dependency.Name,
+                    targetDependencies,
+                    libraries,
+                    selectedTfm,
+                    out var packageReference))
+                {
+                    continue;
+                }
+
+                var packageKey = $"{packageReference.PackageName}/{packageReference.Version}";
+                if (!TryGetPropertyCaseInsensitive(libraries, packageKey, out var library)
+                    || !library.TryGetProperty("files", out var files)
+                    || files.ValueKind != JsonValueKind.Array)
+                {
+                    continue;
+                }
+
+                foreach (var file in files.EnumerateArray())
+                {
+                    var path = NormalizeAssetPath(file.GetString());
+                    if (path.Length == 0 || !MatchesAny(path, normalizedPatterns))
+                        continue;
+
+                    results.Add(new ProjectPackageFileEntry(
+                        packageReference.PackageName,
+                        packageReference.Version,
+                        path,
+                        packageReference.PackagePath,
+                        ResolvePackageFilePath(packageReference.PackagePath, path),
+                        packageReference.TargetFramework));
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            log?.Invoke($"Warning: Failed to parse project.assets.json: {ex.Message}");
+        }
+
+        return results
+            .OrderBy(result => result.PackageName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(result => result.Path, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    public static bool HasPackageFileEntries(
+        string assetsPath,
+        string? tfmFilter,
+        IEnumerable<string> patterns,
+        Action<string>? log)
+        => ParsePackageFileEntries(assetsPath, tfmFilter, patterns, log).Count > 0;
+
     private static string? SelectTargetFramework(JsonElement targets, string? tfmFilter)
     {
         if (!string.IsNullOrEmpty(tfmFilter))
@@ -379,6 +484,24 @@ public static class ProjectAssetsParser
             ? Path.GetFullPath(normalized)
             : Path.GetFullPath(Path.Combine(NuGetCache.GetNuGetCachePath(), normalized));
     }
+
+    private static string? ResolvePackageFilePath(string? packagePath, string packageRelativePath)
+    {
+        if (string.IsNullOrWhiteSpace(packagePath))
+            return null;
+
+        return Path.GetFullPath(Path.Combine(
+            packagePath,
+            packageRelativePath.Replace('/', Path.DirectorySeparatorChar)));
+    }
+
+    private static string NormalizeAssetPath(string? path)
+        => string.IsNullOrWhiteSpace(path)
+            ? ""
+            : path.Replace('\\', '/').TrimStart('/');
+
+    private static bool MatchesAny(string path, IEnumerable<string> patterns)
+        => patterns.Any(pattern => FileSystemName.MatchesSimpleExpression(pattern, path, ignoreCase: true));
 
     private static bool TryGetPropertyCaseInsensitive(JsonElement element, string propertyName, out JsonElement value)
     {

--- a/src/DotnetInspector.Services/ProjectAssetsParser.cs
+++ b/src/DotnetInspector.Services/ProjectAssetsParser.cs
@@ -330,6 +330,9 @@ public static class ProjectAssetsParser
 
                 foreach (var file in files.EnumerateArray())
                 {
+                    if (file.ValueKind != JsonValueKind.String)
+                        continue;
+
                     var path = NormalizeAssetPath(file.GetString());
                     if (path.Length == 0 || !MatchesAny(path, normalizedPatterns))
                         continue;

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -214,7 +214,17 @@ public class CommandExecutionTests
         var libraryEntries = string.Join(",\n", packages.Select(package =>
         {
             var packageRoot = Path.Combine(tempDir, "packages", package.Id.ToLowerInvariant(), package.Version.ToLowerInvariant());
-            return $"{JsonString($"{package.Id}/{package.Version}")}: {{ \"type\": \"package\", \"path\": {JsonString(packageRoot.Replace('\\', '/'))} }}";
+            var files = new List<string> { $"{package.Id.ToLowerInvariant()}.nuspec" };
+            if (!package.OmitReadme)
+                files.Add(package.ReadmeFile.Replace('\\', '/'));
+            if (package.AgentsText != null)
+                files.Add("AGENTS.md");
+            if (package.ProjectText != null)
+                files.Add("PROJECT.md");
+            files.AddRange((package.Skills ?? []).Select(skill => skill.Path.Replace('\\', '/')));
+
+            var fileEntries = string.Join(", ", files.Select(JsonString));
+            return $"{JsonString($"{package.Id}/{package.Version}")}: {{ \"type\": \"package\", \"path\": {JsonString(packageRoot.Replace('\\', '/'))}, \"files\": [ {fileEntries} ] }}";
         }));
         var dependencyEntries = string.Join(",\n", packages.Select(package =>
             $"{JsonString(package.Id)}: {{ \"target\": \"Package\", \"version\": {JsonString($"[{package.Version}, )")} }}"));

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -145,12 +145,16 @@ public class CommandExecutionTests
         return (packagePath, tempDir);
     }
 
+    private sealed record ProjectSkillDoc(string Path, string Text);
+
     private sealed record ProjectDocPackage(
         string Id,
         string Version,
         string ReadmeFile,
         string ReadmeText,
         string? AgentsText = null,
+        ProjectSkillDoc[]? Skills = null,
+        string? ProjectText = null,
         bool OmitReadme = false);
 
     private static (string ProjectPath, string TempDir) CreateProjectWithPackageDocs(params ProjectDocPackage[] packages)
@@ -182,6 +186,14 @@ public class CommandExecutionTests
             }
             if (package.AgentsText != null)
                 File.WriteAllText(Path.Combine(packageRoot, "AGENTS.md"), package.AgentsText);
+            if (package.ProjectText != null)
+                File.WriteAllText(Path.Combine(packageRoot, "PROJECT.md"), package.ProjectText);
+            foreach (var skill in package.Skills ?? [])
+            {
+                var skillPath = Path.Combine(packageRoot, skill.Path.Replace('/', Path.DirectorySeparatorChar));
+                Directory.CreateDirectory(Path.GetDirectoryName(skillPath)!);
+                File.WriteAllText(skillPath, skill.Text);
+            }
 
             File.WriteAllText(Path.Combine(packageRoot, $"{package.Id.ToLowerInvariant()}.nuspec"), $$"""
                 <?xml version="1.0" encoding="utf-8"?>
@@ -8254,39 +8266,46 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Project_GroundingSection_EmitsBestGroundingRows()
+    public async Task Project_SkillsSection_EmitsSkillRows()
     {
-        var agents = """
+        var querySkill = """
             ---
-            name: Markout guidance
-            description: Prefer Markout tables for structured markdown.
+            name: Query guidance
+            description: Find APIs from restored dependencies.
             ---
-            # Body
+            # Query skill
+            """;
+        var sourceSkill = """
+            ---
+            name: Source guidance
+            description: Inspect SourceLink-backed files.
+            ---
+            # Source skill
             """;
         var (projectPath, tempDir) = CreateProjectWithPackageDocs(
-            new ProjectDocPackage("Test.Project.Grounding.Agents", "1.2.3", "README.md", "readme", agents),
-            new ProjectDocPackage("Test.Project.Grounding.Readme", "4.5.6", "README.md", "readme"));
+            new ProjectDocPackage("Test.Project.Skills.Query", "1.2.3", "README.md", "readme", Skills:
+                [new ProjectSkillDoc("skills/query/SKILL.md", querySkill)]),
+            new ProjectDocPackage("Test.Project.Skills.Source", "4.5.6", "README.md", "readme", Skills:
+                [new ProjectSkillDoc("skills/source/SKILL.md", sourceSkill)]));
 
         try
         {
             var (exit, output, error) = await RunAppAsync(
-                "project", projectPath, "-S", "Grounding", "--jsonl");
+                "project", projectPath, "-S", "Skills", "--jsonl");
 
             Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
             Assert.Empty(error);
             var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
             Assert.Equal(2, lines.Length);
 
-            using var agentsDocument = JsonDocument.Parse(lines.Single(line => line.Contains("Test.Project.Grounding.Agents")));
-            Assert.Equal("Test.Project.Grounding.Agents", agentsDocument.RootElement.GetProperty("package").GetString());
-            Assert.Equal("agents", agentsDocument.RootElement.GetProperty("kind").GetString());
-            Assert.Equal("AGENTS.md", agentsDocument.RootElement.GetProperty("path").GetString());
-            Assert.Equal("Markout guidance", agentsDocument.RootElement.GetProperty("name").GetString());
-            Assert.Equal("Prefer Markout tables for structured markdown.", agentsDocument.RootElement.GetProperty("description").GetString());
+            using var queryDocument = JsonDocument.Parse(lines.Single(line => line.Contains("Test.Project.Skills.Query")));
+            Assert.Equal("Test.Project.Skills.Query", queryDocument.RootElement.GetProperty("package").GetString());
+            Assert.Equal("skills/query/SKILL.md", queryDocument.RootElement.GetProperty("path").GetString());
+            Assert.Equal("Query guidance", queryDocument.RootElement.GetProperty("name").GetString());
+            Assert.Equal("Find APIs from restored dependencies.", queryDocument.RootElement.GetProperty("description").GetString());
 
-            using var readmeDocument = JsonDocument.Parse(lines.Single(line => line.Contains("Test.Project.Grounding.Readme")));
-            Assert.Equal("readme", readmeDocument.RootElement.GetProperty("kind").GetString());
-            Assert.Equal("README.md", readmeDocument.RootElement.GetProperty("path").GetString());
+            using var sourceDocument = JsonDocument.Parse(lines.Single(line => line.Contains("Test.Project.Skills.Source")));
+            Assert.Equal("skills/source/SKILL.md", sourceDocument.RootElement.GetProperty("path").GetString());
         }
         finally
         {
@@ -8295,20 +8314,22 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Project_GroundingPaths_EmitsPrintablePaths()
+    public async Task Project_SkillsPaths_EmitsSkillPaths()
     {
         var (projectPath, tempDir) = CreateProjectWithPackageDocs(
-            new ProjectDocPackage("Test.Project.Paths.One", "1.0.0", "README.md", "one"),
-            new ProjectDocPackage("Test.Project.Paths.Two", "1.0.0", "PACKAGE.md", "two"));
+            new ProjectDocPackage("Test.Project.Paths.One", "1.0.0", "README.md", "one", Skills:
+                [new ProjectSkillDoc("skills/one/SKILL.md", "one")]),
+            new ProjectDocPackage("Test.Project.Paths.Two", "1.0.0", "README.md", "two", Skills:
+                [new ProjectSkillDoc("skills/two/SKILL.md", "two")]));
 
         try
         {
             var (exit, output, error) = await RunAppAsync(
-                "project", projectPath, "-S", "Grounding", "--paths");
+                "project", projectPath, "-S", "Skills", "--paths");
 
             Assert.Equal(0, exit);
             Assert.Empty(error);
-            Assert.Equal(["README.md", "PACKAGE.md"], output.Split('\n', StringSplitOptions.RemoveEmptyEntries));
+            Assert.Equal(["skills/one/SKILL.md", "skills/two/SKILL.md"], output.Split('\n', StringSplitOptions.RemoveEmptyEntries));
         }
         finally
         {
@@ -8317,15 +8338,16 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Project_GroundingValue_UsesSelectedField()
+    public async Task Project_SkillsValue_UsesSelectedField()
     {
         var (projectPath, tempDir) = CreateProjectWithPackageDocs(
-            new ProjectDocPackage("Test.Project.Value.One", "1.2.3", "README.md", "one"));
+            new ProjectDocPackage("Test.Project.Value.One", "1.2.3", "README.md", "one", Skills:
+                [new ProjectSkillDoc("skills/value/SKILL.md", "one")]));
 
         try
         {
             var (exit, output, error) = await RunAppAsync(
-                "project", projectPath, "-S", "Grounding", "--fields", "Version", "--value");
+                "project", projectPath, "-S", "Skills", "--fields", "Version", "--value");
 
             Assert.Equal(0, exit);
             Assert.Empty(error);
@@ -8338,25 +8360,26 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Project_GroundingPrint_PrintsFirstGroundingDocument()
+    public async Task Project_SkillsPrint_PrintsFirstSkillDocument()
     {
-        var agents = """
+        var skill = """
             ---
             name: selected
             ---
-            # Agent guidance
+            # Skill guidance
             """;
         var (projectPath, tempDir) = CreateProjectWithPackageDocs(
-            new ProjectDocPackage("Test.Project.Print", "2.0.0", "README.md", "# README body", agents));
+            new ProjectDocPackage("Test.Project.Print", "2.0.0", "README.md", "# README body", Skills:
+                [new ProjectSkillDoc("skills/selected/SKILL.md", skill)]));
 
         try
         {
             var (exit, output, error) = await RunAppAsync(
-                "project", projectPath, "-S", "Grounding", "--print", "--body");
+                "project", projectPath, "-S", "Skills", "--print", "--body");
 
             Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
             Assert.Empty(error);
-            Assert.Contains("# Agent guidance", output);
+            Assert.Contains("# Skill guidance", output);
             Assert.DoesNotContain("name: selected", output);
             Assert.DoesNotContain("# README body", output);
         }
@@ -8367,16 +8390,17 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Project_GroundingPrint_SkipsDependenciesWithoutPrintableGrounding()
+    public async Task Project_SkillsPrint_SkipsDependenciesWithoutSkills()
     {
         var (projectPath, tempDir) = CreateProjectWithPackageDocs(
-            new ProjectDocPackage("A.Project.NoGrounding", "1.0.0", "README.md", "", OmitReadme: true),
-            new ProjectDocPackage("B.Project.HasGrounding", "1.0.0", "README.md", "selected"));
+            new ProjectDocPackage("A.Project.NoSkills", "1.0.0", "README.md", "readme"),
+            new ProjectDocPackage("B.Project.HasSkills", "1.0.0", "README.md", "readme", Skills:
+                [new ProjectSkillDoc("skills/selected/SKILL.md", "selected")]));
 
         try
         {
             var (exit, output, error) = await RunAppAsync(
-                "project", projectPath, "-S", "Grounding", "--print");
+                "project", projectPath, "-S", "Skills", "--print");
 
             Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
             Assert.Empty(error);
@@ -8389,15 +8413,16 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Project_GroundingPrint_JsonlIsSingleCompactRecord()
+    public async Task Project_SkillsPrint_JsonlIsSingleCompactRecord()
     {
         var (projectPath, tempDir) = CreateProjectWithPackageDocs(
-            new ProjectDocPackage("Test.Project.Print.Jsonl", "1.0.0", "README.md", "selected"));
+            new ProjectDocPackage("Test.Project.Print.Jsonl", "1.0.0", "README.md", "readme", Skills:
+                [new ProjectSkillDoc("skills/jsonl/SKILL.md", "selected")]));
 
         try
         {
             var (exit, output, error) = await RunAppAsync(
-                "project", projectPath, "-S", "Grounding", "--print", "--jsonl");
+                "project", projectPath, "-S", "Skills", "--print", "--jsonl");
 
             Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
             Assert.Empty(error);
@@ -8413,16 +8438,18 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Project_GroundingPrint_RequiresRowWhenMultipleGroundingDocuments()
+    public async Task Project_SkillsPrint_RequiresRowWhenMultipleSkillDocuments()
     {
         var (projectPath, tempDir) = CreateProjectWithPackageDocs(
-            new ProjectDocPackage("Test.Project.Print.One", "1.0.0", "README.md", "one"),
-            new ProjectDocPackage("Test.Project.Print.Two", "1.0.0", "README.md", "two"));
+            new ProjectDocPackage("Test.Project.Print.One", "1.0.0", "README.md", "readme", Skills:
+                [new ProjectSkillDoc("skills/one/SKILL.md", "one")]),
+            new ProjectDocPackage("Test.Project.Print.Two", "1.0.0", "README.md", "readme", Skills:
+                [new ProjectSkillDoc("skills/two/SKILL.md", "two")]));
 
         try
         {
             var (exit, output, error) = await RunAppAsync(
-                "project", projectPath, "-S", "Grounding", "--print");
+                "project", projectPath, "-S", "Skills", "--print");
 
             Assert.Equal(1, exit);
             Assert.Empty(output);
@@ -8435,16 +8462,18 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Project_GroundingPrint_RowSelectionPrintsSelectedDocument()
+    public async Task Project_SkillsPrint_RowSelectionPrintsSelectedDocument()
     {
         var (projectPath, tempDir) = CreateProjectWithPackageDocs(
-            new ProjectDocPackage("Test.Project.Print.One", "1.0.0", "README.md", "one"),
-            new ProjectDocPackage("Test.Project.Print.Two", "1.0.0", "README.md", "two"));
+            new ProjectDocPackage("Test.Project.Print.One", "1.0.0", "README.md", "readme", Skills:
+                [new ProjectSkillDoc("skills/one/SKILL.md", "one")]),
+            new ProjectDocPackage("Test.Project.Print.Two", "1.0.0", "README.md", "readme", Skills:
+                [new ProjectSkillDoc("skills/two/SKILL.md", "two")]));
 
         try
         {
             var (exit, output, error) = await RunAppAsync(
-                "project", projectPath, "-S", "Grounding", "--print", "--row", "2");
+                "project", projectPath, "-S", "Skills", "--print", "--row", "2");
 
             Assert.Equal(0, exit);
             Assert.Empty(error);
@@ -8457,17 +8486,19 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Project_GroundingPrint_RowSelectionCountsPrintableRowsOnly()
+    public async Task Project_SkillsPrint_RowSelectionCountsPrintableRowsOnly()
     {
         var (projectPath, tempDir) = CreateProjectWithPackageDocs(
-            new ProjectDocPackage("A.Project.NoGrounding", "1.0.0", "README.md", "", OmitReadme: true),
-            new ProjectDocPackage("B.Project.FirstPrintable", "1.0.0", "README.md", "first"),
-            new ProjectDocPackage("C.Project.SecondPrintable", "1.0.0", "README.md", "second"));
+            new ProjectDocPackage("A.Project.NoSkills", "1.0.0", "README.md", "readme"),
+            new ProjectDocPackage("B.Project.FirstPrintable", "1.0.0", "README.md", "readme", Skills:
+                [new ProjectSkillDoc("skills/first/SKILL.md", "first")]),
+            new ProjectDocPackage("C.Project.SecondPrintable", "1.0.0", "README.md", "readme", Skills:
+                [new ProjectSkillDoc("skills/second/SKILL.md", "second")]));
 
         try
         {
             var (exit, output, error) = await RunAppAsync(
-                "project", projectPath, "-S", "Grounding", "--print", "--row", "1");
+                "project", projectPath, "-S", "Skills", "--print", "--row", "1");
 
             Assert.Equal(0, exit);
             Assert.Empty(error);
@@ -8480,21 +8511,23 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Project_GroundingPrintAll_UsesSeparators()
+    public async Task Project_SkillsPrintAll_UsesSeparators()
     {
         var (projectPath, tempDir) = CreateProjectWithPackageDocs(
-            new ProjectDocPackage("Test.Project.PrintAll.One", "1.0.0", "README.md", "one"),
-            new ProjectDocPackage("Test.Project.PrintAll.Two", "1.0.0", "README.md", "two"));
+            new ProjectDocPackage("Test.Project.PrintAll.One", "1.0.0", "README.md", "readme", Skills:
+                [new ProjectSkillDoc("skills/one/SKILL.md", "one")]),
+            new ProjectDocPackage("Test.Project.PrintAll.Two", "1.0.0", "README.md", "readme", Skills:
+                [new ProjectSkillDoc("skills/two/SKILL.md", "two")]));
 
         try
         {
             var (exit, output, error) = await RunAppAsync(
-                "project", projectPath, "-S", "Grounding", "--print-all");
+                "project", projectPath, "-S", "Skills", "--print-all");
 
             Assert.Equal(0, exit);
             Assert.Empty(error);
-            Assert.Contains("--- Test.Project.PrintAll.One README.md ---", output);
-            Assert.Contains("--- Test.Project.PrintAll.Two README.md ---", output);
+            Assert.Contains("--- Test.Project.PrintAll.One skills/one/SKILL.md ---", output);
+            Assert.Contains("--- Test.Project.PrintAll.Two skills/two/SKILL.md ---", output);
             Assert.Contains("one", output);
             Assert.Contains("two", output);
         }
@@ -8505,15 +8538,16 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Project_GroundingBare_PrintsFirstGroundingDocument()
+    public async Task Project_SkillsBare_PrintsFirstSkillDocument()
     {
         var (projectPath, tempDir) = CreateProjectWithPackageDocs(
-            new ProjectDocPackage("Test.Project.Bare", "1.0.0", "README.md", "selected"));
+            new ProjectDocPackage("Test.Project.Bare", "1.0.0", "README.md", "readme", Skills:
+                [new ProjectSkillDoc("skills/bare/SKILL.md", "selected")]));
 
         try
         {
             var (exit, output, error) = await RunAppAsync(
-                "project", projectPath, "-S", "Grounding", "--bare");
+                "project", projectPath, "-S", "Skills", "--bare");
 
             Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
             Assert.Empty(error);
@@ -8526,17 +8560,19 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Project_GroundingBare_MultipleDocuments_PrintsFirstPrintableDocument()
+    public async Task Project_SkillsBare_MultipleDocuments_PrintsFirstPrintableDocument()
     {
         var (projectPath, tempDir) = CreateProjectWithPackageDocs(
-            new ProjectDocPackage("A.Project.NoGrounding", "1.0.0", "README.md", "", OmitReadme: true),
-            new ProjectDocPackage("B.Project.FirstPrintable", "1.0.0", "README.md", "first"),
-            new ProjectDocPackage("C.Project.SecondPrintable", "1.0.0", "README.md", "second"));
+            new ProjectDocPackage("A.Project.NoSkills", "1.0.0", "README.md", "readme"),
+            new ProjectDocPackage("B.Project.FirstPrintable", "1.0.0", "README.md", "readme", Skills:
+                [new ProjectSkillDoc("skills/first/SKILL.md", "first")]),
+            new ProjectDocPackage("C.Project.SecondPrintable", "1.0.0", "README.md", "readme", Skills:
+                [new ProjectSkillDoc("skills/second/SKILL.md", "second")]));
 
         try
         {
             var (exit, output, error) = await RunAppAsync(
-                "project", projectPath, "-S", "Grounding", "--bare");
+                "project", projectPath, "-S", "Skills", "--bare");
 
             Assert.Equal(0, exit);
             Assert.Empty(error);
@@ -8552,12 +8588,13 @@ public class CommandExecutionTests
     public async Task Project_Columns_ReturnsClearUnsupportedError()
     {
         var (projectPath, tempDir) = CreateProjectWithPackageDocs(
-            new ProjectDocPackage("Test.Project.Columns", "1.0.0", "README.md", "selected"));
+            new ProjectDocPackage("Test.Project.Columns", "1.0.0", "README.md", "readme", Skills:
+                [new ProjectSkillDoc("skills/selected/SKILL.md", "selected")]));
 
         try
         {
             var (exit, output, error) = await RunAppAsync(
-                "project", projectPath, "-S", "Grounding", "--columns", "Package");
+                "project", projectPath, "-S", "Skills", "--columns", "Package");
 
             Assert.Equal(1, exit);
             Assert.Empty(output);
@@ -8591,16 +8628,20 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Project_GroundingCount_CountsDirectDependencies()
+    public async Task Project_SkillsCount_CountsSkillFiles()
     {
         var (projectPath, tempDir) = CreateProjectWithPackageDocs(
-            new ProjectDocPackage("Test.Project.Count.One", "1.0.0", "README.md", "one"),
-            new ProjectDocPackage("Test.Project.Count.Two", "1.0.0", "README.md", "two"));
+            new ProjectDocPackage("Test.Project.Count.One", "1.0.0", "README.md", "readme", Skills:
+                [
+                    new ProjectSkillDoc("skills/one/SKILL.md", "one"),
+                    new ProjectSkillDoc("skills/two/SKILL.md", "two")
+                ]),
+            new ProjectDocPackage("Test.Project.Count.None", "1.0.0", "README.md", "readme"));
 
         try
         {
             var (exit, output, error) = await RunAppAsync(
-                "project", projectPath, "-S", "Grounding", "--count");
+                "project", projectPath, "-S", "Skills", "--count");
 
             Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
             Assert.Empty(error);
@@ -8613,9 +8654,9 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Project_Discover_ListsGroundingSection()
+    public async Task Project_Discover_ListsSkillsSection()
     {
-        var (exit, output, error) = await RunAppAsync("project", "-D", "Grounding");
+        var (exit, output, error) = await RunAppAsync("project", "-D", "Skills");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
@@ -8624,7 +8665,7 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Project_Readme_UsesProjectResolvedDependencyVersion()
+    public async Task Project_Readme_PrefersReadmeOverAgentsAndProjectMd()
     {
         var agents = """
             ---
@@ -8633,7 +8674,7 @@ public class CommandExecutionTests
             # Agent guidance
             """;
         var (projectPath, tempDir) = CreateProjectWithPackageDocs(
-            new ProjectDocPackage("Test.Project.Readme", "2.0.0", "README.md", "# README body", agents));
+            new ProjectDocPackage("Test.Project.Readme", "2.0.0", "README.md", "# README body", agents, ProjectText: "# PROJECT body"));
 
         try
         {
@@ -8642,8 +8683,30 @@ public class CommandExecutionTests
 
             Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
             Assert.Empty(error);
-            Assert.Contains("# Agent guidance", output);
-            Assert.DoesNotContain("# README body", output);
+            Assert.Contains("# README body", output);
+            Assert.DoesNotContain("# Agent guidance", output);
+            Assert.DoesNotContain("# PROJECT body", output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Project_Readme_FallsBackToProjectMd()
+    {
+        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+            new ProjectDocPackage("Test.Project.ProjectMd", "2.0.0", "README.md", "", ProjectText: "# PROJECT body", OmitReadme: true));
+
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "project", projectPath, "--readme", "Test.Project.ProjectMd");
+
+            Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
+            Assert.Empty(error);
+            Assert.Contains("# PROJECT body", output);
         }
         finally
         {
@@ -8654,9 +8717,9 @@ public class CommandExecutionTests
     [Fact]
     public async Task Project_Readme_NormalizesGithubBlobLinksToRaw()
     {
-        const string agents = "See https://github.com/owner/repo/blob/main/docs/guide.md";
+        const string readme = "See https://github.com/owner/repo/blob/main/docs/guide.md";
         var (projectPath, tempDir) = CreateProjectWithPackageDocs(
-            new ProjectDocPackage("Test.Project.RawLinks", "1.0.0", "README.md", "readme", agents));
+            new ProjectDocPackage("Test.Project.RawLinks", "1.0.0", "README.md", readme));
 
         try
         {

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -8328,7 +8328,7 @@ public class CommandExecutionTests
     {
         var (projectPath, tempDir) = CreateProjectWithPackageDocs(
             new ProjectDocPackage("Test.Project.Paths.One", "1.0.0", "README.md", "one", Skills:
-                [new ProjectSkillDoc("skills/one/SKILL.md", "one")]),
+                [new ProjectSkillDoc("skills/SKILL.md", "one")]),
             new ProjectDocPackage("Test.Project.Paths.Two", "1.0.0", "README.md", "two", Skills:
                 [new ProjectSkillDoc("skills/two/SKILL.md", "two")]));
 
@@ -8339,7 +8339,7 @@ public class CommandExecutionTests
 
             Assert.Equal(0, exit);
             Assert.Empty(error);
-            Assert.Equal(["skills/one/SKILL.md", "skills/two/SKILL.md"], output.Split('\n', StringSplitOptions.RemoveEmptyEntries));
+            Assert.Equal(["skills/SKILL.md", "skills/two/SKILL.md"], output.Split('\n', StringSplitOptions.RemoveEmptyEntries));
         }
         finally
         {

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -134,7 +134,7 @@ public static class CommandLineBuilder
                 new Tip(TypeCommand.Name, "--package <package>", "discover types in package"),
                 new Tip(MemberCommand.Name, "JsonSerializer --package System.Text.Json", "inspect type members"),
                 new Tip(FindCommand.Name, "<pattern> --package <package>", "search package types"),
-                new Tip(ProjectCommand.Name, "--agents-index", "index package grounding for a project"),
+                new Tip(ProjectCommand.Name, "-S Skills", "index package skills for a project"),
                 new Tip(FindCommand.Name, "<pattern> --platform", "search platform libraries"));
             return 0;
         });

--- a/src/dotnet-inspect/Commands/ProjectCommand.cs
+++ b/src/dotnet-inspect/Commands/ProjectCommand.cs
@@ -143,7 +143,7 @@ public class ProjectCommand
             return WriteAgentsIndex(dependencies, options);
 
         if (sectionMode)
-            return WriteSkills(dependencies, options);
+            return WriteSkills(assetsPath, options, logger.Log);
 
         return await WriteReadmeAsync(dependencies, options, context);
     }
@@ -328,10 +328,16 @@ public class ProjectCommand
         return builder.ToString();
     }
 
-    private static int WriteSkills(IReadOnlyList<ProjectPackageReference> dependencies, ProjectOptions options)
+    private static int WriteSkills(string assetsPath, ProjectOptions options, Action<string>? log)
     {
-        var rows = dependencies
-            .SelectMany(CreateSkillRows)
+        var rows = ProjectAssetsParser.ParsePackageFileEntries(
+                assetsPath,
+                options.Tfm,
+                ["skills/**/SKILL.md"],
+                log)
+            .Select(CreateSkillRow)
+            .Where(row => row is not null)
+            .Cast<ProjectSkillRow>()
             .ToList();
 
         if (options.Value || options.Urls || options.Paths)
@@ -354,33 +360,24 @@ public class ProjectCommand
         return 0;
     }
 
-    private static IEnumerable<ProjectSkillRow> CreateSkillRows(ProjectPackageReference dependency)
+    private static ProjectSkillRow? CreateSkillRow(ProjectPackageFileEntry file)
     {
-        if (string.IsNullOrWhiteSpace(dependency.PackagePath) || !Directory.Exists(dependency.PackagePath))
-            yield break;
+        if (string.IsNullOrWhiteSpace(file.FullPath) || !File.Exists(file.FullPath))
+            return null;
 
-        var skillsRoot = Path.Combine(dependency.PackagePath, "skills");
-        if (!Directory.Exists(skillsRoot))
-            yield break;
+        var content = File.ReadAllText(file.FullPath);
+        var frontmatter = MarkdownContent.ParseYamlFrontmatter(content);
+        frontmatter.TryGetValue("name", out var name);
+        frontmatter.TryGetValue("description", out var description);
 
-        foreach (var fullPath in Directory.EnumerateFiles(skillsRoot, "SKILL.md", SearchOption.AllDirectories)
-            .Order(StringComparer.Ordinal))
-        {
-            var path = Path.GetRelativePath(dependency.PackagePath, fullPath).Replace('\\', '/');
-            var content = File.ReadAllText(fullPath);
-            var frontmatter = MarkdownContent.ParseYamlFrontmatter(content);
-            frontmatter.TryGetValue("name", out var name);
-            frontmatter.TryGetValue("description", out var description);
-
-            yield return new ProjectSkillRow(
-                dependency.PackageName,
-                dependency.Version,
-                path,
-                new FileInfo(fullPath).Length,
-                name ?? "",
-                description ?? "",
-                fullPath);
-        }
+        return new ProjectSkillRow(
+            file.PackageName,
+            file.Version,
+            file.Path,
+            new FileInfo(file.FullPath).Length,
+            name ?? "",
+            description ?? "",
+            file.FullPath);
     }
 
     private static string RenderSkillJsonl(IEnumerable<ProjectSkillRow> rows)

--- a/src/dotnet-inspect/Commands/ProjectCommand.cs
+++ b/src/dotnet-inspect/Commands/ProjectCommand.cs
@@ -143,7 +143,7 @@ public class ProjectCommand
             return WriteAgentsIndex(dependencies, options);
 
         if (sectionMode)
-            return WriteSkills(assetsPath, options, logger.Log);
+            return WriteSkills(assetsPath, options, log: null);
 
         return await WriteReadmeAsync(dependencies, options, context);
     }
@@ -333,7 +333,7 @@ public class ProjectCommand
         var rows = ProjectAssetsParser.ParsePackageFileEntries(
                 assetsPath,
                 options.Tfm,
-                ["skills/**/SKILL.md"],
+                ["skills/SKILL.md", "skills/**/SKILL.md"],
                 log)
             .Select(CreateSkillRow)
             .Where(row => row is not null)

--- a/src/dotnet-inspect/Commands/ProjectCommand.cs
+++ b/src/dotnet-inspect/Commands/ProjectCommand.cs
@@ -8,7 +8,6 @@ using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
 using DotnetInspector.Services;
-using DotnetInspector.Views;
 using Markout;
 
 namespace DotnetInspector.Commands;
@@ -16,17 +15,18 @@ namespace DotnetInspector.Commands;
 public class ProjectCommand
 {
     public const string Name = "project";
-    private static readonly string[] ProjectSectionNames = [PackageSections.PackageReadme];
-    private static readonly string[] ProjectGroundingColumnNames =
+    private const string ProjectSkillsSection = "Skills";
+    private static readonly string[] ProjectSectionNames = [ProjectSkillsSection];
+    private static readonly string[] ProjectSkillColumnNames =
     [
         "Package",
         "Version",
-        "Kind",
         "Path",
         "Size",
         "Name",
         "Description"
     ];
+    private static readonly string[] ProjectReadmeCandidates = ["README.md", "PROJECT.md"];
 
     public static async Task<int> ExecuteAsync(ProjectOptions options)
     {
@@ -119,7 +119,7 @@ public class ProjectCommand
 
         if (!sectionMode && !legacyMode)
         {
-            Console.Error.WriteLine("Error: Specify exactly one project mode: -S Grounding, --agents-index, or --readme <package-id>.");
+            Console.Error.WriteLine("Error: Specify exactly one project mode: -S Skills, --agents-index, or --readme <package-id>.");
             return 1;
         }
 
@@ -143,7 +143,7 @@ public class ProjectCommand
             return WriteAgentsIndex(dependencies, options);
 
         if (sectionMode)
-            return WriteGrounding(dependencies, options);
+            return WriteSkills(dependencies, options);
 
         return await WriteReadmeAsync(dependencies, options, context);
     }
@@ -217,7 +217,7 @@ public class ProjectCommand
 
     private static bool ValidateProjectPrintSelection(HashSet<string>? sections)
     {
-        if (sections is { Count: 1 } && sections.Contains(PackageSections.PackageReadme))
+        if (sections is { Count: 1 } && sections.Contains(ProjectSkillsSection))
             return true;
 
         Console.Error.WriteLine("Error: --print requires -S/--select to match exactly one printable section.");
@@ -227,7 +227,7 @@ public class ProjectCommand
     private static DocumentSchema ProjectDiscoverySchema()
     {
         var schema = new DocumentSchema();
-        schema.Add(PackageSections.PackageReadme, "column", ProjectGroundingColumnNames);
+        schema.Add(ProjectSkillsSection, "column", ProjectSkillColumnNames);
         return schema;
     }
 
@@ -328,111 +328,80 @@ public class ProjectCommand
         return builder.ToString();
     }
 
-    private static int WriteGrounding(IReadOnlyList<ProjectPackageReference> dependencies, ProjectOptions options)
+    private static int WriteSkills(IReadOnlyList<ProjectPackageReference> dependencies, ProjectOptions options)
     {
         var rows = dependencies
-            .Select(CreateGroundingRow)
+            .SelectMany(CreateSkillRows)
             .ToList();
 
         if (options.Value || options.Urls || options.Paths)
-            return WriteGroundingShapeProjection(rows, options);
+            return WriteSkillShapeProjection(rows, options);
 
         if (options.Print || options.PrintAll || options.Bare)
-            return PrintFirstGroundingDocument(rows, options);
+            return PrintSkillDocument(rows, options);
 
         var output = options.Count
             ? rows.Count.ToString(CultureInfo.InvariantCulture) + Environment.NewLine
             : options.JsonOutput
-                ? JsonSerializer.Serialize(rows.ToArray(), ProjectCommandJsonContext.Default.ProjectGroundingRowArray)
+                ? JsonSerializer.Serialize(rows.ToArray(), ProjectCommandJsonContext.Default.ProjectSkillRowArray)
                 : options.Jsonl
-                    ? RenderGroundingJsonl(rows)
+                    ? RenderSkillJsonl(rows)
                     : options.OneLine
-                        ? RenderGroundingTable(rows, options)
-                        : RenderGroundingMarkdown(rows);
+                        ? RenderSkillTable(rows, options)
+                        : RenderSkillMarkdown(rows);
 
         WriteOutput(output, options.OutputPath);
         return 0;
     }
 
-    private static ProjectGroundingRow CreateGroundingRow(ProjectPackageReference dependency)
+    private static IEnumerable<ProjectSkillRow> CreateSkillRows(ProjectPackageReference dependency)
     {
         if (string.IsNullOrWhiteSpace(dependency.PackagePath) || !Directory.Exists(dependency.PackagePath))
-            return EmptyGroundingRow(dependency);
+            yield break;
 
-        var declaredReadme = ReadDeclaredReadme(dependency.PackagePath);
-        var readme = PackageFileLister.ResolvePackageReadme(dependency.PackagePath, declaredReadme);
-        if (readme == null)
-            return EmptyGroundingRow(dependency);
+        var skillsRoot = Path.Combine(dependency.PackagePath, "skills");
+        if (!Directory.Exists(skillsRoot))
+            yield break;
 
-        var fullPath = Path.Combine(dependency.PackagePath, readme.Replace('/', Path.DirectorySeparatorChar));
-        if (!File.Exists(fullPath))
-            return EmptyGroundingRow(dependency);
-
-        var content = File.ReadAllText(fullPath);
-        var frontmatter = MarkdownContent.ParseYamlFrontmatter(content);
-        frontmatter.TryGetValue("name", out var name);
-        frontmatter.TryGetValue("description", out var description);
-
-        return new ProjectGroundingRow(
-            dependency.PackageName,
-            dependency.Version,
-            ClassifyGroundingKind(readme, declaredReadme),
-            readme,
-            new FileInfo(fullPath).Length,
-            name ?? "",
-            description ?? "",
-            fullPath);
-    }
-
-    private static ProjectGroundingRow EmptyGroundingRow(ProjectPackageReference dependency)
-        => new(
-            dependency.PackageName,
-            dependency.Version,
-            Kind: "",
-            Path: "",
-            Size: 0,
-            Name: "",
-            Description: "",
-            FullPath: null);
-
-    private static string ClassifyGroundingKind(string path, string? declaredReadme)
-    {
-        var fileName = Path.GetFileName(path);
-        if (fileName.Equals("AGENTS.md", StringComparison.OrdinalIgnoreCase))
-            return "agents";
-        if (fileName.Equals("README.md", StringComparison.OrdinalIgnoreCase))
-            return "readme";
-        if (fileName.Equals("PACKAGE.md", StringComparison.OrdinalIgnoreCase))
-            return "package";
-        if (!string.IsNullOrWhiteSpace(declaredReadme)
-            && path.Equals(declaredReadme, StringComparison.OrdinalIgnoreCase))
+        foreach (var fullPath in Directory.EnumerateFiles(skillsRoot, "SKILL.md", SearchOption.AllDirectories)
+            .Order(StringComparer.Ordinal))
         {
-            return "declared";
-        }
+            var path = Path.GetRelativePath(dependency.PackagePath, fullPath).Replace('\\', '/');
+            var content = File.ReadAllText(fullPath);
+            var frontmatter = MarkdownContent.ParseYamlFrontmatter(content);
+            frontmatter.TryGetValue("name", out var name);
+            frontmatter.TryGetValue("description", out var description);
 
-        return "markdown";
+            yield return new ProjectSkillRow(
+                dependency.PackageName,
+                dependency.Version,
+                path,
+                new FileInfo(fullPath).Length,
+                name ?? "",
+                description ?? "",
+                fullPath);
+        }
     }
 
-    private static string RenderGroundingJsonl(IEnumerable<ProjectGroundingRow> rows)
+    private static string RenderSkillJsonl(IEnumerable<ProjectSkillRow> rows)
     {
         var builder = new StringBuilder();
         foreach (var row in rows)
-            builder.AppendLine(JsonSerializer.Serialize(row, ProjectCommandCompactJsonContext.Default.ProjectGroundingRow));
+            builder.AppendLine(JsonSerializer.Serialize(row, ProjectCommandCompactJsonContext.Default.ProjectSkillRow));
         return builder.ToString();
     }
 
-    private static string RenderGroundingTable(IReadOnlyList<ProjectGroundingRow> rows, ProjectOptions options)
+    private static string RenderSkillTable(IReadOnlyList<ProjectSkillRow> rows, ProjectOptions options)
         => OutputFormatter.RenderTable(!options.NoHeader, (writer, formatter) =>
         {
             var markoutWriter = new MarkoutWriter(writer, formatter, OutputFormatter.CreateTableWriterOptions(options.Tsv, options.Jsonl));
             markoutWriter.WriteTable(
-                ["Package", "Version", "Kind", "Path", "Size", "Name", "Description"],
-                ["package", "version", "kind", "path", "size", "name", "description"],
+                ["Package", "Version", "Path", "Size", "Name", "Description"],
+                ["package", "version", "path", "size", "name", "description"],
                 rows.Select(row => new[]
                 {
                     row.Package,
                     row.Version,
-                    row.Kind,
                     row.Path,
                     row.Size.ToString(CultureInfo.InvariantCulture),
                     row.Name,
@@ -441,21 +410,19 @@ public class ProjectCommand
             markoutWriter.Flush();
         });
 
-    private static string RenderGroundingMarkdown(IReadOnlyList<ProjectGroundingRow> rows)
+    private static string RenderSkillMarkdown(IReadOnlyList<ProjectSkillRow> rows)
     {
         var builder = new StringBuilder();
-        builder.AppendLine("## Grounding");
+        builder.AppendLine("## Skills");
         builder.AppendLine();
-        builder.AppendLine("| Package | Version | Kind | Path | Size | Name | Description |");
-        builder.AppendLine("| ------- | ------- | ---- | ---- | ---: | ---- | ----------- |");
+        builder.AppendLine("| Package | Version | Path | Size | Name | Description |");
+        builder.AppendLine("| ------- | ------- | ---- | ---: | ---- | ----------- |");
         foreach (var row in rows)
         {
             builder.Append("| ");
             builder.Append(EscapeMarkdownTableCell(row.Package));
             builder.Append(" | ");
             builder.Append(EscapeMarkdownTableCell(row.Version));
-            builder.Append(" | ");
-            builder.Append(EscapeMarkdownTableCell(row.Kind));
             builder.Append(" | ");
             builder.Append(EscapeMarkdownTableCell(row.Path));
             builder.Append(" | ");
@@ -470,10 +437,10 @@ public class ProjectCommand
         return builder.ToString();
     }
 
-    private static int PrintFirstGroundingDocument(IReadOnlyList<ProjectGroundingRow> rows, ProjectOptions options)
+    private static int PrintSkillDocument(IReadOnlyList<ProjectSkillRow> rows, ProjectOptions options)
     {
         var documents = rows
-            .Select((row, index) => CreatePrintableGroundingDocument(row, index + 1, options))
+            .Select((row, index) => CreatePrintableSkillDocument(row, index + 1, options))
             .Where(document => document is not null)
             .Cast<PrintableDocument>()
             .ToList();
@@ -490,7 +457,7 @@ public class ProjectCommand
                 options.OutputPath));
     }
 
-    private static int WriteGroundingShapeProjection(IReadOnlyList<ProjectGroundingRow> rows, ProjectOptions options)
+    private static int WriteSkillShapeProjection(IReadOnlyList<ProjectSkillRow> rows, ProjectOptions options)
     {
         var kind = ShapeProjectionOutput.GetKind(options.Value, options.Urls, options.Paths);
         List<ShapeProjectionRow> projected = [];
@@ -500,12 +467,12 @@ public class ProjectCommand
             string? value = kind switch
             {
                 ShapeProjectionKind.Paths => row.Path,
-                ShapeProjectionKind.Value => SelectGroundingValue(row, options),
+                ShapeProjectionKind.Value => SelectSkillValue(row, options),
                 _ => null
             };
             if (string.IsNullOrWhiteSpace(value))
                 continue;
-            projected.Add(new ShapeProjectionRow(i + 1, PackageSections.PackageReadme, value, Label: row.Package, Path: row.Path));
+            projected.Add(new ShapeProjectionRow(i + 1, ProjectSkillsSection, value, Label: row.Package, Path: row.Path));
         }
 
         return ShapeProjectionOutput.Write(
@@ -513,14 +480,13 @@ public class ProjectCommand
             new ShapeProjectionOptions(kind, options.PrintRow, options.JsonOutput, options.Jsonl, options.JsonArray));
     }
 
-    private static string? SelectGroundingValue(ProjectGroundingRow row, ProjectOptions options)
+    private static string? SelectSkillValue(ProjectSkillRow row, ProjectOptions options)
     {
         var column = options.Columns?.SingleOrDefault() ?? options.Fields?.SingleOrDefault();
         return column?.ToLowerInvariant() switch
         {
             "package" => row.Package,
             "version" => row.Version,
-            "kind" => row.Kind,
             "path" => row.Path,
             "size" => row.Size.ToString(CultureInfo.InvariantCulture),
             "name" => row.Name,
@@ -529,7 +495,7 @@ public class ProjectCommand
         };
     }
 
-    private static PrintableDocument? CreatePrintableGroundingDocument(ProjectGroundingRow row, int rowNumber, ProjectOptions options)
+    private static PrintableDocument? CreatePrintableSkillDocument(ProjectSkillRow row, int rowNumber, ProjectOptions options)
     {
         if (row.FullPath == null || !File.Exists(row.FullPath))
             return null;
@@ -538,7 +504,7 @@ public class ProjectCommand
             MarkdownContent.ApplyScope(File.ReadAllText(row.FullPath), options.ContentScope));
         return new PrintableDocument(
             rowNumber,
-            PackageSections.PackageReadme,
+            ProjectSkillsSection,
             $"{row.Package} {row.Path}",
             row.Path,
             null,
@@ -639,8 +605,7 @@ public class ProjectCommand
         if (string.IsNullOrWhiteSpace(dependency.PackagePath) || !Directory.Exists(dependency.PackagePath))
             return null;
 
-        var declaredReadme = ReadDeclaredReadme(dependency.PackagePath);
-        var readme = PackageFileLister.ResolvePackageReadme(dependency.PackagePath, declaredReadme);
+        var readme = ResolveProjectReadme(dependency.PackagePath);
         if (readme == null)
             return null;
 
@@ -658,9 +623,17 @@ public class ProjectCommand
             content);
     }
 
-    private static string? ReadDeclaredReadme(string packagePath)
+    private static string? ResolveProjectReadme(string packagePath)
     {
-        return NuspecParser.FindAndParse(packagePath)?.ReadmeFile;
+        foreach (var candidate in ProjectReadmeCandidates)
+        {
+            var match = Directory.EnumerateFiles(packagePath, "*", SearchOption.TopDirectoryOnly)
+                .FirstOrDefault(file => Path.GetFileName(file).Equals(candidate, StringComparison.OrdinalIgnoreCase));
+            if (match != null)
+                return Path.GetRelativePath(packagePath, match).Replace('\\', '/');
+        }
+
+        return null;
     }
 
     private static void WriteOutput(string output, string? outputPath)
@@ -693,10 +666,9 @@ internal sealed record ProjectPackageDocument(
     long Size,
     string Content);
 
-internal sealed record ProjectGroundingRow(
+internal sealed record ProjectSkillRow(
     string Package,
     string Version,
-    string Kind,
     string Path,
     long Size,
     string Name,
@@ -710,8 +682,8 @@ internal sealed record ProjectGroundingRow(
 [JsonSerializable(typeof(ProjectAgentsIndexRow))]
 [JsonSerializable(typeof(ProjectAgentsIndexRow[]))]
 [JsonSerializable(typeof(ProjectPackageDocument))]
-[JsonSerializable(typeof(ProjectGroundingRow))]
-[JsonSerializable(typeof(ProjectGroundingRow[]))]
+[JsonSerializable(typeof(ProjectSkillRow))]
+[JsonSerializable(typeof(ProjectSkillRow[]))]
 internal partial class ProjectCommandJsonContext : JsonSerializerContext
 {
 }
@@ -721,7 +693,7 @@ internal partial class ProjectCommandJsonContext : JsonSerializerContext
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 [JsonSerializable(typeof(ProjectAgentsIndexRow))]
 [JsonSerializable(typeof(ProjectPackageDocument))]
-[JsonSerializable(typeof(ProjectGroundingRow))]
+[JsonSerializable(typeof(ProjectSkillRow))]
 internal partial class ProjectCommandCompactJsonContext : JsonSerializerContext
 {
 }


### PR DESCRIPTION
## Summary

- Replace `project -S Grounding` with `project -S Skills` for direct dependency package `skills/**/SKILL.md` discovery.
- Change `project --readme <package-id>` to resolve root `README.md`, then root `PROJECT.md`.
- Update project command docs, tips, and command execution tests for the new behavior.

## Validation

- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -method "*Project_*"`
- `npx markdownlint-cli README.md docs/architecture.md docs/design/rendering-model.md docs/workflows/core/package-inspection.md`
- `dotnet build src/dotnet-inspect/dotnet-inspect.csproj -c Release --configfile nuget.config -p:PublishAot=false`

## Review

Behavior change; adversarial review requested before marking ready.
