### PR TITLE
Add CFG-backed stack slot copy propagation

### DIFF
--- a/src/ILInspector.Decompiler.Tests/StackSlotCopyPropagationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackSlotCopyPropagationPassTests.cs
@@ -252,6 +252,67 @@ public class StackSlotCopyPropagationPassTests
     }
 
     [Fact]
+    public void DoesNotPropagateWhenNestedBranchCanEnterUseRegion()
+    {
+        var body = new BlockContainer();
+        var entry = new Block(0);
+        entry.Add(new ConditionalBranch(new LoadArgument(1, "flag", Bool), 8));
+        body.Add(entry);
+        var firstSourceStore = new Block(4);
+        firstSourceStore.Add(new StoreStackSlot(0, new LoadArgument(0, "x", Int32)));
+        firstSourceStore.Add(new Branch(12));
+        body.Add(firstSourceStore);
+        var secondSourceStore = new Block(8);
+        secondSourceStore.Add(new StoreStackSlot(0, new LoadArgument(2, "y", Int32)));
+        secondSourceStore.Add(new ConditionalBranch(new LoadArgument(1, "flag", Bool), 16));
+        body.Add(secondSourceStore);
+        var copyJoin = new Block(12);
+        copyJoin.Add(new StoreStackSlot(1, new LoadStackSlot(0, Int32)));
+        copyJoin.Add(new Branch(24));
+        body.Add(copyJoin);
+        var nestedBranch = new Block(16);
+        var thenArm = new Block(17);
+        thenArm.Add(new Branch(24));
+        nestedBranch.Add(new IfStatement(new LoadArgument(1, "flag", Bool), thenArm, null));
+        nestedBranch.Add(new Return(null));
+        body.Add(nestedBranch);
+        var use = new Block(24);
+        use.Add(UseSlot(1));
+        use.Add(new Return(null));
+        body.Add(use);
+        var function = Function(body);
+
+        new StackSlotCopyPropagationPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Contains(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 1);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
+    }
+
+    [Fact]
+    public void DoesNotPropagateWhenNestedLoopTerminatorIsPresent()
+    {
+        var body = MultiBlockSourceBeforeCopy();
+        var copy = new Block(12);
+        copy.Add(new StoreStackSlot(1, new LoadStackSlot(0, Int32)));
+        body.Add(copy);
+        var use = new Block(16);
+        use.Add(UseSlot(1));
+        var thenArm = new Block(17);
+        thenArm.Add(new Continue());
+        use.Add(new IfStatement(new LoadArgument(1, "flag", Bool), thenArm, null));
+        use.Add(new Return(null));
+        body.Add(use);
+        var function = Function(body);
+
+        new StackSlotCopyPropagationPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Contains(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 1);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
+    }
+
+    [Fact]
     public void DoesNotCrossNestedBodyScope()
     {
         var lambdaBody = new BlockContainer();

--- a/src/ILInspector.Decompiler.Tests/StackSlotCopyPropagationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackSlotCopyPropagationPassTests.cs
@@ -1,0 +1,262 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class StackSlotCopyPropagationPassTests
+{
+    static readonly TypeRef Holder = TypeRef.Definition("Synthetic", "Samples", "Holder", ValueTypeHint.ReferenceType);
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
+
+    [Fact]
+    public void PropagatesSingleUseCopyAcrossFallthroughBlock()
+    {
+        var body = MultiBlockSourceBeforeCopy();
+        var copy = new Block(12);
+        copy.Add(new StoreStackSlot(1, new LoadStackSlot(0, Int32)));
+        body.Add(copy);
+        var use = new Block(16);
+        use.Add(UseSlot(1));
+        use.Add(new Return(null));
+        body.Add(use);
+        var function = Function(body);
+
+        new StackSlotCopyPropagationPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.DoesNotContain(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 1);
+        Assert.DoesNotContain(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
+        Assert.Single(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 0);
+    }
+
+    [Fact]
+    public void PropagatesOnlyWhenEveryBranchPathKeepsSourceStable()
+    {
+        var body = MultiBlockSourceBeforeCopy();
+        var copy = new Block(12);
+        copy.Add(new StoreStackSlot(1, new LoadStackSlot(0, Int32)));
+        copy.Add(new ConditionalBranch(new LoadArgument(1, "flag", Bool), 20));
+        body.Add(copy);
+        var fallthrough = new Block(16);
+        fallthrough.Add(new Branch(24));
+        body.Add(fallthrough);
+        var target = new Block(20);
+        target.Add(new Branch(24));
+        body.Add(target);
+        var join = new Block(24);
+        join.Add(UseSlot(1));
+        join.Add(new Return(null));
+        body.Add(join);
+        var function = Function(body);
+
+        new StackSlotCopyPropagationPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.DoesNotContain(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 1);
+        Assert.DoesNotContain(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
+        Assert.Single(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 0);
+    }
+
+    [Fact]
+    public void DoesNotPropagateWhenSourceIsRewrittenBeforeUse()
+    {
+        var function = RewriteSourceBeforeUse();
+
+        new StackSlotCopyPropagationPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Contains(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 1);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
+    }
+
+    [Fact]
+    public void DoesNotPropagateWhenDestinationHasMultipleUses()
+    {
+        var body = MultiBlockSourceBeforeCopy();
+        var copy = new Block(12);
+        copy.Add(new StoreStackSlot(1, new LoadStackSlot(0, Int32)));
+        body.Add(copy);
+        var firstUse = new Block(16);
+        firstUse.Add(UseSlot(1));
+        body.Add(firstUse);
+        var secondUse = new Block(20);
+        secondUse.Add(UseSlot(1));
+        secondUse.Add(new Return(null));
+        body.Add(secondUse);
+        var function = Function(body);
+
+        new StackSlotCopyPropagationPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Contains(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 1);
+        Assert.Equal(2, function.Descendants.OfType<LoadStackSlot>().Count(load => load.Slot == 1));
+    }
+
+    [Fact]
+    public void DoesNotPropagateWhenOutsideEdgeCanEnterUseRegion()
+    {
+        var body = new BlockContainer();
+        var entry = new Block(0);
+        entry.Add(new ConditionalBranch(new LoadArgument(1, "flag", Bool), 8));
+        body.Add(entry);
+        var firstSourceStore = new Block(4);
+        firstSourceStore.Add(new StoreStackSlot(0, new LoadArgument(0, "x", Int32)));
+        firstSourceStore.Add(new Branch(12));
+        body.Add(firstSourceStore);
+        var secondSourceStore = new Block(8);
+        secondSourceStore.Add(new StoreStackSlot(0, new LoadArgument(2, "y", Int32)));
+        secondSourceStore.Add(new ConditionalBranch(new LoadArgument(1, "flag", Bool), 16));
+        body.Add(secondSourceStore);
+        var copyJoin = new Block(12);
+        copyJoin.Add(new StoreStackSlot(1, new LoadStackSlot(0, Int32)));
+        copyJoin.Add(new Branch(20));
+        body.Add(copyJoin);
+        var outside = new Block(16);
+        outside.Add(new Branch(20));
+        body.Add(outside);
+        var join = new Block(20);
+        join.Add(UseSlot(1));
+        join.Add(new Return(null));
+        body.Add(join);
+        var function = Function(body);
+
+        new StackSlotCopyPropagationPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Contains(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 1);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
+    }
+
+    [Fact]
+    public void DoesNotCrossNestedBodyScope()
+    {
+        var lambdaBody = new BlockContainer();
+        var lambdaBlock = new Block(0);
+        lambdaBlock.Add(UseSlot(1));
+        lambdaBlock.Add(new Return(null));
+        lambdaBody.Add(lambdaBlock);
+        var lambda = new Lambda(
+            TypeRef.CoreLib("System", "Action"),
+            [], [], [],
+            usesUpdatedMemorySafetyRules: false,
+            skipLocalsInit: false,
+            lambdaBody);
+
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new LoadArgument(0, "x", Int32)));
+        block.Add(new StoreStackSlot(1, new LoadStackSlot(0, Int32)));
+        block.Add(new StoreLocal(0, lambda.ResultType!, lambda));
+        block.Add(new Return(null));
+        body.Add(block);
+        var function = Function(body);
+
+        new StackSlotCopyPropagationPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Contains(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 1);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
+    }
+
+    [Fact]
+    public void DoesNotPropagateIntoLockReceiverCarrier()
+    {
+        var body = new BlockContainer();
+        var entry = new Block(0);
+        entry.Add(new ConditionalBranch(new LoadArgument(1, "flag", Bool), 8));
+        body.Add(entry);
+        var firstSourceStore = new Block(4);
+        firstSourceStore.Add(new StoreStackSlot(0, new LoadArgument(3, "gate", Object)));
+        firstSourceStore.Add(new Branch(12));
+        body.Add(firstSourceStore);
+        var secondSourceStore = new Block(8);
+        secondSourceStore.Add(new StoreStackSlot(0, new LoadArgument(3, "gate", Object)));
+        secondSourceStore.Add(new Branch(12));
+        body.Add(secondSourceStore);
+        var block = new Block(12);
+        block.Add(new StoreStackSlot(1, new LoadStackSlot(0, Object)));
+        block.Add(new StoreLocal(0, Object, new LoadStackSlot(1, Object)));
+        var lockBody = new BlockContainer();
+        var lockBlock = new Block(16);
+        lockBlock.Add(new Return(null));
+        lockBody.Add(lockBlock);
+        block.Add(new Pipeline.Lock(new LoadLocal(0, Object), lockBody));
+        body.Add(block);
+        var function = Function(body);
+
+        new StackSlotCopyPropagationPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Contains(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 1);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
+    }
+
+    [Fact]
+    public void DoesNotPropagateNonSlotCopyValue()
+    {
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(1, new LoadArgument(0, "x", Int32)));
+        block.Add(UseSlot(1));
+        block.Add(new Return(null));
+        body.Add(block);
+        var function = Function(body);
+
+        new StackSlotCopyPropagationPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Contains(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 1);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
+    }
+
+    static IrFunction RewriteSourceBeforeUse()
+    {
+        var body = MultiBlockSourceBeforeCopy();
+        var copy = new Block(12);
+        copy.Add(new StoreStackSlot(1, new LoadStackSlot(0, Int32)));
+        body.Add(copy);
+        var rewrite = new Block(16);
+        rewrite.Add(new StoreStackSlot(0, new LoadArgument(2, "y", Int32)));
+        body.Add(rewrite);
+        var use = new Block(20);
+        use.Add(UseSlot(1));
+        use.Add(new Return(null));
+        body.Add(use);
+        return Function(body);
+    }
+
+    static BlockContainer MultiBlockSourceBeforeCopy()
+    {
+        var body = new BlockContainer();
+        var entry = new Block(0);
+        entry.Add(new ConditionalBranch(new LoadArgument(1, "flag", Bool), 8));
+        body.Add(entry);
+        var firstSourceStore = new Block(4);
+        firstSourceStore.Add(new StoreStackSlot(0, new LoadArgument(0, "x", Int32)));
+        firstSourceStore.Add(new Branch(12));
+        body.Add(firstSourceStore);
+        var secondSourceStore = new Block(8);
+        secondSourceStore.Add(new StoreStackSlot(0, new LoadArgument(2, "y", Int32)));
+        secondSourceStore.Add(new Branch(12));
+        body.Add(secondSourceStore);
+        return body;
+    }
+
+    static ExpressionStatement UseSlot(int slot)
+        => new(new Call(new MethodRef(Holder, "Use", Void, [Int32], HasThis: false), isVirtual: false, [new LoadStackSlot(slot, Int32)]));
+
+    static IrFunction Function(BlockContainer body)
+        => new(
+            "M",
+            Holder,
+            new MethodSignature(Void, [
+                new Parameter("x", Int32),
+                new Parameter("flag", Bool),
+                new Parameter("y", Int32),
+                new Parameter("gate", Object),
+            ], HasThis: false, GenericParameterCount: 0),
+            [TypeRef.CoreLib("System", "Action")],
+            body);
+}

