### PR TITLE
Fix package dependency cache serialization

### DIFF
--- a/src/dotnet-inspect.Tests/CacheCommandTests.cs
+++ b/src/dotnet-inspect.Tests/CacheCommandTests.cs
@@ -1,5 +1,6 @@
 using DotnetInspector.Commands;
 using DotnetInspector.Core;
+using DotnetInspector.Inspectors;
 using DotnetInspector.Options;
 using DotnetInspector.Packages;
 
@@ -58,14 +59,14 @@ public class CacheCommandTests : IDisposable
     [Fact]
     public void CacheMiss_CleansObsoleteVersionedCategories()
     {
-        var oldDir = Path.Combine(_cacheBasePath, "pkg-index-v8");
-        var currentDir = Path.Combine(_cacheBasePath, "pkg-index-v9");
+        var oldDir = Path.Combine(_cacheBasePath, "pkg-index-v9");
+        var currentDir = Path.Combine(_cacheBasePath, PackageIndexCache.Category);
         Directory.CreateDirectory(oldDir);
         Directory.CreateDirectory(currentDir);
         File.WriteAllText(Path.Combine(oldDir, "old.txt"), new string('x', 4096));
         File.WriteAllText(Path.Combine(currentDir, "current.txt"), "keep");
 
-        CoreCache.RegisterVersionedCategory("pkg-index-v", "pkg-index-v9");
+        CoreCache.RegisterVersionedCategory("pkg-index-v", PackageIndexCache.Category);
 
         Assert.Null(CoreCache.TryGet("versions", $"missing-{Guid.NewGuid():N}", extension: "txt"));
         var result = CoreCache.CancelAndWaitForMaintenance(TimeSpan.FromSeconds(5));

--- a/src/dotnet-inspect.Tests/PackageIndexCacheTests.cs
+++ b/src/dotnet-inspect.Tests/PackageIndexCacheTests.cs
@@ -1,66 +1,34 @@
-using DotnetInspector.Core;
 using DotnetInspector.Inspectors;
-using DotnetInspector.Models;
 using DotnetInspector.Packages;
 
 namespace DotnetInspector.Tests;
 
-[Collection("Console")]
-public sealed class PackageIndexCacheTests : IDisposable
+public sealed class PackageIndexCacheTests
 {
-    private readonly string _cacheBasePath = Path.Combine(
-        Path.GetTempPath(),
-        "dotnet-inspect-package-index-cache-tests-" + Guid.NewGuid().ToString("N"));
-
-    public PackageIndexCacheTests()
-    {
-        CoreCache.Initialize(
-            "dotnet-inspect-package-index-cache-tests-" + Guid.NewGuid().ToString("N"),
-            basePath: _cacheBasePath);
-    }
-
-    public void Dispose()
-    {
-        if (Directory.Exists(_cacheBasePath))
-            Directory.Delete(_cacheBasePath, recursive: true);
-    }
-
     [Theory]
     [InlineData("[1.0.0,2.0.0)")]
     [InlineData("[3.0.0,)")]
     [InlineData("(,4.0.0]")]
     public void DependencyRange_RoundTripsWithoutSplitting(string versionRange)
     {
-        const string packageName = "Package.With.Range";
-        const string packageVersion = "1.0.0";
-        var result = new InspectionResult
+        var group = new DependencyGroup
         {
-            PackageName = packageName,
-            Version = packageVersion,
-            DependencyGroups =
+            TargetFramework = "net10.0",
+            Dependencies =
             [
-                new DependencyGroup
+                new PackageDependency
                 {
-                    TargetFramework = "net10.0",
-                    Dependencies =
-                    [
-                        new PackageDependency
-                        {
-                            Id = "Dependency.With.Range",
-                            Version = versionRange
-                        }
-                    ]
+                    Id = "Dependency.With.Range",
+                    Version = versionRange
                 }
             ]
         };
 
-        PackageIndexCache.Set(packageName, packageVersion, result);
+        var serialized = PackageIndexCache.SerializeDependencyGroup(group);
+        var cached = PackageIndexCache.DeserializeDependencyGroup(serialized);
 
-        var cached = Assert.IsType<InspectionResult>(
-            PackageIndexCache.TryGet(packageName, packageVersion));
-        var group = Assert.Single(Assert.IsType<List<DependencyGroup>>(cached.DependencyGroups));
-        Assert.Equal("net10.0", group.TargetFramework);
-        var dependency = Assert.Single(group.Dependencies);
+        Assert.Equal("net10.0", cached.TargetFramework);
+        var dependency = Assert.Single(cached.Dependencies);
         Assert.Equal("Dependency.With.Range", dependency.Id);
         Assert.Equal(versionRange, dependency.Version);
     }

--- a/src/dotnet-inspect.Tests/PackageIndexCacheTests.cs
+++ b/src/dotnet-inspect.Tests/PackageIndexCacheTests.cs
@@ -1,0 +1,67 @@
+using DotnetInspector.Core;
+using DotnetInspector.Inspectors;
+using DotnetInspector.Models;
+using DotnetInspector.Packages;
+
+namespace DotnetInspector.Tests;
+
+[Collection("Console")]
+public sealed class PackageIndexCacheTests : IDisposable
+{
+    private readonly string _cacheBasePath = Path.Combine(
+        Path.GetTempPath(),
+        "dotnet-inspect-package-index-cache-tests-" + Guid.NewGuid().ToString("N"));
+
+    public PackageIndexCacheTests()
+    {
+        CoreCache.Initialize(
+            "dotnet-inspect-package-index-cache-tests-" + Guid.NewGuid().ToString("N"),
+            basePath: _cacheBasePath);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_cacheBasePath))
+            Directory.Delete(_cacheBasePath, recursive: true);
+    }
+
+    [Theory]
+    [InlineData("[1.0.0,2.0.0)")]
+    [InlineData("[3.0.0,)")]
+    [InlineData("(,4.0.0]")]
+    public void DependencyRange_RoundTripsWithoutSplitting(string versionRange)
+    {
+        const string packageName = "Package.With.Range";
+        const string packageVersion = "1.0.0";
+        var result = new InspectionResult
+        {
+            PackageName = packageName,
+            Version = packageVersion,
+            DependencyGroups =
+            [
+                new DependencyGroup
+                {
+                    TargetFramework = "net10.0",
+                    Dependencies =
+                    [
+                        new PackageDependency
+                        {
+                            Id = "Dependency.With.Range",
+                            Version = versionRange
+                        }
+                    ]
+                }
+            ]
+        };
+
+        PackageIndexCache.Set(packageName, packageVersion, result);
+
+        var cached = Assert.IsType<InspectionResult>(
+            PackageIndexCache.TryGet(packageName, packageVersion));
+        var group = Assert.Single(Assert.IsType<List<DependencyGroup>>(cached.DependencyGroups));
+        Assert.Equal("net10.0", group.TargetFramework);
+        var dependency = Assert.Single(group.Dependencies);
+        Assert.Equal("Dependency.With.Range", dependency.Id);
+        Assert.Equal(versionRange, dependency.Version);
+    }
+}

