### PR TITLE
Compose timelines with analysis findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ dotnet-inspect member MyType MyMethod:1 --library MyLib.dll -S "Unsafe*"
 dotnet-inspect library System.Text.Json --il-offset 0x06000004+0x15
 dotnet-inspect diff --package System.Text.Json@9.0.0..10.0.0 --breaking
 dotnet-inspect timeline --package System.Text.Json@8.0.0..9.0.0 --type System.Text.Json.JsonSerializer --members --at all
+dotnet-inspect timeline --package MyLib@1.0.0..2.0.0 --type MyType --member Parse --finding analysis.unsafety --at all
 dotnet-inspect diff --library old/Foo.dll..new/Foo.dll -S "Implementation Diff" -m MyType.HotPath
 dotnet-inspect depends Stream --markdown --mermaid
 dotnet-inspect implements IEquatable --project ./src/App -v:q

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,7 @@ The tool is organized around source inspection, API lookup, relationship, and ut
 │  Compare API, analysis, or implementation evidence           │
 ├─────────────────────────────────────────────────────────────┤
 │                       timeline                               │
-│  Correlate type-owned Findings across a package range         │
+│  Correlate API or member-body Findings across a package range │
 ├─────────────────────────────────────────────────────────────┤
 │            depends / extensions / implements                 │
 │  Relationship discovery for APIs, packages, and libraries    │
@@ -110,12 +110,15 @@ Compares two package, platform, or local-library versions:
 
 ### timeline
 
-Correlates one type-focused Finding census across an inclusive package version
-vector:
+Correlates one type- or member-focused Finding census across an inclusive
+package version vector:
 
 - `--finding api.type` observes the type's own presence and facets.
 - `--finding api.member` observes all members owned by the type.
+- `--finding api.member --member M` selects one exact member identity track.
 - `--finding api.attribute` observes applied attribute occurrences.
+- `--finding analysis.allocation`, `analysis.call-site`, or
+  `analysis.unsafety` observes one selected method's Analysis census.
 - No `--at` evaluates zero package payloads; repeated `--at` selectors perform
   sparse probes; `--at all` explicitly authorizes dense traversal.
 - `Evaluations` preserves `Present`/`Missing` self-presence through an exact
@@ -124,6 +127,8 @@ vector:
   identity tracks derive from the census correlation rather than bypassing it.
   `Transitions` compares adjacent evaluated cells; a
   gap-spanning row is qualified and never claims an exact transition version.
+  Analysis cells decode only the selected method body from the selected package
+  assembly.
 
 ### find
 

--- a/docs/design/command-transition-model.md
+++ b/docs/design/command-transition-model.md
@@ -422,6 +422,24 @@ identify the active observation in their title/schema:
 Changing among those timelines changes the observation producer, not the focus
 or operation.
 
+Adding `--member` changes the focus from the type-owned census to one exact
+member. With `--finding api.member`, the correlation selects that member's
+native identity key and reports `Present`, `Missing`, `SubjectAbsent`, and
+`Failed` cells. With `analysis.allocation`, `analysis.call-site`, or
+`analysis.unsafety`, the selected member is the Analysis subject and the
+correlated values are its producer-native occurrence censuses:
+
+```bash
+dotnet-inspect timeline --package Foo@1.0.0..2.0.0 \
+  --type Foo.Parser --member Parse \
+  --finding analysis.unsafety --at all
+```
+
+This is the cross-family composition proof: Metadata resolves the structural
+member focus, Analysis supplies the selected observation census, and Findings
+owns the N-address correlation. The command does not introduce a Research-owned
+timeline model.
+
 ### Dense timeline
 
 A bounded, explicit full-range traversal may evaluate every version in the

--- a/docs/design/finding-producers.md
+++ b/docs/design/finding-producers.md
@@ -187,6 +187,13 @@ Allocation, call-site, and unsafety comparisons share one descriptor-keyed
 retention container; new descriptors do not add parallel flags, lists,
 constructors, or merge branches.
 
+The same three Analysis censuses now compose with the N-address correlation
+tier. `timeline --member M --finding analysis.*` uses Metadata only to resolve
+the structural method focus, then correlates the producer-native Analysis
+inspections directly through `FindingCensusCorrelation<T>`. Exact
+`api.member --member M` tracks use that census correlation's `Correlate(key)`
+bridge rather than a command-owned identity model.
+
 Decompiler fidelity uses the same retention rule in the single-version product
 path. The member command's opt-in `Fidelity Causes` section keeps the complete
 `FindingInspection<DecompilerFidelityCause>` through member acquisition and

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -76,8 +76,21 @@ no `--at`, it renders every address as `Unevaluated` and recommends a probe
 without downloading package payloads. Repeated `--at` selectors perform sparse
 correlation; `--at all` is the explicit dense-traversal opt-in. Type focus may
 select the type-presence (`api.type`), owned-member (`api.member`), or applied
-attribute (`api.attribute`) census. Sparse transitions spanning unevaluated
-cells are labeled as gaps and do not claim the exact version of a change.
+attribute (`api.attribute`) census. Adding `--member` to `api.member` selects
+one exact member identity track. The same member focus composes with
+`analysis.allocation`, `analysis.call-site`, and `analysis.unsafety`; only the
+selected method body is decoded at each evaluated address. Sparse transitions
+spanning unevaluated cells are labeled as gaps and do not claim the exact
+version of a change.
+
+```bash
+dotnet-inspect timeline --package Foo@1.0.0..2.0.0 \
+  --type Foo.Parser --member Parse \
+  --finding analysis.unsafety --at first --at last
+```
+
+This locates candidate unsafe-operation boundaries without replacing the final
+adjacent `diff --finding analysis.unsafety` introduction proof.
 
 Stable endpoints exclude prereleases by default. A prerelease endpoint or
 `--preview` on `package --versions` includes prereleases within the range.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -12,7 +12,7 @@ It is built for both humans and agents. Markdown is the default output because h
 - `src/ILInspector.Analysis/` indexes IL method-body evidence such as direct call sites, allocation and unsafety occurrences, method signals, and whole-assembly leverage without decompiling to C#. `AnalysisFindings` exposes reusable typed censuses and comparisons for allocations, call sites, unsafe operations, and unsafe declaration/body evidence.
 - `src/ILInspector.Analysis.App/` is a temporary console harness for exercising Analysis queries until CLI wiring exists.
 - `src/ILInspector.ControlFlow/` contains shared block-edge, dominance, and dataflow kernels used below Analysis and Decompiler without depending on either.
