### PR TITLE
Preserve structured labels and align quality samples

### DIFF
--- a/src/ILInspector.Decompiler.Tests/BooleanFoldingSourceOffsetTests.cs
+++ b/src/ILInspector.Decompiler.Tests/BooleanFoldingSourceOffsetTests.cs
@@ -14,6 +14,31 @@ public class BooleanFoldingSourceOffsetTests
     static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");
 
     [Fact]
+    public void NestedGuardFold_PreservesSourceOffset()
+    {
+        var innerThen = new Block(0);
+        innerThen.Add(new Return(null));
+        var inner = new IfStatement(new LoadArgument(1, "b", Boolean), innerThen, null);
+        var outerThen = new Block(0);
+        outerThen.Add(inner);
+        var outer = new IfStatement(new LoadArgument(0, "a", Boolean), outerThen, null);
+        outer.SetSourceOffset(0x08);
+
+        var block = new Block(0);
+        block.Add(outer);
+        var function = Function(
+            block,
+            Void,
+            [new Parameter("a", Boolean), new Parameter("b", Boolean)]);
+
+        new BooleanFoldingPass().Run(function, PassContext.None);
+
+        var folded = Assert.IsType<IfStatement>(Assert.Single(block.Children));
+        Assert.IsType<LogicalBinary>(folded.Condition);
+        Assert.Equal(0x08, folded.SourceOffset);
+    }
+
+    [Fact]
     public void GuardReturnFold_PreservesSourceOffset()
     {
         var then = new Block(0);

--- a/src/ILInspector.Decompiler.Tests/BooleanFoldingSourceOffsetTests.cs
+++ b/src/ILInspector.Decompiler.Tests/BooleanFoldingSourceOffsetTests.cs
@@ -7,7 +7,10 @@ namespace ILInspector.Decompiler.Tests;
 public class BooleanFoldingSourceOffsetTests
 {
     static readonly TypeRef Boolean = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef Byte = TypeRef.CoreLib("System", "Byte");
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
     static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");
 
     [Fact]
@@ -53,6 +56,80 @@ public class BooleanFoldingSourceOffsetTests
 
         var folded = Assert.IsType<Return>(Assert.Single(block.Children));
         Assert.Equal(0x20, folded.SourceOffset);
+    }
+
+    [Fact]
+    public void BooleanElementStoreRetype_PreservesSourceOffset()
+    {
+        var store = new StoreElement(
+            Byte,
+            new LoadArgument(0, "values", TypeRef.SzArray(Boolean)),
+            new Constant(0, Int32),
+            new Constant(1, Int32));
+        store.SetSourceOffset(0x30);
+
+        var block = new Block(0);
+        block.Add(store);
+        var function = Function(
+            block,
+            Void,
+            [new Parameter("values", TypeRef.SzArray(Boolean))]);
+
+        new BooleanFoldingPass().Run(function, PassContext.None);
+
+        var folded = Assert.IsType<StoreElement>(Assert.Single(block.Children));
+        Assert.Equal(0x30, folded.SourceOffset);
+    }
+
+    [Fact]
+    public void CoalesceStoreFold_PreservesSourceOffset()
+    {
+        var initial = new StoreLocal(0, Object, new LoadArgument(0, "value", Object));
+        initial.SetSourceOffset(0x40);
+        var then = new Block(0);
+        then.Add(new StoreLocal(0, Object, new LoadArgument(1, "fallback", Object)));
+        var guard = new IfStatement(
+            new Comparison(
+                ComparisonKind.Equal,
+                isUnsigned: false,
+                new LoadArgument(0, "value", Object),
+                new Constant(null, Object)),
+            then,
+            null);
+
+        var block = new Block(0);
+        block.Add(initial);
+        block.Add(guard);
+        var function = Function(
+            block,
+            Void,
+            [new Parameter("value", Object), new Parameter("fallback", Object)]);
+
+        new BooleanFoldingPass().Run(function, PassContext.None);
+
+        var folded = Assert.IsType<StoreLocal>(Assert.Single(block.Children));
+        Assert.Equal(0x40, folded.SourceOffset);
+    }
+
+    [Fact]
+    public void SlotDiamondFold_PreservesSourceOffset()
+    {
+        var then = new Block(0);
+        then.Add(new StoreStackSlot(0, new Constant(1, Int32)));
+        var @else = new Block(0);
+        @else.Add(new StoreStackSlot(0, new Constant(2, Int32)));
+        var diamond = new IfStatement(new LoadArgument(0, "c", Boolean), then, @else);
+        diamond.SetSourceOffset(0x50);
+
+        var block = new Block(0);
+        block.Add(diamond);
+        block.Add(new Return(new LoadStackSlot(0, Int32)));
+        var function = Function(block, Int32, [new Parameter("c", Boolean)]);
+
+        new BooleanFoldingPass().Run(function, PassContext.None);
+
+        var folded = Assert.IsType<StoreStackSlot>(block.Children[0]);
+        Assert.Equal(0x50, folded.SourceOffset);
     }
 
     static IrFunction Function(

--- a/src/ILInspector.Decompiler.Tests/BooleanFoldingSourceOffsetTests.cs
+++ b/src/ILInspector.Decompiler.Tests/BooleanFoldingSourceOffsetTests.cs
@@ -1,0 +1,72 @@
+using System.Collections.Immutable;
+
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class BooleanFoldingSourceOffsetTests
+{
+    static readonly TypeRef Boolean = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");
+
+    [Fact]
+    public void GuardReturnFold_PreservesSourceOffset()
+    {
+        var then = new Block(0);
+        then.Add(new Return(new Constant(true, Boolean)));
+        var guard = new IfStatement(new LoadArgument(0, "c", Boolean), then, null);
+        guard.SetSourceOffset(0x10);
+
+        var block = new Block(0);
+        block.Add(guard);
+        block.Add(new Return(new Constant(false, Boolean)));
+        var function = Function(block, Boolean, [new Parameter("c", Boolean)]);
+
+        new BooleanFoldingPass().Run(function, PassContext.None);
+
+        var folded = Assert.IsType<Return>(Assert.Single(block.Children));
+        Assert.Equal(0x10, folded.SourceOffset);
+    }
+
+    [Fact]
+    public void TernaryReturnFold_PreservesSourceOffset()
+    {
+        var then = new Block(0);
+        then.Add(new Return(new Constant(1, Int32)));
+        var guard = new IfStatement(
+            new Comparison(
+                ComparisonKind.GreaterThan,
+                isUnsigned: false,
+                new LoadArgument(0, "x", Int32),
+                new Constant(0, Int32)),
+            then,
+            null);
+        guard.SetSourceOffset(0x20);
+
+        var block = new Block(0);
+        block.Add(guard);
+        block.Add(new Return(new Constant(2, Int32)));
+        var function = Function(block, Int32, [new Parameter("x", Int32)]);
+
+        new BooleanFoldingPass().Run(function, PassContext.None);
+
+        var folded = Assert.IsType<Return>(Assert.Single(block.Children));
+        Assert.Equal(0x20, folded.SourceOffset);
+    }
+
+    static IrFunction Function(
+        Block block,
+        TypeRef returnType,
+        ImmutableArray<Parameter> parameters)
+    {
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(returnType, parameters, HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/BooleanFoldingSourceOffsetTests.cs
+++ b/src/ILInspector.Decompiler.Tests/BooleanFoldingSourceOffsetTests.cs
@@ -39,6 +39,103 @@ public class BooleanFoldingSourceOffsetTests
     }
 
     [Fact]
+    public void NestedGuardFold_DeclinesWhenInnerGuardIsBranchTarget()
+    {
+        var innerThen = new Block(0);
+        innerThen.Add(new Return(null));
+        var inner = new IfStatement(new LoadArgument(1, "b", Boolean), innerThen, null);
+        inner.SetSourceOffset(0x09);
+        var outerThen = new Block(0);
+        outerThen.Add(inner);
+        var outer = new IfStatement(new LoadArgument(0, "a", Boolean), outerThen, null);
+        outer.SetSourceOffset(0x08);
+
+        var block = new Block(0);
+        block.Add(outer);
+        var function = Function(
+            block,
+            Void,
+            [new Parameter("a", Boolean), new Parameter("b", Boolean)],
+            liveTarget: 0x09);
+
+        new BooleanFoldingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Same(outer, Assert.Single(block.Children));
+        Assert.Equal(0x09, inner.SourceOffset);
+    }
+
+    [Theory]
+    [InlineData(0x11)]
+    [InlineData(0x12)]
+    public void GuardReturnFold_DeclinesWhenConsumedReturnIsBranchTarget(int liveTarget)
+    {
+        var thenReturn = new Return(new Constant(true, Boolean));
+        thenReturn.SetSourceOffset(0x11);
+        var then = new Block(0);
+        then.Add(thenReturn);
+        var guard = new IfStatement(new LoadArgument(0, "c", Boolean), then, null);
+        guard.SetSourceOffset(0x10);
+        var tailReturn = new Return(new Constant(false, Boolean));
+        tailReturn.SetSourceOffset(0x12);
+
+        var block = new Block(0);
+        block.Add(guard);
+        block.Add(tailReturn);
+        var function = Function(
+            block,
+            Boolean,
+            [new Parameter("c", Boolean)],
+            liveTarget);
+
+        new BooleanFoldingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Equal(2, block.Children.Count);
+        Assert.Same(guard, block.Children[0]);
+        Assert.Contains(block.Descendants, node => node.SourceOffset == liveTarget);
+    }
+
+    [Fact]
+    public void GuardReturnFold_IgnoresCollidingTargetInNestedLocalFunction()
+    {
+        var then = new Block(0);
+        then.Add(new Return(new Constant(true, Boolean)));
+        var guard = new IfStatement(new LoadArgument(0, "c", Boolean), then, null);
+        guard.SetSourceOffset(0x10);
+        var tailReturn = new Return(new Constant(false, Boolean));
+        tailReturn.SetSourceOffset(0x12);
+
+        var localBlock = new Block(0);
+        localBlock.Add(new Branch(0x12));
+        var localBody = new BlockContainer();
+        localBody.Add(localBlock);
+        var localFunction = new LocalFunctionStatement(
+            "Inner",
+            Void,
+            [],
+            isStatic: false,
+            [],
+            [],
+            usesUpdatedMemorySafetyRules: false,
+            skipLocalsInit: false,
+            localBody);
+
+        var block = new Block(0);
+        block.Add(guard);
+        block.Add(tailReturn);
+        block.Add(localFunction);
+        var function = Function(block, Boolean, [new Parameter("c", Boolean)]);
+
+        new BooleanFoldingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        var folded = Assert.IsType<Return>(block.Children[0]);
+        Assert.Equal(0x10, folded.SourceOffset);
+        Assert.Same(localFunction, block.Children[1]);
+    }
+
+    [Fact]
     public void GuardReturnFold_PreservesSourceOffset()
     {
         var then = new Block(0);
@@ -81,6 +178,40 @@ public class BooleanFoldingSourceOffsetTests
 
         var folded = Assert.IsType<Return>(Assert.Single(block.Children));
         Assert.Equal(0x20, folded.SourceOffset);
+    }
+
+    [Fact]
+    public void TernaryReturnFold_DeclinesWhenTailReturnIsBranchTarget()
+    {
+        var then = new Block(0);
+        then.Add(new Return(new Constant(1, Int32)));
+        var guard = new IfStatement(
+            new Comparison(
+                ComparisonKind.GreaterThan,
+                isUnsigned: false,
+                new LoadArgument(0, "x", Int32),
+                new Constant(0, Int32)),
+            then,
+            null);
+        guard.SetSourceOffset(0x20);
+        var tailReturn = new Return(new Constant(2, Int32));
+        tailReturn.SetSourceOffset(0x21);
+
+        var block = new Block(0);
+        block.Add(guard);
+        block.Add(tailReturn);
+        var function = Function(
+            block,
+            Int32,
+            [new Parameter("x", Int32)],
+            liveTarget: 0x21);
+
+        new BooleanFoldingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Equal(2, block.Children.Count);
+        Assert.Same(guard, block.Children[0]);
+        Assert.Equal(0x21, tailReturn.SourceOffset);
     }
 
     [Fact]
@@ -137,6 +268,73 @@ public class BooleanFoldingSourceOffsetTests
     }
 
     [Fact]
+    public void CoalesceStackSlotFold_PreservesSourceOffset()
+    {
+        var initial = new StoreStackSlot(0, new LoadArgument(0, "value", Object));
+        initial.SetSourceOffset(0x48);
+        var then = new Block(0);
+        then.Add(new StoreStackSlot(0, new LoadArgument(1, "fallback", Object)));
+        var guard = new IfStatement(
+            new Comparison(
+                ComparisonKind.Equal,
+                isUnsigned: false,
+                new LoadArgument(0, "value", Object),
+                new Constant(null, Object)),
+            then,
+            null);
+
+        var block = new Block(0);
+        block.Add(initial);
+        block.Add(guard);
+        var function = Function(
+            block,
+            Void,
+            [new Parameter("value", Object), new Parameter("fallback", Object)]);
+
+        new BooleanFoldingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        var folded = Assert.IsType<StoreStackSlot>(Assert.Single(block.Children));
+        Assert.IsType<Coalesce>(folded.Value);
+        Assert.Equal(0x48, folded.SourceOffset);
+    }
+
+    [Fact]
+    public void CoalesceFold_DeclinesWhenConsumedFallbackStoreIsBranchTarget()
+    {
+        var initial = new StoreLocal(0, Object, new LoadArgument(0, "value", Object));
+        initial.SetSourceOffset(0x40);
+        var fallbackStore = new StoreLocal(0, Object, new LoadArgument(1, "fallback", Object));
+        fallbackStore.SetSourceOffset(0x41);
+        var then = new Block(0);
+        then.Add(fallbackStore);
+        var guard = new IfStatement(
+            new Comparison(
+                ComparisonKind.Equal,
+                isUnsigned: false,
+                new LoadArgument(0, "value", Object),
+                new Constant(null, Object)),
+            then,
+            null);
+
+        var block = new Block(0);
+        block.Add(initial);
+        block.Add(guard);
+        var function = Function(
+            block,
+            Void,
+            [new Parameter("value", Object), new Parameter("fallback", Object)],
+            liveTarget: 0x41);
+
+        new BooleanFoldingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Equal(2, block.Children.Count);
+        Assert.Same(guard, block.Children[1]);
+        Assert.Equal(0x41, fallbackStore.SourceOffset);
+    }
+
+    [Fact]
     public void SlotDiamondFold_PreservesSourceOffset()
     {
         var then = new Block(0);
@@ -157,13 +355,48 @@ public class BooleanFoldingSourceOffsetTests
         Assert.Equal(0x50, folded.SourceOffset);
     }
 
+    [Fact]
+    public void SlotDiamondFold_DeclinesWhenConsumedStoreIsBranchTarget()
+    {
+        var thenStore = new StoreStackSlot(0, new Constant(1, Int32));
+        thenStore.SetSourceOffset(0x51);
+        var then = new Block(0);
+        then.Add(thenStore);
+        var @else = new Block(0);
+        @else.Add(new StoreStackSlot(0, new Constant(2, Int32)));
+        var diamond = new IfStatement(new LoadArgument(0, "c", Boolean), then, @else);
+        diamond.SetSourceOffset(0x50);
+
+        var block = new Block(0);
+        block.Add(diamond);
+        block.Add(new Return(new LoadStackSlot(0, Int32)));
+        var function = Function(
+            block,
+            Int32,
+            [new Parameter("c", Boolean)],
+            liveTarget: 0x51);
+
+        new BooleanFoldingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Same(diamond, block.Children[0]);
+        Assert.Equal(0x51, thenStore.SourceOffset);
+    }
+
     static IrFunction Function(
         Block block,
         TypeRef returnType,
-        ImmutableArray<Parameter> parameters)
+        ImmutableArray<Parameter> parameters,
+        int? liveTarget = null)
     {
         var body = new BlockContainer();
         body.Add(block);
+        if (liveTarget is { } target)
+        {
+            var branch = new Block(0x100);
+            branch.Add(new Branch(target));
+            body.Add(branch);
+        }
         return new IrFunction(
             "M",
             Holder,

--- a/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
@@ -123,11 +123,37 @@ public class CorpusSensorComparisonTests
         Assert.DoesNotContain("sampling differs", report);
     }
 
+    [Fact]
+    public void QualityMetricChanges_TreatsValidityMovementAsContextWithoutMethodDetails()
+    {
+        var baseline = Snapshot(
+            totalMethods: 2,
+            fullyRaisedMethods: 2,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: null,
+            validityCompileCap: 2,
+            semanticCheckedMethods: 2,
+            semanticDefectMethods: 1);
+        var current = Snapshot(
+            totalMethods: 2,
+            fullyRaisedMethods: 2,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: ValidityMethods(("One", "valid"), ("Two", "valid")),
+            validityCompileCap: 2,
+            semanticCheckedMethods: 2,
+            semanticDefectMethods: 0);
+
+        string report = CorpusSensor.QualityMetricChangesForTesting(baseline, current);
+
+        Assert.Contains("Full malformed (sampling differs)", report);
+        Assert.Contains("Semantic defects (sampling differs)", report);
+    }
+
     static CorpusSensorSnapshot Snapshot(
         int totalMethods,
         int fullyRaisedMethods,
         int fullyRaisedBasisPoints,
-        IReadOnlyList<CorpusMethodSnapshot> pinnedMethods,
+        IReadOnlyList<CorpusMethodSnapshot>? pinnedMethods,
         int validityCompileCap = 0,
         int semanticCheckedMethods = 0,
         int semanticDefectMethods = 0)

--- a/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
@@ -124,6 +124,33 @@ public class CorpusSensorComparisonTests
     }
 
     [Fact]
+    public void QualityMetricChanges_SeparatesSyntacticAndSemanticSamples()
+    {
+        var baseline = Snapshot(
+            totalMethods: 2,
+            fullyRaisedMethods: 2,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: ValidityMethods(("One", "semantic-defect:CS0159"), ("Two", "valid")),
+            validityCompileCap: 2,
+            semanticCheckedMethods: 2,
+            semanticDefectMethods: 1);
+        var current = Snapshot(
+            totalMethods: 2,
+            fullyRaisedMethods: 2,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: ValidityMethods(("One", "syntax-valid"), ("Two", "syntax-valid")),
+            validityCompileCap: 1,
+            semanticCheckedMethods: 0,
+            semanticDefectMethods: 0);
+
+        string report = CorpusSensor.QualityMetricChangesForTesting(baseline, current);
+
+        Assert.Contains("Full malformed (-)", report);
+        Assert.DoesNotContain("Full malformed (sampling differs)", report);
+        Assert.Contains("Semantic defects (sampling differs)", report);
+    }
+
+    [Fact]
     public void QualityMetricChanges_TreatsValidityMovementAsContextWithoutMethodDetails()
     {
         var baseline = Snapshot(

--- a/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
@@ -64,6 +64,104 @@ public class CorpusSensorComparisonTests
     }
 
     [Fact]
+    public void Compare_DoesNotGateFidelityCountsWhenPinnedSamplesDiffer()
+    {
+        var baseline = Snapshot(
+            totalMethods: 1,
+            fullyRaisedMethods: 1,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: FidelityMethods(("One", "Exact")),
+            fidelityCompileCap: 1,
+            fidelityCheckedMethods: 1,
+            fidelityExactMethods: 1);
+        var current = Snapshot(
+            totalMethods: 1,
+            fullyRaisedMethods: 1,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: FidelityMethods(("Two", "OpcodeDiff")),
+            fidelityCompileCap: 1,
+            fidelityCheckedMethods: 1,
+            fidelityOpcodeDiffMethods: 1);
+
+        var regressions = CorpusSensor.Compare(baseline, current, [], gateAggregateRates: false);
+
+        Assert.DoesNotContain(regressions, regression => regression.StartsWith("fidelity opcode diffs", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Compare_GatesFidelityCountsWhenPinnedSamplesMatch()
+    {
+        var baseline = Snapshot(
+            totalMethods: 1,
+            fullyRaisedMethods: 1,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: FidelityMethods(("One", "Exact")),
+            fidelityCompileCap: 1,
+            fidelityCheckedMethods: 1,
+            fidelityExactMethods: 1);
+        var current = Snapshot(
+            totalMethods: 1,
+            fullyRaisedMethods: 1,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: FidelityMethods(("One", "OpcodeDiff")),
+            fidelityCompileCap: 1,
+            fidelityCheckedMethods: 1,
+            fidelityOpcodeDiffMethods: 1);
+
+        var regressions = CorpusSensor.Compare(baseline, current, [], gateAggregateRates: false);
+
+        Assert.Contains(regressions, regression => regression.StartsWith("fidelity opcode diffs (pinned)", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Compare_DoesNotGateSemanticCountsWhenPinnedSamplesDiffer()
+    {
+        var baseline = Snapshot(
+            totalMethods: 1,
+            fullyRaisedMethods: 1,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: ValidityMethods(("One", "valid")),
+            validityCompileCap: 1,
+            semanticCheckedMethods: 1);
+        var current = Snapshot(
+            totalMethods: 1,
+            fullyRaisedMethods: 1,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: ValidityMethods(("Two", "semantic-defect:CS0159")),
+            validityCompileCap: 1,
+            semanticCheckedMethods: 1,
+            semanticDefectMethods: 1);
+
+        var regressions = CorpusSensor.Compare(baseline, current, [], gateAggregateRates: false);
+
+        Assert.DoesNotContain(regressions, regression => regression.StartsWith("semantic defect methods", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Compare_GatesSemanticCountsWhenPinnedSamplesMatch()
+    {
+        var baseline = Snapshot(
+            totalMethods: 1,
+            fullyRaisedMethods: 1,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: ValidityMethods(("One", "valid")),
+            validityCompileCap: 1,
+            semanticCheckedMethods: 1);
+        var current = Snapshot(
+            totalMethods: 1,
+            fullyRaisedMethods: 1,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: ValidityMethods(("One", "semantic-defect:CS0159")),
+            validityCompileCap: 1,
+            semanticCheckedMethods: 1,
+            semanticDefectMethods: 1);
+
+        var regressions = CorpusSensor.Compare(baseline, current, [], gateAggregateRates: false);
+
+        Assert.Contains(regressions, regression => regression.StartsWith("semantic defect methods (pinned)", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void QualityMetricChanges_TreatsSemanticDefectMovementAsContextWhenSamplesDiffer()
     {
         var baseline = Snapshot(
@@ -176,6 +274,34 @@ public class CorpusSensorComparisonTests
         Assert.Contains("Semantic defects (sampling differs)", report);
     }
 
+    [Fact]
+    public void QualityMetricChanges_TreatsFidelityMovementAsContextWhenSamplesDiffer()
+    {
+        var baseline = Snapshot(
+            totalMethods: 1,
+            fullyRaisedMethods: 1,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: FidelityMethods(("One", "Exact")),
+            fidelityCompileCap: 1,
+            fidelityCheckedMethods: 1,
+            fidelityExactMethods: 1);
+        var current = Snapshot(
+            totalMethods: 1,
+            fullyRaisedMethods: 1,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: FidelityMethods(("Two", "OpcodeDiff")),
+            fidelityCompileCap: 1,
+            fidelityCheckedMethods: 1,
+            fidelityOpcodeDiffMethods: 1);
+
+        string report = CorpusSensor.QualityMetricChangesForTesting(baseline, current);
+
+        Assert.Contains("Fidelity opcode diffs (sampling differs)", report);
+        Assert.Contains("Fidelity exact (sampling differs)", report);
+        Assert.DoesNotContain("Fidelity opcode diffs (-)", report);
+        Assert.DoesNotContain("(bad)", report);
+    }
+
     static CorpusSensorSnapshot Snapshot(
         int totalMethods,
         int fullyRaisedMethods,
@@ -183,14 +309,18 @@ public class CorpusSensorComparisonTests
         IReadOnlyList<CorpusMethodSnapshot>? pinnedMethods,
         int validityCompileCap = 0,
         int semanticCheckedMethods = 0,
-        int semanticDefectMethods = 0)
+        int semanticDefectMethods = 0,
+        int fidelityCompileCap = 0,
+        int fidelityCheckedMethods = 0,
+        int fidelityExactMethods = 0,
+        int fidelityOpcodeDiffMethods = 0)
     {
         return new CorpusSensorSnapshot(
             SchemaVersion: 1,
             Description: "test",
             GeneratedUtc: DateTimeOffset.UnixEpoch,
             ValidityCompileCap: validityCompileCap,
-            FidelityCompileCap: 0,
+            FidelityCompileCap: fidelityCompileCap,
             MethodCap: 100,
             Tolerances: CorpusSensorTolerances.Default,
             Assemblies: [new CorpusAssemblySnapshot("Test", "test.dll", totalMethods)],
@@ -209,7 +339,13 @@ public class CorpusSensorComparisonTests
                 PassBugs: 0,
                 ResidualBuckets: ImmutableDictionary<string, int>.Empty,
                 Structuring: new StructuringSensorMetrics(0, 0, 0, 0, 0, ImmutableDictionary<string, int>.Empty),
-                Fidelity: new FidelitySensorMetrics(0, 0, 0, 0, 0, 0)));
+                Fidelity: new FidelitySensorMetrics(
+                    fidelityCheckedMethods,
+                    fidelityExactMethods,
+                    fidelityOpcodeDiffMethods,
+                    RecompileFailMethods: 0,
+                    ContextFailMethods: 0,
+                    NotFullMethods: 0)));
     }
 
     static IReadOnlyList<CorpusMethodSnapshot> PinnedMethods(int fullyRaised, int conditional)
@@ -255,6 +391,29 @@ public class CorpusSensorComparisonTests
                 PassBug: null,
                 Validity: value.Validity,
                 FidelityCheck: "not-sampled"));
+        }
+        return methods.ToImmutable();
+    }
+
+    static IReadOnlyList<CorpusMethodSnapshot> FidelityMethods(
+        params (string Method, string FidelityCheck)[] values)
+    {
+        var methods = ImmutableArray.CreateBuilder<CorpusMethodSnapshot>(values.Length);
+        foreach (var value in values)
+        {
+            methods.Add(new CorpusMethodSnapshot(
+                Assembly: "Pinned",
+                AssemblyPath: "nuget:pinned/lib.dll",
+                Type: "T",
+                Method: value.Method,
+                Overload: 0,
+                Signature: "()",
+                Fidelity: "Full",
+                FullyRaised: true,
+                Residual: null,
+                PassBug: null,
+                Validity: "not-sampled",
+                FidelityCheck: value.FidelityCheck));
         }
         return methods.ToImmutable();
     }

--- a/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
@@ -63,17 +63,80 @@ public class CorpusSensorComparisonTests
         Assert.Contains(regressions, regression => regression.StartsWith("fully-raised rate (pinned) dropped", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void QualityMetricChanges_TreatsSemanticDefectMovementAsContextWhenSamplesDiffer()
+    {
+        var baseline = Snapshot(
+            totalMethods: 2,
+            fullyRaisedMethods: 2,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: ValidityMethods(("One", "semantic-defect:CS0159"), ("Two", "valid")),
+            validityCompileCap: 2,
+            semanticCheckedMethods: 2,
+            semanticDefectMethods: 1);
+        var current = Snapshot(
+            totalMethods: 2,
+            fullyRaisedMethods: 2,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: ValidityMethods(("Three", "valid"), ("Four", "valid")),
+            validityCompileCap: 2,
+            semanticCheckedMethods: 2,
+            semanticDefectMethods: 0);
+
+        string report = CorpusSensor.QualityMetricChangesForTesting(baseline, current);
+        string semanticRow = report.Split('\n').Single(line => line.Contains("Semantic defects", StringComparison.Ordinal));
+        string malformedRow = report.Split('\n').Single(line => line.Contains("Full malformed", StringComparison.Ordinal));
+
+        Assert.Contains("Semantic defects (sampling differs)", semanticRow);
+        Assert.DoesNotContain("(good)", semanticRow);
+        Assert.EndsWith("| n/a |", semanticRow.TrimEnd());
+        Assert.Contains("Full malformed (sampling differs)", malformedRow);
+        Assert.EndsWith("| n/a |", malformedRow.TrimEnd());
+    }
+
+    [Fact]
+    public void QualityMetricChanges_ScoresSemanticDefectMovementWhenSamplesMatch()
+    {
+        var baseline = Snapshot(
+            totalMethods: 2,
+            fullyRaisedMethods: 2,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: ValidityMethods(("One", "semantic-defect:CS0159"), ("Two", "valid")),
+            validityCompileCap: 2,
+            semanticCheckedMethods: 2,
+            semanticDefectMethods: 1);
+        var current = Snapshot(
+            totalMethods: 2,
+            fullyRaisedMethods: 2,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: ValidityMethods(("One", "valid"), ("Two", "valid")),
+            validityCompileCap: 2,
+            semanticCheckedMethods: 2,
+            semanticDefectMethods: 0);
+
+        string report = CorpusSensor.QualityMetricChangesForTesting(baseline, current);
+        string semanticRow = report.Split('\n').Single(line => line.Contains("Semantic defects", StringComparison.Ordinal));
+
+        Assert.Contains("Semantic defects (-)", semanticRow);
+        Assert.Contains("(good)", semanticRow);
+        Assert.EndsWith("| -1 |", semanticRow.TrimEnd());
+        Assert.DoesNotContain("sampling differs", report);
+    }
+
     static CorpusSensorSnapshot Snapshot(
         int totalMethods,
         int fullyRaisedMethods,
         int fullyRaisedBasisPoints,
-        IReadOnlyList<CorpusMethodSnapshot> pinnedMethods)
+        IReadOnlyList<CorpusMethodSnapshot> pinnedMethods,
+        int validityCompileCap = 0,
+        int semanticCheckedMethods = 0,
+        int semanticDefectMethods = 0)
     {
         return new CorpusSensorSnapshot(
             SchemaVersion: 1,
             Description: "test",
             GeneratedUtc: DateTimeOffset.UnixEpoch,
-            ValidityCompileCap: 0,
+            ValidityCompileCap: validityCompileCap,
             FidelityCompileCap: 0,
             MethodCap: 100,
             Tolerances: CorpusSensorTolerances.Default,
@@ -88,8 +151,8 @@ public class CorpusSensorComparisonTests
                 ForwardMergeStoppedContainers: 0,
                 ForwardMergeBasisPoints: 0,
                 FullMalformedMethods: 0,
-                SemanticCheckedMethods: 0,
-                SemanticDefectMethods: 0,
+                SemanticCheckedMethods: semanticCheckedMethods,
+                SemanticDefectMethods: semanticDefectMethods,
                 PassBugs: 0,
                 ResidualBuckets: ImmutableDictionary<string, int>.Empty,
                 Structuring: new StructuringSensorMetrics(0, 0, 0, 0, 0, ImmutableDictionary<string, int>.Empty),
@@ -115,6 +178,29 @@ public class CorpusSensorComparisonTests
                 Residual: isConditional ? "structuring: conditional-branch" : isFullyRaised ? null : "fidelity: unsupported-node",
                 PassBug: null,
                 Validity: "not-sampled",
+                FidelityCheck: "not-sampled"));
+        }
+        return methods.ToImmutable();
+    }
+
+    static IReadOnlyList<CorpusMethodSnapshot> ValidityMethods(
+        params (string Method, string Validity)[] values)
+    {
+        var methods = ImmutableArray.CreateBuilder<CorpusMethodSnapshot>(values.Length);
+        foreach (var value in values)
+        {
+            methods.Add(new CorpusMethodSnapshot(
+                Assembly: "Pinned",
+                AssemblyPath: "nuget:pinned/lib.dll",
+                Type: "T",
+                Method: value.Method,
+                Overload: 0,
+                Signature: "()",
+                Fidelity: "Full",
+                FullyRaised: true,
+                Residual: null,
+                PassBug: null,
+                Validity: value.Validity,
                 FidelityCheck: "not-sampled"));
         }
         return methods.ToImmutable();

--- a/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
@@ -162,6 +162,33 @@ public class CorpusSensorComparisonTests
     }
 
     [Fact]
+    public void PinnedGateSummary_MarksSkippedCountGatesAsUngated()
+    {
+        var baseline = Snapshot(
+            totalMethods: 1,
+            fullyRaisedMethods: 1,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: ValidityMethods(("One", "valid")),
+            validityCompileCap: 1,
+            semanticCheckedMethods: 1);
+        var current = Snapshot(
+            totalMethods: 1,
+            fullyRaisedMethods: 1,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: ValidityMethods(("Two", "semantic-defect:CS0159")),
+            validityCompileCap: 1,
+            semanticCheckedMethods: 1,
+            semanticDefectMethods: 1);
+
+        string summary = Assert.IsType<string>(
+            CorpusSensor.PinnedGateSummaryForTesting(baseline, current));
+
+        Assert.Contains("Full malformed ungated (sampling differs)", summary);
+        Assert.Contains("semantic defects ungated (sampling differs)", summary);
+        Assert.Contains("fidelity ungated (sampling differs; rely on changed-method fidelity)", summary);
+    }
+
+    [Fact]
     public void QualityMetricChanges_TreatsSemanticDefectMovementAsContextWhenSamplesDiffer()
     {
         var baseline = Snapshot(

--- a/src/ILInspector.Decompiler.Tests/SwitchBranchRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwitchBranchRenderingTests.cs
@@ -142,6 +142,49 @@ public class SwitchBranchRenderingTests
     }
 
     [Fact]
+    public void Structuring_PreservesLabelOutsideTargetedInfiniteLoop()
+    {
+        var entry = new Block(0);
+        entry.Add(new SwitchBranch(new LoadArgument(0, "x", Int32), [0x10]));
+
+        var fallthrough = new Block(0x04);
+        fallthrough.Add(new Return(null));
+
+        var loopHead = new Block(0x10);
+        loopHead.Add(new StoreLocal(0, Int32, new Constant(1, Int32)));
+
+        var latch = new Block(0x14);
+        latch.Add(new Branch(0x10));
+
+        var container = new BlockContainer();
+        foreach (var block in (Block[])[entry, fallthrough, loopHead, latch])
+            container.Add(block);
+
+        var function = new IrFunction(
+            "M",
+            TypeRef.CoreLib("System", "Sample"),
+            new MethodSignature(
+                Void,
+                [new Parameter("x", Int32)],
+                HasThis: false,
+                GenericParameterCount: 0),
+            [Int32],
+            container);
+
+        new StructuringPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+        string output = CSharpPrinter.Print(function).Output ?? "";
+
+        Assert.Contains("if (__dotnet_inspect_switch0 == 0) goto IL_0010;", output);
+        Assert.Contains("while (true)", output);
+        Assert.True(
+            output.IndexOf("IL_0010:", StringComparison.Ordinal)
+                < output.IndexOf("while (true)", StringComparison.Ordinal),
+            output);
+        AssertGotoTargetsHaveLabels(output);
+    }
+
+    [Fact]
     public void BooleanFolding_PreservesLabelWhenSwitchTargetBecomesGuardReturn()
     {
         var entry = new Block(0);

--- a/src/ILInspector.Decompiler.Tests/SwitchBranchRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwitchBranchRenderingTests.cs
@@ -142,6 +142,49 @@ public class SwitchBranchRenderingTests
     }
 
     [Fact]
+    public void BooleanFolding_PreservesLabelWhenSwitchTargetBecomesGuardReturn()
+    {
+        var entry = new Block(0);
+        entry.Add(new SwitchBranch(new LoadArgument(0, "x", Int32), [0x10]));
+
+        var fallthrough = new Block(0x04);
+        fallthrough.Add(new Return(new Constant(false, Boolean)));
+
+        var target = new Block(0x10);
+        target.Add(new ConditionalBranch(new LoadArgument(1, "flag", Boolean), 0x14));
+
+        var arm = new Block(0x12);
+        arm.Add(new Return(new Constant(true, Boolean)));
+
+        var exit = new Block(0x14);
+        exit.Add(new Return(new Constant(false, Boolean)));
+
+        var container = new BlockContainer();
+        foreach (var block in (Block[])[entry, fallthrough, target, arm, exit])
+            container.Add(block);
+
+        var function = new IrFunction(
+            "M",
+            TypeRef.CoreLib("System", "Sample"),
+            new MethodSignature(
+                Boolean,
+                [new Parameter("x", Int32), new Parameter("flag", Boolean)],
+                HasThis: false,
+                GenericParameterCount: 0),
+            [],
+            container);
+
+        new StructuringPass().Run(function, PassContext.None);
+        new BooleanFoldingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+        string output = CSharpPrinter.Print(function).Output ?? "";
+
+        Assert.Contains("if (__dotnet_inspect_switch0 == 0) goto IL_0010;", output);
+        Assert.Contains("IL_0010:", output);
+        AssertGotoTargetsHaveLabels(output);
+    }
+
+    [Fact]
     public void FullPipeline_PreservesEveryResidualSwitchTargetLabel()
     {
         using var source = MetadataSource.Open(typeof(CSharpSpellability).Assembly.Location);

--- a/src/ILInspector.Decompiler.Tests/SwitchBranchRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwitchBranchRenderingTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Text.RegularExpressions;
 using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
@@ -11,7 +12,24 @@ namespace ILInspector.Decompiler.Tests;
 public class SwitchBranchRenderingTests
 {
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Boolean = TypeRef.CoreLib("System", "Boolean");
     static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+
+    static void AssertGotoTargetsHaveLabels(string output)
+    {
+        var targets = Regex.Matches(output, @"goto (IL_[0-9A-F]+);")
+            .Select(match => match.Groups[1].Value)
+            .Distinct()
+            .Order()
+            .ToList();
+        var labels = Regex.Matches(output, @"(?m)^\s*(IL_[0-9A-F]+):\s*$")
+            .Select(match => match.Groups[1].Value)
+            .ToHashSet();
+        var missing = targets.Where(target => !labels.Contains(target)).ToList();
+
+        Assert.True(missing.Count == 0,
+            $"goto targets without labels: {string.Join(", ", missing)}\n{output}");
+    }
 
     static DecompilerResult RenderSwitch(params int[] targets)
     {
@@ -77,5 +95,67 @@ public class SwitchBranchRenderingTests
         Assert.Contains("goto IL_024F;", output);
         Assert.Contains("IL_024F:", output);
         Assert.DoesNotContain("case 0: goto", output);
+    }
+
+    [Fact]
+    public void Structuring_PreservesLabelWhenSwitchTargetBecomesIfStatement()
+    {
+        var entry = new Block(0);
+        entry.Add(new SwitchBranch(new LoadArgument(0, "x", Int32), [0x10]));
+
+        var fallthrough = new Block(0x04);
+        fallthrough.Add(new Return(null));
+
+        var target = new Block(0x10);
+        target.Add(new ConditionalBranch(new LoadArgument(1, "flag", Boolean), 0x14));
+
+        var arm = new Block(0x12);
+        arm.Add(new Return(null));
+
+        var exit = new Block(0x14);
+        exit.Add(new StoreLocal(0, Int32, new Constant(1, Int32)));
+        exit.Add(new Return(null));
+
+        var container = new BlockContainer();
+        foreach (var block in (Block[])[entry, fallthrough, target, arm, exit])
+            container.Add(block);
+
+        var signature = new MethodSignature(
+            Void,
+            [new Parameter("x", Int32), new Parameter("flag", Boolean)],
+            HasThis: false,
+            GenericParameterCount: 0);
+        var function = new IrFunction(
+            "M",
+            TypeRef.CoreLib("System", "Sample"),
+            signature,
+            [Int32],
+            container);
+
+        new StructuringPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+        string output = CSharpPrinter.Print(function).Output ?? "";
+
+        Assert.Contains("if (__dotnet_inspect_switch0 == 0) goto IL_0010;", output);
+        Assert.DoesNotContain("goto IL_0014;", output);
+        Assert.Contains("IL_0010:", output);
+    }
+
+    [Fact]
+    public void FullPipeline_PreservesEveryResidualSwitchTargetLabel()
+    {
+        using var source = MetadataSource.Open(typeof(CSharpSpellability).Assembly.Location);
+        var function = IrImporter.Import(
+            source,
+            typeof(CSharpSpellability).FullName!,
+            "TypeReason");
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(function);
+        string output = result.Output ?? "";
+
+        Assert.Equal(DecompilationFidelity.Full, result.Fidelity);
+        Assert.Contains("if (__dotnet_inspect_switch", output);
+        AssertGotoTargetsHaveLabels(output);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -471,6 +471,8 @@ public sealed partial class CSharpPrinter
 
     void AppendLabel(StringBuilder sb, string pad, int offset)
     {
+        // First printed occurrence owns the label; structured replacements stamp
+        // the enclosing statement so it must render before any same-offset child.
         if (_emittedLabels.Add(offset))
             sb.Append(pad).AppendLine($"IL_{offset:X4}:");
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -57,7 +57,9 @@ public sealed class BooleanFoldingPass : IIrPass
                     if (value is Constant { Value: int intValue } && intValue is 0 or 1)
                         value = new Constant(intValue == 1, boolType);
                     stepper.StepOver("retype bool-array element store", store);
-                    store.ReplaceWith(new StoreElement(boolType, (IrExpression)parts[0], (IrExpression)parts[1], value));
+                    var replacement = new StoreElement(boolType, (IrExpression)parts[0], (IrExpression)parts[1], value);
+                    replacement.InheritSourceOffset(store);
+                    store.ReplaceWith(replacement);
                     return true;
                 }
             }
@@ -658,11 +660,19 @@ public sealed class BooleanFoldingPass : IIrPass
         switch (previous)
         {
             case StoreStackSlot slot:
-                previous.ReplaceWith(new StoreStackSlot(slot.Slot, coalesce));
+            {
+                var replacement = new StoreStackSlot(slot.Slot, coalesce);
+                replacement.InheritSourceOffset(previous);
+                previous.ReplaceWith(replacement);
                 break;
+            }
             case StoreLocal local:
-                previous.ReplaceWith(new StoreLocal(local.Index, local.Type, coalesce));
+            {
+                var replacement = new StoreLocal(local.Index, local.Type, coalesce);
+                replacement.InheritSourceOffset(previous);
+                previous.ReplaceWith(replacement);
                 break;
+            }
         }
         return true;
     }
@@ -699,7 +709,11 @@ public sealed class BooleanFoldingPass : IIrPass
         var whenTrue = (IrExpression)thenStore.DetachChildren()[0];
         var whenFalse = (IrExpression)elseStore.DetachChildren()[0];
         stepper.StepOver("fold store diamond into ternary", diamond);
-        diamond.ReplaceWith(new StoreStackSlot(thenStore.Slot, new Conditional(condition, whenTrue, whenFalse) { MergedType = mergedType }));
+        var foldedStore = new StoreStackSlot(
+            thenStore.Slot,
+            new Conditional(condition, whenTrue, whenFalse) { MergedType = mergedType });
+        foldedStore.InheritSourceOffset(diamond);
+        diamond.ReplaceWith(foldedStore);
         return true;
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -508,7 +508,9 @@ public sealed class BooleanFoldingPass : IIrPass
 
         tailReturn.Detach();
         stepper.StepOver("fold guarded return into short-circuit", guard);
-        guard.ReplaceWith(new Return(folded));
+        var foldedReturn = new Return(folded);
+        foldedReturn.InheritSourceOffset(guard);
+        guard.ReplaceWith(foldedReturn);
         return true;
     }
 
@@ -581,8 +583,10 @@ public sealed class BooleanFoldingPass : IIrPass
         tailReturn.Detach();
 
         stepper.StepOver("fold guarded return into ternary", guard);
-        guard.ReplaceWith(new Return(
-            new Conditional(Conditions.Negate(condition), tailValue, thenValue) { MergedType = mergedType }));
+        var foldedReturn = new Return(
+            new Conditional(Conditions.Negate(condition), tailValue, thenValue) { MergedType = mergedType });
+        foldedReturn.InheritSourceOffset(guard);
+        guard.ReplaceWith(foldedReturn);
         return true;
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -239,9 +239,10 @@ public sealed class BooleanFoldingPass : IIrPass
                 continue;
             bool folded = node switch
             {
-                IfStatement statement => FoldNestedGuard(statement, stepper) || FoldGuardReturn(statement, stepper)
+                IfStatement statement => FoldNestedGuard(function, statement, stepper)
+                    || FoldGuardReturn(function, statement, stepper)
                     || FoldElseReturn(function, statement, stepper)
-                    || FoldTernaryReturn(statement, stepper)
+                    || FoldTernaryReturn(function, statement, stepper)
                     || FoldSlotDiamond(function, statement, stepper) || FoldCoalesce(function, statement, stepper),
                 Call call => FoldNullableGetValueOrDefault(call, stepper),
                 Comparison comparison => FoldBoolConstantComparison(comparison, stepper),
@@ -433,13 +434,16 @@ public sealed class BooleanFoldingPass : IIrPass
     };
 
     /// <summary>if (a) { if (b) { T } } → if (a &amp;&amp; b) { T }</summary>
-    static bool FoldNestedGuard(IfStatement outer, Stepper stepper)
+    static bool FoldNestedGuard(IrFunction function, IfStatement outer, Stepper stepper)
     {
         if (outer.HasElse || outer.Then.Children.Count != 1
             || outer.Then.Children[0] is not IfStatement { HasElse: false } inner)
         {
             return false;
         }
+        if (ConsumesBranchTarget(function, outer, inner))
+            return false;
+
         var outerCondition = outer.Condition;
         outerCondition.Detach();
         var innerParts = inner.DetachChildren();  // [condition, then]
@@ -454,11 +458,12 @@ public sealed class BooleanFoldingPass : IIrPass
     }
 
     /// <summary>if (c) return A; return B; → short-circuit when either side is a bool constant.</summary>
-    static bool FoldGuardReturn(IfStatement guard, Stepper stepper)
+    static bool FoldGuardReturn(IrFunction function, IfStatement guard, Stepper stepper)
     {
         if (guard.HasElse || guard.Parent is not Block container)
             return false;
-        if (guard.Then.Children.Count != 1 || guard.Then.Children[0] is not Return { Value: { } thenValue })
+        if (guard.Then.Children.Count != 1
+            || guard.Then.Children[0] is not Return { Value: { } thenValue } thenReturn)
             return false;
         if (guard.ChildIndex + 1 >= container.Children.Count
             || container.Children[guard.ChildIndex + 1] is not Return { Value: { } tailValue } tailReturn)
@@ -470,6 +475,8 @@ public sealed class BooleanFoldingPass : IIrPass
         {
             return false;
         }
+        if (ConsumesBranchTarget(function, guard, thenReturn, tailReturn))
+            return false;
 
         // Decide the shape COMPLETELY before any detach: bailing after a
         // mutation leaves a mutilated IfStatement whose slots have shifted.
@@ -549,13 +556,14 @@ public sealed class BooleanFoldingPass : IIrPass
     /// top-level relational value arms. The polarity swap recovers the source-like
     /// comparison shape csc lowered into the guard.
     /// </summary>
-    static bool FoldTernaryReturn(IfStatement guard, Stepper stepper)
+    static bool FoldTernaryReturn(IrFunction function, IfStatement guard, Stepper stepper)
     {
         if (guard.HasElse || guard.Parent is not Block container)
             return false;
         if (container.Parent is not BlockContainer { Parent: IrFunction } || container.Children.Count != 2)
             return false;
-        if (guard.Then.Children.Count != 1 || guard.Then.Children[0] is not Return { Value: { } thenValue })
+        if (guard.Then.Children.Count != 1
+            || guard.Then.Children[0] is not Return { Value: { } thenValue } thenReturn)
             return false;
         if (guard.ChildIndex + 1 >= container.Children.Count
             || container.Children[guard.ChildIndex + 1] is not Return { Value: { } tailValue } tailReturn)
@@ -568,6 +576,8 @@ public sealed class BooleanFoldingPass : IIrPass
             return false;
         }
         if (!IsTernaryComparison(guard.Condition) || !IsSimpleTernaryArm(thenValue) || !IsSimpleTernaryArm(tailValue))
+            return false;
+        if (ConsumesBranchTarget(function, guard, thenReturn, tailReturn))
             return false;
 
         TypeRef? mergedType = null;
@@ -651,6 +661,8 @@ public sealed class BooleanFoldingPass : IIrPass
         };
         if (!match)
             return false;
+        if (ConsumesBranchTarget(function, guard, guard, inner))
+            return false;
 
         var first = previous.DetachChildren()[0];
         var fallback = inner.DetachChildren()[0];
@@ -694,6 +706,9 @@ public sealed class BooleanFoldingPass : IIrPass
         {
             return false;
         }
+        if (ConsumesBranchTarget(function, diamond, thenStore, elseStore))
+            return false;
+
         // The importer merged this slot to the genuine common supertype at the
         // join this diamond feeds. Slot numbers are stack-depth positions and can
         // be reused by earlier live ranges, so look after the whole diamond, not
@@ -715,6 +730,54 @@ public sealed class BooleanFoldingPass : IIrPass
         foldedStore.InheritSourceOffset(diamond);
         diamond.ReplaceWith(foldedStore);
         return true;
+    }
+
+    static bool ConsumesBranchTarget(
+        IrFunction function,
+        IrNode anchor,
+        IrNode firstConsumed,
+        IrNode? secondConsumed = null)
+    {
+        var targets = new HashSet<int>();
+        CollectBranchTargets(EnclosingBodyScope(function, anchor), targets);
+        return IsTarget(firstConsumed) || secondConsumed is not null && IsTarget(secondConsumed);
+
+        bool IsTarget(IrNode node)
+            => node.SourceOffset >= 0 && targets.Contains(node.SourceOffset);
+    }
+
+    static IrNode EnclosingBodyScope(IrFunction function, IrNode node)
+    {
+        for (var current = node.Parent; current is not null && !ReferenceEquals(current, function); current = current.Parent)
+            if (current is Lambda or LocalFunctionStatement)
+                return current;
+        return function;
+    }
+
+    static void CollectBranchTargets(IrNode scope, HashSet<int> targets)
+    {
+        foreach (var child in scope.Children)
+        {
+            switch (child)
+            {
+                case Branch branch:
+                    targets.Add(branch.TargetOffset);
+                    break;
+                case ConditionalBranch conditional:
+                    targets.Add(conditional.TargetOffset);
+                    break;
+                case Leave leave:
+                    targets.Add(leave.TargetOffset);
+                    break;
+                case SwitchBranch @switch:
+                    foreach (int target in @switch.TargetOffsets)
+                        targets.Add(target);
+                    break;
+            }
+
+            if (child is not (Lambda or LocalFunctionStatement))
+                CollectBranchTargets(child, targets);
+        }
     }
 
     static bool HasNullArmForNonNullableValue(IrExpression whenTrue, IrExpression whenFalse, TypeRef? mergedType, IrFunction function)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -442,10 +442,12 @@ public sealed class BooleanFoldingPass : IIrPass
         outerCondition.Detach();
         var innerParts = inner.DetachChildren();  // [condition, then]
         stepper.StepOver("fold nested if guards into &&", outer);
-        outer.ReplaceWith(new IfStatement(
+        var folded = new IfStatement(
             new LogicalBinary(LogicalKind.And, outerCondition, (IrExpression)innerParts[0]),
             (Block)innerParts[1],
-            null));
+            null);
+        folded.InheritSourceOffset(outer);
+        outer.ReplaceWith(folded);
         return true;
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -1235,7 +1235,9 @@ public sealed class StructuringPass : IIrPass
                     int branchTarget = offsetToIndex[branch.TargetOffset];
                     if (breakTarget == branchTarget)
                     {
-                        result.Add(new Break());
+                        var next = new Break();
+                        next.InheritSourceOffset(branch);
+                        result.Add(next);
                         i++;
                         break;
                     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -1121,7 +1121,15 @@ public sealed class StructuringPass : IIrPass
         || block.Children[^1] is not (Return or Throw or Branch or Leave or EndFinally or EndFilter);
 
     /// <summary>Phase 2: same walk, moving statements into the structured tree. Mirrors Validate exactly; shapes were already proven.</summary>
-    static Block BuildRegion(Ctx ctx, int start, int stop, int joinIndex, int? breakTarget, int? continueTarget, int? regionExitBreakTarget = null)
+    static Block BuildRegion(
+        Ctx ctx,
+        int start,
+        int stop,
+        int joinIndex,
+        int? breakTarget,
+        int? continueTarget,
+        int? regionExitBreakTarget = null,
+        bool suppressStartTargetLabel = false)
     {
         var blocks = ctx.Blocks;
         var offsetToIndex = ctx.OffsetToIndex;
@@ -1142,11 +1150,21 @@ public sealed class StructuringPass : IIrPass
             {
                 bool fallthroughExits = IsLeaveRetryLoopHead(ctx, i)
                     && MayFallThroughAfterRetryReplacement(blocks[latch], blocks[i].StartOffset);
-                var loopBody = BuildRegion(ctx, i, latch + 1, joinIndex: latch + 1, breakTarget: latch + 1, continueTarget: i);
+                var loopBody = BuildRegion(
+                    ctx,
+                    i,
+                    latch + 1,
+                    joinIndex: latch + 1,
+                    breakTarget: latch + 1,
+                    continueTarget: i,
+                    suppressStartTargetLabel: true);
                 ReplaceRetryLeavesWithContinues(loopBody, blocks[i].StartOffset);
                 if (fallthroughExits)
                     loopBody.Add(new Break());
-                result.Add(new WhileLoop(TrueLiteral(), loopBody));
+                var loop = new WhileLoop(TrueLiteral(), loopBody);
+                if (ctx.BranchTargets.Contains(blocks[i].StartOffset))
+                    loop.SetSourceOffset(blocks[i].StartOffset);
+                result.Add(loop);
                 i = latch + 1;
                 continue;
             }
@@ -1337,8 +1355,12 @@ public sealed class StructuringPass : IIrPass
                     i++;
                     break;
             }
-            if (ctx.BranchTargets.Contains(block.StartOffset) && result.Children.Count > resultStart)
+            if (!(suppressStartTargetLabel && block.StartOffset == blocks[start].StartOffset)
+                && ctx.BranchTargets.Contains(block.StartOffset)
+                && result.Children.Count > resultStart)
+            {
                 result.Children[resultStart].SetSourceOffset(block.StartOffset);
+            }
         }
         return result;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -1157,8 +1157,7 @@ public sealed class StructuringPass : IIrPass
                 continue;
             }
             var statements = block.DetachChildren();
-            if (ctx.BranchTargets.Contains(block.StartOffset) && statements.Count > 0)
-                statements[0].SetSourceOffset(block.StartOffset);
+            int resultStart = result.Children.Count;
             var last = statements[^1];
             for (int s = 0; s < statements.Count - 1; s++)
                 result.Add(statements[s]);
@@ -1338,6 +1337,8 @@ public sealed class StructuringPass : IIrPass
                     i++;
                     break;
             }
+            if (ctx.BranchTargets.Contains(block.StartOffset) && result.Children.Count > resultStart)
+                result.Children[resultStart].SetSourceOffset(block.StartOffset);
         }
         return result;
     }

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -869,7 +869,10 @@ internal static class CorpusSensor
         return lines;
     }
 
-    static void PrintQualityMetricChanges(CorpusSensorSnapshot baseline, CorpusSensorSnapshot current)
+    static void PrintQualityMetricChanges(
+        CorpusSensorSnapshot baseline,
+        CorpusSensorSnapshot current,
+        TextWriter? output = null)
     {
         var rows = new List<MultiSourceRow>
         {
@@ -898,14 +901,25 @@ internal static class CorpusSensor
 
         if (current.ValidityCompileCap > 0)
         {
-            rows.Add(CountChangeRow("Full malformed", baseline.Metrics.FullMalformedMethods, current.Metrics.FullMalformedMethods, Goal.Lower));
+            bool comparableValiditySamples = HaveSameValiditySample(baseline.Methods, current.Methods);
+            rows.Add(CountChangeRow(
+                comparableValiditySamples
+                    ? "Full malformed"
+                    : "Full malformed (sampling differs)",
+                baseline.Metrics.FullMalformedMethods,
+                current.Metrics.FullMalformedMethods,
+                comparableValiditySamples ? Goal.Lower : Goal.Context,
+                countDeltaKnown: comparableValiditySamples));
             rows.Add(ShareChangeRow(
-                "Semantic defects",
+                comparableValiditySamples
+                    ? "Semantic defects"
+                    : "Semantic defects (sampling differs)",
                 baseline.Metrics.SemanticDefectMethods,
                 baseline.Metrics.SemanticCheckedMethods,
                 current.Metrics.SemanticDefectMethods,
                 current.Metrics.SemanticCheckedMethods,
-                Goal.Lower));
+                comparableValiditySamples ? Goal.Lower : Goal.Context,
+                countDeltaKnown: comparableValiditySamples));
         }
 
         if (current.FidelityCompileCap > 0)
@@ -949,21 +963,59 @@ internal static class CorpusSensor
 
         rows.Add(CountChangeRow("Pass bugs", baseline.Metrics.PassBugs, current.Metrics.PassBugs, Goal.Lower));
 
-        var writer = new MarkoutWriter(Console.Out, new MarkdownFormatter());
+        var writer = new MarkoutWriter(output ?? Console.Out, new MarkdownFormatter());
         writer.WriteMultiSourceTable("Metric", rows);
     }
 
-    static MultiSourceRow CountChangeRow(string metric, int baseline, int current, Goal goal)
+    internal static string QualityMetricChangesForTesting(
+        CorpusSensorSnapshot baseline,
+        CorpusSensorSnapshot current)
+    {
+        using var writer = new StringWriter();
+        PrintQualityMetricChanges(baseline, current, writer);
+        return writer.ToString();
+    }
+
+    static MultiSourceRow CountChangeRow(
+        string metric,
+        int baseline,
+        int current,
+        Goal goal,
+        bool countDeltaKnown = true)
         => new(
             MetricLabel(metric, goal),
             new Source("Change", new Change<int>(baseline, current), new MarkoutCellFormat { Goal = goal }),
-            new Source("Count delta", new QualityText(Delta(current - baseline))));
+            new Source("Count delta", new QualityText(countDeltaKnown ? Delta(current - baseline) : "n/a")));
 
