### PR TITLE
Move diff acquisition onto assembly sets

### DIFF
--- a/docs/design/assembly-inspection-query.md
+++ b/docs/design/assembly-inspection-query.md
@@ -196,6 +196,14 @@ assembly that *defines* the selected member (via the type-lookup path), so a mem
 query over a package resolves to one reference, not many. Fan-out therefore happens only for
 assembly-level inspection without a selector.
 
+**Incremental acquisition bridge.** `AssemblySetResolver` is the current lower-layer primitive
+for that fan-out. It returns an owned `AssemblySet`: entries retain source, version, source kind,
+and selected TFM, while the set owns package-extraction directories until disposal.
+`AssemblySetSurfaceBuilder` composes an acquired set into one deterministic `ApiSurface` when a
+consumer, such as `diff`, needs package-level API comparison. The CLI still owns endpoint-range
+parsing, compatibility filtering, ranking, and rendering; it does not select package TFMs, merge
+assembly surfaces, or manage extraction directories.
+
 ### 3. `AssemblyInspectionSession` — one PE-lifetime owner, composing `PdbContext`
 
 Opened from a `ResolvedAssemblyReference`, it owns the `PEReader`/`MetadataReader`, opens once,

--- a/src/DotnetInspector.Services.Tests/AssemblySetResolverTests.cs
+++ b/src/DotnetInspector.Services.Tests/AssemblySetResolverTests.cs
@@ -1,4 +1,5 @@
 using System.IO.Compression;
+using ILInspector.Metadata;
 
 namespace DotnetInspector.Services.Tests;
 
@@ -40,6 +41,88 @@ public class AssemblySetResolverTests
             assemblySet.Dispose();
 
             Assert.False(Directory.Exists(tempDir));