-- `src/ILInspector.Findings/` contains the domain-free observation, inspection, matching, transition, comparison, whole-census correlation, and exact-identity correlation contracts shared by product producers.
+- `src/ILInspector.Findings/` contains the domain-free observation, inspection, matching, transition, comparison, whole-census correlation, and exact-identity correlation contracts shared by product producers. The `timeline` command composes Metadata and Analysis producers over those same correlation contracts.
 - `src/ILInspector.Instructions/` is the shared IL decode + EH-aware basic-block substrate (one decoder the analyzer and decompiler converge onto); see [instruction substrate](design/instruction-substrate.md).
 - `src/ILInspector.Text/` provides the reusable `TextFindings` API for exact, ordered line inspection and generic text comparison on the shared Finding spine.
 - `src/DotnetInspector.Packages/` handles NuGet package extraction, package/source caches, feeds, symbol package acquisition, and version resolution.

--- a/skills/compatibility/SKILL.md
+++ b/skills/compatibility/SKILL.md
@@ -123,6 +123,9 @@ dnx dotnet-inspect -y -- type TargetType --package Foo@1.0.0..2.0.0 --at '#5'
 dnx dotnet-inspect -y -- member TargetType TargetMember --package Foo@1.0.0..2.0.0 --at 1.6.0
 dnx dotnet-inspect -y -- timeline --package Foo@1.0.0..2.0.0 \
   --type TargetType --members --at first --at last
+dnx dotnet-inspect -y -- timeline --package Foo@1.0.0..2.0.0 \
+  --type TargetType --member TargetMember \
+  --finding analysis.unsafety --at first --at last
 ```
 
 `--at` accepts an exact version, one-based `#N`, `first`, or `last`. Vector
@@ -136,6 +139,9 @@ absence; use binary search only for a predicate known to be monotonic.
 `--at` for sparse probes, or pass `--at all` for explicit dense traversal.
 Choose the type-focused census with `--type-presence`, `--members`, or
 `--attributes` (aliases for `api.type`, `api.member`, and `api.attribute`).
+Add `--member` to `api.member` for one exact member identity track. The same
+member selector scopes `analysis.allocation`, `analysis.call-site`, and
+`analysis.unsafety` timelines to one method body.
 Gap-spanning transitions are evidence across the selected probes, not claims
 about the exact introduction or removal version.
 

--- a/skills/correctness/SKILL.md
+++ b/skills/correctness/SKILL.md
@@ -42,7 +42,17 @@ with IL evidence. For the library-wide safety *surface* (unsafe members, P/Invok
 methods) and provenance/supply-chain signals, see the `signals` skill.
 
 To confirm whether one definite unsafe operation appeared at an adjacent
-version boundary:
+version boundary, first correlate caller-selected package cells:
+
+```bash
+dnx dotnet-inspect -y -- timeline --package MyLib@1.0.0..2.0.0 \
+  -t MyType -m Method \
+  --finding analysis.unsafety --at first --at last
+```
+
+Repeat `--at` for sparse probes or use `--at all` for an explicitly bounded
+dense traversal. A gap-spanning `Added` row locates a candidate boundary; it
+does not claim the exact introduction version. Confirm the adjacent pair:
 
 ```bash
 dnx dotnet-inspect -y -- diff --package MyLib@1.4.0..1.5.0 \

--- a/skills/performance/SKILL.md
+++ b/skills/performance/SKILL.md
@@ -62,8 +62,18 @@ real per-item cost with a profiler before optimizing.
 
 ## Confirm when an allocation appeared
 
-The version vector and point probes locate a candidate old/new boundary; they do
-not establish onset. Confirm one method's adjacent pair with Analysis's native
+Correlate one method's native allocation census across caller-selected package
+cells:
+
+```bash
+dnx dotnet-inspect -y -- timeline --package MyLib@1.0.0..2.0.0 \
+  -t MyType -m HotPath \
+  --finding analysis.allocation --at first --at last
+```
+
+Repeat `--at` for sparse probes or use `--at all` for an explicitly bounded
+dense traversal. These probes locate a candidate old/new boundary; they do not
+establish onset. Confirm one method's adjacent pair with Analysis's native
 allocation Findings:
 
 ```bash

--- a/src/dotnet-inspect.Tests/TimelineCommandTests.cs
+++ b/src/dotnet-inspect.Tests/TimelineCommandTests.cs
@@ -1,6 +1,10 @@
+using System.Collections.Immutable;
 using DotnetInspector.Commands;
 using DotnetInspector.Packages;
+using ILInspector.Analysis;
+using ILInspector.Findings;
 using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
 
 namespace DotnetInspector.Tests;
 
