### PR TITLE
Preserve typed decompiler results through CLI formatting

### DIFF
--- a/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
@@ -1,3 +1,4 @@
+using ILInspector.Decompiler;
 using ILInspector.Decompiler.Annotations;
 using ILInspector.Decompiler.Pipeline;
 
@@ -13,6 +14,33 @@ public class ResearchFactRegistryTests
             new TestProducer("source"));
 
         Assert.Equal(["source", "consumer"], registry.ProducerNames);
+    }
+
+    [Fact]
+    public void MemberProjection_PreservesConstructorChainMetadata()
+    {
+        using var source = MetadataSource.Open(typeof(ResearchConstructorFixture).Assembly.Location);
+
+        var projection = ResearchViews.ProjectMember(new ResearchViews.MemberProjectionRequest(
+            source,
+            typeof(ResearchConstructorFixture).FullName!,
+            ".ctor",
+            AnnotatedSource: true,
+            CostOverlay: true,
+            SemanticsOverlay: true));
+
+        var results = new[]
+        {
+            Assert.IsType<DecompilerResult>(projection.AnnotatedSource),
+            Assert.IsType<DecompilerResult>(projection.CostOverlay?.Body),
+            Assert.IsType<DecompilerResult>(projection.SemanticsOverlay)
+        };
+        Assert.All(results, result =>
+        {
+            Assert.True(result.Succeeded, string.Join(Environment.NewLine, result.Diagnostics));
+            Assert.StartsWith("this(", result.ConstructorChain);
+            Assert.DoesNotContain(": this(", result.Output);
+        });
     }
 
     [Fact]
@@ -397,4 +425,17 @@ public static class ResearchFixture
     public static int LoopCaller18(int count) { int total = 18; for (int i = 0; i < count; i++) total += HighLoopLeverageCallee(i); return total; }
     public static int LoopCaller19(int count) { int total = 19; for (int i = 0; i < count; i++) total += HighLoopLeverageCallee(i); return total; }
     public static int LoopCaller20(int count) { int total = 20; for (int i = 0; i < count; i++) total += HighLoopLeverageCallee(i); return total; }
+}
+
+public sealed class ResearchConstructorFixture
+{
+    public ResearchConstructorFixture()
+        : this(42)
+    {
+    }
+
+    public ResearchConstructorFixture(int value)
+    {
+        GC.KeepAlive(value);
+    }
 }

--- a/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
@@ -44,6 +44,22 @@ public class ResearchFactRegistryTests
     }
 
     [Fact]
