### PR TITLE
Expose call-site Finding transitions

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,7 +160,9 @@ separate axes; see [Finding Coordinates](design/finding-coordinates.md).
   Allocation changes retain Analysis's
   `FindingComparison<AllocationOccurrence>` on their Research projection;
   count, hot/cold, and ranking fields are derived from that comparison rather
-  than from a separate count-only diff.
+  than from a separate count-only diff. Focused endpoint-confirmation consumers
+  can also request complete allocation or direct-call comparisons, including
+  exact pairs that have no `ResearchChange` row.
 
 `ResearchFactRegistry` is the dogfooded analyzer registry for the overlay.
 Producers implement `IResearchFactProducer` with a stable name, produced fact

--- a/docs/design/finding-nomenclature.md
+++ b/docs/design/finding-nomenclature.md
@@ -141,6 +141,21 @@ Research retains exact as well as changed allocation comparisons when this lens
 requests them, so it can report `PairFinding.Present`, not only candidate
 boundaries.
 
+The same contract identifies a likely cause after an allocation onset. The
+caller method is the subject; each exact instantiated callee is a call-site
+observation:
+
+```bash
+dotnet-inspect diff --package Foo@1.4.0..1.5.0 \
+  -t Foo.Parser -m Parse \
+  --finding analysis.call-site
+```
+
+`PairFinding.Added` confirms a new direct-call occurrence. `Changed` can report
+that a retained call changed dispatch, opcode, or loop context. IL offsets and
+metadata tokens remain endpoint-local provenance rather than correspondence
+identity.
+
 ## Research composition
 
 Research is the join layer for sibling producers. It may retain a producer's

--- a/docs/design/finding-producers.md
+++ b/docs/design/finding-producers.md
@@ -174,11 +174,14 @@ projection from the same comparison path; there is no separate count-only
 allocation diff path. The CLI selects and retains the native comparison with
 `diff --finding analysis.allocation`.
 
+Direct calls are the second end-to-end Analysis proof. Research's call-site
+fact producers and `diff --finding analysis.call-site` consume the same
+IL-ordered `Finding<DirectCall>` census. Research retains the complete native
+comparison only when requested, so `Present` remains observable without
+increasing the ordinary Body Signals result.
+
 The remaining Analysis body observations preserve their native families:
 
-- direct calls use an IL-ordered `Finding<DirectCall>` census keyed by exact
-  instantiated callee identity; dispatch, opcode, and loop context remain
-  transition facets, while IL offsets and metadata tokens remain provenance;
 - definite unsafe IL operations use an IL-ordered
   `Finding<UnsafetyOccurrence>` census;
 - declaration, signature, local, call, and opcode evidence use an identity

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -95,6 +95,20 @@ dotnet-inspect diff --package Foo@1.4.0..1.5.0 \
 `Removed`, and `Changed` distinguish a wrong boundary, disappearance, or
 allocation-facet change without inferring those states from aggregate counts.
 
+After locating an allocation boundary, the same caller-selected endpoint pair
+can test whether a new direct call explains it:
+
+```bash
+dotnet-inspect diff --package Foo@1.4.0..1.5.0 \
+  -t Foo.Parser -m Parse \
+  --finding analysis.call-site
+```
+
+Here `PairFinding.Added` confirms a new call-site occurrence in `Parse`.
+`PairFinding.Changed` can instead show that an existing call moved into a loop
+or changed dispatch/opcode facets. The caller method is the target; the rows
+identify its callees.
+
 ## Cache locations
 
 | Cache | Location | TTL | Written by |

--- a/skills/compatibility/SKILL.md
+++ b/skills/compatibility/SKILL.md
@@ -58,6 +58,18 @@ dnx dotnet-inspect -y -- diff --package Foo@1.4.0..1.5.0 \
 onset. `Present`, `Removed`, and `Changed` remain distinct; do not infer onset
 from an aggregate allocation-count delta.
 
+For a direct-call boundary in one caller method, select the call-site producer:
+
+```bash
+dnx dotnet-inspect -y -- diff --package Foo@1.4.0..1.5.0 \
+  -t Foo.Parser -m Parse \
+  --finding analysis.call-site
+```
+
+Rows identify the callees. `PairFinding.Added` confirms a new direct-call
+occurrence; `Changed` reports retained-call facet changes such as moving into a
+loop.
+
 ## Did the implementation change? (C# + IL)
 
 `-S "Implementation Diff"` selects Research-composed body evidence instead of
