### PR TITLE
Guard remaining Metadata signature providers against decode StackOverflow (#2575)

### DIFF
--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -94,7 +94,18 @@ public static class ApiMemberIdentity
             => TypeResolver.GetTypeNameFromReference(reader, handle).Replace('+', '.');
 
         public string GetTypeFromSpecification(MetadataReader reader, GenericContext? context, TypeSpecificationHandle handle, byte rawTypeKind)
-            => reader.GetTypeSpecification(handle).DecodeSignature(this, context);
+        {
+            if (!TypeSpecGuard.TryEnter(reader, handle, out int blobLength))
+                return "System.Object";
+            try
+            {
+                return reader.GetTypeSpecification(handle).DecodeSignature(this, context);
+            }
+            finally
+            {
+                TypeSpecGuard.Exit(blobLength);
+            }
+        }
 
         public string GetSZArrayType(string elementType) => $"{elementType}[]";
 
@@ -238,11 +249,11 @@ public static class ApiMemberIdentity
         PropertyDefinition property)
     {
         var context = GenericContext.ForType(reader, markerType);
-        var markerSignature = markerMethod.DecodeSignature(AnchorSignatureTypeProvider.Instance, context);
+        var markerSignature = GuardedProviderDecode.Method(reader, markerMethod, AnchorSignatureTypeProvider.Instance, context, "System.Object");
         if (markerSignature.ParameterTypes.Length != 1)
             throw new BadImageFormatException("An extension marker must have exactly one receiver parameter.");
 
-        var propertySignature = property.DecodeSignature(AnchorSignatureTypeProvider.Instance, context);
+        var propertySignature = GuardedProviderDecode.Property(reader, property, AnchorSignatureTypeProvider.Instance, context, "System.Object");
         string propertyName = reader.GetString(property.Name);
         string typeFullName = FormatDefinitionName(reader, extensionClassHandle);
         string extendedType = markerSignature.ParameterTypes[0];
@@ -268,9 +279,12 @@ public static class ApiMemberIdentity
     {
         var type = reader.GetTypeDefinition(typeHandle);
         string methodName = reader.GetString(method.Name);
-        var signature = method.DecodeSignature(
+        var signature = GuardedProviderDecode.Method(
+            reader,
+            method,
             AnchorSignatureTypeProvider.Instance,
-            GenericContext.ForMethod(reader, type, method));
+            GenericContext.ForMethod(reader, type, method),
+            "System.Object");
         string typeFullName = FormatDefinitionName(reader, typeHandle);
         string memberName = MethodMemberName(reader, methodName, method);
         // Route the SRM-direct producer through the single full-name grammar core so it

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -569,7 +569,7 @@ public static class ApiSurfaceExtractor
         byte typeNullableContext)
     {
         var context = GenericContext.ForType(reader, typeDef);
-        var fieldNode = field.DecodeSignature(TypeNodeProvider.Instance, context);
+        var fieldNode = GuardedProviderDecode.Field(reader, field, TypeNodeProvider.Instance, context, (TypeNode)new NamedTypeNode("object", isReferenceType: true));
         var fieldBytes = NullabilityReader.GetNullableBytes(reader, field.GetCustomAttributes());
         int pos = 0;
         fieldNode.ApplyNullability(fieldBytes, ref pos, typeNullableContext);
@@ -744,7 +744,7 @@ public static class ApiSurfaceExtractor
     {
         string name = reader.GetString(method.Name);
         var context = GenericContext.ForMethod(reader, typeDef, method);
-        var treeSignature = method.DecodeSignature(TypeNodeProvider.Instance, context);
+        var treeSignature = GuardedProviderDecode.Method(reader, method, TypeNodeProvider.Instance, context, (TypeNode)new NamedTypeNode("object", isReferenceType: true));
 
         // Determine the effective nullable default: method overrides type
         byte methodContext = NullabilityReader.GetNullableContext(reader, method.GetCustomAttributes());
@@ -1282,7 +1282,7 @@ public static class ApiSurfaceExtractor
     {
         string name = reader.GetString(prop.Name);
         var context = GenericContext.ForType(reader, typeDef);
-        var treeSignature = prop.DecodeSignature(TypeNodeProvider.Instance, context);
+        var treeSignature = GuardedProviderDecode.Property(reader, prop, TypeNodeProvider.Instance, context, (TypeNode)new NamedTypeNode("object", isReferenceType: true));
 
         // Apply nullability to the property type
         var propBytes = NullabilityReader.GetNullableBytes(reader, prop.GetCustomAttributes());

--- a/src/ILInspector.Metadata/AssemblyDetailScanner.cs
+++ b/src/ILInspector.Metadata/AssemblyDetailScanner.cs
@@ -462,7 +462,7 @@ public static class AssemblyDetailScanner
                     {
                         try
                         {
-                            var sig = method.DecodeSignature(PointerDetector.Instance, null);
+                            var sig = GuardedProviderDecode.Method(reader, method, PointerDetector.Instance, (object?)null, false);
                             if (sig.ReturnType || sig.ParameterTypes.Any(p => p))
                                 flags.HasUnsafeCode = true;
                         }

--- a/src/ILInspector.Metadata/CanonicalIL.cs
+++ b/src/ILInspector.Metadata/CanonicalIL.cs
@@ -46,7 +46,18 @@ public sealed class ILSignatureTypeProvider : ISignatureTypeProvider<string, Gen
         => Prefix(rawTypeKind) + CanonicalIL.QualifiedName(reader, handle);
 
     public string GetTypeFromSpecification(MetadataReader reader, GenericContext? context, TypeSpecificationHandle handle, byte rawTypeKind)
-        => reader.GetTypeSpecification(handle).DecodeSignature(this, context);
+    {
+        if (!TypeSpecGuard.TryEnter(reader, handle, out int blobLength))
+            return "object";
+        try
+        {
+            return reader.GetTypeSpecification(handle).DecodeSignature(this, context);
+        }
+        finally
+        {
+            TypeSpecGuard.Exit(blobLength);
+        }
+    }
 
     public string GetSZArrayType(string elementType) => $"{elementType}[]";
     public string GetArrayType(string elementType, ArrayShape shape) => $"{elementType}[{new string(',', Math.Max(shape.Rank - 1, 0))}]";
@@ -110,8 +121,8 @@ public static class CanonicalIL
     {
         HandleKind.TypeDefinition => QualifiedName(reader, (TypeDefinitionHandle)handle),
         HandleKind.TypeReference => QualifiedName(reader, (TypeReferenceHandle)handle),
-        HandleKind.TypeSpecification => reader.GetTypeSpecification((TypeSpecificationHandle)handle)
-            .DecodeSignature(ILSignatureTypeProvider.Instance, null),
+        HandleKind.TypeSpecification => GuardedProviderDecode.TypeSpec(
+            reader, (TypeSpecificationHandle)handle, ILSignatureTypeProvider.Instance, (GenericContext?)null, "object"),
         _ => $"0x{MetadataTokens.GetToken(handle):X8}"
     };
 
@@ -269,7 +280,7 @@ public static class CanonicalIL
         var method = reader.GetMethodDefinition(handle);
         string name = reader.GetString(method.Name);
         string parent = QualifiedName(reader, method.GetDeclaringType());
-        var sig = method.DecodeSignature(ILSignatureTypeProvider.Instance, genericContext: null);
+        var sig = GuardedProviderDecode.Method(reader, method, ILSignatureTypeProvider.Instance, (GenericContext?)null, "object");
         return FormatCall(sig, parent, name, genericArgs: null);
     }
 
@@ -278,14 +289,14 @@ public static class CanonicalIL
         var memberRef = reader.GetMemberReference(handle);
         string name = reader.GetString(memberRef.Name);
         string parent = FormatMemberRefParent(reader, memberRef.Parent);
-        var sig = memberRef.DecodeMethodSignature(ILSignatureTypeProvider.Instance, genericContext: null);
+        var sig = GuardedProviderDecode.MemberRefMethod(reader, memberRef, ILSignatureTypeProvider.Instance, (GenericContext?)null, "object");
         return FormatCall(sig, parent, name, genericArgs: null);
     }
 
     static string FormatMethodSpec(MetadataReader reader, MethodSpecificationHandle handle)
     {
         var spec = reader.GetMethodSpecification(handle);
-        var typeArgs = spec.DecodeSignature(ILSignatureTypeProvider.Instance, genericContext: null);
+        var typeArgs = GuardedProviderDecode.MethodSpec(reader, spec, ILSignatureTypeProvider.Instance, (GenericContext?)null);
         string genericArgs = $"<{string.Join(", ", typeArgs)}>";
 
         switch (spec.Method.Kind)
@@ -293,13 +304,13 @@ public static class CanonicalIL
             case HandleKind.MethodDefinition:
             {
                 var method = reader.GetMethodDefinition((MethodDefinitionHandle)spec.Method);
-                var sig = method.DecodeSignature(ILSignatureTypeProvider.Instance, genericContext: null);
+                var sig = GuardedProviderDecode.Method(reader, method, ILSignatureTypeProvider.Instance, (GenericContext?)null, "object");
                 return FormatCall(sig, QualifiedName(reader, method.GetDeclaringType()), reader.GetString(method.Name), genericArgs);
             }
             case HandleKind.MemberReference:
             {
                 var memberRef = reader.GetMemberReference((MemberReferenceHandle)spec.Method);
-                var sig = memberRef.DecodeMethodSignature(ILSignatureTypeProvider.Instance, genericContext: null);
+                var sig = GuardedProviderDecode.MemberRefMethod(reader, memberRef, ILSignatureTypeProvider.Instance, (GenericContext?)null, "object");
                 return FormatCall(sig, FormatMemberRefParent(reader, memberRef.Parent), reader.GetString(memberRef.Name), genericArgs);
             }
             default:
@@ -319,14 +330,14 @@ public static class CanonicalIL
     static string FormatFieldDef(MetadataReader reader, FieldDefinitionHandle handle)
     {
         var field = reader.GetFieldDefinition(handle);
-        string fieldType = field.DecodeSignature(ILSignatureTypeProvider.Instance, genericContext: null);
+        string fieldType = GuardedProviderDecode.Field(reader, field, ILSignatureTypeProvider.Instance, (GenericContext?)null, "object");
         return $"{fieldType} {QualifiedName(reader, field.GetDeclaringType())}::{QuoteName(reader.GetString(field.Name))}";
     }
 
     static string FormatFieldMemberRef(MetadataReader reader, MemberReferenceHandle handle)
     {
         var memberRef = reader.GetMemberReference(handle);
-        string fieldType = memberRef.DecodeFieldSignature(ILSignatureTypeProvider.Instance, genericContext: null);
+        string fieldType = GuardedProviderDecode.MemberRefField(reader, memberRef, ILSignatureTypeProvider.Instance, (GenericContext?)null, "object");
         return $"{fieldType} {FormatMemberRefParent(reader, memberRef.Parent)}::{QuoteName(reader.GetString(memberRef.Name))}";
     }
 
@@ -339,8 +350,8 @@ public static class CanonicalIL
     {
         HandleKind.TypeDefinition => QualifiedName(reader, (TypeDefinitionHandle)parent),
         HandleKind.TypeReference => QualifiedName(reader, (TypeReferenceHandle)parent),
-        HandleKind.TypeSpecification => reader.GetTypeSpecification((TypeSpecificationHandle)parent)
-            .DecodeSignature(ILSignatureTypeProvider.Instance, null),
+        HandleKind.TypeSpecification => GuardedProviderDecode.TypeSpec(
+            reader, (TypeSpecificationHandle)parent, ILSignatureTypeProvider.Instance, (GenericContext?)null, "object"),
         HandleKind.MethodDefinition => "?", // varargs call-site refs — not produced by Roslyn
         _ => $"0x{MetadataTokens.GetToken(parent):X8}"
     };

--- a/src/ILInspector.Metadata/GuardedProviderDecode.cs
+++ b/src/ILInspector.Metadata/GuardedProviderDecode.cs
@@ -1,0 +1,96 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Top-level entry gateway for the <see cref="ISignatureTypeProvider{TType,TContext}"/>
+/// implementations in this assembly. SRM's <c>DecodeSignature</c> recurses on the
+/// native stack for every nested element <em>before</em> it invokes the first
+/// provider callback, so a single over-deep blob overflows the stack in a way no
+/// managed <c>try/catch</c> can contain. Each helper prescans the blob with
+/// <see cref="SignatureBlobGuard"/> and, when the blob is too deep or malformed,
+/// returns a fail-closed fallback instead of entering the recursive decode.
+///
+/// Valid signatures pass the prescan unchanged, so guarded decodes are
+/// byte-identical to direct decodes for well-formed assemblies. The nested
+/// cross-handle TypeSpec vector is bounded separately by each provider's own
+/// <c>GetTypeFromSpecification</c> via <see cref="TypeSpecGuard"/>.
+/// </summary>
+internal static class GuardedProviderDecode
+{
+    public static MethodSignature<T> Method<T, TContext>(
+        MetadataReader reader,
+        MethodDefinition method,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        T fallbackReturn)
+        => SignatureBlobGuard.IsSafeToDecode(reader, method.Signature, SignatureBlobGuard.Kind.Method)
+            ? method.DecodeSignature(provider, context)
+            : FallbackSignature(fallbackReturn);
+
+    public static MethodSignature<T> MemberRefMethod<T, TContext>(
+        MetadataReader reader,
+        MemberReference member,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        T fallbackReturn)
+        => SignatureBlobGuard.IsSafeToDecode(reader, member.Signature, SignatureBlobGuard.Kind.Method)
+            ? member.DecodeMethodSignature(provider, context)
+            : FallbackSignature(fallbackReturn);
+
+    public static MethodSignature<T> Property<T, TContext>(
+        MetadataReader reader,
+        PropertyDefinition property,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        T fallbackReturn)
+        => SignatureBlobGuard.IsSafeToDecode(reader, property.Signature, SignatureBlobGuard.Kind.Method)
+            ? property.DecodeSignature(provider, context)
+            : FallbackSignature(fallbackReturn);
+
+    public static T Field<T, TContext>(
+        MetadataReader reader,
+        FieldDefinition field,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        T fallback)
+        => SignatureBlobGuard.IsSafeToDecode(reader, field.Signature, SignatureBlobGuard.Kind.Field)
+            ? field.DecodeSignature(provider, context)
+            : fallback;
+
+    public static T MemberRefField<T, TContext>(
+        MetadataReader reader,
+        MemberReference member,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        T fallback)
+        => SignatureBlobGuard.IsSafeToDecode(reader, member.Signature, SignatureBlobGuard.Kind.Field)
+            ? member.DecodeFieldSignature(provider, context)
+            : fallback;
+
+    public static ImmutableArray<T> MethodSpec<T, TContext>(
+        MetadataReader reader,
+        MethodSpecification spec,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context)
+        => SignatureBlobGuard.IsSafeToDecode(reader, spec.Signature, SignatureBlobGuard.Kind.MethodSpecification)
+            ? spec.DecodeSignature(provider, context)
+            : ImmutableArray<T>.Empty;
+
+    public static T TypeSpec<T, TContext>(
+        MetadataReader reader,
+        TypeSpecificationHandle handle,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        T fallback)
+    {
+        var spec = reader.GetTypeSpecification(handle);
+        return SignatureBlobGuard.IsSafeToDecode(reader, spec.Signature, SignatureBlobGuard.Kind.TypeSpecification)
+            ? spec.DecodeSignature(provider, context)
+            : fallback;
+    }
+
+    static MethodSignature<T> FallbackSignature<T>(T fallbackReturn)
+        => new(default, fallbackReturn, requiredParameterCount: 0, genericParameterCount: 0, ImmutableArray<T>.Empty);
+}

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -351,8 +351,8 @@ public static class MetadataDeclarationQuery
     /// evidence (<see cref="TypeNode.HasRequiredModifier"/>) that the API surface uses for
     /// <c>in</c>/<c>ref readonly</c>, so callers do not re-decode the signature to spot the modifier.
     /// </summary>
-    public static bool IsVolatileField(FieldDefinition field, GenericContext context)
-        => field.DecodeSignature(TypeNodeProvider.Instance, context)
+    public static bool IsVolatileField(MetadataReader reader, FieldDefinition field, GenericContext context)
+        => GuardedProviderDecode.Field(reader, field, TypeNodeProvider.Instance, context, (TypeNode)new NamedTypeNode("object", isReferenceType: true))
             .HasRequiredModifier("System.Runtime.CompilerServices", "IsVolatile");
 
     /// <summary>

--- a/src/ILInspector.Metadata/PointerDetector.cs
+++ b/src/ILInspector.Metadata/PointerDetector.cs
@@ -17,8 +17,16 @@ internal sealed class PointerDetector : ISignatureTypeProvider<bool, object?>
 
     public bool GetTypeFromSpecification(MetadataReader reader, object? context, TypeSpecificationHandle handle, byte rawTypeKind)
     {
-        var typeSpec = reader.GetTypeSpecification(handle);
-        return typeSpec.DecodeSignature(this, context);
+        if (!TypeSpecGuard.TryEnter(reader, handle, out int blobLength))
+            return false;
+        try
+        {
+            return reader.GetTypeSpecification(handle).DecodeSignature(this, context);
+        }
+        finally
+        {
+            TypeSpecGuard.Exit(blobLength);
+        }
     }
 
     public bool GetSZArrayType(bool elementType) => elementType;

--- a/src/ILInspector.Metadata/SignatureSpellability.cs
+++ b/src/ILInspector.Metadata/SignatureSpellability.cs
@@ -23,7 +23,7 @@ public sealed class SignatureSpellability
 
     public bool CanSpellField(MetadataReader reader, FieldDefinition field, GenericContext context)
     {
-        try { return !field.DecodeSignature(new InaccessibleTypeDetector(this), context); }
+        try { return !GuardedProviderDecode.Field(reader, field, new InaccessibleTypeDetector(this), context, false); }
         catch (Exception ex) when (IsDecodeException(ex)) { return true; }
     }
 
@@ -31,7 +31,7 @@ public sealed class SignatureSpellability
     {
         try
         {
-            var signature = property.DecodeSignature(new InaccessibleTypeDetector(this), context);
+            var signature = GuardedProviderDecode.Property(reader, property, new InaccessibleTypeDetector(this), context, false);
             return !signature.ReturnType && !signature.ParameterTypes.Any(inaccessible => inaccessible);
         }
         catch (Exception ex) when (IsDecodeException(ex)) { return true; }
@@ -41,7 +41,7 @@ public sealed class SignatureSpellability
     {
         try
         {
-            var signature = method.DecodeSignature(new InaccessibleTypeDetector(this), context);
+            var signature = GuardedProviderDecode.Method(reader, method, new InaccessibleTypeDetector(this), context, false);
             return !signature.ReturnType && !signature.ParameterTypes.Any(inaccessible => inaccessible);
         }
         catch (Exception ex) when (IsDecodeException(ex)) { return true; }
@@ -153,7 +153,18 @@ public sealed class SignatureSpellability
         public bool GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
             => spellability.IsInaccessible(reader, handle);
         public bool GetTypeFromSpecification(MetadataReader reader, GenericContext? context, TypeSpecificationHandle handle, byte rawTypeKind)
-            => reader.GetTypeSpecification(handle).DecodeSignature(this, context);
+        {
+            if (!TypeSpecGuard.TryEnter(reader, handle, out int blobLength))
+                return false;
+            try
+            {
+                return reader.GetTypeSpecification(handle).DecodeSignature(this, context);
+            }
+            finally
+            {
+                TypeSpecGuard.Exit(blobLength);
+            }
+        }
         public bool GetSZArrayType(bool elementType) => elementType;
         public bool GetArrayType(bool elementType, ArrayShape shape) => elementType;
         public bool GetByReferenceType(bool elementType) => elementType;

--- a/src/ILInspector.Metadata/TypeNodeProvider.cs
+++ b/src/ILInspector.Metadata/TypeNodeProvider.cs
@@ -37,8 +37,16 @@ internal sealed class TypeNodeProvider : ISignatureTypeProvider<TypeNode, Generi
 
     public TypeNode GetTypeFromSpecification(MetadataReader reader, GenericContext? context, TypeSpecificationHandle handle, byte rawTypeKind)
     {
-        var typeSpec = reader.GetTypeSpecification(handle);
-        return typeSpec.DecodeSignature(this, context);
+        if (!TypeSpecGuard.TryEnter(reader, handle, out int blobLength))
+            return new NamedTypeNode("object", isReferenceType: true);
+        try
+        {
+            return reader.GetTypeSpecification(handle).DecodeSignature(this, context);
+        }
+        finally
+        {
+            TypeSpecGuard.Exit(blobLength);
+        }
     }
 
     public TypeNode GetSZArrayType(TypeNode elementType) => new SZArrayTypeNode(elementType);

--- a/src/ILInspector.MetadataPrimitives/AttributeDecoder.cs
+++ b/src/ILInspector.MetadataPrimitives/AttributeDecoder.cs
@@ -93,8 +93,15 @@ public static class AttributeDecoder
                 foreach (var fieldHandle in def.GetFields())
                 {
                     var field = reader.GetFieldDefinition(fieldHandle);
-                    if ((field.Attributes & FieldAttributes.Static) == 0)
-                        return field.DecodeSignature(new PrimitiveCodeProvider(), null);
+                    if ((field.Attributes & FieldAttributes.Static) != 0)
+                        continue;
+
+                    // SRM decodes this field signature on the native stack before the
+                    // first provider callback, so an over-deep enum field blob would
+                    // overflow uncatchably. Prescan and fail closed to Int32.
+                    return SignatureBlobGuard.IsSafeToDecode(reader, field.Signature, SignatureBlobGuard.Kind.Field)
+                        ? field.DecodeSignature(new PrimitiveCodeProvider(), null)
+                        : PrimitiveTypeCode.Int32;
                 }
             }
             return PrimitiveTypeCode.Int32;

--- a/src/ILInspector.MetadataPrimitives/TypeSpecGuard.cs
+++ b/src/ILInspector.MetadataPrimitives/TypeSpecGuard.cs
@@ -7,7 +7,7 @@ namespace ILInspector.Metadata;
 /// A top-level blob prescan cannot see a custom modifier that resolves another
 /// TypeSpec, including a cycle back to the current row.
 /// </summary>
-internal static class TypeSpecGuard
+public static class TypeSpecGuard
 {
     const int MaxBlobLength = 1024;
     const int MaxCumulativeBytes = 4096;

--- a/tests/ILInspector.Metadata.Tests/ILInspector.Metadata.Tests.csproj
+++ b/tests/ILInspector.Metadata.Tests/ILInspector.Metadata.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="xunit.v3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -204,8 +204,8 @@ public sealed class MetadataDeclarationQueryTests
     {
         var type = GetTypeDefinition(typeof(MetadataDeclarationQueryFixtures));
         var context = GenericContext.ForType(Reader, type);
-        Assert.True(MetadataDeclarationQuery.IsVolatileField(GetField(type, "VolatileField"), context));
-        Assert.False(MetadataDeclarationQuery.IsVolatileField(GetField(type, "PlainField"), context));
+        Assert.True(MetadataDeclarationQuery.IsVolatileField(Reader, GetField(type, "VolatileField"), context));
+        Assert.False(MetadataDeclarationQuery.IsVolatileField(Reader, GetField(type, "PlainField"), context));
     }
 
     [Fact]

--- a/tests/ILInspector.Metadata.Tests/ProviderSignatureDecodeBoundaryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ProviderSignatureDecodeBoundaryTests.cs
@@ -127,16 +127,23 @@ public class ProviderSignatureDecodeBoundaryTests
             && receiver.Expression is MemberAccessExpressionSyntax receiverMember
             && receiverMember.Name.Identifier.Text == "GetTypeSpecification";
 
-    // `SignatureBlobGuard.IsSafeToDecode(...) ? <decode> : <fallback>`: some
-    // enclosing conditional expression guards this decode in its true-branch
-    // with an IsSafeToDecode prescan.
+    // `SignatureBlobGuard.IsSafeToDecode(reader, <recv>.Signature, ...) ?
+    // <recv>.Decode*Signature(...) : <fallback>`: some enclosing conditional
+    // guards this decode in its true-branch with a prescan of the SAME
+    // receiver's signature blob. Binding the guard to the decoded blob prevents
+    // laundering an unguarded decode past the census behind an unrelated or
+    // nil-handle IsSafeToDecode call.
     static bool IsPrescanGuardedTernary(InvocationExpressionSyntax invocation)
     {
+        if (invocation.Expression is not MemberAccessExpressionSyntax decodeMember)
+            return false;
+        var decodeReceiver = decodeMember.Expression.ToString();
+
         foreach (var ancestor in invocation.Ancestors())
         {
             if (ancestor is ConditionalExpressionSyntax conditional
                 && conditional.WhenTrue.Span.Contains(invocation.Span)
-                && ConditionCallsIsSafeToDecode(conditional.Condition))
+                && ConditionGuardsReceiverSignature(conditional.Condition, decodeReceiver))
             {
                 return true;
             }
@@ -144,13 +151,17 @@ public class ProviderSignatureDecodeBoundaryTests
         return false;
     }
 
-    static bool ConditionCallsIsSafeToDecode(ExpressionSyntax condition)
+    static bool ConditionGuardsReceiverSignature(ExpressionSyntax condition, string decodeReceiver)
         => condition.DescendantNodesAndSelf()
             .OfType<InvocationExpressionSyntax>()
             .Any(i => i.Expression is MemberAccessExpressionSyntax member
                 && member.Name.Identifier.Text == "IsSafeToDecode"
                 && member.Expression is IdentifierNameSyntax id
-                && id.Identifier.Text == "SignatureBlobGuard");
+                && id.Identifier.Text == "SignatureBlobGuard"
+                && i.ArgumentList.Arguments.Any(a =>
+                    a.Expression is MemberAccessExpressionSyntax blob
+                    && blob.Name.Identifier.Text == "Signature"
+                    && blob.Expression.ToString() == decodeReceiver));
 
     static IEnumerable<string> EnumerateSourceFiles(string root)
     {

--- a/tests/ILInspector.Metadata.Tests/ProviderSignatureDecodeBoundaryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ProviderSignatureDecodeBoundaryTests.cs
@@ -1,0 +1,116 @@
+using System.Text.RegularExpressions;
+
+namespace ILInspector.Metadata.Tests;
+
+/// <summary>
+/// Freezes the provider-closure contract for issue #2575. Every
+/// <see cref="System.Reflection.Metadata.ISignatureTypeProvider{TType,TContext}"/>
+/// in <c>ILInspector.Metadata</c> is guarded on both crash vectors:
+///
+/// 1. Top-level decodes route through <c>GuardedProviderDecode</c>, which prescans
+///    the blob with <c>SignatureBlobGuard</c> (SRM recurses on the native stack
+///    before the first callback, so only a prescan stops a deep single blob).
+/// 2. Each provider's own <c>GetTypeFromSpecification</c> bounds cross-handle
+///    TypeSpec re-entry through <c>TypeSpecGuard</c>.
+///
+/// These assertions are the anti-ratchet completeness proof: a newly added
+/// provider or an un-gated top-level decode fails this test rather than shipping
+/// an unguarded same-mechanism hole.
+/// </summary>
+public class ProviderSignatureDecodeBoundaryTests
+{
+    static readonly string[] Providers =
+    {
+        "PointerDetector.Instance",
+        "ILSignatureTypeProvider.Instance",
+        "TypeNodeProvider.Instance",
+        "AnchorSignatureTypeProvider.Instance",
+        "new InaccessibleTypeDetector",
+    };
+
+    // The provider files whose nested TypeSpec re-entry must be bounded by TypeSpecGuard.
+    static readonly string[] ProviderFiles =
+    {
+        "PointerDetector.cs",
+        "CanonicalIL.cs",              // ILSignatureTypeProvider
+        "TypeNodeProvider.cs",
+        "ApiMemberIdentity.cs",        // AnchorSignatureTypeProvider
+        "SignatureSpellability.cs",    // InaccessibleTypeDetector
+    };
+
+    static readonly Regex RawDecode = new(
+        @"\.Decode(Method|Field)?Signature\(",
+        RegexOptions.Compiled);
+
+    [Fact]
+    public void ProviderTopLevelDecodes_OnlyThroughGuardedGateway()
+    {
+        var metadataRoot = Path.Combine(FindRepoRoot(), "src", "ILInspector.Metadata");
+        var violations = new List<string>();
+
+        foreach (var file in Directory.EnumerateFiles(metadataRoot, "*.cs", SearchOption.AllDirectories))
+        {
+            var fileName = Path.GetFileName(file);
+            if (fileName == "GuardedProviderDecode.cs")
+                continue; // the gateway is the single sanctioned raw-decode site
+
+            var lines = File.ReadAllLines(file);
+            for (int i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i];
+                if (!RawDecode.IsMatch(line))
+                    continue;
+
+                // A provider's own guarded GetTypeFromSpecification re-enters via `this`
+                // inside TypeSpecGuard.TryEnter/Exit — that is allowed.
+                if (line.Contains(".DecodeSignature(this,", StringComparison.Ordinal))
+                    continue;
+
+                foreach (var provider in Providers)
+                {
+                    if (line.Contains(provider, StringComparison.Ordinal))
+                        violations.Add($"{Path.GetRelativePath(FindRepoRoot(), file)}:{i + 1}");
+                }
+            }
+        }
+
+        Assert.True(
+            violations.Count == 0,
+            "Provider signatures must enter through GuardedProviderDecode. Raw top-level decodes:\n  "
+            + string.Join("\n  ", violations));
+    }
+
+    [Fact]
+    public void EveryProvider_BoundsNestedTypeSpecReentry()
+    {
+        var metadataRoot = Path.Combine(FindRepoRoot(), "src", "ILInspector.Metadata");
+        var missing = new List<string>();
+
+        foreach (var providerFile in ProviderFiles)
+        {
+            var path = Path.Combine(metadataRoot, providerFile);
+            Assert.True(File.Exists(path), $"Expected provider file {providerFile} to exist.");
+            var text = File.ReadAllText(path);
+            if (!text.Contains("TypeSpecGuard.TryEnter", StringComparison.Ordinal))
+                missing.Add(providerFile);
+        }
+
+        Assert.True(
+            missing.Count == 0,
+            "Every provider's GetTypeFromSpecification must bound re-entry with TypeSpecGuard. Unguarded:\n  "
+            + string.Join("\n  ", missing));
+    }
+
+    static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null
+            && !File.Exists(Path.Combine(directory.FullName, "dotnet-inspect.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        Assert.NotNull(directory);
+        return directory!.FullName;
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/ProviderSignatureDecodeBoundaryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ProviderSignatureDecodeBoundaryTests.cs
@@ -1,4 +1,6 @@
-using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace ILInspector.Metadata.Tests;
 
@@ -8,14 +10,19 @@ namespace ILInspector.Metadata.Tests;
 /// stack for every nested element <em>before</em> the first provider callback,
 /// so a single over-deep blob overflows the stack in a way no managed
 /// <c>try/catch</c> can contain. Every top-level provider decode must therefore
-/// be prescanned with <c>SignatureBlobGuard</c>, and every nested cross-handle
-/// TypeSpec re-entry must be bounded by <c>TypeSpecGuard</c>.
+/// be prescanned with <c>SignatureBlobGuard.IsSafeToDecode</c>, and every nested
+/// cross-handle TypeSpec re-entry must be bounded by <c>TypeSpecGuard</c>.
 ///
-/// The assertions below are a deny-list, not an allow-list: any raw
-/// <c>Decode*Signature</c> call that is not one of the sanctioned guarded forms
-/// is a violation. A newly added provider, a decode routed through a local
-/// alias, or an un-gated site fails this test rather than shipping an unguarded
-/// same-mechanism hole. This is the anti-ratchet completeness proof.
+/// This census is a deny-list: any <c>Decode*Signature</c> invocation that is
+/// not one of the two sanctioned guarded forms is a violation. A newly added
+/// provider, an un-gated site, or a decode routed through a local alias fails
+/// this test rather than shipping an unguarded same-mechanism hole. This is the
+/// anti-ratchet closure proof.
+///
+/// The classification is performed on the Roslyn syntax tree, not by string or
+/// regex matching, so it cannot be evaded by comments, line splits, whitespace,
+/// aliasing, or spoofed tokens: an invocation is classified purely by its actual
+/// receiver and enclosing guard expression.
 /// </summary>
 public class ProviderSignatureDecodeBoundaryTests
 {
@@ -25,20 +32,12 @@ public class ProviderSignatureDecodeBoundaryTests
         Path.Combine("src", "ILInspector.MetadataPrimitives"),
     };
 
-    // Files that perform a top-level provider decode behind an inline
-    // SignatureBlobGuard prescan. Each is asserted to actually contain the
-    // prescan by GatewayFiles_PrescanWithSignatureBlobGuard.
-    static readonly string[] PrescanGatewayFiles =
+    static readonly string[] DecodeMethodNames =
     {
-        "GuardedProviderDecode.cs",
-        "GuardedSignatureText.cs",
-        "AttributeDecoder.cs",
+        "DecodeSignature",
+        "DecodeMethodSignature",
+        "DecodeFieldSignature",
     };
-
-    // Whitespace-tolerant so a `.DecodeSignature (` mutation cannot slip past.
-    static readonly Regex RawDecode = new(
-        @"\.Decode(Method|Field)?Signature\s*\(",
-        RegexOptions.Compiled);
 
     [Fact]
     public void EveryProviderDecode_IsGuarded()
@@ -48,58 +47,32 @@ public class ProviderSignatureDecodeBoundaryTests
 
         foreach (var file in EnumerateSourceFiles(root))
         {
-            var fileName = Path.GetFileName(file);
-            var lines = File.ReadAllLines(file);
-            for (int i = 0; i < lines.Length; i++)
+            foreach (var invocation in DecodeInvocations(file))
             {
-                var line = lines[i];
-                if (!RawDecode.IsMatch(line))
+                // Sanctioned form 1: a nested cross-handle TypeSpec re-entry,
+                // `reader.GetTypeSpecification(handle).Decode*Signature(...)`,
+                // bounded by TypeSpecGuard in its enclosing provider file
+                // (asserted by NestedTypeSpecReentry_IsBoundedByTypeSpecGuard).
+                if (IsNestedTypeSpecReentry(invocation))
                     continue;
 
-                // Sanctioned form 1: an inline-prescanned gateway file.
-                if (PrescanGatewayFiles.Contains(fileName))
+                // Sanctioned form 2: this decode is the true-branch of a
+                // `SignatureBlobGuard.IsSafeToDecode(...) ? decode : fallback`
+                // prescan ternary.
+                if (IsPrescanGuardedTernary(invocation))
                     continue;
 
-                // Sanctioned form 2: a nested cross-handle TypeSpec re-entry,
-                // bounded by TypeSpecGuard in its enclosing provider file.
-                if (line.Contains("GetTypeSpecification(", StringComparison.Ordinal))
-                    continue;
-
-                violations.Add($"{Path.GetRelativePath(root, file)}:{i + 1}");
+                var line = invocation.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+                violations.Add($"{Path.GetRelativePath(root, file)}:{line}");
             }
         }
 
         Assert.True(
             violations.Count == 0,
-            "Every provider signature decode must be prescanned (GuardedProviderDecode / "
-            + "GuardedSignatureText / AttributeDecoder) or a TypeSpecGuard-bounded nested "
-            + "re-entry. Unguarded raw decodes:\n  " + string.Join("\n  ", violations));
-    }
-
-    [Fact]
-    public void GatewayFiles_PrescanWithSignatureBlobGuard()
-    {
-        var root = FindRepoRoot();
-        var present = new HashSet<string>(StringComparer.Ordinal);
-        var missing = new List<string>();
-
-        foreach (var file in EnumerateSourceFiles(root))
-        {
-            var fileName = Path.GetFileName(file);
-            if (!PrescanGatewayFiles.Contains(fileName))
-                continue;
-
-            present.Add(fileName);
-            if (!File.ReadAllText(file).Contains("SignatureBlobGuard.IsSafeToDecode", StringComparison.Ordinal))
-                missing.Add(Path.GetRelativePath(root, file));
-        }
-
-        // Every declared prescan gateway must exist and actually prescan.
-        Assert.Equal(PrescanGatewayFiles.Length, present.Count);
-        Assert.True(
-            missing.Count == 0,
-            "Declared prescan gateways must call SignatureBlobGuard.IsSafeToDecode:\n  "
-            + string.Join("\n  ", missing));
+            "Every top-level provider signature decode must be the true-branch of a "
+            + "SignatureBlobGuard.IsSafeToDecode prescan ternary or a "
+            + "TypeSpecGuard-bounded nested GetTypeSpecification re-entry. "
+            + "Unguarded raw decodes:\n  " + string.Join("\n  ", violations));
     }
 
     [Fact]
@@ -110,13 +83,19 @@ public class ProviderSignatureDecodeBoundaryTests
 
         foreach (var file in EnumerateSourceFiles(root))
         {
-            var lines = File.ReadAllLines(file);
-            bool hasNestedReentry = lines.Any(line =>
-                RawDecode.IsMatch(line)
-                && line.Contains("GetTypeSpecification(", StringComparison.Ordinal));
+            var invocations = AllInvocations(file);
 
-            if (hasNestedReentry
-                && !File.ReadAllText(file).Contains("TypeSpecGuard.TryEnter", StringComparison.Ordinal))
+            bool hasNestedReentry = invocations.Any(i => IsDecodeInvocation(i) && IsNestedTypeSpecReentry(i));
+            if (!hasNestedReentry)
+                continue;
+
+            bool boundsWithTypeSpecGuard = invocations.Any(i =>
+                i.Expression is MemberAccessExpressionSyntax member
+                && member.Name.Identifier.Text == "TryEnter"
+                && member.Expression is IdentifierNameSyntax id
+                && id.Identifier.Text == "TypeSpecGuard");
+
+            if (!boundsWithTypeSpecGuard)
                 unguarded.Add(Path.GetRelativePath(root, file));
         }
 
@@ -125,6 +104,53 @@ public class ProviderSignatureDecodeBoundaryTests
             "Every file that re-enters a nested TypeSpec decode must bound it with "
             + "TypeSpecGuard.TryEnter:\n  " + string.Join("\n  ", unguarded));
     }
+
+    static IEnumerable<InvocationExpressionSyntax> DecodeInvocations(string file)
+        => AllInvocations(file).Where(IsDecodeInvocation);
+
+    static InvocationExpressionSyntax[] AllInvocations(string file)
+    {
+        var token = TestContext.Current.CancellationToken;
+        var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(file), cancellationToken: token);
+        return tree.GetRoot(token).DescendantNodes().OfType<InvocationExpressionSyntax>().ToArray();
+    }
+
+    static bool IsDecodeInvocation(InvocationExpressionSyntax invocation)
+        => invocation.Expression is MemberAccessExpressionSyntax member
+            && DecodeMethodNames.Contains(member.Name.Identifier.Text);
+
+    // `<expr>.GetTypeSpecification(...).Decode*Signature(...)`: the decode's
+    // immediate receiver is itself a GetTypeSpecification invocation.
+    static bool IsNestedTypeSpecReentry(InvocationExpressionSyntax invocation)
+        => invocation.Expression is MemberAccessExpressionSyntax member
+            && member.Expression is InvocationExpressionSyntax receiver
+            && receiver.Expression is MemberAccessExpressionSyntax receiverMember
+            && receiverMember.Name.Identifier.Text == "GetTypeSpecification";
+
+    // `SignatureBlobGuard.IsSafeToDecode(...) ? <decode> : <fallback>`: some
+    // enclosing conditional expression guards this decode in its true-branch
+    // with an IsSafeToDecode prescan.
+    static bool IsPrescanGuardedTernary(InvocationExpressionSyntax invocation)
+    {
+        foreach (var ancestor in invocation.Ancestors())
+        {
+            if (ancestor is ConditionalExpressionSyntax conditional
+                && conditional.WhenTrue.Span.Contains(invocation.Span)
+                && ConditionCallsIsSafeToDecode(conditional.Condition))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static bool ConditionCallsIsSafeToDecode(ExpressionSyntax condition)
+        => condition.DescendantNodesAndSelf()
+            .OfType<InvocationExpressionSyntax>()
+            .Any(i => i.Expression is MemberAccessExpressionSyntax member
+                && member.Name.Identifier.Text == "IsSafeToDecode"
+                && member.Expression is IdentifierNameSyntax id
+                && id.Identifier.Text == "SignatureBlobGuard");
 
     static IEnumerable<string> EnumerateSourceFiles(string root)
     {

--- a/tests/ILInspector.Metadata.Tests/ProviderSignatureDecodeBoundaryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ProviderSignatureDecodeBoundaryTests.cs
@@ -3,57 +3,52 @@ using System.Text.RegularExpressions;
 namespace ILInspector.Metadata.Tests;
 
 /// <summary>
-/// Freezes the provider-closure contract for issue #2575. Every
-/// <see cref="System.Reflection.Metadata.ISignatureTypeProvider{TType,TContext}"/>
-/// in <c>ILInspector.Metadata</c> is guarded on both crash vectors:
+/// Freezes the signature-provider closure contract for issue #2575 across both
+/// SRM-only assemblies. SRM's <c>DecodeSignature</c> recurses on the native
+/// stack for every nested element <em>before</em> the first provider callback,
+/// so a single over-deep blob overflows the stack in a way no managed
+/// <c>try/catch</c> can contain. Every top-level provider decode must therefore
+/// be prescanned with <c>SignatureBlobGuard</c>, and every nested cross-handle
+/// TypeSpec re-entry must be bounded by <c>TypeSpecGuard</c>.
 ///
-/// 1. Top-level decodes route through <c>GuardedProviderDecode</c>, which prescans
-///    the blob with <c>SignatureBlobGuard</c> (SRM recurses on the native stack
-///    before the first callback, so only a prescan stops a deep single blob).
-/// 2. Each provider's own <c>GetTypeFromSpecification</c> bounds cross-handle
-///    TypeSpec re-entry through <c>TypeSpecGuard</c>.
-///
-/// These assertions are the anti-ratchet completeness proof: a newly added
-/// provider or an un-gated top-level decode fails this test rather than shipping
-/// an unguarded same-mechanism hole.
+/// The assertions below are a deny-list, not an allow-list: any raw
+/// <c>Decode*Signature</c> call that is not one of the sanctioned guarded forms
+/// is a violation. A newly added provider, a decode routed through a local
+/// alias, or an un-gated site fails this test rather than shipping an unguarded
+/// same-mechanism hole. This is the anti-ratchet completeness proof.
 /// </summary>
 public class ProviderSignatureDecodeBoundaryTests
 {
-    static readonly string[] Providers =
+    static readonly string[] AssemblyRoots =
     {
-        "PointerDetector.Instance",
-        "ILSignatureTypeProvider.Instance",
-        "TypeNodeProvider.Instance",
-        "AnchorSignatureTypeProvider.Instance",
-        "new InaccessibleTypeDetector",
+        Path.Combine("src", "ILInspector.Metadata"),
+        Path.Combine("src", "ILInspector.MetadataPrimitives"),
     };
 
-    // The provider files whose nested TypeSpec re-entry must be bounded by TypeSpecGuard.
-    static readonly string[] ProviderFiles =
+    // Files that perform a top-level provider decode behind an inline
+    // SignatureBlobGuard prescan. Each is asserted to actually contain the
+    // prescan by GatewayFiles_PrescanWithSignatureBlobGuard.
+    static readonly string[] PrescanGatewayFiles =
     {
-        "PointerDetector.cs",
-        "CanonicalIL.cs",              // ILSignatureTypeProvider
-        "TypeNodeProvider.cs",
-        "ApiMemberIdentity.cs",        // AnchorSignatureTypeProvider
-        "SignatureSpellability.cs",    // InaccessibleTypeDetector
+        "GuardedProviderDecode.cs",
+        "GuardedSignatureText.cs",
+        "AttributeDecoder.cs",
     };
 
+    // Whitespace-tolerant so a `.DecodeSignature (` mutation cannot slip past.
     static readonly Regex RawDecode = new(
-        @"\.Decode(Method|Field)?Signature\(",
+        @"\.Decode(Method|Field)?Signature\s*\(",
         RegexOptions.Compiled);
 
     [Fact]
-    public void ProviderTopLevelDecodes_OnlyThroughGuardedGateway()
+    public void EveryProviderDecode_IsGuarded()
     {
-        var metadataRoot = Path.Combine(FindRepoRoot(), "src", "ILInspector.Metadata");
+        var root = FindRepoRoot();
         var violations = new List<string>();
 
-        foreach (var file in Directory.EnumerateFiles(metadataRoot, "*.cs", SearchOption.AllDirectories))
+        foreach (var file in EnumerateSourceFiles(root))
         {
             var fileName = Path.GetFileName(file);
-            if (fileName == "GuardedProviderDecode.cs")
-                continue; // the gateway is the single sanctioned raw-decode site
-
             var lines = File.ReadAllLines(file);
             for (int i = 0; i < lines.Length; i++)
             {
@@ -61,44 +56,86 @@ public class ProviderSignatureDecodeBoundaryTests
                 if (!RawDecode.IsMatch(line))
                     continue;
 
-                // A provider's own guarded GetTypeFromSpecification re-enters via `this`
-                // inside TypeSpecGuard.TryEnter/Exit — that is allowed.
-                if (line.Contains(".DecodeSignature(this,", StringComparison.Ordinal))
+                // Sanctioned form 1: an inline-prescanned gateway file.
+                if (PrescanGatewayFiles.Contains(fileName))
                     continue;
 
-                foreach (var provider in Providers)
-                {
-                    if (line.Contains(provider, StringComparison.Ordinal))
-                        violations.Add($"{Path.GetRelativePath(FindRepoRoot(), file)}:{i + 1}");
-                }
+                // Sanctioned form 2: a nested cross-handle TypeSpec re-entry,
+                // bounded by TypeSpecGuard in its enclosing provider file.
+                if (line.Contains("GetTypeSpecification(", StringComparison.Ordinal))
+                    continue;
+
+                violations.Add($"{Path.GetRelativePath(root, file)}:{i + 1}");
             }
         }
 
         Assert.True(
             violations.Count == 0,
-            "Provider signatures must enter through GuardedProviderDecode. Raw top-level decodes:\n  "
-            + string.Join("\n  ", violations));
+            "Every provider signature decode must be prescanned (GuardedProviderDecode / "
+            + "GuardedSignatureText / AttributeDecoder) or a TypeSpecGuard-bounded nested "
+            + "re-entry. Unguarded raw decodes:\n  " + string.Join("\n  ", violations));
     }
 
     [Fact]
-    public void EveryProvider_BoundsNestedTypeSpecReentry()
+    public void GatewayFiles_PrescanWithSignatureBlobGuard()
     {
-        var metadataRoot = Path.Combine(FindRepoRoot(), "src", "ILInspector.Metadata");
+        var root = FindRepoRoot();
+        var present = new HashSet<string>(StringComparer.Ordinal);
         var missing = new List<string>();
 
-        foreach (var providerFile in ProviderFiles)
+        foreach (var file in EnumerateSourceFiles(root))
         {
-            var path = Path.Combine(metadataRoot, providerFile);
-            Assert.True(File.Exists(path), $"Expected provider file {providerFile} to exist.");
-            var text = File.ReadAllText(path);
-            if (!text.Contains("TypeSpecGuard.TryEnter", StringComparison.Ordinal))
-                missing.Add(providerFile);
+            var fileName = Path.GetFileName(file);
+            if (!PrescanGatewayFiles.Contains(fileName))
+                continue;
+
+            present.Add(fileName);
+            if (!File.ReadAllText(file).Contains("SignatureBlobGuard.IsSafeToDecode", StringComparison.Ordinal))
+                missing.Add(Path.GetRelativePath(root, file));
+        }
+
+        // Every declared prescan gateway must exist and actually prescan.
+        Assert.Equal(PrescanGatewayFiles.Length, present.Count);
+        Assert.True(
+            missing.Count == 0,
+            "Declared prescan gateways must call SignatureBlobGuard.IsSafeToDecode:\n  "
+            + string.Join("\n  ", missing));
+    }
+
+    [Fact]
+    public void NestedTypeSpecReentry_IsBoundedByTypeSpecGuard()
+    {
+        var root = FindRepoRoot();
+        var unguarded = new List<string>();
+
+        foreach (var file in EnumerateSourceFiles(root))
+        {
+            var lines = File.ReadAllLines(file);
+            bool hasNestedReentry = lines.Any(line =>
+                RawDecode.IsMatch(line)
+                && line.Contains("GetTypeSpecification(", StringComparison.Ordinal));
+
+            if (hasNestedReentry
+                && !File.ReadAllText(file).Contains("TypeSpecGuard.TryEnter", StringComparison.Ordinal))
+                unguarded.Add(Path.GetRelativePath(root, file));
         }
 
         Assert.True(
-            missing.Count == 0,
-            "Every provider's GetTypeFromSpecification must bound re-entry with TypeSpecGuard. Unguarded:\n  "
-            + string.Join("\n  ", missing));
+            unguarded.Count == 0,
+            "Every file that re-enters a nested TypeSpec decode must bound it with "
+            + "TypeSpecGuard.TryEnter:\n  " + string.Join("\n  ", unguarded));
+    }
+
+    static IEnumerable<string> EnumerateSourceFiles(string root)
+    {
+        foreach (var assemblyRoot in AssemblyRoots)
+        {
+            var dir = Path.Combine(root, assemblyRoot);
+            if (!Directory.Exists(dir))
+                continue;
+            foreach (var file in Directory.EnumerateFiles(dir, "*.cs", SearchOption.AllDirectories))
+                yield return file;
+        }
     }
 
     static string FindRepoRoot()

--- a/tests/ILInspector.Metadata.Tests/ProviderSignatureDecodeBoundaryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ProviderSignatureDecodeBoundaryTests.cs
@@ -36,11 +36,20 @@ public class ProviderSignatureDecodeBoundaryTests
         Path.Combine("src", "ILInspector.MetadataPrimitives"),
     };
 
+    // The complete set of SRM top-level signature-blob decoders that recurse on
+    // the native stack (once per nested element, before the first provider
+    // callback) and can therefore StackOverflow uncatchably on an over-deep
+    // blob. This is a denylist of dangerous entry points, so names the product
+    // does not currently call are still listed to freeze the anti-ratchet gate.
+    // Lower-level sub-decoders (DecodeType, DecodeTypeSequence) are reached only
+    // from within one of these and are covered transitively.
     static readonly string[] DecodeMethodNames =
     {
         "DecodeSignature",
         "DecodeMethodSignature",
         "DecodeFieldSignature",
+        "DecodeLocalSignature",
+        "DecodeMethodSpecificationSignature",
     };
 
     [Fact]

--- a/tests/ILInspector.Metadata.Tests/ProviderSignatureDecodeBoundaryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ProviderSignatureDecodeBoundaryTests.cs
@@ -21,8 +21,12 @@ namespace ILInspector.Metadata.Tests;
 ///
 /// The classification is performed on the Roslyn syntax tree, not by string or
 /// regex matching, so it cannot be evaded by comments, line splits, whitespace,
-/// aliasing, or spoofed tokens: an invocation is classified purely by its actual
-/// receiver and enclosing guard expression.
+/// aliasing, or spoofed tokens. It enumerates every occurrence of a decode
+/// method name and requires each to be the invoked member of a sanctioned call,
+/// so null-conditional (`x?.Decode...`), method-group, and delegate forms are
+/// flagged rather than skipped. Form 2 additionally binds the prescan to the
+/// decoded blob (same receiver's `.Signature`), so an unrelated or nil-handle
+/// guard cannot launder an unguarded decode past the census.
 /// </summary>
 public class ProviderSignatureDecodeBoundaryTests
 {
@@ -47,22 +51,26 @@ public class ProviderSignatureDecodeBoundaryTests
 
         foreach (var file in EnumerateSourceFiles(root))
         {
-            foreach (var invocation in DecodeInvocations(file))
+            foreach (var name in DecodeNameOccurrences(file))
             {
-                // Sanctioned form 1: a nested cross-handle TypeSpec re-entry,
-                // `reader.GetTypeSpecification(handle).Decode*Signature(...)`,
-                // bounded by TypeSpecGuard in its enclosing provider file
-                // (asserted by NestedTypeSpecReentry_IsBoundedByTypeSpecGuard).
-                if (IsNestedTypeSpecReentry(invocation))
+                // A decode method name may appear ONLY as the invoked method of a
+                // sanctioned decode call. Any other occurrence — a method-group /
+                // delegate reference, or a call whose name node is not the invoked
+                // member — is an unguarded escape and a violation.
+                if (TryGetInvokedDecode(name, out var invocation)
+                    && (IsNestedTypeSpecReentry(invocation) || IsPrescanGuardedTernary(invocation)))
+                {
+                    // Sanctioned form 1: a nested cross-handle TypeSpec re-entry,
+                    // `reader.GetTypeSpecification(handle).Decode*Signature(...)`,
+                    // bounded by TypeSpecGuard in its enclosing provider file
+                    // (asserted by NestedTypeSpecReentry_IsBoundedByTypeSpecGuard).
+                    // Sanctioned form 2: the decode is the true-branch of a
+                    // `SignatureBlobGuard.IsSafeToDecode(reader, <recv>.Signature,
+                    // ...) ? decode : fallback` prescan ternary.
                     continue;
+                }
 
-                // Sanctioned form 2: this decode is the true-branch of a
-                // `SignatureBlobGuard.IsSafeToDecode(...) ? decode : fallback`
-                // prescan ternary.
-                if (IsPrescanGuardedTernary(invocation))
-                    continue;
-
-                var line = invocation.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+                var line = name.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
                 violations.Add($"{Path.GetRelativePath(root, file)}:{line}");
             }
         }
@@ -105,14 +113,46 @@ public class ProviderSignatureDecodeBoundaryTests
             + "TypeSpecGuard.TryEnter:\n  " + string.Join("\n  ", unguarded));
     }
 
-    static IEnumerable<InvocationExpressionSyntax> DecodeInvocations(string file)
-        => AllInvocations(file).Where(IsDecodeInvocation);
+    static IEnumerable<SimpleNameSyntax> DecodeNameOccurrences(string file)
+        => ParseRoot(file).DescendantNodes()
+            .OfType<SimpleNameSyntax>()
+            .Where(name => DecodeMethodNames.Contains(name.Identifier.Text));
 
     static InvocationExpressionSyntax[] AllInvocations(string file)
+        => ParseRoot(file).DescendantNodes().OfType<InvocationExpressionSyntax>().ToArray();
+
+    static SyntaxNode ParseRoot(string file)
     {
         var token = TestContext.Current.CancellationToken;
         var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(file), cancellationToken: token);
-        return tree.GetRoot(token).DescendantNodes().OfType<InvocationExpressionSyntax>().ToArray();
+        return tree.GetRoot(token);
+    }
+
+    // Resolves a decode-method name occurrence to the invocation that invokes it,
+    // handling both `x.Decode*Signature(...)` (MemberAccess) and
+    // `x?.Decode*Signature(...)` (MemberBinding). Returns false when the name is
+    // not the invoked member — e.g. a method-group / delegate reference — which
+    // is itself a violation.
+    static bool TryGetInvokedDecode(SimpleNameSyntax name, out InvocationExpressionSyntax invocation)
+    {
+        switch (name.Parent)
+        {
+            case MemberAccessExpressionSyntax member
+                when member.Name == name
+                && member.Parent is InvocationExpressionSyntax invoked
+                && invoked.Expression == member:
+                invocation = invoked;
+                return true;
+            case MemberBindingExpressionSyntax binding
+                when binding.Name == name
+                && binding.Parent is InvocationExpressionSyntax invoked
+                && invoked.Expression == binding:
+                invocation = invoked;
+                return true;
+            default:
+                invocation = null!;
+                return false;
+        }
     }
 
     static bool IsDecodeInvocation(InvocationExpressionSyntax invocation)

--- a/tests/ILInspector.Metadata.Tests/SignatureDecoderSafetyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SignatureDecoderSafetyTests.cs
@@ -48,6 +48,10 @@ public class SignatureDecoderSafetyTests
         => RunWorker(nameof(DeepMethodSignatureThroughSpellabilityWorker));
 
     [Fact]
+    public void DeepEnumField_ThroughAttributeDecoder_IsContainedInChildProcess()
+        => RunWorker(nameof(DeepEnumFieldThroughAttributeDecoderWorker));
+
+    [Fact]
     public void SignatureBlobGuard_OldAssemblyIdentity_IsForwarded()
         => Assert.Equal(
             typeof(SignatureBlobGuard),
@@ -213,6 +217,35 @@ public class SignatureDecoderSafetyTests
         var spellability = new SignatureSpellability(new NullReferenceResolver());
         _ = spellability.CanSpellMethod(
             reader, method, GenericContext.ForMethod(reader, reader.GetTypeDefinition(typeHandle), method));
+    }
+
+    [Fact]
+    public void DeepEnumFieldThroughAttributeDecoderWorker()
+    {
+        if (!IsSelectedWorker(nameof(DeepEnumFieldThroughAttributeDecoderWorker)))
+            return;
+
+        // AttributeDecoder.TryDecode -> CustomAttribute.DecodeValue reads the
+        // ctor's enum-typed argument, and SRM resolves the enum's size by
+        // decoding the enum's first instance-field signature via
+        // ArgTypeProvider.GetUnderlyingEnumType. An over-deep enum field blob
+        // recurses on the native stack there before any provider callback, so
+        // the prescan-and-degrade guard is the only thing between this and an
+        // uncatchable StackOverflow. This worker crashes the child process
+        // (nonzero exit) if that guard regresses in strength — the census only
+        // pins its shape.
+        var image = BuildDeepEnumAttributePe();
+        using var peReader = new PEReader(new MemoryStream(image));
+        var reader = peReader.GetMetadataReader();
+        var attribute = reader.GetCustomAttribute(reader.CustomAttributes.Single());
+
+        var decoded = AttributeDecoder.TryDecode(reader, attribute);
+
+        // Containment also means graceful degrade: the guard trips, the enum is
+        // read as Int32, and decoding completes with the single fixed argument
+        // rather than throwing.
+        Assert.NotNull(decoded);
+        Assert.Single(decoded!.Value.FixedArguments);
     }
 
     static bool IsSelectedWorker(string methodName)
@@ -403,6 +436,104 @@ public class SignatureDecoderSafetyTests
             FieldAttributes.Public | FieldAttributes.Static,
             metadata.GetOrAddString("F"),
             metadata.GetOrAddBlob(fieldSignature));
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    /// <summary>
+    /// Builds a PE with an enum <c>N.E</c> whose single instance field carries an
+    /// over-deep signature blob, and an attribute <c>N.A</c> whose constructor
+    /// takes an <c>N.E</c> argument, applied to <c>N.A</c>. Decoding that custom
+    /// attribute drives <c>ArgTypeProvider.GetUnderlyingEnumType</c> through the
+    /// deep enum-field signature — the exact path guarded in AttributeDecoder.
+    /// </summary>
+    static byte[] BuildDeepEnumAttributePe()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString("Synthetic.dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Synthetic"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        // TypeDef row 2: the enum. Owns field row 1 (its deep instance field) and
+        // no methods.
+        var enumType = metadata.AddTypeDefinition(
+            TypeAttributes.Public | TypeAttributes.Sealed,
+            metadata.GetOrAddString("N"),
+            metadata.GetOrAddString("E"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        // TypeDef row 3: the attribute. Owns no fields and method row 1 (.ctor).
+        var attributeType = metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            metadata.GetOrAddString("N"),
+            metadata.GetOrAddString("A"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(2),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        // Field row 1: the enum's instance field, with an over-deep signature.
+        var enumFieldSignature = new BlobBuilder();
+        enumFieldSignature.WriteByte(0x06); // field signature
+        for (int i = 0; i < 100_000; i++)
+            enumFieldSignature.WriteByte(0x1d); // SZARRAY
+        enumFieldSignature.WriteByte(0x08);     // I4
+        metadata.AddFieldDefinition(
+            FieldAttributes.Public, // instance (non-static): GetUnderlyingEnumType reads the first such field
+            metadata.GetOrAddString("value__"),
+            metadata.GetOrAddBlob(enumFieldSignature));
+
+        // Method row 1: `.ctor(N.E)` on the attribute. HASTHIS, void return, one
+        // VALUETYPE parameter referencing the enum TypeDef (coded index below).
+        int enumCodedIndex = CodedIndex.TypeDefOrRefOrSpec(enumType);
+        Assert.True(enumCodedIndex < 0x80); // single-byte compressed integer
+        var ctorSignature = new BlobBuilder();
+        ctorSignature.WriteByte(0x20);              // HASTHIS | DEFAULT
+        ctorSignature.WriteByte(0x01);              // one parameter
+        ctorSignature.WriteByte(0x01);              // return type VOID
+        ctorSignature.WriteByte(0x11);              // ELEMENT_TYPE_VALUETYPE
+        ctorSignature.WriteByte((byte)enumCodedIndex);
+        var ctor = metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString(".ctor"),
+            metadata.GetOrAddBlob(ctorSignature),
+            bodyOffset: -1,
+            parameterList: MetadataTokens.ParameterHandle(1));
+
+        // A(default(E)) applied to the attribute type: prolog, a 4-byte enum
+        // value (read as Int32 after the guard degrades), zero named arguments.
+        var value = new BlobBuilder();
+        value.WriteUInt16(0x0001); // prolog
+        value.WriteInt32(0);       // fixed enum argument
+        value.WriteUInt16(0);      // named argument count
+        metadata.AddCustomAttribute(attributeType, ctor, metadata.GetOrAddBlob(value));
 
         var pe = new ManagedPEBuilder(
             PEHeaderBuilder.CreateLibraryHeader(),

--- a/tests/ILInspector.Metadata.Tests/SignatureDecoderSafetyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SignatureDecoderSafetyTests.cs
@@ -23,9 +23,29 @@ public class SignatureDecoderSafetyTests
     public void DeepMethodSignatureGateway_IsContainedInChildProcess()
         => RunWorker(nameof(DeepMethodSignatureGatewayWorker));
 
-    [Fact(Skip = "Known TypeNodeProvider crash tracked by #2575.")]
+    [Fact]
     public void CyclicTypeSpec_ThroughApiSurfaceExtractor_IsContainedInChildProcess()
         => RunWorker(nameof(CyclicTypeSpecThroughApiSurfaceExtractorWorker));
+
+    [Fact]
+    public void DeepFieldSignature_ThroughApiSurfaceExtractor_IsContainedInChildProcess()
+        => RunWorker(nameof(DeepFieldSignatureThroughApiSurfaceExtractorWorker));
+
+    [Fact]
+    public void DeepTypeSpec_ThroughCanonicalIl_IsContainedInChildProcess()
+        => RunWorker(nameof(DeepTypeSpecThroughCanonicalIlWorker));
+
+    [Fact]
+    public void DeepMethodSignature_ThroughPointerDetector_IsContainedInChildProcess()
+        => RunWorker(nameof(DeepMethodSignatureThroughPointerDetectorWorker));
+
+    [Fact]
+    public void DeepMethodSignature_ThroughAnchorProvider_IsContainedInChildProcess()
+        => RunWorker(nameof(DeepMethodSignatureThroughAnchorProviderWorker));
+
+    [Fact]
+    public void DeepMethodSignature_ThroughSpellability_IsContainedInChildProcess()
+        => RunWorker(nameof(DeepMethodSignatureThroughSpellabilityWorker));
 
     [Fact]
     public void SignatureBlobGuard_OldAssemblyIdentity_IsForwarded()
@@ -125,6 +145,76 @@ public class SignatureDecoderSafetyTests
         _ = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
     }
 
+    [Fact]
+    public void DeepFieldSignatureThroughApiSurfaceExtractorWorker()
+    {
+        if (!IsSelectedWorker(nameof(DeepFieldSignatureThroughApiSurfaceExtractorWorker)))
+            return;
+
+        var fieldSignature = new BlobBuilder();
+        fieldSignature.WriteByte(0x06); // field signature
+        for (int i = 0; i < 100_000; i++)
+            fieldSignature.WriteByte(0x1d); // SZARRAY
+        fieldSignature.WriteByte(0x08);     // I4
+
+        var image = BuildSurfacePe(fieldSignature: fieldSignature, methodSignature: null);
+        using var peReader = new PEReader(new MemoryStream(image));
+        _ = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+    }
+
+    [Fact]
+    public void DeepTypeSpecThroughCanonicalIlWorker()
+    {
+        if (!IsSelectedWorker(nameof(DeepTypeSpecThroughCanonicalIlWorker)))
+            return;
+
+        var reader = BuildTypeSpec(signature =>
+        {
+            for (int i = 0; i < 100_000; i++)
+                signature.WriteByte(0x1d); // SZARRAY
+            signature.WriteByte(0x08);     // I4
+        });
+
+        Assert.Equal(
+            "object",
+            CanonicalIL.ResolveTypeHandle(reader, MetadataTokens.TypeSpecificationHandle(1)));
+    }
+
+    [Fact]
+    public void DeepMethodSignatureThroughPointerDetectorWorker()
+    {
+        if (!IsSelectedWorker(nameof(DeepMethodSignatureThroughPointerDetectorWorker)))
+            return;
+
+        var image = BuildSurfacePe(fieldSignature: null, methodSignature: DeepMethodSignature());
+        using var peReader = new PEReader(new MemoryStream(image));
+        _ = AssemblyDetailScanner.ScanPresenceFlags(peReader);
+    }
+
+    [Fact]
+    public void DeepMethodSignatureThroughAnchorProviderWorker()
+    {
+        if (!IsSelectedWorker(nameof(DeepMethodSignatureThroughAnchorProviderWorker)))
+            return;
+
+        var (reader, typeHandle, methodHandle) = BuildTypeWithMethod(DeepMethodSignature());
+        _ = ApiMemberIdentity.CreateMethodAnchorInfo(
+            reader, typeHandle, reader.GetMethodDefinition(methodHandle));
+    }
+
+    [Fact]
+    public void DeepMethodSignatureThroughSpellabilityWorker()
+    {
+        if (!IsSelectedWorker(nameof(DeepMethodSignatureThroughSpellabilityWorker)))
+            return;
+
+        var (reader, typeHandle, methodHandle) = BuildTypeWithMethod(DeepMethodSignature());
+        var method = reader.GetMethodDefinition(methodHandle);
+        var spellability = new SignatureSpellability(new NullReferenceResolver());
+        _ = spellability.CanSpellMethod(
+            reader, method, GenericContext.ForMethod(reader, reader.GetTypeDefinition(typeHandle), method));
+    }
+
     static bool IsSelectedWorker(string methodName)
         => Environment.GetEnvironmentVariable(WorkerVariable) == methodName;
 
@@ -157,6 +247,114 @@ public class SignatureDecoderSafetyTests
         var signature = new BlobBuilder();
         writeSignature(signature);
         return BuildAssembly(metadata => metadata.AddTypeSpecification(metadata.GetOrAddBlob(signature)));
+    }
+
+    static BlobBuilder DeepMethodSignature()
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x00); // default method signature
+        signature.WriteByte(0x00); // zero parameters
+        for (int i = 0; i < 100_000; i++)
+            signature.WriteByte(0x1d); // SZARRAY return type
+        signature.WriteByte(0x08);     // I4
+        return signature;
+    }
+
+    static (MetadataReader Reader, TypeDefinitionHandle TypeHandle, MethodDefinitionHandle MethodHandle)
+        BuildTypeWithMethod(BlobBuilder methodSignature)
+    {
+        MethodDefinitionHandle methodHandle = default;
+        TypeDefinitionHandle typeHandle = default;
+        var reader = BuildAssembly(metadata =>
+        {
+            methodHandle = metadata.AddMethodDefinition(
+                MethodAttributes.Public | MethodAttributes.Static,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("M"),
+                metadata.GetOrAddBlob(methodSignature),
+                bodyOffset: -1,
+                parameterList: MetadataTokens.ParameterHandle(1));
+            typeHandle = metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("C"),
+                default,
+                MetadataTokens.FieldDefinitionHandle(1),
+                methodHandle);
+        });
+        return (reader, typeHandle, methodHandle);
+    }
+
+    /// <summary>
+    /// Builds a minimal PE image exposing a public type <c>N.C</c> with a single
+    /// static field and/or method carrying the supplied signature blob, so
+    /// PE-level scanners (ApiSurfaceExtractor, AssemblyDetailScanner) reach the
+    /// crafted signature through their real entry points.
+    /// </summary>
+    static byte[] BuildSurfacePe(BlobBuilder? fieldSignature, BlobBuilder? methodSignature)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString("Synthetic.dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Synthetic"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            metadata.GetOrAddString("N"),
+            metadata.GetOrAddString("C"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        if (fieldSignature is not null)
+        {
+            metadata.AddFieldDefinition(
+                FieldAttributes.Public | FieldAttributes.Static,
+                metadata.GetOrAddString("F"),
+                metadata.GetOrAddBlob(fieldSignature));
+        }
+
+        if (methodSignature is not null)
+        {
+            metadata.AddMethodDefinition(
+                MethodAttributes.Public | MethodAttributes.Static,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("M"),
+                metadata.GetOrAddBlob(methodSignature),
+                bodyOffset: -1,
+                parameterList: MetadataTokens.ParameterHandle(1));
+        }
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    sealed class NullReferenceResolver : IAssemblyReferenceResolver
+    {
+        public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
+            => null;
     }
 
     static byte[] BuildApiSurfaceTypeSpecCycle()

--- a/tests/ILInspector.Metadata.Tests/StringSignatureDecodeBoundaryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/StringSignatureDecodeBoundaryTests.cs
@@ -16,8 +16,10 @@ public class StringSignatureDecodeBoundaryTests
             "GuardedSignatureText.cs",
             "SignatureDecoder.cs",
             "TypeResolver.cs",
-            // TypeNodeProvider delegates leaf-name callbacks to the string provider; its own
-            // top-level and nested-TypeSpec safety belongs to provider-closure issue #2575.
+            // TypeNodeProvider delegates leaf-name callbacks to the string provider for
+            // primitive/def/ref names; its top-level and nested-TypeSpec decode safety is
+            // enforced separately by GuardedProviderDecode + TypeSpecGuard (issue #2575) and
+            // frozen by ProviderSignatureDecodeBoundaryTests.
             "TypeNodeProvider.cs",
         };
         var violations = new List<string>();

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -2700,7 +2700,7 @@ static class FidelityCheck
         string? initializer = fieldInits.FirstOrDefault(fi => fi.Field == name).Value;
         string suffix = initializer is not null && !isStatic ? $" = {initializer}" : "";
         bool isVolatile = false;
-        try { isVolatile = MetadataDeclarationQuery.IsVolatileField(field, context); }
+        try { isVolatile = MetadataDeclarationQuery.IsVolatileField(reader, field, context); }
         catch { /* signature already decoded above; treat as non-volatile */ }
         string fieldType = Clean(type);
         string unsafeModifier = RequiresUnsafeSignature(fieldType) ? "unsafe " : "";


### PR DESCRIPTION
## Summary

Slice B of #2490 (fixes #2575). Closes the last unguarded
`ISignatureTypeProvider` implementations in `ILInspector.Metadata` against SRM
native-stack `StackOverflowException` from over-deep or cyclic signature blobs.
This is the frozen-scope follow-up to the abandoned #2574: the complete provider
census is enumerated up front and frozen by a completeness test, so the scope
cannot ratchet round-by-round.

## Providers closed (all 5)

| Provider | File | Nested guard | Top-level gateway |
| --- | --- | --- | --- |
| `PointerDetector` | PointerDetector.cs | ✓ `TypeSpecGuard` | ✓ `GuardedProviderDecode` |
| `ILSignatureTypeProvider` | CanonicalIL.cs | ✓ | ✓ |
| `TypeNodeProvider` | TypeNodeProvider.cs | ✓ | ✓ |
| `AnchorSignatureTypeProvider` | ApiMemberIdentity.cs | ✓ | ✓ |
| `InaccessibleTypeDetector` | SignatureSpellability.cs | ✓ | ✓ |

## Mechanism (both vectors per provider)

1. **Top-level deep blob** — SRM's `DecodeSignature` recurses on the native
   stack for every nested element *before* the first provider callback, so a
   deep single blob overflows the stack uncatchably. The new
   `GuardedProviderDecode` gateway prescans every top-level provider decode with
   `SignatureBlobGuard.IsSafeToDecode` and fails closed to the provider's
   degraded sentinel (`false` / `"object"` / `"System.Object"` /
   `NamedTypeNode("object")`) when the blob is too deep or malformed.
2. **Nested cross-handle TypeSpec cycle** — each provider's own
   `GetTypeFromSpecification` now bounds re-entry through `TypeSpecGuard`
   (made `public` to mirror the already-public `SignatureBlobGuard`).

This mirrors slice A (#2677): `SignatureDecoder` nested guard + `GuardedSignatureText`
top-level gateway.

## Completeness (anti-ratchet)

`ProviderSignatureDecodeBoundaryTests` freezes the contract:

- **No raw top-level provider decode** may bypass `GuardedProviderDecode`.
- **Every provider** must bound nested re-entry with `TypeSpecGuard`.

A newly added provider or an un-gated decode fails this test rather than
shipping a same-mechanism hole. This is the fix for what killed #2574.

## Crash-containment proofs

Process-isolated child-process regressions (exit-0 = contained):

- `CyclicTypeSpec_ThroughApiSurfaceExtractor_*` — the previously-**skipped**
  #2575 pin, now **un-skipped and passing** (real `ApiSurfaceExtractor.Extract`
  entry, TypeNodeProvider nested cycle).
- `DeepFieldSignature_ThroughApiSurfaceExtractor_*` — TypeNodeProvider top-level.
- `DeepTypeSpec_ThroughCanonicalIl_*` — ILSignatureTypeProvider via `ResolveTypeHandle`.
- `DeepMethodSignature_ThroughPointerDetector_*` — via `ScanPresenceFlags`.
- `DeepMethodSignature_ThroughAnchorProvider_*` — via `CreateMethodAnchorInfo`.
- `DeepMethodSignature_ThroughSpellability_*` — via `CanSpellMethod`.

The shared `TypeSpecGuard`/`SignatureBlobGuard` are additionally crash-proven by
slice A's `TypeResolver`/`MetadataDeclarationQuery` workers.

## Validation

- Build clean (`dotnet build dotnet-inspect.slnx -c Release`).
- Tests: Metadata **440**, product **1797** (10 pre-existing ilasm skips),
  Analysis **421**, targeted Decompiler IL-projection/importer/printer **113** —
  all green, 0 failures.
- **CoreLib A/B byte-identical** (base 81ba0eec vs head) for `type`, `library`,
  `extensions`, `member -S IL` (String, List), and `member --unsafe`. Valid
  signatures pass the prescan, so guarded output equals direct output.

## Non-goals (separate #2490 slices)

TypeRef/TypeDef graph cycles (slice C), amplification (slice D),
custom-attribute `DecodeValue` (slice E), and the #2689 degradation-contract
follow-up.

## Adversarial review

Requesting two cross-model reviews per AGENTS.md (isolated worktrees, reproduce
on clean head) before Ready to merge.
