### PR TITLE
Define value equality for Finding collection records

### DIFF
--- a/docs/design/finding-value-equality.md
+++ b/docs/design/finding-value-equality.md
@@ -1,0 +1,73 @@
+# Finding Value Equality
+
+Finding correspondence and .NET value equality are separate contracts.
+`FindingKey` controls cross-version correspondence. Equality answers whether
+two already-materialized information or outcome values represent the same
+content.
+
+## Core collection contracts
+
+Public Finding records use the semantics of the collection they expose:
+
+| Shape | Collection meaning | Equality |
+| --- | --- | --- |
+| `FindingInspection<T>.Complete.Findings` | Ordered census | Sequence equality |
+| `FindingMatch.Edges` | Ordered committed alignment | Sequence equality |
+| `FindingMatch.MoveCandidates` | Ordered candidate evidence | Sequence equality |
+| `FindingComparison<T>.Complete.Pairs` | Ordered transition stream | Sequence equality |
+| `CorrelatedFinding<T>.Occurrences` | Version-position order | Sequence equality |
+| `FindingEquivalence` allow-lists | Identity sets | Set equality |
+
+Sequence equality is order- and multiplicity-sensitive. Independently allocated
+arrays with equal elements are equal and produce equal hash codes. Reordering
+elements, adding a duplicate, or removing a duplicate changes the value.
+Default `ImmutableArray<T>` values are rejected at construction; empty
+initialized arrays remain valid values.
+
+Set equality is independent of enumeration and construction order. Duplicate
+inputs are normalized by `ImmutableHashSet<T>` and do not change the value.
+Null sets are rejected at construction. Allow-lists normalize custom collection
+comparers to the enum's default identity comparer so equal policies cannot
+behave differently.
+
+The union wrappers compose the active case's equality. Consequently,
+independently materialized inspections and comparisons are equal when their
+cases and complete ordered content are equal. `FindingCorrelation<T>` remains a
+reference-identity operation object; its durable `CorrelatedFinding<T>` value
+has collection-aware equality.
+
+## Payload boundary
+
+`Finding<T>` and `PairFinding<T>` compose `EqualityComparer<T>.Default`.
+Payload types therefore own their .NET equality contract. A producer record
+that contains `ImmutableArray<T>` or `ImmutableHashSet<T>` must define
+collection-aware equality if it promises semantic value equality; the generic
+Finding layer does not reinterpret opaque payloads.
+
+Payload equality never controls correspondence. `FindingMatcher` consumes
+`FindingKey` streams and does not call `T.Equals` or `T.GetHashCode`. Two
+findings may therefore correspond by key even when their producer-owned
+payload equality reports them as different.
+
+## Producer inventory
+
+The current Finding payloads fall into three groups:
+
+- scalar-only value records such as `CanonicalIlOperation`,
+  `CSharpCanonicalLine`, and `DecompilerFidelityCause` already have correct
+  generated equality;
+- `MethodIdentity` and `MemberRef` carry ordered type/name arrays and define
+  sequence equality and matching hashes. `DirectCall`, `UnsafetyOccurrence`,
+  and `UnsafeEvidence` compose those leaf contracts;
+- Metadata's union payload comparison supplies its own set-oriented comparer
+  instead of relying on the payload record's generated equality.
+
+Generic producer promotion may use `EqualityComparer<T>.Default` when no
+producer comparer is supplied. A collection-bearing payload must therefore
+either define semantic equality itself or supply the producer operation with
+an explicit comparer.
+
+Collection-bearing Analysis summaries and Research diff/composition results
+are operation or presentation outputs rather than Finding payload values. They
+are not cache or correspondence identities and retain their existing
+operation-result semantics.