+    public void RunProjection_PreservesFailureDiagnostics()
+    {
+        var failure = DecompilerResult.Failure(
+            DiagnosticIds.ContextUnavailable,
+            "overlay context unavailable");
+
+        var result = ResearchViews.RunProjection(
+            () => failure,
+            emptyOutputIsFailure: true);
+
+        Assert.Same(failure, result);
+        Assert.Equal(DiagnosticIds.ContextUnavailable, Assert.Single(result.Diagnostics).Id);
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == DiagnosticIds.EmptyOutput);
+    }
+
+    [Fact]
     public void EmptyRegistry_ProducesNoOverlayFacts()
     {
         using var source = MetadataSource.Open(typeof(ResearchFixture).Assembly.Location);

--- a/src/ILInspector.Research/ILInspector.Research.csproj
+++ b/src/ILInspector.Research/ILInspector.Research.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="ILInspector.Research.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler\ILInspector.Decompiler.csproj" />
     <ProjectReference Include="..\ILInspector.Findings\ILInspector.Findings.csproj" />

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -68,7 +68,7 @@ public static class ResearchViews
             if (request.AnnotatedSource)
             {
                 annotatedSource = WithTrace(
-                    Run(() => RenderMixedCore(
+                    RunProjection(() => RenderMixedCore(
                         request.Source,
                         request.Type,
                         request.Method,
@@ -91,7 +91,7 @@ public static class ResearchViews
                     .Where(fact => fact.Descriptor.Category == AnnotationCategory.Cost)
                     .ToList();
                 var body = WithTrace(
-                    Run(() => RenderRaisedOverlay(imported, costAnnotations), emptyOutputIsFailure: true),
+                    RunProjection(() => RenderRaisedOverlay(imported, costAnnotations), emptyOutputIsFailure: true),
                     request.Source);
                 costOverlay = new CostOverlayResult(body, costHeaderFacts);
             }
@@ -103,7 +103,7 @@ public static class ResearchViews
                     .Where(annotation => annotation.Descriptor.Category == AnnotationCategory.Semantics)
                     .ToList();
                 semanticsOverlay = WithTrace(
-                    Run(() => RenderRaisedOverlay(imported, semanticsAnnotations), emptyOutputIsFailure: true),
+                    RunProjection(() => RenderRaisedOverlay(imported, semanticsAnnotations), emptyOutputIsFailure: true),
                     request.Source);
             }
 
@@ -209,7 +209,7 @@ public static class ResearchViews
         MetadataSource source, string type, string method, int overloadIndex = 0, bool publicOnly = false,
         ResearchFactRegistry? registry = null)
     {
-        return Run(() =>
+        return RunProjection(() =>
         {
             var imported = IrImporter.Import(source, type, method, overloadIndex, publicOnly)
                 ?? throw new InvalidOperationException($"{type}::{method} has no IL body");
@@ -241,7 +241,7 @@ public static class ResearchViews
         MetadataSource source, string type, string method, int overloadIndex = 0, bool publicOnly = false,
         ResearchFactRegistry? registry = null)
     {
-        return Run(() =>
+        return RunProjection(() =>
         {
             var annotations = CollectFacts(source, type, method, overloadIndex, publicOnly, registry);
             var result = IlProjection.Project(source, type, method, IlProjectionDepth.Annotated, overloadIndex, publicOnly);
@@ -468,7 +468,9 @@ public static class ResearchViews
         return line[..i];
     }
 
-    static DecompilerResult Run(Func<DecompilerResult> pipeline, bool emptyOutputIsFailure)
+    internal static DecompilerResult RunProjection(
+        Func<DecompilerResult> pipeline,
+        bool emptyOutputIsFailure)
     {
         DecompilerResult result;
         try

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -216,8 +216,11 @@ public static class ResearchViews
             var annotations = CollectFacts(source, imported, registry);
             var result = CSharpPrinter.PrintRaised(imported, out var statementLines);
             if (result.Output is null || annotations.Count == 0)
-                return result.Output ?? "";
-            return AddTrailingComments(imported, result.Output, statementLines, annotations);
+                return result;
+            return result with
+            {
+                Output = AddTrailingComments(imported, result.Output, statementLines, annotations)
+            };
         }, emptyOutputIsFailure: true);
     }
 
@@ -243,12 +246,12 @@ public static class ResearchViews
             var annotations = CollectFacts(source, type, method, overloadIndex, publicOnly, registry);
             var result = IlProjection.Project(source, type, method, IlProjectionDepth.Annotated, overloadIndex, publicOnly);
             if (result.Output is null)
-                return "";
-            return AddFactsToAnnotatedIl(result.Output, annotations);
+                return result;
+            return result with { Output = AddFactsToAnnotatedIl(result.Output, annotations) };
         }, emptyOutputIsFailure: true);
     }
 
-    static string RenderMixedCore(
+    static DecompilerResult RenderMixedCore(
         MetadataSource source, string type, string method, AnnotationStage stage, int overloadIndex, bool publicOnly,
         ResearchFactRegistry? registry)
     {
@@ -258,7 +261,7 @@ public static class ResearchViews
         return RenderMixedCore(source, type, method, imported, annotations, stage, overloadIndex, publicOnly);
     }
 
-    static string RenderMixedCore(
+    static DecompilerResult RenderMixedCore(
         MetadataSource source,
         string type,
         string method,
@@ -274,7 +277,7 @@ public static class ResearchViews
             ? CSharpPrinter.PrintLowered(imported, out var statementLines, importMethodBody: ImportMethodBody)
             : CSharpPrinter.PrintRaised(imported, out statementLines, importMethodBody: ImportMethodBody);
         if (csResult.Output is not { } csText)
-            return "";
+            return csResult;
 
         var spans = AnnotationAnchor.ComputeSpans(imported);
         var commentByLine = new Dictionary<int, string>();
@@ -321,19 +324,18 @@ public static class ResearchViews
         }
 
         var body = sb.ToString().TrimEnd();
-        if (csResult.ConstructorChain is { } chain)
-            return body.Length == 0 ? $": {chain}" : $": {chain}{Environment.NewLine}{body}";
-        return body;
+        return csResult with { Output = body };
     }
 
-    static string RenderRaisedOverlay(IrFunction imported, IReadOnlyList<Annotation> annotations)
+    static DecompilerResult RenderRaisedOverlay(IrFunction imported, IReadOnlyList<Annotation> annotations)
     {
         var result = CSharpPrinter.PrintRaised(imported, out var statementLines);
         if (result.Output is not { } output)
-            return "";
-        return annotations.Count == 0
+            return result;
+        var projected = annotations.Count == 0
             ? output
             : AddTrailingComments(imported, output, statementLines, annotations);
+        return result with { Output = projected };
     }
 
     static IReadOnlyList<FactRow> BuildFactRows(
@@ -466,19 +468,23 @@ public static class ResearchViews
         return line[..i];
     }
 
-    static DecompilerResult Run(Func<string> pipeline, bool emptyOutputIsFailure)
+    static DecompilerResult Run(Func<DecompilerResult> pipeline, bool emptyOutputIsFailure)
     {
-        string output;
+        DecompilerResult result;
         try
         {
-            output = pipeline();
+            result = pipeline();
         }
         catch (Exception ex)
         {
             return DecompilerResult.Failure(DiagnosticIds.InternalError, $"{ex.GetType().Name}: {ex.Message}");
         }
-        return emptyOutputIsFailure && string.IsNullOrWhiteSpace(output)
+        if (!result.Succeeded)
+            return result;
+        return emptyOutputIsFailure
+            && string.IsNullOrWhiteSpace(result.Output)
+            && result.ConstructorChain is null
             ? DecompilerResult.Failure(DiagnosticIds.EmptyOutput, "projection produced no output for a method with a body")
-            : DecompilerResult.Success(output);
+            : result;
     }
 }

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -3,8 +3,10 @@ using System.IO;
 using System.Linq;
 using System.Reflection.PortableExecutable;
 using DotnetInspector.Commands;
+using DotnetInspector.Inspectors;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
+using DotnetInspector.Views;
 using ILInspector.Analysis;
 using ILInspector.Decompiler;
 using ILInspector.Metadata;
@@ -176,6 +178,76 @@ public class ApiOutputFormatterTests
 
         Assert.Equal(expectedAsync, declaration.Contains(" async ", StringComparison.Ordinal));
     }
+
+    [Fact]
+    public void PopulateCSharpSections_PreservesOverlayFailureDiagnostics()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Worker", Kind = "class" };
+        var member = Method("Run");
+        var code = new MemberCodeProvider.Item(
+            DecompiledResult: null,
+            MethodGenericParameters: null,
+            AnnotatedResult: DecompilerResult.Failure(DiagnosticIds.ContextUnavailable, "annotated failure"),
+            CostOverlayResult: DecompilerResult.Failure(DiagnosticIds.UnsupportedConstruct, "cost failure"),
+            CostOverlayHeaderComments: null,
+            SemanticsOverlayResult: DecompilerResult.Failure(DiagnosticIds.UnsupportedType, "semantics failure"),
+            ILText: null,
+            ILDiagnostic: null,
+            Attributes: null);
+        var sections = new MemberCodeView();
+
+        Assert.True(ApiOutputFormatter.PopulateCSharpSections(sections, type, member, code));
+        Assert.Equal("// DEC0002: annotated failure", sections.AnnotatedSourceCode.Content);
+        Assert.Equal("// DEC0004: cost failure", sections.CostOverlayCode.Content);
+        Assert.Equal("// DEC0005: semantics failure", sections.SemanticsOverlayCode.Content);
+    }
+
+    [Fact]
+    public void PopulateCSharpSections_AppliesTypedAsyncEvidenceToAllOverlays()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Worker", Kind = "class" };
+        var member = Method("Run");
+        var containsAwait = DecompilerResult.Success("await Task.Yield();") with
+        {
+            ContainsAwaitExpression = true
+        };
+        var requiresAsync = DecompilerResult.Success("await Task.Yield();") with
+        {
+            RequiresAsyncBodyModifier = true
+        };
+        var code = new MemberCodeProvider.Item(
+            DecompiledResult: null,
+            MethodGenericParameters: null,
+            AnnotatedResult: containsAwait,
+            CostOverlayResult: containsAwait,
+            CostOverlayHeaderComments: ["// cost evidence"],
+            SemanticsOverlayResult: requiresAsync,
+            ILText: null,
+            ILDiagnostic: null,
+            Attributes: null);
+        var sections = new MemberCodeView();
+
+        Assert.True(ApiOutputFormatter.PopulateCSharpSections(sections, type, member, code));
+        Assert.Contains(" async ", Declaration(sections.AnnotatedSourceCode.Content));
+        Assert.Contains(" async ", Declaration(sections.CostOverlayCode.Content));
+        Assert.Contains("// cost evidence", sections.CostOverlayCode.Content);
+        Assert.Contains(" async ", Declaration(sections.SemanticsOverlayCode.Content));
+    }
+
+    static ApiMember Method(string name)
+        => new()
+        {
+            Name = name,
+            Kind = "method",
+            SignatureModel = new ApiSignature
+            {
+                MemberName = name,
+                ReturnType = "System.Threading.Tasks.Task"
+            }
+        };
+
+    static string Declaration(string source)
+        => source.ReplaceLineEndings("\n").Split('\n')[0];
 
     // --- Extraction: MetadataName reconstruction from real metadata (no ilasm) ---
 

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -6,6 +6,7 @@ using DotnetInspector.Commands;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using ILInspector.Analysis;
+using ILInspector.Decompiler;
 using ILInspector.Metadata;
 using Xunit;
 
@@ -90,6 +91,90 @@ public class ApiOutputFormatterTests
         var typeRef = TypeRef.SzArray(TypeRef.Definition(Asm, "", "A+B"));
 
         Assert.False(ApiOutputFormatter.SameType(typeRef, apiType));
+    }
+
+    [Fact]
+    public void FormatSourceWithDeclaration_UsesTypedConstructorChain()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Widget", Kind = "class" };
+        var constructor = new ApiMember
+        {
+            Name = ".ctor",
+            Kind = "constructor",
+            SignatureModel = new ApiSignature { MemberName = "#ctor" }
+        };
+        var result = DecompilerResult.Success("return;") with
+        {
+            ConstructorChain = "base(42)"
+        };
+
+        var source = ApiOutputFormatter.FormatSourceWithDeclaration(
+            type,
+            constructor,
+            methodGenericParameters: null,
+            result);
+
+        Assert.Contains("Widget() : base(42)", source.ReplaceLineEndings("\n").Split('\n')[0]);
+        Assert.DoesNotContain("    : base(42)", source);
+    }
+
+    [Fact]
+    public void FormatSourceWithDeclaration_DoesNotParseConstructorChainFromBodyText()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Widget", Kind = "class" };
+        var constructor = new ApiMember
+        {
+            Name = ".ctor",
+            Kind = "constructor",
+            SignatureModel = new ApiSignature { MemberName = "#ctor" }
+        };
+        var result = DecompilerResult.Success(": base(42)\nreturn;");
+
+        var source = ApiOutputFormatter.FormatSourceWithDeclaration(
+            type,
+            constructor,
+            methodGenericParameters: null,
+            result);
+        var lines = source.ReplaceLineEndings("\n").Split('\n');
+
+        Assert.DoesNotContain(": base(42)", lines[0]);
+        Assert.Contains("    : base(42)", lines);
+    }
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    public void FormatSourceWithDeclaration_UsesTypedAsyncEvidence(
+        bool containsAwaitExpression,
+        bool requiresAsyncBodyModifier,
+        bool expectedAsync)
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Worker", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Run",
+            Kind = "method",
+            SignatureModel = new ApiSignature
+            {
+                MemberName = "Run",
+                ReturnType = "System.Threading.Tasks.Task"
+            }
+        };
+        var result = DecompilerResult.Success("Console.WriteLine(\"await\");") with
+        {
+            ContainsAwaitExpression = containsAwaitExpression,
+            RequiresAsyncBodyModifier = requiresAsyncBodyModifier
+        };
+
+        var source = ApiOutputFormatter.FormatSourceWithDeclaration(
+            type,
+            member,
+            methodGenericParameters: null,
+            result);
+        var declaration = source.ReplaceLineEndings("\n").Split('\n')[0];
+
+        Assert.Equal(expectedAsync, declaration.Contains(" async ", StringComparison.Ordinal));
     }
 
     // --- Extraction: MetadataName reconstruction from real metadata (no ilasm) ---

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -32,6 +32,27 @@ public class CommandExecutionTests
         public int Value { get; }
     }
 
