### PR TITLE
Add --rows --tail and --row first|last selectors (#2694)

### DIFF
--- a/docs/design/command-transition-model.md
+++ b/docs/design/command-transition-model.md
@@ -229,7 +229,7 @@ Shape reducers do not revise operation arity. In particular:
 - `--urls` may expose registry URLs if version rows gain such a field, but it
   must not download package contents to manufacture them;
 - `--print` is exactly-one, not implicit-first: one printable row prints
-  directly, multiple printable rows require `--row N` or `--print-all`, and zero
+  directly, multiple printable rows require `--row N|first|last` or `--print-all`, and zero
   printable rows reject;
 - `--head N` and `--tail N` run after print selection and fetching, so
   `--print --head 1` does not select the first printable row and

--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -139,9 +139,8 @@ windows:
 - `--rows --tail N` keeps the last N data rows.
 
 Both row-window forms are incompatible with `--print` and `--print-all`;
-`--row N|first|last` is the explicit printable-row selector. The current CLI
-implements head rows and rejects tail rows; tail-row support is a follow-up to
-this symmetric contract.
+`--row N|first|last` is the explicit printable-row selector. The CLI implements
+both head and tail data-row windows symmetrically.
 
 This policy deliberately rejects implicit-first behavior. Row order may change
 with filtering, producer evolution, or package versions, and choosing the first
@@ -173,7 +172,7 @@ payloads on already evaluated rows; it cannot probe missing cells.
 | `-n N` / `--head N` / numeric shorthand such as `-20` | keep the first N rendered output lines unless `--rows` is active |
 | `--tail N` | keep the last N rendered output lines unless `--rows` is active |
 | `--rows --head N` | keep the first N **data rows per table**, across Markdown, TSV, and JSONL |
-| `--rows --tail N` | keep the last N **data rows per table**; target symmetry, not yet implemented |
+| `--rows --tail N` | keep the last N **data rows per table**, across Markdown, TSV, and JSONL |
 | `--bare` | render the selected payload without document decoration; it changes presentation only, not the selected shape |
 | `--plaintext` | render a whole-document plain-text view; distinct from `--bare` |
 

--- a/docs/design/rendering-model.md
+++ b/docs/design/rendering-model.md
@@ -56,10 +56,10 @@ The `package` command inspects a NuGet package. Its default view is *package ide
 | `--path` | File resolution | Table of package-relative file paths and sizes; repeatable with `--match all` or `--match first` |
 | `--content` | File content | Contents for files selected by `--path`, with separator blocks or `--jsonl` rows |
 | `--readme` | README content | Compatibility alias for best package grounding content (`AGENTS.md` > `README.md` > `PACKAGE.md` > declared readme); supports `--frontmatter`/`--body` |
-| `--value` | Scalar projection | Prints one scalar cell or field from a selected section; use `--row N` when multiple rows match |
+| `--value` | Scalar projection | Prints one scalar cell or field from a selected section; use `--row N\|first\|last` when multiple rows match |
 | `--urls` | URL projection | Prints URL-bearing selected-section rows as a URL list, JSONL rows, or a JSON array |
 | `--paths` | Path projection | Prints path-bearing selected-section rows as a path list, JSONL rows, or a JSON array |
-| `--print` | Row payload | Prints one document behind a selected printable section row; use `--row N` to choose the Nth printable row when multiple printable rows exist |
+| `--print` | Row payload | Prints one document behind a selected printable section row; use `--row N\|first\|last` to choose the printable row when multiple printable rows exist |
 | `--print-all` | Row payloads | Prints every printable row from one selected section, using separators for text, JSONL rows, or one JSON array with `--json-array` |
 | `--versions` | Version history | Available versions from nuget.org |
 | `--library` | Library metadata | Delegates to library inspection |

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -399,7 +399,16 @@ public class CommandExecutionTests
         {
             args = CommandLineBuilder.PreprocessArgs(args);
             var root = CommandLineBuilder.CreateRootCommand();
-            return await root.Parse(args).InvokeAsync();
+            try
+            {
+                return await root.Parse(args).InvokeAsync();
+            }
+            catch (RowWindowValidationException ex)
+            {
+                // Mirror Program.cs so --rows window validation surfaces as exit 1 + stderr.
+                Console.Error.WriteLine($"Error: {ex.Message}");
+                return 1;
+            }
         });
     }
 
@@ -1332,6 +1341,67 @@ public class CommandExecutionTests
         Assert.Contains("# System.Text.RegularExpressions.Regex", output);
         Assert.Contains("`Match:1`", output);
         Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Rows_TailWindowDiffersFromHeadWindow()
+    {
+        // A real command must wire ParseRows and honor the tail branch: the last-N
+        // window selects a different endpoint than the first-N window.
+        var head = await RunAppAsync(
+            "type", "System.String", "-S", "Member Index", "--rows", "-n", "2", "--tsv", "--tips", "q");
+        var tail = await RunAppAsync(
+            "type", "System.String", "-S", "Member Index", "--rows", "--tail", "2", "--tsv", "--tips", "q");
+
+        Assert.Equal(0, head.Exit);
+        Assert.Equal(0, tail.Exit);
+        Assert.Empty(head.Error);
+        Assert.Empty(tail.Error);
+        var headLines = head.Output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var tailLines = tail.Output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        // header + exactly 2 data rows in each.
+        Assert.Equal(3, headLines.Length);
+        Assert.Equal(3, tailLines.Length);
+        // Same header row, different data rows.
+        Assert.Equal(headLines[0], tailLines[0]);
+        Assert.NotEqual(headLines[1], tailLines[1]);
+    }
+
+    [Fact]
+    public async Task Rows_TailEqualsSyntaxAppliesTailWindow()
+    {
+        // Regression: --tail=2 (=-syntax) used to falsely error "requires -n/--head N
+        // or --tail N" because the token scanner missed it. It now applies a tail window.
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.String", "-S", "Member Index", "--rows", "--tail=2", "--tsv", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Equal(3, output.Split('\n', StringSplitOptions.RemoveEmptyEntries).Length);
+    }
+
+    [Fact]
+    public async Task Rows_RejectsBothHeadAndTailWithEqualsSyntax()
+    {
+        // Regression: --head=3 (=-syntax) used to slip past the both-set gate and
+        // silently apply a head window. It now conflicts with --tail as expected.
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.String", "-S", "Member Index", "--rows", "--head=3", "--tail", "2", "--tsv", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("--rows cannot combine -n/--head with --tail", error);
+    }
+
+    [Fact]
+    public async Task Rows_RequiresHeadOrTailWindow()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.String", "-S", "Member Index", "--rows", "--tsv", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("--rows requires -n/--head N or --tail N", error);
     }
 
     [Fact]
@@ -2438,6 +2508,36 @@ public class CommandExecutionTests
         Assert.Equal(2, document.RootElement.GetProperty("row").GetInt32());
         Assert.EndsWith("/Src/Newtonsoft.Json/JsonReader.Async.cs", document.RootElement.GetProperty("url").GetString());
         Assert.Contains("ReadAsInt32Async", document.RootElement.GetProperty("content").GetString());
+    }
+
+    [Fact]
+    public async Task Type_SourceFiles_PrintRowFirstFetchesFirstSource()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "JsonReader", "--package", "Newtonsoft.Json@13.0.3",
+            "-S", "Source Files", "--print", "--row", "first", "--jsonl", "--raw", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        var line = Assert.Single(output.Split('\n', StringSplitOptions.RemoveEmptyEntries));
+        using var document = JsonDocument.Parse(line);
+        Assert.Equal(1, document.RootElement.GetProperty("row").GetInt32());
+        Assert.EndsWith("/Src/Newtonsoft.Json/JsonReader.cs", document.RootElement.GetProperty("url").GetString());
+    }
+
+    [Fact]
+    public async Task Type_SourceFiles_PrintRowLastFetchesLastSource()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "JsonReader", "--package", "Newtonsoft.Json@13.0.3",
+            "-S", "Source Files", "--print", "--row", "last", "--jsonl", "--raw", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        var line = Assert.Single(output.Split('\n', StringSplitOptions.RemoveEmptyEntries));
+        using var document = JsonDocument.Parse(line);
+        Assert.Equal(2, document.RootElement.GetProperty("row").GetInt32());
+        Assert.EndsWith("/Src/Newtonsoft.Json/JsonReader.Async.cs", document.RootElement.GetProperty("url").GetString());
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -2421,7 +2421,7 @@ public class CommandExecutionTests
 
         Assert.Equal(1, exit);
         Assert.Empty(output);