--- a/src/dotnet-inspect/Inspectors/PackageIndexCache.cs
+++ b/src/dotnet-inspect/Inspectors/PackageIndexCache.cs
@@ -248,7 +248,7 @@ internal static class PackageIndexCache
 
     // ── Dependency group serialization ──
 
-    private static string SerializeDependencyGroup(DependencyGroup group)
+    internal static string SerializeDependencyGroup(DependencyGroup group)
     {
         var buffer = new ArrayBufferWriter<byte>();
         using var writer = new Utf8JsonWriter(buffer);
@@ -269,7 +269,7 @@ internal static class PackageIndexCache
         return Encoding.UTF8.GetString(buffer.WrittenSpan);
     }
 
-    private static DependencyGroup DeserializeDependencyGroup(string raw)
+    internal static DependencyGroup DeserializeDependencyGroup(string raw)
     {
         using var document = JsonDocument.Parse(raw);
         var root = document.RootElement;

--- a/src/dotnet-inspect/Inspectors/PackageIndexCache.cs
+++ b/src/dotnet-inspect/Inspectors/PackageIndexCache.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Text;
+using System.Text.Json;
 using DotnetInspector.Core;
 using DotnetInspector.Models;
 using DotnetInspector.Packages;
@@ -15,7 +16,7 @@ namespace DotnetInspector.Inspectors;
 /// </summary>
 internal static class PackageIndexCache
 {
-    internal const string Category = "pkg-index-v9";
+    internal const string Category = "pkg-index-v10";
 
     static PackageIndexCache()
     {
@@ -95,11 +96,11 @@ internal static class PackageIndexCache
                 result.BuiltDate = builtDate;
             }
 
-            // Dependency groups stored as compact strings: "tfm|name@ver,name@ver"
+            // Dependency groups are stored as JSON objects within the field array.
             var depGroupsRaw = doc.GetArrayList("dependencyGroups");
             if (depGroupsRaw != null)
             {
-                result.DependencyGroups = depGroupsRaw.Select(ParseDependencyGroup).ToList();
+                result.DependencyGroups = depGroupsRaw.Select(DeserializeDependencyGroup).ToList();
             }
 
             var ridPackagesRaw = doc.GetArrayList("runtimeIdentifierPackages");
@@ -180,10 +181,10 @@ internal static class PackageIndexCache
             WriteArray(buf, "runtimeIdentifierPackages"u8,
                 result.RuntimeIdentifierPackages.Select(FormatRidPackageReference).ToList());
 
-        // Dependency groups stored as compact strings: "tfm|name@ver,name@ver"
+        // Each dependency group is one structured JSON value in the field array.
         if (result.DependencyGroups is { Count: > 0 })
         {
-            var groupStrings = result.DependencyGroups.Select(FormatDependencyGroup).ToList();
+            var groupStrings = result.DependencyGroups.Select(SerializeDependencyGroup).ToList();
             WriteArray(buf, "dependencyGroups"u8, groupStrings);
         }
 
@@ -247,31 +248,46 @@ internal static class PackageIndexCache
 
     // ── Dependency group serialization ──
 
-    private static string FormatDependencyGroup(DependencyGroup group)
+    private static string SerializeDependencyGroup(DependencyGroup group)
     {
-        var deps = group.Dependencies?.Select(d =>
-            d.Version.Length > 0 ? $"{d.Id}@{d.Version}" : d.Id) ?? [];
-        return $"{group.TargetFramework ?? "any"}|{string.Join(",", deps)}";
+        var buffer = new ArrayBufferWriter<byte>();
+        using var writer = new Utf8JsonWriter(buffer);
+        writer.WriteStartObject();
+        writer.WriteString("targetFramework", group.TargetFramework);
+        writer.WritePropertyName("dependencies");
+        writer.WriteStartArray();
+        foreach (var dependency in group.Dependencies ?? [])
+        {
+            writer.WriteStartObject();
+            writer.WriteString("id", dependency.Id);
+            writer.WriteString("version", dependency.Version);
+            writer.WriteEndObject();
+        }
+        writer.WriteEndArray();
+        writer.WriteEndObject();
+        writer.Flush();
+        return Encoding.UTF8.GetString(buffer.WrittenSpan);
     }
 
-    private static DependencyGroup ParseDependencyGroup(string raw)
+    private static DependencyGroup DeserializeDependencyGroup(string raw)
     {
-        var parts = raw.Split('|', 2);
-        var tfm = parts[0] == "any" ? null : parts[0];
-        List<PackageDependency>? deps = null;
-
-        if (parts.Length > 1 && parts[1].Length > 0)
+        using var document = JsonDocument.Parse(raw);
+        var root = document.RootElement;
+        var dependencies = new List<PackageDependency>();
+        foreach (var dependency in root.GetProperty("dependencies").EnumerateArray())
         {
-            deps = parts[1].Split(',').Select(d =>
+            dependencies.Add(new PackageDependency
             {
-                var at = d.IndexOf('@');
-                return at > 0
-                    ? new PackageDependency { Id = d[..at], Version = d[(at + 1)..] }
-                    : new PackageDependency { Id = d };
-            }).ToList();
+                Id = dependency.GetProperty("id").GetString() ?? "",
+                Version = dependency.GetProperty("version").GetString() ?? ""
+            });
         }
 
-        return new DependencyGroup { TargetFramework = tfm ?? "", Dependencies = deps ?? [] };
+        return new DependencyGroup
+        {
+            TargetFramework = root.GetProperty("targetFramework").GetString() ?? "",
+            Dependencies = dependencies
+        };
     }
 
     private static string FormatRidPackageReference(RidPackageReference reference)


### PR DESCRIPTION
## Summary

- replace delimiter-based dependency-group cache entries with structured JSON
- invalidate lossy `pkg-index-v9` entries by advancing the cache category to v10
- cover bounded and open NuGet version ranges that contain commas

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build`
- `dotnet publish src/dotnet-inspect/dotnet-inspect.csproj -c Release -r linux-x64 --self-contained -p:PublishAot=true`

This is a focused cache-format correctness fix with no public output or API changes.