--- a/src/ILInspector.Decompiler.Tests/StackSlotCopyPropagationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackSlotCopyPropagationPassTests.cs
@@ -95,6 +95,129 @@ public class StackSlotCopyPropagationPassTests
     }
 
     [Fact]
+    public void DoesNotPropagateWhenDestinationHasMultipleStores()
+    {
+        var body = MultiBlockSourceBeforeCopy();
+        var firstCopy = new Block(12);
+        firstCopy.Add(new StoreStackSlot(1, new LoadStackSlot(0, Int32)));
+        firstCopy.Add(new Branch(16));
+        body.Add(firstCopy);
+        var secondCopy = new Block(16);
+        secondCopy.Add(new StoreStackSlot(1, new LoadStackSlot(0, Int32)));
+        secondCopy.Add(UseSlot(1));
+        secondCopy.Add(new Return(null));
+        body.Add(secondCopy);
+        var function = Function(body);
+
+        new StackSlotCopyPropagationPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Equal(2, function.Descendants.OfType<StoreStackSlot>().Count(store => store.Slot == 1));
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
+    }
+
+    [Fact]
+    public void DoesNotPropagateSelfCopy()
+    {
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(1, new LoadStackSlot(1, Int32)));
+        block.Add(UseSlot(1));
+        block.Add(new Return(null));
+        body.Add(block);
+        var function = Function(body);
+
+        new StackSlotCopyPropagationPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Contains(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 1);
+        Assert.Equal(2, function.Descendants.OfType<LoadStackSlot>().Count(load => load.Slot == 1));
+    }
+
+    [Fact]
+    public void DoesNotPropagateWhenSourceHasSingleStore()
+    {
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new LoadArgument(0, "x", Int32)));
+        block.Add(new StoreStackSlot(1, new LoadStackSlot(0, Int32)));
+        block.Add(UseSlot(1));
+        block.Add(new Return(null));
+        body.Add(block);
+        var function = Function(body);
+
+        new StackSlotCopyPropagationPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Contains(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 1);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
+    }
+
+    [Fact]
+    public void DoesNotPropagateWhenSourceStoresAreInOneBlock()
+    {
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new LoadArgument(0, "x", Int32)));
+        block.Add(new StoreStackSlot(0, new LoadArgument(2, "y", Int32)));
+        block.Add(new StoreStackSlot(1, new LoadStackSlot(0, Int32)));
+        block.Add(UseSlot(1));
+        block.Add(new Return(null));
+        body.Add(block);
+        var function = Function(body);
+
+        new StackSlotCopyPropagationPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Contains(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 1);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
+    }
+
+    [Fact]
+    public void DoesNotPropagateIntoIncrementDecrementTarget()
+    {
+        var body = MultiBlockSourceBeforeCopy();
+        var copy = new Block(12);
+        copy.Add(new StoreStackSlot(1, new LoadStackSlot(0, Int32)));
+        body.Add(copy);
+        var use = new Block(16);
+        use.Add(new ExpressionStatement(new IncrementDecrement(new LoadStackSlot(1, Int32), isIncrement: true, isPrefix: false)));
+        use.Add(new Return(null));
+        body.Add(use);
+        var function = Function(body);
+
+        new StackSlotCopyPropagationPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Contains(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 1);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
+    }
+
+    [Fact]
+    public void DoesNotPropagateAcrossCyclicCopiedValueRegion()
+    {
+        var body = MultiBlockSourceBeforeCopy();
+        var copy = new Block(12);
+        copy.Add(new StoreStackSlot(1, new LoadStackSlot(0, Int32)));
+        body.Add(copy);
+        var loop = new Block(16);
+        loop.Add(UseSlot(1));
+        loop.Add(new StoreStackSlot(0, new LoadArgument(2, "y", Int32)));
+        loop.Add(new ConditionalBranch(new LoadArgument(1, "flag", Bool), 16));
+        body.Add(loop);
+        var exit = new Block(20);
+        exit.Add(new Return(null));
+        body.Add(exit);
+        var function = Function(body);
+
+        new StackSlotCopyPropagationPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Contains(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 1);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
+    }
+
+    [Fact]
     public void DoesNotPropagateWhenOutsideEdgeCanEnterUseRegion()
     {
         var body = new BlockContainer();
@@ -303,6 +426,32 @@ public class StackSlotCopyPropagationPassTests
         use.Add(new IfStatement(new LoadArgument(1, "flag", Bool), thenArm, null));
         use.Add(new Return(null));
         body.Add(use);
+        var function = Function(body);
+
+        new StackSlotCopyPropagationPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Contains(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 1);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
+    }
+
+    [Fact]
+    public void DoesNotPropagateInsideNestedStructuredContainer()
+    {
+        var lockBody = MultiBlockSourceBeforeCopy();
+        var copy = new Block(12);
+        copy.Add(new StoreStackSlot(1, new LoadStackSlot(0, Int32)));
+        lockBody.Add(copy);
+        var use = new Block(16);
+        use.Add(UseSlot(1));
+        use.Add(new Return(null));
+        lockBody.Add(use);
+
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new Pipeline.Lock(new LoadArgument(3, "gate", Object), lockBody));
+        block.Add(new Return(null));
+        body.Add(block);
         var function = Function(body);
 
         new StackSlotCopyPropagationPass().Run(function, PassContext.None);

