### PR TITLE
Consume extension member Findings in DotnetInspector

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -188,6 +188,11 @@ producers or preserve producer-native structural evidence. Failed censuses stay
 distinct from empty results and render as inspection diagnostics without
 suppressing unaffected sections.
 
+Extension discovery follows the same rule for both `library` and `extensions`:
+each assembly is scanned once into Metadata's extension-member Finding census,
+then CLI target, reachability, overload, and display projections consume that
+shared inventory.
+
 ### Metadata Extraction
 
 ```text

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3972,6 +3972,40 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Extensions_FailedAssemblyWarnsAndPreservesSuccessfulResults()
+    {
+        var corruptPath = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-corrupt-{Guid.NewGuid():N}.dll");
+        try
+        {
+            await File.WriteAllTextAsync(
+                corruptPath,
+                "not a PE image",
+                TestContext.Current.CancellationToken);
+
+            var (exit, output, error) = await RunAppAsync(
+                "extensions",
+                "MetadataReader",
+                "--library", typeof(MetadataFindings).Assembly.Location,
+                "--library", corruptPath,
+                "--count",
+                "--tips", "q");
+
+            Assert.Equal(0, exit);
+            Assert.True(int.Parse(output.Trim()) > 0);
+            Assert.Contains(
+                "Warning: Extension member inspection failed",
+                error,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(corruptPath);
+        }
+    }
+
+    [Fact]
     public async Task Extensions_JsonlAfterPackage_RendersJsonlAndDoesNotWarnAboutPackageFlag()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
+++ b/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
@@ -139,7 +139,7 @@ public class ExtensionsCommandTests
     }
 
     [Fact]
-    public void CommandProjection_ConsumesFindingCensusAndPreservesDisplayShape()
+    public void CommandProjection_ConsumesFindingCensusAndHandlesEdgeCases()
     {
         var assembly = new AssemblyCollector.AssemblyInfo(
             typeof(ExtensionsCommandTests).Assembly.Location,
@@ -158,27 +158,12 @@ public class ExtensionsCommandTests
         Assert.Contains("this string", result.Signature, StringComparison.Ordinal);
         Assert.Equal("tests", result.Source);
         Assert.Equal("1.0.0", result.SourceVersion);
-    }
-
-    [Fact]
-    public void CommandProjection_MatchesGenericReceiverDisplayType()
-    {
-        var assembly = new AssemblyCollector.AssemblyInfo(
-            typeof(ExtensionsCommandTests).Assembly.Location,
-            "tests",
-            "1.0.0");
-
-        var census = ExtensionsCommand.InspectExtensionAssembly(assembly, includeAll: true);
-        var result = Assert.Single(
+        var genericResult = Assert.Single(
             ExtensionsCommand.ProjectExtensions(census, "IEnumerable"),
             result => result.MethodName == "FirstOrNull");
 
-        Assert.Contains("IEnumerable<T>", result.ExtendedType, StringComparison.Ordinal);
-    }
+        Assert.Contains("IEnumerable<T>", genericResult.ExtendedType, StringComparison.Ordinal);
 
-    [Fact]
-    public void CommandProjection_AllowsDuplicateFindingAnchors()
-    {
         var first = FindingTestData.ExtensionMember(
             "Duplicate",
             "string",
@@ -189,16 +174,12 @@ public class ExtensionsCommandTests
             ReturnType = "System.Int32",
         };
         var members = new[] { first, second };
-        var assembly = new AssemblyCollector.AssemblyInfo(
-            typeof(ExtensionsCommandTests).Assembly.Location,
-            "tests",
-            "1.0.0");
-        var census = new ExtensionsCommand.ExtensionAssemblyCensus(
+        var duplicateCensus = new ExtensionsCommand.ExtensionAssemblyCensus(
             assembly,
             members,
             MetadataFindings.InspectExtensionMembers(members, FindingTestData.Subject));
 
-        var results = ExtensionsCommand.ProjectExtensions(census, "System.String");
+        var results = ExtensionsCommand.ProjectExtensions(duplicateCensus, "System.String");
 
         Assert.Equal(2, results.Count);
         Assert.Contains(results, result => result.Signature == first.Signature);

--- a/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
+++ b/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
@@ -161,6 +161,51 @@ public class ExtensionsCommandTests
     }
 
     [Fact]
+    public void CommandProjection_MatchesGenericReceiverDisplayType()
+    {
+        var assembly = new AssemblyCollector.AssemblyInfo(
+            typeof(ExtensionsCommandTests).Assembly.Location,
+            "tests",
+            "1.0.0");
+
+        var census = ExtensionsCommand.InspectExtensionAssembly(assembly, includeAll: true);
+        var result = Assert.Single(
+            ExtensionsCommand.ProjectExtensions(census, "IEnumerable"),
+            result => result.MethodName == "FirstOrNull");
+
+        Assert.Contains("IEnumerable<T>", result.ExtendedType, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CommandProjection_AllowsDuplicateFindingAnchors()
+    {
+        var first = FindingTestData.ExtensionMember(
+            "Duplicate",
+            "string",
+            signature: "void Duplicate(this string value)");
+        var second = first with
+        {
+            Signature = "int Duplicate(this string value)",
+            ReturnType = "System.Int32",
+        };
+        var members = new[] { first, second };
+        var assembly = new AssemblyCollector.AssemblyInfo(
+            typeof(ExtensionsCommandTests).Assembly.Location,
+            "tests",
+            "1.0.0");
+        var census = new ExtensionsCommand.ExtensionAssemblyCensus(
+            assembly,
+            members,
+            MetadataFindings.InspectExtensionMembers(members, FindingTestData.Subject));
+
+        var results = ExtensionsCommand.ProjectExtensions(census, "System.String");
+
+        Assert.Equal(2, results.Count);
+        Assert.Contains(results, result => result.Signature == first.Signature);
+        Assert.Contains(results, result => result.Signature == second.Signature);
+    }
+
+    [Fact]
     public void CommandProjection_SurfacesFindingInspectionFailure()
     {
         var missingPath = Path.Combine(

--- a/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
+++ b/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
@@ -1,5 +1,8 @@
 using System.Reflection.PortableExecutable;
 using DotnetInspector.Commands;
+using DotnetInspector.Inspectors;
+using DotnetInspector.Models;
+using ILInspector.Findings;
 using ILInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
@@ -133,6 +136,47 @@ public class ExtensionsCommandTests
         var typeDefExtensions = extensions.Where(e =>
             e.ExtendedType.Contains("TypeDefinition")).ToList();
         Assert.Contains(typeDefExtensions, e => e.MethodName == "IsPublic" && e.Kind == "property");
+    }
+
+    [Fact]
+    public void CommandProjection_ConsumesFindingCensusAndPreservesDisplayShape()
+    {
+        var assembly = new AssemblyCollector.AssemblyInfo(
+            typeof(ExtensionsCommandTests).Assembly.Location,
+            "tests",
+            "1.0.0");
+
+        var census = ExtensionsCommand.InspectExtensionAssembly(assembly, includeAll: true);
+        var finding = Assert.Single(
+            census.Inspection.Findings(),
+            finding => finding.Payload.Anchor.MemberName == "ToUpperCase");
+        var result = Assert.Single(
+            ExtensionsCommand.ProjectExtensions(census, "System.String"),
+            result => result.MethodName == "ToUpperCase");
+
+        Assert.Same(MetadataFindings.ExtensionMemberDescriptor, finding.Descriptor);
+        Assert.Contains("this string", result.Signature, StringComparison.Ordinal);
+        Assert.Equal("tests", result.Source);
+        Assert.Equal("1.0.0", result.SourceVersion);
+    }
+
+    [Fact]
+    public void CommandProjection_SurfacesFindingInspectionFailure()
+    {
+        var missingPath = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-missing-{Guid.NewGuid():N}.dll");
+        var census = ExtensionsCommand.InspectExtensionAssembly(
+            new AssemblyCollector.AssemblyInfo(missingPath, "missing", null),
+            includeAll: false);
+
+        var failure = Assert.IsType<FindingInspection<ExtensionMemberObservation>.Failed>(
+            census.Inspection.Value);
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => ExtensionsCommand.ProjectExtensions(census, "System.String"));
+
+        Assert.Same(MetadataFindings.ExtensionMemberDescriptor, failure.Error.Descriptor);
+        Assert.Contains("Finding inspection failed", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/FindingTestData.cs
+++ b/src/dotnet-inspect.Tests/FindingTestData.cs
@@ -1,8 +1,41 @@
 using ILInspector.Findings;
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
 
 namespace DotnetInspector.Tests;
 
 internal static class FindingTestData
 {
     public static readonly FindingSubject Subject = new("test-library", "Test library");
+
+    public static ExtensionMethodInfo ExtensionMember(
+        string methodName,
+        string extendedType,
+        string extensionClass = "Test.Extensions",
+        string kind = "method",
+        string? signature = null)
+    {
+        string canonicalSignature =
+            $"{(kind == "property" ? "P" : "M")}:{extensionClass}.{methodName}({extendedType})";
+        string fingerprint = MemberAnchor.ComputeFingerprint(canonicalSignature);
+        var anchor = new MemberAnchor(
+            $"extension:{methodName}~{fingerprint}",
+            canonicalSignature,
+            fingerprint,
+            extensionClass,
+            methodName);
+        return new ExtensionMethodInfo(
+            methodName,
+            extensionClass,
+            "Test",
+            extendedType,
+            signature ?? $"void {methodName}(this {extendedType} value)",
+            "Test",
+            kind)
+        {
+            Anchor = anchor,
+            CanonicalExtendedType = extendedType,
+            ReturnType = kind == "property" ? "System.Object" : "System.Void",
+        };
+    }
 }

--- a/src/dotnet-inspect.Tests/LibraryFindingConsumerTests.cs
+++ b/src/dotnet-inspect.Tests/LibraryFindingConsumerTests.cs
@@ -45,6 +45,28 @@ public class LibraryFindingConsumerTests
     }
 
     [Fact]
+    public void ExtensionScanner_RetainsFindingSemanticsAndDisplayProjection()
+    {
+        var inspection = new LibraryInspection();
+
+        LibraryMetadataService.ScanExtensionMembers(
+            typeof(ExtensionsCommandTests).Assembly.Location,
+            inspection,
+            new VerboseLogger(enabled: false));
+
+        var finding = Assert.Single(
+            inspection.ExtensionMemberInspection.Findings(),
+            finding => finding.Payload.Anchor.MemberName == "ToUpperCase");
+        var row = Assert.Single(
+            inspection.ExtensionMethods!,
+            row => row.MethodName == "ToUpperCase");
+
+        Assert.Same(MetadataFindings.ExtensionMemberDescriptor, finding.Descriptor);
+        Assert.Equal(ExtensionMemberKind.Method, finding.Payload.Kind);
+        Assert.Contains("string", row.ExtendedType, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void LibraryJson_ProjectsFindingPayloadsWithExistingShape()
     {
         AssemblyAttributeInfo[] attributes =
@@ -84,6 +106,15 @@ public class LibraryFindingConsumerTests
                 attributes,
                 FindingTestData.Subject),
             attributes);
+        ExtensionMethodInfo[] extensionMembers =
+        [
+            FindingTestData.ExtensionMember("Ext", "Test.Target"),
+        ];
+        inspection.SetExtensionMemberInspection(
+            MetadataFindings.InspectExtensionMembers(
+                extensionMembers,
+                FindingTestData.Subject),
+            extensionMembers);
 
         var json = JsonSerializer.Serialize(inspection, JsonContext.Default.LibraryInspection);
         using var document = JsonDocument.Parse(json);
@@ -103,6 +134,8 @@ public class LibraryFindingConsumerTests
         Assert.Equal("Test.Forwarded", root.GetProperty("type_forwarders")[0].GetProperty("type_name").GetString());
         Assert.Equal("Test.Union", root.GetProperty("union_types")[0].GetProperty("type_name").GetString());
         Assert.Equal("Test.Switch", root.GetProperty("switches")[0].GetProperty("switch").GetString());
+        Assert.Equal("Ext", root.GetProperty("extension_methods")[0].GetProperty("method_name").GetString());
+        Assert.Equal("Test.Target", root.GetProperty("extension_methods")[0].GetProperty("extended_type").GetString());
         Assert.Equal(EcosystemIntegrationNames.AI, root.GetProperty("integrations")[0].GetProperty("integration").GetString());
         Assert.Equal("Test.ChatClient", root.GetProperty("ai")[0].GetProperty("name").GetString());
         Assert.Equal("Test.ActivitySource", root.GetProperty("open_telemetry")[0].GetProperty("name").GetString());
@@ -112,11 +145,15 @@ public class LibraryFindingConsumerTests
     [Fact]
     public void AssemblyAttributeInspection_RequiresExplicitJsonOrder()
     {
-        var property = typeof(LibraryInspection).GetProperty(
+        var attributeProperty = typeof(LibraryInspection).GetProperty(
             nameof(LibraryInspection.AssemblyAttributeInspection));
+        var extensionProperty = typeof(LibraryInspection).GetProperty(
+            nameof(LibraryInspection.ExtensionMemberInspection));
 
-        Assert.NotNull(property);
-        Assert.False(property.CanWrite);
+        Assert.NotNull(attributeProperty);
+        Assert.False(attributeProperty.CanWrite);
+        Assert.NotNull(extensionProperty);
+        Assert.False(extensionProperty.CanWrite);
     }
 
     [Fact]
@@ -134,11 +171,13 @@ public class LibraryFindingConsumerTests
         };
 
         LibraryMetadataService.ScanClassifiedMethods(missingPath, inspection, logger);
+        LibraryMetadataService.ScanExtensionMembers(missingPath, inspection, logger);
         LibraryMetadataService.ScanCustomAttributes(missingPath, inspection, logger);
         LibraryMetadataService.ScanTypeForwarders(missingPath, inspection, logger);
         LibraryMetadataService.ScanIntegrations(missingPath, inspection, logger);
 
         AssertFailure(inspection.ClassifiedMethodInspection, MetadataFindings.ClassifiedMethodDescriptor);
+        AssertFailure(inspection.ExtensionMemberInspection, MetadataFindings.ExtensionMemberDescriptor);
         AssertFailure(inspection.ResourceInspection, MetadataFindings.ResourceDescriptor);
         AssertFailure(inspection.AssemblyAttributeInspection, MetadataFindings.AssemblyAttributeDescriptor);
         AssertFailure(inspection.TypeForwarderInspection, MetadataFindings.TypeForwarderDescriptor);
@@ -146,7 +185,7 @@ public class LibraryFindingConsumerTests
         AssertFailure(inspection.SwitchInspection, MetadataFindings.SwitchDescriptor);
         AssertFailure(inspection.EcosystemIntegrationInspection, MetadataFindings.EcosystemIntegrationDescriptor);
         AssertFailure(inspection.OpenTelemetryInspection, MetadataFindings.OpenTelemetrySignalDescriptor);
-        Assert.Equal(8, inspection.InspectionFailures!.Count);
+        Assert.Equal(9, inspection.InspectionFailures!.Count);
     }
 
     [Fact]
@@ -208,6 +247,29 @@ public class LibraryFindingConsumerTests
     }
 
     [Fact]
+    public void FailedExtensionInspection_DoesNotRenderPresentationRows()
+    {
+        var member = FindingTestData.ExtensionMember("Ext", "Test.Target");
+        var inspection = new LibraryInspection();
+        inspection.SetExtensionMemberInspection(
+            new FindingInspection<ExtensionMemberObservation>.Failed(
+                new InspectionError(
+                    FindingTestData.Subject,
+                    MetadataFindings.ExtensionMemberDescriptor,
+                    "extension scan failed")),
+            [member]);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => inspection.ExtensionMemberInspection.Findings());
+        Assert.Contains("extension scan failed", exception.Message);
+        Assert.Null(inspection.ExtensionMethods);
+
+        var failure = Assert.Single(inspection.InspectionFailures!);
+        Assert.Equal("Extension Methods", failure.Section);
+        Assert.Equal("extension scan failed", failure.Reason);
+    }
+
+    [Fact]
     public void FindingJsonProjections_AreCachedAndInvalidatedWithTheirInspection()
     {
         var inspection = new LibraryInspection
@@ -251,6 +313,7 @@ public class LibraryFindingConsumerTests
     public void ExplicitSelectionFailureWarnings_AreCorrelatedToAffectedSections()
     {
         Assert.True(LibraryCommand.FailureAffectsSection("Classified Methods", "P/Invoke Methods"));
+        Assert.True(LibraryCommand.FailureAffectsSection("Extension Methods", "Library Info"));
         Assert.True(LibraryCommand.FailureAffectsSection("Switches", "Library Info"));
         Assert.True(LibraryCommand.FailureAffectsSection(
             LibraryIntegrationCatalog.RollupName,

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -1221,11 +1221,16 @@ public class OutputFormatterTests
             new UnsafeMemberSummary { Member = "B.Type.A()", Reason = "Unsafe signature", Detail = "void A()", Kind = "signature" },
             new UnsafeMemberSummary { Member = "A.Type.Z()", Reason = "Unsafe signature", Detail = "void Z()", Kind = "signature" }
         ];
-        inspection.ExtensionMethods =
+        ExtensionMethodInfo[] extensionMembers =
         [
-            new ExtensionMethodSummary { ExtendedType = "B.Type", MethodName = "A", ExtensionClass = "Extensions" },
-            new ExtensionMethodSummary { ExtendedType = "A.Type", MethodName = "Z", ExtensionClass = "Extensions" }
+            FindingTestData.ExtensionMember("A", "B.Type"),
+            FindingTestData.ExtensionMember("Z", "A.Type"),
         ];
+        inspection.SetExtensionMemberInspection(
+            MetadataFindings.InspectExtensionMembers(
+                extensionMembers,
+                FindingTestData.Subject),
+            extensionMembers);
 
         var output = Serialize(inspection);
 

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1444,7 +1444,6 @@ public class SectionPipelineTests
             SwitchInspection = MetadataFindings.InspectSwitches(
                 [new SwitchInfo("Feature Switch", "Switch", "Api")],
                 FindingTestData.Subject),
-            ExtensionMethods = [new ExtensionMethodSummary { MethodName = "Ext", ExtendedType = "Target", ExtensionClass = "Extensions" }],
             UnsafeMembers = [new UnsafeMemberSummary { Member = "T.M()", Reason = "Unsafe signature", Detail = "int*", Kind = "signature" }],
             TopLeverage = [new MethodLeverageSummary { Member = "T.M()", Callers = 1 }],
             OptimizationOpportunities =
@@ -1493,6 +1492,15 @@ public class SectionPipelineTests
                 [new AssemblyAttributeInfo("Attr", "Assembly", null)],
                 FindingTestData.Subject),
             jsonOrder: null);
+        ExtensionMethodInfo[] extensionMembers =
+        [
+            FindingTestData.ExtensionMember("Ext", "Target"),
+        ];
+        library.SetExtensionMemberInspection(
+            MetadataFindings.InspectExtensionMembers(
+                extensionMembers,
+                FindingTestData.Subject),
+            extensionMembers);
         yield return DiscoverableCase("library", libraryPipeline, library);
 
         var packagePipeline = PackageSectionDescriptors.CreatePipeline();

--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -92,9 +92,18 @@ public class ExtensionsCommand
                 var censuses = assemblyInfos
                     .Select(assembly => InspectExtensionAssembly(assembly, options.IncludeAll))
                     .ToList();
+                var availableCensuses = new List<ExtensionAssemblyCensus>(censuses.Count);
 
                 foreach (var census in censuses)
                 {
+                    if (census.Inspection.Failure() is { } failure)
+                    {
+                        Console.Error.WriteLine(
+                            $"Warning: Extension member inspection failed for {failure.Subject.Display}: {failure.Reason}");
+                        continue;
+                    }
+
+                    availableCensuses.Add(census);
                     results.AddRange(ProjectExtensions(census, targetType));
                 }
 
@@ -107,7 +116,7 @@ public class ExtensionsCommand
                 {
                     if (reachableType == targetType) continue;
 
-                    foreach (var census in censuses)
+                    foreach (var census in availableCensuses)
                     {
                         results.AddRange(ProjectExtensions(
                             census,

--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -1,6 +1,8 @@
 using DotnetInspector.Packages;
 using System.Text.Json.Serialization;
 using DotnetInspector.Inspectors;
+using DotnetInspector.Models;
+using ILInspector.Findings;
 using ILInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
@@ -32,25 +34,7 @@ public class ExtensionsCommand
                 };
             }
 
-            List<ExtensionMethodResult> results;
-            if (options.Reachable)
-            {
-                results = await ScanReachableExtensionsAsync(options, context, logger, targetType);
-            }
-            else
-            {
-                results = await AssemblyCollector.ScanAsync(
-                    context.HttpClient,
-                    options,
-                    logger,
-                    "inspect-ext",
-                    assemblyInfo => ScanForExtensions(assemblyInfo.Path, targetType, options.IncludeAll, logger),
-                    (result, assemblyInfo) =>
-                    {
-                        result.Source = assemblyInfo.Source;
-                        result.SourceVersion = assemblyInfo.Version;
-                    });
-            }
+            var results = await ScanExtensionsAsync(options, context, logger, targetType);
 
             // Apply limit
             if (options.Limit.HasValue && results.Count > options.Limit.Value)
@@ -91,7 +75,7 @@ public class ExtensionsCommand
         }
     }
 
-    private static async Task<List<ExtensionMethodResult>> ScanReachableExtensionsAsync(
+    private static async Task<List<ExtensionMethodResult>> ScanExtensionsAsync(
         ExtensionsOptions options,
         CommandContext context,
         VerboseLogger logger,
@@ -105,22 +89,17 @@ public class ExtensionsCommand
             assemblyInfos =>
             {
                 List<ExtensionMethodResult> results = [];
+                var censuses = assemblyInfos
+                    .Select(assembly => InspectExtensionAssembly(assembly, options.IncludeAll))
+                    .ToList();
 
-                void Stamp(ExtensionMethodResult ext, AssemblyCollector.AssemblyInfo asmInfo)
+                foreach (var census in censuses)
                 {
-                    ext.Source = asmInfo.Source;
-                    ext.SourceVersion = asmInfo.Version;
+                    results.AddRange(ProjectExtensions(census, targetType));
                 }
 
-                foreach (var asmInfo in assemblyInfos)
-                {
-                    var extensions = ScanForExtensions(asmInfo.Path, targetType, options.IncludeAll, logger);
-                    foreach (var ext in extensions)
-                    {
-                        Stamp(ext, asmInfo);
-                        results.Add(ext);
-                    }
-                }
+                if (!options.Reachable)
+                    return results;
 
                 var assemblyPaths = assemblyInfos.Select(a => a.Path).ToList();
                 var reachableTypes = ExtensionMethodScanner.FindReachableTypes(targetType, assemblyPaths, options.Depth);
@@ -128,16 +107,13 @@ public class ExtensionsCommand
                 {
                     if (reachableType == targetType) continue;
 
-                    foreach (var asmInfo in assemblyInfos)
+                    foreach (var census in censuses)
                     {
-                        var extensions = ScanForExtensions(asmInfo.Path, reachableType, options.IncludeAll, logger);
-                        foreach (var ext in extensions)
-                        {
-                            Stamp(ext, asmInfo);
-                            ext.ReachablePath = path;
-                            ext.ReachableFromType = reachableType;
-                            results.Add(ext);
-                        }
+                        results.AddRange(ProjectExtensions(
+                            census,
+                            reachableType,
+                            reachablePath: path,
+                            reachableFromType: reachableType));
                     }
                 }
 
@@ -145,35 +121,81 @@ public class ExtensionsCommand
             });
     }
 
-    private static List<ExtensionMethodResult> ScanForExtensions(
-        string assemblyPath,
-        string targetType,
-        bool includeAll,
-        VerboseLogger logger)
-    {
-        List<ExtensionMethodResult> results = [];
+    internal sealed record ExtensionAssemblyCensus(
+        AssemblyCollector.AssemblyInfo Assembly,
+        IReadOnlyList<ExtensionMethodInfo> Members,
+        FindingInspection<ExtensionMemberObservation> Inspection);
 
+    internal static ExtensionAssemblyCensus InspectExtensionAssembly(
+        AssemblyCollector.AssemblyInfo assembly,
+        bool includeAll)
+    {
         try
         {
-            using var stream = File.OpenRead(assemblyPath);
-            var assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
-
-            foreach (var ext in ExtensionMethodScanner.FindExtensions(stream, targetType, includeAll))
-            {
-                results.Add(new ExtensionMethodResult
-                {
-                    MethodName = ext.MethodName,
-                    ExtensionClass = ext.ExtensionClass,
-                    ExtendedType = ext.ExtendedType,
-                    Assembly = assemblyName,
-                    Signature = ext.Signature,
-                    Kind = ext.Kind
-                });
-            }
+            using var stream = File.OpenRead(assembly.Path);
+            var members = ExtensionMethodScanner.FindAllExtensions(stream, includeAll).ToList();
+            var inspection = MetadataFindings.InspectExtensionMembers(
+                members,
+                new FindingSubject(Path.GetFullPath(assembly.Path), Path.GetFileName(assembly.Path)));
+            return new ExtensionAssemblyCensus(assembly, members, inspection);
         }
         catch (Exception ex)
         {
-            logger.Log($"Warning: Error scanning {assemblyPath}: {ex.Message}");
+            return new ExtensionAssemblyCensus(
+                assembly,
+                [],
+                new FindingInspection<ExtensionMemberObservation>.Failed(
+                    new InspectionError(
+                        new FindingSubject(
+                            Path.GetFullPath(assembly.Path),
+                            Path.GetFileName(assembly.Path)),
+                        MetadataFindings.ExtensionMemberDescriptor,
+                        ex.Message)));
+        }
+    }
+
+    internal static List<ExtensionMethodResult> ProjectExtensions(
+        ExtensionAssemblyCensus census,
+        string targetType,
+        string? reachablePath = null,
+        string? reachableFromType = null)
+    {
+        var observationsByAnchor = census.Inspection.Findings()
+            .ToDictionary(
+                static finding => finding.Payload.Anchor,
+                static finding => finding.Payload);
+        var normalizedTarget = TypeMatcher.Normalize(targetType);
+        List<ExtensionMethodResult> results = [];
+
+        foreach (var member in census.Members)
+        {
+            if (member.Anchor is not { } anchor
+                || !observationsByAnchor.TryGetValue(anchor, out var observation))
+            {
+                throw new InvalidOperationException(
+                    $"Extension member census for {census.Assembly.Path} does not correspond to its scanner inventory.");
+            }
+
+            if (!TypeMatcher.Matches(
+                    TypeMatcher.Normalize(observation.ExtendedType),
+                    normalizedTarget))
+            {
+                continue;
+            }
+
+            results.Add(new ExtensionMethodResult
+            {
+                MethodName = member.MethodName,
+                ExtensionClass = member.ExtensionClass,
+                ExtendedType = member.ExtendedType,
+                Assembly = Path.GetFileNameWithoutExtension(census.Assembly.Path),
+                Signature = member.Signature,
+                Kind = observation.Kind == ExtensionMemberKind.Method ? "method" : "property",
+                Source = census.Assembly.Source,
+                SourceVersion = census.Assembly.Version,
+                ReachablePath = reachablePath,
+                ReachableFromType = reachableFromType,
+            });
         }
 
         return results;

--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -170,7 +170,7 @@ public class ExtensionsCommand
         string? reachableFromType = null)
     {
         var observationsByAnchor = census.Inspection.Findings()
-            .ToDictionary(
+            .ToLookup(
                 static finding => finding.Payload.Anchor,
                 static finding => finding.Payload);
         var normalizedTarget = TypeMatcher.Normalize(targetType);
@@ -178,15 +178,33 @@ public class ExtensionsCommand
 
         foreach (var member in census.Members)
         {
-            if (member.Anchor is not { } anchor
-                || !observationsByAnchor.TryGetValue(anchor, out var observation))
+            var expectedKind = member.Kind == "method"
+                ? ExtensionMemberKind.Method
+                : ExtensionMemberKind.Property;
+            var observation = member.Anchor is { } anchor
+                ? observationsByAnchor[anchor].FirstOrDefault(candidate =>
+                    candidate.Kind == expectedKind
+                    && string.Equals(
+                        candidate.ExtendedType,
+                        member.CanonicalExtendedType,
+                        StringComparison.Ordinal)
+                    && string.Equals(
+                        candidate.ReturnType,
+                        member.ReturnType,
+                        StringComparison.Ordinal)
+                    && string.Equals(
+                        candidate.Assembly,
+                        member.Assembly,
+                        StringComparison.Ordinal))
+                : null;
+            if (observation is null)
             {
                 throw new InvalidOperationException(
                     $"Extension member census for {census.Assembly.Path} does not correspond to its scanner inventory.");
             }
 
             if (!TypeMatcher.Matches(
-                    TypeMatcher.Normalize(observation.ExtendedType),
+                    TypeMatcher.Normalize(member.ExtendedType),
                     normalizedTarget))
             {
                 continue;

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -1495,7 +1495,8 @@ public class LibraryCommand
 
         if (section.Equals("Library Info", StringComparison.OrdinalIgnoreCase))
         {
-            return failureSection is "Resources"
+            return failureSection is "Extension Methods"
+                or "Resources"
                 or "Custom Attributes"
                 or "Type Forwarders"
                 or "Union Types"

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -150,7 +150,7 @@ internal static class LibraryMetadataService
                 try
                 {
                     using var session = AssemblyInspectionSession.Open(path);
-                    inspection.ExtensionMethods = ScanExtensionMethods(session, path, logger);
+                    ScanExtensionMembers(session, path, inspection, logger);
                     ScanClassifiedMethods(session, path, inspection, logger);
                     inspection.ResourceInspection = ScanResources(session, path, logger);
                     ScanCustomAttributes(session, path, inspection, logger);
@@ -160,6 +160,13 @@ internal static class LibraryMetadataService
                 catch (Exception ex)
                 {
                     logger.Log($"Warning: Error opening {path} for scanning: {ex.Message}");
+                    if (inspection.ExtensionMemberInspection is null)
+                    {
+                        inspection.SetExtensionMemberInspection(
+                            FailedInspection<ExtensionMemberObservation>(
+                                path, MetadataFindings.ExtensionMemberDescriptor, ex),
+                            displayOrder: null);
+                    }
                     inspection.ClassifiedMethodInspection ??= FailedInspection<ClassifiedMethodObservation>(
                         path, MetadataFindings.ClassifiedMethodDescriptor, ex);
                     inspection.ResourceInspection ??= FailedInspection<MetadataResource>(
@@ -453,52 +460,50 @@ internal static class LibraryMetadataService
     }
 
     /// <summary>
-    /// Scans an assembly for all extension methods and returns collapsed summaries.
+    /// Scans an assembly for extension members and retains Metadata's typed census.
     /// </summary>
-    internal static List<ExtensionMethodSummary>? ScanExtensionMethods(string path, VerboseLogger logger)
+    internal static void ScanExtensionMembers(
+        string path,
+        LibraryInspection inspection,
+        VerboseLogger logger)
     {
         try
         {
             using var session = AssemblyInspectionSession.Open(path);
-            return ScanExtensionMethods(session, path, logger);
+            ScanExtensionMembers(session, path, inspection, logger);
         }
         catch (Exception ex)
         {
             logger.Log($"Warning: Error scanning extensions in {path}: {ex.Message}");
-            return null;
+            inspection.SetExtensionMemberInspection(
+                FailedInspection<ExtensionMemberObservation>(
+                    path, MetadataFindings.ExtensionMemberDescriptor, ex),
+                displayOrder: null);
         }
     }
 
-    internal static List<ExtensionMethodSummary>? ScanExtensionMethods(AssemblyInspectionSession session, string path, VerboseLogger logger)
+    internal static void ScanExtensionMembers(
+        AssemblyInspectionSession session,
+        string path,
+        LibraryInspection inspection,
+        VerboseLogger logger)
     {
         try
         {
-            var extensions = session.ExtensionMethods();
-
-            var collapsed = extensions
-                .GroupBy(e => (e.MethodName, e.Kind, e.ExtensionClass, e.ExtendedType))
-                .Select(g =>
-                {
-                    var count = g.Count();
-                    return new ExtensionMethodSummary
-                    {
-                        MethodName = g.Key.MethodName,
-                        ExtendedType = g.Key.ExtendedType,
-                        ExtensionClass = g.Key.ExtensionClass,
-                        Kind = g.Key.Kind,
-                        Overloads = count > 1 ? count : null
-                    };
-                })
-                .OrderBy(e => e.ExtendedType)
-                .ThenBy(e => e.MethodName)
-                .ToList();
-
-            return collapsed.Count > 0 ? collapsed : null;
+            var extensions = session.ExtensionMethods().ToArray();
+            inspection.SetExtensionMemberInspection(
+                MetadataFindings.InspectExtensionMembers(
+                    extensions,
+                    FindingSubjectFor(path)),
+                extensions);
         }
         catch (Exception ex)
         {
             logger.Log($"Warning: Error scanning extensions in {path}: {ex.Message}");
-            return null;
+            inspection.SetExtensionMemberInspection(
+                FailedInspection<ExtensionMemberObservation>(
+                    path, MetadataFindings.ExtensionMemberDescriptor, ex),
+                displayOrder: null);
         }
     }
 
@@ -1149,7 +1154,8 @@ internal static class LibraryMetadataService
         try
         {
             using var session = AssemblyInspectionSession.Open(path);
-            inspection.ExtensionMethods ??= ScanExtensionMethods(session, path, logger);
+            if (inspection.ExtensionMemberInspection is null)
+                ScanExtensionMembers(session, path, inspection, logger);
             ScanClassifiedMethods(session, path, inspection, logger);
             inspection.ResourceInspection ??= ScanResources(session, path, logger);
             ScanCustomAttributes(session, path, inspection, logger);
@@ -1158,6 +1164,13 @@ internal static class LibraryMetadataService
         catch (Exception ex)
         {
             logger.Log($"Warning: Error opening {path} for scanning: {ex.Message}");
+            if (inspection.ExtensionMemberInspection is null)
+            {
+                inspection.SetExtensionMemberInspection(
+                    FailedInspection<ExtensionMemberObservation>(
+                        path, MetadataFindings.ExtensionMemberDescriptor, ex),
+                    displayOrder: null);
+            }
             inspection.ClassifiedMethodInspection ??= FailedInspection<ClassifiedMethodObservation>(
                 path, MetadataFindings.ClassifiedMethodDescriptor, ex);
             inspection.ResourceInspection ??= FailedInspection<MetadataResource>(

--- a/src/dotnet-inspect/JsonContext.cs
+++ b/src/dotnet-inspect/JsonContext.cs
@@ -27,6 +27,8 @@ namespace DotnetInspector;
 [JsonSerializable(typeof(List<LibraryInspectionFailureJson>))]
 [JsonSerializable(typeof(LibraryResourceJson))]
 [JsonSerializable(typeof(List<LibraryResourceJson>))]
+[JsonSerializable(typeof(LibraryExtensionMethodJson))]
+[JsonSerializable(typeof(List<LibraryExtensionMethodJson>))]
 [JsonSerializable(typeof(LibraryCustomAttributeJson))]
 [JsonSerializable(typeof(List<LibraryCustomAttributeJson>))]
 [JsonSerializable(typeof(TypeForwarderInfo))]

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -235,11 +235,32 @@ public class LibraryInspection
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ApiSurface? ApiSurface { get; set; }
 
-    /// <summary>
-    /// Extension methods defined in this assembly, grouped by extended type.
-    /// </summary>
+    private FindingInspection<ExtensionMemberObservation>? _extensionMemberInspection;
+    private IReadOnlyList<ExtensionMethodInfo>? _extensionMemberDisplayOrder;
+    private bool _extensionMethodsInitialized;
+    private List<LibraryExtensionMethodJson>? _extensionMethods;
+
+    [JsonIgnore]
+    public FindingInspection<ExtensionMemberObservation>? ExtensionMemberInspection =>
+        _extensionMemberInspection;
+
+    internal void SetExtensionMemberInspection(
+        FindingInspection<ExtensionMemberObservation> inspection,
+        IReadOnlyList<ExtensionMethodInfo>? displayOrder)
+    {
+        ArgumentNullException.ThrowIfNull(inspection);
+
+        _extensionMemberInspection = inspection;
+        _extensionMemberDisplayOrder = displayOrder?.ToArray();
+        ResetFindingProjectionCaches();
+    }
+
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public List<ExtensionMethodSummary>? ExtensionMethods { get; set; }
+    public List<LibraryExtensionMethodJson>? ExtensionMethods =>
+        GetOrCreate(
+            ref _extensionMethodsInitialized,
+            ref _extensionMethods,
+            ProjectExtensionMethods);
 
     private List<ClassifiedMethodSummary>? _unsafeMethods;
 
@@ -454,6 +475,7 @@ public class LibraryInspection
             List<LibraryInspectionFailureJson> failures = [];
             AddFailure(failures, "References", AssemblyReferenceInspection);
             AddFailure(failures, "Classified Methods", ClassifiedMethodInspection);
+            AddFailure(failures, "Extension Methods", ExtensionMemberInspection);
             AddFailure(failures, LibraryIntegrationCatalog.RollupName, EcosystemIntegrationInspection);
             AddFailure(failures, EcosystemIntegrationNames.OpenTelemetry, OpenTelemetryInspection);
             AddFailure(failures, "Resources", ResourceInspection);
@@ -723,6 +745,8 @@ public class LibraryInspection
 
     private void ResetFindingProjectionCaches()
     {
+        _extensionMethodsInitialized = false;
+        _extensionMethods = null;
         _inspectionFailuresInitialized = false;
         _inspectionFailures = null;
         _integrationsInitialized = false;
@@ -745,6 +769,37 @@ public class LibraryInspection
             ? fallback
             : ClassifiedMethodInspection.PayloadsForRendering().Count(
                 method => method.Classification == classification);
+
+    private List<LibraryExtensionMethodJson>? ProjectExtensionMethods()
+    {
+        if (_extensionMemberDisplayOrder is null)
+            return null;
+
+        var anchors = ExtensionMemberInspection.PayloadsForRendering()
+            .Select(static observation => observation.Anchor)
+            .ToHashSet();
+        var rows = _extensionMemberDisplayOrder
+            .Where(member => member.Anchor is { } anchor && anchors.Contains(anchor))
+            .GroupBy(member => (
+                member.MethodName,
+                member.Kind,
+                member.ExtensionClass,
+                member.ExtendedType))
+            .Select(group =>
+            {
+                int count = group.Count();
+                return new LibraryExtensionMethodJson(
+                    group.Key.MethodName,
+                    group.Key.ExtendedType,
+                    group.Key.ExtensionClass,
+                    group.Key.Kind,
+                    count > 1 ? count : null);
+            })
+            .OrderBy(member => member.ExtendedType)
+            .ThenBy(member => member.MethodName)
+            .ToList();
+        return NullIfEmpty(rows);
+    }
 
     private static void AddFailure<T>(
         List<LibraryInspectionFailureJson> failures,
@@ -925,16 +980,14 @@ public class ILOffsetCostContext
 public sealed record SourceFileInfo(string Type, string? Url);
 
 /// <summary>
-/// Summary of an extension method defined in a library.
+/// JSON projection of extension members defined in a library.
 /// </summary>
-public record class ExtensionMethodSummary
-{
-    public string MethodName { get; init; } = "";
-    public string ExtendedType { get; init; } = "";
-    public string ExtensionClass { get; init; } = "";
-    public string Kind { get; init; } = "method";
-    public int? Overloads { get; init; }
-}
+public sealed record LibraryExtensionMethodJson(
+    string MethodName,
+    string ExtendedType,
+    string ExtensionClass,
+    string Kind,
+    int? Overloads);
 
 /// <summary>
 /// Summary of a classified method (unsafe or P/Invoke).

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -91,7 +91,7 @@ public static class LibrarySections
     {
         return new ScannerRegistry()
             .Add(ScannerExtensionMethods, ctx =>
-                ctx.Model.ExtensionMethods = LibraryMetadataService.ScanExtensionMethods(ctx.AssemblyPath, ctx.Logger))
+                LibraryMetadataService.ScanExtensionMembers(ctx.AssemblyPath, ctx.Model, ctx.Logger))
             .Add(ScannerClassifiedMethods, ctx =>
                 LibraryMetadataService.ScanClassifiedMethods(ctx.AssemblyPath, ctx.Model, ctx.Logger))
             .Add(ScannerResources, ctx =>
@@ -482,7 +482,7 @@ public static class LibrarySections
         public static bool ExplicitOnly => true;
         public static string? ScannerKey => ScannerExtensionMethods;
         public static bool CanRender(LibraryInspection model)
-            => model.ExtensionMethods is { Count: > 0 } || model.HasExtensionTypes;
+            => model.ExtensionMemberInspection.CanRenderWithPresence(model.HasExtensionTypes);
     }
 
     public sealed class UnsafeMembers : ISectionDescriptor<LibraryInspection>

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -795,7 +795,7 @@ public class LibraryInspectionView
 
     private static int CountOrZero<T>(List<T>? values) => values?.Count ?? 0;
 
-    private static int CountExtensionMethods(List<ExtensionMethodSummary>? methods)
+    private static int CountExtensionMethods(List<LibraryExtensionMethodJson>? methods)
         => methods?.Sum(m => m.Overloads ?? 1) ?? 0;
 
     private static int CountIntegrations(LibraryInspection inspection)


### PR DESCRIPTION
## Summary

- consume Metadata extension-member Findings in both library inspection and the `extensions` command
- retain display signatures as CLI compatibility data while carrying typed inspection state through projection
- scan each assembly once for direct and reachable queries, with visible per-assembly failure isolation
- preserve successful output and harden generic receivers and duplicate metadata anchors

Addresses #2653 (C1).

## Validation

- solution build
- `dotnet-inspect.Tests`: 1,756 passed, 10 expected skips
- `ILInspector.Metadata.Tests`: 452 passed
- byte-identical successful library/direct/reachable JSON output
- architecture Markdown lint

## Adversarial review

Claude Opus 4.8 and Gemini 3.1 Pro independently reviewed isolated clean worktrees. Initial findings covered mixed-input failure isolation, generic receiver matching, and duplicate stable anchors; commits `4f2aff7a` and `a22f9028` resolve them with regressions. Both reviewers returned CLEAN on final head `d0d83ce7`.