-        Assert.Contains("selected section has 2 printable rows; use --row N to choose one row or --print-all", error);
+        Assert.Contains("selected section has 2 printable rows; use --row N|first|last to choose one row or --print-all", error);
     }
 
     [Fact]
@@ -8963,7 +8963,7 @@ public class CommandExecutionTests
 
             Assert.Equal(1, exit);
             Assert.Empty(output);
-            Assert.Contains("selected section has 2 printable rows; use --row N to choose one row or --print-all", error);
+            Assert.Contains("selected section has 2 printable rows; use --row N|first|last to choose one row or --print-all", error);
         }
         finally
         {

--- a/src/dotnet-inspect.Tests/IndexBuildInvariantTests.cs
+++ b/src/dotnet-inspect.Tests/IndexBuildInvariantTests.cs
@@ -1,6 +1,7 @@
 using DotnetInspector.Commands;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Options;
+using DotnetInspector.Output;
 using DotnetInspector.Sections;
 
 namespace DotnetInspector.Tests;
@@ -95,7 +96,7 @@ public class IndexBuildInvariantTests
                 SectionNames.PerformanceTriage,
             ],
             Markdown = true,
-            Rows = 25,
+            Rows = new RowWindow(25, FromEnd: false),
         }));
 
         Assert.Equal(0, result.ExitCode);

--- a/src/dotnet-inspect.Tests/LibraryTopLeverageTests.cs
+++ b/src/dotnet-inspect.Tests/LibraryTopLeverageTests.cs
@@ -1,5 +1,6 @@
 using DotnetInspector.Commands;
 using DotnetInspector.Options;
+using DotnetInspector.Output;
 using DotnetInspector.Sections;
 
 namespace DotnetInspector.Tests;
@@ -15,7 +16,7 @@ public class LibraryTopLeverageTests
             AssemblyName = typeof(LibraryLeverageFixture).Assembly.Location,
             IncludeSections = ["Top Leverage"],
             Markdown = true,
-            Rows = 25,
+            Rows = new RowWindow(25, FromEnd: false),
         }));
 
         Assert.Equal(0, result.ExitCode);

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -36,10 +36,10 @@ public class OutputFormatterTests
         Action<TextWriter, Markout.Formatting.IMarkoutFormatter> serialize = (writer, _) => writer.Write("Name\tValue\nA\t1\nB\t2\n");
 
         var capped = new StringWriter();
-        OutputFormatter.WriteTable(capped, showHeader: true, serialize, maxRows: 1);
+        OutputFormatter.WriteTable(capped, showHeader: true, serialize, maxRows: new RowWindow(1, FromEnd: false));
 
         Assert.Equal(
-            OutputFormatter.LimitRenderedTableRows(OutputFormatter.RenderTable(true, serialize), 1, hasHeader: true),
+            OutputFormatter.LimitRenderedTableRows(OutputFormatter.RenderTable(true, serialize), new RowWindow(1, FromEnd: false), hasHeader: true),
             capped.ToString());
     }
 
@@ -1053,7 +1053,7 @@ public class OutputFormatterTests
     {
         var tsv = "name\tcount\nA\t1\nB\t2\nC\t3\n";
 
-        var output = OutputFormatter.LimitRenderedTableRows(tsv, 2, hasHeader: true).ReplaceLineEndings("\n");
+        var output = OutputFormatter.LimitRenderedTableRows(tsv, new RowWindow(2, FromEnd: false), hasHeader: true).ReplaceLineEndings("\n");
 
         Assert.Equal("name\tcount\nA\t1\nB\t2\n", output);
     }
@@ -1063,7 +1063,7 @@ public class OutputFormatterTests
     {
         var tsv = "A\t1\nB\t2\nC\t3\n";
 
-        var output = OutputFormatter.LimitRenderedTableRows(tsv, 2, hasHeader: false).ReplaceLineEndings("\n");
+        var output = OutputFormatter.LimitRenderedTableRows(tsv, new RowWindow(2, FromEnd: false), hasHeader: false).ReplaceLineEndings("\n");
 
         Assert.Equal("A\t1\nB\t2\n", output);
     }
@@ -1074,7 +1074,7 @@ public class OutputFormatterTests
         var jsonl = "{\"name\":\"A\"}\n{\"name\":\"B\"}\n{\"name\":\"C\"}\n";
 
         // hasHeader is true (callers pass !--no-header) but jsonl rows are self-describing.
-        var output = OutputFormatter.LimitRenderedTableRows(jsonl, 2, hasHeader: true).ReplaceLineEndings("\n");
+        var output = OutputFormatter.LimitRenderedTableRows(jsonl, new RowWindow(2, FromEnd: false), hasHeader: true).ReplaceLineEndings("\n");
 
         Assert.Equal("{\"name\":\"A\"}\n{\"name\":\"B\"}\n", output);
     }
@@ -1084,7 +1084,7 @@ public class OutputFormatterTests
     {
         var markdown = "| Name |\n| ---- |\n| A |\n| B |\n| C |\n";
 
-        var output = OutputFormatter.LimitRenderedTableRows(markdown, 2, hasHeader: true).ReplaceLineEndings("\n");
+        var output = OutputFormatter.LimitRenderedTableRows(markdown, new RowWindow(2, FromEnd: false), hasHeader: true).ReplaceLineEndings("\n");
 
         Assert.Contains("| A |", output);
         Assert.Contains("| B |", output);
@@ -1121,7 +1121,7 @@ public class OutputFormatterTests
         | 2 |
         """;
 
-        var output = MarkdownTableRowLimiter.Apply(markdown, 2);
+        var output = MarkdownTableRowLimiter.Apply(markdown, new RowWindow(2, FromEnd: false));
 
         Assert.Contains("| A |", output);
         Assert.Contains("| B |", output);
@@ -1147,7 +1147,7 @@ public class OutputFormatterTests
         | B |
         """;
 
-        var output = MarkdownTableRowLimiter.Apply(markdown, 1);
+        var output = MarkdownTableRowLimiter.Apply(markdown, new RowWindow(1, FromEnd: false));
 
         Assert.Contains("| B |\n```", output.ReplaceLineEndings("\n"));
         Assert.DoesNotContain("| B |\n", output.ReplaceLineEndings("\n").Split("```")[2]);
@@ -1258,6 +1258,56 @@ public class OutputFormatterTests
         Assert.Equal(1, RowSelector.First.Resolve(7));
         Assert.Equal(7, RowSelector.Last.Resolve(7));
         Assert.Equal(3, RowSelector.FromIndex(3).Resolve(7));
+    }
+
+    [Fact]
+    public void BuildRowWindow_HeadOnlyIsLeadingWindow()
+    {
+        var window = SharedOptions.BuildRowWindow(rows: true, head: 3, tail: null);
+        Assert.Equal(new RowWindow(3, FromEnd: false), window);
+    }
+
+    [Fact]
+    public void BuildRowWindow_TailOnlyIsTrailingWindow()
+    {
+        var window = SharedOptions.BuildRowWindow(rows: true, head: null, tail: 3);
+        Assert.Equal(new RowWindow(3, FromEnd: true), window);
+    }
+
+    [Fact]
+    public void BuildRowWindow_WithoutRowsIsNull()
+    {
+        Assert.Null(SharedOptions.BuildRowWindow(rows: false, head: 3, tail: null));
+        Assert.Null(SharedOptions.BuildRowWindow(rows: false, head: null, tail: 3));
+    }
+
+    [Fact]
+    public void BuildRowWindow_RejectsBothHeadAndTail()
+    {
+        var ex = Assert.Throws<RowWindowValidationException>(
+            () => SharedOptions.BuildRowWindow(rows: true, head: 3, tail: 2));
+        Assert.Equal("--rows cannot combine -n/--head with --tail; choose one row window.", ex.Message);
+    }
+
+    [Fact]
+    public void BuildRowWindow_RejectsNeitherHeadNorTail()
+    {
+        var ex = Assert.Throws<RowWindowValidationException>(
+            () => SharedOptions.BuildRowWindow(rows: true, head: null, tail: null));
+        Assert.Equal("--rows requires -n/--head N or --tail N.", ex.Message);
+    }
+
+    [Fact]
+    public void LimitMarkdownTableRows_KeepsInteriorSeparatorInPlace()
+    {
+        // A pathological table with an interior separator: the separator must stay in
+        // its original position rather than being hoisted after the windowed rows.
+        var markdown = "| Name |\n| ---- |\n| A |\n| ---- |\n| B |\n| C |\n";
+
+        var output = MarkdownTableRowLimiter.Apply(markdown, new RowWindow(2, FromEnd: false)).ReplaceLineEndings("\n");
+
+        // Head window of 2 data rows keeps A and B; the interior separator sits between them.
+        Assert.Equal("| Name |\n| ---- |\n| A |\n| ---- |\n| B |\n", output);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -1154,6 +1154,82 @@ public class OutputFormatterTests
     }
 
     [Fact]
