### PR TITLE
Expose ImplementationDiff as an opt-in diff section

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ context for copied DLLs. A future `--deps` source can represent runtime
 | `type X` | Discover types or render a single type shape. |
 | `member X` | Inspect members, docs, overloads, decompiled/lowered C#, SourceLink-backed original source, and IL. |
 | `find X` | Search for types across packages, frameworks, projects, and local assets. |
-| `diff X` | Compare API surfaces between versions. |
+| `diff X` | Compare API surfaces by default; opt into analysis or C# + IL implementation evidence. |
 | `extensions X` | Find extension methods and C# extension properties for a type. |
 | `implements X` | Find concrete implementors or subclasses. |
 | `depends X` | Walk type, package, or library dependency graphs; emits Mermaid diagrams. |
@@ -301,6 +301,7 @@ dotnet-inspect member JsonSerializer --package System.Text.Json Serialize:1 -S "
 dotnet-inspect member MyType MyMethod:1 --library MyLib.dll -S "Unsafe*"
 dotnet-inspect library System.Text.Json --il-offset 0x06000004+0x15
 dotnet-inspect diff --package System.Text.Json@9.0.0..10.0.0 --breaking
+dotnet-inspect diff --library old/Foo.dll..new/Foo.dll -S "Implementation Diff" -m MyType.HotPath
 dotnet-inspect depends Stream --markdown --mermaid
 dotnet-inspect implements IEquatable --project ./src/App -v:q
 dotnet-inspect extensions string --project ./src/App -v:n

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,7 @@ The tool is organized around source inspection, API lookup, relationship, and ut
 │  Search for types across packages, platform, and assets      │
 ├─────────────────────────────────────────────────────────────┤
 │                         diff                                 │
-│  Compare API surfaces between package/platform versions      │
+│  Compare API, analysis, or implementation evidence           │
 ├─────────────────────────────────────────────────────────────┤
 │            depends / extensions / implements                 │
 │  Relationship discovery for APIs, packages, and libraries    │
@@ -85,11 +85,14 @@ Extract public API surface using metadata:
 
 ### diff
 
-Compares API surfaces between two package versions:
+Compares two package, platform, or local-library versions:
 
-- Added, removed, and modified types
-- Member-level changes within types
-- Version range syntax: `Package@v1..v2`
+- API compatibility is the default lens: added, removed, and modified types and
+  members.
+- `-S "Analysis Diff"` selects body-signal changes.
+- `-S "Implementation Diff"` selects Research-composed C# + IL evidence grouped
+  by member.
+- Version range syntax is `Package@v1..v2` or `old/Foo.dll..new/Foo.dll`.
 
 ### find
 

--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -2,7 +2,7 @@
 
 `ImplementationDiff` is the product-side C# + IL/body diff projection in
 `ILInspector.Research`. It is the reusable implementation-diff component for
-future CLI sections, ReturnToSender, harnesses, and other consumers that need one
+the CLI, ReturnToSender, harnesses, and other consumers that need one
 member-centric change model instead of separate C# and IL renderers.
 
 Terminology follows [Finding Nomenclature](finding-nomenclature.md):
@@ -65,9 +65,13 @@ Use `ImplementationDiff.UnifiedLines(change)` only at presentation boundaries.
 The durable model keeps the producer-owned typed display rows rather than a
 third implementation-specific row family.
 
-The component is intentionally not a CLI section yet. CLI wiring should be a
-separate usability change that chooses section names, verbosity, table schema,
-and row limits without changing the product change primitive.
+The `diff` command exposes this component through the explicit-only
+`Implementation Diff` section. The CLI projects one row per producer-owned
+unified line with `Member`, `Mechanism`, `Change`, and `Evidence` columns.
+Package, platform, and local-library ranges use the same acquisition path as the
+default API diff; `--type`, `--member`, row limits, table, TSV, and JSONL
+projection continue to apply. The CLI consumes this product component and does
+not invoke or reconstruct the C# and IL producers independently.
 
 ## Non-goals
 