@@ -118,5 +130,6 @@ dnx dotnet-inspect -y -- diff \
 An introduction boundary is a row with `PairFinding.Added`, `Old=absent`, and
 `New=present`. `PairFinding.Present` means the target exists at both endpoints;
 for a type target, no row means it exists at neither. Use `-m Type.Member:1` for
-an API member boundary. Use `--finding analysis.allocation` with exactly one
-method target for an allocation boundary.
+an API member boundary. Use `--finding analysis.allocation` or
+`--finding analysis.call-site` with exactly one method target for the
+corresponding Analysis boundary.

--- a/skills/performance/SKILL.md
+++ b/skills/performance/SKILL.md
@@ -78,6 +78,23 @@ and `Changed` identify a wrong boundary, disappearance, or changed allocation
 facets. The command does not traverse versions; the caller owns the search
 policy and bound.
 
+## Trace a likely cause to a new call
+
+After confirming an allocation boundary, compare the same caller method's
+direct-call census:
+
+```bash
+dnx dotnet-inspect -y -- diff --package MyLib@1.4.0..1.5.0 \
+  -t MyType -m HotPath \
+  --finding analysis.call-site
+```
+
+The target method is the caller and each row identifies a callee.
+`PairFinding.Added` confirms a new call occurrence, such as a newly introduced
+`Enumerable.ToArray`. `Changed` can show that an existing call moved into a loop
+or changed dispatch/opcode facets. Use the single-version `Calls` section while
+probing versions; use this final adjacent comparison as the onset proof.
+
 ## Drill a candidate
 
 `Call Graph` is a bounded outbound tree; `Caller Graph` is a bounded reverse

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -23,6 +23,13 @@ public class ResearchDiffTests
             typeof(ApiDiff),
             typeof(ApiFindingComparison),
         ]));
+        Assert.NotNull(typeof(ResearchComparison).GetConstructor(
+        [
+            typeof(ImmutableArray<ResearchChange>),
+            typeof(ApiDiff),
+            typeof(ApiFindingComparison),
+            typeof(ImmutableArray<AllocationFindingComparison>),
+        ]));
         Assert.NotNull(typeof(ResearchDiffOptions).GetConstructor(
         [
             typeof(ResearchChangeMechanism),
@@ -798,6 +805,37 @@ public class ResearchDiffTests
             _ => throw new InvalidOperationException("Expected a complete allocation comparison."),
         };
         Assert.Equal(PairKind.Present, Assert.Single(comparison.Pairs).Kind);
+    }
+
+    [Fact]
+    public void CompareAssemblies_BodySignals_RetainsNativeCallSiteComparison()
+    {
+        var diff = ResearchDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            new ResearchDiffOptions(
+                ResearchChangeMechanism.BodySignals,
+                TypeFilters: new HashSet<string>(StringComparer.Ordinal)
+                {
+                    "DiffFixtureSample.DiffSample",
+                })
+            {
+                RetainCallSiteComparisons = true,
+            });
+
+        var retained = Assert.Single(diff.CallSiteComparisons, comparison =>
+            comparison.Subject.Display.Contains("RegressesAllocInLoop", StringComparison.Ordinal));
+        var comparison = retained.Comparison switch
+        {
+            FindingComparison<DirectCall>.Complete complete => complete,
+            _ => throw new InvalidOperationException("Expected a complete call-site comparison."),
+        };
+        Assert.Contains(comparison.Pairs, pair =>
+            pair is PairFinding<DirectCall>.Present present
+            && present.New.Payload.Callee.Name == "Add");
+        Assert.Contains(comparison.Pairs, pair =>
+            pair is PairFinding<DirectCall>.Added added
+            && added.New.Payload.Callee.Name == "Add");
     }
 
     [Fact]

--- a/src/ILInspector.Research/ResearchChanges.cs
+++ b/src/ILInspector.Research/ResearchChanges.cs
@@ -319,6 +319,10 @@ public sealed record AllocationFindingComparison(
     ResearchSubjectKey Subject,
     FindingComparison<AllocationOccurrence> Comparison);
 
+public sealed record CallSiteFindingComparison(
+    ResearchSubjectKey Subject,
+    FindingComparison<DirectCall> Comparison);
+
 /// <summary>
 /// Outcome of one Research diff operation. Changes are stored once; subject grouping is a
 /// projection so flat and grouped consumers cannot observe divergent state.
