### PR TITLE
Add type-focused package timelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ dotnet-inspect member JsonSerializer --package System.Text.Json Serialize:1 -S "
 dotnet-inspect member MyType MyMethod:1 --library MyLib.dll -S "Unsafe*"
 dotnet-inspect library System.Text.Json --il-offset 0x06000004+0x15
 dotnet-inspect diff --package System.Text.Json@9.0.0..10.0.0 --breaking
+dotnet-inspect timeline --package System.Text.Json@8.0.0..9.0.0 --type System.Text.Json.JsonSerializer --members --at all
 dotnet-inspect diff --library old/Foo.dll..new/Foo.dll -S "Implementation Diff" -m MyType.HotPath
 dotnet-inspect depends Stream --markdown --mermaid
 dotnet-inspect implements IEquatable --project ./src/App -v:q

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,6 +38,9 @@ The tool is organized around source inspection, API lookup, relationship, and ut
 │                         diff                                 │
 │  Compare API, analysis, or implementation evidence           │
 ├─────────────────────────────────────────────────────────────┤
+│                       timeline                               │
+│  Correlate type-owned Findings across a package range         │
+├─────────────────────────────────────────────────────────────┤
 │            depends / extensions / implements                 │
 │  Relationship discovery for APIs, packages, and libraries    │
 ├─────────────────────────────────────────────────────────────┤
@@ -51,8 +54,8 @@ The tool is organized around source inspection, API lookup, relationship, and ut
 
 The command surface has independent source, focus, operation, lens, traversal,
 and rendering axes. Noun-first commands (`package`, `type`, `member`) select a
-structural focus for unary inspection; operation-first commands (`diff`, and a
-future `timeline`) change arity while retaining source/focus selectors. See
+structural focus for unary inspection; operation-first commands (`diff` and
+`timeline`) change arity while retaining source/focus selectors. See
 [Command Transition Model](design/command-transition-model.md) for the decision
 rules and version-range cardinality contract.
 
@@ -104,6 +107,21 @@ Compares two package, platform, or local-library versions:
 - Multiple selected sections compose in Markdown and JSON. Explicit
   table/TSV/JSONL output requires exactly one selected section.
 - Version range syntax is `Package@v1..v2` or `old/Foo.dll..new/Foo.dll`.
+
+### timeline
+
+Correlates one type-focused Finding census across an inclusive package version
+vector:
+
+- `--finding api.type` observes the type's own presence and facets.
+- `--finding api.member` observes all members owned by the type.
+- `--finding api.attribute` observes applied attribute occurrences.
+- No `--at` evaluates zero package payloads; repeated `--at` selectors perform
+  sparse probes; `--at all` explicitly authorizes dense traversal.
+- `Evaluations` preserves `Present`/`Missing` self-presence and
+  `Complete`/`SubjectAbsent` owned censuses, plus `Failed` and `Unevaluated`
+  cells. `Transitions` compares adjacent evaluated cells; a
+  gap-spanning row is qualified and never claims an exact transition version.
 
 ### find
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -118,9 +118,11 @@ vector:
 - `--finding api.attribute` observes applied attribute occurrences.
 - No `--at` evaluates zero package payloads; repeated `--at` selectors perform
   sparse probes; `--at all` explicitly authorizes dense traversal.
-- `Evaluations` preserves `Present`/`Missing` self-presence and
-  `Complete`/`SubjectAbsent` owned censuses, plus `Failed` and `Unevaluated`
-  cells. `Transitions` compares adjacent evaluated cells; a
+- `Evaluations` preserves `Present`/`Missing` self-presence through an exact
+  `FindingCorrelation<T>` and `Complete`/`SubjectAbsent` owned censuses through
+  `FindingCensusCorrelation<T>`, plus `Failed` and `Unevaluated` cells. Exact
+  identity tracks derive from the census correlation rather than bypassing it.
+  `Transitions` compares adjacent evaluated cells; a
   gap-spanning row is qualified and never claims an exact transition version.
 
 ### find

--- a/docs/design/command-transition-model.md
+++ b/docs/design/command-transition-model.md
@@ -242,7 +242,7 @@ Shape reducers do not revise operation arity. In particular:
   transition from version-address rows to package artifact inspection. The
   explicit transition remains `package Package@version`.
 
-The same rule applies to a future timeline. `--count` can reduce an already
+The same rule applies to `timeline`. `--count` can reduce an already
 assembled Timeline table; it cannot probe additional cells. `--print` and
 `--print-all` can print only payloads already carried or explicitly referenced
 by evaluated rows; they cannot turn unevaluated rows into implicit acquisition.

--- a/docs/design/command-transition-model.md
+++ b/docs/design/command-transition-model.md
@@ -437,18 +437,24 @@ is deferred, but the architecture permits it.
 ### Sparse timeline and bisect
 
 A sparse traversal evaluates only caller-selected cells. It preserves the
-Finding correlation semantics:
+Finding census-correlation semantics:
 
-- `Present`: a completed census contains the exact identity;
-- `Missing`: a completed census does not contain it;
+- `Complete`: the focused census completed, including when it contains zero
+  observations;
 - `SubjectAbsent`: the producer has no applicable subject input;
 - `Failed`: inspection did not complete;
 - `Unevaluated`: the address exists in the resolved vector but was not supplied
-  to `FindingCorrelation`.
+  to `FindingCensusCorrelation`.
 
 `Unevaluated` is a presentation state formed by joining the version vector with
 the sparse correlation. It is not fabricated as a Finding or inspection
 outcome.
+
+When a projection selects one exact observation identity,
+`FindingCensusCorrelation.Correlate` produces its `FindingCorrelation` track:
+`Present` means the completed census contains that identity and `Missing` means
+it does not. Whole-census and exact-identity states must not be combined into
+one shadow cell-state model.
 
 Probe order does not define timeline order. Positions come from the resolved
 version vector in the caller's range direction; evaluated inspections retain

--- a/docs/design/command-transition-model.md
+++ b/docs/design/command-transition-model.md
@@ -161,9 +161,11 @@ Multi-address operations are operation-first:
 ```bash
 dotnet-inspect diff --package System.Text.Json@8.0.0..9.0.0 \
   --type System.Text.Json.JsonSerializer
+dotnet-inspect timeline --package System.Text.Json@8.0.0..9.0.0 \
+  --type System.Text.Json.JsonSerializer --finding api.member --at all
 ```
 
-A future `timeline` belongs beside `diff`, not behind `type --timeline` or a
+`timeline` belongs beside `diff`, not behind `type --timeline` or a
 `Timeline` section. It changes arity, acquisition, failure topology, and the
 top-level result from a subject document to an ordered history.
 
@@ -179,7 +181,7 @@ It does not by itself authorize payload acquisition, choose a cell, compare
 endpoints, or infer monotonic history.
 
 Operations do not have to materialize that address space in the same way.
-`package --versions`, addressed unary inspection, and a future timeline need the
+`package --versions`, addressed unary inspection, and `timeline` need the
 published interior vector and resolve it through `PackageVersionVector`.
 `diff` needs only the two literal endpoints, so it currently acquires those
 endpoints without enumerating or validating the interior vector first. Endpoint
@@ -194,7 +196,7 @@ The selected lens or operation supplies the payload-acquisition contract:
 | Select version Vector | 0 | `package Package@A..B --versions` resolves and renders range metadata without acquiring package payloads. |
 | Inspect | 1 | `type` and `member` require one explicit `--at <version\|#N\|first\|last>` and acquire only that exact package. |
 | Compare | 2 | `diff --package Package@A..B` acquires and compares the two endpoints. |
-| Correlate | N explicit cells | A future `timeline` resolves the full address space but acquires only caller-selected probe cells. |
+| Correlate | N explicit cells | `timeline` resolves the full address space but acquires only repeated `--at` probe cells; `--at all` explicitly authorizes every cell. |
 
 The first row is a package lens and output-shape selection. It is not an
 operation peer of `diff` and `timeline`.

--- a/docs/design/finding-nomenclature.md
+++ b/docs/design/finding-nomenclature.md
@@ -54,7 +54,7 @@ second semantic axis.
 | **Diff** | A comparison operation, artifact, report, or presentation containing changes. | Appropriate for `ApiDiff`, `IlBodyDiff`, unified diff text, and CLI `diff`; not for one-version observations. |
 | **Evidence** | Information used to support a conclusion. | A Finding, transition, structural diff, failure, or provenance record may serve as evidence. Do not create a parallel `Evidence*` row hierarchy merely to rename the Finding model. |
 | **Detail** | Explanatory payload or rendered elaboration. | A field or presentation concept, not a model family. |
-| **Census** | The complete observation collection from a successful inspection. | A documentation concept, not a competing API type family. |
+| **Census** | The complete observation collection from a successful inspection. | Usually a semantic unit rather than a payload family. `FindingCensusCorrelation<T>` is the explicit N-address operation outcome when whole-census state, including `Complete([])`, must survive correlation. |
 | **Fact** | A curated or interpreted statement derived from observations where the product intentionally distinguishes that rung. | Do not use it as a synonym for every raw observation. |
 | **Triage** | Downstream prioritization or judgment over observations, changes, and facts. | Never present it as raw producer currency. |
 
@@ -75,7 +75,8 @@ Operation outcomes describe one invocation:
 | Match | `FindingMatch` | Alignment edges and fringe candidates. |
 | Inspect | `FindingInspection<T>` | `Complete(Finding<T>[])`, `Absent`, or `Failed(InspectionError)`. |
 | Compare | `FindingComparison<T>` | Completed pairs/match/inspections, or the failed inspections that prevented matching. |
-| Correlate | `FindingCorrelation<T>` | A sparse, ordered timeline assembled from caller-supplied version-labelled inspections. |
+| Correlate census | `FindingCensusCorrelation<T>` | Sparse, ordered, caller-supplied version-labelled inspections without selecting one observation identity. |
+| Correlate identity | `FindingCorrelation<T>` | `Present`, `Missing`, `SubjectAbsent`, or `Failed` for one exact identity selected from correlated censuses. |
 
 Outcome types carry information types; information types do not depend on
 outcome envelopes. Use the nominalized operation name instead of generic
@@ -100,11 +101,23 @@ The governing invariant is:
 
 ## Sparse correlation and onset
 
-`FindingCorrelation<T>` does not traverse a version range. The caller chooses
-which addresses to inspect and supplies each `FindingInspection<T>` with a
-stable `FindingVersion`. This keeps bisect, backward scanning, retry, and probe
-limits in the agent or calling workflow rather than hiding an unbounded search
-inside the Finding layer.
+Neither correlation outcome traverses a version range. The caller chooses which
+addresses to inspect and supplies each `FindingInspection<T>` with a stable
+`FindingVersion`. This keeps bisect, backward scanning, retry, and probe limits
+in the agent or calling workflow rather than hiding an unbounded search inside
+the Finding layer.
+
+`FindingCensusCorrelation<T>` is the whole-census tier. It preserves each
+evaluated inspection, so `Complete([])` remains distinguishable from
+`SubjectAbsent` and `Failed` even when there is no observation identity from
+which to construct an exact track. This is the appropriate operation outcome
+for a type-focused member or attribute timeline: the focus selects a subject
+and producer, not one member or attribute key. `Complete` is therefore a census
+inspection state, not a fifth exact-identity correlation state.
+
+`FindingCorrelation<T>` selects one `FindingCorrelationKey` from those same
+version-labelled inspections. `FindingCensusCorrelation<T>.Correlate` is the
+explicit bridge from the census tier to this exact-identity tier.
 
 For one exact `FindingCorrelationKey`, an evaluated address has one of four
 states:

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -59,6 +59,10 @@ dotnet-inspect type JsonSerializer \
   --package System.Text.Json@8.0.0..8.0.5 --at '#4'
 dotnet-inspect member JsonSerializer Serialize \
   --package System.Text.Json@8.0.0..8.0.5 --at 8.0.5
+dotnet-inspect timeline \
+  --package System.Text.Json@8.0.0..8.0.5 \
+  --type System.Text.Json.JsonSerializer \
+  --finding api.member --at first --at last
 ```
 
 `package --versions` enumerates the vector. Range-capable API commands require
@@ -66,6 +70,14 @@ dotnet-inspect member JsonSerializer Serialize \
 Resolving the vector reads version metadata only. The command downloads or
 opens a package only after the caller selects an address, so an agent can probe
 previous, midpoint, or adjacent versions without triggering an unbounded scan.
+
+`timeline` uses the same vector without changing that authorization rule. With
+no `--at`, it renders every address as `Unevaluated` and recommends a probe
+without downloading package payloads. Repeated `--at` selectors perform sparse
+correlation; `--at all` is the explicit dense-traversal opt-in. Type focus may
+select the type-presence (`api.type`), owned-member (`api.member`), or applied
+attribute (`api.attribute`) census. Sparse transitions spanning unevaluated
+cells are labeled as gaps and do not claim the exact version of a change.
 
 Stable endpoints exclude prereleases by default. A prerelease endpoint or
 `--preview` on `package --versions` includes prereleases within the range.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -12,7 +12,7 @@ It is built for both humans and agents. Markdown is the default output because h
 - `src/ILInspector.Analysis/` indexes IL method-body evidence such as direct call sites, allocation and unsafety occurrences, method signals, and whole-assembly leverage without decompiling to C#. `AnalysisFindings` exposes reusable typed censuses and comparisons for allocations, call sites, unsafe operations, and unsafe declaration/body evidence.
 - `src/ILInspector.Analysis.App/` is a temporary console harness for exercising Analysis queries until CLI wiring exists.
 - `src/ILInspector.ControlFlow/` contains shared block-edge, dominance, and dataflow kernels used below Analysis and Decompiler without depending on either.
-- `src/ILInspector.Findings/` contains the domain-free observation, inspection, matching, transition, and comparison contracts shared by product producers.
+- `src/ILInspector.Findings/` contains the domain-free observation, inspection, matching, transition, comparison, whole-census correlation, and exact-identity correlation contracts shared by product producers.
 - `src/ILInspector.Instructions/` is the shared IL decode + EH-aware basic-block substrate (one decoder the analyzer and decompiler converge onto); see [instruction substrate](design/instruction-substrate.md).
 - `src/ILInspector.Text/` provides the reusable `TextFindings` API for exact, ordered line inspection and generic text comparison on the shared Finding spine.
 - `src/DotnetInspector.Packages/` handles NuGet package extraction, package/source caches, feeds, symbol package acquisition, and version resolution.

--- a/skills/compatibility/SKILL.md
+++ b/skills/compatibility/SKILL.md
@@ -121,6 +121,8 @@ then probe only the cells you choose:
 dnx dotnet-inspect -y -- package Foo@1.0.0..2.0.0 --versions
 dnx dotnet-inspect -y -- type TargetType --package Foo@1.0.0..2.0.0 --at '#5'
 dnx dotnet-inspect -y -- member TargetType TargetMember --package Foo@1.0.0..2.0.0 --at 1.6.0
+dnx dotnet-inspect -y -- timeline --package Foo@1.0.0..2.0.0 \
+  --type TargetType --members --at first --at last
 ```
 
 `--at` accepts an exact version, one-based `#N`, `first`, or `last`. Vector
@@ -128,6 +130,14 @@ resolution does not download every package; only the selected probe is
 acquired. The agent owns the search policy and bound. For recurrence-safe
 current onset, walk backward from the bad version until the first successful
 absence; use binary search only for a predicate known to be monotonic.
