### PR TITLE
Define CLI command transition model

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,6 +49,13 @@ The tool is organized around source inspection, API lookup, relationship, and ut
 └─────────────────────────────────────────────────────────────┘
 ```
 
+The command surface has independent source, focus, operation, lens, traversal,
+and rendering axes. Noun-first commands (`package`, `type`, `member`) select a
+structural focus for unary inspection; operation-first commands (`diff`, and a
+future `timeline`) change arity while retaining source/focus selectors. See
+[Command Transition Model](design/command-transition-model.md) for the decision
+rules and version-range cardinality contract.
+
 ### package
 
 Inspects NuGet package metadata without extracting libraries:

--- a/docs/design/command-transition-model.md
+++ b/docs/design/command-transition-model.md
@@ -200,6 +200,7 @@ package payloads. Once selected, the normal output-shape rules apply:
 | `--urls` | Project URL-bearing rows to a URL Vector. | None. Valid only if the version-row schema exposes a URL. |
 | `--print` | Resolve a printable payload already referenced by one selected row. | May fetch that declared payload at the same evaluated address; must not add or evaluate another source address. |
 | `--print-all` | Resolve every declared printable row payload in stable row order. | Explicitly authorizes payload fan-out only for already selected/evaluated rows; must not evaluate source addresses. |
+| `--head N` / `--tail N` | Clip rendered output lines after projection. | None. They do not select printable rows or limit payload fetches. |
 
 Shape reducers do not revise operation arity. In particular:
 
@@ -211,6 +212,12 @@ Shape reducers do not revise operation arity. In particular:
 - `--print` is exactly-one, not implicit-first: one printable row prints
   directly, multiple printable rows require `--row N` or `--print-all`, and zero
   printable rows reject;
+- `--head N` and `--tail N` run after print selection and fetching, so
+  `--print --head 1` does not select the first printable row and
+  `--print-all --head 1` still authorizes all declared payload fetches;
+- `--rows --head N` and the symmetric `--rows --tail N` are first/last
+  table-row rendering windows and remain incompatible with `--print` and
+  `--print-all`; `--row N|first|last` selects exactly one printable row;
 - a plain version string has no printable document. `--print` and `--print-all`
   must report that the selected shape is not printable rather than silently
   transition from version-address rows to package artifact inspection. The

--- a/docs/design/command-transition-model.md
+++ b/docs/design/command-transition-model.md
@@ -1,0 +1,329 @@
+# Command Transition Model
+
+`dotnet-inspect` has two kinds of top-level commands today:
+
+- noun-first inspection commands such as `package`, `library`, `type`, and
+  `member`;
+- operation-first commands such as `diff`.
+
+That split is useful, but only if transitions between commands follow an
+explicit model. A user should be able to predict whether a new gesture changes
+the subject, the operation, the lens, or only the rendering.
+
+The governing rule is:
+
+> One transition should change one axis. Change commands when subject identity
+> or operation arity changes; use options and sections for context, lenses, and
+> projection.
+
+## Independent axes
+
+| Axis | Question | Examples | CLI shape |
+| --- | --- | --- | --- |
+| Source context | Where is the subject acquired from? | package, platform, local library, restored project, TFM | Named options such as `--package`, `--platform`, `--library`, `--project`, `--tfm` |
+| Focus / zoom | What structural subject is being addressed? | package artifact, library, type, member, member coordinate | Noun-first inspection command or an explicit focus selector on an operation-first command |
+| Operation / arity | What is being done, and across how many addresses? | inspect one cell, compare two cells, correlate N cells | Top-level operation when the acquisition lifecycle and outcome shape change |
+| Lens / representation | Which view of the same subject and operation is wanted? | API, analysis, implementation, source, IL, Findings | `-S`, descriptor selectors, or focused mode options |
+| Traversal policy | Which addresses are evaluated, and in what order? | `--at`, endpoints, caller-directed probes, next-probe recommendation | Operation-owned options; never implicit payload acquisition |
+| Projection / rendering | How is the same result shaped for output? | fields, columns, rows, table, Markdown, JSON | Query and writer options |
+
+Source context is not focus. In:
+
+```bash
+dotnet-inspect type JsonSerializer --package System.Text.Json
+```
+
+`type` selects the structural focus. `--package` says where that type should be
+resolved. Conversely:
+
+```bash
+dotnet-inspect package System.Text.Json
+```
+
+`package` selects the package artifact itself as the focus. The command noun and
+the source option use the same domain word but play different roles.
+
+An IL offset is a coordinate within a member, not a standalone command today.
+`library --il-offset` resolves that coordinate and sections such as
+`Instruction Context` render it. Raw `IL` is a representation lens over a
+member. The coordinate and the representation therefore occupy different axes.
+
+## When a command transition is justified
+
+A command transition is justified when either of these changes:
+
+1. **Structural focus:** the addressed identity and primary schema change.
+   `type -> member` is a valid transition because a member has a different
+   selector, identity, default view, and drill-in surface.
+2. **Operation arity:** the acquisition topology and outcome envelope change.
+   Unary inspection, pairwise comparison, and N-address correlation have
+   different failure semantics, backpressure, and result shapes.
+
+Keep the current command when only a lens, section, traversal choice, or output
+projection changes. `member -S IL` does not become an `il` command; it is the
+same member under another representation. `--json` does not become a command;
+it is another writer over the same result.
+
+An execution lifecycle is different when at least one of these is true:
+
+- the required inputs have a different cardinality;
+- a different acquisition plan is required;
+- operation outcomes have a structurally incompatible top-level schema;
+- the addressed subject has a different identity model.
+
+Additional optional work does not by itself justify a command. A selected
+section may authorize another scanner or network request while remaining one
+lens over the same subject and arity.
+
+## Unary inspection and explicit multi-address operations
+
+Unary inspection remains noun-first:
+
+```bash
+dotnet-inspect package System.Text.Json@9.0.0
+dotnet-inspect type JsonSerializer --package System.Text.Json@9.0.0
+dotnet-inspect member JsonSerializer Serialize:1 \
+  --package System.Text.Json@9.0.0
+```
+
+These commands are ergonomic spellings of the conceptual unary operation
+`inspect(package|type|member)`. There is no need to add a literal `inspect`
+command until it enables a concrete composition benefit.
+
+Multi-address operations are operation-first:
+
+```bash
+dotnet-inspect diff --package System.Text.Json@8.0.0..9.0.0 \
+  --type System.Text.Json.JsonSerializer
+```
+
+A future `timeline` belongs beside `diff`, not behind `type --timeline` or a
+`Timeline` section. It changes arity, acquisition, failure topology, and the
+top-level result from a subject document to an ordered history.
+
+Operation-first commands carry source and focus as explicit selectors. Existing
+positional source shorthands, such as `diff Package@A..B`, may remain compatible,
+but documentation and new cross-operation examples should prefer the named form
+so the source/focus/operation axes stay visible.
+
+## A version range is an address space
+
+`Package@A..B` defines an immutable, inclusive, caller-directed address space.
+It does not by itself authorize payload acquisition, choose a cell, compare
+endpoints, or infer monotonic history.
+
+Operations do not have to materialize that address space in the same way.
+`package --versions`, addressed unary inspection, and a future timeline need the
+published interior vector and resolve it through `PackageVersionVector`.
+`diff` needs only the two literal endpoints, so it currently acquires those
+endpoints without enumerating or validating the interior vector first. Endpoint
+selectors such as `#N`, `first`, and `last` are `--at` selectors over a resolved
+vector; they are not valid replacements for the literal `A` or `B` in the range
+syntax.
+
+The operation supplies the cardinality contract:
+
+| Operation | Evaluated payload cells | Current or intended behavior |
+| --- | ---: | --- |
+| Enumerate | 0 | `package Package@A..B --versions` resolves and renders range metadata without acquiring package payloads. |
+| Inspect | 1 | `type` and `member` require one explicit `--at <version\|#N\|first\|last>` and acquire only that exact package. |
+| Compare | 2 | `diff --package Package@A..B` acquires and compares the two endpoints. |
+| Correlate | N explicit cells | A future `timeline` resolves the full address space but acquires only caller-selected probe cells. |
+
+`library --package` does not currently accept a package range, and an IL offset
+has no independent package-range contract. If retained range navigation becomes
+useful at library focus, it must adopt the same explicit one-cell address rule
+as `type` and `member`; it must not pass a range through as though it were one
+package version.
+
+The same syntax can therefore participate in several commands without changing
+meaning. The range always names addresses; the operation decides how many are
+evaluated and what envelope is produced.
+
+### Valid range scenarios
+
+Package enumeration:
+
+```bash
+dotnet-inspect package System.Text.Json@8.0.0..8.0.5 --versions
+```
+
+This is a metadata view over the bounded address space. It is not aggregate
+package inspection.
+
+Unary type/member inspection within a retained range:
+
+```bash
+dotnet-inspect type JsonSerializer \
+  --package System.Text.Json@8.0.0..8.0.5 --at '#4'
+
+dotnet-inspect member JsonSerializer Serialize:1 \
+  --package System.Text.Json@8.0.0..8.0.5 --at 8.0.5
+```
+
+This is useful for caller-directed onset work: the range supplies stable
+addresses and `--at` selects one cell. The selected exact package reference must
+replace the range in all downstream symbol, PDB, SourceLink, and source-content
+acquisition.
+
+Pairwise confirmation:
+
+```bash
+dotnet-inspect diff \
+  --package System.Text.Json@8.0.4..8.0.5 \
+  --type System.Text.Json.JsonSerializer \
+  -S "Finding Transitions"
+```
+
+The endpoints are the two cells. For a non-default producer, the confirmation
+must retain its descriptor:
+
+```bash
+dotnet-inspect diff --package Foo@1.4.0..1.5.0 \
+  --type Foo.Parser --member Parse \
+  --finding analysis.allocation
+```
+
+### Invalid or misleading range scenarios
+
+An unaddressed unary range is an error:
+
+```bash
+dotnet-inspect type JsonSerializer \
+  --package System.Text.Json@8.0.0..8.0.5
+```
+
+The command must not aggregate cells or silently choose `first`, `last`, or
+latest. Its diagnostic should name the accepted `--at` forms.
+
+Likewise, package artifact inspection cannot treat a range as one package:
+
+```bash
+dotnet-inspect package System.Text.Json@8.0.0..8.0.5
+```
+
+Today the range requires `--versions`. A future need to correlate package
+metadata belongs in the multi-address operation, not in an implicit aggregate
+package view.
+
+`package --at` is intentionally absent. For one package artifact,
+`package Package@version` is already the direct spelling. Retaining a larger
+range has user-visible value for type/member navigation and correlation, but not
+for a one-shot package artifact view unless that range context is itself part of
+the rendered result.
+
+## Focus transitions versus operation transitions
+
+These transitions answer different questions.
+
+### Focus / zoom
+
+```text
+package -> library -> type -> member -> member coordinate
+```
+
+The user changes what structural thing is being addressed. Identity and schema
+change; the operation remains unary inspection. The final step is expressed
+today with a coordinate option such as `--il-offset`, not an `offset` command.
+
+### Operation / arity
+
+```text
+inspect -> diff -> timeline
+```
+
+The user keeps the source and structural focus but changes the question:
+
+- inspect: what is true at this address?
+- diff: what transition exists between these two addresses?
+- timeline: what is known across this ordered address space?
+
+A workflow may move on either axis, but one command transition should not hide
+both. For example:
+
+```text
+type at #6
+  -> member at #6       structural zoom
+  -> timeline member    operation change, same member focus
+  -> diff member        pairwise confirmation, same member focus
+```
+
+Because the CLI is stateless, source and focus selectors must be repeated when
+changing operations. That repetition is not a reason to conflate the commands;
+it makes the transition explicit and reproducible.
+
+## Timeline and bisect consequences
+
+`timeline` and `diff` are peers. Both are multi-address operations over the same
+source and focus selectors:
+
+- `diff` has exactly two evaluated cells and emits pair transitions;
+- `timeline` has an ordered address space, zero or more explicitly evaluated
+  cells, and emits correlation states.
+
+The first timeline UX should preserve the Finding correlation semantics:
+
+- `Present`: a completed census contains the exact identity;
+- `Missing`: a completed census does not contain it;
+- `SubjectAbsent`: the producer has no applicable subject input;
+- `Failed`: inspection did not complete;
+- `Unevaluated`: the address exists in the resolved vector but was not supplied
+  to `FindingCorrelation`.
+
+`Unevaluated` is a presentation state formed by joining the version vector with
+the sparse correlation. It is not fabricated as a Finding or inspection
+outcome.
+
+Probe order does not define timeline order. Positions come from the resolved
+version vector in the caller's range direction; evaluated inspections retain
+those positions regardless of the order in which probes were requested.
+
+The default bisect behavior should recommend, not acquire. A recommendation may
+name the next unevaluated midpoint and print a copyable command, but it must not
+download another payload without explicit caller intent. This preserves:
+
+- network and package-cache backpressure;
+- visible retry/failure boundaries;
+- the caller-owned probe budget;
+- the distinction between recurrence-safe backward scanning and a binary search
+  that assumes a monotonic predicate.
+
+A timeline locates a candidate boundary. It does not claim introduction.
+The adjacent endpoint comparison must still produce the producer's native
+`PairFinding.Added` transition.
+
+## Decision checklist
+
+Before adding a command or mode, answer in order:
+
+1. What is the structural focus and its stable identity?
+2. What is the source context?
+3. What is the operation arity and acquisition plan?
+4. Does the change require a new top-level outcome schema?
+5. Is this only another lens over the same focus and operation?
+6. Is this only traversal policy or output projection?
+7. Does every range-consuming path state how many payload cells it may acquire?
+8. Are unevaluated, absent, missing, and failed states kept distinct?
+
+Question 4 does not discriminate by itself. Pair it with question 1 or 3:
+
+- changed identity plus a changed schema means a focus transition;
+- changed arity/acquisition plus a changed schema means an operation transition.
+
+Otherwise, prefer an option, section, or writer.
+
+## Non-goals
+
+This model does not:
+
+- add an `inspect` command;
+- remove existing positional shorthands;
+- make source options global;
+- add session state that implicitly carries source/focus between commands;
+- authorize automatic range scans;
+- turn sections into operation substitutes;
+- define the final `timeline` syntax before its bounded producer/view contract
+  is designed.
+
+The immediate purpose is to make that future syntax derivable rather than
+ad hoc.