--- a/docs/design/rendering-model.md
+++ b/docs/design/rendering-model.md
@@ -125,4 +125,4 @@ When a lens has multiple possible rendering modes, the default should be the mos
 | `library` | Library info, PE headers | `--sourcelink`, `--references` |
 | `platform` | Framework listing | (delegates to `library` when given a name) |
 | `type` | Type shape | (single view, verbosity controls depth) |
-| `diff` | Change summary | `--table`, `--tsv`, `--name-only` |
+| `diff` | API change summary | `-S "Analysis Diff"`, `-S "Implementation Diff"`, `--table`, `--tsv`, `--name-only` |

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -46,7 +46,7 @@ Agents working in this repo should preserve these principles:
 - [Finding nomenclature](design/finding-nomenclature.md): observation/change semantics, operation outcomes, and Research composition boundaries.
 - [Finding producer design](design/finding-producers.md): how to choose owners, payloads, identities, result shapes, and matching modes.
 - [Finding coordinates](design/finding-coordinates.md): separation of subject identity, correspondence, optional producer order, and typed provenance.
-- [Implementation Diff](design/implementation-diff.md): product C# + IL/body diff projection shared by future CLI surfaces, RTS, and harnesses.
+- [Implementation Diff](design/implementation-diff.md): product C# + IL/body diff projection shared by the opt-in `diff` section, RTS, and harnesses.
 - [Fixture governance](fixture-governance.md): fixture catalog, project-boundary, and semantic-axis rules.
 - [Integrations](design/integrations.md): library ecosystem integration roll-ups and focused API currency.
 - [Section model](design/section-model.md): section selection and query behavior.

--- a/docs/workflows/discovery/api-diff.md
+++ b/docs/workflows/discovery/api-diff.md
@@ -135,7 +135,29 @@ Member filters also target body-signal diffs:
 dotnet-inspect diff --library old/Foo.dll..new/Foo.dll -S "Analysis Diff" -m MyType.HotPath --changed
 ```
 
-## 6. Name-only output
+## 6. Compare implementation evidence
+
+> Goal: See body-level C# and IL changes without replacing the default API compatibility lens.
+
+Select the explicit `Implementation Diff` section. Rows are grouped by member
+identity and identify the producer in the `Mechanism` column:
+
+```bash
+dotnet-inspect diff --library old/Foo.dll..new/Foo.dll -S "Implementation Diff" -t MyType -m HotPath
+```
+
+The same section works for package and platform ranges. Use `--table`, `--tsv`,
+or `--jsonl` for columnar output:
+
+```bash
+dotnet-inspect diff --package Foo@1.0.0..2.0.0 -S "Implementation Diff" --jsonl
+```
+
+This is implementation evidence, not an API compatibility classification or a
+semantic-equivalence proof. Omit `-S "Implementation Diff"` to retain the
+default API diff.
+
+## 7. Name-only output
 
 > Goal: Get a quick list of which types changed, without details.
 
@@ -153,11 +175,11 @@ System.Text.Json.JsonElement
 wc -l | tr -d ' '
 ```
 
-## 7. Oneline output for scripting
+## 8. Oneline output for scripting
 
 > Goal: Columnar output showing change type and summary per type.
 
-### 6a. With header
+### 8a. With header
 
 ```bash
 dotnet-inspect diff System.Text.Json@8.0.0..10.0.0 --table | head -5
@@ -169,7 +191,7 @@ TYPE
 DETAIL
 ```
 
-### 6b. Without header
+### 8b. Without header
 
 ```bash
 dotnet-inspect diff System.Text.Json@8.0.0..10.0.0 --table --no-headers | head -5
@@ -183,7 +205,7 @@ additive
 CHANGE
 ```
 
-## 7. Large migration diff (beta to stable)
+## 9. Large migration diff (beta to stable)
 
 > Goal: Compare a pre-release version to a stable release — common for migration planning.
 
