### PR TITLE
Fix shadowed type qualifiers in decompiler output

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CSharpPrinterReceiverTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpPrinterReceiverTests.cs
@@ -214,6 +214,52 @@ public sealed class CSharpPrinterReceiverTests
             "public static class TypeNameShadow { public static int M(int value) => value + 1; }");
     }
 
+    [Fact]
+    public void StaticCall_OnNamespacedKeywordType_WhenTypeQualifierIsShadowed_EscapesNamespace()
+    {
+        var other = TypeRef.Definition("synthetic", "event.Models", "TypeNameShadow");
+        var call = new Call(
+            new MethodRef(other, "M", Int32Type, [Int32Type], HasThis: false),
+            isVirtual: false,
+            [new LoadArgument(0, "M", Int32Type)]);
+
+        string body = RenderReturn(
+            call,
+            Int32Type,
+            [
+                new Parameter("M", Int32Type),
+                new Parameter("TypeNameShadow", Int32Type),
+            ]);
+
+        Assert.Contains("return global::@event.Models.TypeNameShadow.M(M);", body);
+        Assert.DoesNotContain("return global::event.Models.TypeNameShadow.M(M);", body);
+        AssertCompiles(
+            "public static int Uses(int M, int TypeNameShadow)",
+            body,
+            "namespace @event.Models { public static class TypeNameShadow { public static int M(int value) => value + 1; } }");
+    }
+
+    [Fact]
+    public void EnumMember_OnCrossType_WhenTypeQualifierIsShadowed_UsesGlobalAlias()
+    {
+        var color = TypeRef.Definition("synthetic", "", "Color");
+        string body = RenderReturn(
+            new Constant(1, color),
+            color,
+            [new Parameter("Color", color)],
+            enumMembers: new Dictionary<TypeRef, IReadOnlyDictionary<long, string>>
+            {
+                [color] = new Dictionary<long, string> { [1] = "Red" },
+            });
+
+        Assert.Contains("return global::Color.Red;", body);
+        Assert.DoesNotContain("return Color.Red;", body);
+        AssertCompiles(
+            "public static Color Uses(Color Color)",
+            body,
+            "public enum Color { Red = 1 }");
+    }
+
     static MethodRef Extension(string name, TypeRef receiverType)
         => new(
             TypeRef.Definition("synthetic", "", "Extensions"),
@@ -225,7 +271,11 @@ public sealed class CSharpPrinterReceiverTests
             IsExtension = MetadataFactState.Yes,
         };
 
-    static string RenderReturn(IrExpression value, TypeRef returnType, IReadOnlyList<Parameter>? parameters = null)
+    static string RenderReturn(
+        IrExpression value,
+        TypeRef returnType,
+        IReadOnlyList<Parameter>? parameters = null,
+        IReadOnlyDictionary<TypeRef, IReadOnlyDictionary<long, string>>? enumMembers = null)
     {
         var block = new Block(0);
         block.Add(new Return(value));
@@ -233,7 +283,10 @@ public sealed class CSharpPrinterReceiverTests
         container.Add(block);
         var parameterList = parameters is null ? ImmutableArray<Parameter>.Empty : [.. parameters];
         var signature = new MethodSignature(returnType, parameterList, HasThis: false, GenericParameterCount: 0);
-        var function = new IrFunction("M", TypeRef.Definition("synthetic", "", "Holder"), signature, [], container);
+        var function = new IrFunction("M", TypeRef.Definition("synthetic", "", "Holder"), signature, [], container)
+        {
+            EnumMembers = enumMembers ?? ImmutableDictionary<TypeRef, IReadOnlyDictionary<long, string>>.Empty,
+        };
         return CSharpPrinter.Print(function).Output!.Trim();
     }
 

--- a/src/ILInspector.Decompiler.Tests/CSharpPrinterReceiverTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpPrinterReceiverTests.cs
@@ -166,6 +166,54 @@ public sealed class CSharpPrinterReceiverTests
         Assert.Contains("return Other.Helper(1);", body);
     }
 