--- a/docs/design/command-transition-model.md
+++ b/docs/design/command-transition-model.md
@@ -12,8 +12,9 @@ the subject, the observation, the operation, the lens, or only the rendering.
 
 The governing rule is:
 
-> One transition should change one axis. Change commands when subject identity
-> or operation arity changes; use options and sections for context,
+> One transition should change one axis. Change commands when the independently
+> navigable subject domain or operation arity changes; use selectors for points
+> within an established domain, and options or sections for context,
 > observations, lenses, and projection.
 
 Related docs:
@@ -23,13 +24,16 @@ Related docs:
 - [Output Composition](output-composition.md) separates data selection,
   filtering, and rendering.
 - [Rendering Model](rendering-model.md) defines verbosity and alternate lenses.
+- [Method Body Inspection](method-body-inspection.md) defines the shared member
+  and IL-coordinate query model.
 
 ## Independent axes
 
 | Axis | Question | Examples | CLI shape |
 | --- | --- | --- | --- |
 | Source context | Where is the subject acquired from? | package, platform, local library, restored project, TFM | Named options such as `--package`, `--platform`, `--library`, `--project`, `--tfm` |
-| Focus / zoom | What structural subject is being addressed? | package artifact, library, type, member, member coordinate | Noun-first inspection command or an explicit focus selector on an operation-first command |
+| Focus / zoom | What structural subject is being addressed? | package artifact, library, type, member | Noun-first inspection command or an explicit focus selector on an operation-first command |
+| Point selector / coordinate | Which exact instance or point is selected within that structural scope? | overload, MethodDef token, IL offset | Positional/named selector whose identity is complete within the current scope |
 | Observation / census | Which identities or facts are measured under that focus? | subject presence, child-member census, allocation sites, call sites | Section or producer descriptor such as `--finding` |
 | Operation / arity | What is being done, and across how many addresses? | inspect one cell, compare two cells, correlate N cells | Top-level operation when the acquisition lifecycle and outcome shape change |
 | Lens / representation | Which view of the same subject and operation is wanted? | API, analysis, implementation, source, IL, versions | `-S` or focused mode options |
