### PR TITLE
Add RTS source-body fault isolation

### DIFF
--- a/docs/design/fact-planned-compile-back-harness.md
+++ b/docs/design/fact-planned-compile-back-harness.md
@@ -730,6 +730,16 @@ the existing compile-back status buckets.
 | artifact source does not compile | `RecompileFail` |
 | unsupported product body shape before compile | `RecompileFail` or `ContextFail`, with explicit reason |
 
+SourceLink or fixture source coverage is a sidecar oracle, not a replacement RTS
+verdict. When a product artifact fails to recompile and an authored source body
+is available for the same requested target, RTS may substitute only that authored
+body into the same `ArtifactRequest` shell and retry compilation. If the authored
+body compiles, the `RecompileFail` is isolated to a product/decompiler body
+defect. If the authored body also fails, the failure is isolated to the RTS
+shell, closure, reference, or standalone source-consumption context. The original
+status remains `RecompileFail`; the sidecar reason may refine reporting as
+`body-defect` or `shell-or-closure-defect`.
+
 The existing corpus sensor gates on `Exact`, `OpcodeDiff`, `RecompileFail`, and
 `ContextFail`. ReturnToSender planning reasons should be structured details
 underneath those statuses, not replacement top-level metrics.
@@ -851,6 +861,7 @@ Tests should name the oracle they exercise:
 | fact agreement | Do independently produced facts agree on the same IL/member/type evidence? |
 | product diff parity | Do product API/IL/C# diffs match for the requested artifact scope? |
 | source artifact validity | Does the product artifact compile without RTS-side C# construction? |
+| authored-source isolation | Does the authored body compile in the same RTS shell after a product artifact `RecompileFail`? |
 | API/platform resolution | Did package/framework/shared-service resolution select the intended asset? |
 | performance-signal precision | Does a signal identify useful targets without noisy over-reporting? |
 

--- a/docs/design/fact-planned-compile-back-harness.md
+++ b/docs/design/fact-planned-compile-back-harness.md
@@ -738,7 +738,11 @@ body compiles, the `RecompileFail` is isolated to a product/decompiler body
 defect. If the authored body also fails, the failure is isolated to the RTS
 shell, closure, reference, or standalone source-consumption context. The original
 status remains `RecompileFail`; the sidecar reason may refine reporting as
-`body-defect` or `shell-or-closure-defect`.
+`body-defect` or `shell-or-closure-defect`, composed with the original compiler
+diagnostic bucket. On closure root or iteration budget exits, `body-defect`
+means the authored body fit inside the final RTS shell while the decompiled body
+did not; it may still point at a harness closure budget limit rather than a
+semantic product-body bug.
 
 The existing corpus sensor gates on `Exact`, `OpcodeDiff`, `RecompileFail`, and
 `ContextFail`. ReturnToSender planning reasons should be structured details

--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -1157,6 +1157,7 @@ public class GeneratedFixtureCatalogTests
                         "abcdef1234",
                         "TestType",
                         "Method1"),
+                    FaultIsolation: null,
                     ClosureEvidence: new ReturnToSenderClosureEvidence(
                         RequiredTypes: 2,
                         RequiredMembers: 1,
@@ -1276,6 +1277,7 @@ public class GeneratedFixtureCatalogTests
                         "abcdef1234",
                         "TestType",
                         "Method1"),
+                    FaultIsolation: null,
                     ClosureEvidence: null,
                     IsFrontier: false,
                     Note: null),

--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -1320,7 +1320,7 @@ public class GeneratedFixtureCatalogTests
                     Overload: 0,
                     GeneratedFixtureReturnToSenderStatus.Fail,
                     FidelityCheck.CompileBackStatus.RecompileFail,
-                    "body-defect",
+                    "body-defect (CS0103)",
                     Detail: "CS0103: missing symbol",
                     IlDiffDiagnostic: null,
                     IlDiff: null,
@@ -1345,11 +1345,41 @@ public class GeneratedFixtureCatalogTests
         Assert.DoesNotContain(Path.GetDirectoryName(sourcePath)!, json);
         using var document = JsonDocument.Parse(json);
         var result = Assert.Single(document.RootElement.GetProperty("Results").EnumerateArray());
+        Assert.Equal("RecompileFail", result.GetProperty("ActualStatus").GetString());
+        Assert.Equal("body-defect (CS0103)", result.GetProperty("Reason").GetString());
         var faultIsolation = result.GetProperty("FaultIsolation");
         Assert.Equal("BodyDefect", faultIsolation.GetProperty("Kind").GetString());
         Assert.Equal("Authored.cs", faultIsolation.GetProperty("SourcePath").GetString());
         Assert.Equal("authored body compiled in the same RTS shell", faultIsolation.GetProperty("Detail").GetString());
     }
