### PR TITLE
Expose analysis.unsafety transitions with descriptor-keyed retention

### DIFF
--- a/docs/design/finding-nomenclature.md
+++ b/docs/design/finding-nomenclature.md
@@ -156,6 +156,20 @@ that a retained call changed dispatch, opcode, or loop context. IL offsets and
 metadata tokens remain endpoint-local provenance rather than correspondence
 identity.
 
+The same lens confirms when a definite unsafe IL operation appeared or
+disappeared:
+
+```bash
+dotnet-inspect diff --package Foo@1.4.0..1.5.0 \
+  -t Foo.Parser -m Parse \
+  --finding analysis.unsafety
+```
+
+Each row identifies an unsafe operation kind and producer detail.
+`PairFinding.Added` confirms introduction, while `Present` and `Removed`
+distinguish a wrong boundary from disappearance. IL offsets remain endpoint
+provenance and do not establish cross-version identity.
+
 ## Research composition
 
 Research is the join layer for sibling producers. It may retain a producer's
@@ -171,6 +185,11 @@ This is a migration boundary, not authorization for a second universal spine:
   inspection failures, and provenance as evidence;
 - Research must not wrap those values in a parallel generic `EvidenceRow`
   hierarchy solely to make them look uniform.
+
+When a consumer needs complete native comparisons, including exact pairs,
+Research retains typed comparisons in one descriptor-keyed container. Adding a
+producer descriptor extends that container rather than adding a payload-specific
+flag, list, constructor, or merge path.
 
 ## Coordinates
 

--- a/docs/design/finding-producers.md
+++ b/docs/design/finding-producers.md
@@ -180,16 +180,21 @@ IL-ordered `Finding<DirectCall>` census. Research retains the complete native
 comparison only when requested, so `Present` remains observable without
 increasing the ordinary Body Signals result.
 
+Definite unsafe IL operations are the third end-to-end Analysis proof.
+`diff --finding analysis.unsafety` consumes the same IL-ordered
+`Finding<UnsafetyOccurrence>` census used by Research's safety projection.
+Allocation, call-site, and unsafety comparisons share one descriptor-keyed
+retention container; new descriptors do not add parallel flags, lists,
+constructors, or merge branches.
+
 Decompiler fidelity uses the same retention rule in the single-version product
 path. The member command's opt-in `Fidelity Causes` section keeps the complete
 `FindingInspection<DecompilerFidelityCause>` through member acquisition and
 projects it only when rendering. A complete empty census, absent method body,
 and failed inspection therefore remain distinct product outcomes.
 
-The remaining Analysis body observations preserve their native families:
+The remaining Analysis safety observations preserve their native families:
 
-- definite unsafe IL operations use an IL-ordered
-  `Finding<UnsafetyOccurrence>` census;
 - declaration, signature, local, call, and opcode evidence use an identity
   multiset of `Finding<UnsafeEvidence>` values because some observations have no
   IL coordinate.

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -109,6 +109,19 @@ Here `PairFinding.Added` confirms a new call-site occurrence in `Parse`.
 or changed dispatch/opcode facets. The caller method is the target; the rows
 identify its callees.
 
+To confirm a definite unsafe-operation boundary in the same method:
+
+```bash
+dotnet-inspect diff --package Foo@1.4.0..1.5.0 \
+  -t Foo.Parser -m Parse \
+  --finding analysis.unsafety
+```
+
+`PairFinding.Added` confirms that an unsafe operation was introduced;
+`Present` and `Removed` distinguish persistence from disappearance. Operation
+kind and producer detail establish identity, while IL offsets remain local to
+each endpoint.
+
 ## Cache locations
 
 | Cache | Location | TTL | Written by |

--- a/skills/compatibility/SKILL.md
+++ b/skills/compatibility/SKILL.md
@@ -70,6 +70,19 @@ Rows identify the callees. `PairFinding.Added` confirms a new direct-call
 occurrence; `Changed` reports retained-call facet changes such as moving into a
 loop.
 
+For a definite unsafe-operation boundary in one method, select the unsafety
+producer:
+
+```bash
+dnx dotnet-inspect -y -- diff --package Foo@1.4.0..1.5.0 \
+  -t Foo.Parser -m Parse \
+  --finding analysis.unsafety
+```
+
+Rows identify unsafe operation kinds and details. `PairFinding.Added` confirms
+introduction; `Present` and `Removed` distinguish persistence from
+disappearance without treating endpoint-local IL offsets as identity.
+
 ## Did the implementation change? (C# + IL)
 
 `-S "Implementation Diff"` selects Research-composed body evidence instead of
@@ -130,6 +143,6 @@ dnx dotnet-inspect -y -- diff \
 An introduction boundary is a row with `PairFinding.Added`, `Old=absent`, and
 `New=present`. `PairFinding.Present` means the target exists at both endpoints;
 for a type target, no row means it exists at neither. Use `-m Type.Member:1` for
-an API member boundary. Use `--finding analysis.allocation` or
-`--finding analysis.call-site` with exactly one method target for the
-corresponding Analysis boundary.
+an API member boundary. Use `--finding analysis.allocation`,
+`--finding analysis.call-site`, or `--finding analysis.unsafety` with exactly
+one method target for the corresponding Analysis boundary.

--- a/skills/correctness/SKILL.md
+++ b/skills/correctness/SKILL.md
@@ -40,3 +40,16 @@ dnx dotnet-inspect -y -- member Type Method:1 --library MyLib.dll -S "Unsafe Ope
 `-S "Unsafe Operations"` shows the unsafe operations in a single method body,
 with IL evidence. For the library-wide safety *surface* (unsafe members, P/Invoke
 methods) and provenance/supply-chain signals, see the `signals` skill.
