### PR TITLE
Add RTS source correspondence census

### DIFF
--- a/docs/design/fact-planned-compile-back-harness.md
+++ b/docs/design/fact-planned-compile-back-harness.md
@@ -744,6 +744,15 @@ means the authored body fit inside the final RTS shell while the decompiled body
 did not; it may still point at a harness closure budget limit rather than a
 semantic product-body bug.
 
+The same sidecar lane also produces a source-correspondence census for
+fixture-source coverage. The census projects source-probe rows into
+Finding-style evidence keyed by member stable selector when available, but it
+does not change the RTS status. Descriptor IDs remain the structural source
+reason (`source.correspondence.<reason>`), while a coarse category separates
+ignorable taste/options, not-yet-raised source sugar, structuring residue,
+semantic opcode deltas, invalid rows, and unclassified frontiers. Shared JSON
+uses source file names, not absolute local paths, in the finding projection.
+
 The existing corpus sensor gates on `Exact`, `OpcodeDiff`, `RecompileFail`, and
 `ContextFail`. ReturnToSender planning reasons should be structured details
 underneath those statuses, not replacement top-level metrics.

--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -1307,7 +1307,7 @@ public class GeneratedFixtureCatalogTests
     [Fact]
     public void ReturnToSenderCatalogJson_RedactsFaultIsolationSourcePath()
     {
-        string sourcePath = Path.Combine(Path.GetTempPath(), "rts-source-path-redaction", Guid.NewGuid().ToString("N"), "Authored.cs");
+        const string sourcePath = @"C:\Users\builder\repo\Authored.cs";
         var run = new GeneratedFixtureReturnToSenderRunResult(
             ProjectDirectory: "",
             AssemblyPath: "",
@@ -1342,7 +1342,8 @@ public class GeneratedFixtureCatalogTests
         string json = GeneratedFixtureRunner.FormatReturnToSenderCatalogJson(run);
 
         Assert.DoesNotContain(sourcePath, json);
-        Assert.DoesNotContain(Path.GetDirectoryName(sourcePath)!, json);
+        Assert.DoesNotContain("Users", json);
+        Assert.DoesNotContain("builder", json);
         using var document = JsonDocument.Parse(json);
         var result = Assert.Single(document.RootElement.GetProperty("Results").EnumerateArray());
         Assert.Equal("RecompileFail", result.GetProperty("ActualStatus").GetString());

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -109,6 +109,13 @@ public class ReturnToSenderFixtureCatalogTests
         Assert.Contains("System.Math", result.Detail);
         Assert.Equal("returnSystem.Math.Abs(value);", Normalize(result.ExpectedBody));
         Assert.Equal("returnMath.Abs(value);", Normalize(result.ActualBody));
+
+        var finding = Assert.Single(ReturnToSenderSourceProbe.BuildFindings([result]));
+        Assert.Equal("source.correspondence.valid_different.known_taste", finding.DescriptorId);
+        Assert.Equal("ignorable", finding.Category);
+        Assert.Equal(result.MemberAnchor!.StableSelector, finding.SubjectId);
+        Assert.Equal("DiffSample.cs", finding.SourceFile);
+        Assert.False(finding.HasOpcodeDiffEvidence);
     }
 
     [Fact]
@@ -139,6 +146,25 @@ public class ReturnToSenderFixtureCatalogTests
         Assert.Equal("valid_different.semantic_opcode_diff.checked_context", reason);
         Assert.Contains("checked_context", detail);
         Assert.Contains("OpcodeDiff", detail);
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_BucketsResidualFrontiersAsStructuringResidue()
+    {
+        var result = new ReturnToSenderSourceProbeResult(
+            new ReturnToSender.RequestedTarget("T", "M", 0),
+            ReturnToSenderSourceOutcome.ValidDifferent,
+            FidelityCheck.CompileBackStatus.Exact,
+            "valid_different.source_shape_frontier.unsafe_residual.exact",
+            Detail: "synthetic residual frontier",
+            SourcePath: "/tmp/Fixture.cs",
+            ExpectedBody: "return 1;",
+            ActualBody: "/* residual */ return 1;");
+
+        var finding = Assert.Single(ReturnToSenderSourceProbe.BuildFindings([result]));
+
+        Assert.Equal("structuring-residue", finding.Category);
+        Assert.Equal("Fixture.cs", finding.SourceFile);
     }
 
     [Fact]
@@ -445,6 +471,13 @@ public class ReturnToSenderFixtureCatalogTests
         Assert.False(string.IsNullOrWhiteSpace(result.RecompiledOpcodes));
         Assert.NotEmpty(result.IlDiffLines ?? []);
         Assert.Contains(result.IlDiffLines!, line => line.StartsWith("h", StringComparison.Ordinal));
+
+        var finding = Assert.Single(ReturnToSenderSourceProbe.BuildFindings([result]));
+        Assert.Equal("source.correspondence.valid_different.compiler_lowering.dynamic_callsite.opcode_diff", finding.DescriptorId);
+        Assert.Equal("not-yet-raised-sugar", finding.Category);
+        Assert.StartsWith("DynamicAdd~", finding.SubjectId, StringComparison.Ordinal);
+        Assert.Equal("LadderRung9.cs", finding.SourceFile);
+        Assert.True(finding.HasOpcodeDiffEvidence);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -168,6 +168,26 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_RedactsWindowsSourcePathInFindings()
+    {
+        var result = new ReturnToSenderSourceProbeResult(
+            new ReturnToSender.RequestedTarget("T", "M", 0),
+            ReturnToSenderSourceOutcome.ValidDifferent,
+            FidelityCheck.CompileBackStatus.Exact,
+            "valid_different.known_taste",
+            Detail: "synthetic taste frontier",
+            SourcePath: @"C:\Users\builder\repo\Fixture.cs",
+            ExpectedBody: "return System.Math.Abs(value);",
+            ActualBody: "return Math.Abs(value);");
+
+        var finding = Assert.Single(ReturnToSenderSourceProbe.BuildFindings([result]));
+
+        Assert.Equal("Fixture.cs", finding.SourceFile);
+        Assert.DoesNotContain("Users", finding.SourceFile, StringComparison.Ordinal);
+        Assert.DoesNotContain(@"\", finding.SourceFile, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_DoesNotHideResidualInsideCheckedContext()
     {
         var reason = ReturnToSenderSourceProbe.ClassifyValidDifference(

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -2402,7 +2402,7 @@ internal static class GeneratedFixtureRunner
             : new
             {
                 result.Kind,
-                SourcePath = Path.GetFileName(result.SourcePath),
+                SourcePath = ReturnToSenderSourceProbe.SourceFileName(result.SourcePath),
                 result.Detail,
             };
 

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -178,6 +178,7 @@ static class Program
                     case "--return-to-sender-ab": returnToSenderAb = true; break;
                     case "--return-to-sender-markout": returnToSenderMarkout = true; break;
                     case "--return-to-sender-source-probe": returnToSenderSourceProbe = true; break;
+                    case "--source-correspondence-census": returnToSenderSourceProbe = true; break;
                     case "--return-to-sender-fixtures": returnToSenderFixtureGroup = NextArg(args, ref i, flag); break;
                     case "--return-to-sender-catalog":
                         returnToSenderCatalog = true;
@@ -294,7 +295,7 @@ static class Program
         if (returnToSenderFixtureGroup is not null
             && !(returnToSender || returnToSenderAb || returnToSenderSourceProbe))
         {
-            return Fail("--return-to-sender-fixtures requires --return-to-sender, --return-to-sender-ab, or --return-to-sender-source-probe.");
+            return Fail("--return-to-sender-fixtures requires --return-to-sender, --return-to-sender-ab, --return-to-sender-source-probe, or --source-correspondence-census.");
         }
 
         using var packageInputs = ResolvePackageAssemblies(packages, packageVersion, packageTfm, packageAssembly);
@@ -1682,6 +1683,10 @@ static class Program
                                 reports valid_match, valid_different, invalid,
                                 source_unavailable, and unsupported_target buckets.
                                 Use --json for machine-readable row output.
+          --source-correspondence-census
+                                alias for --return-to-sender-source-probe that
+                                emphasizes the Finding-style source-correspondence
+                                projection emitted in --json output.
           --return-to-sender-fixtures <group>
                                 add built fixture assemblies from a FixtureCatalog
                                 group (for example rts.candidates) as inputs for

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -190,6 +190,16 @@ frontier. Shape frontiers record both the accepted current shape and the desired
 frontier shape. ReturnToSender catalog rows can also carry body-scoped fragment
 expectations; those match only the decompiled target body, not the reconstructed
 type shell, so metadata scaffolding cannot satisfy a target-body assertion.
+`--source-correspondence-census` is an alias for the source probe when the task
+is source-fidelity triage rather than RTS compile-back triage. Its `--json`
+payload includes `source_correspondence_findings`: stable Finding-style rows
+keyed by member stable selector when available. Each row carries a descriptor ID
+such as `source.correspondence.valid_different.known_taste`, a coarse category
+(`ignorable`, `not-yet-raised-sugar`, `structuring-residue`,
+`semantic-opcode-diff`, `invalid`, or `unclassified`), the source file name, and
+whether opcode-diff evidence is attached. The finding projection intentionally
+uses source file names rather than absolute source paths so the census can be
+shared without leaking local checkout paths.
 
 The generated fixture ladder is intentionally staged:
 

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -8,6 +8,7 @@ using DotnetInspector.Fixtures;
 using ILInspector.Decompiler;
 using ILInspector.Instructions;
 using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -35,13 +36,27 @@ sealed record ReturnToSenderSourceProbeResult(
     string? ActualBody,
     string? OriginalOpcodes = null,
     string? RecompiledOpcodes = null,
-    IReadOnlyList<string>? IlDiffLines = null)
+    IReadOnlyList<string>? IlDiffLines = null,
+    MemberAnchor? MemberAnchor = null)
 {
     public bool Passed => Outcome == ReturnToSenderSourceOutcome.ValidMatch;
     public bool Different => Outcome == ReturnToSenderSourceOutcome.ValidDifferent;
     public bool Failed => Outcome == ReturnToSenderSourceOutcome.Invalid;
     public bool Skipped => Outcome is ReturnToSenderSourceOutcome.SourceUnavailable or ReturnToSenderSourceOutcome.UnsupportedTarget;
 }
+
+sealed record SourceCorrespondenceFinding(
+    string FindingId,
+    string DescriptorId,
+    string Category,
+    string SubjectId,
+    string Display,
+    string Outcome,
+    string? CompileBackStatus,
+    string Reason,
+    string? Detail,
+    string? SourceFile,
+    bool HasOpcodeDiffEvidence);
 
 static partial class ReturnToSenderSourceProbe
 {
@@ -59,10 +74,11 @@ static partial class ReturnToSenderSourceProbe
             .OrderByDescending(group => group.Count())
             .ThenBy(group => group.Key, StringComparer.Ordinal)
             .ToArray();
+        var findings = BuildFindings(results);
 
         if (json)
         {
-            WriteJson(results, buckets, passed, different, failed, skipped);
+            WriteJson(results, buckets, findings, passed, different, failed, skipped);
             return failed == 0 ? 0 : 1;
         }
 
@@ -84,6 +100,18 @@ static partial class ReturnToSenderSourceProbe
             Console.WriteLine("Buckets:");
             foreach (var bucket in buckets)
                 Console.WriteLine($"  {bucket.Count()}: {bucket.Key}");
+        }
+        if (findings.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Source-correspondence findings:");
+            foreach (var bucket in findings
+                .GroupBy(finding => finding.Category, StringComparer.Ordinal)
+                .OrderByDescending(group => group.Count())
+                .ThenBy(group => group.Key, StringComparer.Ordinal))
+            {
+                Console.WriteLine($"  {bucket.Count()}: {bucket.Key}");
+            }
         }
         var examples = results
             .Where(result => result.Outcome != ReturnToSenderSourceOutcome.ValidMatch)
@@ -203,7 +231,8 @@ static partial class ReturnToSenderSourceProbe
                     result.Detail,
                     SourcePath: sourceMember?.SourcePath,
                     ExpectedBody: sourceMember?.Body,
-                    ActualBody: result.TargetBody));
+                    ActualBody: result.TargetBody,
+                    MemberAnchor: result.MemberAnchor));
                 continue;
             }
 