+        }
+        finally
+        {
+            Directory.Delete(packageDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CollectAsync_PackageSelectsStableHighestTfmAssemblySet()
+    {
+        var packageDir = Directory.CreateTempSubdirectory("assembly-set-tfm-package-test").FullName;
+        var packagePath = Path.Combine(packageDir, "MultiSurface.1.0.0.nupkg");
+        var sourceAssembly = typeof(AssemblySetResolverTests).Assembly.Location;
+
+        try
+        {
+            using (var archive = ZipFile.Open(packagePath, ZipArchiveMode.Create))
+            {
+                archive.CreateEntryFromFile(sourceAssembly, "lib/net8.0/Old.dll");
+                archive.CreateEntryFromFile(sourceAssembly, "lib/net10.0/Zeta.dll");
+                archive.CreateEntryFromFile(sourceAssembly, "lib/net10.0/Alpha.dll");
+                archive.CreateEntryFromFile(sourceAssembly, "lib/net10.0/fr/Alpha.resources.dll");
+            }
+
+            using var httpClient = new HttpClient();
+            using var assemblySet = await AssemblySetResolver.CollectAsync(
+                httpClient,
+                new AssemblySetRequest { Packages = [packagePath] });
+
+            Assert.Equal(["Alpha.dll", "Zeta.dll"], assemblySet.Assemblies
+                .Select(static entry => Path.GetFileName(entry.Path))
+                .ToArray());
+            Assert.All(assemblySet.Assemblies, static entry => Assert.Equal("net10.0", entry.Tfm));
+
+            var expected = AssemblyReader.ExtractApiSurface(sourceAssembly)!;
+            var merged = AssemblySetSurfaceBuilder.Build(assemblySet);
+
+            Assert.NotNull(merged);
+            Assert.Equal("MultiSurface", merged.Name);
+            Assert.Equal("net10.0", merged.Tfm);
+            Assert.Equal(expected.PublicTypeCount * 2, merged.PublicTypeCount);
+            Assert.Equal(
+                merged.Types.OrderBy(static type => type.FullName).Select(static type => type.FullName),
+                merged.Types.Select(static type => type.FullName));
+        }
+        finally
+        {
+            Directory.Delete(packageDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CollectAsync_AllTfmsIncludesEveryNonResourcePackageAssembly()
+    {
+        var packageDir = Directory.CreateTempSubdirectory("assembly-set-all-tfm-package-test").FullName;
+        var packagePath = Path.Combine(packageDir, "AllTfms.1.0.0.nupkg");
+        var sourceAssembly = typeof(AssemblySetResolverTests).Assembly.Location;
+
+        try
+        {
+            using (var archive = ZipFile.Open(packagePath, ZipArchiveMode.Create))
+            {
+                archive.CreateEntryFromFile(sourceAssembly, "lib/net8.0/Old.dll");
+                archive.CreateEntryFromFile(sourceAssembly, "lib/net10.0/New.dll");
+                archive.CreateEntryFromFile(sourceAssembly, "runtimes/any/lib/net10.0/Runtime.dll");
+                archive.CreateEntryFromFile(sourceAssembly, "lib/net10.0/fr/New.resources.dll");
+            }
+
+            using var httpClient = new HttpClient();
+            using var assemblySet = await AssemblySetResolver.CollectAsync(
+                httpClient,
+                new AssemblySetRequest
+                {
+                    Packages = [packagePath],
+                    Tfm = "all",
+                    IncludePackageRuntimeAssemblies = true,
+                });
+
+            Assert.Equal(["New.dll", "Old.dll", "Runtime.dll"], assemblySet.Assemblies
+                .Select(static entry => Path.GetFileName(entry.Path))
+                .ToArray());
+            Assert.All(assemblySet.Assemblies, static entry => Assert.Null(entry.Tfm));
         }
         finally
         {

--- a/src/DotnetInspector.Services.Tests/AssemblySetResolverTests.cs
+++ b/src/DotnetInspector.Services.Tests/AssemblySetResolverTests.cs
@@ -49,7 +49,7 @@ public class AssemblySetResolverTests
     }
 
     [Fact]
-    public async Task CollectAsync_PackageSelectsStableHighestTfmAssemblySet()
+    public async Task CollectAsync_PackageSelectsStableHighestTfmAssemblySetAndFiltersSatellites()
     {
         var packageDir = Directory.CreateTempSubdirectory("assembly-set-tfm-package-test").FullName;
         var packagePath = Path.Combine(packageDir, "MultiSurface.1.0.0.nupkg");
@@ -123,6 +123,48 @@ public class AssemblySetResolverTests
                 .Select(static entry => Path.GetFileName(entry.Path))
                 .ToArray());
             Assert.All(assemblySet.Assemblies, static entry => Assert.Null(entry.Tfm));
+        }
+        finally
+        {
+            Directory.Delete(packageDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CollectAsync_ExceptionAfterPackageExtractionCleansOwnedDirectory()
+    {
+        var packageDir = Directory.CreateTempSubdirectory("assembly-set-exception-package-test").FullName;
+        var packagePath = Path.Combine(packageDir, "Cleanup.1.0.0.nupkg");
+        var sourceAssembly = typeof(AssemblySetResolverTests).Assembly.Location;
+        var tempDirPrefix = $"assembly-set-exception-test-{Guid.NewGuid():N}";
+
+        try
+        {
+            using (var archive = ZipFile.Open(packagePath, ZipArchiveMode.Create))
+            {
+                archive.CreateEntryFromFile(sourceAssembly, "lib/net10.0/Cleanup.dll");
+            }
+
+            using var httpClient = new HttpClient();
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                AssemblySetResolver.CollectAsync(
+                    httpClient,
+                    new AssemblySetRequest
+                    {
+                        Packages = [packagePath],
+                        Directories = [packageDir],
+                        TempDirPrefix = tempDirPrefix,
+                    },
+                    message =>
+                    {
+                        if (message.StartsWith("Scanning ", StringComparison.Ordinal))
+                            throw new InvalidOperationException("Injected directory scan failure.");
+                    }));
+
+            Assert.Empty(Directory.GetDirectories(
+                Path.GetTempPath(),
+                $"{tempDirPrefix}*",
+                SearchOption.TopDirectoryOnly));
         }
         finally
         {

--- a/src/DotnetInspector.Services/AssemblySetResolver.cs
+++ b/src/DotnetInspector.Services/AssemblySetResolver.cs
@@ -37,7 +37,8 @@ public sealed record AssemblySetEntry(
     string Path,
     string Source,
     string? Version,
-    AssemblySetSourceKind SourceKind);
+    AssemblySetSourceKind SourceKind,
+    string? Tfm = null);
 
 public enum AssemblySetSourceKind
 {
@@ -139,6 +140,7 @@ public static class AssemblySetResolver
                     tempDirs.Add(extracted.TempDir);
 
                 IEnumerable<string> dlls;
+                string? selectedTfm = null;
                 if (request.PackageSelectionMode == AssemblySetPackageSelectionMode.LibAssembliesDescending)
                 {
                     dlls = Directory.GetFiles(extracted.ExtractPath, "*.dll", SearchOption.AllDirectories)
@@ -148,22 +150,17 @@ public static class AssemblySetResolver
                 }
                 else
                 {
-                    var searchPath = TfmResolver.ResolvePackagePath(extracted.ExtractPath, request.Tfm)
-                        ?? extracted.ExtractPath;
-
-                    if (File.Exists(searchPath) && searchPath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                    var selection = TfmSelector.SelectHighestAssembliesFromPackage(
+                        extracted.ExtractPath,
+                        request.Tfm);
+                    selectedTfm = selection.tfm;
+                    dlls = selection.paths;
+                    if (!request.IncludePackageRuntimeAssemblies)
                     {
-                        dlls = [searchPath];
+                        dlls = dlls.Where(p => !p.Contains("/runtimes/", StringComparison.Ordinal)
+                            && !p.Contains("\\runtimes\\", StringComparison.Ordinal));
                     }
-                    else
-                    {
-                        dlls = Directory.GetFiles(searchPath, "*.dll", SearchOption.AllDirectories);
-                        if (!request.IncludePackageRuntimeAssemblies)
-                        {
-                            dlls = dlls.Where(p => !p.Contains("/runtimes/", StringComparison.Ordinal)
-                                && !p.Contains("\\runtimes\\", StringComparison.Ordinal));
-                        }
-                    }
+                    dlls = dlls.OrderBy(static p => p, StringComparer.Ordinal);
                 }
 
                 var foundAssembly = false;
@@ -174,11 +171,16 @@ public static class AssemblySetResolver
                         dll,
                         extracted.PackageName ?? pkg,
                         extracted.Version,
-                        AssemblySetSourceKind.Package));
+                        AssemblySetSourceKind.Package,
+                        selectedTfm));
                 }
 
                 if (!foundAssembly && request.PackageSelectionMode == AssemblySetPackageSelectionMode.LibAssembliesDescending)
                     Error($"No libraries found in package '{pkg}'.");
+                else if (!foundAssembly)
+                    Error(string.IsNullOrWhiteSpace(request.Tfm)
+                        ? $"No assemblies found in package '{pkg}'."
+                        : $"No assemblies found for target framework '{request.Tfm}' in package '{pkg}'.");
             }
         }
 

--- a/src/DotnetInspector.Services/AssemblySetResolver.cs
+++ b/src/DotnetInspector.Services/AssemblySetResolver.cs
@@ -91,12 +91,16 @@ public sealed class AssemblySet : IDisposable
         if (_disposed)
             return;
 
-        foreach (var dir in _tempDirs)
+        DeleteOwnedTemporaryDirectories(_tempDirs);
+        _disposed = true;
+    }
+
+    internal static void DeleteOwnedTemporaryDirectories(IEnumerable<string> tempDirs)
+    {
+        foreach (var dir in tempDirs)
         {
             try { Directory.Delete(dir, recursive: true); } catch { }
         }
-
-        _disposed = true;
     }
 }
 
