### PR TITLE
Finish C# spelling ownership and remove RTS transition alias

### DIFF
--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -1,6 +1,6 @@
 using ILInspector.Metadata;
 
-namespace ILInspector.Metadata.Tests;
+namespace ILInspector.CSharp.Tests;
 
 public sealed class CSharpDeclarationWriterTests
 {

--- a/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
@@ -92,13 +92,27 @@ public sealed class CSharpFormatterTests
                 DefaultValueText = "default"
             },
             new() { Type = "class", Name = "value" },
-            new() { Type = "System.Collections.Generic.List<class>", Name = "items" }
+            new() { Type = "System.Collections.Generic.List<class>", Name = "items" },
+            new() { Type = "delegate", Name = "delegateValue" },
+            new() { Type = "readonly", Name = "readonlyValue" },
+            new() { Type = "scoped", Name = "scopedValue" },
+            new() { Type = "delegate*<ref int, void>", Name = "callback" }
         };
 
         Assert.Equal(
-            "([System.Runtime.InteropServices.Optional] System.@event.MyClass @event = default, @class value, System.Collections.Generic.List<@class> items)",
+            "([System.Runtime.InteropServices.Optional] System.@event.MyClass @event = default, @class value, System.Collections.Generic.List<@class> items, @delegate delegateValue, @readonly readonlyValue, @scoped scopedValue, delegate*<ref int, void> callback)",
             CSharpFormatter.FormatParameterList(parameters));
     }
+
+    [Theory]
+    [InlineData("await")]
+    [InlineData("file")]
+    [InlineData("init")]
+    [InlineData("record")]
+    [InlineData("required")]
+    [InlineData("scoped")]
+    public void EscapesConservativeContextualKeywordSet(string identifier)
+        => Assert.Equal($"@{identifier}", CSharpFormatter.EscapeIdentifier(identifier));
 
     [Fact]
     public void FormatsDelegateWithStructuredAccessibility()

--- a/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
@@ -79,6 +79,55 @@ public sealed class CSharpFormatterTests
     }
 
     [Fact]
+    public void FormatsParameterListsWithAttributesDefaultsAndEscapedKeywords()
+    {
+        var parameters = new ApiParameter[]
+        {
+            new()
+            {
+                Attributes = ["System.Runtime.InteropServices.Optional"],
+                Type = "System.event.MyClass",
+                Name = "event",
+                HasDefault = true,
+                DefaultValueText = "default"
+            }
+        };
+
+        Assert.Equal(
+            "([System.Runtime.InteropServices.Optional] System.@event.MyClass @event = default)",
+            CSharpFormatter.FormatParameterList(parameters));
+    }
+
+    [Fact]
+    public void FormatsDelegateWithStructuredAccessibility()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Callback",
+            Kind = "delegate",
+            Accessibility = "private",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = "Invoke",
+                    Kind = "method",
+                    SignatureModel = new ApiSignature
+                    {
+                        ReturnType = "void",
+                        MemberName = "Invoke"
+                    }
+                }
+            ]
+        };
+
+        Assert.Equal(
+            "private delegate void Callback();",
+            new CSharpFormatter().FormatDelegate(type, type.Members.Single()));
+    }
+
+    [Fact]
     public void RejectsUndefinedPolicies()
     {
         Assert.Throws<ArgumentOutOfRangeException>(

--- a/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
@@ -90,11 +90,13 @@ public sealed class CSharpFormatterTests
                 Name = "event",
                 HasDefault = true,
                 DefaultValueText = "default"
-            }
+            },
+            new() { Type = "class", Name = "value" },
+            new() { Type = "System.Collections.Generic.List<class>", Name = "items" }
         };
 
         Assert.Equal(
-            "([System.Runtime.InteropServices.Optional] System.@event.MyClass @event = default)",
+            "([System.Runtime.InteropServices.Optional] System.@event.MyClass @event = default, @class value, System.Collections.Generic.List<@class> items)",
             CSharpFormatter.FormatParameterList(parameters));
     }
 

--- a/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
@@ -130,6 +130,17 @@ public sealed class CSharpFormatterTests
     }
 
     [Fact]
