### PR TITLE
Replace message-based validity classification

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ValidityCoverageReportingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ValidityCoverageReportingTests.cs
@@ -1,4 +1,5 @@
 using ILInspector.DecompilerHarness;
+using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -7,6 +8,7 @@ public class ValidityCoverageReportingTests
 {
     static readonly object ConsoleGate = new();
     static string FixturePath => typeof(LadderRung1.Foundation).Assembly.Location;
+    static string DecompilerPath => typeof(IrImporter).Assembly.Location;
 
     [Fact]
     public void ValidityCheck_CappedRunLabelsSemanticFindingsAsPerSample()
@@ -27,6 +29,32 @@ public class ValidityCoverageReportingTests
         Assert.Contains("No compilation performed", output);
         Assert.Contains("conditional-arm-numeric-join-cast", output);
         Assert.Contains("conditional-target-numeric-cast", output);
+    }
+
+    [Fact]
+    [Trait("Speed", "Slow")]
+    public void DecompilerAssembly_MissingReturnPopulationIsPinned()
+    {
+        var actual = ValidityCheck.Evaluate(DecompilerPath)
+            .Where(result => result.SemanticDiagnostics.Any(diagnostic => diagnostic.Id == "CS0161"))
+            .Select(result => result.Id)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        string[] expected =
+        [
+            "ILInspector.Decompiler.Pipeline.BooleanFoldingPass::IsNullableCoalesceExpressionContext",
+            "ILInspector.Decompiler.Pipeline.CSharpPrinter::ForLoopIncrementText",
+            "ILInspector.Decompiler.Pipeline.DeconstructionAssignmentPass::TryMatchTupleSeed",
+            "ILInspector.Decompiler.Pipeline.FixedArrayRaising::SameLoadPlace",
+            "ILInspector.Decompiler.Pipeline.IndexFromEndPass::LengthReceiver",
+            "ILInspector.Decompiler.Pipeline.InlineArrayCollectionPass::PlaceFromAddress",
+            "ILInspector.Decompiler.Pipeline.IsPatternPass::IsPatternLocalNull",
+            "ILInspector.Decompiler.Pipeline.NullConditionalPass::MemberReceiver",
+            "ILInspector.Decompiler.Pipeline.UnionSwitchExpressionPass::SameTailNode",
+            "ILInspector.Decompiler.TypeSourceComposer::DecompileBody",
+        ];
+        Assert.Equal(expected, actual);
     }
 
     static string CaptureConsole(Func<int> action)

--- a/src/ILInspector.Decompiler.Tests/ValidityCoverageReportingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ValidityCoverageReportingTests.cs
@@ -42,6 +42,11 @@ public class ValidityCoverageReportingTests
             .ToArray();
 
         string[] expected =
+#if DEBUG
+        [
+            "ILInspector.Decompiler.TypeSourceComposer::DecompileBody",
+        ];
+#else
         [
             "ILInspector.Decompiler.Pipeline.BooleanFoldingPass::IsNullableCoalesceExpressionContext",
             "ILInspector.Decompiler.Pipeline.CSharpPrinter::ForLoopIncrementText",
@@ -54,6 +59,7 @@ public class ValidityCoverageReportingTests
             "ILInspector.Decompiler.Pipeline.UnionSwitchExpressionPass::SameTailNode",
             "ILInspector.Decompiler.TypeSourceComposer::DecompileBody",
         ];
+#endif
         Assert.Equal(expected, actual);
     }
 

--- a/src/ILInspector.Decompiler.Tests/ValidityShellNoiseTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ValidityShellNoiseTests.cs
@@ -17,7 +17,9 @@ public class ValidityShellNoiseTests
     [Theory]
     [InlineData("CS0029", "class Real {} sealed class __Shell { Real M() => this; }")]
     [InlineData("CS0019", "sealed class Real {} sealed class __Shell { bool M(Real value) => this == value; }")]
+    [InlineData("CS0019", "class Real {} sealed class __Shell { bool M((int, Real) value) => (1, this) == value; }")]
     [InlineData("CS0030", "sealed class Real {} sealed class __Shell { Real M() => (Real)this; }")]
+    [InlineData("CS0030", "class Real {} sealed class __Shell { Real[] M() => (Real[])new[] { this }; }")]
     [InlineData("CS0023", "sealed class __Shell { bool M() => !this; }")]
     [InlineData("CS8121", "class Real {} sealed class Derived : Real {} sealed class __Shell { bool M() => this is Derived; }")]
     public void SyntheticShellThisDiagnostics_AreFiltered(string diagnosticId, string source)
@@ -68,6 +70,22 @@ public class ValidityShellNoiseTests
             semanticModel);
 
         Assert.Equal([diagnosticId], defects.Select(d => d.Id));
