### PR TITLE
Route RTS target body rendering through provider

### DIFF
--- a/docs/design/fact-planned-compile-back-harness.md
+++ b/docs/design/fact-planned-compile-back-harness.md
@@ -266,6 +266,9 @@ Initial typed closure derivation belongs with artifact production: the provider
 can derive same-assembly roots, source facts, and member requirements from the
 raised `IrFunction`. RTS remains responsible for Roslyn oracle growth and passes
 only the target/oracle closure roots and facts discovered by compile feedback.
+Target-body rendering is also provider-owned: RTS selects the target and carries
+the provider-produced body/provenance, but should not call the C# output printer
+directly.
 
 The product/shared side should own truthful declaration facts that are useful
 beyond ReturnToSender: namespaces, type/member signatures, base/interface

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -777,9 +777,7 @@ static class ReturnToSender
 
         var function = IrImporter.Import(source, fullType, methodName, overload)
             ?? throw new InvalidOperationException($"Could not import {fullType}::{methodName}.");
-        var printed = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
-        if (printed.Output is null)
-            throw new InvalidOperationException($"Could not print {fullType}::{methodName}.");
+        var targetBody = CompileBackSourceComposer.CreateTargetBody(source, function, fullType, methodName);
 
         var original = ILInstructionPrinter.Disassemble(pe, reader, getter)
             ?? throw new InvalidOperationException($"Could not disassemble {fullType}::{methodName}.");
@@ -812,7 +810,7 @@ static class ReturnToSender
                 TargetType: typeHandle,
                 TargetMethod: getterHandle,
                 TargetProperty: propertyHandle,
-                TargetBody: printed.Output,
+                TargetBody: targetBody,
                 FullType: fullType,
                 MethodName: methodName,
                 Overload: overload,
@@ -830,9 +828,9 @@ static class ReturnToSender
                     string.Join(" ", originalOps),
                     "",
                     $"{identityDiagnostic.Reason}: {identityDiagnostic.Detail}",
-                    TargetBody: printed.Output,
+                    TargetBody: targetBody.Source,
                     MemberAnchor: memberAnchor,
-                    Decisions: printed.Decisions);
+                    Decisions: targetBody.Decisions);
             }
 
             string unit = sourceResult.Source;
@@ -861,9 +859,9 @@ static class ReturnToSender
                         string.Join(" ", originalOps),
                         "",
                         "method-not-found",
-                        TargetBody: printed.Output,
+                        TargetBody: targetBody.Source,
                         MemberAnchor: memberAnchor,
-                        Decisions: printed.Decisions);
+                        Decisions: targetBody.Decisions);
                 }
 
                 return new Result(
@@ -875,11 +873,11 @@ static class ReturnToSender
                     string.Join(" ", originalOps),
                     string.Join(" ", recompiledOps),
                     null,
-                    TargetBody: printed.Output,
+                    TargetBody: targetBody.Source,
                     IlDiffDiagnostic: ilDiffDiagnostic,
                     IlDiff: ilDiff,
                     MemberAnchor: memberAnchor,
-                    Decisions: printed.Decisions);
+                    Decisions: targetBody.Decisions);
             }
 
             var errors = emit.Diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
@@ -908,9 +906,9 @@ static class ReturnToSender
                     string.Join(" ", originalOps),
                     "",
                     $"{reason}: {FormatDiagnostic(error)}",
-                    TargetBody: printed.Output,
+                    TargetBody: targetBody.Source,
                     MemberAnchor: memberAnchor,
-                    Decisions: printed.Decisions);
+                    Decisions: targetBody.Decisions);
             }
         }
 
@@ -922,7 +920,7 @@ static class ReturnToSender
                 TargetType: typeHandle,
                 TargetMethod: getterHandle,
                 TargetProperty: propertyHandle,
-                TargetBody: printed.Output,
+                TargetBody: targetBody,
                 FullType: fullType,
                 MethodName: methodName,
                 Overload: overload,
@@ -937,9 +935,9 @@ static class ReturnToSender
                 string.Join(" ", originalOps),
                 "",
                 $"closure-iteration-budget: {FormatDiagnostic(firstError)}",
-                TargetBody: printed.Output,
+                TargetBody: targetBody.Source,
                 MemberAnchor: memberAnchor,
-                Decisions: printed.Decisions);
+                Decisions: targetBody.Decisions);
         }
     }
 