-    static MultiSourceRow ShareChangeRow(string metric, int baseline, int baselineTotal, int current, int currentTotal, Goal goal)
+    static MultiSourceRow ShareChangeRow(
+        string metric,
+        int baseline,
+        int baselineTotal,
+        int current,
+        int currentTotal,
+        Goal goal,
+        bool countDeltaKnown = true)
         => new(
             MetricLabel(metric, goal),
             new Source("Change", new Change<QualityRate>(new QualityRate(baseline, baselineTotal), new QualityRate(current, currentTotal)), new MarkoutCellFormat { Goal = goal }),
-            new Source("Count delta", new QualityText(Delta(current - baseline))));
+            new Source("Count delta", new QualityText(countDeltaKnown ? Delta(current - baseline) : "n/a")));
+
+    static bool HaveSameValiditySample(
+        IReadOnlyList<CorpusMethodSnapshot>? baselineMethods,
+        IReadOnlyList<CorpusMethodSnapshot>? currentMethods)
+    {
+        if (baselineMethods is null || currentMethods is null)
+            return false;
+
+        static bool IsValidityChecked(CorpusMethodSnapshot method)
+            => method.Validity != "not-sampled";
+
+        return baselineMethods
+            .Where(IsValidityChecked)
+            .Select(MethodKey)
+            .ToHashSet(StringComparer.Ordinal)
+            .SetEquals(currentMethods.Where(IsValidityChecked).Select(MethodKey));
+    }
 
     static string MetricLabel(string metric, Goal goal)
         => goal switch

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -901,25 +901,33 @@ internal static class CorpusSensor
 
         if (current.ValidityCompileCap > 0)
         {
-            bool comparableValiditySamples = HaveSameValiditySample(baseline.Methods, current.Methods);
+            bool comparableMalformedSamples = HaveSameValiditySample(
+                baseline.Methods,
+                current.Methods,
+                static method => method.Validity != "not-sampled");
+            bool comparableSemanticSamples = HaveSameValiditySample(
+                baseline.Methods,
+                current.Methods,
+                static method => method.Validity == "valid"
+                    || method.Validity.StartsWith("semantic-defect:", StringComparison.Ordinal));
             rows.Add(CountChangeRow(
-                comparableValiditySamples
+                comparableMalformedSamples
                     ? "Full malformed"
                     : "Full malformed (sampling differs)",
                 baseline.Metrics.FullMalformedMethods,
                 current.Metrics.FullMalformedMethods,
-                comparableValiditySamples ? Goal.Lower : Goal.Context,
-                countDeltaKnown: comparableValiditySamples));
+                comparableMalformedSamples ? Goal.Lower : Goal.Context,
+                countDeltaKnown: comparableMalformedSamples));
             rows.Add(ShareChangeRow(
-                comparableValiditySamples
+                comparableSemanticSamples
                     ? "Semantic defects"
                     : "Semantic defects (sampling differs)",
                 baseline.Metrics.SemanticDefectMethods,
                 baseline.Metrics.SemanticCheckedMethods,
                 current.Metrics.SemanticDefectMethods,
                 current.Metrics.SemanticCheckedMethods,
-                comparableValiditySamples ? Goal.Lower : Goal.Context,
-                countDeltaKnown: comparableValiditySamples));
+                comparableSemanticSamples ? Goal.Lower : Goal.Context,
+                countDeltaKnown: comparableSemanticSamples));
         }
 
         if (current.FidelityCompileCap > 0)