+    [Fact]
+    public void StaticCall_OnCrossType_WhenTypeQualifierIsShadowed_UsesGlobalAlias()
+    {
+        var other = TypeRef.Definition("synthetic", "", "TypeNameShadow");
+        var call = new Call(
+            new MethodRef(other, "M", Int32Type, [Int32Type], HasThis: false),
+            isVirtual: false,
+            [new LoadArgument(0, "M", Int32Type)]);
+
+        string body = RenderReturn(
+            call,
+            Int32Type,
+            [
+                new Parameter("M", Int32Type),
+                new Parameter("TypeNameShadow", Int32Type),
+            ]);
+
+        Assert.Contains("return global::TypeNameShadow.M(M);", body);
+        Assert.DoesNotContain("return TypeNameShadow.M(M);", body);
+        AssertCompiles(
+            "public static int Uses(int M, int TypeNameShadow)",
+            body,
+            "public static class TypeNameShadow { public static int M(int value) => value + 1; }");
+    }
+
+    [Fact]
+    public void StaticCall_OnCrossType_WhenTypeQualifierIsShadowedByLocal_UsesGlobalAlias()
+    {
+        var other = TypeRef.Definition("synthetic", "", "TypeNameShadow");
+        var call = new Call(
+            new MethodRef(other, "M", Int32Type, [Int32Type], HasThis: false),
+            isVirtual: false,
+            [new Constant(1, Int32Type)]);
+
+        string body = RenderWithLocal(
+            [Int32Type],
+            ["TypeNameShadow"],
+            new StoreLocal(0, Int32Type, new Constant(0, Int32Type)),
+            new Return(call));
+
+        Assert.Contains("return global::TypeNameShadow.M(1);", body);
+        Assert.DoesNotContain("return TypeNameShadow.M(1);", body);
+        AssertCompiles(
+            "public static int UsesLocal()",
+            body,
+            "public static class TypeNameShadow { public static int M(int value) => value + 1; }");
+    }
+
     static MethodRef Extension(string name, TypeRef receiverType)
         => new(
             TypeRef.Definition("synthetic", "", "Extensions"),
@@ -186,6 +234,21 @@ public sealed class CSharpPrinterReceiverTests
         var parameterList = parameters is null ? ImmutableArray<Parameter>.Empty : [.. parameters];
         var signature = new MethodSignature(returnType, parameterList, HasThis: false, GenericParameterCount: 0);
         var function = new IrFunction("M", TypeRef.Definition("synthetic", "", "Holder"), signature, [], container);
+        return CSharpPrinter.Print(function).Output!.Trim();
+    }
+
+    static string RenderWithLocal(IReadOnlyList<TypeRef> locals, IReadOnlyList<string?> localNames, params IrNode[] statements)
+    {
+        var block = new Block(0);
+        foreach (var statement in statements)
+            block.Add(statement);
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(Int32Type, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.Definition("synthetic", "", "Holder"), signature, [.. locals], container)
+        {
+            LocalNames = [.. localNames],
+        };
         return CSharpPrinter.Print(function).Output!.Trim();
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -287,7 +287,7 @@ public sealed partial class CSharpPrinter
             // static abstract member: CS0119/CS0314). The constrained type is the
             // receiver, and the spelling recompiles to the same constrained call.
             if (call.ConstrainedTo is { } staticReceiver)
-                return $"{TypeText(staticReceiver)}.{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({Arguments(arguments, call.Callee.ParameterTypes, call.Callee.ParameterRefKinds)})";
+                return $"{TypeQualifierText(staticReceiver)}.{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({Arguments(arguments, call.Callee.ParameterTypes, call.Callee.ParameterRefKinds)})";
             // A static call to a member of the current type needs no type
             // qualifier — `M(args)`, not `SelfType.M(args)` — just as a this-
             // receiver instance call drops `this.` and a same-type static method

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -21,7 +21,7 @@ public sealed partial class CSharpPrinter
         if (field.BackingPropertyName is { } property)
             return instance switch
             {
-                null => $"{TypeText(field.DeclaringType)}.{CSharpNaming.EscapeIdentifier(property)}",
+                null => $"{TypeQualifierText(field.DeclaringType)}.{CSharpNaming.EscapeIdentifier(property)}",
                 LoadArgument { Index: 0, Name: "this" } => $"this.{CSharpNaming.EscapeIdentifier(property)}",
                 _ => $"{ReceiverText(instance)}.{CSharpNaming.EscapeIdentifier(property)}",
             };
@@ -35,7 +35,7 @@ public sealed partial class CSharpPrinter
             string captured = CSharpNaming.EscapeIdentifier(capture);
             return instance switch
             {
-                null => $"{TypeText(field.DeclaringType)}.{captured}",
+                null => $"{TypeQualifierText(field.DeclaringType)}.{captured}",
                 LoadArgument { Index: 0, Name: "this" } => IsShadowedByLocal(capture) ? $"this.{captured}" : captured,
                 _ => $"{ReceiverText(instance)}.{captured}",
             };
@@ -43,7 +43,7 @@ public sealed partial class CSharpPrinter
         string fieldName = CSharpNaming.SafeIdentifier(field.Name);
         return instance switch
         {
-            null => $"{TypeText(field.DeclaringType)}.{fieldName}",
+            null => $"{TypeQualifierText(field.DeclaringType)}.{fieldName}",
             // A parameter or local with the same name shadows the field, so the
             // bare name binds to it, not the field (e.g. int Foo(int _x) =>
             // this._x + _x). Qualify with this. to reach the field; an
@@ -93,7 +93,7 @@ public sealed partial class CSharpPrinter
             // A NON-virtual this-receiver access to a base-declared member is
             // C#'s base. — the call opcode deliberately skips dispatch.
             LoadArgument { Index: 0, Name: "this" } when !isVirtual && IsCrossType(accessor.DeclaringType) => "base",
-            null => TypeText(accessor.DeclaringType),
+            null => TypeQualifierText(accessor.DeclaringType),
             // A parameter or local with the same name shadows the property, so a
             // bare read binds to it, not the property (e.g. the synthesized record
             // Deconstruct(out int X, ...) whose body reads this.X). Qualify with
@@ -224,7 +224,7 @@ public sealed partial class CSharpPrinter
     {
         string name = CSharpNaming.SourceMethodName(method.Name);
         if (target is Constant { Value: null })
-            return $"{TypeText(method.DeclaringType)}.{name}";
+            return $"{TypeQualifierText(method.DeclaringType)}.{name}";
         if (target is LoadArgument { Index: 0, Name: "this" })
             return name;
         if (PointerMethodReceiver(target) is { } pointerReceiver)
@@ -246,7 +246,7 @@ public sealed partial class CSharpPrinter
             : $"<{string.Join(", ", method.TypeArguments.Select(TypeText))}>";
         string name = $"{CSharpNaming.SourceMethodName(method.Name)}{typeArguments}";
         return IsCrossType(method.DeclaringType)
-            ? $"&{TypeText(method.DeclaringType)}.{name}"
+            ? $"&{TypeQualifierText(method.DeclaringType)}.{name}"
             : $"&{name}";
     }
 
@@ -277,7 +277,7 @@ public sealed partial class CSharpPrinter
                 if (PointerRefExtensionReceiver(call.Callee, arguments[0]) is { } extensionReceiver)
                     return $"{extensionReceiver}->{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({extensionArgs})";
                 if (arguments[0].ResultType is { Kind: TypeRefKind.Pointer })
-                    return $"{TypeText(call.Callee.DeclaringType)}.{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({Arguments(arguments, call.Callee.ParameterTypes, call.Callee.ParameterRefKinds)})";
+                    return $"{TypeQualifierText(call.Callee.DeclaringType)}.{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({Arguments(arguments, call.Callee.ParameterTypes, call.Callee.ParameterRefKinds)})";
                 return $"{ReceiverText(arguments[0])}.{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({extensionArgs})";
             }
             // A static abstract/virtual interface member invoked through a type
@@ -311,7 +311,7 @@ public sealed partial class CSharpPrinter
             string staticArgs = Arguments(arguments, call.Callee.ParameterTypes, call.Callee.ParameterRefKinds);
             return IsCurrentStaticScope(call.Callee.DeclaringType) && !IsStaticCallNameShadowed(sourceName)
                 ? $"{staticName}({staticArgs})"
-                : $"{TypeText(call.Callee.DeclaringType)}.{staticName}({staticArgs})";
+                : $"{TypeQualifierText(call.Callee.DeclaringType)}.{staticName}({staticArgs})";
         }
         var receiver = arguments[0];
         string rest = Arguments(arguments.Skip(1), call.Callee.ParameterTypes, call.Callee.ParameterRefKinds);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -3790,7 +3790,7 @@ public sealed partial class CSharpPrinter
         => constant.Value is int or long
             && _function.EnumMembers.TryGetValue(constant.Type, out var members)
             && members.TryGetValue(constant.Value is int i ? i : (long)constant.Value!, out var name)
