### PR TITLE
Compose selected diff sections

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,6 +92,8 @@ Compares two package, platform, or local-library versions:
 - `-S "Analysis Diff"` selects body-signal changes.
 - `-S "Implementation Diff"` selects Research-composed C# + IL evidence grouped
   by member.
+- Multiple selected sections compose in Markdown and JSON. Explicit
+  table/TSV/JSONL output requires exactly one selected section.
 - Version range syntax is `Package@v1..v2` or `old/Foo.dll..new/Foo.dll`.
 
 ### find

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -803,6 +803,119 @@ public class DiffCommandTests
         Assert.DoesNotContain("API Diff", output, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task ExecuteAsync_MultipleSelectedSections_ComposesMarkdown()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var (exitCode, output, error) = await ConsoleCapture.RunAsync(() =>
+            DiffCommand.ExecuteAsync(new DiffOptions
+            {
+                LibraryVersionRange = $"{v1}..{v2}",
+                Select = ["Analysis Diff", "Implementation Diff"],
+                TypeFilter = ["DiffSample"],
+                ChangedOnly = true
+            }));
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(error);
+        Assert.Contains("## Analysis Diff", output, StringComparison.Ordinal);
+        Assert.Contains("## Implementation Diff", output, StringComparison.Ordinal);
+        Assert.Contains("RegressesAllocInLoop", output, StringComparison.Ordinal);
+        Assert.Contains("ConstantValue", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MultipleSelectedSections_ExplicitTableReturnsError()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var (exitCode, output, error) = await ConsoleCapture.RunAsync(() =>
+            DiffCommand.ExecuteAsync(new DiffOptions
+            {
+                LibraryVersionRange = $"{v1}..{v2}",
+                Select = ["Changes", "Implementation Diff"],
+                OneLine = true,
+                OneLineExplicitlySet = true
+            }));
+
+        Assert.Equal(1, exitCode);
+        Assert.Empty(output);
+        Assert.Contains("Selection matches 2 sections", error, StringComparison.Ordinal);
+        Assert.Contains("--table, --tsv, and --jsonl display one section at a time", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MultipleSelectedSections_ComposesJson()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var (exitCode, output, error) = await ConsoleCapture.RunAsync(() =>
+            DiffCommand.ExecuteAsync(new DiffOptions
+            {
+                LibraryVersionRange = $"{v1}..{v2}",
+                Select = ["Analysis Diff", "Implementation Diff"],
+                JsonOutput = true,
+                TypeFilter = ["DiffSample"],
+                ChangedOnly = true
+            }));
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(error);
+        using var document = System.Text.Json.JsonDocument.Parse(output);
+        Assert.True(document.RootElement.TryGetProperty("analysis_diff", out var analysis));
+        Assert.True(document.RootElement.TryGetProperty("implementation_diff", out var implementation));
+        Assert.True(analysis.GetArrayLength() > 0);
+        Assert.True(implementation.GetArrayLength() > 0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AllSections_ComposesEveryMarkdownSection()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var (exitCode, output, error) = await ConsoleCapture.RunAsync(() =>
+            DiffCommand.ExecuteAsync(new DiffOptions
+            {
+                LibraryVersionRange = $"{v1}..{v2}",
+                Select = ["@All"],
+                TypeFilter = ["MethodRemovalSample"]
+            }));
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(error);
+        Assert.Contains("## Changes", output, StringComparison.Ordinal);
+        Assert.Contains("## Analysis Diff", output, StringComparison.Ordinal);
+        Assert.Contains("## Implementation Diff", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_JsonAllocationRegressions_SelectsAnalysisDiff()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var (exitCode, output, error) = await ConsoleCapture.RunAsync(() =>
+            DiffCommand.ExecuteAsync(new DiffOptions
+            {
+                LibraryVersionRange = $"{v1}..{v2}",
+                JsonOutput = true,
+                AllocRegressionsOnly = true,
+                TypeFilter = ["DiffSample"]
+            }));
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(error);
+        using var document = System.Text.Json.JsonDocument.Parse(output);
+        Assert.True(document.RootElement.TryGetProperty("analysis_diff", out var analysis));
+        Assert.False(document.RootElement.TryGetProperty("changes", out _));
+        Assert.True(analysis.GetArrayLength() > 0);
+    }
+
     [Theory]
     [InlineData("int*", "System.Int32*")]
     [InlineData("int[,]", "System.Int32[,]")]

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -86,11 +86,12 @@ public class DiffCommandTests
     {
         var markdown = DiffOutputFormatter.RenderAnalysisDiffMarkdown(
             "Sample",
-            [new AnalysisDiffRow("`Sample.Type.M()`", "allocations", "0", "1", "+1", null, "old -; new IL_0001")],
+            [new AnalysisDiffRow("Sample.Type.M()", "allocations", "0", "1", "+1", null, "old -; new IL_0001")],
             "old.dll",
             "new.dll");
 
         Assert.Contains("## Analysis Diff", markdown);
+        Assert.Contains("`Sample.Type.M()`", markdown);
         Assert.Contains("allocations", markdown);
         Assert.Contains("+1", markdown);
         Assert.Contains("IL_0001", markdown);
@@ -884,6 +885,11 @@ public class DiffCommandTests
         Assert.Equal(
             "C# and IL implementation evidence is body-level evidence, not public API compatibility.",
             document.RootElement.GetProperty("implementation_diff_note").GetString());
+        Assert.DoesNotContain(analysis.EnumerateArray(), row =>
+            row.GetProperty("member").GetString()!.Contains("<code>", StringComparison.Ordinal)
+            || row.GetProperty("member").GetString()!.Contains("&lt;", StringComparison.Ordinal));
+        Assert.Contains(analysis.EnumerateArray(), row =>
+            row.GetProperty("member").GetString()!.Contains("List<object>", StringComparison.Ordinal));
         Assert.True(analysis.GetArrayLength() > 0);
         Assert.True(implementation.GetArrayLength() > 0);
     }

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -1,3 +1,5 @@
+using System.CommandLine;
+using DotnetInspector.CommandLine;
 using DotnetInspector.Fixtures;
 using ILInspector.Analysis;
 using ILInspector.Metadata;
@@ -870,6 +872,28 @@ public class DiffCommandTests
         Assert.True(document.RootElement.TryGetProperty("implementation_diff", out var implementation));
         Assert.True(analysis.GetArrayLength() > 0);
         Assert.True(implementation.GetArrayLength() > 0);
+    }
+
+    [Fact]
+    public async Task CommandLine_MultipleSelectedSections_ComposesJson()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+        var args = CommandLineBuilder.PreprocessArgs(
+        [
+            "diff", "--library", $"{v1}..{v2}",
+            "-S", "Analysis Diff,Implementation Diff",
+            "--json", "--type", "DiffSample"
+        ]);
+
+        var (exitCode, output, error) = await ConsoleCapture.RunAsync(async () =>
+            await CommandLineBuilder.CreateRootCommand().Parse(args).InvokeAsync());
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(error);
+        using var document = System.Text.Json.JsonDocument.Parse(output);
+        Assert.True(document.RootElement.TryGetProperty("analysis_diff", out _));
+        Assert.True(document.RootElement.TryGetProperty("implementation_diff", out _));
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -826,6 +826,14 @@ public class DiffCommandTests
         Assert.Contains("## Implementation Diff", output, StringComparison.Ordinal);
         Assert.Contains("RegressesAllocInLoop", output, StringComparison.Ordinal);
         Assert.Contains("ConstantValue", output, StringComparison.Ordinal);
+        Assert.Contains(
+            "Analysis signal changes are body-level evidence, not public API compatibility changes.",
+            output,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "C# and IL implementation evidence is body-level evidence, not public API compatibility.",
+            output,
+            StringComparison.Ordinal);
     }
 
     [Fact]
@@ -870,6 +878,12 @@ public class DiffCommandTests
         using var document = System.Text.Json.JsonDocument.Parse(output);
         Assert.True(document.RootElement.TryGetProperty("analysis_diff", out var analysis));
         Assert.True(document.RootElement.TryGetProperty("implementation_diff", out var implementation));
+        Assert.Equal(
+            "Analysis signal changes are body-level evidence, not public API compatibility changes.",
+            document.RootElement.GetProperty("analysis_diff_note").GetString());
+        Assert.Equal(
+            "C# and IL implementation evidence is body-level evidence, not public API compatibility.",
+            document.RootElement.GetProperty("implementation_diff_note").GetString());
         Assert.True(analysis.GetArrayLength() > 0);
         Assert.True(implementation.GetArrayLength() > 0);
     }

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -71,6 +71,8 @@ public static class InspectionCommandDefinitions
         diffCommand.Options.Add(typeFilterOption);
         diffCommand.Options.Add(memberFilterOption);
         opts.AddTableOptionsTo(diffCommand);
+        diffCommand.Options.Add(opts.Json);
+        diffCommand.Options.Add(opts.Markdown);
         diffCommand.Options.Add(nameOnlyOption);
         diffCommand.Options.Add(breakingOption);
         diffCommand.Options.Add(additiveOption);

--- a/src/dotnet-inspect/CommandLine/Parsers/DiffOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/DiffOptionsParser.cs
@@ -118,7 +118,7 @@ public static class DiffOptionsParser
             OneLine = opts.ResolveOneLine(parseResult),
             Tsv = opts.ResolveTsv(parseResult),
             Jsonl = opts.ResolveJsonl(parseResult),
-            JsonOutput = parseResult.GetValue(opts.Json),
+            JsonOutput = opts.ResolveFormat(parseResult) == OutputFormat.Json,
             OneLineExplicitlySet = opts.IsTableExplicitlySet(parseResult),
             FormatExplicitlySet = opts.IsFormatExplicitlySet(parseResult),
             NoHeader = parseResult.GetValue(opts.NoHeaders),

--- a/src/dotnet-inspect/CommandLine/Parsers/DiffOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/DiffOptionsParser.cs
@@ -118,6 +118,8 @@ public static class DiffOptionsParser
             OneLine = opts.ResolveOneLine(parseResult),
             Tsv = opts.ResolveTsv(parseResult),
             Jsonl = opts.ResolveJsonl(parseResult),
+            JsonOutput = parseResult.GetValue(opts.Json),
+            OneLineExplicitlySet = opts.IsTableExplicitlySet(parseResult),
             FormatExplicitlySet = opts.IsFormatExplicitlySet(parseResult),
             NoHeader = parseResult.GetValue(opts.NoHeaders),
             NameOnly = parseResult.GetValue(args.NameOnlyOption),

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -8,6 +8,7 @@ using DotnetInspector.Views;
 using ILInspector.Analysis;
 using ILInspector.Research;
 using Markout;
+using System.Text.Json;
 
 namespace DotnetInspector.Commands;
 
@@ -41,6 +42,11 @@ public class DiffCommand
                 sectionCostAnnotations: pipeline.GetCostAnnotations(),
                 sectionCategories: pipeline.GetCategoryMap());
         }