+    public void LimitMarkdownTableRows_TailKeepsLastRowsAndHeader()
+    {
+        var markdown = "| Name |\n| ---- |\n| A |\n| B |\n| C |\n";
+
+        var output = MarkdownTableRowLimiter.Apply(markdown, new RowWindow(2, FromEnd: true)).ReplaceLineEndings("\n");
+
+        Assert.Contains("| Name |", output);
+        Assert.Contains("| ---- |", output);
+        Assert.DoesNotContain("| A |", output);
+        Assert.Contains("| B |", output);
+        Assert.Contains("| C |", output);
+    }
+
+    [Fact]
+    public void LimitMarkdownTableRows_TailWiderThanTableKeepsAllRows()
+    {
+        var markdown = "| Name |\n| ---- |\n| A |\n| B |\n";
+
+        var output = MarkdownTableRowLimiter.Apply(markdown, new RowWindow(10, FromEnd: true)).ReplaceLineEndings("\n");
+
+        Assert.Contains("| A |", output);
+        Assert.Contains("| B |", output);
+    }
+
+    [Fact]
+    public void LimitRenderedTableRows_TsvTailKeepsHeaderAndLastRows()
+    {
+        var tsv = "name\tcount\nA\t1\nB\t2\nC\t3\n";
+
+        var output = OutputFormatter.LimitRenderedTableRows(tsv, new RowWindow(2, FromEnd: true), hasHeader: true).ReplaceLineEndings("\n");
+
+        Assert.Equal("name\tcount\nB\t2\nC\t3\n", output);
+    }
+
+    [Fact]
+    public void LimitRenderedTableRows_JsonlTailKeepsLastRows()
+    {
+        var jsonl = "{\"name\":\"A\"}\n{\"name\":\"B\"}\n{\"name\":\"C\"}\n";
+
+        var output = OutputFormatter.LimitRenderedTableRows(jsonl, new RowWindow(2, FromEnd: true), hasHeader: true).ReplaceLineEndings("\n");
+
+        Assert.Equal("{\"name\":\"B\"}\n{\"name\":\"C\"}\n", output);
+    }
+
+    [Theory]
+    [InlineData("first", RowSelectorKind.First)]
+    [InlineData("FIRST", RowSelectorKind.First)]
+    [InlineData("last", RowSelectorKind.Last)]
+    [InlineData("Last", RowSelectorKind.Last)]
+    [InlineData("3", RowSelectorKind.Index)]
+    public void RowSelector_ParsesKeywordsAndIndex(string token, RowSelectorKind expected)
+    {
+        Assert.True(RowSelector.TryParse(token, out var selector));
+        Assert.Equal(expected, selector.Kind);
+    }
+
+    [Theory]
+    [InlineData("firstish")]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("abc")]
+    [InlineData(null)]
+    public void RowSelector_RejectsInvalidTokens(string? token)
+    {
+        Assert.False(RowSelector.TryParse(token, out _));
+    }
+
+    [Fact]
+    public void RowSelector_ResolvesFirstLastAndIndex()
+    {
+        Assert.Equal(1, RowSelector.First.Resolve(7));
+        Assert.Equal(7, RowSelector.Last.Resolve(7));
+        Assert.Equal(3, RowSelector.FromIndex(3).Resolve(7));
+    }
+
+    [Fact]
     public void MultiAssemblyReport_HasSingleH1()
     {
         var report = CreateTestReport("Test.dll", false, "net9.0", "net8.0");

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -1198,8 +1198,39 @@ public class OutputFormatterTests
         Assert.Equal("{\"name\":\"B\"}\n{\"name\":\"C\"}\n", output);
     }
 
+    [Fact]
+    public void LimitRenderedTableRows_JsonlZeroWindowEmitsNothing()
+    {
+        var jsonl = "{\"name\":\"A\"}\n{\"name\":\"B\"}\n{\"name\":\"C\"}\n";
+
+        var tail = OutputFormatter.LimitRenderedTableRows(jsonl, new RowWindow(0, FromEnd: true), hasHeader: true);
+        var head = OutputFormatter.LimitRenderedTableRows(jsonl, new RowWindow(0, FromEnd: false), hasHeader: true);
+
+        Assert.Equal(string.Empty, tail);
+        Assert.Equal(string.Empty, head);
+    }
+
+    [Fact]
+    public void LimitRenderedTableRows_TsvNoHeaderZeroWindowEmitsNothing()
+    {
+        var tsv = "A\t1\nB\t2\nC\t3\n";
+
+        var output = OutputFormatter.LimitRenderedTableRows(tsv, new RowWindow(0, FromEnd: true), hasHeader: false);
+
+        Assert.Equal(string.Empty, output);
+    }
+
+    [Fact]
+    public void LimitRenderedTableRows_TsvHeaderZeroWindowKeepsHeader()
+    {
+        var tsv = "name\tcount\nA\t1\nB\t2\n";
+
+        var output = OutputFormatter.LimitRenderedTableRows(tsv, new RowWindow(0, FromEnd: true), hasHeader: true).ReplaceLineEndings("\n");
+
+        Assert.Equal("name\tcount\n", output);
+    }
+
     [Theory]
-    [InlineData("first", RowSelectorKind.First)]
     [InlineData("FIRST", RowSelectorKind.First)]
     [InlineData("last", RowSelectorKind.Last)]
     [InlineData("Last", RowSelectorKind.Last)]

--- a/src/dotnet-inspect.Tests/TopLeverageSectionTests.cs
+++ b/src/dotnet-inspect.Tests/TopLeverageSectionTests.cs
@@ -1,6 +1,7 @@
 using DotnetInspector.Commands;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Options;
+using DotnetInspector.Output;
 using DotnetInspector.Sections;
 using ILInspector.Analysis;
 
@@ -18,7 +19,7 @@ public class TopLeverageSectionTests
             AssemblyPath = typeof(LeverageSampleType).Assembly.Location,
             IncludeSections = [SectionNames.TopLeverage],
             Tsv = true,