@@ -52,10 +56,23 @@ dotnet-inspect package System.Text.Json
 `package` selects the package artifact itself as the focus. The command noun and
 the source option use the same domain word but play different roles.
 
-An IL offset is a coordinate within a member, not a standalone command today.
-`library --il-offset` resolves that coordinate and sections such as
-`Instruction Context` render it. Raw `IL` is a representation lens over a
-member. The coordinate and the representation therefore occupy different axes.
+An IL offset is a point selector into method-body facts, not a standalone
+command today. It is reachable from more than one structural scope:
+
+- `library --il-offset <MethodDef>+<offset>` supplies a composite coordinate
+  that is complete within the library and discovers its containing member;
+- member-focused body views already have the member identity and expose the
+  peer offset-scoped facts within that narrower scope.
+
+These are two entry points into the same method-body inspection model, not
+different meanings for the coordinate. Sections such as `Instruction Context`
+choose the observation/projection, while raw `IL` is a representation lens.
+Neither changes coordinate identity.
+
+This means focus is not a strict parent-child ladder. A complete coordinate may
+refine a broad scope directly and still return the containing type/member
+context. Intermediate focus commands remain useful navigation surfaces, but
+they are not mandatory waypoints.
 
 Focus is also not the identity family emitted by an observation. A producer may
 measure the focused subject itself or a collection structurally owned by that
@@ -78,9 +95,13 @@ family within that scope.
 
 A command transition is justified when either of these changes:
 
-1. **Structural focus:** the addressed identity and primary schema change.
-   `type -> member` is a valid transition because a member has a different
-   selector, identity, default view, and drill-in surface.
+1. **Structural focus domain:** the addressed identity family and primary
+   workflow change to another independently navigable surface. `type -> member`
+   is a valid transition because a member has a different selector, identity,
+   default view, and drill-in surface. A coordinate refinement such as
+   `library --il-offset`, however, remains an option when the selector is
+   complete within the established library scope and does not need an
+   independent command surface.
 2. **Operation arity:** the acquisition topology and outcome envelope change.
    Unary inspection, pairwise comparison, and N-address correlation have
    different failure semantics, backpressure, and result shapes.
