### PR TITLE
Measure native RTS parity in the corpus sensor

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
@@ -138,7 +138,7 @@ public class CorpusSensorComparisonTests
 
         Assert.Contains(
             regressions,
-            regression => regression == "fidelity oracle differs (baseline compile-back, current return-to-sender)");
+            regression => regression == "fidelity oracle differs (baseline compile-back, current rts-parity)");
         string report = CorpusSensor.QualityMetricChangesForTesting(baseline, current);
         Assert.Contains("Fidelity exact (oracle differs)", report);
     }

--- a/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
@@ -114,6 +114,115 @@ public class CorpusSensorComparisonTests
     }
 
     [Fact]
+    public void Compare_RejectsFidelityOracleMismatch()
+    {
+        var baseline = Snapshot(
+            totalMethods: 1,
+            fullyRaisedMethods: 1,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: FidelityMethods(("One", "Exact")),
+            fidelityCompileCap: 1,
+            fidelityCheckedMethods: 1,
+            fidelityExactMethods: 1);
+        var current = Snapshot(
+            totalMethods: 1,
+            fullyRaisedMethods: 1,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: FidelityMethods(("One", "Exact")),
+            fidelityCompileCap: 1,
+            fidelityCheckedMethods: 1,
+            fidelityExactMethods: 1,
+            fidelityOracle: CorpusFidelityOracle.ReturnToSender);
+
+        var regressions = CorpusSensor.Compare(baseline, current, [], gateAggregateRates: false);
+
+        Assert.Contains(
+            regressions,
+            regression => regression == "fidelity oracle differs (baseline compile-back, current return-to-sender)");
+        string report = CorpusSensor.QualityMetricChangesForTesting(baseline, current);
+        Assert.Contains("Fidelity exact (oracle differs)", report);
+    }
+
+    [Fact]
+    public void AlignReturnToSenderResults_ReportsUnavailableTarget()
+    {
+        var target = new FidelityCheck.CompileBackResult(
+            "Fixture",
+            "Method",
+            1,
+            "(corelib:System.Int32) -> corelib:System.Int32",
+            FidelityCheck.CompileBackStatus.Exact,
+            "ldarg.1 ret",
+            "ldarg.1 ret",
+            Detail: null);
+
+        var result = Assert.Single(
+            CorpusSensor.AlignReturnToSenderResultsForTesting(
+                [target],
+                Array.Empty<ReturnToSender.Result>()));
+
+        Assert.Equal(FidelityCheck.CompileBackStatus.ContextFail, result.Status);
+        Assert.Equal("return-to-sender-target-unavailable", result.Detail);
+        Assert.Equal("return-to-sender", result.CaptureDetail);
+        var buckets = FidelityCheck.SummarizeFailures(
+            [result],
+            FidelityCheck.CompileBackStatus.ContextFail);
+        Assert.Equal(1, buckets["return-to-sender target unavailable"].Count);
+    }
+
+    [Fact]
+    public void SummarizeReturnToSenderParity_ClassifiesRescuedSameAndWorse()
+    {
+        var exact = CompileBackResult("Exact", FidelityCheck.CompileBackStatus.Exact);
+        var rescued = CompileBackResult("Rescued", FidelityCheck.CompileBackStatus.OpcodeDiff);
+        var worse = CompileBackResult("Worse", FidelityCheck.CompileBackStatus.Exact);
+
+        var parity = CorpusSensor.SummarizeReturnToSenderParityForTesting(
+            [exact, rescued, worse],
+            [
+                exact,
+                rescued with { Status = FidelityCheck.CompileBackStatus.Exact },
+                worse with { Status = FidelityCheck.CompileBackStatus.OpcodeDiff },
+            ]);
+
+        Assert.Equal(1, parity.RescuedMethods);
+        Assert.Equal(1, parity.SameMethods);
+        Assert.Equal(1, parity.WorseMethods);
+        Assert.Equal(3, parity.ComparedMethods);
+    }
+
+    [Fact]
+    public void Compare_GatesReturnToSenderParityWhenSampleMatches()
+    {
+        var baseline = Snapshot(
+            totalMethods: 1,
+            fullyRaisedMethods: 1,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: FidelityMethods(("One", "Exact")),
+            fidelityCompileCap: 1,
+            fidelityCheckedMethods: 1,
+            fidelityExactMethods: 1,
+            fidelityOracle: CorpusFidelityOracle.ReturnToSender,
+            returnToSenderParity: new ReturnToSenderParityMetrics(0, 1, 0));
+        var current = Snapshot(
+            totalMethods: 1,
+            fullyRaisedMethods: 1,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: FidelityMethods(("One", "OpcodeDiff")),
+            fidelityCompileCap: 1,
+            fidelityCheckedMethods: 1,
+            fidelityOpcodeDiffMethods: 1,
+            fidelityOracle: CorpusFidelityOracle.ReturnToSender,
+            returnToSenderParity: new ReturnToSenderParityMetrics(0, 0, 1));
+
+        var regressions = CorpusSensor.Compare(baseline, current, [], gateAggregateRates: false);
+
+        Assert.Contains(
+            regressions,
+            regression => regression.StartsWith("RTS parity worse methods increased", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Compare_DoesNotGateSemanticCountsWhenPinnedSamplesDiffer()
     {
         var baseline = Snapshot(
@@ -340,7 +449,9 @@ public class CorpusSensorComparisonTests
         int fidelityCompileCap = 0,
         int fidelityCheckedMethods = 0,
         int fidelityExactMethods = 0,
-        int fidelityOpcodeDiffMethods = 0)
+        int fidelityOpcodeDiffMethods = 0,
+        CorpusFidelityOracle fidelityOracle = CorpusFidelityOracle.CompileBack,
+        ReturnToSenderParityMetrics? returnToSenderParity = null)
     {
         return new CorpusSensorSnapshot(
             SchemaVersion: 1,
@@ -372,8 +483,23 @@ public class CorpusSensorComparisonTests
                     fidelityOpcodeDiffMethods,
                     RecompileFailMethods: 0,
                     ContextFailMethods: 0,
-                    NotFullMethods: 0)));
+                    NotFullMethods: 0,
+                    ReturnToSenderParity: returnToSenderParity)),
+            FidelityOracle: fidelityOracle);
     }
