### PR TITLE
Guard Metadata string signature decoding

### DIFF
--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -1455,7 +1455,7 @@ public static class ApiSurfaceExtractor
     private static string? GetFirstParameterType(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)
     {
         var context = GenericContext.ForMethod(reader, typeDef, method);
-        var signature = method.DecodeSignature(SignatureDecoder.Instance, context);
+        var signature = GuardedSignatureText.MethodText(reader, method, context);
         return signature.ParameterTypes.Length > 0 ? signature.ParameterTypes[0] : null;
     }
 

--- a/src/ILInspector.Metadata/EcosystemIntegrationScanner.cs
+++ b/src/ILInspector.Metadata/EcosystemIntegrationScanner.cs
@@ -614,7 +614,7 @@ public static class EcosystemIntegrationScanner
             MethodSignature<string> signature;
             try
             {
-                signature = method.DecodeSignature(SignatureDecoder.Instance, context);
+                signature = GuardedSignatureText.MethodText(reader, method, context);
             }
             catch (BadImageFormatException)
             {

--- a/src/ILInspector.Metadata/ExtensionMethodScanner.cs
+++ b/src/ILInspector.Metadata/ExtensionMethodScanner.cs
@@ -125,7 +125,7 @@ public static class ExtensionMethodScanner
                 // Decode signature to get first parameter type
                 {
                     var context = GenericContext.ForMethod(reader, typeDef, method);
-                    var signature = method.DecodeSignature(SignatureDecoder.Instance, context);
+                    var signature = GuardedSignatureText.MethodText(reader, method, context);
                     if (signature.ParameterTypes.Length == 0) continue;
 
                     var extendedType = signature.ParameterTypes[0];
@@ -222,7 +222,7 @@ public static class ExtensionMethodScanner
 
                 {
                     var context = GenericContext.ForMethod(reader, typeDef, method);
-                    var signature = method.DecodeSignature(SignatureDecoder.Instance, context);
+                    var signature = GuardedSignatureText.MethodText(reader, method, context);
                     if (signature.ParameterTypes.Length == 0) continue;
 
                     var extendedType = signature.ParameterTypes[0];
@@ -331,7 +331,7 @@ public static class ExtensionMethodScanner
 
                     try
                     {
-                        var sig = prop.DecodeSignature(SignatureDecoder.Instance, context);
+                        var sig = GuardedSignatureText.PropertyText(reader, prop, context);
                         var propType = UnwrapAsyncType(sig.ReturnType);
 
                         if (!string.IsNullOrEmpty(propType) && !IsPrimitiveType(propType) && visited.Add(propType))
@@ -360,7 +360,7 @@ public static class ExtensionMethodScanner
                     try
                     {
                         var methodContext = GenericContext.ForMethod(reader, typeDef, method);
-                        var sig = method.DecodeSignature(SignatureDecoder.Instance, methodContext);
+                        var sig = GuardedSignatureText.MethodText(reader, method, methodContext);
                         var retType = UnwrapAsyncType(sig.ReturnType);
 
                         if (!string.IsNullOrEmpty(retType) && retType != "void" &&
@@ -487,15 +487,17 @@ public static class ExtensionMethodScanner
                     continue;
 
                 var displayContext = GenericContext.ForType(reader, markerType);
-                var markerSignature = markerMethod.DecodeSignature(
-                    SignatureDecoder.Instance,
+                var markerSignature = GuardedSignatureText.MethodText(
+                    reader,
+                    markerMethod,
                     displayContext);
                 if (markerSignature.ParameterTypes.Length != 1)
                     throw new BadImageFormatException(
                         "An extension marker must have exactly one receiver parameter.");
 
-                var propertySignature = property.DecodeSignature(
-                    SignatureDecoder.Instance,
+                var propertySignature = GuardedSignatureText.PropertyText(
+                    reader,
+                    property,
                     displayContext);
                 string propertyName = reader.GetString(property.Name);
                 string parameterText = propertySignature.ParameterTypes.Length == 0
@@ -563,7 +565,7 @@ public static class ExtensionMethodScanner
         GenericContext? context)
     {
         string name = reader.GetString(method.Name);
-        var signature = method.DecodeSignature(SignatureDecoder.Instance, context);
+        var signature = GuardedSignatureText.MethodText(reader, method, context);
 
         // First parameter is the extension receiver, rendered with a 'this ' prefix.
         return SignatureRenderer.RenderDecodedSignature(reader, method, name, signature, extensionThis: true);

--- a/src/ILInspector.Metadata/GuardedSignatureText.cs
+++ b/src/ILInspector.Metadata/GuardedSignatureText.cs
@@ -1,0 +1,71 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Top-level prescan gateway for string-producing signature decodes in Metadata.
+/// Nested TypeSpec re-entry is guarded by <see cref="SignatureDecoder"/>.
+/// </summary>
+internal static class GuardedSignatureText
+{
+    const string Unresolved = "object";
+    static readonly MethodSignature<string> UnresolvedMethod = new(default, Unresolved, 0, 0, []);
+
+    public static MethodSignature<string> MethodText(
+        MetadataReader reader,
+        MethodDefinition method,
+        GenericContext? context)
+        => SignatureBlobGuard.IsSafeToDecode(reader, method.Signature, SignatureBlobGuard.Kind.Method)
+            ? method.DecodeSignature(SignatureDecoder.Instance, context)
+            : UnresolvedMethod;
+
+    public static MethodSignature<string> MemberRefMethodText(
+        MetadataReader reader,
+        MemberReference member,
+        GenericContext? context)
+        => SignatureBlobGuard.IsSafeToDecode(reader, member.Signature, SignatureBlobGuard.Kind.Method)
+            ? member.DecodeMethodSignature(SignatureDecoder.Instance, context)
+            : UnresolvedMethod;
+
+    public static MethodSignature<string> PropertyText(
+        MetadataReader reader,
+        PropertyDefinition property,
+        GenericContext? context)
+        => SignatureBlobGuard.IsSafeToDecode(reader, property.Signature, SignatureBlobGuard.Kind.Method)
+            ? property.DecodeSignature(SignatureDecoder.Instance, context)
+            : UnresolvedMethod;
+
+    public static string FieldText(
+        MetadataReader reader,
+        FieldDefinition field,
+        GenericContext? context)
+        => SignatureBlobGuard.IsSafeToDecode(reader, field.Signature, SignatureBlobGuard.Kind.Field)
+            ? field.DecodeSignature(SignatureDecoder.Instance, context)
+            : Unresolved;
+
+    public static ImmutableArray<string> MethodSpecTypeArgs(
+        MetadataReader reader,
+        MethodSpecification specification,
+        GenericContext? context)
+        => SignatureBlobGuard.IsSafeToDecode(
+            reader,
+            specification.Signature,
+            SignatureBlobGuard.Kind.MethodSpecification)
+            ? specification.DecodeSignature(SignatureDecoder.Instance, context)
+            : [];
+
+    public static string TypeSpecText(
+        MetadataReader reader,
+        TypeSpecificationHandle handle,
+        GenericContext? context)
+    {
+        var specification = reader.GetTypeSpecification(handle);
+        return SignatureBlobGuard.IsSafeToDecode(
+            reader,
+            specification.Signature,
+            SignatureBlobGuard.Kind.TypeSpecification)
+            ? specification.DecodeSignature(SignatureDecoder.Instance, context)
+            : Unresolved;
+    }
+}

--- a/src/ILInspector.Metadata/ILTokenResolver.cs
+++ b/src/ILInspector.Metadata/ILTokenResolver.cs
@@ -110,7 +110,7 @@ public static class ILTokenResolver
 
         try
         {
-            var sig = method.DecodeSignature(SignatureDecoder.Instance, genericContext: null);
+            var sig = GuardedSignatureText.MethodText(reader, method, context: null);
             return $"{baseName}({string.Join(", ", sig.ParameterTypes)})";
         }
         catch
@@ -131,7 +131,7 @@ public static class ILTokenResolver
             if (memberRef.GetKind() == MemberReferenceKind.Method)
             {
                 var genericCtx = BuildGenericContext(reader, memberRef);
-                var sig = memberRef.DecodeMethodSignature(SignatureDecoder.Instance, genericCtx);
+                var sig = GuardedSignatureText.MemberRefMethodText(reader, memberRef, genericCtx);
                 return $"{baseName}({string.Join(", ", sig.ParameterTypes)})";
             }
         }
@@ -155,7 +155,7 @@ public static class ILTokenResolver
 
         try
         {
-            var typeArgs = spec.DecodeSignature(SignatureDecoder.Instance, genericContext: null);
+            var typeArgs = GuardedSignatureText.MethodSpecTypeArgs(reader, spec, context: null);
             return $"{baseName}<{string.Join(", ", typeArgs)}>";
         }
         catch
@@ -182,8 +182,7 @@ public static class ILTokenResolver
         {
             if (memberRef.Parent.Kind == HandleKind.TypeSpecification)
             {
-                var typeSpec = reader.GetTypeSpecification((TypeSpecificationHandle)memberRef.Parent);
-                var parentType = typeSpec.DecodeSignature(SignatureDecoder.Instance, genericContext: null);
+                var parentType = GuardedSignatureText.TypeSpecText(reader, (TypeSpecificationHandle)memberRef.Parent, context: null);
                 var typeArgs = ExtractGenericArguments(parentType);
                 if (typeArgs.Count > 0)
                     return new GenericContext(typeArgs, []);

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -188,7 +188,7 @@ public static class MetadataDeclarationQuery
         TypeDefinition typeDef,
         MethodDefinition method)
     {
-        var signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method));
+        var signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, typeDef, method));
         return GetMethod(reader, typeDef, method, signature);
     }
 
@@ -197,7 +197,7 @@ public static class MetadataDeclarationQuery
         TypeDefinition typeDef,
         MethodDefinition method)
     {
-        var signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method));
+        var signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, typeDef, method));
         return FormatMethodReturnType(reader, signature.ReturnType, method.GetParameters());
     }
 