+
+To confirm whether one definite unsafe operation appeared at an adjacent
+version boundary:
+
+```bash
+dnx dotnet-inspect -y -- diff --package MyLib@1.4.0..1.5.0 \
+  -t MyType -m Method \
+  --finding analysis.unsafety
+```
+
+`PairFinding.Added` is the introduction proof. `Present` and `Removed`
+distinguish persistence from disappearance; the command compares only the two
+supplied endpoints.

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -15,7 +15,7 @@ namespace ILInspector.Research.Tests;
 public class ResearchDiffTests
 {
     [Fact]
-    public void FindingRetention_PreservesExistingPublicConstructorSignatures()
+    public void FindingRetention_UsesGeneralizedPublicContainerSignature()
     {
         Assert.NotNull(typeof(ResearchComparison).GetConstructor(
         [
@@ -28,7 +28,7 @@ public class ResearchDiffTests
             typeof(ImmutableArray<ResearchChange>),
             typeof(ApiDiff),
             typeof(ApiFindingComparison),
-            typeof(ImmutableArray<AllocationFindingComparison>),
+            typeof(RetainedFindingComparisonSet),
         ]));
         Assert.NotNull(typeof(ResearchDiffOptions).GetConstructor(
         [
@@ -38,6 +38,77 @@ public class ResearchDiffTests
             typeof(IReadOnlySet<string>),
             typeof(IReadOnlySet<string>),
         ]));
+    }
+
+    [Fact]
+    public void FindingRetention_IndexesTypedComparisonsByDescriptor()
+    {
+        var subject = new ResearchSubjectKey(
+            ResearchSubjectKind.Member,
+            "M~1234567890",
+            "Sample.Widget.M()");
+        var findingSubject = new FindingSubject(subject.Id, subject.Display);
+        var retained = new RetainedFindingComparisonSet(
+        [
+            new RetainedFindingComparison<AllocationOccurrence>(
+                subject,
+                AnalysisFindings.AllocationDescriptor,
+                AnalysisFindings.CompareAllocations([], [], findingSubject)),
+            new RetainedFindingComparison<UnsafetyOccurrence>(
+                subject,
+                AnalysisFindings.UnsafetyDescriptor,
+                AnalysisFindings.CompareUnsafety([], [], findingSubject)),
+        ]);
+
+        Assert.Equal(2, retained.Count);
+        Assert.Single(retained.Get<AllocationOccurrence>(
+            AnalysisFindings.AllocationDescriptor));
+        Assert.Single(retained.Get<UnsafetyOccurrence>(
+            AnalysisFindings.UnsafetyDescriptor));
+        Assert.Empty(retained.Get<DirectCall>(
+            AnalysisFindings.CallSiteDescriptor));
+        Assert.Throws<InvalidOperationException>(() =>
+            retained.Get<DirectCall>(AnalysisFindings.AllocationDescriptor));
+    }
+
+    [Fact]
+    public void FindingRetention_CombineMergesDescriptorBuckets()
+    {
+        var subject = new ResearchSubjectKey(
+            ResearchSubjectKind.Member,
+            "M~1234567890",
+            "Sample.Widget.M()");
+        var findingSubject = new FindingSubject(subject.Id, subject.Display);
+        var allocations = new ResearchComparison(
+            [],
+            null,
+            null,
+            new RetainedFindingComparisonSet(
+            [
+                new RetainedFindingComparison<AllocationOccurrence>(
+                    subject,
+                    AnalysisFindings.AllocationDescriptor,
+                    AnalysisFindings.CompareAllocations([], [], findingSubject)),
+            ]));
+        var unsafety = new ResearchComparison(
+            [],
+            null,
+            null,
+            new RetainedFindingComparisonSet(
+            [
+                new RetainedFindingComparison<UnsafetyOccurrence>(
+                    subject,
+                    AnalysisFindings.UnsafetyDescriptor,
+                    AnalysisFindings.CompareUnsafety([], [], findingSubject)),
+            ]));
+
+        var combined = ResearchDiff.Combine(allocations, unsafety);
+
+        Assert.Equal(2, combined.RetainedComparisons.Count);
+        Assert.Single(combined.RetainedComparisons.Get<AllocationOccurrence>(
+            AnalysisFindings.AllocationDescriptor));
+        Assert.Single(combined.RetainedComparisons.Get<UnsafetyOccurrence>(
+            AnalysisFindings.UnsafetyDescriptor));
     }
 
     [Fact]
@@ -755,12 +826,16 @@ public class ResearchDiffTests
             ResearchDiffInput.FromAssembly("new.dll", bodyIndex: newIndex),
             new ResearchDiffOptions(ResearchChangeMechanism.BodySignals)
             {
-                RetainAllocationComparisons = true,
+                RetainedComparisonDescriptorIds = ImmutableHashSet.Create(
+                    StringComparer.Ordinal,
+                    AnalysisFindings.AllocationDescriptor.Id),
             });
 
         Assert.DoesNotContain(diff.Changes, change =>
             change.Descriptor == AnalysisFindings.AllocationDescriptor);
-        var retained = Assert.Single(diff.AllocationComparisons);
+        var retained = Assert.Single(
+            diff.RetainedComparisons.Get<AllocationOccurrence>(
+                AnalysisFindings.AllocationDescriptor));
         var comparison = retained.Comparison switch
         {
             FindingComparison<AllocationOccurrence>.Complete complete => complete,
@@ -782,11 +857,17 @@ public class ResearchDiffTests
                     "DiffFixtureSample.DiffSample",
                 })
             {
-                RetainCallSiteComparisons = true,
+                RetainedComparisonDescriptorIds = ImmutableHashSet.Create(
+                    StringComparer.Ordinal,
+                    AnalysisFindings.CallSiteDescriptor.Id),
             });
 
