### PR TITLE
Fix reader-backed implementation IL diff

### DIFF
--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -1002,6 +1002,39 @@ public class ResearchDiffTests
     }
 
     [Fact]
+    public void ImplementationDiff_CompareAssemblies_SameTokenBearingAssemblyIsExact()
+    {
+        var path = FixtureCatalog.DiffPair.OldAssemblyPath();
+
+        var diff = ImplementationDiff.CompareAssemblies(
+            path,
+            path,
+            new ImplementationDiffOptions(
+                ImplementationDiffMechanism.IlBody,
+                TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" }));
+
+        Assert.True(diff.IsEmpty);
+    }
+
+    [Fact]
+    public void ImplementationDiff_CompareAssemblies_ResolvesChangedTokenOperandsSymbolically()
+    {
+        var diff = ImplementationDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            new ImplementationDiffOptions(
+                ImplementationDiffMechanism.IlBody,
+                TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" }));
+
+        var changed = Assert.Single(diff.Members, member => member.Subject.MemberName == "CallToken");
+        Assert.DoesNotContain(changed.Changes, change => change.IlDisplayFailureRow is not null);
+        Assert.Contains(changed.Changes, change =>
+            ImplementationDiff.UnifiedLines(change).Any(line => line.Contains("::Abs(", StringComparison.Ordinal)));
+        Assert.Contains(changed.Changes, change =>
+            ImplementationDiff.UnifiedLines(change).Any(line => line.Contains("::Sign(", StringComparison.Ordinal)));
+    }
+
+    [Fact]
     public void ImplementationDiff_CompareAssemblies_FiltersIlEvidenceByType()
     {
         var diff = ImplementationDiff.CompareAssemblies(

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -667,7 +667,11 @@ public static class ResearchDiff
                     continue;
                 }
 
-                var diff = IlBodyDiff.Compare(oldBody!, newBody!);
+                var diff = IlBodyDiff.Compare(
+                    oldBodies.MetadataReader,
+                    oldBody!,
+                    newBodies.MetadataReader,
+                    newBody!);
                 if (diff.IsExact)
                     continue;
                 if (!diff.FailureRows.IsDefaultOrEmpty)
@@ -1134,7 +1138,9 @@ public static class ResearchDiff
             _metadataReader = _peReader.GetMetadataReader();
         }
 
-        public bool TryDecode(int metadataToken, out MethodInstructions? body, out string? unavailableReason)
+        public MetadataReader MetadataReader => _metadataReader;
+
+        public bool TryDecode(int metadataToken, out MethodBodyBlock? body, out string? unavailableReason)
         {
             body = null;
             unavailableReason = null;
@@ -1152,7 +1158,7 @@ public static class ResearchDiff
                 return false;
             }
 
-            body = MethodInstructions.Decode(_peReader.GetMethodBody(method.RelativeVirtualAddress));
+            body = _peReader.GetMethodBody(method.RelativeVirtualAddress);
             return true;
         }
 

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -893,6 +893,12 @@ public class DiffCommandTests
             row.Member.Contains("ConstantValue", StringComparison.Ordinal)
             && row.Mechanism == "IL"
             && row.Evidence.Contains("ldc.i4 1", StringComparison.Ordinal));
+        Assert.Contains(view.Rows!, row =>
+            row.Member.Contains("CallToken", StringComparison.Ordinal)
+            && row.Mechanism == "IL"
+            && row.Evidence.Contains("System.Math::Abs", StringComparison.Ordinal));
+        Assert.DoesNotContain(view.Rows!, row =>
+            row.Evidence.Contains("requires a MetadataReader-backed comparison", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -938,6 +944,19 @@ public class DiffCommandTests
         {
             TypeFilter = ["DiffSample"],
             MemberFilter = ["ConstantValue"]
+        });
+
+        Assert.True(result.IsEmpty);
+    }
+
+    [Fact]
+    public void BuildImplementationDiff_SameTokenBearingAssembly_IsEmpty()
+    {
+        var assembly = FixtureCatalog.DiffPair.OldAssemblyPath();
+
+        var result = DiffCommand.BuildImplementationDiff([assembly], [assembly], new DiffOptions
+        {
+            TypeFilter = ["DiffSample"]
         });
 
         Assert.True(result.IsEmpty);


### PR DESCRIPTION
## Summary

Fix assembly-wide `ImplementationDiff` so metadata-token operands use the
`MetadataReader` instances already owned by Research.

- compare `MethodBodyBlock` values through the reader-backed `IlBodyDiff`
  overload
- preserve fail-closed behavior for genuinely readerless comparisons
- cover exact token-bearing self-diff and symbolic changed-token evidence in
  Research and CLI tests

The issue reproduction now reports:

```text
Summary   No implementation differences detected.
```

Cross-version `CallToken` evidence resolves symbolically from
`System.Math::Abs(int32)` to `System.Math::Sign(int32)`.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- `dotnet run --project src/ILInspector.Research.Tests -c Release --no-restore`
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-restore -- -class "*DiffCommandTests*"`
- exact CLI self-diff reproduction from #2635

Fixes #2635