@@ -960,9 +958,7 @@ static class ReturnToSender
 
         var function = IrImporter.Import(source, fullType, methodName, overload)
             ?? throw new InvalidOperationException($"Could not import {fullType}::{methodName}.");
-        var printed = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
-        if (printed.Output is null)
-            throw new InvalidOperationException($"Could not print {fullType}::{methodName}.");
+        var targetBody = CompileBackSourceComposer.CreateTargetBody(source, function, fullType, methodName);
 
         var original = ILInstructionPrinter.Disassemble(pe, reader, method)
             ?? throw new InvalidOperationException($"Could not disassemble {fullType}::{methodName}.");
@@ -994,7 +990,7 @@ static class ReturnToSender
                 Function: function,
                 TargetType: typeHandle,
                 TargetMethod: methodHandle,
-                TargetBody: printed.Output,
+                TargetBody: targetBody,
                 FullType: fullType,
                 MethodName: methodName,
                 Overload: overload,
@@ -1012,9 +1008,9 @@ static class ReturnToSender
                     string.Join(" ", originalOps),
                     "",
                     $"{identityDiagnostic.Reason}: {identityDiagnostic.Detail}",
-                    TargetBody: printed.Output,
+                    TargetBody: targetBody.Source,
                     MemberAnchor: memberAnchor,
-                    Decisions: printed.Decisions);
+                    Decisions: targetBody.Decisions);
             }
 
             string unit = sourceResult.Source;
@@ -1043,9 +1039,9 @@ static class ReturnToSender
                         string.Join(" ", originalOps),
                         "",
                         "method-not-found",
-                        TargetBody: printed.Output,
+                        TargetBody: targetBody.Source,
                         MemberAnchor: memberAnchor,
-                        Decisions: printed.Decisions);
+                        Decisions: targetBody.Decisions);
                 }
 
                 return new Result(
@@ -1057,11 +1053,11 @@ static class ReturnToSender
                     string.Join(" ", originalOps),
                     string.Join(" ", recompiledOps),
                     null,
-                    TargetBody: printed.Output,
+                    TargetBody: targetBody.Source,
                     IlDiffDiagnostic: ilDiffDiagnostic,
                     IlDiff: ilDiff,
                     MemberAnchor: memberAnchor,
-                    Decisions: printed.Decisions);
+                    Decisions: targetBody.Decisions);
             }
 
             var errors = emit.Diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
@@ -1090,9 +1086,9 @@ static class ReturnToSender
                     string.Join(" ", originalOps),
                     "",
                     $"{reason}: {FormatDiagnostic(error)}",
-                    TargetBody: printed.Output,
+                    TargetBody: targetBody.Source,
                     MemberAnchor: memberAnchor,
-                    Decisions: printed.Decisions);
+                    Decisions: targetBody.Decisions);
             }
         }
 
@@ -1103,7 +1099,7 @@ static class ReturnToSender
                 Function: function,
                 TargetType: typeHandle,
                 TargetMethod: methodHandle,
-                TargetBody: printed.Output,
+                TargetBody: targetBody,
                 FullType: fullType,
                 MethodName: methodName,
                 Overload: overload,
@@ -1118,9 +1114,9 @@ static class ReturnToSender
                 string.Join(" ", originalOps),
                 "",
                 $"closure-iteration-budget: {FormatDiagnostic(firstError)}",
-                TargetBody: printed.Output,
+                TargetBody: targetBody.Source,
                 MemberAnchor: memberAnchor,
-                Decisions: printed.Decisions);
+                Decisions: targetBody.Decisions);
         }
     }
 
@@ -1142,9 +1138,7 @@ static class ReturnToSender
 
         var function = IrImporter.Import(source, fullType, methodName, overload)
             ?? throw new InvalidOperationException($"Could not import {fullType}::{methodName}.");
-        var printed = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
-        if (printed.Output is null)
-            throw new InvalidOperationException($"Could not print {fullType}::{methodName}.");
+        var targetBody = CompileBackSourceComposer.CreateTargetBody(source, function, fullType, methodName);
 
         var original = ILInstructionPrinter.Disassemble(pe, reader, setter)
             ?? throw new InvalidOperationException($"Could not disassemble {fullType}::{methodName}.");
@@ -1177,7 +1171,7 @@ static class ReturnToSender
                 TargetType: typeHandle,
                 TargetMethod: setterHandle,
                 TargetProperty: propertyHandle,