@@ -217,7 +246,8 @@ static partial class ReturnToSenderSourceProbe
                     result.Detail,
                     SourcePath: null,
                     ExpectedBody: null,
-                    ActualBody: result.TargetBody));
+                    ActualBody: result.TargetBody,
+                    MemberAnchor: result.MemberAnchor));
                 continue;
             }
 
@@ -231,7 +261,8 @@ static partial class ReturnToSenderSourceProbe
                     sourceUnavailableDetail,
                     SourcePath: null,
                     ExpectedBody: null,
-                    ActualBody: result.TargetBody));
+                    ActualBody: result.TargetBody,
+                    MemberAnchor: result.MemberAnchor));
                 continue;
             }
 
@@ -252,7 +283,8 @@ static partial class ReturnToSenderSourceProbe
                     $"no source member matched {target.Type}::{target.Method}#{target.Overload}",
                     SourcePath: null,
                     ExpectedBody: null,
-                    ActualBody: result.TargetBody));
+                    ActualBody: result.TargetBody,
+                    MemberAnchor: result.MemberAnchor));
                 continue;
             }
 
@@ -273,7 +305,8 @@ static partial class ReturnToSenderSourceProbe
                     Detail: null,
                     sourceMember.SourcePath,
                     expected,
-                    actual));
+                    actual,
+                    MemberAnchor: result.MemberAnchor));
                 continue;
             }
 