@@ -291,15 +312,18 @@ These transitions answer different questions.
 ### Focus / zoom
 
 ```text
-package -> library -> type -> member -> member coordinate
+package -> library -> type -> member
+library + MethodDef/offset -> IL coordinate
+member + body offset       -> IL coordinate
 ```
 
 The user changes what structural thing is being addressed. Identity and schema
-change; the operation remains unary inspection. The final step is expressed
-today with a coordinate option such as `--il-offset`, not an `offset` command.
-Zooming to a member means selecting one member as the input subject. It does not
-mean "observe the members owned by this type"; that remains a type-focused
-collection census.
+change; the operation remains unary inspection. The diagram shows common entry
+paths, not a required sequence: the composite library coordinate can jump
+directly to an IL point, while member scope can expose facts at offsets within
+the selected body. Zooming to a member means selecting one member as the input
+subject. It does not mean "observe the members owned by this type"; that remains
+a type-focused collection census.
 
 ### Operation / arity
 
@@ -411,15 +435,16 @@ Before adding a command or mode, answer in order:
 
 1. What is the structural focus and its stable identity?
 2. What is the source context?
-3. What observation census runs within that focus?
-4. What is the operation arity and acquisition plan?
-5. Does the change require a new top-level outcome schema?
-6. Is this only another lens over the same focus and operation?
-7. Is this only traversal policy or output projection?
-8. Does every range-consuming path state how many payload cells it may acquire?
-9. Are unevaluated, absent, missing, and failed states kept distinct?
+3. Is there a point selector, and is its identity complete within that scope?
+4. What observation census runs within that focus?
+5. What is the operation arity and acquisition plan?
+6. Does the change require a new top-level outcome schema?
+7. Is this only another lens over the same focus and operation?
+8. Is this only traversal policy or output projection?
+9. Does every range-consuming path state how many payload cells it may acquire?
+10. Are unevaluated, absent, missing, and failed states kept distinct?
 
-Question 5 does not discriminate by itself. Pair it with question 1 or 4:
+Question 6 does not discriminate by itself. Pair it with question 1 or 5:
 
 - changed addressed-subject identity plus a changed schema means a focus
   transition;

--- a/docs/design/command-transition-model.md
+++ b/docs/design/command-transition-model.md
@@ -16,6 +16,14 @@ The governing rule is:
 > or operation arity changes; use options and sections for context, lenses, and
 > projection.
 
+Related docs:
+
+- [Output Shapes](output-shapes.md) defines the
+  Document → Table → Vector → Scalar ladder.
+- [Output Composition](output-composition.md) separates data selection,
+  filtering, and rendering.
+- [Rendering Model](rendering-model.md) defines verbosity and alternate lenses.
+
 ## Independent axes
 
 | Axis | Question | Examples | CLI shape |
@@ -23,9 +31,9 @@ The governing rule is:
 | Source context | Where is the subject acquired from? | package, platform, local library, restored project, TFM | Named options such as `--package`, `--platform`, `--library`, `--project`, `--tfm` |
 | Focus / zoom | What structural subject is being addressed? | package artifact, library, type, member, member coordinate | Noun-first inspection command or an explicit focus selector on an operation-first command |
 | Operation / arity | What is being done, and across how many addresses? | inspect one cell, compare two cells, correlate N cells | Top-level operation when the acquisition lifecycle and outcome shape change |
-| Lens / representation | Which view of the same subject and operation is wanted? | API, analysis, implementation, source, IL, Findings | `-S`, descriptor selectors, or focused mode options |
+| Lens / representation | Which view of the same subject and operation is wanted? | API, analysis, implementation, source, IL, Findings, versions | `-S`, descriptor selectors, or focused mode options |
 | Traversal policy | Which addresses are evaluated, and in what order? | `--at`, endpoints, caller-directed probes, next-probe recommendation | Operation-owned options; never implicit payload acquisition |
-| Projection / rendering | How is the same result shaped for output? | fields, columns, rows, table, Markdown, JSON | Query and writer options |
+| Projection / rendering | How is the same result shaped for output? | fields, columns, count, URLs, printable payload, table, Markdown, JSON | Shape reducers, projectors, and writer options |
 
 Source context is not focus. In:
 
@@ -121,14 +129,58 @@ selectors such as `#N`, `first`, and `last` are `--at` selectors over a resolved
 vector; they are not valid replacements for the literal `A` or `B` in the range
 syntax.
 
-The operation supplies the cardinality contract:
+The selected lens or operation supplies the payload-acquisition contract:
 
-| Operation | Evaluated payload cells | Current or intended behavior |
+| Address-space use | Evaluated payload cells | Current or intended behavior |
 | --- | ---: | --- |
-| Enumerate | 0 | `package Package@A..B --versions` resolves and renders range metadata without acquiring package payloads. |
+| Select version Vector | 0 | `package Package@A..B --versions` resolves and renders range metadata without acquiring package payloads. |
 | Inspect | 1 | `type` and `member` require one explicit `--at <version\|#N\|first\|last>` and acquire only that exact package. |
 | Compare | 2 | `diff --package Package@A..B` acquires and compares the two endpoints. |
 | Correlate | N explicit cells | A future `timeline` resolves the full address space but acquires only caller-selected probe cells. |
+
+The first row is a package lens and output-shape selection. It is not an
+operation peer of `diff` and `timeline`.
+
+### Acquisition cardinality versus output shape
+
+Operation arity controls how many source addresses may be evaluated and how
+many primary subject payloads may be acquired. Output shape controls how
+already-selected data is projected or reduced. These cardinalities are
+independent.
+
+`--versions` selects a version **Vector** while retaining package focus. For a
+range, resolving that Vector uses registry/cache metadata and acquires zero
+package payloads. Once selected, the normal output-shape rules apply:
+
+| Gesture | Shape effect | Acquisition effect |
+| --- | --- | --- |
+| `--versions` | Select the version Vector. | Resolve version metadata; acquire zero package payloads. |
+| `--count` | Reduce the selected Vector to a Scalar count. | None. Count the bounded, prerelease-filtered addresses already selected. |
+| `--urls` | Project URL-bearing rows to a URL Vector. | None. Valid only if the version-row schema exposes a URL. |
+| `--print` | Resolve a printable payload already referenced by one selected row. | May fetch that declared payload at the same evaluated address; must not add or evaluate another source address. |
+
+Shape reducers do not revise operation arity. In particular:
+
+- `package Package@A..B --versions --count` means "how many addresses are in
+  this bounded Vector?", not "inspect these packages and count successful
+  payloads";
+- `--urls` may expose registry URLs if version rows gain such a field, but it
+  must not download package contents to manufacture them;
+- a plain version string has no printable document. `--print` must report that
+  the selected shape is not printable rather than silently transition from a
+  version-address row to package artifact inspection. The explicit transition
+  remains `package Package@version`.
+
+The same rule applies to a future timeline. `--count` can reduce an already
+assembled Timeline table; it cannot probe additional cells. `--print` can print
+only a payload already carried or explicitly referenced by an evaluated row; it
+cannot turn an unevaluated row into an implicit acquisition.
+
+The current package `--versions` path is implemented as a specialized early-exit
+list writer, so some shared reducers and projectors are not yet honored
+uniformly. That is an implementation gap against the output-shape model, not a
+precedent for treating `--versions` as a separate operation or bespoke rendering
+island.
 
 `library --package` does not currently accept a package range, and an IL offset
 has no independent package-range contract. If retained range navigation becomes