@@ -98,6 +102,116 @@ public sealed class TimelineCommandTests
         var row = Assert.Single(view.Transitions!);
         Assert.Equal("Changed", row.Transition);
         Assert.Contains("accessibility: public -> protected", row.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MemberSelector_CorrelatesOneExactIdentity()
+    {
+        var vector = Vector("1.0.0", "1.0.1");
+        var oldSurface = Surface(Type("Widget", members:
+        [
+            Method("Run", "void Run()"),
+            Method("Stop", "void Stop()"),
+        ]));
+        var newSurface = Surface(Type("Widget", members:
+        [
+            Method("Stop", "void Stop()", accessibility: "protected"),
+        ]));
+
+        var view = TimelineCommand.BuildView(
+            vector,
+            "Sample.Widget",
+            "api.member",
+            [
+                Evaluation(vector, 0, oldSurface),
+                Evaluation(vector, 1, newSurface),
+            ],
+            Sections(),
+            memberName: "Run");
+
+        Assert.Equal("Run", view.Member);
+        Assert.Collection(
+            view.Evaluations!,
+            row => Assert.Equal("Present", row.State),
+            row => Assert.Equal("Missing", row.State));
+        var removed = Assert.Single(view.Transitions!);
+        Assert.Equal("Removed", removed.Transition);
+        Assert.Contains("Run", removed.Target, StringComparison.Ordinal);
+        Assert.DoesNotContain("Stop", removed.Target, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnsafetyTimeline_UsesMemberScopedAnalysisCensus()
+    {
+        var vector = Vector("1.0.0", "1.0.1");
+        var subject = new FindingSubject(
+            "analysis.member:Sample.Widget:Run",
+            "Sample.Widget.Run");
+        var occurrence = new UnsafetyOccurrence(
+            MethodIdentity(),
+            4,
+            UnsafetyKind.StackAlloc,
+            "byte*");
+
+        var view = TimelineCommand.BuildUnsafetyView(
+            vector,
+            "Sample.Widget",
+            "Run",
+            [
+                new TimelineCommand.TimelineFindingEvaluation<UnsafetyOccurrence>(
+                    vector.Addresses[0],
+                    new FindingInspection<UnsafetyOccurrence>.Complete([])),
+                new TimelineCommand.TimelineFindingEvaluation<UnsafetyOccurrence>(
+                    vector.Addresses[1],
+                    new FindingInspection<UnsafetyOccurrence>.Complete(
+                        AnalysisFindings.InspectUnsafety([occurrence], subject))),
+            ],
+            Sections());
+
+        Assert.Equal("Run", view.Member);
+        Assert.Collection(
+            view.Evaluations!,
+            row => Assert.Equal(0, row.Findings),
+            row => Assert.Equal(1, row.Findings));
+        var added = Assert.Single(view.Transitions!);
+        Assert.Equal("Added", added.Transition);
+        Assert.Equal("analysis.unsafety", added.Finding);
+        Assert.Contains("StackAlloc byte*", added.Target, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AnalysisTimeline_RequiresMemberBeforeAcquisition()
+    {
+        var result = await ConsoleCapture.RunAsync(() =>
+            TimelineCommand.ExecuteAsync(new TimelineOptions
+            {
+                PackageVersionRange = "Sample@1.0.0..1.0.1",
+                TypeName = "Sample.Widget",
+                Finding = "analysis.unsafety",
+            }));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains(
+            "--finding analysis.unsafety requires exactly one --member target",
+            result.Error,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnalysisTimeline_InspectsOnlyResolvedMethodBody()
+    {
+        var inspection = TimelineCommand.InspectUnsafetyAssemblies(
+            [typeof(TimelineCommandTests).Assembly.Location],
+            typeof(TimelineCommandTests).FullName!,
+            nameof(ReadPointer));
+
+        var complete = inspection switch
+        {
+            FindingInspection<UnsafetyOccurrence>.Complete value => value,
+            _ => throw new InvalidOperationException("Expected a complete unsafety census."),
+        };
+        var finding = Assert.Single(complete.Findings);
+        Assert.Equal(UnsafetyKind.Deref, finding.Payload.Kind);
     }
 
     [Fact]
@@ -238,10 +352,11 @@ public sealed class TimelineCommandTests
         var evaluations = await TimelineCommand.EvaluateCellsAsync(
             vector.Addresses,
             address => address.Position == 1
-                ? Task.FromException<(ApiSurface?, string?)>(
+                ? Task.FromException<(ApiSurface?, string?, DotnetInspector.Inspectors.ApiSurfaceEndpoint?)>(
                     new InvalidOperationException("package exploded"))
-                : Task.FromResult<(ApiSurface?, string?)>((
+                : Task.FromResult<(ApiSurface?, string?, DotnetInspector.Inspectors.ApiSurfaceEndpoint?)>((
                     Surface(Type("Widget")),
+                    null,
                     null)));
 
         Assert.Equal(3, evaluations.Count);
@@ -341,4 +456,18 @@ public sealed class TimelineCommandTests
             Signature = signature,
             Accessibility = accessibility,
         };
+
+    static MethodIdentity MethodIdentity()
+        => new(
+            "Sample",
+            Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            TypeRef.Definition("Sample", "Sample", "Widget"),
+            "Run",
+            ImmutableArray<TypeRef>.Empty,
+            TypeRef.CoreLib("System", "Void"),
+            0x06000001,
+            IsStatic: true);
+
+    public static unsafe int ReadPointer(int* value)
+        => *value;
 }

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -17,7 +17,7 @@ public static class InspectionCommandDefinitions
     {
         var command = new Command(
             TimelineCommand.Name,
-            "Correlate type, member, or applied-attribute Findings across a package version range");
+            "Correlate API or member-body Findings across a package version range");
         var argsArgument = new Argument<string[]>("args")
         {
             Description = "Package@A..B and type focus when --package/--type are omitted",
@@ -32,9 +32,14 @@ public static class InspectionCommandDefinitions
             Description = "Type focus (full name or unique short name)",
         };
         typeOption.Aliases.Add("-t");
+        var memberOption = new Option<string?>("--member")
+        {
+            Description = "Exact member selector; required for Analysis Findings",
+        };
+        memberOption.Aliases.Add("-m");
         var findingOption = new Option<string?>("--finding")
         {
-            Description = "Observation census: api.type, api.member, or api.attribute",
+            Description = "Observation census: api.type, api.member, api.attribute, analysis.allocation, analysis.call-site, or analysis.unsafety",
         };
         var atOption = new Option<string[]>("--at")
         {
@@ -70,6 +75,7 @@ public static class InspectionCommandDefinitions
         command.Arguments.Add(argsArgument);
         command.Options.Add(packageOption);
         command.Options.Add(typeOption);
+        command.Options.Add(memberOption);
         command.Options.Add(findingOption);
         command.Options.Add(atOption);
         command.Options.Add(membersOption);
@@ -123,6 +129,7 @@ public static class InspectionCommandDefinitions
             {
                 PackageVersionRange = package ?? "",
                 TypeName = type ?? "",
+                MemberName = parseResult.GetValue(memberOption),
                 Finding = aliases.Count == 1
                     ? aliases[0]
                     : explicitFinding ?? MetadataFindings.MemberDescriptor.Id,

--- a/src/dotnet-inspect/Commands/TimelineCommand.cs
+++ b/src/dotnet-inspect/Commands/TimelineCommand.cs
@@ -6,8 +6,10 @@ using DotnetInspector.Output;
 using DotnetInspector.Packages;
 using DotnetInspector.Services;
 using DotnetInspector.Views;
+using ILInspector.Analysis;
 using ILInspector.Findings;
 using ILInspector.Metadata;
+using ILInspector.Research;
 using Markout;
 
 namespace DotnetInspector.Commands;
@@ -46,20 +48,30 @@ public static class TimelineCommand
                 vector.PackageId,
                 selectedAddresses,
                 options);
-            if (!TryResolveTypeName(options.TypeName, evaluations, out var typeFullName, out error))
+            try
             {
-                Console.Error.WriteLine($"Error: {error}");
-                return 1;
-            }
+                if (!TryResolveTypeName(options.TypeName, evaluations, out var typeFullName, out error))
+                {
+                    Console.Error.WriteLine($"Error: {error}");
+                    return 1;
+                }
 
-            var view = BuildView(
-                vector,
-                typeFullName!,
-                descriptor!,
-                evaluations,
-                selectedSections);
-            Write(view, options, selectedSections);
-            return 0;
+                var view = BuildView(
+                    vector,
+                    typeFullName!,
+                    descriptor!,
+                    evaluations,
+                    selectedSections,
+                    options.MemberName,
+                    options.IncludeAll);
+                Write(view, options, selectedSections);
+                return 0;
+            }
+            finally
+            {
+                foreach (var evaluation in evaluations)
+                    evaluation.Dispose();
+            }
         }
         catch (Exception ex)
         {
@@ -73,13 +85,16 @@ public static class TimelineCommand
         string typeFullName,
         string descriptor,
         IReadOnlyList<TimelineEvaluation> evaluated,
-        HashSet<string> selectedSections)
+        HashSet<string> selectedSections,
+        string? memberName = null,
+        bool includeAll = false)
         => descriptor switch
         {
             var id when id == MetadataFindings.TypeDescriptor.Id =>
-                BuildView(
+                BuildMetadataView(
                     vector,
                     typeFullName,
+                    null,
                     MetadataFindings.TypeDescriptor,
                     evaluated,
                     selectedSections,
@@ -97,13 +112,17 @@ public static class TimelineCommand
                         Subject(typeFullName),
                         typeFullName)),
             var id when id == MetadataFindings.MemberDescriptor.Id =>
-                BuildView(
+                BuildMetadataView(
                     vector,
                     typeFullName,
+                    memberName,
                     MetadataFindings.MemberDescriptor,
                     evaluated,
                     selectedSections,
-                    null,
+                    ResolveMemberCorrelationKey(
+                        typeFullName,
+                        memberName,
+                        evaluated),
                     surface => MetadataFindings.InspectApiMembers(
                         surface,
                         Subject(typeFullName),
@@ -114,9 +133,10 @@ public static class TimelineCommand
                         Subject(typeFullName),
                         typeFullName)),
             var id when id == MetadataFindings.AttributeDescriptor.Id =>
-                BuildView(
+                BuildMetadataView(
                     vector,
                     typeFullName,
+                    null,
                     MetadataFindings.AttributeDescriptor,
                     evaluated,
                     selectedSections,
@@ -130,13 +150,74 @@ public static class TimelineCommand
                         newSurface,
                         Subject(typeFullName),
                         typeFullName)),
+            var id when id == AnalysisFindings.AllocationDescriptor.Id =>
+                BuildAllocationView(
+                    vector,
+                    typeFullName,
+                    memberName!,
+                    EvaluateAnalysis<AllocationOccurrence>(
+                        evaluated,
+                        typeFullName,
+                        memberName!,
+                        includeAll,
+                        AnalysisFindings.AllocationDescriptor,
+                        static (index, token, subject) =>
+                        {
+                            index.GetAllocationOccurrences().TryGetValue(token, out var occurrences);
+                            return new FindingInspection<AllocationOccurrence>.Complete(
+                                AnalysisFindings.InspectAllocations(
+                                    occurrences.IsDefault ? [] : occurrences,
+                                    subject));
+                        }),
+                    selectedSections),
+            var id when id == AnalysisFindings.CallSiteDescriptor.Id =>
+                BuildCallSiteView(
+                    vector,
+                    typeFullName,
+                    memberName!,
+                    EvaluateAnalysis<DirectCall>(
+                        evaluated,
+                        typeFullName,
+                        memberName!,
+                        includeAll,
+                        AnalysisFindings.CallSiteDescriptor,
+                        static (index, token, subject) =>
+                        {
+                            index.GetDirectCallsByCaller().TryGetValue(token, out var calls);
+                            return new FindingInspection<DirectCall>.Complete(
+                                AnalysisFindings.InspectCallSites(
+                                    calls.IsDefault ? [] : calls,
+                                    subject));
+                        }),
+                    selectedSections),
+            var id when id == AnalysisFindings.UnsafetyDescriptor.Id =>
+                BuildUnsafetyView(
+                    vector,
+                    typeFullName,
+                    memberName!,
+                    EvaluateAnalysis<UnsafetyOccurrence>(
+                        evaluated,
+                        typeFullName,
+                        memberName!,
+                        includeAll,
+                        AnalysisFindings.UnsafetyDescriptor,
+                        static (index, token, subject) =>
+                        {
+                            index.GetUnsafetyOccurrences().TryGetValue(token, out var occurrences);
+                            return new FindingInspection<UnsafetyOccurrence>.Complete(
+                                AnalysisFindings.InspectUnsafety(
+                                    occurrences.IsDefault ? [] : occurrences,
+                                    subject));
+                        }),
+                    selectedSections),
             _ => throw new InvalidOperationException(
                 $"Unsupported Finding descriptor '{descriptor}'."),
         };
 
-    static TimelineDocumentView BuildView<T>(
+    static TimelineDocumentView BuildMetadataView<T>(
         PackageVersionVector vector,
         string typeFullName,
+        string? memberName,
         FindingDescriptor descriptor,
         IReadOnlyList<TimelineEvaluation> evaluated,
         HashSet<string> selectedSections,
@@ -145,8 +226,7 @@ public static class TimelineCommand
         Func<ApiSurface?, ApiSurface?, FindingComparison<T>> compare)
         where T : notnull
     {
-        var correlation = FindingCensusCorrelation<T>.Create(
-            evaluated.Select(evaluation => new VersionedFindingInspection<T>(
+        var versioned = evaluated.Select(evaluation => new VersionedFindingInspection<T>(
                 new FindingVersion(
                     evaluation.Address.Selector,
                     evaluation.Address.Version.ToNormalizedString(),
@@ -157,7 +237,350 @@ public static class TimelineCommand
                         new InspectionError(
                             Subject(typeFullName),
                             descriptor,
-                            evaluation.Error)))));
+                            evaluation.Error))))
+            .ToArray();
+        var evaluationsByPosition = evaluated.ToDictionary(item => item.Address.Position);
+        return BuildCorrelatedView(
+            vector,
+            typeFullName,
+            memberName,
+            descriptor,
+            versioned,
+            selectedSections,
+            identityKey,
+            (oldPosition, newPosition, _, _) => compare(
+                evaluationsByPosition[oldPosition].Surface,
+                evaluationsByPosition[newPosition].Surface));
+    }
+
+    static FindingCorrelationKey? ResolveMemberCorrelationKey(
+        string typeFullName,
+        string? memberName,
+        IReadOnlyList<TimelineEvaluation> evaluated)
+    {
+        if (string.IsNullOrWhiteSpace(memberName))
+            return null;
+
+        var selector = MemberTargetSelector.Parse(memberName);
+        foreach (var evaluation in evaluated.OrderBy(item => item.Address.Position))
+        {
+            var type = evaluation.Surface?.Types.FirstOrDefault(type =>
+                string.Equals(type.FullName, typeFullName, StringComparison.OrdinalIgnoreCase));
+            if (type is null)
+                continue;
+
+            var resolution = MemberTargetResolver.Resolve(type, selector);
+            if (resolution.Found)
+            {
+                var handle = resolution.Target!.ApiMember;
+                return new FindingCorrelationKey(
+                    Subject(typeFullName),
+                    MetadataFindings.MemberDescriptor,
+                    new FindingKey(
+                        handle.CanonicalSignature ?? handle.Identity,
+                        type.FullName));
+            }
+
+            if (resolution.Diagnostic is { Kind: MemberTargetDiagnosticKind.AmbiguousMember
+                    or MemberTargetDiagnosticKind.DigestAmbiguous
+                    or MemberTargetDiagnosticKind.ConflictingSelectors } diagnostic)
+            {
+                throw new InvalidOperationException(diagnostic.Message);
+            }
+        }
+
+        return new FindingCorrelationKey(
+            Subject(typeFullName),
+            MetadataFindings.MemberDescriptor,
+            new FindingKey($"selector:{selector.NormalizedSelector}", typeFullName));
+    }
+
+    static TimelineDocumentView BuildAllocationView(
+        PackageVersionVector vector,
+        string typeFullName,
+        string memberName,
+        IReadOnlyList<TimelineFindingEvaluation<AllocationOccurrence>> evaluated,
+        HashSet<string> selectedSections)
+        => BuildAnalysisView(
+            vector,
+            typeFullName,
+            memberName,
+            AnalysisFindings.AllocationDescriptor,
+            evaluated,
+            selectedSections,
+            AnalysisFindings.CompareAllocations);
+
+    static TimelineDocumentView BuildCallSiteView(
+        PackageVersionVector vector,
+        string typeFullName,
+        string memberName,
+        IReadOnlyList<TimelineFindingEvaluation<DirectCall>> evaluated,
+        HashSet<string> selectedSections)
+        => BuildAnalysisView(
+            vector,
+            typeFullName,
+            memberName,
+            AnalysisFindings.CallSiteDescriptor,
+            evaluated,
+            selectedSections,
+            AnalysisFindings.CompareCallSites);
+
+    internal static TimelineDocumentView BuildUnsafetyView(
+        PackageVersionVector vector,
+        string typeFullName,
+        string memberName,
+        IReadOnlyList<TimelineFindingEvaluation<UnsafetyOccurrence>> evaluated,
+        HashSet<string> selectedSections)
+        => BuildAnalysisView(
+            vector,
+            typeFullName,
+            memberName,
+            AnalysisFindings.UnsafetyDescriptor,
+            evaluated,
+            selectedSections,
+            AnalysisFindings.CompareUnsafety);
+
+    static TimelineDocumentView BuildAnalysisView<T>(
+        PackageVersionVector vector,
+        string typeFullName,
+        string memberName,
+        FindingDescriptor descriptor,
+        IReadOnlyList<TimelineFindingEvaluation<T>> evaluated,
+        HashSet<string> selectedSections,
+        Func<IEnumerable<T>, IEnumerable<T>, FindingSubject, int, FindingComparison<T>> compare)
+        where T : notnull
+    {
+        var subject = MemberSubject(typeFullName, memberName);
+        var versioned = evaluated.Select(evaluation => new VersionedFindingInspection<T>(
+            new FindingVersion(
+                evaluation.Address.Selector,
+                evaluation.Address.Version.ToNormalizedString(),
+                evaluation.Address.Position),
+            evaluation.Inspection)).ToArray();
+        return BuildCorrelatedView(
+            vector,
+            typeFullName,
+            memberName,
+            descriptor,
+            versioned,
+            selectedSections,
+            null,
+            (_, _, oldInspection, newInspection) => CompareAnalysis(
+                oldInspection,
+                newInspection,
+                subject,
+                compare));
+    }
+
+    static FindingComparison<T> CompareAnalysis<T>(
+        FindingInspection<T> oldInspection,
+        FindingInspection<T> newInspection,
+        FindingSubject subject,
+        Func<IEnumerable<T>, IEnumerable<T>, FindingSubject, int, FindingComparison<T>> compare)
+        where T : notnull
+    {
+        if (oldInspection is FindingInspection<T>.Complete oldComplete
+            && newInspection is FindingInspection<T>.Complete newComplete)
+        {
+            return compare(
+                oldComplete.Findings.Select(static finding => finding.Payload),
+                newComplete.Findings.Select(static finding => finding.Payload),
+                subject,
+                100);
+        }
+
+        return FindingComparison.Compare(oldInspection, newInspection);
+    }
+
+    static IReadOnlyList<TimelineFindingEvaluation<T>> EvaluateAnalysis<T>(
+        IReadOnlyList<TimelineEvaluation> evaluated,
+        string typeFullName,
+        string memberName,
+        bool includeAll,
+        FindingDescriptor descriptor,
+        Func<LibraryBodyIndex, int, FindingSubject, FindingInspection<T>> inspect)
+        where T : notnull
+    {
+        var subject = MemberSubject(typeFullName, memberName);
+        List<TimelineFindingEvaluation<T>> results = [];
+        foreach (var evaluation in evaluated)
+        {
+            FindingInspection<T> inspection;
+            if (evaluation.Error is not null)
+            {
+                inspection = new FindingInspection<T>.Failed(
+                    new InspectionError(subject, descriptor, evaluation.Error));
+            }
+            else
+            {
+                try
+                {
+                    inspection = InspectAnalysisEndpoint(
+                        evaluation,
+                        typeFullName,
+                        memberName,
+                        includeAll,
+                        descriptor,
+                        subject,
+                        inspect);
+                }
+                catch (Exception ex)
+                {
+                    inspection = new FindingInspection<T>.Failed(
+                        new InspectionError(
+                            subject,
+                            descriptor,
+                            $"{ex.GetType().Name}: {ex.Message}"));
+                }
+            }
+
+            results.Add(new TimelineFindingEvaluation<T>(evaluation.Address, inspection));
+        }
+
+        return results;
+    }
+
+    static FindingInspection<T> InspectAnalysisEndpoint<T>(
+        TimelineEvaluation evaluation,
+        string typeFullName,
+        string memberName,
+        bool includeAll,
+        FindingDescriptor descriptor,
+        FindingSubject subject,
+        Func<LibraryBodyIndex, int, FindingSubject, FindingInspection<T>> inspect)
+        where T : notnull
+    {
+        if (evaluation.Endpoint is null)
+            return new FindingInspection<T>.Absent("The package cell has no acquired assembly set.");
+
+        return InspectAnalysisAssemblies<T>(
+            evaluation.Endpoint.Paths,
+            typeFullName,
+            memberName,
+            includeAll,
+            descriptor,
+            subject,
+            inspect);
+    }
+
+    internal static FindingInspection<UnsafetyOccurrence> InspectUnsafetyAssemblies(
+        IReadOnlyList<string> assemblyPaths,
+        string typeFullName,
+        string memberName,
+        bool includeAll = false)
+    {
+        var subject = MemberSubject(typeFullName, memberName);
+        return InspectAnalysisAssemblies<UnsafetyOccurrence>(
+            assemblyPaths,
+            typeFullName,
+            memberName,
+            includeAll,
+            AnalysisFindings.UnsafetyDescriptor,
+            subject,
+            static (index, token, findingSubject) =>
+            {
+                index.GetUnsafetyOccurrences().TryGetValue(token, out var occurrences);
+                return new FindingInspection<UnsafetyOccurrence>.Complete(
+                    AnalysisFindings.InspectUnsafety(
+                        occurrences.IsDefault ? [] : occurrences,
+                        findingSubject));
+            });
+    }
+
+    static FindingInspection<T> InspectAnalysisAssemblies<T>(
+        IReadOnlyList<string> assemblyPaths,
+        string typeFullName,
+        string memberName,
+        bool includeAll,
+        FindingDescriptor descriptor,
+        FindingSubject subject,
+        Func<LibraryBodyIndex, int, FindingSubject, FindingInspection<T>> inspect)
+        where T : notnull
+    {
+        var selector = MemberTargetSelector.Parse(memberName);
+        List<(string Path, ResolvedMemberTarget Target)> targets = [];
+        bool typeFound = false;
+        foreach (string path in assemblyPaths)
+        {
+            var surface = AssemblyReader.ExtractApiSurface(path, includeAll);
+            var type = surface?.Types.FirstOrDefault(type =>
+                string.Equals(type.FullName, typeFullName, StringComparison.OrdinalIgnoreCase));
+            if (type is null)
+                continue;
+
+            typeFound = true;
+            var resolution = MemberTargetResolver.Resolve(type, selector);
+            if (resolution.Found)
+            {
+                targets.Add((path, resolution.Target!));
+                continue;
+            }
+
+            if (resolution.Diagnostic is { Kind: MemberTargetDiagnosticKind.AmbiguousMember
+                    or MemberTargetDiagnosticKind.DigestAmbiguous
+                    or MemberTargetDiagnosticKind.ConflictingSelectors } diagnostic)
+            {
+                return new FindingInspection<T>.Failed(
+                    new InspectionError(subject, descriptor, diagnostic.Message));
+            }
+        }
+
+        if (targets.Count == 0)
+        {
+            string detail = typeFound
+                ? $"Member '{memberName}' is absent."
+                : $"Type '{typeFullName}' is absent.";
+            return new FindingInspection<T>.Absent(detail);
+        }
+        if (targets.Count > 1)
+        {
+            return new FindingInspection<T>.Failed(
+                new InspectionError(
+                    subject,
+                    descriptor,
+                    $"Member '{memberName}' resolved in more than one package assembly."));
+        }
+
+        var (assemblyPath, target) = targets[0];
+        if (target.Kind is not (MemberTargetKind.Constructor
+            or MemberTargetKind.Method
+            or MemberTargetKind.Operator
+            or MemberTargetKind.ExplicitInterfaceImplementation
+            or MemberTargetKind.ExtensionMethod))
+        {
+            return new FindingInspection<T>.Failed(
+                new InspectionError(
+                    subject,
+                    descriptor,
+                    $"Finding '{descriptor.Id}' requires a method-like target; "
+                    + $"'{memberName}' resolved to {target.Kind}."));
+        }
+        if (target.Body?.MetadataToken is not { } token)
+        {
+            return new FindingInspection<T>.Absent(
+                $"Member '{memberName}' has no method-body target.");
+        }
+
+        var index = LibraryBodyIndex.Open(
+            assemblyPath,
+            includeAllocations: descriptor == AnalysisFindings.AllocationDescriptor,
+            includeOpportunities: false,
+            bodyScope: ImmutableHashSet.Create(token));
+        return inspect(index, token, subject);
+    }
+
+    static TimelineDocumentView BuildCorrelatedView<T>(
+        PackageVersionVector vector,
+        string typeFullName,
+        string? memberName,
+        FindingDescriptor descriptor,
+        IReadOnlyList<VersionedFindingInspection<T>> versioned,
+        HashSet<string> selectedSections,
+        FindingCorrelationKey? identityKey,
+        Func<int, int, FindingInspection<T>, FindingInspection<T>, FindingComparison<T>> compare)
+        where T : notnull
+    {
+        var correlation = FindingCensusCorrelation<T>.Create(versioned);
         var inspectionsByPosition = correlation.Inspections.ToDictionary(
             item => item.Version.Position);
         var identityByPosition = identityKey is null
@@ -186,9 +609,10 @@ public static class TimelineCommand
         List<TimelineTransitionRow>? transitionRows = selectedSections.Contains(TransitionsSection)
             ? BuildTransitionRows(
                 correlation,
-                evaluated,
                 descriptor.Id,
                 typeFullName,
+                memberName,
+                identityKey,
                 compare)
             : null;
 
@@ -197,8 +621,14 @@ public static class TimelineCommand
             Title = $"Timeline: {vector.PackageId}",
             Range = $"{vector.Start.ToNormalizedString()}..{vector.End.ToNormalizedString()}",
             Type = typeFullName,
+            Member = memberName,
             Finding = descriptor.Id,
-            Recommendation = RecommendProbe(vector, typeFullName, descriptor.Id, evaluated),
+            Recommendation = RecommendProbe(
+                vector,
+                typeFullName,
+                memberName,
+                descriptor.Id,
+                correlation.Inspections.Select(item => item.Version.Position)),
             Evaluations = evaluationRows,
             Transitions = transitionRows,
         };
@@ -276,14 +706,17 @@ public static class TimelineCommand
 
     static List<TimelineTransitionRow> BuildTransitionRows<T>(
         FindingCensusCorrelation<T> correlation,
-        IReadOnlyList<TimelineEvaluation> evaluations,
         string descriptor,
         string typeFullName,
-        Func<ApiSurface?, ApiSurface?, FindingComparison<T>> compare)
+        string? memberName,
+        FindingCorrelationKey? identityKey,
+        Func<int, int, FindingInspection<T>, FindingInspection<T>, FindingComparison<T>> compare)
         where T : notnull
     {
         var ordered = correlation.Inspections;
-        var evaluationsByPosition = evaluations.ToDictionary(item => item.Address.Position);
+        string focusTarget = memberName is null
+            ? typeFullName
+            : $"{typeFullName}.{memberName}";
         List<TimelineTransitionRow> rows = [];
         for (int i = 1; i < ordered.Length; i++)
         {
@@ -304,19 +737,11 @@ public static class TimelineCommand
             }
             else
             {
-                if (!evaluationsByPosition.TryGetValue(
-                        oldInspection.Version.Position,
-                        out var oldEvaluation)
-                    || !evaluationsByPosition.TryGetValue(
-                        newInspection.Version.Position,
-                        out var newEvaluation))
-                {
-                    throw new InvalidOperationException(
-                        $"Timeline correlation lost an evaluated cell for {descriptor} "
-                        + $"{oldInspection.Version.Key}..{newInspection.Version.Key}.");
-                }
-
-                comparison = compare(oldEvaluation.Surface, newEvaluation.Surface);
+                comparison = compare(
+                    oldInspection.Version.Position,
+                    newInspection.Version.Position,
+                    oldInspection.Inspection,
+                    newInspection.Inspection);
             }
 
             if (comparison.OldInspection != oldInspection.Inspection
@@ -336,7 +761,7 @@ public static class TimelineCommand
                     span,
                     "Failed",
                     descriptor,
-                    typeFullName,
+                    focusTarget,
                     failure.Failure));
                 continue;
             }
@@ -354,21 +779,24 @@ public static class TimelineCommand
             if (subjectTransition is not null)
             {
                 string detail = subjectTransition == "SubjectAvailable"
-                    ? "The focused type became available to this census."
-                    : "The focused type ceased to be available to this census.";
+                    ? $"The focused {(memberName is null ? "type" : "member")} became available to this census."
+                    : $"The focused {(memberName is null ? "type" : "member")} ceased to be available to this census.";
                 rows.Add(new TimelineTransitionRow(
                     oldInspection.Version.Key,
                     newInspection.Version.Key,
                     span,
                     subjectTransition,
                     descriptor,
-                    typeFullName,
+                    focusTarget,
                     exact ? detail : AppendGapQualification(detail)));
             }
 
             var changes = completeComparison.Pairs
                 .Where(pair => pair.Kind != PairKind.Present)
                 .Cast<IPairFinding>()
+                .Where(pair => identityKey is null
+                    || ((pair.Old ?? pair.New) is Finding<T> finding
+                        && Matches(identityKey, finding)))
                 .ToArray();
             if (changes.Length == 0 && subjectTransition is null)
             {
@@ -378,7 +806,7 @@ public static class TimelineCommand
                     span,
                     "None",
                     descriptor,
-                    typeFullName,
+                    focusTarget,
                     exact ? null : "No change was observed across the evaluated gap."));
                 continue;
             }
@@ -396,6 +824,12 @@ public static class TimelineCommand
         return rows;
     }
 
+    static bool Matches<T>(FindingCorrelationKey key, Finding<T> finding)
+        where T : notnull
+        => finding.Subject.Key == key.Subject.Key
+            && finding.Descriptor.Id == key.Descriptor.Id
+            && finding.Key == key.Key;
+
     static string? AppendGapQualification(string? detail)
         => string.IsNullOrEmpty(detail)
             ? "Observed across a gap; the exact transition version is unknown."
@@ -403,6 +837,14 @@ public static class TimelineCommand
 
     static FindingSubject Subject(string typeFullName)
         => new($"api.type:{typeFullName}", typeFullName);
+
+    static FindingSubject MemberSubject(string typeFullName, string memberName)
+    {
+        var selector = MemberTargetSelector.Parse(memberName);
+        return new(
+            $"analysis.member:{typeFullName}:{selector.NormalizedSelector}",
+            $"{typeFullName}.{selector.NormalizedSelector}");
+    }
 
     static string GetTarget(IPairFinding pair)
     {
@@ -412,8 +854,49 @@ public static class TimelineCommand
             Finding<ApiTypeHandle> type => type.Payload.TypeFullName,
             Finding<ApiMemberHandle> member => member.Payload.Identity,
             Finding<ApiAttributeHandle> attribute => attribute.Payload.Attribute,
+            Finding<AllocationOccurrence> allocation => AllocationTarget(allocation),
+            Finding<DirectCall> callSite => CallSiteTarget(callSite),
+            Finding<UnsafetyOccurrence> unsafety => UnsafetyTarget(unsafety),
             _ => pair.Subject.Display,
         };
+    }
+
+    static string AllocationTarget(Finding<AllocationOccurrence> finding)
+    {
+        var occurrence = finding.Payload;
+        var allocatedType = occurrence.AllocatedType?.ToQualifiedDisplayString()
+            ?? occurrence.RuntimeAllocationType
+            ?? occurrence.Detail
+            ?? "?";
+        return $"{finding.Subject.Display} :: {occurrence.Source}/{occurrence.Kind} {allocatedType}";
+    }
+
+    static string CallSiteTarget(Finding<DirectCall> finding)
+    {
+        var callee = finding.Payload.Callee;
+        if (callee.Kind == MemberKind.Unsupported)
+            return $"{finding.Subject.Display} :: {callee.DeclaringType.ToDisplayString()}";
+
+        var typeArguments = callee.TypeArguments.IsDefaultOrEmpty
+            ? ""
+            : $"<{string.Join(", ", callee.TypeArguments.Select(type => type.ToQualifiedDisplayString()))}>";
+        var parameters = string.Join(
+            ", ",
+            callee.ParameterTypes.Select(type => type.ToQualifiedDisplayString()));
+        var declaringType = callee.DeclaringType.ToQualifiedDisplayString();
+        var calleeDisplay = callee.Kind == MemberKind.Constructor
+            ? $"{declaringType}{typeArguments}({parameters})"
+            : $"{declaringType}.{callee.Name}{typeArguments}({parameters})";
+        return $"{finding.Subject.Display} :: {calleeDisplay}";
+    }
+
+    static string UnsafetyTarget(Finding<UnsafetyOccurrence> finding)
+    {
+        var occurrence = finding.Payload;
+        string detail = string.IsNullOrWhiteSpace(occurrence.Detail)
+            ? ""
+            : $" {occurrence.Detail}";
+        return $"{finding.Subject.Display} :: {occurrence.Kind}{detail}";
     }
 
     static async Task<List<TimelineEvaluation>> EvaluateAsync(
@@ -437,15 +920,18 @@ public static class TimelineCommand
                 options.IncludeAll,
                 context.Logger);
             if (result.Error is not null)