+
+    [Fact]
+    public void ReturnToSenderCatalogFailureReason_ComposesFaultIsolationWithDiagnosticBucket()
+    {
+        var result = new ReturnToSender.Result(
+            MinimalReturnToSenderPlan(),
+            Source: "",
+            Status: FidelityCheck.CompileBackStatus.RecompileFail,
+            OriginalOpcodes: "",
+            RecompiledOpcodes: "",
+            Detail: "CS0103: The name 'Missing' does not exist in the current context",
+            FaultIsolation: new ReturnToSender.FaultIsolationResult(
+                ReturnToSender.FaultIsolationKind.BodyDefect,
+                "Authored.cs",
+                "authored body compiled in the same RTS shell"));
+
+        Assert.Equal("body-defect (CS0103)", GeneratedFixtureRunner.FailureReason(result));
+        Assert.Equal(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+    }
+
+    static CompileBackReconstructionPlan MinimalReturnToSenderPlan()
+        => new(
+            AssemblyPath: "",
+            TargetMethod: new CompileBackMethodIdentity("TestType", "Method1", 0, ""),
+            Module: new CompileBackModuleRequirement(Usings: [], AssemblyAttributes: [], ModuleAttributes: []),
+            Types: [],
+            PrintRequests: [],
+            Diagnostics: []);
 
     [Fact]
     public void ReturnToSenderRecordCatalog_CoversGeneratedRecordHelpers()

--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -1305,6 +1305,53 @@ public class GeneratedFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderCatalogJson_RedactsFaultIsolationSourcePath()
+    {
+        string sourcePath = Path.Combine(Path.GetTempPath(), "rts-source-path-redaction", Guid.NewGuid().ToString("N"), "Authored.cs");
+        var run = new GeneratedFixtureReturnToSenderRunResult(
+            ProjectDirectory: "",
+            AssemblyPath: "",
+            Results:
+            [
+                new GeneratedFixtureReturnToSenderResult(
+                    "test.fault-isolation",
+                    "TestType",
+                    "Method1",
+                    Overload: 0,
+                    GeneratedFixtureReturnToSenderStatus.Fail,
+                    FidelityCheck.CompileBackStatus.RecompileFail,
+                    "body-defect",
+                    Detail: "CS0103: missing symbol",
+                    IlDiffDiagnostic: null,
+                    IlDiff: null,
+                    MemberAnchor: new MemberAnchor(
+                        "Method1~abcdef1234",
+                        "M:TestType.Method1()",
+                        "abcdef1234",
+                        "TestType",
+                        "Method1"),
+                    FaultIsolation: new ReturnToSender.FaultIsolationResult(
+                        ReturnToSender.FaultIsolationKind.BodyDefect,
+                        sourcePath,
+                        "authored body compiled in the same RTS shell"),
+                    ClosureEvidence: null,
+                    IsFrontier: false,
+                    Note: null),
+            ]);
+
+        string json = GeneratedFixtureRunner.FormatReturnToSenderCatalogJson(run);
+
+        Assert.DoesNotContain(sourcePath, json);
+        Assert.DoesNotContain(Path.GetDirectoryName(sourcePath)!, json);
+        using var document = JsonDocument.Parse(json);
+        var result = Assert.Single(document.RootElement.GetProperty("Results").EnumerateArray());
+        var faultIsolation = result.GetProperty("FaultIsolation");
+        Assert.Equal("BodyDefect", faultIsolation.GetProperty("Kind").GetString());
+        Assert.Equal("Authored.cs", faultIsolation.GetProperty("SourcePath").GetString());
+        Assert.Equal("authored body compiled in the same RTS shell", faultIsolation.GetProperty("Detail").GetString());
+    }
+
+    [Fact]
     public void ReturnToSenderRecordCatalog_CoversGeneratedRecordHelpers()
     {
         var run = GeneratedFixtureRunner.RunReturnToSenderCatalog(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1778,6 +1778,74 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
+    [Fact]
+    public void TryIsolateRecompileFailure_ClassifiesBodyDefectWhenAuthoredBodyCompiles()
+    {
+        const string assemblySource = """
+            public class Class1
+            {
+                public int M() { return 42; }
+            }
+            """;
+        var sourcePath = WriteTempSource("BodyDefect.cs", assemblySource, out var sourceDirectory);
+        var assemblyPath = CompileFixture(assemblySource, sourceDirectory);
+        try
+        {
+            var result = TryIsolateRecompileFailureForMethod(
+                assemblyPath,
+                sourcePath,
+                "return Missing.Symbol;");
+
+            Assert.NotNull(result);
+            Assert.Equal(ReturnToSender.FaultIsolationKind.BodyDefect, result.Kind);
+            Assert.Equal(sourcePath, result.SourcePath);
+            Assert.Contains("authored body compiled", result.Detail);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+            TryDeleteDirectory(sourceDirectory);
+        }
+    }
+
+    [Fact]
+    public void TryIsolateRecompileFailure_ClassifiesShellOrClosureDefectWhenAuthoredBodyAlsoFails()
+    {
+        const string assemblySource = """
+            public class Class1
+            {
+                public int M() { return 42; }
+            }
+            """;
+        var sourcePath = WriteTempSource(
+            "ShellOrClosureDefect.cs",
+            """
+            public class Class1
+            {
+                public int M() { return Missing.Symbol; }
+            }
+            """,
+            out var sourceDirectory);
+        var assemblyPath = CompileFixture(assemblySource, sourceDirectory);
+        try
+        {
+            var result = TryIsolateRecompileFailureForMethod(
+                assemblyPath,
+                sourcePath,
+                "return AlsoMissing.Symbol;");
+
+            Assert.NotNull(result);
+            Assert.Equal(ReturnToSender.FaultIsolationKind.ShellOrClosureDefect, result.Kind);
+            Assert.Equal(sourcePath, result.SourcePath);
+            Assert.Contains("CS0103", result.Detail);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+            TryDeleteDirectory(sourceDirectory);
+        }
+    }
+
     static string WriteTempSource(string fileName, string source, out string directory)
     {
         directory = Path.Combine(Path.GetTempPath(), $"rts-signature-{Guid.NewGuid():N}");
@@ -1796,6 +1864,70 @@ public class ReturnToSenderPrototypeTests
         catch (IOException)
         {
         }
+    }
+
+    static ReturnToSender.FaultIsolationResult? TryIsolateRecompileFailureForMethod(
+        string assemblyPath,
+        string sourcePath,
+        string rejectedTargetBody)
+    {
+        using var pe = new PEReader(File.OpenRead(assemblyPath));
+        var reader = pe.GetMetadataReader();
+        using var metadata = CorpusMetadata.Create([assemblyPath]);
+        using var source = MetadataSource.Open(assemblyPath, context: metadata);
+
+        var (typeHandle, methodHandle) = FindMethod(reader, "Class1", "M");
+        var function = IrImporter.Import(source, "Class1", "M", 0)
+            ?? throw new InvalidOperationException("Could not import Class1::M.");
+        var request = new MethodArtifactRequest(
+            AssemblyPath: assemblyPath,
+            Reader: reader,
+            Function: function,
+            TargetType: typeHandle,
+            TargetMethod: methodHandle,
+            TargetBody: new ProductTargetBody(rejectedTargetBody, []),
+            FullType: "Class1",
+            MethodName: "M",
+            Overload: 0,
+            SignatureText: "",
+            ClosureRoots: new HashSet<TypeDefinitionHandle> { typeHandle },
+            ClosureFacts: new Dictionary<TypeDefinitionHandle, List<CompileBackFact>>());
+        var sourceIndex = ReturnToSenderSourceIndex.TryCreate([sourcePath]);
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
+        var compileOptions = new CSharpCompilationOptions(
+            OutputKind.DynamicallyLinkedLibrary,
+            optimizationLevel: OptimizationLevel.Release,
+            nullableContextOptions: NullableContextOptions.Disable,
+            allowUnsafe: true);
+
+        return ReturnToSender.TryIsolateRecompileFailure(
+            request,
+            sourceIndex,
+            parseOptions,
+            compileOptions,
+            RoslynTestReferences.TrustedPlatform.ToArray());
+    }
+
+    static (TypeDefinitionHandle Type, MethodDefinitionHandle Method) FindMethod(
+        MetadataReader reader,
+        string typeName,
+        string methodName)
+    {
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var type = reader.GetTypeDefinition(typeHandle);
+            if (!string.Equals(reader.GetFullTypeName(type), typeName, StringComparison.Ordinal))
+                continue;
+
+            foreach (var methodHandle in type.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (string.Equals(reader.GetString(method.Name), methodName, StringComparison.Ordinal))
+                    return (typeHandle, methodHandle);
+            }
+        }
+
+        throw new InvalidOperationException($"Could not find {typeName}::{methodName}.");
     }
 
     [Fact]

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -2068,6 +2068,7 @@ internal sealed record GeneratedFixtureReturnToSenderResult(
     IlDiffDisplayResult? IlDiffDiagnostic,
     IlMemberDiffResult? IlDiff,
     MemberAnchor? MemberAnchor,
+    ReturnToSender.FaultIsolationResult? FaultIsolation,
     ReturnToSenderClosureEvidence? ClosureEvidence,
     bool IsFrontier,
     string? Note)
@@ -2154,7 +2155,10 @@ internal static class GeneratedFixtureRunner
                 .Select(target => new ReturnToSender.RequestedTarget(target.Type, target.Method, target.Overload))
                 .Distinct()
                 .ToArray();
-            IReadOnlyDictionary<string, ReturnToSender.Result> rtsResults = ReturnToSender.CompileBackTargets(assemblyPath, requestedTargets)
+            var sourcePaths = Directory.GetFiles(root, "*.cs", SearchOption.TopDirectoryOnly)
+                .Order(StringComparer.Ordinal)
+                .ToArray();
+            IReadOnlyDictionary<string, ReturnToSender.Result> rtsResults = ReturnToSender.CompileBackTargets(assemblyPath, requestedTargets, sourcePaths)
                 .ToDictionary(result => Key(
                     result.Plan.TargetMethod.Type,
                     result.Plan.TargetMethod.Method,
@@ -2204,6 +2208,7 @@ internal static class GeneratedFixtureRunner
                         actual.IlDiffDiagnostic,
                         actual.IlDiff,
                         actual.MemberAnchor,
+                        actual.FaultIsolation,
                         ReturnToSenderClosureEvidenceBuilder.FromPlan(actual.Plan),
                         target.IsFrontier,
                         target.Note));
@@ -2241,17 +2246,23 @@ internal static class GeneratedFixtureRunner
             IlDiffDiagnostic: null,
             IlDiff: null,
             MemberAnchor: null,
+            FaultIsolation: null,
             ClosureEvidence: null,
             target.IsFrontier,
             target.Note);
 
     static string FailureReason(ReturnToSender.Result result)
-        => result.Status switch
+        => result.FaultIsolation?.Kind switch
         {
-            FidelityCheck.CompileBackStatus.RecompileFail => DiagnosticCode(result.Detail),
-            FidelityCheck.CompileBackStatus.ContextFail => string.IsNullOrWhiteSpace(result.Detail) ? "context-fail" : result.Detail,
-            FidelityCheck.CompileBackStatus.OpcodeDiff => "opcode-diff",
-            _ => result.Status.ToString(),
+            ReturnToSender.FaultIsolationKind.BodyDefect => "body-defect",
+            ReturnToSender.FaultIsolationKind.ShellOrClosureDefect => "shell-or-closure-defect",
+            _ => result.Status switch
+            {
+                FidelityCheck.CompileBackStatus.RecompileFail => DiagnosticCode(result.Detail),
+                FidelityCheck.CompileBackStatus.ContextFail => string.IsNullOrWhiteSpace(result.Detail) ? "context-fail" : result.Detail,
+                FidelityCheck.CompileBackStatus.OpcodeDiff => "opcode-diff",
+                _ => result.Status.ToString(),
+            }
         };
 
     internal static T RunWithMaterializedFixtures<T>(
@@ -2369,6 +2380,7 @@ internal static class GeneratedFixtureRunner
             IlDiffDiagnostic = SerializableIlDiffDisplayResult(result.IlDiffDiagnostic),
             IlDiff = SerializableIlMemberDiff(result.IlDiff),
             result.MemberAnchor,
+            result.FaultIsolation,
             result.ClosureEvidence,
             result.IsFrontier,
             result.Note,

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -2380,12 +2380,22 @@ internal static class GeneratedFixtureRunner
             IlDiffDiagnostic = SerializableIlDiffDisplayResult(result.IlDiffDiagnostic),
             IlDiff = SerializableIlMemberDiff(result.IlDiff),
             result.MemberAnchor,
-            result.FaultIsolation,
+            FaultIsolation = SerializableFaultIsolation(result.FaultIsolation),
             result.ClosureEvidence,
             result.IsFrontier,
             result.Note,
             result.DisplayMember,
         };
+
+    static object? SerializableFaultIsolation(ReturnToSender.FaultIsolationResult? result)
+        => result is null
+            ? null
+            : new
+            {
+                result.Kind,
+                SourcePath = Path.GetFileName(result.SourcePath),
+                result.Detail,
+            };
 
     static object? SerializableIlDiffDisplayResult(IlDiffDisplayResult? result)
         => result is null

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -2251,19 +2251,28 @@ internal static class GeneratedFixtureRunner
             target.IsFrontier,
             target.Note);
 
