### PR TITLE
Add shared Research member projection

### DIFF
--- a/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
@@ -63,6 +63,33 @@ public class ResearchFactRegistryTests
     }
 
     [Fact]
+    public void MemberProjection_CollectsFactsOnceForRequestedViews()
+    {
+        using var source = MetadataSource.Open(typeof(ResearchFixture).Assembly.Location);
+        var producer = new CountingProducer();
+        var registry = new ResearchFactRegistry(producer);
+
+        var projection = ResearchViews.ProjectMember(new ResearchViews.MemberProjectionRequest(
+            source,
+            typeof(ResearchFixture).FullName!,
+            nameof(ResearchFixture.BoxInt),
+            AnnotatedSource: true,
+            CostOverlay: true,
+            SemanticsOverlay: true,
+            FactRows: true,
+            Registry: registry));
+
+        Assert.Equal(1, producer.FactCollectCount);
+        Assert.Equal(1, producer.HeaderFactCollectCount);
+        Assert.NotNull(producer.AssemblyContext);
+        Assert.Same(producer.AssemblyContext, producer.HeaderAssemblyContext);
+        Assert.Contains("cost.test", projection.AnnotatedSource!.Output);
+        Assert.Contains("cost.test", projection.CostOverlay!.Body.Output);
+        Assert.Contains("semantics.test", projection.SemanticsOverlay!.Output);
+        Assert.Contains(projection.Facts!, row => row.Id == "cost.header.test");
+    }
+
+    [Fact]
     public void DefaultAllocationProducer_ProjectsAnalysisFindingCensus()
     {
         using var source = MetadataSource.Open(typeof(ResearchFixture).Assembly.Location);
@@ -245,6 +272,46 @@ public class ResearchFactRegistryTests
         public IReadOnlyList<string> Produces { get; } = produces ?? [];
         public IReadOnlyList<string> DependsOn { get; } = dependsOn ?? [];
         public IReadOnlyList<Annotation> Produce(ResearchFactContext context) => facts ?? [];
+    }
+
+    sealed class CountingProducer : IResearchFactProducer
+    {
+        public int FactCollectCount { get; private set; }
+        public int HeaderFactCollectCount { get; private set; }
+        public ResearchAssemblyContext? AssemblyContext { get; private set; }
+        public ResearchAssemblyContext? HeaderAssemblyContext { get; private set; }
+        public string Name => "counting";
+        public IReadOnlyList<string> Produces { get; } = ["cost.test", "semantics.test", "cost.header.test"];
+        public IReadOnlyList<string> DependsOn => [];
+
+        public IReadOnlyList<Annotation> Produce(ResearchFactContext context)
+        {
+            FactCollectCount++;
+            AssemblyContext = context.Assembly;
+            return
+            [
+                new Annotation(
+                    new AnnotationDescriptor("cost.test", AnnotationCategory.Cost, "test cost"),
+                    SourceOffset: 0,
+                    Detail: "shared"),
+                new Annotation(
+                    new AnnotationDescriptor("semantics.test", AnnotationCategory.Semantics, "test semantics"),
+                    SourceOffset: 0,
+                    Detail: "shared")
+            ];
+        }
+
+        public IReadOnlyList<ResearchHeaderFact> ProduceHeaderFacts(ResearchFactContext context)
+        {
+            HeaderFactCollectCount++;
+            HeaderAssemblyContext = context.Assembly;
+            return
+            [
+                new ResearchHeaderFact(
+                    new AnnotationDescriptor("cost.header.test", AnnotationCategory.Cost, "test header"),
+                    "shared")
+            ];
+        }
     }
 }
 

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -22,6 +22,121 @@ public static class ResearchViews
         DecompilerResult Body,
         IReadOnlyList<ResearchHeaderFact> HeaderFacts);
 