+
+    static FidelityCheck.CompileBackResult CompileBackResult(
+        string method,
+        FidelityCheck.CompileBackStatus status)
+        => new(
+            "Fixture",
+            method,
+            0,
+            "() -> corelib:System.Int32",
+            status,
+            "ldc.i4.0 ret",
+            "ldc.i4.0 ret",
+            Detail: null);
 
     static IReadOnlyList<CorpusMethodSnapshot> PinnedMethods(int fullyRaised, int conditional)
     {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -191,6 +191,40 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CorpusFidelity_EvaluatesCompileBackSelectedTargetsThroughReturnToSender()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public int Value => 42;
+                public int Transform(int value) => value + 1;
+                public int Transform(string value) => value.Length;
+            }
+            """);
+        try
+        {
+            var results = CorpusSensor.EvaluateReturnToSenderForTesting(assemblyPath, cap: 10);
+            var getter = Assert.Single(results, result => result.Method == "get_Value");
+            var overloads = results
+                .Where(result => result.Method == "Transform")
+                .OrderBy(result => result.Overload)
+                .ToArray();
+
+            Assert.Equal("Class1", getter.Type);
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, getter.Status);
+            Assert.StartsWith("return-to-sender", getter.CaptureDetail);
+            Assert.Equal(2, overloads.Length);
+            Assert.Equal(new[] { 0, 1 }, overloads.Select(result => result.Overload));
+            Assert.Equal(2, overloads.Select(result => result.Signature).Distinct().Count());
+            Assert.All(overloads, result => Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackPropertyGetters_AddsSameAssemblyReturnTypeClosureRoot()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -115,6 +115,52 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CorpusParity_DoesNotApplyCompileBackFloorToRtsFailure()
+    {
+        var assemblyPath = CompileFixture("""
+            using System;
+
+            public abstract class BaseMarkerAttribute : Attribute
+            {
+            }
+
+            [AttributeUsage(AttributeTargets.Class)]
+            public sealed class MarkerAttribute : BaseMarkerAttribute
+            {
+                public bool Flag => true;
+            }
+            """);
+        try
+        {
+            var target = new ReturnToSender.RequestedTarget("MarkerAttribute", "get_Flag", 0);
+            var floored = Assert.Single(ReturnToSender.CompileBackTargets(assemblyPath, [target]));
+            Assert.True(floored.UsedCompileBackFloor, floored.Detail);
+            var reference = Assert.IsType<FidelityCheck.CompileBackResult>(floored.CompileBackFloor);
+
+            var native = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [target],
+                applyCompileBackFloor: false));
+            Assert.False(native.UsedCompileBackFloor);
+            Assert.True(
+                native.Status is FidelityCheck.CompileBackStatus.RecompileFail
+                    or FidelityCheck.CompileBackStatus.ContextFail,
+                $"{native.Status}: {native.Detail}");
+
+            var aligned = CorpusSensor.AlignReturnToSenderResultsForTesting([reference], [native]);
+            var parity = CorpusSensor.SummarizeReturnToSenderParityForTesting([reference], aligned);
+
+            Assert.Equal(0, parity.RescuedMethods);
+            Assert.Equal(0, parity.SameMethods);
+            Assert.Equal(1, parity.WorseMethods);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_UsesDependencyReferencesAndNamespaces()
     {
         var directory = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");

--- a/tools/DecompilerHarness/CorpusMethodDelta.cs
+++ b/tools/DecompilerHarness/CorpusMethodDelta.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace ILInspector.DecompilerHarness;
 
 // The corpus-method snapshot and changed-method delta artifact schema. Kept in
@@ -17,7 +19,11 @@ internal sealed record CorpusMethodSnapshot(
     string? Residual,
     string? PassBug,
     string Validity,
-    string FidelityCheck)
+    string FidelityCheck,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? FidelityCapture = null,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? FidelityReference = null)
 {
     public string DisplayMethod => $"{Assembly}!{Type}::{Method}#{Overload}";
 }

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -15,7 +15,7 @@ internal enum CorpusFidelityOracle
     [JsonStringEnumMemberName("compile-back")]
     CompileBack,
 
-    [JsonStringEnumMemberName("return-to-sender")]
+    [JsonStringEnumMemberName("rts-parity")]
     ReturnToSender,
 }
 
@@ -370,10 +370,21 @@ internal static class CorpusSensor
             foreach (var assembly in assemblies)
             {
                 var portablePath = PortablePath(assembly);
-                var evaluation = fidelityOracle == CorpusFidelityOracle.CompileBack
-                    ? new FidelityOracleEvaluation(
-                        FidelityCheck.Evaluate([assembly], cap, lowered: false, includeAllResults: false, workers, sequential))
-                    : EvaluateReturnToSender(assembly, cap, workers, sequential);
+                FidelityOracleEvaluation evaluation;
+                try
+                {
+                    evaluation = fidelityOracle == CorpusFidelityOracle.CompileBack
+                        ? new FidelityOracleEvaluation(
+                            FidelityCheck.Evaluate([assembly], cap, lowered: false, includeAllResults: false, workers, sequential))
+                        : EvaluateReturnToSender(assembly, cap, workers, sequential);
+                }
+                catch (Exception ex) when (
+                    fidelityOracle == CorpusFidelityOracle.ReturnToSender
+                    && ex is IOException or BadImageFormatException or InvalidOperationException or UnauthorizedAccessException)
+                {
+                    HarnessLog.Status($"RTS parity skipped {portablePath}: {ex.Message}");
+                    continue;
+                }
                 var assemblyUsefulResults = evaluation.Results;
                 usefulResults.AddRange(assemblyUsefulResults);
                 if (evaluation.Parity is { } parity)
@@ -457,7 +468,10 @@ internal static class CorpusSensor
                 result.Overload,
                 result.Signature))
             .ToArray();
-        var returnToSenderResults = ReturnToSender.CompileBackTargets(assemblyPath, requestedTargets)
+        var returnToSenderResults = ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                requestedTargets,
+                applyCompileBackFloor: false)
             .ToArray();
         var alignedResults = AlignReturnToSenderResults(targetSample, returnToSenderResults);
         return new FidelityOracleEvaluation(
@@ -1364,7 +1378,7 @@ internal static class CorpusSensor
         => oracle switch
         {
             CorpusFidelityOracle.CompileBack => "compile-back",
-            CorpusFidelityOracle.ReturnToSender => "return-to-sender",
+            CorpusFidelityOracle.ReturnToSender => "rts-parity",
             _ => throw new ArgumentOutOfRangeException(nameof(oracle)),
         };
 

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -2,12 +2,22 @@ using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
 using Markout;
 using Markout.Formatting;
 
 namespace ILInspector.DecompilerHarness;
+
+internal enum CorpusFidelityOracle
+{
+    [JsonStringEnumMemberName("compile-back")]
+    CompileBack,
+
+    [JsonStringEnumMemberName("return-to-sender")]
+    ReturnToSender,
+}
 
 internal static class CorpusSensor
 {
@@ -32,7 +42,8 @@ internal static class CorpusSensor
         bool qualityCardRisky = false,
         int methodCap = int.MaxValue,
         int? workers = null,
-        bool sequential = false)
+        bool sequential = false,
+        CorpusFidelityOracle fidelityOracle = CorpusFidelityOracle.CompileBack)
     {
         if (assemblies.Count == 0)
         {
@@ -57,7 +68,15 @@ internal static class CorpusSensor
             return 1;
         }
 
-        var (current, fidelityReports) = Capture(assemblies, validityCompileCap, fidelityCompileCaps, maxExamples, methodCap, workers, sequential);
+        var (current, fidelityReports) = Capture(
+            assemblies,
+            validityCompileCap,
+            fidelityCompileCaps,
+            maxExamples,
+            methodCap,
+            workers,
+            sequential,
+            fidelityOracle);
         if (!qualityDiffCard)
             PrintSummary(current, fidelityReports);
 
@@ -119,7 +138,8 @@ internal static class CorpusSensor
         int maxExamples,
         int methodCap,
         int? workers,
-        bool sequential)
+        bool sequential,
+        CorpusFidelityOracle fidelityOracle)
     {
         var completeness = AnalyzeCompleteness(assemblies, maxExamples, methodCap, workers, sequential);
         var methods = completeness.Methods.ToDictionary(MethodKey, StringComparer.Ordinal);
@@ -131,7 +151,14 @@ internal static class CorpusSensor
         var forwardMergeContainers = ForwardMergeStopReasons.Sum(reason => structuring.StopReasons.GetValueOrDefault(reason));
         var requestedCaps = fidelityCompileCaps.Where(cap => cap > 0).Distinct().ToArray();
         var primaryFidelityCap = requestedCaps.FirstOrDefault();
-        var fidelityReports = AnalyzeFidelity(assemblies, fidelityCompileCaps, methods, primaryFidelityCap, workers, sequential);
+        var fidelityReports = AnalyzeFidelity(
+            assemblies,
+            fidelityCompileCaps,
+            methods,
+            primaryFidelityCap,
+            workers,
+            sequential,
+            fidelityOracle);
         var selectedFidelity = fidelityReports.FirstOrDefault(report => report.Cap == primaryFidelityCap)?.Metrics
             ?? fidelityReports.LastOrDefault()?.Metrics
             ?? new FidelitySensorMetrics(0, 0, 0, 0, 0, 0);
@@ -162,7 +189,8 @@ internal static class CorpusSensor
             Tolerances: CorpusSensorTolerances.Default,
             Assemblies: completeness.Assemblies,
             Methods: methods.Values.OrderBy(MethodKey, StringComparer.Ordinal).ToImmutableArray(),
-            Metrics: metrics);
+            Metrics: metrics,
+            FidelityOracle: fidelityOracle);
 
         return (snapshot, fidelityReports);
     }
@@ -330,28 +358,51 @@ internal static class CorpusSensor
         Dictionary<string, CorpusMethodSnapshot> methods,
         int primaryCap,
         int? workers,
-        bool sequential)
+        bool sequential,
+        CorpusFidelityOracle fidelityOracle)
     {
         var reports = ImmutableArray.CreateBuilder<FidelityCapReport>();
         foreach (var cap in caps.Where(cap => cap > 0).Distinct().OrderBy(cap => cap))
         {
             var usefulResults = new List<FidelityCheck.CompileBackResult>();
             var allResults = new List<FidelityCheck.CompileBackResult>();
+            int parityRescued = 0, paritySame = 0, parityWorse = 0;
             foreach (var assembly in assemblies)
             {
                 var portablePath = PortablePath(assembly);
-                var assemblyUsefulResults = FidelityCheck.Evaluate([assembly], cap, lowered: false, includeAllResults: false, workers, sequential);
+                var evaluation = fidelityOracle == CorpusFidelityOracle.CompileBack
+                    ? new FidelityOracleEvaluation(
+                        FidelityCheck.Evaluate([assembly], cap, lowered: false, includeAllResults: false, workers, sequential))
+                    : EvaluateReturnToSender(assembly, cap, workers, sequential);
+                var assemblyUsefulResults = evaluation.Results;
                 usefulResults.AddRange(assemblyUsefulResults);
+                if (evaluation.Parity is { } parity)
+                {
+                    parityRescued += parity.RescuedMethods;
+                    paritySame += parity.SameMethods;
+                    parityWorse += parity.WorseMethods;
+                }
                 if (cap == primaryCap)
                 {
                     foreach (var result in assemblyUsefulResults)
                     {
                         string key = MethodKey(portablePath, result.Type, result.Method, result.Signature);
                         if (methods.TryGetValue(key, out var methodSnapshot))
-                            methods[key] = methodSnapshot with { FidelityCheck = result.Status.ToString() };
+                        {
+                            methods[key] = methodSnapshot with
+                            {
+                                FidelityCheck = result.Status.ToString(),
+                                FidelityCapture = fidelityOracle == CorpusFidelityOracle.ReturnToSender
+                                    ? result.CaptureDetail ?? result.Capture.ToString()
+                                    : methodSnapshot.FidelityCapture,
+                                FidelityReference = ReferenceStatus(evaluation, result),
+                            };
+                        }
                     }
                 }
-                allResults.AddRange(FidelityCheck.Evaluate([assembly], cap, lowered: false, includeAllResults: true, workers, sequential));
+                allResults.AddRange(fidelityOracle == CorpusFidelityOracle.CompileBack
+                    ? FidelityCheck.Evaluate([assembly], cap, lowered: false, includeAllResults: true, workers, sequential)
+                    : assemblyUsefulResults);
             }
             var metrics = new FidelitySensorMetrics(
                 usefulResults.Count,
@@ -359,7 +410,10 @@ internal static class CorpusSensor
                 usefulResults.Count(result => result.Status == FidelityCheck.CompileBackStatus.OpcodeDiff),
                 usefulResults.Count(result => result.Status == FidelityCheck.CompileBackStatus.RecompileFail),
                 usefulResults.Count(result => result.Status == FidelityCheck.CompileBackStatus.ContextFail),
-                usefulResults.Count(result => result.Status == FidelityCheck.CompileBackStatus.NotFull));
+                usefulResults.Count(result => result.Status == FidelityCheck.CompileBackStatus.NotFull),
+                fidelityOracle == CorpusFidelityOracle.ReturnToSender
+                    ? new ReturnToSenderParityMetrics(parityRescued, paritySame, parityWorse)
+                    : null);
             var contextBuckets = FidelityCheck.SummarizeFailures(allResults, FidelityCheck.CompileBackStatus.ContextFail);
             var recompileBuckets = FidelityCheck.SummarizeFailures(allResults, FidelityCheck.CompileBackStatus.RecompileFail);
             reports.Add(new FidelityCapReport(cap, metrics, contextBuckets, recompileBuckets));
@@ -369,6 +423,142 @@ internal static class CorpusSensor
             reports.Add(new FidelityCapReport(0, new FidelitySensorMetrics(0, 0, 0, 0, 0, 0), ImmutableDictionary<string, FidelityCheck.FailureBucketSummary>.Empty, ImmutableDictionary<string, FidelityCheck.FailureBucketSummary>.Empty));
         return reports.ToImmutable();
     }
+
+    internal static IReadOnlyList<FidelityCheck.CompileBackResult> EvaluateReturnToSenderForTesting(
+        string assemblyPath,
+        int cap)
+        => EvaluateReturnToSender(assemblyPath, cap, workers: 1, sequential: true).Results;
+
+    internal static ReturnToSenderParityMetrics SummarizeReturnToSenderParityForTesting(
+        IReadOnlyList<FidelityCheck.CompileBackResult> referenceResults,
+        IReadOnlyList<FidelityCheck.CompileBackResult> currentResults)
+        => SummarizeReturnToSenderParity(referenceResults, currentResults);
+
+    static FidelityOracleEvaluation EvaluateReturnToSender(
+        string assemblyPath,
+        int cap,
+        int? workers,
+        bool sequential)
+    {
+        var targetSample = FidelityCheck.Evaluate(
+            [assemblyPath],
+            cap,
+            lowered: false,
+            includeAllResults: false,
+            workers,
+            sequential);
+        if (targetSample.Count == 0)
+            return new FidelityOracleEvaluation([]);
+
+        var requestedTargets = targetSample
+            .Select(result => new ReturnToSender.RequestedTarget(
+                result.Type,
+                result.Method,
+                result.Overload,
+                result.Signature))
+            .ToArray();
+        var returnToSenderResults = ReturnToSender.CompileBackTargets(assemblyPath, requestedTargets)
+            .ToArray();
+        var alignedResults = AlignReturnToSenderResults(targetSample, returnToSenderResults);
+        return new FidelityOracleEvaluation(
+            alignedResults,
+            targetSample.ToDictionary(
+                FidelityResultKey,
+                result => result.Status,
+                StringComparer.Ordinal),
+            SummarizeReturnToSenderParity(targetSample, alignedResults));
+    }
+
+    internal static IReadOnlyList<FidelityCheck.CompileBackResult> AlignReturnToSenderResultsForTesting(
+        IReadOnlyList<FidelityCheck.CompileBackResult> targetSample,
+        IReadOnlyList<ReturnToSender.Result> returnToSenderResults)
+        => AlignReturnToSenderResults(targetSample, returnToSenderResults);
+
+    static IReadOnlyList<FidelityCheck.CompileBackResult> AlignReturnToSenderResults(
+        IReadOnlyList<FidelityCheck.CompileBackResult> targetSample,
+        IReadOnlyList<ReturnToSender.Result> returnToSenderResults)
+    {
+        var resultsByTarget = returnToSenderResults
+            .GroupBy(ReturnToSenderKey, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+        var results = new FidelityCheck.CompileBackResult[targetSample.Count];
+        for (int i = 0; i < targetSample.Count; i++)
+        {
+            var target = targetSample[i];
+            if (!resultsByTarget.TryGetValue(FidelityResultKey(target), out var result))
+            {
+                results[i] = target with
+                {
+                    Status = FidelityCheck.CompileBackStatus.ContextFail,
+                    OriginalOpcodes = "",
+                    RecompiledOpcodes = "",
+                    Detail = "return-to-sender-target-unavailable",
+                    Capture = FidelityCheck.CaptureMode.WholeModule,
+                    CaptureDetail = "return-to-sender",
+                };
+                continue;
+            }
+
+            results[i] = new FidelityCheck.CompileBackResult(
+                result.Plan.TargetMethod.Type,
+                result.Plan.TargetMethod.Method,
+                result.Plan.TargetMethod.Overload,
+                result.Plan.TargetMethod.Signature,
+                result.Status,
+                result.OriginalOpcodes,
+                result.RecompiledOpcodes,
+                result.Detail,
+                result.CompileBackFloor?.Capture ?? FidelityCheck.CaptureMode.WholeModule,
+                result.UsedCompileBackFloor
+                    ? "return-to-sender; compile-back-floor"
+                    : "return-to-sender");
+        }
+        return results;
+    }
+
+    static ReturnToSenderParityMetrics SummarizeReturnToSenderParity(
+        IReadOnlyList<FidelityCheck.CompileBackResult> referenceResults,
+        IReadOnlyList<FidelityCheck.CompileBackResult> currentResults)
+    {
+        var currentByTarget = currentResults.ToDictionary(FidelityResultKey, StringComparer.Ordinal);
+        int rescued = 0, same = 0, worse = 0;
+        foreach (var reference in referenceResults)
+        {
+            if (!currentByTarget.TryGetValue(FidelityResultKey(reference), out var current))
+            {
+                worse++;
+                continue;
+            }
+
+            if (reference.Status == current.Status)
+                same++;
+            else if (reference.Status == FidelityCheck.CompileBackStatus.OpcodeDiff
+                     && current.Status == FidelityCheck.CompileBackStatus.Exact)
+                rescued++;
+            else
+                worse++;
+        }
+        return new ReturnToSenderParityMetrics(rescued, same, worse);
+    }
+
+    static string? ReferenceStatus(
+        FidelityOracleEvaluation evaluation,
+        FidelityCheck.CompileBackResult result)
+        => evaluation.ReferenceStatuses is { } references
+           && references.TryGetValue(FidelityResultKey(result), out var status)
+            ? status.ToString()
+            : null;
+
+    static string FidelityResultKey(FidelityCheck.CompileBackResult result)
+        => $"{result.Type}::{result.Method}::{result.Overload}::{result.Signature}";
+
+    static string ReturnToSenderKey(ReturnToSender.Result result)
+        => $"{result.Plan.TargetMethod.Type}::{result.Plan.TargetMethod.Method}::{result.Plan.TargetMethod.Overload}::{result.Plan.TargetMethod.Signature}";
+
+    sealed record FidelityOracleEvaluation(
+        IReadOnlyList<FidelityCheck.CompileBackResult> Results,
+        IReadOnlyDictionary<string, FidelityCheck.CompileBackStatus>? ReferenceStatuses = null,
+        ReturnToSenderParityMetrics? Parity = null);
 
     static string MethodKey(CorpusMethodSnapshot method)
         => MethodKey(method.AssemblyPath, method.Type, method.Method, method.Signature);
@@ -419,16 +609,23 @@ internal static class CorpusSensor
             ?? fidelityReports.LastOrDefault();
         var currentFidelityMetrics = matchedFidelityReport?.Metrics ?? current.Metrics.Fidelity;
         var currentFidelityCap = matchedFidelityReport?.Cap ?? current.FidelityCompileCap;
+        bool sameFidelityOracle = baseline.FidelityOracle == current.FidelityOracle;
 
         if (current.ValidityCompileCap < baseline.ValidityCompileCap)
             failures.Add($"validity cap lower than baseline (baseline {baseline.ValidityCompileCap}, current {current.ValidityCompileCap})");
         if (currentFidelityCap < baseline.FidelityCompileCap)
             failures.Add($"fidelity cap lower than baseline (baseline {baseline.FidelityCompileCap}, current {currentFidelityCap})");
+        if (!sameFidelityOracle && (baseline.FidelityCompileCap > 0 || current.FidelityCompileCap > 0))
+        {
+            failures.Add(
+                $"fidelity oracle differs (baseline {FidelityOracleName(baseline.FidelityOracle)}, "
+                + $"current {FidelityOracleName(current.FidelityOracle)})");
+        }
         if (current.MethodCap != baseline.MethodCap)
             failures.Add($"method cap differs from baseline (baseline {CapText(baseline.MethodCap)}, current {CapText(current.MethodCap)})");
         if (current.Metrics.SemanticCheckedMethods < baseline.Metrics.SemanticCheckedMethods)
             failures.Add($"semantic checked methods lower than baseline (baseline {baseline.Metrics.SemanticCheckedMethods}, current {current.Metrics.SemanticCheckedMethods})");
-        if (currentFidelityMetrics.CheckedMethods < baseline.Metrics.Fidelity.CheckedMethods)
+        if (sameFidelityOracle && currentFidelityMetrics.CheckedMethods < baseline.Metrics.Fidelity.CheckedMethods)
             failures.Add($"fidelity checked methods lower than baseline (baseline {baseline.Metrics.Fidelity.CheckedMethods}, current {currentFidelityMetrics.CheckedMethods})");
 
         if (gateAggregateRates || baselinePinned is null || currentPinned is null)
@@ -482,6 +679,7 @@ internal static class CorpusSensor
             // samples when the corpus changes, so gate only when the exact checked-method
             // populations match. Otherwise rely on changed-method fidelity.
             if (basePinned.FidelityChecked > 0 && curPinned.FidelityChecked > 0
+                && sameFidelityOracle
                 && current.FidelityCompileCap == baseline.FidelityCompileCap
                 && HaveSameMethodSample(
                     baseline.Methods,
@@ -498,12 +696,28 @@ internal static class CorpusSensor
         {
             AddCountRegression(failures, "Full malformed methods", baseline.Metrics.FullMalformedMethods, current.Metrics.FullMalformedMethods, tolerance.FullMalformedIncrease);
             AddCountRegression(failures, "semantic defect methods", baseline.Metrics.SemanticDefectMethods, current.Metrics.SemanticDefectMethods, tolerance.SemanticDefectIncrease);
-            if (baseline.Metrics.Fidelity.CheckedMethods > 0)
+            if (sameFidelityOracle && baseline.Metrics.Fidelity.CheckedMethods > 0)
             {
                 AddCountRegression(failures, "fidelity opcode diffs", baseline.Metrics.Fidelity.OpcodeDiffMethods, currentFidelityMetrics.OpcodeDiffMethods, tolerance.FidelityOpcodeDiffIncrease);
                 AddCountRegression(failures, "fidelity recompile failures", baseline.Metrics.Fidelity.RecompileFailMethods, currentFidelityMetrics.RecompileFailMethods, tolerance.FidelityRecompileFailIncrease);
                 AddCountRegression(failures, "fidelity context failures", baseline.Metrics.Fidelity.ContextFailMethods, currentFidelityMetrics.ContextFailMethods, tolerance.FidelityContextFailIncrease);
             }
+        }
+
+        if (sameFidelityOracle
+            && baseline.Metrics.Fidelity.ReturnToSenderParity is { } baselineParity
+            && currentFidelityMetrics.ReturnToSenderParity is { } currentParity
+            && HaveSameMethodSample(
+                baseline.Methods,
+                current.Methods,
+                static method => method.FidelityCheck != "not-sampled"))
+        {
+            AddCountRegression(
+                failures,
+                "RTS parity worse methods",
+                baselineParity.WorseMethods,
+                currentParity.WorseMethods,
+                tolerance: 0);
         }
 
         AddCountRegression(failures, "pass bugs", baseline.Metrics.PassBugs, current.Metrics.PassBugs, tolerance.PassBugIncrease);
@@ -626,6 +840,8 @@ internal static class CorpusSensor
         Add("residual", before.Residual, after.Residual);
         Add("validity", before.Validity, after.Validity);
         Add("fidelityCheck", before.FidelityCheck, after.FidelityCheck);
+        Add("fidelityCapture", before.FidelityCapture, after.FidelityCapture);
+        Add("fidelityReference", before.FidelityReference, after.FidelityReference);
         Add("passBug", before.PassBug, after.PassBug);
         return deltas.ToImmutable();
 
@@ -656,6 +872,7 @@ internal static class CorpusSensor
     static void PrintSummary(CorpusSensorSnapshot snapshot, ImmutableArray<FidelityCapReport> fidelityReports)
     {
         var metrics = snapshot.Metrics;
+        string fidelityOracle = FidelityOracleName(snapshot.FidelityOracle);
         Console.WriteLine("# Decompiler corpus sensor");
         Console.WriteLine();
         Console.WriteLine($"Assemblies: {snapshot.Assemblies.Count}");
@@ -681,18 +898,30 @@ internal static class CorpusSensor
         else if (fidelityReports.Length == 1)
         {
             var report = fidelityReports[0];
-            Console.WriteLine($"Fidelity (cap {report.Cap}): {report.Metrics.ExactMethods} exact, {report.Metrics.OpcodeDiffMethods} opcode diffs, {report.Metrics.RecompileFailMethods} recompile failures, {report.Metrics.ContextFailMethods} context failures over {report.Metrics.CheckedMethods} checked");
+            Console.WriteLine($"Fidelity ({fidelityOracle}, cap {report.Cap}): {report.Metrics.ExactMethods} exact, {report.Metrics.OpcodeDiffMethods} opcode diffs, {report.Metrics.RecompileFailMethods} recompile failures, {report.Metrics.ContextFailMethods} context failures over {report.Metrics.CheckedMethods} checked");
+            PrintReturnToSenderParity(report.Metrics, "");
             PrintFailureBuckets(report.ContextFailureBuckets, report.RecompileFailureBuckets, "  ");
         }
         else
         {
-            Console.WriteLine("Fidelity coverage by cap:");
+            Console.WriteLine($"Fidelity coverage by cap ({fidelityOracle}):");
             foreach (var report in fidelityReports)
             {
                 Console.WriteLine($"  cap {report.Cap}: {report.Metrics.ExactMethods} exact, {report.Metrics.OpcodeDiffMethods} opcode diffs, {report.Metrics.RecompileFailMethods} recompile failures, {report.Metrics.ContextFailMethods} context failures over {report.Metrics.CheckedMethods} checked");
+                PrintReturnToSenderParity(report.Metrics, "  ");
                 PrintFailureBuckets(report.ContextFailureBuckets, report.RecompileFailureBuckets, "    ");
             }
         }
+    }
+
+    static void PrintReturnToSenderParity(FidelitySensorMetrics metrics, string indent)
+    {
+        if (metrics.ReturnToSenderParity is not { } parity)
+            return;
+
+        Console.WriteLine(
+            $"{indent}RTS parity: {parity.RescuedMethods} rescued, {parity.SameMethods} same, "
+            + $"{parity.WorseMethods} worse over {parity.ComparedMethods} compile-back targets");
     }
 
     static void PrintFailureBuckets(
@@ -794,7 +1023,8 @@ internal static class CorpusSensor
             static method => IsPinnedAssembly(method.AssemblyPath)
                 && (method.Validity == "valid"
                     || method.Validity.StartsWith("semantic-defect:", StringComparison.Ordinal)));
-        bool comparableFidelitySamples = basePinned.FidelityChecked > 0 && curPinned.FidelityChecked > 0
+        bool comparableFidelitySamples = baseline.FidelityOracle == current.FidelityOracle
+            && basePinned.FidelityChecked > 0 && curPinned.FidelityChecked > 0
             && current.FidelityCompileCap == baseline.FidelityCompileCap
             && HaveSameMethodSample(
                 baseline.Methods,
@@ -804,7 +1034,9 @@ internal static class CorpusSensor
         var fidelity = comparableFidelitySamples
             ? $"opcode diffs {Number(basePinned.OpcodeDiff)} -> {Number(curPinned.OpcodeDiff)} "
                 + $"({Delta(curPinned.OpcodeDiff - basePinned.OpcodeDiff)})"
-            : "fidelity ungated (sampling differs; rely on changed-method fidelity)";
+            : baseline.FidelityOracle != current.FidelityOracle
+                ? "fidelity ungated (oracle differs)"
+                : "fidelity ungated (sampling differs; rely on changed-method fidelity)";
         var fullMalformed = current.ValidityCompileCap > 0
             ? comparableMalformedSamples
                 ? $"Full malformed {Number(basePinned.FullMalformed)} -> {Number(curPinned.FullMalformed)} "
@@ -977,14 +1209,16 @@ internal static class CorpusSensor
 
         if (current.FidelityCompileCap > 0)
         {
-            bool comparableFidelitySamples = HaveSameMethodSample(
+            bool sameFidelityOracle = baseline.FidelityOracle == current.FidelityOracle;
+            bool comparableFidelitySamples = sameFidelityOracle && HaveSameMethodSample(
                 baseline.Methods,
                 current.Methods,
                 static method => method.FidelityCheck != "not-sampled");
+            string fidelityDifference = sameFidelityOracle ? "sampling differs" : "oracle differs";
             rows.Add(ShareChangeRow(
                 comparableFidelitySamples
                     ? "Fidelity opcode diffs"
-                    : "Fidelity opcode diffs (sampling differs)",
+                    : $"Fidelity opcode diffs ({fidelityDifference})",
                 baseline.Metrics.Fidelity.OpcodeDiffMethods,
                 baseline.Metrics.Fidelity.CheckedMethods,
                 current.Metrics.Fidelity.OpcodeDiffMethods,
@@ -994,7 +1228,7 @@ internal static class CorpusSensor
             rows.Add(ShareChangeRow(
                 comparableFidelitySamples
                     ? "Fidelity exact"
-                    : "Fidelity exact (sampling differs)",
+                    : $"Fidelity exact ({fidelityDifference})",
                 baseline.Metrics.Fidelity.ExactMethods,
                 baseline.Metrics.Fidelity.CheckedMethods,
                 current.Metrics.Fidelity.ExactMethods,
@@ -1004,7 +1238,7 @@ internal static class CorpusSensor
             rows.Add(ShareChangeRow(
                 comparableFidelitySamples
                     ? "Fidelity recompile failures"
-                    : "Fidelity recompile failures (sampling differs)",
+                    : $"Fidelity recompile failures ({fidelityDifference})",
                 baseline.Metrics.Fidelity.RecompileFailMethods,
                 baseline.Metrics.Fidelity.CheckedMethods,
                 current.Metrics.Fidelity.RecompileFailMethods,
@@ -1014,13 +1248,29 @@ internal static class CorpusSensor
             rows.Add(ShareChangeRow(
                 comparableFidelitySamples
                     ? "Fidelity context failures"
-                    : "Fidelity context failures (sampling differs)",
+                    : $"Fidelity context failures ({fidelityDifference})",
                 baseline.Metrics.Fidelity.ContextFailMethods,
                 baseline.Metrics.Fidelity.CheckedMethods,
                 current.Metrics.Fidelity.ContextFailMethods,
                 current.Metrics.Fidelity.CheckedMethods,
                 comparableFidelitySamples ? Goal.Lower : Goal.Context,
                 countDeltaKnown: comparableFidelitySamples));
+            if (current.Metrics.Fidelity.ReturnToSenderParity is { } currentParity)
+            {
+                var baselineParity = baseline.Metrics.Fidelity.ReturnToSenderParity;
+                bool comparableParity = comparableFidelitySamples && baselineParity is not null;
+                string parityDifference = baselineParity is null && comparableFidelitySamples
+                    ? "baseline unavailable"
+                    : fidelityDifference;
+                rows.Add(CountChangeRow(
+                    comparableParity
+                        ? "RTS parity worse"
+                        : $"RTS parity worse ({parityDifference})",
+                    baselineParity?.WorseMethods ?? 0,
+                    currentParity.WorseMethods,
+                    comparableParity ? Goal.Lower : Goal.Context,
+                    countDeltaKnown: comparableParity));
+            }
             rows.Add(ShareChangeRow(
                 "Fidelity check coverage",
                 baseline.Metrics.Fidelity.CheckedMethods,
@@ -1100,9 +1350,23 @@ internal static class CorpusSensor
                 + ValidityCompileCapNote(snapshot.ValidityCompileCap);
         var fidelity = snapshot.FidelityCompileCap <= 0
             ? "fidelity not run"
-            : $"fidelity sampled {Coverage(snapshot.Metrics.Fidelity.CheckedMethods, snapshot.Metrics.TotalMethods)}";
+            : $"fidelity ({FidelityOracleName(snapshot.FidelityOracle)}) sampled "
+                + Coverage(snapshot.Metrics.Fidelity.CheckedMethods, snapshot.Metrics.TotalMethods);
+        if (snapshot.Metrics.Fidelity.ReturnToSenderParity is { } parity)
+        {
+            fidelity += $", RTS parity {Number(parity.WorseMethods)} worse / "
+                + $"{Number(parity.ComparedMethods)} compared";
+        }
         return $"{validity}; {fidelity}";
     }
+
+    static string FidelityOracleName(CorpusFidelityOracle oracle)
+        => oracle switch
+        {
+            CorpusFidelityOracle.CompileBack => "compile-back",
+            CorpusFidelityOracle.ReturnToSender => "return-to-sender",
+            _ => throw new ArgumentOutOfRangeException(nameof(oracle)),
+        };
 
     static void PrintRiskyCoverageGuidance(CorpusSensorSnapshot snapshot)
     {
@@ -1205,7 +1469,9 @@ internal sealed record CorpusSensorSnapshot(
     CorpusSensorTolerances? Tolerances,
     IReadOnlyList<CorpusAssemblySnapshot> Assemblies,
     IReadOnlyList<CorpusMethodSnapshot>? Methods,
-    CorpusSensorMetrics Metrics);
+    CorpusSensorMetrics Metrics,
+    [property: JsonConverter(typeof(JsonStringEnumConverter<CorpusFidelityOracle>))]
+    CorpusFidelityOracle FidelityOracle = CorpusFidelityOracle.CompileBack);
 
 internal sealed record CorpusAssemblySnapshot(string Assembly, string Path, int TotalMethods);
 
@@ -1264,7 +1530,17 @@ internal sealed record FidelitySensorMetrics(
     int OpcodeDiffMethods,
     int RecompileFailMethods,
     int ContextFailMethods,
-    int NotFullMethods);
+    int NotFullMethods,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    ReturnToSenderParityMetrics? ReturnToSenderParity = null);
+
+internal sealed record ReturnToSenderParityMetrics(
+    int RescuedMethods,
+    int SameMethods,
+    int WorseMethods)
+{
+    public int ComparedMethods => RescuedMethods + SameMethods + WorseMethods;
+}
 
 internal sealed record FidelityCapReport(
     int Cap,

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1780,6 +1780,8 @@ static class FidelityCheck
             return "generated/synthesized member (unsupported)";
         if (detail.Contains("target-method-not-found", StringComparison.OrdinalIgnoreCase))
             return "target method not found";
+        if (detail.Contains("return-to-sender-target-unavailable", StringComparison.OrdinalIgnoreCase))
+            return "return-to-sender target unavailable";
         if (detail.Contains("method", StringComparison.OrdinalIgnoreCase)
             && detail.Contains("not found", StringComparison.OrdinalIgnoreCase))
             return "target method not found";

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -110,6 +110,7 @@ static class Program
         bool qualityDiffCard = false;
         bool qualityCardRisky = false;
         var corpusFidelityCaps = new List<int>();
+        var corpusFidelityOracle = CorpusFidelityOracle.CompileBack;
         int corpusMethodCap = int.MaxValue;
         bool json = false;
         int topPatterns = 10;
@@ -231,6 +232,9 @@ static class Program
                             corpusFidelityCaps.Add(int.Parse(token));
                         }
                         break;
+                    case "--corpus-fidelity-oracle":
+                        corpusFidelityOracle = ParseCorpusFidelityOracle(NextArg(args, ref i, flag));
+                        break;
                     case "--corpus-method-cap": corpusMethodCap = int.Parse(NextArg(args, ref i, flag)); break;
                     case "--json": json = true; break;
                     case "--top-patterns": topPatterns = int.Parse(NextArg(args, ref i, flag)); break;
@@ -255,6 +259,10 @@ static class Program
         catch (MissingArgumentException ex)
         {
             return Fail($"{ex.Flag} requires a value.");
+        }
+        catch (ArgumentException ex)
+        {
+            return Fail(ex.Message);
         }
 
         if (returnToSenderMarkout && !returnToSenderCatalog)
@@ -389,7 +397,7 @@ static class Program
             return Dec0009Classifier.Run(assemblies, maxExamples, json);
 
         if (emitCorpusSnapshot is not null || diffCorpusBaseline is not null || emitCorpusDelta is not null || qualityDiffCard)
-            return CorpusSensor.Run(assemblies, compileCap, corpusFidelityCaps, maxExamples, emitCorpusSnapshot, diffCorpusBaseline, emitCorpusDelta, qualityDiffCard, qualityCardRisky, corpusMethodCap, workers, sequential);
+            return CorpusSensor.Run(assemblies, compileCap, corpusFidelityCaps, maxExamples, emitCorpusSnapshot, diffCorpusBaseline, emitCorpusDelta, qualityDiffCard, qualityCardRisky, corpusMethodCap, workers, sequential, corpusFidelityOracle);
 
         if (renderAb is not null || emitRenderAb is not null)
             return RenderAbSensor.Run(assemblies, renderAb, emitRenderAb, maxExamples, corpusMethodCap, workers, sequential);
@@ -1511,6 +1519,15 @@ static class Program
             ? int.MaxValue
             : int.Parse(value);
 
+    static CorpusFidelityOracle ParseCorpusFidelityOracle(string value)
+        => value.ToLowerInvariant() switch
+        {
+            "compile-back" => CorpusFidelityOracle.CompileBack,
+            "return-to-sender" or "rts" => CorpusFidelityOracle.ReturnToSender,
+            _ => throw new ArgumentException(
+                $"Unknown corpus fidelity oracle '{value}'. Expected compile-back, return-to-sender, or rts."),
+        };
+
     static void PrintUsage() => Console.WriteLine("""
         usage: decompiler-harness [assembly-or-directory ...] [options]
 
