### PR TITLE
Fix class union not-pattern slot diamond

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SlotStoreDiamondPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SlotStoreDiamondPassTests.cs
@@ -137,6 +137,57 @@ public class SlotStoreDiamondPassTests
     static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
 
     [Fact]
+    public void RaisesClassUnionStackSlotNotPatternReturnBeforeGenericDiamondFold()
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Matcher");
+        var pet = TypeRef.Definition("Synthetic", "Samples", "Pet");
+        var cat = TypeRef.Definition("Synthetic", "Samples", "Cat");
+        var getValue = new MethodRef(pet, "get_Value", Object, [], HasThis: true)
+        {
+            AccessorKind = AccessorKind.PropertyGet,
+        };
+        var body = new BlockContainer();
+        var head = new Block(0);
+        head.Add(new ConditionalBranch(new LogicalNot(new LoadArgument(0, "pet", pet)), 12));
+        var testArm = new Block(4);
+        testArm.Add(new StoreStackSlot(0, new Comparison(
+            ComparisonKind.GreaterThan,
+            isUnsigned: true,
+            new IsInstance(cat, new LoadProperty(getValue, new LoadArgument(0, "pet", pet), [])),
+            new Constant(null, Object))));
+        testArm.Add(new Branch(16));
+        var nullArm = new Block(12);
+        nullArm.Add(new StoreStackSlot(0, new Constant(0, Int32)));
+        var merge = new Block(16);
+        merge.Add(new Return(new Comparison(
+            ComparisonKind.Equal,
+            isUnsigned: false,
+            new LoadStackSlot(0, Bool),
+            new Constant(0, Int32))));
+        foreach (var block in (Block[])[head, testArm, nullArm, merge])
+            body.Add(block);
+        var function = new IrFunction(
+            "IsNotCat",
+            owner,
+            new MethodSignature(Bool, [new Parameter("pet", pet)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body)
+        {
+            UnionTypes = new[] { pet }.ToHashSet(),
+        };
+
+        new SlotStoreDiamondPass().Run(function, PassContext.None);
+
+        var ret = Assert.Single(function.Descendants.OfType<Return>());
+        var and = Assert.IsType<LogicalBinary>(ret.Value);
+        Assert.Equal(LogicalKind.And, and.Kind);
+        Assert.IsType<LoadArgument>(and.Left);
+        Assert.IsType<LogicalNot>(and.Right);
+        Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
+        Assert.Empty(function.Descendants.OfType<Conditional>());
+    }
+
+    [Fact]
     public void FoldsNestedNullableBoolDiamondAheadOfSharedTrueArm()
     {
         var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");

--- a/src/ILInspector.Decompiler.Tests/SlotStoreDiamondPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SlotStoreDiamondPassTests.cs
@@ -179,12 +179,64 @@ public class SlotStoreDiamondPassTests
         new SlotStoreDiamondPass().Run(function, PassContext.None);
 
         var ret = Assert.Single(function.Descendants.OfType<Return>());
-        var and = Assert.IsType<LogicalBinary>(ret.Value);
+        var not = Assert.IsType<LogicalNot>(ret.Value);
+        var and = Assert.IsType<LogicalBinary>(not.Operand);
         Assert.Equal(LogicalKind.And, and.Kind);
         Assert.IsType<LoadArgument>(and.Left);
-        Assert.IsType<LogicalNot>(and.Right);
+        Assert.IsType<IsInstance>(and.Right);
         Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
         Assert.Empty(function.Descendants.OfType<Conditional>());
+    }
+
+    [Fact]
+    public void DoesNotRaiseClassUnionStackSlotReturnAcrossIntermediateBlock()
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Matcher");
+        var pet = TypeRef.Definition("Synthetic", "Samples", "Pet");
+        var cat = TypeRef.Definition("Synthetic", "Samples", "Cat");
+        var getValue = new MethodRef(pet, "get_Value", Object, [], HasThis: true)
+        {
+            AccessorKind = AccessorKind.PropertyGet,
+        };
+        var body = new BlockContainer();
+        var head = new Block(0);
+        head.Add(new ConditionalBranch(new LogicalNot(new LoadArgument(0, "pet", pet)), 12));
+        var testArm = new Block(4);
+        testArm.Add(new StoreStackSlot(0, new Comparison(
+            ComparisonKind.GreaterThan,
+            isUnsigned: true,
+            new IsInstance(cat, new LoadProperty(getValue, new LoadArgument(0, "pet", pet), [])),
+            new Constant(null, Object))));
+        testArm.Add(new Branch(16));
+        var gap = new Block(8);
+        gap.Add(new StoreLocal(0, Object, new Constant(null, Object)));
+        var nullArm = new Block(12);
+        nullArm.Add(new StoreStackSlot(0, new Constant(0, Int32)));
+        var merge = new Block(16);
+        merge.Add(new Return(new Comparison(
+            ComparisonKind.Equal,
+            isUnsigned: false,
+            new LoadStackSlot(0, Bool),
+            new Constant(0, Int32))));
+        var external = new Block(20);
+        external.Add(new Branch(8));
+        foreach (var block in (Block[])[head, testArm, gap, nullArm, merge, external])
+            body.Add(block);
+        var function = new IrFunction(
+            "IsNotCat",
+            owner,
+            new MethodSignature(Bool, [new Parameter("pet", pet)], HasThis: false, GenericParameterCount: 0),
+            [Object],
+            body)
+        {
+            UnionTypes = new[] { pet }.ToHashSet(),
+        };
+
+        new SlotStoreDiamondPass().Run(function, PassContext.None);
+
+        Assert.Contains(function.Body.Blocks, block => block.StartOffset == 8);
+        var ret = Assert.Single(function.Descendants.OfType<Return>());
+        Assert.IsType<Comparison>(ret.Value);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -1552,7 +1552,7 @@ public class TypeSourceComposerUnionTests
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "TernaryGuard"));
         Assert.Equal("return pet is Cat || pet is Dog;",
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCatOrDog"));
-        Assert.Equal("return pet is not null && pet is not Cat;",
+        Assert.Equal("return !(pet is not null && pet is Cat);",
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNotCat"));
         Assert.Equal("return pet.Value is not Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsNotCat"));
         var classValueNotNamedCat = RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsNotNamedCat");

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -1552,8 +1552,9 @@ public class TypeSourceComposerUnionTests
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "TernaryGuard"));
         Assert.Equal("return pet is Cat || pet is Dog;",
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCatOrDog"));
-        Assert.Equal("return !(pet is not null && pet is Cat);",
-            RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNotCat"));
+        var classIsNotCat = RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNotCat");
+        Assert.True(classIsNotCat is "return !(pet is not null && pet is Cat);"
+            or "return pet is not null && pet is not Cat;", classIsNotCat);
         Assert.Equal("return pet.Value is not Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsNotCat"));
         var classValueNotNamedCat = RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsNotNamedCat");
         Assert.Contains("pet.Value as Cat", classValueNotNamedCat);

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -1553,8 +1553,16 @@ public class TypeSourceComposerUnionTests
         Assert.Equal("return pet is Cat || pet is Dog;",
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCatOrDog"));
         var classIsNotCat = RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNotCat");
-        Assert.True(classIsNotCat is "return !(pet is not null && pet is Cat);"
-            or "return pet is not null && pet is not Cat;", classIsNotCat);
+        // .NET 11 previews have emitted two different class-union not-pattern
+        // lowerings. Assert the spelling that matches the imported IL shape.
+        if (UsesNegatingStackSlotClassUnionTypeTest(assembly.Path))
+        {
+            Assert.Equal("return !(pet is not null && pet is Cat);", classIsNotCat);
+        }
+        else
+        {
+            Assert.Equal("return pet is not null && pet is not Cat;", classIsNotCat);
+        }
         Assert.Equal("return pet.Value is not Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsNotCat"));
         var classValueNotNamedCat = RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsNotNamedCat");
         Assert.Contains("pet.Value as Cat", classValueNotNamedCat);
@@ -1765,6 +1773,54 @@ public class TypeSourceComposerUnionTests
         Assert.NotNull(result.Output);
         return result.Output!.Trim();
     }
