### PR TITLE
Throttle decompiler test runner parallelism

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -23,6 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\ILInspector.Decompiler\ILInspector.Decompiler.csproj" />
     <ProjectReference Include="..\ILInspector.CSharp\ILInspector.CSharp.csproj" />
     <ProjectReference Include="..\ILInspector.Instructions\ILInspector.Instructions.csproj" />

--- a/src/ILInspector.Decompiler.Tests/xunit.runner.json
+++ b/src/ILInspector.Decompiler.Tests/xunit.runner.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "diagnosticMessages": true,
+  "longRunningTestSeconds": 300,
+  "maxParallelThreads": 2,
+  "parallelAlgorithm": "conservative"
+}


### PR DESCRIPTION
## Summary

- Cap `ILInspector.Decompiler.Tests` xUnit collection parallelism at 2 threads.
- Enable long-running-test diagnostics after 300 seconds.
- Copy `xunit.runner.json` to the test output so `dotnet run --project src/ILInspector.Decompiler.Tests` picks it up automatically.

## Context

This addresses observed machine contention from four orphaned/lingering `ILInspector.Decompiler.Tests` processes, each running for ~4 hours at ~270% CPU after agents were otherwise idle. The immediate cleanup killed only those specific test PIDs after capturing process evidence.

## Validation

```bash
dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config --verbosity quiet
ls -l artifacts/bin/ILInspector.Decompiler.Tests/release/xunit.runner.json
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method '*PrintLowered_DesugarsLockToExplicitMonitor*'
```

The filtered run reported `parallel test collections = on [2 threads]` and passed 1/1.