@@ -1002,19 +1010,17 @@ internal static class CorpusSensor
 
     static bool HaveSameValiditySample(
         IReadOnlyList<CorpusMethodSnapshot>? baselineMethods,
-        IReadOnlyList<CorpusMethodSnapshot>? currentMethods)
+        IReadOnlyList<CorpusMethodSnapshot>? currentMethods,
+        Func<CorpusMethodSnapshot, bool> isChecked)
     {
         if (baselineMethods is null || currentMethods is null)
             return false;
 
-        static bool IsValidityChecked(CorpusMethodSnapshot method)
-            => method.Validity != "not-sampled";
-
         return baselineMethods
-            .Where(IsValidityChecked)
+            .Where(isChecked)
             .Select(MethodKey)
             .ToHashSet(StringComparer.Ordinal)
-            .SetEquals(currentMethods.Where(IsValidityChecked).Select(MethodKey));
+            .SetEquals(currentMethods.Where(isChecked).Select(MethodKey));
     }
 
     static string MetricLabel(string metric, Goal goal)

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -777,31 +777,66 @@ internal static class CorpusSensor
     /// </summary>
     static void PrintPinnedGate(CorpusSensorSnapshot baseline, CorpusSensorSnapshot current)
     {
-        if (PinnedCounts(baseline) is not { } basePinned || PinnedCounts(current) is not { } curPinned)
+        string? summary = PinnedGateSummary(baseline, current);
+        if (summary is null)
             return;
-        var fidelity = basePinned.FidelityChecked > 0 && curPinned.FidelityChecked > 0
+
+        Console.WriteLine();
+        Console.WriteLine(summary);
+    }
+
+    internal static string? PinnedGateSummaryForTesting(
+        CorpusSensorSnapshot baseline,
+        CorpusSensorSnapshot current)
+        => PinnedGateSummary(baseline, current);
+
+    static string? PinnedGateSummary(CorpusSensorSnapshot baseline, CorpusSensorSnapshot current)
+    {
+        if (PinnedCounts(baseline) is not { } basePinned || PinnedCounts(current) is not { } curPinned)
+            return null;
+
+        bool comparableMalformedSamples = HaveSameMethodSample(
+            baseline.Methods,
+            current.Methods,
+            static method => IsPinnedAssembly(method.AssemblyPath)
+                && method.Validity != "not-sampled");
+        bool comparableSemanticSamples = HaveSameMethodSample(
+            baseline.Methods,
+            current.Methods,
+            static method => IsPinnedAssembly(method.AssemblyPath)
+                && (method.Validity == "valid"
+                    || method.Validity.StartsWith("semantic-defect:", StringComparison.Ordinal)));
+        bool comparableFidelitySamples = basePinned.FidelityChecked > 0 && curPinned.FidelityChecked > 0
             && current.FidelityCompileCap == baseline.FidelityCompileCap
             && HaveSameMethodSample(
                 baseline.Methods,
                 current.Methods,
                 static method => IsPinnedAssembly(method.AssemblyPath)
-                    && method.FidelityCheck != "not-sampled")
+                    && method.FidelityCheck != "not-sampled");
+        var fidelity = comparableFidelitySamples
             ? $"opcode diffs {Number(basePinned.OpcodeDiff)} -> {Number(curPinned.OpcodeDiff)} "
                 + $"({Delta(curPinned.OpcodeDiff - basePinned.OpcodeDiff)})"
             : "fidelity ungated (sampling differs; rely on changed-method fidelity)";
         var fullMalformed = current.ValidityCompileCap > 0