@@ -332,34 +336,42 @@ public static class AssemblySetResolver
                 sourceOrder.Add(sourceKind);
         }
 
-        foreach (var sourceKind in sourceOrder)
+        try
         {
-            switch (sourceKind)
+            foreach (var sourceKind in sourceOrder)
             {
-                case AssemblySetSourceKind.Package:
-                    await AddPackagesAsync();
-                    break;
-                case AssemblySetSourceKind.Assembly:
-                    AddAssemblies();
-                    break;
-                case AssemblySetSourceKind.PlatformAssembly:
-                    await AddPlatformAssembliesAsync();
-                    break;
-                case AssemblySetSourceKind.PlatformFramework:
-                    await AddPlatformFrameworksAsync();
-                    break;
-                case AssemblySetSourceKind.Project:
-                    AddProjects();
-                    break;
-                case AssemblySetSourceKind.Directory:
-                    AddDirectories();
-                    break;
-                default:
-                    Warn($"Unknown assembly source kind '{sourceKind}' ignored.");
-                    break;
+                switch (sourceKind)
+                {
+                    case AssemblySetSourceKind.Package:
+                        await AddPackagesAsync();
+                        break;
+                    case AssemblySetSourceKind.Assembly:
+                        AddAssemblies();
+                        break;
+                    case AssemblySetSourceKind.PlatformAssembly:
+                        await AddPlatformAssembliesAsync();
+                        break;
+                    case AssemblySetSourceKind.PlatformFramework:
+                        await AddPlatformFrameworksAsync();
+                        break;
+                    case AssemblySetSourceKind.Project:
+                        AddProjects();
+                        break;
+                    case AssemblySetSourceKind.Directory:
+                        AddDirectories();
+                        break;
+                    default:
+                        Warn($"Unknown assembly source kind '{sourceKind}' ignored.");
+                        break;
+                }
             }
-        }
 
-        return new AssemblySet(assemblies, diagnostics, tempDirs);
+            return new AssemblySet(assemblies, diagnostics, tempDirs);
+        }
+        catch
+        {
+            AssemblySet.DeleteOwnedTemporaryDirectories(tempDirs);
+            throw;
+        }
     }
 }

--- a/src/DotnetInspector.Services/AssemblySetSurfaceBuilder.cs
+++ b/src/DotnetInspector.Services/AssemblySetSurfaceBuilder.cs
@@ -1,0 +1,78 @@
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Services;
+
+/// <summary>
+/// Builds one API surface from an acquired assembly set.
+/// </summary>
+public static class AssemblySetSurfaceBuilder
+{
+    public static ApiSurface? Build(
+        AssemblySet assemblySet,
+        bool includeAll = false,
+        Action<string>? log = null)
+    {
+        var entries = assemblySet.Assemblies;
+        var packageName = entries.Count > 0
+            && entries.All(static entry => entry.SourceKind == AssemblySetSourceKind.Package)
+            && entries.All(entry => string.Equals(entry.Source, entries[0].Source, StringComparison.Ordinal))
+                ? entries[0].Source
+                : null;
+        var tfms = entries
+            .Select(static entry => entry.Tfm)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var tfm = tfms.Count == 1 ? tfms[0] : null;
+
+        return Build(
+            entries.Select(static entry => entry.Path).ToList(),
+            includeAll,
+            packageName,
+            tfm,
+            log);
+    }
+
+    public static ApiSurface? Build(
+        IReadOnlyList<string> assemblyPaths,
+        bool includeAll = false,
+        string? name = null,
+        string? tfm = null,
+        Action<string>? log = null)
+    {
+        if (assemblyPaths.Count == 0)
+            return null;
+
+        if (assemblyPaths.Count == 1)
+        {
+            var single = AssemblyReader.ExtractApiSurface(assemblyPaths[0], includeAll);
+            if (single is not null)
+            {
+                single.Name = name ?? Path.GetFileNameWithoutExtension(assemblyPaths[0]);
+                single.Tfm = tfm;
+            }
+            return single;
+        }
+
+        var merged = new ApiSurface { Name = name, Tfm = tfm };
+        foreach (var path in assemblyPaths)
+        {
+            var surface = AssemblyReader.ExtractApiSurface(path, includeAll);
+            if (surface is null)
+            {
+                log?.Invoke($"  ! {Path.GetFileName(path)}: API surface unavailable");
+                continue;
+            }
+
+            log?.Invoke($"  + {Path.GetFileNameWithoutExtension(path)}: {surface.PublicTypeCount} types");
+            merged.Types.AddRange(surface.Types);
+            merged.PublicTypeCount += surface.PublicTypeCount;
+            merged.PublicMethodCount += surface.PublicMethodCount;
+            merged.PublicPropertyCount += surface.PublicPropertyCount;
+            merged.PublicEventCount += surface.PublicEventCount;
+            merged.PublicFieldCount += surface.PublicFieldCount;
+        }
+
+        merged.Types = merged.Types.OrderBy(static type => type.FullName).ToList();
+        return merged.Types.Count == 0 ? null : merged;
+    }
+}

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -1232,6 +1232,15 @@ public class DiffCommandTests
     }
 
     [Fact]