-        var retained = Assert.Single(diff.CallSiteComparisons, comparison =>
-            comparison.Subject.Display.Contains("RegressesAllocInLoop", StringComparison.Ordinal));
+        var retained = Assert.Single(
+            diff.RetainedComparisons.Get<DirectCall>(
+                AnalysisFindings.CallSiteDescriptor),
+            comparison => comparison.Subject.Display.Contains(
+                "RegressesAllocInLoop",
+                StringComparison.Ordinal));
         var comparison = retained.Comparison switch
         {
             FindingComparison<DirectCall>.Complete complete => complete,
@@ -798,6 +879,49 @@ public class ResearchDiffTests
         Assert.Contains(comparison.Pairs, pair =>
             pair is PairFinding<DirectCall>.Added added
             && added.New.Payload.Callee.Name == "Add");
+    }
+
+    [Fact]
+    public void CompareAssemblies_BodySignals_RetainsNativeUnsafetyComparison()
+    {
+        var diff = ResearchDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            new ResearchDiffOptions(
+                ResearchChangeMechanism.BodySignals,
+                TypeFilters: new HashSet<string>(StringComparer.Ordinal)
+                {
+                    "DiffFixtureSample.DiffSample",
+                })
+            {
+                RetainedComparisonDescriptorIds = ImmutableHashSet.Create(
+                    StringComparer.Ordinal,
+                    AnalysisFindings.UnsafetyDescriptor.Id),
+            });
+
+        var retained = Assert.Single(
+            diff.RetainedComparisons.Get<UnsafetyOccurrence>(
+                AnalysisFindings.UnsafetyDescriptor),
+            comparison => comparison.Subject.Display.Contains(
+                "AddsUnsafe",
+                StringComparison.Ordinal));
+        var comparison = retained.Comparison switch
+        {
+            FindingComparison<UnsafetyOccurrence>.Complete complete => complete,
+            _ => throw new InvalidOperationException(
+                "Expected a complete unsafety comparison."),
+        };
+        var pair = Assert.Single(
+            comparison.Pairs,
+            pair => pair is PairFinding<UnsafetyOccurrence>.Added added
+                && added.New.Payload.Kind == UnsafetyKind.StackAlloc);
+        var added = pair switch
+        {
+            PairFinding<UnsafetyOccurrence>.Added value => value,
+            _ => throw new InvalidOperationException(
+                "Expected an added unsafe operation."),
+        };
+        Assert.Equal(UnsafetyKind.StackAlloc, added.New.Payload.Kind);
     }
 
     [Fact]

--- a/src/ILInspector.Research/ResearchChanges.cs
+++ b/src/ILInspector.Research/ResearchChanges.cs
@@ -307,13 +307,90 @@ public sealed record ResearchSubjectChanges
         => Changes.Any(change => change.Category == category);
 }
 
-public sealed record AllocationFindingComparison(
-    ResearchSubjectKey Subject,
-    FindingComparison<AllocationOccurrence> Comparison);
+public abstract record RetainedFindingComparison
+{
+    protected RetainedFindingComparison(
+        ResearchSubjectKey subject,
+        FindingDescriptor descriptor)
+    {
+        Subject = subject ?? throw new ArgumentNullException(nameof(subject));
+        Descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
+    }
 
-public sealed record CallSiteFindingComparison(
-    ResearchSubjectKey Subject,
-    FindingComparison<DirectCall> Comparison);
+    public ResearchSubjectKey Subject { get; }
+    public FindingDescriptor Descriptor { get; }
+}
+
+public sealed record RetainedFindingComparison<T> : RetainedFindingComparison
+    where T : notnull
+{
+    public RetainedFindingComparison(
+        ResearchSubjectKey subject,
+        FindingDescriptor descriptor,
+        FindingComparison<T> comparison)
+        : base(subject, descriptor)
+    {
+        Comparison = comparison ?? throw new ArgumentNullException(nameof(comparison));
+    }
+
+    public FindingComparison<T> Comparison { get; }
+}
+
+public sealed class RetainedFindingComparisonSet
+{
+    readonly ImmutableDictionary<string, ImmutableArray<RetainedFindingComparison>> _byDescriptor;
+
+    public RetainedFindingComparisonSet(IEnumerable<RetainedFindingComparison> comparisons)
+    {
+        ArgumentNullException.ThrowIfNull(comparisons);
+        var items = comparisons.ToImmutableArray();
+        if (items.Any(comparison => comparison is null))
+        {
+            throw new ArgumentException(
+                "Retained comparisons cannot contain null entries.",
+                nameof(comparisons));
+        }
+
+        Items = items;
+        _byDescriptor = items
+            .GroupBy(comparison => comparison.Descriptor.Id, StringComparer.Ordinal)
+            .ToImmutableDictionary(
+                group => group.Key,
+                group => group.ToImmutableArray(),
+                StringComparer.Ordinal);
+    }
+
+    public static RetainedFindingComparisonSet Empty { get; } = new([]);
+
+    public int Count => Items.Length;
+    public bool IsEmpty => Items.IsEmpty;
+
+    public ImmutableArray<RetainedFindingComparison<T>> Get<T>(FindingDescriptor descriptor)
+        where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+        if (!_byDescriptor.TryGetValue(descriptor.Id, out var comparisons))
+            return [];
+
+        var typed = ImmutableArray.CreateBuilder<RetainedFindingComparison<T>>(
+            comparisons.Length);
+        foreach (var comparison in comparisons)
+        {
+            if (comparison is not RetainedFindingComparison<T> value)
+            {
+                throw new InvalidOperationException(
+                    $"Retained Finding descriptor '{descriptor.Id}' does not carry "
+                    + $"{typeof(T).Name} payloads.");
+            }
+
+            typed.Add(value);
+        }
+
+        return typed.MoveToImmutable();
+    }
+
+    internal ImmutableArray<RetainedFindingComparison> Items { get; }
+}
 
 /// <summary>
 /// Outcome of one Research diff operation. Changes are stored once; subject grouping is a
@@ -325,7 +402,7 @@ public sealed record ResearchComparison
         ImmutableArray<ResearchChange> changes,
         ApiDiff? apiDiff = null,
         ApiFindingComparison? apiComparison = null)
-        : this(changes, apiDiff, apiComparison, [], [])
+        : this(changes, apiDiff, apiComparison, null)
     {
     }
 
@@ -333,36 +410,12 @@ public sealed record ResearchComparison
         ImmutableArray<ResearchChange> changes,
         ApiDiff? apiDiff,
         ApiFindingComparison? apiComparison,