@@ -251,7 +251,7 @@ public static class MetadataDeclarationQuery
         PropertyDefinition property)
     {
         var accessors = property.GetAccessors();
-        var signature = property.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForType(reader, typeDef));
+        var signature = GuardedSignatureText.PropertyText(reader, property, GenericContext.ForType(reader, typeDef));
         var getter = accessors.Getter.IsNil ? default : reader.GetMethodDefinition(accessors.Getter);
         var setter = accessors.Setter.IsNil ? default : reader.GetMethodDefinition(accessors.Setter);
 
@@ -340,7 +340,7 @@ public static class MetadataDeclarationQuery
             (attributes & FieldAttributes.Static) != 0,
             (attributes & FieldAttributes.InitOnly) != 0,
             (attributes & FieldAttributes.Literal) != 0,
-            field.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForType(reader, typeDef)),
+            GuardedSignatureText.FieldText(reader, field, GenericContext.ForType(reader, typeDef)),
             RenderMemberAttributes(reader, field.GetCustomAttributes()));
     }
 
@@ -644,7 +644,7 @@ public static class MetadataDeclarationQuery
         {
             HandleKind.TypeDefinition => TypeResolver.GetFullName(reader, reader.GetTypeDefinition((TypeDefinitionHandle)handle)),
             HandleKind.TypeReference => TypeResolver.GetTypeNameFromReference(reader, (TypeReferenceHandle)handle),
-            HandleKind.TypeSpecification => reader.GetTypeSpecification((TypeSpecificationHandle)handle).DecodeSignature(SignatureDecoder.Instance, context),
+            HandleKind.TypeSpecification => GuardedSignatureText.TypeSpecText(reader, (TypeSpecificationHandle)handle, context),
             _ => null,
         };
 