+    public void KnownIdentifierEscapingIsIdempotent()
+    {
+        Assert.Equal(
+            "System.Action<@event>",
+            CSharpFormatter.EscapeKnownIdentifiers("System.Action<@event>", ["event"]));
+        Assert.Equal(
+            "System.Action<@event>",
+            CSharpFormatter.EscapeKnownIdentifiers("System.Action<event>", ["event"]));
+    }
+
+    [Fact]
     public void RejectsUndefinedPolicies()
     {
         Assert.Throws<ArgumentOutOfRangeException>(

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -791,6 +791,7 @@ public sealed class CSharpTypePrinterTests
             Namespace = "Samples",
             Name = "Converter`1",
             MetadataName = "Converter`1",
+            Accessibility = "internal",
             Kind = "delegate",
             TypeParameters =
             [
@@ -820,7 +821,7 @@ public sealed class CSharpTypePrinterTests
 
         Assert.Contains("public enum Choice\n{\n    One = 1\n}", result.Units[0].Source, StringComparison.Ordinal);
         Assert.Contains(
-            "public delegate int Converter<in @event>(string value) where @event : System.IEquatable<@event>;",
+            "internal delegate int Converter<in @event>(string value) where @event : System.IEquatable<@event>;",
             result.Units[0].Source,
             StringComparison.Ordinal);
     }

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -669,9 +669,11 @@ internal static class CSharpDeclarationWriter
                 end++;
 
             string identifier = type[index..end];
+            bool isTypeSyntaxKeyword = IsTypeSyntaxKeyword(identifier)
+                && (end == type.Length || type[end] != '.');
             if ((index == 0 || type[index - 1] != '@')
                 && EscapeIdentifier(identifier) != identifier
-                && !IsTypeSyntaxKeyword(identifier))
+                && !isTypeSyntaxKeyword)
             {
                 builder.Append('@');
             }

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -1,21 +1,22 @@
 using System.Text;
+using ILInspector.Metadata;
 
-namespace ILInspector.Metadata;
+namespace ILInspector.CSharp;
 
-public enum CSharpTypeNameMode
+internal enum CSharpTypeNameMode
 {
     Qualified,
     ShortWithUsings,
     ContextualShort
 }
 
-public enum CSharpNamespaceMode
+internal enum CSharpNamespaceMode
 {
     Omit,
     FileScoped
 }
 
-public sealed record CSharpDeclarationOptions
+internal sealed record CSharpDeclarationOptions
 {
     public CSharpTypeNameMode TypeNameMode { get; init; } = CSharpTypeNameMode.Qualified;
     public string? ContainingNamespace { get; init; }
@@ -31,7 +32,7 @@ public sealed record CSharpDeclarationOptions
     public bool OmitPropertyAccessors { get; init; }
 }
 
-public sealed record CSharpRenderedDeclaration(
+internal sealed record CSharpRenderedDeclaration(
     string Source,
     IReadOnlyList<string> Usings,
     IReadOnlyList<string> Diagnostics);
@@ -40,7 +41,7 @@ public sealed record CSharpRenderedDeclaration(
 /// Cheap C# declaration and signature composition over the API metadata model.
 /// It never imports method bodies, opens inspected assemblies, or depends on the decompiler.
 /// </summary>
-public static class CSharpDeclarationWriter
+internal static class CSharpDeclarationWriter
 {
     public static CSharpRenderedDeclaration RenderMemberUnit(
         ApiType type,
@@ -138,7 +139,7 @@ public static class CSharpDeclarationWriter
 
     static string RenderTypeDeclarationCore(ApiType type, CSharpDeclarationOptions options)
     {
-        var parts = new List<string> { "public" };
+        var parts = new List<string> { TypeAccessibility(type) };
         if (type.Kind is "class" or "record")
         {
             if (type.IsStatic)
@@ -555,7 +556,7 @@ public static class CSharpDeclarationWriter
             return false;
         }
 
-        var parameters = string.Join(", ", model.Parameters.Select(ParameterDeclaration));
+        var parameters = string.Join(", ", model.Parameters.Select(FormatParameter));
         if (member.Name == ".cctor")
         {
             signature = $"{FormatConstructorTypeName(type.Name)}()";
@@ -635,7 +636,7 @@ public static class CSharpDeclarationWriter
                || !name.Contains('.', StringComparison.Ordinal);
     }
 
-    static string ParameterDeclaration(ApiParameter parameter)
+    internal static string FormatParameter(ApiParameter parameter)
     {
         var head = parameter.TypeWithModifier;
         var declaration = string.IsNullOrWhiteSpace(parameter.Name)
@@ -930,6 +931,9 @@ public static class CSharpDeclarationWriter
                 ".",
                 name.Split('.').Select(segment =>
                     segment.StartsWith('@') ? segment : EscapeIdentifier(segment)));
+
+    internal static string TypeAccessibility(ApiType type)
+        => type.Accessibility ?? "public";
 
     static string AddExtensionThisModifier(string signature)
     {

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -638,7 +638,10 @@ internal static class CSharpDeclarationWriter
 
     internal static string FormatParameter(ApiParameter parameter)
     {
-        var head = parameter.TypeWithModifier;
+        string type = EscapeTypeKeywords(parameter.Type);
+        string head = string.IsNullOrEmpty(parameter.Modifier)
+            ? type
+            : $"{parameter.Modifier} {type}";
         var declaration = string.IsNullOrWhiteSpace(parameter.Name)
             ? head
             : $"{head} {EscapeIdentifier(parameter.Name)}";
@@ -649,6 +652,40 @@ internal static class CSharpDeclarationWriter
             ? declaration
             : $"[{string.Join(", ", parameter.Attributes)}] {declaration}";
     }
+
+    static string EscapeTypeKeywords(string type)
+    {
+        var builder = new StringBuilder(type.Length);
+        for (int index = 0; index < type.Length;)
+        {
+            if (!IsIdentifierStart(type[index]))
+            {
+                builder.Append(type[index++]);
+                continue;
+            }
+
+            int end = index + 1;
+            while (end < type.Length && IsIdentifierPart(type[end]))
+                end++;
+
+            string identifier = type[index..end];
+            if ((index == 0 || type[index - 1] != '@')
+                && EscapeIdentifier(identifier) != identifier
+                && !IsTypeSyntaxKeyword(identifier))
+            {
+                builder.Append('@');
+            }
+            builder.Append(identifier);
+            index = end;
+        }
+        return builder.ToString();
+    }
+
+    static bool IsTypeSyntaxKeyword(string identifier)
+        => identifier is "bool" or "byte" or "sbyte" or "char" or "decimal" or "double"
+            or "float" or "int" or "uint" or "nint" or "nuint" or "long" or "ulong"
+            or "object" or "short" or "ushort" or "string" or "void" or "delegate"
+            or "ref" or "in" or "out" or "params" or "readonly" or "scoped" or "unmanaged";
 
     static string FormatTypeDisplayName(string name, IReadOnlyList<TypeParameter> typeParameters)
     {

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -669,8 +669,7 @@ internal static class CSharpDeclarationWriter
                 end++;
 
             string identifier = type[index..end];
-            bool isTypeSyntaxKeyword = IsTypeSyntaxKeyword(identifier)
-                && (end == type.Length || type[end] != '.');
+            bool isTypeSyntaxKeyword = IsTypeSyntaxKeyword(type, identifier, index, end);
             if ((index == 0 || type[index - 1] != '@')
                 && EscapeIdentifier(identifier) != identifier
                 && !isTypeSyntaxKeyword)
@@ -683,11 +682,29 @@ internal static class CSharpDeclarationWriter
         return builder.ToString();
     }
 
-    static bool IsTypeSyntaxKeyword(string identifier)
-        => identifier is "bool" or "byte" or "sbyte" or "char" or "decimal" or "double"
+    static bool IsTypeSyntaxKeyword(string type, string identifier, int start, int end)
+    {
+        if (identifier is "bool" or "byte" or "sbyte" or "char" or "decimal" or "double"
             or "float" or "int" or "uint" or "nint" or "nuint" or "long" or "ulong"
-            or "object" or "short" or "ushort" or "string" or "void" or "delegate"
-            or "ref" or "in" or "out" or "params" or "readonly" or "scoped" or "unmanaged";
+            or "object" or "short" or "ushort" or "string" or "void")
+        {
+            return end == type.Length || type[end] != '.';
+        }
+
+        if (identifier == "delegate")
+            return end < type.Length && type[end] == '*';
+
+        if (type.StartsWith("delegate*", StringComparison.Ordinal)
+            && identifier is "ref" or "in" or "out" or "readonly" or "unmanaged")
+        {
+            return true;
+        }
+
+        return start == 0
+            && end < type.Length
+            && char.IsWhiteSpace(type[end])
+            && identifier is "ref" or "in" or "out" or "params" or "readonly" or "scoped";
+    }
 
     static string FormatTypeDisplayName(string name, IReadOnlyList<TypeParameter> typeParameters)
     {
@@ -938,7 +955,7 @@ internal static class CSharpDeclarationWriter
         => string.Join(".", name.Split('.').Select(part => string.Join("+", part.Split('+').Select(EscapeIdentifier))));
 
     public static string EscapeIdentifier(string name)
-        => s_csharpReservedKeywords.Contains(name) || name == "await" ? "@" + name : name;
+        => s_csharpReservedKeywords.Contains(name) ? "@" + name : name;
 
     static bool IsIdentifierStart(char c) => char.IsLetter(c) || c == '_';
 
@@ -1282,6 +1299,7 @@ internal static class CSharpDeclarationWriter
 
     static readonly string[] s_parameterModifiers = ["this", "params", "ref", "out", "in", "scoped"];
 
+    // Keep synchronized with MetadataDeclarationQuery's legacy compatibility escaper.
     static readonly HashSet<string> s_csharpReservedKeywords = new(StringComparer.Ordinal)
     {
         "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked",
@@ -1292,6 +1310,6 @@ internal static class CSharpDeclarationWriter
         "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short",
         "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true",
         "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual",
-        "void", "volatile", "while",
+        "void", "volatile", "while", "await", "record", "required", "init", "file", "scoped",
     };
 }

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -920,7 +920,8 @@ internal static class CSharpDeclarationWriter
                 while (i < text.Length && IsIdentifierPart(text[i]))
                     i++;
                 string token = text[start..i];
-                sb.Append(names.Contains(token) ? EscapeIdentifier(token) : token);
+                bool alreadyEscaped = start > 0 && text[start - 1] == '@';
+                sb.Append(!alreadyEscaped && names.Contains(token) ? EscapeIdentifier(token) : token);
                 continue;
             }
             sb.Append(text[i++]);

--- a/src/ILInspector.CSharp/CSharpFormatter.cs
+++ b/src/ILInspector.CSharp/CSharpFormatter.cs
@@ -41,7 +41,7 @@ public sealed record CSharpFormattedDeclaration(
 /// </summary>
 public sealed class CSharpFormatter
 {
-    readonly CSharpDeclarationOptions _metadataOptions;
+    readonly CSharpDeclarationOptions _declarationOptions;
 
     public CSharpFormatter(CSharpFormatOptions? options = null)
     {
@@ -52,7 +52,7 @@ public sealed class CSharpFormatter
             throw new ArgumentOutOfRangeException(nameof(options), options.NamespacePolicy, "C# namespace policy must be defined.");
         var usings = options.Usings?.ToArray()
             ?? throw new ArgumentException("C# formatter usings cannot be null.", nameof(options));
-        _metadataOptions = ToMetadataOptions(options, usings);
+        _declarationOptions = ToDeclarationOptions(options, usings);
     }
 
     public string FormatMember(
@@ -65,7 +65,7 @@ public sealed class CSharpFormatter
         return CSharpDeclarationWriter.RenderMemberDeclaration(
             type,
             member,
-            _metadataOptions,
+            _declarationOptions,
             methodParameters);
     }
 
@@ -79,7 +79,7 @@ public sealed class CSharpFormatter
         return ToFormattedDeclaration(CSharpDeclarationWriter.RenderMemberUnit(
             type,
             member,
-            _metadataOptions,
+            _declarationOptions,
             methodParameters));
     }
 
@@ -88,13 +88,13 @@ public sealed class CSharpFormatter
         IReadOnlyList<ApiParameter>? primaryConstructorParameters = null)
     {
         ArgumentNullException.ThrowIfNull(type);
-        string declaration = CSharpDeclarationWriter.RenderTypeDeclaration(type, _metadataOptions);
+        string declaration = CSharpDeclarationWriter.RenderTypeDeclaration(type, _declarationOptions);
         if (primaryConstructorParameters is not { Count: > 0 })
             return declaration;
 
         string declarationWithoutAttributes = CSharpDeclarationWriter.RenderTypeDeclaration(
             type,
-            _metadataOptions with { IncludeCustomAttributes = false });
+            _declarationOptions with { IncludeCustomAttributes = false });
         if (!declaration.EndsWith(declarationWithoutAttributes, StringComparison.Ordinal))
         {
             throw new InvalidOperationException(
@@ -120,13 +120,13 @@ public sealed class CSharpFormatter
                 $"Delegate '{type.FullName}' requires a structured Invoke signature.");
         }
 
-        string attributes = _metadataOptions.IncludeCustomAttributes && type.Attributes.Count > 0
+        string attributes = _declarationOptions.IncludeCustomAttributes && type.Attributes.Count > 0
             ? $"[{string.Join(", ", type.Attributes)}] "
             : "";
         string unsafeText = invoke.IsUnsafe ? " unsafe" : "";
-        string parameters = string.Join(", ", signature.Parameters.Select(parameter => parameter.Declaration));
+        string parameters = FormatParameterList(signature.Parameters);
         string declaration =
-            $"{attributes}public{unsafeText} delegate {signature.ReturnType ?? "void"} {FormatTypeName(type, includeVariance: true)}({parameters})";
+            $"{attributes}{CSharpDeclarationWriter.TypeAccessibility(type)}{unsafeText} delegate {signature.ReturnType ?? "void"} {FormatTypeName(type, includeVariance: true)}{parameters}";
         foreach (var typeParameter in type.TypeParameters)
         {
             if (typeParameter.ConstraintsSummary is { } constraints)
@@ -150,7 +150,7 @@ public sealed class CSharpFormatter
         return ToFormattedDeclaration(CSharpDeclarationWriter.RenderTypeUnit(
             type,
             members,
-            _metadataOptions));
+            _declarationOptions));
     }
 
     public static string EscapeIdentifier(string identifier)
@@ -161,6 +161,22 @@ public sealed class CSharpFormatter
 
     public static string EscapeKnownIdentifiers(string text, IEnumerable<string> rawNames)
         => CSharpDeclarationWriter.EscapeKnownIdentifiers(text, rawNames);
+
+    public static string FormatParameter(ApiParameter parameter)
+    {
+        ArgumentNullException.ThrowIfNull(parameter);
+        return CSharpDeclarationWriter.EscapeQualifiedKeywordSegments(
+            CSharpDeclarationWriter.FormatParameter(parameter));
+    }
+
+    public static string FormatParameterList(IEnumerable<ApiParameter> parameters)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+        var values = parameters.ToArray();
+        if (values.Any(parameter => parameter is null))
+            throw new ArgumentException("C# parameter lists cannot contain null entries.", nameof(parameters));
+        return $"({string.Join(", ", values.Select(FormatParameter))})";
+    }
 
     public static string FormatTypeName(ApiType type, bool includeVariance = false)
     {
@@ -207,7 +223,7 @@ public sealed class CSharpFormatter
         return $": {target}({string.Join(", ", initializer.Arguments)})";
     }
 
-    static CSharpDeclarationOptions ToMetadataOptions(
+    static CSharpDeclarationOptions ToDeclarationOptions(
         CSharpFormatOptions options,
         IReadOnlyCollection<string> usings)
         => new()
@@ -249,13 +265,13 @@ public sealed class CSharpFormatter
         string declaration,
         IReadOnlyList<ApiParameter> parameters)
     {
-        string parameterList = string.Join(", ", parameters.Select(parameter => parameter.Declaration));
+        string parameterList = FormatParameterList(parameters);
         int constraints = declaration.IndexOf(" where ", StringComparison.Ordinal);
         string head = constraints >= 0 ? declaration[..constraints] : declaration;
         string tail = constraints >= 0 ? declaration[constraints..] : "";
         int inheritance = head.IndexOf(" : ", StringComparison.Ordinal);
         return inheritance >= 0
-            ? head[..inheritance] + $"({parameterList})" + head[inheritance..] + tail
-            : $"{head}({parameterList}){tail}";
+            ? head[..inheritance] + parameterList + head[inheritance..] + tail
+            : $"{head}{parameterList}{tail}";
     }
 }

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -427,6 +427,7 @@ public sealed class CSharpTypePrinter
             Namespace = type.Namespace,
             Name = type.Name,
             MetadataName = type.MetadataName,
+            Accessibility = type.Accessibility,
             Kind = type.Kind,
             Attributes = attributes?.ToList()!,
             EnumUnderlyingType = type.EnumUnderlyingType,

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -215,7 +215,7 @@ public class ReturnToSenderPrototypeTests
                     Assert.Equal("get_SameAssemblyType", first.Plan.TargetMethod.Method);
                     Assert.Equal(FidelityCheck.CompileBackStatus.Exact, first.Status);
                     Assert.Contains(first.Plan.Types, type => type.Name == "Helper");
-                    Assert.Contains(first.Plan.TypeRequirements, requirement =>
+                    Assert.Contains(first.Plan.Types, requirement =>
                         requirement.Type.DisplayName == "Helper"
                         && requirement.SourceFacts.Any(fact => fact.Id == "body-type"
                             && fact.Producer == "metadata"

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -230,7 +230,8 @@ public class ApiType
     public string? MetadataName { get; set; }
     
     /// <summary>
-    /// Access level for non-public types. Null for public types.
+    /// Access level for non-public types. Null means public, including for older
+    /// serialized surfaces; C# rendering preserves that compatibility fallback.
     /// </summary>
     public string? Accessibility { get; set; }
     public string Kind { get; set; } = "";  // class, struct, interface, enum, delegate

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -186,11 +186,6 @@ public class ApiSignature
         ? ""
         : $"({string.Join(", ", Parameters.Select(parameter => parameter.TypeWithModifier))})";
 
-    public string ParameterDeclarationsSummary => Parameters.Count == 0
-        ? "()"
-        : CSharpDeclarationWriter.EscapeQualifiedKeywordSegments(
-            $"({string.Join(", ", Parameters.Select(parameter => parameter.Declaration))})");
-
     public List<(string name, string type, bool hasDefault)> ParameterInfoSummary => Parameters
         .Select(parameter => (parameter.Name, parameter.TypeWithModifier, parameter.HasDefault))
         .ToList();
@@ -213,23 +208,6 @@ public class ApiParameter
     public string TypeWithModifier => string.IsNullOrEmpty(Modifier)
         ? Type
         : $"{Modifier} {Type}";
-
-    public string Declaration
-    {
-        get
-        {
-            var attributes = Attributes.Count == 0
-                ? ""
-                : $"[{string.Join(", ", Attributes)}] ";
-            var head = string.IsNullOrWhiteSpace(Name)
-                ? TypeWithModifier
-                : $"{TypeWithModifier} {CSharpDeclarationWriter.EscapeIdentifier(Name)}";
-            var declaration = HasDefault && DefaultValueText is { Length: > 0 }
-                ? $"{head} = {DefaultValueText}"
-                : head;
-            return attributes + declaration;
-        }
-    }
 }
 
 public class ApiAccessor
@@ -251,6 +229,10 @@ public class ApiType
     /// </summary>
     public string? MetadataName { get; set; }
     
+    /// <summary>
+    /// Access level for non-public types. Null for public types.
+    /// </summary>
+    public string? Accessibility { get; set; }
     public string Kind { get; set; } = "";  // class, struct, interface, enum, delegate
     public List<string> Attributes { get; set; } = [];
 

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -49,6 +49,7 @@ public static class ApiSurfaceExtractor
                 Namespace = typeNamespace,
                 Name = typeName,
                 MetadataName = GetMetadataName(reader, typeDef),
+                Accessibility = MetadataDeclarationQuery.TypeAccessibility(typeDef),
                 IsSealed = (attributes & TypeAttributes.Sealed) != 0,
                 IsAbstract = (attributes & TypeAttributes.Abstract) != 0,
                 Attributes = AttributeReader.RenderAttributes(reader, typeDef.GetCustomAttributes(), qualifyNames: true),

--- a/src/ILInspector.Metadata/AttributeReader.cs
+++ b/src/ILInspector.Metadata/AttributeReader.cs
@@ -581,7 +581,7 @@ public static class AttributeReader
         // Anything else with an integral value is an enum constant; a cast is
         // always valid. Naming the member is a later refinement.
         _ when value is byte or sbyte or short or ushort or int or uint or long or ulong
-            => $"({type}){value}",
+            => $"({MetadataDeclarationQuery.EscapeCompatibilityTypeKeywords(type)}){value}",
         _ => null,
     };
 
@@ -589,7 +589,9 @@ public static class AttributeReader
     {
         if (typeName.IndexOfAny(['`', '[', ',']) >= 0)
             return null;
-        return $"typeof({typeName.Replace('+', '.')})";
+        string escapedType = MetadataDeclarationQuery.EscapeCompatibilityTypeKeywords(
+            typeName.Replace('+', '.'));
+        return $"typeof({escapedType})";
     }
 
     static string EscapeCharLiteral(char value) => value switch

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -792,8 +792,7 @@ public static class MetadataDeclarationQuery
             }
 
             string identifier = type[index..end];
-            bool isTypeSyntaxKeyword = IsTypeSyntaxKeyword(identifier)
-                && (end == type.Length || type[end] != '.');
+            bool isTypeSyntaxKeyword = IsTypeSyntaxKeyword(type, identifier, index, end);
             if ((index == 0 || type[index - 1] != '@')
                 && EscapeIdentifier(identifier) != identifier
                 && !isTypeSyntaxKeyword)
@@ -806,11 +805,29 @@ public static class MetadataDeclarationQuery
         return builder.ToString();
     }
 
-    static bool IsTypeSyntaxKeyword(string identifier)
-        => identifier is "bool" or "byte" or "sbyte" or "char" or "decimal" or "double"
+    static bool IsTypeSyntaxKeyword(string type, string identifier, int start, int end)
+    {
+        if (identifier is "bool" or "byte" or "sbyte" or "char" or "decimal" or "double"
             or "float" or "int" or "uint" or "nint" or "nuint" or "long" or "ulong"
-            or "object" or "short" or "ushort" or "string" or "void" or "delegate"
-            or "ref" or "in" or "out" or "params" or "readonly" or "scoped" or "unmanaged";
+            or "object" or "short" or "ushort" or "string" or "void")
+        {
+            return end == type.Length || type[end] != '.';
+        }
+
+        if (identifier == "delegate")
+            return end < type.Length && type[end] == '*';
+
+        if (type.StartsWith("delegate*", StringComparison.Ordinal)
+            && identifier is "ref" or "in" or "out" or "readonly" or "unmanaged")
+        {
+            return true;
+        }
+
+        return start == 0
+            && end < type.Length
+            && char.IsWhiteSpace(type[end])
+            && identifier is "ref" or "in" or "out" or "params" or "readonly" or "scoped";
+    }
 
     // ApiMember.Signature is a legacy compatibility string. Keep its qualified
     // keyword escaping local rather than restoring declaration ownership to Metadata.
@@ -1192,6 +1209,7 @@ public static class MetadataDeclarationQuery
     static string EscapeIdentifier(string name)
         => ReservedKeywords.Contains(name) ? "@" + name : name;
 
+    // Keep synchronized with CSharpDeclarationWriter's owning spelling policy.
     static readonly HashSet<string> ReservedKeywords = new(StringComparer.Ordinal)
     {
         "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked",
@@ -1202,6 +1220,6 @@ public static class MetadataDeclarationQuery
         "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short",
         "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true",
         "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual",
-        "void", "volatile", "while", "record", "required", "init", "file", "scoped",
+        "void", "volatile", "while", "await", "record", "required", "init", "file", "scoped",
     };
 }

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -773,7 +773,7 @@ public static class MetadataDeclarationQuery
         return EscapeCompatibilityQualifiedKeywordSegments(attributes + declaration);
     }
 