@@ -295,11 +328,69 @@ static partial class ReturnToSenderSourceProbe
                 actual,
                 OriginalOpcodes: opcodeEvidence?.OriginalOpcodes,
                 RecompiledOpcodes: opcodeEvidence?.RecompiledOpcodes,
-                IlDiffLines: opcodeEvidence?.IlDiffLines));
+                IlDiffLines: opcodeEvidence?.IlDiffLines,
+                MemberAnchor: result.MemberAnchor));
         }
 
         return results;
     }
+
+    internal static IReadOnlyList<SourceCorrespondenceFinding> BuildFindings(
+        IReadOnlyList<ReturnToSenderSourceProbeResult> results)
+        => [.. results
+            .Where(result => result.Outcome is ReturnToSenderSourceOutcome.ValidDifferent or ReturnToSenderSourceOutcome.Invalid)
+            .Select(SourceCorrespondenceFindingFor)];
+
+    static SourceCorrespondenceFinding SourceCorrespondenceFindingFor(ReturnToSenderSourceProbeResult result)
+    {
+        string descriptorId = $"source.correspondence.{result.Reason}";
+        string subjectId = result.MemberAnchor?.StableSelector ?? TargetId(result.Target);
+        string display = result.MemberAnchor is { } anchor
+            ? $"{anchor.TypeFullName}.{anchor.MemberName}"
+            : TargetDisplay(result.Target);
+        return new SourceCorrespondenceFinding(
+            $"{descriptorId}|{subjectId}",
+            descriptorId,
+            SourceCorrespondenceCategory(result),
+            subjectId,
+            display,
+            OutcomeId(result.Outcome),
+            result.CompileBackStatus?.ToString(),
+            result.Reason,
+            result.Detail,
+            Path.GetFileName(result.SourcePath),
+            result.IlDiffLines is { Count: > 0 }
+                || !string.IsNullOrWhiteSpace(result.OriginalOpcodes)
+                || !string.IsNullOrWhiteSpace(result.RecompiledOpcodes));
+    }
+
+    static string SourceCorrespondenceCategory(ReturnToSenderSourceProbeResult result)
+    {
+        if (result.Outcome == ReturnToSenderSourceOutcome.Invalid)
+            return "invalid";
+
+        string reason = result.Reason;
+        if (reason.StartsWith("valid_different.known_taste", StringComparison.Ordinal)
+            || reason.StartsWith("valid_different.known_compiler_option", StringComparison.Ordinal))
+            return "ignorable";
+        if (reason.StartsWith("valid_different.semantic_opcode_diff", StringComparison.Ordinal))
+            return "semantic-opcode-diff";
+        if (reason.Contains(".compiler_lowering.", StringComparison.Ordinal))
+            return "not-yet-raised-sugar";
+        if (reason.StartsWith("valid_different.source_shape_frontier", StringComparison.Ordinal)
+            && reason.Contains("residual", StringComparison.Ordinal))
+            return "structuring-residue";
+        if (reason.StartsWith("valid_different.source_shape_frontier", StringComparison.Ordinal))
+            return "not-yet-raised-sugar";
+
+        return "unclassified";
+    }
+
+    static string TargetId(ReturnToSender.RequestedTarget target)
+        => $"{target.Type}::{target.Method}#{target.Overload}";
+
+    static string TargetDisplay(ReturnToSender.RequestedTarget target)
+        => $"{target.Type}.{target.Method}#{target.Overload}";
 
     static OpcodeDiffEvidence? OpcodeEvidence(ReturnToSender.Result result)
     {
@@ -326,6 +417,7 @@ static partial class ReturnToSenderSourceProbe
     static void WriteJson(
         IReadOnlyList<ReturnToSenderSourceProbeResult> results,
         IReadOnlyList<IGrouping<string, ReturnToSenderSourceProbeResult>> buckets,
+        IReadOnlyList<SourceCorrespondenceFinding> findings,
         int passed,
         int different,
         int failed,
@@ -346,10 +438,37 @@ static partial class ReturnToSenderSourceProbe
                 failed,
                 skipped,
             },
+            source_correspondence = new
+            {
+                findings = findings.Count,
+                categories = findings
+                    .GroupBy(finding => finding.Category, StringComparer.Ordinal)
+                    .OrderByDescending(group => group.Count())
+                    .ThenBy(group => group.Key, StringComparer.Ordinal)
+                    .Select(group => new
+                    {
+                        category = group.Key,
+                        count = group.Count(),
+                    }),
+            },
             buckets = buckets.Select(bucket => new
             {
                 reason = bucket.Key,
                 count = bucket.Count(),
+            }),
+            source_correspondence_findings = findings.Select(finding => new
+            {
+                finding_id = finding.FindingId,
+                descriptor_id = finding.DescriptorId,
+                category = finding.Category,
+                subject_id = finding.SubjectId,
+                display = finding.Display,
+                outcome = finding.Outcome,
+                compile_back_status = finding.CompileBackStatus,
+                reason = finding.Reason,
+                detail = finding.Detail,
+                source_file = finding.SourceFile,
+                has_opcode_diff_evidence = finding.HasOpcodeDiffEvidence,
             }),
             results = results.Select(result => new
             {
@@ -389,7 +508,8 @@ static partial class ReturnToSenderSourceProbe
             $"source member matched {target.Type}::{target.Method}#{target.Overload}, but it has no explicit source body; compile-back status is {result.Status}",
             sourcePath,
             ExpectedBody: null,
-            ActualBody: result.TargetBody));
+            ActualBody: result.TargetBody,
+            MemberAnchor: result.MemberAnchor));
     }
 
 }

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -358,10 +358,18 @@ static partial class ReturnToSenderSourceProbe
             result.CompileBackStatus?.ToString(),
             result.Reason,
             result.Detail,