@@ -329,7 +333,7 @@ public sealed record ResearchComparison
         ImmutableArray<ResearchChange> changes,
         ApiDiff? apiDiff = null,
         ApiFindingComparison? apiComparison = null)
-        : this(changes, apiDiff, apiComparison, [])
+        : this(changes, apiDiff, apiComparison, [], [])
     {
     }
 
@@ -338,6 +342,16 @@ public sealed record ResearchComparison
         ApiDiff? apiDiff,
         ApiFindingComparison? apiComparison,
         ImmutableArray<AllocationFindingComparison> allocationComparisons)
+        : this(changes, apiDiff, apiComparison, allocationComparisons, [])
+    {
+    }
+
+    public ResearchComparison(
+        ImmutableArray<ResearchChange> changes,
+        ApiDiff? apiDiff,
+        ApiFindingComparison? apiComparison,
+        ImmutableArray<AllocationFindingComparison> allocationComparisons,
+        ImmutableArray<CallSiteFindingComparison> callSiteComparisons)
     {
         if (changes.IsDefault)
             throw new ArgumentException("Changes must be initialized.", nameof(changes));
@@ -349,6 +363,13 @@ public sealed record ResearchComparison
             throw new ArgumentException(
                 "Allocation comparisons cannot contain null entries.",
                 nameof(allocationComparisons));
+        }
+        if (!callSiteComparisons.IsDefault
+            && callSiteComparisons.Any(comparison => comparison is null))
+        {
+            throw new ArgumentException(
+                "Call-site comparisons cannot contain null entries.",
+                nameof(callSiteComparisons));
         }
         if (apiDiff is not null
             && apiComparison is not null
@@ -362,12 +383,14 @@ public sealed record ResearchComparison
         ApiComparison = apiComparison;
         ApiDiff = apiComparison?.ApiDiff ?? apiDiff;
         AllocationComparisons = allocationComparisons.IsDefault ? [] : allocationComparisons;
+        CallSiteComparisons = callSiteComparisons.IsDefault ? [] : callSiteComparisons;
     }
 
     public ImmutableArray<ResearchChange> Changes { get; }
     public ApiDiff? ApiDiff { get; }
     public ApiFindingComparison? ApiComparison { get; }
     public ImmutableArray<AllocationFindingComparison> AllocationComparisons { get; }
+    public ImmutableArray<CallSiteFindingComparison> CallSiteComparisons { get; }
     public bool IsEmpty => Changes.IsEmpty;
 
     public IReadOnlyList<ResearchSubjectChanges> BySubject()

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -19,6 +19,7 @@ public sealed record ResearchDiffOptions(
     IReadOnlySet<string>? MemberTargetIdentities = null)
 {
     public bool RetainAllocationComparisons { get; init; }
+    public bool RetainCallSiteComparisons { get; init; }
 }
 
 public sealed record ResearchDiffInput(
@@ -218,7 +219,11 @@ public static class ResearchDiff
             [.. results.SelectMany(result =>
                 result.AllocationComparisons.IsDefault
                     ? []
-                    : result.AllocationComparisons)]);
+                    : result.AllocationComparisons)],
+            [.. results.SelectMany(result =>
+                result.CallSiteComparisons.IsDefault
+                    ? []
+                    : result.CallSiteComparisons)]);
     }
 
     public static ResearchComparison CompareAssemblies(string oldAssemblyPath, string newAssemblyPath, ResearchDiffOptions? options = null)
@@ -247,7 +252,8 @@ public static class ResearchDiff
                 newInput,
                 options.TypeFilters,
                 options.MemberTargetIdentities,
-                options.RetainAllocationComparisons);
+                options.RetainAllocationComparisons,
+                options.RetainCallSiteComparisons);
         }
 
         if (options.Mechanisms.HasFlag(ResearchChangeMechanism.IlBody))
@@ -299,7 +305,8 @@ public static class ResearchDiff
         ResearchDiffInput newInput,
         IReadOnlySet<string>? typeFilters,
         IReadOnlySet<string>? memberTargetIdentities,
-        bool retainAllocationComparisons)
+        bool retainAllocationComparisons,
+        bool retainCallSiteComparisons)
     {
         foreach (var (oldIndex, newIndex) in PairedBodyIndexes(oldInput, newInput))
         {
@@ -309,7 +316,8 @@ public static class ResearchDiff
                 newIndex,
                 typeFilters,
                 memberTargetIdentities,
-                retainAllocationComparisons);
+                retainAllocationComparisons,
+                retainCallSiteComparisons);
 
             var methods = MethodSubjectsByBodySignalKey(oldIndex, newIndex);
             foreach (var row in BodySignalDiff.CompareUnsafe(oldIndex, newIndex).Rows)