--- a/docs/design/command-transition-model.md
+++ b/docs/design/command-transition-model.md
@@ -8,13 +8,13 @@
 
 That split is useful, but only if transitions between commands follow an
 explicit model. A user should be able to predict whether a new gesture changes
-the subject, the operation, the lens, or only the rendering.
+the subject, the observation, the operation, the lens, or only the rendering.
 
 The governing rule is:
 
 > One transition should change one axis. Change commands when subject identity
-> or operation arity changes; use options and sections for context, lenses, and
-> projection.
+> or operation arity changes; use options and sections for context,
+> observations, lenses, and projection.
 
 Related docs:
 
@@ -30,8 +30,9 @@ Related docs:
 | --- | --- | --- | --- |
 | Source context | Where is the subject acquired from? | package, platform, local library, restored project, TFM | Named options such as `--package`, `--platform`, `--library`, `--project`, `--tfm` |
 | Focus / zoom | What structural subject is being addressed? | package artifact, library, type, member, member coordinate | Noun-first inspection command or an explicit focus selector on an operation-first command |
+| Observation / census | Which identities or facts are measured under that focus? | subject presence, child-member census, allocation sites, call sites | Section or producer descriptor such as `--finding` |
 | Operation / arity | What is being done, and across how many addresses? | inspect one cell, compare two cells, correlate N cells | Top-level operation when the acquisition lifecycle and outcome shape change |
-| Lens / representation | Which view of the same subject and operation is wanted? | API, analysis, implementation, source, IL, Findings, versions | `-S`, descriptor selectors, or focused mode options |
+| Lens / representation | Which view of the same subject and operation is wanted? | API, analysis, implementation, source, IL, versions | `-S` or focused mode options |
 | Traversal policy | Which addresses are evaluated, and in what order? | `--at`, endpoints, caller-directed probes, next-probe recommendation | Operation-owned options; never implicit payload acquisition |
 | Projection / rendering | How is the same result shaped for output? | fields, columns, count, URLs, printable payload, table, Markdown, JSON | Shape reducers, projectors, and writer options |
 
@@ -56,6 +57,23 @@ An IL offset is a coordinate within a member, not a standalone command today.
 `Instruction Context` render it. Raw `IL` is a representation lens over a
 member. The coordinate and the representation therefore occupy different axes.
 
+Focus is also not the identity family emitted by an observation. A producer may
+measure the focused subject itself or a collection structurally owned by that
+subject:
+
+| Focus | Observation census | Pairwise question |
+| --- | --- | --- |
+| Type `T` | Type identity for `T` | Was `T` added or removed? |
+| Type `T` | Member identities declared by `T` | Which members of `T` were added or removed? |
+| Member `M` | Member identity for `M` | Was this particular `M` added or removed? |
+
+The first two questions retain type focus and differ by observation producer.
+Dropping to member focus answers the third question; it cannot replace the
+type-scoped member census. A child-identity row is therefore not evidence that
+the command should have zoomed to that child. Focus defines the producer's
+scope and input subject; the producer defines the Finding identity and payload
+family within that scope.
+
 ## When a command transition is justified
 
 A command transition is justified when either of these changes:
@@ -67,10 +85,12 @@ A command transition is justified when either of these changes:
    Unary inspection, pairwise comparison, and N-address correlation have
    different failure semantics, backpressure, and result shapes.
 
-Keep the current command when only a lens, section, traversal choice, or output
-projection changes. `member -S IL` does not become an `il` command; it is the
-same member under another representation. `--json` does not become a command;
-it is another writer over the same result.
+Keep the current command when only an observation producer, lens, section,
+traversal choice, or output projection changes. A type-presence census and a
+type-scoped member census can both participate in `diff --type T`;
+`member -S IL` does not become an `il` command because it is the same member
+under another representation. `--json` does not become a command; it is another
+writer over the same result.
 
 An execution lifecycle is different when at least one of these is true:
 
@@ -277,6 +297,9 @@ package -> library -> type -> member -> member coordinate
 The user changes what structural thing is being addressed. Identity and schema
 change; the operation remains unary inspection. The final step is expressed
 today with a coordinate option such as `--il-offset`, not an `offset` command.
+Zooming to a member means selecting one member as the input subject. It does not
+mean "observe the members owned by this type"; that remains a type-focused
+collection census.
 
 ### Operation / arity
 
@@ -286,18 +309,19 @@ inspect -> diff -> timeline
 
 The user keeps the source and structural focus but changes the question:
 
-- inspect: what is true at this address?
-- diff: what transition exists between these two addresses?
-- timeline: what is known across this ordered address space?
+- inspect: what does the selected observation report at this address?
+- diff: how does the selected observation transition between these addresses?
+- timeline: what is known for the selected observation across this ordered
+  address space?
 
-A workflow may move on either axis, but one command transition should not hide
-both. For example:
+A workflow may move on any axis, but one command transition should not hide
+multiple changes. For example:
 
 ```text
-type at #6
-  -> member at #6       structural zoom
-  -> timeline member    operation change, same member focus
-  -> diff member        pairwise confirmation, same member focus
+diff type presence
+  -> diff type members  observation change, same type focus and operation
+  -> diff member        structural zoom to one member
+  -> timeline member    operation change, same member focus and observation
 ```
 
 Because the CLI is stateless, source and focus selectors must be repeated when