-            Path.GetFileName(result.SourcePath),
+            SourceFileName(result.SourcePath),
             result.IlDiffLines is { Count: > 0 }
                 || !string.IsNullOrWhiteSpace(result.OriginalOpcodes)
                 || !string.IsNullOrWhiteSpace(result.RecompiledOpcodes));
+    }
+
+    internal static string? SourceFileName(string? sourcePath)
+    {
+        if (string.IsNullOrWhiteSpace(sourcePath))
+            return null;
+
+        return Path.GetFileName(sourcePath.Replace('\\', '/'));
     }
 
     static string SourceCorrespondenceCategory(ReturnToSenderSourceProbeResult result)


### PR DESCRIPTION
- Advances #2673
- Adds a source-correspondence census projection over existing ReturnToSender source-probe rows.
- Card revision: `5faeb896`

## Change

**Conclusion:** **REVIEW** — this is a tools-only RTS/source-probe reporting change; it does not change decompiler raising, printing, compile-back verdicts, or shipped product behavior.

The source probe now emits stable Finding-style rows in `--json` under `source_correspondence_findings`, keyed by member stable selector when available and bucketed into coarse source-fidelity categories:

- `ignorable`
- `not-yet-raised-sugar`
- `structuring-residue`
- `semantic-opcode-diff`
- `invalid`
- `unclassified`