+
+        if (!OutputFormatResolver.ValidateSingleSectionForTabular(
+                options.OneLineExplicitlySet,
+                options.IncludeSections))
+            return 1;
 
         if (!hasPlatform && !hasPackage && !hasLibrary)
         {
@@ -98,6 +104,12 @@ public class DiffCommand
 
             try
             {
+                if (options.JsonOutput || options.IncludeSections is { Count: > 1 })
+                {
+                    WriteSelectedDocument(inputs, options);
+                    return 0;
+                }
+
                 if (SelectsImplementationDiff(options) && !SelectsAnalysisDiff(options))
                 {
                     var implementation = BuildImplementationDiff(
@@ -377,13 +389,86 @@ public class DiffCommand
 
     private static bool SelectsAnalysisDiff(DiffOptions options)
         => options.AllocRegressionsOnly
-            || options.IncludeSections?.Contains("Analysis Diff") == true;
+            || options.IncludeSections?.Contains(DiffSections.AnalysisDiff.Name) == true;
 
     private static bool SelectsImplementationDiff(DiffOptions options)
-        => options.IncludeSections?.Contains("Implementation Diff") == true;
+        => options.IncludeSections?.Contains(DiffSections.ImplementationDiff.Name) == true;
 
     private static bool SelectsDetailedChanges(DiffOptions options)
-        => options.IncludeSections?.Contains("Changes") == true;
+        => options.IncludeSections?.Contains(DiffSections.Changes.Name) == true;
+
+    private static void WriteSelectedDocument(DiffInputs inputs, DiffOptions options)
+    {
+        var selected = options.IncludeSections
+            ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                options.AllocRegressionsOnly
+                    ? DiffSections.AnalysisDiff.Name
+                    : DiffSections.Changes.Name
+            };
+
+        DiffDetailedChangesView? changesView = null;
+        if (selected.Contains(DiffSections.Changes.Name))
+        {
+            var diff = BuildApiDiff(inputs.FromSurface, inputs.ToSurface, options);
+            changesView = DiffOutputFormatter.BuildDetailedChangesView(
+                inputs.Name,
+                ApplyFilters(diff, options),
+                inputs.FromVersion,
+                inputs.ToVersion);
+        }
+
+        AnalysisDiffView? analysisView = null;
+        if (selected.Contains(DiffSections.AnalysisDiff.Name))
+        {
+            var analysis = BuildAnalysisDiff(
+                inputs.FromPaths,
+                inputs.ToPaths,
+                options,
+                inputs.FromSurface,
+                inputs.ToSurface);
+            analysisView = DiffOutputFormatter.BuildAnalysisDiffView(
+                inputs.Name,
+                analysis.Rows,
+                analysis.Summary,
+                inputs.FromVersion,
+                inputs.ToVersion);
+        }
+
+        ImplementationDiffView? implementationView = null;
+        if (selected.Contains(DiffSections.ImplementationDiff.Name))
+        {
+            var implementation = BuildImplementationDiff(
+                inputs.FromPaths,
+                inputs.ToPaths,
+                options,
+                inputs.FromSurface,
+                inputs.ToSurface);
+            implementationView = DiffOutputFormatter.BuildImplementationDiffView(
+                inputs.Name,
+                implementation,
+                inputs.FromVersion,
+                inputs.ToVersion);
+        }
+
+        var view = DiffOutputFormatter.BuildDocumentView(
+            inputs.Name,
+            inputs.FromVersion,
+            inputs.ToVersion,
+            changesView,
+            analysisView,
+            implementationView);
+
+        if (options.JsonOutput)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(view, DiffJsonContext.Default.DiffDocumentView));
+            return;
+        }
+
+        Console.WriteLine(OutputFormatter.ApplyRowLimit(
+            DiffOutputFormatter.RenderDocumentView(view),
+            options.Rows));
+    }
 
     internal sealed record AnalysisDiffResult(List<AnalysisDiffRow> Rows, string Summary);
 
@@ -948,6 +1033,8 @@ public record DiffOptions
     public bool OneLine { get; init; }
     public bool Tsv { get; init; }
     public bool Jsonl { get; init; }
+    public bool JsonOutput { get; init; }
+    public bool OneLineExplicitlySet { get; init; }
     public bool FormatExplicitlySet { get; init; }
     public bool NoHeader { get; init; }
     public bool NameOnly { get; init; }

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -142,7 +142,13 @@ public class DiffCommand
                 if (SelectsAnalysisDiff(options))
                 {
                     var analysis = BuildAnalysisDiff(inputs.FromPaths, inputs.ToPaths, options, inputs.FromSurface, inputs.ToSurface);
-                    var view = DiffOutputFormatter.BuildAnalysisDiffView(inputs.Name, analysis.Rows, analysis.Summary, inputs.FromVersion, inputs.ToVersion);
+                    var view = DiffOutputFormatter.BuildAnalysisDiffView(
+                        inputs.Name,
+                        analysis.Rows,
+                        analysis.Summary,
+                        inputs.FromVersion,
+                        inputs.ToVersion,
+                        decorateMember: !options.Jsonl);
                     if (options.Tsv || options.Jsonl)
                     {
                         OutputFormatter.WriteProjectedTable(Console.Out, !options.NoHeader, options.Tsv, options.Jsonl,
@@ -432,7 +438,8 @@ public class DiffCommand
                 analysis.Rows,
                 analysis.Summary,
                 inputs.FromVersion,
-                inputs.ToVersion);
+                inputs.ToVersion,
+                decorateMember: false);
         }
 
         ImplementationDiffView? implementationView = null;
@@ -506,7 +513,7 @@ public class DiffCommand
                 && change.Signal is { Length: > 0 })
             .Select(change => new RankedAnalysisRow(
                 new AnalysisDiffRow(
-                    MarkoutInline.Code(change.Subject.Display),
+                    change.Subject.Display,
                     change.Signal!,
                     change.OldValue ?? "",
                     change.NewValue ?? "",

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -1055,5 +1055,5 @@ public record DiffOptions
     /// <summary>
     /// True when output is raw text (not rendered markdown).
     /// </summary>
-    public bool IsRawOutput => OneLine || Jsonl || NoHeader || NameOnly;
+    public bool IsRawOutput => OneLine || Jsonl || JsonOutput || NoHeader || NameOnly;
 }

--- a/src/dotnet-inspect/JsonContext.cs
+++ b/src/dotnet-inspect/JsonContext.cs
@@ -50,6 +50,15 @@ public partial class JsonContext : JsonSerializerContext
 {
 }
 
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(DiffDocumentView))]
+internal partial class DiffJsonContext : JsonSerializerContext
+{
+}
+
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
 [JsonSerializable(typeof(PackageFileJsonRow))]
 internal partial class PackageFileJsonRowContext : JsonSerializerContext