-    static string EscapeCompatibilityTypeKeywords(string type)
+    internal static string EscapeCompatibilityTypeKeywords(string type)
     {
         var builder = new StringBuilder(type.Length);
         for (int index = 0; index < type.Length;)
@@ -792,9 +792,11 @@ public static class MetadataDeclarationQuery
             }
 
             string identifier = type[index..end];
+            bool isTypeSyntaxKeyword = IsTypeSyntaxKeyword(identifier)
+                && (end == type.Length || type[end] != '.');
             if ((index == 0 || type[index - 1] != '@')
                 && EscapeIdentifier(identifier) != identifier
-                && !IsTypeSyntaxKeyword(identifier))
+                && !isTypeSyntaxKeyword)
             {
                 builder.Append('@');
             }
@@ -1062,7 +1064,8 @@ public static class MetadataDeclarationQuery
                 continue;
             }
 
-            return $"({parameterType}){defaultValue.ToString(CultureInfo.InvariantCulture)}";
+            string escapedType = EscapeCompatibilityTypeKeywords(parameterType);
+            return $"({escapedType}){defaultValue.ToString(CultureInfo.InvariantCulture)}";
         }
 
         return "";

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -766,7 +766,74 @@ public static class MetadataDeclarationQuery
         var declaration = parameter.HasDefault && parameter.DefaultValueText is { Length: > 0 }
             ? $"{head} = {parameter.DefaultValueText}"
             : head;