-            ? $"{TypeText(constant.Type)}.{name}"
+            ? $"{TypeQualifierText(constant.Type)}.{name}"
             : null;
 
     /// <summary>
@@ -3969,8 +3969,11 @@ public sealed partial class CSharpPrinter
             text = text[..tick];
         return definition.Namespace.Length == 0
             ? $"global::{text}"
-            : $"global::{definition.Namespace}.{text}";
+            : $"global::{EscapeNamespace(definition.Namespace)}.{text}";
     }
+
+    static string EscapeNamespace(string ns)
+        => string.Join(".", ns.Split('.').Select(CSharpNaming.EscapeIdentifier));
 
     void RecordFrameworkTypeImportDecision(TypeRef type, string rendered)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -3920,11 +3920,56 @@ public sealed partial class CSharpPrinter
         // qualified through its declaring chain (ImmutableArray<string>.Builder)
         // unless the reference is made from inside that enclosing type, where the
         // innermost name is in scope (Enumerator inside List<T>.GetEnumerator).
-        string text = type.ToDisplayString(_function.DeclaringType);
+        string text = TypeTextCore(type);
         int tick = text.IndexOf('`');
         string rendered = tick < 0 ? text : text[..tick];
         RecordFrameworkTypeImportDecision(type, rendered);
         return rendered;