-    static string FailureReason(ReturnToSender.Result result)
-        => result.FaultIsolation?.Kind switch
+    internal static string FailureReason(ReturnToSender.Result result)
+    {
+        var baseReason = result.Status switch
         {
-            ReturnToSender.FaultIsolationKind.BodyDefect => "body-defect",
-            ReturnToSender.FaultIsolationKind.ShellOrClosureDefect => "shell-or-closure-defect",
-            _ => result.Status switch
-            {
-                FidelityCheck.CompileBackStatus.RecompileFail => DiagnosticCode(result.Detail),
-                FidelityCheck.CompileBackStatus.ContextFail => string.IsNullOrWhiteSpace(result.Detail) ? "context-fail" : result.Detail,
-                FidelityCheck.CompileBackStatus.OpcodeDiff => "opcode-diff",
-                _ => result.Status.ToString(),
-            }
+            FidelityCheck.CompileBackStatus.RecompileFail => DiagnosticCode(result.Detail),
+            FidelityCheck.CompileBackStatus.ContextFail => string.IsNullOrWhiteSpace(result.Detail) ? "context-fail" : result.Detail,
+            FidelityCheck.CompileBackStatus.OpcodeDiff => "opcode-diff",
+            _ => result.Status.ToString(),
         };
+
+        return result.FaultIsolation?.Kind switch
+        {
+            ReturnToSender.FaultIsolationKind.BodyDefect => ComposeFaultIsolationReason("body-defect", baseReason),
+            ReturnToSender.FaultIsolationKind.ShellOrClosureDefect => ComposeFaultIsolationReason("shell-or-closure-defect", baseReason),
+            _ => baseReason,
+        };
+    }
+
+    static string ComposeFaultIsolationReason(string isolationReason, string baseReason)
+        => string.IsNullOrWhiteSpace(baseReason) || string.Equals(isolationReason, baseReason, StringComparison.Ordinal)
+            ? isolationReason
+            : $"{isolationReason} ({baseReason})";
 
     internal static T RunWithMaterializedFixtures<T>(
         IReadOnlyList<GeneratedFixtureDefinition> fixtures,

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1478,10 +1478,7 @@ static class ReturnToSender
         }
         catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
         {
-            return new FaultIsolationResult(
-                FaultIsolationKind.ShellOrClosureDefect,
-                sourceMember.SourcePath,
-                $"{ex.GetType().Name}: {ex.Message}");
+            return null;
         }
     }
 

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -24,6 +24,17 @@ namespace ILInspector.DecompilerHarness;
 /// </summary>
 static class ReturnToSender
 {
+    public enum FaultIsolationKind
+    {
+        BodyDefect,
+        ShellOrClosureDefect,
+    }
+
+    public sealed record FaultIsolationResult(
+        FaultIsolationKind Kind,
+        string SourcePath,
+        string? Detail);
+
     public sealed record Result(
         CompileBackReconstructionPlan Plan,
         string Source,
@@ -36,7 +47,8 @@ static class ReturnToSender
         IlMemberDiffResult? IlDiff = null,
         MemberAnchor? MemberAnchor = null,
         IReadOnlyList<DecompilerDecision>? Decisions = null,
-        FidelityCheck.CompileBackResult? CompileBackFloor = null)
+        FidelityCheck.CompileBackResult? CompileBackFloor = null,
+        FaultIsolationResult? FaultIsolation = null)
     {
         public bool UsedCompileBackFloor => CompileBackFloor is not null;
     }