--- a/src/ILInspector.Analysis.Tests/MemberIdentityValueEqualityTests.cs
+++ b/src/ILInspector.Analysis.Tests/MemberIdentityValueEqualityTests.cs
@@ -1,0 +1,158 @@
+using System.Collections.Immutable;
+
+namespace ILInspector.Analysis.Tests;
+
+public class MemberIdentityValueEqualityTests
+{
+    static readonly TypeRef DeclaringType = TypeRef.Definition(
+        "Example",
+        "Example",
+        "Container");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef String = TypeRef.CoreLib("System", "String");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+
+    [Fact]
+    public void MethodIdentity_UsesOrderedSequenceEquality()
+    {
+        var first = Method(
+            ImmutableArray.Create(Int32, Int32, String),
+            ImmutableArray.Create("T", "U"));
+        var equivalent = Method(
+            ImmutableArray.Create(Int32, Int32, String),
+            ImmutableArray.Create("T", "U"));
+        var reordered = Method(
+            ImmutableArray.Create(String, Int32, Int32),
+            ImmutableArray.Create("T", "U"));
+        var differentDuplicates = Method(
+            ImmutableArray.Create(Int32, String, String),
+            ImmutableArray.Create("T", "U"));
+
+        Assert.Equal(first, equivalent);
+        Assert.Equal(first.GetHashCode(), equivalent.GetHashCode());
+        Assert.NotEqual(first, reordered);
+        Assert.NotEqual(first, differentDuplicates);
+    }
+
+    [Fact]
+    public void MethodIdentity_NormalizesOmittedGenericNamesAndRejectsInvalidParameters()
+    {
+        var omitted = Method([]);
+        var explicitEmpty = Method([], []);
+
+        Assert.False(omitted.GenericParameterNames.IsDefault);
+        Assert.Equal(omitted, explicitEmpty);
+        Assert.Throws<ArgumentException>(() => Method(default));
+        Assert.Throws<ArgumentException>(() => Method([null!]));
+        Assert.Throws<ArgumentException>(
+            () => omitted with { GenericParameterNames = [null!] });
+    }
+
+    [Fact]
+    public void MemberRef_ComposesAllOrderedCollectionProperties()
+    {
+        var first = Member(
+            ImmutableArray.Create(Int32, String),
+            ImmutableArray.Create(String),
+            ImmutableArray.Create(Int32));
+        var equivalent = Member(
+            ImmutableArray.Create(Int32, String),
+            ImmutableArray.Create(String),
+            ImmutableArray.Create(Int32));
+        var reordered = Member(
+            ImmutableArray.Create(String, Int32),
+            ImmutableArray.Create(String),
+            ImmutableArray.Create(Int32));
+        var differentTypeArguments = Member(
+            ImmutableArray.Create(Int32, String),
+            ImmutableArray.Create(Int32),
+            ImmutableArray.Create(Int32));
+        var differentOpenParameters = Member(
+            ImmutableArray.Create(Int32, String),
+            ImmutableArray.Create(String),
+            ImmutableArray.Create(String));
+
+        Assert.Equal(first, equivalent);
+        Assert.Equal(first.GetHashCode(), equivalent.GetHashCode());
+        Assert.NotEqual(first, reordered);
+        Assert.NotEqual(first, differentTypeArguments);
+        Assert.NotEqual(first, differentOpenParameters);
+    }
+
+    [Fact]
+    public void MemberRef_RejectsDefaultCollectionsIncludingWithExpressions()
+    {
+        Assert.Throws<ArgumentException>(() => Member(default, [], []));
+
+        var member = Member([], [], []);
+        Assert.Throws<ArgumentException>(
+            () => member with { ParameterTypes = default });
+        Assert.Throws<ArgumentException>(
+            () => member with { TypeArguments = default });
+        Assert.Throws<ArgumentException>(
+            () => member with { OpenParameterTypes = default });
+    }
+
+    [Fact]
+    public void DirectCall_ComposesMemberIdentityValueEquality()
+    {
+        var first = new DirectCall(
+            Method(ImmutableArray.Create(Int32, String)),
+            Member(
+                ImmutableArray.Create(Int32),
+                ImmutableArray.Create(String),
+                ImmutableArray.Create(Int32)),
+            ILOffset: 3,
+            OperandToken: 0x0a000001,
+            CalleeDefinitionToken: 0x06000002,
+            CallKind.Call)
+        {
+            Opcode = "call",
+        };
+        var equivalent = new DirectCall(
+            Method(ImmutableArray.Create(Int32, String)),
+            Member(
+                ImmutableArray.Create(Int32),
+                ImmutableArray.Create(String),
+                ImmutableArray.Create(Int32)),
+            ILOffset: 3,
+            OperandToken: 0x0a000001,
+            CalleeDefinitionToken: 0x06000002,
+            CallKind.Call)
+        {
+            Opcode = "call",
+        };
+
+        Assert.Equal(first, equivalent);
+        Assert.Equal(first.GetHashCode(), equivalent.GetHashCode());
+    }
+
+    static MethodIdentity Method(
+        ImmutableArray<TypeRef> parameterTypes,
+        ImmutableArray<string> genericParameterNames = default)
+        => new(
+            "Example",
+            Guid.Parse("252451b8-cd83-4e7b-b7e6-8f05b6e4900c"),
+            DeclaringType,
+            "M",
+            parameterTypes,
+            Void,
+            MetadataToken: 0x06000001,
+            IsStatic: true,
+            GenericArity: genericParameterNames.IsDefault ? 0 : genericParameterNames.Length,
+            GenericParameterNames: genericParameterNames);
+
+    static MemberRef Member(
+        ImmutableArray<TypeRef> parameterTypes,
+        ImmutableArray<TypeRef> typeArguments,
+        ImmutableArray<TypeRef> openParameterTypes)
+        => new(DeclaringType, "M", parameterTypes, Void, MemberKind.Method)
+        {
+            TypeArguments = typeArguments,
+            HasThis = true,
+            SignatureHeader = 0x20,
+            GenericArity = typeArguments.Length,
+            OpenParameterTypes = openParameterTypes,
+            OpenReturnType = String,
+        };
+}