-            Rows = 2,
+            Rows = new RowWindow(2, FromEnd: false),
             OneLine = true,
             OneLineExplicitlySet = true,
             TipLevel = TipLevel.Quiet,

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -1025,14 +1025,14 @@ public class ApiCommand
         {
             if (options.PrintRow is null && printableRows.Count != 1)
             {
-                Console.Error.WriteLine($"Error: selected section has {printableRows.Count} printable rows; use --row N to choose one row or --print-all.");
+                Console.Error.WriteLine($"Error: selected section has {printableRows.Count} printable rows; use --row N|first|last to choose one row or --print-all.");
                 return 1;
             }
 
-            var targetIndex = options.PrintRow ?? 1;
+            var targetIndex = options.PrintRow?.Resolve(printableRows.Count) ?? 1;
             if (targetIndex < 1 || targetIndex > printableRows.Count)
             {
-                Console.Error.WriteLine($"Error: printable row {targetIndex} is out of range. Use 1 through {printableRows.Count}.");
+                Console.Error.WriteLine($"Error: printable row {targetIndex} is out of range. Use 1 through {printableRows.Count}, first, or last.");
                 return 1;
             }
 

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -134,7 +134,7 @@ public class ApiCommand
             }
             if (options.Rows is not null)
             {
-                Console.Error.WriteLine($"Error: --rows cannot be combined with {optionName}; use -n N to limit projected output lines or --row N to select a projected row.");
+                Console.Error.WriteLine($"Error: --rows cannot be combined with {optionName}; use -n N to limit projected output lines or --row N|first|last to select a projected row.");
                 return (null!, 1);
             }
         }
@@ -156,7 +156,7 @@ public class ApiCommand
 
         if ((options.Print || options.PrintAll) && options.Rows is not null)
         {
-            Console.Error.WriteLine("Error: --rows cannot be combined with --print or --print-all; use --row N to choose a printed row.");
+            Console.Error.WriteLine("Error: --rows cannot be combined with --print or --print-all; use --row N|first|last to choose a printed row.");
             return (null!, 1);
         }
 

--- a/src/dotnet-inspect/Commands/DependsCommand.cs
+++ b/src/dotnet-inspect/Commands/DependsCommand.cs
@@ -322,7 +322,7 @@ public class DependsCommand
         mdWriter.Flush();
     }
 
-    private static void WriteMarkdown(PackageDependenciesView view, int? rows)
+    private static void WriteMarkdown(PackageDependenciesView view, RowWindow? rows)
     {
         OutputFormatter.WriteLimitedMarkdown(Console.Out,
             MarkoutSerializer.Serialize(view, PackageDependenciesContext.Default), rows);

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -1687,7 +1687,7 @@ public record DiffOptions
     public HashSet<string>? IncludeSections { get; init; }
     public string[]? Columns { get; init; }
     public string[]? Fields { get; init; }
-    public int? Rows { get; init; }
+    public RowWindow? Rows { get; init; }
     public NuGetSourceOptions? SourceOptions { get; init; }
 
     /// <summary>

--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -237,7 +237,7 @@ public class ExtensionsCommand
         Console.WriteLine(results.Count);
     }
 
-    private static void WriteMarkoutOutput(string targetType, List<ExtensionMethodResult> results, Verbosity verbosity, int? rows)
+    private static void WriteMarkoutOutput(string targetType, List<ExtensionMethodResult> results, Verbosity verbosity, RowWindow? rows)
     {
         var view = ExtensionsOutputFormatter.BuildView(targetType, results, verbosity);
         OutputFormatter.WriteLimitedMarkdown(Console.Out,

--- a/src/dotnet-inspect/Commands/ImplementsCommand.cs
+++ b/src/dotnet-inspect/Commands/ImplementsCommand.cs
@@ -141,7 +141,7 @@ public class ImplementsCommand
         Console.WriteLine(results.Count);
     }
 
-    private static void WriteMarkoutOutput(string targetType, List<ImplementerResult> results, bool oneLine, bool tsv, bool jsonl, bool noHeader, string[]? columns, string[]? fields, int? rows)
+    private static void WriteMarkoutOutput(string targetType, List<ImplementerResult> results, bool oneLine, bool tsv, bool jsonl, bool noHeader, string[]? columns, string[]? fields, RowWindow? rows)
     {
         var view = ImplementsOutputFormatter.BuildView(targetType, results);
 

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -133,7 +133,7 @@ public class LibraryCommand
             }
             if (options.Rows is not null)
             {
-                Console.Error.WriteLine($"Error: --rows cannot be combined with {optionName}; use -n N to limit projected output lines or --row N to select a projected row.");
+                Console.Error.WriteLine($"Error: --rows cannot be combined with {optionName}; use -n N to limit projected output lines or --row N|first|last to select a projected row.");
                 return 1;
             }
         }
@@ -155,7 +155,7 @@ public class LibraryCommand
 
         if ((options.Print || options.PrintAll) && options.Rows is not null)
         {
-            Console.Error.WriteLine("Error: --rows cannot be combined with --print or --print-all; use --row N to choose a printed row.");
+            Console.Error.WriteLine("Error: --rows cannot be combined with --print or --print-all; use --row N|first|last to choose a printed row.");
             return 1;
         }
 

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -81,7 +81,7 @@ public class PackageCommand
                 }
                 if (options.Rows is not null)
                 {
-                    Console.Error.WriteLine($"Error: --rows cannot be combined with {optionName}; use -n N to limit projected output lines or --row N to select a projected row.");
+                    Console.Error.WriteLine($"Error: --rows cannot be combined with {optionName}; use -n N to limit projected output lines or --row N|first|last to select a projected row.");
                     return 1;
                 }
             }
@@ -856,7 +856,7 @@ public class PackageCommand
 
         if ((options.Print || options.PrintAll) && options.Rows is not null)
         {
-            Console.Error.WriteLine("Error: --rows cannot be combined with --print or --print-all; use --row N to choose a printed row.");
+            Console.Error.WriteLine("Error: --rows cannot be combined with --print or --print-all; use --row N|first|last to choose a printed row.");
             return false;
         }
 

--- a/src/dotnet-inspect/Commands/ProjectCommand.cs
+++ b/src/dotnet-inspect/Commands/ProjectCommand.cs
@@ -446,7 +446,7 @@ public class ProjectCommand
             documents,
             new PrintProjectionOptions(
                 options.PrintAll,
-                options.Bare && !options.Print && !options.PrintAll ? 1 : options.PrintRow,
+                options.Bare && !options.Print && !options.PrintAll ? RowSelector.FromIndex(1) : options.PrintRow,
                 options.JsonOutput,
                 options.Jsonl,
                 options.JsonArray,

--- a/src/dotnet-inspect/Commands/ProjectCommand.cs
+++ b/src/dotnet-inspect/Commands/ProjectCommand.cs
@@ -76,7 +76,7 @@ public class ProjectCommand
             }
             if (options.Rows is not null)
             {
-                Console.Error.WriteLine($"Error: --rows cannot be combined with {optionName}; use -n N to limit projected output lines or --row N to select a projected row.");
+                Console.Error.WriteLine($"Error: --rows cannot be combined with {optionName}; use -n N to limit projected output lines or --row N|first|last to select a projected row.");
                 return 1;
             }
         }
@@ -198,7 +198,7 @@ public class ProjectCommand
 
         if ((options.Print || options.PrintAll) && options.Rows is not null)
         {
-            Console.Error.WriteLine("Error: --rows cannot be combined with --print or --print-all; use --row N to choose a printed row.");
+            Console.Error.WriteLine("Error: --rows cannot be combined with --print or --print-all; use --row N|first|last to choose a printed row.");
             return false;
         }
 

--- a/src/dotnet-inspect/Commands/TimelineCommand.cs
+++ b/src/dotnet-inspect/Commands/TimelineCommand.cs
@@ -1299,7 +1299,7 @@ public sealed record TimelineOptions
     public bool Jsonl { get; init; }
     public bool NoHeader { get; init; }
     public bool Count { get; init; }
-    public int? Rows { get; init; }
+    public RowWindow? Rows { get; init; }
     public string[]? Select { get; init; }
     public string[]? Columns { get; init; }
     public string[]? Fields { get; init; }

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -1,3 +1,4 @@
+using DotnetInspector.Output;
 using DotnetInspector.Packages;
 using Markout;
 using Markout.Formatting;
@@ -58,7 +59,7 @@ public partial record ApiOptions
 
     public bool PrintAll { get; init; }
 
-    public int? PrintRow { get; init; }
+    public RowSelector? PrintRow { get; init; }
 
     public bool Value { get; init; }
 
@@ -87,7 +88,7 @@ public partial record ApiOptions
     public string[]? Fields { get; init; }
     public bool Schema { get; init; }
     public bool Count { get; init; }