--- a/docs/design/command-transition-model.md
+++ b/docs/design/command-transition-model.md
@@ -82,14 +82,31 @@ subject:
 | --- | --- | --- |
 | Type `T` | Type identity for `T` | Was `T` added or removed? |
 | Type `T` | Member identities declared by `T` | Which members of `T` were added or removed? |
+| Type `T` | Attribute occurrences applied to `T` | Which applied attributes were added, removed, or changed? |
 | Member `M` | Member identity for `M` | Was this particular `M` added or removed? |
+| Member `M` | Attribute occurrences applied to `M` | Which applied attributes on `M` were added, removed, or changed? |
 
-The first two questions retain type focus and differ by observation producer.
-Dropping to member focus answers the third question; it cannot replace the
-type-scoped member census. A child-identity row is therefore not evidence that
-the command should have zoomed to that child. Focus defines the producer's
-scope and input subject; the producer defines the Finding identity and payload
-family within that scope.
+These observations have three distinct relationships to the focused subject:
+
+- **self presence:** whether the focused identity exists;
+- **owned children:** the census of identities structurally contained by the
+  focus, such as members declared by a type;
+- **attached facets:** the census of occurrences applied to the focus, such as
+  custom attributes.
+
+All three may participate in the same unary, pairwise, or timeline operation
+without changing focus. A conceptual "type transition" is therefore incomplete
+until its observation census is named. A human default view may compose several
+clearly labelled transition sections, while a focused or machine-readable query
+selects one producer explicitly.
+
+Dropping to member focus answers the particular-member questions; it cannot
+replace the type-scoped member census. Attributes likewise do not require an
+`attribute` focus command merely because attribute identities appear as rows. A
+child or attached-facet identity row is not evidence that the command should
+have zoomed to that identity. Focus defines the producer's scope and input
+subject; the producer defines the Finding identity and payload family within
+that scope.
 
 ## When a command transition is justified
 
@@ -390,6 +407,18 @@ provides the stable scope; each member is an observation identity. Joining the
 complete member censuses by identity creates one longitudinal track per member,
 so the result shows how the type's API surface evolved without requiring the
 caller to name each member in advance.
+
+The same type focus can instead select the type-presence census or the
+applied-attribute census. Those timelines answer different questions and must
+identify the active observation in their title/schema:
+
+- type presence: when the type itself appeared or disappeared;
+- members: when each declared member was added, removed, or re-added;
+- applied attributes: when each attribute occurrence was added, removed, or
+  changed.
+
+Changing among those timelines changes the observation producer, not the focus
+or operation.
 
 ### Dense timeline
 

--- a/docs/design/command-transition-model.md
+++ b/docs/design/command-transition-model.md
@@ -199,6 +199,7 @@ package payloads. Once selected, the normal output-shape rules apply:
 | `--count` | Reduce the selected Vector to a Scalar count. | None. Count the bounded, prerelease-filtered addresses already selected. |
 | `--urls` | Project URL-bearing rows to a URL Vector. | None. Valid only if the version-row schema exposes a URL. |
 | `--print` | Resolve a printable payload already referenced by one selected row. | May fetch that declared payload at the same evaluated address; must not add or evaluate another source address. |
+| `--print-all` | Resolve every declared printable row payload in stable row order. | Explicitly authorizes payload fan-out only for already selected/evaluated rows; must not evaluate source addresses. |
 
 Shape reducers do not revise operation arity. In particular:
 
@@ -207,15 +208,18 @@ Shape reducers do not revise operation arity. In particular:
   payloads";
 - `--urls` may expose registry URLs if version rows gain such a field, but it
   must not download package contents to manufacture them;
-- a plain version string has no printable document. `--print` must report that
-  the selected shape is not printable rather than silently transition from a
-  version-address row to package artifact inspection. The explicit transition
-  remains `package Package@version`.
+- `--print` is exactly-one, not implicit-first: one printable row prints
+  directly, multiple printable rows require `--row N` or `--print-all`, and zero
+  printable rows reject;
+- a plain version string has no printable document. `--print` and `--print-all`
+  must report that the selected shape is not printable rather than silently
+  transition from version-address rows to package artifact inspection. The
+  explicit transition remains `package Package@version`.
 
 The same rule applies to a future timeline. `--count` can reduce an already
-assembled Timeline table; it cannot probe additional cells. `--print` can print
-only a payload already carried or explicitly referenced by an evaluated row; it
-cannot turn an unevaluated row into an implicit acquisition.
+assembled Timeline table; it cannot probe additional cells. `--print` and
+`--print-all` can print only payloads already carried or explicitly referenced
+by evaluated rows; they cannot turn unevaluated rows into implicit acquisition.
 
 The current package `--versions` path is implemented as a specialized early-exit
 list writer, so some shared reducers and projectors are not yet honored

--- a/docs/design/command-transition-model.md
+++ b/docs/design/command-transition-model.md
@@ -334,10 +334,44 @@ it makes the transition explicit and reproducible.
 source and focus selectors:
 
 - `diff` has exactly two evaluated cells and emits pair transitions;
-- `timeline` has an ordered address space, zero or more explicitly evaluated
-  cells, and emits correlation states.
+- `timeline` has an ordered address space, evaluates a caller-selected dense or
+  sparse set of cells, and emits correlation states plus transitions between
+  evaluated censuses.
 
-The first timeline UX should preserve the Finding correlation semantics:
+The most informative initial composition is not necessarily a timeline of one
+type or one member. It is a type-focused timeline over a member census:
+
+| Axis | Selection |
+| --- | --- |
+| Source context | A package version range |
+| Focus | One type |
+| Observation | The members structurally owned by that type |
+| Operation | Timeline |
+| Traversal | Every version in the range, or an explicit sparse subset |
+| Projection | Member identity tracks and adjacent added/removed transitions |
+
+This is intentionally between package-wide and member-specific focus. The type
+provides the stable scope; each member is an observation identity. Joining the
+complete member censuses by identity creates one longitudinal track per member,
+so the result shows how the type's API surface evolved without requiring the
+caller to name each member in advance.
+
+### Dense timeline
+
+A bounded, explicit full-range traversal may evaluate every version in the
+address space. Comparing each pair of adjacent complete censuses then yields
+the producer's native member transitions at every boundary. This is a true
+transition timeline: it can show additions, removals, and later re-additions
+without assuming monotonic history.
+
+Selecting full traversal authorizes N package-payload acquisitions and must be
+explicit; merely supplying a range does not. The final syntax for that selector
+is deferred, but the architecture permits it.
+
+### Sparse timeline and bisect
+
+A sparse traversal evaluates only caller-selected cells. It preserves the
+Finding correlation semantics:
 
 - `Present`: a completed census contains the exact identity;
 - `Missing`: a completed census does not contain it;
