### PR TITLE
Add product fidelity cause section

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ context for copied DLLs. A future `--deps` source can represent runtime
 | Relationships | `depends`, `extensions`, `implements` | Type hierarchies, package dependencies, library reference graphs, extension methods/properties, implementors and subclasses. Add `--project` to search project-referenced packages. |
 | Source mapping | `type`/`library`/`package -S "Source Files"`, `member -S "Source Locations"` / `"Original Source"` | SourceLink URLs, member file/line locations, source fetching, URL verification, token+IL-offset to source-line resolution. |
 | Performance analysis *(experimental)* | `library`/`type`/`member -S "Top Leverage"`, `"Performance Triage"`, `"Call Graph"`, `"Caller Graph"` | Whole-assembly call-graph leverage ranking — direct callers, root reach, fanout, depth, loop calls — with opt-in per-node cost signals (alloc, copy, unsafe, reflection, throw/exception, catch/finally) and actionable rewrite-shape detection. |
-| Decompiler *(experimental)* | `member -S @Source` (`Decompiled Source`, `Annotated Source`, `Original Source`, `Source Diff`, `IL`) | Raises method bodies to C#, interleaves IL and hidden-fact annotations, diffs SourceLink-backed source against decompiled source, and degrades honestly with `DEC####` fidelity diagnostics rather than emitting plausible-but-wrong source. |
+| Decompiler *(experimental)* | `member -S @Source` (`Decompiled Source`, `Annotated Source`, `Original Source`, `Source Diff`, `IL`); `member -S "Fidelity Causes"` | Raises method bodies to C#, interleaves IL and hidden-fact annotations, diffs SourceLink-backed source against decompiled source, and exposes typed `DEC####` fidelity causes rather than emitting plausible-but-wrong source. |
 | Agent-friendly output | global flags | Markdown by default, compact `--table`, normalized `--tsv`, `--jsonl`, `--plaintext`, `--json`, Mermaid diagrams, section/field projection, `--count`, table row limiting, built-in head/tail limiting. |
 
 ## Command inventory
@@ -226,13 +226,16 @@ honestly: IL with no faithful C# spelling renders as a visible comment and
 lowers the result's fidelity level (`Full` → `Partial` → `StructuredOnly` →
 `IlOnly` → `Failed`) instead of emitting plausible-but-wrong source, with a
 stable `DEC####` diagnostic on every degradation. If output looks wrong,