-    public int? Rows { get; init; }
+    public RowWindow? Rows { get; init; }
     public PerformanceTriageOptions PerformanceTriage { get; init; } = PerformanceTriageOptions.Default;
     public TipLevel TipLevel { get; init; } = TipLevel.Minimal;
 

--- a/src/dotnet-inspect/Options/DependsOptions.cs
+++ b/src/dotnet-inspect/Options/DependsOptions.cs
@@ -1,3 +1,4 @@
+using DotnetInspector.Output;
 using DotnetInspector.Packages;
 
 namespace DotnetInspector.Options;
@@ -75,7 +76,7 @@ public record DependsOptions : IAssemblySourceOptions
     /// <summary>
     /// Limit data rows per rendered table.
     /// </summary>
-    public int? Rows { get; init; }
+    public RowWindow? Rows { get; init; }
 
     /// <summary>
     /// Output the number of dependency nodes in the rendered tree.

--- a/src/dotnet-inspect/Options/ExtensionsOptions.cs
+++ b/src/dotnet-inspect/Options/ExtensionsOptions.cs
@@ -1,3 +1,4 @@
+using DotnetInspector.Output;
 using DotnetInspector.Packages;
 
 namespace DotnetInspector.Options;
@@ -65,7 +66,7 @@ public record ExtensionsOptions : IAssemblySourceOptions
     /// <summary>
     /// Limit data rows per rendered table.
     /// </summary>
-    public int? Rows { get; init; }
+    public RowWindow? Rows { get; init; }
 
     /// <summary>
     /// Output the number of rendered result rows.

--- a/src/dotnet-inspect/Options/FindOptions.cs
+++ b/src/dotnet-inspect/Options/FindOptions.cs
@@ -1,3 +1,4 @@
+using DotnetInspector.Output;
 using DotnetInspector.Packages;
 
 namespace DotnetInspector.Options;
@@ -60,7 +61,7 @@ public record FindOptions : IAssemblySourceOptions
     /// <summary>
     /// Limit data rows per rendered table.
     /// </summary>
-    public int? Rows { get; init; }
+    public RowWindow? Rows { get; init; }
 
     /// <summary>
     /// Output the number of rendered result rows.

--- a/src/dotnet-inspect/Options/ImplementsOptions.cs
+++ b/src/dotnet-inspect/Options/ImplementsOptions.cs
@@ -1,3 +1,4 @@
+using DotnetInspector.Output;
 using DotnetInspector.Packages;
 
 namespace DotnetInspector.Options;
@@ -55,7 +56,7 @@ public record ImplementsOptions : IAssemblySourceOptions
     /// <summary>
     /// Limit data rows per rendered table.
     /// </summary>
-    public int? Rows { get; init; }
+    public RowWindow? Rows { get; init; }
 
     /// <summary>
     /// Output the number of rendered result rows.

--- a/src/dotnet-inspect/Options/InspectionOptions.cs
+++ b/src/dotnet-inspect/Options/InspectionOptions.cs
@@ -1,3 +1,4 @@
+using DotnetInspector.Output;
 using DotnetInspector.Packages;
 
 namespace DotnetInspector.Options;
@@ -110,7 +111,7 @@ public record InspectionOptions
 
     public bool PrintAll { get; init; }
 
-    public int? PrintRow { get; init; }
+    public RowSelector? PrintRow { get; init; }
 
     public bool Value { get; init; }
 
@@ -256,7 +257,7 @@ public record InspectionOptions
     /// <summary>
     /// Limit data rows per rendered table.
     /// </summary>
-    public int? Rows { get; init; }
+    public RowWindow? Rows { get; init; }
 
     /// <summary>
     /// True when output is raw text (not rendered markdown).

--- a/src/dotnet-inspect/Options/LibraryOptions.cs
+++ b/src/dotnet-inspect/Options/LibraryOptions.cs
@@ -1,3 +1,4 @@
+using DotnetInspector.Output;
 using DotnetInspector.Packages;
 
 namespace DotnetInspector.Options;
@@ -200,14 +201,14 @@ public record LibraryOptions
 
     public bool JsonArray { get; init; }
 
-    public int? PrintRow { get; init; }
+    public RowSelector? PrintRow { get; init; }
 
-    public int? ProjectionRow { get; init; }
+    public RowSelector? ProjectionRow { get; init; }
 
     /// <summary>
     /// Limit data rows per rendered table.
     /// </summary>
-    public int? Rows { get; init; }
+    public RowWindow? Rows { get; init; }
 
     /// <summary>
     /// Row predicates for the Performance Triage section.

--- a/src/dotnet-inspect/Options/ProjectOptions.cs
+++ b/src/dotnet-inspect/Options/ProjectOptions.cs
@@ -1,3 +1,4 @@
+using DotnetInspector.Output;
 using DotnetInspector.Packages;
 
 namespace DotnetInspector.Options;
@@ -14,7 +15,7 @@ public record ProjectOptions
 
     public bool PrintAll { get; init; }
 
-    public int? PrintRow { get; init; }
+    public RowSelector? PrintRow { get; init; }
 
     public bool Value { get; init; }
 
@@ -60,7 +61,7 @@ public record ProjectOptions
 
     public bool Count { get; init; }
 
-    public int? Rows { get; init; }
+    public RowWindow? Rows { get; init; }
 
     public bool Verbose { get; init; }
 

--- a/src/dotnet-inspect/Output/MarkdownTableRowLimiter.cs
+++ b/src/dotnet-inspect/Output/MarkdownTableRowLimiter.cs
@@ -2,9 +2,9 @@ namespace DotnetInspector.Output;
 
 internal static class MarkdownTableRowLimiter
 {
-    public static string Apply(string markdown, int? maxRows)
+    public static string Apply(string markdown, RowWindow? window)
     {
-        if (maxRows is null or < 0)
+        if (window is not { Count: >= 0 } limit)
             return markdown;
 
         var normalized = markdown.ReplaceLineEndings("\n");
@@ -31,24 +31,32 @@ internal static class MarkdownTableRowLimiter
             output.Add(line);
             output.Add(lines[++i]);
 
-            var rows = 0;
+            // Collect the table's data rows (separator lines pass through), then
+            // keep the leading or trailing window before emitting.
+            List<string> dataRows = [];
+            List<string> separators = [];
             while (i + 1 < lines.Length && MarkdownScan.IsTableLine(lines[i + 1]))
             {
                 i++;
                 if (MarkdownScan.IsSeparatorLine(lines[i]))
                 {
-                    output.Add(lines[i]);
+                    separators.Add(lines[i]);
                     continue;
                 }
 
-                if (rows < maxRows.Value)
-                {
-                    output.Add(lines[i]);
-                    rows++;
-                }
+                dataRows.Add(lines[i]);
             }
+
+            foreach (var kept in Window(dataRows, limit))
+                output.Add(kept);
+            output.AddRange(separators);
         }
 
         return string.Join('\n', output);
     }
+
+    private static IEnumerable<string> Window(List<string> rows, RowWindow limit) =>
+        limit.FromEnd
+            ? rows.Skip(Math.Max(0, rows.Count - limit.Count))
+            : rows.Take(limit.Count);
 }

--- a/src/dotnet-inspect/Output/MarkdownTableRowLimiter.cs
+++ b/src/dotnet-inspect/Output/MarkdownTableRowLimiter.cs
@@ -31,32 +31,31 @@ internal static class MarkdownTableRowLimiter
             output.Add(line);
             output.Add(lines[++i]);
 
-            // Collect the table's data rows (separator lines pass through), then
-            // keep the leading or trailing window before emitting.
-            List<string> dataRows = [];
-            List<string> separators = [];
+            // Collect the table body (data rows + any interior separators) in order,
+            // then emit it preserving original positions: separators pass through in
+            // place and only the head/tail window of data rows is kept.
+            List<string> body = [];
             while (i + 1 < lines.Length && MarkdownScan.IsTableLine(lines[i + 1]))