-                return (null, result.Error);
+                return (null, result.Error, (ApiSurfaceEndpoint?)null);
 
-            using var endpoint = result.Endpoint!;
-            return (endpoint.Surface, null);
+            var endpoint = result.Endpoint!;
+            return (endpoint.Surface, (string?)null, endpoint);
         });
 
     internal static async Task<List<TimelineEvaluation>> EvaluateCellsAsync(
         ImmutableArray<PackageVersionAddress> addresses,
-        Func<PackageVersionAddress, Task<(ApiSurface? Surface, string? Error)>> evaluate)
+        Func<PackageVersionAddress, Task<(
+            ApiSurface? Surface,
+            string? Error,
+            ApiSurfaceEndpoint? Endpoint)>> evaluate)
     {
         ArgumentNullException.ThrowIfNull(evaluate);
         List<TimelineEvaluation> evaluations = [];
@@ -454,7 +940,11 @@ public static class TimelineCommand
             try
             {
                 var result = await evaluate(address);
-                evaluations.Add(new TimelineEvaluation(address, result.Surface, result.Error));
+                evaluations.Add(new TimelineEvaluation(
+                    address,
+                    result.Surface,
+                    result.Error,
+                    result.Endpoint));
             }
             catch (Exception ex)
             {
@@ -560,10 +1050,11 @@ public static class TimelineCommand
     static string? RecommendProbe(
         PackageVersionVector vector,
         string typeFullName,
+        string? memberName,
         string descriptor,
-        IReadOnlyList<TimelineEvaluation> evaluations)
+        IEnumerable<int> evaluatedPositions)
     {
-        var evaluated = evaluations.Select(item => item.Address.Position).ToHashSet();
+        var evaluated = evaluatedPositions.ToHashSet();
         if (evaluated.Count == vector.Addresses.Length)
             return null;
 
@@ -593,6 +1084,7 @@ public static class TimelineCommand
         return $"Probe {address.Selector} ({address.Version.ToNormalizedString()}): "
             + $"dotnet-inspect timeline --package {ShellQuote(range)} "
             + $"--type {ShellQuote(typeFullName)} "
+            + (memberName is null ? "" : $"--member {ShellQuote(memberName)} ")
             + $"--finding {ShellQuote(descriptor)} "
             + $"--at {ShellQuote(address.Selector)}";
     }
@@ -627,7 +1119,21 @@ public static class TimelineCommand
 
         if (descriptor is null)
         {
-            error = $"Unknown Finding '{options.Finding}'. Use api.type, api.member, or api.attribute.";
+            error = $"Unknown Finding '{options.Finding}'. Use api.type, api.member, api.attribute, analysis.allocation, analysis.call-site, or analysis.unsafety.";
+            return false;
+        }
+
+        bool analysis = IsAnalysisDescriptor(descriptor);
+        if (analysis && string.IsNullOrWhiteSpace(options.MemberName))
+        {
+            error = $"--finding {descriptor} requires exactly one --member target.";
+            return false;
+        }
+        if (!string.IsNullOrWhiteSpace(options.MemberName)
+            && descriptor != MetadataFindings.MemberDescriptor.Id
+            && !analysis)
+        {
+            error = $"--member is not supported with --finding {descriptor}.";
             return false;
         }
 
@@ -652,8 +1158,16 @@ public static class TimelineCommand
             "api.type" => "api.type",
             "api.member" => "api.member",
             "api.attribute" => "api.attribute",
+            "analysis.allocation" => "analysis.allocation",
+            "analysis.call-site" => "analysis.call-site",
+            "analysis.unsafety" => "analysis.unsafety",
             _ => null,
         };