+    public void AsEndpointError_RemovesCollectionSkippingSuffix()
+    {
+        Assert.Equal(
+            "'Microsoft.AspNetCore.App' is a framework, not a library.",
+            DiffCommand.AsEndpointError(
+                "'Microsoft.AspNetCore.App' is a framework, not a library., skipping."));
+    }
+
+    [Fact]
     public async Task ExecuteAsync_FindingTransitions_ComposesJson()
     {
         var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -1203,6 +1203,35 @@ public class DiffCommandTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_InvalidLibraryReportsSurfaceFailure()
+    {
+        var directory = Directory.CreateTempSubdirectory("diff-invalid-library-test").FullName;
+        var invalidAssembly = Path.Combine(directory, "Invalid.dll");
+        File.WriteAllText(invalidAssembly, "not a managed assembly");
+
+        try
+        {
+            var (exitCode, output, error) = await ConsoleCapture.RunAsync(() =>
+                DiffCommand.ExecuteAsync(new DiffOptions
+                {
+                    LibraryVersionRange = $"{invalidAssembly}..{invalidAssembly}",
+                }));
+
+            Assert.Equal(1, exitCode);
+            Assert.Empty(output);
+            Assert.Contains(
+                "Failed to extract API surface from one or both libraries",
+                error,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain("File not found", error, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task ExecuteAsync_FindingTransitions_ComposesJson()
     {
         var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -156,7 +156,7 @@ public class DiffCommand
             }
             else
             {
-                var result = ExecuteLibraryDiff(options);
+                var result = await ExecuteLibraryDiffAsync(options, logger, context.HttpClient);
                 if (result.error != null)
                 {
                     Console.Error.WriteLine(result.error);
@@ -296,29 +296,32 @@ public class DiffCommand
         }
     }
 
+    sealed record DiffEndpoint(
+        AssemblySet AssemblySet,
+        ApiSurface Surface) : IDisposable
+    {
+        public IReadOnlyList<string> Paths =>
+            AssemblySet.Assemblies.Select(static entry => entry.Path).ToList();
+
+        public void Dispose() => AssemblySet.Dispose();
+    }
+
     sealed record DiffInputs(
-        ApiSurface FromSurface,
-        ApiSurface ToSurface,
+        DiffEndpoint From,
+        DiffEndpoint To,
         string FromVersion,
         string ToVersion,
-        string Name,
-        IReadOnlyList<string> FromPaths,
-        IReadOnlyList<string> ToPaths,
-        string? FromTempDir = null,
-        string? ToTempDir = null) : IDisposable
+        string Name) : IDisposable
     {
+        public ApiSurface FromSurface => From.Surface;
+        public ApiSurface ToSurface => To.Surface;
+        public IReadOnlyList<string> FromPaths => From.Paths;
+        public IReadOnlyList<string> ToPaths => To.Paths;
+
         public void Dispose()
         {
-            DeleteTemp(FromTempDir);
-            DeleteTemp(ToTempDir);
-        }
-
-        static void DeleteTemp(string? tempDir)
-        {
-            if (!string.IsNullOrEmpty(tempDir) && Directory.Exists(tempDir))
-            {
-                try { Directory.Delete(tempDir, recursive: true); } catch { }
-            }
+            From.Dispose();
+            To.Dispose();
         }
     }
 
@@ -333,19 +336,40 @@ public class DiffCommand
 
         logger.Log($"Comparing {packageName} v{fromVersion} -> v{toVersion}");
 
-        var from = await ExtractPackageInputAsync($"{packageName}@{fromVersion}", options, logger, httpClient);
+        var from = await ResolveDiffEndpointAsync(
+            httpClient,
+            new AssemblySetRequest
+            {
+                Packages = [$"{packageName}@{fromVersion}"],
+                Tfm = options.Tfm,
+                SourceOptions = options.SourceOptions,
+                TempDirPrefix = "inspect-diff",
+                IncludePackageRuntimeAssemblies = true,
+            },
+            options.IncludeAll,
+            logger);
         if (from.error is not null)
             return (null, $"Error resolving v{fromVersion}: {from.error}");
-        var to = await ExtractPackageInputAsync($"{packageName}@{toVersion}", options, logger, httpClient);
+        var to = await ResolveDiffEndpointAsync(
+            httpClient,
+            new AssemblySetRequest
+            {
+                Packages = [$"{packageName}@{toVersion}"],
+                Tfm = options.Tfm,
+                SourceOptions = options.SourceOptions,
+                TempDirPrefix = "inspect-diff",
+                IncludePackageRuntimeAssemblies = true,
+            },
+            options.IncludeAll,
+            logger);
         if (to.error is not null)
         {
-            DeleteTempDir(from.tempDir);
+            from.endpoint!.Dispose();
             return (null, $"Error resolving v{toVersion}: {to.error}");
         }
 
         return (new DiffInputs(
-            from.surface!, to.surface!, fromVersion, toVersion, packageName,
-            from.paths!, to.paths!, from.tempDir, to.tempDir), null);
+            from.endpoint!, to.endpoint!, fromVersion, toVersion, packageName), null);
     }
 
     private static async Task<(DiffInputs? inputs, string? error)>
@@ -360,116 +384,114 @@ public class DiffCommand
         var framework = options.Framework ?? "runtime";
         logger.Log($"Comparing {assemblyName} in {framework} v{fromVersion} -> v{toVersion}");
 
-        // Resolve assemblies for both versions (downloads ref packs as needed)
-        var (fromPath, _, _, fromError) = await PlatformResolver.ResolveAssemblyAsync(
-            assemblyName,
+        var from = await ResolveDiffEndpointAsync(
             httpClient,
-            logger.Log,
-            $"{framework}@{fromVersion}");
+            new AssemblySetRequest
+            {
+                PlatformAssemblies = [assemblyName],
+                PlatformAssemblyFrameworkHint = $"{framework}@{fromVersion}",
+                TempDirPrefix = "inspect-diff",
+            },
+            options.IncludeAll,
+            logger);
+        if (from.error is not null)
+            return (null, from.assembliesResolved
+                ? "Error: Failed to extract API surface from one or both versions."
+                : $"Error resolving v{fromVersion}: {from.error}");
 
-        if (fromError != null)
-        {
-            return (null, $"Error resolving v{fromVersion}: {fromError}");
-        }
-
-        var (toPath, _, _, toError) = await PlatformResolver.ResolveAssemblyAsync(
-            assemblyName,
+        var to = await ResolveDiffEndpointAsync(
             httpClient,
-            logger.Log,
-            $"{framework}@{toVersion}");
-
-        if (toError != null)
+            new AssemblySetRequest
+            {
+                PlatformAssemblies = [assemblyName],
+                PlatformAssemblyFrameworkHint = $"{framework}@{toVersion}",
+                TempDirPrefix = "inspect-diff",
+            },
+            options.IncludeAll,
+            logger);
+        if (to.error is not null)
         {
-            return (null, $"Error resolving v{toVersion}: {toError}");
-        }
-
-        // Extract API surfaces from both assemblies
-        var fromSurface = ExtractApiSurface(fromPath!, options.IncludeAll);
-        var toSurface = ExtractApiSurface(toPath!, options.IncludeAll);
-
-        if (fromSurface == null || toSurface == null)
-        {
-            return (null, "Error: Failed to extract API surface from one or both versions.");
+            from.endpoint!.Dispose();
+            return (null, to.assembliesResolved
+                ? "Error: Failed to extract API surface from one or both versions."
+                : $"Error resolving v{toVersion}: {to.error}");
         }
 
         return (new DiffInputs(
-            fromSurface, toSurface, fromVersion, toVersion, assemblyName,
-            [fromPath!], [toPath!]), null);
+            from.endpoint!, to.endpoint!, fromVersion, toVersion, assemblyName), null);
     }
 