+    private abstract class ConstructorChainBase
+    {
+        protected ConstructorChainBase(int value)
+        {
+            GC.KeepAlive(value);
+        }
+    }
+
+    private sealed class ConstructorChainTarget : ConstructorChainBase
+    {
+        public ConstructorChainTarget(int value)
+            : base(value)
+        {
+        }
+    }
+
+    private sealed class AwaitTextTarget
+    {
+        public string AwaitText() => "await";
+    }
+
     private sealed class ILOffsetAsyncFixture
     {
         public async Task<int> StateMachineAsync()
@@ -617,6 +638,38 @@ public class CommandExecutionTests
         Assert.Empty(error);
         Assert.Contains("NestedDrillTarget", output);
         Assert.Contains("Value = value", output);
+    }
+
+    [Fact]
+    public async Task MemberCommand_PlacesTypedConstructorChainOnDeclaration()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "DotnetInspector.Tests.CommandExecutionTests+ConstructorChainTarget", ".ctor:1",
+            "--library", TestAssemblyPath,
+            "--all",
+            "-S", "Decompiled Source",
+            "-n", "80");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("ConstructorChainTarget(int value) : base(value)", output);
+        Assert.DoesNotContain("\n    : base(value)", output);
+    }
+
+    [Fact]
+    public async Task MemberCommand_DoesNotInferAsyncFromRenderedText()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "DotnetInspector.Tests.CommandExecutionTests+AwaitTextTarget", "AwaitText:1",
+            "--library", TestAssemblyPath,
+            "--all",
+            "-S", "Decompiled Source",
+            "-n", "80");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("\"await\"", output);
+        Assert.DoesNotContain(" async ", output);
     }
 
     // ── bare router ───────────────────────────────────────────────────

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -20,27 +20,21 @@ internal static class MemberCodeProvider
     internal sealed record Request(bool DecompiledSource, bool AnnotatedSource, bool CostOverlay, bool SemanticsOverlay, bool IL, bool Attributes, bool Calls, bool Callers, bool CallGraph, bool UnsafeOperations, bool Facts = false, string? ProjectAssetsPath = null, string? TargetFramework = null);
 
     /// <summary>