+
+    static bool UsesNegatingStackSlotClassUnionTypeTest(string assemblyPath)
+    {
+        using var source = MetadataSource.Open(assemblyPath);
+        var function = IrImporter.Import(source, "UnionFixtures.Matcher", "IsNotCat");
+        Assert.NotNull(function);
+        var blocks = function.Body.Blocks;
+        if (blocks is not [var head, var testArm, var nullArm, var merge]
+            || head.Children is not [ConditionalBranch nullBranch]
+            || nullBranch.Condition is not LogicalNot { Operand: LoadArgument { Name: "pet" } }
+            || testArm.Children is not [StoreStackSlot conditionStore, Branch branch]
+            || nullArm.Children is not [StoreStackSlot nullStore]
+            || merge.Children is not [Return ret]
+            || nullBranch.TargetOffset != nullArm.StartOffset
+            || branch.TargetOffset != merge.StartOffset
+            || conditionStore.Slot != nullStore.Slot
+            || nullStore.Value is not Constant { Value: 0 or false }
+            || !IsCatValueTest(conditionStore.Value)
+            || ret.Value is not Comparison { Kind: ComparisonKind.Equal } equal
+            || !IsSlotZeroComparison(equal, conditionStore.Slot))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    static bool IsCatValueTest(IrExpression expression)
+        => expression is Comparison { Kind: ComparisonKind.GreaterThan, IsUnsigned: true } comparison
+            && comparison.Left is IsInstance { Type.Name: "Cat", Operand: var operand }
+            && comparison.Right is Constant { Value: null }
+            && IsPetValueAccess(operand);
+
+    static bool IsPetValueAccess(IrExpression expression)
+        => expression switch
+        {
+            Call { Callee.Name: "get_Value", Arguments: [LoadArgument { Name: "pet" }] } => true,
+            LoadProperty { PropertyName: "Value", Instance: LoadArgument { Name: "pet" } } => true,
+            _ => false,
+        };
+
+    static bool IsSlotZeroComparison(Comparison comparison, int slot)
+        => comparison.Left is LoadStackSlot { Slot: var leftSlot }
+            && leftSlot == slot
+            && comparison.Right is Constant { Value: 0 }
+        || comparison.Right is LoadStackSlot { Slot: var rightSlot }
+            && rightSlot == slot
+            && comparison.Left is Constant { Value: 0 };
 
     static async Task AssertSdkPreviewBuilds(string source)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
@@ -132,13 +132,13 @@ public sealed class SlotStoreDiamondPass : IIrPass
 
     static bool ReturnsBoolSlot(Return ret, int slot, out bool negates)
     {
-        if (ret.Value is LoadStackSlot load && load.Slot == slot)
+        if (ret.Value is LoadStackSlot load && IsBoolSlotLoad(load, slot))
         {
             negates = false;
             return true;
         }
 
-        if (ret.Value is LogicalNot { Operand: LoadStackSlot notLoad } && notLoad.Slot == slot)
+        if (ret.Value is LogicalNot { Operand: LoadStackSlot notLoad } && IsBoolSlotLoad(notLoad, slot))
         {
             negates = true;
             return true;
@@ -162,6 +162,10 @@ public sealed class SlotStoreDiamondPass : IIrPass
         return false;
     }
 
+    static bool IsBoolSlotLoad(LoadStackSlot load, int slot)
+        => load.Slot == slot
+            && (load.Type is null || IsBool(load.Type));
+
     static bool IsSlotZeroComparison(Comparison comparison, int slot)
         => comparison.Left is LoadStackSlot leftLoad
             && leftLoad.Slot == slot
@@ -182,7 +186,7 @@ public sealed class SlotStoreDiamondPass : IIrPass
 
     static bool IsSimpleUnionValueReceiver(IrExpression? receiver) => receiver switch
     {
-        LoadArgumentAddress or LoadArgument or LoadLocalAddress or LoadLocal => true,
+        LoadArgument or LoadLocal => true,
         _ => false,
     };
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
@@ -86,7 +86,7 @@ public sealed class SlotStoreDiamondPass : IIrPass
             || blocks[mergeIndex].Children is not [Return ret]
             || nullIndex == p
             || nullIndex == conditionIndex
-            || nullIndex <= conditionIndex
+            || nullIndex != conditionIndex + 1
             || mergeIndex == p
             || mergeIndex == conditionIndex
             || mergeIndex == nullIndex
@@ -106,8 +106,9 @@ public sealed class SlotStoreDiamondPass : IIrPass
             return false;
         }
 
-        var tested = returnNegates ? Conditions.Negate(condition) : condition;
-        var expression = new LogicalBinary(LogicalKind.And, (IrExpression)receiver.Clone(), tested);
+        IrExpression expression = new LogicalBinary(LogicalKind.And, (IrExpression)receiver.Clone(), condition);
+        if (returnNegates)
+            expression = Conditions.Negate(expression);
         FoldClassUnionStackSlotBoolReturn(container, p, removedIndices, expression, stepper);
         return true;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
@@ -44,6 +44,9 @@ public sealed class SlotStoreDiamondPass : IIrPass
 
             for (int p = 0; p + 2 < blocks.Count; p++)
             {
+                if (TryFoldClassUnionStackSlotBoolReturn(function, container, blocks, offsetToIndex, leaveTargets, p, stepper))
+                    return true;
+
                 if (Match(function, blocks, offsetToIndex, leaveTargets, p, scopedSlotTypes) is { } shape)
                 {
                     Fold(container, blocks, p, shape, stepper);
@@ -52,6 +55,194 @@ public sealed class SlotStoreDiamondPass : IIrPass
             }
         }
         return false;
+    }
+
+    static bool TryFoldClassUnionStackSlotBoolReturn(
+        IrFunction function,
+        BlockContainer container,
+        IReadOnlyList<Block> blocks,
+        Dictionary<int, int> offsetToIndex,
+        HashSet<int> leaveTargets,
+        int p,
+        Stepper stepper)
+    {
+        var head = blocks[p];
+        if (head.Children.Count == 0
+            || head.Children[^1] is not ConditionalBranch nullBranch
+            || nullBranch.Condition is not LogicalNot { Operand: var receiver })
+        {
+            return false;
+        }
+
+        for (int s = 0; s < head.Children.Count - 1; s++)
+            if (IsControlFlow(head.Children[s]))
+                return false;
+
+        int conditionIndex = p + 1;
+        if (blocks[conditionIndex].Children is not [StoreStackSlot conditionStore, Branch conditionExit]
+            || !offsetToIndex.TryGetValue(nullBranch.TargetOffset, out int nullIndex)
+            || !offsetToIndex.TryGetValue(conditionExit.TargetOffset, out int mergeIndex)
+            || blocks[nullIndex].Children is not [StoreStackSlot nullStore]
+            || blocks[mergeIndex].Children is not [Return ret]
+            || nullIndex == p
+            || nullIndex == conditionIndex
+            || nullIndex <= conditionIndex
+            || mergeIndex == p
+            || mergeIndex == conditionIndex
+            || mergeIndex == nullIndex
+            || nullIndex + 1 != mergeIndex
+            || conditionStore.Slot != nullStore.Slot
+            || !IsFalseConstant(nullStore.Value)
+            || !ReturnsBoolSlot(ret, conditionStore.Slot, out bool returnNegates)
+            || !TryRewriteClassUnionTypeTest(function, conditionStore.Value, receiver, out var condition))
+        {
+            return false;
+        }
+
+        int[] removedIndices = [conditionIndex, nullIndex, mergeIndex];
+        if (!NoExternalEntry(blocks, p, removedIndices, leaveTargets)
+            || !ReferenceOwnership.StackSlotReferencesOnlyWithin(function, conditionStore.Slot, [conditionStore, nullStore, ret.Value!]))
+        {
+            return false;
+        }
+
+        var tested = returnNegates ? Conditions.Negate(condition) : condition;
+        var expression = new LogicalBinary(LogicalKind.And, (IrExpression)receiver.Clone(), tested);
+        FoldClassUnionStackSlotBoolReturn(container, p, removedIndices, expression, stepper);
+        return true;
+    }
+
+    static bool TryRewriteClassUnionTypeTest(IrFunction function, IrExpression expression, IrExpression receiver, out IrExpression rewritten)
+    {
+        if (expression is Comparison { Kind: ComparisonKind.GreaterThan, IsUnsigned: true } comparison
+            && comparison.Left is IsInstance test
+            && comparison.Right is Constant { Value: null }
+            && test.Operand is LoadProperty unionValue
+            && IsUnionValueProperty(function, unionValue)
+            && PlaceIdentity.SameVariable(unionValue.Instance, receiver))
+        {
+            rewritten = new IsInstance(test.Type, (IrExpression)unionValue.Clone());
+            return true;
+        }
+
+        rewritten = null!;
+        return false;
+    }
+
+    static bool ReturnsBoolSlot(Return ret, int slot, out bool negates)
+    {
+        if (ret.Value is LoadStackSlot load && load.Slot == slot)
+        {
+            negates = false;
+            return true;
+        }
+
+        if (ret.Value is LogicalNot { Operand: LoadStackSlot notLoad } && notLoad.Slot == slot)
+        {
+            negates = true;
+            return true;
+        }
+
+        if (ret.Value is Comparison { Kind: ComparisonKind.NotEqual } notEqual
+            && IsSlotZeroComparison(notEqual, slot))
+        {
+            negates = false;
+            return true;
+        }
+
+        if (ret.Value is Comparison { Kind: ComparisonKind.Equal } equal
+            && IsSlotZeroComparison(equal, slot))
+        {
+            negates = true;
+            return true;
+        }
+
+        negates = false;
+        return false;
+    }
+
+    static bool IsSlotZeroComparison(Comparison comparison, int slot)
+        => comparison.Left is LoadStackSlot leftLoad
+            && leftLoad.Slot == slot
+            && comparison.Right is Constant { Value: 0 }
+        || comparison.Right is LoadStackSlot rightLoad
+            && rightLoad.Slot == slot
+            && comparison.Left is Constant { Value: 0 };
+
+    static bool IsFalseConstant(IrExpression expression)
+        => expression is Constant { Value: false }
+            || expression is Constant { Value: 0 };
+
+    static bool IsUnionValueProperty(IrFunction function, LoadProperty property)
+        => property.PropertyName == "Value"
+            && property.IndexArguments.Count == 0
+            && function.UnionTypes.Contains(NamedDefinition(property.Accessor.DeclaringType))
+            && IsSimpleUnionValueReceiver(property.Instance);
+
+    static bool IsSimpleUnionValueReceiver(IrExpression? receiver) => receiver switch
+    {
+        LoadArgumentAddress or LoadArgument or LoadLocalAddress or LoadLocal => true,
+        _ => false,
+    };
+
+    static TypeRef NamedDefinition(TypeRef type)
+        => type is { Kind: TypeRefKind.GenericInstance, ElementType: { } definition } ? definition : type;
+
+    static bool NoExternalEntry(
+        IReadOnlyList<Block> blocks,
+        int root,
+        IReadOnlyCollection<int> removedIndices,
+        HashSet<int> leaveTargets)
+    {
+        var forbidden = removedIndices.Select(index => blocks[index].StartOffset).ToHashSet();
+        if (forbidden.Overlaps(leaveTargets))
+            return false;
+
+        var removed = removedIndices.ToHashSet();
+        for (int i = 0; i < blocks.Count; i++)
+        {
+            if (i == root || removed.Contains(i))
+                continue;
+            foreach (var node in blocks[i].Children)
+                foreach (int target in Targets(node))
+                    if (forbidden.Contains(target))
+                        return false;
+        }
+        return true;
+    }
+
+    static void FoldClassUnionStackSlotBoolReturn(
+        BlockContainer container,
+        int p,
+        IReadOnlyCollection<int> removedIndices,
+        IrExpression expression,
+        Stepper stepper)
+    {
+        var ordered = container.Blocks.ToList();
+        var folded = new Block(ordered[p].StartOffset);
+        var rootChildren = ordered[p].DetachChildren();
+        for (int k = 0; k < rootChildren.Count - 1; k++)
+            folded.Add(rootChildren[k]);
+        folded.Add(new Return(expression));
+
+        foreach (var block in ordered)
+            block.Detach();
+
+        var removed = removedIndices.ToHashSet();
+        var rebuilt = new BlockContainer();
+        for (int i = 0; i < ordered.Count; i++)
+        {
+            if (i == p)
+            {
+                rebuilt.Add(folded);
+                continue;
+            }
+            if (removed.Contains(i))
+                continue;
+            rebuilt.Add(ordered[i]);
+        }
+        stepper.StepOver("raise class union stack-slot type-test bool dispatch", container);
+        container.ReplaceWith(rebuilt);
     }
 
     sealed record Shape(


### PR DESCRIPTION
- Fixes #2631
- Changes class-union stack-slot bool-return diamonds to raise before the generic slot-store diamond erases the union pattern shape
- Card revision: `68fca623`

## Change

**Conclusion:** **PASS** — the targeted fold restores the class-union not-pattern shape while preserving null semantics, metadata gates, slot ownership, and contiguous CFG safety.

Before:

```csharp
return !(pet is null ? false : (pet.Value is Cat));
```

After for the negating stack-slot bool-return lowering:

```csharp
return !(pet is not null && pet is Cat);
```

Older .NET 11 preview CI may compile a different class-union not-pattern IL shape that decompiles to the alternate non-lowered spelling:

```csharp
return pet is not null && pet is not Cat;
```

The source-level test now branches on the imported fixture IR shape and asserts the specific spelling for that shape; it no longer accepts both spellings blindly. The pass-level regression guards the semantic outer-negation shape for the targeted stack-slot diamond.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --configfile nuget.config` |
| Focused tests | Pass: `ClassUnionSwitchExpression_RendersTypePatternArms`, `RaisesClassUnionStackSlotNotPatternReturnBeforeGenericDiamondFold`, `DoesNotRaiseClassUnionStackSlotReturnAcrossIntermediateBlock` (3 total) |
| Adjacent tests | Pass: `SlotStoreDiamondPassTests` + `TypeSourceComposerUnionTests` (36 total) |
| Decompiler suite | Pass before final rebase/review fix: `ILInspector.Decompiler.Tests` (2426 total) |
| Real witness | `UnionFixtures.Matcher::IsNotCat` raises through `class union stack-slot type-test bool dispatch` for the negating stack-slot shape |
| Render A/B | Pass: 89,065 methods, Changed 0 / Added 0 / Removed 0 |

## Decompiler quality

**Conclusion:** **PASS** — explicit merge-base quick corpus matched baseline tolerances; risk warning is coverage-only and covered by focused/adjacent tests plus render A/B.

### PR quick corpus card

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity compiled 350 methods (compile-cap 25; per-sample, not corpus-wide); fidelity sampled 36 / 89,065 (0.04%)
Risk warning: thin correctness coverage (validity below 1.00% floor; fidelity below 0.10% floor). Add targeted improved examples and still-flat near misses; aggregate numbers are not sufficient alone.

| Metric | Change | Count delta |
| ------ | ------ | ----------- |
| Fully raised (+) | 78,406 (88.03%) → 78,406 (88.03%) (neutral) | 0 |
| Conditional-branch residual (-) | 2,401 (2.70%) → 2,401 (2.70%) (neutral) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) → 2,286 (2.57%) (neutral) | 0 |
| Full malformed (-) | 0 → 0 (neutral) | 0 |
| Semantic defects (sampling differs) | 1 (0.29%) → 1 (0.29%) | n/a |
| Fidelity opcode diffs (sampling differs) | 5 (13.89%) → 5 (13.89%) | n/a |
| Fidelity exact (sampling differs) | 31 (86.11%) → 31 (86.11%) | n/a |
| Fidelity recompile failures (sampling differs) | 0 (0.00%) → 0 (0.00%) | n/a |
| Fidelity context failures (sampling differs) | 0 (0.00%) → 0 (0.00%) | n/a |
| Fidelity check coverage (+) | 36 (0.04%) → 36 (0.04%) (neutral) | 0 |
| Pass bugs (-) | 0 → 0 (neutral) | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 88.03% -> 88.03% (0 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); semantic defects ungated (sampling differs); fidelity ungated (sampling differs; rely on changed-method fidelity).

Verdict: corpus sensor matched baseline tolerances.
```

## Review

First-round adversarial reviews found two real issues:

| Reviewer | Finding | Resolution |
| --- | --- | --- |
| Opus 4.8 | Negating returns (`S == 0` / `!S`) incorrectly emitted `receiver && !condition`, flipping the null path. | Fixed in `452ec7e7` by negating the whole `receiver && condition` conjunction and updating the pass/source regressions. |
| Gemini Pro | The fold allowed intermediate blocks between condition/null/merge, so implicit fallthrough could be corrupted. | Fixed in `452ec7e7` by requiring contiguous condition/null/merge blocks and adding an intermediate-block negative canary. |

Second-round reviews against `452ec7e7` were CLEAN (Opus 4.8 and Gemini Pro). Final-head reviews against `2dd9d54d` were CLEAN, then human review requested that the SDK-portable source assertion branch on detected IL shape instead of accepting both strings blindly. Commit `68fca623` implements that and applies two small hardenings from follow-up notes; short re-reviews are running on `68fca623`.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*ClassUnionSwitchExpression_RendersTypePatternArms*" -method "*RaisesClassUnionStackSlotNotPatternReturnBeforeGenericDiamondFold*" -method "*DoesNotRaiseClassUnionStackSlotReturnAcrossIntermediateBlock*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.SlotStoreDiamondPassTests" -class "ILInspector.Decompiler.Tests.TypeSourceComposerUnionTests"
dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" --workers 20 --render-ab /tmp/issue-2631-base.renderab
dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" --diff-corpus-baseline /tmp/issue-2631-corpus-baseline.json --quality-diff-card --quality-card-risky --compile-cap 25 --corpus-fidelity-cap 3 --max-examples 3
```