@@ -345,10 +353,19 @@ public static class ResearchDiff
             LibraryBodyIndex newIndex,
             IReadOnlySet<string>? typeFilters,
             IReadOnlySet<string>? memberTargetIdentities,
-            bool retainAllocationComparisons)
+            bool retainAllocationComparisons,
+            bool retainCallSiteComparisons)
         {
-            var oldSnapshot = BuildAnalysisSnapshot(oldIndex, typeFilters, memberTargetIdentities);
-            var newSnapshot = BuildAnalysisSnapshot(newIndex, typeFilters, memberTargetIdentities);
+            var oldSnapshot = BuildAnalysisSnapshot(
+                oldIndex,
+                typeFilters,
+                memberTargetIdentities,
+                retainCallSiteComparisons);
+            var newSnapshot = BuildAnalysisSnapshot(
+                newIndex,
+                typeFilters,
+                memberTargetIdentities,
+                retainCallSiteComparisons);
             foreach (var key in oldSnapshot.Keys.Union(newSnapshot.Keys, StringComparer.Ordinal))
             {
                 oldSnapshot.TryGetValue(key, out var oldMethod);
@@ -363,6 +380,14 @@ public static class ResearchDiff
                     newMethod?.Allocations ?? [],
                     Evidence(oldMethod?.Signals, newMethod?.Signals),
                     retainAllocationComparisons);
+                if (retainCallSiteComparisons)
+                {
+                    AddCallSiteComparison(
+                        builder,
+                        subject,
+                        oldMethod?.CallSites ?? [],
+                        newMethod?.CallSites ?? []);
+                }
                 AddCountRows(builder, subject, inBoth, oldMethod?.Signals, newMethod?.Signals);
                 AddExceptionRow(builder, subject, inBoth, oldMethod?.Signals, newMethod?.Signals);
                 AddOptimizationRows(builder, subject, inBoth, oldMethod?.Opportunities, newMethod?.Opportunities);
@@ -372,12 +397,14 @@ public static class ResearchDiff
         static Dictionary<string, ResearchAnalysisMethod> BuildAnalysisSnapshot(
             LibraryBodyIndex index,
             IReadOnlySet<string>? typeFilters,
-            IReadOnlySet<string>? memberTargetIdentities)
+            IReadOnlySet<string>? memberTargetIdentities,
+            bool includeCallSites)
         {
             var methods = new Dictionary<string, ResearchAnalysisMethod>(StringComparer.Ordinal);
             var generatedFrameworkTypes = index.GeneratedFrameworkTypeNames;
             var signalsByToken = index.GetMethodSignals();
             var allocationsByToken = index.GetAllocationOccurrences();
+            var callsByToken = includeCallSites ? index.GetDirectCallsByCaller() : null;
             foreach (var method in index.Methods)
             {
                 if (IsGeneratedMethod(method, generatedFrameworkTypes))
@@ -389,6 +416,12 @@ public static class ResearchDiff
                     continue;
                 signalsByToken.TryGetValue(method.MetadataToken, out var signals);
                 allocationsByToken.TryGetValue(method.MetadataToken, out var allocations);
+                ImmutableArray<DirectCall> callSites = [];
+                if (callsByToken is not null
+                    && callsByToken.TryGetValue(method.MetadataToken, out var retainedCallSites))
+                {
+                    callSites = retainedCallSites;
+                }
                 var key = BodySignalMethodKey(method);
                 if (!methods.TryGetValue(key, out var entry))
                 {
@@ -396,6 +429,7 @@ public static class ResearchDiff
                         subject,
                         signals ?? MethodSignals.None,
                         allocations.IsDefault ? [] : allocations,
+                        callSites,
                         []);
                     methods[key] = entry;
                 }
@@ -405,6 +439,7 @@ public static class ResearchDiff
                     {
                         Signals = signals ?? MethodSignals.None,
                         Allocations = allocations.IsDefault ? [] : allocations,
+                        CallSites = callSites,
                     };
                 }
             }
@@ -421,7 +456,7 @@ public static class ResearchDiff
                 var key = BodySignalMethodKey(opportunity.Method);
                 if (!methods.TryGetValue(key, out var entry))
                 {
-                    entry = new ResearchAnalysisMethod(subject, MethodSignals.None, [], []);
+                    entry = new ResearchAnalysisMethod(subject, MethodSignals.None, [], [], []);
                     methods[key] = entry;
                 }
                 entry.Opportunities.Add(opportunity);