@@ -354,8 +388,9 @@ Probe order does not define timeline order. Positions come from the resolved
 version vector in the caller's range direction; evaluated inspections retain
 those positions regardless of the order in which probes were requested.
 
-The default bisect behavior should recommend, not acquire. A recommendation may
-name the next unevaluated midpoint and print a copyable command, but it must not
+Bisect is a traversal policy over a sparse timeline, not another peer operation.
+Its default behavior should recommend, not acquire. A recommendation may name
+the next unevaluated midpoint and print a copyable command, but it must not
 download another payload without explicit caller intent. This preserves:
 
 - network and package-cache backpressure;
@@ -364,9 +399,11 @@ download another payload without explicit caller intent. This preserves:
 - the distinction between recurrence-safe backward scanning and a binary search
   that assumes a monotonic predicate.
 
-A timeline locates a candidate boundary. It does not claim introduction.
-The adjacent endpoint comparison must still produce the producer's native
-`PairFinding.Added` transition.
+A sparse timeline with an unevaluated gap locates only a candidate boundary. A
+dense timeline, or a sparse timeline whose evaluated cells are adjacent in the
+resolved vector, may claim the exact boundary only when that adjacent census
+comparison produces the producer's native `PairFinding.Added` or
+`PairFinding.Removed` transition.
 
 ## Decision checklist
 
@@ -374,16 +411,18 @@ Before adding a command or mode, answer in order:
 
 1. What is the structural focus and its stable identity?
 2. What is the source context?
-3. What is the operation arity and acquisition plan?
-4. Does the change require a new top-level outcome schema?
-5. Is this only another lens over the same focus and operation?
-6. Is this only traversal policy or output projection?
-7. Does every range-consuming path state how many payload cells it may acquire?
-8. Are unevaluated, absent, missing, and failed states kept distinct?
+3. What observation census runs within that focus?
+4. What is the operation arity and acquisition plan?
+5. Does the change require a new top-level outcome schema?
+6. Is this only another lens over the same focus and operation?
+7. Is this only traversal policy or output projection?
+8. Does every range-consuming path state how many payload cells it may acquire?
+9. Are unevaluated, absent, missing, and failed states kept distinct?
 
-Question 4 does not discriminate by itself. Pair it with question 1 or 3:
+Question 5 does not discriminate by itself. Pair it with question 1 or 4:
 
-- changed identity plus a changed schema means a focus transition;
+- changed addressed-subject identity plus a changed schema means a focus
+  transition;
 - changed arity/acquisition plus a changed schema means an operation transition.
 
 Otherwise, prefer an option, section, or writer.
@@ -396,7 +435,7 @@ This model does not:
 - remove existing positional shorthands;
 - make source options global;
 - add session state that implicitly carries source/focus between commands;
-- authorize automatic range scans;
+- authorize implicit or unbounded range scans;
 - turn sections into operation substitutes;
 - define the final `timeline` syntax before its bounded producer/view contract
   is designed.

--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -107,14 +107,41 @@ modifier changes how a selected payload is rendered.
 it does not mean "take the first row." Cardinality is resolved after section
 selection, filtering, and printable-capability filtering:
 
-| Printable rows | `--print` | `--print --row N` | `--print-all` |
+| Printable rows | `--print` | `--print --row N\|first\|last` | `--print-all` |
 | ---: | --- | --- | --- |
 | 0 | Error: the selected shape is not printable. | Error. | Error: the selected shape is not printable. |
-| 1 | Print the one payload. | Print row 1; any other index is an error. | Print the one payload. |
-| More than 1 | Guidance error requiring `--row N` or `--print-all`. | Print exactly the Nth printable row. | Print every printable payload in stable row order. |
+| 1 | Print the one payload. | Print row `1`, `first`, or `last`; any other index is an error. | Print the one payload. |
+| More than 1 | Guidance error requiring `--row` or `--print-all`. | Print exactly the selected printable row. | Print every printable payload in stable row order. |
 
-`--row N` is one-based and counts printable rows, not every row in the selected
-table. `--print-all` cannot be combined with `--row`.
+Numeric `--row N` is one-based and counts printable rows, not every row in the
+selected table. `first` and `last` are stable aliases for the endpoints of that
+printable-row sequence. `--print-all` cannot be combined with `--row`.
+
+`-n N` / `--head N` and `--tail N` are rendered-line windows applied after
+printable-row cardinality is resolved and payloads are fetched. They do not
+select rows or limit `--print-all` fan-out:
+
+```text
+--print --head 1
+  multi-row selection -> error; does not choose the first row
+
+--print --row 2 --head 20
+  select printable row 2 -> fetch one payload -> render its first 20 lines
+
+--print-all --tail 20
+  fetch every declared printable payload -> render the final 20 combined lines
+```
+
+`--rows` changes head/tail from rendered-line windows into per-table data-row
+windows:
+
+- `--rows --head N` keeps the first N data rows;
+- `--rows --tail N` keeps the last N data rows.
+
+Both row-window forms are incompatible with `--print` and `--print-all`;
+`--row N|first|last` is the explicit printable-row selector. The current CLI
+implements head rows and rejects tail rows; tail-row support is a follow-up to
+this symmetric contract.
 
 This policy deliberately rejects implicit-first behavior. Row order may change
 with filtering, producer evolution, or package versions, and choosing the first
@@ -143,7 +170,10 @@ payloads on already evaluated rows; it cannot probe missing cells.
 | `--tsv` / `--jsonl` | render the single selected section as TSV / JSON Lines (a Table or Vector) |
 | `--table` | render the single selected section as a space-padded pretty table |
 | `--no-header` (`--no-headers`) | drop the Table header row |