+
+`timeline` renders `Evaluations` and `Transitions` over the same vector. Omit
+`--at` for a zero-payload address view and midpoint recommendation, repeat
+`--at` for sparse probes, or pass `--at all` for explicit dense traversal.
+Choose the type-focused census with `--type-presence`, `--members`, or
+`--attributes` (aliases for `api.type`, `api.member`, and `api.attribute`).
+Gap-spanning transitions are evidence across the selected probes, not claims
+about the exact introduction or removal version.
 
 The range and point probes identify a candidate boundary. Confirm the adjacent
 pair with Metadata's real Finding comparison rather than inferring introduction

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -23,6 +23,7 @@ dnx dotnet-inspect -y -- <command>
 | Inspect overloads | `member Type --platform Lib -m Name -S "Member Index"` |
 | Select an overload | `member Type --platform Lib Name:1` or `Name~digest` |
 | Compare APIs | `diff --package Foo@old..new --breaking` (`--additive` new APIs); `--alloc-regressions` for perf regressions (allocations up, hot first). |
+| Trace API evolution | `timeline --package Foo@old..new --type Type --members --at all`; omit `--at` to inspect the vector without acquiring packages. |
 | Inspect packages | `package Foo -S Signals`, `--library`, `--path @readme --content`. |
 | Inspect libraries | `library Foo` or `library path/to.dll`; add `--platform`, `-S Signals`. |
 | Relationships | `depends Type`, `extensions Type`, `implements Interface`. |
@@ -43,8 +44,7 @@ dnx dotnet-inspect -y -- member System.Text.Json.JsonSerializer.Serialize -S "Me
 
 ## Tips
 
-- Default output is Markdown; for formats, `-D`/`-S` discovery, projection, and
-  limits, load `dotnet-inspect skill query`.
+- Default output is Markdown; for formats, `-D`/`-S` discovery, projection, and limits, load `dotnet-inspect skill query`.
 - Add `--project <csproj|dir|project.assets.json>` when project-referenced packages should be in scope; it reads existing restored assets, so restore/build first if dependencies changed.
 - Common BCL types resolve without scope: `type string`, `type 'List<T>'`. Quote generics and patterns: `member 'Dictionary<TKey,TValue>'`, `-S "Async*"`.
 - Unpinned packages use latest stable; add `--preview` for prerelease APIs.

--- a/src/ILInspector.Findings/FindingCorrelation.cs
+++ b/src/ILInspector.Findings/FindingCorrelation.cs
@@ -39,6 +39,62 @@ public sealed record VersionedFindingInspection<T>(
 }
 
 /// <summary>
+/// A caller-assembled sparse correlation of whole censuses. Unlike
+/// <see cref="FindingCorrelation{T}"/>, this outcome does not select one exact finding identity:
+/// it preserves each evaluated <see cref="FindingInspection{T}"/> so successful empty censuses,
+/// subject absence, and failure remain distinguishable.
+/// </summary>
+public sealed class FindingCensusCorrelation<T>
+    where T : notnull
+{
+    readonly ImmutableDictionary<string, FindingInspection<T>> _inspections;
+
+    FindingCensusCorrelation(ImmutableArray<VersionedFindingInspection<T>> inspections)
+    {
+        Inspections = inspections;
+        _inspections = inspections.ToImmutableDictionary(
+            item => item.Version.Key,
+            item => item.Inspection);
+    }
+
+    public ImmutableArray<VersionedFindingInspection<T>> Inspections { get; }
+
+    public static FindingCensusCorrelation<T> Create(
+        IEnumerable<VersionedFindingInspection<T>> inspections)
+        => new(FindingCorrelationValidation.Order(inspections));
+
+    /// <summary>
+    /// Projects any two evaluated censuses through the shared pair fold.
+    /// </summary>
+    public FindingComparison<T> Compare(
+        string oldVersionKey,
+        string newVersionKey,
+        FindingMatchOptions? matchOptions = null,
+        int acceptanceThreshold = 100)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(oldVersionKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(newVersionKey);
+
+        if (!_inspections.TryGetValue(oldVersionKey, out var oldInspection))
+            throw new ArgumentException($"Version '{oldVersionKey}' has not been evaluated.", nameof(oldVersionKey));
+        if (!_inspections.TryGetValue(newVersionKey, out var newInspection))
+            throw new ArgumentException($"Version '{newVersionKey}' has not been evaluated.", nameof(newVersionKey));
+
+        return FindingComparison.Compare(
+            oldInspection,
+            newInspection,
+            matchOptions,
+            acceptanceThreshold);
+    }
+
+    /// <summary>
+    /// Selects one exact finding identity from the correlated censuses.
+    /// </summary>
+    public FindingCorrelation<T> Correlate(FindingCorrelationKey key)
+        => FindingCorrelation<T>.Create(key, Inspections);
+}
+
+/// <summary>
 /// One occurrence labelled with the address where it was observed.
 /// </summary>
 public sealed record VersionedFinding<T>(
@@ -204,23 +260,22 @@ public sealed record FindingCorrelationPoint<T>
 public sealed class FindingCorrelation<T>
     where T : notnull
 {
-    readonly ImmutableDictionary<string, FindingInspection<T>> _inspections;
+    readonly FindingCensusCorrelation<T> _census;
 
     FindingCorrelation(
         FindingCorrelationKey key,
-        ImmutableArray<VersionedFindingInspection<T>> inspections,
+        FindingCensusCorrelation<T> census,
         ImmutableArray<FindingCorrelationPoint<T>> timeline,
         CorrelatedFinding<T> finding)
     {
         Key = key;
-        Inspections = inspections;
+        _census = census;
         Timeline = timeline;
         Finding = finding;
-        _inspections = inspections.ToImmutableDictionary(item => item.Version.Key, item => item.Inspection);
     }
 
     public FindingCorrelationKey Key { get; }
-    public ImmutableArray<VersionedFindingInspection<T>> Inspections { get; }
+    public ImmutableArray<VersionedFindingInspection<T>> Inspections => _census.Inspections;
     public ImmutableArray<FindingCorrelationPoint<T>> Timeline { get; }
     public CorrelatedFinding<T> Finding { get; }
 
@@ -229,25 +284,8 @@ public sealed class FindingCorrelation<T>
         IEnumerable<VersionedFindingInspection<T>> inspections)
     {
         ArgumentNullException.ThrowIfNull(key);
-        ArgumentNullException.ThrowIfNull(inspections);
-
-        var evaluated = inspections.ToImmutableArray();
-        if (evaluated.Any(item => item is null))
-            throw new ArgumentException("Inspections must not contain null values.", nameof(inspections));
-
-        var duplicateKey = evaluated
-            .GroupBy(item => item.Version.Key, StringComparer.Ordinal)
-            .FirstOrDefault(group => group.Count() > 1);
-        if (duplicateKey is not null)
-            throw new ArgumentException($"Version key '{duplicateKey.Key}' is duplicated.", nameof(inspections));
-
-        var duplicatePosition = evaluated
-            .GroupBy(item => item.Version.Position)
-            .FirstOrDefault(group => group.Count() > 1);
-        if (duplicatePosition is not null)
-            throw new ArgumentException($"Version position {duplicatePosition.Key} is duplicated.", nameof(inspections));
-
-        var ordered = evaluated.OrderBy(item => item.Version.Position).ToImmutableArray();
+        var census = FindingCensusCorrelation<T>.Create(inspections);
+        var ordered = census.Inspections;
         var timeline = ImmutableArray.CreateBuilder<FindingCorrelationPoint<T>>(ordered.Length);
         var occurrences = ImmutableArray.CreateBuilder<VersionedFinding<T>>();
 
@@ -287,7 +325,7 @@ public sealed class FindingCorrelation<T>
 
         return new FindingCorrelation<T>(
             key,
-            ordered,
+            census,
             timeline.MoveToImmutable(),
             new CorrelatedFinding<T>(key, occurrences.ToImmutable()));
     }
@@ -298,18 +336,38 @@ public sealed class FindingCorrelation<T>
         FindingMatchOptions? matchOptions = null,
         int acceptanceThreshold = 100)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(oldVersionKey);
-        ArgumentException.ThrowIfNullOrWhiteSpace(newVersionKey);
-
-        if (!_inspections.TryGetValue(oldVersionKey, out var oldInspection))
-            throw new ArgumentException($"Version '{oldVersionKey}' has not been evaluated.", nameof(oldVersionKey));
-        if (!_inspections.TryGetValue(newVersionKey, out var newInspection))
-            throw new ArgumentException($"Version '{newVersionKey}' has not been evaluated.", nameof(newVersionKey));
-
-        return FindingComparison.Compare(
-            oldInspection,
-            newInspection,
+        return _census.Compare(
+            oldVersionKey,
+            newVersionKey,
             matchOptions,
             acceptanceThreshold);
+    }
+}
+
+static class FindingCorrelationValidation
+{
+    internal static ImmutableArray<VersionedFindingInspection<T>> Order<T>(
+        IEnumerable<VersionedFindingInspection<T>> inspections)
+        where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(inspections);
+
+        var evaluated = inspections.ToImmutableArray();
+        if (evaluated.Any(item => item is null))
+            throw new ArgumentException("Inspections must not contain null values.", nameof(inspections));
+
+        var duplicateKey = evaluated
+            .GroupBy(item => item.Version.Key, StringComparer.Ordinal)
+            .FirstOrDefault(group => group.Count() > 1);
+        if (duplicateKey is not null)
+            throw new ArgumentException($"Version key '{duplicateKey.Key}' is duplicated.", nameof(inspections));
+
+        var duplicatePosition = evaluated
+            .GroupBy(item => item.Version.Position)
+            .FirstOrDefault(group => group.Count() > 1);
+        if (duplicatePosition is not null)
+            throw new ArgumentException($"Version position {duplicatePosition.Key} is duplicated.", nameof(inspections));
+
+        return evaluated.OrderBy(item => item.Version.Position).ToImmutableArray();
     }
 }

--- a/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
@@ -71,6 +71,37 @@ public class FindingPilotTests
     }
 
     [Fact]
+    public void FindingCensusCorrelation_PreservesWholeCensusesInAddressOrder()
+    {
+        var present = Atoms("target")[0];
+        var error = new InspectionError(Subject, Descriptor, "declined");
+        var correlation = FindingCensusCorrelation<string>.Create(
+        [
+            new(new FindingVersion("v3", "3.0.0", 2), new FindingInspection<string>.Failed(error)),
+            new(new FindingVersion("v1", "1.0.0", 0), new FindingInspection<string>.Complete([])),
+            new(new FindingVersion("v2", "2.0.0", 1), new FindingInspection<string>.Absent("no body")),
+            new(new FindingVersion("v4", "4.0.0", 3), new FindingInspection<string>.Complete([present])),
+        ]);
+
+        Assert.Equal(["v1", "v2", "v3", "v4"], correlation.Inspections.Select(item => item.Version.Key));
+        Assert.True(correlation.Inspections[0].Inspection is FindingInspection<string>.Complete { Findings.Length: 0 });
+        Assert.True(correlation.Inspections[1].Inspection is FindingInspection<string>.Absent);
+        Assert.True(correlation.Inspections[2].Inspection is FindingInspection<string>.Failed);
+        Assert.True(correlation.Inspections[3].Inspection is FindingInspection<string>.Complete { Findings.Length: 1 });
+
+        var comparison = correlation.Compare("v1", "v4") switch
+        {
+            FindingComparison<string>.Complete value => value,
+            FindingComparison<string>.Failed failed => throw new Xunit.Sdk.XunitException(failed.Failure),
+        };
+        Assert.Equal(PairKind.Added, Assert.Single(comparison.Pairs).Kind);
+
+        var exact = correlation.Correlate(FindingCorrelationKey.From(present));
+        Assert.True(exact.Timeline[0] is FindingCorrelationPoint<string>.Missing);
+        Assert.True(exact.Timeline[3] is FindingCorrelationPoint<string>.Present);
+    }
+
+    [Fact]
     public void FindingCorrelation_ProjectsAnyEvaluatedPairThroughTheSharedFold()
     {
         var present = Atoms("target")[0];

--- a/src/ILInspector.Metadata/MetadataFindings.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.cs
@@ -12,6 +12,7 @@ public static partial class MetadataFindings
 {
     public static readonly FindingDescriptor TypeDescriptor = new("api.type", "API type");
     public static readonly FindingDescriptor MemberDescriptor = new("api.member", "API member");
+    public static readonly FindingDescriptor AttributeDescriptor = new("api.attribute", "API attribute");
 
     static readonly FindingMatchOptions IdentitySetOptions = new()
     {
@@ -58,6 +59,94 @@ public static partial class MetadataFindings
         ]);
     }
 
+    public static FindingInspection<ApiTypeHandle> InspectApiType(
+        ApiSurface? surface,
+        FindingSubject subject,
+        string typeFullName)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+        ArgumentException.ThrowIfNullOrEmpty(typeFullName);
+        if (surface is null)
+            return new FindingInspection<ApiTypeHandle>.Absent();
+
+        var type = FindType(surface, typeFullName);
+        return type is null
+            ? new FindingInspection<ApiTypeHandle>.Complete([])
+            : new FindingInspection<ApiTypeHandle>.Complete(
+            [
+                new Finding<ApiTypeHandle>(
+                    subject,
+                    TypeDescriptor,
+                    new FindingKey(type.FullName),
+                    new ApiTypeHandle(type)),
+            ]);
+    }
+
+    public static FindingInspection<ApiMemberHandle> InspectApiMembers(
+        ApiSurface? surface,
+        FindingSubject subject,
+        string typeFullName)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+        ArgumentException.ThrowIfNullOrEmpty(typeFullName);
+        if (surface is null)
+            return new FindingInspection<ApiMemberHandle>.Absent();
+
+        var type = FindType(surface, typeFullName);
+        return type is null
+            ? new FindingInspection<ApiMemberHandle>.Absent()
+            : new FindingInspection<ApiMemberHandle>.Complete(
+            [
+                .. EnumerateMembers(type).Select(item =>
+                {
+                    var handle = ApiMemberIdentity.CreateHandle(item.Type, item.Member);
+                    return new Finding<ApiMemberHandle>(
+                        subject,
+                        MemberDescriptor,
+                        new FindingKey(
+                            handle.CanonicalSignature ?? handle.Identity,
+                            item.Type.FullName),
+                        handle);
+                }),
+            ]);
+    }
+
+    public static FindingInspection<ApiAttributeHandle> InspectApiAttributes(
+        ApiSurface? surface,
+        FindingSubject subject,
+        string typeFullName)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+        ArgumentException.ThrowIfNullOrEmpty(typeFullName);
+        if (surface is null)
+            return new FindingInspection<ApiAttributeHandle>.Absent();
+
+        var type = FindType(surface, typeFullName);
+        if (type is null)
+            return new FindingInspection<ApiAttributeHandle>.Absent();
+
+        var occurrences = new Dictionary<string, int>(StringComparer.Ordinal);
+        return new FindingInspection<ApiAttributeHandle>.Complete(
+        [
+            .. type.Attributes.Select(attribute =>
+            {
+                string name = GetAttributeName(attribute);
+                int occurrence = occurrences.GetValueOrDefault(name);
+                occurrences[name] = occurrence + 1;
+                return new Finding<ApiAttributeHandle>(
+                    subject,
+                    AttributeDescriptor,
+                    new FindingKey($"{type.FullName}|{name}|{occurrence}"),
+                    new ApiAttributeHandle(
+                        type.FullName,
+                        name,
+                        attribute,
+                        occurrence),
+                    Detail: attribute);
+            }),
+        ]);
+    }
+
     public static FindingComparison<ApiTypeHandle> CompareApiTypes(
         ApiSurface oldSurface,
         ApiSurface newSurface,
@@ -86,6 +175,73 @@ public static partial class MetadataFindings
 
         var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface, options);
         return CompareApiMembers(oldSurface, newSurface, subject, options, diff);
