### PR TITLE
Stabilize corpus sensor sampling

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
@@ -223,6 +223,26 @@ public class CorpusSensorComparisonTests
     }
 
     [Fact]
+    public void DeterministicCompileBackTargetAttempts_UsesStableSampleRegardlessOfInputOrder()
+    {
+        string assemblyPath = Path.Combine(Environment.CurrentDirectory, "pinned.dll");
+        var methods = Enumerable.Range(0, 105)
+            .Select(i => SnapshotMethod($"M{i:000}", assemblyPath: "pinned.dll", fidelityCheck: "not-sampled"))
+            .Append(SnapshotMethod("<Generated>", assemblyPath: "pinned.dll", fidelityCheck: "not-sampled"))
+            .ToArray();
+
+        var forward = CorpusSensor.DeterministicCompileBackTargetAttemptsForTesting(methods, assemblyPath, cap: 1);
+        var reversed = CorpusSensor.DeterministicCompileBackTargetAttemptsForTesting(methods.Reverse().ToArray(), assemblyPath, cap: 1);
+
+        Assert.Equal(100, forward.Count);
+        Assert.Equal(
+            forward.Select(target => $"{target.Type}::{target.Method}{target.Signature}"),
+            reversed.Select(target => $"{target.Type}::{target.Method}{target.Signature}"));
+        Assert.DoesNotContain(forward, target => target.Method.Contains('<', StringComparison.Ordinal));
+        Assert.All(forward, target => Assert.Equal(assemblyPath, target.AssemblyPath));
+    }
+
+    [Fact]
     public void Compare_DoesNotGateSemanticCountsWhenPinnedSamplesDiffer()
     {
         var baseline = Snapshot(
@@ -525,25 +545,32 @@ public class CorpusSensorComparisonTests
         return methods.ToImmutable();
     }
 
+    static CorpusMethodSnapshot SnapshotMethod(
+        string method,
+        string assemblyPath = "nuget:pinned/lib.dll",
+        string validity = "not-sampled",
+        string fidelityCheck = "not-sampled")
+        => new(
+            Assembly: "Pinned",
+            AssemblyPath: assemblyPath,
+            Type: "T",
+            Method: method,
+            Overload: 0,
+            Signature: "()",
+            Fidelity: "Full",
+            FullyRaised: true,
+            Residual: null,
+            PassBug: null,
+            Validity: validity,
+            FidelityCheck: fidelityCheck);
+
     static IReadOnlyList<CorpusMethodSnapshot> ValidityMethods(
         params (string Method, string Validity)[] values)
     {
         var methods = ImmutableArray.CreateBuilder<CorpusMethodSnapshot>(values.Length);
         foreach (var value in values)
         {
-            methods.Add(new CorpusMethodSnapshot(
-                Assembly: "Pinned",
-                AssemblyPath: "nuget:pinned/lib.dll",
-                Type: "T",
-                Method: value.Method,
-                Overload: 0,
-                Signature: "()",
-                Fidelity: "Full",
-                FullyRaised: true,
-                Residual: null,
-                PassBug: null,
-                Validity: value.Validity,
-                FidelityCheck: "not-sampled"));
+            methods.Add(SnapshotMethod(value.Method, validity: value.Validity));
         }
         return methods.ToImmutable();
     }
@@ -554,19 +581,7 @@ public class CorpusSensorComparisonTests
         var methods = ImmutableArray.CreateBuilder<CorpusMethodSnapshot>(values.Length);
         foreach (var value in values)
         {
-            methods.Add(new CorpusMethodSnapshot(
-                Assembly: "Pinned",
-                AssemblyPath: "nuget:pinned/lib.dll",
-                Type: "T",
-                Method: value.Method,
-                Overload: 0,
-                Signature: "()",
-                Fidelity: "Full",
-                FullyRaised: true,
-                Residual: null,
-                PassBug: null,
-                Validity: "not-sampled",
-                FidelityCheck: value.FidelityCheck));
+            methods.Add(SnapshotMethod(value.Method, fidelityCheck: value.FidelityCheck));
         }
         return methods.ToImmutable();
     }

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -458,12 +458,12 @@ internal static class CorpusSensor
         IReadOnlyList<FidelityCheck.CompileBackTarget> targetAttempts,
         int cap)
     {
-        var allResults = EvaluateTargetsInAttemptOrder(assemblies, targetAttempts);
-        var usefulResults = allResults
+        var evaluatedResults = EvaluateTargetsInAttemptOrderUntilUseful(assemblies, targetAttempts, cap);
+        var usefulResults = evaluatedResults
             .Where(FidelityCheck.IsUsefulCorpusSample)
             .Take(cap)
             .ToArray();
-        return new FidelityOracleEvaluation(usefulResults, AllResults: allResults);
+        return new FidelityOracleEvaluation(usefulResults, AllResults: evaluatedResults);
     }
 
     static FidelityOracleEvaluation EvaluateReturnToSender(
@@ -471,7 +471,8 @@ internal static class CorpusSensor
         IReadOnlyList<FidelityCheck.CompileBackTarget> targetAttempts,
         int cap)
     {
-        var targetSample = EvaluateTargetsInAttemptOrder([assemblyPath], targetAttempts)
+        var evaluatedResults = EvaluateTargetsInAttemptOrderUntilUseful([assemblyPath], targetAttempts, cap);
+        var targetSample = evaluatedResults
             .Where(FidelityCheck.IsUsefulCorpusSample)
             .Take(cap)
             .ToArray();
@@ -499,6 +500,33 @@ internal static class CorpusSensor
                 result => result.Status,
                 StringComparer.Ordinal),
             SummarizeReturnToSenderParity(targetSample, alignedResults));