-                TargetBody: printed.Output,
+                TargetBody: targetBody,
                 FullType: fullType,
                 MethodName: methodName,
                 Overload: overload,
@@ -1195,9 +1189,9 @@ static class ReturnToSender
                     string.Join(" ", originalOps),
                     "",
                     $"{identityDiagnostic.Reason}: {identityDiagnostic.Detail}",
-                    TargetBody: printed.Output,
+                    TargetBody: targetBody.Source,
                     MemberAnchor: memberAnchor,
-                    Decisions: printed.Decisions);
+                    Decisions: targetBody.Decisions);
             }
 
             string unit = sourceResult.Source;
@@ -1226,9 +1220,9 @@ static class ReturnToSender
                         string.Join(" ", originalOps),
                         "",
                         "method-not-found",
-                        TargetBody: printed.Output,
+                        TargetBody: targetBody.Source,
                         MemberAnchor: memberAnchor,
-                        Decisions: printed.Decisions);
+                        Decisions: targetBody.Decisions);
                 }
 
                 return new Result(
@@ -1240,11 +1234,11 @@ static class ReturnToSender
                     string.Join(" ", originalOps),
                     string.Join(" ", recompiledOps),
                     null,
-                    TargetBody: printed.Output,
+                    TargetBody: targetBody.Source,
                     IlDiffDiagnostic: ilDiffDiagnostic,
                     IlDiff: ilDiff,
                     MemberAnchor: memberAnchor,
-                    Decisions: printed.Decisions);
+                    Decisions: targetBody.Decisions);
             }
 
             var errors = emit.Diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
@@ -1273,9 +1267,9 @@ static class ReturnToSender
                     string.Join(" ", originalOps),
                     "",
                     $"{reason}: {FormatDiagnostic(error)}",
-                    TargetBody: printed.Output,
+                    TargetBody: targetBody.Source,
                     MemberAnchor: memberAnchor,
-                    Decisions: printed.Decisions);
+                    Decisions: targetBody.Decisions);
             }
         }
 
@@ -1287,7 +1281,7 @@ static class ReturnToSender
                 TargetType: typeHandle,
                 TargetMethod: setterHandle,
                 TargetProperty: propertyHandle,
-                TargetBody: printed.Output,
+                TargetBody: targetBody,
                 FullType: fullType,
                 MethodName: methodName,
                 Overload: overload,
@@ -1302,9 +1296,9 @@ static class ReturnToSender
                 string.Join(" ", originalOps),
                 "",
                 $"closure-iteration-budget: {FormatDiagnostic(firstError)}",
-                TargetBody: printed.Output,
+                TargetBody: targetBody.Source,
                 MemberAnchor: memberAnchor,
-                Decisions: printed.Decisions);
+                Decisions: targetBody.Decisions);
         }
     }
 

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -3,7 +3,6 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Text;
-using DotnetInspector.Services;
 using ILInspector.CSharp;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Text;
+using DotnetInspector.Services;
 using ILInspector.CSharp;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