@@ -206,11 +228,11 @@ signature changed
 grep -oE '[0-9]+ breaking'
 ```
 
-## 8. Platform library diff
+## 10. Platform library diff
 
 > Goal: Compare platform assembly versions (not NuGet packages).
 
-### 8a. NuGet 8 to 10
+### 10a. NuGet 8 to 10
 
 ```bash
 dotnet-inspect diff --platform System.Text.Json@8.0.0..10.0.0 -v:q -n 15
@@ -221,7 +243,7 @@ dotnet-inspect diff --platform System.Text.Json@8.0.0..10.0.0 -v:q -n 15
 Versions: **8.0.0** -> **10.0.0**
 ```
 
-### 8b. Diff against preview SDK
+### 10b. Diff against preview SDK
 
 ```prompt
 What changed in the platform System.Text.Json assembly between .NET 8 and the .NET 11 preview?

--- a/skills/compatibility/SKILL.md
+++ b/skills/compatibility/SKILL.md
@@ -44,6 +44,19 @@ dnx dotnet-inspect -y -- diff --package Foo@1.0.0..2.0.0 -S "Analysis Diff"
 dnx dotnet-inspect -y -- diff --library old/Foo.dll..new/Foo.dll -S "Analysis Diff" --changed
 ```
 
+## Did the implementation change? (C# + IL)
+
+`-S "Implementation Diff"` selects Research-composed body evidence instead of
+the default API compatibility view. Rows identify the member, producer (`C#` or
+`IL`), change kind, and producer-owned evidence. Narrow with `-t` and `-m`; use
+`--table`, `--tsv`, or `--jsonl` for columnar output.
+
+```bash
+dnx dotnet-inspect -y -- diff --library old/Foo.dll..new/Foo.dll -S "Implementation Diff" -t MyType -m HotPath
+```
+
+Treat these rows as implementation evidence, not semantic-equivalence proof.
+
 ## What can be configured? (feature switches)
 
 `-S Switches` (alias `-S @Switches`) on `library` or `package --library` reports

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -786,6 +786,16 @@ public class CommandLineTests
     }
 
     [Fact]