-    /// Code content for one member. Body and diagnostic are mutually
-    /// exclusive per section: a body renders (with declaration formatting
-    /// applied by the caller), a diagnostic renders verbatim as comments.
+    /// Code content for one member. C# sections retain the complete decompiler
+    /// result so declaration formatting consumes typed constructor and async
+    /// evidence instead of recovering it from rendered text.
     /// </summary>
     internal sealed record Item(
-        string? LoweredBody,
-        string? LoweredDiagnostic,
+        Decompiler.DecompilerResult? DecompiledResult,
         IReadOnlyList<string>? MethodGenericParameters,
-        string? AnnotatedBody,
-        string? AnnotatedDiagnostic,
-        string? CostOverlayBody,
+        Decompiler.DecompilerResult? AnnotatedResult,
+        Decompiler.DecompilerResult? CostOverlayResult,
         IReadOnlyList<string>? CostOverlayHeaderComments,
-        string? CostOverlayDiagnostic,
-        string? SemanticsOverlayBody,
-        string? SemanticsOverlayDiagnostic,
+        Decompiler.DecompilerResult? SemanticsOverlayResult,
         string? ILText,
         string? ILDiagnostic,
         IReadOnlyList<(string Name, string? Value)>? Attributes,
-        IReadOnlyList<ILInspector.Research.ResearchViews.FactRow>? Facts = null,
-        Decompiler.DecompilerTrace? DecompileTrace = null,
-        bool RequiresAsyncDeclaration = false);
+        IReadOnlyList<ILInspector.Research.ResearchViews.FactRow>? Facts = null);
 
     internal static List<(ApiMember Member, Item Code)> Collect(
         ApiType type, List<ApiMember> methods, string dllPath, int? overloadIndex,
@@ -112,16 +106,22 @@ internal static class MemberCodeProvider
                 reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
 
             // Decompiled source: raised C# only, without annotations or interleaved IL.
-            string? loweredBody = null, loweredDiagnostic = null;
-            Decompiler.DecompilerTrace? decompileTrace = null;
+            Decompiler.DecompilerResult? decompiledResult = null;
             if (request.DecompiledSource && pipelineSource is not null)
             {
-                var plainSourceResult = RenderPlainSource(pipelineSource, lookupType, method.Name, Decompiler.Annotations.AnnotationStage.Raised, lookupOverloadIndex, publicOnly);
-                decompileTrace = new Decompiler.DecompilerTrace(plainSourceResult.Fidelity, pipelineSource.Symbols, plainSourceResult.Diagnostics);
-                if (plainSourceResult.Output is { } plain)
-                    loweredBody = plain.TrimEnd();
-                else
-                    loweredDiagnostic = DiagnosticComment(plainSourceResult);
+                decompiledResult = TrimOutput(RenderDecompiledSource(
+                    pipelineSource,
+                    lookupType,
+                    method.Name,
+                    lookupOverloadIndex,
+                    publicOnly));
+                decompiledResult = decompiledResult with
+                {
+                    Trace = new Decompiler.DecompilerTrace(
+                        decompiledResult.Fidelity,
+                        pipelineSource.Symbols,
+                        decompiledResult.Diagnostics)
+                };
             }
 
             ILInspector.Research.ResearchViews.MemberProjectionResult? researchProjection = null;
@@ -138,45 +138,33 @@ internal static class MemberCodeProvider
                         CostOverlay: request.CostOverlay,
                         SemanticsOverlay: request.SemanticsOverlay,
                         FactRows: request.Facts));