--- a/src/ILInspector.Analysis/MemberIdentity.cs
+++ b/src/ILInspector.Analysis/MemberIdentity.cs
@@ -71,7 +71,60 @@ public sealed record MethodIdentity(
     bool IsExtension = false,
     CallerUnsafeMode CallerUnsafeMode = CallerUnsafeMode.None,
     int GenericArity = 0,
-    ImmutableArray<string> GenericParameterNames = default);
+    ImmutableArray<string> GenericParameterNames = default)
+{
+    ImmutableArray<TypeRef> _parameterTypes
+        = ImmutableArrayValueEquality.RequireInitialized(ParameterTypes, nameof(ParameterTypes));
+    ImmutableArray<string> _genericParameterNames
+        = ImmutableArrayValueEquality.EmptyIfDefault(GenericParameterNames, nameof(GenericParameterNames));
+
+    public ImmutableArray<TypeRef> ParameterTypes
+    {
+        get => _parameterTypes;
+        init => _parameterTypes = ImmutableArrayValueEquality.RequireInitialized(value, nameof(ParameterTypes));
+    }
+
+    public ImmutableArray<string> GenericParameterNames
+    {
+        get => _genericParameterNames;
+        init => _genericParameterNames = ImmutableArrayValueEquality.EmptyIfDefault(value, nameof(GenericParameterNames));
+    }
+
+    public bool Equals(MethodIdentity? other)
+        => other is not null
+            && AssemblyName == other.AssemblyName
+            && ModuleVersionId == other.ModuleVersionId
+            && Equals(DeclaringType, other.DeclaringType)
+            && Name == other.Name
+            && ImmutableArrayValueEquality.SequenceEqual(ParameterTypes, other.ParameterTypes)
+            && Equals(ReturnType, other.ReturnType)
+            && MetadataToken == other.MetadataToken
+            && IsStatic == other.IsStatic
+            && IsExtension == other.IsExtension
+            && CallerUnsafeMode == other.CallerUnsafeMode
+            && GenericArity == other.GenericArity
+            && ImmutableArrayValueEquality.SequenceEqual(
+                GenericParameterNames,
+                other.GenericParameterNames);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(AssemblyName);
+        hash.Add(ModuleVersionId);
+        hash.Add(DeclaringType);
+        hash.Add(Name);
+        ImmutableArrayValueEquality.AddToHash(ref hash, ParameterTypes);
+        hash.Add(ReturnType);
+        hash.Add(MetadataToken);
+        hash.Add(IsStatic);
+        hash.Add(IsExtension);
+        hash.Add(CallerUnsafeMode);
+        hash.Add(GenericArity);
+        ImmutableArrayValueEquality.AddToHash(ref hash, GenericParameterNames);
+        return hash.ToHashCode();
+    }
+}
 
 public sealed record MemberRef(
     TypeRef DeclaringType,
@@ -80,7 +133,22 @@ public sealed record MemberRef(
     TypeRef ReturnType,
     MemberKind Kind)
 {
-    public ImmutableArray<TypeRef> TypeArguments { get; init; } = [];
+    ImmutableArray<TypeRef> _parameterTypes
+        = ImmutableArrayValueEquality.RequireInitialized(ParameterTypes, nameof(ParameterTypes));
+    ImmutableArray<TypeRef> _typeArguments = [];
+    ImmutableArray<TypeRef> _openParameterTypes = [];
+
+    public ImmutableArray<TypeRef> ParameterTypes
+    {
+        get => _parameterTypes;
+        init => _parameterTypes = ImmutableArrayValueEquality.RequireInitialized(value, nameof(ParameterTypes));
+    }
+
+    public ImmutableArray<TypeRef> TypeArguments
+    {
+        get => _typeArguments;
+        init => _typeArguments = ImmutableArrayValueEquality.RequireInitialized(value, nameof(TypeArguments));
+    }
 
     /// <summary>
     /// True when the method has a `this` parameter (instance call), so a call site pops one
@@ -107,7 +175,11 @@ public sealed record MemberRef(
     /// separately captured, in which case <see cref="OpenSignatureParameters"/> falls
     /// back to <see cref="ParameterTypes"/>.
     /// </summary>
-    public ImmutableArray<TypeRef> OpenParameterTypes { get; init; } = [];
+    public ImmutableArray<TypeRef> OpenParameterTypes
+    {
+        get => _openParameterTypes;
+        init => _openParameterTypes = ImmutableArrayValueEquality.RequireInitialized(value, nameof(OpenParameterTypes));
+    }
 
     public ImmutableArray<TypeRef> OpenSignatureParameters
         => OpenParameterTypes.IsDefaultOrEmpty ? ParameterTypes : OpenParameterTypes;
@@ -122,8 +194,74 @@ public sealed record MemberRef(
 
     public TypeRef OpenSignatureReturn => OpenReturnType ?? ReturnType;
 
+    public bool Equals(MemberRef? other)
+        => other is not null
+            && Equals(DeclaringType, other.DeclaringType)
+            && Name == other.Name
+            && ImmutableArrayValueEquality.SequenceEqual(ParameterTypes, other.ParameterTypes)
+            && Equals(ReturnType, other.ReturnType)
+            && Kind == other.Kind
+            && ImmutableArrayValueEquality.SequenceEqual(TypeArguments, other.TypeArguments)
+            && HasThis == other.HasThis
+            && SignatureHeader == other.SignatureHeader
+            && GenericArity == other.GenericArity
+            && ImmutableArrayValueEquality.SequenceEqual(OpenParameterTypes, other.OpenParameterTypes)
+            && Equals(OpenReturnType, other.OpenReturnType);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(DeclaringType);
+        hash.Add(Name);
+        ImmutableArrayValueEquality.AddToHash(ref hash, ParameterTypes);
+        hash.Add(ReturnType);
+        hash.Add(Kind);
+        ImmutableArrayValueEquality.AddToHash(ref hash, TypeArguments);
+        hash.Add(HasThis);
+        hash.Add(SignatureHeader);
+        hash.Add(GenericArity);
+        ImmutableArrayValueEquality.AddToHash(ref hash, OpenParameterTypes);
+        hash.Add(OpenReturnType);
+        return hash.ToHashCode();
+    }
+
     public static MemberRef Unsupported(string reason)
         => new(TypeRef.Unsupported(reason), "?", [], TypeRef.Unsupported("unknown return"), MemberKind.Unsupported);
+}
+
+static class ImmutableArrayValueEquality
+{
+    public static ImmutableArray<T> RequireInitialized<T>(
+        ImmutableArray<T> values,
+        string parameterName)
+        where T : notnull
+    {
+        if (values.IsDefault)
+            throw new ArgumentException("Collection must be initialized.", parameterName);
+        if (values.Any(value => value is null))
+            throw new ArgumentException("Collection must not contain null values.", parameterName);
+        return values;
+    }
+
+    public static ImmutableArray<T> EmptyIfDefault<T>(
+        ImmutableArray<T> values,
+        string parameterName)
+        where T : notnull
+        => RequireInitialized(values.IsDefault ? [] : values, parameterName);
+
+    public static bool SequenceEqual<T>(
+        ImmutableArray<T> left,
+        ImmutableArray<T> right)
+        => left.SequenceEqual(right, EqualityComparer<T>.Default);
+
+    public static void AddToHash<T>(
+        ref HashCode hash,
+        ImmutableArray<T> values)
+    {
+        hash.Add(values.Length);
+        foreach (var value in values)
+            hash.Add(value, EqualityComparer<T>.Default);
+    }
 }
 
 /// <summary>This IL instruction definitely references this metadata token.</summary>

--- a/src/ILInspector.Findings/FindingComparison.cs
+++ b/src/ILInspector.Findings/FindingComparison.cs
@@ -106,6 +106,20 @@ public sealed record FindingComparison<T> where T : notnull
         public ImmutableArray<Finding<T>> OldAtoms => FindingComparison.InspectionAtoms(OldInspection);
         public ImmutableArray<Finding<T>> NewAtoms => FindingComparison.InspectionAtoms(NewInspection);
 
+        public bool Equals(Complete? other)
+            => other is not null
+                && FindingValueEquality.SequenceEqual(Pairs, other.Pairs)
+                && Match == other.Match
+                && OldInspection == other.OldInspection
+                && NewInspection == other.NewInspection;
+
+        public override int GetHashCode()
+            => HashCode.Combine(
+                FindingValueEquality.SequenceHashCode(Pairs),
+                Match,
+                OldInspection,
+                NewInspection);
+
         public bool IsExact =>
             SameInspectionState(OldInspection, NewInspection)
             && FindingEquivalence.Exact.IsEquivalent(Pairs);

--- a/src/ILInspector.Findings/FindingCorrelation.cs
+++ b/src/ILInspector.Findings/FindingCorrelation.cs
@@ -119,6 +119,16 @@ public sealed record CorrelatedFinding<T>
 
     public FindingCorrelationKey Key { get; }
     public ImmutableArray<VersionedFinding<T>> Occurrences { get; }
+
+    public bool Equals(CorrelatedFinding<T>? other)
+        => other is not null
+            && Key == other.Key
+            && FindingValueEquality.SequenceEqual(Occurrences, other.Occurrences);
+
+    public override int GetHashCode()
+        => HashCode.Combine(
+            Key,
+            FindingValueEquality.SequenceHashCode(Occurrences));
 }
 
 /// <summary>

--- a/src/ILInspector.Findings/FindingEquivalence.cs
+++ b/src/ILInspector.Findings/FindingEquivalence.cs
@@ -13,6 +13,42 @@ public sealed record FindingEquivalence(
     ImmutableHashSet<PairKind> AllowedKinds,
     ImmutableHashSet<FindingDifferenceKind> AllowedDifferenceKinds)
 {
+    ImmutableHashSet<PairKind> _allowedKinds
+        = Normalize(AllowedKinds, nameof(AllowedKinds));
+    ImmutableHashSet<FindingDifferenceKind> _allowedDifferenceKinds
+        = Normalize(AllowedDifferenceKinds, nameof(AllowedDifferenceKinds));
+
+    public ImmutableHashSet<PairKind> AllowedKinds
+    {
+        get => _allowedKinds;
+        init => _allowedKinds = Normalize(value, nameof(AllowedKinds));
+    }
+
+    public ImmutableHashSet<FindingDifferenceKind> AllowedDifferenceKinds
+    {
+        get => _allowedDifferenceKinds;
+        init => _allowedDifferenceKinds = Normalize(value, nameof(AllowedDifferenceKinds));
+    }
+
+    public bool Equals(FindingEquivalence? other)
+        => other is not null
+            && FindingValueEquality.SetEquals(AllowedKinds, other.AllowedKinds)
+            && FindingValueEquality.SetEquals(
+                AllowedDifferenceKinds,
+                other.AllowedDifferenceKinds);
+
+    public override int GetHashCode()
+        => HashCode.Combine(
+            FindingValueEquality.SetHashCode(AllowedKinds),
+            FindingValueEquality.SetHashCode(AllowedDifferenceKinds));
+
+    static ImmutableHashSet<T> Normalize<T>(
+        ImmutableHashSet<T> values,
+        string parameterName)
+        where T : notnull
+        => (values ?? throw new ArgumentNullException(parameterName))
+            .WithComparer(EqualityComparer<T>.Default);
+
     public bool IsEquivalent(IReadOnlyList<IPairFinding> pairs)
     {
         ArgumentNullException.ThrowIfNull(pairs);

--- a/src/ILInspector.Findings/FindingInspection.cs
+++ b/src/ILInspector.Findings/FindingInspection.cs
@@ -50,8 +50,20 @@ public sealed record FindingInspection<T>
     public sealed record Complete(
         ImmutableArray<Finding<T>> Findings)
     {
-        public ImmutableArray<Finding<T>> Findings { get; }
-            = Validate(Findings);
+        ImmutableArray<Finding<T>> _findings = Validate(Findings);
+
+        public ImmutableArray<Finding<T>> Findings
+        {
+            get => _findings;
+            init => _findings = Validate(value);
+        }
+
+        public bool Equals(Complete? other)
+            => other is not null
+                && FindingValueEquality.SequenceEqual(Findings, other.Findings);
+
+        public override int GetHashCode()
+            => FindingValueEquality.SequenceHashCode(Findings);
 
         static ImmutableArray<Finding<T>> Validate(ImmutableArray<Finding<T>> findings)
         {

--- a/src/ILInspector.Findings/FindingMatcher.cs
+++ b/src/ILInspector.Findings/FindingMatcher.cs
@@ -44,7 +44,46 @@ public sealed record FindingMoveCandidate(int OldIndex, int NewIndex, int Confid
 /// </param>
 public sealed record FindingMatch(
     ImmutableArray<FindingEdge> Edges,
-    ImmutableArray<FindingMoveCandidate> MoveCandidates);
+    ImmutableArray<FindingMoveCandidate> MoveCandidates)
+{
+    ImmutableArray<FindingEdge> _edges = Validate(Edges, nameof(Edges));
+    ImmutableArray<FindingMoveCandidate> _moveCandidates
+        = Validate(MoveCandidates, nameof(MoveCandidates));
+
+    public ImmutableArray<FindingEdge> Edges
+    {
+        get => _edges;
+        init => _edges = Validate(value, nameof(Edges));
+    }
+
+    public ImmutableArray<FindingMoveCandidate> MoveCandidates
+    {
+        get => _moveCandidates;
+        init => _moveCandidates = Validate(value, nameof(MoveCandidates));
+    }
+
+    public bool Equals(FindingMatch? other)
+        => other is not null
+            && FindingValueEquality.SequenceEqual(Edges, other.Edges)
+            && FindingValueEquality.SequenceEqual(MoveCandidates, other.MoveCandidates);
+
+    public override int GetHashCode()
+        => HashCode.Combine(
+            FindingValueEquality.SequenceHashCode(Edges),
+            FindingValueEquality.SequenceHashCode(MoveCandidates));
+
+    static ImmutableArray<TItem> Validate<TItem>(
+        ImmutableArray<TItem> items,
+        string parameterName)
+        where TItem : class
+    {
+        if (items.IsDefault)
+            throw new ArgumentException("Match arrays must be initialized.", parameterName);
+        if (items.Any(item => item is null))
+            throw new ArgumentException("Match arrays must not contain null values.", parameterName);
+        return items;
+    }
+}
 
 /// <summary>
 /// Whether a finding stream's order carries meaning. The choice is per <see cref="FindingMatcher.Match"/>

--- a/src/ILInspector.Findings/FindingValueEquality.cs
+++ b/src/ILInspector.Findings/FindingValueEquality.cs
@@ -32,11 +32,8 @@ internal static class FindingValueEquality
     {
         if (ReferenceEquals(left, right))
             return true;
-        if (left.Count != right.Count)
-            return false;
 
-        var comparer = EqualityComparer<T>.Default;
-        return left.All(value => right.Contains(value, comparer));
+        return left.SetEquals(right);
     }
 
     public static int SetHashCode<T>(ImmutableHashSet<T> values)

--- a/src/ILInspector.Findings/FindingValueEquality.cs
+++ b/src/ILInspector.Findings/FindingValueEquality.cs
@@ -1,0 +1,56 @@
+using System.Collections.Immutable;
+
+namespace ILInspector.Findings;
+
+internal static class FindingValueEquality
+{
+    public static bool SequenceEqual<T>(
+        ImmutableArray<T> left,
+        ImmutableArray<T> right)
+    {
+        if (left.IsDefault || right.IsDefault)
+            return left.IsDefault && right.IsDefault;
+
+        return left.SequenceEqual(right, EqualityComparer<T>.Default);
+    }
+
+    public static int SequenceHashCode<T>(ImmutableArray<T> values)
+    {
+        if (values.IsDefault)
+            return 0;
+
+        var hash = new HashCode();
+        hash.Add(values.Length);
+        foreach (var value in values)
+            hash.Add(value, EqualityComparer<T>.Default);
+        return hash.ToHashCode();
+    }
+
+    public static bool SetEquals<T>(
+        ImmutableHashSet<T> left,
+        ImmutableHashSet<T> right)
+    {
+        if (ReferenceEquals(left, right))
+            return true;
+        if (left.Count != right.Count)
+            return false;
+
+        var comparer = EqualityComparer<T>.Default;
+        return left.All(value => right.Contains(value, comparer));
+    }
+
+    public static int SetHashCode<T>(ImmutableHashSet<T> values)
+    {
+        var comparer = EqualityComparer<T>.Default;
+        int xor = 0;
+        int sum = 0;
+        foreach (var value in values)
+        {
+            int elementHash = value is null ? 0 : comparer.GetHashCode(value);
+            xor ^= elementHash;
+            sum = unchecked(sum + elementHash);
+        }
+
+        return HashCode.Combine(values.Count, xor, sum);
+    }
+}

--- a/src/ILInspector.Instructions.Tests/FindingValueEqualityTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingValueEqualityTests.cs
@@ -1,0 +1,192 @@
+using System.Collections.Immutable;
+
+using ILInspector.Findings;
+
+namespace ILInspector.Instructions.Tests;
+
+public class FindingValueEqualityTests
+{
+    static readonly FindingSubject Subject = new("test", "test");
+    static readonly FindingDescriptor Descriptor = new("test.item", "item");
+
+    static Finding<string> Atom(string key)
+        => new(Subject, Descriptor, new FindingKey(key), key);
+
+    static ImmutableArray<Finding<string>> Atoms(params string[] keys)
+        => [.. keys.Select(Atom)];
+
+    [Fact]
+    public void InspectionComplete_UsesOrderedSequenceEquality()
+    {
+        var first = new FindingInspection<string>.Complete(Atoms("a", "a", "b"));
+        var equivalent = new FindingInspection<string>.Complete(Atoms("a", "a", "b"));
+        var reordered = new FindingInspection<string>.Complete(Atoms("b", "a", "a"));
+        var differentDuplicates = new FindingInspection<string>.Complete(Atoms("a", "b", "b"));
+
+        Assert.Equal(first, equivalent);
+        Assert.Equal(first.GetHashCode(), equivalent.GetHashCode());
+        Assert.NotEqual(first, reordered);
+        Assert.NotEqual(first, differentDuplicates);
+        Assert.Equal(
+            new FindingInspection<string>.Complete([]),
+            new FindingInspection<string>.Complete([]));
+        Assert.Throws<ArgumentException>(
+            () => new FindingInspection<string>.Complete(default));
+        Assert.Throws<ArgumentException>(
+            () => first with { Findings = default });
+    }
+
+    [Fact]
+    public void FindingMatch_UsesOrderedSequenceEquality()
+    {
+        var first = new FindingMatch(
+            [
+                new FindingEdge(FindingEdgeKind.Matched, 0, 0, 100),
+                new FindingEdge(FindingEdgeKind.Added, -1, 1, 100),
+            ],
+            [
+                new FindingMoveCandidate(0, 1, 75, "content+scope"),
+                new FindingMoveCandidate(0, 1, 75, "content+scope"),
+            ]);
+        var equivalent = new FindingMatch(
+            [
+                new FindingEdge(FindingEdgeKind.Matched, 0, 0, 100),
+                new FindingEdge(FindingEdgeKind.Added, -1, 1, 100),
+            ],
+            [
+                new FindingMoveCandidate(0, 1, 75, "content+scope"),
+                new FindingMoveCandidate(0, 1, 75, "content+scope"),
+            ]);
+        var reordered = new FindingMatch(
+            [first.Edges[1], first.Edges[0]],
+            first.MoveCandidates);
+        var fewerDuplicates = new FindingMatch(
+            first.Edges,
+            [first.MoveCandidates[0]]);
+
+        Assert.Equal(first, equivalent);
+        Assert.Equal(first.GetHashCode(), equivalent.GetHashCode());
+        Assert.NotEqual(first, reordered);
+        Assert.NotEqual(first, fewerDuplicates);
+        Assert.Throws<ArgumentException>(
+            () => new FindingMatch(default, []));
+        Assert.Throws<ArgumentException>(
+            () => new FindingMatch([], default));
+        Assert.Throws<ArgumentException>(
+            () => new FindingMatch([null!], []));
+        Assert.Throws<ArgumentException>(
+            () => first with { MoveCandidates = default });
+    }
+
+    [Fact]
+    public void FindingEquivalence_UsesSetEquality()
+    {
+        var first = new FindingEquivalence(
+            [PairKind.Present, PairKind.Added],
+            [FindingDifferenceKind.None, FindingDifferenceKind.Moved]);
+        var equivalent = new FindingEquivalence(
+            [PairKind.Added, PairKind.Present, PairKind.Present],
+            [FindingDifferenceKind.Moved, FindingDifferenceKind.None]);
+        var different = new FindingEquivalence(
+            [PairKind.Present],
+            [FindingDifferenceKind.None, FindingDifferenceKind.Moved]);
+
+        Assert.Equal(first, equivalent);
+        Assert.Equal(first.GetHashCode(), equivalent.GetHashCode());
+        Assert.NotEqual(first, different);
+        Assert.Throws<ArgumentNullException>(
+            () => new FindingEquivalence(null!, []));
+        Assert.Throws<ArgumentNullException>(
+            () => new FindingEquivalence([], null!));
+        Assert.Throws<ArgumentNullException>(
+            () => first with { AllowedKinds = null! });
+    }
+
+    [Fact]
+    public void FindingEquivalence_NormalizesCustomSetComparers()
+    {
+        var customComparer = ImmutableHashSet.Create<PairKind>(
+            new AllPairKindsEqualComparer(),
+            PairKind.Present);
+        var custom = new FindingEquivalence(
+            customComparer,
+            [FindingDifferenceKind.None]);
+        var defaultComparer = new FindingEquivalence(
+            [PairKind.Present],
+            [FindingDifferenceKind.None]);
+
+        Assert.Equal(defaultComparer, custom);
+        Assert.Equal(defaultComparer.GetHashCode(), custom.GetHashCode());
+        Assert.DoesNotContain(PairKind.Added, custom.AllowedKinds);
+    }
+
+    [Fact]
+    public void FindingComparison_ComposesCollectionValueEquality()
+    {
+        FindingInspection<string> firstOld =
+            new FindingInspection<string>.Complete(Atoms("a", "b"));
+        FindingInspection<string> firstNew =
+            new FindingInspection<string>.Complete(Atoms("a", "c"));
+        FindingInspection<string> secondOld =
+            new FindingInspection<string>.Complete(Atoms("a", "b"));
+        FindingInspection<string> secondNew =
+            new FindingInspection<string>.Complete(Atoms("a", "c"));
+
+        var first = FindingComparison.Compare(firstOld, firstNew);
+        var equivalent = FindingComparison.Compare(secondOld, secondNew);
+
+        Assert.Equal(first, equivalent);
+        Assert.Equal(first.GetHashCode(), equivalent.GetHashCode());
+    }
+
+    [Fact]
+    public void CorrelatedFinding_UsesOccurrenceSequenceEquality()
+    {
+        var firstFinding = Atom("a");
+        var secondFinding = Atom("a");
+        var key = FindingCorrelationKey.From(firstFinding);
+        var first = new CorrelatedFinding<string>(
+            key,
+            [
+                new(new FindingVersion("v1", "1.0", 0), firstFinding),
+                new(new FindingVersion("v2", "2.0", 1), firstFinding),
+            ]);
+        var equivalent = new CorrelatedFinding<string>(
+            FindingCorrelationKey.From(secondFinding),
+            [
+                new(new FindingVersion("v1", "1.0", 0), secondFinding),
+                new(new FindingVersion("v2", "2.0", 1), secondFinding),
+            ]);
+
+        Assert.Equal(first, equivalent);
+        Assert.Equal(first.GetHashCode(), equivalent.GetHashCode());
+    }
+
+    [Fact]
+    public void FindingPayloadEquality_IsProducerOwnedButMatchingRemainsKeyDriven()
+    {
+        var first = new Finding<CollectionPayload>(
+            Subject,
+            Descriptor,
+            new FindingKey("same"),
+            new CollectionPayload(ImmutableArray.Create(1, 2)));
+        var second = new Finding<CollectionPayload>(
+            Subject,
+            Descriptor,
+            new FindingKey("same"),
+            new CollectionPayload(ImmutableArray.Create(1, 2)));
+
+        Assert.NotEqual(first, second);
+
+        var match = FindingMatcher.Match([first.Key], [second.Key]);
+        Assert.Equal(FindingEdgeKind.Matched, Assert.Single(match.Edges).Kind);
+    }
+
+    sealed record CollectionPayload(ImmutableArray<int> Values);
+
+    sealed class AllPairKindsEqualComparer : IEqualityComparer<PairKind>
+    {
+        public bool Equals(PairKind x, PairKind y) => true;
+        public int GetHashCode(PairKind obj) => 0;
+    }
+}


### PR DESCRIPTION
## Conclusion

Finding collection records now expose semantic .NET value equality instead of
immutable-collection instance equality, without changing `FindingKey`-driven
correspondence.

Ordered streams compare by sequence and multiplicity. Equivalence allow-lists
compare as sets. Analysis payload leaves that carry immutable arrays now own
the same explicit sequence contract.

## What changed

- Added sequence-aware equality and hashes for completed inspections, matches,
  completed comparisons, and correlated durable findings.
- Added set-aware equality and hashes for `FindingEquivalence`; allow-lists
  normalize custom collection comparers to enum identity semantics.
- Preserved positional-record `init`/`with` behavior while validating default,
  null, and null-element collection states.
- Added ordered equality for `MethodIdentity` and `MemberRef`, which makes
  `DirectCall`, `UnsafetyOccurrence`, and `UnsafeEvidence` compose correctly.
- Documented the payload boundary: `Finding<T>` uses producer-owned payload
  equality, while matching remains exclusively key-driven.

## Behavior

```csharp
var first = new FindingMatch(
    [new(FindingEdgeKind.Matched, 0, 0, 100)],
    []);
var independent = new FindingMatch(
    [new(FindingEdgeKind.Matched, 0, 0, 100)],
    []);

Debug.Assert(first == independent);
Debug.Assert(first.GetHashCode() == independent.GetHashCode());
var changed = independent with
{
    Edges = [new(FindingEdgeKind.Matched, 1, 0, 100)],
};
Debug.Assert(first != changed);
```

Set construction order does not affect `FindingEquivalence`; ordered array
reordering and duplicate-count changes do affect inspection, match, comparison,
and payload values.

## Compatibility

- Public positional record properties retain their `init` setters.
- Required immutable arrays reject `default`; optional generic-parameter names
  normalize omission to an initialized empty array.
- No matcher or fold path calls payload `Equals` or `GetHashCode`.
- Open Analysis/Research PR files are untouched.

## Evidence

| Check | Result |
| --- | --- |
| Release solution build | Pass |
| `ILInspector.Instructions.Tests` | 111 passed |
| `ILInspector.Analysis.Tests` | 426 passed |
| `ILInspector.Research.Tests` | 96 passed |
| Focused Decompiler member-identity tests | 27 passed |
| Changed Markdown | markdownlint clean |

## Review

| Reviewer | Exact head | Result |
| --- | --- | --- |
| Claude Opus 4.8 | `f98497c0` | CLEAN |
| Gemini 3.1 Pro | `f98497c0` | CLEAN |

Gemini's first pass found that set equality accidentally selected LINQ's
quadratic comparer overload. Commit `f98497c0` switched to native
`ImmutableHashSet.SetEquals`; both reviewers independently verified the fix and
the complete final diff with real tests and throwaway probes.

Closes #2669.