-| `-n N` / `--rows` | with `--rows`, `-n` trims to N **data rows per table**, across Markdown, TSV, and JSONL |
+| `-n N` / `--head N` / numeric shorthand such as `-20` | keep the first N rendered output lines unless `--rows` is active |
+| `--tail N` | keep the last N rendered output lines unless `--rows` is active |
+| `--rows --head N` | keep the first N **data rows per table**, across Markdown, TSV, and JSONL |
+| `--rows --tail N` | keep the last N **data rows per table**; target symmetry, not yet implemented |
 | `--bare` | render the selected payload without document decoration; it changes presentation only, not the selected shape |
 | `--plaintext` | render a whole-document plain-text view; distinct from `--bare` |
 
@@ -344,6 +374,10 @@ The stable vocabulary is:
   of multiple printable rows implicitly.
 - `--print-all` is the explicit row-payload fan-out projection: it does not make
   non-printable rows printable or evaluate new addresses.
+- `--head` / `--tail` are post-projection line windows: they do not select rows
+  or constrain payload acquisition.
+- `--rows` promotes head/tail to first/last data-row windows, but those windows
+  remain presentation limits rather than printable-row selectors.
 - `--bare` is a presentation modifier: it strips the surrounding framing from an
   already-selected payload.
 - `--raw` / `--blob` are URL-shape modifiers: they control the form of emitted

--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -4,7 +4,8 @@ dotnet-inspect output narrows through a small ladder of **shapes**. Markout
 defines the shapes and produces them; dotnet-inspect flags choose which rung you
 land on. Naming the ladder gives a shared vocabulary for the output flags
 (`-S`, `--fields`/`--columns`, `--tsv`/`--jsonl`, `--count`, `-n`/`--rows`,
-`--bare`, …) and for deciding what a new flag should do.
+`--print`, `--print-all`, `--bare`, …) and for deciding what a new flag should
+do.
 
 Related docs:
 
@@ -99,6 +100,39 @@ modifier changes how a selected payload is rendered.
 `-D`/`--discover` is orthogonal: it does not render the subject, it lists the
 *available* shapes — the sections of the Document and the columns of a Table (see
 [schema-query.md](schema-query.md)).
+
+### Printable payload projections
+
+`--print` projects a selected row's declared printable payload. It is unary, but
+it does not mean "take the first row." Cardinality is resolved after section
+selection, filtering, and printable-capability filtering:
+
+| Printable rows | `--print` | `--print --row N` | `--print-all` |
+| ---: | --- | --- | --- |
+| 0 | Error: the selected shape is not printable. | Error. | Error: the selected shape is not printable. |
+| 1 | Print the one payload. | Print row 1; any other index is an error. | Print the one payload. |
+| More than 1 | Guidance error requiring `--row N` or `--print-all`. | Print exactly the Nth printable row. | Print every printable payload in stable row order. |
+
+`--row N` is one-based and counts printable rows, not every row in the selected
+table. `--print-all` cannot be combined with `--row`.
+
+This policy deliberately rejects implicit-first behavior. Row order may change
+with filtering, producer evolution, or package versions, and choosing the first
+row could silently fetch the wrong document. It also rejects implicit fan-out:
+`--print-all` is the gesture that explicitly accepts every declared payload
+fetch.
+
+Printability is a row capability, not a property implied by Table or Vector
+shape. Neither `--print` nor `--print-all` may:
+
+- reinterpret an address row as the artifact at that address;
+- evaluate an unevaluated address;
+- change operation arity or primary-subject acquisition cardinality.
+
+A version-address Vector is therefore not printable merely because each row
+could name a package. The explicit transition to that package artifact remains
+`package Package@version`. Likewise, printing a timeline may use only declared
+payloads on already evaluated rows; it cannot probe missing cells.
 
 ### Presentation modifiers (render the chosen shape)
 
@@ -306,6 +340,10 @@ The stable vocabulary is:
 
 - `--count` is a shape-reduction selector: it collapses a selected table/vector to a
   single scalar count.
+- `--print` is an exactly-one row-payload projection: it never chooses the first
+  of multiple printable rows implicitly.
+- `--print-all` is the explicit row-payload fan-out projection: it does not make
+  non-printable rows printable or evaluate new addresses.
 - `--bare` is a presentation modifier: it strips the surrounding framing from an
   already-selected payload.
 - `--raw` / `--blob` are URL-shape modifiers: they control the form of emitted

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -40,6 +40,7 @@ Agents working in this repo should preserve these principles:
 - [PDB acquisition](pdb-acquisition.md): symbols and SourceLink acquisition.
 - [Rendering model](design/rendering-model.md): output mode and verbosity design.
 - [Progressive disclosure](design/progressive-disclosure.md): verbosity, `-D`/`-S`, opt-in sections, `-S @All`, and limiter behavior.
+- [Command transitions](design/command-transition-model.md): when source, focus, operation arity, lens, traversal, or rendering changes should switch commands versus stay within one command.
 - [Row query and ordering](design/row-query-order.md): proposed field-scoped row predicates, ordering, `--top`, and schema-discoverable defaults.
 - [Analysis UX scopes](design/analysis-ux-scopes.md): shared analysis vocabulary across offset, member, type, and library scopes.
 - [IL coordinate workflows](design/il-coordinate-workflows.md): prototype workflows for explaining sparse runtime coordinates from debugger, profiler, or analyzer artifacts.


### PR DESCRIPTION
## Conclusion

Define the command-transition doctrine before adding correlation UX.

## Model

- Separate source context, structural focus/zoom, operation/arity, lens,
  traversal policy, and output projection.
- Change commands when subject identity or operation arity changes; keep lens
  and rendering changes within the current command.
- Treat `type -> member` as structural zoom.
- Treat `inspect -> diff -> timeline` as operation/arity transitions over the
  same source and focus.
- Define `Package@A..B` as an address space. The active operation owns payload
  cardinality: enumerate zero cells, inspect one addressed cell, compare two
  endpoints, or correlate N explicit probes.
- Preserve explicit acquisition backpressure and distinguish unevaluated,
  missing, absent, and failed cells.

The document evaluates where ranges make sense today on `package`, `type`, and
`member`; records the current `library` limitation; and concludes that a future
`timeline` should be a peer to `diff`, not a mode or section under unary
inspection.

## Scope

Docs only. This PR does not add `timeline`, change command syntax, or alter
range resolution.

## Validation

- `markdownlint` passed for all changed Markdown.
- Architecture review verified current claims against the command parsers,
  package-vector implementation, and Finding correlation semantics.

Context: #2625 and #2604.