+    }
+
+    public static FindingComparison<ApiTypeHandle> CompareApiType(
+        ApiSurface? oldSurface,
+        ApiSurface? newSurface,
+        FindingSubject subject,
+        string typeFullName,
+        ApiDiffOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+        ArgumentException.ThrowIfNullOrEmpty(typeFullName);
+        options ??= ApiDiffOptions.Default;
+
+        var comparison = FindingComparison.Compare(
+            InspectApiType(oldSurface, subject, typeFullName),
+            InspectApiType(newSurface, subject, typeFullName),
+            IdentitySetOptions);
+        if (oldSurface is null || newSurface is null)
+            return comparison;
+
+        var diff = ApiDiffAnalyzer.Compare(
+            FocusSurface(oldSurface, typeFullName),
+            FocusSurface(newSurface, typeFullName),
+            options);
+        return comparison.TransformPairs(
+            pairs => ApplyTypeFacetChanges(pairs, diff, options.Scope));
+    }
+
+    public static FindingComparison<ApiMemberHandle> CompareApiMembers(
+        ApiSurface? oldSurface,
+        ApiSurface? newSurface,
+        FindingSubject subject,
+        string typeFullName,
+        ApiDiffOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+        ArgumentException.ThrowIfNullOrEmpty(typeFullName);
+        options ??= ApiDiffOptions.Default;
+
+        var comparison = FindingComparison.Compare(
+            InspectApiMembers(oldSurface, subject, typeFullName),
+            InspectApiMembers(newSurface, subject, typeFullName),
+            IdentitySetOptions);
+        if (oldSurface is null || newSurface is null)
+            return comparison;
+
+        var diff = ApiDiffAnalyzer.Compare(
+            FocusSurface(oldSurface, typeFullName),
+            FocusSurface(newSurface, typeFullName),
+            options);
+        return comparison.TransformPairs(
+            pairs => ApplyMemberFacetChanges(pairs, diff, options.Scope));
+    }
+
+    public static FindingComparison<ApiAttributeHandle> CompareApiAttributes(
+        ApiSurface? oldSurface,
+        ApiSurface? newSurface,
+        FindingSubject subject,
+        string typeFullName)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+        ArgumentException.ThrowIfNullOrEmpty(typeFullName);
+        return FindingComparison.Compare(
+            InspectApiAttributes(oldSurface, subject, typeFullName),
+            InspectApiAttributes(newSurface, subject, typeFullName),
+            IdentitySetOptions)
+            .TransformPairs(ApplyAttributeValueChanges);
     }
 
     public static ApiFindingComparison CompareApi(
@@ -204,6 +360,22 @@ public static partial class MetadataFindings
 
         return builder.ToImmutable();
     }
+
+    static ImmutableArray<PairFinding<ApiAttributeHandle>> ApplyAttributeValueChanges(
+        ImmutableArray<PairFinding<ApiAttributeHandle>> pairs)
+        => pairs
+            .Select(pair => pair is PairFinding<ApiAttributeHandle>.Present present
+                && !string.Equals(
+                    present.Old.Payload.Attribute,
+                    present.New.Payload.Attribute,
+                    StringComparison.Ordinal)
+                    ? new PairFinding<ApiAttributeHandle>.Changed(
+                        present.Old,
+                        present.New,
+                        present.Difference,
+                        $"{present.Old.Payload.Attribute} -> {present.New.Payload.Attribute}")
+                    : pair)
+            .ToImmutableArray();
 
     static Dictionary<string, List<ApiChange>> BuildTypeChangeMap(ApiDiff diff)
     {
@@ -357,11 +529,40 @@ public static partial class MetadataFindings
     {
         foreach (var type in surface.Types)
         {
-            foreach (var member in type.Members)
-                yield return (type, member);
+            foreach (var item in EnumerateMembers(type))
+                yield return item;
         }
     }
+
+    static IEnumerable<(ApiType Type, ApiMember Member)> EnumerateMembers(ApiType type)
+    {
+        foreach (var member in type.Members)
+            yield return (type, member);
+    }
+
+    static ApiType? FindType(ApiSurface surface, string typeFullName)
+        => surface.Types.FirstOrDefault(
+            type => string.Equals(type.FullName, typeFullName, StringComparison.Ordinal));
+
+    static ApiSurface FocusSurface(ApiSurface surface, string typeFullName)
+    {
+        var type = FindType(surface, typeFullName);
+        return new ApiSurface { Types = type is null ? [] : [type] };
+    }
+
+    static string GetAttributeName(string attribute)
+    {
+        int arguments = attribute.IndexOf('(');
+        return arguments < 0 ? attribute : attribute[..arguments];
+    }
+
 }
+
+public sealed record ApiAttributeHandle(
+    string TypeFullName,
+    string Name,
+    string Attribute,
+    int Occurrence);
 
 /// <summary>
 /// One API comparison operation: generic type/member transitions plus Metadata-owned

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -225,6 +225,54 @@ public class DiffCommandTests
     }
 
     [Fact]
