### PR TITLE
Classify pointer store compile-back diff

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -102,6 +102,13 @@ public class FidelityGateTests
         // over-render. Pre-existing slow-docket gap surfaced by running the gate
         // locally — the lowered/sugared gates are Speed=Slow (Deep Inspect / publish only).
         "CharConditionalElementStore",
+        // PointerStoreUsesOriginalAddress (#2644): the raised source preserves
+        // the original pointer address across the argument reassignment
+        // (`*S_... =`, never `*ptr =`), but compile-back introduces locals around
+        // the conditional value before the indirect store. Valid C#, not
+        // opcode-exact; the address-preservation shape is pinned separately by
+        // Rung6PointerStore_PreservesOriginalAddressAcrossArgumentStore.
+        "PointerStoreUsesOriginalAddress",
         // Unmasked by the in/out skeleton-parameter fix (#1931): these CfgSampleClass
         // methods were RecompileFail before — the whole reconstructed type failed to
         // compile because InOperatorVec's in-parameter operators rendered as illegal

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -107,7 +107,8 @@ public class FidelityGateTests
         // (`*S_... =`, never `*ptr =`), but compile-back introduces locals around
         // the conditional value before the indirect store. Valid C#, not
         // opcode-exact; the address-preservation shape is pinned separately by
-        // Rung6PointerStore_PreservesOriginalAddressAcrossArgumentStore.
+        // Rung6PointerStore_PreservesOriginalAddressAcrossArgumentStore and
+        // checkability is pinned below.
         "PointerStoreUsesOriginalAddress",
         // Unmasked by the in/out skeleton-parameter fix (#1931): these CfgSampleClass
         // methods were RecompileFail before — the whole reconstructed type failed to
@@ -341,6 +342,22 @@ public class FidelityGateTests
                 result.Status is FidelityCheck.CompileBackStatus.Exact or FidelityCheck.CompileBackStatus.OpcodeDiff,
                 $"SwitchStoreThenUse regressed to {result.Status}: the switch-store fold (#1710) no longer "
                     + "recompiles. Its decompiled C# must stay recompilable.\n"
+                    + $"  original : {result.OriginalOpcodes}\n  recompiled: {result.RecompiledOpcodes}");
+    }
+
+    [Fact]
+    public void PointerStoreUsesOriginalAddress_StaysCompileBackCheckable()
+    {
+        var matches = EvaluateFixtures().Where(r => r.Method == "PointerStoreUsesOriginalAddress").ToList();
+
+        Assert.True(matches.Count > 0,
+            "Expected the fidelity check to render PointerStoreUsesOriginalAddress, but it was not evaluated.");
+        foreach (var result in matches)
+            Assert.True(
+                result.Status is FidelityCheck.CompileBackStatus.Exact or FidelityCheck.CompileBackStatus.OpcodeDiff,
+                $"PointerStoreUsesOriginalAddress regressed to {result.Status}: the pointer-store residual (#2644) "
+                    + "no longer recompiles. Its decompiled C# must stay recompilable so the known-diff docket "
+                    + "continues to check the address-preservation shape.\n"
                     + $"  original : {result.OriginalOpcodes}\n  recompiled: {result.RecompiledOpcodes}");
     }
 }

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -666,6 +666,16 @@ public class LadderRung6GateTests
     }
 
     [Fact]
+    public void Rung6LoweredPointerStore_PreservesOriginalAddressAcrossArgumentStore()
+    {
+        var output = LoweredCfg(nameof(CfgSampleClass.PointerStoreUsesOriginalAddress));
+
+        Assert.Contains("ptr =", output);
+        Assert.Contains("*S_", output);
+        Assert.DoesNotContain("*ptr =", output);
+    }
+
+    [Fact]
     public void Rung6UnspellableVolatileAndPinnedShapes_DegradeHonestly()
     {
         var volatileLoad = VolatileIndirectRead(isVolatile: true);
@@ -1018,6 +1028,14 @@ public class LadderRung6GateTests
         var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
         Assert.NotNull(function);
         return CSharpPrinter.PrintRaised(function!, method => IrImporter.Import(source, method)).Output ?? "";
+    }
+
+    static string LoweredCfg(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        return CSharpPrinter.PrintLowered(function!).Output ?? "";
     }
 
     static List<(string Name, IrFunction Function, DecompilerResult Result, string Body)> LoadRaisedMembers(

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -96,7 +96,8 @@ public class LoweredFidelityGateTests
         // the sugared view. The lowered body keeps the original pointer address
         // in the store target, but compile-back introduces locals around the
         // conditional value before stind.i4, so the canonical opcode stream
-        // differs without changing the represented address semantics.
+        // differs without changing the represented address semantics. Checkability
+        // is pinned below.
         "PointerStoreUsesOriginalAddress",
         // Unmasked by the in/out skeleton-parameter fix (#1931): RecompileFail before
         // (the reconstructed CfgSampleClass failed to compile on InOperatorVec's
@@ -208,5 +209,21 @@ public class LoweredFidelityGateTests
                     $"{method} regressed to {result.Status} in the lowered view: a prior fidelity check fix no longer holds.\n" +
                     $"  original : {result.OriginalOpcodes}\n  recompiled: {result.RecompiledOpcodes}");
         }