-        ImmutableArray<AllocationFindingComparison> allocationComparisons)
-        : this(changes, apiDiff, apiComparison, allocationComparisons, [])
-    {
-    }
-
-    public ResearchComparison(
-        ImmutableArray<ResearchChange> changes,
-        ApiDiff? apiDiff,
-        ApiFindingComparison? apiComparison,
-        ImmutableArray<AllocationFindingComparison> allocationComparisons,
-        ImmutableArray<CallSiteFindingComparison> callSiteComparisons)
+        RetainedFindingComparisonSet? retainedComparisons)
     {
         if (changes.IsDefault)
             throw new ArgumentException("Changes must be initialized.", nameof(changes));
         if (changes.Any(change => change is null))
             throw new ArgumentException("Changes cannot contain null entries.", nameof(changes));
-        if (!allocationComparisons.IsDefault
-            && allocationComparisons.Any(comparison => comparison is null))
-        {
-            throw new ArgumentException(
-                "Allocation comparisons cannot contain null entries.",
-                nameof(allocationComparisons));
-        }
-        if (!callSiteComparisons.IsDefault
-            && callSiteComparisons.Any(comparison => comparison is null))
-        {
-            throw new ArgumentException(
-                "Call-site comparisons cannot contain null entries.",
-                nameof(callSiteComparisons));
-        }
         if (apiDiff is not null
             && apiComparison is not null
             && !ReferenceEquals(apiDiff, apiComparison.ApiDiff))
@@ -374,15 +427,13 @@ public sealed record ResearchComparison
         Changes = changes;
         ApiComparison = apiComparison;
         ApiDiff = apiComparison?.ApiDiff ?? apiDiff;
-        AllocationComparisons = allocationComparisons.IsDefault ? [] : allocationComparisons;
-        CallSiteComparisons = callSiteComparisons.IsDefault ? [] : callSiteComparisons;
+        RetainedComparisons = retainedComparisons ?? RetainedFindingComparisonSet.Empty;
     }
 
     public ImmutableArray<ResearchChange> Changes { get; }
     public ApiDiff? ApiDiff { get; }
     public ApiFindingComparison? ApiComparison { get; }
-    public ImmutableArray<AllocationFindingComparison> AllocationComparisons { get; }
-    public ImmutableArray<CallSiteFindingComparison> CallSiteComparisons { get; }
+    public RetainedFindingComparisonSet RetainedComparisons { get; }
     public bool IsEmpty => Changes.IsEmpty;
 
     public IReadOnlyList<ResearchSubjectChanges> BySubject()

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -18,8 +18,8 @@ public sealed record ResearchDiffOptions(
     IReadOnlySet<string>? TypeFilters = null,
     IReadOnlySet<string>? MemberTargetIdentities = null)
 {
-    public bool RetainAllocationComparisons { get; init; }
-    public bool RetainCallSiteComparisons { get; init; }
+    public ImmutableHashSet<string> RetainedComparisonDescriptorIds { get; init; } =
+        ImmutableHashSet.Create<string>(StringComparer.Ordinal);
 }
 
 public sealed record ResearchDiffInput(
@@ -189,14 +189,8 @@ public static class ResearchDiff
             [.. results.SelectMany(result => result.Changes)],
             apiDiff,
             apiComparison,
-            [.. results.SelectMany(result =>
-                result.AllocationComparisons.IsDefault
-                    ? []
-                    : result.AllocationComparisons)],
-            [.. results.SelectMany(result =>
-                result.CallSiteComparisons.IsDefault
-                    ? []
-                    : result.CallSiteComparisons)]);
+            new RetainedFindingComparisonSet(
+                results.SelectMany(result => result.RetainedComparisons.Items)));
     }
 
     public static ResearchComparison CompareAssemblies(string oldAssemblyPath, string newAssemblyPath, ResearchDiffOptions? options = null)
@@ -225,8 +219,7 @@ public static class ResearchDiff
                 newInput,
                 options.TypeFilters,
                 options.MemberTargetIdentities,
-                options.RetainAllocationComparisons,
-                options.RetainCallSiteComparisons);
+                options.RetainedComparisonDescriptorIds);
         }
 
         if (options.Mechanisms.HasFlag(ResearchChangeMechanism.IlBody))
@@ -278,9 +271,9 @@ public static class ResearchDiff
         ResearchDiffInput newInput,
         IReadOnlySet<string>? typeFilters,
         IReadOnlySet<string>? memberTargetIdentities,