-                decompileTrace = researchProjection.Trace ?? decompileTrace;
             }
 
             // Annotated source: raised C# with hidden-fact comments and the
             // raw IL interleaved beneath each statement.
-            string? annotatedBody = null, annotatedDiagnostic = null;
-            if (request.AnnotatedSource && researchProjection?.AnnotatedSource is { } annotatedResult)
-            {
-                if (annotatedResult.Output is { } annotated)
-                    annotatedBody = annotated.TrimEnd();
-                else
-                    annotatedDiagnostic = DiagnosticComment(annotatedResult);
-            }
+            var annotatedResult = request.AnnotatedSource
+                && researchProjection?.AnnotatedSource is { } annotated
+                    ? TrimOutput(annotated)
+                    : null;
 
-            string? costOverlayBody = null, costOverlayDiagnostic = null;
+            Decompiler.DecompilerResult? costOverlayResult = null;
             IReadOnlyList<string>? costOverlayHeaderComments = null;
             if (request.CostOverlay && researchProjection?.CostOverlay is { } overlay)
             {
-                var costResult = overlay.Body;
-                if (costResult.Output is { } costOverlay)
+                costOverlayResult = TrimOutput(overlay.Body);
+                if (costOverlayResult.Output is not null)
                 {
-                    costOverlayBody = costOverlay.TrimEnd();
                     if (overlay.HeaderFacts.Count > 0)
                         costOverlayHeaderComments = overlay.HeaderFacts
                             .Select(fact => $"// {fact.Format()}")
                             .ToList();
                 }
-                else
-                    costOverlayDiagnostic = DiagnosticComment(costResult);
             }
 
-            string? semanticsOverlayBody = null, semanticsOverlayDiagnostic = null;
-            if (request.SemanticsOverlay && researchProjection?.SemanticsOverlay is { } semanticsResult)
-            {
-                if (semanticsResult.Output is { } semanticsOverlay)
-                    semanticsOverlayBody = semanticsOverlay.TrimEnd();
-                else
-                    semanticsOverlayDiagnostic = DiagnosticComment(semanticsResult);
-            }
+            var semanticsOverlayResult = request.SemanticsOverlay
+                && researchProjection?.SemanticsOverlay is { } semantics
+                    ? TrimOutput(semantics)
+                    : null;
 
             string? ilText = null, ilDiagnostic = null;
             if (request.IL)
@@ -201,52 +189,25 @@ internal static class MemberCodeProvider
                 facts = researchProjection.Facts;
 
             results.Add((method, new Item(
-                loweredBody,
-                loweredDiagnostic,
+                decompiledResult,
                 methodGenericParameters,
-                annotatedBody,
-                annotatedDiagnostic,
-                costOverlayBody,
+                annotatedResult,
+                costOverlayResult,
                 costOverlayHeaderComments,
-                costOverlayDiagnostic,
-                semanticsOverlayBody,
-                semanticsOverlayDiagnostic,
+                semanticsOverlayResult,
                 ilText,
                 ilDiagnostic,
                 attributes,
-                facts,
-                decompileTrace,
-                RequiresAsyncDeclaration: ContainsAwaitKeyword(loweredBody))));
+                facts)));
         }
 
         return results;
     }
 
-    /// <summary>Renders a failed result as comment lines so sections degrade honestly instead of disappearing.</summary>
-    static string DiagnosticComment(Decompiler.DecompilerResult result)
-        => string.Join(Environment.NewLine, result.Diagnostics.Select(d => $"// {d}"));
-
-    static bool ContainsAwaitKeyword(string? text)
-    {
-        if (string.IsNullOrEmpty(text))
-            return false;
-        const string keyword = "await";
-        var span = text.AsSpan();
-        var index = text.IndexOf(keyword, StringComparison.Ordinal);
-        while (index >= 0)
-        {
-            var before = index == 0 ? '\0' : span[index - 1];
-            var afterIndex = index + keyword.Length;
-            var after = afterIndex >= span.Length ? '\0' : span[afterIndex];
-            if (!IsIdentifierPart(before) && !IsIdentifierPart(after))
-                return true;
-            index = text.IndexOf(keyword, index + keyword.Length, StringComparison.Ordinal);
-        }
-        return false;
-    }
-
-    static bool IsIdentifierPart(char c)
-        => c == '_' || char.IsLetterOrDigit(c);
+    static Decompiler.DecompilerResult TrimOutput(Decompiler.DecompilerResult result)
+        => result.Output is { } output
+            ? result with { Output = output.TrimEnd() }
+            : result;
 
     /// <summary>
     /// Resolves the selected method overload's generic parameter names directly
@@ -310,23 +271,25 @@ internal static class MemberCodeProvider
         }
     }
 