@@ -522,6 +557,18 @@ public static class ResearchDiff
                 inLoop: inLoop,
                 allocationComparison: comparison));
         }
+
+        static void AddCallSiteComparison(
+            ResultBuilder builder,
+            ResearchSubjectKey subject,
+            ImmutableArray<DirectCall> oldCallSites,
+            ImmutableArray<DirectCall> newCallSites)
+            => builder.Add(new CallSiteFindingComparison(
+                subject,
+                AnalysisFindings.CompareCallSites(
+                    oldCallSites,
+                    newCallSites,
+                    new FindingSubject(subject.Id, subject.Display))));
 
         static bool IsHotAllocation(AllocationOccurrence occurrence)
             => occurrence.CountsAsHeapAllocation
@@ -1138,12 +1185,14 @@ public static class ResearchDiff
         ResearchSubjectKey Subject,
         MethodSignals Signals,
         ImmutableArray<AllocationOccurrence> Allocations,
+        ImmutableArray<DirectCall> CallSites,
         List<OptimizationOpportunity> Opportunities);
 
     sealed class ResultBuilder
     {
         readonly List<ResearchChange> _changes = [];
         readonly List<AllocationFindingComparison> _allocationComparisons = [];
+        readonly List<CallSiteFindingComparison> _callSiteComparisons = [];
 
         public ApiFindingComparison? ApiComparison { get; set; }
 
@@ -1152,12 +1201,16 @@ public static class ResearchDiff
         public void Add(AllocationFindingComparison comparison)
             => _allocationComparisons.Add(comparison);
 
+        public void Add(CallSiteFindingComparison comparison)
+            => _callSiteComparisons.Add(comparison);
+
         public ResearchComparison ToResult()
             => new(
                 [.. _changes],
                 apiDiff: null,
                 apiComparison: ApiComparison,
-                allocationComparisons: [.. _allocationComparisons]);
+                allocationComparisons: [.. _allocationComparisons],
+                callSiteComparisons: [.. _callSiteComparisons]);
     }
 
     sealed class MethodBodyLookup : IDisposable

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1325,6 +1325,29 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Diff_FindingTransitions_ConfirmsCallSiteIntroduction()
+    {
+        var oldPath = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var newPath = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var (exit, output, error) = await RunAppAsync(
+            "diff", "--library", $"{oldPath}..{newPath}",
+            "-t", "DiffFixtureSample.DiffSample",
+            "-m", "RegressesAllocInLoop",
+            "--finding", "analysis.call-site",
+            "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("PairFinding.Added", output);
+        Assert.Contains("analysis.call-site", output);
+        Assert.Contains("RegressesAllocInLoop", output);
+        Assert.Contains(".Add(", output);
+        Assert.Contains("absent", output);
+        Assert.Contains("present", output);
+    }
+
+    [Fact]
     public async Task Diff_FindingTransitions_AllocationRequiresOneMemberBeforeAcquisition()
     {
         var (exit, output, error) = await RunAppAsync(
@@ -1336,6 +1359,23 @@ public class CommandExecutionTests
         Assert.Equal(1, exit);
         Assert.Empty(output);
         Assert.Contains("requires exactly one --member", error);
+        Assert.DoesNotContain("not found", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Diff_FindingTransitions_CallSiteRequiresOneMemberBeforeAcquisition()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "diff", "--library", "missing-old.dll..missing-new.dll",
+            "-t", "Sample.Widget",
+            "--finding", "analysis.call-site",
+            "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains(
+            "--finding analysis.call-site requires exactly one --member",
+            error);
         Assert.DoesNotContain("not found", error, StringComparison.OrdinalIgnoreCase);
     }
 

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -307,6 +307,57 @@ public class DiffCommandTests
     }
 
     [Fact]
+    public void BuildCallSiteFindingTransitions_AddedOccurrence_IsNativeAddedPair()
+    {
+        var rows = BuildCallSiteFindingTransitions("RegressesAllocInLoop");
+
+        var added = Assert.Single(rows, row =>
+            row.Transition == "PairFinding.Added"
+            && row.Target.Contains(".Add(", StringComparison.Ordinal));
+        Assert.Equal("analysis.call-site", added.Finding);
+        Assert.Contains("RegressesAllocInLoop", added.Target);
+        Assert.Equal("absent", added.Old);
+        Assert.Equal("present", added.New);
+        Assert.Contains(rows, row =>
+            row.Transition == "PairFinding.Present"
+            && row.Target.Contains(".Add(", StringComparison.Ordinal));
+        Assert.DoesNotContain(rows, row =>
+            row.Target.Contains("..ctor", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void BuildCallSiteFindingTransitions_ChangedCallee_IsRemovedAndAdded()
+    {
+        var rows = BuildCallSiteFindingTransitions("CallToken");
+
+        Assert.Contains(rows, row =>
+            row.Transition == "PairFinding.Removed"
+            && row.Target.Contains("System.Math.Abs(", StringComparison.Ordinal));
+        Assert.Contains(rows, row =>
+            row.Transition == "PairFinding.Added"
+            && row.Target.Contains("System.Math.Sign(", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void BuildCallSiteFindingTransitions_LoopFacetChange_IsNativeChangedPair()
+    {
+        var changed = Assert.Single(
+            BuildCallSiteFindingTransitions("SameAllocationCountBecomesHot"),
+            row => row.Target.Contains(".Add(", StringComparison.Ordinal));
+
+        Assert.Equal("PairFinding.Changed", changed.Transition);
+        Assert.Contains("in loop: False -> True", changed.Detail);
+        Assert.Equal("present", changed.Old);
+        Assert.Equal("present", changed.New);
+    }
+
+    [Fact]
+    public void BuildCallSiteFindingTransitions_EmptyCensuses_HaveNoPair()
+    {
+        Assert.Empty(BuildCallSiteFindingTransitions("Stable"));
+    }
+
+    [Fact]
     public void RenderFindingTransitionsMarkdown_LabelsPairBoundary()
     {
         var view = DiffOutputFormatter.BuildFindingTransitionsView(
@@ -491,6 +542,28 @@ public class DiffCommandTests
             new DiffOptions
             {
                 Finding = AnalysisFindings.AllocationDescriptor.Id,
+                TypeFilter = ["DiffFixtureSample.DiffSample"],
+                MemberFilter = [member],
+            });
+    }
+
+    private static IReadOnlyList<FindingTransitionRow> BuildCallSiteFindingTransitions(
+        string member)
+    {
+        var oldPath = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var newPath = FixtureCatalog.DiffPair.NewAssemblyPath();
+        var oldSurface = AssemblyReader.ExtractApiSurface(oldPath)!;
+        var newSurface = AssemblyReader.ExtractApiSurface(newPath)!;
+        return DiffCommand.BuildCallSiteFindingTransitions(
+            [oldPath],
+            [newPath],
+            oldSurface,
+            newSurface,
+            "v1",
+            "v2",
+            new DiffOptions
+            {
+                Finding = AnalysisFindings.CallSiteDescriptor.Id,
                 TypeFilter = ["DiffFixtureSample.DiffSample"],
                 MemberFilter = [member],
             });
@@ -1256,6 +1329,38 @@ public class DiffCommandTests
         Assert.Contains(transitions, transition =>
             transition.GetProperty("transition").GetString() == "PairFinding.Added"
             && transition.GetProperty("finding").GetString() == "analysis.allocation");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CallSiteFindingTransitions_ComposesJson()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var (exitCode, output, error) = await ConsoleCapture.RunAsync(() =>
+            DiffCommand.ExecuteAsync(new DiffOptions
+            {
+                LibraryVersionRange = $"{v1}..{v2}",
+                JsonOutput = true,
+                Finding = AnalysisFindings.CallSiteDescriptor.Id,
+                TypeFilter = ["DiffFixtureSample.DiffSample"],
+                MemberFilter = ["RegressesAllocInLoop"]
+            }));
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(error);
+        using var document = System.Text.Json.JsonDocument.Parse(output);
+        Assert.False(document.RootElement.TryGetProperty("changes", out _));
+        var transitions = document.RootElement
+            .GetProperty("finding_transitions")
+            .EnumerateArray()
+            .ToList();
+        Assert.Contains(transitions, transition =>
+            transition.GetProperty("transition").GetString() == "PairFinding.Added"
+            && transition.GetProperty("finding").GetString() == "analysis.call-site"
+            && transition.GetProperty("target").GetString()!.Contains(
+                ".Add(",
+                StringComparison.Ordinal));
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -97,11 +97,13 @@ public class DiffCommand
                 Console.Error.WriteLine($"Error: {findingError}");
                 return 1;
             }
-            if (findingDescriptor == AnalysisFindings.AllocationDescriptor.Id)
+            if (findingDescriptor == AnalysisFindings.AllocationDescriptor.Id
+                || findingDescriptor == AnalysisFindings.CallSiteDescriptor.Id)
             {
                 if (options.MemberFilter.Count != 1)
                 {
-                    Console.Error.WriteLine("Error: --finding analysis.allocation requires exactly one --member target.");
+                    Console.Error.WriteLine(
+                        $"Error: --finding {findingDescriptor} requires exactly one --member target.");
                     return 1;
                 }
             }
@@ -515,8 +517,14 @@ public class DiffCommand
             error = null;
             return true;
         }
+        if (string.Equals(descriptor, AnalysisFindings.CallSiteDescriptor.Id, StringComparison.OrdinalIgnoreCase))
+        {
+            descriptor = AnalysisFindings.CallSiteDescriptor.Id;
+            error = null;
+            return true;
+        }
 
-        error = $"Unsupported Finding descriptor '{descriptor}'. Supported descriptors: api.type, api.member, analysis.allocation.";
+        error = $"Unsupported Finding descriptor '{descriptor}'. Supported descriptors: api.type, api.member, analysis.allocation, analysis.call-site.";
         return false;
     }
 
@@ -532,21 +540,33 @@ public class DiffCommand
     private static IReadOnlyList<FindingTransitionRow> BuildSelectedFindingTransitions(
         DiffInputs inputs,
         DiffOptions options)
-        => ResolveFindingDescriptor(options) == AnalysisFindings.AllocationDescriptor.Id
-            ? BuildAllocationFindingTransitions(
-                inputs.FromPaths,
-                inputs.ToPaths,
+        => ResolveFindingDescriptor(options) switch
+        {
+            var descriptor when descriptor == AnalysisFindings.AllocationDescriptor.Id =>
+                BuildAllocationFindingTransitions(
+                    inputs.FromPaths,
+                    inputs.ToPaths,
+                    inputs.FromSurface,
+                    inputs.ToSurface,
+                    inputs.FromVersion,
+                    inputs.ToVersion,
+                    options),
+            var descriptor when descriptor == AnalysisFindings.CallSiteDescriptor.Id =>
+                BuildCallSiteFindingTransitions(
+                    inputs.FromPaths,
+                    inputs.ToPaths,
+                    inputs.FromSurface,
+                    inputs.ToSurface,
+                    inputs.FromVersion,
+                    inputs.ToVersion,
+                    options),
+            _ => BuildFindingTransitions(
                 inputs.FromSurface,
                 inputs.ToSurface,
                 inputs.FromVersion,
                 inputs.ToVersion,
-                options)
-            : BuildFindingTransitions(
-                inputs.FromSurface,
-                inputs.ToSurface,
-                inputs.FromVersion,
-                inputs.ToVersion,
-                options);
+                options),
+        };
 
     private static bool SelectsImplementationDiff(DiffOptions options)
         => options.IncludeSections?.Contains(DiffSections.ImplementationDiff.Name) == true;
@@ -997,6 +1017,48 @@ public class DiffCommand
             .ToList();
     }
 
+    internal static IReadOnlyList<FindingTransitionRow> BuildCallSiteFindingTransitions(
+        IReadOnlyList<string> fromPaths,
+        IReadOnlyList<string> toPaths,
+        ApiSurface fromSurface,
+        ApiSurface toSurface,
+        string fromVersion,
+        string toVersion,
+        DiffOptions options)
+    {
+        if (options.MemberFilter.Count != 1)
+            throw new InvalidOperationException("--finding analysis.call-site requires exactly one --member target.");
+
+        var targets = ResolveMemberTargetIdentities(
+            fromSurface,
+            toSurface,
+            options.MemberFilter,
+            options.TypeFilter,
+            requireBodyTargets: true,
+            bodySectionName: "Finding Transitions");
+        var research = ResearchDiff.Compare(
+            ResearchDiffInput.FromAssemblies(fromPaths),
+            ResearchDiffInput.FromAssemblies(toPaths),
+            new ResearchDiffOptions(
+                ResearchChangeMechanism.BodySignals,
+                TypeFilters: options.TypeFilter,
+                MemberTargetIdentities: targets.MemberIdentities)
+            {
+                RetainCallSiteComparisons = true,
+            });
+
+        return research.CallSiteComparisons
+            .SelectMany(comparison => CompletePairs(comparison.Comparison)
+                .Select(pair => ToCallSiteTransitionRow(
+                    comparison.Subject,
+                    pair,
+                    fromVersion,
+                    toVersion)))
+            .OrderBy(row => row.Target, StringComparer.Ordinal)
+            .ThenBy(row => row.Transition, StringComparer.Ordinal)
+            .ToList();
+    }
+
     static IReadOnlyList<PairFinding<T>> CompletePairs<T>(FindingComparison<T> comparison)
         where T : notnull
         => comparison switch
@@ -1075,6 +1137,46 @@ public class DiffCommand
             ?? occurrence.Detail
             ?? "?";
         return $"{subject.Display} :: {occurrence.Source}/{occurrence.Kind} {allocatedType}";
+    }
+
+    static FindingTransitionRow ToCallSiteTransitionRow(
+        ResearchSubjectKey subject,
+        PairFinding<DirectCall> pair,
+        string fromVersion,
+        string toVersion)
+    {
+        var oldFinding = OldSide(pair);
+        var newFinding = NewSide(pair);
+        return new FindingTransitionRow(
+            $"PairFinding.{pair.Kind}",
+            pair.Descriptor.Id,
+            CallSiteTarget(subject, newFinding ?? oldFinding!),
+            fromVersion,
+            toVersion,
+            oldFinding is null ? "absent" : "present",
+            newFinding is null ? "absent" : "present",
+            pair.Detail);
+    }
+
+    static string CallSiteTarget(
+        ResearchSubjectKey subject,
+        Finding<DirectCall> finding)
+    {
+        var callee = finding.Payload.Callee;
+        if (callee.Kind == MemberKind.Unsupported)
+            return $"{subject.Display} :: {callee.DeclaringType.ToDisplayString()}";
+
+        var typeArguments = callee.TypeArguments.IsDefaultOrEmpty
+            ? ""
+            : $"<{string.Join(", ", callee.TypeArguments.Select(type => type.ToQualifiedDisplayString()))}>";
+        var parameters = string.Join(
+            ", ",
+            callee.ParameterTypes.Select(type => type.ToQualifiedDisplayString()));
+        var declaringType = callee.DeclaringType.ToQualifiedDisplayString();
+        var calleeDisplay = callee.Kind == MemberKind.Constructor
+            ? $"{declaringType}{typeArguments}({parameters})"
+            : $"{declaringType}.{callee.Name}{typeArguments}({parameters})";
+        return $"{subject.Display} :: {calleeDisplay}";
     }
 
     static string TypeTarget(PairFinding<ApiTypeHandle> pair)


### PR DESCRIPTION
## Conclusion

`diff --finding analysis.call-site` now confirms when one caller method gained,
lost, retained, or changed a direct-call occurrence using Analysis's native
`PairFinding<DirectCall>` comparison.

## What changed

- Added `analysis.call-site` to the existing focused `Finding Transitions`
  descriptor selector.
- Requires exactly one caller method and compares only the supplied endpoints.
- Retains complete call-site comparisons in Research only when requested, so
  exact `Present` pairs remain visible without increasing ordinary Body Signals
  work.
- Preserves Analysis-owned exact instantiated-callee identity and
  dispatch/opcode/loop facet classification.
- Supports standalone table/Markdown output and composed JSON documents.
- Documents the allocation-onset to call-cause workflow in design and agent
  guidance.

```bash
dotnet-inspect diff --package Foo@1.4.0..1.5.0 \
  -t Foo.Parser -m Parse \
  --finding analysis.call-site
```

`PairFinding.Added` is the authoritative new-call occurrence. `Changed` can
show that a retained call moved into a loop or changed dispatch/opcode facets.

## Validation

- Solution build succeeded.
- Analysis: 430 passed.
- Research: 87 passed.
- CLI: 1,765 passed, 10 environment skips.
- Changed Markdown passes markdownlint.

## Adversarial review

- **Claude Opus 4.8: CLEAN.** Verified producer authority, structural callee
  identity, opt-in default-path cost, parameter threading, public constructor
  compatibility, pre-acquisition validation, JSON routing, and real focused
  tests.
- **Gemini 3.1 Pro: CLEAN.** Verified generic/overload identity, duplicate
  occurrence matching, complete native pair retention, lazy call-index
  acquisition, descriptor normalization, Combine propagation, and full
  Research/CLI diff tests.

The reviewers agreed and reported no actionable findings, so no review
resolution commit applies.