-    private static (DiffInputs? inputs, string? error) ExecuteLibraryDiff(DiffOptions options)
+    private static async Task<(DiffInputs? inputs, string? error)> ExecuteLibraryDiffAsync(
+        DiffOptions options,
+        VerboseLogger logger,
+        HttpClient httpClient)
     {
         var (fromPath, toPath) = ParsePathRange(options.LibraryVersionRange!);
         if (fromPath is null || toPath is null)
             return (null, "Error: Invalid library range. Use format: old/Foo.dll..new/Foo.dll");
-        if (!File.Exists(fromPath))
-            return (null, $"Error: File not found: {fromPath}");
-        if (!File.Exists(toPath))
-            return (null, $"Error: File not found: {toPath}");
-        var fromSurface = ExtractApiSurface(fromPath, options.IncludeAll);
-        var toSurface = ExtractApiSurface(toPath, options.IncludeAll);
-        if (fromSurface is null || toSurface is null)
-            return (null, "Error: Failed to extract API surface from one or both libraries.");
+
+        var from = await ResolveDiffEndpointAsync(
+            httpClient,
+            new AssemblySetRequest
+            {
+                Assemblies = [fromPath],
+                TempDirPrefix = "inspect-diff",
+            },
+            options.IncludeAll,
+            logger);
+        if (from.error is not null)
+            return (null, from.assembliesResolved
+                ? "Error: Failed to extract API surface from one or both libraries."
+                : $"Error: File not found: {fromPath}");
+
+        var to = await ResolveDiffEndpointAsync(
+            httpClient,
+            new AssemblySetRequest
+            {
+                Assemblies = [toPath],
+                TempDirPrefix = "inspect-diff",
+            },
+            options.IncludeAll,
+            logger);
+        if (to.error is not null)
+        {
+            from.endpoint!.Dispose();
+            return (null, to.assembliesResolved
+                ? "Error: Failed to extract API surface from one or both libraries."
+                : $"Error: File not found: {toPath}");
+        }
 
         var name = Path.GetFileNameWithoutExtension(toPath);
         return (new DiffInputs(
-            fromSurface, toSurface,
-            Path.GetFileName(fromPath), Path.GetFileName(toPath), name,
-            [fromPath], [toPath]), null);
+            from.endpoint!, to.endpoint!,
+            Path.GetFileName(fromPath), Path.GetFileName(toPath), name), null);
     }
 
