### PR TITLE
Move RTS closure seed behind artifact provider

### DIFF
--- a/docs/design/fact-planned-compile-back-harness.md
+++ b/docs/design/fact-planned-compile-back-harness.md
@@ -262,6 +262,11 @@ The artifact provider should return structured diagnostics when it cannot
 produce an artifact. RTS should surface those diagnostics; it should not patch
 the artifact with local C#.
 
+Initial typed closure derivation belongs with artifact production: the provider
+can derive same-assembly roots, source facts, and member requirements from the
+raised `IrFunction`. RTS remains responsible for Roslyn oracle growth and passes
+only the target/oracle closure roots and facts discovered by compile feedback.
+
 The product/shared side should own truthful declaration facts that are useful
 beyond ReturnToSender: namespaces, type/member signatures, base/interface
 relationships, constructor signatures, generic constraints, explicit interface

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -799,10 +799,6 @@ static class ReturnToSender
             targetRoot,
         };
         var closureFacts = new Dictionary<TypeDefinitionHandle, List<CompileBackFact>>();
-        var closureMemberRequirements = new Dictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>>();
-        // PrintRaised mutates the imported function in place, so raised evidence
-        // such as WithExpression is available to typed shell seeding here.
-        SeedTypedClosureRoots(reader, function, typeHandle, targetRoot, closureRoots, closureFacts, closureMemberRequirements);
         const int maxRoots = 200;
         const int maxIterations = 80;
         Diagnostic? firstError = null;
@@ -822,8 +818,7 @@ static class ReturnToSender
                 Overload: overload,
                 SignatureText: CorpusMethodIdentity.SignatureText(function.Signature),
                 ClosureRoots: closureRoots,
-                ClosureFacts: closureFacts,
-                ClosureMemberRequirements: closureMemberRequirements));
+                ClosureFacts: closureFacts));
             var plan = sourceResult.Plan;
 
             if (plan.Diagnostics.FirstOrDefault(diagnostic => diagnostic.Layer == "type identity") is { } identityDiagnostic)
@@ -932,8 +927,7 @@ static class ReturnToSender
                 Overload: overload,
                 SignatureText: CorpusMethodIdentity.SignatureText(function.Signature),
                 ClosureRoots: closureRoots,
-                ClosureFacts: closureFacts,
-                ClosureMemberRequirements: closureMemberRequirements));
+                ClosureFacts: closureFacts));
             var plan = sourceResult.Plan;
             return new Result(
                 plan,
@@ -987,8 +981,6 @@ static class ReturnToSender
             targetRoot,
         };
         var closureFacts = new Dictionary<TypeDefinitionHandle, List<CompileBackFact>>();
-        var closureMemberRequirements = new Dictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>>();
-        SeedTypedClosureRoots(reader, function, typeHandle, targetRoot, closureRoots, closureFacts, closureMemberRequirements);
         const int maxRoots = 200;
         const int maxIterations = 80;
         Diagnostic? firstError = null;
@@ -1007,8 +999,7 @@ static class ReturnToSender
                 Overload: overload,
                 SignatureText: CorpusMethodIdentity.SignatureText(function.Signature),
                 ClosureRoots: closureRoots,
-                ClosureFacts: closureFacts,
-                ClosureMemberRequirements: closureMemberRequirements));
+                ClosureFacts: closureFacts));
             var plan = sourceResult.Plan;
 
             if (plan.Diagnostics.FirstOrDefault(diagnostic => diagnostic.Layer == "type identity") is { } identityDiagnostic)
@@ -1116,8 +1107,7 @@ static class ReturnToSender
                 Overload: overload,
                 SignatureText: CorpusMethodIdentity.SignatureText(function.Signature),
                 ClosureRoots: closureRoots,
-                ClosureFacts: closureFacts,
-                ClosureMemberRequirements: closureMemberRequirements));
+                ClosureFacts: closureFacts));
             var plan = sourceResult.Plan;
             return new Result(
                 plan,
@@ -1172,8 +1162,6 @@ static class ReturnToSender
             targetRoot,
         };
         var closureFacts = new Dictionary<TypeDefinitionHandle, List<CompileBackFact>>();
-        var closureMemberRequirements = new Dictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>>();
-        SeedTypedClosureRoots(reader, function, typeHandle, targetRoot, closureRoots, closureFacts, closureMemberRequirements);
         const int maxRoots = 200;
         const int maxIterations = 80;
         Diagnostic? firstError = null;
@@ -1193,8 +1181,7 @@ static class ReturnToSender
                 Overload: overload,
                 SignatureText: CorpusMethodIdentity.SignatureText(function.Signature),
                 ClosureRoots: closureRoots,