--- a/src/dotnet-inspect/Output/DiffOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/DiffOutputFormatter.cs
@@ -90,6 +90,92 @@ public static class DiffOutputFormatter
         };
     }
 
+    public static DiffDocumentView BuildDocumentView(
+        string name,
+        string fromVersion,
+        string toVersion,
+        DiffDetailedChangesView? changes,
+        AnalysisDiffView? analysisDiff,
+        ImplementationDiffView? implementationDiff)
+        => new()
+        {
+            Title = $"Diff: {name}",
+            Versions = $"{fromVersion} -> {toVersion}",
+            ChangesSummary = changes?.Summary,
+            AnalysisDiffSummary = analysisDiff?.Summary,
+            ImplementationDiffSummary = implementationDiff?.Summary,
+            Changes = changes?.Rows,
+            AnalysisDiff = analysisDiff?.Rows,
+            ImplementationDiff = implementationDiff?.Rows
+        };
+
+    public static string RenderDocumentView(DiffDocumentView view)
+    {
+        var writer = new MarkoutWriter(new MarkdownFormatter());
+        writer.WriteHeading(1, view.Title);
+        writer.WriteParagraph($"**Versions:** {view.Versions}");
+
+        if (view.ChangesSummary is not null)
+        {
+            WriteDocumentSection(
+                writer,
+                "Changes",
+                view.ChangesSummary,
+                ["Change", "Classification", "Type", "Member", "Kind", "Detail", "Old", "New"],
+                ["change", "classification", "type", "member", "kind", "detail", "old", "new"],
+                view.Changes?.Select(row => new[]
+                {
+                    row.Change, row.Classification, row.Type, row.Member,
+                    row.Kind, row.Detail, row.Old, row.New
+                }));
+        }
+
+        if (view.AnalysisDiffSummary is not null)
+        {
+            WriteDocumentSection(
+                writer,
+                "Analysis Diff",
+                view.AnalysisDiffSummary,
+                ["Member", "Signal", "Old", "New", "Delta", "Shape", "Evidence"],
+                ["member", "signal", "old", "new", "delta", "shape", "evidence"],
+                view.AnalysisDiff?.Select(row => new[]
+                {
+                    row.Member, row.Signal, row.Old, row.New, row.Delta,
+                    row.Shape ?? "", row.Evidence ?? ""
+                }));
+        }
+
+        if (view.ImplementationDiffSummary is not null)
+        {
+            WriteDocumentSection(
+                writer,
+                "Implementation Diff",
+                view.ImplementationDiffSummary,
+                ["Member", "Mechanism", "Change", "Evidence"],
+                ["member", "mechanism", "change", "evidence"],
+                view.ImplementationDiff?.Select(row => new[]
+                {
+                    row.Member, row.Mechanism, row.Change, row.Evidence
+                }));
+        }
+
+        return writer.ToString().TrimEnd();
+    }
+
+    private static void WriteDocumentSection(
+        MarkoutWriter writer,
+        string name,
+        string summary,
+        string[] headers,
+        string[] stableHeaders,
+        IEnumerable<string[]>? rows)
+    {
+        writer.WriteHeading(2, name);
+        writer.WriteParagraph(summary);
+        if (rows is not null)
+            writer.WriteTable(headers, stableHeaders, rows.ToArray());
+    }
+
     public static DiffFullView BuildFullView(string name, IReadOnlyList<TypeDiff> typeDiffs, string fromVersion, string toVersion)
     {
         var view = new DiffFullView

--- a/src/dotnet-inspect/Output/DiffOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/DiffOutputFormatter.cs
@@ -103,7 +103,9 @@ public static class DiffOutputFormatter
             Versions = $"{fromVersion} -> {toVersion}",
             ChangesSummary = changes?.Summary,
             AnalysisDiffSummary = analysisDiff?.Summary,
+            AnalysisDiffNote = DistinctStatusMessage(analysisDiff),
             ImplementationDiffSummary = implementationDiff?.Summary,
+            ImplementationDiffNote = DistinctStatusMessage(implementationDiff),
             Changes = changes?.Rows,
             AnalysisDiff = analysisDiff?.Rows,
             ImplementationDiff = implementationDiff?.Rows
@@ -121,6 +123,7 @@ public static class DiffOutputFormatter
                 writer,
                 "Changes",
                 view.ChangesSummary,
+                null,
                 ["Change", "Classification", "Type", "Member", "Kind", "Detail", "Old", "New"],
                 ["change", "classification", "type", "member", "kind", "detail", "old", "new"],
                 view.Changes?.Select(row => new[]
@@ -136,6 +139,7 @@ public static class DiffOutputFormatter
                 writer,
                 "Analysis Diff",
                 view.AnalysisDiffSummary,
+                view.AnalysisDiffNote,
                 ["Member", "Signal", "Old", "New", "Delta", "Shape", "Evidence"],
                 ["member", "signal", "old", "new", "delta", "shape", "evidence"],
                 view.AnalysisDiff?.Select(row => new[]
@@ -151,6 +155,7 @@ public static class DiffOutputFormatter
                 writer,
                 "Implementation Diff",
                 view.ImplementationDiffSummary,
+                view.ImplementationDiffNote,
                 ["Member", "Mechanism", "Change", "Evidence"],
                 ["member", "mechanism", "change", "evidence"],
                 view.ImplementationDiff?.Select(row => new[]
@@ -166,15 +171,28 @@ public static class DiffOutputFormatter
         MarkoutWriter writer,
         string name,
         string summary,
+        string? note,
         string[] headers,
         string[] stableHeaders,
         IEnumerable<string[]>? rows)
     {
         writer.WriteHeading(2, name);
         writer.WriteParagraph(summary);
+        if (note is not null)
+            writer.WriteCallout(CalloutSeverity.Note, note);
         if (rows is not null)
             writer.WriteTable(headers, stableHeaders, rows.ToArray());
     }
+
+    private static string? DistinctStatusMessage(AnalysisDiffView? view)
+        => view is not null && !string.Equals(view.Status.Message, view.Summary, StringComparison.Ordinal)
+            ? view.Status.Message
+            : null;
+
+    private static string? DistinctStatusMessage(ImplementationDiffView? view)
+        => view is not null && !string.Equals(view.Status.Message, view.Summary, StringComparison.Ordinal)
+            ? view.Status.Message
+            : null;
 
     public static DiffFullView BuildFullView(string name, IReadOnlyList<TypeDiff> typeDiffs, string fromVersion, string toVersion)
     {

--- a/src/dotnet-inspect/Output/DiffOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/DiffOutputFormatter.cs
@@ -144,7 +144,7 @@ public static class DiffOutputFormatter
                 ["member", "signal", "old", "new", "delta", "shape", "evidence"],
                 view.AnalysisDiff?.Select(row => new[]
                 {
-                    row.Member, row.Signal, row.Old, row.New, row.Delta,
+                    MarkoutInline.Code(row.Member), row.Signal, row.Old, row.New, row.Delta,
                     row.Shape ?? "", row.Evidence ?? ""
                 }));
         }
@@ -236,7 +236,13 @@ public static class DiffOutputFormatter
     /// <summary>
     /// Builds the Analysis Diff view with a caller-supplied summary line.
     /// </summary>
-    public static AnalysisDiffView BuildAnalysisDiffView(string name, IReadOnlyList<AnalysisDiffRow> rows, string summary, string fromVersion, string toVersion)
+    public static AnalysisDiffView BuildAnalysisDiffView(
+        string name,
+        IReadOnlyList<AnalysisDiffRow> rows,
+        string summary,
+        string fromVersion,
+        string toVersion,
+        bool decorateMember = true)
         => new()
         {
             Title = $"Analysis Diff: {name}",
@@ -245,7 +251,11 @@ public static class DiffOutputFormatter
             Status = rows.Count == 0
                 ? new Callout(CalloutSeverity.Note, summary)
                 : new Callout(CalloutSeverity.Note, "Analysis signal changes are body-level evidence, not public API compatibility changes."),
-            Rows = rows.Count > 0 ? rows.ToList() : null
+            Rows = rows.Count > 0
+                ? rows.Select(row => decorateMember
+                    ? row with { Member = MarkoutInline.Code(row.Member) }
+                    : row).ToList()
+                : null
         };
 
     /// <summary>

--- a/src/dotnet-inspect/Views/DiffViews.cs
+++ b/src/dotnet-inspect/Views/DiffViews.cs
@@ -42,6 +42,27 @@ public record DiffDetailedChangeRow(
     string Old,
     string New);
 
+[MarkoutSerializable(
+    TitleProperty = nameof(Title),
+    FieldLayout = FieldLayout.Table)]
+public class DiffDocumentView
+{
+    [MarkoutIgnore] public string Title { get; set; } = "";
+    public string Versions { get; set; } = "";
+    public string? ChangesSummary { get; set; }
+    public string? AnalysisDiffSummary { get; set; }
+    public string? ImplementationDiffSummary { get; set; }
+
+    [MarkoutSection(Name = "Changes")]
+    public List<DiffDetailedChangeRow>? Changes { get; set; }
+
+    [MarkoutSection(Name = "Analysis Diff")]
+    public List<AnalysisDiffRow>? AnalysisDiff { get; set; }
+
+    [MarkoutSection(Name = "Implementation Diff")]
+    public List<ImplementationDiffRow>? ImplementationDiff { get; set; }
+}
+
 /// <summary>
 /// View model for full diff rendering. Uses GroupBy to partition changes
 /// by type name, rendering each type as a subheading with its changes as list items.
@@ -119,6 +140,7 @@ public record DiffChangeRow(
 [MarkoutContext(typeof(DiffOneLineRow))]
 [MarkoutContext(typeof(DiffDetailedChangesView))]
 [MarkoutContext(typeof(DiffDetailedChangeRow))]
+[MarkoutContext(typeof(DiffDocumentView))]
 [MarkoutContext(typeof(DiffFullView))]
 [MarkoutContext(typeof(DiffChangeRow))]
 [MarkoutContext(typeof(AnalysisDiffView))]

--- a/src/dotnet-inspect/Views/DiffViews.cs
+++ b/src/dotnet-inspect/Views/DiffViews.cs
@@ -51,7 +51,9 @@ public class DiffDocumentView
     public string Versions { get; set; } = "";
     public string? ChangesSummary { get; set; }
     public string? AnalysisDiffSummary { get; set; }
+    public string? AnalysisDiffNote { get; set; }
     public string? ImplementationDiffSummary { get; set; }
+    public string? ImplementationDiffNote { get; set; }
 
     [MarkoutSection(Name = "Changes")]
     public List<DiffDetailedChangeRow>? Changes { get; set; }


### PR DESCRIPTION
## Summary

- compose every selected diff section in Markdown and JSON, including empty-state summaries
- reject explicit table, TSV, and JSONL output when multiple sections are selected
- register `diff --json`/`--markdown` and preserve single-section/default rendering

## Validation

- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-restore -- -class DotnetInspector.Tests.DiffCommandTests`
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-restore -- -class DotnetInspector.Tests.CommandLineTests`
- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- `npx markdownlint-cli docs/architecture.md`

## Adversarial review

Claude Opus 4.8 and Gemini 3.1 Pro both identified the missing real CLI JSON registration in the first round. Commit c8437879 wires JSON/Markdown through the shared format resolver and adds end-to-end CLI coverage. Both reviewers returned CLEAN on the final head.

Fixes #2639