@@ -175,7 +176,7 @@ internal abstract record ArtifactRequest(
     IrFunction Function,
     TypeDefinitionHandle TargetType,
     MethodDefinitionHandle TargetMethod,
-    string TargetBody,
+    ProductTargetBody TargetBody,
     string FullType,
     string MethodName,
     int Overload,
@@ -189,7 +190,7 @@ internal sealed record MethodArtifactRequest(
     IrFunction Function,
     TypeDefinitionHandle TargetType,
     MethodDefinitionHandle TargetMethod,
-    string TargetBody,
+    ProductTargetBody TargetBody,
     string FullType,
     string MethodName,
     int Overload,
@@ -217,7 +218,7 @@ internal abstract record PropertyAccessorArtifactRequest(
     TypeDefinitionHandle TargetType,
     MethodDefinitionHandle TargetMethod,
     PropertyDefinitionHandle TargetProperty,
-    string TargetBody,
+    ProductTargetBody TargetBody,
     string FullType,
     string MethodName,
     int Overload,
@@ -245,7 +246,7 @@ internal sealed record PropertyGetterArtifactRequest(
     TypeDefinitionHandle TargetType,
     MethodDefinitionHandle TargetMethod,
     PropertyDefinitionHandle TargetProperty,
-    string TargetBody,
+    ProductTargetBody TargetBody,
     string FullType,
     string MethodName,
     int Overload,
@@ -274,7 +275,7 @@ internal sealed record PropertySetterArtifactRequest(
     TypeDefinitionHandle TargetType,
     MethodDefinitionHandle TargetMethod,
     PropertyDefinitionHandle TargetProperty,
-    string TargetBody,
+    ProductTargetBody TargetBody,
     string FullType,
     string MethodName,
     int Overload,
@@ -298,6 +299,7 @@ internal sealed record PropertySetterArtifactRequest(
 
 internal sealed record ProductArtifact(
     ArtifactRequest Request,
+    ProductTargetBody TargetBody,
     string Source,
     IReadOnlyList<CompileBackFact> SourceFacts,
     IReadOnlyList<CompileBackPlanningDiagnostic> Diagnostics,
@@ -310,6 +312,7 @@ internal sealed record ProductArtifact(
         IReadOnlySet<TypeDefinitionHandle> closureRoots)
         => new(
             request,
+            request.TargetBody,
             result.Source,
             result.Plan.Types
                 .SelectMany(type => type.SourceFacts
@@ -486,8 +489,22 @@ public sealed record CompileBackMemberRequirement(
 
 public sealed record CompileBackPlanningDiagnostic(string Layer, string Reason, string Detail);
 
+internal sealed record ProductTargetBody(string Source, IReadOnlyList<DecompilerDecision> Decisions);
+
 public static class CompileBackSourceComposer
 {
+    internal static ProductTargetBody CreateTargetBody(
+        MetadataSource source,
+        IrFunction function,
+        string fullType,
+        string methodName)
+    {
+        var printed = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
+        if (printed.Output is null)
+            throw new InvalidOperationException($"Could not print {fullType}::{methodName}.");
+        return new ProductTargetBody(printed.Output, printed.Decisions);
+    }
+
     internal static ProductArtifact Compose(ArtifactRequest request)
     {
         var closure = CreateClosureInputs(request);
@@ -500,7 +517,7 @@ public static class CompileBackSourceComposer
                 request.TargetType,
                 getter.TargetProperty,
                 request.TargetMethod,
-                request.TargetBody,
+                request.TargetBody.Source,
                 request.FullType,
                 request.MethodName,
                 request.Overload,
@@ -515,7 +532,7 @@ public static class CompileBackSourceComposer
                 request.TargetType,
                 setter.TargetProperty,
                 request.TargetMethod,
-                request.TargetBody,
+                request.TargetBody.Source,
                 request.FullType,
                 request.MethodName,
                 request.Overload,
@@ -529,7 +546,7 @@ public static class CompileBackSourceComposer
                 request.Function,
                 request.TargetType,
                 request.TargetMethod,
-                request.TargetBody,
+                request.TargetBody.Source,
                 request.FullType,
                 request.MethodName,
                 request.Overload,


### PR DESCRIPTION
- Advances #2529
- Changes harness-only RTS/provider boundary: target-body C# rendering is now represented as a provider-produced `ProductTargetBody` carried through `ArtifactRequest` / `ProductArtifact`.
- Evidence revision: `009c2f1e`

## Change

**Conclusion:** **REVIEW** — RTS still selects/imports the target method and owns Roslyn compile feedback, but it no longer calls `CSharpPrinter.PrintRaised` directly for ReturnToSender artifacts.

## Scope and safety

- **Root cause:** The previous envelope still accepted raw target-body source text from RTS, so the planner called the product C# output printer directly before constructing an artifact request.
- **Fix shape:** Add `ProductTargetBody` and `CompileBackSourceComposer.CreateTargetBody(...)`; artifact requests carry the typed provider-produced body/provenance, and `Compose(...)` consumes its source text.
- **Product impact:** Harness-only boundary cleanup; emitted target body, decisions, and compile-back source should be unchanged.
- **RTS boundary:** RTS orchestrates target selection/import, Roslyn diagnostics, closure growth, compilation, and opcode comparison. Product/provider path owns target-body rendering and artifact composition.

## Evidence

| Check | Result |
| --- | --- |
| Harness build | `dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet` passed |
| Focused tests | `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.ReturnToSenderPrototypeTests` passed, 96/96 |
| Markdown | `npx markdownlint-cli docs/design/fact-planned-compile-back-harness.md` passed |

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Importing the target `IrFunction` | Not moved | RTS still selects and imports the target for this behavior-preserving slice. |
| Roslyn diagnostic/oracle closure growth | Not moved | It remains RTS/tools-only compile feedback. |

## Review

Adversarial review requested separately per repo policy.