-                ClosureFacts: closureFacts,
-                ClosureMemberRequirements: closureMemberRequirements));
+                ClosureFacts: closureFacts));
             var plan = sourceResult.Plan;
 
             if (plan.Diagnostics.FirstOrDefault(diagnostic => diagnostic.Layer == "type identity") is { } identityDiagnostic)
@@ -1303,8 +1290,7 @@ static class ReturnToSender
                 Overload: overload,
                 SignatureText: CorpusMethodIdentity.SignatureText(function.Signature),
                 ClosureRoots: closureRoots,
-                ClosureFacts: closureFacts,
-                ClosureMemberRequirements: closureMemberRequirements));
+                ClosureFacts: closureFacts));
             var plan = sourceResult.Plan;
             return new Result(
                 plan,
@@ -1657,225 +1643,6 @@ static class ReturnToSender
         Dictionary<string, List<TypeDefinitionHandle>> Fields,
         Dictionary<string, List<TypeDefinitionHandle>> Namespaces,
         Dictionary<TypeDefinitionHandle, string> RootNamespaces);
-
-    static void SeedTypedClosureRoots(
-        MetadataReader reader,
-        IrFunction function,
-        TypeDefinitionHandle targetType,
-        TypeDefinitionHandle targetRoot,
-        HashSet<TypeDefinitionHandle> closureRoots,
-        Dictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
-        Dictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements)
-    {
-        // Canonicalize the local assembly name so TryResolveHandle's same-assembly
-        // gate matches TypeRef.Assembly, which TypeRefDecoder canonicalizes (corelib
-        // facades collapse to one identity). Without this, a target assembly whose
-        // own name is a canonicalized facade (System.Runtime, mscorlib, ...) would
-        // fail to resolve its own definitions and drop their closure roots/facts.
-        string assemblyName = TypeRefDecoder.Canonical(reader.GetString(reader.GetAssemblyDefinition().Name));
-        var definitions = TypeDefinitionsByTypeRefIdentity(reader);
-        var consumedMemberEvidence = new List<ConsumedMemberEvidence>();
-        AddTargetInterfaceRoots(targetType);
-        foreach (var node in function.Descendants.Prepend(function))
-        {
-            foreach (var type in node.DirectTypes)
-                AddTypedClosureRoot(type);
-            if (node is IrExpression expression)
-                AddTypedClosureRoot(expression.ResultType);
-            AddTypedClosureMemberFacts(node);
-        }
-
-        void AddTypedClosureRoot(TypeRef? type)
-        {
-            switch (type?.Kind)
-            {
-                case TypeRefKind.Definition:
-                    if (TryResolveRoot(type) is not { } root)
-                        return;
-                    if (root == targetRoot)
-                        return;
-                    closureRoots.Add(root);
-                    AddClosureFact(
-                        closureFacts,
-                        root,
-                        new CompileBackFact("metadata", "body-type", TypeRefIdentityKey(type.Namespace, type.Name, separator: ".")));
-                    break;
-                case TypeRefKind.GenericInstance:
-                    AddTypedClosureRoot(type.ElementType);
-                    foreach (var argument in type.TypeArguments)
-                        AddTypedClosureRoot(argument);
-                    break;
-                case TypeRefKind.SzArray or TypeRefKind.Array
-                    or TypeRefKind.ByRef or TypeRefKind.Pointer or TypeRefKind.Pinned:
-                    AddTypedClosureRoot(type.ElementType);
-                    break;
-                case TypeRefKind.FunctionPointer:
-                    AddTypedClosureRoot(type.ElementType);
-                    foreach (var argument in type.TypeArguments)
-                        AddTypedClosureRoot(argument);
-                    break;
-            }
-        }
-
-        void AddTargetInterfaceRoots(TypeDefinitionHandle handle)
-        {
-            // Interface discovery is product knowledge: the decompiler decodes the
-            // target type's same-assembly interface definitions to typed refs. RTS
-            // keeps only closure-root bookkeeping — resolve each interface definition
-            // (TryResolveHandle applies the same-assembly + supported-root gates) and
-            // seed it as a root, matching the prior TypeDefinition-only walk.
-            foreach (var interfaceType in IrImporter.ImportImplementedInterfaces(reader, handle))
-            {
-                if (TryResolveHandle(interfaceType) is not { } interfaceHandle)
-                    continue;
-
-                var root = TopLevelRootOf(reader, interfaceHandle);
-                if (root == targetRoot)
-                    continue;
-
-                var interfaceDef = reader.GetTypeDefinition(interfaceHandle);
-                closureRoots.Add(root);
-                AddClosureFact(
-                    closureFacts,
-                    root,
-                    new CompileBackFact("metadata", "target-interface", reader.GetFullTypeName(interfaceDef)));
-            }
-        }
-
-        TypeDefinitionHandle? TryResolveRoot(TypeRef? type)
-            => TryResolveHandle(type) is { } handle
-                ? TopLevelRootOf(reader, handle)
-                : null;
-
-        TypeDefinitionHandle? TryResolveHandle(TypeRef? type)
-        {
-            if (type is not { Kind: TypeRefKind.Definition } || type.Assembly != assemblyName)
-                return null;
-            string key = TypeRefIdentityKey(type.Namespace, type.Name);
-            if (!definitions.TryGetValue(key, out var handle))
-                return null;
-            return IsSupportedClosureRoot(reader, reader.GetTypeDefinition(handle)) ? handle : null;
-        }
-
-        void AddMemberFact(TypeRef declaringType, string kind, string name)
-        {
-            var definition = declaringType.Kind == TypeRefKind.GenericInstance
-                ? declaringType.ElementType ?? declaringType
-                : declaringType;
-            if (TryResolveHandle(definition) is not { } handle)
-                return;
-            var root = TopLevelRootOf(reader, handle);
-            if (root == targetRoot && handle == root)
-                return;
-            AddClosureFact(
-                closureFacts,
-                handle,
-                new CompileBackFact("metadata", "typed-member-ref", $"{kind}: {TypeRefIdentityKey(definition.Namespace, definition.Name, separator: ".")}.{name}"));
-        }
-
-        void AddMethodFact(MethodRef method, bool allowTargetRoot = false)
-        {
-            AddSingleMethodFact(method, allowTargetRoot);
-            if (OperatorNames.UncheckedOperator(method.Name) is { } siblingName)
-                AddSingleMethodFact(method with { Name = siblingName }, allowTargetRoot);
-        }
-
-        void AddSingleMethodFact(MethodRef method, bool allowTargetRoot)
-        {
-            AddMemberFact(method.DeclaringType, "method", method.Name);
-            AddMemberRequirement(
-                method.DeclaringType,
-                root => CompileBackSourceComposer.TryCreateClosureMemberRequirement(reader, root, method),
-                allowTargetRoot);
-        }
-
-        void AddFieldFact(FieldRef field)
-        {
-            AddTypedClosureRoot(field.Type);
-            AddMemberFact(field.DeclaringType, "field", field.Name);
-            AddMemberRequirement(
-                field.DeclaringType,
-                root => CompileBackSourceComposer.TryCreateClosureMemberRequirement(reader, root, field),
-                allowTargetRoot: true);
-        }
-
-        void AddRecordShellFact(TypeRef? type)
-        {
-            var definition = type?.Kind == TypeRefKind.GenericInstance
-                ? type.ElementType ?? type
-                : type;
-            if (TryResolveHandle(definition) is not { } handle)
-                return;
-            var root = TopLevelRootOf(reader, handle);
-            closureRoots.Add(root);
-            AddClosureFact(
-                closureFacts,
-                handle,
-                new CompileBackFact("metadata", "record-shell", TypeRefIdentityKey(definition!.Namespace, definition.Name, separator: ".")));
-        }
-
-        void AddMemberRequirement(TypeRef declaringType, Func<TypeDefinitionHandle, CompileBackMemberRequirement?> create, bool allowTargetRoot)
-        {
-            var definition = declaringType.Kind == TypeRefKind.GenericInstance
-                ? declaringType.ElementType ?? declaringType
-                : declaringType;
-            if (TryResolveHandle(definition) is not { } handle)
-                return;
-            var root = TopLevelRootOf(reader, handle);
-            if (root == targetRoot && handle == root && !allowTargetRoot)
-                return;
-            if (create(handle) is not { } requirement)
-                return;
-            if (!closureMemberRequirements.TryGetValue(handle, out var requirements))
-                closureMemberRequirements[handle] = requirements = [];
-            if (!requirements.Any(existing => existing.Kind == requirement.Kind && existing.Identity == requirement.Identity))
-                requirements.Add(requirement);
-        }
-
-        void AddTypedClosureMemberFacts(IrNode node)
-        {
-            consumedMemberEvidence.Clear();
-            ConsumedMemberEvidence.AddFrom(node, consumedMemberEvidence);
-            foreach (var evidence in consumedMemberEvidence)
-            {
-                if (evidence.Method is { } method)
-                    AddMethodFact(method, evidence.EffectiveAllowTargetRoot);
-                if (evidence.Field is { } field)
-                    AddFieldFact(field);
-                if (evidence.RecordShellType is { } recordShell)
-                    AddRecordShellFact(recordShell);
-            }
-        }
-    }
-
-    static Dictionary<string, TypeDefinitionHandle> TypeDefinitionsByTypeRefIdentity(MetadataReader reader)
-    {
-        var definitions = new Dictionary<string, TypeDefinitionHandle>(StringComparer.Ordinal);
-        foreach (var handle in reader.TypeDefinitions)
-        {
-            var typeDef = reader.GetTypeDefinition(handle);
-            if (!IsSupportedClosureRoot(reader, typeDef))
-                continue;
-            var (ns, name) = TypeRefIdentity(reader, handle);
-            definitions.TryAdd(TypeRefIdentityKey(ns, name), handle);
-        }
-
-        return definitions;
-    }
-
-    static (string Namespace, string Name) TypeRefIdentity(MetadataReader reader, TypeDefinitionHandle handle)
-    {
-        var typeDef = reader.GetTypeDefinition(handle);
-        string name = reader.GetString(typeDef.Name);
-        if (!typeDef.IsNested)
-            return (reader.GetString(typeDef.Namespace), name);
-
-        var declaring = TypeRefIdentity(reader, typeDef.GetDeclaringType());
-        return (declaring.Namespace, $"{declaring.Name}+{name}");
-    }
-
-    static string TypeRefIdentityKey(string ns, string name, string separator = "|")
-        => ns.Length == 0 ? name : $"{ns}{separator}{name}";
 
     static void AddClosureFact(
         Dictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -892,9 +892,10 @@ static class ReturnToSender
                 TopLevelRootOf(reader, typeHandle),
                 closureRoots,
                 closureFacts);
