### PR TITLE
Add decompiler fidelity-cause Finding producer

### DIFF
--- a/docs/design/finding-producers.md
+++ b/docs/design/finding-producers.md
@@ -32,7 +32,7 @@ AnalysisFindings.InspectCallSites(...)
 AnalysisFindings.InspectUnsafety(...)
 MetadataFindings.InspectApiMembers(...)
 MetadataFindings.InspectApiTypes(...)
-DecompilerFindings.InspectDiagnostics(...)
+DecompilerFindings.InspectFidelityCauses(...)
 ```
 
 Do not create `AllocationFindings`, `CallSiteFindings`, or
@@ -88,6 +88,11 @@ transitions into a product view, but it does not become their source of truth.
 
 An inspection failure is an operation outcome, not an observation. Do not wrap
 it in `Finding<InspectionError>` or make it implement `IFinding`.
+
+For decompilation, fidelity causes are the raw per-site observations. Import,
+context, and projection failures such as `DEC0001`-`DEC0003` are inspection
+failures, while a method's `Full` or `Partial` fidelity is a fold over its cause
+census. Human diagnostic messages are not occurrence identity.
 
 ## 5. Choose identity and ordering semantics
 

--- a/src/ILInspector.Decompiler.Tests/DecompilerFindingsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DecompilerFindingsTests.cs
@@ -79,6 +79,21 @@ public class DecompilerFindingsTests
     }
 
     [Fact]
+    public void Inspect_CauseInSyntheticBlock_HasUnknownLocation()
+    {
+        var function = Function(new Continue(), blockOffset: -10);
+
+        var cause = Assert.Single(
+            CompleteInspection(DecompilerFindings.InspectFidelityCauses(function, Subject))
+                .Findings).Payload;
+
+        Assert.Equal(DiagnosticIds.UnverifiedContinue, cause.Code);
+        Assert.Equal(DecompilerFidelityLocationKind.Unknown, cause.Location.Kind);
+        Assert.Null(cause.Location.ILOffset);
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
     public void Inspect_UnsupportedTypesAtOneSite_AggregateEveryReason()
     {
         var container = new BlockContainer();

--- a/src/ILInspector.Decompiler.Tests/DecompilerFindingsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DecompilerFindingsTests.cs
@@ -136,7 +136,26 @@ public class DecompilerFindingsTests
     }
 
     [Fact]
-    public void Compare_CauseDetailChange_IsChanged()
+    public void Compare_LocationKindOnlyChange_IsExact()
+    {
+        var oldFunction = Function(new Continue(), blockOffset: 0x20);
+        var newFunction = Function(new Continue(), blockOffset: -10);
+
+        var comparison = CompleteComparison(
+            DecompilerFindings.CompareFidelityCauses(oldFunction, newFunction, Subject));
+
+        Assert.True(comparison.IsExact);
+        var present = Assert.Single(comparison.Pairs) switch
+        {
+            PairFinding<DecompilerFidelityCause>.Present value => value,
+            _ => throw new InvalidOperationException("Expected a present pair."),
+        };
+        Assert.Equal(DecompilerFidelityLocationKind.IlOffset, present.Old.Payload.Location.Kind);
+        Assert.Equal(DecompilerFidelityLocationKind.Unknown, present.New.Payload.Location.Kind);
+    }
+
+    [Fact]
+    public void Compare_ProseOnlyCauseDetailChange_IsExact()
     {
         var oldFunction = Function(
             new Return(new UnsupportedNode(0x05, "calli", "unsupported call site")));
@@ -146,13 +165,43 @@ public class DecompilerFindingsTests
         var comparison = CompleteComparison(
             DecompilerFindings.CompareFidelityCauses(oldFunction, newFunction, Subject));
 
+        Assert.True(comparison.IsExact);
+        Assert.All(comparison.Pairs, pair => Assert.Equal(PairKind.Present, pair.Kind));
+    }
+
+    [Fact]
+    public void Compare_DiscriminatorChange_IsChanged()
+    {
+        var oldFunction = Function(
+            new Return(new UnsupportedNode(0x05, "calli", "unsupported call site")));
+        var newFunction = Function(
+            new Return(new UnsupportedNode(0x05, "jmp", "unsupported call site")));
+
+        var comparison = CompleteComparison(
+            DecompilerFindings.CompareFidelityCauses(oldFunction, newFunction, Subject));
+
         var changed = Assert.Single(comparison.Pairs) switch
         {
             PairFinding<DecompilerFidelityCause>.Changed value => value,
             _ => throw new InvalidOperationException("Expected a changed pair."),
         };
-        Assert.Contains("reason", changed.Detail);
+        Assert.Contains("discriminator", changed.Detail);
         Assert.False(comparison.IsExact);
+    }
+
+    [Fact]
+    public void GetFidelityCauseIdentityKey_UsesStableCodeOnly()
+    {
+        var cause = new DecompilerFidelityCause(
+            DiagnosticIds.UnverifiedContinue,
+            DecompilerFidelityLocation.AtIlOffset(0x20),
+            nameof(Continue),
+            "continue;",
+            "residual continue is not currently proven opcode-exact");
+
+        Assert.Equal(
+            DiagnosticIds.UnverifiedContinue,
+            DecompilerFindings.GetFidelityCauseIdentityKey(cause));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/DecompilerFindingsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DecompilerFindingsTests.cs
@@ -1,0 +1,205 @@
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Findings;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class DecompilerFindingsTests
+{
+    static readonly FindingSubject Subject = new("M", "M");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
+
+    [Fact]
+    public void Inspect_FullFunction_IsCompleteEmptyCensus()
+    {
+        var inspection = CompleteInspection(
+            DecompilerFindings.InspectFidelityCauses(
+                Function(new Return(new Constant(0, Int32))),
+                Subject));
+
+        Assert.Empty(inspection.Findings);
+    }
+
+    [Fact]
+    public void Inspect_MissingFunction_IsAbsent()
+    {
+        var inspection = DecompilerFindings.InspectFidelityCauses(null, Subject);
+
+        Assert.True(inspection is FindingInspection<DecompilerFidelityCause>.Absent);
+    }
+
+    [Theory]
+    [InlineData(DiagnosticIds.InternalError)]
+    [InlineData(DiagnosticIds.ContextUnavailable)]
+    [InlineData(DiagnosticIds.EmptyOutput)]
+    public void Inspect_OperationFailure_IsFailedRatherThanFinding(string diagnosticId)
+    {
+        var function = Function(new Return(new Constant(0, Int32)));
+        function.Diagnostics.Add(new DecompilerDiagnostic(diagnosticId, "pipeline failed"));
+
+        var inspection = DecompilerFindings.InspectFidelityCauses(function, Subject);
+        var failed = inspection switch
+        {
+            FindingInspection<DecompilerFidelityCause>.Failed value => value,
+            _ => throw new InvalidOperationException("Expected a failed inspection."),
+        };
+
+        Assert.Contains(diagnosticId, failed.Error.Reason);
+    }
+
+    [Fact]
+    public void Inspect_UnsupportedNodes_PreserveEveryOccurrenceAndOrder()
+    {
+        var function = Function([
+            new ExpressionStatement(new UnsupportedNode(0x05, "calli", "unsupported call site")),
+            new Return(new UnsupportedNode(0x09, "jmp", "unsupported transfer"))]);
+
+        var inspection = CompleteInspection(
+            DecompilerFindings.InspectFidelityCauses(function, Subject));
+
+        Assert.Equal(2, inspection.Findings.Length);
+        Assert.Equal<int?>([0, 1], inspection.Findings.Select(static finding => finding.Ordinal));
+        Assert.Equal(["calli", "jmp"], inspection.Findings.Select(static finding => finding.Payload.Discriminator));
+        Assert.Equal([0x05, 0x09], inspection.Findings.Select(static finding => finding.Payload.Location.ILOffset));
+    }
+
+    [Fact]
+    public void Inspect_ResidualContinue_HasTypedIlLocation()
+    {
+        var function = Function(new Continue(), blockOffset: 0x20);
+
+        var cause = Assert.Single(
+            CompleteInspection(DecompilerFindings.InspectFidelityCauses(function, Subject))
+                .Findings).Payload;
+
+        Assert.Equal(DiagnosticIds.UnverifiedContinue, cause.Code);
+        Assert.Equal(DecompilerFidelityLocationKind.IlOffset, cause.Location.Kind);
+        Assert.Equal(0x20, cause.Location.ILOffset);
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void Inspect_UnsupportedTypesAtOneSite_AggregateEveryReason()
+    {
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new Return(new Constant(0, Int32)));
+        var signature = new MethodSignature(
+            Int32,
+            [
+                new Parameter("first", TypeRef.Unsupported("function pointer")),
+                new Parameter("second", TypeRef.Unsupported("custom modifier")),
+            ],
+            HasThis: false,
+            GenericParameterCount: 0);
+        var function = new IrFunction("M", Object, signature, [], container);
+
+        var cause = Assert.Single(
+            CompleteInspection(DecompilerFindings.InspectFidelityCauses(function, Subject))
+                .Findings).Payload;
+
+        Assert.Equal(DiagnosticIds.UnsupportedType, cause.Code);
+        Assert.Contains("function pointer", cause.Discriminator);
+        Assert.Contains("custom modifier", cause.Discriminator);
+        Assert.Equal(DecompilerFidelityLocationKind.Signature, cause.Location.Kind);
+    }
+
+    [Fact]
+    public void Compare_CoordinateOnlyChange_IsExact()
+    {
+        var oldFunction = Function(
+            new Return(new UnsupportedNode(0x05, "calli", "unsupported call site")));
+        var newFunction = Function(
+            new Return(new UnsupportedNode(0x25, "calli", "unsupported call site")));
+
+        var comparison = CompleteComparison(
+            DecompilerFindings.CompareFidelityCauses(oldFunction, newFunction, Subject));
+
+        Assert.True(comparison.IsExact);
+        Assert.All(comparison.Pairs, pair => Assert.Equal(PairKind.Present, pair.Kind));
+    }
+
+    [Fact]
+    public void Compare_CauseDetailChange_IsChanged()
+    {
+        var oldFunction = Function(
+            new Return(new UnsupportedNode(0x05, "calli", "unsupported call site")));
+        var newFunction = Function(
+            new Return(new UnsupportedNode(0x05, "calli", "different unsupported shape")));
+
+        var comparison = CompleteComparison(
+            DecompilerFindings.CompareFidelityCauses(oldFunction, newFunction, Subject));
+
+        var changed = Assert.Single(comparison.Pairs) switch
+        {
+            PairFinding<DecompilerFidelityCause>.Changed value => value,
+            _ => throw new InvalidOperationException("Expected a changed pair."),
+        };
+        Assert.Contains("reason", changed.Detail);
+        Assert.False(comparison.IsExact);
+    }
+
+    [Fact]
+    public void Compare_AbsentFunctions_IsExactWithoutFindings()
+    {
+        var comparison = CompleteComparison(
+            DecompilerFindings.CompareFidelityCauses(null, null, Subject));
+
+        Assert.True(comparison.IsExact);
+        Assert.Empty(comparison.Pairs);
+    }
+
+    [Fact]
+    public void Compare_OperationFailure_DoesNotRunMatching()
+    {
+        var failedFunction = Function(new Return(new Constant(0, Int32)));
+        failedFunction.Diagnostics.Add(new DecompilerDiagnostic(
+            DiagnosticIds.InternalError,
+            "importer failed"));
+
+        var comparison = DecompilerFindings.CompareFidelityCauses(
+            failedFunction,
+            Function(new Return(new Constant(0, Int32))),
+            Subject);
+
+        Assert.True(comparison is FindingComparison<DecompilerFidelityCause>.Failed);
+        Assert.Contains(DiagnosticIds.InternalError, comparison.Failure);
+    }
+
+    static IrFunction Function(IrNode statement, int blockOffset = 0)
+        => Function([statement], blockOffset);
+
+    static IrFunction Function(IReadOnlyList<IrNode> statements, int blockOffset = 0)
+    {
+        var container = new BlockContainer();
+        var block = new Block(blockOffset);
+        container.Add(block);
+        foreach (var statement in statements)
+            block.Add(statement);
+
+        var signature = new MethodSignature(
+            Int32,
+            [],
+            HasThis: false,
+            GenericParameterCount: 0);
+        return new IrFunction("M", Object, signature, [], container);
+    }
+
+    static FindingInspection<DecompilerFidelityCause>.Complete CompleteInspection(
+        FindingInspection<DecompilerFidelityCause> inspection)
+        => inspection switch
+        {
+            FindingInspection<DecompilerFidelityCause>.Complete complete => complete,
+            _ => throw new InvalidOperationException("Expected a complete inspection."),
+        };
+
+    static FindingComparison<DecompilerFidelityCause>.Complete CompleteComparison(
+        FindingComparison<DecompilerFidelityCause> comparison)
+        => comparison switch
+        {
+            FindingComparison<DecompilerFidelityCause>.Complete complete => complete,
+            FindingComparison<DecompilerFidelityCause>.Failed failed => throw new InvalidOperationException(
+                $"Expected a completed comparison: {failed.Failure}"),
+        };
+}

--- a/src/ILInspector.Decompiler.Tests/FidelityCauseBucketsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCauseBucketsTests.cs
@@ -1,0 +1,61 @@
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class FidelityCauseBucketsTests
+{
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+
+    [Fact]
+    public void PrimaryBucket_UsesStructuredOpcodeDiscriminator()
+    {
+        var function = Function(
+            new Return(new UnsupportedNode(0x05, "calli", "unsupported call site")));
+
+        Assert.Equal("calli", FidelityCauseBuckets.PrimaryBucket(function, "M"));
+    }
+
+    [Fact]
+    public void PrimaryBucket_UsesStableCodeWhenCauseHasNoDiscriminator()
+    {
+        var function = Function(new Continue());
+
+        Assert.Equal(
+            DiagnosticIds.UnverifiedContinue,
+            FidelityCauseBuckets.PrimaryBucket(function, "M"));
+    }
+
+    [Fact]
+    public void Inspect_OperationFailure_IsSurfaced()
+    {
+        var function = Function(new Return(new Constant(0, Int32)));
+        function.Diagnostics.Add(new DecompilerDiagnostic(
+            DiagnosticIds.InternalError,
+            "importer failed"));
+
+        var census = FidelityCauseBuckets.Inspect(function, "M");
+
+        Assert.False(census.Succeeded);
+        Assert.Contains(DiagnosticIds.InternalError, census.Failure);
+        Assert.Empty(census.Causes);
+    }
+
+    static IrFunction Function(IrNode statement)
+    {
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(statement);
+        return new IrFunction(
+            "M",
+            TypeRef.CoreLib("System", "Object"),
+            new MethodSignature(
+                Int32,
+                [],
+                HasThis: false,
+                GenericParameterCount: 0),
+            [],
+            container);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -63,6 +63,8 @@
              Link="CorpusMethodDelta.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\CorpusSensor.cs"
              Link="CorpusSensor.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\FidelityCauseBuckets.cs"
+             Link="FidelityCauseBuckets.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\FidelityCheck.cs"
              Link="FidelityCheck.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\ClosureDiagnosticEvidence.cs"

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -4,6 +4,7 @@ using DotnetInspector.Fixtures;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.DecompilerHarness;
+using ILInspector.Findings;
 using ILInspector.Metadata;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -842,7 +843,15 @@ public class LadderRung6GateTests
         {
             var member = members.Single(m => m.Name == name);
             Assert.Equal(DecompilationFidelity.Partial, member.Function.Fidelity);
-            Assert.Contains(FidelityRemarks.Collect(member.Function), r => r.Code == DiagnosticIds.UnsupportedConstruct);
+            var findings = DecompilerFindings.InspectFidelityCauses(
+                member.Function,
+                new FindingSubject($"{typeName}::{name}", name)) switch
+            {
+                FindingInspection<DecompilerFidelityCause>.Complete complete => complete.Findings,
+                _ => throw new InvalidOperationException("Expected a complete fidelity-cause inspection."),
+            };
+            Assert.Contains(findings, finding =>
+                finding.Payload.Code == DiagnosticIds.UnsupportedConstruct);
             Assert.Contains("cpblk", member.Body);
             Assert.Contains("return default;", member.Body);
         }

--- a/src/ILInspector.Decompiler.Tests/PinnedLocalFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PinnedLocalFidelityTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
+using ILInspector.Findings;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -49,6 +50,15 @@ public class PinnedLocalFidelityTests
         var function = Function([PinnedRefInt], body);
 
         Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+        var cause = Assert.Single(
+            DecompilerFindings.InspectFidelityCauses(function, new FindingSubject("M", "M")) switch
+            {
+                FindingInspection<DecompilerFidelityCause>.Complete complete => complete.Findings,
+                _ => throw new InvalidOperationException("Expected a complete fidelity-cause inspection."),
+            }).Payload;
+        Assert.Equal(DiagnosticIds.UnraisedPinnedLocal, cause.Code);
+        Assert.Equal(DecompilerFidelityLocationKind.Local, cause.Location.Kind);
+        Assert.Equal(0, cause.Location.LocalIndex);
     }
 
     [Fact]
@@ -63,6 +73,7 @@ public class PinnedLocalFidelityTests
         var function = Function([PinnedRefInt], body);
 
         Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Empty(FidelityRemarks.Collect(function));
     }
 
     [Fact]
@@ -76,5 +87,6 @@ public class PinnedLocalFidelityTests
         var function = Function([PinnedRefInt, Int32], body);
 
         Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Empty(FidelityRemarks.Collect(function));
     }
 }

--- a/src/ILInspector.Decompiler/DecompilerFidelityCause.cs
+++ b/src/ILInspector.Decompiler/DecompilerFidelityCause.cs
@@ -2,6 +2,7 @@ namespace ILInspector.Decompiler;
 
 public enum DecompilerFidelityLocationKind
 {
+    Unknown,
     Signature,
     IlOffset,
     Local,
@@ -28,6 +29,9 @@ public readonly record struct DecompilerFidelityLocation
     public int? ILOffset { get; }
 
     public int? LocalIndex { get; }
+
+    public static DecompilerFidelityLocation Unknown { get; } =
+        new(DecompilerFidelityLocationKind.Unknown, null, null);
 
     public static DecompilerFidelityLocation Signature { get; } =
         new(DecompilerFidelityLocationKind.Signature, null, null);

--- a/src/ILInspector.Decompiler/DecompilerFidelityCause.cs
+++ b/src/ILInspector.Decompiler/DecompilerFidelityCause.cs
@@ -1,0 +1,98 @@
+namespace ILInspector.Decompiler;
+
+public enum DecompilerFidelityLocationKind
+{
+    Signature,
+    IlOffset,
+    Local,
+}
+
+/// <summary>
+/// Typed provenance for one fidelity-lowering cause. IL offsets and local slots
+/// are version-local coordinates, not cross-version correspondence identity.
+/// </summary>
+public readonly record struct DecompilerFidelityLocation
+{
+    DecompilerFidelityLocation(
+        DecompilerFidelityLocationKind kind,
+        int? ilOffset,
+        int? localIndex)
+    {
+        Kind = kind;
+        ILOffset = ilOffset;
+        LocalIndex = localIndex;
+    }
+
+    public DecompilerFidelityLocationKind Kind { get; }
+
+    public int? ILOffset { get; }
+
+    public int? LocalIndex { get; }
+
+    public static DecompilerFidelityLocation Signature { get; } =
+        new(DecompilerFidelityLocationKind.Signature, null, null);
+
+    public static DecompilerFidelityLocation AtIlOffset(int offset)
+    {
+        if (offset < 0)
+            throw new ArgumentOutOfRangeException(nameof(offset));
+        return new DecompilerFidelityLocation(
+            DecompilerFidelityLocationKind.IlOffset,
+            offset,
+            null);
+    }
+
+    public static DecompilerFidelityLocation AtLocal(int localIndex)
+    {
+        if (localIndex < 0)
+            throw new ArgumentOutOfRangeException(nameof(localIndex));
+        return new DecompilerFidelityLocation(
+            DecompilerFidelityLocationKind.Local,
+            null,
+            localIndex);
+    }
+}
+
+/// <summary>
+/// One concrete site that prevents a decompiled method from claiming
+/// <see cref="DecompilationFidelity.Full"/> fidelity.
+/// </summary>
+public sealed record DecompilerFidelityCause
+{
+    public DecompilerFidelityCause(
+        string code,
+        DecompilerFidelityLocation location,
+        string nodeKind,
+        string node,
+        string reason,
+        string? discriminator = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(code);
+        ArgumentException.ThrowIfNullOrWhiteSpace(nodeKind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(node);
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+
+        Code = code;
+        Location = location;
+        NodeKind = nodeKind;
+        Node = node;
+        Reason = reason;
+        Discriminator = discriminator;
+    }
+
+    public string Code { get; }
+
+    public DecompilerFidelityLocation Location { get; }
+
+    public string NodeKind { get; }
+
+    public string Node { get; }
+
+    public string Reason { get; }
+
+    /// <summary>
+    /// Producer-owned structured detail used by consumers that group causes,
+    /// such as an unsupported opcode or type-shape reason.
+    /// </summary>
+    public string? Discriminator { get; }
+}

--- a/src/ILInspector.Decompiler/DecompilerFindings.cs
+++ b/src/ILInspector.Decompiler/DecompilerFindings.cs
@@ -79,7 +79,9 @@ public static class DecompilerFindings
     public static string GetFidelityCauseIdentityKey(DecompilerFidelityCause cause)
     {
         ArgumentNullException.ThrowIfNull(cause);
-        return $"{cause.Code}|{(int)cause.Location.Kind}";
+        // Fidelity cause matching is an ordered stream keyed by the stable DEC#### cause code.
+        // Location kind/offset/slot are version-local coordinates, not correspondence identity.
+        return cause.Code;
     }
 
     static bool IsOperationFailure(string id)
@@ -114,10 +116,12 @@ public static class DecompilerFindings
     static bool SameSemanticFacets(
         DecompilerFidelityCause oldCause,
         DecompilerFidelityCause newCause)
+        // Deliberate whitelist: only stable producer-owned classification facets can turn a
+        // matched cause into Changed. Human prose, CLR implementation type names, rendered node
+        // text, and location coordinates are diagnostic/display details and may drift without
+        // changing the logical fidelity cause.
         => oldCause.Code == newCause.Code
-            && oldCause.NodeKind == newCause.NodeKind
-            && oldCause.Discriminator == newCause.Discriminator
-            && oldCause.Reason == newCause.Reason;
+            && oldCause.Discriminator == newCause.Discriminator;
 
     static string DescribeFacetChanges(
         DecompilerFidelityCause oldCause,
@@ -125,9 +129,7 @@ public static class DecompilerFindings
     {
         var changes = new List<string>();
         AddChange(changes, "code", oldCause.Code, newCause.Code);
-        AddChange(changes, "node kind", oldCause.NodeKind, newCause.NodeKind);
         AddChange(changes, "discriminator", oldCause.Discriminator, newCause.Discriminator);
-        AddChange(changes, "reason", oldCause.Reason, newCause.Reason);
         return changes.Count == 0 ? "other fidelity-cause facets changed" : string.Join("; ", changes);
     }
 

--- a/src/ILInspector.Decompiler/DecompilerFindings.cs
+++ b/src/ILInspector.Decompiler/DecompilerFindings.cs
@@ -1,0 +1,141 @@
+using System.Collections.Immutable;
+
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Findings;
+
+namespace ILInspector.Decompiler;
+
+/// <summary>Decompiler-owned observations and comparisons over the Finding substrate.</summary>
+public static class DecompilerFindings
+{
+    public static readonly FindingDescriptor FidelityCauseDescriptor =
+        new("decompiler.fidelity-cause", "Decompiler fidelity cause");
+
+    public static readonly FindingDescriptor FidelityInspectionDescriptor =
+        new("decompiler.fidelity.inspect", "Decompiler fidelity inspection");
+
+    /// <summary>
+    /// Inspects one final decompiler IR tree. A null tree means no method body was
+    /// available; an importer/pipeline failure remains an operation failure rather
+    /// than being projected as a fidelity-cause observation.
+    /// </summary>
+    public static FindingInspection<DecompilerFidelityCause> InspectFidelityCauses(
+        IrFunction? function,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+
+        if (function is null)
+        {
+            return new FindingInspection<DecompilerFidelityCause>.Absent(
+                "Method has no decompiler IR body.");
+        }
+
+        foreach (var diagnostic in function.Diagnostics)
+        {
+            if (!IsOperationFailure(diagnostic.Id))
+                continue;
+
+            return new FindingInspection<DecompilerFidelityCause>.Failed(
+                new InspectionError(
+                    subject,
+                    FidelityInspectionDescriptor,
+                    $"{diagnostic.Id}: {diagnostic.Message}"));
+        }
+
+        var causes = FidelityRemarks.CollectCauses(function);
+        var findings = ImmutableArray.CreateBuilder<Finding<DecompilerFidelityCause>>(causes.Count);
+        for (int i = 0; i < causes.Count; i++)
+        {
+            var cause = causes[i];
+            findings.Add(new Finding<DecompilerFidelityCause>(
+                subject,
+                FidelityCauseDescriptor,
+                new FindingKey(GetFidelityCauseIdentityKey(cause)),
+                cause,
+                Ordinal: i,
+                Detail: cause.Reason));
+        }
+
+        return new FindingInspection<DecompilerFidelityCause>.Complete(
+            findings.MoveToImmutable());
+    }
+
+    public static FindingComparison<DecompilerFidelityCause> CompareFidelityCauses(
+        IrFunction? oldFunction,
+        IrFunction? newFunction,
+        FindingSubject subject,
+        int acceptanceThreshold = 100)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return FindingComparison.Compare(
+                InspectFidelityCauses(oldFunction, subject),
+                InspectFidelityCauses(newFunction, subject),
+                acceptanceThreshold: acceptanceThreshold)
+            .TransformPairs(ClassifyFacetChanges);
+    }
+
+    public static string GetFidelityCauseIdentityKey(DecompilerFidelityCause cause)
+    {
+        ArgumentNullException.ThrowIfNull(cause);
+        return $"{cause.Code}|{(int)cause.Location.Kind}";
+    }
+
+    static bool IsOperationFailure(string id)
+        => id is DiagnosticIds.InternalError
+            or DiagnosticIds.ContextUnavailable
+            or DiagnosticIds.EmptyOutput;
+
+    static ImmutableArray<PairFinding<DecompilerFidelityCause>> ClassifyFacetChanges(
+        ImmutableArray<PairFinding<DecompilerFidelityCause>> pairs)
+    {
+        var builder = ImmutableArray.CreateBuilder<PairFinding<DecompilerFidelityCause>>(pairs.Length);
+        foreach (var pair in pairs)
+        {
+            if (pair is PairFinding<DecompilerFidelityCause>.Present present
+                && !SameSemanticFacets(present.Old.Payload, present.New.Payload))
+            {
+                builder.Add(new PairFinding<DecompilerFidelityCause>.Changed(
+                    present.Old,
+                    present.New,
+                    present.Difference,
+                    DescribeFacetChanges(present.Old.Payload, present.New.Payload)));
+            }
+            else
+            {
+                builder.Add(pair);
+            }
+        }
+
+        return builder.MoveToImmutable();
+    }
+
+    static bool SameSemanticFacets(
+        DecompilerFidelityCause oldCause,
+        DecompilerFidelityCause newCause)
+        => oldCause.Code == newCause.Code
+            && oldCause.NodeKind == newCause.NodeKind
+            && oldCause.Discriminator == newCause.Discriminator
+            && oldCause.Reason == newCause.Reason;
+
+    static string DescribeFacetChanges(
+        DecompilerFidelityCause oldCause,
+        DecompilerFidelityCause newCause)
+    {
+        var changes = new List<string>();
+        AddChange(changes, "code", oldCause.Code, newCause.Code);
+        AddChange(changes, "node kind", oldCause.NodeKind, newCause.NodeKind);
+        AddChange(changes, "discriminator", oldCause.Discriminator, newCause.Discriminator);
+        AddChange(changes, "reason", oldCause.Reason, newCause.Reason);
+        return changes.Count == 0 ? "other fidelity-cause facets changed" : string.Join("; ", changes);
+    }
+
+    static void AddChange<T>(List<string> changes, string name, T oldValue, T newValue)
+    {
+        if (EqualityComparer<T>.Default.Equals(oldValue, newValue))
+            return;
+
+        changes.Add($"{name}: {oldValue?.ToString() ?? "none"} -> {newValue?.ToString() ?? "none"}");
+    }
+}

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -26,7 +26,9 @@ public enum DecompilationFidelity
 /// <summary>
 /// A diagnostic with a stable machine-readable identifier. Identifiers drive
 /// fallback routing and CI triage, so they are stable across releases; the
-/// message is for humans and carries no contract.
+/// message is for humans and carries no contract. Use
+/// <see cref="DecompilerFindings.InspectFidelityCauses"/> for the complete
+/// identity-bearing census of fidelity-lowering sites.
 /// </summary>
 public readonly record struct DecompilerDiagnostic(string Id, string Message)
 {
@@ -167,6 +169,18 @@ public static class DiagnosticIds
     /// faithful — the volatility lives on the field declaration.
     /// </summary>
     public const string VolatileIndirectAccess = "DEC0012";
+
+    /// <summary>
+    /// A residual <c>continue</c> whose source-like spelling is not currently
+    /// proven opcode-exact.
+    /// </summary>
+    public const string UnverifiedContinue = "DEC0013";
+
+    /// <summary>
+    /// A referenced <c>pinned</c> local survived without an owning
+    /// <c>fixed</c> statement and has no faithful C# declaration spelling.
+    /// </summary>
+    public const string UnraisedPinnedLocal = "DEC0014";
 }
 
 /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/FidelityRemarks.cs
+++ b/src/ILInspector.Decompiler/Pipeline/FidelityRemarks.cs
@@ -6,72 +6,214 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <c>DEC####</c> code and a human reason — the optimization-remarks analog
 /// (LLVM <c>-Rpass</c> / opt-viewer) for the decompiler (issue #637). The walk
 /// applies the same predicate as <see cref="IrFunction.Fidelity"/>, so a remark
-/// exists for exactly the nodes that lower fidelity and the view cannot drift
+/// exists for every site that lowers fidelity and the view cannot drift
 /// from the score. Fidelity is computed from the final tree (never asserted by a
 /// pass), so a remark names the <em>IR site</em> and cause rather than a pass.
 /// </summary>
 public static class FidelityRemarks
 {
     /// <summary>
-    /// One fidelity-lowering site. <paramref name="Offset"/> is the enclosing
-    /// block's IL offset (or the node's own offset when it carries one); -1 for
-    /// a signature-level cause (an unrepresentable parameter, return, or local
-    /// type) that belongs to no block.
+    /// Compatibility view over the typed fidelity-cause census. Local and
+    /// signature causes have no IL coordinate and retain the historical -1.
     /// </summary>
     public sealed record Remark(string Code, int Offset, string Node, string Reason);
 
     public static IReadOnlyList<Remark> Collect(IrFunction function)
     {
-        var remarks = new List<Remark>();
+        ArgumentNullException.ThrowIfNull(function);
+        return Enumerate(function)
+            .Select(static cause => new Remark(
+                cause.Code,
+                cause.Location.ILOffset ?? -1,
+                cause.Node,
+                cause.Reason))
+            .ToArray();
+    }
+
+    internal static IReadOnlyList<DecompilerFidelityCause> CollectCauses(IrFunction function)
+    {
+        ArgumentNullException.ThrowIfNull(function);
+        return Enumerate(function).ToArray();
+    }
+
+    internal static bool HasAny(IrFunction function)
+    {
+        ArgumentNullException.ThrowIfNull(function);
+        return Enumerate(function).Any();
+    }
+
+    static IEnumerable<DecompilerFidelityCause> Enumerate(IrFunction function)
+    {
         foreach (var node in function.Descendants.Prepend(function))
         {
             switch (node)
             {
                 case UnsupportedNode u:
-                    Add(remarks, DiagnosticIds.UnsupportedConstruct, u.ILOffset, u, $"{u.Opcode}: {u.Reason}");
+                    yield return Cause(
+                        DiagnosticIds.UnsupportedConstruct,
+                        u.ILOffset >= 0
+                            ? DecompilerFidelityLocation.AtIlOffset(u.ILOffset)
+                            : LocationOf(u),
+                        u,
+                        $"{u.Opcode}: {u.Reason}",
+                        u.Opcode);
                     continue;  // its own type checks are noise next to the explicit reason
                 case LoadFunctionPointer:
-                    Add(remarks, DiagnosticIds.UnsupportedFunctionPointer, OffsetOf(node), node,
+                    yield return Cause(
+                        DiagnosticIds.UnsupportedFunctionPointer,
+                        LocationOf(node),
+                        node,
                         "bare function-pointer load (ldftn/ldvirtftn) with no C# spelling");
                     break;
                 case Call { HasUnverifiedByRefArgument: true }:
                 case NewObject { HasUnverifiedByRefArgument: true }:
-                    Add(remarks, DiagnosticIds.UnverifiedByRefArgument, OffsetOf(node), node,
+                    yield return Cause(
+                        DiagnosticIds.UnverifiedByRefArgument,
+                        LocationOf(node),
+                        node,
                         "by-ref argument rendered against an unknown call-site ref-kind (out/in cannot be distinguished from ref)");
                     break;
                 case LoadToken { Kind: not RuntimeTokenKind.Type }:
-                    Add(remarks, DiagnosticIds.UnsupportedRuntimeToken, OffsetOf(node), node,
+                    yield return Cause(
+                        DiagnosticIds.UnsupportedRuntimeToken,
+                        LocationOf(node),
+                        node,
                         "runtime method/field token load (ldtoken) with no C# expression spelling");
                     break;
                 case EndFilter:
-                    Add(remarks, DiagnosticIds.UnsupportedExceptionFilter, OffsetOf(node), node,
+                    yield return Cause(
+                        DiagnosticIds.UnsupportedExceptionFilter,
+                        LocationOf(node),
+                        node,
                         "residual exception filter boundary (endfilter) with no standalone C# spelling");
+                    break;
+                case Continue:
+                    yield return Cause(
+                        DiagnosticIds.UnverifiedContinue,
+                        LocationOf(node),
+                        node,
+                        "residual continue is not currently proven opcode-exact");
                     break;
                 case LoadIndirect { IsVolatile: true }:
                 case StoreIndirect { IsVolatile: true }:
-                    Add(remarks, DiagnosticIds.VolatileIndirectAccess, OffsetOf(node), node,
+                    yield return Cause(
+                        DiagnosticIds.VolatileIndirectAccess,
+                        LocationOf(node),
+                        node,
                         "volatile. indirect access (volatile. ldind/stind) renders as a bare *p, dropping the acquire/release ordering — no faithful plain-C# spelling");
                     break;
             }
 
-            var unsupportedType = node.DirectTypes.FirstOrDefault(t => t.ContainsUnsupported)
-                ?? ((node as IrExpression)?.ResultType is { ContainsUnsupported: true } rt ? rt : null);
-            if (unsupportedType is not null)
-                Add(remarks, DiagnosticIds.UnsupportedType, OffsetOf(node), node,
-                    $"references an unrepresentable type ({UnrepresentableTypeText(unsupportedType)})");
+            List<TypeRef>? unsupportedTypes = null;
+            foreach (var type in node.DirectTypes)
+            {
+                if (type.ContainsUnsupported
+                    && (unsupportedTypes is null || !unsupportedTypes.Contains(type)))
+                {
+                    (unsupportedTypes ??= []).Add(type);
+                }
+            }
+            if ((node as IrExpression)?.ResultType is { ContainsUnsupported: true } resultType
+                && (unsupportedTypes is null || !unsupportedTypes.Contains(resultType)))
+            {
+                (unsupportedTypes ??= []).Add(resultType);
+            }
+            if (unsupportedTypes is not null)
+            {
+                string types = string.Join("; ", unsupportedTypes.Select(UnrepresentableTypeText));
+                string discriminator = string.Join(
+                    "; ",
+                    unsupportedTypes
+                        .SelectMany(static type => type.UnsupportedReasons())
+                        .Distinct(StringComparer.Ordinal)
+                        .Order(StringComparer.Ordinal));
+                yield return Cause(
+                    DiagnosticIds.UnsupportedType,
+                    LocationOf(node),
+                    node,
+                    $"references an unrepresentable type ({types})",
+                    discriminator);
+            }
 
             if (CSharpSpellability.UnrepresentableMetadataNameReason(node) is { } nameReason)
-                Add(remarks, DiagnosticIds.UnrepresentableMetadataName, OffsetOf(node), node, nameReason);
+            {
+                yield return Cause(
+                    DiagnosticIds.UnrepresentableMetadataName,
+                    LocationOf(node),
+                    node,
+                    nameReason);
+            }
 
             if (node is IrExpression { ResultType: null })
-                Add(remarks, DiagnosticIds.UnknownResultType, OffsetOf(node), node,
+            {
+                yield return Cause(
+                    DiagnosticIds.UnknownResultType,
+                    LocationOf(node),
+                    node,
                     "expression result type is unknown (e.g. a slot merged from conflicting types)");
+            }
         }
-        return remarks;
+
+        foreach (int localIndex in UnraisedPinnedLocals(function))
+        {
+            yield return new DecompilerFidelityCause(
+                DiagnosticIds.UnraisedPinnedLocal,
+                DecompilerFidelityLocation.AtLocal(localIndex),
+                "PinnedLocal",
+                $"Pinned local V_{localIndex}",
+                "referenced pinned local has no owning fixed statement and no faithful C# declaration",
+                function.Locals[localIndex].ToDisplayString());
+        }
     }
 
-    static void Add(List<Remark> remarks, string code, int offset, IrNode node, string reason)
-        => remarks.Add(new Remark(code, offset, node.Describe(), reason));
+    static DecompilerFidelityCause Cause(
+        string code,
+        DecompilerFidelityLocation location,
+        IrNode node,
+        string reason,
+        string? discriminator = null)
+        => new(
+            code,
+            location,
+            node.GetType().Name,
+            node.Describe(),
+            reason,
+            discriminator);
+
+    static IEnumerable<int> UnraisedPinnedLocals(IrFunction function)
+    {
+        HashSet<int>? pinned = null;
+        for (int i = 0; i < function.Locals.Length; i++)
+        {
+            if (function.Locals[i].Kind == TypeRefKind.Pinned)
+                (pinned ??= []).Add(i);
+        }
+        if (pinned is null)
+            yield break;
+
+        var fixedOwned = function.Descendants
+            .OfType<Fixed>()
+            .Select(static fixedStatement => fixedStatement.LocalIndex)
+            .ToHashSet();
+        var reported = new HashSet<int>();
+        foreach (var node in function.Descendants)
+        {
+            int slot = node switch
+            {
+                LoadLocal load => load.Index,
+                StoreLocal store => store.Index,
+                LoadLocalAddress address => address.Index,
+                _ => -1,
+            };
+            if (slot >= 0
+                && pinned.Contains(slot)
+                && !fixedOwned.Contains(slot)
+                && reported.Add(slot))
+            {
+                yield return slot;
+            }
+        }
+    }
 
     static string UnrepresentableTypeText(TypeRef type)
     {
@@ -93,12 +235,14 @@ public static class FidelityRemarks
             _ => type.ToDisplayString(),
         };
 
-    /// <summary>The enclosing block's offset, climbing parents; -1 when the node hangs off the signature.</summary>
-    static int OffsetOf(IrNode node)
+    static DecompilerFidelityLocation LocationOf(IrNode node)
     {
+        if (node.SourceOffset >= 0)
+            return DecompilerFidelityLocation.AtIlOffset(node.SourceOffset);
+
         for (IrNode? n = node; n is not null; n = n.Parent)
             if (n is Block b)
-                return b.StartOffset;
-        return -1;
+                return DecompilerFidelityLocation.AtIlOffset(b.StartOffset);
+        return DecompilerFidelityLocation.Signature;
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/FidelityRemarks.cs
+++ b/src/ILInspector.Decompiler/Pipeline/FidelityRemarks.cs
@@ -154,7 +154,10 @@ public static class FidelityRemarks
             }
         }
 
-        foreach (int localIndex in UnraisedPinnedLocals(function))
+        if (UnraisedPinnedLocals(function) is not { } unraisedPinnedLocals)
+            yield break;
+
+        foreach (int localIndex in unraisedPinnedLocals)
         {
             yield return new DecompilerFidelityCause(
                 DiagnosticIds.UnraisedPinnedLocal,
@@ -180,7 +183,7 @@ public static class FidelityRemarks
             reason,
             discriminator);
 
-    static IEnumerable<int> UnraisedPinnedLocals(IrFunction function)
+    static IEnumerable<int>? UnraisedPinnedLocals(IrFunction function)
     {
         HashSet<int>? pinned = null;
         for (int i = 0; i < function.Locals.Length; i++)
@@ -189,8 +192,15 @@ public static class FidelityRemarks
                 (pinned ??= []).Add(i);
         }
         if (pinned is null)
-            yield break;
+            return null;
 
+        return EnumerateUnraisedPinnedLocals(function, pinned);
+    }
+
+    static IEnumerable<int> EnumerateUnraisedPinnedLocals(
+        IrFunction function,
+        HashSet<int> pinned)
+    {
         var fixedOwned = function.Descendants
             .OfType<Fixed>()
             .Select(static fixedStatement => fixedStatement.LocalIndex)
@@ -241,8 +251,10 @@ public static class FidelityRemarks
             return DecompilerFidelityLocation.AtIlOffset(node.SourceOffset);
 
         for (IrNode? n = node; n is not null; n = n.Parent)
-            if (n is Block b)
+            if (n is Block { StartOffset: >= 0 } b)
                 return DecompilerFidelityLocation.AtIlOffset(b.StartOffset);
-        return DecompilerFidelityLocation.Signature;
+        return node is IrFunction
+            ? DecompilerFidelityLocation.Signature
+            : DecompilerFidelityLocation.Unknown;
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -365,61 +365,9 @@ public sealed class IrFunction : IrNode
     /// <see cref="DecompilationFidelity.Partial"/>.
     /// </summary>
     public DecompilationFidelity Fidelity
-        => Descendants.Prepend(this).Any(n =>
-            n is UnsupportedNode
-            || n is LoadFunctionPointer
-            || n is Call { HasUnverifiedByRefArgument: true }
-            || n is NewObject { HasUnverifiedByRefArgument: true }
-            || n is LoadToken { Kind: not RuntimeTokenKind.Type }
-            || n is EndFilter
-            || n is Continue
-            || n is LoadIndirect { IsVolatile: true }
-            || n is StoreIndirect { IsVolatile: true }
-            || n.DirectTypes.Any(t => t.ContainsUnsupported)
-            || CSharpSpellability.HasUnrepresentableMetadataName(n)
-            || n is IrExpression { ResultType: null }
-            || (n as IrExpression)?.ResultType?.ContainsUnsupported == true)
-            || HasUnraisedPinnedLocal()
+        => FidelityRemarks.HasAny(this)
             ? DecompilationFidelity.Partial
             : DecompilationFidelity.Full;
-
-    /// <summary>
-    /// True when a <c>pinned</c> local survives un-raised: still referenced by a
-    /// load/store/address yet owned by no <see cref="Fixed"/> statement. Such a
-    /// slot renders as the IL-only <c>pinned ref T name;</c> declaration, which is
-    /// not legal C# (CS1585) — so the method must degrade honestly rather than
-    /// claim <see cref="DecompilationFidelity.Full"/>. <see cref="FixedStatementPass"/>
-    /// raises the provable shapes (the marshalling-stub forms it cannot prove are
-    /// deliberately left flat); a raised pin is either its owning <c>fixed</c>
-    /// variable or, when the derived pointer is folded, left unreferenced — both
-    /// excluded here, so only the genuinely flat pin trips this.
-    /// </summary>
-    bool HasUnraisedPinnedLocal()
-    {
-        HashSet<int>? pinned = null;
-        for (int i = 0; i < Locals.Length; i++)
-        {
-            if (Locals[i].Kind == TypeRefKind.Pinned)
-                (pinned ??= []).Add(i);
-        }
-        if (pinned is null)
-            return false;
-
-        var fixedOwned = Descendants.OfType<Fixed>().Select(f => f.LocalIndex).ToHashSet();
-        foreach (var node in Descendants)
-        {
-            int slot = node switch
-            {
-                LoadLocal load => load.Index,
-                StoreLocal store => store.Index,
-                LoadLocalAddress address => address.Index,
-                _ => -1,
-            };
-            if (slot >= 0 && pinned.Contains(slot) && !fixedOwned.Contains(slot))
-                return true;
-        }
-        return false;
-    }
 
     public override string Describe()
         => $"Function {Signature.ReturnType.ToDisplayString()} {Name}({string.Join(", ", Signature.Parameters.Select(p => $"{p.Type.ToDisplayString()} {p.Name}"))})";

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -209,9 +209,10 @@ internal static class CorpusSensor
 
                 if (passBug is null)
                 {
+                    string id = $"{typeName}::{methodName}{overload}";
                     residual = Completeness.Residual(function)
                         ?? (function.Fidelity != DecompilationFidelity.Full
-                            ? $"fidelity: {BucketFor(function.Diagnostics.FirstOrDefault())}"
+                            ? $"fidelity: {FidelityCauseBuckets.PrimaryBucket(function, id)}"
                             : null);
                 }
                 if (passBug is null && residual is null)
@@ -367,19 +368,6 @@ internal static class CorpusSensor
         if (reports.Count == 0)
             reports.Add(new FidelityCapReport(0, new FidelitySensorMetrics(0, 0, 0, 0, 0, 0), ImmutableDictionary<string, FidelityCheck.FailureBucketSummary>.Empty, ImmutableDictionary<string, FidelityCheck.FailureBucketSummary>.Empty));
         return reports.ToImmutable();
-    }
-
-    static string BucketFor(DecompilerDiagnostic diagnostic)
-    {
-        if (diagnostic.Id is null)
-            return "(typed)";
-        if (diagnostic.Id == DiagnosticIds.UnsupportedType)
-        {
-            var message = diagnostic.Message ?? "(typed)";
-            int detail = message.IndexOf('(');
-            return detail < 0 ? message : message[..detail].TrimEnd();
-        }
-        return diagnostic.Message?.Split(' ').ElementAtOrDefault(1) ?? "(typed)";
     }
 
     static string MethodKey(CorpusMethodSnapshot method)

--- a/tools/DecompilerHarness/Dec0009Classifier.cs
+++ b/tools/DecompilerHarness/Dec0009Classifier.cs
@@ -79,7 +79,13 @@ internal static class Dec0009Classifier
                     continue;
                 }
 
-                var allRemarks = FidelityRemarks.Collect(function);
+                var census = FidelityCauseBuckets.Inspect(function, id);
+                if (!census.Succeeded)
+                {
+                    passBugs++;
+                    continue;
+                }
+                var allRemarks = census.Causes;
                 var methodRemarks = allRemarks
                     .Where(r => r.Code == DiagnosticIds.UnrepresentableMetadataName)
                     .ToArray();
@@ -128,7 +134,7 @@ internal static class Dec0009Classifier
                 .Select(b => new Dec0009CategoryReport(b.Category, b.Disposition, b.Methods, b.PrimaryMethods, b.Remarks, [.. b.Examples]))]);
     }
 
-    internal static string Classify(string methodId, IReadOnlyList<FidelityRemarks.Remark> remarks)
+    internal static string Classify(string methodId, IReadOnlyList<DecompilerFidelityCause> remarks)
     {
         string haystack = methodId + "\n" + string.Join('\n', remarks.Select(r => r.Reason + "\n" + r.Node));
 

--- a/tools/DecompilerHarness/FidelityCauseBuckets.cs
+++ b/tools/DecompilerHarness/FidelityCauseBuckets.cs
@@ -1,0 +1,77 @@
+using System.Collections.Immutable;
+
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Findings;
+
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// Harness-owned grouping policy over producer-owned fidelity observations.
+/// Human diagnostic prose is deliberately not part of the bucket contract.
+/// </summary>
+internal static class FidelityCauseBuckets
+{
+    internal readonly record struct Census(
+        ImmutableArray<DecompilerFidelityCause> Causes,
+        string? Failure)
+    {
+        internal bool Succeeded => Failure is null;
+    }
+
+    internal static Census Inspect(
+        IrFunction function,
+        string subjectKey)
+    {
+        ArgumentNullException.ThrowIfNull(function);
+        ArgumentException.ThrowIfNullOrWhiteSpace(subjectKey);
+
+        return DecompilerFindings.InspectFidelityCauses(
+            function,
+            new FindingSubject(subjectKey, subjectKey)) switch
+        {
+            FindingInspection<DecompilerFidelityCause>.Complete complete =>
+                new Census(
+                    [.. complete.Findings.Select(static finding => finding.Payload)],
+                    null),
+            FindingInspection<DecompilerFidelityCause>.Absent absent =>
+                new Census([], absent.Detail ?? "Decompiler IR was absent."),
+            FindingInspection<DecompilerFidelityCause>.Failed failed =>
+                new Census([], failed.Error.Reason),
+        };
+    }
+
+    internal static string PrimaryBucket(IrFunction function, string subjectKey)
+    {
+        ArgumentNullException.ThrowIfNull(function);
+        ArgumentException.ThrowIfNullOrWhiteSpace(subjectKey);
+
+        var census = Inspect(function, subjectKey);
+        if (!census.Succeeded)
+        {
+            return
+                function.Diagnostics
+                    .FirstOrDefault(static diagnostic =>
+                        diagnostic.Id is DiagnosticIds.InternalError
+                            or DiagnosticIds.ContextUnavailable
+                            or DiagnosticIds.EmptyOutput)
+                    .Id
+                    ?? "inspection-failed";
+        }
+
+        return census.Causes.Length > 0
+            ? BucketFor(census.Causes[0])
+            : "(typed)";
+    }
+
+    internal static string BucketFor(DecompilerFidelityCause cause)
+    {
+        ArgumentNullException.ThrowIfNull(cause);
+        return cause.Code switch
+        {
+            DiagnosticIds.UnsupportedConstruct or DiagnosticIds.UnsupportedType =>
+                cause.Discriminator ?? cause.Code,
+            _ => cause.Code,
+        };
+    }
+}

--- a/tools/DecompilerHarness/LibraryReport.cs
+++ b/tools/DecompilerHarness/LibraryReport.cs
@@ -114,7 +114,7 @@ internal static class LibraryReport
                 }
 
                 string? residual = Completeness.Residual(function)
-                    ?? (!full ? $"fidelity: {BucketFor(function, function.Diagnostics.FirstOrDefault())}" : null);
+                    ?? (!full ? $"fidelity: {FidelityCauseBuckets.PrimaryBucket(function, id)}" : null);
                 if (residual is null)
                 {
                     report.FullyRaisedMethods++;
@@ -203,30 +203,6 @@ internal static class LibraryReport
         }
 
         return report.ToReport(buckets);
-    }
-
-    static string BucketFor(IrFunction function, DecompilerDiagnostic diagnostic)
-    {
-        if (diagnostic.Id is null)
-        {
-            // No pass recorded a reason — but fidelity is computed from the final
-            // tree, never asserted by a pass, so the lowering cause still lives in
-            // the tree (an unrepresentable compiler-generated name, an unverified
-            // by-ref argument, a residual function pointer, ...). Recover it with the
-            // same walk the score uses (FidelityRemarks) and bucket by the stable
-            // DEC#### code, so the opaque "(typed)" catch-all becomes the same
-            // per-cause buckets the recorded diagnostics already produce. The walk
-            // always finds at least one site for a non-Full function, so the
-            // "(typed)" fallback is unreachable in practice — kept only for safety.
-            return FidelityRemarks.Collect(function).FirstOrDefault()?.Code ?? "(typed)";
-        }
-        if (diagnostic.Id == DiagnosticIds.UnsupportedType)
-        {
-            var message = diagnostic.Message ?? "(typed)";
-            int detail = message.IndexOf('(');
-            return detail < 0 ? message : message[..detail].TrimEnd();
-        }
-        return diagnostic.Message?.Split(' ').ElementAtOrDefault(1) ?? "(typed)";
     }
 
     static void Record(Dictionary<string, Bucket> buckets, string key, string example, int maxExamples)

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -703,8 +703,9 @@ static class Program
                     full++;
                     continue;
                 }
-                var diagnostic = function.Diagnostics.FirstOrDefault();
-                if (diagnostic.Id == DiagnosticIds.InternalError)
+                var diagnostic = function.Diagnostics.FirstOrDefault(static diagnostic =>
+                    diagnostic.Id == DiagnosticIds.InternalError);
+                if (diagnostic.Id is not null)
                 {
                     crashes++;
                     Console.Error.WriteLine($"IMPORTER BUG: {diagnostic.Message}");

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -599,7 +599,7 @@ static class Program
                 string id = $"{typeName}::{methodName}";
                 string? bucket = Completeness.Residual(function)
                     ?? (function.Fidelity != DecompilationFidelity.Full
-                        ? $"fidelity: {BucketFor(function.Diagnostics.FirstOrDefault())}"
+                        ? $"fidelity: {FidelityCauseBuckets.PrimaryBucket(function, id)}"
                         : null);
 
                 if (bucket is null)
@@ -684,9 +684,10 @@ static class Program
         {
             using var source = MetadataSource.Open(assemblyPath, context: metadata);
             var context = PassContext.ForImport(ImportSeam(source));
-            foreach (var (_, _, function) in IrImporter.ImportAssembly(source))
+            foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
             {
                 total++;
+                string id = $"{typeName}::{methodName}";
                 try
                 {
                     IrPasses.Run(function, IrPasses.Default, context);
@@ -709,7 +710,7 @@ static class Program
                     Console.Error.WriteLine($"IMPORTER BUG: {diagnostic.Message}");
                     continue;
                 }
-                string bucket = BucketFor(diagnostic);
+                string bucket = FidelityCauseBuckets.PrimaryBucket(function, id);
                 stops[bucket] = stops.GetValueOrDefault(bucket) + 1;
             }
         }
@@ -719,25 +720,6 @@ static class Program
         foreach (var stop in stops.OrderByDescending(s => s.Value).Take(15))
             Console.WriteLine($"  {stop.Value,8}  {stop.Key}");
         return crashes > 0 ? 1 : 0;
-    }
-
-    /// <summary>
-    /// The roadmap bucket for a stop. Type-level stops
-    /// (<see cref="DiagnosticIds.UnsupportedType"/>) group by their reason —
-    /// the function-pointer and custom-modifier signatures that used to sink
-    /// fidelity silently into the "(typed)" catch-all; the parenthetical detail
-    /// (the specific modifier type) is trimmed so they aggregate. Opcode-level
-    /// stops keep their second message token (the IL opcode).
-    /// </summary>
-    static string BucketFor(DecompilerDiagnostic diagnostic)
-    {
-        if (diagnostic.Id == DiagnosticIds.UnsupportedType)
-        {
-            var message = diagnostic.Message ?? "(typed)";
-            int detail = message.IndexOf('(');
-            return detail < 0 ? message : message[..detail].TrimEnd();
-        }
-        return diagnostic.Message?.Split(' ').ElementAtOrDefault(1) ?? "(typed)";
     }
 
     /// <summary>
@@ -1202,22 +1184,30 @@ static class Program
                 continue;
 
             IrPasses.Run(function, IrPasses.Default, PassContext.ForImport(ImportSeam(source)));  // raise through the canonical pipeline, as the product does
-            var remarks = FidelityRemarks.Collect(function);
+            var census = FidelityCauseBuckets.Inspect(function, dumpMethod);
+            if (!census.Succeeded)
+                return Fail($"Fidelity-cause inspection failed: {census.Failure}");
+            var remarks = census.Causes;
 
             Console.WriteLine($"// {dumpMethod} in {Path.GetFileName(assemblyPath)} (pipeline: next, fidelity remarks)");
             Console.WriteLine();
             Console.WriteLine($"fidelity: {function.Fidelity}");
-            if (remarks.Count == 0)
+            if (remarks.Length == 0)
             {
                 Console.WriteLine("remarks: (none) — every construct raised; representable C#");
                 return 0;
             }
 
-            Console.WriteLine($"remarks: {remarks.Count} site{(remarks.Count == 1 ? "" : "s")} cap fidelity below Full");
+            Console.WriteLine($"remarks: {remarks.Length} site{(remarks.Length == 1 ? "" : "s")} cap fidelity below Full");
             Console.WriteLine();
             foreach (var r in remarks)
             {
-                string where = r.Offset >= 0 ? $"IL_{r.Offset:X4}" : "(signature)";
+                string where = r.Location.Kind switch
+                {
+                    DecompilerFidelityLocationKind.IlOffset => $"IL_{r.Location.ILOffset:X4}",
+                    DecompilerFidelityLocationKind.Local => $"V_{r.Location.LocalIndex}",
+                    _ => "(signature)",
+                };
                 Console.WriteLine($"  {r.Code}  {where,-12}  {r.Reason}");
                 Console.WriteLine($"           at: {r.Node}");
             }

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -1207,7 +1207,8 @@ static class Program
                 {
                     DecompilerFidelityLocationKind.IlOffset => $"IL_{r.Location.ILOffset:X4}",
                     DecompilerFidelityLocationKind.Local => $"V_{r.Location.LocalIndex}",
-                    _ => "(signature)",
+                    DecompilerFidelityLocationKind.Signature => "(signature)",
+                    _ => "(synthetic)",
                 };
                 Console.WriteLine($"  {r.Code}  {where,-12}  {r.Reason}");
                 Console.WriteLine($"           at: {r.Node}");


### PR DESCRIPTION
## Change

**Conclusion:** **PASS** — decompiler fidelity lowering now has one complete,
typed, identity-bearing cause census shared by grading, Findings, compatibility
remarks, and harness consumers.

- Adds `DecompilerFindings.InspectFidelityCauses` and
  `CompareFidelityCauses`.
- Adds typed unknown/signature/IL/local provenance without using version-local
  coordinate values as Finding identity.
- Derives `IrFunction.Fidelity` from the same cause enumerator.
- Adds `DEC0013` for residual `continue` and `DEC0014` for referenced unraised
  pinned locals, closing cases where `Partial` previously had no remark.
- Keeps `FidelityRemarks.Collect` as a compatibility projection.
- Migrates harness reports, corpus sensing, `--remarks`, and DEC0009
  classification away from diagnostic-message parsing.

Card revision: `0d88f230`

## Evidence

| Check | Result |
| --- | --- |
| Release solution build | Pass |
| Non-AOT product build | Pass |
| Focused producer/consumer tests | 19 passed |
| Decompiler fast suite | 2,300 passed after excluding two failures reproduced on merge-base `59565b7f` |
| Markdownlint | Pass |
| Real imported witness | `StackallocInitializerResiduals::StackallocPointerInitializer` reports typed `DEC0004` at `IL_001E` |
| Full-path allocation probe | 744 -> 664 bytes per `Fidelity` call on a 100-node Full function after final review hardening |

This does not change raised/printer C# text, so render-text A/B is not
applicable. The highest relevant boss is the Stage 9 PR quick corpus sensor.

## Decompiler quality

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 15 assemblies, 1,486 methods
Sample: hash-stable 100 methods per assembly
Correctness coverage: validity not run; fidelity not run

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-26). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 1,461 -> 1,486 (+25)
- ILInspector.MetadataPrimitives: 61 -> 86 methods (+25)

| Metric | Change | Count delta |
| ------ | ------ | ----------- |
| Fully raised (+) | 1,213 (83.03%) → 1,235 (83.11%) (good) | +22 |
| Conditional-branch residual (-) | 35 (2.40%) → 43 (2.89%) (bad) | +8 |
| Forward-merge stops (-) | 27 (1.85%) → 31 (2.09%) (bad) | +4 |
| Pass bugs (-) | 0 → 0 (neutral) | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 82.17% -> 82.33% (+0.16 pp); conditional residual 3.00% -> 3.00% (0 pp); fidelity ungated (no pinned fidelity sample; rely on changed-method fidelity).

Advisory aggregate rate movement (not a PR quick hard gate; review for decompiler-risky changes):
- conditional-branch residual increased 0.49 pp (baseline 2.40%, PR 2.89%, tolerance 0.10 pp)
- forward-merge stop increased 0.24 pp (baseline 1.85%, PR 2.09%, tolerance 0.10 pp)

Verdict: corpus sensor matched baseline tolerances.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Clean final review | First found late `DEC0001` accounting and then negative synthetic offsets / a Full-path iterator allocation; resolved by `bf8e4729` and `0d88f230`, then re-reviewed exact head clean. |
| Gemini 3.1 Pro | Clean final review | Independently checked predicate parity, typed locations, repeated-cause matching, failure propagation, compatibility, and harness migration at exact head. |

**Review conclusion:** **PASS** — both isolated reviewers returned clean on
`0d88f230`; all actionable guidance has resolution commits.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*DecompilerFindingsTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*PinnedLocalFidelityTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*FidelityCauseBucketsTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
npx markdownlint-cli docs/design/finding-producers.md
```

The unfiltered fast command has two local .NET 11 daily-SDK failures
(`CoreLibStaticFieldLock_PreservesCopiedReceiverLocal` and
`ClassUnionSwitchExpression_RendersTypePatternArms`); both reproduce unchanged
on merge-base `59565b7f`. The remaining 2,300 fast tests pass.