--- a/src/ILInspector.Decompiler.Tests/StackSlotCopyPropagationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackSlotCopyPropagationPassTests.cs
@@ -130,6 +130,128 @@ public class StackSlotCopyPropagationPassTests
     }
 
     [Fact]
+    public void DoesNotPropagateWhenSwitchEdgeCanEnterUseRegion()
+    {
+        var body = OutsideEntryBody();
+        var outside = new Block(16);
+        outside.Add(new SwitchBranch(new LoadArgument(0, "x", Int32), [20]));
+        body.Add(outside);
+        var join = new Block(20);
+        join.Add(UseSlot(1));
+        join.Add(new Return(null));
+        body.Add(join);
+        var function = Function(body);
+
+        new StackSlotCopyPropagationPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Contains(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 1);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
+    }
+
+    [Fact]
+    public void DoesNotPropagateWhenSwitchTargetRewritesSourceBeforeUse()
+    {
+        var body = MultiBlockSourceBeforeCopy();
+        var copy = new Block(12);
+        copy.Add(new StoreStackSlot(1, new LoadStackSlot(0, Int32)));
+        copy.Add(new SwitchBranch(new LoadArgument(0, "x", Int32), [20]));
+        body.Add(copy);
+        var fallthrough = new Block(16);
+        fallthrough.Add(new Branch(24));
+        body.Add(fallthrough);
+        var switchTarget = new Block(20);
+        switchTarget.Add(new StoreStackSlot(0, new LoadArgument(2, "y", Int32)));
+        switchTarget.Add(new Branch(24));
+        body.Add(switchTarget);
+        var join = new Block(24);
+        join.Add(UseSlot(1));
+        join.Add(new Return(null));
+        body.Add(join);
+        var function = Function(body);
+
+        new StackSlotCopyPropagationPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Contains(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 1);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
+    }
+
+    [Fact]
+    public void DoesNotPropagateWhenLeaveEdgeCanEnterUseRegion()
+    {
+        var body = OutsideEntryBody();
+        var outside = new Block(16);
+        outside.Add(new Leave(20));
+        body.Add(outside);
+        var join = new Block(20);
+        join.Add(UseSlot(1));
+        join.Add(new Return(null));
+        body.Add(join);
+        var function = Function(body);
+
+        new StackSlotCopyPropagationPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Contains(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 1);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
+    }
+
+    [Fact]
+    public void DoesNotPropagateWhenLeaveTargetRewritesSourceBeforeUse()
+    {
+        var body = MultiBlockSourceBeforeCopy();
+        var copy = new Block(12);
+        copy.Add(new StoreStackSlot(1, new LoadStackSlot(0, Int32)));
+        copy.Add(new ConditionalBranch(new LoadArgument(1, "flag", Bool), 20));
+        body.Add(copy);
+        var fallthrough = new Block(16);
+        fallthrough.Add(new Leave(24));
+        body.Add(fallthrough);
+        var branchTarget = new Block(20);
+        branchTarget.Add(new Branch(28));
+        body.Add(branchTarget);
+        var leaveTarget = new Block(24);
+        leaveTarget.Add(new StoreStackSlot(0, new LoadArgument(2, "y", Int32)));
+        leaveTarget.Add(new Branch(28));
+        body.Add(leaveTarget);
+        var join = new Block(28);
+        join.Add(UseSlot(1));
+        join.Add(new Return(null));
+        body.Add(join);
+        var function = Function(body);
+
+        new StackSlotCopyPropagationPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Contains(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 1);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
+    }
+
+    [Fact]
+    public void DoesNotPropagateWhenContainerHasUnmodeledLoopTerminator()
+    {
+        var body = MultiBlockSourceBeforeCopy();
+        var copy = new Block(12);
+        copy.Add(new StoreStackSlot(1, new LoadStackSlot(0, Int32)));
+        body.Add(copy);
+        var use = new Block(16);
+        use.Add(UseSlot(1));
+        use.Add(new Return(null));
+        body.Add(use);
+        var loopExit = new Block(20);
+        loopExit.Add(new Break());
+        body.Add(loopExit);
+        var function = Function(body);
+
+        new StackSlotCopyPropagationPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Contains(function.Descendants.OfType<StoreStackSlot>(), store => store.Slot == 1);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 1);
+    }
+
+    [Fact]
     public void DoesNotCrossNestedBodyScope()
     {
         var lambdaBody = new BlockContainer();
@@ -241,6 +363,27 @@ public class StackSlotCopyPropagationPassTests
         secondSourceStore.Add(new StoreStackSlot(0, new LoadArgument(2, "y", Int32)));
         secondSourceStore.Add(new Branch(12));
         body.Add(secondSourceStore);
+        return body;
+    }
+
+    static BlockContainer OutsideEntryBody()
+    {
+        var body = new BlockContainer();
+        var entry = new Block(0);
+        entry.Add(new ConditionalBranch(new LoadArgument(1, "flag", Bool), 8));
+        body.Add(entry);
+        var firstSourceStore = new Block(4);
+        firstSourceStore.Add(new StoreStackSlot(0, new LoadArgument(0, "x", Int32)));
+        firstSourceStore.Add(new Branch(12));
+        body.Add(firstSourceStore);
+        var secondSourceStore = new Block(8);
+        secondSourceStore.Add(new StoreStackSlot(0, new LoadArgument(2, "y", Int32)));
+        secondSourceStore.Add(new ConditionalBranch(new LoadArgument(1, "flag", Bool), 16));
+        body.Add(secondSourceStore);
+        var copyJoin = new Block(12);
+        copyJoin.Add(new StoreStackSlot(1, new LoadStackSlot(0, Int32)));
+        copyJoin.Add(new Branch(20));
+        body.Add(copyJoin);
         return body;
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -334,6 +334,11 @@ public static class IrPasses
         // reconstructed `x++` would inline to an invalid `1++`; see the pass
         // doc and #2379 piece 1 census).
         new ExpressionInliningPass(slotsOnly: true),
+        // Collapse proof-backed synthetic slot copies (`S_dst = S_src`) that
+        // survive the slots-only inliner only because the use sits across
+        // control-flow blocks. This keeps copy carriers out of the printer's
+        // residual unifier while preserving the source slot's live value.
+        new StackSlotCopyPropagationPass(),
         // A decided in-domain slot (one testified type, all stores at it or
         // renderably coercible) is a finished variable: materialize it as a
         // typed local BEFORE insertion, so its minted locals are coerced at

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -29,6 +29,8 @@ internal static class NativePasses
     // ───────── EmitArtifact — inverse of codegen/spilling, not a LocalRewriter ─────────
     [Native(NativeCategory.EmitArtifact, "inverse of expression spilling — fold single-use temps back into their use")]
     public static ExpressionInliningPass ExpressionInlining => new();
+    [Native(NativeCategory.EmitArtifact, "CFG-backed synthetic stack-slot copy propagation removes single-use copy carriers")]
+    public static StackSlotCopyPropagationPass StackSlotCopyPropagation => new();
     [Native(NativeCategory.EmitArtifact, "reused evaluation-stack slot live ranges split into distinct typed synthetic carriers")]
     public static StackSlotLiveRangePass StackSlotLiveRange => new();
     [Native(NativeCategory.EmitArtifact, "in-place struct .ctor (ldloca; call S::.ctor) back to s = new S(...)")]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackSlotCopyPropagationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackSlotCopyPropagationPass.cs
@@ -1,0 +1,260 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Eliminates a proof-backed synthetic stack-slot copy, <c>S_dst = S_src</c>, by
+/// replacing the single destination use with a direct source-slot load. This is
+/// not expression inlining: the source value is still loaded at the original use
+/// site, so no user expression or side effect moves. The pass only proves that
+/// the copied source slot cannot be rewritten between the copy and the use, and
+/// that no control-flow edge can enter the use region while bypassing the copy.
+/// </summary>
+public sealed class StackSlotCopyPropagationPass : IIrPass
+{
+    public string Name => "stack-slot-copy-propagation";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        while (PropagateOnce(function, function.Body, context.Stepper))
+        {
+        }
+    }
+
+    static bool PropagateOnce(IrFunction function, IrNode scope, Stepper stepper)
+    {
+        if (PropagateInScope(function, scope, stepper))
+            return true;
+
+        foreach (var node in CoercionSinks.ScopeNodes(scope))
+        {
+            switch (node)
+            {
+                case Lambda lambda when PropagateOnce(function, lambda, stepper):
+                    return true;
+                case LocalFunctionStatement local when PropagateOnce(function, local, stepper):
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    static bool PropagateInScope(IrFunction function, IrNode scope, Stepper stepper)
+    {
+        var nodes = CoercionSinks.ScopeNodes(scope).ToList();
+        var storesBySlot = nodes.OfType<StoreStackSlot>().GroupBy(store => store.Slot)
+            .ToDictionary(group => group.Key, group => group.ToList());
+        var loadsBySlot = nodes.OfType<LoadStackSlot>().GroupBy(load => load.Slot)
+            .ToDictionary(group => group.Key, group => group.ToList());
+
+        foreach (var store in nodes.OfType<StoreStackSlot>().ToList())
+        {
+            if (store.Value is not LoadStackSlot source || source.Slot == store.Slot)
+                continue;
+            if (storesBySlot.GetValueOrDefault(store.Slot) is not { Count: 1 })
+                continue;
+            if (loadsBySlot.GetValueOrDefault(store.Slot) is not [var use])
+                continue;
+            if (!IsMultiBlockSourceResidual(source.Slot, storesBySlot))
+                continue;
+            if (FeedsLockReceiverCarrier(use))
+                continue;
+            if (use.Parent is IncrementDecrement)
+                continue;
+            if (TryGetCopyPath(store, use) is not { } path)
+                continue;
+            if (!SourceStableOnEveryPath(path, source.Slot))
+                continue;
+            if (!RegionDominatedByCopy(path))
+                continue;
+
+            var replacement = new LoadStackSlot(source.Slot, use.Type ?? source.Type);
+            replacement.InheritSourceOffset(use);
+            stepper.StepOver($"propagate stack-slot copy S_{store.Slot} from S_{source.Slot}", use);
+            use.ReplaceWith(replacement);
+            store.Detach();
+            return true;
+        }
+        return false;
+    }
+
+    static bool IsMultiBlockSourceResidual(int sourceSlot, Dictionary<int, List<StoreStackSlot>> storesBySlot)
+        => storesBySlot.GetValueOrDefault(sourceSlot) is { Count: > 1 } stores
+            && stores.Select(store => store.Parent).Distinct().Count() > 1;
+
+    static bool FeedsLockReceiverCarrier(LoadStackSlot use)
+        => EnclosingStatement(use) is StoreLocal store
+            && ReferenceOwnership.IsInside(use, store.Value)
+            && LocalFeedsLockObject(store);
+
+    static bool LocalFeedsLockObject(StoreLocal store)
+        => Root(store).Descendants.OfType<Lock>()
+            .Any(lockNode => lockNode.LockObject is LoadLocal load && load.Index == store.Index);
+
+    static IrNode Root(IrNode node)
+    {
+        var current = node;
+        while (current.Parent is { } parent)
+            current = parent;
+        return current;
+    }
+
+    sealed record CopyPath(
+        IReadOnlyList<Block> Blocks,
+        int CopyBlockIndex,
+        int CopyStatementIndex,
+        int UseBlockIndex,
+        IrNode UseStatement,
+        HashSet<int> RegionBlocks);
+
+    static CopyPath? TryGetCopyPath(StoreStackSlot copy, LoadStackSlot use)
+    {
+        if (copy.Parent is not Block copyBlock || copyBlock.Parent is not BlockContainer container)
+            return null;
+        if (EnclosingStatement(use) is not { } useStatement || useStatement.Parent is not Block useBlock)
+            return null;
+        if (!ReferenceEquals(useBlock.Parent, container))
+            return null;
+
+        var blocks = container.Blocks;
+        int copyBlockIndex = copyBlock.ChildIndex;
+        int useBlockIndex = useBlock.ChildIndex;
+        if (copyBlockIndex < 0 || useBlockIndex < 0)
+            return null;
+
+        var region = new HashSet<int>();
+        var stack = new Stack<(int BlockIndex, int StartStatement)>();
+        var visited = new HashSet<(int BlockIndex, int StartStatement)>();
+        bool foundUse = false;
+
+        stack.Push((copyBlockIndex, copy.ChildIndex + 1));
+        while (stack.Count > 0)
+        {
+            var state = stack.Pop();
+            if (!visited.Add(state))
+                continue;
+            if ((uint)state.BlockIndex >= (uint)blocks.Count)
+                return null;
+
+            region.Add(state.BlockIndex);
+            var block = blocks[state.BlockIndex];
+            for (int i = state.StartStatement; i < block.Children.Count; i++)
+            {
+                var statement = block.Children[i];
+                if (ReferenceEquals(statement, useStatement))
+                {
+                    foundUse = true;
+                    continue;
+                }
+                if (ReferenceOwnership.IsInside(use, statement))
+                    return null; // The use must be the statement we identified.
+            }
+
+            if (state.BlockIndex == useBlockIndex)
+                continue;
+
+            foreach (int successor in Successors(blocks, state.BlockIndex))
+                stack.Push((successor, 0));
+        }
+
+        return foundUse
+            ? new CopyPath(blocks, copyBlockIndex, copy.ChildIndex, useBlockIndex, useStatement, region)
+            : null;
+    }
+
+    static bool SourceStableOnEveryPath(CopyPath path, int sourceSlot)
+    {
+        foreach (int blockIndex in path.RegionBlocks)
+        {
+            var block = path.Blocks[blockIndex];
+            int start = blockIndex == path.CopyBlockIndex ? path.CopyStatementIndex + 1 : 0;
+            int end = blockIndex == path.UseBlockIndex ? path.UseStatement.ChildIndex : block.Children.Count - 1;
+            for (int i = start; i <= end; i++)
+            {
+                var statement = block.Children[i];
+                if (WritesSlot(statement, sourceSlot))
+                    return false;
+            }
+        }
+        return true;
+    }
+
+    static bool RegionDominatedByCopy(CopyPath path)
+    {
+        var predecessors = Predecessors(path.Blocks);
+        foreach (int blockIndex in path.RegionBlocks)
+        {
+            if (blockIndex == path.CopyBlockIndex)
+                continue;
+            foreach (int predecessor in predecessors[blockIndex])
+                if (!path.RegionBlocks.Contains(predecessor))
+                    return false;
+        }
+        return true;
+    }
+
+    static List<int>[] Predecessors(IReadOnlyList<Block> blocks)
+    {
+        var predecessors = new List<int>[blocks.Count];
+        for (int i = 0; i < predecessors.Length; i++)
+            predecessors[i] = [];
+        for (int i = 0; i < blocks.Count; i++)
+        {
+            foreach (int successor in Successors(blocks, i))
+                predecessors[successor].Add(i);
+        }
+        return predecessors;
+    }
+
+    static IEnumerable<int> Successors(IReadOnlyList<Block> blocks, int index)
+    {
+        var children = blocks[index].Children;
+        if (children.Count == 0)
+        {
+            if (index + 1 < blocks.Count)
+                yield return index + 1;
+            yield break;
+        }
+
+        switch (children[^1])
+        {
+            case Branch branch:
+                int branchTarget = IndexOfOffset(blocks, branch.TargetOffset);
+                if (branchTarget >= 0)
+                    yield return branchTarget;
+                yield break;
+            case ConditionalBranch branch:
+                int conditionalTarget = IndexOfOffset(blocks, branch.TargetOffset);
+                if (conditionalTarget >= 0)
+                    yield return conditionalTarget;
+                if (index + 1 < blocks.Count)
+                    yield return index + 1;
+                yield break;
+            case Return or Throw or Leave or EndFinally or EndFilter or SwitchBranch:
+                yield break;
+            default:
+                if (index + 1 < blocks.Count)
+                    yield return index + 1;
+                yield break;
+        }
+    }
+
+    static int IndexOfOffset(IReadOnlyList<Block> blocks, int offset)
+    {
+        for (int i = 0; i < blocks.Count; i++)
+            if (blocks[i].StartOffset == offset)
+                return i;
+        return -1;
+    }
+
+    static IrNode? EnclosingStatement(IrNode node)
+    {
+        for (var current = node; current is not null; current = current.Parent)
+            if (current.Parent is Block)
+                return current;
+        return null;
+    }
+
+    static bool WritesSlot(IrNode statement, int slot)
+        => statement.Descendants.Prepend(statement)
+            .OfType<StoreStackSlot>()
+            .Any(store => store.Slot == slot);
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackSlotCopyPropagationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackSlotCopyPropagationPass.cs
@@ -63,6 +63,8 @@ public sealed class StackSlotCopyPropagationPass : IIrPass
                 continue;
             if (!SourceStableOnEveryPath(path, source.Slot))
                 continue;
+            if (RegionHasCycle(path))
+                continue;
             if (!RegionDominatedByCopy(path))
                 continue;
 
@@ -112,6 +114,9 @@ public sealed class StackSlotCopyPropagationPass : IIrPass
         if (EnclosingStatement(use) is not { } useStatement || useStatement.Parent is not Block useBlock)
             return null;
         if (!ReferenceEquals(useBlock.Parent, container))
+            return null;
+
+        if (!IsIndependentBodyScope(container))
             return null;
 
         var blocks = container.Blocks;
@@ -178,6 +183,32 @@ public sealed class StackSlotCopyPropagationPass : IIrPass
             }
         }
         return true;
+    }
+
+    static bool RegionHasCycle(CopyPath path)
+    {
+        var state = new Dictionary<int, int>();
+        foreach (int blockIndex in path.RegionBlocks)
+            if (Visit(blockIndex))
+                return true;
+        return false;
+
+        bool Visit(int blockIndex)
+        {
+            if (!path.RegionBlocks.Contains(blockIndex))
+                return false;
+            if (state.GetValueOrDefault(blockIndex) == 1)
+                return true;
+            if (state.GetValueOrDefault(blockIndex) == 2)
+                return false;
+
+            state[blockIndex] = 1;
+            foreach (int successor in Successors(path.Blocks, blockIndex))
+                if (Visit(successor))
+                    return true;
+            state[blockIndex] = 2;
+            return false;
+        }
     }
 
     static bool RegionDominatedByCopy(CopyPath path)
@@ -254,6 +285,9 @@ public sealed class StackSlotCopyPropagationPass : IIrPass
                 yield break;
         }
     }