+    }
+
+    static IReadOnlyList<FidelityCheck.CompileBackResult> EvaluateTargetsInAttemptOrderUntilUseful(
+        IReadOnlyList<string> assemblies,
+        IReadOnlyList<FidelityCheck.CompileBackTarget> targetAttempts,
+        int cap)
+    {
+        if (cap <= 0 || targetAttempts.Count == 0)
+            return [];
+
+        int batchSize = cap == int.MaxValue
+            ? targetAttempts.Count
+            : Math.Min(targetAttempts.Count, Math.Max(cap, 100));
+        var results = new List<FidelityCheck.CompileBackResult>();
+        int useful = 0;
+        for (int offset = 0; offset < targetAttempts.Count && useful < cap; offset += batchSize)
+        {
+            var batch = targetAttempts.Skip(offset).Take(batchSize).ToArray();
+            foreach (var result in EvaluateTargetsInAttemptOrder(assemblies, batch))
+            {
+                results.Add(result);
+                if (FidelityCheck.IsUsefulCorpusSample(result) && ++useful >= cap)
+                    break;
+            }
+        }
+
+        return results;
     }
 
     static IReadOnlyList<FidelityCheck.CompileBackResult> EvaluateTargetsInAttemptOrder(

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -370,13 +370,13 @@ internal static class CorpusSensor
             foreach (var assembly in assemblies)
             {
                 var portablePath = PortablePath(assembly);
+                var targetAttempts = DeterministicCompileBackTargetAttempts(methods.Values, assembly, cap);
                 FidelityOracleEvaluation evaluation;
                 try
                 {
                     evaluation = fidelityOracle == CorpusFidelityOracle.CompileBack
-                        ? new FidelityOracleEvaluation(
-                            FidelityCheck.Evaluate([assembly], cap, lowered: false, includeAllResults: false, workers, sequential))
-                        : EvaluateReturnToSender(assembly, cap, workers, sequential);
+                        ? EvaluateCompileBackTargets([assembly], targetAttempts, cap)
+                        : EvaluateReturnToSender(assembly, targetAttempts, cap);
                 }
                 catch (Exception ex) when (
                     fidelityOracle == CorpusFidelityOracle.ReturnToSender
@@ -411,9 +411,7 @@ internal static class CorpusSensor
                         }
                     }
                 }