`--source-correspondence-census` is an alias for the existing `--return-to-sender-source-probe` path, so source-fidelity triage has an explicit entrypoint while preserving the existing source probe behavior.

## Evidence

| Check | Result |
| --- | --- |
| Focused build | Pass: `dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config --nologo -v:q` |
| Focused tests | Pass: `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -method "*ReturnToSenderSourceProbe*"` |
| Harness build/help | Pass: `dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --nologo -v:q`; help includes `--source-correspondence-census` |
| JSON smoke | Pass: `dotnet run --project tools/DecompilerHarness/DecompilerHarness.csproj -c Release --no-build -- artifacts/bin/DiffFixtures.V1/release/DiffFixtureSample.dll --source-correspondence-census --json` emitted `source_correspondence_findings` |
| Markdown | Pass: `npx markdownlint-cli tools/DecompilerHarness/README.md docs/design/fact-planned-compile-back-harness.md` |
| Solution build | Pass: `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --nologo -v:q` |

## Decompiler quality

**Conclusion:** **PASS** — not applicable to corpus quality gates because this PR only adds harness reporting/JSON projection over existing source-probe results; it does not alter decompiler output, raise rules, structuring, or fidelity decisions.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Gemini 3.1 Pro | Pending | Adversarial review requested after PR opens. |
| Claude Opus 4.8 | Pending | Adversarial review requested after PR opens. |

**Review conclusion:** **REVIEW** — hold ready-to-merge until both adversarial reviews are clean and any findings are reconciled on the PR.