-    private static async Task<(ApiSurface? surface, List<string>? paths, string? tempDir, string? error)> ExtractPackageInputAsync(
-        string packageReference, DiffOptions options, VerboseLogger logger, HttpClient httpClient)
+    private static async Task<(DiffEndpoint? endpoint, string? error, bool assembliesResolved)> ResolveDiffEndpointAsync(
+        HttpClient httpClient,
+        AssemblySetRequest request,
+        bool includeAll,
+        VerboseLogger logger)
     {
-        var outcome = await PackageExtractor.ExtractPackageAsync(httpClient, packageReference, logger.Log, "inspect-diff", options.SourceOptions).ConfigureAwait(false);
-        if (!outcome.IsSuccess)
-            return (null, null, null, outcome.ErrorMessage);
-
-        var extracted = outcome.Result!;
-        var (paths, selectedTfm) = TfmSelector.SelectHighestAssembliesFromPackage(extracted.ExtractPath, options.Tfm);
-        if (paths.Count == 0 && string.IsNullOrEmpty(options.Tfm))
-            return (null, null, extracted.TempDir, "No DLLs found in package.");
-
-        paths = paths.OrderBy(path => path, StringComparer.Ordinal).ToList();
-
-        if (paths.Count == 0)
-            return (null, null, extracted.TempDir, "No DLLs found for selected TFM.");
-
-        var surface = MergeSurfaces(paths, extracted.PackageName, selectedTfm, options.IncludeAll, logger);
-        return surface is null
-            ? (null, null, extracted.TempDir, "Failed to extract API surface.")
-            : (surface, paths, extracted.TempDir, null);
-    }
-
-    private static ApiSurface? MergeSurfaces(IReadOnlyList<string> paths, string? name, string? tfm, bool includeAll, VerboseLogger logger)
-    {
-        if (paths.Count == 1)
+        var assemblySet = await AssemblySetResolver
+            .CollectAsync(httpClient, request, logger.Log)
+            .ConfigureAwait(false);
+        if (assemblySet.Assemblies.Count == 0)
         {
-            var single = AssemblyReader.ExtractApiSurface(paths[0], includeAll);
-            if (single is not null)
-            {
-                single.Name = name ?? Path.GetFileNameWithoutExtension(paths[0]);
-                single.Tfm = tfm;
-            }
-            return single;
+            var error = assemblySet.Diagnostics.LastOrDefault()?.Message
+                ?? "No assemblies were resolved.";
+            assemblySet.Dispose();
+            return (null, error, false);
         }
 
-        var merged = new ApiSurface { Name = name, Tfm = tfm };
-        foreach (var path in paths)
+        var surface = AssemblySetSurfaceBuilder.Build(assemblySet, includeAll, logger.Log);
+        if (surface is null)
         {
-            var surface = AssemblyReader.ExtractApiSurface(path, includeAll);
-            if (surface is null)
-                continue;
-            logger.Log($"  + {Path.GetFileNameWithoutExtension(path)}: {surface.PublicTypeCount} types");
-            merged.Types.AddRange(surface.Types);
-            merged.PublicTypeCount += surface.PublicTypeCount;
-            merged.PublicMethodCount += surface.PublicMethodCount;
-            merged.PublicPropertyCount += surface.PublicPropertyCount;
-            merged.PublicEventCount += surface.PublicEventCount;
-            merged.PublicFieldCount += surface.PublicFieldCount;
+            assemblySet.Dispose();
+            return (null, "Failed to extract API surface.", true);
         }
-        merged.Types = merged.Types.OrderBy(type => type.FullName).ToList();
-        return merged.Types.Count == 0 ? null : merged;
+
+        return (new DiffEndpoint(assemblySet, surface), null, true);
     }
 
     private static (string? fromPath, string? toPath) ParsePathRange(string input)
@@ -658,8 +680,8 @@ public class DiffCommand
         var memberTargetIdentities = options.MemberFilter.Count == 0
             ? null
             : ResolveMemberTargetIdentities(
-                fromSurface ?? MergeSurfaces(fromPaths, name: null, tfm: null, includeAll: options.IncludeAll, logger: new VerboseLogger(enabled: false)) ?? new ApiSurface(),
-                toSurface ?? MergeSurfaces(toPaths, name: null, tfm: null, includeAll: options.IncludeAll, logger: new VerboseLogger(enabled: false)) ?? new ApiSurface(),
+                fromSurface ?? AssemblySetSurfaceBuilder.Build(fromPaths, includeAll: options.IncludeAll) ?? new ApiSurface(),
+                toSurface ?? AssemblySetSurfaceBuilder.Build(toPaths, includeAll: options.IncludeAll) ?? new ApiSurface(),
                 options.MemberFilter,
                 options.TypeFilter,
                 requireBodyTargets: true).MemberIdentities;