-                allResults.AddRange(fidelityOracle == CorpusFidelityOracle.CompileBack
-                    ? FidelityCheck.Evaluate([assembly], cap, lowered: false, includeAllResults: true, workers, sequential)
-                    : assemblyUsefulResults);
+                allResults.AddRange(evaluation.AllResults);
             }
             var metrics = new FidelitySensorMetrics(
                 usefulResults.Count,
@@ -450,16 +448,35 @@ internal static class CorpusSensor
         int cap,
         int? workers,
         bool sequential)
+        => EvaluateReturnToSender(
+            assemblyPath,
+            DeterministicCompileBackTargetAttemptsForAssembly(assemblyPath, cap),
+            cap);
+
+    static FidelityOracleEvaluation EvaluateCompileBackTargets(
+        IReadOnlyList<string> assemblies,
+        IReadOnlyList<FidelityCheck.CompileBackTarget> targetAttempts,
+        int cap)
     {
-        var targetSample = FidelityCheck.Evaluate(
-            [assemblyPath],
-            cap,
-            lowered: false,
-            includeAllResults: false,
-            workers,
-            sequential);
-        if (targetSample.Count == 0)
-            return new FidelityOracleEvaluation([]);
+        var allResults = EvaluateTargetsInAttemptOrder(assemblies, targetAttempts);
+        var usefulResults = allResults
+            .Where(FidelityCheck.IsUsefulCorpusSample)
+            .Take(cap)
+            .ToArray();
+        return new FidelityOracleEvaluation(usefulResults, AllResults: allResults);
+    }
+
+    static FidelityOracleEvaluation EvaluateReturnToSender(
+        string assemblyPath,
+        IReadOnlyList<FidelityCheck.CompileBackTarget> targetAttempts,
+        int cap)
+    {
+        var targetSample = EvaluateTargetsInAttemptOrder([assemblyPath], targetAttempts)
+            .Where(FidelityCheck.IsUsefulCorpusSample)
+            .Take(cap)
+            .ToArray();
+        if (targetSample.Length == 0)
+            return new FidelityOracleEvaluation([], AllResults: targetSample);
 
         var requestedTargets = targetSample
             .Select(result => new ReturnToSender.RequestedTarget(
@@ -476,11 +493,26 @@ internal static class CorpusSensor
         var alignedResults = AlignReturnToSenderResults(targetSample, returnToSenderResults);
         return new FidelityOracleEvaluation(
             alignedResults,
+            AllResults: alignedResults,
             targetSample.ToDictionary(
                 FidelityResultKey,
                 result => result.Status,
                 StringComparer.Ordinal),
             SummarizeReturnToSenderParity(targetSample, alignedResults));
+    }
+
+    static IReadOnlyList<FidelityCheck.CompileBackResult> EvaluateTargetsInAttemptOrder(
+        IReadOnlyList<string> assemblies,
+        IReadOnlyList<FidelityCheck.CompileBackTarget> targetAttempts)
+    {
+        var resultsByTarget = FidelityCheck.EvaluateTargets(assemblies, targetAttempts, lowered: false)
+            .GroupBy(FidelityResultKey, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+        return targetAttempts
+            .Select(CompileBackTargetKey)
+            .Where(resultsByTarget.ContainsKey)
+            .Select(key => resultsByTarget[key])
+            .ToArray();
     }
 
     internal static IReadOnlyList<FidelityCheck.CompileBackResult> AlignReturnToSenderResultsForTesting(
@@ -566,13 +598,99 @@ internal static class CorpusSensor
     static string FidelityResultKey(FidelityCheck.CompileBackResult result)
         => $"{result.Type}::{result.Method}::{result.Overload}::{result.Signature}";
 
+    static string CompileBackTargetKey(FidelityCheck.CompileBackTarget target)
+        => $"{target.Type}::{target.Method}::{target.Overload}::{target.Signature}";
+
     static string ReturnToSenderKey(ReturnToSender.Result result)
         => $"{result.Plan.TargetMethod.Type}::{result.Plan.TargetMethod.Method}::{result.Plan.TargetMethod.Overload}::{result.Plan.TargetMethod.Signature}";
 
     sealed record FidelityOracleEvaluation(
         IReadOnlyList<FidelityCheck.CompileBackResult> Results,
+        IReadOnlyList<FidelityCheck.CompileBackResult> AllResults,
         IReadOnlyDictionary<string, FidelityCheck.CompileBackStatus>? ReferenceStatuses = null,
         ReturnToSenderParityMetrics? Parity = null);
+
+    internal static IReadOnlyList<FidelityCheck.CompileBackTarget> DeterministicCompileBackTargetAttemptsForTesting(
+        IReadOnlyList<CorpusMethodSnapshot> methods,
+        string assemblyPath,
+        int cap)
+        => DeterministicCompileBackTargetAttempts(methods, assemblyPath, cap);
+
+    static IReadOnlyList<FidelityCheck.CompileBackTarget> DeterministicCompileBackTargetAttemptsForAssembly(
+        string assemblyPath,
+        int cap)
+    {
+        using var metadata = CorpusMetadata.Create([assemblyPath]);
+        using var source = MetadataSource.Open(assemblyPath, context: metadata);
+        string portablePath = PortablePath(assemblyPath);
+        var methods = IrImporter.GetStableSampleCandidates(source, DeterministicAttemptCap(cap))
+            .Select(candidate =>
+            {
+                var function = candidate.Build(source);
+                return new CorpusMethodSnapshot(
+                    source.AssemblyName,
+                    portablePath,
+                    candidate.TypeName,
+                    candidate.MethodName,
+                    candidate.Overload,
+                    CorpusMethodIdentity.SignatureText(function.Signature),
+                    function.Fidelity.ToString(),
+                    FullyRaised: function.Fidelity == DecompilationFidelity.Full,
+                    Residual: null,
+                    PassBug: null,
+                    Validity: "not-sampled",
+                    FidelityCheck: "not-sampled");
+            })
+            .ToArray();
+        return DeterministicCompileBackTargetAttempts(methods, assemblyPath, cap);
+    }
+
+    static IReadOnlyList<FidelityCheck.CompileBackTarget> DeterministicCompileBackTargetAttempts(
+        IEnumerable<CorpusMethodSnapshot> methods,
+        string assemblyPath,
+        int cap)
+    {
+        if (cap <= 0)
+            return [];
+
+        string portablePath = PortablePath(assemblyPath);
+        return methods
+            .Where(method => string.Equals(method.AssemblyPath, portablePath, StringComparison.Ordinal)
+                && !FidelityCheck.IsSynthesizedMember(method.Type, method.Method))
+            .OrderBy(StableMethodHash)
+            .ThenBy(MethodKey, StringComparer.Ordinal)
+            .Take(DeterministicAttemptCap(cap))
+            .Select(method => new FidelityCheck.CompileBackTarget(
+                assemblyPath,
+                method.Type,
+                method.Method,
+                method.Overload,
+                method.Signature))
+            .ToArray();
+    }
+
+    static int DeterministicAttemptCap(int cap)
+        => cap > int.MaxValue / 10
+            ? int.MaxValue
+            : Math.Max(cap * 10, 100);
+
+    static ulong StableMethodHash(CorpusMethodSnapshot method)
+        => StableHash(MethodKey(method));
+
+    static ulong StableHash(string text)
+    {
+        const ulong offset = 14695981039346656037UL;
+        const ulong prime = 1099511628211UL;
+        ulong hash = offset;
+        foreach (char ch in text)
+        {
+            hash ^= (byte)ch;
+            hash *= prime;
+            hash ^= (byte)(ch >> 8);
+            hash *= prime;
+        }
+        return hash;
+    }
 
     static string MethodKey(CorpusMethodSnapshot method)
         => MethodKey(method.AssemblyPath, method.Type, method.Method, method.Signature);

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -269,7 +269,7 @@ dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
   --emit-corpus-snapshot /tmp/corpus-snapshot.json \
   --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json \
   --quality-diff-card \
-  --compile-cap 25 \
+  --compile-cap 4000 \
   --corpus-fidelity-cap 3 \
   --max-examples 3
 ```
@@ -288,8 +288,11 @@ dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
 Add `--quality-diff-card` to emit a Markdown PR block generated directly from
 the baseline/current snapshots. The card includes a correctness-coverage line
 and per-row sampled denominators for semantic validity and compile-back fidelity
-so reviewers can tell when evidence is strong or thin. Paste that block as the
-PR's aggregate corpus evidence; do not re-key the table by hand.
+so reviewers can tell when evidence is strong or thin. Semantic validity and
+compile-back fidelity samples are hash-stable, so zero-tolerance rows such as
+RTS parity compare the same target population when the corpus and caps match.
+Paste that block as the PR's aggregate corpus evidence; do not re-key the table
+by hand.
 
 **Render A/B** (`--emit-render-ab` / `--render-ab`): the before/after text
 oracle for raise and printer changes. The first run writes a method-keyed JSON

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -178,7 +178,7 @@ static class ValidityCheck
                 // constrained generic calls the runtime accepts (no phantom CS0314).
                 var constraints = ShellConstraints.Build(source);
                 
-                var candidates = new List<(string TypeName, string MethodName, IrFunction Function, string? ProductParameterList)>();
+                var candidates = new List<ValidityCandidate>();
                 foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
                 {
                     // Compiler-generated types/members (anonymous types, closures,
@@ -194,14 +194,18 @@ static class ValidityCheck
                         ? productSignatureParameters
                         : null;
 
-                    candidates.Add((typeName, methodName, function, productParameterList));
+                    candidates.Add(new ValidityCandidate(typeName, methodName, function, productParameterList));
                 }
 
                 var evaluationTargets = candidates;
+                var semanticEligible = new ConcurrentBag<ValidityCandidate>();
 
                 Parallel.ForEach(evaluationTargets, options, item =>
                 {
-                    var (typeName, methodName, function, productParameterList) = item;
+                    var typeName = item.TypeName;
+                    var methodName = item.MethodName;
+                    var function = item.Function;
+                    var productParameterList = item.ProductParameterList;
 
                     Func<MethodRef, IrFunction?>? importMethodBody = importSiblingBodies
                         ? method => IrImporter.Import(source, method)
@@ -233,15 +237,53 @@ static class ValidityCheck
 
                     // Bind only Full, syntactically-valid methods (the set that
                     // claims to be good) up to the cap — binding is the slow part.
-                    // To maintain deterministic sets while processing in parallel, we allow early evaluation
-                    // threads to consume the cap. This is an accepted heuristic over exact sequential metadata order
-                    // for the validity subset.
-                    if (!full || Interlocked.Increment(ref semChecked) > cap)
+                    // Syntax is evaluated for the whole sample first, then the
+                    // semantic subset is chosen by a hash-stable key. That keeps
+                    // tolerance-0 corpus gates comparable across parallel runs and
+                    // unrelated metadata-order changes.
+                    if (!full)
                     {
-                        if (full) Interlocked.Decrement(ref semChecked);
                         results.Add(new MethodResult(typeName, methodName, CorpusMethodIdentity.SignatureText(function.Signature), full, [], SemanticChecked: false, []));
                         return; // parallel return
                     }
+
+                    semanticEligible.Add(item);
+                });
+
+                var semanticSample = semanticEligible
+                    .OrderBy(StableValidityHash)
+                    .ThenBy(candidate => StableValidityKey(candidate), StringComparer.Ordinal)
+                    .Take(cap)
+                    .ToHashSet();
+
+                foreach (var item in semanticEligible.Except(semanticSample))
+                {
+                    results.Add(new MethodResult(
+                        item.TypeName,
+                        item.MethodName,
+                        CorpusMethodIdentity.SignatureText(item.Function.Signature),
+                        true,
+                        [],
+                        false,
+                        []));
+                }
+
+                Parallel.ForEach(semanticSample, options, item =>
+                {
+                    var typeName = item.TypeName;
+                    var methodName = item.MethodName;
+                    var function = item.Function;
+                    var productParameterList = item.ProductParameterList;
+                    Func<MethodRef, IrFunction?>? importMethodBody = importSiblingBodies
+                        ? method => IrImporter.Import(source, method)
+                        : null;
+                    var rendered = (lowered
+                        ? CSharpPrinter.PrintLowered(function, importMethodBody)
+                        : CSharpPrinter.PrintRaised(function, importMethodBody)).Output;
+                    if (rendered is null)
+                        return;
+
+                    Interlocked.Increment(ref semChecked);
                     var semantic = EvaluateRenderedBody(
                         function,
                         rendered,
@@ -253,7 +295,7 @@ static class ValidityCheck
                         parseOptions,
                         compileOptions,
                         bindSemantics: true);
-                    results.Add(new MethodResult(typeName, methodName, CorpusMethodIdentity.SignatureText(function.Signature), full, [], SemanticChecked: true, semantic.SemanticDiagnostics));
+                    results.Add(new MethodResult(typeName, methodName, CorpusMethodIdentity.SignatureText(function.Signature), true, [], true, semantic.SemanticDiagnostics));
                 });
             }
         }
@@ -261,6 +303,33 @@ static class ValidityCheck
             .ThenBy(r => r.MethodName, StringComparer.Ordinal)
             .ThenBy(r => r.Signature, StringComparer.Ordinal)
             .ToList();
+    }
+
+    sealed record ValidityCandidate(
+        string TypeName,
+        string MethodName,
+        IrFunction Function,
+        string? ProductParameterList);
+
+    static string StableValidityKey(ValidityCandidate candidate)
+        => $"{candidate.TypeName}|{candidate.MethodName}|{CorpusMethodIdentity.SignatureText(candidate.Function.Signature)}";
+
+    static ulong StableValidityHash(ValidityCandidate candidate)
+        => StableHash(StableValidityKey(candidate));
+
+    static ulong StableHash(string text)
+    {
+        const ulong offset = 14695981039346656037UL;
+        const ulong prime = 1099511628211UL;
+        ulong hash = offset;
+        foreach (char ch in text)
+        {
+            hash ^= (byte)ch;
+            hash *= prime;
+            hash ^= (byte)(ch >> 8);
+            hash *= prime;
+        }
+        return hash;
     }
 
     internal static CSharpParseOptions ParseOptions()


### PR DESCRIPTION
## Summary
- make corpus semantic validity sampling hash-stable after syntax filtering instead of consuming the cap by parallel race
- make corpus compile-back and RTS parity use hash-stable target attempts and preserve target-attempt order before applying caps
- update the real-world quality-card command to match the checked-in baseline compile cap

## Validation
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.CorpusSensorComparisonTests
- dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet
- npx markdownlint-cli tools/DecompilerHarness/README.md
- dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler/release/ILInspector.Decompiler.dll --emit-corpus-snapshot /tmp/corpus-sensor-health-smoke.json --compile-cap 1 --corpus-fidelity-cap 1 --corpus-method-cap 10 --max-examples 1

## Notes
This removes the documented cap mismatch that produced the recurring real-world quality-card advisory and gives tolerance-0 rows such as RTS parity a deterministic target population when corpus inputs and caps match.