+                body.Add(lines[++i]);
+
+            var dataCount = body.Count(static l => !MarkdownScan.IsSeparatorLine(l));
+            var keepStart = limit.FromEnd ? Math.Max(0, dataCount - limit.Count) : 0;
+            var keepEnd = limit.FromEnd ? dataCount : Math.Min(dataCount, limit.Count);
+            var dataIndex = 0;
+            foreach (var bodyLine in body)
             {
-                i++;
-                if (MarkdownScan.IsSeparatorLine(lines[i]))
+                if (MarkdownScan.IsSeparatorLine(bodyLine))
                 {
-                    separators.Add(lines[i]);
+                    output.Add(bodyLine);
                     continue;
                 }
 
-                dataRows.Add(lines[i]);
+                if (dataIndex >= keepStart && dataIndex < keepEnd)
+                    output.Add(bodyLine);
+                dataIndex++;
             }
-
-            foreach (var kept in Window(dataRows, limit))
-                output.Add(kept);
-            output.AddRange(separators);
         }
 
         return string.Join('\n', output);
     }
-
-    private static IEnumerable<string> Window(List<string> rows, RowWindow limit) =>
-        limit.FromEnd
-            ? rows.Skip(Math.Max(0, rows.Count - limit.Count))
-            : rows.Take(limit.Count);
 }

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -81,6 +81,11 @@ public static class OutputFormatter
             ? dataRows.Skip(Math.Max(0, (lines.Length - headerLines) - limit.Count))
             : dataRows.Take(limit.Count);
         var kept = string.Join('\n', header.Concat(windowed));
+        // A zero-width window over a headerless format (JSONL, --no-header TSV) keeps
+        // nothing; return empty rather than re-adding the trailing newline, which would
+        // emit a phantom blank row / invalid empty JSONL record.
+        if (kept.Length == 0)
+            return string.Empty;
         return trailingNewline ? kept + "\n" : kept;
     }
 

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -26,7 +26,7 @@ public static class OutputFormatter
         return sw.ToString();
     }
 
-    public static void WriteTable(TextWriter output, bool showHeader, Action<TextWriter, IMarkoutFormatter> serialize, int? maxRows = null)
+    public static void WriteTable(TextWriter output, bool showHeader, Action<TextWriter, IMarkoutFormatter> serialize, RowWindow? maxRows = null)
     {
         // Row-limiting operates on the rendered text, so the capped path must materialize
         // the table first. Without a cap, serialize straight to the destination writer and
@@ -36,7 +36,7 @@ public static class OutputFormatter
         // so a single buffered Write(string) is not interchangeable with row-by-row writes
         // (it changes which trailing content survives the limit). Keep the buffered path for
         // those wrappers to preserve byte-identical output; their output is already small.
-        if (maxRows is null or < 0 && output is not (LineLimitingTextWriter or TailLineLimitingTextWriter))
+        if (maxRows is null or { Count: < 0 } && output is not (LineLimitingTextWriter or TailLineLimitingTextWriter))
         {
             serialize(output, new TableFormatter(showHeader));
             return;
@@ -53,9 +53,9 @@ public static class OutputFormatter
     /// table mode is a Markdown table delimited by a separator line. A null/negative limit
     /// (no <c>--rows</c>) leaves the output untouched.
     /// </summary>
-    public static string LimitRenderedTableRows(string rendered, int? maxRows, bool hasHeader)
+    public static string LimitRenderedTableRows(string rendered, RowWindow? maxRows, bool hasHeader)
     {
-        if (maxRows is null or < 0 || string.IsNullOrEmpty(rendered))
+        if (maxRows is not { Count: >= 0 } limit || string.IsNullOrEmpty(rendered))
             return rendered;
 
         var trailingNewline = rendered.EndsWith('\n');
@@ -75,7 +75,12 @@ public static class OutputFormatter
         if (lines.Length <= headerLines)
             return rendered;
 
-        var kept = string.Join('\n', lines.Take(headerLines + maxRows.Value));
+        var header = lines.Take(headerLines);
+        var dataRows = lines.Skip(headerLines);
+        var windowed = limit.FromEnd
+            ? dataRows.Skip(Math.Max(0, (lines.Length - headerLines) - limit.Count))
+            : dataRows.Take(limit.Count);
+        var kept = string.Join('\n', header.Concat(windowed));
         return trailingNewline ? kept + "\n" : kept;
     }
 
@@ -119,13 +124,13 @@ public static class OutputFormatter
         string[]? columns,
         string[]? fields,
         Action<TextWriter, IMarkoutFormatter, MarkoutWriterOptions> serialize,
-        int? maxRows = null) =>
+        RowWindow? maxRows = null) =>
         output.Write(LimitRenderedTableRows(RenderProjectedTable(showHeader, tsv, jsonl, columns, fields, serialize), maxRows, showHeader));
 
-    public static string ApplyRowLimit(string markdown, int? rows) =>
+    public static string ApplyRowLimit(string markdown, RowWindow? rows) =>
         MarkdownTableRowLimiter.Apply(markdown.TrimEnd(), rows);
 