+    }
+
+    [Fact]
+    public void PointerStoreUsesOriginalAddress_StaysCompileBackCheckable()
+    {
+        var matches = EvaluateFixtures().Where(r => r.Method == "PointerStoreUsesOriginalAddress").ToList();
+
+        Assert.True(matches.Count > 0,
+            "Expected the lowered fidelity check to render PointerStoreUsesOriginalAddress, but it was not evaluated.");
+        foreach (var result in matches)
+            Assert.True(
+                result.Status is FidelityCheck.CompileBackStatus.Exact or FidelityCheck.CompileBackStatus.OpcodeDiff,
+                $"PointerStoreUsesOriginalAddress regressed to {result.Status} in the lowered view: the pointer-store "
+                    + "residual (#2644) no longer recompiles. Its lowered C# must stay recompilable so the known-diff "
+                    + "docket continues to check the address-preservation shape.\n"
+                    + $"  original : {result.OriginalOpcodes}\n  recompiled: {result.RecompiledOpcodes}");
     }
 }

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -92,6 +92,12 @@ public class LoweredFidelityGateTests
         // neither). See the sibling FidelityGateTests docket.
         "CharConditionalElementStore",
         "WhileNestedContinueKeepsArmExclusive",
+        // PointerStoreUsesOriginalAddress (#2644): same intentional residual as
+        // the sugared view. The lowered body keeps the original pointer address
+        // in the store target, but compile-back introduces locals around the
+        // conditional value before stind.i4, so the canonical opcode stream
+        // differs without changing the represented address semantics.
+        "PointerStoreUsesOriginalAddress",
         // Unmasked by the in/out skeleton-parameter fix (#1931): RecompileFail before
         // (the reconstructed CfgSampleClass failed to compile on InOperatorVec's
         // in-parameter operators rendered as illegal `ref`). Now compile-checked,


### PR DESCRIPTION
Fixes #2644

## Change

**Conclusion:** **PASS** - `PointerStoreUsesOriginalAddress` is an intentional compile-back opcode residual, not an unpinned product regression.

The fixture still renders through the preserved original pointer address (`*S_...`, not `*ptr =`) while Roslyn compile-back introduces locals around the conditional value/store, producing a canonical opcode diff.

## Evidence

| Check | Result |
| --- | --- |
| Stage 8 opcode boss | `NoNewOpcodeDiffsBeyondKnownDocket` passed for sugared and lowered gates |
| Pointer checkability pins | Sugared and lowered `PointerStoreUsesOriginalAddress_StaysCompileBackCheckable` passed |
| Address-preservation guards | Raised and lowered `Rung6*PointerStore_PreservesOriginalAddressAcrossArgumentStore` passed |

Opcode evidence:

```text
orig : ldarg ldarg dup starg ldc.i4 conv.u beq ldc.i4 br ldc.i4 stind.i4 ldarg ldind.i4 ret
recmp: ldarg ldarg stloc dup starg ldc.i4 conv.u beq ldc.i4 br ldc.i4 stloc ldloc ldloc stind.i4 ldarg ldind.i4 ret
```

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Clean after fix | First pass requested explicit checkability and lowered address-preservation guards; `33445884` added them. Second pass reported CLEAN with only a non-blocking assertion wording note. |
| Gemini 3.1 Pro | Clean | Confirmed both dockets are updated, both gates stay green, and the new guards cover the silent `RecompileFail` and lowered-shape risks. |

**Review conclusion:** **PASS** - two clean second-pass adversarial reviews; the only first-pass finding was resolved by `33445884`.

## Validation

```bash
dotnet restore dotnet-inspect.slnx --configfile nuget.config
dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- \
  -method "*NoNewOpcodeDiffsBeyondKnownDocket*" \
  -method "*PointerStoreUsesOriginalAddress_StaysCompileBackCheckable*" \
  -method "*Rung6PointerStore_PreservesOriginalAddressAcrossArgumentStore*" \
  -method "*Rung6LoweredPointerStore_PreservesOriginalAddressAcrossArgumentStore*"
```

Result: `Total: 6, Errors: 0, Failed: 0, Skipped: 0`.