+    public void DiffCommand_WithImplementationDiffSection_ParsesCorrectly()
+    {
+        var result = CommandLineBuilder.CreateRootCommand().Parse(
+            ["diff", "--library", "old/Foo.dll..new/Foo.dll", "-S", "Implementation Diff"]);
+
+        Assert.Empty(result.Errors);
+        Assert.Equal("diff", result.CommandResult.Command.Name);
+    }
+
+    [Fact]
     public void DiffCommand_WithChangedOption_ParsesCorrectly()
     {
         var result = CommandLineBuilder.CreateRootCommand().Parse(["diff", "--library", "old/Foo.dll..new/Foo.dll", "-S", "Analysis Diff", "--changed"]);

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -699,6 +699,110 @@ public class DiffCommandTests
         Assert.Contains("method-like target", error.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void BuildImplementationDiff_VersionPair_ProjectsCSharpAndIlEvidence()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var result = DiffCommand.BuildImplementationDiff([v1], [v2], new DiffOptions
+        {
+            TypeFilter = ["DiffSample"]
+        });
+        var view = DiffOutputFormatter.BuildImplementationDiffView(
+            "DiffFixtureSample",
+            result,
+            "old.dll",
+            "new.dll");
+
+        var member = Assert.Single(result.Members, candidate =>
+            candidate.Subject.MemberName == "ConstantValue");
+        Assert.True(member.HasCSharpChanges);
+        Assert.True(member.HasIlChanges);
+        Assert.Contains(view.Rows!, row =>
+            row.Member.Contains("ConstantValue", StringComparison.Ordinal)
+            && row.Mechanism == "C#"
+            && row.Evidence.Contains("return 1", StringComparison.Ordinal));
+        Assert.Contains(view.Rows!, row =>
+            row.Member.Contains("ConstantValue", StringComparison.Ordinal)
+            && row.Mechanism == "IL"
+            && row.Evidence.Contains("ldc.i4 1", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void BuildImplementationDiff_MemberFilter_UsesResolverBackedTarget()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var result = DiffCommand.BuildImplementationDiff([v1], [v2], new DiffOptions
+        {
+            TypeFilter = ["DiffSample"],
+            MemberFilter = ["ConstantValue"]
+        });
+
+        var member = Assert.Single(result.Members);
+        Assert.Equal("ConstantValue", member.Subject.MemberName);
+        Assert.True(member.HasCSharpChanges);
+        Assert.True(member.HasIlChanges);
+    }
+
+    [Fact]
+    public void BuildImplementationDiff_MemberFilter_RejectsNonMethodTargets()
+    {
+        var surface = DiffSurface(DiffProperty("Value"));
+
+        var error = Assert.Throws<InvalidOperationException>(() =>
+            DiffCommand.BuildImplementationDiff([], [], new DiffOptions
+            {
+                TypeFilter = ["Widget"],
+                MemberFilter = ["Value"]
+            }, surface, surface));
+
+        Assert.Contains("Implementation Diff --member", error.Message, StringComparison.Ordinal);
+        Assert.Contains("method-like target", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildImplementationDiff_SameMember_IsEmpty()
+    {
+        var assembly = FixtureCatalog.DiffPair.OldAssemblyPath();
+
+        var result = DiffCommand.BuildImplementationDiff([assembly], [assembly], new DiffOptions
+        {
+            TypeFilter = ["DiffSample"],
+            MemberFilter = ["ConstantValue"]
+        });
+
+        Assert.True(result.IsEmpty);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ImplementationDiff_RendersSelectedTable()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var (exitCode, output, error) = await ConsoleCapture.RunAsync(() =>
+            DiffCommand.ExecuteAsync(new DiffOptions
+            {
+                LibraryVersionRange = $"{v1}..{v2}",
+                Select = ["Implementation Diff"],
+                OneLine = true,
+                TypeFilter = ["DiffSample"],
+                MemberFilter = ["ConstantValue"]
+            }));
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(error);
+        Assert.Contains("Member", output, StringComparison.Ordinal);
+        Assert.Contains("Mechanism", output, StringComparison.Ordinal);
+        Assert.Contains("ConstantValue", output, StringComparison.Ordinal);
+        Assert.Contains("C#", output, StringComparison.Ordinal);
+        Assert.Contains("IL", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("API Diff", output, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData("int*", "System.Int32*")]
     [InlineData("int[,]", "System.Int32[,]")]

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -14,7 +14,9 @@ public static class InspectionCommandDefinitions
 {
     public static Command CreateDiffCommand(SharedOptions opts)
     {
-        var diffCommand = new Command(DiffCommand.Name, "Compare API surfaces between package, platform, or local library versions");
+        var diffCommand = new Command(
+            DiffCommand.Name,
+            "Compare API surfaces, analysis signals, or implementation evidence between versions");
 
         var argsArg = new Argument<string[]>("args")
         {

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -12,7 +12,7 @@ using Markout;
 namespace DotnetInspector.Commands;
 
 /// <summary>
-/// Compares API surfaces between two package or platform versions.
+/// Compares API surfaces or selected body-level evidence between two versions.
 /// </summary>
 public class DiffCommand
 {
@@ -98,6 +98,35 @@ public class DiffCommand
 
             try
             {
+                if (SelectsImplementationDiff(options) && !SelectsAnalysisDiff(options))
+                {
+                    var implementation = BuildImplementationDiff(
+                        inputs.FromPaths,
+                        inputs.ToPaths,
+                        options,
+                        inputs.FromSurface,
+                        inputs.ToSurface);
+                    var view = DiffOutputFormatter.BuildImplementationDiffView(
+                        inputs.Name,
+                        implementation,
+                        inputs.FromVersion,
+                        inputs.ToVersion);
+                    if (options.OneLine)
+                    {
+                        OutputFormatter.WriteProjectedTable(Console.Out, !options.NoHeader, options.Tsv, options.Jsonl,
+                            options.Columns, options.Fields,
+                            (writer, formatter, writerOptions) =>
+                                MarkoutSerializer.Serialize(view, writer, formatter, DiffViewContext.Default, writerOptions),
+                            options.Rows);
+                    }
+                    else
+                    {
+                        var output = DiffOutputFormatter.RenderImplementationDiffView(view);
+                        Console.WriteLine(OutputFormatter.ApplyRowLimit(output, options.Rows));
+                    }
+                    return 0;
+                }
+
                 if (SelectsAnalysisDiff(options))
                 {
                     var analysis = BuildAnalysisDiff(inputs.FromPaths, inputs.ToPaths, options, inputs.FromSurface, inputs.ToSurface);
@@ -350,6 +379,9 @@ public class DiffCommand
         => options.AllocRegressionsOnly
             || options.IncludeSections?.Contains("Analysis Diff") == true;
 
+    private static bool SelectsImplementationDiff(DiffOptions options)
+        => options.IncludeSections?.Contains("Implementation Diff") == true;
+
     private static bool SelectsDetailedChanges(DiffOptions options)
         => options.IncludeSections?.Contains("Changes") == true;
 
@@ -403,6 +435,31 @@ public class DiffCommand
             .ToList();
 
         return RankAnalysisRows(ranked, options.ChangedOnly, options.AllocRegressionsOnly);
+    }
+
+    internal static ImplementationDiffResult BuildImplementationDiff(
+        IReadOnlyList<string> fromPaths,
+        IReadOnlyList<string> toPaths,
+        DiffOptions options,
+        ApiSurface? fromSurface = null,
+        ApiSurface? toSurface = null)
+    {
+        var memberTargetIdentities = options.MemberFilter.Count == 0
+            ? null
+            : ResolveMemberTargetIdentities(
+                fromSurface ?? MergeSurfaces(fromPaths, name: null, tfm: null, includeAll: options.IncludeAll, logger: new VerboseLogger(enabled: false)) ?? new ApiSurface(),
+                toSurface ?? MergeSurfaces(toPaths, name: null, tfm: null, includeAll: options.IncludeAll, logger: new VerboseLogger(enabled: false)) ?? new ApiSurface(),
+                options.MemberFilter,
+                options.TypeFilter,
+                requireBodyTargets: true,
+                bodySectionName: "Implementation Diff").MemberIdentities;
+
+        return ImplementationDiff.Compare(
+            ResearchDiffInput.FromAssemblies(fromPaths),
+            ResearchDiffInput.FromAssemblies(toPaths),
+            new ImplementationDiffOptions(
+                TypeFilters: options.TypeFilter,
+                MemberTargetIdentities: memberTargetIdentities));
     }
 
     // Applies the changed-only / allocation-regression filters, ranks rows (in-place
@@ -644,7 +701,8 @@ public class DiffCommand
         ApiSurface toSurface,
         IReadOnlyCollection<string> memberTargets,
         IReadOnlyCollection<string> typeFilters,
-        bool requireBodyTargets = false)
+        bool requireBodyTargets = false,
+        string bodySectionName = "Analysis Diff")
     {
         HashSet<string> identities = new(StringComparer.Ordinal);
         HashSet<string> typeNames = new(StringComparer.OrdinalIgnoreCase);
@@ -694,7 +752,7 @@ public class DiffCommand
             if (!found)
                 throw new InvalidOperationException(nonFatalDiagnostic?.Message ?? $"Member target '{rawTarget}' did not resolve in either diff input.");
             if (requireBodyTargets && !bodyFound)
-                throw new InvalidOperationException($"Analysis Diff --member requires a method-like target; '{rawTarget}' resolved to a member with no method body.");
+                throw new InvalidOperationException($"{bodySectionName} --member requires a method-like target; '{rawTarget}' resolved to a member with no method body.");
         }
 
         return new ResolvedDiffMemberTargets(identities, typeNames);

--- a/src/dotnet-inspect/Output/DiffOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/DiffOutputFormatter.cs
@@ -1,4 +1,5 @@
 using ILInspector.Metadata;
+using ILInspector.Research;
 using DotnetInspector.Views;
 using Markout;
 
@@ -157,6 +158,73 @@ public static class DiffOutputFormatter
     {
         var summary = rows.Count == 0 ? "No analysis signal changes detected." : $"{rows.Count} changed analysis signals";
         return RenderAnalysisDiffView(BuildAnalysisDiffView(name, rows, summary, fromVersion, toVersion));
+    }
+
+    public static ImplementationDiffView BuildImplementationDiffView(
+        string name,
+        ImplementationDiffResult diff,
+        string fromVersion,
+        string toVersion)
+    {
+        List<ImplementationDiffRow> rows = [];
+        foreach (var member in diff.Members)
+        {
+            foreach (var change in member.Changes)
+            {
+                var mechanism = change.Mechanism switch
+                {
+                    ResearchChangeMechanism.CSharp => "C#",
+                    ResearchChangeMechanism.IlBody => "IL",
+                    _ => change.Mechanism.ToString()
+                };
+                var evidenceLines = ImplementationDiff.UnifiedLines(change);
+                if (evidenceLines.IsDefaultOrEmpty)
+                {
+                    rows.Add(new ImplementationDiffRow(
+                        member.Subject.Display,
+                        mechanism,
+                        change.Kind.ToString().ToLowerInvariant(),
+                        change.Detail ?? change.Descriptor.Title));
+                    continue;
+                }
+
+                foreach (var evidence in evidenceLines)
+                {
+                    rows.Add(new ImplementationDiffRow(
+                        member.Subject.Display,
+                        mechanism,
+                        change.Kind.ToString().ToLowerInvariant(),
+                        evidence));
+                }
+            }
+        }
+
+        var csharpCount = rows.Count(row => row.Mechanism == "C#");
+        var ilCount = rows.Count(row => row.Mechanism == "IL");
+        var summary = rows.Count == 0
+            ? "No implementation differences detected."
+            : $"{diff.Members.Count} changed member{(diff.Members.Count == 1 ? "" : "s")}; "
+              + $"{csharpCount} C# and {ilCount} IL evidence row{(rows.Count == 1 ? "" : "s")}.";
+
+        return new ImplementationDiffView
+        {
+            Title = $"Implementation Diff: {name}",
+            Versions = $"{fromVersion} -> {toVersion}",
+            Summary = summary,
+            Status = rows.Count == 0
+                ? new Callout(CalloutSeverity.Note, summary)
+                : new Callout(
+                    CalloutSeverity.Note,
+                    "C# and IL implementation evidence is body-level evidence, not public API compatibility."),
+            Rows = rows.Count > 0 ? rows : null
+        };
+    }
+
+    public static string RenderImplementationDiffView(ImplementationDiffView view)
+    {
+        var writer = new MarkoutWriter(new MarkdownFormatter());
+        DiffViewContext.Default.Serialize(view, writer);
+        return writer.ToString().TrimEnd();
     }
 
     internal static string FormatSummaryCounts(int breaking, int additive, int potentiallyBreaking)

--- a/src/dotnet-inspect/Sections/DiffSections.cs
+++ b/src/dotnet-inspect/Sections/DiffSections.cs
@@ -10,14 +10,16 @@ public static class DiffSections
     {
         return new SectionPipeline<DiffDiscoveryModel>()
             .Add<Changes>()
-            .Add<AnalysisDiff>();
+            .Add<AnalysisDiff>()
+            .Add<ImplementationDiff>();
     }
 
     public static DocumentSchema CreateSchema()
     {
         return new DocumentSchema()
             .Add(Changes.Name, "column", "Change", "Classification", "Type", "Member", "Kind", "Detail", "Old", "New")
-            .Add(AnalysisDiff.Name, "section", "Member", "Signal", "Old", "New", "Delta", "Shape", "Evidence");
+            .Add(AnalysisDiff.Name, "section", "Member", "Signal", "Old", "New", "Delta", "Shape", "Evidence")
+            .Add(ImplementationDiff.Name, "section", "Member", "Mechanism", "Change", "Evidence");
     }
 
     public sealed class Changes : ISectionDescriptor<DiffDiscoveryModel>
@@ -33,6 +35,15 @@ public static class DiffSections
     {
         public static string Name => "Analysis Diff";
         public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static string? ScannerKey => null;
+        public static bool CanRender(DiffDiscoveryModel model) => true;
+    }
+
+    public sealed class ImplementationDiff : ISectionDescriptor<DiffDiscoveryModel>
+    {
+        public static string Name => "Implementation Diff";
+        public static bool IsExpensive => true;
         public static bool ExplicitOnly => true;
         public static string? ScannerKey => null;
         public static bool CanRender(DiffDiscoveryModel model) => true;

--- a/src/dotnet-inspect/Views/DiffViews.cs
+++ b/src/dotnet-inspect/Views/DiffViews.cs
@@ -88,6 +88,27 @@ public record AnalysisDiffRow(
     string? Shape,
     string? Evidence);
 
+[MarkoutSerializable(
+    TitleProperty = nameof(Title),
+    FieldLayout = FieldLayout.Table)]
+public class ImplementationDiffView
+{
+    [MarkoutIgnore] public string Title { get; set; } = "";
+    public string Versions { get; set; } = "";
+    public string Summary { get; set; } = "";
+    public Callout Status { get; set; }
+
+    [MarkoutSection(Name = "Implementation Diff")]
+    public List<ImplementationDiffRow>? Rows { get; set; }
+}
+
+[MarkoutSerializable]
+public record ImplementationDiffRow(
+    string Member,
+    string Mechanism,
+    string Change,
+    string Evidence);
+
 [MarkoutSerializable]
 public record DiffChangeRow(
     [property: MarkoutIgnore] string TypeName,
@@ -102,6 +123,8 @@ public record DiffChangeRow(
 [MarkoutContext(typeof(DiffChangeRow))]
 [MarkoutContext(typeof(AnalysisDiffView))]
 [MarkoutContext(typeof(AnalysisDiffRow))]
+[MarkoutContext(typeof(ImplementationDiffView))]
+[MarkoutContext(typeof(ImplementationDiffRow))]
 public partial class DiffViewContext : MarkoutSerializerContext
 {
 }


### PR DESCRIPTION
## Summary

- Add an explicit-only `Implementation Diff` section to `diff` discovery.
- Project Research-owned C# and IL unified evidence as
  `Member | Mechanism | Change | Evidence` rows.
- Reuse package, platform, and local-library acquisition plus existing
  type/member selectors and Markdown/table/TSV/JSONL output.
- Preserve the default API compatibility view and existing `Analysis Diff`
  behavior.

Closes #2543.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `ILInspector.Research.Tests`: 78 passed
- `DiffCommandTests`: 66 passed
- `CommandLineTests`: 174 passed
- Full `dotnet-inspect.Tests`: 1,725 passed, 10 skipped, 1 known
  dirty-worktree failure tracked by #2637
- `markdownlint` passed for all changed Markdown
- Live fixture-pair output checked in Markdown, table, TSV, and JSONL

## Adversarial review

Exact head `ff95a3c2` was reviewed in isolated clean worktrees by Claude Opus
4.8 and Gemini 3.1 Pro.

- Gemini's first pass was clean.
- Opus reproduced metadata-token IL comparison failures and pre-existing
  multi-section first-lens precedence. These are tracked by #2635 and #2639;
  neither is introduced by this CLI projection. Failure rows remain visible
  rather than being hidden.
- Final exact-head re-reviews by both Opus and Gemini were clean with no
  outstanding findings.