-        bool retainAllocationComparisons,
-        bool retainCallSiteComparisons)
+        IReadOnlySet<string> retainedComparisonDescriptorIds)
     {
+        ArgumentNullException.ThrowIfNull(retainedComparisonDescriptorIds);
         foreach (var (oldIndex, newIndex) in PairedBodyIndexes(oldInput, newInput))
         {
             AddAnalysisSignalDiff(
@@ -289,8 +282,7 @@ public static class ResearchDiff
                 newIndex,
                 typeFilters,
                 memberTargetIdentities,
-                retainAllocationComparisons,
-                retainCallSiteComparisons);
+                retainedComparisonDescriptorIds);
 
             var methods = MethodSubjectsByBodySignalKey(oldIndex, newIndex);
             foreach (var change in UnsafetyFindingDiff.Compare(
@@ -333,19 +325,26 @@ public static class ResearchDiff
             LibraryBodyIndex newIndex,
             IReadOnlySet<string>? typeFilters,
             IReadOnlySet<string>? memberTargetIdentities,
-            bool retainAllocationComparisons,
-            bool retainCallSiteComparisons)
+            IReadOnlySet<string> retainedComparisonDescriptorIds)
         {
+            bool retainAllocations = retainedComparisonDescriptorIds.Contains(
+                AnalysisFindings.AllocationDescriptor.Id);
+            bool retainCallSites = retainedComparisonDescriptorIds.Contains(
+                AnalysisFindings.CallSiteDescriptor.Id);
+            bool retainUnsafety = retainedComparisonDescriptorIds.Contains(
+                AnalysisFindings.UnsafetyDescriptor.Id);
             var oldSnapshot = BuildAnalysisSnapshot(
                 oldIndex,
                 typeFilters,
                 memberTargetIdentities,
-                retainCallSiteComparisons);
+                retainCallSites,
+                retainUnsafety);
             var newSnapshot = BuildAnalysisSnapshot(
                 newIndex,
                 typeFilters,
                 memberTargetIdentities,
-                retainCallSiteComparisons);
+                retainCallSites,
+                retainUnsafety);
             foreach (var key in oldSnapshot.Keys.Union(newSnapshot.Keys, StringComparer.Ordinal))
             {
                 oldSnapshot.TryGetValue(key, out var oldMethod);
@@ -359,14 +358,28 @@ public static class ResearchDiff
                     oldMethod?.Allocations ?? [],
                     newMethod?.Allocations ?? [],
                     Evidence(oldMethod?.Signals, newMethod?.Signals),
-                    retainAllocationComparisons);
-                if (retainCallSiteComparisons)
+                    retainAllocations);
+                if (retainCallSites)
                 {
-                    AddCallSiteComparison(
+                    AddRetainedComparison(
                         builder,
                         subject,
-                        oldMethod?.CallSites ?? [],
-                        newMethod?.CallSites ?? []);
+                        AnalysisFindings.CallSiteDescriptor,
+                        AnalysisFindings.CompareCallSites(
+                            oldMethod?.CallSites ?? [],
+                            newMethod?.CallSites ?? [],
+                            new FindingSubject(subject.Id, subject.Display)));
+                }
+                if (retainUnsafety)
+                {
+                    AddRetainedComparison(
+                        builder,
+                        subject,
+                        AnalysisFindings.UnsafetyDescriptor,
+                        AnalysisFindings.CompareUnsafety(
+                            oldMethod?.Unsafety ?? [],
+                            newMethod?.Unsafety ?? [],
+                            new FindingSubject(subject.Id, subject.Display)));
                 }
                 AddCountRows(builder, subject, inBoth, oldMethod?.Signals, newMethod?.Signals);
                 AddExceptionRow(builder, subject, inBoth, oldMethod?.Signals, newMethod?.Signals);
@@ -378,13 +391,15 @@ public static class ResearchDiff
             LibraryBodyIndex index,
             IReadOnlySet<string>? typeFilters,
             IReadOnlySet<string>? memberTargetIdentities,
-            bool includeCallSites)
+            bool includeCallSites,
+            bool includeUnsafety)
         {
             var methods = new Dictionary<string, ResearchAnalysisMethod>(StringComparer.Ordinal);
             var generatedFrameworkTypes = index.GeneratedFrameworkTypeNames;
             var signalsByToken = index.GetMethodSignals();
             var allocationsByToken = index.GetAllocationOccurrences();
             var callsByToken = includeCallSites ? index.GetDirectCallsByCaller() : null;
+            var unsafetyByToken = includeUnsafety ? index.GetUnsafetyOccurrences() : null;
             foreach (var method in index.Methods)
             {
                 if (IsGeneratedMethod(method, generatedFrameworkTypes))
@@ -402,6 +417,12 @@ public static class ResearchDiff
                 {
                     callSites = retainedCallSites;
                 }
+                ImmutableArray<UnsafetyOccurrence> unsafety = [];
+                if (unsafetyByToken is not null
+                    && unsafetyByToken.TryGetValue(method.MetadataToken, out var retainedUnsafety))
+                {
+                    unsafety = retainedUnsafety;
+                }
                 var key = BodySignalMethodKey(method);
                 if (!methods.TryGetValue(key, out var entry))
                 {
@@ -410,6 +431,7 @@ public static class ResearchDiff
                         signals ?? MethodSignals.None,
                         allocations.IsDefault ? [] : allocations,
                         callSites,
+                        unsafety,
                         []);
                     methods[key] = entry;
                 }
@@ -420,6 +442,7 @@ public static class ResearchDiff
                         Signals = signals ?? MethodSignals.None,
                         Allocations = allocations.IsDefault ? [] : allocations,
                         CallSites = callSites,
+                        Unsafety = unsafety,
                     };
                 }
             }
@@ -436,7 +459,13 @@ public static class ResearchDiff
                 var key = BodySignalMethodKey(opportunity.Method);
                 if (!methods.TryGetValue(key, out var entry))
                 {
-                    entry = new ResearchAnalysisMethod(subject, MethodSignals.None, [], [], []);
+                    entry = new ResearchAnalysisMethod(
+                        subject,
+                        MethodSignals.None,
+                        [],
+                        [],
+                        [],
+                        []);
                     methods[key] = entry;
                 }
                 entry.Opportunities.Add(opportunity);
@@ -469,7 +498,13 @@ public static class ResearchDiff
                 newOccurrences,
                 new FindingSubject(subject.Id, subject.Display));
             if (retainComparison)
-                builder.Add(new AllocationFindingComparison(subject, comparison));
+            {
+                AddRetainedComparison(
+                    builder,
+                    subject,
+                    AnalysisFindings.AllocationDescriptor,
+                    comparison);
+            }
             var complete = comparison switch
             {
                 FindingComparison<AllocationOccurrence>.Complete value => value,
@@ -538,17 +573,16 @@ public static class ResearchDiff
                 allocationComparison: comparison));
         }
 
-        static void AddCallSiteComparison(
+        static void AddRetainedComparison<T>(
             ResultBuilder builder,
             ResearchSubjectKey subject,
-            ImmutableArray<DirectCall> oldCallSites,
-            ImmutableArray<DirectCall> newCallSites)
-            => builder.Add(new CallSiteFindingComparison(
+            FindingDescriptor descriptor,
+            FindingComparison<T> comparison)
+            where T : notnull
+            => builder.Add(new RetainedFindingComparison<T>(
                 subject,
-                AnalysisFindings.CompareCallSites(
-                    oldCallSites,
-                    newCallSites,
-                    new FindingSubject(subject.Id, subject.Display))));
+                descriptor,
+                comparison));
 
         static bool IsHotAllocation(AllocationOccurrence occurrence)
             => occurrence.CountsAsHeapAllocation