-    static Decompiler.DecompilerResult RenderPlainSource(Decompiler.Pipeline.MetadataSource source, string type, string method, Decompiler.Annotations.AnnotationStage stage, int overloadIndex, bool publicOnly)
+    static Decompiler.DecompilerResult RenderDecompiledSource(
+        Decompiler.Pipeline.MetadataSource source,
+        string type,
+        string method,
+        int overloadIndex,
+        bool publicOnly)
     {
         try
         {
             var imported = IrImporter.Import(source, type, method, overloadIndex, publicOnly)
                 ?? throw new InvalidOperationException($"{type}::{method} has no IL body");
-            var result = stage == Decompiler.Annotations.AnnotationStage.Lowered
-                ? Decompiler.Pipeline.CSharpPrinter.PrintLowered(imported, target => IrImporter.Import(source, target))
-                : Decompiler.Pipeline.CSharpPrinter.PrintRaised(imported, target => IrImporter.Import(source, target));
+            var result = Decompiler.Pipeline.CSharpPrinter.PrintRaised(
+                imported,
+                target => IrImporter.Import(source, target));
             if (result.Output is not { } output)
                 return result;
-            var body = result.ConstructorChain is { } chain
-                ? output.Length == 0 ? $": {chain}" : $": {chain}{Environment.NewLine}{output}"
-                : output;
-            return string.IsNullOrWhiteSpace(body)
+            return string.IsNullOrWhiteSpace(output) && result.ConstructorChain is null
                 ? Decompiler.DecompilerResult.Failure(Decompiler.DiagnosticIds.EmptyOutput, "projection produced no output for a method with a body")
-                : result with { Output = body };
+                : result;
         }
         catch (Exception ex)
         {

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1467,102 +1467,49 @@ public static class ApiOutputFormatter
                     .ToList();
             }
 
-            if (code.LoweredBody is { } lowered)
+            if (code.DecompiledResult is { } decompiledResult)
             {
-                EmitDecompileBreadcrumb(member.Name, code.DecompileTrace);
-                string source;
-                try
-                {
-                    source = FormatSourceWithDeclaration(
-                        type,
-                        member,
-                        code.MethodGenericParameters,
-                        lowered,
-                        code.RequiresAsyncDeclaration,
-                        preferExpressionBodied: true);
-                }
-                catch (Exception ex)
-                {
-                    source = $"// {Decompiler.DiagnosticIds.InternalError}: declaration formatting failed: {ex.GetType().Name}: {ex.Message}";
-                }
-                memberCode.DecompiledSourceCode = new CodeSection("csharp", source);
-                hasCode = true;
-            }
-            else if (code.LoweredDiagnostic is { } loweredDiagnostic)
-            {
-                EmitDecompileBreadcrumb(member.Name, code.DecompileTrace);
-                memberCode.DecompiledSourceCode = new CodeSection("csharp", loweredDiagnostic);
+                EmitDecompileBreadcrumb(member.Name, decompiledResult.Trace);
+                memberCode.DecompiledSourceCode = FormatCSharpResult(
+                    type,
+                    member,
+                    code.MethodGenericParameters,
+                    decompiledResult,
+                    preferExpressionBodied: true);
                 hasCode = true;
             }
 
-            if (code.AnnotatedBody is { } annotated)
+            if (code.AnnotatedResult is { } annotatedResult)
             {
-                EmitDecompileBreadcrumb(member.Name, code.DecompileTrace);
-                string source;
-                try
-                {
-                    source = FormatSourceWithDeclaration(type, member, code.MethodGenericParameters, annotated);
-                }
-                catch (Exception ex)
-                {
-                    source = $"// {Decompiler.DiagnosticIds.InternalError}: declaration formatting failed: {ex.GetType().Name}: {ex.Message}";
-                }
-                memberCode.AnnotatedSourceCode = new CodeSection("csharp", source);
-                hasCode = true;
-            }
-            else if (code.AnnotatedDiagnostic is { } annotatedDiagnostic)
-            {
-                EmitDecompileBreadcrumb(member.Name, code.DecompileTrace);
-                memberCode.AnnotatedSourceCode = new CodeSection("csharp", annotatedDiagnostic);
+                EmitDecompileBreadcrumb(member.Name, annotatedResult.Trace);
+                memberCode.AnnotatedSourceCode = FormatCSharpResult(
+                    type,
+                    member,
+                    code.MethodGenericParameters,
+                    annotatedResult);
                 hasCode = true;
             }
 
-            if (code.CostOverlayBody is { } costOverlay)
+            if (code.CostOverlayResult is { } costOverlayResult)
             {
-                EmitDecompileBreadcrumb(member.Name, code.DecompileTrace);
-                string source;
-                try
-                {
-                    source = FormatSourceWithDeclaration(
-                        type,
-                        member,
-                        code.MethodGenericParameters,
-                        costOverlay,
-                        leadingBodyComments: code.CostOverlayHeaderComments);
-                }
-                catch (Exception ex)
-                {
-                    source = $"// {Decompiler.DiagnosticIds.InternalError}: declaration formatting failed: {ex.GetType().Name}: {ex.Message}";
-                }
-                memberCode.CostOverlayCode = new CodeSection("csharp", source);
-                hasCode = true;
-            }
-            else if (code.CostOverlayDiagnostic is { } costDiagnostic)
-            {
-                EmitDecompileBreadcrumb(member.Name, code.DecompileTrace);
-                memberCode.CostOverlayCode = new CodeSection("csharp", costDiagnostic);
+                EmitDecompileBreadcrumb(member.Name, costOverlayResult.Trace);
+                memberCode.CostOverlayCode = FormatCSharpResult(
+                    type,
+                    member,
+                    code.MethodGenericParameters,
+                    costOverlayResult,
+                    leadingBodyComments: code.CostOverlayHeaderComments);
                 hasCode = true;
             }
 
-            if (code.SemanticsOverlayBody is { } semanticsOverlay)
+            if (code.SemanticsOverlayResult is { } semanticsOverlayResult)
             {
-                EmitDecompileBreadcrumb(member.Name, code.DecompileTrace);
-                string source;
-                try
-                {
-                    source = FormatSourceWithDeclaration(type, member, code.MethodGenericParameters, semanticsOverlay);
-                }
-                catch (Exception ex)
-                {
-                    source = $"// {Decompiler.DiagnosticIds.InternalError}: declaration formatting failed: {ex.GetType().Name}: {ex.Message}";
-                }
-                memberCode.SemanticsOverlayCode = new CodeSection("csharp", source);
-                hasCode = true;
-            }
-            else if (code.SemanticsOverlayDiagnostic is { } semanticsDiagnostic)
-            {
-                EmitDecompileBreadcrumb(member.Name, code.DecompileTrace);
-                memberCode.SemanticsOverlayCode = new CodeSection("csharp", semanticsDiagnostic);
+                EmitDecompileBreadcrumb(member.Name, semanticsOverlayResult.Trace);
+                memberCode.SemanticsOverlayCode = FormatCSharpResult(
+                    type,
+                    member,
+                    code.MethodGenericParameters,
+                    semanticsOverlayResult);
                 hasCode = true;
             }
 
@@ -2148,35 +2095,62 @@ public static class ApiOutputFormatter
         RequestTelemetry.Breadcrumb(stage, detail);
     }
 