+    }
+
+    string TypeQualifierText(TypeRef type)
+    {
+        string rendered = TypeTextCore(type);
+        int tick = rendered.IndexOf('`');
+        if (tick >= 0)
+            rendered = rendered[..tick];
+
+        if (FirstTypeQualifierSegment(rendered) is { } segment && IsStaticCallNameShadowed(segment))
+            rendered = FullyQualifiedTypeText(type);
+
+        RecordFrameworkTypeImportDecision(type, rendered);
+        return rendered;
+    }
+
+    string TypeTextCore(TypeRef type)
+        => type.ToDisplayString(_function.DeclaringType);
+
+    static string? FirstTypeQualifierSegment(string rendered)
+    {
+        if (rendered.Length == 0 || rendered.StartsWith("global::", StringComparison.Ordinal))
+            return null;
+        int i = rendered[0] == '@' ? 1 : 0;
+        if (i >= rendered.Length || !(char.IsLetter(rendered[i]) || rendered[i] == '_'))
+            return null;
+        while (++i < rendered.Length && (char.IsLetterOrDigit(rendered[i]) || rendered[i] == '_'))
+        {
+        }
+        return rendered[..i];
+    }
+
+    static string FullyQualifiedTypeText(TypeRef type)
+    {
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
+        if (definition.Kind != TypeRefKind.Definition || definition.Namespace.Length == 0 && definition.Name.Length == 0)
+            return type.ToDisplayString();
+
+        string text = type.ToDisplayString(TypeRef.Definition("__dotnet_inspect", "__", "__"));
+        int tick = text.IndexOf('`');
+        if (tick >= 0)
+            text = text[..tick];
+        return definition.Namespace.Length == 0
+            ? $"global::{text}"
+            : $"global::{definition.Namespace}.{text}";
     }
 
     void RecordFrameworkTypeImportDecision(TypeRef type, string rendered)