+    public sealed record MemberProjectionRequest(
+        MetadataSource Source,
+        string Type,
+        string Method,
+        int OverloadIndex = 0,
+        bool PublicOnly = false,
+        bool AnnotatedSource = false,
+        bool CostOverlay = false,
+        bool SemanticsOverlay = false,
+        bool FactRows = false,
+        AnnotationStage AnnotatedStage = AnnotationStage.Raised,
+        ResearchFactRegistry? Registry = null);
+
+    public sealed record MemberProjectionResult(
+        DecompilerResult? AnnotatedSource,
+        CostOverlayResult? CostOverlay,
+        DecompilerResult? SemanticsOverlay,
+        IReadOnlyList<FactRow>? Facts,
+        DecompilerTrace? Trace);
+
+    public static MemberProjectionResult ProjectMember(MemberProjectionRequest request)
+    {
+        try
+        {
+            var imported = IrImporter.Import(
+                request.Source,
+                request.Type,
+                request.Method,
+                request.OverloadIndex,
+                request.PublicOnly)
+                ?? throw new InvalidOperationException($"{request.Type}::{request.Method} has no IL body");
+
+            var assembly = imported.AssemblyPath is { Length: > 0 } path
+                ? ResearchAssemblyContext.Create(AnalysisIndexCache.ForPath(path))
+                : null;
+            var effectiveRegistry = request.Registry ?? ResearchFactRegistry.Default;
+            var context = new ResearchFactContext(request.Source, imported, assembly);
+            var facts = effectiveRegistry.Collect(context);
+            var headerFacts = request.CostOverlay || request.FactRows
+                ? effectiveRegistry.CollectHeaderFacts(context)
+                : [];
+
+            DecompilerResult? annotatedSource = null;
+            if (request.AnnotatedSource)
+            {
+                annotatedSource = WithTrace(
+                    Run(() => RenderMixedCore(
+                        request.Source,
+                        request.Type,
+                        request.Method,
+                        imported,
+                        facts,
+                        request.AnnotatedStage,
+                        request.OverloadIndex,
+                        request.PublicOnly),
+                        emptyOutputIsFailure: true),
+                    request.Source);
+            }
+
+            CostOverlayResult? costOverlay = null;
+            if (request.CostOverlay)
+            {
+                var costAnnotations = facts
+                    .Where(annotation => annotation.Descriptor.Category == AnnotationCategory.Cost)
+                    .ToList();
+                var costHeaderFacts = headerFacts
+                    .Where(fact => fact.Descriptor.Category == AnnotationCategory.Cost)
+                    .ToList();
+                var body = WithTrace(
+                    Run(() => RenderRaisedOverlay(imported, costAnnotations), emptyOutputIsFailure: true),
+                    request.Source);
+                costOverlay = new CostOverlayResult(body, costHeaderFacts);
+            }
+
+            DecompilerResult? semanticsOverlay = null;
+            if (request.SemanticsOverlay)
+            {
+                var semanticsAnnotations = facts
+                    .Where(annotation => annotation.Descriptor.Category == AnnotationCategory.Semantics)
+                    .ToList();
+                semanticsOverlay = WithTrace(
+                    Run(() => RenderRaisedOverlay(imported, semanticsAnnotations), emptyOutputIsFailure: true),
+                    request.Source);
+            }
+
+            IReadOnlyList<FactRow>? factRows = null;
+            if (request.FactRows)
+                factRows = BuildFactRows(request.Type, request.Method, imported, facts, headerFacts);
+
+            return new MemberProjectionResult(
+                annotatedSource,
+                costOverlay,
+                semanticsOverlay,
+                factRows,
+                annotatedSource?.Trace ?? costOverlay?.Body.Trace ?? semanticsOverlay?.Trace);
+        }
+        catch (Exception ex)
+        {
+            if (request.FactRows)
+                throw;
+
+            var failure = DecompilerResult.Failure(
+                DiagnosticIds.InternalError,
+                $"{ex.GetType().Name}: {ex.Message}");
+            failure = WithTrace(failure, request.Source);
+
+            return new MemberProjectionResult(
+                request.AnnotatedSource ? failure : null,
+                request.CostOverlay ? new CostOverlayResult(failure, []) : null,
+                request.SemanticsOverlay ? failure : null,
+                request.FactRows ? [] : null,
+                failure.Trace);
+        }
+    }
+
     public static IReadOnlyList<Annotation> CollectFacts(
         MetadataSource source, string type, string method, int overloadIndex = 0, bool publicOnly = false,
         ResearchFactRegistry? registry = null)
@@ -57,28 +172,8 @@ public static class ResearchViews
         var context = new ResearchFactContext(source, imported, assembly);
         var effectiveRegistry = registry ?? ResearchFactRegistry.Default;
         var facts = effectiveRegistry.Collect(context);