+
+    static bool IsIndependentBodyScope(BlockContainer container)
+        => container.Parent is IrFunction or Lambda or LocalFunctionStatement;
 
     static bool HasUnmodeledControlFlow(IReadOnlyList<Block> blocks)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackSlotCopyPropagationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackSlotCopyPropagationPass.cs
@@ -115,7 +115,7 @@ public sealed class StackSlotCopyPropagationPass : IIrPass
             return null;
 
         var blocks = container.Blocks;
-        if (HasUnmodeledTerminator(blocks))
+        if (HasUnmodeledControlFlow(blocks))
             return null;
 
         int copyBlockIndex = copyBlock.ChildIndex;
@@ -255,8 +255,29 @@ public sealed class StackSlotCopyPropagationPass : IIrPass
         }
     }
 
-    static bool HasUnmodeledTerminator(IReadOnlyList<Block> blocks)
-        => blocks.Any(block => block.Children is [.., Break or Continue]);
+    static bool HasUnmodeledControlFlow(IReadOnlyList<Block> blocks)
+    {
+        foreach (var block in blocks)
+            foreach (var statement in block.Children)
+                if (ContainsUnmodeledControlFlow(statement))
+                    return true;
+        return false;
+    }
+
+    static bool ContainsUnmodeledControlFlow(IrNode node)
+    {
+        if (node is Lambda or LocalFunctionStatement)
+            return false;
+        if (node is Break or Continue)
+            return true;
+        if (node is Block or BlockContainer)
+            return true;
+
+        foreach (var child in node.Children)
+            if (ContainsUnmodeledControlFlow(child))
+                return true;
+        return false;
+    }
 
     static int IndexOfOffset(IReadOnlyList<Block> blocks, int offset)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackSlotCopyPropagationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackSlotCopyPropagationPass.cs
@@ -115,6 +115,9 @@ public sealed class StackSlotCopyPropagationPass : IIrPass
             return null;
 
         var blocks = container.Blocks;
+        if (HasUnmodeledTerminator(blocks))
+            return null;
+
         int copyBlockIndex = copyBlock.ChildIndex;
         int useBlockIndex = useBlock.ChildIndex;
         if (copyBlockIndex < 0 || useBlockIndex < 0)
@@ -228,7 +231,22 @@ public sealed class StackSlotCopyPropagationPass : IIrPass
                 if (index + 1 < blocks.Count)
                     yield return index + 1;
                 yield break;
-            case Return or Throw or Leave or EndFinally or EndFilter or SwitchBranch:
+            case Leave leave:
+                int leaveTarget = IndexOfOffset(blocks, leave.TargetOffset);
+                if (leaveTarget >= 0)
+                    yield return leaveTarget;
+                yield break;
+            case SwitchBranch branch:
+                foreach (int targetOffset in branch.TargetOffsets)
+                {
+                    int switchTarget = IndexOfOffset(blocks, targetOffset);
+                    if (switchTarget >= 0)
+                        yield return switchTarget;
+                }
+                if (index + 1 < blocks.Count)
+                    yield return index + 1;
+                yield break;
+            case Return or Throw or EndFinally or EndFilter:
                 yield break;
             default:
                 if (index + 1 < blocks.Count)