+    public void BuildFindingTransitions_TypeScopedMemberCensus_DoesNotRequireMemberSelector()
+    {
+        var oldSurface = DiffSurface(DiffMember("Existing"));
+        var newSurface = DiffSurface(DiffMember("Existing"), DiffMember("Added"));
+
+        var rows = DiffCommand.BuildFindingTransitions(
+            oldSurface,
+            newSurface,
+            "1.0.0",
+            "2.0.0",
+            new DiffOptions
+            {
+                Finding = "api.member",
+                TypeFilter = ["Sample.Widget"],
+            });
+
+        var added = Assert.Single(rows, row => row.Transition == "PairFinding.Added");
+        Assert.Equal("api.member", added.Finding);
+        Assert.StartsWith("Sample.Widget.Added~", added.Target);
+        Assert.Contains(rows, row => row.Transition == "PairFinding.Present");
+    }
+
+    [Fact]
+    public void BuildFindingTransitions_TypeAttributeCensus_ReportsAppliedOccurrences()
+    {
+        var oldType = DiffType("Sample", "Widget");
+        oldType.Attributes = ["System.Obsolete(\"old\")"];
+        var newType = DiffType("Sample", "Widget");
+        newType.Attributes = ["System.Obsolete(\"new\")"];
+
+        var rows = DiffCommand.BuildFindingTransitions(
+            DiffSurface(oldType),
+            DiffSurface(newType),
+            "1.0.0",
+            "2.0.0",
+            new DiffOptions
+            {
+                Finding = "api.attribute",
+                TypeFilter = ["Sample.Widget"],
+            });
+
+        var changed = Assert.Single(rows);
+        Assert.Equal("PairFinding.Changed", changed.Transition);
+        Assert.Equal("Sample.Widget [System.Obsolete(\"new\")]", changed.Target);
+        Assert.Contains("System.Obsolete(\"old\") -> System.Obsolete(\"new\")", changed.Detail);
+    }
+
+    [Fact]
     public void BuildFindingTransitions_RemovedMember_ReportsOldSide()
     {
         var oldSurface = DiffSurface(DiffMember("Removed"));

--- a/src/dotnet-inspect.Tests/TimelineCommandTests.cs
+++ b/src/dotnet-inspect.Tests/TimelineCommandTests.cs
@@ -1,0 +1,211 @@
+using DotnetInspector.Commands;
+using DotnetInspector.Packages;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Tests;
+
+public sealed class TimelineCommandTests
+{
+    [Fact]
+    public void ZeroEvaluationVector_RemainsUnevaluatedAndRecommendsProbe()
+    {
+        var vector = Vector("1.0.0", "1.0.1", "1.0.2");
+
+        var view = TimelineCommand.BuildView(
+            vector,
+            "Sample.Widget",
+            "api.member",
+            [],
+            Sections());
+
+        Assert.Equal(3, view.Evaluations!.Count);
+        Assert.All(view.Evaluations, row => Assert.Equal("Unevaluated", row.State));
+        Assert.Empty(view.Transitions!);
+        Assert.Contains("--at #2", view.Recommendation, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SparseMemberTimeline_QualifiesGapWithoutClaimingExactVersion()
+    {
+        var vector = Vector("1.0.0", "1.0.1", "1.0.2");
+        var oldSurface = Surface(Type("Widget"));
+        var newSurface = Surface(Type("Widget", members: [Method("Run", "void Run()")]));
+
+        var view = TimelineCommand.BuildView(
+            vector,
+            "Sample.Widget",
+            "api.member",
+            [
+                Evaluation(vector, 0, oldSurface),
+                Evaluation(vector, 2, newSurface),
+            ],
+            Sections());
+
+        var row = Assert.Single(view.Transitions!);
+        Assert.Equal("Gap (1)", row.Span);
+        Assert.Equal("Added", row.Transition);
+        Assert.Contains("exact transition version is unknown", row.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DenseTypePresenceTimeline_ReportsNativeAddition()
+    {
+        var vector = Vector("1.0.0", "1.0.1");
+
+        var view = TimelineCommand.BuildView(
+            vector,
+            "Sample.Widget",
+            "api.type",
+            [
+                Evaluation(vector, 0, Surface()),
+                Evaluation(vector, 1, Surface(Type("Widget"))),
+            ],
+            Sections());
+
+        var row = Assert.Single(view.Transitions!);
+        Assert.Equal("Adjacent", row.Span);
+        Assert.Equal("Added", row.Transition);
+        Assert.Equal("Sample.Widget", row.Target);
+    }
+
+    [Fact]
+    public void MemberTimeline_PreservesMetadataFacetChanges()
+    {
+        var vector = Vector("1.0.0", "1.0.1");
+        var oldSurface = Surface(Type("Widget", members: [Method("Run", "void Run()")]));
+        var newSurface = Surface(Type("Widget", members:
+        [
+            Method("Run", "void Run()", accessibility: "protected"),
+        ]));
+
+        var view = TimelineCommand.BuildView(
+            vector,
+            "Sample.Widget",
+            "api.member",
+            [
+                Evaluation(vector, 0, oldSurface),
+                Evaluation(vector, 1, newSurface),
+            ],
+            Sections());
+
+        var row = Assert.Single(view.Transitions!);
+        Assert.Equal("Changed", row.Transition);
+        Assert.Contains("accessibility: public -> protected", row.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AttributeTimeline_ReportsExactAppliedOccurrenceTransitions()
+    {
+        var vector = Vector("1.0.0", "1.0.1");
+        var oldSurface = Surface(Type("Widget", attributes: ["System.Obsolete(\"old\")"]));
+        var newSurface = Surface(Type("Widget", attributes: ["System.Obsolete(\"new\")"]));
+
+        var view = TimelineCommand.BuildView(
+            vector,
+            "Sample.Widget",
+            "api.attribute",
+            [
+                Evaluation(vector, 0, oldSurface),
+                Evaluation(vector, 1, newSurface),
+            ],
+            Sections());
+
+        var changed = Assert.Single(view.Transitions!);
+        Assert.Equal("Changed", changed.Transition);
+        Assert.Equal("System.Obsolete(\"new\")", changed.Target);
+        Assert.Contains("System.Obsolete(\"old\") -> System.Obsolete(\"new\")", changed.Detail);
+    }
+
+    [Fact]
+    public void TypePresenceEvaluation_DistinguishesMissingFromSubjectAbsent()
+    {
+        var vector = Vector("1.0.0");
+
+        var view = TimelineCommand.BuildView(
+            vector,
+            "Sample.Widget",
+            "api.type",
+            [Evaluation(vector, 0, Surface(Type("Other")))],
+            Sections());
+
+        var evaluation = Assert.Single(view.Evaluations!);
+        Assert.Equal("Missing", evaluation.State);
+        Assert.Equal(0, evaluation.Findings);
+    }
+
+    [Fact]
+    public void Evaluations_PreserveSubjectAbsentAndFailure()
+    {
+        var vector = Vector("1.0.0", "1.0.1");
+
+        var view = TimelineCommand.BuildView(
+            vector,
+            "Sample.Widget",
+            "api.member",
+            [
+                Evaluation(vector, 0, Surface(Type("Other"))),
+                new TimelineCommand.TimelineEvaluation(
+                    vector.Addresses[1],
+                    null,
+                    "package unavailable"),
+            ],
+            Sections());
+
+        Assert.Equal("SubjectAbsent", view.Evaluations![0].State);
+        Assert.Equal("Failed", view.Evaluations[1].State);
+        Assert.Equal("package unavailable", view.Evaluations[1].Detail);
+        Assert.Equal("Failed", Assert.Single(view.Transitions!).Transition);
+    }
+
+    static TimelineCommand.TimelineEvaluation Evaluation(
+        PackageVersionVector vector,
+        int position,
+        ApiSurface surface)
+        => new(vector.Addresses[position], surface, null);
+
+    static PackageVersionVector Vector(params string[] versions)
+    {
+        Assert.True(
+            PackageVersionRange.TryParse(
+                $"Sample@{versions[0]}..{versions[^1]}",
+                out var range,
+                out var error),
+            error);
+        return PackageVersionVector.Create(range!, versions);
+    }
+
+    static HashSet<string> Sections()
+        => new(StringComparer.OrdinalIgnoreCase)
+        {
+            TimelineCommand.EvaluationsSection,
+            TimelineCommand.TransitionsSection,
+        };
+
+    static ApiSurface Surface(params ApiType[] types)
+        => new() { Types = [.. types] };
+
+    static ApiType Type(
+        string name,
+        List<ApiMember>? members = null,
+        List<string>? attributes = null)
+        => new()
+        {
+            Namespace = "Sample",
+            Name = name,
+            Kind = "class",
+            Members = members ?? [],
+            Attributes = attributes ?? [],
+        };
+
+    static ApiMember Method(
+        string name,
+        string signature,
+        string? accessibility = null)
+        => new()
+        {
+            Name = name,
+            Kind = "method",
+            Signature = signature,
+            Accessibility = accessibility,
+        };
+}

--- a/src/dotnet-inspect.Tests/TimelineCommandTests.cs
+++ b/src/dotnet-inspect.Tests/TimelineCommandTests.cs
@@ -21,7 +21,14 @@ public sealed class TimelineCommandTests
         Assert.Equal(3, view.Evaluations!.Count);
         Assert.All(view.Evaluations, row => Assert.Equal("Unevaluated", row.State));
         Assert.Empty(view.Transitions!);
-        Assert.Contains("--at #2", view.Recommendation, StringComparison.Ordinal);
+        Assert.Contains(
+            "dotnet-inspect timeline --package 'Sample@1.0.0..1.0.2'",
+            view.Recommendation,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "--type 'Sample.Widget' --finding 'api.member' --at '#2'",
+            view.Recommendation,
+            StringComparison.Ordinal);
     }
 
     [Fact]
@@ -187,6 +194,101 @@ public sealed class TimelineCommandTests
             });
     }
 
+    [Fact]
+    public void ProbeOrder_DoesNotChangeTimelineOrder()
+    {
+        var vector = Vector("1.0.0", "1.0.1", "1.0.2");
+        var first = Evaluation(vector, 0, Surface(Type("Widget")));
+        var middle = Evaluation(
+            vector,
+            1,
+            Surface(Type("Widget", members: [Method("Run", "void Run()")])));
+        var last = Evaluation(
+            vector,
+            2,
+            Surface(Type("Widget", members:
+            [
+                Method("Run", "void Run()"),
+                Method("Stop", "void Stop()"),
+            ])));
+
+        var forward = TimelineCommand.BuildView(
+            vector,
+            "Sample.Widget",
+            "api.member",
+            [first, last, middle],
+            Sections());
+        var reverse = TimelineCommand.BuildView(
+            vector,
+            "Sample.Widget",
+            "api.member",
+            [middle, first, last],
+            Sections());
+
+        Assert.Equal(forward.Evaluations, reverse.Evaluations);
+        Assert.Equal(forward.Transitions, reverse.Transitions);
+        Assert.Equal(forward.Recommendation, reverse.Recommendation);
+    }
+
+    [Fact]
+    public async Task CellException_BecomesFailureAndLaterCellsStillEvaluate()
+    {
+        var vector = Vector("1.0.0", "1.0.1", "1.0.2");
+
+        var evaluations = await TimelineCommand.EvaluateCellsAsync(
+            vector.Addresses,
+            address => address.Position == 1
+                ? Task.FromException<(ApiSurface?, string?)>(
+                    new InvalidOperationException("package exploded"))
+                : Task.FromResult<(ApiSurface?, string?)>((
+                    Surface(Type("Widget")),
+                    null)));
+
+        Assert.Equal(3, evaluations.Count);
+        Assert.Null(evaluations[0].Error);
+        Assert.Equal(
+            "InvalidOperationException: package exploded",
+            evaluations[1].Error);
+        Assert.Null(evaluations[2].Error);
+
+        var view = TimelineCommand.BuildView(
+            vector,
+            "Sample.Widget",
+            "api.member",
+            evaluations,
+            Sections());
+        Assert.Equal("Failed", view.Evaluations![1].State);
+        Assert.Equal("Complete", view.Evaluations[2].State);
+        Assert.Collection(
+            view.Transitions!,
+            row => Assert.Equal("Failed", row.Transition),
+            row => Assert.Equal("Failed", row.Transition));
+    }
+
+    [Fact]
+    public void ExactFullTypeName_TakesPrecedenceOverSuffixMatch()
+    {
+        var vector = Vector("1.0.0");
+        var evaluations = new[]
+        {
+            Evaluation(
+                vector,
+                0,
+                Surface(
+                    Type("Widget", @namespace: "Other.Sample"),
+                    Type("Widget"))),
+        };
+
+        bool resolved = TimelineCommand.TryResolveTypeName(
+            "Sample.Widget",
+            evaluations,
+            out var typeFullName,
+            out var error);
+
+        Assert.True(resolved, error);
+        Assert.Equal("Sample.Widget", typeFullName);
+    }
+
     static TimelineCommand.TimelineEvaluation Evaluation(
         PackageVersionVector vector,
         int position,
@@ -217,10 +319,11 @@ public sealed class TimelineCommandTests
     static ApiType Type(
         string name,
         List<ApiMember>? members = null,
-        List<string>? attributes = null)
+        List<string>? attributes = null,
+        string @namespace = "Sample")
         => new()
         {
-            Namespace = "Sample",
+            Namespace = @namespace,
             Name = name,
             Kind = "class",
             Members = members ?? [],

--- a/src/dotnet-inspect.Tests/TimelineCommandTests.cs
+++ b/src/dotnet-inspect.Tests/TimelineCommandTests.cs
@@ -157,6 +157,36 @@ public sealed class TimelineCommandTests
         Assert.Equal("Failed", Assert.Single(view.Transitions!).Transition);
     }
 
+    [Fact]
+    public void EmptyOwnedCensus_PreservesSubjectAvailabilityTransitions()
+    {
+        var vector = Vector("1.0.0", "1.0.1", "1.0.2");
+
+        var view = TimelineCommand.BuildView(
+            vector,
+            "Sample.Widget",
+            "api.member",
+            [
+                Evaluation(vector, 0, Surface()),
+                Evaluation(vector, 1, Surface(Type("Widget"))),
+                Evaluation(vector, 2, Surface()),
+            ],
+            Sections());
+
+        Assert.Collection(
+            view.Transitions!,
+            row =>
+            {
+                Assert.Equal("SubjectAvailable", row.Transition);
+                Assert.Equal("Adjacent", row.Span);
+            },
+            row =>
+            {
+                Assert.Equal("SubjectUnavailable", row.Transition);
+                Assert.Equal("Adjacent", row.Span);
+            });
+    }
+
     static TimelineCommand.TimelineEvaluation Evaluation(
         PackageVersionVector vector,
         int position,

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -4,6 +4,7 @@ using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Sections;
 using DotnetInspector.Services;
+using ILInspector.Metadata;
 
 namespace DotnetInspector.CommandLine;
 
@@ -12,6 +13,141 @@ namespace DotnetInspector.CommandLine;
 /// </summary>
 public static class InspectionCommandDefinitions
 {
+    public static Command CreateTimelineCommand(SharedOptions opts)
+    {
+        var command = new Command(
+            TimelineCommand.Name,
+            "Correlate type, member, or applied-attribute Findings across a package version range");
+        var argsArgument = new Argument<string[]>("args")
+        {
+            Description = "Package@A..B and type focus when --package/--type are omitted",
+            Arity = ArgumentArity.ZeroOrMore,
+        };
+        var packageOption = new Option<string?>("--package")
+        {
+            Description = "Package version range (e.g., System.Text.Json@8.0.0..10.0.0)",
+        };
+        var typeOption = new Option<string?>("--type")
+        {
+            Description = "Type focus (full name or unique short name)",
+        };
+        typeOption.Aliases.Add("-t");
+        var findingOption = new Option<string?>("--finding")
+        {
+            Description = "Observation census: api.type, api.member, or api.attribute",
+        };
+        var atOption = new Option<string[]>("--at")
+        {
+            Description = "Evaluate an exact version, #N, first, last, or all; repeat for sparse probes",
+            AllowMultipleArgumentsPerToken = false,
+        };
+        var membersOption = new Option<bool>("--members")
+        {
+            Description = "Alias for --finding api.member",
+        };
+        var typePresenceOption = new Option<bool>("--type-presence")
+        {
+            Description = "Alias for --finding api.type",
+        };
+        var attributesOption = new Option<bool>("--attributes")
+        {
+            Description = "Alias for --finding api.attribute",
+        };
+        var tfmOption = new Option<string?>("--tfm")
+        {
+            Description = "Target framework (e.g., net8.0)",
+        };
+        var allOption = new Option<bool>("--all")
+        {
+            Description = "Include non-public, hidden, and obsolete API",
+        };
+        var prereleaseOption = new Option<bool>("--preview")
+        {
+            Description = "Include prerelease versions inside the range",
+        };
+        prereleaseOption.Aliases.Add("--prerelease");
+
+        command.Arguments.Add(argsArgument);
+        command.Options.Add(packageOption);
+        command.Options.Add(typeOption);
+        command.Options.Add(findingOption);
+        command.Options.Add(atOption);
+        command.Options.Add(membersOption);
+        command.Options.Add(typePresenceOption);
+        command.Options.Add(attributesOption);
+        command.Options.Add(tfmOption);
+        command.Options.Add(allOption);
+        command.Options.Add(prereleaseOption);
+        opts.AddTableOptionsTo(command);
+        opts.AddJsonOptionTo(command);
+        command.Options.Add(opts.Markdown);
+        opts.AddOutputOptionsTo(command);
+        command.Options.Add(opts.Select);
+        command.Options.Add(opts.Columns);
+        command.Options.Add(opts.Fields);
+        opts.AddCountOptionTo(command);
+        opts.AddNuGetOptionsTo(command);
+
+        command.SetAction(async (parseResult, ct) =>
+        {
+            string[] positional = parseResult.GetValue(argsArgument) ?? [];
+            string? package = parseResult.GetValue(packageOption);
+            string? type = parseResult.GetValue(typeOption);
+            int positionalIndex = 0;
+            if (package is null && positionalIndex < positional.Length)
+                package = positional[positionalIndex++];
+            if (type is null && positionalIndex < positional.Length)
+                type = positional[positionalIndex++];
+            if (positionalIndex < positional.Length)
+            {
+                Console.Error.WriteLine("Error: too many positional arguments.");
+                return 1;
+            }
+
+            var aliases = new List<string>();
+            if (parseResult.GetValue(membersOption))
+                aliases.Add(MetadataFindings.MemberDescriptor.Id);
+            if (parseResult.GetValue(typePresenceOption))
+                aliases.Add(MetadataFindings.TypeDescriptor.Id);
+            if (parseResult.GetValue(attributesOption))
+                aliases.Add(MetadataFindings.AttributeDescriptor.Id);
+            string? explicitFinding = parseResult.GetValue(findingOption);
+            if (aliases.Count > 1 || (aliases.Count == 1 && explicitFinding is not null))
+            {
+                Console.Error.WriteLine(
+                    "Error: specify only one of --finding, --members, --type-presence, or --attributes.");
+                return 1;
+            }
+
+            return await TimelineCommand.ExecuteAsync(new TimelineOptions
+            {
+                PackageVersionRange = package ?? "",
+                TypeName = type ?? "",
+                Finding = aliases.Count == 1
+                    ? aliases[0]
+                    : explicitFinding ?? MetadataFindings.MemberDescriptor.Id,
+                At = parseResult.GetValue(atOption) ?? [],
+                Tfm = parseResult.GetValue(tfmOption),
+                IncludeAll = parseResult.GetValue(allOption),
+                IncludePrerelease = parseResult.GetValue(prereleaseOption),
+                Verbose = parseResult.GetValue(opts.Verbose),
+                JsonOutput = opts.ResolveFormat(parseResult) == OutputFormat.Json,
+                OneLine = opts.ResolveOneLine(parseResult),
+                Tsv = opts.ResolveTsv(parseResult),
+                Jsonl = opts.ResolveJsonl(parseResult),
+                NoHeader = parseResult.GetValue(opts.NoHeaders),
+                Count = parseResult.GetValue(opts.Count),
+                Rows = opts.ParseRows(parseResult),
+                Select = opts.ParseSelect(parseResult),
+                Columns = opts.ParseColumns(parseResult),
+                Fields = opts.ParseFields(parseResult),
+                SourceOptions = opts.ParseNuGetSourceOptions(parseResult),
+            });
+        });
+
+        return command;
+    }
+
     public static Command CreateDiffCommand(SharedOptions opts)
     {
         var diffCommand = new Command(
@@ -59,7 +195,7 @@ public static class InspectionCommandDefinitions
         var additiveOption = new Option<bool>("--additive") { Description = "Show only additive changes" };
         var changedOption = new Option<bool>("--changed") { Description = "Analysis Diff only: show only in-place changes to members present in both versions (drop added/removed members)" };
         var allocRegressionsOption = new Option<bool>("--alloc-regressions") { Description = "Analysis Diff focus: show only allocation increases on members present in both versions (the file-able set), in-loop (hot) ones first" };
-        var findingOption = new Option<string?>("--finding") { Description = "Finding Transitions producer: api.type, api.member, or analysis.allocation" };
+        var findingOption = new Option<string?>("--finding") { Description = "Finding Transitions producer: api.type, api.member, api.attribute, analysis.allocation, or analysis.call-site" };
         var legendOption = new Option<bool>("--legend") { Description = "Show legend explaining change symbols" };
 
         diffCommand.Arguments.Add(argsArg);

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -83,6 +83,7 @@ public static class RouterCommandDefinition
         TypeCommand.Name,
         MemberCommand.Name,
         DiffCommand.Name,
+        TimelineCommand.Name,
         FindCommand.Name,
         "extensions",
         "implements",

--- a/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
+++ b/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
@@ -25,7 +25,7 @@ public static class ArgumentPreprocessor
     public static readonly HashSet<string> KnownCommands = new(StringComparer.OrdinalIgnoreCase)
     {
         "audit", // removed command, reserved so it is not treated as an implicit package target
-        "package", "project", "library", "api", "type", "member", "diff", "find", "source", "list", "ls", "skill", "extensions", "implements", "depends", "cache", "help", "--help", "-h", "-?", "--version", "--flavor"
+        "package", "project", "library", "api", "type", "member", "diff", "timeline", "find", "source", "list", "ls", "skill", "extensions", "implements", "depends", "cache", "help", "--help", "-h", "-?", "--version", "--flavor"
     };
 
     /// <summary>

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -84,6 +84,7 @@ public static class CommandLineBuilder
 
         // Diff command
         rootCommand.Subcommands.Add(InspectionCommandDefinitions.CreateDiffCommand(opts));
+        rootCommand.Subcommands.Add(InspectionCommandDefinitions.CreateTimelineCommand(opts));
 
         // Depends command
         rootCommand.Subcommands.Add(SearchCommandDefinitions.CreateDependsCommand(opts));

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -118,9 +118,19 @@ public class DiffCommand
                     return 1;
                 }
             }
-            else if (options.MemberFilter.Count == 0)
+            else if (findingDescriptor == MetadataFindings.AttributeDescriptor.Id)
             {
-                Console.Error.WriteLine("Error: --finding api.member requires --member.");
+                if (options.TypeFilter.Count == 0 || options.MemberFilter.Count > 0)
+                {
+                    Console.Error.WriteLine("Error: --finding api.attribute requires --type and cannot be combined with --member.");
+                    return 1;
+                }
+            }
+            else if (findingDescriptor == MetadataFindings.MemberDescriptor.Id
+                && options.TypeFilter.Count == 0
+                && options.MemberFilter.Count == 0)
+            {
+                Console.Error.WriteLine("Error: --finding api.member requires --type or --member.");
                 return 1;
             }
             if (options.Breaking || options.Additive || options.ChangedOnly
@@ -301,19 +311,9 @@ public class DiffCommand
         }
     }
 
-    sealed record DiffEndpoint(
-        AssemblySet AssemblySet,
-        ApiSurface Surface) : IDisposable
-    {
-        public IReadOnlyList<string> Paths =>
-            AssemblySet.Assemblies.Select(static entry => entry.Path).ToList();
-
-        public void Dispose() => AssemblySet.Dispose();
-    }
-
     sealed record DiffInputs(
-        DiffEndpoint From,
-        DiffEndpoint To,
+        ApiSurfaceEndpoint From,
+        ApiSurfaceEndpoint To,
         string FromVersion,
         string ToVersion,
         string Name) : IDisposable
@@ -355,7 +355,7 @@ public class DiffCommand
             logger);
         if (from.error is not null)
             return (null, $"Error resolving v{fromVersion}: {from.error}");
-        (DiffEndpoint? endpoint, string? error, bool assembliesResolved) to;
+        (ApiSurfaceEndpoint? endpoint, string? error, bool assembliesResolved) to;
         try
         {
             to = await ResolveDiffEndpointAsync(
@@ -413,7 +413,7 @@ public class DiffCommand
                 ? "Error: Failed to extract API surface from one or both versions."
                 : $"Error resolving v{fromVersion}: {AsEndpointError(from.error)}");
 
-        (DiffEndpoint? endpoint, string? error, bool assembliesResolved) to;
+        (ApiSurfaceEndpoint? endpoint, string? error, bool assembliesResolved) to;
         try
         {
             to = await ResolveDiffEndpointAsync(
@@ -467,7 +467,7 @@ public class DiffCommand
                 ? "Error: Failed to extract API surface from one or both libraries."
                 : $"Error: File not found: {fromPath}");
 
-        (DiffEndpoint? endpoint, string? error, bool assembliesResolved) to;
+        (ApiSurfaceEndpoint? endpoint, string? error, bool assembliesResolved) to;
         try
         {
             to = await ResolveDiffEndpointAsync(
@@ -499,42 +499,16 @@ public class DiffCommand
             Path.GetFileName(fromPath), Path.GetFileName(toPath), name), null);
     }
 
-    private static async Task<(DiffEndpoint? endpoint, string? error, bool assembliesResolved)> ResolveDiffEndpointAsync(
+    private static Task<(ApiSurfaceEndpoint? endpoint, string? error, bool assembliesResolved)> ResolveDiffEndpointAsync(
         HttpClient httpClient,
         AssemblySetRequest request,
         bool includeAll,
         VerboseLogger logger)
-    {
-        var assemblySet = await AssemblySetResolver
-            .CollectAsync(httpClient, request, logger.Log)
-            .ConfigureAwait(false);
-        try
-        {
-            if (assemblySet.Assemblies.Count == 0)
-            {
-                var error = assemblySet.Diagnostics.Count > 0
-                    ? string.Join("; ", assemblySet.Diagnostics.Select(static diagnostic => diagnostic.Message))
-                    : "No assemblies were resolved.";
-                assemblySet.Dispose();
-                return (null, error, false);
-            }
-
-            AssemblySetDiagnosticWriter.Write(assemblySet);
-            var surface = AssemblySetSurfaceBuilder.Build(assemblySet, includeAll, logger.Log);
-            if (surface is null)
-            {
-                assemblySet.Dispose();
-                return (null, "Failed to extract API surface.", true);
-            }
-
-            return (new DiffEndpoint(assemblySet, surface), null, true);
-        }
-        catch
-        {
-            assemblySet.Dispose();
-            throw;
-        }
-    }
+        => ApiSurfaceEndpointResolver.ResolveAsync(
+            httpClient,
+            request,
+            includeAll,
+            logger);
 
     internal static string AsEndpointError(string error)
     {
@@ -581,6 +555,12 @@ public class DiffCommand
             error = null;
             return true;
         }
+        if (string.Equals(descriptor, MetadataFindings.AttributeDescriptor.Id, StringComparison.OrdinalIgnoreCase))
+        {
+            descriptor = MetadataFindings.AttributeDescriptor.Id;
+            error = null;
+            return true;
+        }
         if (string.Equals(descriptor, AnalysisFindings.AllocationDescriptor.Id, StringComparison.OrdinalIgnoreCase))
         {
             descriptor = AnalysisFindings.AllocationDescriptor.Id;
@@ -600,7 +580,7 @@ public class DiffCommand
             return true;
         }
 
-        error = $"Unsupported Finding descriptor '{descriptor}'. Supported descriptors: api.type, api.member, analysis.allocation, analysis.call-site, analysis.unsafety.";
+        error = $"Unsupported Finding descriptor '{descriptor}'. Supported descriptors: api.type, api.member, api.attribute, analysis.allocation, analysis.call-site, analysis.unsafety.";
         return false;
     }
 
@@ -1015,7 +995,8 @@ public class DiffCommand
         var subject = new FindingSubject("api", "API surface");
         var diffOptions = new ApiDiffOptions(
             options.IncludeAll ? ApiDiffScope.All : ApiDiffScope.Signature);
-        if (options.MemberFilter.Count == 0)
+        string descriptor = ResolveFindingDescriptor(options);
+        if (descriptor == MetadataFindings.TypeDescriptor.Id)
         {
             var typeComparison = MetadataFindings.CompareApiTypes(
                 fromSurface,
@@ -1030,16 +1011,40 @@ public class DiffCommand
                 .ToList();
         }
 
-        var targets = ResolveMemberTargetIdentities(
-            fromSurface,
-            toSurface,
-            options.MemberFilter,
-            options.TypeFilter);
+        if (descriptor == MetadataFindings.AttributeDescriptor.Id)
+        {
+            var typeNames = ResolveFindingTypeNames(fromSurface, toSurface, options.TypeFilter);
+            return typeNames
+                .SelectMany(typeName => CompletePairs(MetadataFindings.CompareApiAttributes(
+                    fromSurface,
+                    toSurface,
+                    subject,
+                    typeName)))
+                .Select(pair => ToAttributeTransitionRow(pair, fromVersion, toVersion))
+                .OrderBy(row => row.Target, StringComparer.Ordinal)
+                .ToList();
+        }
+
         var memberComparison = MetadataFindings.CompareApiMembers(
             fromSurface,
             toSurface,
             subject,
             diffOptions);
+        if (options.MemberFilter.Count == 0)
+        {
+            return CompletePairs(memberComparison)
+                .Where(pair => options.TypeFilter.Any(filter =>
+                    MatchesDiffTypeFilter(MemberTypeTarget(pair), filter)))
+                .Select(pair => ToMemberTransitionRow(pair, fromVersion, toVersion))
+                .OrderBy(row => row.Target, StringComparer.Ordinal)
+                .ToList();
+        }
+
+        var targets = ResolveMemberTargetIdentities(
+            fromSurface,
+            toSurface,
+            options.MemberFilter,
+            options.TypeFilter);
         return CompletePairs(memberComparison)
             .Where(pair => MatchesMemberPair(pair, targets))
             .Select(pair => ToMemberTransitionRow(pair, fromVersion, toVersion))
@@ -1203,6 +1208,20 @@ public class DiffCommand
             NewSide(pair) is null ? "absent" : "present",
             pair.Detail);
 
+    static FindingTransitionRow ToAttributeTransitionRow(
+        PairFinding<ApiAttributeHandle> pair,
+        string fromVersion,
+        string toVersion)
+        => new(
+            $"PairFinding.{pair.Kind}",
+            pair.Descriptor.Id,
+            AttributeTarget(pair),
+            fromVersion,
+            toVersion,
+            OldSide(pair) is null ? "absent" : "present",
+            NewSide(pair) is null ? "absent" : "present",
+            pair.Detail);
+
     static FindingTransitionRow ToAllocationTransitionRow(
         ResearchSubjectKey subject,
         PairFinding<AllocationOccurrence> pair,
@@ -1311,6 +1330,15 @@ public class DiffCommand
     {
         var handle = (NewSide(pair) ?? OldSide(pair))!.Payload;
         return $"{handle.TypeFullName}.{handle.StableSelector ?? handle.Identity}";
+    }
+
+    static string MemberTypeTarget(PairFinding<ApiMemberHandle> pair)
+        => (NewSide(pair) ?? OldSide(pair))!.Payload.TypeFullName;
+
+    static string AttributeTarget(PairFinding<ApiAttributeHandle> pair)
+    {
+        var handle = (NewSide(pair) ?? OldSide(pair))!.Payload;
+        return $"{handle.TypeFullName} [{handle.Attribute}]";
     }
 
     static Finding<T>? OldSide<T>(PairFinding<T> pair)
@@ -1576,6 +1604,22 @@ public class DiffCommand
         foreach (var type in surface.Types)
             if (TypeMatcher.MatchesTypeFilter(type.FullName, query))
                 yield return type;
+    }
+
+    static IReadOnlyList<string> ResolveFindingTypeNames(
+        ApiSurface fromSurface,
+        ApiSurface toSurface,
+        IReadOnlyCollection<string> typeFilters)
+    {
+        var names = typeFilters
+            .SelectMany(filter => FindTypes(fromSurface, filter)
+                .Concat(FindTypes(toSurface, filter))
+                .Select(type => type.FullName)
+                .DefaultIfEmpty(filter))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        return names;
     }
 
     static ApiType? FindExactType(ApiSurface surface, string fullName)

--- a/src/dotnet-inspect/Commands/TimelineCommand.cs
+++ b/src/dotnet-inspect/Commands/TimelineCommand.cs
@@ -74,12 +74,100 @@ public static class TimelineCommand
         string descriptor,
         IReadOnlyList<TimelineEvaluation> evaluated,
         HashSet<string> selectedSections)
+        => descriptor switch
+        {
+            var id when id == MetadataFindings.TypeDescriptor.Id =>
+                BuildView(
+                    vector,
+                    typeFullName,
+                    MetadataFindings.TypeDescriptor,
+                    evaluated,
+                    selectedSections,
+                    new FindingCorrelationKey(
+                        Subject(typeFullName),
+                        MetadataFindings.TypeDescriptor,
+                        new FindingKey(typeFullName)),
+                    surface => MetadataFindings.InspectApiType(
+                        surface,
+                        Subject(typeFullName),
+                        typeFullName),
+                    (oldSurface, newSurface) => MetadataFindings.CompareApiType(
+                        oldSurface,
+                        newSurface,
+                        Subject(typeFullName),
+                        typeFullName)),
+            var id when id == MetadataFindings.MemberDescriptor.Id =>
+                BuildView(
+                    vector,
+                    typeFullName,
+                    MetadataFindings.MemberDescriptor,
+                    evaluated,
+                    selectedSections,
+                    null,
+                    surface => MetadataFindings.InspectApiMembers(
+                        surface,
+                        Subject(typeFullName),
+                        typeFullName),
+                    (oldSurface, newSurface) => MetadataFindings.CompareApiMembers(
+                        oldSurface,
+                        newSurface,
+                        Subject(typeFullName),
+                        typeFullName)),
+            var id when id == MetadataFindings.AttributeDescriptor.Id =>
+                BuildView(
+                    vector,
+                    typeFullName,
+                    MetadataFindings.AttributeDescriptor,
+                    evaluated,
+                    selectedSections,
+                    null,
+                    surface => MetadataFindings.InspectApiAttributes(
+                        surface,
+                        Subject(typeFullName),
+                        typeFullName),
+                    (oldSurface, newSurface) => MetadataFindings.CompareApiAttributes(
+                        oldSurface,
+                        newSurface,
+                        Subject(typeFullName),
+                        typeFullName)),
+            _ => throw new InvalidOperationException(
+                $"Unsupported Finding descriptor '{descriptor}'."),
+        };
+
+    static TimelineDocumentView BuildView<T>(
+        PackageVersionVector vector,
+        string typeFullName,
+        FindingDescriptor descriptor,
+        IReadOnlyList<TimelineEvaluation> evaluated,
+        HashSet<string> selectedSections,
+        FindingCorrelationKey? identityKey,
+        Func<ApiSurface?, FindingInspection<T>> inspect,
+        Func<ApiSurface?, ApiSurface?, FindingComparison<T>> compare)
+        where T : notnull
     {
-        var evaluatedByPosition = evaluated.ToDictionary(item => item.Address.Position);
+        var correlation = FindingCensusCorrelation<T>.Create(
+            evaluated.Select(evaluation => new VersionedFindingInspection<T>(
+                new FindingVersion(
+                    evaluation.Address.Selector,
+                    evaluation.Address.Version.ToNormalizedString(),
+                    evaluation.Address.Position),
+                evaluation.Error is null
+                    ? inspect(evaluation.Surface)
+                    : new FindingInspection<T>.Failed(
+                        new InspectionError(
+                            Subject(typeFullName),
+                            descriptor,
+                            evaluation.Error)))));
+        var inspectionsByPosition = correlation.Inspections.ToDictionary(
+            item => item.Version.Position);
+        var identityByPosition = identityKey is null
+            ? null
+            : correlation.Correlate(identityKey).Timeline.ToDictionary(
+                item => GetVersion(item).Position);
         List<TimelineEvaluationRow>? evaluationRows = selectedSections.Contains(EvaluationsSection)
             ? vector.Addresses.Select(address =>
             {
-                if (!evaluatedByPosition.TryGetValue(address.Position, out var evaluation))
+                if (!inspectionsByPosition.TryGetValue(address.Position, out var evaluation))
                 {
                     return new TimelineEvaluationRow(
                         address.Selector,
@@ -89,12 +177,19 @@ public static class TimelineCommand
                         null);
                 }
 
-                return BuildEvaluationRow(evaluation, descriptor, typeFullName);
+                return identityByPosition is null
+                    ? BuildCensusEvaluationRow(evaluation)
+                    : BuildIdentityEvaluationRow(identityByPosition[address.Position]);
             }).ToList()
             : null;
 
         List<TimelineTransitionRow>? transitionRows = selectedSections.Contains(TransitionsSection)
-            ? BuildTransitionRows(evaluated, descriptor, typeFullName)
+            ? BuildTransitionRows(
+                correlation,
+                evaluated,
+                descriptor.Id,
+                typeFullName,
+                compare)
             : null;
 
         return new TimelineDocumentView
@@ -102,106 +197,158 @@ public static class TimelineCommand
             Title = $"Timeline: {vector.PackageId}",
             Range = $"{vector.Start.ToNormalizedString()}..{vector.End.ToNormalizedString()}",
             Type = typeFullName,
-            Finding = descriptor,
-            Recommendation = RecommendProbe(vector, evaluated),
+            Finding = descriptor.Id,
+            Recommendation = RecommendProbe(vector, typeFullName, descriptor.Id, evaluated),
             Evaluations = evaluationRows,
             Transitions = transitionRows,
         };
     }
 
-    static TimelineEvaluationRow BuildEvaluationRow(
-        TimelineEvaluation evaluation,
-        string descriptor,
-        string typeFullName)
-    {
-        if (evaluation.Error is not null)
+    static TimelineEvaluationRow BuildCensusEvaluationRow<T>(
+        VersionedFindingInspection<T> evaluation)
+        where T : notnull
+        => evaluation.Inspection switch
         {
-            return new TimelineEvaluationRow(
-                evaluation.Address.Selector,
-                evaluation.Address.Version.ToNormalizedString(),
-                "Failed",
-                null,
-                evaluation.Error);
-        }
-
-        var inspection = Inspect(evaluation.Surface, descriptor, typeFullName);
-        return inspection switch
-        {
-            InspectionProjection.Complete complete => new TimelineEvaluationRow(
-                evaluation.Address.Selector,
-                evaluation.Address.Version.ToNormalizedString(),
-                descriptor == MetadataFindings.TypeDescriptor.Id
-                    ? complete.Count == 0 ? "Missing" : "Present"
-                    : "Complete",
-                complete.Count,
+            FindingInspection<T>.Complete complete => new TimelineEvaluationRow(
+                evaluation.Version.Key,
+                evaluation.Version.Display,
+                "Complete",
+                complete.Findings.Length,
                 null),
-            InspectionProjection.Absent absent => new TimelineEvaluationRow(
-                evaluation.Address.Selector,
-                evaluation.Address.Version.ToNormalizedString(),
+            FindingInspection<T>.Absent absent => new TimelineEvaluationRow(
+                evaluation.Version.Key,
+                evaluation.Version.Display,
                 "SubjectAbsent",
                 0,
                 absent.Detail),
-            InspectionProjection.Failed failed => new TimelineEvaluationRow(
-                evaluation.Address.Selector,
-                evaluation.Address.Version.ToNormalizedString(),
+            FindingInspection<T>.Failed failed => new TimelineEvaluationRow(
+                evaluation.Version.Key,
+                evaluation.Version.Display,
                 "Failed",
                 null,
-                failed.Error),
-            _ => throw new InvalidOperationException("Unknown inspection state."),
+                failed.Error.Reason),
         };
-    }
 
-    static List<TimelineTransitionRow> BuildTransitionRows(
+    static TimelineEvaluationRow BuildIdentityEvaluationRow<T>(
+        FindingCorrelationPoint<T> point)
+        where T : notnull
+        => point.Value switch
+        {
+            FindingCorrelationPoint<T>.Present present => new TimelineEvaluationRow(
+                present.Version.Key,
+                present.Version.Display,
+                "Present",
+                1,
+                null),
+            FindingCorrelationPoint<T>.Missing missing => new TimelineEvaluationRow(
+                missing.Version.Key,
+                missing.Version.Display,
+                "Missing",
+                0,
+                null),
+            FindingCorrelationPoint<T>.SubjectAbsent absent => new TimelineEvaluationRow(
+                absent.Version.Key,
+                absent.Version.Display,
+                "SubjectAbsent",
+                0,
+                absent.Detail),
+            FindingCorrelationPoint<T>.Failed failed => new TimelineEvaluationRow(
+                failed.Version.Key,
+                failed.Version.Display,
+                "Failed",
+                null,
+                failed.Error.Reason),
+            _ => throw new InvalidOperationException(
+                "Finding correlation returned an unknown point."),
+        };
+
+    static FindingVersion GetVersion<T>(FindingCorrelationPoint<T> point)
+        where T : notnull
+        => point.Value switch
+        {
+            FindingCorrelationPoint<T>.Present present => present.Version,
+            FindingCorrelationPoint<T>.Missing missing => missing.Version,
+            FindingCorrelationPoint<T>.SubjectAbsent absent => absent.Version,
+            FindingCorrelationPoint<T>.Failed failed => failed.Version,
+            _ => throw new InvalidOperationException(
+                "Finding correlation returned an unknown point."),
+        };
+
+    static List<TimelineTransitionRow> BuildTransitionRows<T>(
+        FindingCensusCorrelation<T> correlation,
         IReadOnlyList<TimelineEvaluation> evaluations,
         string descriptor,
-        string typeFullName)
+        string typeFullName,
+        Func<ApiSurface?, ApiSurface?, FindingComparison<T>> compare)
+        where T : notnull
     {
-        var ordered = evaluations.OrderBy(item => item.Address.Position).ToArray();
+        var ordered = correlation.Inspections;
+        var evaluationsByPosition = evaluations.ToDictionary(item => item.Address.Position);
         List<TimelineTransitionRow> rows = [];
         for (int i = 1; i < ordered.Length; i++)
         {
-            var oldEvaluation = ordered[i - 1];
-            var newEvaluation = ordered[i];
-            bool exact = newEvaluation.Address.Position - oldEvaluation.Address.Position == 1;
+            var oldInspection = ordered[i - 1];
+            var newInspection = ordered[i];
+            bool exact = newInspection.Version.Position - oldInspection.Version.Position == 1;
             string span = exact
                 ? "Adjacent"
-                : $"Gap ({newEvaluation.Address.Position - oldEvaluation.Address.Position - 1})";
+                : $"Gap ({newInspection.Version.Position - oldInspection.Version.Position - 1})";
 
-            if (oldEvaluation.Error is not null || newEvaluation.Error is not null)
+            FindingComparison<T> comparison;
+            if (oldInspection.Inspection is FindingInspection<T>.Failed
+                || newInspection.Inspection is FindingInspection<T>.Failed)
+            {
+                comparison = correlation.Compare(
+                    oldInspection.Version.Key,
+                    newInspection.Version.Key);
+            }
+            else
+            {
+                if (!evaluationsByPosition.TryGetValue(
+                        oldInspection.Version.Position,
+                        out var oldEvaluation)
+                    || !evaluationsByPosition.TryGetValue(
+                        newInspection.Version.Position,
+                        out var newEvaluation))
+                {
+                    throw new InvalidOperationException(
+                        $"Timeline correlation lost an evaluated cell for {descriptor} "
+                        + $"{oldInspection.Version.Key}..{newInspection.Version.Key}.");
+                }
+
+                comparison = compare(oldEvaluation.Surface, newEvaluation.Surface);
+            }
+
+            if (comparison.OldInspection != oldInspection.Inspection
+                || comparison.NewInspection != newInspection.Inspection)
+            {
+                throw new InvalidOperationException(
+                    $"Producer comparison for {descriptor} returned inspections that differ "
+                    + $"from the correlated censuses at "
+                    + $"{oldInspection.Version.Key}..{newInspection.Version.Key}.");
+            }
+
+            if (comparison.Value is FindingComparison<T>.Failed failure)
             {
                 rows.Add(new TimelineTransitionRow(
-                    oldEvaluation.Address.Selector,
-                    newEvaluation.Address.Selector,
+                    oldInspection.Version.Key,
+                    newInspection.Version.Key,
                     span,
                     "Failed",
                     descriptor,
                     typeFullName,
-                    oldEvaluation.Error ?? newEvaluation.Error));
+                    failure.Failure));
                 continue;
             }
 
-            var oldInspection = Inspect(oldEvaluation.Surface, descriptor, typeFullName);
-            var newInspection = Inspect(newEvaluation.Surface, descriptor, typeFullName);
-            if (oldInspection is InspectionProjection.Failed
-                || newInspection is InspectionProjection.Failed)
+            var completeComparison = comparison.Value as FindingComparison<T>.Complete
+                ?? throw new InvalidOperationException(
+                    $"Producer comparison for {descriptor} returned an unknown outcome at "
+                    + $"{oldInspection.Version.Key}..{newInspection.Version.Key}.");
+            string? subjectTransition = (oldInspection.Inspection, newInspection.Inspection) switch
             {
-                var failure = oldInspection as InspectionProjection.Failed
-                    ?? (InspectionProjection.Failed)newInspection;
-                rows.Add(new TimelineTransitionRow(
-                    oldEvaluation.Address.Selector,
-                    newEvaluation.Address.Selector,
-                    span,
-                    "Failed",
-                    descriptor,
-                    typeFullName,
-                    failure.Error));
-                continue;
-            }
-
-            string? subjectTransition = (oldInspection, newInspection) switch
-            {
-                (InspectionProjection.Absent, InspectionProjection.Complete) => "SubjectAvailable",
-                (InspectionProjection.Complete, InspectionProjection.Absent) => "SubjectUnavailable",
+                (FindingInspection<T>.Absent, FindingInspection<T>.Complete) => "SubjectAvailable",
+                (FindingInspection<T>.Complete, FindingInspection<T>.Absent) => "SubjectUnavailable",
                 _ => null,
             };
             if (subjectTransition is not null)
@@ -210,8 +357,8 @@ public static class TimelineCommand
                     ? "The focused type became available to this census."
                     : "The focused type ceased to be available to this census.";
                 rows.Add(new TimelineTransitionRow(
-                    oldEvaluation.Address.Selector,
-                    newEvaluation.Address.Selector,
+                    oldInspection.Version.Key,
+                    newInspection.Version.Key,
                     span,
                     subjectTransition,
                     descriptor,
@@ -219,30 +366,15 @@ public static class TimelineCommand
                     exact ? detail : AppendGapQualification(detail)));
             }
 
-            var pairs = Compare(
-                oldEvaluation.Surface,
-                newEvaluation.Surface,
-                descriptor,
-                typeFullName);
-            if (pairs is null)
-            {
-                rows.Add(new TimelineTransitionRow(
-                    oldEvaluation.Address.Selector,
-                    newEvaluation.Address.Selector,
-                    span,
-                    "Failed",
-                    descriptor,
-                    typeFullName,
-                    "Finding comparison failed."));
-                continue;
-            }
-
-            var changes = pairs.Where(pair => pair.Kind != PairKind.Present).ToArray();
+            var changes = completeComparison.Pairs
+                .Where(pair => pair.Kind != PairKind.Present)
+                .Cast<IPairFinding>()
+                .ToArray();
             if (changes.Length == 0 && subjectTransition is null)
             {
                 rows.Add(new TimelineTransitionRow(
-                    oldEvaluation.Address.Selector,
-                    newEvaluation.Address.Selector,
+                    oldInspection.Version.Key,
+                    newInspection.Version.Key,
                     span,
                     "None",
                     descriptor,
@@ -252,8 +384,8 @@ public static class TimelineCommand
             }
 
             rows.AddRange(changes.Select(pair => new TimelineTransitionRow(
-                oldEvaluation.Address.Selector,
-                newEvaluation.Address.Selector,
+                oldInspection.Version.Key,
+                newInspection.Version.Key,
                 span,
                 pair.Kind.ToString(),
                 descriptor,
@@ -268,53 +400,6 @@ public static class TimelineCommand
         => string.IsNullOrEmpty(detail)
             ? "Observed across a gap; the exact transition version is unknown."
             : $"{detail}; observed across a gap; the exact transition version is unknown.";
-
-    static IReadOnlyList<IPairFinding>? Compare(
-        ApiSurface? oldSurface,
-        ApiSurface? newSurface,
-        string descriptor,
-        string typeFullName)
-        => descriptor switch
-        {
-            "api.type" => GetPairs(
-                MetadataFindings.CompareApiType(oldSurface, newSurface, Subject(typeFullName), typeFullName)),
-            "api.member" => GetPairs(
-                MetadataFindings.CompareApiMembers(oldSurface, newSurface, Subject(typeFullName), typeFullName)),
-            "api.attribute" => GetPairs(
-                MetadataFindings.CompareApiAttributes(oldSurface, newSurface, Subject(typeFullName), typeFullName)),
-            _ => throw new InvalidOperationException($"Unsupported Finding descriptor '{descriptor}'."),
-        };
-
-    static IReadOnlyList<IPairFinding>? GetPairs<T>(FindingComparison<T> comparison)
-        where T : notnull
-        => comparison.Value is FindingComparison<T>.Complete complete
-            ? complete.Pairs.Cast<IPairFinding>().ToArray()
-            : null;
-
-    static InspectionProjection Inspect(
-        ApiSurface? surface,
-        string descriptor,
-        string typeFullName)
-        => descriptor switch
-        {
-            "api.type" => Project(
-                MetadataFindings.InspectApiType(surface, Subject(typeFullName), typeFullName)),
-            "api.member" => Project(
-                MetadataFindings.InspectApiMembers(surface, Subject(typeFullName), typeFullName)),
-            "api.attribute" => Project(
-                MetadataFindings.InspectApiAttributes(surface, Subject(typeFullName), typeFullName)),
-            _ => throw new InvalidOperationException($"Unsupported Finding descriptor '{descriptor}'."),
-        };
-
-    static InspectionProjection Project<T>(FindingInspection<T> inspection)
-        where T : notnull
-        => inspection.Value switch
-        {
-            FindingInspection<T>.Complete complete => new InspectionProjection.Complete(complete.Findings.Length),
-            FindingInspection<T>.Absent absent => new InspectionProjection.Absent(absent.Detail),
-            FindingInspection<T>.Failed failed => new InspectionProjection.Failed(failed.Error.Reason),
-            _ => throw new InvalidOperationException("Unknown inspection state."),
-        };
 
     static FindingSubject Subject(string typeFullName)
         => new($"api.type:{typeFullName}", typeFullName);
@@ -336,9 +421,7 @@ public static class TimelineCommand
         string packageId,
         ImmutableArray<PackageVersionAddress> addresses,
         TimelineOptions options)
-    {
-        List<TimelineEvaluation> evaluations = [];
-        foreach (var address in addresses)
+        => await EvaluateCellsAsync(addresses, async address =>
         {
             context.Logger.Log($"Evaluating {packageId}@{address.Version.ToNormalizedString()} ({address.Selector})");
             var result = await ApiSurfaceEndpointResolver.ResolveAsync(
@@ -354,33 +437,68 @@ public static class TimelineCommand
                 options.IncludeAll,
                 context.Logger);
             if (result.Error is not null)
-            {
-                evaluations.Add(new TimelineEvaluation(address, null, result.Error));
-                continue;
-            }
+                return (null, result.Error);
 
             using var endpoint = result.Endpoint!;
-            evaluations.Add(new TimelineEvaluation(address, endpoint.Surface, null));
+            return (endpoint.Surface, null);
+        });
+
+    internal static async Task<List<TimelineEvaluation>> EvaluateCellsAsync(
+        ImmutableArray<PackageVersionAddress> addresses,
+        Func<PackageVersionAddress, Task<(ApiSurface? Surface, string? Error)>> evaluate)
+    {
+        ArgumentNullException.ThrowIfNull(evaluate);
+        List<TimelineEvaluation> evaluations = [];
+        foreach (var address in addresses)
+        {
+            try
+            {
+                var result = await evaluate(address);
+                evaluations.Add(new TimelineEvaluation(address, result.Surface, result.Error));
+            }
+            catch (Exception ex)
+            {
+                evaluations.Add(new TimelineEvaluation(
+                    address,
+                    null,
+                    $"{ex.GetType().Name}: {ex.Message}"));
+            }
         }
 
         return evaluations;
     }
 
-    static bool TryResolveTypeName(
+    internal static bool TryResolveTypeName(
         string requested,
         IReadOnlyList<TimelineEvaluation> evaluations,
         out string? typeFullName,
         out string? error)
     {
-        var matches = evaluations
+        var types = evaluations
             .Where(evaluation => evaluation.Surface is not null)
             .SelectMany(evaluation => evaluation.Surface!.Types)
+            .ToArray();
+        var exactMatches = types
+            .Where(type => string.Equals(
+                type.FullName,
+                requested,
+                StringComparison.OrdinalIgnoreCase))
+            .Select(type => type.FullName)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (exactMatches.Length == 1)
+        {
+            typeFullName = exactMatches[0];
+            error = null;
+            return true;
+        }
+
+        var matches = types
             .Where(type =>
-                string.Equals(type.FullName, requested, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(type.Name, requested, StringComparison.OrdinalIgnoreCase)
+                string.Equals(type.Name, requested, StringComparison.OrdinalIgnoreCase)
                 || type.FullName.EndsWith($".{requested}", StringComparison.OrdinalIgnoreCase))
             .Select(type => type.FullName)
-            .Distinct(StringComparer.Ordinal)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
         if (matches.Length > 1)
@@ -441,6 +559,8 @@ public static class TimelineCommand
 
     static string? RecommendProbe(
         PackageVersionVector vector,
+        string typeFullName,
+        string descriptor,
         IReadOnlyList<TimelineEvaluation> evaluations)
     {
         var evaluated = evaluations.Select(item => item.Address.Position).ToHashSet();
@@ -469,8 +589,16 @@ public static class TimelineCommand
 
         int probe = bestStart + ((bestLength - 1) / 2);
         var address = vector.Addresses[probe];
-        return $"Probe {address.Selector} ({address.Version.ToNormalizedString()}) with --at {address.Selector}.";
+        string range = $"{vector.PackageId}@{vector.Start.ToNormalizedString()}..{vector.End.ToNormalizedString()}";
+        return $"Probe {address.Selector} ({address.Version.ToNormalizedString()}): "
+            + $"dotnet-inspect timeline --package {ShellQuote(range)} "
+            + $"--type {ShellQuote(typeFullName)} "
+            + $"--finding {ShellQuote(descriptor)} "
+            + $"--at {ShellQuote(address.Selector)}";
     }
+
+    static string ShellQuote(string value)
+        => $"'{value.Replace("'", "'\"'\"'", StringComparison.Ordinal)}'";
 
     static bool TryValidate(
         TimelineOptions options,
@@ -629,13 +757,6 @@ public static class TimelineCommand
         PackageVersionAddress Address,
         ApiSurface? Surface,
         string? Error);
-
-    abstract record InspectionProjection
-    {
-        public sealed record Complete(int Count) : InspectionProjection;
-        public sealed record Absent(string? Detail) : InspectionProjection;
-        public sealed record Failed(string Error) : InspectionProjection;
-    }
 }
 
 public sealed record TimelineOptions

--- a/src/dotnet-inspect/Commands/TimelineCommand.cs
+++ b/src/dotnet-inspect/Commands/TimelineCommand.cs
@@ -1,0 +1,629 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DotnetInspector.Inspectors;
+using DotnetInspector.Output;
+using DotnetInspector.Packages;
+using DotnetInspector.Services;
+using DotnetInspector.Views;
+using ILInspector.Findings;
+using ILInspector.Metadata;
+using Markout;
+
+namespace DotnetInspector.Commands;
+
+public static class TimelineCommand
+{
+    public const string Name = "timeline";
+    public const string EvaluationsSection = "Evaluations";
+    public const string TransitionsSection = "Transitions";
+
+    public static async Task<int> ExecuteAsync(TimelineOptions options)
+    {
+        if (!TryValidate(options, out var range, out var descriptor, out var selectedSections, out var error))
+        {
+            Console.Error.WriteLine($"Error: {error}");
+            return 1;
+        }
+
+        var context = new CommandContext(options.Verbose);
+        try
+        {
+            var vector = await PackageVersionVector.ResolveAsync(
+                context.HttpClient,
+                range!,
+                options.SourceOptions,
+                context.Logger.Log,
+                options.IncludePrerelease);
+            if (!TrySelectAddresses(vector, options.At, out var selectedAddresses, out error))
+            {
+                Console.Error.WriteLine($"Error: {error}");
+                return 1;
+            }
+
+            var evaluations = await EvaluateAsync(
+                context,
+                vector.PackageId,
+                selectedAddresses,
+                options);
+            if (!TryResolveTypeName(options.TypeName, evaluations, out var typeFullName, out error))
+            {
+                Console.Error.WriteLine($"Error: {error}");
+                return 1;
+            }
+
+            var view = BuildView(
+                vector,
+                typeFullName!,
+                descriptor!,
+                evaluations,
+                selectedSections);
+            Write(view, options, selectedSections);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            return 1;
+        }
+    }
+
+    internal static TimelineDocumentView BuildView(
+        PackageVersionVector vector,
+        string typeFullName,
+        string descriptor,
+        IReadOnlyList<TimelineEvaluation> evaluated,
+        HashSet<string> selectedSections)
+    {
+        var evaluatedByPosition = evaluated.ToDictionary(item => item.Address.Position);
+        List<TimelineEvaluationRow>? evaluationRows = selectedSections.Contains(EvaluationsSection)
+            ? vector.Addresses.Select(address =>
+            {
+                if (!evaluatedByPosition.TryGetValue(address.Position, out var evaluation))
+                {
+                    return new TimelineEvaluationRow(
+                        address.Selector,
+                        address.Version.ToNormalizedString(),
+                        "Unevaluated",
+                        null,
+                        null);
+                }
+
+                return BuildEvaluationRow(evaluation, descriptor, typeFullName);
+            }).ToList()
+            : null;
+
+        List<TimelineTransitionRow>? transitionRows = selectedSections.Contains(TransitionsSection)
+            ? BuildTransitionRows(evaluated, descriptor, typeFullName)
+            : null;
+
+        return new TimelineDocumentView
+        {
+            Title = $"Timeline: {vector.PackageId}",
+            Range = $"{vector.Start.ToNormalizedString()}..{vector.End.ToNormalizedString()}",
+            Type = typeFullName,
+            Finding = descriptor,
+            Recommendation = RecommendProbe(vector, evaluated),
+            Evaluations = evaluationRows,
+            Transitions = transitionRows,
+        };
+    }
+
+    static TimelineEvaluationRow BuildEvaluationRow(
+        TimelineEvaluation evaluation,
+        string descriptor,
+        string typeFullName)
+    {
+        if (evaluation.Error is not null)
+        {
+            return new TimelineEvaluationRow(
+                evaluation.Address.Selector,
+                evaluation.Address.Version.ToNormalizedString(),
+                "Failed",
+                null,
+                evaluation.Error);
+        }
+
+        var inspection = Inspect(evaluation.Surface, descriptor, typeFullName);
+        return inspection switch
+        {
+            InspectionProjection.Complete complete => new TimelineEvaluationRow(
+                evaluation.Address.Selector,
+                evaluation.Address.Version.ToNormalizedString(),
+                descriptor == MetadataFindings.TypeDescriptor.Id
+                    ? complete.Count == 0 ? "Missing" : "Present"
+                    : "Complete",
+                complete.Count,
+                null),
+            InspectionProjection.Absent absent => new TimelineEvaluationRow(
+                evaluation.Address.Selector,
+                evaluation.Address.Version.ToNormalizedString(),
+                "SubjectAbsent",
+                0,
+                absent.Detail),
+            InspectionProjection.Failed failed => new TimelineEvaluationRow(
+                evaluation.Address.Selector,
+                evaluation.Address.Version.ToNormalizedString(),
+                "Failed",
+                null,
+                failed.Error),
+            _ => throw new InvalidOperationException("Unknown inspection state."),
+        };
+    }
+
+    static List<TimelineTransitionRow> BuildTransitionRows(
+        IReadOnlyList<TimelineEvaluation> evaluations,
+        string descriptor,
+        string typeFullName)
+    {
+        var ordered = evaluations.OrderBy(item => item.Address.Position).ToArray();
+        List<TimelineTransitionRow> rows = [];
+        for (int i = 1; i < ordered.Length; i++)
+        {
+            var oldEvaluation = ordered[i - 1];
+            var newEvaluation = ordered[i];
+            bool exact = newEvaluation.Address.Position - oldEvaluation.Address.Position == 1;
+            string span = exact
+                ? "Adjacent"
+                : $"Gap ({newEvaluation.Address.Position - oldEvaluation.Address.Position - 1})";
+
+            if (oldEvaluation.Error is not null || newEvaluation.Error is not null)
+            {
+                rows.Add(new TimelineTransitionRow(
+                    oldEvaluation.Address.Selector,
+                    newEvaluation.Address.Selector,
+                    span,
+                    "Failed",
+                    descriptor,
+                    typeFullName,
+                    oldEvaluation.Error ?? newEvaluation.Error));
+                continue;
+            }
+
+            var pairs = Compare(
+                oldEvaluation.Surface,
+                newEvaluation.Surface,
+                descriptor,
+                typeFullName);
+            if (pairs is null)
+            {
+                rows.Add(new TimelineTransitionRow(
+                    oldEvaluation.Address.Selector,
+                    newEvaluation.Address.Selector,
+                    span,
+                    "Failed",
+                    descriptor,
+                    typeFullName,
+                    "Finding comparison failed."));
+                continue;
+            }
+
+            var changes = pairs.Where(pair => pair.Kind != PairKind.Present).ToArray();
+            if (changes.Length == 0)
+            {
+                rows.Add(new TimelineTransitionRow(
+                    oldEvaluation.Address.Selector,
+                    newEvaluation.Address.Selector,
+                    span,
+                    "None",
+                    descriptor,
+                    typeFullName,
+                    exact ? null : "No change was observed across the evaluated gap."));
+                continue;
+            }
+
+            rows.AddRange(changes.Select(pair => new TimelineTransitionRow(
+                oldEvaluation.Address.Selector,
+                newEvaluation.Address.Selector,
+                span,
+                pair.Kind.ToString(),
+                descriptor,
+                GetTarget(pair),
+                exact ? pair.Detail : AppendGapQualification(pair.Detail))));
+        }
+
+        return rows;
+    }
+
+    static string? AppendGapQualification(string? detail)
+        => string.IsNullOrEmpty(detail)
+            ? "Observed across a gap; the exact transition version is unknown."
+            : $"{detail}; observed across a gap; the exact transition version is unknown.";
+
+    static IReadOnlyList<IPairFinding>? Compare(
+        ApiSurface? oldSurface,
+        ApiSurface? newSurface,
+        string descriptor,
+        string typeFullName)
+        => descriptor switch
+        {
+            "api.type" => GetPairs(
+                MetadataFindings.CompareApiType(oldSurface, newSurface, Subject(typeFullName), typeFullName)),
+            "api.member" => GetPairs(
+                MetadataFindings.CompareApiMembers(oldSurface, newSurface, Subject(typeFullName), typeFullName)),
+            "api.attribute" => GetPairs(
+                MetadataFindings.CompareApiAttributes(oldSurface, newSurface, Subject(typeFullName), typeFullName)),
+            _ => throw new InvalidOperationException($"Unsupported Finding descriptor '{descriptor}'."),
+        };
+
+    static IReadOnlyList<IPairFinding>? GetPairs<T>(FindingComparison<T> comparison)
+        where T : notnull
+        => comparison.Value is FindingComparison<T>.Complete complete
+            ? complete.Pairs.Cast<IPairFinding>().ToArray()
+            : null;
+
+    static InspectionProjection Inspect(
+        ApiSurface? surface,
+        string descriptor,
+        string typeFullName)
+        => descriptor switch
+        {
+            "api.type" => Project(
+                MetadataFindings.InspectApiType(surface, Subject(typeFullName), typeFullName)),
+            "api.member" => Project(
+                MetadataFindings.InspectApiMembers(surface, Subject(typeFullName), typeFullName)),
+            "api.attribute" => Project(
+                MetadataFindings.InspectApiAttributes(surface, Subject(typeFullName), typeFullName)),
+            _ => throw new InvalidOperationException($"Unsupported Finding descriptor '{descriptor}'."),
+        };
+
+    static InspectionProjection Project<T>(FindingInspection<T> inspection)
+        where T : notnull
+        => inspection.Value switch
+        {
+            FindingInspection<T>.Complete complete => new InspectionProjection.Complete(complete.Findings.Length),
+            FindingInspection<T>.Absent absent => new InspectionProjection.Absent(absent.Detail),
+            FindingInspection<T>.Failed failed => new InspectionProjection.Failed(failed.Error.Reason),
+            _ => throw new InvalidOperationException("Unknown inspection state."),
+        };
+
+    static FindingSubject Subject(string typeFullName)
+        => new($"api.type:{typeFullName}", typeFullName);
+
+    static string GetTarget(IPairFinding pair)
+    {
+        var finding = pair.New ?? pair.Old;
+        return finding switch
+        {
+            Finding<ApiTypeHandle> type => type.Payload.TypeFullName,
+            Finding<ApiMemberHandle> member => member.Payload.Identity,
+            Finding<ApiAttributeHandle> attribute => attribute.Payload.Attribute,
+            _ => pair.Subject.Display,
+        };
+    }
+
+    static async Task<List<TimelineEvaluation>> EvaluateAsync(
+        CommandContext context,
+        string packageId,
+        ImmutableArray<PackageVersionAddress> addresses,
+        TimelineOptions options)
+    {
+        List<TimelineEvaluation> evaluations = [];
+        foreach (var address in addresses)
+        {
+            context.Logger.Log($"Evaluating {packageId}@{address.Version.ToNormalizedString()} ({address.Selector})");
+            var result = await ApiSurfaceEndpointResolver.ResolveAsync(
+                context.HttpClient,
+                new AssemblySetRequest
+                {
+                    Packages = [$"{packageId}@{address.Version.ToNormalizedString()}"],
+                    Tfm = options.Tfm,
+                    SourceOptions = options.SourceOptions,
+                    TempDirPrefix = "inspect-timeline",
+                    IncludePackageRuntimeAssemblies = true,
+                },
+                options.IncludeAll,
+                context.Logger);
+            if (result.Error is not null)
+            {
+                evaluations.Add(new TimelineEvaluation(address, null, result.Error));
+                continue;
+            }
+
+            using var endpoint = result.Endpoint!;
+            evaluations.Add(new TimelineEvaluation(address, endpoint.Surface, null));
+        }
+
+        return evaluations;
+    }
+
+    static bool TryResolveTypeName(
+        string requested,
+        IReadOnlyList<TimelineEvaluation> evaluations,
+        out string? typeFullName,
+        out string? error)
+    {
+        var matches = evaluations
+            .Where(evaluation => evaluation.Surface is not null)
+            .SelectMany(evaluation => evaluation.Surface!.Types)
+            .Where(type =>
+                string.Equals(type.FullName, requested, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(type.Name, requested, StringComparison.OrdinalIgnoreCase)
+                || type.FullName.EndsWith($".{requested}", StringComparison.OrdinalIgnoreCase))
+            .Select(type => type.FullName)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        if (matches.Length > 1)
+        {
+            typeFullName = null;
+            error = $"Type selector '{requested}' is ambiguous: {string.Join(", ", matches)}.";
+            return false;
+        }
+
+        typeFullName = matches.Length == 1 ? matches[0] : requested;
+        error = null;
+        return true;
+    }
+
+    static bool TrySelectAddresses(
+        PackageVersionVector vector,
+        IReadOnlyList<string> selectors,
+        out ImmutableArray<PackageVersionAddress> addresses,
+        out string? error)
+    {
+        if (selectors.Count == 0)
+        {
+            addresses = [];
+            error = null;
+            return true;
+        }
+
+        if (selectors.Any(selector => selector.Equals("all", StringComparison.OrdinalIgnoreCase)))
+        {
+            if (selectors.Count != 1)
+            {
+                addresses = [];
+                error = "--at all cannot be combined with another --at selector.";
+                return false;
+            }
+
+            addresses = vector.Addresses;
+            error = null;
+            return true;
+        }
+
+        var selected = new Dictionary<int, PackageVersionAddress>();
+        foreach (string selector in selectors)
+        {
+            if (!vector.TrySelect(selector, out var address, out error))
+            {
+                addresses = [];
+                return false;
+            }
+
+            selected[address!.Position] = address;
+        }
+
+        addresses = [.. selected.Values.OrderBy(address => address.Position)];
+        error = null;
+        return true;
+    }
+
+    static string? RecommendProbe(
+        PackageVersionVector vector,
+        IReadOnlyList<TimelineEvaluation> evaluations)
+    {
+        var evaluated = evaluations.Select(item => item.Address.Position).ToHashSet();
+        if (evaluated.Count == vector.Addresses.Length)
+            return null;
+
+        int bestStart = -1;
+        int bestLength = 0;
+        int start = -1;
+        for (int position = 0; position <= vector.Addresses.Length; position++)
+        {
+            bool unevaluated = position < vector.Addresses.Length && !evaluated.Contains(position);
+            if (unevaluated && start < 0)
+                start = position;
+            if (!unevaluated && start >= 0)
+            {
+                int length = position - start;
+                if (length > bestLength)
+                {
+                    bestStart = start;
+                    bestLength = length;
+                }
+                start = -1;
+            }
+        }
+
+        int probe = bestStart + ((bestLength - 1) / 2);
+        var address = vector.Addresses[probe];
+        return $"Probe {address.Selector} ({address.Version.ToNormalizedString()}) with --at {address.Selector}.";
+    }
+
+    static bool TryValidate(
+        TimelineOptions options,
+        out PackageVersionRange? range,
+        out string? descriptor,
+        out HashSet<string> selectedSections,
+        out string? error)
+    {
+        range = null;
+        descriptor = NormalizeDescriptor(options.Finding);
+        selectedSections = ResolveSections(options.Select, out error);
+        if (error is not null)
+            return false;
+
+        if (!PackageVersionRange.TryParse(options.PackageVersionRange, out range, out error))
+        {
+            error ??= $"Invalid package version range '{options.PackageVersionRange}'. Expected Package@A..B.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(options.TypeName))
+        {
+            error = "A type focus is required. Use --type TypeName or pass it after the package range.";
+            return false;
+        }
+
+        if (descriptor is null)
+        {
+            error = $"Unknown Finding '{options.Finding}'. Use api.type, api.member, or api.attribute.";
+            return false;
+        }
+
+        if (options.Count && selectedSections.Count != 1)
+        {
+            error = "--count requires exactly one selected section: Evaluations or Transitions.";
+            return false;
+        }
+        if (options.IsTabular && selectedSections.Count != 1)
+        {
+            error = "Table, TSV, and JSONL output require exactly one selected section: Evaluations or Transitions.";
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    static string? NormalizeDescriptor(string descriptor)
+        => descriptor.ToLowerInvariant() switch
+        {
+            "api.type" => "api.type",
+            "api.member" => "api.member",
+            "api.attribute" => "api.attribute",
+            _ => null,
+        };
+
+    static HashSet<string> ResolveSections(string[]? select, out string? error)
+    {
+        HashSet<string> sections = new(StringComparer.OrdinalIgnoreCase);
+        if (select is null || select.Length == 0)
+        {
+            sections.Add(EvaluationsSection);
+            sections.Add(TransitionsSection);
+            error = null;
+            return sections;
+        }
+
+        foreach (string value in select)
+        {
+            if (value.Equals(EvaluationsSection, StringComparison.OrdinalIgnoreCase))
+                sections.Add(EvaluationsSection);
+            else if (value.Equals(TransitionsSection, StringComparison.OrdinalIgnoreCase))
+                sections.Add(TransitionsSection);
+            else
+            {
+                error = $"Unknown timeline section '{value}'. Use Evaluations or Transitions.";
+                return sections;
+            }
+        }
+
+        error = null;
+        return sections;
+    }
+
+    static void Write(
+        TimelineDocumentView view,
+        TimelineOptions options,
+        HashSet<string> selectedSections)
+    {
+        if (options.Count)
+        {
+            int count = selectedSections.Contains(EvaluationsSection)
+                ? view.Evaluations?.Count ?? 0
+                : view.Transitions?.Count ?? 0;
+            Console.WriteLine(count);
+            return;
+        }
+
+        if (options.JsonOutput)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(
+                view,
+                TimelineJsonContext.Default.TimelineDocumentView));
+            return;
+        }
+
+        if (options.IsTabular)
+        {
+            if (selectedSections.Contains(EvaluationsSection))
+            {
+                var evaluations = new TimelineEvaluationsView { Rows = view.Evaluations };
+                OutputFormatter.WriteProjectedTable(
+                    Console.Out,
+                    !options.NoHeader,
+                    options.Tsv,
+                    options.Jsonl,
+                    options.Columns,
+                    options.Fields,
+                    (writer, formatter, writerOptions) =>
+                        MarkoutSerializer.Serialize(
+                            evaluations,
+                            writer,
+                            formatter,
+                            TimelineViewContext.Default,
+                            writerOptions),
+                    options.Rows);
+            }
+            else
+            {
+                var transitions = new TimelineTransitionsView { Rows = view.Transitions };
+                OutputFormatter.WriteProjectedTable(
+                    Console.Out,
+                    !options.NoHeader,
+                    options.Tsv,
+                    options.Jsonl,
+                    options.Columns,
+                    options.Fields,
+                    (writer, formatter, writerOptions) =>
+                        MarkoutSerializer.Serialize(
+                            transitions,
+                            writer,
+                            formatter,
+                            TimelineViewContext.Default,
+                            writerOptions),
+                    options.Rows);
+            }
+            return;
+        }
+
+        var writer = new MarkoutWriter(new MarkdownFormatter());
+        TimelineViewContext.Default.Serialize(view, writer);
+        Console.WriteLine(OutputFormatter.ApplyRowLimit(writer.ToString(), options.Rows));
+    }
+
+    internal sealed record TimelineEvaluation(
+        PackageVersionAddress Address,
+        ApiSurface? Surface,
+        string? Error);
+
+    abstract record InspectionProjection
+    {
+        public sealed record Complete(int Count) : InspectionProjection;
+        public sealed record Absent(string? Detail) : InspectionProjection;
+        public sealed record Failed(string Error) : InspectionProjection;
+    }
+}
+
+public sealed record TimelineOptions
+{
+    public string PackageVersionRange { get; init; } = "";
+    public string TypeName { get; init; } = "";
+    public string Finding { get; init; } = MetadataFindings.MemberDescriptor.Id;
+    public string[] At { get; init; } = [];
+    public string? Tfm { get; init; }
+    public bool IncludeAll { get; init; }
+    public bool IncludePrerelease { get; init; }
+    public bool Verbose { get; init; }
+    public bool JsonOutput { get; init; }
+    public bool OneLine { get; init; }
+    public bool Tsv { get; init; }
+    public bool Jsonl { get; init; }
+    public bool NoHeader { get; init; }
+    public bool Count { get; init; }
+    public int? Rows { get; init; }
+    public string[]? Select { get; init; }
+    public string[]? Columns { get; init; }
+    public string[]? Fields { get; init; }
+    public NuGetSourceOptions? SourceOptions { get; init; }
+    public bool IsTabular => OneLine || Tsv || Jsonl;
+}
+
+[JsonSerializable(typeof(TimelineDocumentView))]
+internal partial class TimelineJsonContext : JsonSerializerContext
+{
+}

--- a/src/dotnet-inspect/Commands/TimelineCommand.cs
+++ b/src/dotnet-inspect/Commands/TimelineCommand.cs
@@ -180,6 +180,45 @@ public static class TimelineCommand
                 continue;
             }
 
+            var oldInspection = Inspect(oldEvaluation.Surface, descriptor, typeFullName);
+            var newInspection = Inspect(newEvaluation.Surface, descriptor, typeFullName);
+            if (oldInspection is InspectionProjection.Failed
+                || newInspection is InspectionProjection.Failed)
+            {
+                var failure = oldInspection as InspectionProjection.Failed
+                    ?? (InspectionProjection.Failed)newInspection;
+                rows.Add(new TimelineTransitionRow(
+                    oldEvaluation.Address.Selector,
+                    newEvaluation.Address.Selector,
+                    span,
+                    "Failed",
+                    descriptor,
+                    typeFullName,
+                    failure.Error));
+                continue;
+            }
+
+            string? subjectTransition = (oldInspection, newInspection) switch
+            {
+                (InspectionProjection.Absent, InspectionProjection.Complete) => "SubjectAvailable",
+                (InspectionProjection.Complete, InspectionProjection.Absent) => "SubjectUnavailable",
+                _ => null,
+            };
+            if (subjectTransition is not null)
+            {
+                string detail = subjectTransition == "SubjectAvailable"
+                    ? "The focused type became available to this census."
+                    : "The focused type ceased to be available to this census.";
+                rows.Add(new TimelineTransitionRow(
+                    oldEvaluation.Address.Selector,
+                    newEvaluation.Address.Selector,
+                    span,
+                    subjectTransition,
+                    descriptor,
+                    typeFullName,
+                    exact ? detail : AppendGapQualification(detail)));
+            }
+
             var pairs = Compare(
                 oldEvaluation.Surface,
                 newEvaluation.Surface,
@@ -199,7 +238,7 @@ public static class TimelineCommand
             }
 
             var changes = pairs.Where(pair => pair.Kind != PairKind.Present).ToArray();
-            if (changes.Length == 0)
+            if (changes.Length == 0 && subjectTransition is null)
             {
                 rows.Add(new TimelineTransitionRow(
                     oldEvaluation.Address.Selector,

--- a/src/dotnet-inspect/Inspectors/ApiSurfaceEndpointResolver.cs
+++ b/src/dotnet-inspect/Inspectors/ApiSurfaceEndpointResolver.cs
@@ -1,0 +1,55 @@
+using DotnetInspector.Output;
+using DotnetInspector.Services;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Inspectors;
+
+internal sealed record ApiSurfaceEndpoint(
+    AssemblySet AssemblySet,
+    ApiSurface Surface) : IDisposable
+{
+    public IReadOnlyList<string> Paths =>
+        AssemblySet.Assemblies.Select(static entry => entry.Path).ToList();
+
+    public void Dispose() => AssemblySet.Dispose();
+}
+
+internal static class ApiSurfaceEndpointResolver
+{
+    public static async Task<(ApiSurfaceEndpoint? Endpoint, string? Error, bool AssembliesResolved)> ResolveAsync(
+        HttpClient httpClient,
+        AssemblySetRequest request,
+        bool includeAll,
+        VerboseLogger logger)
+    {
+        var assemblySet = await AssemblySetResolver
+            .CollectAsync(httpClient, request, logger.Log)
+            .ConfigureAwait(false);
+        try
+        {
+            if (assemblySet.Assemblies.Count == 0)
+            {
+                string error = assemblySet.Diagnostics.Count > 0
+                    ? string.Join("; ", assemblySet.Diagnostics.Select(static diagnostic => diagnostic.Message))
+                    : "No assemblies were resolved.";
+                assemblySet.Dispose();
+                return (null, error, false);
+            }
+
+            AssemblySetDiagnosticWriter.Write(assemblySet);
+            var surface = AssemblySetSurfaceBuilder.Build(assemblySet, includeAll, logger.Log);
+            if (surface is null)
+            {
+                assemblySet.Dispose();
+                return (null, "Failed to extract API surface.", true);
+            }
+
+            return (new ApiSurfaceEndpoint(assemblySet, surface), null, true);
+        }
+        catch
+        {
+            assemblySet.Dispose();
+            throw;
+        }
+    }
+}

--- a/src/dotnet-inspect/Views/TimelineViews.cs
+++ b/src/dotnet-inspect/Views/TimelineViews.cs
@@ -1,0 +1,63 @@
+using Markout;
+
+namespace DotnetInspector.Views;
+
+[MarkoutSerializable(
+    TitleProperty = nameof(Title),
+    FieldLayout = FieldLayout.Table)]
+public sealed class TimelineDocumentView
+{
+    [MarkoutIgnore] public string Title { get; init; } = "";
+    public string Range { get; init; } = "";
+    public string Type { get; init; } = "";
+    public string Finding { get; init; } = "";
+    public string? Recommendation { get; init; }
+
+    [MarkoutSection(Name = "Evaluations")]
+    public List<TimelineEvaluationRow>? Evaluations { get; init; }
+
+    [MarkoutSection(Name = "Transitions")]
+    public List<TimelineTransitionRow>? Transitions { get; init; }
+}
+
+[MarkoutSerializable]
+public sealed record TimelineEvaluationRow(
+    string Address,
+    string Version,
+    string State,
+    int? Findings,
+    string? Detail);
+
+[MarkoutSerializable]
+public sealed record TimelineTransitionRow(
+    string From,
+    string To,
+    string Span,
+    string Transition,
+    string Finding,
+    string Target,
+    string? Detail);
+
+[MarkoutSerializable(FieldLayout = FieldLayout.Table)]
+public sealed class TimelineEvaluationsView
+{
+    [MarkoutSection(Name = "Evaluations")]
+    public List<TimelineEvaluationRow>? Rows { get; init; }
+}
+
+[MarkoutSerializable(FieldLayout = FieldLayout.Table)]
+public sealed class TimelineTransitionsView
+{
+    [MarkoutSection(Name = "Transitions")]
+    public List<TimelineTransitionRow>? Rows { get; init; }
+}
+
+[MarkoutContextOptions(SuppressTableWarnings = true)]
+[MarkoutContext(typeof(TimelineDocumentView))]
+[MarkoutContext(typeof(TimelineEvaluationRow))]
+[MarkoutContext(typeof(TimelineTransitionRow))]
+[MarkoutContext(typeof(TimelineEvaluationsView))]
+[MarkoutContext(typeof(TimelineTransitionsView))]
+public partial class TimelineViewContext : MarkoutSerializerContext
+{
+}

--- a/tests/ILInspector.Metadata.Tests/MetadataFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataFindingsTests.cs
@@ -186,6 +186,92 @@ public class MetadataFindingsTests
     }
 
     [Fact]
+    public void TypeScopedCensuses_DistinguishMissingTypeFromExistingEmptyType()
+    {
+        var missing = Surface(Type("Other"));
+        var empty = Surface(Type("Widget"));
+
+        var missingMembers = MetadataFindings.InspectApiMembers(
+            missing,
+            Subject,
+            "TestNamespace.Widget");
+        var emptyMembers = MetadataFindings.InspectApiMembers(
+            empty,
+            Subject,
+            "TestNamespace.Widget");
+
+        Assert.IsType<FindingInspection<ApiMemberHandle>.Absent>(missingMembers.Value);
+        Assert.Empty(
+            Assert.IsType<FindingInspection<ApiMemberHandle>.Complete>(emptyMembers.Value).Findings);
+    }
+
+    [Fact]
+    public void TypeSelfPresence_RepresentsMissingTypeAsCompleteEmptyCensus()
+    {
+        var inspection = MetadataFindings.InspectApiType(
+            Surface(Type("Other")),
+            Subject,
+            "TestNamespace.Widget");
+
+        Assert.Empty(
+            Assert.IsType<FindingInspection<ApiTypeHandle>.Complete>(inspection.Value).Findings);
+    }
+
+    [Fact]
+    public void TypeScopedMemberComparison_PreservesFacetClassification()
+    {
+        var oldSurface = Surface(Type("Widget", members:
+        [
+            Method("Run", "void Run()"),
+        ]));
+        var newSurface = Surface(Type("Widget", members:
+        [
+            Method("Run", "void Run()", accessibility: "protected"),
+        ]));
+
+        var comparison = MetadataFindings.CompareApiMembers(
+            oldSurface,
+            newSurface,
+            Subject,
+            "TestNamespace.Widget");
+
+        var changed = Assert.IsType<PairFinding<ApiMemberHandle>.Changed>(
+            Assert.Single(Pairs(comparison)).Value);
+        Assert.Contains("accessibility: public -> protected", changed.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TypeAttributeComparison_ExactMatchesBeforeClassifyingValueChanges()
+    {
+        var oldSurface = Surface(Type("Widget", attributes:
+        [
+            "System.Obsolete",
+            "System.Tag(\"A\")",
+            "System.Tag(\"A\")",
+        ]));
+        var newSurface = Surface(Type("Widget", attributes:
+        [
+            "System.Tag(\"A\")",
+            "System.Tag(\"B\")",
+        ]));
+
+        var comparison = MetadataFindings.CompareApiAttributes(
+            oldSurface,
+            newSurface,
+            Subject,
+            "TestNamespace.Widget");
+        var pairs = Pairs(comparison);
+
+        Assert.Equal(1, pairs.Count(pair => pair.Kind == PairKind.Present));
+        Assert.Equal(1, pairs.Count(pair => pair.Kind == PairKind.Changed));
+        Assert.Equal(1, pairs.Count(pair => pair.Kind == PairKind.Removed));
+        var changed = Assert.IsType<PairFinding<ApiAttributeHandle>.Changed>(
+            Assert.Single(pairs, pair => pair.Kind == PairKind.Changed).Value);
+        Assert.Equal("System.Tag", changed.Old.Payload.Name);
+        Assert.Contains("System.Tag(\"A\") -> System.Tag(\"B\")", changed.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RealAssemblySelfCompare_IsExact()
     {
         using var stream = File.OpenRead(typeof(ApiDiffAnalyzer).Assembly.Location);
@@ -253,7 +339,8 @@ public class MetadataFindingsTests
         string kind = "class",
         string? ns = "TestNamespace",
         bool isByRefLike = false,
-        List<ApiMember>? members = null)
+        List<ApiMember>? members = null,
+        List<string>? attributes = null)
         => new()
         {
             Name = name,
@@ -261,6 +348,7 @@ public class MetadataFindingsTests
             Namespace = ns,
             IsByRefLike = isByRefLike,
             Members = members ?? [],
+            Attributes = attributes ?? [],
         };
 
     static ApiMember Method(


### PR DESCRIPTION
## Summary

- add top-level `timeline` correlation over inclusive package version vectors
- support type presence, owned-member, and applied-attribute Finding censuses
- preserve unevaluated, missing, subject-absent, failed, dense, and sparse-gap semantics
- align pairwise `diff --finding` with the same type-scoped member and attribute observations

## Acquisition and output

- no `--at` resolves version metadata but acquires zero package payloads
- repeated `--at` evaluates only the selected sparse cells; `--at all` explicitly authorizes dense traversal
- `Evaluations` and `Transitions` compose with selection, count, table, TSV, JSONL, JSON, and row windows
- gap-spanning transitions are qualified and never claim an exact onset/removal version

## Validation

- solution build
- full Metadata executable suite: 432 total, 0 failed, 1 known skip
- full CLI executable suite: 1806 total, 0 failed, 10 tool-availability skips
- live zero-payload, sparse, dense, reverse-range, missing-type, count, and JSONL runs
- markdownlint on all changed Markdown

## Review

Two isolated adversarial reviews completed cleanly on `285f66c6`: Gemini 3.1
Pro and Claude Opus 4.8. The attributed reconciliation is in the PR comments.