@@ -1166,31 +1200,28 @@ public static class ResearchDiff
         MethodSignals Signals,
         ImmutableArray<AllocationOccurrence> Allocations,
         ImmutableArray<DirectCall> CallSites,
+        ImmutableArray<UnsafetyOccurrence> Unsafety,
         List<OptimizationOpportunity> Opportunities);
 
     sealed class ResultBuilder
     {
         readonly List<ResearchChange> _changes = [];
-        readonly List<AllocationFindingComparison> _allocationComparisons = [];
-        readonly List<CallSiteFindingComparison> _callSiteComparisons = [];
+        readonly List<RetainedFindingComparison> _retainedComparisons = [];
 
         public ApiFindingComparison? ApiComparison { get; set; }
 
         public void Add(ResearchChange change) => _changes.Add(change);
 
-        public void Add(AllocationFindingComparison comparison)
-            => _allocationComparisons.Add(comparison);
-
-        public void Add(CallSiteFindingComparison comparison)
-            => _callSiteComparisons.Add(comparison);
+        public void Add(RetainedFindingComparison comparison)
+            => _retainedComparisons.Add(comparison);
 
         public ResearchComparison ToResult()
             => new(
                 [.. _changes],
                 apiDiff: null,
                 apiComparison: ApiComparison,
-                allocationComparisons: [.. _allocationComparisons],
-                callSiteComparisons: [.. _callSiteComparisons]);
+                retainedComparisons: new RetainedFindingComparisonSet(
+                    _retainedComparisons));
     }
 
     sealed class MethodBodyLookup : IDisposable

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1455,6 +1455,29 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Diff_FindingTransitions_ConfirmsUnsafetyIntroduction()
+    {
+        var oldPath = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var newPath = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var (exit, output, error) = await RunAppAsync(
+            "diff", "--library", $"{oldPath}..{newPath}",
+            "-t", "DiffFixtureSample.DiffSample",
+            "-m", "AddsUnsafe",
+            "--finding", "analysis.unsafety",
+            "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("PairFinding.Added", output);
+        Assert.Contains("analysis.unsafety", output);
+        Assert.Contains("AddsUnsafe", output);
+        Assert.Contains("StackAlloc", output);
+        Assert.Contains("absent", output);
+        Assert.Contains("present", output);
+    }
+
+    [Fact]
     public async Task Diff_FindingTransitions_AllocationRequiresOneMemberBeforeAcquisition()
     {
         var (exit, output, error) = await RunAppAsync(
@@ -1482,6 +1505,23 @@ public class CommandExecutionTests
         Assert.Empty(output);
         Assert.Contains(
             "--finding analysis.call-site requires exactly one --member",
+            error);
+        Assert.DoesNotContain("not found", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Diff_FindingTransitions_UnsafetyRequiresOneMemberBeforeAcquisition()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "diff", "--library", "missing-old.dll..missing-new.dll",
+            "-t", "Sample.Widget",
+            "--finding", "analysis.unsafety",
+            "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains(
+            "--finding analysis.unsafety requires exactly one --member",
             error);
         Assert.DoesNotContain("not found", error, StringComparison.OrdinalIgnoreCase);
     }

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -358,6 +358,36 @@ public class DiffCommandTests
     }
 
     [Fact]
+    public void BuildUnsafetyFindingTransitions_AddedOperation_IsNativeAddedPair()
+    {
+        var rows = BuildUnsafetyFindingTransitions("AddsUnsafe");
+
+        var added = Assert.Single(rows, row =>
+            row.Transition == "PairFinding.Added"
+            && row.Target.Contains("StackAlloc", StringComparison.Ordinal));
+        Assert.Equal("analysis.unsafety", added.Finding);
+        Assert.Contains("AddsUnsafe", added.Target);
+        Assert.Equal("absent", added.Old);
+        Assert.Equal("present", added.New);
+    }
+
+    [Fact]
+    public void BuildUnsafetyFindingTransitions_RetainsPresentOperations()
+    {
+        var rows = BuildUnsafetyFindingTransitions("MethodToken");
+
+        Assert.Contains(rows, row =>
+            row.Transition == "PairFinding.Present"
+            && row.Target.Contains("CallIndirect", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void BuildUnsafetyFindingTransitions_EmptyCensuses_HaveNoPair()
+    {
+        Assert.Empty(BuildUnsafetyFindingTransitions("Stable"));
+    }
+
+    [Fact]
     public void RenderFindingTransitionsMarkdown_LabelsPairBoundary()
     {
         var view = DiffOutputFormatter.BuildFindingTransitionsView(
@@ -564,6 +594,28 @@ public class DiffCommandTests
             new DiffOptions
             {
                 Finding = AnalysisFindings.CallSiteDescriptor.Id,
+                TypeFilter = ["DiffFixtureSample.DiffSample"],
+                MemberFilter = [member],
+            });
+    }
+
+    private static IReadOnlyList<FindingTransitionRow> BuildUnsafetyFindingTransitions(
+        string member)
+    {
+        var oldPath = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var newPath = FixtureCatalog.DiffPair.NewAssemblyPath();
+        var oldSurface = AssemblyReader.ExtractApiSurface(oldPath)!;
+        var newSurface = AssemblyReader.ExtractApiSurface(newPath)!;
+        return DiffCommand.BuildUnsafetyFindingTransitions(
+            [oldPath],
+            [newPath],
+            oldSurface,
+            newSurface,
+            "v1",
+            "v2",
+            new DiffOptions
+            {
+                Finding = AnalysisFindings.UnsafetyDescriptor.Id,
                 TypeFilter = ["DiffFixtureSample.DiffSample"],
                 MemberFilter = [member],
             });
@@ -1398,6 +1450,38 @@ public class DiffCommandTests
             && transition.GetProperty("finding").GetString() == "analysis.call-site"
             && transition.GetProperty("target").GetString()!.Contains(
                 ".Add(",
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnsafetyFindingTransitions_ComposesJson()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var (exitCode, output, error) = await ConsoleCapture.RunAsync(() =>
+            DiffCommand.ExecuteAsync(new DiffOptions
+            {
+                LibraryVersionRange = $"{v1}..{v2}",
+                JsonOutput = true,
+                Finding = AnalysisFindings.UnsafetyDescriptor.Id,
+                TypeFilter = ["DiffFixtureSample.DiffSample"],
+                MemberFilter = ["AddsUnsafe"]
+            }));
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(error);
+        using var document = System.Text.Json.JsonDocument.Parse(output);
+        Assert.False(document.RootElement.TryGetProperty("changes", out _));
+        var transitions = document.RootElement
+            .GetProperty("finding_transitions")
+            .EnumerateArray()
+            .ToList();
+        Assert.Contains(transitions, transition =>
+            transition.GetProperty("transition").GetString() == "PairFinding.Added"
+            && transition.GetProperty("finding").GetString() == "analysis.unsafety"
+            && transition.GetProperty("target").GetString()!.Contains(
+                "StackAlloc",
                 StringComparison.Ordinal));
     }
 

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -10,6 +10,7 @@ using ILInspector.Analysis;
 using ILInspector.Findings;
 using ILInspector.Research;
 using Markout;
+using System.Collections.Immutable;
 using System.Text.Json;
 
 namespace DotnetInspector.Commands;
@@ -99,7 +100,8 @@ public class DiffCommand
                 return 1;
             }
             if (findingDescriptor == AnalysisFindings.AllocationDescriptor.Id
-                || findingDescriptor == AnalysisFindings.CallSiteDescriptor.Id)
+                || findingDescriptor == AnalysisFindings.CallSiteDescriptor.Id
+                || findingDescriptor == AnalysisFindings.UnsafetyDescriptor.Id)
             {
                 if (options.MemberFilter.Count != 1)
                 {
@@ -591,8 +593,14 @@ public class DiffCommand
             error = null;
             return true;
         }
+        if (string.Equals(descriptor, AnalysisFindings.UnsafetyDescriptor.Id, StringComparison.OrdinalIgnoreCase))
+        {
+            descriptor = AnalysisFindings.UnsafetyDescriptor.Id;
+            error = null;
+            return true;
+        }
 
-        error = $"Unsupported Finding descriptor '{descriptor}'. Supported descriptors: api.type, api.member, analysis.allocation, analysis.call-site.";
+        error = $"Unsupported Finding descriptor '{descriptor}'. Supported descriptors: api.type, api.member, analysis.allocation, analysis.call-site, analysis.unsafety.";
         return false;
     }
 
@@ -621,6 +629,15 @@ public class DiffCommand
                     options),
             var descriptor when descriptor == AnalysisFindings.CallSiteDescriptor.Id =>
                 BuildCallSiteFindingTransitions(
+                    inputs.FromPaths,
+                    inputs.ToPaths,
+                    inputs.FromSurface,
+                    inputs.ToSurface,
+                    inputs.FromVersion,
+                    inputs.ToVersion,
+                    options),
+            var descriptor when descriptor == AnalysisFindings.UnsafetyDescriptor.Id =>
+                BuildUnsafetyFindingTransitions(
                     inputs.FromPaths,
                     inputs.ToPaths,
                     inputs.FromSurface,
@@ -1038,39 +1055,16 @@ public class DiffCommand
         string fromVersion,
         string toVersion,
         DiffOptions options)
-    {
-        if (options.MemberFilter.Count != 1)
-            throw new InvalidOperationException("--finding analysis.allocation requires exactly one --member target.");
-
-        var targets = ResolveMemberTargetIdentities(
+        => BuildAnalysisFindingTransitions<AllocationOccurrence>(
+            fromPaths,
+            toPaths,
             fromSurface,
             toSurface,
-            options.MemberFilter,
-            options.TypeFilter,
-            requireBodyTargets: true,
-            bodySectionName: "Finding Transitions");
-        var research = ResearchDiff.Compare(
-            ResearchDiffInput.FromAssemblies(fromPaths),
-            ResearchDiffInput.FromAssemblies(toPaths),
-            new ResearchDiffOptions(
-                ResearchChangeMechanism.BodySignals,
-                TypeFilters: options.TypeFilter,
-                MemberTargetIdentities: targets.MemberIdentities)
-            {
-                RetainAllocationComparisons = true,
-            });
-
-        return research.AllocationComparisons
-            .SelectMany(comparison => CompletePairs(comparison.Comparison)
-                .Select(pair => ToAllocationTransitionRow(
-                    comparison.Subject,
-                    pair,
-                    fromVersion,
-                    toVersion)))
-            .OrderBy(row => row.Target, StringComparer.Ordinal)
-            .ThenBy(row => row.Transition, StringComparer.Ordinal)
-            .ToList();
-    }
+            fromVersion,
+            toVersion,
+            options,
+            AnalysisFindings.AllocationDescriptor,
+            ToAllocationTransitionRow);
 
     internal static IReadOnlyList<FindingTransitionRow> BuildCallSiteFindingTransitions(
         IReadOnlyList<string> fromPaths,
@@ -1080,9 +1074,54 @@ public class DiffCommand
         string fromVersion,
         string toVersion,
         DiffOptions options)
+        => BuildAnalysisFindingTransitions<DirectCall>(
+            fromPaths,
+            toPaths,
+            fromSurface,
+            toSurface,
+            fromVersion,
+            toVersion,
+            options,
+            AnalysisFindings.CallSiteDescriptor,
+            ToCallSiteTransitionRow);
+
+    internal static IReadOnlyList<FindingTransitionRow> BuildUnsafetyFindingTransitions(
+        IReadOnlyList<string> fromPaths,
+        IReadOnlyList<string> toPaths,
+        ApiSurface fromSurface,
+        ApiSurface toSurface,
+        string fromVersion,
+        string toVersion,
+        DiffOptions options)
+        => BuildAnalysisFindingTransitions<UnsafetyOccurrence>(
+            fromPaths,
+            toPaths,
+            fromSurface,
+            toSurface,
+            fromVersion,
+            toVersion,
+            options,
+            AnalysisFindings.UnsafetyDescriptor,
+            ToUnsafetyTransitionRow);
+
+    static IReadOnlyList<FindingTransitionRow> BuildAnalysisFindingTransitions<T>(
+        IReadOnlyList<string> fromPaths,
+        IReadOnlyList<string> toPaths,
+        ApiSurface fromSurface,
+        ApiSurface toSurface,
+        string fromVersion,
+        string toVersion,
+        DiffOptions options,
+        FindingDescriptor descriptor,
+        Func<ResearchSubjectKey, PairFinding<T>, string, string, FindingTransitionRow>
+            toTransitionRow)
+        where T : notnull
     {
         if (options.MemberFilter.Count != 1)
-            throw new InvalidOperationException("--finding analysis.call-site requires exactly one --member target.");
+        {
+            throw new InvalidOperationException(
+                $"--finding {descriptor.Id} requires exactly one --member target.");
+        }
 
         var targets = ResolveMemberTargetIdentities(
             fromSurface,
@@ -1099,12 +1138,13 @@ public class DiffCommand
                 TypeFilters: options.TypeFilter,
                 MemberTargetIdentities: targets.MemberIdentities)
             {
-                RetainCallSiteComparisons = true,
+                RetainedComparisonDescriptorIds =
+                    ImmutableHashSet.Create(StringComparer.Ordinal, descriptor.Id),
             });
 
-        return research.CallSiteComparisons
+        return research.RetainedComparisons.Get<T>(descriptor)
             .SelectMany(comparison => CompletePairs(comparison.Comparison)
-                .Select(pair => ToCallSiteTransitionRow(
+                .Select(pair => toTransitionRow(
                     comparison.Subject,
                     pair,
                     fromVersion,
@@ -1232,6 +1272,36 @@ public class DiffCommand
             ? $"{declaringType}{typeArguments}({parameters})"
             : $"{declaringType}.{callee.Name}{typeArguments}({parameters})";
         return $"{subject.Display} :: {calleeDisplay}";
+    }
+
+    static FindingTransitionRow ToUnsafetyTransitionRow(
+        ResearchSubjectKey subject,
+        PairFinding<UnsafetyOccurrence> pair,
+        string fromVersion,
+        string toVersion)
+    {
+        var oldFinding = OldSide(pair);
+        var newFinding = NewSide(pair);
+        return new FindingTransitionRow(
+            $"PairFinding.{pair.Kind}",
+            pair.Descriptor.Id,
+            UnsafetyTarget(subject, newFinding ?? oldFinding!),
+            fromVersion,
+            toVersion,
+            oldFinding is null ? "absent" : "present",
+            newFinding is null ? "absent" : "present",
+            pair.Detail ?? newFinding?.Detail ?? oldFinding?.Detail);
+    }
+
+    static string UnsafetyTarget(
+        ResearchSubjectKey subject,
+        Finding<UnsafetyOccurrence> finding)
+    {
+        var occurrence = finding.Payload;
+        string detail = string.IsNullOrWhiteSpace(occurrence.Detail)
+            ? ""
+            : $" {occurrence.Detail}";
+        return $"{subject.Display} :: {occurrence.Kind}{detail}";
     }
 
     static string TypeTarget(PairFinding<ApiTypeHandle> pair)


### PR DESCRIPTION
## Conclusion

`diff --finding analysis.unsafety` now confirms whether one method gained,
retained, or lost definite unsafe IL operations using Analysis's native
`PairFinding<UnsafetyOccurrence>` comparison.

This is the fourth descriptor on the focused Finding Transitions lens and the
agreed refactor trigger from the #2671 review: retained comparisons now use one
typed, descriptor-keyed container instead of adding a third payload-specific
copy.

## What changed

- Added `analysis.unsafety` descriptor selection for exactly one method target.
- Renders unsafe operation kind/detail while keeping IL offsets as
  endpoint-local provenance.
- Replaced allocation/call-site retention records, flags, result lists,
  constructor branches, builder overloads, and merge branches with
  `RetainedFindingComparison<T>` plus `RetainedFindingComparisonSet`.
- Selects retained comparisons by descriptor ID, so future producers extend the
  container rather than the plumbing shape.
- Preserves opt-in cost: direct-call indexing is still acquired only when the
  call-site descriptor is retained; ordinary Body Signals output is unchanged.
- Updated Finding design, version-resolution, compatibility, and correctness
  guidance.

```bash
dotnet-inspect diff --package Foo@1.4.0..1.5.0 \
  -t Foo.Parser -m Parse \
  --finding analysis.unsafety
```

`PairFinding.Added` is the unsafe-operation introduction proof. `Present` and
`Removed` distinguish persistence from disappearance.

## Evidence

| Check | Result |
| --- | --- |
| Release solution build | Pass |
| `ILInspector.Analysis.Tests` | 421 passed |
| `ILInspector.Research.Tests` | 99 passed |
| `dotnet-inspect.Tests` | 1,803 passed, 10 tool-dependent skips |
| Changed Markdown | markdownlint clean |

Focused coverage includes native Added/Present/empty unsafety censuses,
descriptor/payload type enforcement, multi-descriptor merge, pre-acquisition
validation, table output, composed JSON, and real CLI execution against the
compiled V1/V2 fixture pair.

## Review

Two isolated exact-head adversarial reviews are clean:

| Reviewer | Result |
| --- | --- |
| Claude Opus 4.8 | CLEAN |
| Gemini 3.1 Pro | CLEAN |

Both verified descriptor/payload type safety, bucket-preserving Combine
semantics, native unsafety identity, duplicate multiset behavior, opt-in
call-site acquisition, pre-acquisition validation, output routing, and clean
real fixture runs. No actionable findings were reported.