@@ -702,8 +724,8 @@ public class DiffCommand
         var memberTargetIdentities = options.MemberFilter.Count == 0
             ? null
             : ResolveMemberTargetIdentities(
-                fromSurface ?? MergeSurfaces(fromPaths, name: null, tfm: null, includeAll: options.IncludeAll, logger: new VerboseLogger(enabled: false)) ?? new ApiSurface(),
-                toSurface ?? MergeSurfaces(toPaths, name: null, tfm: null, includeAll: options.IncludeAll, logger: new VerboseLogger(enabled: false)) ?? new ApiSurface(),
+                fromSurface ?? AssemblySetSurfaceBuilder.Build(fromPaths, includeAll: options.IncludeAll) ?? new ApiSurface(),
+                toSurface ?? AssemblySetSurfaceBuilder.Build(toPaths, includeAll: options.IncludeAll) ?? new ApiSurface(),
                 options.MemberFilter,
                 options.TypeFilter,
                 requireBodyTargets: true,
@@ -774,19 +796,6 @@ public class DiffCommand
 
     internal static string MethodKey(MethodIdentity method)
         => $"{method.AssemblyName}|{GenericMemberIdentity.KeyFragment(method.DeclaringType)}|{method.Name}|{string.Join(",", method.ParameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(method.ReturnType)}";
-
-    private static void DeleteTempDir(string? tempDir)
-    {
-        if (!string.IsNullOrEmpty(tempDir) && Directory.Exists(tempDir))
-        {
-            try { Directory.Delete(tempDir, recursive: true); } catch { }
-        }
-    }
-
-    private static ApiSurface? ExtractApiSurface(string assemblyPath, bool includeAll)
-    {
-        return AssemblyReader.ExtractApiSurface(assemblyPath, includeAll);
-    }
 
     private static (string? package, string? fromVersion, string? toVersion) ParseVersionRange(string input)
     {

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -1,4 +1,5 @@
 using ILInspector.Metadata;
+using DotnetInspector.Inspectors;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
@@ -350,18 +351,27 @@ public class DiffCommand
             logger);
         if (from.error is not null)
             return (null, $"Error resolving v{fromVersion}: {from.error}");
-        var to = await ResolveDiffEndpointAsync(
-            httpClient,
-            new AssemblySetRequest
-            {
-                Packages = [$"{packageName}@{toVersion}"],
-                Tfm = options.Tfm,
-                SourceOptions = options.SourceOptions,
-                TempDirPrefix = "inspect-diff",
-                IncludePackageRuntimeAssemblies = true,
-            },
-            options.IncludeAll,
-            logger);
+        (DiffEndpoint? endpoint, string? error, bool assembliesResolved) to;
+        try
+        {
+            to = await ResolveDiffEndpointAsync(
+                httpClient,
+                new AssemblySetRequest
+                {
+                    Packages = [$"{packageName}@{toVersion}"],
+                    Tfm = options.Tfm,
+                    SourceOptions = options.SourceOptions,
+                    TempDirPrefix = "inspect-diff",
+                    IncludePackageRuntimeAssemblies = true,
+                },
+                options.IncludeAll,
+                logger);
+        }
+        catch
+        {
+            from.endpoint!.Dispose();
+            throw;
+        }
         if (to.error is not null)
         {
             from.endpoint!.Dispose();
@@ -397,24 +407,33 @@ public class DiffCommand
         if (from.error is not null)
             return (null, from.assembliesResolved
                 ? "Error: Failed to extract API surface from one or both versions."
-                : $"Error resolving v{fromVersion}: {from.error}");
+                : $"Error resolving v{fromVersion}: {AsEndpointError(from.error)}");
 
-        var to = await ResolveDiffEndpointAsync(
-            httpClient,
-            new AssemblySetRequest
-            {
-                PlatformAssemblies = [assemblyName],
-                PlatformAssemblyFrameworkHint = $"{framework}@{toVersion}",
-                TempDirPrefix = "inspect-diff",
-            },
-            options.IncludeAll,
-            logger);
+        (DiffEndpoint? endpoint, string? error, bool assembliesResolved) to;
+        try
+        {
+            to = await ResolveDiffEndpointAsync(
+                httpClient,
+                new AssemblySetRequest
+                {
+                    PlatformAssemblies = [assemblyName],
+                    PlatformAssemblyFrameworkHint = $"{framework}@{toVersion}",
+                    TempDirPrefix = "inspect-diff",
+                },
+                options.IncludeAll,
+                logger);
+        }
+        catch
+        {
+            from.endpoint!.Dispose();
+            throw;
+        }
         if (to.error is not null)
         {
             from.endpoint!.Dispose();
             return (null, to.assembliesResolved
                 ? "Error: Failed to extract API surface from one or both versions."
-                : $"Error resolving v{toVersion}: {to.error}");
+                : $"Error resolving v{toVersion}: {AsEndpointError(to.error)}");
         }
 
         return (new DiffInputs(
@@ -444,15 +463,24 @@ public class DiffCommand
                 ? "Error: Failed to extract API surface from one or both libraries."
                 : $"Error: File not found: {fromPath}");
 
-        var to = await ResolveDiffEndpointAsync(
-            httpClient,
-            new AssemblySetRequest
-            {
-                Assemblies = [toPath],
-                TempDirPrefix = "inspect-diff",
-            },
-            options.IncludeAll,
-            logger);
+        (DiffEndpoint? endpoint, string? error, bool assembliesResolved) to;
+        try
+        {
+            to = await ResolveDiffEndpointAsync(
+                httpClient,
+                new AssemblySetRequest
+                {
+                    Assemblies = [toPath],
+                    TempDirPrefix = "inspect-diff",
+                },
+                options.IncludeAll,
+                logger);
+        }
+        catch
+        {
+            from.endpoint!.Dispose();
+            throw;
+        }
         if (to.error is not null)
         {
             from.endpoint!.Dispose();
@@ -476,22 +504,40 @@ public class DiffCommand
         var assemblySet = await AssemblySetResolver
             .CollectAsync(httpClient, request, logger.Log)
             .ConfigureAwait(false);
-        if (assemblySet.Assemblies.Count == 0)
+        try
         {
-            var error = assemblySet.Diagnostics.LastOrDefault()?.Message
-                ?? "No assemblies were resolved.";
-            assemblySet.Dispose();
-            return (null, error, false);
-        }
+            if (assemblySet.Assemblies.Count == 0)
+            {
+                var error = assemblySet.Diagnostics.Count > 0
+                    ? string.Join("; ", assemblySet.Diagnostics.Select(static diagnostic => diagnostic.Message))
+                    : "No assemblies were resolved.";
+                assemblySet.Dispose();
+                return (null, error, false);
+            }
 
-        var surface = AssemblySetSurfaceBuilder.Build(assemblySet, includeAll, logger.Log);
-        if (surface is null)
+            AssemblySetDiagnosticWriter.Write(assemblySet);
+            var surface = AssemblySetSurfaceBuilder.Build(assemblySet, includeAll, logger.Log);
+            if (surface is null)
+            {
+                assemblySet.Dispose();
+                return (null, "Failed to extract API surface.", true);
+            }
+
+            return (new DiffEndpoint(assemblySet, surface), null, true);
+        }
+        catch
         {
             assemblySet.Dispose();
-            return (null, "Failed to extract API surface.", true);
+            throw;
         }
+    }
 
-        return (new DiffEndpoint(assemblySet, surface), null, true);
+    internal static string AsEndpointError(string error)
+    {
+        const string SkippingSuffix = ", skipping.";
+        return error.EndsWith(SkippingSuffix, StringComparison.Ordinal)
+            ? error[..^SkippingSuffix.Length]
+            : error;
     }
 
     private static (string? fromPath, string? toPath) ParsePathRange(string input)