-            ? $"Full malformed {Number(basePinned.FullMalformed)} -> {Number(curPinned.FullMalformed)} "
-                + $"({Delta(curPinned.FullMalformed - basePinned.FullMalformed)}); "
+            ? comparableMalformedSamples
+                ? $"Full malformed {Number(basePinned.FullMalformed)} -> {Number(curPinned.FullMalformed)} "
+                    + $"({Delta(curPinned.FullMalformed - basePinned.FullMalformed)}); "
+                : "Full malformed ungated (sampling differs); "
             : "";
-        Console.WriteLine();
-        Console.WriteLine(
-            "Pinned-subset gate (PR quick rate/count regressions evaluated here): "
+        var semanticDefects = current.ValidityCompileCap > 0
+            ? comparableSemanticSamples
+                ? $"semantic defects {Number(basePinned.SemanticDefect)} -> {Number(curPinned.SemanticDefect)} "
+                    + $"({Delta(curPinned.SemanticDefect - basePinned.SemanticDefect)}); "
+                : "semantic defects ungated (sampling differs); "
+            : "";
+        return "Pinned-subset gate (PR quick rate/count regressions evaluated here): "
             + $"Fully raised {FormatBps(basePinned.FullyRaisedBasisPoints)} -> {FormatBps(curPinned.FullyRaisedBasisPoints)} "
             + $"({DeltaPercentagePoints(curPinned.FullyRaisedBasisPoints - basePinned.FullyRaisedBasisPoints)}); "
             + $"conditional residual {FormatBps(basePinned.ConditionalBranchBasisPoints)} -> {FormatBps(curPinned.ConditionalBranchBasisPoints)} "
             + $"({DeltaPercentagePoints(curPinned.ConditionalBranchBasisPoints - basePinned.ConditionalBranchBasisPoints)}); "
             + fullMalformed
-            + fidelity + ".");
+            + semanticDefects
+            + fidelity + ".";
     }
 
     static void PrintAdvisoryRateMovements(CorpusSensorSnapshot baseline, CorpusSensorSnapshot current)

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -470,19 +470,36 @@ internal static class CorpusSensor
         // per-method detail.
         if (baselinePinned is { } basePinned && currentPinned is { } curPinned)
         {
-            AddCountRegression(failures, "Full malformed methods (pinned)", basePinned.FullMalformed, curPinned.FullMalformed, tolerance.FullMalformedIncrease);
-            AddCountRegression(failures, "semantic defect methods (pinned)", basePinned.SemanticDefect, curPinned.SemanticDefect, tolerance.SemanticDefectIncrease);
+            if (HaveSameMethodSample(
+                baseline.Methods,
+                current.Methods,
+                static method => IsPinnedAssembly(method.AssemblyPath)
+                    && method.Validity != "not-sampled"))
+            {
+                AddCountRegression(failures, "Full malformed methods (pinned)", basePinned.FullMalformed, curPinned.FullMalformed, tolerance.FullMalformedIncrease);
+            }
+            if (HaveSameMethodSample(
+                baseline.Methods,
+                current.Methods,
+                static method => IsPinnedAssembly(method.AssemblyPath)
+                    && (method.Validity == "valid"
+                        || method.Validity.StartsWith("semantic-defect:", StringComparison.Ordinal))))
+            {
+                AddCountRegression(failures, "semantic defect methods (pinned)", basePinned.SemanticDefect, curPinned.SemanticDefect, tolerance.SemanticDefectIncrease);
+            }
 
             // Fidelity is sampled far more thinly than validity, and that small sample
             // currently lands almost entirely on repo assemblies, so the pinned subset
-            // often has zero fidelity-checked methods. Gate fidelity counts on the pinned
-            // subset only when it actually holds a fidelity sample and the caps match
-            // (per-method FidelityCheck is recorded at the primary cap); otherwise the
-            // aggregate fidelity count is drift-contaminated, so leave it ungated and rely
-            // on changed-method fidelity (the authoritative fidelity proof) instead of
-            // re-introducing a repo-growth false positive.
+            // often has zero fidelity-checked methods. Equal caps do not guarantee equal
+            // samples when the corpus changes, so gate only when the exact checked-method
+            // populations match. Otherwise rely on changed-method fidelity.
             if (basePinned.FidelityChecked > 0 && curPinned.FidelityChecked > 0
-                && current.FidelityCompileCap == baseline.FidelityCompileCap)
+                && current.FidelityCompileCap == baseline.FidelityCompileCap
+                && HaveSameMethodSample(
+                    baseline.Methods,
+                    current.Methods,
+                    static method => IsPinnedAssembly(method.AssemblyPath)
+                        && method.FidelityCheck != "not-sampled"))
             {
                 AddCountRegression(failures, "fidelity opcode diffs (pinned)", basePinned.OpcodeDiff, curPinned.OpcodeDiff, tolerance.FidelityOpcodeDiffIncrease);
                 AddCountRegression(failures, "fidelity recompile failures (pinned)", basePinned.RecompileFail, curPinned.RecompileFail, tolerance.FidelityRecompileFailIncrease);
@@ -764,9 +781,14 @@ internal static class CorpusSensor
             return;
         var fidelity = basePinned.FidelityChecked > 0 && curPinned.FidelityChecked > 0
             && current.FidelityCompileCap == baseline.FidelityCompileCap
+            && HaveSameMethodSample(
+                baseline.Methods,
+                current.Methods,
+                static method => IsPinnedAssembly(method.AssemblyPath)
+                    && method.FidelityCheck != "not-sampled")
             ? $"opcode diffs {Number(basePinned.OpcodeDiff)} -> {Number(curPinned.OpcodeDiff)} "
                 + $"({Delta(curPinned.OpcodeDiff - basePinned.OpcodeDiff)})"
-            : "fidelity ungated (no pinned fidelity sample; rely on changed-method fidelity)";
+            : "fidelity ungated (sampling differs; rely on changed-method fidelity)";
         var fullMalformed = current.ValidityCompileCap > 0
             ? $"Full malformed {Number(basePinned.FullMalformed)} -> {Number(curPinned.FullMalformed)} "
                 + $"({Delta(curPinned.FullMalformed - basePinned.FullMalformed)}); "
@@ -901,11 +923,11 @@ internal static class CorpusSensor
 
         if (current.ValidityCompileCap > 0)
         {
-            bool comparableMalformedSamples = HaveSameValiditySample(
+            bool comparableMalformedSamples = HaveSameMethodSample(
                 baseline.Methods,
                 current.Methods,
                 static method => method.Validity != "not-sampled");
-            bool comparableSemanticSamples = HaveSameValiditySample(
+            bool comparableSemanticSamples = HaveSameMethodSample(
                 baseline.Methods,
                 current.Methods,
                 static method => method.Validity == "valid"
@@ -932,34 +954,50 @@ internal static class CorpusSensor
 
         if (current.FidelityCompileCap > 0)
         {
+            bool comparableFidelitySamples = HaveSameMethodSample(
+                baseline.Methods,
+                current.Methods,
+                static method => method.FidelityCheck != "not-sampled");
             rows.Add(ShareChangeRow(
-                "Fidelity opcode diffs",
+                comparableFidelitySamples
+                    ? "Fidelity opcode diffs"
+                    : "Fidelity opcode diffs (sampling differs)",
                 baseline.Metrics.Fidelity.OpcodeDiffMethods,
                 baseline.Metrics.Fidelity.CheckedMethods,
                 current.Metrics.Fidelity.OpcodeDiffMethods,
                 current.Metrics.Fidelity.CheckedMethods,
-                Goal.Lower));
+                comparableFidelitySamples ? Goal.Lower : Goal.Context,
+                countDeltaKnown: comparableFidelitySamples));
             rows.Add(ShareChangeRow(
-                "Fidelity exact",
+                comparableFidelitySamples
+                    ? "Fidelity exact"
+                    : "Fidelity exact (sampling differs)",
                 baseline.Metrics.Fidelity.ExactMethods,
                 baseline.Metrics.Fidelity.CheckedMethods,
                 current.Metrics.Fidelity.ExactMethods,
                 current.Metrics.Fidelity.CheckedMethods,
-                Goal.Higher));
+                comparableFidelitySamples ? Goal.Higher : Goal.Context,
+                countDeltaKnown: comparableFidelitySamples));
             rows.Add(ShareChangeRow(
-                "Fidelity recompile failures",
+                comparableFidelitySamples
+                    ? "Fidelity recompile failures"
+                    : "Fidelity recompile failures (sampling differs)",
                 baseline.Metrics.Fidelity.RecompileFailMethods,
                 baseline.Metrics.Fidelity.CheckedMethods,
                 current.Metrics.Fidelity.RecompileFailMethods,
                 current.Metrics.Fidelity.CheckedMethods,
-                Goal.Lower));
+                comparableFidelitySamples ? Goal.Lower : Goal.Context,
+                countDeltaKnown: comparableFidelitySamples));
             rows.Add(ShareChangeRow(
-                "Fidelity context failures",
+                comparableFidelitySamples
+                    ? "Fidelity context failures"
+                    : "Fidelity context failures (sampling differs)",
                 baseline.Metrics.Fidelity.ContextFailMethods,
                 baseline.Metrics.Fidelity.CheckedMethods,
                 current.Metrics.Fidelity.ContextFailMethods,
                 current.Metrics.Fidelity.CheckedMethods,
-                Goal.Lower));
+                comparableFidelitySamples ? Goal.Lower : Goal.Context,
+                countDeltaKnown: comparableFidelitySamples));
             rows.Add(ShareChangeRow(
                 "Fidelity check coverage",
                 baseline.Metrics.Fidelity.CheckedMethods,
@@ -1008,7 +1046,7 @@ internal static class CorpusSensor
             new Source("Change", new Change<QualityRate>(new QualityRate(baseline, baselineTotal), new QualityRate(current, currentTotal)), new MarkoutCellFormat { Goal = goal }),
             new Source("Count delta", new QualityText(countDeltaKnown ? Delta(current - baseline) : "n/a")));
 
-    static bool HaveSameValiditySample(
+    static bool HaveSameMethodSample(
         IReadOnlyList<CorpusMethodSnapshot>? baselineMethods,
         IReadOnlyList<CorpusMethodSnapshot>? currentMethods,
         Func<CorpusMethodSnapshot, bool> isChecked)


### PR DESCRIPTION
Incorporates the quality-card sampling feedback from #2626.

- Preserves branch-target labels when structuring and boolean-folding replace statements.
- Keeps externally targeted infinite-loop labels outside the synthesized loop scope.
- Makes semantic/fidelity card outcomes and pinned gates neutral when sampled method identities differ.
- Card revision: `13671f5c`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — exhaustive validity removes 14 `CS0159` defects with
zero regressions, and render A/B has no valid-to-invalid transition.

Before (`CSharpSpellability.TypeReason`):

```csharp
if (__dotnet_inspect_switch0 == 0) goto IL_003C;
// ...
if (IsCoreLibPrimitive(type))
```

After:

```csharp
if (__dotnet_inspect_switch0 == 0) goto IL_003C;
// ...
IL_003C:
if (IsCoreLibPrimitive(type))
```

The same sibling defect affected statement replacements in
`BooleanFoldingPass`; all replacement families now inherit the replaced
statement's offset. Infinite-loop synthesis also transfers a targeted loop-head
offset to the `while` statement instead of leaving its label inside the loop,
where an external `goto` would be illegal.

## Evidence

| Check | Result |
| --- | --- |
| Product/solution build | Pass |
| Focused tests | 25 passed |
| Decompiler fast suite | 2,250 passed |
| Decompiler exhaustive suite | 2,384 passed, 1 skipped, 2 failures reproduced identically on clean `main` |
| Exhaustive validity | 73,064 `Full` methods compiled; 14 `CS0159` improvements; 0 regressions |
| Render A/B | 89,065 methods; 18 changed; 14 invalid-to-valid, 0 valid-to-invalid, 4 invalid-to-invalid |
| Real witness | `CSharpSpellability.TypeReason` restores `IL_003C`; `System.Xml.XmlSubtreeReader.Read` restores `IL_00F8` and `IL_0109` |

The 18 render changes are 17 structural and one unparsed classification. The
changed-method compile-back lane attempted all 18: 5 existing opcode diffs, 12
recompile failures, and 1 generated-member context failure; no row was
`NotFull`, but none produced an exact opcode proof. These are reported as
current outcomes, not passing evidence. The semantic render lane and exhaustive
validity differential are the decisive evidence for this label-validity fix.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **ADVISORY** — structural pinned gates are neutral; semantic and
fidelity outcome gates are intentionally ungated because their sampled method
identities differ. The remaining verdict items are only the quick run's lower
validity cap/coverage versus the daily baseline.

### Generated quality-diff card

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity compiled 350 methods (compile-cap 25; per-sample, not corpus-wide); fidelity sampled 36 / 89,065 (0.04%)

| Metric | Change | Count delta |
| ------ | ------ | ----------- |
| Fully raised (+) | 78,406 (88.03%) → 78,406 (88.03%) (neutral) | 0 |
| Conditional-branch residual (-) | 2,401 (2.70%) → 2,401 (2.70%) (neutral) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) → 2,286 (2.57%) (neutral) | 0 |
| Full malformed (-) | 0 → 0 (neutral) | 0 |
| Semantic defects (sampling differs) | 54 (0.21%) → 0 (0.00%) | n/a |
| Fidelity opcode diffs (sampling differs) | 4 (11.11%) → 4 (11.11%) | n/a |
| Fidelity exact (sampling differs) | 32 (88.89%) → 32 (88.89%) | n/a |
| Fidelity recompile failures (sampling differs) | 0 (0.00%) → 0 (0.00%) | n/a |
| Fidelity context failures (sampling differs) | 0 (0.00%) → 0 (0.00%) | n/a |
| Fidelity check coverage (+) | 36 (0.04%) → 36 (0.04%) (neutral) | 0 |
| Pass bugs (-) | 0 → 0 (neutral) | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 88.03% -> 88.03% (0 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); fidelity ungated (sampling differs; rely on changed-method fidelity).

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- validity cap lower than baseline (baseline 4000, current 25)
- semantic checked methods lower than baseline (baseline 25183, current 350)

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Gemini 3.1 Pro | Clean on `13671f5c` | Found the infinite-loop scope hole; fix and focused regression verified clean |
| Claude Opus 4.8 | Clean on `13671f5c` | Mutation-tested loop-label ownership and checked ordinary/EH loop siblings |

**Review conclusion:** **PASS** — two independent exact-head reviews are clean.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.SwitchBranchRenderingTests -class ILInspector.Decompiler.Tests.BooleanFoldingSourceOffsetTests -class ILInspector.Decompiler.Tests.CorpusSensorComparisonTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
```