-        return attributes + declaration;
+        return EscapeCompatibilityQualifiedKeywordSegments(attributes + declaration);
+    }
+
+    // ApiMember.Signature is a legacy compatibility string. Keep its qualified
+    // keyword escaping local rather than restoring declaration ownership to Metadata.
+    static string EscapeCompatibilityQualifiedKeywordSegments(string signature)
+    {
+        var builder = new StringBuilder(signature.Length);
+        bool inString = false;
+        bool inChar = false;
+        bool escapedCharacter = false;
+        for (int index = 0; index < signature.Length; index++)
+        {
+            char character = signature[index];
+            builder.Append(character);
+            if (inString || inChar)
+            {
+                if (escapedCharacter)
+                {
+                    escapedCharacter = false;
+                    continue;
+                }
+                if (character == '\\')
+                {
+                    escapedCharacter = true;
+                    continue;
+                }
+                if (inString && character == '"')
+                    inString = false;
+                else if (inChar && character == '\'')
+                    inChar = false;
+                continue;
+            }
+            if (character == '"')
+            {
+                inString = true;
+                continue;
+            }
+            if (character == '\'')
+            {
+                inChar = true;
+                continue;
+            }
+            if (character != '.'
+                || index + 1 >= signature.Length
+                || signature[index + 1] == '@'
+                || !(char.IsLetter(signature[index + 1]) || signature[index + 1] == '_'))
+            {
+                continue;
+            }
+
+            int start = index + 1;
+            int end = start + 1;
+            while (end < signature.Length
+                   && (char.IsLetterOrDigit(signature[end]) || signature[end] == '_'))
+            {
+                end++;
+            }
+
+            string segment = signature[start..end];
+            string escaped = EscapeIdentifier(segment);
+            if (escaped != segment)
+            {
+                builder.Append(escaped);
+                index = end - 1;
+            }
+        }
+        return builder.ToString();
     }
 
     static string AccessorText(ApiAccessor accessor)

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -760,14 +760,55 @@ public static class MetadataDeclarationQuery
         var attributes = parameter.Attributes.Count == 0
             ? ""
             : $"[{string.Join(", ", parameter.Attributes)}] ";