+    }
+
+    [Fact]
+    public void ShellThisInStructuralOperand_DoesNotHideOtherTypeMismatch()
+    {
+        var (diagnostics, tree, semanticModel) = CompileWithModel(
+            "class Real {} sealed class __Shell { bool M((string, Real) value) => (1, this) == value; }");
+
+        var defects = ValidityCheck.ClassifySemanticDiagnostics(
+            diagnostics.Where(d => d.Id == "CS0019"),
+            tree,
+            Function(TypeRef.Definition("fixture", "", "Real")),
+            semanticModel);
+
+        Assert.Equal(diagnostics.Count(d => d.Id == "CS0019"), defects.Length);
+        Assert.All(defects, defect => Assert.Equal("CS0019", defect.Id));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ValidityShellNoiseTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ValidityShellNoiseTests.cs
@@ -21,13 +21,26 @@ public class ValidityShellNoiseTests
     [InlineData("CS0030", "sealed class Real {} sealed class __Shell { Real M() => (Real)this; }")]
     [InlineData("CS0030", "class Real {} sealed class __Shell { Real[] M() => (Real[])new[] { this }; }")]
     [InlineData("CS0023", "sealed class __Shell { bool M() => !this; }")]
-    [InlineData("CS8121", "class Real {} sealed class Derived : Real {} sealed class __Shell { bool M() => this is Derived; }")]
+    [InlineData(
+        "CS0266",
+        "class Real { public static explicit operator Real(__Shell value) => new(); } sealed class __Shell { Real M() => this; }")]
+    [InlineData(
+        "CS1605",
+        "sealed class __Shell { static void Take(ref __Shell value) {} void M() { Take(ref this); } }")]
+    [InlineData(
+        "CS8121",
+        "class Real {} sealed class Derived : Real {} sealed class __Shell { object M() { if (this is Derived value) return value; return null; } }")]
+    [InlineData(
+        "CS8129",
+        "class Real { public void Deconstruct(out int x, out int y) { x = y = 0; } } sealed class __Shell { void M() { (int x, int y) = this; } }")]
     public void SyntheticShellThisDiagnostics_AreFiltered(string diagnosticId, string source)
     {
         var (diagnostics, tree, semanticModel) = CompileWithModel(source);
+        var matching = diagnostics.Where(d => d.Id == diagnosticId).ToImmutableArray();
+        Assert.NotEmpty(matching);
 
         var defects = ValidityCheck.ClassifySemanticDiagnostics(
-            diagnostics.Where(d => d.Id == diagnosticId),
+            matching,
             tree,
             Function(TypeRef.Definition("fixture", "", "Real")),
             semanticModel);
@@ -89,6 +102,22 @@ public class ValidityShellNoiseTests
     }
 
     [Fact]
+    public void UnenumeratedShellDiagnostic_StaysReportedWithoutEvidenceMiss()
+    {
+        var (diagnostics, tree, semanticModel) = CompileWithModel(
+            "class Real {} sealed class Derived : Real {} sealed class __Shell { Derived M() => this as Derived; }");
+        var diagnostic = Assert.Single(diagnostics, d => d.Id == "CS0039");
+
+        var defects = ValidityCheck.ClassifySemanticDiagnostics(
+            [diagnostic],
+            tree,
+            Function(TypeRef.Definition("fixture", "", "Real")),
+            semanticModel);
+
+        Assert.Equal(["CS0039"], defects.Select(d => d.Id));
+    }
+
+    [Fact]
     public void ProtectedAccessThroughDeclaringTypeReceiver_IsFiltered()
     {
         var (diagnostics, tree, semanticModel) = CompileWithModel("""
@@ -144,9 +173,11 @@ public class ValidityShellNoiseTests
     {
         var (diagnostics, tree, semanticModel) = CompileWithModel(
             "using System;" + Environment.NewLine + source);
+        var matching = diagnostics.Where(d => d.Id == diagnosticId).ToImmutableArray();
+        Assert.NotEmpty(matching);
 
         var defects = ValidityCheck.ClassifySemanticDiagnostics(
-            diagnostics.Where(d => d.Id == diagnosticId),
+            matching,
             tree,
             Function(
                 TypeRef.Definition("fixture", "", "Host"),
@@ -194,6 +225,34 @@ public class ValidityShellNoiseTests
 
         Assert.Equal(
             [diagnosticId, ValidityCheck.StructuredEvidenceMissId],
+            defects.Select(d => d.Id));
+    }
+
+    [Fact]
+    public void SupportedShellDiagnosticWithoutExpectedSyntax_IsFailVisible()
+    {
+        var (diagnostics, tree, semanticModel) = CompileWithModel("class __Shell {}");
+        var descriptor = new DiagnosticDescriptor(
+            "CS0029",
+            "Synthetic",
+            "Synthetic",
+            "Compiler",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+        var diagnostic = Diagnostic.Create(
+            descriptor,
+            Location.Create(
+                tree,
+                tree.GetRoot(TestContext.Current.CancellationToken).FullSpan));
+
+        var defects = ValidityCheck.ClassifySemanticDiagnostics(
+            [diagnostic],
+            tree,
+            Function(TypeRef.Definition("fixture", "", "Real")),
+            semanticModel);
+
+        Assert.Equal(
+            ["CS0029", ValidityCheck.StructuredEvidenceMissId],
             defects.Select(d => d.Id));
     }
 

--- a/src/ILInspector.Decompiler.Tests/ValidityShellNoiseTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ValidityShellNoiseTests.cs
@@ -48,6 +48,28 @@ public class ValidityShellNoiseTests
         Assert.Equal(["CS0161"], defects.Select(d => d.Id));
     }
 
+    [Theory]
+    [InlineData(
+        "CS0266",
+        "sealed class __Shell { byte M(long value) => this.Equals(null) ? value : value; }")]
+    [InlineData(
+        "CS0029",
+        "sealed class __Shell { void M() { (string, object) value; value = (1, this); } }")]
+    public void ShellThisInSiblingSubexpression_DoesNotHideDefect(
+        string diagnosticId,
+        string source)
+    {
+        var (diagnostics, tree, semanticModel) = CompileWithModel(source);
+
+        var defects = ValidityCheck.ClassifySemanticDiagnostics(
+            diagnostics.Where(d => d.Id == diagnosticId),
+            tree,
+            Function(TypeRef.Definition("fixture", "", "Real")),
+            semanticModel);
+
+        Assert.Equal([diagnosticId], defects.Select(d => d.Id));
+    }
+
     [Fact]
     public void ProtectedAccessThroughDeclaringTypeReceiver_IsFiltered()
     {
@@ -93,6 +115,9 @@ public class ValidityShellNoiseTests
     [Theory]
     [InlineData("CS0712", "class __Shell { object M() => new Convert(); }")]
     [InlineData("CS0721", "class __Shell { void M(Convert value) {} }")]
+    [InlineData(
+        "CS0721",
+        "class __Shell { System.Threading.Tasks.Task M(System.Convert value) => null; }")]
     [InlineData("CS0722", "class __Shell { Convert M() => null; }")]
     [InlineData("CS0723", "class __Shell { void M() { Convert value = null; } }")]
     public void StaticTypeNameCollisions_UseDiagnosticSyntax(

--- a/src/ILInspector.Decompiler.Tests/ValidityShellNoiseTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ValidityShellNoiseTests.cs
@@ -11,6 +11,149 @@ public class ValidityShellNoiseTests
     static readonly TypeRef ReferenceEqualityComparerType =
         TypeRef.Definition("Microsoft.CodeAnalysis", "System.Collections.Generic", "ReferenceEqualityComparer");
 
+    static readonly TypeRef NonGenericConvertType =
+        TypeRef.Definition("ILInspector.Decompiler", "ILInspector.Decompiler.Pipeline", "Convert");
+
+    [Theory]
+    [InlineData("CS0029", "class Real {} sealed class __Shell { Real M() => this; }")]
+    [InlineData("CS0019", "sealed class Real {} sealed class __Shell { bool M(Real value) => this == value; }")]
+    [InlineData("CS0030", "sealed class Real {} sealed class __Shell { Real M() => (Real)this; }")]
+    [InlineData("CS0023", "sealed class __Shell { bool M() => !this; }")]
+    [InlineData("CS8121", "class Real {} sealed class Derived : Real {} sealed class __Shell { bool M() => this is Derived; }")]
+    public void SyntheticShellThisDiagnostics_AreFiltered(string diagnosticId, string source)
+    {
+        var (diagnostics, tree, semanticModel) = CompileWithModel(source);
+
+        var defects = ValidityCheck.ClassifySemanticDiagnostics(
+            diagnostics.Where(d => d.Id == diagnosticId),
+            tree,
+            Function(TypeRef.Definition("fixture", "", "Real")),
+            semanticModel);
+
+        Assert.Empty(defects);
+    }
+
+    [Fact]
+    public void ShellNameInMethodLevelDiagnostic_StaysReported()
+    {
+        var (diagnostics, tree, semanticModel) = CompileWithModel(
+            "sealed class __Shell { bool M() { } }");
+
+        var defects = ValidityCheck.ClassifySemanticDiagnostics(
+            diagnostics,
+            tree,
+            Function(TypeRef.Definition("fixture", "", "Real")),
+            semanticModel);
+
+        Assert.Equal(["CS0161"], defects.Select(d => d.Id));
+    }
+
+    [Fact]
+    public void ProtectedAccessThroughDeclaringTypeReceiver_IsFiltered()
+    {
+        var (diagnostics, tree, semanticModel) = CompileWithModel("""
+            class Base { protected object Clone() => new(); }
+            class Real : Base {}
+            class __Shell : Base
+            {
+                object M(Real value) => value.Clone();
+            }
+            """);
+
+        var defects = ValidityCheck.ClassifySemanticDiagnostics(
+            diagnostics,
+            tree,
+            Function(TypeRef.Definition("fixture", "", "Real")),
+            semanticModel);
+
+        Assert.Empty(defects);
+    }
+
+    [Fact]
+    public void ProtectedAccessThroughOtherTypeReceiver_StaysReported()
+    {
+        var (diagnostics, tree, semanticModel) = CompileWithModel("""
+            class Base { protected object Clone() => new(); }
+            class Real : Base {}
+            class __Shell : Base
+            {
+                object M(Real value) => value.Clone();
+            }
+            """);
+
+        var defects = ValidityCheck.ClassifySemanticDiagnostics(
+            diagnostics,
+            tree,
+            Function(TypeRef.Definition("fixture", "", "Other")),
+            semanticModel);
+
+        Assert.Equal(["CS1540"], defects.Select(d => d.Id));
+    }
+
+    [Theory]
+    [InlineData("CS0712", "class __Shell { object M() => new Convert(); }")]
+    [InlineData("CS0721", "class __Shell { void M(Convert value) {} }")]
+    [InlineData("CS0722", "class __Shell { Convert M() => null; }")]
+    [InlineData("CS0723", "class __Shell { void M() { Convert value = null; } }")]
+    public void StaticTypeNameCollisions_UseDiagnosticSyntax(
+        string diagnosticId,
+        string source)
+    {
+        var (diagnostics, tree, semanticModel) = CompileWithModel(
+            "using System;" + Environment.NewLine + source);
+
+        var defects = ValidityCheck.ClassifySemanticDiagnostics(
+            diagnostics.Where(d => d.Id == diagnosticId),
+            tree,
+            Function(
+                TypeRef.Definition("fixture", "", "Host"),
+                [NonGenericConvertType]),
+            semanticModel);
+
+        Assert.Empty(defects);
+    }
+
+    [Fact]
+    public void StaticTypeDiagnosticWithoutModelCollision_StaysReported()
+    {
+        var (diagnostics, tree, semanticModel) = CompileWithModel(
+            "using System; class __Shell { void M() { Convert value = null; } }");
+
+        var defects = ValidityCheck.ClassifySemanticDiagnostics(
+            diagnostics.Where(d => d.Id == "CS0723"),
+            tree,
+            Function(TypeRef.Definition("fixture", "", "Host")),
+            semanticModel);
+
+        Assert.Equal(["CS0723"], defects.Select(d => d.Id));
+    }
+
+    [Theory]
+    [InlineData("CS0029")]
+    [InlineData("CS0723")]
+    public void SupportedDiagnosticWithoutSourceLocation_IsFailVisible(string diagnosticId)
+    {
+        var (diagnostics, tree, semanticModel) = CompileWithModel("class __Shell {}");
+        var descriptor = new DiagnosticDescriptor(
+            diagnosticId,
+            "Synthetic",
+            "Synthetic",
+            "Compiler",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+        var diagnostic = Diagnostic.Create(descriptor, Location.None);
+
+        var defects = ValidityCheck.ClassifySemanticDiagnostics(
+            [diagnostic],
+            tree,
+            Function(TypeRef.Definition("fixture", "", "Host")),
+            semanticModel);
+
+        Assert.Equal(
+            [diagnosticId, ValidityCheck.StructuredEvidenceMissId],
+            defects.Select(d => d.Id));
+    }
+
     [Fact]
     public void DeclaringTypeStaticPropertyCtorAssignmentCollision_IsFiltered()
     {
@@ -76,6 +219,20 @@ public class ValidityShellNoiseTests
         return (diagnostic, tree, compilation.GetSemanticModel(tree));
     }
 
+    static (ImmutableArray<Diagnostic> Diagnostics, SyntaxTree Tree, SemanticModel SemanticModel)
+        CompileWithModel(string source)
+    {
+        var tree = CSharpSyntaxTree.ParseText(
+            source,
+            new CSharpParseOptions(LanguageVersion.Preview),
+            cancellationToken: TestContext.Current.CancellationToken);
+        var compilation = CreateCompilation(tree);
+        return (
+            compilation.GetDiagnostics(TestContext.Current.CancellationToken),
+            tree,
+            compilation.GetSemanticModel(tree));
+    }
+
     static ImmutableArray<Diagnostic> Compile(string source)
         => CreateCompilation(CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview)))
             .GetDiagnostics();
@@ -105,4 +262,18 @@ public class ValidityShellNoiseTests
             [],
             body);
     }
+
+    static IrFunction Function(
+        TypeRef declaringType,
+        ImmutableArray<TypeRef> locals = default)
+        => new(
+            "M",
+            declaringType,
+            new MethodSignature(
+                TypeRef.CoreLib("System", "Void"),
+                [],
+                HasThis: false,
+                GenericParameterCount: 0),
+            locals.IsDefault ? [] : locals,
+            new BlockContainer());
 }

--- a/tools/DecompilerHarness/LibraryReport.cs
+++ b/tools/DecompilerHarness/LibraryReport.cs
@@ -176,15 +176,12 @@ internal static class LibraryReport
 
                 var compilation = CSharpCompilation.Create("check", [tree], references, compileOptions);
                 var semanticModel = compilation.GetSemanticModel(tree);
-                var defects = compilation.GetDiagnostics()
-                    .Where(ValidityCheck.IsError)
-                    .Where(d => !ValidityCheck.BindingNoise.Contains(d.Id))
-                    .Where(d => !ValidityCheck.IsShellArtifact(d))
-                    .Where(d => !ValidityCheck.IsGenericArityCollisionNoise(d, tree, function))
-                    .Where(d => !ValidityCheck.IsSimpleNameStaticTypeCollisionNoise(d, tree, function))
-                    .Where(d => !ValidityCheck.IsDeclaringTypeStaticPropertyCtorAssignmentNoise(d, tree, function, semanticModel))
-                    .ToList();
-                if (defects.Count == 0)
+                var defects = ValidityCheck.ClassifySemanticDiagnostics(
+                    compilation.GetDiagnostics(),
+                    tree,
+                    function,
+                    semanticModel);
+                if (defects.Length == 0)
                 {
                     continue;
                 }

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -521,8 +521,9 @@ Diagnostics outside the enumerated shell-noise set, such as `CS0039`, stay
 reported as ordinary defects without `VLD0001` until they are explicitly
 modeled; surfacing an unknown code is preferred to blanket suppression.
 This intentionally stops suppressing method-level `CS0161` merely because its
-message names `__Shell.__M`; the current decompiler fixture assembly consequently
-exposes ten previously hidden missing-return defects, pinned by
+message names `__Shell.__M`; the current Release decompiler assembly consequently
+exposes ten previously hidden missing-return defects, while Debug IL exposes one.
+Both configuration-specific populations are pinned by
 `ValidityCoverageReportingTests.DecompilerAssembly_MissingReturnPopulationIsPinned`.
 The separate type-binding report still extracts a `CS0104` ambiguous simple
 name from invariant-culture message text for display; that reporting-only value

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -512,6 +512,15 @@ lowerings at once).
 
 **Validity check** (`--validity-check`): the *validity* check — `--gaps` is *completeness*, `--fidelity-check` is *fidelity*, this is *does it even compile*. The pipeline guarantees by construction only that it never crashes and never silently fabricates (unrepresentable IL becomes a visible `/* … */` comment and drops fidelity to `Partial`) — **not** that the rendered text is valid C#. This mode measures the gap: each body is wrapped in a method shell carrying its real signature (return type, generic parameters with their `where` constraints reconstructed from metadata, parameters, so locals/params/type-params and `this` all bind — without the constraints a constrained generic-math call like `byte.TryConvertFromTruncating<TOther>` spuriously fails CS0314), then (1) parsed — a parse error is unambiguously a decompiler defect; (2) checked for statement legality (the CS0201 rule — a bare cast/expression statement parses but isn't valid); (3) bound against the runtime references. Diagnostics are bucketed by code with the member/type-**visibility** codes (the shell can't see the real declaring type's fields/methods) filtered as noise, so genuine defects stand out — `CS0193` (`*`-deref of a managed ref), `CS0175` (`base(...)` rendered as a statement), `CS1620` (an `out` argument not marked `out`), `CS0165` (a local used before the decompiler assigned it). Reported split by fidelity: a `Partial` method is *expected* to carry invalid fragments; a **`Full` method that fails to compile is the real "claimed good but isn't" signal** and the prioritized fix docket. Compiler-generated members are excluded (their metadata names aren't valid identifiers). `--compile-cap N` bounds the (slow) semantic-binding pass; `--compile-cap all` runs an exhaustive binding sweep. Capped reports print how many eligible `Full` methods were actually compiled and label semantic findings as per-sample, not corpus-wide.
 
+Shell-noise classification uses diagnostic IDs, source spans, syntax, and
+semantic symbols rather than localized diagnostic prose. If a supported
+diagnostic lacks the source evidence needed to classify it, the original error
+stays reported and the method also receives `VLD0001`; evidence gaps therefore
+remain visible instead of silently joining an ordinary validity bucket.
+This intentionally stops suppressing method-level `CS0161` merely because its
+message names `__Shell.__M`; the current decompiler fixture assembly consequently
+exposes ten previously hidden missing-return defects.
+
 **Validity predicate scan** (`--validity-predicate-scan`): the cheap exhaustive
 coverage lane for known validity-risk classes. It does **not** compile or replace
 `--validity-check`; instead it runs the decompiler pipeline over every input

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -517,9 +517,16 @@ semantic symbols rather than localized diagnostic prose. If a supported
 diagnostic lacks the source evidence needed to classify it, the original error
 stays reported and the method also receives `VLD0001`; evidence gaps therefore
 remain visible instead of silently joining an ordinary validity bucket.
+Diagnostics outside the enumerated shell-noise set, such as `CS0039`, stay
+reported as ordinary defects without `VLD0001` until they are explicitly
+modeled; surfacing an unknown code is preferred to blanket suppression.
 This intentionally stops suppressing method-level `CS0161` merely because its
 message names `__Shell.__M`; the current decompiler fixture assembly consequently
-exposes ten previously hidden missing-return defects.
+exposes ten previously hidden missing-return defects, pinned by
+`ValidityCoverageReportingTests.DecompilerAssembly_MissingReturnPopulationIsPinned`.
+The separate type-binding report still extracts a `CS0104` ambiguous simple
+name from invariant-culture message text for display; that reporting-only value
+does not control filtering or classification.
 
 **Validity predicate scan** (`--validity-predicate-scan`): the cheap exhaustive
 coverage lane for known validity-risk classes. It does **not** compile or replace

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -728,7 +728,11 @@ static class ValidityCheck
             diagnostic.Location.SourceSpan,
             getInnermostNodeForTie: true);
         if (diagnostic.Id != "CS1540")
-            return ClassifySyntheticShellThis(diagnostic.Id, node, semanticModel);
+            return ClassifySyntheticShellThis(
+                diagnostic.Id,
+                node,
+                function.DeclaringType,
+                semanticModel);
 
         var memberAccess = node.FirstAncestorOrSelf<MemberAccessExpressionSyntax>()
             ?? node.DescendantNodesAndSelf()
@@ -754,11 +758,18 @@ static class ValidityCheck
     static EvidenceDisposition ClassifySyntheticShellThis(
         string diagnosticId,
         SyntaxNode node,
+        TypeRef declaringType,
         SemanticModel semanticModel)
     {
+        if (diagnosticId == "CS0019")
+        {
+            return IsSyntheticShellBinaryArtifact(node, declaringType, semanticModel)
+                ? EvidenceDisposition.Filter
+                : EvidenceDisposition.Keep;
+        }
+
         ExpressionSyntax? subject = diagnosticId switch
         {
-            "CS0019" => ShellTypedBinaryOperand(node, semanticModel),
             "CS0023" => node.FirstAncestorOrSelf<PrefixUnaryExpressionSyntax>()?.Operand,
             "CS0030" => node.FirstAncestorOrSelf<CastExpressionSyntax>()?.Expression,
             "CS8121" => node.FirstAncestorOrSelf<IsPatternExpressionSyntax>()?.Expression,
@@ -769,23 +780,43 @@ static class ValidityCheck
         if (subject is null)
             return EvidenceDisposition.Keep;
 
-        return IsSyntheticShellValue(subject, semanticModel)
+        ITypeSymbol? targetType = diagnosticId switch
+        {
+            "CS0030" => node.FirstAncestorOrSelf<CastExpressionSyntax>() is { } cast
+                ? semanticModel.GetTypeInfo(cast.Type).Type
+                : null,
+            "CS0029" or "CS0266" => semanticModel.GetTypeInfo(subject).ConvertedType,
+            _ => null,
+        };
+        bool shellArtifact = targetType is null
+            ? IsDirectSyntheticShellValue(subject, semanticModel)
+            : IsSyntheticShellConversionArtifact(
+                subject,
+                targetType,
+                declaringType,
+                semanticModel);
+        return shellArtifact
             ? EvidenceDisposition.Filter
             : EvidenceDisposition.Keep;
     }
 
-    static ExpressionSyntax? ShellTypedBinaryOperand(
+    static bool IsSyntheticShellBinaryArtifact(
         SyntaxNode node,
+        TypeRef declaringType,
         SemanticModel semanticModel)
     {
         var binary = node.FirstAncestorOrSelf<BinaryExpressionSyntax>();
         if (binary is null)
-            return null;
-        if (IsSyntheticShellValue(binary.Left, semanticModel))
-            return binary.Left;
-        if (IsSyntheticShellValue(binary.Right, semanticModel))
-            return binary.Right;
-        return binary;
+            return false;
+
+        var leftType = semanticModel.GetTypeInfo(binary.Left).Type;
+        var rightType = semanticModel.GetTypeInfo(binary.Right).Type;
+        return IsSyntheticShellValue(binary.Left, semanticModel)
+                && (IsSyntheticShellType(leftType)
+                    || TypesEquivalentAfterShellReplacement(leftType, rightType, declaringType))
+            || IsSyntheticShellValue(binary.Right, semanticModel)
+                && (IsSyntheticShellType(rightType)
+                    || TypesEquivalentAfterShellReplacement(rightType, leftType, declaringType));
     }
 
     static ExpressionSyntax? ClosestExpression(SyntaxNode node)
@@ -801,8 +832,85 @@ static class ValidityCheck
         => expression.DescendantNodesAndSelf()
             .OfType<ThisExpressionSyntax>()
             .Any(candidate => IsSyntheticShellThis(candidate, semanticModel))
-        && semanticModel.GetTypeInfo(expression).Type is INamedTypeSymbol type
-        && IsSyntheticShellType(type);
+        && ContainsSyntheticShellType(semanticModel.GetTypeInfo(expression).Type);
+
+    static bool IsDirectSyntheticShellValue(
+        ExpressionSyntax expression,
+        SemanticModel semanticModel)
+        => expression.DescendantNodesAndSelf()
+            .OfType<ThisExpressionSyntax>()
+            .Any(candidate => IsSyntheticShellThis(candidate, semanticModel))
+        && IsSyntheticShellType(semanticModel.GetTypeInfo(expression).Type);
+
+    static bool IsSyntheticShellConversionArtifact(
+        ExpressionSyntax expression,
+        ITypeSymbol targetType,
+        TypeRef declaringType,
+        SemanticModel semanticModel)
+    {
+        if (!IsSyntheticShellValue(expression, semanticModel))
+            return false;
+
+        var sourceType = semanticModel.GetTypeInfo(expression).Type;
+        return IsSyntheticShellType(sourceType)
+            || TypesEquivalentAfterShellReplacement(sourceType, targetType, declaringType);
+    }
+
+    static bool ContainsSyntheticShellType(ITypeSymbol? type)
+        => type switch
+        {
+            INamedTypeSymbol namedType => IsSyntheticShellType(namedType)
+                || namedType.TypeArguments.Any(ContainsSyntheticShellType),
+            IArrayTypeSymbol arrayType => ContainsSyntheticShellType(arrayType.ElementType),
+            IPointerTypeSymbol pointerType => ContainsSyntheticShellType(pointerType.PointedAtType),
+            _ => false,
+        };
+
+    static bool TypesEquivalentAfterShellReplacement(
+        ITypeSymbol? left,
+        ITypeSymbol? right,
+        TypeRef declaringType)
+    {
+        if (left is null || right is null)
+            return false;
+        if (IsSyntheticShellType(left))
+            return right is INamedTypeSymbol rightNamed
+                && MetadataFullName(rightNamed) == MetadataFullName(declaringType);
+        if (IsSyntheticShellType(right))
+            return left is INamedTypeSymbol leftNamed
+                && MetadataFullName(leftNamed) == MetadataFullName(declaringType);
+        if (left is IArrayTypeSymbol leftArray && right is IArrayTypeSymbol rightArray)
+        {
+            return leftArray.Rank == rightArray.Rank
+                && TypesEquivalentAfterShellReplacement(
+                    leftArray.ElementType,
+                    rightArray.ElementType,
+                    declaringType);
+        }
+        if (left is IPointerTypeSymbol leftPointer && right is IPointerTypeSymbol rightPointer)
+        {
+            return TypesEquivalentAfterShellReplacement(
+                leftPointer.PointedAtType,
+                rightPointer.PointedAtType,
+                declaringType);
+        }
+        if (left is INamedTypeSymbol leftNamedType
+            && right is INamedTypeSymbol rightNamedType
+            && SymbolEqualityComparer.Default.Equals(
+                leftNamedType.OriginalDefinition,
+                rightNamedType.OriginalDefinition)
+            && leftNamedType.TypeArguments.Length == rightNamedType.TypeArguments.Length)
+        {
+            return leftNamedType.TypeArguments
+                .Zip(rightNamedType.TypeArguments)
+                .All(pair => TypesEquivalentAfterShellReplacement(
+                    pair.First,
+                    pair.Second,
+                    declaringType));
+        }
+
+        return SymbolEqualityComparer.Default.Equals(left, right);
+    }
 
     static bool IsSyntheticShellThis(
         ThisExpressionSyntax expression,
@@ -817,6 +925,9 @@ static class ValidityCheck
             ContainingType: null,
             ContainingNamespace.IsGlobalNamespace: true,
         };
+
+    static bool IsSyntheticShellType(ITypeSymbol? type)
+        => type is INamedTypeSymbol namedType && IsSyntheticShellType(namedType);
 
     static bool IsProtected(ISymbol? symbol)
         => symbol?.DeclaredAccessibility is

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -727,23 +727,8 @@ static class ValidityCheck
         var node = tree.GetRoot().FindNode(
             diagnostic.Location.SourceSpan,
             getInnermostNodeForTie: true);
-        var expressions = node.AncestorsAndSelf()
-            .OfType<ExpressionSyntax>()
-            .Concat(node.DescendantNodesAndSelf().OfType<ExpressionSyntax>())
-            .ToList();
-        if (expressions.Count == 0)
-            return EvidenceDisposition.Unextracted;
-
-        if (expressions.Any(expression =>
-            expression.DescendantNodesAndSelf()
-                .OfType<ThisExpressionSyntax>()
-                .Any(candidate => IsSyntheticShellThis(candidate, semanticModel))))
-        {
-            return EvidenceDisposition.Filter;
-        }
-
         if (diagnostic.Id != "CS1540")
-            return EvidenceDisposition.Keep;
+            return ClassifySyntheticShellThis(diagnostic.Id, node, semanticModel);
 
         var memberAccess = node.FirstAncestorOrSelf<MemberAccessExpressionSyntax>()
             ?? node.DescendantNodesAndSelf()
@@ -766,10 +751,67 @@ static class ValidityCheck
             : EvidenceDisposition.Keep;
     }
 
+    static EvidenceDisposition ClassifySyntheticShellThis(
+        string diagnosticId,
+        SyntaxNode node,
+        SemanticModel semanticModel)
+    {
+        ExpressionSyntax? subject = diagnosticId switch
+        {
+            "CS0019" => ShellTypedBinaryOperand(node, semanticModel),
+            "CS0023" => node.FirstAncestorOrSelf<PrefixUnaryExpressionSyntax>()?.Operand,
+            "CS0030" => node.FirstAncestorOrSelf<CastExpressionSyntax>()?.Expression,
+            "CS8121" => node.FirstAncestorOrSelf<IsPatternExpressionSyntax>()?.Expression,
+            "CS8129" => node.FirstAncestorOrSelf<AssignmentExpressionSyntax>()?.Right
+                ?? ClosestExpression(node),
+            _ => ClosestExpression(node),
+        };
+        if (subject is null)
+            return EvidenceDisposition.Keep;
+
+        return IsSyntheticShellValue(subject, semanticModel)
+            ? EvidenceDisposition.Filter
+            : EvidenceDisposition.Keep;
+    }
+
+    static ExpressionSyntax? ShellTypedBinaryOperand(
+        SyntaxNode node,
+        SemanticModel semanticModel)
+    {
+        var binary = node.FirstAncestorOrSelf<BinaryExpressionSyntax>();
+        if (binary is null)
+            return null;
+        if (IsSyntheticShellValue(binary.Left, semanticModel))
+            return binary.Left;
+        if (IsSyntheticShellValue(binary.Right, semanticModel))
+            return binary.Right;
+        return binary;
+    }
+
+    static ExpressionSyntax? ClosestExpression(SyntaxNode node)
+        => node.FirstAncestorOrSelf<ExpressionSyntax>()
+            ?? node.DescendantNodesAndSelf()
+                .OfType<ExpressionSyntax>()
+                .OrderBy(candidate => candidate.Span.Length)
+                .FirstOrDefault();
+
+    static bool IsSyntheticShellValue(
+        ExpressionSyntax expression,
+        SemanticModel semanticModel)
+        => expression.DescendantNodesAndSelf()
+            .OfType<ThisExpressionSyntax>()
+            .Any(candidate => IsSyntheticShellThis(candidate, semanticModel))
+        && semanticModel.GetTypeInfo(expression).Type is INamedTypeSymbol type
+        && IsSyntheticShellType(type);
+
     static bool IsSyntheticShellThis(
         ThisExpressionSyntax expression,
         SemanticModel semanticModel)
-        => semanticModel.GetTypeInfo(expression).Type is INamedTypeSymbol
+        => semanticModel.GetTypeInfo(expression).Type is INamedTypeSymbol type
+        && IsSyntheticShellType(type);
+
+    static bool IsSyntheticShellType(INamedTypeSymbol type)
+        => type is
         {
             Name: "__Shell",
             ContainingType: null,
@@ -934,17 +976,33 @@ static class ValidityCheck
         var root = tree.GetRoot();
         var span = diagnostic.Location.SourceSpan;
         var node = root.FindNode(span, getInnermostNodeForTie: true);
+        TypeSyntax? type = diagnostic.Id switch
+        {
+            "CS0712" => node.FirstAncestorOrSelf<ObjectCreationExpressionSyntax>()?.Type,
+            "CS0721" => node.FirstAncestorOrSelf<ParameterSyntax>()?.Type,
+            "CS0722" => node.FirstAncestorOrSelf<MethodDeclarationSyntax>()?.ReturnType,
+            "CS0723" => node.FirstAncestorOrSelf<VariableDeclarationSyntax>()?.Type,
+            _ => null,
+        };
+        if (type is not null)
+            return RightmostSimpleName(type)?.Identifier.ValueText;
+
         var name = node.FirstAncestorOrSelf<SimpleNameSyntax>()
-            ?? node.FirstAncestorOrSelf<MethodDeclarationSyntax>()?.ReturnType
-                .DescendantNodesAndSelf()
-                .OfType<SimpleNameSyntax>()
-                .LastOrDefault()
             ?? node.DescendantNodesAndSelf()
                 .OfType<SimpleNameSyntax>()
-                .OrderBy(candidate => candidate.Span.Length)
-                .FirstOrDefault();
+                .Where(candidate =>
+                    span.Start <= candidate.Span.Start
+                    && candidate.Span.End <= span.End)
+                .OrderBy(candidate => candidate.Span.Start)
+                .LastOrDefault();
         return name?.Identifier.ValueText;
     }
+
+    static SimpleNameSyntax? RightmostSimpleName(SyntaxNode node)
+        => node.DescendantNodesAndSelf()
+            .OfType<SimpleNameSyntax>()
+            .OrderBy(candidate => candidate.Span.Start)
+            .LastOrDefault();
 
     enum EvidenceDisposition
     {

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -762,11 +762,7 @@ static class ValidityCheck
         SemanticModel semanticModel)
     {
         if (diagnosticId == "CS0019")
-        {
-            return IsSyntheticShellBinaryArtifact(node, declaringType, semanticModel)
-                ? EvidenceDisposition.Filter
-                : EvidenceDisposition.Keep;
-        }
+            return ClassifySyntheticShellBinary(node, declaringType, semanticModel);
 
         ExpressionSyntax? subject = diagnosticId switch
         {
@@ -778,7 +774,7 @@ static class ValidityCheck
             _ => ClosestExpression(node),
         };
         if (subject is null)
-            return EvidenceDisposition.Keep;
+            return EvidenceDisposition.Unextracted;
 
         ITypeSymbol? targetType = diagnosticId switch
         {
@@ -800,23 +796,26 @@ static class ValidityCheck
             : EvidenceDisposition.Keep;
     }
 
-    static bool IsSyntheticShellBinaryArtifact(
+    static EvidenceDisposition ClassifySyntheticShellBinary(
         SyntaxNode node,
         TypeRef declaringType,
         SemanticModel semanticModel)
     {
         var binary = node.FirstAncestorOrSelf<BinaryExpressionSyntax>();
         if (binary is null)
-            return false;
+            return EvidenceDisposition.Unextracted;
 
         var leftType = semanticModel.GetTypeInfo(binary.Left).Type;
         var rightType = semanticModel.GetTypeInfo(binary.Right).Type;
-        return IsSyntheticShellValue(binary.Left, semanticModel)
+        bool shellArtifact = IsSyntheticShellValue(binary.Left, semanticModel)
                 && (IsSyntheticShellType(leftType)
                     || TypesEquivalentAfterShellReplacement(leftType, rightType, declaringType))
             || IsSyntheticShellValue(binary.Right, semanticModel)
                 && (IsSyntheticShellType(rightType)
                     || TypesEquivalentAfterShellReplacement(rightType, leftType, declaringType));
+        return shellArtifact
+            ? EvidenceDisposition.Filter
+            : EvidenceDisposition.Keep;
     }
 
     static ExpressionSyntax? ClosestExpression(SyntaxNode node)

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -63,6 +63,14 @@ static class ValidityCheck
         "CS1929", "CS0428", "CS1955", "CS1729", "CS0704",
     ];
 
+    internal const string StructuredEvidenceMissId = "VLD0001";
+
+    static readonly HashSet<string> ShellTypeDiagnosticIds =
+    [
+        "CS0019", "CS0023", "CS0029", "CS0030", "CS0266",
+        "CS1540", "CS1605", "CS8121", "CS8129",
+    ];
+
     public sealed record ValidityDiagnostic(string Id, string Message);
 
     public sealed record MethodResult(
@@ -306,16 +314,55 @@ static class ValidityCheck
 
         var compilation = CSharpCompilation.Create("check", [tree], references, compileOptions);
         var semanticModel = compilation.GetSemanticModel(tree);
-        var defects = compilation.GetDiagnostics()
-            .Where(IsError)
-            .Where(d => !BindingNoise.Contains(d.Id))
-            .Where(d => !IsShellArtifact(d))
-            .Where(d => !IsGenericArityCollisionNoise(d, tree, function))
-            .Where(d => !IsSimpleNameStaticTypeCollisionNoise(d, tree, function))
-            .Where(d => !IsDeclaringTypeStaticPropertyCtorAssignmentNoise(d, tree, function, semanticModel))
-            .Select(d => new ValidityDiagnostic(d.Id, d.GetMessage()))
-            .ToImmutableArray();
+        var defects = ClassifySemanticDiagnostics(
+            compilation.GetDiagnostics(),
+            tree,
+            function,
+            semanticModel);
         return new RenderedBodyResult([], SemanticChecked: true, defects);
+    }
+
+    internal static ImmutableArray<ValidityDiagnostic> ClassifySemanticDiagnostics(
+        IEnumerable<Diagnostic> diagnostics,
+        SyntaxTree tree,
+        IrFunction function,
+        SemanticModel semanticModel)
+    {
+        var defects = ImmutableArray.CreateBuilder<ValidityDiagnostic>();
+        foreach (var diagnostic in diagnostics)
+        {
+            if (!IsError(diagnostic) || BindingNoise.Contains(diagnostic.Id))
+                continue;
+
+            var shellArtifact = ClassifyShellArtifact(diagnostic, tree, function, semanticModel);
+            if (shellArtifact == EvidenceDisposition.Filter)
+                continue;
+
+            var staticTypeCollision = ClassifySimpleNameStaticTypeCollision(diagnostic, tree, function);
+            if (staticTypeCollision == EvidenceDisposition.Filter)
+                continue;
+
+            if (IsGenericArityCollisionNoise(diagnostic, tree, function)
+                || IsDeclaringTypeStaticPropertyCtorAssignmentNoise(
+                    diagnostic,
+                    tree,
+                    function,
+                    semanticModel))
+            {
+                continue;
+            }
+
+            defects.Add(new ValidityDiagnostic(diagnostic.Id, diagnostic.GetMessage()));
+            if (shellArtifact == EvidenceDisposition.Unextracted
+                || staticTypeCollision == EvidenceDisposition.Unextracted)
+            {
+                defects.Add(new ValidityDiagnostic(
+                    StructuredEvidenceMissId,
+                    $"structured validity evidence unavailable for {diagnostic.Id}"));
+            }
+        }
+
+        return defects.ToImmutable();
     }
 
     static void Record(Dictionary<string, SortedSet<string>> map, string method, IEnumerable<string> codes)
@@ -662,29 +709,78 @@ static class ValidityCheck
 
     /// <summary>
     /// The body is wrapped in an instance method on a synthetic <c>__Shell</c>
-    /// class, so the only <c>__Shell</c>-typed expression in scope is <c>this</c>
-    /// — which in the real method is the declaring type. A diagnostic that names
-    /// <c>__Shell</c> is therefore the shell mistyping <c>this</c> (the original
-    /// source compiled, so the declaring-type form is valid), not a defect in the
-    /// decompiled output. Filtered like the binding-visibility codes.
+    /// class. Diagnostics caused by Roslyn binding <c>this</c> to that class, or
+    /// by protected access that would be legal inside the real declaring type,
+    /// are shell artifacts rather than decompiler defects.
     /// </summary>
-    internal static bool IsShellArtifact(Diagnostic diagnostic)
-        => diagnostic.GetMessage().Contains("__Shell") || IsThisRefShellArtifact(diagnostic);
-
-    static bool IsThisRefShellArtifact(Diagnostic diagnostic)
+    static EvidenceDisposition ClassifyShellArtifact(
+        Diagnostic diagnostic,
+        SyntaxTree tree,
+        IrFunction function,
+        SemanticModel semanticModel)
     {
-        // `out this` / `ref this` is valid inside a struct instance method, but
-        // the validity shell wraps every body in a reference-type __Shell method.
-        // Roslyn therefore reports CS1605 against `this` even when the original
-        // declaring type accepts the spelling.
-        if (diagnostic.Id != "CS1605" || diagnostic.Location.SourceTree is not { } tree)
-            return false;
-        var lineSpan = diagnostic.Location.GetLineSpan();
-        if (lineSpan.StartLinePosition.Line < 0)
-            return false;
-        var line = tree.GetText().Lines[lineSpan.StartLinePosition.Line].ToString();
-        return line.Contains("this", StringComparison.Ordinal);
+        if (!ShellTypeDiagnosticIds.Contains(diagnostic.Id))
+            return EvidenceDisposition.Keep;
+        if (diagnostic.Location.SourceTree != tree)
+            return EvidenceDisposition.Unextracted;
+
+        var node = tree.GetRoot().FindNode(
+            diagnostic.Location.SourceSpan,
+            getInnermostNodeForTie: true);
+        var expressions = node.AncestorsAndSelf()
+            .OfType<ExpressionSyntax>()
+            .Concat(node.DescendantNodesAndSelf().OfType<ExpressionSyntax>())
+            .ToList();
+        if (expressions.Count == 0)
+            return EvidenceDisposition.Unextracted;
+
+        if (expressions.Any(expression =>
+            expression.DescendantNodesAndSelf()
+                .OfType<ThisExpressionSyntax>()
+                .Any(candidate => IsSyntheticShellThis(candidate, semanticModel))))
+        {
+            return EvidenceDisposition.Filter;
+        }
+
+        if (diagnostic.Id != "CS1540")
+            return EvidenceDisposition.Keep;
+
+        var memberAccess = node.FirstAncestorOrSelf<MemberAccessExpressionSyntax>()
+            ?? node.DescendantNodesAndSelf()
+                .OfType<MemberAccessExpressionSyntax>()
+                .FirstOrDefault(candidate =>
+                    diagnostic.Location.SourceSpan.IntersectsWith(candidate.Span));
+        if (memberAccess is null)
+            return EvidenceDisposition.Unextracted;
+
+        var symbolInfo = semanticModel.GetSymbolInfo(memberAccess.Name);
+        var member = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
+        if (member is null)
+            return EvidenceDisposition.Unextracted;
+        return IsProtected(member)
+            && ReceiverResolvesToDeclaringType(
+                memberAccess.Expression,
+                function.DeclaringType,
+                semanticModel)
+            ? EvidenceDisposition.Filter
+            : EvidenceDisposition.Keep;
     }
+
+    static bool IsSyntheticShellThis(
+        ThisExpressionSyntax expression,
+        SemanticModel semanticModel)
+        => semanticModel.GetTypeInfo(expression).Type is INamedTypeSymbol
+        {
+            Name: "__Shell",
+            ContainingType: null,
+            ContainingNamespace.IsGlobalNamespace: true,
+        };
+
+    static bool IsProtected(ISymbol? symbol)
+        => symbol?.DeclaredAccessibility is
+            Accessibility.Protected or
+            Accessibility.ProtectedAndInternal or
+            Accessibility.ProtectedOrInternal;
 
     /// <summary>
     /// CS0305 ("the generic type 'X&lt;T&gt;' requires N type arguments") on a
@@ -731,19 +827,27 @@ static class ValidityCheck
     /// such as <c>System.Convert</c> or <c>System.Environment</c>.
     /// </summary>
     internal static bool IsSimpleNameStaticTypeCollisionNoise(Diagnostic diagnostic, SyntaxTree tree, IrFunction function)
+        => ClassifySimpleNameStaticTypeCollision(diagnostic, tree, function)
+            == EvidenceDisposition.Filter;
+
+    static EvidenceDisposition ClassifySimpleNameStaticTypeCollision(
+        Diagnostic diagnostic,
+        SyntaxTree tree,
+        IrFunction function)
     {
         if (diagnostic.Id is not ("CS0712" or "CS0721" or "CS0722" or "CS0723"))
-            return false;
+            return EvidenceDisposition.Keep;
         if (diagnostic.Location.SourceTree != tree)
-            return false;
+            return EvidenceDisposition.Unextracted;
 
-        string? simpleName = SimpleNameAtDiagnosticLocation(diagnostic, tree)
-            ?? SimpleNameFromDiagnosticMessage(diagnostic);
+        string? simpleName = SimpleNameAtDiagnosticLocation(diagnostic, tree);
         if (simpleName is null)
-            return false;
+            return EvidenceDisposition.Unextracted;
 
         return ShellNoise.ReferencesNonGenericTypeNamed(function, simpleName)
-            && !ShellNoise.ReferencesGenericTypeNamed(function, simpleName);
+            && !ShellNoise.ReferencesGenericTypeNamed(function, simpleName)
+            ? EvidenceDisposition.Filter
+            : EvidenceDisposition.Keep;
     }
 
     /// <summary>
@@ -789,7 +893,9 @@ static class ValidityCheck
             ?? symbolInfo.CandidateSymbols.OfType<INamedTypeSymbol>().FirstOrDefault();
         if (symbol is IAliasSymbol alias)
             symbol = alias.Target;
-        if (symbol is not INamedTypeSymbol namedType)
+        var namedType = symbol as INamedTypeSymbol
+            ?? semanticModel.GetTypeInfo(receiver).Type as INamedTypeSymbol;
+        if (namedType is null)
             return false;
 
         return MetadataFullName(namedType) == MetadataFullName(declaringType);
@@ -825,27 +931,26 @@ static class ValidityCheck
 
     static string? SimpleNameAtDiagnosticLocation(Diagnostic diagnostic, SyntaxTree tree)
     {
-        var node = tree.GetRoot().FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
-        if (node.FirstAncestorOrSelf<IdentifierNameSyntax>() is { } name)
-            return name.Identifier.ValueText;
-        if (node.FirstAncestorOrSelf<ObjectCreationExpressionSyntax>() is { Type: IdentifierNameSyntax objectType })
-            return objectType.Identifier.ValueText;
-        return null;
+        var root = tree.GetRoot();
+        var span = diagnostic.Location.SourceSpan;
+        var node = root.FindNode(span, getInnermostNodeForTie: true);
+        var name = node.FirstAncestorOrSelf<SimpleNameSyntax>()
+            ?? node.FirstAncestorOrSelf<MethodDeclarationSyntax>()?.ReturnType
+                .DescendantNodesAndSelf()
+                .OfType<SimpleNameSyntax>()
+                .LastOrDefault()
+            ?? node.DescendantNodesAndSelf()
+                .OfType<SimpleNameSyntax>()
+                .OrderBy(candidate => candidate.Span.Length)
+                .FirstOrDefault();
+        return name?.Identifier.ValueText;
     }
 
-    static string? SimpleNameFromDiagnosticMessage(Diagnostic diagnostic)
+    enum EvidenceDisposition
     {
-        var message = diagnostic.GetMessage();
-        int start = message.IndexOf('\'');
-        if (start < 0)
-            return null;
-        int end = message.IndexOf('\'', start + 1);
-        if (end <= start + 1)
-            return null;
-        var quoted = message[(start + 1)..end];
-        if (quoted.Any(c => !(char.IsLetterOrDigit(c) || c is '_' or '.' or '+')))
-            return null;
-        return ShellNoise.SimpleName(quoted);
+        Keep,
+        Filter,
+        Unextracted,
     }
 
     internal static ImmutableArray<MetadataReference> RuntimeReferences()


### PR DESCRIPTION
Fixes #2657

- Replaces localized-message validity decisions with structured Roslyn and
  decompiler-model evidence.
- Card revision: `83dc4c7213f885b35bfca6c730c0d7c9a421872e`

## Change

**Conclusion: PASS** - validity classification now uses diagnostic IDs, source
syntax, semantic symbols/types, and decompiler model types; missing structured
evidence remains visible as `VLD0001`.

- Centralizes semantic diagnostic classification for `ValidityCheck` and
  `LibraryReport`.
- Anchors shell-`this` decisions to diagnostic-specific operands, including
  structurally equivalent array/tuple/generic shapes without hiding unrelated
  sibling mismatches.
- Resolves static-name collisions from diagnostic-specific type syntax,
  including qualified names.
- Intentionally exposes genuine method-level `CS0161` and protected-access
  defects that the former `__Shell` message substring filter hid.

## Evidence

| Check | Result |
| --- | --- |
| Product/test/fixture solution build | Pass |
| Focused validity and shell-noise tests | 38 passed |
| Decompiler fixture validity boss | 5,350/5,350 checked; 10 newly visible `CS0161`; no other delta |
| CoreLib validity boss | 38,434/38,434 checked; 25 newly visible `CS0161` rows and one genuine `CS1540`; no `VLD0001` |
| Markdown lint | Pass |
| PR CI | Pass |
| Full decompiler suite | 2,486 passed; one unrelated `TypeSourceComposerUnionTests` failure reproduces on `origin/main` |

The intentional fixture-bucket correction is documented in the harness README.

## Decompiler quality

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity compiled 25,183 methods (compile-cap 4,000; per-sample, not corpus-wide); fidelity sampled 36 / 89,065 (0.04%)

| Metric | Change | Count delta |
| ------ | ------ | ----------- |
| Fully raised (+) | 78,406 (88.03%) → 78,406 (88.03%) (neutral) | 0 |
| Conditional-branch residual (-) | 2,401 (2.70%) → 2,401 (2.70%) (neutral) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) → 2,286 (2.57%) (neutral) | 0 |
| Full malformed (-) | 0 → 0 (neutral) | 0 |
| Semantic defects (sampling differs) | 54 (0.21%) → 101 (0.40%) | n/a |
| Fidelity opcode diffs (sampling differs) | 4 (11.11%) → 3 (8.33%) | n/a |
| Fidelity exact (sampling differs) | 32 (88.89%) → 33 (91.67%) | n/a |
| Fidelity recompile failures (sampling differs) | 0 (0.00%) → 0 (0.00%) | n/a |
| Fidelity context failures (sampling differs) | 0 (0.00%) → 0 (0.00%) | n/a |
| Fidelity check coverage (+) | 36 (0.04%) → 36 (0.04%) (neutral) | 0 |
| Pass bugs (-) | 0 → 0 (neutral) | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 88.03% -> 88.03% (0 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); semantic defects ungated (sampling differs); fidelity ungated (sampling differs; rely on changed-method fidelity).

Verdict: corpus sensor matched baseline tolerances.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | CLEAN at `83dc4c72` | Reproduced direct/structural positives, mixed/sibling negatives, static collisions, `CS1540`, and `VLD0001` |
| Gemini 3.1 Pro | CLEAN at `83dc4c72` | Verified recursive structural equivalence, operand symmetry, qualified names, fail-visible fallback, and report parity |

**Review conclusion: PASS** - both isolated exact-head reviewers are clean.
