### PR TITLE
Use structural RTS artifact requests

### DIFF
--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -809,13 +809,13 @@ static class ReturnToSender
 
         for (int iteration = 0; iteration < maxIterations; iteration++)
         {
-            var sourceResult = CompileBackSourceComposer.Compose(new ArtifactRequest(
-                Kind: ArtifactKind.PropertyGetter,
+            var sourceResult = CompileBackSourceComposer.Compose(new PropertyGetterArtifactRequest(
                 AssemblyPath: assemblyPath,
                 Reader: reader,
                 Function: function,
                 TargetType: typeHandle,
                 TargetMethod: getterHandle,
+                TargetProperty: propertyHandle,
                 TargetBody: printed.Output,
                 FullType: fullType,
                 MethodName: methodName,
@@ -823,8 +823,7 @@ static class ReturnToSender
                 SignatureText: CorpusMethodIdentity.SignatureText(function.Signature),
                 ClosureRoots: closureRoots,
                 ClosureFacts: closureFacts,
-                ClosureMemberRequirements: closureMemberRequirements,
-                TargetProperty: propertyHandle));
+                ClosureMemberRequirements: closureMemberRequirements));
             var plan = sourceResult.Plan;
 
             if (plan.Diagnostics.FirstOrDefault(diagnostic => diagnostic.Layer == "type identity") is { } identityDiagnostic)
@@ -909,13 +908,13 @@ static class ReturnToSender
         }
 
         {
-            var sourceResult = CompileBackSourceComposer.Compose(new ArtifactRequest(
-                Kind: ArtifactKind.PropertyGetter,
+            var sourceResult = CompileBackSourceComposer.Compose(new PropertyGetterArtifactRequest(
                 AssemblyPath: assemblyPath,
                 Reader: reader,
                 Function: function,
                 TargetType: typeHandle,
                 TargetMethod: getterHandle,
+                TargetProperty: propertyHandle,
                 TargetBody: printed.Output,
                 FullType: fullType,
                 MethodName: methodName,
@@ -923,8 +922,7 @@ static class ReturnToSender
                 SignatureText: CorpusMethodIdentity.SignatureText(function.Signature),
                 ClosureRoots: closureRoots,
                 ClosureFacts: closureFacts,
-                ClosureMemberRequirements: closureMemberRequirements,
-                TargetProperty: propertyHandle));
+                ClosureMemberRequirements: closureMemberRequirements));
             var plan = sourceResult.Plan;
             return new Result(
                 plan,
@@ -986,8 +984,7 @@ static class ReturnToSender
 
         for (int iteration = 0; iteration < maxIterations; iteration++)
         {
-            var sourceResult = CompileBackSourceComposer.Compose(new ArtifactRequest(
-                Kind: ArtifactKind.Method,
+            var sourceResult = CompileBackSourceComposer.Compose(new MethodArtifactRequest(
                 AssemblyPath: assemblyPath,
                 Reader: reader,
                 Function: function,
@@ -1000,8 +997,7 @@ static class ReturnToSender
                 SignatureText: CorpusMethodIdentity.SignatureText(function.Signature),
                 ClosureRoots: closureRoots,
                 ClosureFacts: closureFacts,
-                ClosureMemberRequirements: closureMemberRequirements,
-                TargetProperty: null));
+                ClosureMemberRequirements: closureMemberRequirements));
             var plan = sourceResult.Plan;
 
             if (plan.Diagnostics.FirstOrDefault(diagnostic => diagnostic.Layer == "type identity") is { } identityDiagnostic)
@@ -1086,8 +1082,7 @@ static class ReturnToSender
         }
 
         {
-            var sourceResult = CompileBackSourceComposer.Compose(new ArtifactRequest(
-                Kind: ArtifactKind.Method,
+            var sourceResult = CompileBackSourceComposer.Compose(new MethodArtifactRequest(
                 AssemblyPath: assemblyPath,
                 Reader: reader,
                 Function: function,
@@ -1100,8 +1095,7 @@ static class ReturnToSender
                 SignatureText: CorpusMethodIdentity.SignatureText(function.Signature),
                 ClosureRoots: closureRoots,
                 ClosureFacts: closureFacts,
-                ClosureMemberRequirements: closureMemberRequirements,
-                TargetProperty: null));
+                ClosureMemberRequirements: closureMemberRequirements));
             var plan = sourceResult.Plan;
             return new Result(
                 plan,
@@ -1164,13 +1158,13 @@ static class ReturnToSender
 
         for (int iteration = 0; iteration < maxIterations; iteration++)
         {
-            var sourceResult = CompileBackSourceComposer.Compose(new ArtifactRequest(
-                Kind: ArtifactKind.PropertySetter,
+            var sourceResult = CompileBackSourceComposer.Compose(new PropertySetterArtifactRequest(
                 AssemblyPath: assemblyPath,
                 Reader: reader,
                 Function: function,
                 TargetType: typeHandle,
                 TargetMethod: setterHandle,
+                TargetProperty: propertyHandle,
                 TargetBody: printed.Output,
                 FullType: fullType,
                 MethodName: methodName,
@@ -1178,8 +1172,7 @@ static class ReturnToSender
                 SignatureText: CorpusMethodIdentity.SignatureText(function.Signature),
                 ClosureRoots: closureRoots,
                 ClosureFacts: closureFacts,
-                ClosureMemberRequirements: closureMemberRequirements,
-                TargetProperty: propertyHandle));
+                ClosureMemberRequirements: closureMemberRequirements));
             var plan = sourceResult.Plan;
 
             if (plan.Diagnostics.FirstOrDefault(diagnostic => diagnostic.Layer == "type identity") is { } identityDiagnostic)
@@ -1264,13 +1257,13 @@ static class ReturnToSender
         }
 
         {
-            var sourceResult = CompileBackSourceComposer.Compose(new ArtifactRequest(
-                Kind: ArtifactKind.PropertySetter,
+            var sourceResult = CompileBackSourceComposer.Compose(new PropertySetterArtifactRequest(
                 AssemblyPath: assemblyPath,
                 Reader: reader,
                 Function: function,
                 TargetType: typeHandle,
                 TargetMethod: setterHandle,
+                TargetProperty: propertyHandle,
                 TargetBody: printed.Output,
                 FullType: fullType,
                 MethodName: methodName,
@@ -1278,8 +1271,7 @@ static class ReturnToSender
                 SignatureText: CorpusMethodIdentity.SignatureText(function.Signature),
                 ClosureRoots: closureRoots,
                 ClosureFacts: closureFacts,
-                ClosureMemberRequirements: closureMemberRequirements,
-                TargetProperty: propertyHandle));
+                ClosureMemberRequirements: closureMemberRequirements));
             var plan = sourceResult.Plan;
             return new Result(
                 plan,

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -169,15 +169,7 @@ static class CompileBackCSharpNames
             or "while" or "record" or "required" or "init" or "file" or "scoped";
 }
 
-internal enum ArtifactKind
-{
-    Method,
-    PropertyGetter,
-    PropertySetter,
-}
-
-internal sealed record ArtifactRequest(
-    ArtifactKind Kind,
+internal abstract record ArtifactRequest(
     string AssemblyPath,
     MetadataReader Reader,
     IrFunction Function,
@@ -190,8 +182,128 @@ internal sealed record ArtifactRequest(
     string SignatureText,
     IReadOnlySet<TypeDefinitionHandle> ClosureRoots,
     IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> ClosureFacts,
-    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> ClosureMemberRequirements,
-    PropertyDefinitionHandle? TargetProperty);
+    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> ClosureMemberRequirements);
+
+internal sealed record MethodArtifactRequest(
+    string AssemblyPath,
+    MetadataReader Reader,
+    IrFunction Function,
+    TypeDefinitionHandle TargetType,
+    MethodDefinitionHandle TargetMethod,
+    string TargetBody,
+    string FullType,
+    string MethodName,
+    int Overload,
+    string SignatureText,
+    IReadOnlySet<TypeDefinitionHandle> ClosureRoots,
+    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> ClosureFacts,
+    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> ClosureMemberRequirements)
+    : ArtifactRequest(
+        AssemblyPath,
+        Reader,
+        Function,
+        TargetType,
+        TargetMethod,
+        TargetBody,
+        FullType,
+        MethodName,
+        Overload,
+        SignatureText,
+        ClosureRoots,
+        ClosureFacts,
+        ClosureMemberRequirements);
+
+internal abstract record PropertyAccessorArtifactRequest(
+    string AssemblyPath,
+    MetadataReader Reader,
+    IrFunction Function,
+    TypeDefinitionHandle TargetType,
+    MethodDefinitionHandle TargetMethod,
+    PropertyDefinitionHandle TargetProperty,
+    string TargetBody,
+    string FullType,
+    string MethodName,
+    int Overload,
+    string SignatureText,
+    IReadOnlySet<TypeDefinitionHandle> ClosureRoots,
+    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> ClosureFacts,
+    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> ClosureMemberRequirements)
+    : ArtifactRequest(
+        AssemblyPath,
+        Reader,
+        Function,
+        TargetType,
+        TargetMethod,
+        TargetBody,
+        FullType,
+        MethodName,
+        Overload,
+        SignatureText,
+        ClosureRoots,
+        ClosureFacts,
+        ClosureMemberRequirements);
+
+internal sealed record PropertyGetterArtifactRequest(
+    string AssemblyPath,
+    MetadataReader Reader,
+    IrFunction Function,
+    TypeDefinitionHandle TargetType,
+    MethodDefinitionHandle TargetMethod,
+    PropertyDefinitionHandle TargetProperty,
+    string TargetBody,
+    string FullType,
+    string MethodName,
+    int Overload,
+    string SignatureText,
+    IReadOnlySet<TypeDefinitionHandle> ClosureRoots,
+    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> ClosureFacts,
+    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> ClosureMemberRequirements)
+    : PropertyAccessorArtifactRequest(
+        AssemblyPath,
+        Reader,
+        Function,
+        TargetType,
+        TargetMethod,
+        TargetProperty,
+        TargetBody,
+        FullType,
+        MethodName,
+        Overload,
+        SignatureText,
+        ClosureRoots,
+        ClosureFacts,
+        ClosureMemberRequirements);
+
+internal sealed record PropertySetterArtifactRequest(
+    string AssemblyPath,
+    MetadataReader Reader,
+    IrFunction Function,
+    TypeDefinitionHandle TargetType,
+    MethodDefinitionHandle TargetMethod,
+    PropertyDefinitionHandle TargetProperty,
+    string TargetBody,
+    string FullType,
+    string MethodName,
+    int Overload,
+    string SignatureText,
+    IReadOnlySet<TypeDefinitionHandle> ClosureRoots,
+    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> ClosureFacts,
+    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> ClosureMemberRequirements)
+    : PropertyAccessorArtifactRequest(
+        AssemblyPath,
+        Reader,
+        Function,
+        TargetType,
+        TargetMethod,
+        TargetProperty,
+        TargetBody,
+        FullType,
+        MethodName,
+        Overload,
+        SignatureText,
+        ClosureRoots,
+        ClosureFacts,
+        ClosureMemberRequirements);
 
 internal sealed record ProductArtifact(
     ArtifactRequest Request,
@@ -382,14 +494,14 @@ public static class CompileBackSourceComposer
 {
     internal static ProductArtifact Compose(ArtifactRequest request)
     {
-        var result = request.Kind switch
+        var result = request switch
         {
-            ArtifactKind.PropertyGetter => ComposePropertyGetter(
+            PropertyGetterArtifactRequest getter => ComposePropertyGetter(
                 request.AssemblyPath,
                 request.Reader,
                 request.Function,
                 request.TargetType,
-                RequiredProperty(request),
+                getter.TargetProperty,
                 request.TargetMethod,
                 request.TargetBody,
                 request.FullType,
@@ -399,12 +511,12 @@ public static class CompileBackSourceComposer
                 request.ClosureRoots,
                 request.ClosureFacts,
                 request.ClosureMemberRequirements),
-            ArtifactKind.PropertySetter => ComposePropertySetter(
+            PropertySetterArtifactRequest setter => ComposePropertySetter(
                 request.AssemblyPath,
                 request.Reader,
                 request.Function,
                 request.TargetType,
-                RequiredProperty(request),
+                setter.TargetProperty,
                 request.TargetMethod,
                 request.TargetBody,
                 request.FullType,
@@ -414,7 +526,7 @@ public static class CompileBackSourceComposer
                 request.ClosureRoots,
                 request.ClosureFacts,
                 request.ClosureMemberRequirements),
-            ArtifactKind.Method => ComposeMethod(
+            MethodArtifactRequest => ComposeMethod(
                 request.AssemblyPath,
                 request.Reader,
                 request.Function,
@@ -428,15 +540,11 @@ public static class CompileBackSourceComposer
                 request.ClosureRoots,
                 request.ClosureFacts,
                 request.ClosureMemberRequirements),
-            _ => throw new ArgumentOutOfRangeException(nameof(request), request.Kind, "Unknown artifact kind."),
+            _ => throw new ArgumentException($"Unknown artifact request type '{request.GetType().FullName}'.", nameof(request)),
         };
 
         return ProductArtifact.From(request, result);
     }
-
-    static PropertyDefinitionHandle RequiredProperty(ArtifactRequest request)
-        => request.TargetProperty
-            ?? throw new ArgumentException($"{request.Kind} artifact requests require a target property.", nameof(request));
 
     public static CompileBackMemberRequirement? TryCreateClosureMemberRequirement(
         MetadataReader reader,


### PR DESCRIPTION
- Follows up #2647 feedback
- Changes harness-only artifact request shape; product output is unchanged
- Evidence revision: `fddad52a`

## Change

**Conclusion:** **PASS** — replaces the nullable `TargetProperty` validated slot with structural method/getter/setter request records, so property handles are required by construction for accessor artifacts and absent from method artifacts.

Before:

```text
ArtifactRequest carried ArtifactKind plus PropertyDefinitionHandle? TargetProperty; getter/setter dispatch validated the nullable slot at runtime.
```

After:

```text
MethodArtifactRequest has no property slot; PropertyGetterArtifactRequest and PropertySetterArtifactRequest require TargetProperty in their constructors.
```

## Scope and safety

- **Root cause:** PR #2647 intentionally used the validated-slot pattern for a transitional wrapper; review feedback noted a structural union is the natural end state.
- **Fix shape:** Internal harness-only request variants and type-pattern dispatch in `CompileBackSourceComposer.Compose`.
- **Product impact:** None intended; the underlying `ComposePropertyGetter`, `ComposePropertySetter`, and `ComposeMethod` calls receive the same values as before.
- **Scope boundary:** `ProductArtifact.SourceFacts` remains pre-positioned and unconsumed; assertions can be added when the first consumer lands.

## Evidence

| Check | Result |
| --- | --- |
| DecompilerHarness build | `dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet` passed |
| Focused tests | `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.ReturnToSenderPrototypeTests` passed: 96/96 |

## Review

Adversarial review requested after PR creation; results will be reconciled before marking ready.