-capture all four sections; maintainers diagnose pipeline state with
+capture all four sections; select `Fidelity Causes` for the typed cause census
+behind the grade. That section distinguishes Full fidelity, an absent method
+body, and inspection failure. Maintainers diagnose pipeline state with
 DecompilerHarness.
 
 ```bash
 dotnet-inspect member JsonSerializer --package System.Text.Json Serialize:1 -S @Source
 dotnet-inspect member MyType Method:1 --library MyLib.dll -S "Decompiled Source"
 dotnet-inspect member MyType Method:1 --library MyLib.dll -S "Annotated Source"
+dotnet-inspect member MyType Method:1 --library MyLib.dll -S "Fidelity Causes"
 dotnet-inspect library MyLib.dll --il-offset 0x06000001+0x5
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,7 +80,9 @@ Inspects .NET library files (PE/COFF format):
 Extract public API surface using metadata:
 
 - `type` renders type shape, summaries, members, and `--shape` declarations
-- `member` renders member tables, docs, `Member Index` selectors, decompiled/lowered C#, SourceLink-backed original source, and IL
+- `member` renders member tables, docs, `Member Index` selectors,
+  decompiled/lowered C#, typed decompiler fidelity causes, SourceLink-backed
+  original source, and IL
 - Both support package/platform/library sources and section/field projection
 
 ### diff

--- a/docs/design/finding-producers.md
+++ b/docs/design/finding-producers.md
@@ -180,6 +180,12 @@ IL-ordered `Finding<DirectCall>` census. Research retains the complete native
 comparison only when requested, so `Present` remains observable without
 increasing the ordinary Body Signals result.
 
+Decompiler fidelity uses the same retention rule in the single-version product
+path. The member command's opt-in `Fidelity Causes` section keeps the complete
+`FindingInspection<DecompilerFidelityCause>` through member acquisition and
+projects it only when rendering. A complete empty census, absent method body,
+and failed inspection therefore remain distinct product outcomes.
+
 The remaining Analysis body observations preserve their native families:
 
 - definite unsafe IL operations use an IL-ordered

--- a/skills/decompiler/SKILL.md
+++ b/skills/decompiler/SKILL.md
@@ -50,6 +50,14 @@ If decompiled output looks wrong, capture `Decompiled Source`, `Annotated
 Source`, `Original Source` (via the `sourcelink` skill), and `IL` together;
 maintainers diagnose pipeline state with DecompilerHarness.
 
+Select `Fidelity Causes` for the typed `DEC####` cause census behind that
+fidelity grade. It distinguishes a Full method (complete, no causes), a method
+without a body (absent), and a failed inspection.
+
+```bash
+dnx dotnet-inspect -y -- member MyType MyMethod:1 --library MyLib.dll -S "Fidelity Causes"
+```
+
 ## Locate code by IL offset
 
 ```bash

--- a/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
@@ -60,6 +60,18 @@ public class ResearchFactRegistryTests
     }
 
     [Fact]
+    public void RunProjection_AllowsEmptyBodyOnlyCSharp()
+    {
+        var result = ResearchViews.RunProjection(
+            () => DecompilerResult.Success(""),
+            emptyOutputIsFailure: false);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("", result.Output);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
     public void EmptyRegistry_ProducesNoOverlayFacts()
     {
         using var source = MetadataSource.Open(typeof(ResearchFixture).Assembly.Location);

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -77,7 +77,7 @@ public static class ResearchViews
                         request.AnnotatedStage,
                         request.OverloadIndex,
                         request.PublicOnly),
-                        emptyOutputIsFailure: true),
+                        emptyOutputIsFailure: false),
                     request.Source);
             }
 
@@ -91,7 +91,7 @@ public static class ResearchViews
                     .Where(fact => fact.Descriptor.Category == AnnotationCategory.Cost)
                     .ToList();
                 var body = WithTrace(
-                    RunProjection(() => RenderRaisedOverlay(imported, costAnnotations), emptyOutputIsFailure: true),
+                    RunProjection(() => RenderRaisedOverlay(imported, costAnnotations), emptyOutputIsFailure: false),
                     request.Source);
                 costOverlay = new CostOverlayResult(body, costHeaderFacts);
             }
@@ -103,7 +103,7 @@ public static class ResearchViews
                     .Where(annotation => annotation.Descriptor.Category == AnnotationCategory.Semantics)
                     .ToList();
                 semanticsOverlay = WithTrace(
-                    RunProjection(() => RenderRaisedOverlay(imported, semanticsAnnotations), emptyOutputIsFailure: true),
+                    RunProjection(() => RenderRaisedOverlay(imported, semanticsAnnotations), emptyOutputIsFailure: false),
                     request.Source);
             }
 
@@ -221,7 +221,7 @@ public static class ResearchViews
             {
                 Output = AddTrailingComments(imported, result.Output, statementLines, annotations)
             };
-        }, emptyOutputIsFailure: true);
+        }, emptyOutputIsFailure: false);
     }
 
     public static DecompilerResult RenderMixed(

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3104,6 +3104,61 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_SelectedOverload_SelectFidelityCauses_ReportsCompleteEmptyCensus()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(FactsTableFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(FactsTableFixture.BoxInt), "-S", "Fidelity Causes", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("Complete", output);
+        Assert.Contains("decompiler fidelity is Full", output);
+    }
+
+    [Fact]
+    public async Task Member_SelectedOverload_SelectFidelityCauses_ReportsAbsentBody()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(SamplePInvokeClass).FullName!, "--library", TestAssemblyPath,
+            nameof(SamplePInvokeClass.GetCurrentProcessId), "--all",
+            "-S", "Fidelity Causes", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("Absent", output);
+        Assert.Contains("no decompiler IR body", output);
+    }
+
+    [Fact]
+    public async Task Member_SelectedOverload_SelectFidelityCauses_RendersTypedCause()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(FidelityCauseFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(FidelityCauseFixture.TypedReferenceType),
+            "-S", "Fidelity Causes", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("Complete", output);
+        Assert.Contains("DEC0004", output);
+        Assert.Contains("IL_0001", output);
+        Assert.Contains("mkrefany", output);
+    }
+
+    [Fact]
+    public async Task Member_FidelityCauses_IsExplicitOnly_NotShownAtDetailed()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(FactsTableFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(FactsTableFixture.BoxInt), "-v:d", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.DoesNotContain("Fidelity Causes", output);
+    }
+
+    [Fact]
     public async Task Member_SelectedOverload_SelectFacts_IncludesResearchHeaderFacts()
     {
         var (exit, output, error) = await RunAppAsync(
@@ -9292,5 +9347,14 @@ public static class CostOverlayFixture
         Span<int> values = stackalloc int[1];
         values[0] = value;
         return values[0];
+    }
+}
+
+public static class FidelityCauseFixture
+{
+    public static Type TypedReferenceType(ref int value)
+    {
+        TypedReference reference = __makeref(value);
+        return __reftype(reference);
     }
 }

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3142,7 +3142,7 @@ public class CommandExecutionTests
         Assert.Empty(error);
         Assert.Contains("Complete", output);
         Assert.Contains("DEC0004", output);
-        Assert.Contains("IL_0001", output);
+        Assert.Matches(@"IL_[0-9A-F]{4}", output);
         Assert.Contains("mkrefany", output);
     }
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1,4 +1,7 @@
 using System.IO.Compression;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Text.Json;
 using DotnetInspector.Fixtures;
@@ -24,6 +27,57 @@ public class CommandExecutionTests
 {
     private static readonly string TestAssemblyPath =
         typeof(CommandExecutionTests).Assembly.Location;
+
+    private static void WriteFidelityFailureAssembly(string path)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString("FidelityFailedFixture.dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("FidelityFailedFixture"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed,
+            metadata.GetOrAddString("FidelityFailedFixture"),
+            metadata.GetOrAddString("Malformed"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        var il = new BlobBuilder();
+        var instructions = new InstructionEncoder(il, new ControlFlowBuilder());
+        // The out-of-range method token is valid IL encoding but forces the
+        // importer down its diagnosed crash path when resolving the call.
+        instructions.Call(MetadataTokens.MethodDefinitionHandle(999));
+        instructions.OpCode(ILOpCode.Ret);
+        var methodBodies = new BlobBuilder();
+        var bodyEncoder = new MethodBodyStreamEncoder(methodBodies);
+        var bodyOffset = bodyEncoder.AddMethodBody(instructions, maxStack: 8);
+        metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Static,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("InvalidCall"),
+            metadata.GetOrAddBlob(new byte[] { 0x00, 0x00, 0x01 }),
+            bodyOffset,
+            MetadataTokens.ParameterHandle(1));
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            methodBodies,
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        File.WriteAllBytes(path, image.ToArray());
+    }
 
     private sealed class NestedDrillTarget
     {
@@ -3122,13 +3176,44 @@ public class CommandExecutionTests
         var (exit, output, error) = await RunAppAsync(
             "member", typeof(FidelityCauseFixture).FullName!, "--library", TestAssemblyPath,
             nameof(FidelityCauseFixture.EmptyBody),
-            "-S", "Fidelity Causes", "--table", "--tips", "q");
+            "-S", "Decompiled Source,Fidelity Causes", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
+        Assert.Contains("## Decompiled Source", output);
+        Assert.Contains("public static void EmptyBody()", output);
         Assert.Contains("Complete", output);
         Assert.Contains("decompiler fidelity is Full", output);
+        Assert.DoesNotContain(ILInspector.Decompiler.DiagnosticIds.EmptyOutput, output);
         Assert.DoesNotContain("Failed", output);
+    }
+
+    [Fact]
+    public async Task Member_SelectedOverload_SelectFidelityCauses_ImporterCrashIsFailed()
+    {
+        var assemblyPath = Path.Combine(
+            Path.GetTempPath(),
+            $"fidelity-failed-{Guid.NewGuid():N}.dll");
+        try
+        {
+            WriteFidelityFailureAssembly(assemblyPath);
+
+            var (exit, output, error) = await RunAppAsync(
+                "member", "FidelityFailedFixture.Malformed", "InvalidCall",
+                "--library", assemblyPath,
+                "-S", "Fidelity Causes", "--table", "--tips", "q");
+
+            Assert.Equal(0, exit);
+            Assert.Empty(error);
+            Assert.Contains("Failed", output);
+            Assert.Contains(ILInspector.Decompiler.DiagnosticIds.InternalError, output);
+            Assert.Contains("importer crash", output);
+            Assert.DoesNotContain("Absent", output);
+        }
+        finally
+        {
+            File.Delete(assemblyPath);
+        }
     }
 
     [Fact]
@@ -3151,14 +3236,27 @@ public class CommandExecutionTests
         var (exit, output, error) = await RunAppAsync(
             "member", typeof(FidelityCauseFixture).FullName!, "--library", TestAssemblyPath,
             nameof(FidelityCauseFixture.TypedReferenceType),
-            "-S", "Fidelity Causes", "--table", "--tips", "q");
+            "-S", "Fidelity Causes", "--tsv", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
+        Assert.StartsWith("state\tcode\tlocation\tnode_kind\tnode\tdiscriminator\treason", output);
         Assert.Contains("Complete", output);
         Assert.Contains("DEC0004", output);
         Assert.Matches(@"IL_[0-9A-F]{4}", output);
         Assert.Contains("mkrefany", output);
+    }
+
+    [Fact]
+    public async Task Member_SelectedOverload_DiscoverSchema_ListsFidelityCauses()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(FidelityCauseFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(FidelityCauseFixture.EmptyBody), "-D", "--schema");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("| Fidelity Causes | section (opt-in) |", output);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3176,11 +3176,15 @@ public class CommandExecutionTests
         var (exit, output, error) = await RunAppAsync(
             "member", typeof(FidelityCauseFixture).FullName!, "--library", TestAssemblyPath,
             nameof(FidelityCauseFixture.EmptyBody),
-            "-S", "Decompiled Source,Fidelity Causes", "--tips", "q");
+            "-S", "Decompiled Source,Fidelity Causes,Annotated Source,Cost Overlay,Semantics Overlay",
+            "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
         Assert.Contains("## Decompiled Source", output);
+        Assert.Contains("## Annotated Source", output);
+        Assert.Contains("## Cost Overlay", output);
+        Assert.Contains("## Semantics Overlay", output);
         Assert.Contains("public static void EmptyBody()", output);
         Assert.Contains("Complete", output);
         Assert.Contains("decompiler fidelity is Full", output);

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3117,6 +3117,21 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_SelectedOverload_SelectFidelityCauses_EmptyBodyIsComplete()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(FidelityCauseFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(FidelityCauseFixture.EmptyBody),
+            "-S", "Fidelity Causes", "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("Complete", output);
+        Assert.Contains("decompiler fidelity is Full", output);
+        Assert.DoesNotContain("Failed", output);
+    }
+
+    [Fact]
     public async Task Member_SelectedOverload_SelectFidelityCauses_ReportsAbsentBody()
     {
         var (exit, output, error) = await RunAppAsync(
@@ -9352,6 +9367,10 @@ public static class CostOverlayFixture
 
 public static class FidelityCauseFixture
 {
+    public static void EmptyBody()
+    {
+    }
+
     public static Type TypedReferenceType(ref int value)
     {
         TypedReference reference = __makeref(value);

--- a/src/dotnet-inspect.Tests/FidelityCauseSectionTests.cs
+++ b/src/dotnet-inspect.Tests/FidelityCauseSectionTests.cs
@@ -1,0 +1,92 @@
+using DotnetInspector.Output;
+using ILInspector.Decompiler;
+using ILInspector.Findings;
+
+namespace DotnetInspector.Tests;
+
+public class FidelityCauseSectionTests
+{
+    static readonly FindingSubject Subject = new("member:test", "Test.M");
+
+    [Fact]
+    public void BuildRows_CompleteEmpty_ReportsFullFidelity()
+    {
+        var inspection = new FindingInspection<DecompilerFidelityCause>.Complete([]);
+
+        var row = Assert.Single(ApiOutputFormatter.BuildFidelityCauseRows(inspection));
+
+        Assert.Equal("Complete", row.State);
+        Assert.Null(row.Code);
+        Assert.Contains("Full", row.Reason);
+    }
+
+    [Fact]
+    public void BuildRows_Complete_PreservesFindingOrderAndTypedLocations()
+    {
+        var inspection = new FindingInspection<DecompilerFidelityCause>.Complete(
+        [
+            Finding(
+                new DecompilerFidelityCause(
+                    "DEC0010",
+                    DecompilerFidelityLocation.Signature,
+                    "Function",
+                    "method signature",
+                    "unsupported signature type",
+                    "typedref"),
+                0),
+            Finding(
+                new DecompilerFidelityCause(
+                    "DEC0004",
+                    DecompilerFidelityLocation.AtIlOffset(0x2a),
+                    "UnsupportedNode",
+                    "mkrefany",
+                    "unsupported opcode",
+                    "mkrefany"),
+                1),
+            Finding(
+                new DecompilerFidelityCause(
+                    "DEC0014",
+                    DecompilerFidelityLocation.AtLocal(3),
+                    "PinnedLocal",
+                    "Pinned local V_3",
+                    "unraised pinned local"),
+                2),
+        ]);
+
+        var rows = ApiOutputFormatter.BuildFidelityCauseRows(inspection);
+
+        Assert.Equal(["DEC0010", "DEC0004", "DEC0014"], rows.Select(row => row.Code));
+        Assert.Equal("signature", rows[0].Location);
+        Assert.Contains("IL_002A", rows[1].Location);
+        Assert.Contains("V_3", rows[2].Location);
+    }
+
+    [Fact]
+    public void BuildRows_AbsentAndFailed_RemainDistinct()
+    {
+        var absent = new FindingInspection<DecompilerFidelityCause>.Absent("no body");
+        var failed = new FindingInspection<DecompilerFidelityCause>.Failed(
+            new InspectionError(
+                Subject,
+                DecompilerFindings.FidelityInspectionDescriptor,
+                "DEC0001: importer failed"));
+
+        var absentRow = Assert.Single(ApiOutputFormatter.BuildFidelityCauseRows(absent));
+        var failedRow = Assert.Single(ApiOutputFormatter.BuildFidelityCauseRows(failed));
+
+        Assert.Equal("Absent", absentRow.State);
+        Assert.Equal("no body", absentRow.Reason);
+        Assert.Equal("Failed", failedRow.State);
+        Assert.Equal("DEC0001: importer failed", failedRow.Reason);
+    }
+
+    static Finding<DecompilerFidelityCause> Finding(
+        DecompilerFidelityCause cause,
+        int ordinal)
+        => new(
+            Subject,
+            DecompilerFindings.FidelityCauseDescriptor,
+            new FindingKey(cause.Code),
+            cause,
+            ordinal);
+}

--- a/src/dotnet-inspect.Tests/FidelityCauseSectionTests.cs
+++ b/src/dotnet-inspect.Tests/FidelityCauseSectionTests.cs
@@ -1,3 +1,4 @@
+using DotnetInspector.Inspectors;
 using DotnetInspector.Output;
 using ILInspector.Decompiler;
 using ILInspector.Findings;
@@ -78,6 +79,30 @@ public class FidelityCauseSectionTests
         Assert.Equal("no body", absentRow.Reason);
         Assert.Equal("Failed", failedRow.State);
         Assert.Equal("DEC0001: importer failed", failedRow.Reason);
+    }
+
+    [Fact]
+    public void BuildInspection_DistinguishesNoBodyFromImporterFailure()
+    {
+        var importerFailure = DecompilerResult.Failure(
+            DiagnosticIds.InternalError,
+            "BadImageFormatException: invalid method body");
+
+        var absent = MemberCodeProvider.BuildFidelityCauseInspection(
+            methodHasBody: false,
+            raisedFunction: null,
+            importerFailure,
+            Subject);
+        var failed = MemberCodeProvider.BuildFidelityCauseInspection(
+            methodHasBody: true,
+            raisedFunction: null,
+            importerFailure,
+            Subject);
+
+        Assert.IsType<FindingInspection<DecompilerFidelityCause>.Absent>(absent.Value);
+        var failure = Assert.IsType<FindingInspection<DecompilerFidelityCause>.Failed>(failed.Value);
+        Assert.Contains(DiagnosticIds.InternalError, failure.Error.Reason);
+        Assert.Contains("BadImageFormatException", failure.Error.Reason);
     }
 
     static Finding<DecompilerFidelityCause> Finding(

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -354,6 +354,7 @@ public class SectionPipelineTests
         SectionNames.Signature,
         SectionNames.CustomAttributes,
         SectionNames.DecompiledSource,
+        SectionNames.FidelityCauses,
         SectionNames.AnnotatedSource,
         SectionNames.CostOverlay,
         SectionNames.SemanticsOverlay,

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -486,6 +486,7 @@ public static class MemberCommand
         SectionNames.Signature,
         SectionNames.CustomAttributes,
         SectionNames.DecompiledSource,
+        SectionNames.FidelityCauses,
         SectionNames.AnnotatedSource,
         SectionNames.OriginalSource,
         SectionNames.SourceDiff,

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -3,6 +3,7 @@ using System.Reflection.PortableExecutable;
 using DotnetInspector.Services;
 using ILInspector.Metadata;
 using ILInspector.Decompiler.Pipeline;
+using ILInspector.Findings;
 
 using Decompiler = ILInspector.Decompiler;
 
@@ -17,7 +18,7 @@ namespace DotnetInspector.Inspectors;
 /// </summary>
 internal static class MemberCodeProvider
 {
-    internal sealed record Request(bool DecompiledSource, bool AnnotatedSource, bool CostOverlay, bool SemanticsOverlay, bool IL, bool Attributes, bool Calls, bool Callers, bool CallGraph, bool UnsafeOperations, bool Facts = false, string? ProjectAssetsPath = null, string? TargetFramework = null);
+    internal sealed record Request(bool DecompiledSource, bool AnnotatedSource, bool CostOverlay, bool SemanticsOverlay, bool IL, bool Attributes, bool Calls, bool Callers, bool CallGraph, bool UnsafeOperations, bool Facts = false, bool FidelityCauses = false, string? ProjectAssetsPath = null, string? TargetFramework = null);
 
     /// <summary>
     /// Code content for one member. C# sections retain the complete decompiler
@@ -34,7 +35,8 @@ internal static class MemberCodeProvider
         string? ILText,
         string? ILDiagnostic,
         IReadOnlyList<(string Name, string? Value)>? Attributes,
-        IReadOnlyList<ILInspector.Research.ResearchViews.FactRow>? Facts = null);
+        IReadOnlyList<ILInspector.Research.ResearchViews.FactRow>? Facts = null,
+        FindingInspection<Decompiler.DecompilerFidelityCause>? FidelityCauses = null);
 
     internal static List<(ApiMember Member, Item Code)> Collect(
         ApiType type, List<ApiMember> methods, string dllPath, int? overloadIndex,
@@ -104,24 +106,58 @@ internal static class MemberCodeProvider
             // shown, independent of which sections were requested.
             var methodGenericParameters = MethodGenericParameterNames(
                 reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
+            var methodHasBody = SelectedMethodHasBody(
+                reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
 
             // Decompiled source: raised C# only, without annotations or interleaved IL.
             Decompiler.DecompilerResult? decompiledResult = null;
-            if (request.DecompiledSource && pipelineSource is not null)
+            Decompiler.DecompilerResult? projectionResult = null;
+            IrFunction? raisedFunction = null;
+            if ((request.DecompiledSource || request.FidelityCauses) && pipelineSource is not null)
             {
-                decompiledResult = TrimOutput(RenderDecompiledSource(
+                projectionResult = TrimOutput(RenderDecompiledSource(
                     pipelineSource,
                     lookupType,
                     method.Name,
                     lookupOverloadIndex,
-                    publicOnly));
-                decompiledResult = decompiledResult with
+                    publicOnly,
+                    out raisedFunction));
+                projectionResult = projectionResult with
                 {
                     Trace = new Decompiler.DecompilerTrace(
-                        decompiledResult.Fidelity,
+                        projectionResult.Fidelity,
                         pipelineSource.Symbols,
-                        decompiledResult.Diagnostics)
+                        projectionResult.Diagnostics)
                 };
+            }
+
+            if (request.DecompiledSource)
+                decompiledResult = projectionResult;
+
+            FindingInspection<Decompiler.DecompilerFidelityCause>? fidelityCauses = null;
+            if (request.FidelityCauses)
+            {
+                var subject = new FindingSubject(
+                    method.MetadataToken is { } token
+                        ? $"{Path.GetFullPath(dllPath)}#0x{token:X8}"
+                        : $"{Path.GetFullPath(dllPath)}::{lookupType}.{method.Name}#{lookupOverloadIndex}",
+                    $"{lookupType}.{method.Name}");
+                if (pipelineSource is null)
+                {
+                    fidelityCauses = new FindingInspection<Decompiler.DecompilerFidelityCause>.Failed(
+                        new InspectionError(
+                            subject,
+                            Decompiler.DecompilerFindings.FidelityInspectionDescriptor,
+                            "Decompiler metadata source could not be opened."));
+                }
+                else
+                {
+                    fidelityCauses = BuildFidelityCauseInspection(
+                        methodHasBody,
+                        raisedFunction,
+                        projectionResult,
+                        subject);
+                }
             }
 
             ILInspector.Research.ResearchViews.MemberProjectionResult? researchProjection = null;
@@ -198,7 +234,8 @@ internal static class MemberCodeProvider
                 ilText,
                 ilDiagnostic,
                 attributes,
-                facts)));
+                facts,
+                fidelityCauses)));
         }
 
         return results;
@@ -240,6 +277,47 @@ internal static class MemberCodeProvider
         return null;
     }
 
+    static bool SelectedMethodHasBody(
+        MetadataReader reader, TypeDefinitionHandle typeHandle, string methodName, int overloadIndex, bool publicOnly)
+    {
+        var typeDef = reader.GetTypeDefinition(typeHandle);
+        int matchCount = 0;
+        foreach (var methodHandle in typeDef.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (reader.GetString(method.Name) != methodName)
+                continue;
+            if (publicOnly && (method.Attributes & System.Reflection.MethodAttributes.MemberAccessMask) != System.Reflection.MethodAttributes.Public)
+                continue;
+            if (matchCount++ != overloadIndex)
+                continue;
+            return method.RelativeVirtualAddress != 0;
+        }
+        return false;
+    }
+
+    internal static FindingInspection<Decompiler.DecompilerFidelityCause> BuildFidelityCauseInspection(
+        bool methodHasBody,
+        IrFunction? raisedFunction,
+        Decompiler.DecompilerResult? projection,
+        FindingSubject subject)
+    {
+        if (!methodHasBody)
+            return Decompiler.DecompilerFindings.InspectFidelityCauses(null, subject);
+
+        if (raisedFunction is not null && projection?.Succeeded == true)
+            return Decompiler.DecompilerFindings.InspectFidelityCauses(raisedFunction, subject);
+
+        return new FindingInspection<Decompiler.DecompilerFidelityCause>.Failed(
+            new InspectionError(
+                subject,
+                Decompiler.DecompilerFindings.FidelityInspectionDescriptor,
+                string.Join(
+                    "; ",
+                    projection?.Diagnostics.Select(static diagnostic => diagnostic.ToString())
+                        ?? ["Decompiler import or projection failed."])));
+    }
+
     /// <summary>
     /// Opens the decompiler's reader for the code sections that need it
     /// (decompiled source, annotated source, IR stages), or null when none are
@@ -251,7 +329,7 @@ internal static class MemberCodeProvider
     /// </summary>
     static Decompiler.Pipeline.MetadataSource? OpenPipelineSource(Request request, string dllPath, string? pdbPath)
     {
-        if (!request.DecompiledSource && !request.AnnotatedSource && !request.CostOverlay && !request.SemanticsOverlay && !request.Facts)
+        if (!request.DecompiledSource && !request.AnnotatedSource && !request.CostOverlay && !request.SemanticsOverlay && !request.Facts && !request.FidelityCauses)
             return null;
         try
         {
@@ -276,20 +354,18 @@ internal static class MemberCodeProvider
         string type,
         string method,
         int overloadIndex,
-        bool publicOnly)
+        bool publicOnly,
+        out IrFunction? imported)
     {
+        imported = null;
         try
         {
-            var imported = IrImporter.Import(source, type, method, overloadIndex, publicOnly)
+            imported = IrImporter.Import(source, type, method, overloadIndex, publicOnly)
                 ?? throw new InvalidOperationException($"{type}::{method} has no IL body");
             var result = Decompiler.Pipeline.CSharpPrinter.PrintRaised(
                 imported,
                 target => IrImporter.Import(source, target));
-            if (result.Output is not { } output)
-                return result;
-            return string.IsNullOrWhiteSpace(output) && result.ConstructorChain is null
-                ? Decompiler.DecompilerResult.Failure(Decompiler.DiagnosticIds.EmptyOutput, "projection produced no output for a method with a body")
-                : result;
+            return result;
         }
         catch (Exception ex)
         {

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -305,8 +305,14 @@ internal static class MemberCodeProvider
         if (!methodHasBody)
             return Decompiler.DecompilerFindings.InspectFidelityCauses(null, subject);
 
-        if (raisedFunction is not null && projection?.Succeeded == true)
+        if (raisedFunction is not null
+            && projection is not null
+            && (projection.Succeeded
+                || projection.Diagnostics.All(
+                    static diagnostic => diagnostic.Id == Decompiler.DiagnosticIds.EmptyOutput)))
+        {
             return Decompiler.DecompilerFindings.InspectFidelityCauses(raisedFunction, subject);
+        }
 
         return new FindingInspection<Decompiler.DecompilerFidelityCause>.Failed(
             new InspectionError(

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -305,14 +305,8 @@ internal static class MemberCodeProvider
         if (!methodHasBody)
             return Decompiler.DecompilerFindings.InspectFidelityCauses(null, subject);
 
-        if (raisedFunction is not null
-            && projection is not null
-            && (projection.Succeeded
-                || projection.Diagnostics.All(
-                    static diagnostic => diagnostic.Id == Decompiler.DiagnosticIds.EmptyOutput)))
-        {
+        if (raisedFunction is not null && projection?.Succeeded == true)
             return Decompiler.DecompilerFindings.InspectFidelityCauses(raisedFunction, subject);
-        }
 
         return new FindingInspection<Decompiler.DecompilerFidelityCause>.Failed(
             new InspectionError(

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -2,6 +2,7 @@ using DotnetInspector.Inspectors;
 using DotnetInspector.Commands;
 using DotnetInspector.Core;
 using ILInspector.CSharp;
+using ILInspector.Findings;
 using ILInspector.Metadata;
 using ILInspector.MetadataPrimitives;
 using System.Collections.Immutable;
@@ -1153,6 +1154,7 @@ public static class ApiOutputFormatter
             CallGraph: requestedSections.Contains(SectionNames.CallGraph),
             UnsafeOperations: requestedSections.Contains(SectionNames.UnsafeOperations),
             Facts: requestedSections.Contains(SectionNames.Facts),
+            FidelityCauses: requestedSections.Contains(SectionNames.FidelityCauses),
             ProjectAssetsPath: options?.ProjectAssetsPath,
             TargetFramework: options?.Tfm);
 
@@ -1455,7 +1457,7 @@ public static class ApiOutputFormatter
             }
         }
 
-        if (request.DecompiledSource || request.AnnotatedSource || request.CostOverlay || request.SemanticsOverlay || request.IL || request.Attributes || request.Facts)
+        if (request.DecompiledSource || request.AnnotatedSource || request.CostOverlay || request.SemanticsOverlay || request.IL || request.Attributes || request.Facts || request.FidelityCauses)
             RequestTelemetry.Breadcrumb("method-body-load", singleMethod?.Name ?? type.Name);
 
         foreach (var (member, code) in MemberCodeProvider.Collect(type, methods, dllPath, overloadIndex, request, pdbPath, options?.IncludeAll ?? false))
@@ -1468,6 +1470,12 @@ public static class ApiOutputFormatter
             }
 
             hasCode |= PopulateCSharpSections(memberCode, type, member, code);
+
+            if (code.FidelityCauses is not null)
+            {
+                memberCode.FidelityCauseRows = BuildFidelityCauseRows(code.FidelityCauses);
+                hasCode = true;
+            }
 
             if ((code.ILText ?? code.ILDiagnostic) is { } ilText)
             {
@@ -1557,6 +1565,72 @@ public static class ApiOutputFormatter
 
         return hasCode;
     }
+
+    internal static List<FidelityCauseRow> BuildFidelityCauseRows(
+        FindingInspection<Decompiler.DecompilerFidelityCause> inspection)
+        => inspection switch
+        {
+            FindingInspection<Decompiler.DecompilerFidelityCause>.Complete complete
+                when complete.Findings.IsEmpty =>
+            [
+                new(
+                    "Complete",
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    "No fidelity causes; decompiler fidelity is Full.")
+            ],
+            FindingInspection<Decompiler.DecompilerFidelityCause>.Complete complete =>
+            [
+                .. complete.Findings.Select(static finding =>
+                {
+                    var cause = finding.Payload;
+                    return new FidelityCauseRow(
+                        "Complete",
+                        cause.Code,
+                        FormatFidelityLocation(cause.Location),
+                        cause.NodeKind,
+                        cause.Node,
+                        cause.Discriminator,
+                        cause.Reason);
+                })
+            ],
+            FindingInspection<Decompiler.DecompilerFidelityCause>.Absent absent =>
+            [
+                new(
+                    "Absent",
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    absent.Detail ?? "Method has no decompiler IR body.")
+            ],
+            FindingInspection<Decompiler.DecompilerFidelityCause>.Failed failed =>
+            [
+                new(
+                    "Failed",
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    failed.Error.Reason)
+            ],
+        };
+
+    static string FormatFidelityLocation(Decompiler.DecompilerFidelityLocation location)
+        => location.Kind switch
+        {
+            Decompiler.DecompilerFidelityLocationKind.Signature => "signature",
+            Decompiler.DecompilerFidelityLocationKind.IlOffset
+                when location.ILOffset is { } offset => MarkoutInline.Code($"IL_{offset:X4}"),
+            Decompiler.DecompilerFidelityLocationKind.Local
+                when location.LocalIndex is { } local => MarkoutInline.Code($"V_{local}"),
+            _ => "unknown",
+        };
 
     static void AddOrReplaceSummaryField(TypeView view, string name, string value)
     {

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -510,6 +510,7 @@ public static class ApiMemberOverloadSectionDescriptors
             .Add<ApiMemberSectionDescriptors.Events>()
             .Add<ApiMemberSectionDescriptors.MethodAttributes>(HasSingleMethodLikeMember)
             .Add<ApiMemberSectionDescriptors.DecompiledSource>(HasSingleMethodLikeMember)
+            .Add<ApiMemberDetailSectionDescriptors.FidelityCauses>(HasSingleMethodLikeMember)
             .Add<ApiMemberDetailSectionDescriptors.AnnotatedSource>(HasSingleMethodLikeMember)
             .Add<ApiMemberSectionDescriptors.OriginalSource>(HasSingleMethodLikeMember)
             .Add<ApiMemberDetailSectionDescriptors.SourceDiff>(HasSingleMethodLikeMember)
@@ -562,6 +563,7 @@ public static class ApiMemberDetailSectionDescriptors
             .Add<Signature>()
             .Add<MethodAttributes>()
             .Add<DecompiledSource>()
+            .Add<FidelityCauses>()
             .Add<AnnotatedSource>()
             .Add<CostOverlay>()
             .Add<SemanticsOverlay>()
@@ -634,6 +636,17 @@ public static class ApiMemberDetailSectionDescriptors
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
         public static SectionCapabilities Capabilities => SectionCapabilities.MayDownloadPdb;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
+    }
+
+    public sealed class FidelityCauses : ISectionDescriptor<ApiType>
+    {
+        public static string Name => SectionNames.FidelityCauses;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static bool ProbeEffectiveness => false;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -81,6 +81,9 @@ public static class SectionNames
     /// <summary>Section for the decompiled C# method body.</summary>
     public const string DecompiledSource = "Decompiled Source";
 
+    /// <summary>Section for typed causes that prevent Full decompiler fidelity.</summary>
+    public const string FidelityCauses = "Fidelity Causes";
+
     /// <summary>Section for the decompiled C# method body with hidden-fact annotations and interleaved IL.</summary>
     public const string AnnotatedSource = "Annotated Source";
 

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -628,6 +628,16 @@ public record ApiOneLineRow(string Kind, string Name,
 [MarkoutSerializable]
 public record ApiSurfaceOneLineRow(string Kind, string Type, string Members, string? Description);
 
+[MarkoutSerializable]
+public sealed record FidelityCauseRow(
+    string State,
+    string? Code,
+    string? Location,
+    [property: MarkoutPropertyName("Node Kind")] string? NodeKind,
+    string? Node,
+    string? Discriminator,
+    string? Reason);
+
 /// <summary>
 /// Code sections for member command output (Decompiled Source, Annotated Source, Original Source, IL).
 /// Serialized separately after the main TypeView.
@@ -637,6 +647,9 @@ public class MemberCodeView
 {
     [MarkoutSection(Name = "Decompiled Source")]
     public CodeSection DecompiledSourceCode { get; set; }
+
+    [MarkoutSection(Name = SectionNames.FidelityCauses)]
+    public List<FidelityCauseRow>? FidelityCauseRows { get; set; }
 
     [MarkoutSection(Name = "Annotated Source")]
     public CodeSection AnnotatedSourceCode { get; set; }
@@ -738,6 +751,7 @@ public partial class TypeViewContext : MarkoutSerializerContext
 [MarkoutContext(typeof(CallerSiteRow))]
 [MarkoutContext(typeof(UnsafeOperationRow))]
 [MarkoutContext(typeof(FactRow))]
+[MarkoutContext(typeof(FidelityCauseRow))]
 [MarkoutContext(typeof(TypeSourceFileRow))]
 [MarkoutContext(typeof(MemberSourceLocationRow))]
 [MarkoutContext(typeof(TypeSummaryRow))]


### PR DESCRIPTION
Follows #2666 by adding its first envelope-retaining product consumer.

## Change

**Conclusion:** **PASS** - the opt-in member `Fidelity Causes` section now
answers why a method is not Full fidelity without collapsing producer outcomes.

```bash
dotnet-inspect member <type> <method> -S "Fidelity Causes"
```

The section retains `FindingInspection<DecompilerFidelityCause>` through
acquisition and renders distinct outcomes for:

- `Complete` with a Full-fidelity empty census
- `Complete` with ordered typed causes and locations
- `Absent` when the selected method has no IL body
- `Failed` when import, context, or projection fails

When selected with `Decompiled Source`, both sections share one imported and
raised `IrFunction`. The section is explicit-only, is not part of `@Source`,
and participates in single-overload auto-selection.

## Evidence

| Check | Result |
| --- | --- |
| Release solution build | Pass |
| Non-AOT product build | Pass |
| Product suite | 1,776 passed, 10 skipped |
| Focused Debug fidelity tests | Pass |
| Changed Markdown | Pass |
| Decompiler quality corpus | Not applicable; no raise, typing, or printer behavior changed |

The compiled `TypedReferenceType` fixture provides a real importer canary for
`DEC0004` / `mkrefany`; an empty-body fixture verifies that valid raised IR
remains `Complete` and renders as valid empty C#. A malformed-token synthetic
PE verifies the command-level `Failed` path.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Clean on `48a3e372` | Verified aligned empty-body output, envelope states, malformed-input safety, and AOT constraints |
| Gemini 3.1 Pro | Clean on `48a3e372` | Verified importer/printer failure paths, synthetic PE determinism, routing, and output modes |

Earlier rounds found four actionable issues:

1. A null import could be misclassified as `Absent`; `13fd71e0` now uses the
   selected method's metadata body state and preserves failures.
2. The `mkrefany` test assumed a Release-only IL offset; `13fd71e0` now checks
   typed IL-location shape in both configurations.
3. A valid empty method body's fidelity inspection could be misclassified as
   `Failed`; `28da09a1` initially corrected the fidelity outcome.
4. Decompiled Source still reported that empty body as `DEC0003` while Fidelity
   Causes reported Full; `48a3e372` removes the invalid body-only C# failure
   synthesis so both sections agree, and adds command-level `Failed`, TSV, and
   discovery coverage.

Both reviewers re-reviewed the exact fixed head with no outstanding findings.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --no-restore --verbosity quiet
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --no-restore --verbosity quiet
dotnet run --project src/dotnet-inspect.Tests -c Release --no-build
dotnet run --project src/dotnet-inspect.Tests -c Debug -- \
  -method "*Member_SelectedOverload_SelectFidelityCauses_EmptyBodyIsComplete*" \
  -method "*Member_SelectedOverload_SelectFidelityCauses_RendersTypedCause*"
npx markdownlint-cli README.md docs/architecture.md \
  docs/design/finding-producers.md skills/decompiler/SKILL.md
```