+        string type = EscapeCompatibilityTypeKeywords(parameter.Type);
+        string typeWithModifier = string.IsNullOrEmpty(parameter.Modifier)
+            ? type
+            : $"{parameter.Modifier} {type}";
         var head = string.IsNullOrWhiteSpace(parameter.Name)
-            ? parameter.TypeWithModifier
-            : $"{parameter.TypeWithModifier} {EscapeIdentifier(parameter.Name)}";
+            ? typeWithModifier
+            : $"{typeWithModifier} {EscapeIdentifier(parameter.Name)}";
         var declaration = parameter.HasDefault && parameter.DefaultValueText is { Length: > 0 }
             ? $"{head} = {parameter.DefaultValueText}"
             : head;
         return EscapeCompatibilityQualifiedKeywordSegments(attributes + declaration);
     }
+
+    static string EscapeCompatibilityTypeKeywords(string type)
+    {
+        var builder = new StringBuilder(type.Length);
+        for (int index = 0; index < type.Length;)
+        {
+            if (!(char.IsLetter(type[index]) || type[index] == '_'))
+            {
+                builder.Append(type[index++]);
+                continue;
+            }
+
+            int end = index + 1;
+            while (end < type.Length
+                   && (char.IsLetterOrDigit(type[end]) || type[end] == '_'))
+            {
+                end++;
+            }
+
+            string identifier = type[index..end];
+            if ((index == 0 || type[index - 1] != '@')
+                && EscapeIdentifier(identifier) != identifier
+                && !IsTypeSyntaxKeyword(identifier))
+            {
+                builder.Append('@');
+            }
+            builder.Append(identifier);
+            index = end;
+        }
+        return builder.ToString();
+    }
+
+    static bool IsTypeSyntaxKeyword(string identifier)
+        => identifier is "bool" or "byte" or "sbyte" or "char" or "decimal" or "double"
+            or "float" or "int" or "uint" or "nint" or "nuint" or "long" or "ulong"
+            or "object" or "short" or "ushort" or "string" or "void" or "delegate"
+            or "ref" or "in" or "out" or "params" or "readonly" or "scoped" or "unmanaged";
 
     // ApiMember.Signature is a legacy compatibility string. Keep its qualified
     // keyword escaping local rather than restoring declaration ownership to Metadata.
@@ -1088,7 +1129,7 @@ public static class MetadataDeclarationQuery
         var sb = new StringBuilder(value.Length + 2);
         sb.Append('"');
         foreach (char ch in value)