+
+    static bool IsAnalysisDescriptor(string descriptor)
+        => descriptor == AnalysisFindings.AllocationDescriptor.Id
+            || descriptor == AnalysisFindings.CallSiteDescriptor.Id
+            || descriptor == AnalysisFindings.UnsafetyDescriptor.Id;
 
     static HashSet<string> ResolveSections(string[]? select, out string? error)
     {
@@ -756,13 +1270,23 @@ public static class TimelineCommand
     internal sealed record TimelineEvaluation(
         PackageVersionAddress Address,
         ApiSurface? Surface,
-        string? Error);
+        string? Error,
+        ApiSurfaceEndpoint? Endpoint = null) : IDisposable
+    {
+        public void Dispose() => Endpoint?.Dispose();
+    }
+
+    internal sealed record TimelineFindingEvaluation<T>(
+        PackageVersionAddress Address,
+        FindingInspection<T> Inspection)
+        where T : notnull;
 }
 
 public sealed record TimelineOptions
 {
     public string PackageVersionRange { get; init; } = "";
     public string TypeName { get; init; } = "";
+    public string? MemberName { get; init; }
     public string Finding { get; init; } = MetadataFindings.MemberDescriptor.Id;
     public string[] At { get; init; } = [];
     public string? Tfm { get; init; }

--- a/src/dotnet-inspect/Views/TimelineViews.cs
+++ b/src/dotnet-inspect/Views/TimelineViews.cs
@@ -10,6 +10,7 @@ public sealed class TimelineDocumentView
     [MarkoutIgnore] public string Title { get; init; } = "";
     public string Range { get; init; } = "";
     public string Type { get; init; } = "";
+    public string? Member { get; init; }
     public string Finding { get; init; } = "";
     public string? Recommendation { get; init; }
 


### PR DESCRIPTION
## Conclusion

`timeline` now composes package version correlation with Analysis descriptors:

```bash
dotnet-inspect timeline --package Foo@1.0.0..2.0.0 \
  --type Foo.Parser --member Parse \
  --finding analysis.unsafety --at all
```

The same member focus supports `analysis.allocation` and
`analysis.call-site`. `api.member --member M` now selects one exact member
identity track rather than the full type-owned member census.

## Contract

- No `--at` still acquires zero package payloads.
- Sparse and dense traversal preserve `Complete([])`, `SubjectAbsent`,
  `Failed`, and `Unevaluated` cells.
- Analysis decodes only the resolved method body in the package assembly.
- Adjacent transitions use each Analysis producer's native comparison;
  gap-spanning rows remain qualified candidate boundaries.
- Metadata resolves structural focus, Analysis owns occurrences, and Findings
  owns N-address correlation; no parallel timeline model was added.

## Evidence

| Check | Result |
| --- | --- |
| Release solution build | Pass |
| Focused timeline tests | 15 passed |
| Full CLI executable suite | 1,821 total, 0 failed, 10 tool-dependent skips |
| Live package timelines | `api.member` plus all three Analysis descriptors |
| Changed Markdown | markdownlint clean |

## Review

Two isolated exact-head adversarial reviews completed cleanly on `1213cc49`:
Claude Opus 4.8 and Gemini 3.1 Pro. Both exercised selector identity,
multi-assembly/body-token scoping, cell-state preservation, package lifetime,
specialized comparisons, zero-acquisition behavior, and output routing.