--- a/src/ILInspector.Metadata/MethodClassificationScanner.cs
+++ b/src/ILInspector.Metadata/MethodClassificationScanner.cs
@@ -165,7 +165,7 @@ public static class MethodClassificationScanner
                 try
                 {
                     var context = GenericContext.ForMethod(reader, typeDef, method);
-                    var sig = method.DecodeSignature(SignatureDecoder.Instance, context);
+                    var sig = GuardedSignatureText.MethodText(reader, method, context);
                     if (HasPointerType(sig))
                     {
                         var signature = SignatureRenderer.RenderDecodedSignature(reader, method, methodName, sig);
@@ -255,7 +255,7 @@ public static class MethodClassificationScanner
         try
         {
             var context = GenericContext.ForMethod(reader, typeDef, method);
-            var sig = method.DecodeSignature(SignatureDecoder.Instance, context);
+            var sig = GuardedSignatureText.MethodText(reader, method, context);
             string methodName = reader.GetString(method.Name);
             return SignatureRenderer.RenderDecodedSignature(reader, method, methodName, sig);
         }

--- a/src/ILInspector.Metadata/OpenTelemetryScanner.cs
+++ b/src/ILInspector.Metadata/OpenTelemetryScanner.cs
@@ -88,7 +88,7 @@ public static class OpenTelemetryScanner
 
                 try
                 {
-                    var signature = property.DecodeSignature(SignatureDecoder.Instance, context);
+                    var signature = GuardedSignatureText.PropertyText(reader, property, context);
                     if (signature.ReturnType != "bool")
                         continue;
                 }
@@ -132,7 +132,7 @@ public static class OpenTelemetryScanner
                 try
                 {
                     var context = GenericContext.ForMethod(metadataReader, typeDefinition, method);
-                    signature = method.DecodeSignature(SignatureDecoder.Instance, context);
+                    signature = GuardedSignatureText.MethodText(metadataReader, method, context);
                 }
                 catch (BadImageFormatException)
                 {
@@ -256,7 +256,7 @@ public static class OpenTelemetryScanner
 
             try
             {
-                if (property.DecodeSignature(SignatureDecoder.Instance, context).ReturnType == "bool")
+                if (GuardedSignatureText.PropertyText(reader, property, context).ReturnType == "bool")
                     return true;
             }
             catch (BadImageFormatException)
@@ -292,7 +292,7 @@ public static class OpenTelemetryScanner
             try
             {
                 var context = GenericContext.ForMethod(reader, typeDefinition, method);
-                var signature = method.DecodeSignature(SignatureDecoder.Instance, context);
+                var signature = GuardedSignatureText.MethodText(reader, method, context);
                 if (TryClassifyTelemetryBuilderMethod(signature, out _))
                     return true;
             }

--- a/src/ILInspector.Metadata/PdbContext.cs
+++ b/src/ILInspector.Metadata/PdbContext.cs
@@ -603,7 +603,7 @@ public class PdbContext : IDisposable
         try
         {
             var context = GenericContext.ForMethod(reader, type, method);
-            var signature = method.DecodeSignature(SignatureDecoder.Instance, context);
+            var signature = GuardedSignatureText.MethodText(reader, method, context);
             return SignatureRenderer.RenderDecodedSignature(reader, method, methodName, signature);
         }
         catch

--- a/src/ILInspector.Metadata/SignatureBlobGuardForwarder.cs
+++ b/src/ILInspector.Metadata/SignatureBlobGuardForwarder.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: TypeForwardedTo(typeof(ILInspector.Metadata.SignatureBlobGuard))]

--- a/src/ILInspector.Metadata/UnionTypeScanner.cs
+++ b/src/ILInspector.Metadata/UnionTypeScanner.cs
@@ -69,7 +69,7 @@ public static class UnionTypeScanner
             MethodSignature<string> signature;
             try
             {
-                signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method));
+                signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, typeDef, method));
             }
             catch
             {

--- a/src/ILInspector.MetadataPrimitives/SignatureBlobGuard.cs
+++ b/src/ILInspector.MetadataPrimitives/SignatureBlobGuard.cs
@@ -3,7 +3,7 @@ using System.Reflection.Metadata;
 namespace ILInspector.Metadata;
 
 /// <summary>
-/// Bounds the structural nesting depth of a metadata signature blob *before* it is handed to
+/// Bounds the structural nesting depth of a metadata signature blob before it is handed to
 /// <c>System.Reflection.Metadata</c>'s <c>SignatureDecoder</c>.
 ///
 /// SRM decodes a signature by recursing on the native stack once per nested structural element

--- a/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
+++ b/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
@@ -9,6 +9,8 @@ namespace ILInspector.Metadata;
 /// </summary>
 public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
 {
+    const string Unresolved = "object";
+
     /// <summary>
     /// Shared instance for common use cases.
     /// </summary>
@@ -45,8 +47,16 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
 
     public string GetTypeFromSpecification(MetadataReader reader, GenericContext? context, TypeSpecificationHandle handle, byte rawTypeKind)
     {
-        var typeSpec = reader.GetTypeSpecification(handle);
-        return typeSpec.DecodeSignature(this, context);
+        if (!TypeSpecGuard.TryEnter(reader, handle, out int blobLength))
+            return Unresolved;
+        try
+        {
+            return reader.GetTypeSpecification(handle).DecodeSignature(this, context);
+        }
+        finally
+        {
+            TypeSpecGuard.Exit(blobLength);
+        }
     }
 
     public string GetSZArrayType(string elementType) => $"{elementType}[]";

--- a/src/ILInspector.MetadataPrimitives/TypeResolver.cs
+++ b/src/ILInspector.MetadataPrimitives/TypeResolver.cs
@@ -52,8 +52,16 @@ public static class TypeResolver
     /// </summary>
     public static string GetTypeNameFromSpecification(MetadataReader reader, TypeSpecificationHandle handle, GenericContext? context = null)
     {
-        var typeSpec = reader.GetTypeSpecification(handle);
-        return typeSpec.DecodeSignature(SignatureDecoder.Instance, context);
+        if (!TypeSpecGuard.TryEnter(reader, handle, out int blobLength))
+            return "object";
+        try
+        {
+            return reader.GetTypeSpecification(handle).DecodeSignature(SignatureDecoder.Instance, context);
+        }
+        finally
+        {
+            TypeSpecGuard.Exit(blobLength);
+        }
     }
 
     /// <summary>

--- a/src/ILInspector.MetadataPrimitives/TypeSpecGuard.cs
+++ b/src/ILInspector.MetadataPrimitives/TypeSpecGuard.cs
@@ -1,0 +1,48 @@
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Bounds cross-handle TypeSpec re-entry performed by signature providers.
+/// A top-level blob prescan cannot see a custom modifier that resolves another
+/// TypeSpec, including a cycle back to the current row.
+/// </summary>
+internal static class TypeSpecGuard
+{
+    const int MaxBlobLength = 1024;
+    const int MaxCumulativeBytes = 4096;
+    const int MaxDepth = 256;
+
+    [ThreadStatic]
+    static int s_cumulativeBytes;
+
+    [ThreadStatic]
+    static int s_depth;
+
+    public static bool TryEnter(MetadataReader reader, TypeSpecificationHandle handle, out int blobLength)
+    {
+        blobLength = 0;
+        if (s_depth >= MaxDepth)
+            return false;
+
+        var signature = reader.GetTypeSpecification(handle).Signature;
+        int length = reader.GetBlobReader(signature).Length;
+        if (length > MaxBlobLength
+            || s_cumulativeBytes + length > MaxCumulativeBytes
+            || !SignatureBlobGuard.IsSafeToDecode(reader, signature, SignatureBlobGuard.Kind.TypeSpecification))
+        {
+            return false;
+        }
+
+        s_depth++;
+        s_cumulativeBytes += length;
+        blobLength = length;
+        return true;
+    }
+
+    public static void Exit(int blobLength)
+    {
+        s_depth--;
+        s_cumulativeBytes -= blobLength;
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/SignatureDecoderSafetyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SignatureDecoderSafetyTests.cs
@@ -1,0 +1,179 @@
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+namespace ILInspector.Metadata.Tests;
+
+public class SignatureDecoderSafetyTests
+{
+    const string WorkerVariable = "DOTNET_INSPECT_SIGNATURE_DECODER_WORKER";
+
+    [Fact]
+    public void SelfReferentialTypeSpec_IsContainedInChildProcess()
+        => RunWorker(nameof(SelfReferentialTypeSpecWorker));
+
+    [Fact]
+    public void DeepTypeSpec_IsContainedInChildProcess()
+        => RunWorker(nameof(DeepTypeSpecWorker));
+
+    [Fact]
+    public void DeepMethodSignatureGateway_IsContainedInChildProcess()
+        => RunWorker(nameof(DeepMethodSignatureGatewayWorker));
+
+    [Fact]
+    public void SignatureBlobGuard_OldAssemblyIdentity_IsForwarded()
+        => Assert.Equal(
+            typeof(SignatureBlobGuard),
+            Type.GetType("ILInspector.Metadata.SignatureBlobGuard, ILInspector.Metadata"));
+
+    [Fact]
+    public void SelfReferentialTypeSpecWorker()
+    {
+        if (!IsSelectedWorker(nameof(SelfReferentialTypeSpecWorker)))
+            return;
+
+        var reader = BuildTypeSpec(signature =>
+        {
+            signature.WriteByte(0x1f); // CMOD_REQD
+            signature.WriteByte(0x06); // TypeDefOrRefOrSpec: TypeSpec row 1
+            signature.WriteByte(0x08); // I4
+        });
+
+        Assert.Equal(
+            "int",
+            TypeResolver.GetTypeNameFromSpecification(
+                reader,
+                MetadataTokens.TypeSpecificationHandle(1)));
+    }
+
+    [Fact]
+    public void DeepTypeSpecWorker()
+    {
+        if (!IsSelectedWorker(nameof(DeepTypeSpecWorker)))
+            return;
+
+        var reader = BuildTypeSpec(signature =>
+        {
+            for (int i = 0; i < 100_000; i++)
+                signature.WriteByte(0x1d); // SZARRAY
+            signature.WriteByte(0x08);     // I4
+        });
+
+        Assert.Equal(
+            "object",
+            TypeResolver.GetTypeNameFromSpecification(
+                reader,
+                MetadataTokens.TypeSpecificationHandle(1)));
+    }
+
+    [Fact]
+    public void DeepMethodSignatureGatewayWorker()
+    {
+        if (!IsSelectedWorker(nameof(DeepMethodSignatureGatewayWorker)))
+            return;
+
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x00); // default method signature
+        signature.WriteByte(0x00); // zero parameters
+        for (int i = 0; i < 100_000; i++)
+            signature.WriteByte(0x1d); // SZARRAY return type
+        signature.WriteByte(0x08);     // I4
+
+        MethodDefinitionHandle methodHandle = default;
+        TypeDefinitionHandle typeHandle = default;
+        var reader = BuildAssembly(metadata =>
+        {
+            methodHandle = metadata.AddMethodDefinition(
+                MethodAttributes.Public | MethodAttributes.Static,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("M"),
+                metadata.GetOrAddBlob(signature),
+                bodyOffset: -1,
+                parameterList: MetadataTokens.ParameterHandle(1));
+            typeHandle = metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("C"),
+                default,
+                MetadataTokens.FieldDefinitionHandle(1),
+                methodHandle);
+        });
+
+        var decoded = MetadataDeclarationQuery.GetMethodReturnType(
+            reader,
+            reader.GetTypeDefinition(typeHandle),
+            reader.GetMethodDefinition(methodHandle));
+
+        Assert.Equal("object", decoded);
+    }
+
+    static bool IsSelectedWorker(string methodName)
+        => Environment.GetEnvironmentVariable(WorkerVariable) == methodName;
+
+    static void RunWorker(string workerMethod)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add(typeof(SignatureDecoderSafetyTests).Assembly.Location);
+        startInfo.ArgumentList.Add("-method");
+        startInfo.ArgumentList.Add($"*{workerMethod}*");
+        startInfo.Environment[WorkerVariable] = workerMethod;
+
+        using var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+        string standardOutput = process.StandardOutput.ReadToEnd();
+        string standardError = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        Assert.True(
+            process.ExitCode == 0,
+            $"Child worker {workerMethod} exited {process.ExitCode}.\nstdout:\n{standardOutput}\nstderr:\n{standardError}");
+    }
+
+    static MetadataReader BuildTypeSpec(Action<BlobBuilder> writeSignature)
+    {
+        var signature = new BlobBuilder();
+        writeSignature(signature);
+        return BuildAssembly(metadata => metadata.AddTypeSpecification(metadata.GetOrAddBlob(signature)));
+    }
+
+    static MetadataReader BuildAssembly(Action<MetadataBuilder> addRows)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString("Synthetic.dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Synthetic"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        addRows(metadata);
+
+        var root = new MetadataRootBuilder(metadata, suppressValidation: true);
+        var image = new BlobBuilder();
+        root.Serialize(image, 0, 0);
+        return MetadataReaderProvider
+            .FromMetadataImage(ImmutableArray.Create(image.ToArray()))
+            .GetMetadataReader();
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/SignatureDecoderSafetyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SignatureDecoderSafetyTests.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
 
 namespace ILInspector.Metadata.Tests;
 
@@ -21,6 +22,10 @@ public class SignatureDecoderSafetyTests
     [Fact]
     public void DeepMethodSignatureGateway_IsContainedInChildProcess()
         => RunWorker(nameof(DeepMethodSignatureGatewayWorker));
+
+    [Fact(Skip = "Known TypeNodeProvider crash tracked by #2575.")]
+    public void CyclicTypeSpec_ThroughApiSurfaceExtractor_IsContainedInChildProcess()
+        => RunWorker(nameof(CyclicTypeSpecThroughApiSurfaceExtractorWorker));
 
     [Fact]
     public void SignatureBlobGuard_OldAssemblyIdentity_IsForwarded()
@@ -109,6 +114,17 @@ public class SignatureDecoderSafetyTests
         Assert.Equal("object", decoded);
     }
 
+    [Fact]
+    public void CyclicTypeSpecThroughApiSurfaceExtractorWorker()
+    {
+        if (!IsSelectedWorker(nameof(CyclicTypeSpecThroughApiSurfaceExtractorWorker)))
+            return;
+
+        var image = BuildApiSurfaceTypeSpecCycle();
+        using var peReader = new PEReader(new MemoryStream(image));
+        _ = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+    }
+
     static bool IsSelectedWorker(string methodName)
         => Environment.GetEnvironmentVariable(WorkerVariable) == methodName;
 
@@ -141,6 +157,63 @@ public class SignatureDecoderSafetyTests
         var signature = new BlobBuilder();
         writeSignature(signature);
         return BuildAssembly(metadata => metadata.AddTypeSpecification(metadata.GetOrAddBlob(signature)));
+    }
+
+    static byte[] BuildApiSurfaceTypeSpecCycle()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString("Synthetic.dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Synthetic"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            metadata.GetOrAddString("N"),
+            metadata.GetOrAddString("C"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        var cyclicTypeSpec = new BlobBuilder();
+        cyclicTypeSpec.WriteByte(0x1f); // CMOD_REQD
+        cyclicTypeSpec.WriteByte(0x06); // TypeDefOrRefOrSpec: TypeSpec row 1
+        cyclicTypeSpec.WriteByte(0x08); // I4
+        metadata.AddTypeSpecification(metadata.GetOrAddBlob(cyclicTypeSpec));
+
+        var fieldSignature = new BlobBuilder();
+        fieldSignature.WriteByte(0x06); // field signature
+        fieldSignature.WriteByte(0x1f); // CMOD_REQD
+        fieldSignature.WriteByte(0x06); // TypeDefOrRefOrSpec: TypeSpec row 1
+        fieldSignature.WriteByte(0x08); // I4
+        metadata.AddFieldDefinition(
+            FieldAttributes.Public | FieldAttributes.Static,
+            metadata.GetOrAddString("F"),
+            metadata.GetOrAddBlob(fieldSignature));
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
     }
 
     static MetadataReader BuildAssembly(Action<MetadataBuilder> addRows)

--- a/tests/ILInspector.Metadata.Tests/StringSignatureDecodeBoundaryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/StringSignatureDecodeBoundaryTests.cs
@@ -1,0 +1,60 @@
+namespace ILInspector.Metadata.Tests;
+
+public class StringSignatureDecodeBoundaryTests
+{
+    [Fact]
+    public void MetadataStringDecoder_IsOnlyReachedThroughTheGateway()
+    {
+        var root = FindRepoRoot();
+        var sourceRoots = new[]
+        {
+            Path.Combine(root, "src", "ILInspector.Metadata"),
+            Path.Combine(root, "src", "ILInspector.MetadataPrimitives"),
+        };
+        var allowedFiles = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "GuardedSignatureText.cs",
+            "SignatureDecoder.cs",
+            "TypeResolver.cs",
+            // TypeNodeProvider delegates leaf-name callbacks to the string provider; its own
+            // top-level and nested-TypeSpec safety belongs to provider-closure issue #2575.
+            "TypeNodeProvider.cs",
+        };
+        var violations = new List<string>();
+
+        foreach (var sourceRoot in sourceRoots)
+        {
+            foreach (var file in Directory.EnumerateFiles(sourceRoot, "*.cs", SearchOption.AllDirectories))
+            {
+                if (allowedFiles.Contains(Path.GetFileName(file)))
+                    continue;
+
+                var lines = File.ReadAllLines(file);
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    if (lines[i].Contains("SignatureDecoder.Instance", StringComparison.Ordinal)
+                        || lines[i].Contains("new SignatureDecoder(", StringComparison.Ordinal))
+                        violations.Add($"{Path.GetRelativePath(root, file)}:{i + 1}");
+                }
+            }
+        }
+
+        Assert.True(
+            violations.Count == 0,
+            "Metadata string signatures must enter through GuardedSignatureText. Raw uses:\n  "
+            + string.Join("\n  ", violations));
+    }
+
+    static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null
+            && !File.Exists(Path.Combine(directory.FullName, "dotnet-inspect.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        Assert.NotNull(directory);
+        return directory!.FullName;
+    }
+}


### PR DESCRIPTION
Advances #2490.

## Change

**Conclusion:** **PASS** — Metadata's string-producing signature decoder now rejects
top-level structural recursion/count hazards before entering SRM and bounds nested
TypeSpec re-entry without changing valid CoreLib output.

This is slice A of the fixed mechanism matrix posted on #2490:

- route every top-level Metadata `SignatureDecoder` decode through
  `GuardedSignatureText`, which applies the iterative `SignatureBlobGuard` prescan;
- bound nested TypeSpec depth, per-blob length, and cumulative bytes in
  `SignatureDecoder.GetTypeFromSpecification`;
- move `SignatureBlobGuard` to MetadataPrimitives so both layers can use it, while
  preserving its old `ILInspector.Metadata` assembly identity with a type forwarder;
- add process-isolated deep-signature/cyclic-TypeSpec regressions and a source census
  that rejects new raw Metadata string-decoder entry points.

## Frozen scope

This PR covers only:

1. SRM native recursion/count preallocation in top-level Metadata string signatures.
2. Cross-handle nested TypeSpec re-entry in the same string provider.
3. Compatibility of the moved `SignatureBlobGuard` public type identity.

Different mechanisms remain separate follow-ups: other
`ISignatureTypeProvider` implementations (#2575), TypeRef/TypeDef graph cycles,
name/arity/output amplification, Analysis/Decompiler provider closure, and
custom-attribute decoding.

## Evidence

| Check | Result |
| --- | --- |
| Solution build | Pass |
| Metadata tests | 452 passed |
| Product tests | 1,768 passed, 10 skipped |
| Analysis tests | 430 passed |
| Decompiler fast suite | 2,333 passed |
| CoreLib valid-output A/B | Byte-identical on all three commands |

Exact merge base: `2b3db7ee9ad405031885fe71872cde7ffe64136a`  
Exact reviewed head: `f774dd5de5be74a6ead9b7a7d04e314297385208`

| CoreLib command | Base/head SHA-256 |
| --- | --- |
| `type System.String --json -v:d` | `0cb3c8d6e7ed6f354839b27853102ee96838980d8170e50ab96b2d8166b8f5e7` |
| `library --json` | `6e48206952b47467883b424f53419ac27d81acf1a609e2df6986e6fc2ab8efc9` |
| `extensions System.String --json` | `cea7b70da91baaf75da00a3f95f8f5542a76bafb341fb7fc4fc9ef95469f414f` |

The decompiler quality card is not applicable: this changes malformed-metadata
containment rather than raising, structuring, or printing, and valid product output
is byte-identical.

## Adversarial review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | CLEAN | Verified gateway closure, iterative grammar bounds, balanced TypeSpec state, child-process regressions, and A/B on the exact head. |
| Gemini 3.1 Pro | CLEAN | Verified all A1/A2/A3 mechanisms, census closure, cyclic/deep fixtures, type forwarding, and A/B on the exact head. |

Both reviewers independently identified only the already-scoped, non-blocking
provider-closure follow-up tracked by #2575. No resolution commit applies because
that mechanism is deliberately excluded from this slice.