-            sb.Append(EscapeCharLiteral(ch));
+            sb.Append(ch == '"' ? "\\\"" : EscapeCharLiteral(ch));
         sb.Append('"');
         return sb.ToString();
     }

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -63,6 +63,7 @@ public static class MetadataDeclarationQuery
         {
             Namespace = ns,
             Name = name,
+            Accessibility = TypeAccessibility(typeDef),
             IsSealed = (attributes & TypeAttributes.Sealed) != 0,
             IsAbstract = (attributes & TypeAttributes.Abstract) != 0,
             Attributes = AttributeReader.RenderAttributes(reader, typeDef.GetCustomAttributes(), qualifyNames: true),
@@ -428,6 +429,18 @@ public static class MetadataDeclarationQuery
     public static string AccessibilityKeyword(MethodDefinition method)
         => AccessibilityKeyword(method.Attributes & MethodAttributes.MemberAccessMask);
 
+    internal static string? TypeAccessibility(TypeDefinition type)
+        => (type.Attributes & TypeAttributes.VisibilityMask) switch
+        {
+            TypeAttributes.NotPublic => "internal",
+            TypeAttributes.NestedPrivate => "private",
+            TypeAttributes.NestedFamily => "protected",
+            TypeAttributes.NestedAssembly => "internal",
+            TypeAttributes.NestedFamANDAssem => "private protected",
+            TypeAttributes.NestedFamORAssem => "protected internal",
+            _ => null,
+        };
+
     static IReadOnlyList<ApiParameter> MethodParameters(
         MetadataReader reader,
         MethodDefinition method,
@@ -726,7 +739,7 @@ public static class MetadataDeclarationQuery
 
     static string MethodSignatureText(MetadataMethodDeclaration declaration)
     {
-        var parameters = declaration.Signature.ParameterDeclarationsSummary;
+        var parameters = $"({string.Join(", ", declaration.Signature.Parameters.Select(ParameterDeclaration))})";
         var returnType = declaration.Signature.ReturnType ?? "void";
         return $"{returnType} {declaration.Signature.MemberName ?? declaration.MetadataName}{parameters}";
     }
@@ -739,7 +752,21 @@ public static class MetadataDeclarationQuery
             : "{ " + string.Join(" ", declaration.Signature.Accessors.Select(AccessorText)) + " }";
         return declaration.Signature.Parameters.Count == 0
             ? $"{returnType} {declaration.CSharpName} {accessors}"
-            : $"{returnType} this[{string.Join(", ", declaration.Signature.Parameters.Select(parameter => parameter.Declaration))}] {accessors}";
+            : $"{returnType} this[{string.Join(", ", declaration.Signature.Parameters.Select(ParameterDeclaration))}] {accessors}";
+    }
+
+    static string ParameterDeclaration(ApiParameter parameter)
+    {
+        var attributes = parameter.Attributes.Count == 0
+            ? ""
+            : $"[{string.Join(", ", parameter.Attributes)}] ";
+        var head = string.IsNullOrWhiteSpace(parameter.Name)
+            ? parameter.TypeWithModifier
+            : $"{parameter.TypeWithModifier} {EscapeIdentifier(parameter.Name)}";
+        var declaration = parameter.HasDefault && parameter.DefaultValueText is { Length: > 0 }
+            ? $"{head} = {parameter.DefaultValueText}"
+            : head;
+        return attributes + declaration;
     }
 
     static string AccessorText(ApiAccessor accessor)

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection.PortableExecutable;
+using ILInspector.CSharp;
 using ILInspector.Metadata;
 
 namespace DotnetInspector.Tests;
@@ -8,6 +9,8 @@ namespace DotnetInspector.Tests;
 /// </summary>
 public class ApiSurfaceExtractorTests
 {
+    static readonly CSharpFormatter Formatter = new();
+
     [Fact]
     public void Extract_IncludesParameterNamesInMethodSignatures()
     {
@@ -82,7 +85,13 @@ public class ApiSurfaceExtractorTests
         {
             var all = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
             // --all surfaces the top-level internal type so its members are inspectable (#1300).
-            Assert.Contains(all.Types, t => t.Name == nameof(InternalTopLevelSurfaceFixture));
+            var internalType = Assert.Single(
+                all.Types,
+                t => t.Name == nameof(InternalTopLevelSurfaceFixture));
+            Assert.Equal("internal", internalType.Accessibility);
+            Assert.StartsWith(
+                "internal class InternalTopLevelSurfaceFixture",
+                Formatter.FormatTypeDeclaration(internalType));
         }
 
         using (var stream = File.OpenRead(assemblyPath))
@@ -111,7 +120,7 @@ public class ApiSurfaceExtractorTests
         Assert.Equal("struct", refStruct.Kind);
         Assert.True(refStruct.IsByRefLike);
         Assert.False(refStruct.IsReadOnly);
-        var refStructDeclaration = CSharpDeclarationWriter.RenderTypeDeclaration(refStruct);
+        var refStructDeclaration = Formatter.FormatTypeDeclaration(refStruct);
         Assert.Contains("ref struct SampleRefStruct", refStructDeclaration);
         Assert.DoesNotContain("CompilerFeatureRequired", refStructDeclaration);
 
@@ -127,7 +136,7 @@ public class ApiSurfaceExtractorTests
 
         var inlineArray = surface.Types.FirstOrDefault(t => t.Name == "SampleInlineBuffer");
         Assert.NotNull(inlineArray);
-        var inlineArrayDeclaration = CSharpDeclarationWriter.RenderTypeDeclaration(inlineArray);
+        var inlineArrayDeclaration = Formatter.FormatTypeDeclaration(inlineArray);
         Assert.DoesNotContain("InlineArray", inlineArrayDeclaration);
     }
 
@@ -250,7 +259,7 @@ public class ApiSurfaceExtractorTests
         var method = testType.Members.FirstOrDefault(m => m.Name == "MethodWithMarshalAs");
         Assert.NotNull(method);
         Assert.NotNull(method.SignatureModel);
-        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(testType, method);
+        var declaration = Formatter.FormatMember(testType, method);
         Assert.Contains(
             "[System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)] int value",
             declaration);
@@ -290,7 +299,7 @@ public class ApiSurfaceExtractorTests
         Assert.NotNull(method);
         Assert.NotNull(method.SignatureModel);
         Assert.DoesNotContain("[return:", method.Signature);
-        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(testType, method);
+        var declaration = Formatter.FormatMember(testType, method);
         Assert.StartsWith(
             "[return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)] public int MethodWithReturnAttributes()",
             declaration,
@@ -298,7 +307,7 @@ public class ApiSurfaceExtractorTests
 
         var notNullMethod = testType.Members.FirstOrDefault(m => m.Name == "MethodWithReturnNotNull");
         Assert.NotNull(notNullMethod);
-        var notNullDeclaration = CSharpDeclarationWriter.RenderMemberDeclaration(testType, notNullMethod);
+        var notNullDeclaration = Formatter.FormatMember(testType, notNullMethod);
         Assert.StartsWith(
             "[return: System.Diagnostics.CodeAnalysis.NotNull] public string MethodWithReturnNotNull()",
             notNullDeclaration,
@@ -307,7 +316,7 @@ public class ApiSurfaceExtractorTests
         var fallbackMethod = testType.Members.FirstOrDefault(m => m.Name == "MethodWithReturnAttributesAndFallbackSignature");
         Assert.NotNull(fallbackMethod);
         Assert.DoesNotContain("[return:", fallbackMethod.Signature);
-        var fallbackDeclaration = CSharpDeclarationWriter.RenderMemberDeclaration(testType, fallbackMethod);
+        var fallbackDeclaration = Formatter.FormatMember(testType, fallbackMethod);
         Assert.StartsWith(
             "[return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)] public int MethodWithReturnAttributesAndFallbackSignature(",
             fallbackDeclaration,
@@ -332,17 +341,17 @@ public class ApiSurfaceExtractorTests
 
         var textProperty = testType.Members.FirstOrDefault(m => m.Name == "PropertyWithReturnNotNull");
         Assert.NotNull(textProperty);
-        var textDeclaration = CSharpDeclarationWriter.RenderMemberDeclaration(testType, textProperty);
+        var textDeclaration = Formatter.FormatMember(testType, textProperty);
         Assert.Contains("string PropertyWithReturnNotNull { [return: System.Diagnostics.CodeAnalysis.NotNull] get; }", textDeclaration);
 
         var numberProperty = testType.Members.FirstOrDefault(m => m.Name == "PropertyWithReturnMarshalAs");
         Assert.NotNull(numberProperty);
-        var numberDeclaration = CSharpDeclarationWriter.RenderMemberDeclaration(testType, numberProperty);
+        var numberDeclaration = Formatter.FormatMember(testType, numberProperty);
         Assert.Contains("int PropertyWithReturnMarshalAs { [return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)] get; }", numberDeclaration);
 
         var indexer = testType.Members.FirstOrDefault(m => m.Name == "Item");
         Assert.NotNull(indexer);
-        var indexerDeclaration = CSharpDeclarationWriter.RenderMemberDeclaration(testType, indexer);
+        var indexerDeclaration = Formatter.FormatMember(testType, indexer);
         Assert.Contains("this[int index] { [return: System.Diagnostics.CodeAnalysis.NotNull] get; }", indexerDeclaration);
     }
 
@@ -360,7 +369,7 @@ public class ApiSurfaceExtractorTests
 
         var method = testType.Members.FirstOrDefault(m => m.Name == "MethodWithMemberAttribute");
         Assert.NotNull(method);
-        var methodDeclaration = CSharpDeclarationWriter.RenderMemberDeclaration(testType, method);
+        var methodDeclaration = Formatter.FormatMember(testType, method);
         Assert.StartsWith(
             "[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage] public int MethodWithMemberAttribute()",
             methodDeclaration,
@@ -368,7 +377,7 @@ public class ApiSurfaceExtractorTests
 
         var property = testType.Members.FirstOrDefault(m => m.Name == "PropertyWithMemberAttribute");
         Assert.NotNull(property);
-        var propertyDeclaration = CSharpDeclarationWriter.RenderMemberDeclaration(testType, property);
+        var propertyDeclaration = Formatter.FormatMember(testType, property);
         Assert.StartsWith(
             "[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage] public string PropertyWithMemberAttribute",
             propertyDeclaration,
@@ -376,7 +385,7 @@ public class ApiSurfaceExtractorTests
 
         var decimalField = testType.Members.FirstOrDefault(m => m.Name == "DecimalField");
         Assert.NotNull(decimalField);
-        var decimalFieldDeclaration = CSharpDeclarationWriter.RenderMemberDeclaration(testType, decimalField);
+        var decimalFieldDeclaration = Formatter.FormatMember(testType, decimalField);
         Assert.DoesNotContain("DecimalConstant", decimalFieldDeclaration);
         Assert.Contains("DecimalField", decimalFieldDeclaration);
     }
@@ -393,7 +402,7 @@ public class ApiSurfaceExtractorTests
         var testType = surface.Types.FirstOrDefault(t => t.Name == nameof(SampleTypeAttributeHost));
         Assert.NotNull(testType);
 
-        var declaration = CSharpDeclarationWriter.RenderTypeDeclaration(testType);
+        var declaration = Formatter.FormatTypeDeclaration(testType);
         Assert.StartsWith(
             "[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage] public class SampleTypeAttributeHost",
             declaration,

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1116,7 +1116,7 @@ public static class ApiOutputFormatter
                     return ConstructorCallFromDeclaration(declaration);
             }
 
-            return signature.ParameterDeclarationsSummary;
+            return CSharpFormatter.FormatParameterList(signature.Parameters);
         }
 
         // Compatibility-only fallback for legacy signatures without complete
@@ -1129,7 +1129,7 @@ public static class ApiOutputFormatter
         return type.TypeParameters
             .Concat(signature.TypeParameters)
             .Select(parameter => parameter.Name)
-            .Any(name => CSharpDeclarationWriter.EscapeIdentifier(name) != name);
+            .Any(name => CSharpFormatter.EscapeIdentifier(name) != name);
     }
 
     private static string ConstructorCallFromDeclaration(string declaration)

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -72,28 +72,9 @@ public sealed class ApiSignatureModelTests
         Assert.Equal("int", ctor.SignatureModel.Parameters[1].Type);
         Assert.True(ctor.SignatureModel.Parameters[1].HasDefault);
         Assert.Equal("1", ctor.SignatureModel.Parameters[1].DefaultValueText);
-        Assert.Equal("(string name, int count = 1)", ctor.SignatureModel.ParameterDeclarationsSummary);
         Assert.Equal(
             [("name", "string", false), ("count", "int", true)],
             ctor.SignatureModel.ParameterInfoSummary);
-    }
-
-    [Fact]
-    public void ParameterDeclarationsSummary_EscapesKeywordNamesAndQualifiedTypeSegments()
-    {
-        var signature = new ApiSignature
-        {
-            Parameters =
-            [
-                new ApiParameter
-                {
-                    Type = "System.event.MyClass",
-                    Name = "event"
-                }
-            ]
-        };
-
-        Assert.Equal("(System.@event.MyClass @event)", signature.ParameterDeclarationsSummary);
     }
 
     [Fact]

--- a/tests/ILInspector.Metadata.Tests/GlobalKeywordTypeFixture.cs
+++ b/tests/ILInspector.Metadata.Tests/GlobalKeywordTypeFixture.cs
@@ -1,3 +1,13 @@
 public class @class
 {
 }
+
+public enum @event
+{
+    None
+}
+
+[System.AttributeUsage(System.AttributeTargets.Parameter)]
+public sealed class GlobalTypeAttribute(System.Type type, @event mode) : System.Attribute
+{
+}

--- a/tests/ILInspector.Metadata.Tests/GlobalKeywordTypeFixture.cs
+++ b/tests/ILInspector.Metadata.Tests/GlobalKeywordTypeFixture.cs
@@ -1,0 +1,3 @@
+public class @class
+{
+}

--- a/tests/ILInspector.Metadata.Tests/GlobalKeywordTypeFixture.cs
+++ b/tests/ILInspector.Metadata.Tests/GlobalKeywordTypeFixture.cs
@@ -7,6 +7,18 @@ public enum @event
     None
 }
 
+public class @delegate
+{
+}
+
+public class @readonly
+{
+}
+
+public class @scoped
+{
+}
+
 [System.AttributeUsage(System.AttributeTargets.Parameter)]
 public sealed class GlobalTypeAttribute : System.Attribute
 {

--- a/tests/ILInspector.Metadata.Tests/GlobalKeywordTypeFixture.cs
+++ b/tests/ILInspector.Metadata.Tests/GlobalKeywordTypeFixture.cs
@@ -8,6 +8,11 @@ public enum @event
 }
 
 [System.AttributeUsage(System.AttributeTargets.Parameter)]
-public sealed class GlobalTypeAttribute(System.Type type, @event mode) : System.Attribute
+public sealed class GlobalTypeAttribute : System.Attribute
 {
+    public GlobalTypeAttribute(System.Type type, @event mode)
+    {
+        _ = type;
+        _ = mode;
+    }
 }

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -122,6 +122,22 @@ public sealed class MetadataDeclarationQueryTests
     }
 
     [Fact]