-    public static void WriteLimitedMarkdown(TextWriter output, string markdown, int? rows) =>
+    public static void WriteLimitedMarkdown(TextWriter output, string markdown, RowWindow? rows) =>
         output.WriteLine(ApplyRowLimit(markdown, rows));
 
     public static void WriteStringList(IEnumerable<string> values, string displayName, string stableName,

--- a/src/dotnet-inspect/Output/PrintProjectionOutput.cs
+++ b/src/dotnet-inspect/Output/PrintProjectionOutput.cs
@@ -13,7 +13,7 @@ public sealed record PrintableDocument(
 
 public sealed record PrintProjectionOptions(
     bool PrintAll,
-    int? Row,
+    RowSelector? Row,
     bool JsonOutput,
     bool Jsonl,
     bool JsonArray,
@@ -47,11 +47,12 @@ public static class PrintProjectionOutput
 
             selected = documents;
         }
-        else if (options.Row is { } row)
+        else if (options.Row is { } selector)
         {
+            var row = selector.Resolve(documents.Count);
             if (row < 1 || row > documents.Count)
             {
-                Console.Error.WriteLine($"Error: printable row {row} is out of range. Use 1 through {documents.Count}.");
+                Console.Error.WriteLine($"Error: printable row {row} is out of range. Use 1 through {documents.Count}, first, or last.");
                 return 1;
             }
 
@@ -61,7 +62,7 @@ public static class PrintProjectionOutput
         {
             if (documents.Count != 1)
             {
-                Console.Error.WriteLine($"Error: selected section has {documents.Count} printable rows; use --row N to choose one row or --print-all.");
+                Console.Error.WriteLine($"Error: selected section has {documents.Count} printable rows; use --row N|first|last to choose one row or --print-all.");
                 return 1;
             }
 

--- a/src/dotnet-inspect/Output/RowSelection.cs
+++ b/src/dotnet-inspect/Output/RowSelection.cs
@@ -7,15 +7,13 @@ namespace DotnetInspector.Output;
 /// rows of each rendered table, preserving headings and table headers. A
 /// negative <see cref="Count"/> is treated as "no limit" by the row limiters.
 /// </summary>
-public readonly record struct RowWindow(int Count, bool FromEnd)
-{
-    /// <summary>
-    /// A bare row count is a leading (head) window: <c>--rows --head N</c>. This
-    /// keeps count-only call sites (and tests) concise while <c>--tail N</c> uses
-    /// the explicit <see cref="FromEnd"/> constructor.
-    /// </summary>
-    public static implicit operator RowWindow(int count) => new(count, FromEnd: false);
-}
+public readonly record struct RowWindow(int Count, bool FromEnd);
+
+/// <summary>
+/// Thrown when <c>--rows</c> is combined with an invalid head/tail window
+/// (both or neither). Surfaced as a one-line CLI error by the entry point.
+/// </summary>
+public sealed class RowWindowValidationException(string message) : Exception(message);
 
 /// <summary>
 /// A printable/projected-row selector parsed from <c>--row</c>: an explicit

--- a/src/dotnet-inspect/Output/RowSelection.cs
+++ b/src/dotnet-inspect/Output/RowSelection.cs
@@ -1,0 +1,96 @@
+namespace DotnetInspector.Output;
+
+/// <summary>
+/// A per-table data-row window applied by <c>--rows</c>: keep the first
+/// (<see cref="FromEnd"/> false, from <c>--head N</c>) or last
+/// (<see cref="FromEnd"/> true, from <c>--tail N</c>) <see cref="Count"/> data
+/// rows of each rendered table, preserving headings and table headers. A
+/// negative <see cref="Count"/> is treated as "no limit" by the row limiters.
+/// </summary>
+public readonly record struct RowWindow(int Count, bool FromEnd)
+{
+    /// <summary>
+    /// A bare row count is a leading (head) window: <c>--rows --head N</c>. This
+    /// keeps count-only call sites (and tests) concise while <c>--tail N</c> uses
+    /// the explicit <see cref="FromEnd"/> constructor.
+    /// </summary>
+    public static implicit operator RowWindow(int count) => new(count, FromEnd: false);
+}
+
+/// <summary>
+/// A printable/projected-row selector parsed from <c>--row</c>: an explicit
+/// 1-based index, or the symbolic <c>first</c>/<c>last</c> endpoints resolved
+/// against the actual row count at render time.
+/// </summary>
+public readonly record struct RowSelector
+{
+    private readonly int _index;
+
+    private RowSelector(RowSelectorKind kind, int index)
+    {
+        Kind = kind;
+        _index = index;
+    }
+
+    public RowSelectorKind Kind { get; }
+
+    /// <summary>The first printable/projected row.</summary>
+    public static RowSelector First { get; } = new(RowSelectorKind.First, 0);
+
+    /// <summary>The last printable/projected row.</summary>
+    public static RowSelector Last { get; } = new(RowSelectorKind.Last, 0);
+
+    /// <summary>An explicit 1-based row index (range-checked by the caller).</summary>
+    public static RowSelector FromIndex(int index) => new(RowSelectorKind.Index, index);
+
+    /// <summary>
+    /// Resolves this selector to a 1-based row index against a known row count:
+    /// <c>first</c> → 1, <c>last</c> → <paramref name="count"/>, and an explicit
+    /// index passes through unchanged (still range-checked by the caller).
+    /// </summary>
+    public int Resolve(int count) => Kind switch
+    {
+        RowSelectorKind.First => 1,
+        RowSelectorKind.Last => count,
+        _ => _index,
+    };
+
+    /// <summary>
+    /// Parses a <c>--row</c> token: a case-insensitive <c>first</c>/<c>last</c>
+    /// keyword or an integer. Returns false for any other token.
+    /// </summary>
+    public static bool TryParse(string? text, out RowSelector selector)
+    {
+        selector = default;
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        var trimmed = text.Trim();
+        if (trimmed.Equals("first", StringComparison.OrdinalIgnoreCase))
+        {
+            selector = First;
+            return true;
+        }
+
+        if (trimmed.Equals("last", StringComparison.OrdinalIgnoreCase))
+        {
+            selector = Last;
+            return true;
+        }
+
+        if (int.TryParse(trimmed, System.Globalization.NumberStyles.AllowLeadingSign, System.Globalization.CultureInfo.InvariantCulture, out var index))
+        {
+            selector = FromIndex(index);
+            return true;
+        }
+
+        return false;
+    }
+}
+
+public enum RowSelectorKind
+{
+    Index,
+    First,
+    Last,
+}

--- a/src/dotnet-inspect/Output/ShapeProjectionOutput.cs
+++ b/src/dotnet-inspect/Output/ShapeProjectionOutput.cs
@@ -20,7 +20,7 @@ public sealed record ShapeProjectionRow(
 
 public sealed record ShapeProjectionOptions(
     ShapeProjectionKind Kind,
-    int? Row,
+    RowSelector? Row,
     bool JsonOutput,
     bool Jsonl,
     bool JsonArray);
@@ -53,11 +53,12 @@ public static class ShapeProjectionOutput
         }
 
         IReadOnlyList<ShapeProjectionRow> selected = rows;
-        if (options.Row is { } row)
+        if (options.Row is { } selector)
         {
+            var row = selector.Resolve(rows.Count);
             if (row < 1 || row > rows.Count)
             {
-                Console.Error.WriteLine($"Error: row {row} is out of range. Use --row 1 through {rows.Count}.");
+                Console.Error.WriteLine($"Error: row {row} is out of range. Use --row 1 through {rows.Count}, first, or last.");
                 return 1;
             }
 
@@ -66,7 +67,7 @@ public static class ShapeProjectionOutput
 
         if (options.Kind == ShapeProjectionKind.Value && selected.Count != 1)
         {
-            Console.Error.WriteLine($"Error: --value found {selected.Count} rows; use --row N or select a single-row section.");
+            Console.Error.WriteLine($"Error: --value found {selected.Count} rows; use --row N|first|last or select a single-row section.");
             return 1;
         }
 

--- a/src/dotnet-inspect/Program.cs
+++ b/src/dotnet-inspect/Program.cs
@@ -116,22 +116,27 @@ if (showTraceMermaid && args.Length > 0 && argsBeforePreprocess.FirstOrDefault()
 // Install line-limiting writer when -NN shorthand was used (e.g. -30).
 // With --rows, -n/-NN is interpreted by commands as per-table row limits.
 var rowLimitMode = args.Any(a => a == "--rows");
-if (rowLimitMode && CommandLineBuilder.TailLines != null)
+if (rowLimitMode)
 {
-    Console.Error.WriteLine("Error: --rows cannot be combined with --tail.");
-    return 1;
+    if (CommandLineBuilder.HeadLines is not null && CommandLineBuilder.TailLines is not null)
+    {
+        Console.Error.WriteLine("Error: --rows cannot combine -n/--head with --tail; choose one row window.");
+        return 1;
+    }
+    if (CommandLineBuilder.HeadLines is null && CommandLineBuilder.TailLines is null)
+    {
+        Console.Error.WriteLine("Error: --rows requires -n/--head N or --tail N.");
+        return 1;
+    }
 }
-if (rowLimitMode && CommandLineBuilder.HeadLines == null)
-{
-    Console.Error.WriteLine("Error: --rows requires -n/--head or -N.");
-    return 1;
-}
+// Line/tail windows apply only outside --rows mode; in --rows mode the count is a
+// per-table data-row window rendered by the commands, not an output-line window.
 if (!rowLimitMode && CommandLineBuilder.HeadLines is int headLines)
     Console.SetOut(new LineLimitingTextWriter(Console.Out, headLines));
 
 // Install tail writer when --tail N was used
 TailLineLimitingTextWriter? tailWriter = null;
-if (CommandLineBuilder.TailLines is int tailLines)
+if (!rowLimitMode && CommandLineBuilder.TailLines is int tailLines)
 {
     tailWriter = new TailLineLimitingTextWriter(Console.Out, tailLines);
     Console.SetOut(tailWriter);

--- a/src/dotnet-inspect/Program.cs
+++ b/src/dotnet-inspect/Program.cs
@@ -114,21 +114,11 @@ if (showTraceMermaid && args.Length > 0 && argsBeforePreprocess.FirstOrDefault()
     RequestTelemetry.Breadcrumb("preprocess", $"{string.Join(' ', argsBeforePreprocess)} -> {string.Join(' ', args)}");
 
 // Install line-limiting writer when -NN shorthand was used (e.g. -30).
-// With --rows, -n/-NN is interpreted by commands as per-table row limits.
+// With --rows, -n/-NN is interpreted by commands as per-table row limits, and the
+// head/tail conflict is validated by SharedOptions.BuildRowWindow against the real
+// System.CommandLine parse (see the RowWindowValidationException catch below), not
+// the token scan here — the scan misses =-syntax and concatenated forms.
 var rowLimitMode = args.Any(a => a == "--rows");
-if (rowLimitMode)
-{
-    if (CommandLineBuilder.HeadLines is not null && CommandLineBuilder.TailLines is not null)
-    {
-        Console.Error.WriteLine("Error: --rows cannot combine -n/--head with --tail; choose one row window.");
-        return 1;
-    }
-    if (CommandLineBuilder.HeadLines is null && CommandLineBuilder.TailLines is null)
-    {
-        Console.Error.WriteLine("Error: --rows requires -n/--head N or --tail N.");
-        return 1;
-    }
-}
 // Line/tail windows apply only outside --rows mode; in --rows mode the count is a
 // per-table data-row window rendered by the commands, not an output-line window.
 if (!rowLimitMode && CommandLineBuilder.HeadLines is int headLines)
@@ -155,6 +145,11 @@ int exitCode;
 try
 {
     exitCode = await result.InvokeAsync();
+}
+catch (RowWindowValidationException ex)
+{
+    Console.Error.WriteLine($"Error: {ex.Message}");
+    return 1;
 }
 catch (OperationCanceledException)
 {

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -33,13 +33,13 @@ public class SharedOptions
 
     // Output control options
     public Option<int?> Limit { get; }
-    public Option<bool> Rows { get; } = new("--rows") { Description = "Interpret -n/-N as data rows per rendered table instead of output lines" };
+    public Option<bool> Rows { get; } = new("--rows") { Description = "Interpret -n/--head N or --tail N as data rows per rendered table instead of output lines" };
     public Option<int?> Tail { get; }
     public Option<bool> Count { get; } = new("--count") { Description = "Reduce a selected table/vector to a single row count" };
-    public Option<bool> Print { get; } = new("--print") { Description = "Print one document behind a selected section row; use --row N to choose a row when multiple rows are printable" };
+    public Option<bool> Print { get; } = new("--print") { Description = "Print one document behind a selected section row; use --row N|first|last to choose a row when multiple rows are printable" };
     public Option<bool> PrintAll { get; } = new("--print-all") { Description = "Print all documents behind rows in the selected printable section, separated by item headers" };
-    public Option<int?> Row { get; } = new("--row") { Description = "With --print, select the Nth printable row" };
-    public Option<bool> Value { get; } = new("--value") { Description = "Print one scalar value from a selected section; use --row N when multiple rows exist" };
+    public Option<string?> Row { get; } = new("--row") { Description = "With --print or a shape projection, select a printable row: a 1-based index, first, or last" };
+    public Option<bool> Value { get; } = new("--value") { Description = "Print one scalar value from a selected section; use --row N|first|last when multiple rows exist" };
     public Option<bool> Urls { get; } = new("--urls") { Description = "Project URL-bearing selected section rows to a URL list or JSONL rows" };
     public Option<bool> Paths { get; } = new("--paths") { Description = "Project path-bearing selected section rows to a path list or JSONL rows" };
     public Option<bool> JsonArray { get; } = new("--json-array") { Description = "With a shape projection, emit projected rows as one JSON array" };
@@ -138,6 +138,13 @@ public class SharedOptions
 
         NoHeaders.Aliases.Add("--no-header");
         NoHeaders.Aliases.Add("--nh");
+
+        Row.Validators.Add(result =>
+        {
+            var token = result.Tokens.Count > 0 ? result.Tokens[^1].Value : null;
+            if (token is not null && !RowSelector.TryParse(token, out _))
+                result.AddError($"--row must be a 1-based row number, 'first', or 'last' (got '{token}').");
+        });
     }
 
     /// <summary>
@@ -225,11 +232,19 @@ public class SharedOptions
             command.Options.Add(Row);
     }
 
-    public int? ParseRows(ParseResult parseResult)
-        => parseResult.GetValue(Rows) ? parseResult.GetValue(Limit) : null;
+    public RowWindow? ParseRows(ParseResult parseResult)
+    {
+        if (!parseResult.GetValue(Rows))
+            return null;
+        if (parseResult.GetValue(Limit) is int head)
+            return new RowWindow(head, FromEnd: false);
+        if (parseResult.GetValue(Tail) is int tail)
+            return new RowWindow(tail, FromEnd: true);
+        return null;
+    }
 
-    public int? ParsePrintRow(ParseResult parseResult)
-        => parseResult.GetValue(Row);
+    public RowSelector? ParsePrintRow(ParseResult parseResult)
+        => RowSelector.TryParse(parseResult.GetValue(Row), out var selector) ? selector : null;
 
     public PerformanceTriageOptions ParsePerformanceTriageOptions(ParseResult parseResult)
     {

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -233,14 +233,26 @@ public class SharedOptions
     }
 
     public RowWindow? ParseRows(ParseResult parseResult)
+        => BuildRowWindow(parseResult.GetValue(Rows), parseResult.GetValue(Limit), parseResult.GetValue(Tail));
+
+    /// <summary>
+    /// Resolves the <c>--rows</c> data-row window from the parsed head/tail values.
+    /// Validation lives here (not in the arg preprocessor) so it sees the real
+    /// System.CommandLine parse — including <c>=</c>-syntax and concatenated forms
+    /// the token scanner misses. Throws <see cref="RowWindowValidationException"/>
+    /// when <c>--rows</c> is given both windows or neither.
+    /// </summary>
+    public static RowWindow? BuildRowWindow(bool rows, int? head, int? tail)
     {
-        if (!parseResult.GetValue(Rows))
+        if (!rows)
             return null;
-        if (parseResult.GetValue(Limit) is int head)
-            return new RowWindow(head, FromEnd: false);
-        if (parseResult.GetValue(Tail) is int tail)
-            return new RowWindow(tail, FromEnd: true);
-        return null;
+        if (head is not null && tail is not null)
+            throw new RowWindowValidationException("--rows cannot combine -n/--head with --tail; choose one row window.");
+        if (head is int h)
+            return new RowWindow(h, FromEnd: false);
+        if (tail is int t)
+            return new RowWindow(t, FromEnd: true);
+        throw new RowWindowValidationException("--rows requires -n/--head N or --tail N.");
     }
 
     public RowSelector? ParsePrintRow(ParseResult parseResult)


### PR DESCRIPTION
Closes #2694. Follow-up to #2691 (grammar lock).

## What

Completes the symmetric output-shape grammar:

1. **`--rows --tail N`** — keep the **last** N data rows per rendered table (Markdown, TSV, JSONL), mirroring the existing `--rows --head N`. `--rows` now requires exactly one of head/tail and rejects both together.
2. **`--row N|first|last`** — extend printable/projected-row selection with symbolic endpoints. `first`→row 1, `last`→last row, resolved against the actual row count at render time. An invalid token is rejected by an option validator.

Both row-window forms remain incompatible with `--print`/`--print-all`; only `--row` resolves printable-row cardinality. Line/tail **line** windows (`--tail N` without `--rows`) are unchanged and still run post-projection.

## How

New value types in `Output/RowSelection.cs`:

- `RowWindow(Count, FromEnd)` — head (`--head`) vs tail (`--tail`) data-row window. Implicit `int→RowWindow` (bare count = head) keeps count-only call sites concise.
- `RowSelector` (`First`/`Last`/`FromIndex`, `Resolve(count)`, `TryParse`) — the `--row` selection, resolved lazily at the single render site that knows the row count.

`int? Rows`→`RowWindow?` and `int?/int? PrintRow`→`RowSelector?` thread through the options records and the three `--row` resolution sites (`ShapeProjectionOutput`, `PrintProjectionOutput`, `ApiCommand`); call sites like `Apply(markdown, options.Rows)` stay textually identical.

## Tests

- `OutputFormatterTests`: Markdown/TSV/JSONL tail windows (+ tail-wider-than-table), `RowSelector.TryParse` keyword/index/reject-invalid, and `Resolve` first/last/index. Full `dotnet-inspect.Tests` suite green (1832 total, 0 failed, 10 pre-existing skips for ilasm/ildasm).
- CLI: manually verified `--rows --head/--tail`, both-together and neither diagnostics, `--tsv/--jsonl --rows --tail`, and the `--row` invalid-token validator against CoreLib. `RowSelector.Resolve` endpoints covered by unit tests.

## Docs

`docs/design/output-shapes.md` and `docs/design/rendering-model.md` updated to reflect the now-implemented tail rows and `first|last` endpoints. `markdownlint` clean.

## Review

Non-trivial CLI grammar change → requesting two cross-model adversarial reviews per AGENTS.md.