--- a/src/dotnet-inspect/Inspectors/ApiServices.cs
+++ b/src/dotnet-inspect/Inspectors/ApiServices.cs
@@ -159,7 +159,7 @@ internal static class ApiServices
 
     /// <summary>
     /// Extracts the full API surface from a package or assembly, enriching types with source info.
-    /// Used by source command for assembly-wide sample collection and DiffCommand.
+    /// Used by source command for assembly-wide sample collection.
     /// </summary>
     internal static async Task<(ApiSurface? api, string? selectedTfm)> ExtractApiSurfaceAsync(ApiOptions options, VerboseLogger logger, HttpClient httpClient)
     {
@@ -224,92 +224,6 @@ internal static class ApiServices
             }
 
             return (api, selectedTfm);
-        }
-        finally
-        {
-            if (tempDir != null && Directory.Exists(tempDir))
-            {
-                try { Directory.Delete(tempDir, recursive: true); } catch { }
-            }
-        }
-    }
-
-    // ===== Merged API Extraction (multi-library packages) =====
-
-    /// <summary>
-    /// Extracts and merges API surfaces from ALL DLLs in a package at the highest TFM.
-    /// Used by diff to compare multi-library packages.
-    /// </summary>
-    internal static async Task<(ApiSurface? api, string? selectedTfm)> ExtractMergedApiSurfaceAsync(ApiOptions options, VerboseLogger logger, HttpClient httpClient)
-    {
-        string? tempDir = null;
-        try
-        {
-            if (string.IsNullOrEmpty(options.PackagePath))
-                return (null, null);
-
-            var outcome = await PackageExtractor.ExtractPackageAsync(httpClient, options.PackagePath, logger.Log, "inspect-api", options.SourceOptions);
-            if (!outcome.IsSuccess)
-            {
-                Console.Error.WriteLine($"Error: {outcome.ErrorMessage}");
-                return (null, null);
-            }
-            var extracted = outcome.Result!;
-            var (searchPath, packageName) = (extracted.ExtractPath, extracted.PackageName);
-            tempDir = extracted.TempDir;
-
-            var dlls = TfmSelector.GetPackageAssemblies(searchPath);
-            if (dlls.Count == 0)
-                return (null, null);
-
-            // Single DLL — fast path
-            if (dlls.Count == 1)
-                return await ExtractApiSurfaceAsync(options, logger, httpClient);
-
-            var (tfmDlls, selectedTfm) = TfmSelector.SelectHighestAssemblies(dlls, searchPath);
-            if (tfmDlls.Count == 0)
-                return (null, null);
-
-            // Single DLL at this TFM — fast path
-            if (tfmDlls.Count == 1)
-            {
-                var singleApi = AssemblyReader.ExtractApiSurface(tfmDlls[0], options.IncludeAll);
-                if (singleApi != null)
-                {
-                    singleApi.Name = packageName ?? Path.GetFileNameWithoutExtension(tfmDlls[0]);
-                    singleApi.Tfm = selectedTfm;
-                }
-                return (singleApi, selectedTfm);
-            }
-
-            // Multiple DLLs — merge all API surfaces
-            logger.Log($"Merging API surfaces from {tfmDlls.Count} libraries at {selectedTfm}");
-
-            var merged = new ApiSurface
-            {
-                Name = packageName,
-                Tfm = selectedTfm
-            };
-
-            foreach (var dll in tfmDlls)
-            {
-                var surface = AssemblyReader.ExtractApiSurface(dll, options.IncludeAll);
-                if (surface == null)
-                    continue;
-
-                var libName = Path.GetFileNameWithoutExtension(dll);
-                logger.Log($"  + {libName}: {surface.PublicTypeCount} types");
-
-                merged.Types.AddRange(surface.Types);
-                merged.PublicTypeCount += surface.PublicTypeCount;
-                merged.PublicMethodCount += surface.PublicMethodCount;
-                merged.PublicPropertyCount += surface.PublicPropertyCount;
-                merged.PublicEventCount += surface.PublicEventCount;
-                merged.PublicFieldCount += surface.PublicFieldCount;
-            }
-
-            merged.Types = merged.Types.OrderBy(t => t.FullName).ToList();
-            return (merged, selectedTfm);
         }
         finally
         {


### PR DESCRIPTION
## Summary

- Route package, platform, and local diff endpoints through `AssemblySetResolver`.
- Retain selected package TFM and centralize deterministic multi-assembly API surface construction in `DotnetInspector.Services`.
- Let owned `AssemblySet`s control extraction lifetime; remove `DiffCommand.MergeSurfaces`, temp-directory bookkeeping, and the stale duplicate merge path.
- Keep range parsing, compatibility filtering, ranking, and rendering in the CLI.

`AssemblySetPackageSelectionMode.TargetFramework` now uses the historical diff selector for every assembly-set consumer, not only `diff`. Existing consumer coverage remains green. The intentional observable delta is that satellite resource assemblies are excluded before consumers search or merge the set; they do not contribute API types, and the resolver test pins that behavior.

## Demo

```console
$ dotnet-inspect diff --package System.CommandLine@2.0.0-beta4.22272.1..2.0.0 -n 8
# API Diff: System.CommandLine

| Field | Value |
| ----- | ----- |
| Versions | **2.0.0-beta4.22272.1** -> **2.0.0** |
| Summary | **Summary:** 182 breaking, 92 additive, 1 potentially breaking across 83 types |

## Breaking Changes
```

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release`: succeeded.
- `DotnetInspector.Services.Tests`: 254 passed.
- `dotnet-inspect.Tests`: 1760 passed, 10 skipped.
- Package, platform, and local success output A/B against `origin/main`: byte-for-byte identical.
- Platform resolution errors retain the prior fatal wording without the collection-only `skipping` suffix.
- `markdownlint` passes for the changed design doc.

Refs #2653 (C3).