+    public void TypeSurface_EscapesQualifiedKeywordParameterTypesInCompatibilitySignatures()
+    {
+        var surface = MetadataDeclarationQuery.GetTypeSurface(
+            Reader,
+            GetTypeDefinitionHandle(typeof(MetadataDeclarationQueryFixtures)));
+
+        var method = Assert.Single(surface.Members, member => member.Name == "QualifiedKeyword");
+
+        Assert.Contains(
+            "MetadataDeclarationQueryFixtures.@namespace @class",
+            method.Signature,
+            StringComparison.Ordinal);
+        Assert.Contains("\".namespace\"", method.Signature, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void SelfTypeSignature_IncludesDeclaringGenericParameters()
     {
         var type = GetTypeDefinition(typeof(MetadataDeclarationQueryFixtures.Container<>.Row<>));
@@ -271,6 +287,8 @@ public class MetadataDeclarationQueryFixtures
 
     public int @event = 1;
 
+    public void QualifiedKeyword(@namespace @class, string text = ".namespace") { }
+
     public volatile int VolatileField;
 
     public int PlainField;
@@ -289,5 +307,9 @@ public class MetadataDeclarationQueryFixtures
         public class Row<U>
         {
         }
+    }
+
+    public class @namespace
+    {
     }
 }

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -135,6 +135,13 @@ public sealed class MetadataDeclarationQueryTests
             method.Signature,
             StringComparison.Ordinal);
         Assert.Contains("\".namespace\"", method.Signature, StringComparison.Ordinal);
+
+        var globalKeyword = Assert.Single(
+            surface.Members,
+            member => member.Name == "GlobalKeyword");
+        Assert.Contains("@class value", globalKeyword.Signature, StringComparison.Ordinal);
+        Assert.Contains("List<@class> values = null", globalKeyword.Signature, StringComparison.Ordinal);
+        Assert.Contains("\"a\\\"b.class\"", globalKeyword.Signature, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -288,6 +295,13 @@ public class MetadataDeclarationQueryFixtures
     public int @event = 1;
 
     public void QualifiedKeyword(@namespace @class, string text = ".namespace") { }
+
+    public void GlobalKeyword(
+        global::@class value,
+        List<global::@class>? values = null,
+        string text = "a\"b.class")
+    {
+    }
 
     public volatile int VolatileField;
 

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -153,6 +153,13 @@ public sealed class MetadataDeclarationQueryTests
             globalKeyword.Signature,
             StringComparison.Ordinal);
         Assert.Contains("\"a\\\"b.class\"", globalKeyword.Signature, StringComparison.Ordinal);
+
+        var syntaxKeywords = Assert.Single(
+            surface.Members,
+            member => member.Name == "SyntaxKeywordTypes");
+        Assert.Contains("@delegate delegateValue", syntaxKeywords.Signature, StringComparison.Ordinal);
+        Assert.Contains("@readonly readonlyValue", syntaxKeywords.Signature, StringComparison.Ordinal);
+        Assert.Contains("@scoped scopedValue", syntaxKeywords.Signature, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -312,6 +319,13 @@ public class MetadataDeclarationQueryFixtures
         List<global::@class>? values = null,
         global::@event mode = (global::@event)1,
         string text = "a\"b.class")
+    {
+    }
+
+    public void SyntaxKeywordTypes(
+        global::@delegate delegateValue,
+        global::@readonly readonlyValue,
+        global::@scoped scopedValue)
     {
     }
 

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -139,8 +139,19 @@ public sealed class MetadataDeclarationQueryTests
         var globalKeyword = Assert.Single(
             surface.Members,
             member => member.Name == "GlobalKeyword");
+        Assert.Contains(
+            "GlobalType(typeof(@class), (@event)1)",
+            globalKeyword.SignatureModel!.Parameters[0].Attributes);
+        Assert.Equal(
+            "(@event)1",
+            globalKeyword.SignatureModel.Parameters[2].DefaultValueText);
         Assert.Contains("@class value", globalKeyword.Signature, StringComparison.Ordinal);
         Assert.Contains("List<@class> values = null", globalKeyword.Signature, StringComparison.Ordinal);
