### PR TITLE
Use allow-list terminology in finding comments

### DIFF
--- a/src/ILInspector.Analysis/AnalysisFindings.cs
+++ b/src/ILInspector.Analysis/AnalysisFindings.cs
@@ -368,7 +368,7 @@ public static class AnalysisFindings
     }
 
     static bool SameCallSiteFacets(DirectCall oldCall, DirectCall newCall)
-        // Deliberate whitelist: new DirectCall fields are identity or provenance unless
+        // Deliberate allow list: new DirectCall fields are identity or provenance unless
         // explicitly opted into transition classification here.
         => oldCall.Kind == newCall.Kind
             && oldCall.InLoop == newCall.InLoop

--- a/src/ILInspector.Decompiler/DecompilerFindings.cs
+++ b/src/ILInspector.Decompiler/DecompilerFindings.cs
@@ -116,7 +116,7 @@ public static class DecompilerFindings
     static bool SameSemanticFacets(
         DecompilerFidelityCause oldCause,
         DecompilerFidelityCause newCause)
-        // Deliberate whitelist: only stable producer-owned classification facets can turn a
+        // Deliberate allow list: only stable producer-owned classification facets can turn a
         // matched cause into Changed. Human prose, CLR implementation type names, rendered node
         // text, and location coordinates are diagnostic/display details and may drift without
         // changing the logical fidelity cause.


### PR DESCRIPTION
## Change

- Replaces the two remaining `whitelist` references with `allow list`.
- Leaves finding classification behavior unchanged.
- Confirms no `whitelist` or `blacklist` variants remain in tracked repository
  content.

## Evidence

Comment-only change; no product tests were needed. `git diff --check` passes and
the repository-wide terminology search is clean.

## Review

Low-risk comment-only terminology update; adversarial review is not required.