-    private static string FormatSourceWithDeclaration(
+    private static string DiagnosticComment(Decompiler.DecompilerResult result)
+        => string.Join(Environment.NewLine, result.Diagnostics.Select(diagnostic => $"// {diagnostic}"));
+
+    private static CodeSection FormatCSharpResult(
         ApiType type,
         ApiMember member,
         IReadOnlyList<string>? methodGenericParameters,
-        string lowered,
-        bool requiresAsyncDeclaration = false,
+        Decompiler.DecompilerResult result,
         bool preferExpressionBodied = false,
         IReadOnlyList<string>? leadingBodyComments = null)
     {
+        if (!result.Succeeded)
+            return new CodeSection("csharp", DiagnosticComment(result));
+
+        try
+        {
+            return new CodeSection(
+                "csharp",
+                FormatSourceWithDeclaration(
+                    type,
+                    member,
+                    methodGenericParameters,
+                    result,
+                    preferExpressionBodied,
+                    leadingBodyComments));
+        }
+        catch (Exception ex)
+        {
+            return new CodeSection(
+                "csharp",
+                $"// {Decompiler.DiagnosticIds.InternalError}: declaration formatting failed: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    internal static string FormatSourceWithDeclaration(
+        ApiType type,
+        ApiMember member,
+        IReadOnlyList<string>? methodGenericParameters,
+        Decompiler.DecompilerResult result,
+        bool preferExpressionBodied = false,
+        IReadOnlyList<string>? leadingBodyComments = null)
+    {
+        var lowered = result.Output
+            ?? throw new ArgumentException("A successful decompiler result is required.", nameof(result));
         var declaration = FormatMemberDeclaration(
             type,
             member,
             abbreviate: false,
             methodGenericParameters,
-            forceAsync: requiresAsyncDeclaration);
-        var body = lowered.TrimEnd();
-
-        // A constructor's base/this initializer is surfaced by the renderer as a
-        // leading `: base(...)` / `: this(...)` line (it is invalid as a body
-        // statement). Lift it onto the declaration line so the output is valid C#.
-        var bodyLines = body.ReplaceLineEndings("\n").Split('\n');
-        if (bodyLines.Length > 0 && bodyLines[0].TrimStart() is { } first
-            && (first.StartsWith(": base(", StringComparison.Ordinal)
-                || first.StartsWith(": this(", StringComparison.Ordinal)))
+            forceAsync: result.ContainsAwaitExpression || result.RequiresAsyncBodyModifier);
+        if (result.ConstructorChain is { } constructorChain
+            && !string.IsNullOrWhiteSpace(declaration))
         {
-            if (!string.IsNullOrWhiteSpace(declaration))
-                declaration = $"{declaration} {first.TrimEnd()}";
-            body = string.Join("\n", bodyLines.Skip(1)).TrimEnd();
+            declaration = $"{declaration} : {constructorChain}";
         }
+        var body = lowered.TrimEnd();
 
         if (string.IsNullOrWhiteSpace(declaration))
             return body;

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1467,51 +1467,7 @@ public static class ApiOutputFormatter
                     .ToList();
             }
 
-            if (code.DecompiledResult is { } decompiledResult)
-            {
-                EmitDecompileBreadcrumb(member.Name, decompiledResult.Trace);
-                memberCode.DecompiledSourceCode = FormatCSharpResult(
-                    type,
-                    member,
-                    code.MethodGenericParameters,
-                    decompiledResult,
-                    preferExpressionBodied: true);
-                hasCode = true;
-            }
-
-            if (code.AnnotatedResult is { } annotatedResult)
-            {
-                EmitDecompileBreadcrumb(member.Name, annotatedResult.Trace);
-                memberCode.AnnotatedSourceCode = FormatCSharpResult(
-                    type,
-                    member,
-                    code.MethodGenericParameters,
-                    annotatedResult);
-                hasCode = true;
-            }
-
-            if (code.CostOverlayResult is { } costOverlayResult)
-            {
-                EmitDecompileBreadcrumb(member.Name, costOverlayResult.Trace);
-                memberCode.CostOverlayCode = FormatCSharpResult(
-                    type,
-                    member,
-                    code.MethodGenericParameters,
-                    costOverlayResult,
-                    leadingBodyComments: code.CostOverlayHeaderComments);
-                hasCode = true;
-            }
-
-            if (code.SemanticsOverlayResult is { } semanticsOverlayResult)
-            {
-                EmitDecompileBreadcrumb(member.Name, semanticsOverlayResult.Trace);
-                memberCode.SemanticsOverlayCode = FormatCSharpResult(
-                    type,
-                    member,
-                    code.MethodGenericParameters,
-                    semanticsOverlayResult);
-                hasCode = true;
-            }
+            hasCode |= PopulateCSharpSections(memberCode, type, member, code);
 
             if ((code.ILText ?? code.ILDiagnostic) is { } ilText)
             {
@@ -1543,6 +1499,63 @@ public static class ApiOutputFormatter
 
         if (hasCode)
             view.MemberCode = memberCode;
+    }
+
+    internal static bool PopulateCSharpSections(
+        MemberCodeView memberCode,
+        ApiType type,
+        ApiMember member,
+        MemberCodeProvider.Item code)
+    {
+        bool hasCode = false;
+
+        if (code.DecompiledResult is { } decompiledResult)
+        {
+            EmitDecompileBreadcrumb(member.Name, decompiledResult.Trace);
+            memberCode.DecompiledSourceCode = FormatCSharpResult(
+                type,
+                member,
+                code.MethodGenericParameters,
+                decompiledResult,
+                preferExpressionBodied: true);
+            hasCode = true;
+        }
+
+        if (code.AnnotatedResult is { } annotatedResult)
+        {
+            EmitDecompileBreadcrumb(member.Name, annotatedResult.Trace);
+            memberCode.AnnotatedSourceCode = FormatCSharpResult(
+                type,
+                member,
+                code.MethodGenericParameters,
+                annotatedResult);
+            hasCode = true;
+        }
+
+        if (code.CostOverlayResult is { } costOverlayResult)
+        {
+            EmitDecompileBreadcrumb(member.Name, costOverlayResult.Trace);
+            memberCode.CostOverlayCode = FormatCSharpResult(
+                type,
+                member,
+                code.MethodGenericParameters,
+                costOverlayResult,
+                leadingBodyComments: code.CostOverlayHeaderComments);
+            hasCode = true;
+        }
+
+        if (code.SemanticsOverlayResult is { } semanticsOverlayResult)
+        {
+            EmitDecompileBreadcrumb(member.Name, semanticsOverlayResult.Trace);
+            memberCode.SemanticsOverlayCode = FormatCSharpResult(
+                type,
+                member,
+                code.MethodGenericParameters,
+                semanticsOverlayResult);
+            hasCode = true;
+        }
+
+        return hasCode;
     }
 
     static void AddOrReplaceSummaryField(TypeView view, string name, string value)


### PR DESCRIPTION
Advances #2653

- Preserves complete `DecompilerResult` values through Research and CLI composition.
- Removes constructor-chain and `await` source-text protocols from `MemberCodeProvider`.
- Card revision: `a83a8c4a`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the CLI now consumes typed constructor, async,
fidelity, diagnostic, and trace evidence without changing decompiler body
rendering.

Before, a method returning the literal `"await"` could acquire a false `async`
modifier because the CLI scanned rendered text:

```csharp
public async string AwaitText()
{
    return "await";
}
```

After:

```csharp
public string AwaitText()
{
    return "await";
}
```

The same typed path now composes real constructor initializers from
`DecompilerResult.ConstructorChain`; body text resembling `: base(...)` is no
longer reparsed as structural metadata.

## Evidence

| Check | Result |
| --- | --- |
| Product/test build | Pass |
| Research tests | 89 passed |
| CLI tests | 1,765 passed, 10 environment skips; fixed-head formatter tests: 15 passed, 1 environment skip |
| NativeAOT publish | Pass |
| Decompiler fast suite | 2,332 / 2,333 passed; the one failure reproduces unchanged on clean `origin/main` |
| Render A/B | 89,065 evaluated; 0 changed, 0 added, 0 removed |

The pre-existing fast-suite failure is
`TypeSourceComposerUnionTests.ClassUnionSwitchExpression_RendersTypePatternArms`;
the identical expected/actual mismatch reproduces at clean merge-base
`2b3db7ee`.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — the pinned PR quick gate matched baseline tolerances.
Aggregate movement is advisory baseline drift from 25 additional
`ILInspector.MetadataPrimitives` methods, while the explicit render A/B is
empty.

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 15 assemblies, 1,486 methods
Sample: hash-stable 100 methods per assembly
Correctness coverage: validity not run; fidelity not run

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-26). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 1,461 -> 1,486 (+25)
- ILInspector.MetadataPrimitives: 61 -> 86 methods (+25)

| Metric | Change | Count delta |
| ------ | ------ | ----------- |
| Fully raised (+) | 1,213 (83.03%) → 1,232 (82.91%) (bad) | +19 |
| Conditional-branch residual (-) | 35 (2.40%) → 44 (2.96%) (bad) | +9 |
| Forward-merge stops (-) | 27 (1.85%) → 32 (2.15%) (bad) | +5 |
| Pass bugs (-) | 0 → 0 (neutral) | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 82.17% -> 82.33% (+0.16 pp); conditional residual 3.00% -> 3.00% (0 pp); fidelity ungated (sampling differs; rely on changed-method fidelity).

Advisory aggregate rate movement (not a PR quick hard gate; review for decompiler-risky changes):
- fully-raised dropped 0.12 pp (baseline 83.03%, PR 82.91%, tolerance 0.10 pp)
- conditional-branch residual increased 0.56 pp (baseline 2.40%, PR 2.96%, tolerance 0.10 pp)
- forward-merge stop increased 0.30 pp (baseline 1.85%, PR 2.15%, tolerance 0.10 pp)

Verdict: corpus sensor matched baseline tolerances.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | CLEAN | Full fixed-head diff, diagnostics, async, constructor, and live output checks |
| Gemini 3.1 Pro | CLEAN | Fixed-head extraction, diagnostics, async, cost, trace, and API checks |

**Review conclusion:** **PASS** — both isolated reviewers found no actionable
issues on exact head `a83a8c4a`; the
[final reconciliation comment](https://github.com/richlander/dotnet-inspect/pull/2682#issuecomment-4951705465)
records their evidence and why no resolution commit applies.