### PR DESCRIPTION
- Fixes #2583
- Changes expression-side type qualifiers so static member references use `global::...` when the simple type name is shadowed by an in-scope parameter/local.
- Card revision: `2ccaca30`

## Change

**Conclusion:** **PASS** — shadowed type qualifiers now bind to the intended type instead of a same-named value.

Before:

```csharp
return TypeNameShadow.M(M);
```

After:

```csharp
return global::TypeNameShadow.M(M);
```

The normal no-shadow spelling remains unchanged, e.g. `Other.Helper(1)`.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --configfile nuget.config` |
| Focused tests | Pass: `CSharpPrinterReceiverTests`, including parameter and local shadow canaries |
| Adjacent name tests | Pass: `NestedScopeNameCollisionTests`, `MemberNameCollisionRenderingTests`, `ForeignNestedTypeSpellingTests` |
| Decompiler suite | Pass: `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` |
| Render A/B | Pass at `2ccaca30`: merge-base `81ba0eec`, 89,065 methods, 0 changed / 0 added / 0 removed |
| Real witness | Synthetic compile-back canaries for the #2583 binding failure |

## Decompiler quality

**Conclusion:** **PASS** — the pinned corpus gate matched baseline tolerances; semantic/fidelity rows are sampled and ungated as reported by the harness.

### Generated quality-diff card

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity compiled 25,183 methods (compile-cap 4,000; per-sample, not corpus-wide); fidelity (compile-back) sampled 36 / 89,065 (0.04%)

| Metric | Change | Count delta |
| ------ | ------ | ----------- |
| Fully raised (+) | 78,406 (88.03%) → 78,406 (88.03%) (neutral) | 0 |
| Conditional-branch residual (-) | 2,401 (2.70%) → 2,401 (2.70%) (neutral) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) → 2,286 (2.57%) (neutral) | 0 |
| Full malformed (-) | 0 → 0 (neutral) | 0 |
| Semantic defects (sampling differs) | 54 (0.21%) → 95 (0.38%) | n/a |
| Fidelity opcode diffs (sampling differs) | 4 (11.11%) → 3 (8.33%) | n/a |
| Fidelity exact (sampling differs) | 32 (88.89%) → 33 (91.67%) | n/a |
| Fidelity recompile failures (sampling differs) | 0 (0.00%) → 0 (0.00%) | n/a |
| Fidelity context failures (sampling differs) | 0 (0.00%) → 0 (0.00%) | n/a |
| Fidelity check coverage (+) | 36 (0.04%) → 36 (0.04%) (neutral) | 0 |
| Pass bugs (-) | 0 → 0 (neutral) | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 88.03% -> 88.03% (0 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); semantic defects ungated (sampling differs); fidelity ungated (sampling differs; rely on changed-method fidelity).

Verdict: corpus sensor matched baseline tolerances.
```

## Review

Adversarial review requested after PR creation per repo policy.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.CSharpPrinterReceiverTests -class ILInspector.Decompiler.Tests.NestedScopeNameCollisionTests -class ILInspector.Decompiler.Tests.MemberNameCollisionRenderingTests -class ILInspector.Decompiler.Tests.ForeignNestedTypeSpellingTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --configfile nuget.config
bash eng/prepare-decompiler-corpus.sh /tmp/corpus-2583-rebased.txt
mapfile -t assemblies < /tmp/corpus-2583-rebased.txt
git worktree add /tmp/ab-base-2583-rebased --detach "$(git merge-base origin/main HEAD)"
dotnet run --project /tmp/ab-base-2583-rebased/tools/DecompilerHarness -c Release -- "${assemblies[@]}" --workers 20 --emit-render-ab /tmp/base-2583-rebased.renderab
dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" --workers 20 --render-ab /tmp/base-2583-rebased.renderab
dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json --quality-diff-card --corpus-fidelity-cap 3 --max-examples 3
```