@@ -1768,6 +1785,10 @@ static class Program
                                         (repeat or use comma-separated values to compare multiple caps)
                                 checked per assembly by the expensive compile-back
                                 fidelity oracle (default 0, not run).
+          --corpus-fidelity-oracle <name>
+                                with corpus baseline modes: select compile-back
+                                (default) or return-to-sender/rts. RTS evaluates
+                                the same compile-back-selected target population.
           --corpus-method-cap <n>        with corpus baseline modes: cap the
                                 completeness/structuring scan to a deterministic
                                 hash-ranked sample of n methods per assembly.

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -1523,9 +1523,9 @@ static class Program
         => value.ToLowerInvariant() switch
         {
             "compile-back" => CorpusFidelityOracle.CompileBack,
-            "return-to-sender" or "rts" => CorpusFidelityOracle.ReturnToSender,
+            "rts-parity" or "return-to-sender" or "rts" => CorpusFidelityOracle.ReturnToSender,
             _ => throw new ArgumentException(
-                $"Unknown corpus fidelity oracle '{value}'. Expected compile-back, return-to-sender, or rts."),
+                $"Unknown corpus fidelity oracle '{value}'. Expected compile-back or rts-parity."),
         };
 
     static void PrintUsage() => Console.WriteLine("""
@@ -1787,8 +1787,9 @@ static class Program
                                 fidelity oracle (default 0, not run).
           --corpus-fidelity-oracle <name>
                                 with corpus baseline modes: select compile-back
-                                (default) or return-to-sender/rts. RTS evaluates
-                                the same compile-back-selected target population.
+                                (default) or rts-parity (aliases: return-to-sender,
+                                rts). RTS evaluates the same compile-back-selected
+                                target population without applying the compile-back floor.
           --corpus-method-cap <n>        with corpus baseline modes: cap the
                                 completeness/structuring scan to a deterministic
                                 hash-ranked sample of n methods per assembly.

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -226,6 +226,21 @@ fidelity coverage series with the same per-bucket failure breakdown for each cap
 uploads the current JSON snapshot as an artifact so
 trends can be compared without scraping logs.
 
+Use `--corpus-fidelity-oracle return-to-sender` (or `rts`) to run the fidelity
+sample through RTS instead of the default compile-back oracle. The transition
+mode first selects the same bounded target population as compile-back, including
+getters, setters, constructors, and ordinary methods, then records RTS outcomes
+under the existing method identity and fidelity-status contract. Snapshots name
+their oracle; diffing snapshots from different oracles is rejected rather than
+presenting incomparable fidelity movement.
+
+The RTS cap is therefore a parity population: methods the default oracle checked
+as `Exact` or `OpcodeDiff`, re-evaluated through RTS. The report classifies each
+target as rescued, same, or worse and records the compile-back reference status
+beside the RTS result. Rows rescued by RTS's monotonic compile-back floor retain
+`return-to-sender; compile-back-floor` capture provenance in the per-method
+snapshot instead of being presented as native RTS reconstruction.
+
 Standalone `--fidelity-check` reports also print bounded examples for every
 non-success bucket: opcode diffs include canonical opcode streams, while
 recompile and context failures include the method and diagnostic detail. Use
@@ -243,6 +258,17 @@ dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
   --quality-diff-card \
   --compile-cap 25 \
   --corpus-fidelity-cap 3 \
+  --max-examples 3
+```
+
+To capture an RTS snapshot without comparing it to the compile-back baseline:
+
+```bash
+dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
+  --emit-corpus-snapshot /tmp/rts-corpus-snapshot.json \
+  --compile-cap 0 \
+  --corpus-fidelity-cap 3 \
+  --corpus-fidelity-oracle return-to-sender \
   --max-examples 3
 ```
 

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -226,20 +226,23 @@ fidelity coverage series with the same per-bucket failure breakdown for each cap
 uploads the current JSON snapshot as an artifact so
 trends can be compared without scraping logs.
 
-Use `--corpus-fidelity-oracle return-to-sender` (or `rts`) to run the fidelity
-sample through RTS instead of the default compile-back oracle. The transition
-mode first selects the same bounded target population as compile-back, including
-getters, setters, constructors, and ordinary methods, then records RTS outcomes
-under the existing method identity and fidelity-status contract. Snapshots name
-their oracle; diffing snapshots from different oracles is rejected rather than
-presenting incomparable fidelity movement.
+Use `--corpus-fidelity-oracle rts-parity` (`return-to-sender` and `rts` remain
+aliases) to run the fidelity sample through RTS instead of the default
+compile-back oracle. The transition mode first selects the same bounded target
+population as compile-back, including getters, setters, constructors, and
+ordinary methods, then records native RTS outcomes under the existing method
+identity and fidelity-status contract. Snapshots name this mode `rts-parity`;
+diffing snapshots from different modes is rejected rather than presenting
+incomparable fidelity movement.
 
 The RTS cap is therefore a parity population: methods the default oracle checked
 as `Exact` or `OpcodeDiff`, re-evaluated through RTS. The report classifies each
 target as rescued, same, or worse and records the compile-back reference status
-beside the RTS result. Rows rescued by RTS's monotonic compile-back floor retain
-`return-to-sender; compile-back-floor` capture provenance in the per-method
-snapshot instead of being presented as native RTS reconstruction.
+beside the native RTS result. Corpus parity deliberately disables RTS's
+compile-back floor so compile-back evidence cannot rewrite the RTS verdict.
+Because compile-back selects this population before RTS runs, `NotFullMethods`
+is structurally zero and failure buckets describe only the selected parity
+population; this mode measures parity, not independent RTS coverage.
 
 Standalone `--fidelity-check` reports also print bounded examples for every
 non-success bucket: opcode diffs include canonical opcode streams, while
@@ -268,7 +271,7 @@ dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
   --emit-corpus-snapshot /tmp/rts-corpus-snapshot.json \
   --compile-cap 0 \
   --corpus-fidelity-cap 3 \
-  --corpus-fidelity-oracle return-to-sender \
+  --corpus-fidelity-oracle rts-parity \
   --max-examples 3
 ```
 

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -440,18 +440,37 @@ static class ReturnToSender
     }
 
     public static IReadOnlyList<Result> CompileBackTargets(string assemblyPath, IReadOnlyList<RequestedTarget> targets)
-        => CompileBackTargets(assemblyPath, targets, ReturnToSenderSourceIndex.TryCreate(assemblyPath));
+        => CompileBackTargets(
+            assemblyPath,
+            targets,
+            ReturnToSenderSourceIndex.TryCreate(assemblyPath),
+            applyCompileBackFloor: true);
 
     public static IReadOnlyList<Result> CompileBackTargets(
         string assemblyPath,
         IReadOnlyList<RequestedTarget> targets,
         IReadOnlyList<string> sourcePaths)
-        => CompileBackTargets(assemblyPath, targets, ReturnToSenderSourceIndex.TryCreate(sourcePaths));
+        => CompileBackTargets(
+            assemblyPath,
+            targets,
+            ReturnToSenderSourceIndex.TryCreate(sourcePaths),
+            applyCompileBackFloor: true);
+
+    public static IReadOnlyList<Result> CompileBackTargets(
+        string assemblyPath,
+        IReadOnlyList<RequestedTarget> targets,
+        bool applyCompileBackFloor)
+        => CompileBackTargets(
+            assemblyPath,
+            targets,
+            ReturnToSenderSourceIndex.TryCreate(assemblyPath),
+            applyCompileBackFloor);
 
     static IReadOnlyList<Result> CompileBackTargets(
         string assemblyPath,
         IReadOnlyList<RequestedTarget> targets,
-        ReturnToSenderSourceIndex? sourceIndex)
+        ReturnToSenderSourceIndex? sourceIndex,
+        bool applyCompileBackFloor)
     {
         if (targets.Count == 0)
             return [];
@@ -529,7 +548,7 @@ static class ReturnToSender
             }
         }
 
-        return ApplyCompileBackFloor(assemblyPath, results);
+        return applyCompileBackFloor ? ApplyCompileBackFloor(assemblyPath, results) : results;
     }
 
     static IReadOnlyList<Result> ApplyCompileBackFloor(


### PR DESCRIPTION
- Advances #2280
- Changes harness-only corpus fidelity orchestration; product output is unchanged
- Evidence revision: `f353a139`

## Change

**Conclusion:** **PASS** — `CorpusSensor` can now evaluate its exact
compile-back checked sample through native ReturnToSender outcomes, with
explicit mode, reference-status, capture-provenance, failure-bucket, and parity
evidence.

## Scope and safety

- **Root cause:** RTS fidelity was available only through standalone commands,
  so the corpus sensor and baseline schema could not exercise or track the
  strategic replacement oracle.
- **Fix shape:** Add opt-in
  `--corpus-fidelity-oracle rts-parity`, align RTS outcomes to the exact
  compile-back `Exact`/`OpcodeDiff` target sample, and persist rescued/same/worse
  parity plus per-method reference/capture provenance.
- **Oracle isolation:** Corpus parity disables RTS's compile-back floor. The
  compile-back result remains beside each native RTS result as reference
  evidence and cannot rewrite RTS metrics or parity.
- **Product impact:** None; this is harness-only and compile-back remains the
  default corpus oracle.
- **Scope boundary:** This does not retire compile-back or regenerate the
  committed baseline.
- **RTS boundary:** RTS still owns orchestration and proof only. This PR does
  not modify artifact requests, provider-owned target-body rendering,
  `CompileBackSourceComposer`, or closure composition. It only adds an explicit
  no-floor option to the existing target evaluator for corpus parity.

## Evidence

| Check | Result |
| --- | --- |
| Solution build | Pass |
| Focused tests | 117 corpus-sensor and RTS tests pass |
| Merged RTS integration | 80 fixture-catalog + 16 generated-catalog tests pass |
| Prior full-suite failure | #2685 is fixed on current main; targeted regression passes |
| Fixed real-world corpus | 14 assemblies / 89,065 methods / sequential cap 3 |
| RTS parity | 0 rescued / 36 same / 0 worse |
| Native RTS outcomes | 31 Exact / 5 OpcodeDiff / 0 RecompileFail / 0 ContextFail |
| Capture provenance | 36 native RTS / 0 compile-back-floor rows |
| Deep NuGet probe | 48 Exact / 21 OpcodeDiff / 36 RecompileFail; 0 rescued / 48 same / 57 worse |
| Product output | Unchanged; harness-only |

The fixed-corpus run completed in 7:08.80 with a maximum RSS of 2,472,384 KB.
The deterministic 105-target NuGet.Versioning probe demonstrates the review fix:
36 rows previously hidden by the floor now report native `RecompileFail`, and
all 57 native regressions count as worse. The 21 constructor opcode gaps remain
visible under #2678.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Make RTS the committed baseline oracle | Not changed | Requires same-cap daily evidence and the broader retirement decision under #2280/#2560. |
| Remove compile-back sampling | Not changed | Compile-back still defines the bounded parity population. |
| Compile-back floor | Disabled for parity | Native RTS statuses exclusively feed parity metrics; the floor remains the default for other RTS callers. |
| Constructor parity | Exposed, not fixed | A deterministic NuGet.Versioning probe finds 21 constructor `Exact` → `OpcodeDiff` rows (#2678). |
| Parallel cap sampling | Exposed, not fixed | Identical capped runs can select different methods; comparisons gate on sample identity (#2679). |
| Full-suite union fixture | Resolved on main | #2685's targeted regression passes after rebasing over #2683. |
| #2670 provider rendering | Not changed | Rebased over merged #2670; provider rendering remains outside this PR's diff. |

## Review

Exact-head adversarial re-review is in progress for `f353a139`.