@@ -236,6 +254,9 @@ public sealed class StackSlotCopyPropagationPass : IIrPass
                 yield break;
         }
     }
+
+    static bool HasUnmodeledTerminator(IReadOnlyList<Block> blocks)
+        => blocks.Any(block => block.Children is [.., Break or Continue]);
 
     static int IndexOfOffset(IReadOnlyList<Block> blocks, int offset)
     {

--- a/tools/DecompilerHarness/SlotResidualCensus.cs
+++ b/tools/DecompilerHarness/SlotResidualCensus.cs
@@ -112,8 +112,15 @@ static class SlotResidualCensus
     static int F2PassIndex()
     {
         var passes = IrPasses.Default;
-        for (int i = 0; i + 1 < passes.Length; i++)
-            if (passes[i] is ExpressionInliningPass && passes[i + 1] is SlotMaterializationPass)
+        int materialization = -1;
+        for (int i = 0; i < passes.Length; i++)
+            if (passes[i] is SlotMaterializationPass)
+            {
+                materialization = i;
+                break;
+            }
+        for (int i = materialization - 1; i >= 0; i--)
+            if (passes[i] is ExpressionInliningPass)
                 return i;
         throw new InvalidOperationException("Could not find late F2 ExpressionInliningPass before SlotMaterializationPass.");
     }


### PR DESCRIPTION
- Advances #2545
- Changes the decompiler pipeline to remove proof-backed synthetic stack-slot copy carriers before slot materialization.
- Card revision: `701bd10f`

## Change

> Should we accept this change?

**Conclusion:** **REVIEW** — the targeted CFG/lifetime rule removes five copy-carrier render artifacts with no valid→invalid render regressions; adversarial reviews are pending.

Before:

```csharp
S_20 = parameterRefKinds[i];
...
S_21 = S_20;
...
S_22 = parameterScopes[i];
...
S_23 = S_22;
...
S_16.Add(new AnonymousTypeField(S_17, S_18, S_19, S_21, S_23, S_24, S_26, S_27));
```

After:

```csharp
S_20 = parameterRefKinds[i];
...
S_22 = parameterScopes[i];
...
S_16.Add(new AnonymousTypeField(S_17, S_18, S_19, S_20, S_22, S_24, S_26, S_27));
```

The new pass only rewrites `S_dst = S_src` when the destination has exactly one store/use, the source is the deferred multi-block residual class, a same-container CFG walk proves no path rewrites the source before the use, and no outside edge can enter the use region. It declines nested scopes, multiple destination uses, source rewrites, non-slot copy values, and lock receiver carriers.

## Evidence

| Check | Result |
| --- | --- |
| Build | `dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config --no-restore` passed |
| Focused tests | `StackSlotCopyPropagationPassTests` passed (8 tests) |
| Census harness test | `SlotResidualCensus_PrintsPostF2MeasurementCard` passed |
| Pipeline ledger/stage tests | `LoweringCoverageTests` + `PipelineStageTests` passed (20 tests) |
| Real witness | `Microsoft.CodeAnalysis.CSharp.Binder::GetMethodGroupOrLambdaDelegateType` fixed |
| Full decompiler executable | Not used as a blocker: `CoreLibStaticFieldLock_PreservesCopiedReceiverLocal` fails on this SDK/runtime and reproduces on exact base `/tmp/ab-base-2545` |

### C2 slot-unifier census

Explicit merge-base `de0337f4` vs PR head:

| Metric | Base | PR | Delta |
| --- | ---: | ---: | ---: |
| StoreStackSlot nodes reaching printer | 49,803 | 49,797 | -6 |
| LoadStackSlot nodes reaching printer | 77,032 | 77,026 | -6 |
| Distinct slots considered by printer unifier | 43,715 | 43,709 | -6 |
| Methods with residual stack slots | 7,975 | 7,975 | 0 |
| Single-candidate slots | 43,202 | 43,198 | -4 |
| Multi-candidate slots unified by printer | 357 | 357 | 0 |
| Un-unified split slots | 208 | 206 | -2 |
| Stack-slot declarations emitted | 19,117 | 19,114 | -3 |

Pass impact:

```text
Microsoft.CodeAnalysis.CSharp.Binder::GetMethodGroupOrLambdaDelegateType
Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol::AfterMembersChecks
Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator::TryEmitOptimizedReadonlySpan
DotnetInspector.Output.ApiOutputFormatter::ToUnsafeMemberRow
DotnetInspector.Output.ApiOutputFormatter.<>c::<PopulateIndexSections>b__29_21

stack-slot-copy-propagation changed 5/89065 methods (0.01%); 0 pass bugs
```

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — deterministic explicit-base corpus comparison matched baseline tolerances; render A/B found no valid→invalid regressions.

### Render A/B

Explicit merge-base render snapshot, `--workers 20`:

```text
Render A/B Check: 89065 methods evaluated
Changed: 5 (structural: 3, paren-equivalent: 0, unparsed: 2)
Semantic: valid->valid: 2, invalid->valid: 0, valid->invalid: 0, invalid->invalid: 3
Added:   0
Removed: 0
```

### Generated quality-diff card

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity compiled 25,183 methods (compile-cap 4,000; per-sample, not corpus-wide); fidelity sampled 36 / 89,065 (0.04%)

| Metric | Change | Count delta |
| ------ | ------ | ----------- |
| Fully raised (+) | 78,406 (88.03%) → 78,406 (88.03%) (neutral) | 0 |
| Conditional-branch residual (-) | 2,401 (2.70%) → 2,401 (2.70%) (neutral) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) → 2,286 (2.57%) (neutral) | 0 |
| Full malformed (-) | 0 → 0 (neutral) | 0 |
| Semantic defects (-) | 69 (0.27%) → 69 (0.27%) (neutral) | 0 |
| Fidelity opcode diffs (-) | 5 (13.89%) → 5 (13.89%) (neutral) | 0 |
| Fidelity exact (+) | 31 (86.11%) → 31 (86.11%) (neutral) | 0 |
| Fidelity recompile failures (-) | 0 (0.00%) → 0 (0.00%) (neutral) | 0 |
| Fidelity context failures (-) | 0 (0.00%) → 0 (0.00%) (neutral) | 0 |
| Fidelity check coverage (+) | 36 (0.04%) → 36 (0.04%) (neutral) | 0 |
| Pass bugs (-) | 0 → 0 (neutral) | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 88.03% -> 88.03% (0 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); opcode diffs 5 -> 5 (0).

Verdict: corpus sensor matched baseline tolerances.
```

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Pending | Adversarial review requested after PR open |
| Gemini Pro | Pending | Adversarial review requested after PR open |

**Review conclusion:** **REVIEW** — pending two clean adversarial reviews.

## Validation

```bash
dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config --no-restore
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.StackSlotCopyPropagationPassTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -method '*SlotResidualCensus_PrintsPostF2MeasurementCard*'
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.LoweringCoverageTests -class ILInspector.Decompiler.Tests.PipelineStageTests

dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" --slot-unifier-census
dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" --pass-impact stack-slot-copy-propagation
dotnet run --project /tmp/ab-base-2545/tools/DecompilerHarness -c Release -- "${assemblies[@]}" --workers 20 --emit-render-ab /tmp/c2-copy-base.renderab
dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" --workers 20 --render-ab /tmp/c2-copy-base.renderab
dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" --diff-corpus-baseline /tmp/c2-copy-explicit-base-corpus-baseline-seq.json --quality-diff-card --corpus-fidelity-cap 3 --max-examples 3 --sequential
```