-            if (!growth.Grew || closureRoots.Count > maxRoots)
+            int effectiveRootCount = EffectiveClosureRootCount(sourceResult, closureRoots);
+            if (!growth.Grew || effectiveRootCount > maxRoots)
             {
-                string reason = closureRoots.Count > maxRoots
+                string reason = effectiveRootCount > maxRoots
                     ? "closure-root-budget"
                     : ClosureDiagnosticEvidence.FailureReason(
                         "closure-stalled",
@@ -1073,9 +1074,10 @@ static class ReturnToSender
                 TopLevelRootOf(reader, typeHandle),
                 closureRoots,
                 closureFacts);
-            if (!growth.Grew || closureRoots.Count > maxRoots)
+            int effectiveRootCount = EffectiveClosureRootCount(sourceResult, closureRoots);
+            if (!growth.Grew || effectiveRootCount > maxRoots)
             {
-                string reason = closureRoots.Count > maxRoots
+                string reason = effectiveRootCount > maxRoots
                     ? "closure-root-budget"
                     : ClosureDiagnosticEvidence.FailureReason(
                         "closure-stalled",
@@ -1255,9 +1257,10 @@ static class ReturnToSender
                 TopLevelRootOf(reader, typeHandle),
                 closureRoots,
                 closureFacts);
-            if (!growth.Grew || closureRoots.Count > maxRoots)
+            int effectiveRootCount = EffectiveClosureRootCount(sourceResult, closureRoots);
+            if (!growth.Grew || effectiveRootCount > maxRoots)
             {
-                string reason = closureRoots.Count > maxRoots
+                string reason = effectiveRootCount > maxRoots
                     ? "closure-root-budget"
                     : ClosureDiagnosticEvidence.FailureReason(
                         "closure-stalled",
@@ -1630,6 +1633,18 @@ static class ReturnToSender
         return string.IsNullOrWhiteSpace(message)
             ? diagnostic.Id
             : $"{diagnostic.Id}: {message}";
+    }
+
+    static int EffectiveClosureRootCount(ProductArtifact artifact, IReadOnlySet<TypeDefinitionHandle> oracleClosureRoots)
+    {
+        int count = artifact.ClosureRoots.Count;
+        foreach (var root in oracleClosureRoots)
+        {
+            if (!artifact.ClosureRoots.Contains(root))
+                count++;
+        }
+
+        return count;
     }
 
     static string CanonicalOpcode(string op)

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -181,8 +181,7 @@ internal abstract record ArtifactRequest(
     int Overload,
     string SignatureText,
     IReadOnlySet<TypeDefinitionHandle> ClosureRoots,
-    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> ClosureFacts,
-    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> ClosureMemberRequirements);
+    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> ClosureFacts);
 
 internal sealed record MethodArtifactRequest(
     string AssemblyPath,
@@ -196,8 +195,7 @@ internal sealed record MethodArtifactRequest(
     int Overload,
     string SignatureText,
     IReadOnlySet<TypeDefinitionHandle> ClosureRoots,
-    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> ClosureFacts,
-    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> ClosureMemberRequirements)
+    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> ClosureFacts)
     : ArtifactRequest(
         AssemblyPath,
         Reader,
@@ -210,8 +208,7 @@ internal sealed record MethodArtifactRequest(
         Overload,
         SignatureText,
         ClosureRoots,
-        ClosureFacts,
-        ClosureMemberRequirements);
+        ClosureFacts);
 
 internal abstract record PropertyAccessorArtifactRequest(
     string AssemblyPath,
@@ -226,8 +223,7 @@ internal abstract record PropertyAccessorArtifactRequest(
     int Overload,
     string SignatureText,
     IReadOnlySet<TypeDefinitionHandle> ClosureRoots,
-    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> ClosureFacts,
-    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> ClosureMemberRequirements)
+    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> ClosureFacts)
     : ArtifactRequest(
         AssemblyPath,
         Reader,
@@ -240,8 +236,7 @@ internal abstract record PropertyAccessorArtifactRequest(
         Overload,
         SignatureText,
         ClosureRoots,
-        ClosureFacts,
-        ClosureMemberRequirements);
+        ClosureFacts);
 
 internal sealed record PropertyGetterArtifactRequest(
     string AssemblyPath,
@@ -256,8 +251,7 @@ internal sealed record PropertyGetterArtifactRequest(
     int Overload,
     string SignatureText,
     IReadOnlySet<TypeDefinitionHandle> ClosureRoots,
-    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> ClosureFacts,
-    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> ClosureMemberRequirements)
+    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> ClosureFacts)
     : PropertyAccessorArtifactRequest(
         AssemblyPath,
         Reader,
@@ -271,8 +265,7 @@ internal sealed record PropertyGetterArtifactRequest(
         Overload,
         SignatureText,
         ClosureRoots,
-        ClosureFacts,
-        ClosureMemberRequirements);
+        ClosureFacts);
 
 internal sealed record PropertySetterArtifactRequest(
     string AssemblyPath,
@@ -287,8 +280,7 @@ internal sealed record PropertySetterArtifactRequest(
     int Overload,
     string SignatureText,
     IReadOnlySet<TypeDefinitionHandle> ClosureRoots,
-    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> ClosureFacts,
-    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> ClosureMemberRequirements)
+    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> ClosureFacts)
     : PropertyAccessorArtifactRequest(
         AssemblyPath,
         Reader,
@@ -302,8 +294,7 @@ internal sealed record PropertySetterArtifactRequest(
         Overload,
         SignatureText,
         ClosureRoots,
-        ClosureFacts,
-        ClosureMemberRequirements);
+        ClosureFacts);
 
 internal sealed record ProductArtifact(
     ArtifactRequest Request,
@@ -494,6 +485,7 @@ public static class CompileBackSourceComposer
 {
     internal static ProductArtifact Compose(ArtifactRequest request)
     {
+        var closure = CreateClosureInputs(request);
         var result = request switch
         {
             PropertyGetterArtifactRequest getter => ComposePropertyGetter(
@@ -508,9 +500,9 @@ public static class CompileBackSourceComposer
                 request.MethodName,
                 request.Overload,
                 request.SignatureText,
-                request.ClosureRoots,
-                request.ClosureFacts,
-                request.ClosureMemberRequirements),
+                closure.Roots,
+                closure.Facts,
+                closure.MemberRequirements),
             PropertySetterArtifactRequest setter => ComposePropertySetter(
                 request.AssemblyPath,
                 request.Reader,
@@ -523,9 +515,9 @@ public static class CompileBackSourceComposer
                 request.MethodName,
                 request.Overload,
                 request.SignatureText,
-                request.ClosureRoots,
-                request.ClosureFacts,
-                request.ClosureMemberRequirements),
+                closure.Roots,
+                closure.Facts,
+                closure.MemberRequirements),
             MethodArtifactRequest => ComposeMethod(
                 request.AssemblyPath,
                 request.Reader,
@@ -537,9 +529,9 @@ public static class CompileBackSourceComposer
                 request.MethodName,
                 request.Overload,
                 request.SignatureText,
-                request.ClosureRoots,
-                request.ClosureFacts,
-                request.ClosureMemberRequirements),
+                closure.Roots,
+                closure.Facts,
+                closure.MemberRequirements),
             _ => throw new ArgumentException($"Unknown artifact request type '{request.GetType().FullName}'.", nameof(request)),
         };
 
@@ -557,6 +549,275 @@ public static class CompileBackSourceComposer
         TypeDefinitionHandle typeHandle,
         FieldRef field)
         => TypeProducer.TryCreateClosureMemberRequirement(reader, typeHandle, field);
+
+    sealed class ArtifactClosureInputs
+    {
+        public HashSet<TypeDefinitionHandle> Roots { get; } = [];
+        public Dictionary<TypeDefinitionHandle, List<CompileBackFact>> Facts { get; } = [];
+        public Dictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> MemberRequirements { get; } = [];
+    }
+
+    static ArtifactClosureInputs CreateClosureInputs(ArtifactRequest request)
+    {
+        var closure = new ArtifactClosureInputs();
+        var targetRoot = TopLevelRootOf(request.Reader, request.TargetType);
+        closure.Roots.Add(targetRoot);
+        SeedTypedClosureRoots(
+            request.Reader,
+            request.Function,
+            request.TargetType,
+            targetRoot,
+            closure.Roots,
+            closure.Facts,
+            closure.MemberRequirements);
+        foreach (var root in request.ClosureRoots)
+            closure.Roots.Add(root);
+        foreach (var (root, facts) in request.ClosureFacts)
+        {
+            foreach (var fact in facts)
+                AddClosureFact(closure.Facts, root, fact);
+        }
+
+        return closure;
+    }
+
+    static void SeedTypedClosureRoots(
+        MetadataReader reader,
+        IrFunction function,
+        TypeDefinitionHandle targetType,
+        TypeDefinitionHandle targetRoot,
+        HashSet<TypeDefinitionHandle> closureRoots,
+        Dictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
+        Dictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements)
+    {
+        // Canonicalize the local assembly name so TryResolveHandle's same-assembly
+        // gate matches TypeRef.Assembly, which TypeRefDecoder canonicalizes (corelib
+        // facades collapse to one identity). Without this, a target assembly whose
+        // own name is a canonicalized facade (System.Runtime, mscorlib, ...) would
+        // fail to resolve its own definitions and drop their closure roots/facts.
+        string assemblyName = TypeRefDecoder.Canonical(reader.GetString(reader.GetAssemblyDefinition().Name));
+        var definitions = TypeDefinitionsByTypeRefIdentity(reader);
+        var consumedMemberEvidence = new List<ConsumedMemberEvidence>();
+        AddTargetInterfaceRoots(targetType);
+        foreach (var node in function.Descendants.Prepend(function))
+        {
+            foreach (var type in node.DirectTypes)
+                AddTypedClosureRoot(type);
+            if (node is IrExpression expression)
+                AddTypedClosureRoot(expression.ResultType);
+            AddTypedClosureMemberFacts(node);
+        }
+
+        void AddTypedClosureRoot(TypeRef? type)
+        {
+            switch (type?.Kind)
+            {
+                case TypeRefKind.Definition:
+                    if (TryResolveRoot(type) is not { } root)
+                        return;
+                    if (root == targetRoot)
+                        return;
+                    closureRoots.Add(root);
+                    AddClosureFact(
+                        closureFacts,
+                        root,
+                        new CompileBackFact("metadata", "body-type", TypeRefIdentityKey(type.Namespace, type.Name, separator: ".")));
+                    break;
+                case TypeRefKind.GenericInstance:
+                    AddTypedClosureRoot(type.ElementType);
+                    foreach (var argument in type.TypeArguments)
+                        AddTypedClosureRoot(argument);
+                    break;
+                case TypeRefKind.SzArray or TypeRefKind.Array
+                    or TypeRefKind.ByRef or TypeRefKind.Pointer or TypeRefKind.Pinned:
+                    AddTypedClosureRoot(type.ElementType);
+                    break;
+                case TypeRefKind.FunctionPointer:
+                    AddTypedClosureRoot(type.ElementType);
+                    foreach (var argument in type.TypeArguments)
+                        AddTypedClosureRoot(argument);
+                    break;
+            }
+        }
+
+        void AddTargetInterfaceRoots(TypeDefinitionHandle handle)
+        {
+            // Interface discovery is product knowledge: the decompiler decodes the
+            // target type's same-assembly interface definitions to typed refs. RTS
+            // keeps only closure-root bookkeeping — resolve each interface definition
+            // (TryResolveHandle applies the same-assembly + supported-root gates) and
+            // seed it as a root, matching the prior TypeDefinition-only walk.
+            foreach (var interfaceType in IrImporter.ImportImplementedInterfaces(reader, handle))
+            {
+                if (TryResolveHandle(interfaceType) is not { } interfaceHandle)
+                    continue;
+
+                var root = TopLevelRootOf(reader, interfaceHandle);
+                if (root == targetRoot)
+                    continue;
+
+                var interfaceDef = reader.GetTypeDefinition(interfaceHandle);
+                closureRoots.Add(root);
+                AddClosureFact(
+                    closureFacts,
+                    root,
+                    new CompileBackFact("metadata", "target-interface", reader.GetFullTypeName(interfaceDef)));
+            }
+        }
+
+        TypeDefinitionHandle? TryResolveRoot(TypeRef? type)
+            => TryResolveHandle(type) is { } handle
+                ? TopLevelRootOf(reader, handle)
+                : null;
+
+        TypeDefinitionHandle? TryResolveHandle(TypeRef? type)
+        {
+            if (type is not { Kind: TypeRefKind.Definition } || type.Assembly != assemblyName)
+                return null;
+            string key = TypeRefIdentityKey(type.Namespace, type.Name);
+            if (!definitions.TryGetValue(key, out var handle))
+                return null;
+            return IsSupportedTypedClosureRoot(reader, reader.GetTypeDefinition(handle)) ? handle : null;
+        }
+
+        void AddMemberFact(TypeRef declaringType, string kind, string name)
+        {
+            var definition = declaringType.Kind == TypeRefKind.GenericInstance
+                ? declaringType.ElementType ?? declaringType
+                : declaringType;
+            if (TryResolveHandle(definition) is not { } handle)
+                return;
+            var root = TopLevelRootOf(reader, handle);
+            if (root == targetRoot && handle == root)
+                return;
+            AddClosureFact(
+                closureFacts,
+                handle,
+                new CompileBackFact("metadata", "typed-member-ref", $"{kind}: {TypeRefIdentityKey(definition.Namespace, definition.Name, separator: ".")}.{name}"));
+        }
+
+        void AddMethodFact(MethodRef method, bool allowTargetRoot = false)
+        {
+            AddSingleMethodFact(method, allowTargetRoot);
+            if (OperatorNames.UncheckedOperator(method.Name) is { } siblingName)
+                AddSingleMethodFact(method with { Name = siblingName }, allowTargetRoot);
+        }
+
+        void AddSingleMethodFact(MethodRef method, bool allowTargetRoot)
+        {
+            AddMemberFact(method.DeclaringType, "method", method.Name);
+            AddMemberRequirement(
+                method.DeclaringType,
+                root => TryCreateClosureMemberRequirement(reader, root, method),
+                allowTargetRoot);
+        }
+
+        void AddFieldFact(FieldRef field)
+        {
+            AddTypedClosureRoot(field.Type);
+            AddMemberFact(field.DeclaringType, "field", field.Name);
+            AddMemberRequirement(
+                field.DeclaringType,
+                root => TryCreateClosureMemberRequirement(reader, root, field),
+                allowTargetRoot: true);
+        }
+
+        void AddRecordShellFact(TypeRef? type)
+        {
+            var definition = type?.Kind == TypeRefKind.GenericInstance
+                ? type.ElementType ?? type
+                : type;
+            if (TryResolveHandle(definition) is not { } handle)
+                return;
+            var root = TopLevelRootOf(reader, handle);
+            closureRoots.Add(root);
+            AddClosureFact(
+                closureFacts,
+                handle,
+                new CompileBackFact("metadata", "record-shell", TypeRefIdentityKey(definition!.Namespace, definition.Name, separator: ".")));
+        }
+
+        void AddMemberRequirement(TypeRef declaringType, Func<TypeDefinitionHandle, CompileBackMemberRequirement?> create, bool allowTargetRoot)
+        {
+            var definition = declaringType.Kind == TypeRefKind.GenericInstance
+                ? declaringType.ElementType ?? declaringType
+                : declaringType;
+            if (TryResolveHandle(definition) is not { } handle)
+                return;
+            var root = TopLevelRootOf(reader, handle);
+            if (root == targetRoot && handle == root && !allowTargetRoot)
+                return;
+            if (create(handle) is not { } requirement)
+                return;
+            if (!closureMemberRequirements.TryGetValue(handle, out var requirements))
+                closureMemberRequirements[handle] = requirements = [];
+            if (!requirements.Any(existing => existing.Kind == requirement.Kind && existing.Identity == requirement.Identity))
+                requirements.Add(requirement);
+        }
+
+        void AddTypedClosureMemberFacts(IrNode node)
+        {
+            consumedMemberEvidence.Clear();
+            ConsumedMemberEvidence.AddFrom(node, consumedMemberEvidence);
+            foreach (var evidence in consumedMemberEvidence)
+            {
+                if (evidence.Method is { } method)
+                    AddMethodFact(method, evidence.EffectiveAllowTargetRoot);
+                if (evidence.Field is { } field)
+                    AddFieldFact(field);
+                if (evidence.RecordShellType is { } recordShell)
+                    AddRecordShellFact(recordShell);
+            }
+        }
+    }
+
+    static Dictionary<string, TypeDefinitionHandle> TypeDefinitionsByTypeRefIdentity(MetadataReader reader)
+    {
+        var definitions = new Dictionary<string, TypeDefinitionHandle>(StringComparer.Ordinal);
+        foreach (var handle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(handle);
+            if (!IsSupportedTypedClosureRoot(reader, typeDef))
+                continue;
+            var (ns, name) = TypeRefIdentity(reader, handle);
+            definitions.TryAdd(TypeRefIdentityKey(ns, name), handle);
+        }
+
+        return definitions;
+    }
+
+    static (string Namespace, string Name) TypeRefIdentity(MetadataReader reader, TypeDefinitionHandle handle)
+    {
+        var typeDef = reader.GetTypeDefinition(handle);
+        string name = reader.GetString(typeDef.Name);
+        if (!typeDef.IsNested)
+            return (reader.GetString(typeDef.Namespace), name);
+
+        var declaring = TypeRefIdentity(reader, typeDef.GetDeclaringType());
+        return (declaring.Namespace, $"{declaring.Name}+{name}");
+    }
+
+    static bool IsSupportedTypedClosureRoot(MetadataReader reader, TypeDefinition typeDef)
+    {
+        string name = reader.GetString(typeDef.Name);
+        return name is not "<Module>"
+            && !name.Contains('<', StringComparison.Ordinal)
+            && !IsDelegate(reader, typeDef);
+    }
+
+    static string TypeRefIdentityKey(string ns, string name, string separator = "|")
+        => ns.Length == 0 ? name : $"{ns}{separator}{name}";
+
+    static void AddClosureFact(
+        Dictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
+        TypeDefinitionHandle root,
+        CompileBackFact fact)
+    {
+        if (!closureFacts.TryGetValue(root, out var facts))
+            closureFacts[root] = facts = [];
+        if (!facts.Contains(fact))
+            facts.Add(fact);
+    }
 
     public static CompileBackSourceResult ComposePropertyGetter(
         string assemblyPath,

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -301,9 +301,13 @@ internal sealed record ProductArtifact(
     string Source,
     IReadOnlyList<CompileBackFact> SourceFacts,
     IReadOnlyList<CompileBackPlanningDiagnostic> Diagnostics,
+    IReadOnlySet<TypeDefinitionHandle> ClosureRoots,
     CompileBackReconstructionPlan Plan)
 {
-    internal static ProductArtifact From(ArtifactRequest request, CompileBackSourceResult result)
+    internal static ProductArtifact From(
+        ArtifactRequest request,
+        CompileBackSourceResult result,
+        IReadOnlySet<TypeDefinitionHandle> closureRoots)
         => new(
             request,
             result.Source,
@@ -313,6 +317,7 @@ internal sealed record ProductArtifact(
                     .Concat(type.RequiredMembers.SelectMany(member => member.SourceFacts)))
                 .ToArray(),
             result.Plan.Diagnostics,
+            closureRoots,
             result.Plan);
 }
 
@@ -535,7 +540,7 @@ public static class CompileBackSourceComposer
             _ => throw new ArgumentException($"Unknown artifact request type '{request.GetType().FullName}'.", nameof(request)),
         };
 
-        return ProductArtifact.From(request, result);
+        return ProductArtifact.From(request, result, closure.Roots);
     }
 
     public static CompileBackMemberRequirement? TryCreateClosureMemberRequirement(


### PR DESCRIPTION
- Advances #2529
- Changes harness-only RTS/provider boundary: initial typed closure roots/facts/member requirements are now derived inside `CompileBackSourceComposer.Compose(ArtifactRequest)`; RTS carries only target/oracle closure roots and Roslyn feedback facts across iterations.
- Evidence revision: `0dba1240`

## Change

**Conclusion:** **REVIEW** — provider-owned initial closure seeding is now behind the artifact request envelope, while RTS still owns Roslyn oracle closure growth and opcode comparison.

## Scope and safety

- **Root cause:** RTS was still deriving typed closure inputs directly before artifact creation, keeping product-shaped declaration knowledge in the planner/oracle loop.
- **Fix shape:** `ArtifactRequest` no longer carries closure member requirements; `CompileBackSourceComposer` derives initial typed closure inputs from the raised `IrFunction` and overlays RTS oracle roots/facts on every compose.
- **Product impact:** Harness-only; product CLI output is unchanged.
- **RTS boundary:** RTS still orchestrates closure iteration, Roslyn diagnostics, and opcode compare; provider-side composition owns initial same-assembly typed closure derivation.

## Evidence

| Check | Result |
| --- | --- |
| Harness build | `dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet` passed |
| Focused tests | `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.ReturnToSenderPrototypeTests` passed, 96/96 |
| Markdown | `npx markdownlint-cli docs/design/fact-planned-compile-back-harness.md` passed |

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Roslyn diagnostic/oracle closure growth | Not moved | It depends on Roslyn `Diagnostic`/`SemanticModel` and remains RTS/tools-only feedback, not provider-owned initial derivation. |
| Product/shared API extraction | Future slice | This PR keeps the behavior-preserving boundary inside the current harness provider path. |

## Review

Adversarial review requested separately per repo policy.