@@ -364,6 +376,7 @@ static class ReturnToSender
         var reader = pe.GetMetadataReader();
         using var metadata = CorpusMetadata.Create([assemblyPath]);
         using var source = MetadataSource.Open(assemblyPath, context: metadata);
+        var sourceIndex = ReturnToSenderSourceIndex.TryCreate(assemblyPath);
         var memberAnchors = MemberAnchorsByMethodToken(pe);
 
         foreach (var typeHandle in reader.TypeDefinitions)
@@ -414,7 +427,8 @@ static class ReturnToSender
                     typeHandle,
                     propertyHandle,
                     accessors.Getter,
-                    MemberAnchorFor(memberAnchors, accessors.Getter)));
+                    MemberAnchorFor(memberAnchors, accessors.Getter),
+                    sourceIndex));
                 if (results.Count >= maxTargets)
                     return applyCompileBackFloor ? ApplyCompileBackFloor(assemblyPath, results) : results;
             }
@@ -426,6 +440,18 @@ static class ReturnToSender
     }
 
     public static IReadOnlyList<Result> CompileBackTargets(string assemblyPath, IReadOnlyList<RequestedTarget> targets)
+        => CompileBackTargets(assemblyPath, targets, ReturnToSenderSourceIndex.TryCreate(assemblyPath));
+
+    public static IReadOnlyList<Result> CompileBackTargets(
+        string assemblyPath,
+        IReadOnlyList<RequestedTarget> targets,
+        IReadOnlyList<string> sourcePaths)
+        => CompileBackTargets(assemblyPath, targets, ReturnToSenderSourceIndex.TryCreate(sourcePaths));
+
+    static IReadOnlyList<Result> CompileBackTargets(
+        string assemblyPath,
+        IReadOnlyList<RequestedTarget> targets,
+        ReturnToSenderSourceIndex? sourceIndex)
     {
         if (targets.Count == 0)
             return [];
@@ -469,7 +495,8 @@ static class ReturnToSender
                     typeHandle,
                     propertyTarget.Property,
                     propertyTarget.Getter,
-                    MemberAnchorFor(memberAnchors, propertyTarget.Getter)));
+                    MemberAnchorFor(memberAnchors, propertyTarget.Getter),
+                    sourceIndex));
                 continue;
             }
 
@@ -483,7 +510,8 @@ static class ReturnToSender
                     typeHandle,
                     setterTarget.Property,
                     setterTarget.Setter,
-                    MemberAnchorFor(memberAnchors, setterTarget.Setter)));
+                    MemberAnchorFor(memberAnchors, setterTarget.Setter),
+                    sourceIndex));
                 continue;
             }
 
@@ -496,7 +524,8 @@ static class ReturnToSender
                     source,
                     typeHandle,
                     methodHandle,
-                    MemberAnchorFor(memberAnchors, methodHandle)));
+                    MemberAnchorFor(memberAnchors, methodHandle),
+                    sourceIndex));
             }
         }
 
@@ -707,11 +736,12 @@ static class ReturnToSender
         TypeDefinitionHandle typeHandle,
         PropertyDefinitionHandle propertyHandle,
         MethodDefinitionHandle getterHandle,
-        MemberAnchor? memberAnchor)
+        MemberAnchor? memberAnchor,
+        ReturnToSenderSourceIndex? sourceIndex)
     {
         try
         {
-            return CompileBackPropertyGetter(assemblyPath, pe, reader, source, typeHandle, propertyHandle, getterHandle, memberAnchor);
+            return CompileBackPropertyGetter(assemblyPath, pe, reader, source, typeHandle, propertyHandle, getterHandle, memberAnchor, sourceIndex);
         }
         catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
         {
@@ -726,11 +756,12 @@ static class ReturnToSender
         MetadataSource source,
         TypeDefinitionHandle typeHandle,
         MethodDefinitionHandle methodHandle,
-        MemberAnchor? memberAnchor)
+        MemberAnchor? memberAnchor,
+        ReturnToSenderSourceIndex? sourceIndex)
     {
         try
         {
-            return CompileBackMethod(assemblyPath, pe, reader, source, typeHandle, methodHandle, memberAnchor);
+            return CompileBackMethod(assemblyPath, pe, reader, source, typeHandle, methodHandle, memberAnchor, sourceIndex);
         }
         catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
         {
@@ -746,11 +777,12 @@ static class ReturnToSender
         TypeDefinitionHandle typeHandle,
         PropertyDefinitionHandle propertyHandle,
         MethodDefinitionHandle setterHandle,
-        MemberAnchor? memberAnchor)
+        MemberAnchor? memberAnchor,
+        ReturnToSenderSourceIndex? sourceIndex)
     {
         try
         {
-            return CompileBackPropertySetter(assemblyPath, pe, reader, source, typeHandle, propertyHandle, setterHandle, memberAnchor);
+            return CompileBackPropertySetter(assemblyPath, pe, reader, source, typeHandle, propertyHandle, setterHandle, memberAnchor, sourceIndex);
         }
         catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
         {
@@ -766,7 +798,8 @@ static class ReturnToSender
         TypeDefinitionHandle typeHandle,
         PropertyDefinitionHandle propertyHandle,
         MethodDefinitionHandle getterHandle,
-        MemberAnchor? memberAnchor)
+        MemberAnchor? memberAnchor,
+        ReturnToSenderSourceIndex? sourceIndex)
     {
         var typeDef = reader.GetTypeDefinition(typeHandle);
         var getter = reader.GetMethodDefinition(getterHandle);
@@ -794,6 +827,7 @@ static class ReturnToSender
             overload,
             originalOps,
             memberAnchor,
+            sourceIndex,
             (closureRoots, closureFacts) => new PropertyGetterArtifactRequest(
                 AssemblyPath: assemblyPath,
                 Reader: reader,
@@ -817,7 +851,8 @@ static class ReturnToSender
         MetadataSource source,
         TypeDefinitionHandle typeHandle,
         MethodDefinitionHandle methodHandle,
-        MemberAnchor? memberAnchor)
+        MemberAnchor? memberAnchor,
+        ReturnToSenderSourceIndex? sourceIndex)
     {
         var typeDef = reader.GetTypeDefinition(typeHandle);
         var method = reader.GetMethodDefinition(methodHandle);
@@ -845,6 +880,7 @@ static class ReturnToSender
             overload,
             originalOps,
             memberAnchor,
+            sourceIndex,
             (closureRoots, closureFacts) => new MethodArtifactRequest(
                 AssemblyPath: assemblyPath,
                 Reader: reader,
@@ -868,7 +904,8 @@ static class ReturnToSender
         TypeDefinitionHandle typeHandle,
         PropertyDefinitionHandle propertyHandle,
         MethodDefinitionHandle setterHandle,
-        MemberAnchor? memberAnchor)
+        MemberAnchor? memberAnchor,
+        ReturnToSenderSourceIndex? sourceIndex)
     {
         var typeDef = reader.GetTypeDefinition(typeHandle);
         var setter = reader.GetMethodDefinition(setterHandle);
@@ -896,6 +933,7 @@ static class ReturnToSender
             overload,
             originalOps,
             memberAnchor,
+            sourceIndex,
             (closureRoots, closureFacts) => new PropertySetterArtifactRequest(
                 AssemblyPath: assemblyPath,
                 Reader: reader,
@@ -924,6 +962,7 @@ static class ReturnToSender
         int overload,
         string[] originalOps,
         MemberAnchor? memberAnchor,
+        ReturnToSenderSourceIndex? sourceIndex,
         Func<IReadOnlySet<TypeDefinitionHandle>, IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>>, ArtifactRequest> createRequest)
     {
         var typeDef = reader.GetTypeDefinition(typeHandle);
@@ -1034,6 +1073,7 @@ static class ReturnToSender
                         "closure-stalled",
                         growth.UnextractedDiagnosticIds);
                 var error = errors.FirstOrDefault() ?? firstError;
+                var faultIsolation = TryIsolateRecompileFailure(sourceResult.Request, sourceIndex, parseOptions, compileOptions, references);
                 return new Result(
                     plan,
                     unit,
@@ -1043,13 +1083,15 @@ static class ReturnToSender
                     $"{reason}: {FormatDiagnostic(error)}",
                     TargetBody: targetBody.Source,
                     MemberAnchor: memberAnchor,
-                    Decisions: targetBody.Decisions);
+                    Decisions: targetBody.Decisions,
+                    FaultIsolation: faultIsolation);
             }
         }
 
         {
             var sourceResult = Compose();
             var plan = sourceResult.Plan;
+            var faultIsolation = TryIsolateRecompileFailure(sourceResult.Request, sourceIndex, parseOptions, compileOptions, references);
             return new Result(
                 plan,
                 sourceResult.Source,
@@ -1059,7 +1101,8 @@ static class ReturnToSender
                 $"closure-iteration-budget: {FormatDiagnostic(firstError)}",
                 TargetBody: targetBody.Source,
                 MemberAnchor: memberAnchor,
-                Decisions: targetBody.Decisions);
+                Decisions: targetBody.Decisions,
+                FaultIsolation: faultIsolation);
         }
     }
 