+        Assert.Contains("@event mode = (@event)1", globalKeyword.Signature, StringComparison.Ordinal);
+        Assert.Contains(
+            "GlobalType(typeof(@class), (@event)1)",
+            globalKeyword.Signature,
+            StringComparison.Ordinal);
         Assert.Contains("\"a\\\"b.class\"", globalKeyword.Signature, StringComparison.Ordinal);
     }
 
@@ -297,8 +308,9 @@ public class MetadataDeclarationQueryFixtures
     public void QualifiedKeyword(@namespace @class, string text = ".namespace") { }
 
     public void GlobalKeyword(
-        global::@class value,
+        [global::GlobalType(typeof(global::@class), (global::@event)1)] global::@class value,
         List<global::@class>? values = null,
+        global::@event mode = (global::@event)1,
         string text = "a\"b.class")
     {
     }

--- a/tools/DecompilerHarness/ReturnToSenderClosureEvidence.cs
+++ b/tools/DecompilerHarness/ReturnToSenderClosureEvidence.cs
@@ -23,7 +23,7 @@ internal static class ReturnToSenderClosureEvidenceBuilder
     {
         ArgumentNullException.ThrowIfNull(plan);
 
-        var requirements = plan.TypeRequirements.Select(Requirement).ToArray();
+        var requirements = plan.Types.Select(Requirement).ToArray();
         var fallbacks = requirements
             .SelectMany(requirement => requirement.Facts)
             .Select(ParseRoslynFallback)
@@ -34,8 +34,8 @@ internal static class ReturnToSenderClosureEvidenceBuilder
             .ThenBy(fallback => fallback.Recovery, StringComparer.Ordinal)
             .ToArray();
         return new ReturnToSenderClosureEvidence(
-            plan.TypeRequirements.Count,
-            plan.TypeRequirements.Sum(requirement => requirement.RequiredMembers.Count),
+            plan.Types.Count,
+            plan.Types.Sum(requirement => requirement.RequiredMembers.Count),
             requirements.Count(requirement => requirement.RoslynRecovered),
             requirements.Count(requirement => requirement.RoslynRecoveredMemberSurface),
             fallbacks,

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -331,10 +331,7 @@ public sealed record CompileBackReconstructionPlan(
     CompileBackModuleRequirement Module,
     IReadOnlyList<CompileBackTypeRequirement> Types,
     IReadOnlyList<CSharpTypePrintRequest> PrintRequests,
-    IReadOnlyList<CompileBackPlanningDiagnostic> Diagnostics)
-{
-    public IReadOnlyList<CompileBackTypeRequirement> TypeRequirements => Types;
-}
+    IReadOnlyList<CompileBackPlanningDiagnostic> Diagnostics);
 
 public sealed record CompileBackMethodIdentity(
     string Type,


### PR DESCRIPTION
## Change

**Conclusion: PASS** — C# declaration spelling now lives behind
`ILInspector.CSharp.CSharpFormatter`; Metadata retains structured facts and
narrow compatibility signature text only. The obsolete RTS
`TypeRequirements => Types` transition alias is removed.

- Moves `CSharpDeclarationWriter` and its focused tests from Metadata to CSharp
  and makes the implementation internal.
- Moves parameter declaration/list spelling to `CSharpFormatter` and removes
  `ApiParameter.Declaration` / `ApiSignature.ParameterDeclarationsSummary`.
- Removes the RTS `TypeRequirements => Types` transition alias and updates all
  consumers to the canonical `Types` property.
- Carries structured type accessibility through extraction and CSharp snapshots,
  replacing the type/delegate `public` hardcode.
- Hardens keyword spelling at the CSharp/legacy-compatibility boundary and keeps
  the two keyword tables synchronized.
- Evidence revision: `cf7b19328311ae765097f0753928bb3587aac8ed`

## Scope and safety

- **Layering:** Metadata does not depend on CSharp; production declaration
  composition now has one CSharp-owned public seam.
- **Product path:** SRM-only, NativeAOT-friendly, Roslyn-free, and does not load
  inspected assemblies.
- **Accessibility rendering:** declarations for non-public types and delegates
  selected by `--all` now render their actual accessibility instead of the
  incorrect hardcoded `public`.
- **JSON schema:** detailed type JSON now includes `accessibility` for extracted
  non-public types. Public and older serialized `ApiType` values remain null;
  CSharp rendering deliberately treats null as `public` for compatibility.
- **Keyword compatibility:** CSharp and Metadata's narrow legacy-signature
  escaper use the same conservative keyword set. Function-pointer syntax remains
  syntax, while genuine types named `delegate`, `readonly`, or `scoped` escape.
- **RTS boundary:** harness orchestration consumes `Types`; shared CSharp owns
  source spelling.

## Declaration-surface A/B

Targeted A/B compares merge base `96320e8a` with `cf7b1932` against the same
head-built `dotnet-inspect.Tests.dll` fixture.

```diff
-public class InternalTopLevelSurfaceFixture
+internal class InternalTopLevelSurfaceFixture
```

Detailed CLI JSON has the single expected schema addition:

```diff
   "metadata_name": "InternalTopLevelSurfaceFixture",
+  "accessibility": "internal",
   "kind": "class",
```

The `type --all --markdown -v:d` member surface is byte-identical
(`sha256 83454f51b184bc88ca11945621d0ed1f19c8403c7b14227e53a3353e9ff30df1`
on both sides). Focused type-printer tests cover the corresponding non-public
delegate declaration.

## Evidence

| Check | Result |
| --- | --- |
| Release solution build | Pass |
| `ILInspector.CSharp.Tests` | 90 passed |
| `ILInspector.Metadata.Tests` | 418 passed |
| `dotnet-inspect.Tests` | 1,777 passed, 10 tool-dependent skips |
| `ReturnToSenderPrototypeTests` | 96 passed |
| Render-text A/B | 89,065 methods, 0 changed, 0 added, 0 removed |

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity compiled 350 methods (compile-cap 25; per-sample, not corpus-wide); fidelity sampled 36 / 89,065 (0.04%)

| Metric | Change | Count delta |
| ------ | ------ | ----------- |
| Fully raised (+) | 78,406 (88.03%) → 78,406 (88.03%) (neutral) | 0 |
| Conditional-branch residual (-) | 2,401 (2.70%) → 2,401 (2.70%) (neutral) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) → 2,286 (2.57%) (neutral) | 0 |
| Full malformed (-) | 0 → 0 (neutral) | 0 |
| Semantic defects (sampling differs) | 54 (0.21%) → 0 (0.00%) | n/a |
| Fidelity opcode diffs (sampling differs) | 4 (11.11%) → 3 (8.33%) | n/a |
| Fidelity exact (sampling differs) | 32 (88.89%) → 33 (91.67%) | n/a |
| Fidelity recompile failures (sampling differs) | 0 (0.00%) → 0 (0.00%) | n/a |
| Fidelity context failures (sampling differs) | 0 (0.00%) → 0 (0.00%) | n/a |
| Fidelity check coverage (+) | 36 (0.04%) → 36 (0.04%) (neutral) | 0 |
| Pass bugs (-) | 0 → 0 (neutral) | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 88.03% -> 88.03% (0 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); semantic defects ungated (sampling differs); fidelity ungated (sampling differs; rely on changed-method fidelity).

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- validity cap lower than baseline (baseline 4000, current 25)
- semantic checked methods lower than baseline (baseline 25183, current 350)

The generated advisory is the documented cap mismatch: all pinned rate/count
gates are neutral, pass bugs remain zero, and the explicit merge-base render A/B
has no changed methods.

## Review

Earlier adversarial rounds found compatibility-signature keyword escaping,
quoted defaults, global keyword-type, and metadata-expression edge cases; all
were resolved with compiled fixtures and integration coverage. Owner feedback
on declaration evidence, keyword-policy skew, syntax/type-identity ambiguity,
and the null accessibility fallback is addressed by `cf7b1932`. Exact-head
signoff re-review is in progress.
