### PR TITLE
Add RTS artifact request envelope

### DIFF
--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1000,7 +1000,8 @@ static class ReturnToSender
                 SignatureText: CorpusMethodIdentity.SignatureText(function.Signature),
                 ClosureRoots: closureRoots,
                 ClosureFacts: closureFacts,
-                ClosureMemberRequirements: closureMemberRequirements));
+                ClosureMemberRequirements: closureMemberRequirements,
+                TargetProperty: null));
             var plan = sourceResult.Plan;
 
             if (plan.Diagnostics.FirstOrDefault(diagnostic => diagnostic.Layer == "type identity") is { } identityDiagnostic)
@@ -1099,7 +1100,8 @@ static class ReturnToSender
                 SignatureText: CorpusMethodIdentity.SignatureText(function.Signature),
                 ClosureRoots: closureRoots,
                 ClosureFacts: closureFacts,
-                ClosureMemberRequirements: closureMemberRequirements));
+                ClosureMemberRequirements: closureMemberRequirements,
+                TargetProperty: null));
             var plan = sourceResult.Plan;
             return new Result(
                 plan,

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -809,21 +809,22 @@ static class ReturnToSender
 
         for (int iteration = 0; iteration < maxIterations; iteration++)
         {
-            var sourceResult = CompileBackSourceComposer.ComposePropertyGetter(
-                assemblyPath,
-                reader,
-                function,
-                typeHandle,
-                propertyHandle,
-                getterHandle,
-                printed.Output,
-                fullType,
-                methodName,
-                overload,
-                CorpusMethodIdentity.SignatureText(function.Signature),
-                closureRoots,
-                closureFacts,
-                closureMemberRequirements);
+            var sourceResult = CompileBackSourceComposer.Compose(new ArtifactRequest(
+                Kind: ArtifactKind.PropertyGetter,
+                AssemblyPath: assemblyPath,
+                Reader: reader,
+                Function: function,
+                TargetType: typeHandle,
+                TargetMethod: getterHandle,
+                TargetBody: printed.Output,
+                FullType: fullType,
+                MethodName: methodName,
+                Overload: overload,
+                SignatureText: CorpusMethodIdentity.SignatureText(function.Signature),
+                ClosureRoots: closureRoots,
+                ClosureFacts: closureFacts,
+                ClosureMemberRequirements: closureMemberRequirements,
+                TargetProperty: propertyHandle));
             var plan = sourceResult.Plan;
 
             if (plan.Diagnostics.FirstOrDefault(diagnostic => diagnostic.Layer == "type identity") is { } identityDiagnostic)
@@ -908,21 +909,22 @@ static class ReturnToSender
         }
 
         {
-            var sourceResult = CompileBackSourceComposer.ComposePropertyGetter(
-                assemblyPath,
-                reader,
-                function,
-                typeHandle,
-                propertyHandle,
-                getterHandle,
-                printed.Output,
-                fullType,
-                methodName,
-                overload,
-                CorpusMethodIdentity.SignatureText(function.Signature),
-                closureRoots,
-                closureFacts,
-                closureMemberRequirements);
+            var sourceResult = CompileBackSourceComposer.Compose(new ArtifactRequest(
+                Kind: ArtifactKind.PropertyGetter,
+                AssemblyPath: assemblyPath,
+                Reader: reader,
+                Function: function,
+                TargetType: typeHandle,
+                TargetMethod: getterHandle,
+                TargetBody: printed.Output,
+                FullType: fullType,
+                MethodName: methodName,
+                Overload: overload,
+                SignatureText: CorpusMethodIdentity.SignatureText(function.Signature),
+                ClosureRoots: closureRoots,
+                ClosureFacts: closureFacts,
+                ClosureMemberRequirements: closureMemberRequirements,
+                TargetProperty: propertyHandle));
             var plan = sourceResult.Plan;
             return new Result(
                 plan,
@@ -984,20 +986,21 @@ static class ReturnToSender
 
         for (int iteration = 0; iteration < maxIterations; iteration++)
         {
-            var sourceResult = CompileBackSourceComposer.ComposeMethod(
-                assemblyPath,
-                reader,
-                function,
-                typeHandle,
-                methodHandle,
-                printed.Output,
-                fullType,
-                methodName,
-                overload,
-                CorpusMethodIdentity.SignatureText(function.Signature),
-                closureRoots,
-                closureFacts,
-                closureMemberRequirements);
+            var sourceResult = CompileBackSourceComposer.Compose(new ArtifactRequest(
+                Kind: ArtifactKind.Method,
+                AssemblyPath: assemblyPath,
+                Reader: reader,
+                Function: function,
+                TargetType: typeHandle,
+                TargetMethod: methodHandle,
+                TargetBody: printed.Output,
+                FullType: fullType,
+                MethodName: methodName,
+                Overload: overload,
+                SignatureText: CorpusMethodIdentity.SignatureText(function.Signature),
+                ClosureRoots: closureRoots,
+                ClosureFacts: closureFacts,
+                ClosureMemberRequirements: closureMemberRequirements));
             var plan = sourceResult.Plan;
 
             if (plan.Diagnostics.FirstOrDefault(diagnostic => diagnostic.Layer == "type identity") is { } identityDiagnostic)
@@ -1082,20 +1085,21 @@ static class ReturnToSender
         }
 
         {
-            var sourceResult = CompileBackSourceComposer.ComposeMethod(
-                assemblyPath,
-                reader,
-                function,
-                typeHandle,
-                methodHandle,
-                printed.Output,
-                fullType,
-                methodName,
-                overload,
-                CorpusMethodIdentity.SignatureText(function.Signature),
-                closureRoots,
-                closureFacts,
-                closureMemberRequirements);
+            var sourceResult = CompileBackSourceComposer.Compose(new ArtifactRequest(
+                Kind: ArtifactKind.Method,
+                AssemblyPath: assemblyPath,
+                Reader: reader,
+                Function: function,
+                TargetType: typeHandle,
+                TargetMethod: methodHandle,
+                TargetBody: printed.Output,
+                FullType: fullType,
+                MethodName: methodName,
+                Overload: overload,
+                SignatureText: CorpusMethodIdentity.SignatureText(function.Signature),
+                ClosureRoots: closureRoots,
+                ClosureFacts: closureFacts,
+                ClosureMemberRequirements: closureMemberRequirements));
             var plan = sourceResult.Plan;
             return new Result(
                 plan,
@@ -1158,21 +1162,22 @@ static class ReturnToSender
 
         for (int iteration = 0; iteration < maxIterations; iteration++)
         {
-            var sourceResult = CompileBackSourceComposer.ComposePropertySetter(
-                assemblyPath,
-                reader,
-                function,
-                typeHandle,
-                propertyHandle,
-                setterHandle,
-                printed.Output,
-                fullType,
-                methodName,
-                overload,
-                CorpusMethodIdentity.SignatureText(function.Signature),
-                closureRoots,
-                closureFacts,
-                closureMemberRequirements);
+            var sourceResult = CompileBackSourceComposer.Compose(new ArtifactRequest(
+                Kind: ArtifactKind.PropertySetter,
+                AssemblyPath: assemblyPath,
+                Reader: reader,
+                Function: function,
+                TargetType: typeHandle,
+                TargetMethod: setterHandle,
+                TargetBody: printed.Output,
+                FullType: fullType,
+                MethodName: methodName,
+                Overload: overload,
+                SignatureText: CorpusMethodIdentity.SignatureText(function.Signature),
+                ClosureRoots: closureRoots,
+                ClosureFacts: closureFacts,
+                ClosureMemberRequirements: closureMemberRequirements,
+                TargetProperty: propertyHandle));
             var plan = sourceResult.Plan;
 
             if (plan.Diagnostics.FirstOrDefault(diagnostic => diagnostic.Layer == "type identity") is { } identityDiagnostic)
@@ -1257,21 +1262,22 @@ static class ReturnToSender
         }
 
         {
-            var sourceResult = CompileBackSourceComposer.ComposePropertySetter(
-                assemblyPath,
-                reader,
-                function,
-                typeHandle,
-                propertyHandle,
-                setterHandle,
-                printed.Output,
-                fullType,
-                methodName,
-                overload,
-                CorpusMethodIdentity.SignatureText(function.Signature),
-                closureRoots,
-                closureFacts,
-                closureMemberRequirements);
+            var sourceResult = CompileBackSourceComposer.Compose(new ArtifactRequest(
+                Kind: ArtifactKind.PropertySetter,
+                AssemblyPath: assemblyPath,
+                Reader: reader,
+                Function: function,
+                TargetType: typeHandle,
+                TargetMethod: setterHandle,
+                TargetBody: printed.Output,
+                FullType: fullType,
+                MethodName: methodName,
+                Overload: overload,
+                SignatureText: CorpusMethodIdentity.SignatureText(function.Signature),
+                ClosureRoots: closureRoots,
+                ClosureFacts: closureFacts,
+                ClosureMemberRequirements: closureMemberRequirements,
+                TargetProperty: propertyHandle));
             var plan = sourceResult.Plan;
             return new Result(
                 plan,

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -169,14 +169,14 @@ static class CompileBackCSharpNames
             or "while" or "record" or "required" or "init" or "file" or "scoped";
 }
 
-public enum ArtifactKind
+internal enum ArtifactKind
 {
     Method,
     PropertyGetter,
     PropertySetter,
 }
 
-public sealed record ArtifactRequest(
+internal sealed record ArtifactRequest(
     ArtifactKind Kind,
     string AssemblyPath,
     MetadataReader Reader,
@@ -191,9 +191,9 @@ public sealed record ArtifactRequest(
     IReadOnlySet<TypeDefinitionHandle> ClosureRoots,
     IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> ClosureFacts,
     IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> ClosureMemberRequirements,
-    PropertyDefinitionHandle TargetProperty = default);
+    PropertyDefinitionHandle? TargetProperty);
 
-public sealed record ProductArtifact(
+internal sealed record ProductArtifact(
     ArtifactRequest Request,
     string Source,
     IReadOnlyList<CompileBackFact> SourceFacts,
@@ -205,7 +205,9 @@ public sealed record ProductArtifact(
             request,
             result.Source,
             result.Plan.Types
-                .SelectMany(type => type.SourceFacts.Concat(type.RequiredMembers.SelectMany(member => member.SourceFacts)))
+                .SelectMany(type => type.SourceFacts
+                    .Concat(type.PrimaryConstructor?.FieldInitializers.SelectMany(member => member.SourceFacts) ?? [])
+                    .Concat(type.RequiredMembers.SelectMany(member => member.SourceFacts)))
                 .ToArray(),
             result.Plan.Diagnostics,
             result.Plan);
@@ -378,7 +380,7 @@ public sealed record CompileBackPlanningDiagnostic(string Layer, string Reason, 
 
 public static class CompileBackSourceComposer
 {
-    public static ProductArtifact Compose(ArtifactRequest request)
+    internal static ProductArtifact Compose(ArtifactRequest request)
     {
         var result = request.Kind switch
         {
@@ -387,7 +389,7 @@ public static class CompileBackSourceComposer
                 request.Reader,
                 request.Function,
                 request.TargetType,
-                request.TargetProperty,
+                RequiredProperty(request),
                 request.TargetMethod,
                 request.TargetBody,
                 request.FullType,
@@ -402,7 +404,7 @@ public static class CompileBackSourceComposer
                 request.Reader,
                 request.Function,
                 request.TargetType,
-                request.TargetProperty,
+                RequiredProperty(request),
                 request.TargetMethod,
                 request.TargetBody,
                 request.FullType,
@@ -431,6 +433,10 @@ public static class CompileBackSourceComposer
 
         return ProductArtifact.From(request, result);
     }
+
+    static PropertyDefinitionHandle RequiredProperty(ArtifactRequest request)
+        => request.TargetProperty
+            ?? throw new ArgumentException($"{request.Kind} artifact requests require a target property.", nameof(request));
 
     public static CompileBackMemberRequirement? TryCreateClosureMemberRequirement(
         MetadataReader reader,

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -169,6 +169,48 @@ static class CompileBackCSharpNames
             or "while" or "record" or "required" or "init" or "file" or "scoped";
 }
 
+public enum ArtifactKind
+{
+    Method,
+    PropertyGetter,
+    PropertySetter,
+}
+
+public sealed record ArtifactRequest(
+    ArtifactKind Kind,
+    string AssemblyPath,
+    MetadataReader Reader,
+    IrFunction Function,
+    TypeDefinitionHandle TargetType,
+    MethodDefinitionHandle TargetMethod,
+    string TargetBody,
+    string FullType,
+    string MethodName,
+    int Overload,
+    string SignatureText,
+    IReadOnlySet<TypeDefinitionHandle> ClosureRoots,
+    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> ClosureFacts,
+    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> ClosureMemberRequirements,
+    PropertyDefinitionHandle TargetProperty = default);
+
+public sealed record ProductArtifact(
+    ArtifactRequest Request,
+    string Source,
+    IReadOnlyList<CompileBackFact> SourceFacts,
+    IReadOnlyList<CompileBackPlanningDiagnostic> Diagnostics,
+    CompileBackReconstructionPlan Plan)
+{
+    internal static ProductArtifact From(ArtifactRequest request, CompileBackSourceResult result)
+        => new(
+            request,
+            result.Source,
+            result.Plan.Types
+                .SelectMany(type => type.SourceFacts.Concat(type.RequiredMembers.SelectMany(member => member.SourceFacts)))
+                .ToArray(),
+            result.Plan.Diagnostics,
+            result.Plan);
+}
+
 public sealed record CompileBackSourceResult(CompileBackReconstructionPlan Plan, string Source);
 
 public sealed record CompileBackReconstructionPlan(
@@ -336,6 +378,60 @@ public sealed record CompileBackPlanningDiagnostic(string Layer, string Reason, 
 
 public static class CompileBackSourceComposer
 {
+    public static ProductArtifact Compose(ArtifactRequest request)
+    {
+        var result = request.Kind switch
+        {
+            ArtifactKind.PropertyGetter => ComposePropertyGetter(
+                request.AssemblyPath,
+                request.Reader,
+                request.Function,
+                request.TargetType,
+                request.TargetProperty,
+                request.TargetMethod,
+                request.TargetBody,
+                request.FullType,
+                request.MethodName,
+                request.Overload,
+                request.SignatureText,
+                request.ClosureRoots,
+                request.ClosureFacts,
+                request.ClosureMemberRequirements),
+            ArtifactKind.PropertySetter => ComposePropertySetter(
+                request.AssemblyPath,
+                request.Reader,
+                request.Function,
+                request.TargetType,
+                request.TargetProperty,
+                request.TargetMethod,
+                request.TargetBody,
+                request.FullType,
+                request.MethodName,
+                request.Overload,
+                request.SignatureText,
+                request.ClosureRoots,
+                request.ClosureFacts,
+                request.ClosureMemberRequirements),
+            ArtifactKind.Method => ComposeMethod(
+                request.AssemblyPath,
+                request.Reader,
+                request.Function,
+                request.TargetType,
+                request.TargetMethod,
+                request.TargetBody,
+                request.FullType,
+                request.MethodName,
+                request.Overload,
+                request.SignatureText,
+                request.ClosureRoots,
+                request.ClosureFacts,
+                request.ClosureMemberRequirements),
+            _ => throw new ArgumentOutOfRangeException(nameof(request), request.Kind, "Unknown artifact kind."),
+        };
+
+        return ProductArtifact.From(request, result);
+    }
+
     public static CompileBackMemberRequirement? TryCreateClosureMemberRequirement(
         MetadataReader reader,
         TypeDefinitionHandle typeHandle,


### PR DESCRIPTION
- Advances #2529
- Changes harness-only request envelope around RTS compile-back composition; product output is unchanged
- Evidence revision: `f6782105`

## Change

**Conclusion:** **PASS** — this adds the first tools-only `ArtifactRequest` / `ProductArtifact` envelope and routes getter, setter, and method source composition through one request-shaped entry without changing closure derivation, Roslyn oracle growth, or rendering policy.

Before:

```text
RTS called ComposePropertyGetter/ComposePropertySetter/ComposeMethod directly with repeated positional argument lists.
```

After:

```text
RTS constructs ArtifactRequest and calls CompileBackSourceComposer.Compose(request), which wraps the existing compose overloads and returns ProductArtifact.
```

## Scope and safety

- **Root cause:** #2529 still lacked the formal request/result boundary after the Research pass-through shim was removed.
- **Fix shape:** Tools-only orchestration envelope; behavior-preserving wrapper around existing source composition.
- **Product impact:** None intended; this does not change product source rendering, closure seeding, Roslyn compile-back, or IL/opcode comparison.
- **Scope boundary:** Moving closure derivation behind the provider and reducing the three duplicated compile loops are follow-up slices.
- **RTS boundary:** RTS remains the tools-only planner/oracle; Research remains fact/projection-only per current docs.

## Evidence

| Check | Result |
| --- | --- |
| DecompilerHarness build | `dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet` passed |
| Focused tests | `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.ReturnToSenderPrototypeTests` passed: 96/96 |
| ReturnToSender A/B | Not applicable; wrapper-only, no behavior change intended |
| Broad compile-back | Not run; wrapper-only, focused harness tests cover the linked planner path |

## Compile-back quality

**Conclusion:** **PASS** — no checkable population change is claimed; this is an API-boundary slice for future RTS closure/request work.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Move closure derivation behind provider | Left as frontier | Requires request mutation/oracle-addition design beyond this wrapper slice |
| Collapse duplicated compile loops | Left as frontier | Safer after the request/result shape lands |
| Revive Research shell shim | Not changed | Current docs say Research is fact/projection-only and must not host artifact production |

## Review

Adversarial review requested after PR creation; results will be reconciled on the PR before marking ready.

## Validation

```bash
dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.ReturnToSenderPrototypeTests
```