@@ -1389,6 +1432,67 @@ static class ReturnToSender
             ? diagnostic.Id
             : $"{diagnostic.Id}: {message}";
     }
+
+    internal static FaultIsolationResult? TryIsolateRecompileFailure(
+        ArtifactRequest request,
+        ReturnToSenderSourceIndex? sourceIndex,
+        CSharpParseOptions parseOptions,
+        CSharpCompilationOptions compileOptions,
+        IReadOnlyList<MetadataReference> references)
+    {
+        if (sourceIndex is null)
+            return null;
+
+        string? signature = string.IsNullOrWhiteSpace(request.SignatureText)
+            ? null
+            : request.SignatureText;
+        if (!sourceIndex.TryFind(
+                new RequestedTarget(request.FullType, request.MethodName, request.Overload, signature),
+                out var sourceMember)
+            || sourceMember.Body is not { } authoredBody)
+        {
+            return null;
+        }
+
+        var authoredTargetBody = new ProductTargetBody(authoredBody, []);
+        try
+        {
+            var authoredArtifact = CompileBackSourceComposer.Compose(WithTargetBody(request, authoredTargetBody));
+            var tree = CSharpSyntaxTree.ParseText(authoredArtifact.Source, parseOptions);
+            var compilation = CSharpCompilation.Create("return-to-sender-source-oracle", [tree], references, compileOptions);
+            using var ms = new MemoryStream();
+            var emit = compilation.Emit(ms);
+            if (emit.Success)
+            {
+                return new FaultIsolationResult(
+                    FaultIsolationKind.BodyDefect,
+                    sourceMember.SourcePath,
+                    "authored body compiled in the same RTS shell");
+            }
+
+            var error = emit.Diagnostics.FirstOrDefault(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+            return new FaultIsolationResult(
+                FaultIsolationKind.ShellOrClosureDefect,
+                sourceMember.SourcePath,
+                FormatDiagnostic(error));
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            return new FaultIsolationResult(
+                FaultIsolationKind.ShellOrClosureDefect,
+                sourceMember.SourcePath,
+                $"{ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    static ArtifactRequest WithTargetBody(ArtifactRequest request, ProductTargetBody targetBody)
+        => request switch
+        {
+            MethodArtifactRequest method => method with { TargetBody = targetBody },
+            PropertyGetterArtifactRequest getter => getter with { TargetBody = targetBody },
+            PropertySetterArtifactRequest setter => setter with { TargetBody = targetBody },
+            _ => throw new ArgumentException($"Unknown artifact request type '{request.GetType().FullName}'.", nameof(request)),
+        };
 
     static int EffectiveClosureRootCount(ProductArtifact artifact, IReadOnlySet<TypeDefinitionHandle> oracleClosureRoots)
     {

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -43,7 +43,7 @@ sealed record ReturnToSenderSourceProbeResult(
     public bool Skipped => Outcome is ReturnToSenderSourceOutcome.SourceUnavailable or ReturnToSenderSourceOutcome.UnsupportedTarget;
 }
 
-static class ReturnToSenderSourceProbe
+static partial class ReturnToSenderSourceProbe
 {
     internal sealed record ProbeTarget(ReturnToSender.RequestedTarget Target, IReadOnlyList<string> ExpectedFragments);
 
@@ -142,7 +142,7 @@ static class ReturnToSenderSourceProbe
         if (targets.Count == 0)
             return [];
 
-        var sourceIndex = FixtureSourceIndex.TryCreate(assemblyPath);
+        var sourceIndex = ReturnToSenderSourceIndex.TryCreate(assemblyPath);
         return EvaluateTargets(assemblyPath, targets, sourceIndex);
     }
 
@@ -153,13 +153,13 @@ static class ReturnToSenderSourceProbe
         => EvaluateTargets(
             assemblyPath,
             targets,
-            FixtureSourceIndex.TryCreate(sourcePaths),
+            ReturnToSenderSourceIndex.TryCreate(sourcePaths),
             "source index could not be built from the supplied source paths");
 
     static IReadOnlyList<ReturnToSenderSourceProbeResult> EvaluateTargets(
         string assemblyPath,
         IReadOnlyList<ReturnToSender.RequestedTarget> targets,
-        FixtureSourceIndex? sourceIndex,
+        ReturnToSenderSourceIndex? sourceIndex,
         string sourceUnavailableDetail = "assembly is not registered in FixtureCatalog")
     {
         if (targets.Count == 0)
@@ -190,7 +190,7 @@ static class ReturnToSenderSourceProbe
                 continue;
             }
 
-            SourceMember? sourceMember = null;
+            ReturnToSenderSourceMember? sourceMember = null;
             bool sourceFound = sourceIndex?.TryFind(target, out sourceMember) == true;
             if (result.Status is FidelityCheck.CompileBackStatus.RecompileFail
                 or FidelityCheck.CompileBackStatus.ContextFail)
@@ -392,252 +392,177 @@ static class ReturnToSenderSourceProbe
             ActualBody: result.TargetBody));
     }
 
-    sealed record SourceMember(string Type, string Method, int Overload, string Signature, string SourcePath, string? Body);
+}
 
-    sealed class FixtureSourceIndex
+internal sealed record ReturnToSenderSourceMember(string Type, string Method, int Overload, string Signature, string SourcePath, string? Body);
+
+internal sealed class ReturnToSenderSourceIndex
+{
+    readonly Dictionary<string, ReturnToSenderSourceMember> _members;
+    readonly Dictionary<string, ReturnToSenderSourceMember> _membersBySignature;
+    readonly HashSet<string> _ambiguousSignatures;
+    readonly Dictionary<string, RecordSourceInfo> _recordSources;
+
+    ReturnToSenderSourceIndex(
+        Dictionary<string, ReturnToSenderSourceMember> members,
+        Dictionary<string, ReturnToSenderSourceMember> membersBySignature,
+        HashSet<string> ambiguousSignatures,
+        Dictionary<string, RecordSourceInfo> recordSources)
     {
-        readonly Dictionary<string, SourceMember> _members;
-        readonly Dictionary<string, SourceMember> _membersBySignature;
-        readonly HashSet<string> _ambiguousSignatures;
-        readonly Dictionary<string, RecordSourceInfo> _recordSources;
+        _members = members;
+        _membersBySignature = membersBySignature;
+        _ambiguousSignatures = ambiguousSignatures;
+        _recordSources = recordSources;
+    }
 
-        FixtureSourceIndex(
-            Dictionary<string, SourceMember> members,
-            Dictionary<string, SourceMember> membersBySignature,
-            HashSet<string> ambiguousSignatures,
-            Dictionary<string, RecordSourceInfo> recordSources)
+    public static ReturnToSenderSourceIndex? TryCreate(IReadOnlyList<string> sourcePaths)
+    {
+        var members = new Dictionary<string, ReturnToSenderSourceMember>(StringComparer.Ordinal);
+        var membersBySignature = new Dictionary<string, ReturnToSenderSourceMember>(StringComparer.Ordinal);
+        var ambiguousSignatures = new HashSet<string>(StringComparer.Ordinal);
+        var recordSources = new Dictionary<string, RecordSourceInfo>(StringComparer.Ordinal);
+        var overloads = new Dictionary<string, Dictionary<string, int>>(StringComparer.Ordinal);
+        var sourceFiles = new List<(string Path, CompilationUnitSyntax Root)>();
+        foreach (var sourcePath in sourcePaths)
         {
-            _members = members;
-            _membersBySignature = membersBySignature;
-            _ambiguousSignatures = ambiguousSignatures;
-            _recordSources = recordSources;
+            if (!TryReadSourceFile(sourcePath, out var root))
+                return null;
+            sourceFiles.Add((sourcePath, root));
         }
 
-        public static FixtureSourceIndex? TryCreate(IReadOnlyList<string> sourcePaths)
+        var sourceIdentity = CSharpSourceIdentityContext.Create(sourceFiles.Select(file => file.Root));
+        foreach (var sourceFile in sourceFiles)
+            AddSourceFile(members, membersBySignature, ambiguousSignatures, recordSources, overloads, sourceFile.Path, sourceFile.Root, sourceIdentity);
+
+        return new ReturnToSenderSourceIndex(members, membersBySignature, ambiguousSignatures, recordSources);
+    }
+
+    public static ReturnToSenderSourceIndex? TryCreate(string assemblyPath)
+    {
+        foreach (var fixture in FixtureCatalog.All)
         {
-            var members = new Dictionary<string, SourceMember>(StringComparer.Ordinal);
-            var membersBySignature = new Dictionary<string, SourceMember>(StringComparer.Ordinal);
-            var ambiguousSignatures = new HashSet<string>(StringComparer.Ordinal);
-            var recordSources = new Dictionary<string, RecordSourceInfo>(StringComparer.Ordinal);
-            var overloads = new Dictionary<string, Dictionary<string, int>>(StringComparer.Ordinal);
-            var sourceFiles = new List<(string Path, CompilationUnitSyntax Root)>();
-            foreach (var sourcePath in sourcePaths)
+            if (!TryGetFixtureAssemblyPath(fixture, out var fixtureAssemblyPath))
+                continue;
+
+            if (!string.Equals(
+                Path.GetFullPath(fixtureAssemblyPath),
+                Path.GetFullPath(assemblyPath),
+                StringComparison.OrdinalIgnoreCase))
             {
-                if (!TryReadSourceFile(sourcePath, out var root))
-                    return null;
-                sourceFiles.Add((sourcePath, root));
+                continue;
             }
 
-            var sourceIdentity = CSharpSourceIdentityContext.Create(sourceFiles.Select(file => file.Root));
-            foreach (var sourceFile in sourceFiles)
-                AddSourceFile(members, membersBySignature, ambiguousSignatures, recordSources, overloads, sourceFile.Path, sourceFile.Root, sourceIdentity);
+            if (!TryGetSourcePaths(fixture, out var sourcePaths))
+                return null;
 
-            return new FixtureSourceIndex(members, membersBySignature, ambiguousSignatures, recordSources);
+            return TryCreate(sourcePaths);
         }
 
-        public static FixtureSourceIndex? TryCreate(string assemblyPath)
+        return null;
+    }
+
+    static bool TryGetFixtureAssemblyPath(FixtureDefinition fixture, out string path)
+    {
+        try
         {
-            foreach (var fixture in FixtureCatalog.All)
-            {
-                if (!TryGetFixtureAssemblyPath(fixture, out var fixtureAssemblyPath))
-                    continue;
-
-                if (!string.Equals(
-                    Path.GetFullPath(fixtureAssemblyPath),
-                    Path.GetFullPath(assemblyPath),
-                    StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
-                if (!TryGetSourcePaths(fixture, out var sourcePaths))
-                    return null;
-
-                return TryCreate(sourcePaths);
-            }
-
-            return null;
+            path = fixture.AssemblyPath();
+            return true;
         }
-
-        static bool TryGetFixtureAssemblyPath(FixtureDefinition fixture, out string path)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
         {
-            try
-            {
-                path = fixture.AssemblyPath();
-                return true;
-            }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
-            {
-                path = "";
-                return false;
-            }
-        }
-
-        static bool TryGetSourcePaths(FixtureDefinition fixture, out IReadOnlyList<string> paths)
-        {
-            try
-            {
-                paths = fixture.SourcePaths();
-                return true;
-            }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
-            {
-                paths = [];
-                return false;
-            }
-        }
-
-        public bool TryFind(ReturnToSender.RequestedTarget target, out SourceMember member)
-        {
-            if (target.Signature is { } signature)
-            {
-                var signatureKey = SigKey(target.Type, target.Method, signature);
-                if (!_ambiguousSignatures.Contains(signatureKey)
-                    && _membersBySignature.TryGetValue(signatureKey, out member!))
-                {
-                    return true;
-                }
-            }
-
-            return _members.TryGetValue(Key(target.Type, target.Method, target.Overload), out member!);
-        }
-
-        public bool TryFindRecordSynthesizedMember(ReturnToSender.RequestedTarget target, out string sourcePath)
-        {
-            if (_recordSources.TryGetValue(target.Type, out var source)
-                && source.SynthesizedMembers.Contains(target.Method))
-            {
-                sourcePath = source.SourcePath;
-                return true;
-            }
-
-            sourcePath = "";
+            path = "";
             return false;
         }
+    }
 
-        static bool TryReadSourceFile(string sourcePath, out CompilationUnitSyntax root)
+    static bool TryGetSourcePaths(FixtureDefinition fixture, out IReadOnlyList<string> paths)
+    {
+        try
         {
-            string source;
-            try
-            {
-                source = File.ReadAllText(sourcePath);
-            }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
-            {
-                root = null!;
-                return false;
-            }
+            paths = fixture.SourcePaths();
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            paths = [];
+            return false;
+        }
+    }
 
-            var tree = CSharpSyntaxTree.ParseText(source, path: sourcePath);
-            root = tree.GetCompilationUnitRoot();
+    public bool TryFind(ReturnToSender.RequestedTarget target, out ReturnToSenderSourceMember member)
+    {
+        if (target.Signature is { } signature)
+        {
+            var signatureKey = SigKey(target.Type, target.Method, signature);
+            if (!_ambiguousSignatures.Contains(signatureKey)
+                && _membersBySignature.TryGetValue(signatureKey, out member!))
+            {
+                return true;
+            }
+        }
+
+        return _members.TryGetValue(Key(target.Type, target.Method, target.Overload), out member!);
+    }
+
+    public bool TryFindRecordSynthesizedMember(ReturnToSender.RequestedTarget target, out string sourcePath)
+    {
+        if (_recordSources.TryGetValue(target.Type, out var source)
+            && source.SynthesizedMembers.Contains(target.Method))
+        {
+            sourcePath = source.SourcePath;
             return true;
         }
 
-        static void AddSourceFile(
-            Dictionary<string, SourceMember> members,
-            Dictionary<string, SourceMember> membersBySignature,
-            HashSet<string> ambiguousSignatures,
-            Dictionary<string, RecordSourceInfo> recordSources,
-            Dictionary<string, Dictionary<string, int>> overloads,
-            string sourcePath,
-            CompilationUnitSyntax root,
-            CSharpSourceIdentityContext sourceIdentity)
-        {
-            foreach (var member in SourceMembers(root, sourcePath, recordSources, overloads, sourceIdentity))
-            {
-                members.TryAdd(Key(member.Type, member.Method, member.Overload), member);
-
-                var signatureKey = SigKey(member.Type, member.Method, member.Signature);
-                if (ambiguousSignatures.Contains(signatureKey))
-                    continue;
-                if (!membersBySignature.TryAdd(signatureKey, member))
-                {
-                    membersBySignature.Remove(signatureKey);
-                    ambiguousSignatures.Add(signatureKey);
-                }
-            }
-        }
-
-        static IEnumerable<SourceMember> SourceMembers(
-            CompilationUnitSyntax root,
-            string sourcePath,
-            Dictionary<string, RecordSourceInfo> recordSources,
-            Dictionary<string, Dictionary<string, int>> overloads,
-            CSharpSourceIdentityContext sourceIdentity)
-        {
-            foreach (var member in SourceMembers(root.Members, namespaceName: "", containingTypes: [], sourcePath, recordSources, overloads, sourceIdentity))
-                yield return member;
-        }
-
-        static IEnumerable<SourceMember> SourceMembers(
-            SyntaxList<MemberDeclarationSyntax> declarations,
-            string namespaceName,
-            IReadOnlyList<string> containingTypes,
-            string sourcePath,
-            Dictionary<string, RecordSourceInfo> recordSources,
-            Dictionary<string, Dictionary<string, int>> overloads,
-            CSharpSourceIdentityContext sourceIdentity)
-        {
-            foreach (var declaration in declarations)
-            {
-                switch (declaration)
-                {
-                    case BaseNamespaceDeclarationSyntax ns:
-                    {
-                        string nextNamespace = namespaceName.Length == 0
-                            ? ns.Name.ToString()
-                            : $"{namespaceName}.{ns.Name}";
-                        foreach (var member in SourceMembers(ns.Members, nextNamespace, containingTypes, sourcePath, recordSources, overloads, sourceIdentity))
-                            yield return member;
-                        break;
-                    }
-                    case TypeDeclarationSyntax type:
-                    {
-                        string typeName = CSharpSourceIdentityContext.TypeMetadataName(type);
-                        var typeStack = containingTypes.Concat([typeName]).ToArray();
-                        string fullType = namespaceName.Length == 0
-                            ? string.Join(".", typeStack)
-                            : $"{namespaceName}.{string.Join(".", typeStack)}";
-                        if (type is RecordDeclarationSyntax record)
-                            recordSources.TryAdd(fullType, new RecordSourceInfo(sourcePath, RecordSynthesizedMembers(record)));
-
-                        foreach (var member in TypeMembers(type, fullType, sourcePath, overloads, sourceIdentity))
-                            yield return member;
-                        foreach (var member in SourceMembers(type.Members, namespaceName, typeStack, sourcePath, recordSources, overloads, sourceIdentity))
-                            yield return member;
-                        break;
-                    }
-                }
-            }
-
-            static IEnumerable<SourceMember> TypeMembers(
-                TypeDeclarationSyntax type,
-                string fullType,
-                string path,
-                Dictionary<string, Dictionary<string, int>> overloadsByType,
-                CSharpSourceIdentityContext sourceIdentity)
-            {
-                if (!overloadsByType.TryGetValue(fullType, out var overloads))
-                    overloadsByType[fullType] = overloads = new Dictionary<string, int>(StringComparer.Ordinal);
-
-                foreach (var sourceMember in sourceIdentity.TypeMembers(type, fullType))
-                {
-                    int overload = NextOverload(overloads, sourceMember.MetadataName);
-                    yield return new SourceMember(fullType, sourceMember.MetadataName, overload, sourceMember.Signature, path, sourceMember.Body);
-                }
-            }
-
-            static int NextOverload(Dictionary<string, int> overloads, string methodName)
-            {
-                int overload = overloads.GetValueOrDefault(methodName);
-                overloads[methodName] = overload + 1;
-                return overload;
-            }
-        }
-
+        sourcePath = "";
+        return false;
     }
 
-    sealed record RecordSourceInfo(string SourcePath, IReadOnlySet<string> SynthesizedMembers);
+    static bool TryReadSourceFile(string sourcePath, out CompilationUnitSyntax root)
+    {
+        string source;
+        try
+        {
+            source = File.ReadAllText(sourcePath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            root = null!;
+            return false;
+        }
+
+        var tree = CSharpSyntaxTree.ParseText(source, path: sourcePath);
+        root = tree.GetCompilationUnitRoot();
+        return true;
+    }
+
+    static void AddSourceFile(
+        Dictionary<string, ReturnToSenderSourceMember> members,
+        Dictionary<string, ReturnToSenderSourceMember> membersBySignature,
+        HashSet<string> ambiguousSignatures,
+        Dictionary<string, RecordSourceInfo> recordSources,
+        Dictionary<string, Dictionary<string, int>> overloads,
+        string sourcePath,
+        CompilationUnitSyntax root,
+        CSharpSourceIdentityContext sourceIdentity)
+    {
+        foreach (var member in SourceMembers(root, sourcePath, recordSources, overloads, sourceIdentity))
+        {
+            members.TryAdd(Key(member.Type, member.Method, member.Overload), member);
+
+            var signatureKey = SigKey(member.Type, member.Method, member.Signature);
+            if (ambiguousSignatures.Contains(signatureKey))
+                continue;
+            if (!membersBySignature.TryAdd(signatureKey, member))
+            {
+                membersBySignature.Remove(signatureKey);
+                ambiguousSignatures.Add(signatureKey);
+            }
+        }
+    }
+
+    static string Key(string type, string method, int overload) => $"{type}::{method}#{overload}";
+
+    static string SigKey(string type, string method, string signature) => $"{type}::{method}{signature}";
 
     static IReadOnlySet<string> RecordSynthesizedMembers(RecordDeclarationSyntax record)
     {
@@ -659,6 +584,88 @@ static class ReturnToSenderSourceProbe
         return members;
     }
 
+    static IEnumerable<ReturnToSenderSourceMember> SourceMembers(
+        CompilationUnitSyntax root,
+        string sourcePath,
+        Dictionary<string, RecordSourceInfo> recordSources,
+        Dictionary<string, Dictionary<string, int>> overloads,
+        CSharpSourceIdentityContext sourceIdentity)
+    {
+        foreach (var member in SourceMembers(root.Members, namespaceName: "", containingTypes: [], sourcePath, recordSources, overloads, sourceIdentity))
+            yield return member;
+    }
+
+    static IEnumerable<ReturnToSenderSourceMember> SourceMembers(
+        SyntaxList<MemberDeclarationSyntax> declarations,
+        string namespaceName,
+        IReadOnlyList<string> containingTypes,
+        string sourcePath,
+        Dictionary<string, RecordSourceInfo> recordSources,
+        Dictionary<string, Dictionary<string, int>> overloads,
+        CSharpSourceIdentityContext sourceIdentity)
+    {
+        foreach (var declaration in declarations)
+        {
+            switch (declaration)
+            {
+                case BaseNamespaceDeclarationSyntax ns:
+                    {
+                        string nextNamespace = namespaceName.Length == 0
+                            ? ns.Name.ToString()
+                            : $"{namespaceName}.{ns.Name}";
+                        foreach (var member in SourceMembers(ns.Members, nextNamespace, containingTypes, sourcePath, recordSources, overloads, sourceIdentity))
+                            yield return member;
+                        break;
+                    }
+                case TypeDeclarationSyntax type:
+                    {
+                        string typeName = CSharpSourceIdentityContext.TypeMetadataName(type);
+                        var typeStack = containingTypes.Concat([typeName]).ToArray();
+                        string fullType = namespaceName.Length == 0
+                            ? string.Join(".", typeStack)
+                            : $"{namespaceName}.{string.Join(".", typeStack)}";
+                        if (type is RecordDeclarationSyntax record)
+                            recordSources.TryAdd(fullType, new RecordSourceInfo(sourcePath, RecordSynthesizedMembers(record)));
+
+                        foreach (var member in TypeMembers(type, fullType, sourcePath, overloads, sourceIdentity))
+                            yield return member;
+                        foreach (var member in SourceMembers(type.Members, namespaceName, typeStack, sourcePath, recordSources, overloads, sourceIdentity))
+                            yield return member;
+                        break;
+                    }
+            }
+        }
+
+        static IEnumerable<ReturnToSenderSourceMember> TypeMembers(
+            TypeDeclarationSyntax type,
+            string fullType,
+            string path,
+            Dictionary<string, Dictionary<string, int>> overloadsByType,
+            CSharpSourceIdentityContext sourceIdentity)
+        {
+            if (!overloadsByType.TryGetValue(fullType, out var overloads))
+                overloadsByType[fullType] = overloads = new Dictionary<string, int>(StringComparer.Ordinal);
+
+            foreach (var sourceMember in sourceIdentity.TypeMembers(type, fullType))
+            {
+                int overload = NextOverload(overloads, sourceMember.MetadataName);
+                yield return new ReturnToSenderSourceMember(fullType, sourceMember.MetadataName, overload, sourceMember.Signature, path, sourceMember.Body);
+            }
+        }
+
+        static int NextOverload(Dictionary<string, int> overloads, string methodName)
+        {
+            int overload = overloads.GetValueOrDefault(methodName);
+            overloads[methodName] = overload + 1;
+            return overload;
+        }
+    }
+}
+
+internal sealed record RecordSourceInfo(string SourcePath, IReadOnlySet<string> SynthesizedMembers);
+
+static partial class ReturnToSenderSourceProbe
+{
     internal static IReadOnlyList<ProbeTarget> DiscoverTargets(string assemblyPath, int cap)
     {
         var targets = new List<ProbeTarget>();


### PR DESCRIPTION
- Advances #2673
- Changes harness-only RTS reporting: `RecompileFail` rows with authored source coverage now get a sidecar body-vs-shell fault-isolation result.
- Evidence revision: `3eac610a`

## Change

**Conclusion:** **REVIEW** — RTS now retries the same typed `ArtifactRequest` with only the authored target body substituted, preserving the top-level `RecompileFail` verdict while classifying the fault as `body-defect` or `shell-or-closure-defect`.

Before:

```text
RecompileFail conflated invalid product/decompiler bodies with RTS shell, closure, reference, or standalone source-consumption failures.
```

After:

```text
RecompileFail remains the oracle verdict; `FaultIsolation` and generated-catalog reason refine source-covered rows into body-defect vs shell-or-closure-defect.
```

## Scope and safety

- **Root cause:** RTS had only Roslyn diagnostics from the product artifact, so a recompile failure could not distinguish body defects from shell/closure defects.
- **Fix shape:** Reuse the existing fixture/source body index, pass source paths into generated fixture RTS runs, and retry only the target body in the same request shell.
- **Product impact:** none; changes are under `tools/DecompilerHarness` and tests/docs.
- **Scope boundary:** this slice uses existing fixture/source-path coverage; remote SourceLink fetching remains future work.
- **RTS boundary:** RTS only orchestrates the sidecar retry and reporting; product/shared code still owns C# body/artifact generation.

## Evidence

| Check | Result |
| --- | --- |
| Product/test/fixture build | Pass: `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --nologo -v:q` |
| Focused fault-isolation tests | Pass: `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -method "*TryIsolateRecompileFailure*"` |
| Existing source-probe regressions | Pass: `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -method "*ReturnToSenderSourceProbe*"` |
| Generated RTS catalog tests | Pass: `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -method "*ReturnToSenderCatalog*"` |
| Markdown | Pass: `npx markdownlint-cli docs/design/fact-planned-compile-back-harness.md` |
| Full decompiler suite | Existing unrelated failure: `TypeSourceComposerUnionTests.ClassUnionSwitchExpression_RendersTypePatternArms` expects `return pet is not null && pet is not Cat;` but got `return !(pet is null ? false : (pet.Value is Cat))`; isolated rerun reproduces. |

## Compile-back quality

**Conclusion:** **PASS** — the top-level RTS oracle remains unchanged; this adds diagnostic routing for existing `RecompileFail` rows and deterministic tests cover both classification outcomes.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Remote SourceLink download/indexing | Not changed | Slice 1 uses the existing source-probe index and generated fixture source paths; network SourceLink coverage is a later lane. |
| Full decompiler suite union-shape failure | Not changed | Reproduces in an isolated non-RTS test and is outside the files changed here. |

## Review

Adversarial review is required before ready-to-merge. Pending two clean reviews from non-GPT-5.5 model families.