-        var linesByFact = CSharpLinesByFact(imported, facts);
-        string member = $"{type}::{method}";
-        var rows = facts.Select(fact => new FactRow(
-            member,
-            fact.SourceOffset >= 0 ? fact.SourceOffset : null,
-            linesByFact.TryGetValue(fact, out int line) ? line + 1 : null,
-            fact.SourceOffset >= 0 ? "offset" : "member-header",
-            fact.Descriptor.Category.ToString(),
-            fact.Descriptor.Id,
-            fact.Detail,
-            fact.Conditionality.ToString()));
-        var headerRows = effectiveRegistry.CollectHeaderFacts(context)
-            .Select(fact => new FactRow(
-                member,
-                ILOffset: null,
-                CSharpLine: null,
-                Anchor: "member-header",
-                fact.Descriptor.Category.ToString(),
-                fact.Descriptor.Id,
-                fact.Detail,
-                Conditionality: "Always"));
-        return [.. rows.Concat(headerRows)];
+        var headerFacts = effectiveRegistry.CollectHeaderFacts(context);
+        return BuildFactRows(type, method, imported, facts, headerFacts);
     }
 
     public static DecompilerResult RenderCostOverlay(
@@ -89,62 +184,26 @@ public static class ResearchViews
     public static CostOverlayResult RenderCostOverlayWithHeaderFacts(
         MetadataSource source, string type, string method, int overloadIndex = 0, bool publicOnly = false,
         ResearchFactRegistry? registry = null)
-    {
-        IReadOnlyList<ResearchHeaderFact> headerFacts = [];
-        var body = Run(() =>
-        {
-            var imported = IrImporter.Import(source, type, method, overloadIndex, publicOnly)
-                ?? throw new InvalidOperationException($"{type}::{method} has no IL body");
-            var result = CSharpPrinter.PrintRaised(imported, out var statementLines);
-            if (result.Output is not { } output)
-                return "";
-            if (imported.AssemblyPath is not { Length: > 0 } path)
-                return output;
-
-            var context = new ResearchFactContext(
-                source,
-                imported,
-                ResearchAssemblyContext.Create(AnalysisIndexCache.ForPath(path)));
-            var effectiveRegistry = registry ?? ResearchFactRegistry.Default;
-            var annotations = effectiveRegistry.Collect(context)
-                .Where(annotation => annotation.Descriptor.Category == AnnotationCategory.Cost)
-                .ToList();
-            headerFacts = effectiveRegistry.CollectHeaderFacts(context)
-                .Where(fact => fact.Descriptor.Category == AnnotationCategory.Cost)
-                .ToList();
-            if (annotations.Count > 0)
-                output = AddTrailingComments(imported, output, statementLines, annotations);
-            return output;
-        }, emptyOutputIsFailure: true);
-        return new CostOverlayResult(body, headerFacts);
-    }
+        => ProjectMember(new MemberProjectionRequest(
+            source,
+            type,
+            method,
+            overloadIndex,
+            publicOnly,
+            CostOverlay: true,
+            Registry: registry)).CostOverlay!;
 
     public static DecompilerResult RenderSemanticsOverlay(
         MetadataSource source, string type, string method, int overloadIndex = 0, bool publicOnly = false,
         ResearchFactRegistry? registry = null)
-    {
-        return Run(() =>
-        {
-            var imported = IrImporter.Import(source, type, method, overloadIndex, publicOnly)
-                ?? throw new InvalidOperationException($"{type}::{method} has no IL body");
-            var result = CSharpPrinter.PrintRaised(imported, out var statementLines);
-            if (result.Output is not { } output)
-                return "";
-            if (imported.AssemblyPath is not { Length: > 0 } path)
-                return output;
-
-            var context = new ResearchFactContext(
-                source,
-                imported,
-                ResearchAssemblyContext.Create(AnalysisIndexCache.ForPath(path)));
-            var annotations = (registry ?? ResearchFactRegistry.Default).Collect(context)
-                .Where(annotation => annotation.Descriptor.Category == AnnotationCategory.Semantics)
-                .ToList();
-            return annotations.Count == 0
-                ? output
-                : AddTrailingComments(imported, output, statementLines, annotations);
-        }, emptyOutputIsFailure: true);
-    }
+        => ProjectMember(new MemberProjectionRequest(
+            source,
+            type,
+            method,
+            overloadIndex,
+            publicOnly,
+            SemanticsOverlay: true,
+            Registry: registry)).SemanticsOverlay!;
 
     public static DecompilerResult RenderAnnotatedSource(
         MetadataSource source, string type, string method, int overloadIndex = 0, bool publicOnly = false,
@@ -165,16 +224,15 @@ public static class ResearchViews
     public static DecompilerResult RenderMixed(
         MetadataSource source, string type, string method, AnnotationStage stage = AnnotationStage.Raised,
         int overloadIndex = 0, bool publicOnly = false, ResearchFactRegistry? registry = null)
-    {
-        var result = Run(
-            () => RenderMixedCore(source, type, method, stage, overloadIndex, publicOnly, registry),
-            emptyOutputIsFailure: true);
-
-        return result with
-        {
-            Trace = new DecompilerTrace(result.Fidelity, source.Symbols, result.Diagnostics),
-        };
-    }
+        => ProjectMember(new MemberProjectionRequest(
+            source,
+            type,
+            method,
+            overloadIndex,
+            publicOnly,
+            AnnotatedSource: true,
+            AnnotatedStage: stage,
+            Registry: registry)).AnnotatedSource!;
 
     public static DecompilerResult ProjectAnnotatedIl(
         MetadataSource source, string type, string method, int overloadIndex = 0, bool publicOnly = false,
@@ -197,6 +255,19 @@ public static class ResearchViews
         var imported = IrImporter.Import(source, type, method, overloadIndex, publicOnly)
             ?? throw new InvalidOperationException($"{type}::{method} has no IL body");
         var annotations = CollectFacts(source, imported, registry);
+        return RenderMixedCore(source, type, method, imported, annotations, stage, overloadIndex, publicOnly);
+    }
+
+    static string RenderMixedCore(
+        MetadataSource source,
+        string type,
+        string method,
+        IrFunction imported,
+        IReadOnlyList<Annotation> annotations,
+        AnnotationStage stage,
+        int overloadIndex,
+        bool publicOnly)
+    {
 
         IrFunction? ImportMethodBody(MethodRef target) => IrImporter.Import(source, target);
         var csResult = stage == AnnotationStage.Lowered
@@ -254,6 +325,52 @@ public static class ResearchViews
             return body.Length == 0 ? $": {chain}" : $": {chain}{Environment.NewLine}{body}";
         return body;
     }
+
+    static string RenderRaisedOverlay(IrFunction imported, IReadOnlyList<Annotation> annotations)
+    {
+        var result = CSharpPrinter.PrintRaised(imported, out var statementLines);
+        if (result.Output is not { } output)
+            return "";
+        return annotations.Count == 0
+            ? output
+            : AddTrailingComments(imported, output, statementLines, annotations);
+    }
+
+    static IReadOnlyList<FactRow> BuildFactRows(
+        string type,
+        string method,
+        IrFunction imported,
+        IReadOnlyList<Annotation> facts,
+        IReadOnlyList<ResearchHeaderFact> headerFacts)
+    {
+        var linesByFact = CSharpLinesByFact(imported, facts);
+        string member = $"{type}::{method}";
+        var rows = facts.Select(fact => new FactRow(
+            member,
+            fact.SourceOffset >= 0 ? fact.SourceOffset : null,
+            linesByFact.TryGetValue(fact, out int line) ? line + 1 : null,
+            fact.SourceOffset >= 0 ? "offset" : "member-header",
+            fact.Descriptor.Category.ToString(),
+            fact.Descriptor.Id,
+            fact.Detail,
+            fact.Conditionality.ToString()));
+        var headerRows = headerFacts.Select(fact => new FactRow(
+            member,
+            ILOffset: null,
+            CSharpLine: null,
+            Anchor: "member-header",
+            fact.Descriptor.Category.ToString(),
+            fact.Descriptor.Id,
+            fact.Detail,
+            Conditionality: "Always"));
+        return [.. rows.Concat(headerRows)];
+    }
+
+    static DecompilerResult WithTrace(DecompilerResult result, MetadataSource source)
+        => result with
+        {
+            Trace = new DecompilerTrace(result.Fidelity, source.Symbols, result.Diagnostics),
+        };
 
     static string AddTrailingComments(
         IrFunction raised,

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -2868,6 +2868,28 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_SelectDecompiledSourceAndFacts_RequestTraceKeepsDecompileOutcome()
+    {
+        using var diagram = RequestMermaidDiagram.Start();
+
+        var options = new MemberOptions
+        {
+            PlatformAssembly = "System.Text.Json",
+            TypeName = "JsonSerializer",
+            MemberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "SerializeToElement" },
+            OverloadIndex = 1,
+            IncludeSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Decompiled Source", "Facts" }
+        };
+
+        var (exit, _, _) = await ConsoleCapture.RunAsync(
+            () => MemberCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exit);
+        var mermaid = diagram.ToMermaid();
+        Assert.Matches(@"decompile\.method<br/>SerializeToElement \(\w+, pdb:\w+\)", mermaid);
+    }
+
+    [Fact]
     public async Task Member_SelectedOverload_SelectFacts_RendersHiddenFactSection()
     {
         var options = new MemberOptions

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -116,37 +116,48 @@ internal static class MemberCodeProvider
             Decompiler.DecompilerTrace? decompileTrace = null;
             if (request.DecompiledSource && pipelineSource is not null)
             {
-                var result = RenderPlainSource(pipelineSource, lookupType, method.Name, Decompiler.Annotations.AnnotationStage.Raised, lookupOverloadIndex, publicOnly);
-                decompileTrace = new Decompiler.DecompilerTrace(result.Fidelity, pipelineSource.Symbols, result.Diagnostics);
-                if (result.Output is { } plain)
+                var plainSourceResult = RenderPlainSource(pipelineSource, lookupType, method.Name, Decompiler.Annotations.AnnotationStage.Raised, lookupOverloadIndex, publicOnly);
+                decompileTrace = new Decompiler.DecompilerTrace(plainSourceResult.Fidelity, pipelineSource.Symbols, plainSourceResult.Diagnostics);
+                if (plainSourceResult.Output is { } plain)
                     loweredBody = plain.TrimEnd();
                 else
-                    loweredDiagnostic = DiagnosticComment(result);
+                    loweredDiagnostic = DiagnosticComment(plainSourceResult);
+            }
+
+            ILInspector.Research.ResearchViews.MemberProjectionResult? researchProjection = null;
+            if ((request.AnnotatedSource || request.CostOverlay || request.SemanticsOverlay || request.Facts) && pipelineSource is not null)
+            {
+                researchProjection = ILInspector.Research.ResearchViews.ProjectMember(
+                    new ILInspector.Research.ResearchViews.MemberProjectionRequest(
+                        pipelineSource,
+                        lookupType,
+                        method.Name,
+                        lookupOverloadIndex,
+                        publicOnly,
+                        AnnotatedSource: request.AnnotatedSource,
+                        CostOverlay: request.CostOverlay,
+                        SemanticsOverlay: request.SemanticsOverlay,
+                        FactRows: request.Facts));
+                decompileTrace = researchProjection.Trace;
             }
 
             // Annotated source: raised C# with hidden-fact comments and the
             // raw IL interleaved beneath each statement.
             string? annotatedBody = null, annotatedDiagnostic = null;
-            if (request.AnnotatedSource && pipelineSource is not null)
+            if (request.AnnotatedSource && researchProjection?.AnnotatedSource is { } annotatedResult)
             {
-                var result = ILInspector.Research.ResearchViews.RenderMixed(
-                    pipelineSource, lookupType, method.Name, overloadIndex: lookupOverloadIndex, publicOnly: publicOnly);
-                decompileTrace = result.Trace;
-                if (result.Output is { } annotated)
+                if (annotatedResult.Output is { } annotated)
                     annotatedBody = annotated.TrimEnd();
                 else
-                    annotatedDiagnostic = DiagnosticComment(result);
+                    annotatedDiagnostic = DiagnosticComment(annotatedResult);
             }
 
             string? costOverlayBody = null, costOverlayDiagnostic = null;
             IReadOnlyList<string>? costOverlayHeaderComments = null;
-            if (request.CostOverlay && pipelineSource is not null)
+            if (request.CostOverlay && researchProjection?.CostOverlay is { } overlay)
             {
-                var overlay = ILInspector.Research.ResearchViews.RenderCostOverlayWithHeaderFacts(
-                    pipelineSource, lookupType, method.Name, overloadIndex: lookupOverloadIndex, publicOnly: publicOnly);
-                var result = overlay.Body;
-                decompileTrace = result.Trace;
-                if (result.Output is { } costOverlay)
+                var costResult = overlay.Body;
+                if (costResult.Output is { } costOverlay)
                 {
                     costOverlayBody = costOverlay.TrimEnd();
                     if (overlay.HeaderFacts.Count > 0)
@@ -155,19 +166,16 @@ internal static class MemberCodeProvider
                             .ToList();
                 }
                 else
-                    costOverlayDiagnostic = DiagnosticComment(result);
+                    costOverlayDiagnostic = DiagnosticComment(costResult);
             }
 
             string? semanticsOverlayBody = null, semanticsOverlayDiagnostic = null;
-            if (request.SemanticsOverlay && pipelineSource is not null)
+            if (request.SemanticsOverlay && researchProjection?.SemanticsOverlay is { } semanticsResult)
             {
-                var result = ILInspector.Research.ResearchViews.RenderSemanticsOverlay(
-                    pipelineSource, lookupType, method.Name, overloadIndex: lookupOverloadIndex, publicOnly: publicOnly);
-                decompileTrace = result.Trace;
-                if (result.Output is { } semanticsOverlay)
+                if (semanticsResult.Output is { } semanticsOverlay)
                     semanticsOverlayBody = semanticsOverlay.TrimEnd();
                 else
-                    semanticsOverlayDiagnostic = DiagnosticComment(result);
+                    semanticsOverlayDiagnostic = DiagnosticComment(semanticsResult);
             }
 
             string? ilText = null, ilDiagnostic = null;
@@ -189,11 +197,8 @@ internal static class MemberCodeProvider
             // Structured Research overlay rows for one method: the table-shaped
             // projection of the same facts the annotated source/IL views render.
             IReadOnlyList<ILInspector.Research.ResearchViews.FactRow>? facts = null;
-            if (request.Facts && pipelineSource is not null)
-            {
-                facts = ILInspector.Research.ResearchViews.CollectFactRows(
-                    pipelineSource, lookupType, method.Name, lookupOverloadIndex, publicOnly);
-            }
+            if (request.Facts && researchProjection is not null)
+                facts = researchProjection.Facts;
 
             results.Add((method, new Item(
                 loweredBody,

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -138,7 +138,7 @@ internal static class MemberCodeProvider
                         CostOverlay: request.CostOverlay,
                         SemanticsOverlay: request.SemanticsOverlay,
                         FactRows: request.Facts));
-                decompileTrace = researchProjection.Trace;
+                decompileTrace = researchProjection.Trace ?? decompileTrace;
             }
 
             // Annotated source: raised C# with hidden-fact comments and the


### PR DESCRIPTION
Refs #2653 (C6).

## Summary
- Add `ResearchViews.ProjectMember`, a per-member projection request/result that imports one selected method, builds one `ResearchAssemblyContext`, and shares collected facts/header facts across annotated source, cost overlay, semantics overlay, and structured fact rows.
- Keep existing individual `ResearchViews` APIs as wrappers.
- Migrate `MemberCodeProvider` to use one Research projection for the selected member-backed views.
- Add a focused Research test that asserts fact/header producers run once and see the same assembly context across requested views.

## Validation
- `dotnet run --project src/ILInspector.Research.Tests -c Release --no-restore -- -class ILInspector.Research.Tests.ResearchFactRegistryTests`
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-restore -- -class DotnetInspector.Tests.CommandExecutionTests -method "*Member_SelectedOverload_Select*" -method "*Member_SingleOverload_SourceCategory_IncludesSourceDiff*" -method "*Member_SelectedOverload_SourceCategory_IncludesIlAndNoLoweredSource*" -method "*Member_Facts_IsExplicitOnly_NotShownAtDetailed*"`
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-restore -- -class DotnetInspector.Tests.IndexBuildInvariantTests`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --nologo -v:q`

## Review status
Adversarial reviews are required for this Research/analysis behavior change and are pending. This PR is not ready to merge yet.