### PR TITLE
Add portable PDB Finding producers

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -231,6 +231,13 @@ producers or preserve producer-native structural evidence. Failed censuses stay
 distinct from empty results and render as inspection diagnostics without
 suppressing unaffected sections.
 
+Portable-PDB observations use four Metadata Finding families: source documents,
+member-to-document mappings, compilation options, and compilation references.
+Source audit and integrity consume the document census; member source-location
+enrichment consumes the mapping census by metadata token. Network acquisition
+and checksum agreement remain operation outcomes rather than Metadata Findings.
+See [Source Finding Producers](design/source-finding-producers.md).
+
 Extension discovery follows the same rule for both `library` and `extensions`:
 each assembly is scanned once into Metadata's extension-member Finding census,
 then CLI target, reachability, overload, and display projections consume that

--- a/docs/design/finding-producers.md
+++ b/docs/design/finding-producers.md
@@ -193,6 +193,13 @@ path. The member command's opt-in `Fidelity Causes` section keeps the complete
 projects it only when rendering. A complete empty census, absent method body,
 and failed inspection therefore remain distinct product outcomes.
 
+Portable-PDB source observations follow the same product-first path.
+`MetadataFindings` exposes source documents, member-to-document mappings,
+compilation options, and compilation references as separate identity-set
+censuses. Source reachability, checksum verification, authored/decompiled
+correspondence, and rebuild fidelity remain consumer operations over those raw
+observations. See [Source Finding Producers](source-finding-producers.md).
+
 The remaining Analysis safety observations preserve their native families:
 
 - declaration, signature, local, call, and opcode evidence use an identity

--- a/docs/design/source-finding-producers.md
+++ b/docs/design/source-finding-producers.md
@@ -1,0 +1,87 @@
+# Source Finding Producers
+
+Metadata owns the local, SRM-only observations available from PE and portable
+PDB data. Network source acquisition, checksum verdicts, decompiler source
+correspondence, and old/new product interpretation remain separate consumers.
+
+## Producer inventory
+
+| Producer | Input | Output |
+| -------- | ----- | ------ |
+| `InspectSourceDocuments` | A `SourceLinkService` with a loaded portable PDB, or an already-extracted `IEnumerable<SourceDocument>` | `FindingInspection<SourceDocumentObservation>` with one identity-set Finding per PDB document |
+| `InspectMemberSources` | A loaded PE/PDB pair, or extracted `IEnumerable<MemberSourceInfo>`; an optional metadata-token query narrows the census | `FindingInspection<MemberSourceObservation>` with one Finding per member/document relationship |
+| `InspectCompilationOptions` | Portable-PDB module `CompilationOptions` custom debug information, or extracted option rows | `FindingInspection<CompilationOptionInfo>` with one Finding per option |
+| `InspectCompilationReferences` | Portable-PDB module `CompilationMetadataReferences` custom debug information, or extracted reference rows | `FindingInspection<CompilationReferenceInfo>` with one Finding per compiler reference |
+
+The service overloads return `Absent` when no portable PDB is loaded and
+`Failed` when the PDB cannot produce a complete census. The enumerable overloads
+are total over an already-acquired inventory, so an empty input is
+`Complete([])`.
+
+`InspectSourceDocuments` accepts an optional `SourceDocumentQuery`. Its
+`PathContains` value performs an ordinal-ignore-case substring match over the
+canonical source path. A null query returns every PDB document; a query with no
+matches returns `Complete([])`.
+
+The document producer does not restrict file extensions: every portable-PDB
+document is observable. Existing SourceLink availability and integrity sections
+retain their narrower C#, Visual Basic, and F# population when folding the
+census, preserving their established product metrics.
+
+## Identities and coordinates
+
+Source-document identity is the canonical path recovered from the SourceLink
+wildcard mapping when available. The original PDB path, document row, resolved
+URL, storage kind, and expected checksum remain typed payload data. Document-row
+renumbering does not make a comparison `Changed`.
+
+Member-source identity is the canonical `MemberAnchor` signature. Metadata token
+and document row are same-version coordinates; canonical document path and line
+range are the compared relationship. This lets consumers locate the exact PDB
+method without using overload ordinals.
+
+Compilation-option identity is the option name. Compilation-reference identity
+is its normalized reference name; aliases, image kind, embedding, timestamp,
+image size, MVID, and any currently-reserved flag bits are changeable payload
+facets.
+
+All four families use identity-set matching and leave `Finding.Ordinal` null.
+
+## Consumer boundaries
+
+`SourceAuditService` and `SourceIntegrityService` consume the source-document
+census. Their reachability and checksum statuses are operation results and
+presentation folds, not additional Metadata Findings.
+
+`MemberSourceLocationCollector` consumes member-source Findings by metadata
+token. The decompiler SourceLink oracle can later consume the same mappings,
+then join a complete source acquisition with the selected member observation.
+
+Compilation options and references describe available rebuild context. They do
+not claim that the context is complete enough to reproduce the original build.
+
+## Migration and API retirement
+
+The Findings initially sit over the existing PDB extraction substrate. Adoption
+does not require deleting the SRM readers that authoritatively produce document,
+sequence-point, option, and reference rows.
+
+Once all consumers use the censuses, these convenience APIs can be removed or
+made internal:
+
+- `SourceLinkService.GetTrackedFiles` and `GetEmbeddedFiles`; acquisition can
+  consume `SourceDocumentObservation` payloads instead.
+- `PdbContext.EnumerateSourceDocuments`; it remains an internal producer input.
+- the overload-ordinal
+  `SourceLinkService.ResolveMethodSource(type, method, overload)` and matching
+  `PdbContext` method; member-source Findings replace that correspondence.
+- legacy consumer-owned source inventory adapters that only duplicate one of
+  the producer payloads.
+
+These remain product APIs because they answer different questions:
+
+- `SourceLinkService` and `PdbContext` PDB lifecycle/acquisition;
+- low-level document and sequence-point extraction inside Metadata;
+- `SourceFileCollector`'s public-type-to-source presentation;
+- `LibraryInspection` accessibility and integrity counters, which are folds over
+  acquisition results rather than source inventories.

--- a/docs/design/source-finding-producers.md
+++ b/docs/design/source-finding-producers.md
@@ -38,7 +38,14 @@ renumbering does not make a comparison `Changed`.
 Member-source identity is the canonical `MemberAnchor` signature. Metadata token
 and document row are same-version coordinates; canonical document path and line
 range are the compared relationship. This lets consumers locate the exact PDB
-method without using overload ordinals.
+method without using overload ordinals. Token-scoped queries resolve requested
+method handles directly rather than scanning the assembly method table.
+
+Each member/document relationship records whether it is the primary document.
+That is the portable PDB's `MethodDebugInformation.Document` when present. For
+multi-document methods that omit that root, the first visible sequence point's
+document is primary. Presentation consumers prefer the primary relationship and
+use document-row order only as a deterministic fallback.
 
 Compilation-option identity is the option name. Compilation-reference identity
 is its normalized reference name; aliases, image kind, embedding, timestamp,

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,7 +7,7 @@ It is built for both humans and agents. Markdown is the default output because h
 ## Core architecture
 
 - `src/dotnet-inspect/` contains the CLI, command routing, parsers, options, output views, section descriptors, and inspectors.
-- `src/ILInspector.Metadata/` reads PE metadata, API surfaces, SourceLink/PDB data, method classification, and assembly details. `MetadataFindings` projects API type/member observations and comparisons onto the shared Finding spine while retaining compatibility classification through `ApiDiff`.
+- `src/ILInspector.Metadata/` reads PE metadata, API surfaces, SourceLink/PDB data, method classification, and assembly details. `MetadataFindings` projects API, source-document, member-source, and portable-PDB build-context observations and comparisons onto the shared Finding spine while retaining compatibility classification through `ApiDiff`.
 - `src/ILInspector.CSharp/` is the lightweight C# spelling and type-view layer over Metadata shapes. `CSharpFormatter` is the declaration-spelling seam; `CSharpTypePrinter` composes exact typed requests, including skeleton, full, stub, mixed-accessor, primary-constructor, and nested-type shapes, without taking a Decompiler or Research dependency.
 - `src/ILInspector.Analysis/` indexes IL method-body evidence such as direct call sites, allocation and unsafety occurrences, method signals, and whole-assembly leverage without decompiling to C#. `AnalysisFindings` exposes reusable typed censuses and comparisons for allocations, call sites, unsafe operations, and unsafe declaration/body evidence.
 - `src/ILInspector.Analysis.App/` is a temporary console harness for exercising Analysis queries until CLI wiring exists.
@@ -49,6 +49,7 @@ Agents working in this repo should preserve these principles:
 - [Finding producer design](design/finding-producers.md): how to choose owners, payloads, identities, result shapes, and matching modes.
 - [Finding coordinates](design/finding-coordinates.md): separation of subject identity, correspondence, optional producer order, and typed provenance.
 - [Finding adoption](design/finding-adoption.md): consumer migration, failure visibility, native-case presentation, and quality-gate rules.
+- [Source Finding producers](design/source-finding-producers.md): portable-PDB source/build-context inputs, outputs, identities, and migration boundaries.
 - [Implementation Diff](design/implementation-diff.md): product C# + IL/body diff projection shared by the opt-in `diff` section, RTS, and harnesses.
 - [Fixture governance](fixture-governance.md): fixture catalog, project-boundary, and semantic-axis rules.
 - [Integrations](design/integrations.md): library ecosystem integration roll-ups and focused API currency.

--- a/src/ILInspector.Metadata/MetadataFindings.Source.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.Source.cs
@@ -37,7 +37,8 @@ public sealed record MemberSourceObservation(
     string OriginalPath,
     string? ResolvedUrl,
     int StartLine,
-    int EndLine);
+    int EndLine,
+    bool IsPrimaryDocument);
 
 public static partial class MetadataFindings
 {
@@ -419,7 +420,8 @@ public static partial class MetadataFindings
                     mapping.FilePath,
                     mapping.ResolvedUrl,
                     mapping.StartLine,
-                    mapping.EndLine);
+                    mapping.EndLine,
+                    mapping.IsPrimaryDocument);
             }),
             subject,
             MemberSourceDescriptor,
@@ -474,7 +476,8 @@ public static partial class MetadataFindings
         => oldMapping.Anchor == newMapping.Anchor
             && oldMapping.CanonicalPath == newMapping.CanonicalPath
             && oldMapping.StartLine == newMapping.StartLine
-            && oldMapping.EndLine == newMapping.EndLine;
+            && oldMapping.EndLine == newMapping.EndLine
+            && oldMapping.IsPrimaryDocument == newMapping.IsPrimaryDocument;
 
     private static string NormalizeReferenceName(string name)
         => name.Replace('\\', '/');

--- a/src/ILInspector.Metadata/MetadataFindings.Source.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.Source.cs
@@ -1,0 +1,495 @@
+using ILInspector.Findings;
+using ILInspector.MetadataPrimitives;
+
+namespace ILInspector.Metadata;
+
+public sealed record SourceDocumentQuery(string? PathContains = null);
+
+public enum SourceDocumentStorage
+{
+    Unmapped,
+    SourceLink,
+    Embedded,
+}
+
+public sealed record SourceDocumentObservation(
+    string CanonicalPath,
+    string OriginalPath,
+    int DocumentRowId,
+    SourceDocumentStorage Storage,
+    string? ResolvedUrl,
+    string? ChecksumAlgorithm,
+    string? Checksum)
+{
+    public bool IsCompilerLanguageSource =>
+        CanonicalPath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)
+        || CanonicalPath.EndsWith(".vb", StringComparison.OrdinalIgnoreCase)
+        || CanonicalPath.EndsWith(".fs", StringComparison.OrdinalIgnoreCase);
+}
+
+public sealed record MemberSourceQuery(IReadOnlySet<int>? MetadataTokens = null);
+
+public sealed record MemberSourceObservation(
+    MemberAnchor Anchor,
+    int MetadataToken,
+    int DocumentRowId,
+    string CanonicalPath,
+    string OriginalPath,
+    string? ResolvedUrl,
+    int StartLine,
+    int EndLine);
+
+public static partial class MetadataFindings
+{
+    public static readonly FindingDescriptor SourceDocumentDescriptor =
+        new("metadata.source-document", "Source document");
+
+    public static readonly FindingDescriptor MemberSourceDescriptor =
+        new("metadata.member-source", "Member source mapping");
+
+    public static readonly FindingDescriptor CompilationOptionDescriptor =
+        new("metadata.compilation-option", "Compilation option");
+
+    public static readonly FindingDescriptor CompilationReferenceDescriptor =
+        new("metadata.compilation-reference", "Compilation reference");
+
+    public static FindingInspection<SourceDocumentObservation> InspectSourceDocuments(
+        SourceLinkService source,
+        FindingSubject subject,
+        SourceDocumentQuery? query = null)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        if (!source.HasPdb)
+        {
+            return new FindingInspection<SourceDocumentObservation>.Absent(
+                "A portable PDB is unavailable.");
+        }
+
+        try
+        {
+            return InspectSourceDocumentsCore(
+                source.GetTrackedFiles(),
+                subject,
+                query,
+                nameof(source));
+        }
+        catch (Exception ex) when (IsPdbInspectionFailure(ex))
+        {
+            return Failed<SourceDocumentObservation>(
+                subject,
+                SourceDocumentDescriptor,
+                "Could not inspect portable-PDB source documents.",
+                ex);
+        }
+    }
+
+    public static FindingInspection<SourceDocumentObservation> InspectSourceDocuments(
+        IEnumerable<SourceDocument> documents,
+        FindingSubject subject,
+        SourceDocumentQuery? query = null)
+    {
+        ArgumentNullException.ThrowIfNull(documents);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return InspectSourceDocumentsCore(documents, subject, query, nameof(documents));
+    }
+
+    public static FindingComparison<SourceDocumentObservation> CompareSourceDocuments(
+        IEnumerable<SourceDocument> oldDocuments,
+        IEnumerable<SourceDocument> newDocuments,
+        FindingSubject subject,
+        SourceDocumentQuery? query = null)
+    {
+        ArgumentNullException.ThrowIfNull(oldDocuments);
+        ArgumentNullException.ThrowIfNull(newDocuments);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return CompareInventory(
+            InspectSourceDocumentsCore(oldDocuments, subject, query, nameof(oldDocuments)),
+            InspectSourceDocumentsCore(newDocuments, subject, query, nameof(newDocuments)),
+            SourceDocumentsEqual);
+    }
+
+    public static FindingComparison<SourceDocumentObservation> CompareSourceDocuments(
+        SourceLinkService oldSource,
+        SourceLinkService newSource,
+        FindingSubject subject,
+        SourceDocumentQuery? query = null)
+    {
+        ArgumentNullException.ThrowIfNull(oldSource);
+        ArgumentNullException.ThrowIfNull(newSource);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return FindingComparison.Compare(
+            InspectSourceDocuments(oldSource, subject, query),
+            InspectSourceDocuments(newSource, subject, query),
+            IdentitySetOptions)
+            .TransformPairs(pairs => PromoteChangedPayloads(pairs, SourceDocumentsEqual));
+    }
+
+    public static FindingInspection<MemberSourceObservation> InspectMemberSources(
+        SourceLinkService source,
+        FindingSubject subject,
+        MemberSourceQuery? query = null)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        if (!source.HasPdb)
+        {
+            return new FindingInspection<MemberSourceObservation>.Absent(
+                "A portable PDB is unavailable.");
+        }
+
+        try
+        {
+            return InspectMemberSourcesCore(
+                source.Context.EnumerateMemberSources(query?.MetadataTokens),
+                subject,
+                query,
+                nameof(source));
+        }
+        catch (Exception ex) when (IsPdbInspectionFailure(ex))
+        {
+            return Failed<MemberSourceObservation>(
+                subject,
+                MemberSourceDescriptor,
+                "Could not inspect portable-PDB member source mappings.",
+                ex);
+        }
+    }
+
+    public static FindingInspection<MemberSourceObservation> InspectMemberSources(
+        IEnumerable<MemberSourceInfo> mappings,
+        FindingSubject subject,
+        MemberSourceQuery? query = null)
+    {
+        ArgumentNullException.ThrowIfNull(mappings);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return InspectMemberSourcesCore(mappings, subject, query, nameof(mappings));
+    }
+
+    public static FindingComparison<MemberSourceObservation> CompareMemberSources(
+        IEnumerable<MemberSourceInfo> oldMappings,
+        IEnumerable<MemberSourceInfo> newMappings,
+        FindingSubject subject,
+        MemberSourceQuery? query = null)
+    {
+        ArgumentNullException.ThrowIfNull(oldMappings);
+        ArgumentNullException.ThrowIfNull(newMappings);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return CompareInventory(
+            InspectMemberSourcesCore(oldMappings, subject, query, nameof(oldMappings)),
+            InspectMemberSourcesCore(newMappings, subject, query, nameof(newMappings)),
+            MemberSourcesEqual);
+    }
+
+    public static FindingComparison<MemberSourceObservation> CompareMemberSources(
+        SourceLinkService oldSource,
+        SourceLinkService newSource,
+        FindingSubject subject,
+        MemberSourceQuery? query = null)
+    {
+        ArgumentNullException.ThrowIfNull(oldSource);
+        ArgumentNullException.ThrowIfNull(newSource);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return FindingComparison.Compare(
+            InspectMemberSources(oldSource, subject, query),
+            InspectMemberSources(newSource, subject, query),
+            IdentitySetOptions)
+            .TransformPairs(pairs => PromoteChangedPayloads(pairs, MemberSourcesEqual));
+    }
+
+    public static FindingInspection<CompilationOptionInfo> InspectCompilationOptions(
+        SourceLinkService source,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        if (!source.HasPdb)
+        {
+            return new FindingInspection<CompilationOptionInfo>.Absent(
+                "A portable PDB is unavailable.");
+        }
+
+        try
+        {
+            return InspectCompilationOptionsCore(
+                source.Context.GetCompilationOptions(),
+                subject,
+                nameof(source));
+        }
+        catch (Exception ex) when (IsPdbInspectionFailure(ex))
+        {
+            return Failed<CompilationOptionInfo>(
+                subject,
+                CompilationOptionDescriptor,
+                "Could not inspect portable-PDB compilation options.",
+                ex);
+        }
+    }
+
+    public static FindingInspection<CompilationOptionInfo> InspectCompilationOptions(
+        IEnumerable<CompilationOptionInfo> options,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return InspectCompilationOptionsCore(options, subject, nameof(options));
+    }
+
+    public static FindingComparison<CompilationOptionInfo> CompareCompilationOptions(
+        IEnumerable<CompilationOptionInfo> oldOptions,
+        IEnumerable<CompilationOptionInfo> newOptions,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(oldOptions);
+        ArgumentNullException.ThrowIfNull(newOptions);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return CompareInventory(
+            InspectCompilationOptionsCore(oldOptions, subject, nameof(oldOptions)),
+            InspectCompilationOptionsCore(newOptions, subject, nameof(newOptions)));
+    }
+
+    public static FindingComparison<CompilationOptionInfo> CompareCompilationOptions(
+        SourceLinkService oldSource,
+        SourceLinkService newSource,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(oldSource);
+        ArgumentNullException.ThrowIfNull(newSource);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return FindingComparison.Compare(
+            InspectCompilationOptions(oldSource, subject),
+            InspectCompilationOptions(newSource, subject),
+            IdentitySetOptions)
+            .TransformPairs(pairs => PromoteChangedPayloads<CompilationOptionInfo>(pairs, null));
+    }
+
+    public static FindingInspection<CompilationReferenceInfo> InspectCompilationReferences(
+        SourceLinkService source,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        if (!source.HasPdb)
+        {
+            return new FindingInspection<CompilationReferenceInfo>.Absent(
+                "A portable PDB is unavailable.");
+        }
+
+        try
+        {
+            return InspectCompilationReferencesCore(
+                source.Context.GetCompilationReferences(),
+                subject,
+                nameof(source));
+        }
+        catch (Exception ex) when (IsPdbInspectionFailure(ex))
+        {
+            return Failed<CompilationReferenceInfo>(
+                subject,
+                CompilationReferenceDescriptor,
+                "Could not inspect portable-PDB compilation references.",
+                ex);
+        }
+    }
+
+    public static FindingInspection<CompilationReferenceInfo> InspectCompilationReferences(
+        IEnumerable<CompilationReferenceInfo> references,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(references);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return InspectCompilationReferencesCore(references, subject, nameof(references));
+    }
+
+    public static FindingComparison<CompilationReferenceInfo> CompareCompilationReferences(
+        IEnumerable<CompilationReferenceInfo> oldReferences,
+        IEnumerable<CompilationReferenceInfo> newReferences,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(oldReferences);
+        ArgumentNullException.ThrowIfNull(newReferences);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return CompareInventory(
+            InspectCompilationReferencesCore(oldReferences, subject, nameof(oldReferences)),
+            InspectCompilationReferencesCore(newReferences, subject, nameof(newReferences)));
+    }
+
+    public static FindingComparison<CompilationReferenceInfo> CompareCompilationReferences(
+        SourceLinkService oldSource,
+        SourceLinkService newSource,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(oldSource);
+        ArgumentNullException.ThrowIfNull(newSource);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        return FindingComparison.Compare(
+            InspectCompilationReferences(oldSource, subject),
+            InspectCompilationReferences(newSource, subject),
+            IdentitySetOptions)
+            .TransformPairs(pairs => PromoteChangedPayloads<CompilationReferenceInfo>(pairs, null));
+    }
+
+    private static FindingInspection<SourceDocumentObservation> InspectSourceDocumentsCore(
+        IEnumerable<SourceDocument> documents,
+        FindingSubject subject,
+        SourceDocumentQuery? query,
+        string parameterName)
+    {
+        var observations = documents.Select(document =>
+        {
+            if (document is null)
+                throw new ArgumentException("Source document inventory cannot contain null observations.", parameterName);
+
+            string canonicalPath = document.CanonicalPath
+                ?? SourceDocumentPath.Canonicalize(document.FilePath, sourceLinkJson: null);
+            return new SourceDocumentObservation(
+                canonicalPath,
+                document.FilePath,
+                document.DocumentRowId,
+                document.IsEmbedded
+                    ? SourceDocumentStorage.Embedded
+                    : document.ResolvedUrl is not null
+                        ? SourceDocumentStorage.SourceLink
+                        : SourceDocumentStorage.Unmapped,
+                document.ResolvedUrl,
+                document.ChecksumAlgorithm,
+                document.Checksum is null ? null : Convert.ToHexString(document.Checksum));
+        });
+
+        if (!string.IsNullOrEmpty(query?.PathContains))
+        {
+            observations = observations.Where(observation =>
+                observation.CanonicalPath.Contains(
+                    query.PathContains,
+                    StringComparison.OrdinalIgnoreCase));
+        }
+
+        return InspectInventory(
+            observations,
+            subject,
+            SourceDocumentDescriptor,
+            static document => document.CanonicalPath,
+            static document => JoinSortKey(
+                document.CanonicalPath,
+                document.OriginalPath,
+                document.Checksum),
+            parameterName);
+    }
+
+    private static FindingInspection<MemberSourceObservation> InspectMemberSourcesCore(
+        IEnumerable<MemberSourceInfo> mappings,
+        FindingSubject subject,
+        MemberSourceQuery? query,
+        string parameterName)
+    {
+        var materialized = mappings
+            .Select(mapping => mapping is null
+                ? throw new ArgumentException(
+                    "Member source inventory cannot contain null observations.",
+                    parameterName)
+                : mapping)
+            .ToArray();
+        var filtered = query?.MetadataTokens is { } metadataTokens
+            ? materialized.Where(mapping => metadataTokens.Contains(mapping.MetadataToken))
+            : materialized;
+        return InspectInventory(
+            filtered.Select(mapping =>
+            {
+                return new MemberSourceObservation(
+                    mapping.Anchor,
+                    mapping.MetadataToken,
+                    mapping.DocumentRowId,
+                    mapping.CanonicalPath,
+                    mapping.FilePath,
+                    mapping.ResolvedUrl,
+                    mapping.StartLine,
+                    mapping.EndLine);
+            }),
+            subject,
+            MemberSourceDescriptor,
+            static mapping => mapping.Anchor.CanonicalSignature,
+            static mapping => JoinSortKey(
+                mapping.Anchor.CanonicalSignature,
+                mapping.CanonicalPath,
+                $"{mapping.StartLine:D10}:{mapping.EndLine:D10}"),
+            parameterName);
+    }
+
+    private static FindingInspection<CompilationOptionInfo> InspectCompilationOptionsCore(
+        IEnumerable<CompilationOptionInfo> options,
+        FindingSubject subject,
+        string parameterName)
+        => InspectInventory(
+            options,
+            subject,
+            CompilationOptionDescriptor,
+            static option => option.Name,
+            static option => JoinSortKey(option.Name, option.Value),
+            parameterName);
+
+    private static FindingInspection<CompilationReferenceInfo> InspectCompilationReferencesCore(
+        IEnumerable<CompilationReferenceInfo> references,
+        FindingSubject subject,
+        string parameterName)
+        => InspectInventory(
+            references,
+            subject,
+            CompilationReferenceDescriptor,
+            static reference => NormalizeReferenceName(reference.Name),
+            static reference => JoinSortKey(
+                NormalizeReferenceName(reference.Name),
+                reference.Aliases,
+                reference.ModuleVersionId.ToString("D")),
+            parameterName);
+
+    private static bool SourceDocumentsEqual(
+        SourceDocumentObservation oldDocument,
+        SourceDocumentObservation newDocument)
+        => oldDocument.CanonicalPath == newDocument.CanonicalPath
+            && oldDocument.OriginalPath == newDocument.OriginalPath
+            && oldDocument.Storage == newDocument.Storage
+            && oldDocument.ResolvedUrl == newDocument.ResolvedUrl
+            && oldDocument.ChecksumAlgorithm == newDocument.ChecksumAlgorithm
+            && oldDocument.Checksum == newDocument.Checksum;
+
+    private static bool MemberSourcesEqual(
+        MemberSourceObservation oldMapping,
+        MemberSourceObservation newMapping)
+        => oldMapping.Anchor == newMapping.Anchor
+            && oldMapping.CanonicalPath == newMapping.CanonicalPath
+            && oldMapping.StartLine == newMapping.StartLine
+            && oldMapping.EndLine == newMapping.EndLine;
+
+    private static string NormalizeReferenceName(string name)
+        => name.Replace('\\', '/');
+
+    private static bool IsPdbInspectionFailure(Exception exception)
+        => exception is BadImageFormatException
+            or InvalidOperationException
+            or ArgumentOutOfRangeException;
+
+    private static FindingInspection<T> Failed<T>(
+        FindingSubject subject,
+        FindingDescriptor descriptor,
+        string reason,
+        Exception exception)
+        where T : notnull
+        => new FindingInspection<T>.Failed(
+            new InspectionError(subject, descriptor, $"{reason} {exception.Message}"));
+}

--- a/src/ILInspector.Metadata/PdbCompilationInfo.cs
+++ b/src/ILInspector.Metadata/PdbCompilationInfo.cs
@@ -1,0 +1,111 @@
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata;
+
+public sealed record CompilationOptionInfo(string Name, string Value);
+
+public enum CompilationReferenceImageKind
+{
+    Module,
+    Assembly,
+}
+
+public sealed record CompilationReferenceInfo(
+    string Name,
+    string Aliases,
+    CompilationReferenceImageKind ImageKind,
+    bool EmbedInteropTypes,
+    uint Timestamp,
+    uint ImageSize,
+    Guid ModuleVersionId,
+    byte AdditionalFlags = 0);
+
+internal static class PdbCompilationInfoReader
+{
+    private static readonly Guid s_compilationOptions =
+        new("B5FEEC05-8CD0-4A83-96DA-466284BB4BD8");
+
+    private static readonly Guid s_compilationMetadataReferences =
+        new("7E4D4708-096E-4C5C-AEDA-CB10BA6A740D");
+
+    public static IReadOnlyList<CompilationOptionInfo> ReadOptions(MetadataReader pdb)
+    {
+        ArgumentNullException.ThrowIfNull(pdb);
+
+        List<CompilationOptionInfo> options = [];
+        foreach (var handle in pdb.GetCustomDebugInformation(EntityHandle.ModuleDefinition))
+        {
+            var info = pdb.GetCustomDebugInformation(handle);
+            if (pdb.GetGuid(info.Kind) != s_compilationOptions)
+                continue;
+
+            var blob = pdb.GetBlobReader(info.Value);
+            while (blob.RemainingBytes > 0)
+            {
+                string name = ReadNullTerminatedUtf8(ref blob, "compilation option name");
+                if (name.Length == 0)
+                    throw new BadImageFormatException("A portable-PDB compilation option has an empty name.");
+
+                string value = ReadNullTerminatedUtf8(ref blob, $"value for compilation option '{name}'");
+                options.Add(new CompilationOptionInfo(name, value));
+            }
+        }
+
+        return options;
+    }
+
+    public static IReadOnlyList<CompilationReferenceInfo> ReadReferences(MetadataReader pdb)
+    {
+        ArgumentNullException.ThrowIfNull(pdb);
+
+        List<CompilationReferenceInfo> references = [];
+        foreach (var handle in pdb.GetCustomDebugInformation(EntityHandle.ModuleDefinition))
+        {
+            var info = pdb.GetCustomDebugInformation(handle);
+            if (pdb.GetGuid(info.Kind) != s_compilationMetadataReferences)
+                continue;
+
+            var blob = pdb.GetBlobReader(info.Value);
+            while (blob.RemainingBytes > 0)
+            {
+                string name = ReadNullTerminatedUtf8(ref blob, "compilation reference name");
+                if (name.Length == 0)
+                    throw new BadImageFormatException("A portable-PDB compilation reference has an empty name.");
+
+                string aliases = ReadNullTerminatedUtf8(ref blob, $"aliases for compilation reference '{name}'");
+                const int fixedFieldSize = 1 + sizeof(uint) + sizeof(uint) + 16;
+                if (blob.RemainingBytes < fixedFieldSize)
+                {
+                    throw new BadImageFormatException(
+                        $"Portable-PDB compilation reference '{name}' is truncated.");
+                }
+
+                byte flags = blob.ReadByte();
+                references.Add(new CompilationReferenceInfo(
+                    name,
+                    aliases,
+                    (flags & 0b01) != 0
+                        ? CompilationReferenceImageKind.Assembly
+                        : CompilationReferenceImageKind.Module,
+                    EmbedInteropTypes: (flags & 0b10) != 0,
+                    blob.ReadUInt32(),
+                    blob.ReadUInt32(),
+                    blob.ReadGuid(),
+                    AdditionalFlags: (byte)(flags & ~0b11)));
+            }
+        }
+
+        return references;
+    }
+
+    private static string ReadNullTerminatedUtf8(ref BlobReader blob, string field)
+    {
+        int length = blob.IndexOf(0);
+        if (length < 0)
+            throw new BadImageFormatException($"Portable-PDB {field} is not null-terminated.");
+
+        string value = blob.ReadUTF8(length);
+        blob.ReadByte();
+        return value;
+    }
+}

--- a/src/ILInspector.Metadata/PdbContext.cs
+++ b/src/ILInspector.Metadata/PdbContext.cs
@@ -4,6 +4,7 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using ILInspector.Instructions;
+using ILInspector.MetadataPrimitives;
 
 namespace ILInspector.Metadata;
 
@@ -22,7 +23,24 @@ public record SourceDocument(
     bool IsEmbedded,
     string? ResolvedUrl,
     byte[]? Checksum = null,
-    string? ChecksumAlgorithm = null);
+    string? ChecksumAlgorithm = null,
+    int DocumentRowId = 0,
+    string? CanonicalPath = null);
+
+/// <summary>
+/// A method-to-document relationship extracted from portable-PDB sequence points.
+/// The metadata token and document row identify the same-version coordinates; the
+/// member anchor and canonical document path provide cross-version identity.
+/// </summary>
+public sealed record MemberSourceInfo(
+    MemberAnchor Anchor,
+    int MetadataToken,
+    int DocumentRowId,
+    string FilePath,
+    string CanonicalPath,
+    string? ResolvedUrl,
+    int StartLine,
+    int EndLine);
 
 public record ILOffsetMemberContextInfo(
     string? Assembly,
@@ -869,14 +887,6 @@ public class PdbContext : IDisposable
             var document = _pdbReader.GetDocument(docHandle);
             string filePath = _pdbReader.GetString(document.Name);
 
-            // Skip non-source files
-            if (!filePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) &&
-                !filePath.EndsWith(".vb", StringComparison.OrdinalIgnoreCase) &&
-                !filePath.EndsWith(".fs", StringComparison.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-
             bool isEmbedded = false;
             foreach (var cdiHandle in _pdbReader.GetCustomDebugInformation(docHandle))
             {
@@ -898,9 +908,99 @@ public class PdbContext : IDisposable
                 checksumAlgorithm = MapHashAlgorithm(_pdbReader.GetGuid(document.HashAlgorithm));
             }
 
-            yield return new SourceDocument(filePath, isEmbedded, resolvedUrl, checksum, checksumAlgorithm);
+            yield return new SourceDocument(
+                filePath,
+                isEmbedded,
+                resolvedUrl,
+                checksum,
+                checksumAlgorithm,
+                MetadataTokens.GetRowNumber(docHandle),
+                SourceDocumentPath.Canonicalize(filePath, SourceLinkJson));
         }
     }
+
+    /// <summary>
+    /// Enumerates method-to-document mappings from visible portable-PDB sequence points.
+    /// A method may produce multiple rows when sequence points span multiple documents.
+    /// </summary>
+    public IEnumerable<MemberSourceInfo> EnumerateMemberSources(
+        IReadOnlySet<int>? metadataTokens = null)
+    {
+        if (_pdbReader == null || !_peReader.HasMetadata)
+            yield break;
+
+        var metadata = _peReader.GetMetadataReader();
+        foreach (var methodHandle in metadata.MethodDefinitions)
+        {
+            int metadataToken = MetadataTokens.GetToken(methodHandle);
+            if (metadataTokens is not null && !metadataTokens.Contains(metadataToken))
+                continue;
+
+            var debugInfo = _pdbReader.GetMethodDebugInformation(methodHandle.ToDebugInformationHandle());
+            var currentDocument = debugInfo.Document;
+            Dictionary<DocumentHandle, (int StartLine, int EndLine)> ranges = [];
+
+            foreach (var point in debugInfo.GetSequencePoints())
+            {
+                if (!point.Document.IsNil)
+                    currentDocument = point.Document;
+                if (point.IsHidden || currentDocument.IsNil)
+                    continue;
+
+                if (ranges.TryGetValue(currentDocument, out var range))
+                {
+                    ranges[currentDocument] = (
+                        Math.Min(range.StartLine, point.StartLine),
+                        Math.Max(range.EndLine, point.EndLine));
+                }
+                else
+                {
+                    ranges[currentDocument] = (point.StartLine, point.EndLine);
+                }
+            }
+
+            if (ranges.Count == 0)
+                continue;
+
+            var method = metadata.GetMethodDefinition(methodHandle);
+            var anchor = ApiMemberIdentity.CreateMethodAnchor(
+                metadata,
+                method.GetDeclaringType(),
+                method);
+
+            foreach (var (documentHandle, range) in ranges
+                .OrderBy(static item => MetadataTokens.GetRowNumber(item.Key)))
+            {
+                var document = _pdbReader.GetDocument(documentHandle);
+                string filePath = _pdbReader.GetString(document.Name);
+                yield return new MemberSourceInfo(
+                    anchor,
+                    metadataToken,
+                    MetadataTokens.GetRowNumber(documentHandle),
+                    filePath,
+                    SourceDocumentPath.Canonicalize(filePath, SourceLinkJson),
+                    _resolver?.ApplySourceLinkMapping(filePath),
+                    range.StartLine,
+                    range.EndLine);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads compiler options recorded in portable-PDB module custom debug information.
+    /// </summary>
+    public IReadOnlyList<CompilationOptionInfo> GetCompilationOptions()
+        => _pdbReader is null
+            ? []
+            : PdbCompilationInfoReader.ReadOptions(_pdbReader);
+
+    /// <summary>
+    /// Reads compiler references recorded in portable-PDB module custom debug information.
+    /// </summary>
+    public IReadOnlyList<CompilationReferenceInfo> GetCompilationReferences()
+        => _pdbReader is null
+            ? []
+            : PdbCompilationInfoReader.ReadReferences(_pdbReader);
 
     // Well-known source document hash algorithm GUIDs (System.Reflection.Metadata).
     private static readonly Guid s_hashSha1 = new("ff1816ec-aa5e-4d10-87f7-6f4963833460");

--- a/src/ILInspector.Metadata/PdbContext.cs
+++ b/src/ILInspector.Metadata/PdbContext.cs
@@ -40,7 +40,8 @@ public sealed record MemberSourceInfo(
     string CanonicalPath,
     string? ResolvedUrl,
     int StartLine,
-    int EndLine);
+    int EndLine,
+    bool IsPrimaryDocument = false);
 
 public record ILOffsetMemberContextInfo(
     string? Assembly,
@@ -930,14 +931,12 @@ public class PdbContext : IDisposable
             yield break;
 
         var metadata = _peReader.GetMetadataReader();
-        foreach (var methodHandle in metadata.MethodDefinitions)
+        foreach (var methodHandle in EnumerateSelectedMethods(metadata, metadataTokens))
         {
             int metadataToken = MetadataTokens.GetToken(methodHandle);
-            if (metadataTokens is not null && !metadataTokens.Contains(metadataToken))
-                continue;
-
             var debugInfo = _pdbReader.GetMethodDebugInformation(methodHandle.ToDebugInformationHandle());
             var currentDocument = debugInfo.Document;
+            var primaryDocument = debugInfo.Document;
             Dictionary<DocumentHandle, (int StartLine, int EndLine)> ranges = [];
 
             foreach (var point in debugInfo.GetSequencePoints())
@@ -946,6 +945,10 @@ public class PdbContext : IDisposable
                     currentDocument = point.Document;
                 if (point.IsHidden || currentDocument.IsNil)
                     continue;
+                // Multi-document methods may omit the root document; in that case,
+                // the first visible sequence point is the stable presentation choice.
+                if (primaryDocument.IsNil)
+                    primaryDocument = currentDocument;
 
                 if (ranges.TryGetValue(currentDocument, out var range))
                 {
@@ -981,8 +984,34 @@ public class PdbContext : IDisposable
                     SourceDocumentPath.Canonicalize(filePath, SourceLinkJson),
                     _resolver?.ApplySourceLinkMapping(filePath),
                     range.StartLine,
-                    range.EndLine);
+                    range.EndLine,
+                    IsPrimaryDocument: documentHandle == primaryDocument);
             }
+        }
+    }
+
+    private static IEnumerable<MethodDefinitionHandle> EnumerateSelectedMethods(
+        MetadataReader metadata,
+        IReadOnlySet<int>? metadataTokens)
+    {
+        if (metadataTokens is null)
+        {
+            foreach (var methodHandle in metadata.MethodDefinitions)
+                yield return methodHandle;
+            yield break;
+        }
+
+        int methodCount = metadata.GetTableRowCount(TableIndex.MethodDef);
+        foreach (int token in metadataTokens.Order())
+        {
+            const int methodDefinitionToken = 0x06000000;
+            const int tokenTypeMask = unchecked((int)0xFF000000);
+            const int rowMask = 0x00FFFFFF;
+            int row = token & rowMask;
+            if ((token & tokenTypeMask) != methodDefinitionToken || row == 0 || row > methodCount)
+                continue;
+
+            yield return MetadataTokens.MethodDefinitionHandle(row);
         }
     }
 

--- a/src/ILInspector.Metadata/SourceDocumentPath.cs
+++ b/src/ILInspector.Metadata/SourceDocumentPath.cs
@@ -6,7 +6,8 @@ internal static class SourceDocumentPath
 {
     public static string Canonicalize(string filePath, string? sourceLinkJson)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        if (string.IsNullOrWhiteSpace(filePath))
+            throw new BadImageFormatException("A portable-PDB source document has an empty path.");
 
         string normalizedPath = NormalizeSeparators(filePath);
         if (!string.IsNullOrWhiteSpace(sourceLinkJson))
@@ -25,10 +26,10 @@ internal static class SourceDocumentPath
                         if (pattern.EndsWith('*'))
                         {
                             string prefix = pattern[..^1];
-                            if (normalizedPath.StartsWith(prefix, StringComparison.Ordinal))
+                            if (normalizedPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
                                 return normalizedPath[prefix.Length..].TrimStart('/');
                         }
-                        else if (string.Equals(normalizedPath, pattern, StringComparison.Ordinal))
+                        else if (string.Equals(normalizedPath, pattern, StringComparison.OrdinalIgnoreCase))
                         {
                             return normalizedPath.StartsWith("/_/", StringComparison.Ordinal)
                                 ? normalizedPath[3..]

--- a/src/ILInspector.Metadata/SourceDocumentPath.cs
+++ b/src/ILInspector.Metadata/SourceDocumentPath.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+
+namespace ILInspector.Metadata;
+
+internal static class SourceDocumentPath
+{
+    public static string Canonicalize(string filePath, string? sourceLinkJson)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        string normalizedPath = NormalizeSeparators(filePath);
+        if (!string.IsNullOrWhiteSpace(sourceLinkJson))
+        {
+            try
+            {
+                using var document = JsonDocument.Parse(sourceLinkJson);
+                if (document.RootElement.TryGetProperty("documents", out var mappings))
+                {
+                    foreach (var mapping in mappings
+                        .EnumerateObject()
+                        .OrderByDescending(
+                            static mapping => mapping.Name.Length))
+                    {
+                        string pattern = NormalizeSeparators(mapping.Name);
+                        if (pattern.EndsWith('*'))
+                        {
+                            string prefix = pattern[..^1];
+                            if (normalizedPath.StartsWith(prefix, StringComparison.Ordinal))
+                                return normalizedPath[prefix.Length..].TrimStart('/');
+                        }
+                        else if (string.Equals(normalizedPath, pattern, StringComparison.Ordinal))
+                        {
+                            return normalizedPath.StartsWith("/_/", StringComparison.Ordinal)
+                                ? normalizedPath[3..]
+                                : normalizedPath;
+                        }
+                    }
+                }
+            }
+            catch (JsonException)
+            {
+                // The SourceLink resolver owns malformed-map reporting. Keep the PDB path usable.
+            }
+        }
+
+        return normalizedPath.StartsWith("/_/", StringComparison.Ordinal)
+            ? normalizedPath[3..]
+            : normalizedPath;
+    }
+
+    private static string NormalizeSeparators(string path)
+        => path.Replace('\\', '/');
+}

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -203,6 +203,17 @@ internal static class LibraryMetadataService
 
             await AuditAsync(service, inspection, path, packageName, packageVersion, logger, httpClient, isPlatformAssembly, allowPdbDownload: allowPdbDownload);
 
+            var sourceSubject = FindingSubjectFor(path);
+            inspection.SourceDocumentInspection = MetadataFindings.InspectSourceDocuments(
+                service,
+                sourceSubject);
+            inspection.CompilationOptionInspection = MetadataFindings.InspectCompilationOptions(
+                service,
+                sourceSubject);
+            inspection.CompilationReferenceInspection = MetadataFindings.InspectCompilationReferences(
+                service,
+                sourceSubject);
+
             if (needsAuditSignals)
                 AuditSignalBuilder.PopulateLibraryAudit(path, inspection, logger);
 
@@ -211,14 +222,20 @@ internal static class LibraryMetadataService
                 // SourceLink URLs are untrusted: probe them with the SSRF-hardened client, not the
                 // shared client used for trusted NuGet/symbol endpoints.
                 await SourceAuditService.PopulateAsync(
-                    service, inspection, DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch, logger);
+                    inspection.SourceDocumentInspection,
+                    inspection,
+                    DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch,
+                    logger);
                 if (needsAuditSignals)
                     AuditSignalBuilder.PopulateLibraryAudit(path, inspection, logger);
             }
 
             if (runIntegrity && service.HasSourceLink && pdbContext.HasPdb)
             {
-                await SourceIntegrityService.PopulateAsync(service, inspection, logger);
+                await SourceIntegrityService.PopulateAsync(
+                    inspection.SourceDocumentInspection,
+                    inspection,
+                    logger);
                 if (needsAuditSignals)
                     AuditSignalBuilder.PopulateLibraryAudit(path, inspection, logger);
             }

--- a/src/dotnet-inspect/Inspectors/MemberSourceLocationCollector.cs
+++ b/src/dotnet-inspect/Inspectors/MemberSourceLocationCollector.cs
@@ -36,36 +36,33 @@ internal static class MemberSourceLocationCollector
                 return pdbPath;
 
             var targetMembers = GetTargetMembers(apiType, options).ToArray();
-            var metadataTokens = targetMembers
-                .Select(static member => member.MetadataToken)
-                .OfType<int>()
-                .ToHashSet();
-            var sourceInspection = MetadataFindings.InspectMemberSources(
-                service,
-                new FindingSubject(assemblyPath, Path.GetFileName(assemblyPath)),
-                new MemberSourceQuery(metadataTokens));
-            if (sourceInspection.Value is FindingInspection<MemberSourceObservation>.Failed failed)
-            {
-                logger.Log(
-                    $"Warning: Failed to resolve member source locations for {apiType.FullName}: "
-                    + failed.Error.Reason);
-                return pdbPath;
-            }
-
-            if (sourceInspection.Value is not FindingInspection<MemberSourceObservation>.Complete complete)
-                return pdbPath;
-
-            var mappingsByToken = complete.Findings
-                .Select(static finding => finding.Payload)
-                .GroupBy(static mapping => mapping.MetadataToken)
-                .ToDictionary(
-                    static group => group.Key,
-                    static group => group.OrderBy(static mapping => mapping.DocumentRowId).First());
+            var subject = new FindingSubject(assemblyPath, Path.GetFileName(assemblyPath));
 
             foreach (var member in targetMembers)
             {
-                if (member.MetadataToken is not { } token
-                    || !mappingsByToken.TryGetValue(token, out var mapping))
+                if (member.MetadataToken is not { } token)
+                    continue;
+
+                var sourceInspection = MetadataFindings.InspectMemberSources(
+                    service,
+                    subject,
+                    new MemberSourceQuery(new HashSet<int> { token }));
+                if (sourceInspection.Value is FindingInspection<MemberSourceObservation>.Failed failed)
+                {
+                    logger.Log(
+                        $"Warning: Failed to resolve source location for {member.Name}: "
+                        + failed.Error.Reason);
+                    continue;
+                }
+
+                if (sourceInspection.Value is not FindingInspection<MemberSourceObservation>.Complete complete)
+                    continue;
+
+                var mapping = complete.Findings
+                    .Select(static finding => finding.Payload)
+                    .OrderBy(static candidate => candidate.DocumentRowId)
+                    .FirstOrDefault();
+                if (mapping is null)
                     continue;
 
                 member.SourceFilePath = mapping.OriginalPath;

--- a/src/dotnet-inspect/Inspectors/MemberSourceLocationCollector.cs
+++ b/src/dotnet-inspect/Inspectors/MemberSourceLocationCollector.cs
@@ -37,38 +37,48 @@ internal static class MemberSourceLocationCollector
 
             var targetMembers = GetTargetMembers(apiType, options).ToArray();
             var subject = new FindingSubject(assemblyPath, Path.GetFileName(assemblyPath));
+            var membersByToken = targetMembers
+                .Where(static member => member.MetadataToken is not null)
+                .GroupBy(static member => member.MetadataToken!.Value)
+                .ToDictionary(static group => group.Key, static group => group.ToArray());
+            if (membersByToken.Count == 0)
+                return pdbPath;
 
-            foreach (var member in targetMembers)
+            var sourceInspection = MetadataFindings.InspectMemberSources(
+                service,
+                subject,
+                new MemberSourceQuery(membersByToken.Keys.ToHashSet()));
+            if (sourceInspection.Value is FindingInspection<MemberSourceObservation>.Complete complete)
             {
-                if (member.MetadataToken is not { } token)
-                    continue;
+                ApplySourceLocations(membersByToken, complete);
+                return pdbPath;
+            }
 
-                var sourceInspection = MetadataFindings.InspectMemberSources(
+            if (sourceInspection.Value is FindingInspection<MemberSourceObservation>.Absent)
+                return pdbPath;
+
+            // A malformed method must not suppress source locations for healthy selected
+            // members. Token queries are direct lookups, so this fallback remains O(selected).
+            foreach (var (token, members) in membersByToken)
+            {
+                var tokenInspection = MetadataFindings.InspectMemberSources(
                     service,
                     subject,
                     new MemberSourceQuery(new HashSet<int> { token }));
-                if (sourceInspection.Value is FindingInspection<MemberSourceObservation>.Failed failed)
+                if (tokenInspection.Value is FindingInspection<MemberSourceObservation>.Failed failed)
                 {
                     logger.Log(
-                        $"Warning: Failed to resolve source location for {member.Name}: "
+                        $"Warning: Failed to resolve source location for {members[0].Name}: "
                         + failed.Error.Reason);
                     continue;
                 }
 
-                if (sourceInspection.Value is not FindingInspection<MemberSourceObservation>.Complete complete)
+                if (tokenInspection.Value is not FindingInspection<MemberSourceObservation>.Complete tokenComplete)
                     continue;
 
-                var mapping = complete.Findings
-                    .Select(static finding => finding.Payload)
-                    .OrderBy(static candidate => candidate.DocumentRowId)
-                    .FirstOrDefault();
-                if (mapping is null)
-                    continue;
-
-                member.SourceFilePath = mapping.OriginalPath;
-                member.SourceUrl = mapping.ResolvedUrl;
-                member.SourceLineNumber = mapping.StartLine;
-                member.SourceEndLineNumber = mapping.EndLine;
+                ApplySourceLocations(
+                    new Dictionary<int, ApiMember[]> { [token] = members },
+                    tokenComplete);
             }
 
             return pdbPath;
@@ -77,6 +87,32 @@ internal static class MemberSourceLocationCollector
         {
             logger.Log($"Warning: Failed to resolve member source locations for {apiType.FullName}: {ex.Message}");
             return null;
+        }
+    }
+
+    private static void ApplySourceLocations(
+        IReadOnlyDictionary<int, ApiMember[]> membersByToken,
+        FindingInspection<MemberSourceObservation>.Complete inspection)
+    {
+        foreach (var mappings in inspection.Findings
+            .Select(static finding => finding.Payload)
+            .GroupBy(static mapping => mapping.MetadataToken))
+        {
+            if (!membersByToken.TryGetValue(mappings.Key, out var members))
+                continue;
+
+            // Preserve the legacy resolver's preference for MethodDebugInformation.Document.
+            var mapping = mappings
+                .OrderByDescending(static candidate => candidate.IsPrimaryDocument)
+                .ThenBy(static candidate => candidate.DocumentRowId)
+                .First();
+            foreach (var member in members)
+            {
+                member.SourceFilePath = mapping.OriginalPath;
+                member.SourceUrl = mapping.ResolvedUrl;
+                member.SourceLineNumber = mapping.StartLine;
+                member.SourceEndLineNumber = mapping.EndLine;
+            }
         }
     }
 

--- a/src/dotnet-inspect/Inspectors/MemberSourceLocationCollector.cs
+++ b/src/dotnet-inspect/Inspectors/MemberSourceLocationCollector.cs
@@ -1,6 +1,7 @@
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Sections;
+using ILInspector.Findings;
 using ILInspector.Metadata;
 
 namespace DotnetInspector.Inspectors;
@@ -34,25 +35,43 @@ internal static class MemberSourceLocationCollector
             if (!service.HasPdb || !service.HasSourceLink)
                 return pdbPath;
 
-            foreach (var member in GetTargetMembers(apiType, options))
+            var targetMembers = GetTargetMembers(apiType, options).ToArray();
+            var metadataTokens = targetMembers
+                .Select(static member => member.MetadataToken)
+                .OfType<int>()
+                .ToHashSet();
+            var sourceInspection = MetadataFindings.InspectMemberSources(
+                service,
+                new FindingSubject(assemblyPath, Path.GetFileName(assemblyPath)),
+                new MemberSourceQuery(metadataTokens));
+            if (sourceInspection.Value is FindingInspection<MemberSourceObservation>.Failed failed)
             {
-                var typeName = string.IsNullOrWhiteSpace(member.DeclaringType)
-                    ? apiType.FullName
-                    : member.DeclaringType!;
-                var overloadIndex = GetSourceOverloadIndex(apiType, member, options);
-                if (overloadIndex < 0)
+                logger.Log(
+                    $"Warning: Failed to resolve member source locations for {apiType.FullName}: "
+                    + failed.Error.Reason);
+                return pdbPath;
+            }
+
+            if (sourceInspection.Value is not FindingInspection<MemberSourceObservation>.Complete complete)
+                return pdbPath;
+
+            var mappingsByToken = complete.Findings
+                .Select(static finding => finding.Payload)
+                .GroupBy(static mapping => mapping.MetadataToken)
+                .ToDictionary(
+                    static group => group.Key,
+                    static group => group.OrderBy(static mapping => mapping.DocumentRowId).First());
+
+            foreach (var member in targetMembers)
+            {
+                if (member.MetadataToken is not { } token
+                    || !mappingsByToken.TryGetValue(token, out var mapping))
                     continue;
 
-                var publicOnly = !options.IncludeAll
-                                 && member.Kind != "explicit-interface-implementation";
-                var info = service.ResolveMethodSource(typeName, member.Name, overloadIndex, publicOnly);
-                if (info is null)
-                    continue;
-
-                member.SourceFilePath = info.FilePath;
-                member.SourceUrl = info.SourceUrl;
-                member.SourceLineNumber = info.StartLine;
-                member.SourceEndLineNumber = info.EndLine;
+                member.SourceFilePath = mapping.OriginalPath;
+                member.SourceUrl = mapping.ResolvedUrl;
+                member.SourceLineNumber = mapping.StartLine;
+                member.SourceEndLineNumber = mapping.EndLine;
             }
 
             return pdbPath;
@@ -82,19 +101,4 @@ internal static class MemberSourceLocationCollector
         return members;
     }
 
-    private static int GetSourceOverloadIndex(ApiType apiType, ApiMember member, MemberOptions options)
-    {
-        if (member.DeclaringOverloadIndex is { } declaringOverload)
-            return declaringOverload - 1;
-
-        if (options.OverloadIndex is { } selectedOverload && apiType.Members.Count == 1)
-            return selectedOverload - 1;
-
-        var sameName = apiType.Members
-            .Where(m => string.Equals(m.Name, member.Name, StringComparison.Ordinal))
-            .Where(ApiMemberSectionDescriptors.IsMethodLike)
-            .ToList();
-
-        return sameName.IndexOf(member);
-    }
 }

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -232,6 +232,43 @@ public class LibraryInspection
         }
     }
 
+    private FindingInspection<SourceDocumentObservation>? _sourceDocumentInspection;
+    private FindingInspection<CompilationOptionInfo>? _compilationOptionInspection;
+    private FindingInspection<CompilationReferenceInfo>? _compilationReferenceInspection;
+
+    [JsonIgnore]
+    public FindingInspection<SourceDocumentObservation>? SourceDocumentInspection
+    {
+        get => _sourceDocumentInspection;
+        set
+        {
+            _sourceDocumentInspection = value;
+            ResetFindingProjectionCaches();
+        }
+    }
+
+    [JsonIgnore]
+    public FindingInspection<CompilationOptionInfo>? CompilationOptionInspection
+    {
+        get => _compilationOptionInspection;
+        set
+        {
+            _compilationOptionInspection = value;
+            ResetFindingProjectionCaches();
+        }
+    }
+
+    [JsonIgnore]
+    public FindingInspection<CompilationReferenceInfo>? CompilationReferenceInspection
+    {
+        get => _compilationReferenceInspection;
+        set
+        {
+            _compilationReferenceInspection = value;
+            ResetFindingProjectionCaches();
+        }
+    }
+
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ApiSurface? ApiSurface { get; set; }
 
@@ -474,6 +511,9 @@ public class LibraryInspection
             {
             List<LibraryInspectionFailureJson> failures = [];
             AddFailure(failures, "References", AssemblyReferenceInspection);
+            AddFailure(failures, "Source Documents", SourceDocumentInspection);
+            AddFailure(failures, "Compilation Options", CompilationOptionInspection);
+            AddFailure(failures, "Compilation References", CompilationReferenceInspection);
             AddFailure(failures, "Classified Methods", ClassifiedMethodInspection);
             AddFailure(failures, "Extension Methods", ExtensionMemberInspection);
             AddFailure(failures, LibraryIntegrationCatalog.RollupName, EcosystemIntegrationInspection);

--- a/src/dotnet-inspect/Services/SourceAuditService.cs
+++ b/src/dotnet-inspect/Services/SourceAuditService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using DotnetInspector.Core;
+using ILInspector.Findings;
 using ILInspector.Metadata;
 using DotnetInspector.Models;
 using DotnetInspector.Output;
@@ -16,38 +17,49 @@ internal static class SourceAuditService
     private static readonly TimeSpan MutablePositiveCacheTtl = TimeSpan.FromDays(1);
 
     public static async Task PopulateAsync(
-        SourceLinkService service,
+        FindingInspection<SourceDocumentObservation> documentInspection,
         LibraryInspection inspection,
         HttpClient httpClient,
         VerboseLogger logger)
     {
+        ArgumentNullException.ThrowIfNull(documentInspection);
+        ArgumentNullException.ThrowIfNull(inspection);
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        if (documentInspection.Value is not FindingInspection<SourceDocumentObservation>.Complete complete)
+            return;
+
         using var trafficScope = NetworkTelemetry.Scope(NetworkTrafficKind.SourceAudit);
-        var documents = service.GetTrackedFiles();
+        var documents = complete.Findings
+            .Select(static finding => finding.Payload)
+            .Where(static document => document.IsCompilerLanguageSource)
+            .ToArray();
         int embeddedFiles = 0;
         int accessibleCount = 0;
         var missingFiles = new ConcurrentBag<string>();
-        List<SourceDocument> urlDocs = [];
+        List<SourceDocumentObservation> urlDocs = [];
 
         foreach (var doc in documents)
         {
-            if (doc.IsEmbedded)
+            if (doc.Storage == SourceDocumentStorage.Embedded)
             {
                 embeddedFiles++;
                 continue;
             }
 
             // ResolvedUrl comes from untrusted PDB SourceLink data; only probe absolute http/https.
-            if (doc.ResolvedUrl == null || IsBuildArtifact(doc.FilePath)
+            if (doc.ResolvedUrl == null || IsBuildArtifact(doc.OriginalPath)
                 || !Core.HttpClientFactory.IsAllowedFetchScheme(doc.ResolvedUrl))
             {
-                missingFiles.Add(doc.FilePath);
+                missingFiles.Add(doc.OriginalPath);
                 continue;
             }
 
             urlDocs.Add(doc);
         }
 
-        List<SourceDocument> uncachedDocs = [];
+        List<SourceDocumentObservation> uncachedDocs = [];
         foreach (var doc in urlDocs)
         {
             // Permanent positive cache only for commit-pinned URLs; mutable URLs expire after a day.
@@ -62,7 +74,7 @@ internal static class SourceAuditService
             }
             else if (CoreCache.TryGet("source-audit", doc.ResolvedUrl!, NegativeCacheTtl, extension: "miss") != null)
             {
-                missingFiles.Add(doc.FilePath);
+                missingFiles.Add(doc.OriginalPath);
             }
             else
             {
@@ -92,17 +104,17 @@ internal static class SourceAuditService
                         if (result.IsNotFound)
                             CoreCache.Set("source-audit", doc.ResolvedUrl!, "1", extension: "miss");
                         logger.Log($"Source not accessible: {doc.ResolvedUrl}");
-                        missingFiles.Add(doc.FilePath);
+                        missingFiles.Add(doc.OriginalPath);
                     }
                 });
         }
 
         int totalAccessible = accessibleCount + embeddedFiles;
-        inspection.TotalSourceFiles = documents.Count;
+        inspection.TotalSourceFiles = documents.Length;
         inspection.AccessibleSourceFiles = totalAccessible;
         inspection.EmbeddedSourceFiles = embeddedFiles;
         inspection.MissingSourceFiles = missingFiles.IsEmpty ? null : [.. missingFiles.OrderBy(f => f)];
-        inspection.AllSourcesAccessible = documents.Count > 0 && totalAccessible >= documents.Count;
+        inspection.AllSourcesAccessible = documents.Length > 0 && totalAccessible >= documents.Length;
     }
 
     private static bool IsBuildArtifact(string filePath) =>

--- a/src/dotnet-inspect/Services/SourceIntegrityService.cs
+++ b/src/dotnet-inspect/Services/SourceIntegrityService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using DotnetInspector.Core;
+using ILInspector.Findings;
 using ILInspector.Metadata;
 using DotnetInspector.Models;
 using DotnetInspector.Output;
@@ -18,22 +19,32 @@ internal static class SourceIntegrityService
     private const string CacheCategory = "source-integrity";
 
     public static async Task PopulateAsync(
-        SourceLinkService service,
+        FindingInspection<SourceDocumentObservation> documentInspection,
         LibraryInspection inspection,
         VerboseLogger logger,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(documentInspection);
+        ArgumentNullException.ThrowIfNull(inspection);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        if (documentInspection.Value is not FindingInspection<SourceDocumentObservation>.Complete complete)
+            return;
+
         using var trafficScope = NetworkTelemetry.Scope(NetworkTrafficKind.SourceIntegrity);
-        var documents = service.GetTrackedFiles();
+        var documents = complete.Findings
+            .Select(static finding => finding.Payload)
+            .Where(static document => document.IsCompilerLanguageSource)
+            .ToArray();
 
         // Only network-fetchable documents that carry a usable checksum can be verified.
-        List<SourceDocument> verifiable = [];
+        List<SourceDocumentObservation> verifiable = [];
         int unverifiable = 0;
         foreach (var doc in documents)
         {
-            if (doc.IsEmbedded)
+            if (doc.Storage == SourceDocumentStorage.Embedded)
                 continue; // present in the artifact; nothing to fetch
-            if (doc.ResolvedUrl == null || doc.Checksum is not { Length: > 0 } || doc.ChecksumAlgorithm == null
+            if (doc.ResolvedUrl == null || string.IsNullOrEmpty(doc.Checksum) || doc.ChecksumAlgorithm == null
                 || !Core.HttpClientFactory.IsAllowedFetchScheme(doc.ResolvedUrl))
             {
                 unverifiable++;
@@ -66,7 +77,8 @@ internal static class SourceIntegrityService
                 new ParallelOptions { MaxDegreeOfParallelism = 16, CancellationToken = cancellationToken },
                 async (doc, ct) =>
                 {
-                    string cacheKey = $"{doc.ResolvedUrl}|{doc.ChecksumAlgorithm}|{Convert.ToHexString(doc.Checksum!)}";
+                    byte[] checksum = Convert.FromHexString(doc.Checksum!);
+                    string cacheKey = $"{doc.ResolvedUrl}|{doc.ChecksumAlgorithm}|{doc.Checksum}";
                     bool immutable = SourceLinkUrls.IsImmutable(doc.ResolvedUrl!);
 
                     if (immutable && CoreCache.TryGet(CacheCategory, cacheKey, extension: "verified") != null)
@@ -100,13 +112,13 @@ internal static class SourceIntegrityService
                         return;
                     }
 
-                    if (HashMatches(doc.ChecksumAlgorithm!, body, doc.Checksum!))
+                    if (HashMatches(doc.ChecksumAlgorithm!, body, checksum))
                     {
                         Interlocked.Increment(ref verified);
                         if (immutable)
                             CoreCache.Set(CacheCategory, cacheKey, "1", extension: "verified");
                     }
-                    else if (HashMatchesAfterLineEndingNormalization(doc.ChecksumAlgorithm!, body, doc.Checksum!))
+                    else if (HashMatchesAfterLineEndingNormalization(doc.ChecksumAlgorithm!, body, checksum))
                     {
                         Interlocked.Increment(ref verified);
                         Interlocked.Increment(ref lineEndingNormalized);
@@ -116,8 +128,8 @@ internal static class SourceIntegrityService
                     else
                     {
                         Interlocked.Increment(ref mismatched);
-                        mismatches.Add(doc.FilePath);
-                        logger.Log($"Integrity MISMATCH: {doc.FilePath} ({doc.ResolvedUrl})");
+                        mismatches.Add(doc.OriginalPath);
+                        logger.Log($"Integrity MISMATCH: {doc.OriginalPath} ({doc.ResolvedUrl})");
                     }
                 });
         }

--- a/tests/ILInspector.Metadata.Tests/MetadataSourceFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataSourceFindingsTests.cs
@@ -1,4 +1,7 @@
 using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
 using ILInspector.Findings;
 using ILInspector.Metadata;
 using ILInspector.MetadataPrimitives;
@@ -12,6 +15,14 @@ public sealed class MetadataSourceFindingsTests
     static int SourceMappedMethod(int value)
     {
         int adjusted = value + 1;
+        return adjusted * 2;
+    }
+
+    static int MultiDocumentMappedMethod(int value)
+    {
+#line 100 "Generated/MetadataSourceFindings.g.cs"
+        int adjusted = value + 1;
+#line default
         return adjusted * 2;
     }
 
@@ -207,6 +218,65 @@ public sealed class MetadataSourceFindingsTests
     }
 
     [Fact]
+    public void MemberSourceProducer_UsesFirstVisibleDocumentWhenRootIsOmitted()
+    {
+        using var source = SourceLinkService.Open(typeof(MetadataSourceFindingsTests).Assembly.Location);
+        int token = typeof(MetadataSourceFindingsTests)
+            .GetMethod(
+                nameof(MultiDocumentMappedMethod),
+                System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)!
+            .MetadataToken;
+
+        var mappings = Findings(MetadataFindings.InspectMemberSources(
+                source,
+                Subject,
+                new MemberSourceQuery(new HashSet<int> { token })))
+            .Select(static finding => finding.Payload)
+            .ToArray();
+
+        var authored = Assert.Single(mappings, mapping =>
+            mapping.OriginalPath.EndsWith(
+                "tests/ILInspector.Metadata.Tests/MetadataSourceFindingsTests.cs",
+                StringComparison.Ordinal));
+        Assert.False(authored.IsPrimaryDocument);
+        var primary = Assert.Single(mappings, static mapping => mapping.IsPrimaryDocument);
+        Assert.EndsWith(
+            "Generated/MetadataSourceFindings.g.cs",
+            primary.OriginalPath,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MemberSourceQuery_ResolvesMultipleRealTokens()
+    {
+        using var source = SourceLinkService.Open(typeof(MetadataSourceFindingsTests).Assembly.Location);
+        int[] tokens =
+        [
+            typeof(MetadataSourceFindingsTests)
+                .GetMethod(
+                    nameof(SourceMappedMethod),
+                    System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)!
+                .MetadataToken,
+            typeof(MetadataSourceFindingsTests)
+                .GetMethod(
+                    nameof(MultiDocumentMappedMethod),
+                    System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)!
+                .MetadataToken,
+        ];
+
+        var actualTokens = Findings(MetadataFindings.InspectMemberSources(
+                source,
+                Subject,
+                new MemberSourceQuery(tokens.ToHashSet())))
+            .Select(static finding => finding.Payload.MetadataToken)
+            .Distinct()
+            .Order()
+            .ToArray();
+
+        Assert.Equal(tokens.Order(), actualTokens);
+    }
+
+    [Fact]
     public void BuildContextComparisons_PromoteOptionAndReferenceChanges()
     {
         var option = Assert.Single(Pairs(MetadataFindings.CompareCompilationOptions(
@@ -284,6 +354,69 @@ public sealed class MetadataSourceFindingsTests
         {
             Directory.Delete(directory, recursive: true);
         }
+    }
+
+    [Fact]
+    public void MalformedPortablePdb_ProducesFailedInspection()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"metadata-source-findings-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        string assemblyPath = Path.Combine(directory, "Probe.dll");
+        string pdbPath = Path.ChangeExtension(assemblyPath, ".pdb");
+        File.Copy(typeof(MetadataSourceFindingsTests).Assembly.Location, assemblyPath);
+        WriteMalformedCompilationReferencesPdb(assemblyPath, pdbPath);
+
+        try
+        {
+            using var source = SourceLinkService.Open(assemblyPath);
+
+            Assert.True(source.HasPdb);
+            var failed = Assert.IsType<FindingInspection<CompilationReferenceInfo>.Failed>(
+                MetadataFindings.InspectCompilationReferences(source, Subject).Value);
+            Assert.Contains("truncated", failed.Error.Reason, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    static void WriteMalformedCompilationReferencesPdb(string assemblyPath, string pdbPath)
+    {
+        using var stream = File.OpenRead(assemblyPath);
+        using var pe = new PEReader(stream);
+        var metadata = pe.GetMetadataReader();
+        var codeView = pe.ReadDebugDirectory()
+            .Where(static entry => entry.Type == DebugDirectoryEntryType.CodeView)
+            .Select(pe.ReadCodeViewDebugDirectoryData)
+            .First();
+
+        int[] rowCounts = new int[64];
+        foreach (var table in Enum.GetValues<TableIndex>())
+        {
+            int index = (int)table;
+            if ((uint)index < (uint)rowCounts.Length)
+                rowCounts[index] = metadata.GetTableRowCount(table);
+        }
+
+        var pdbMetadata = new MetadataBuilder();
+        var malformedReference = new BlobBuilder();
+        malformedReference.WriteUTF8("Broken.dll");
+        malformedReference.WriteByte(0);
+        malformedReference.WriteByte(0);
+        pdbMetadata.AddCustomDebugInformation(
+            EntityHandle.ModuleDefinition,
+            pdbMetadata.GetOrAddGuid(new Guid("7E4D4708-096E-4C5C-AEDA-CB10BA6A740D")),
+            pdbMetadata.GetOrAddBlob(malformedReference));
+
+        var builder = new PortablePdbBuilder(
+            pdbMetadata,
+            ImmutableArray.Create(rowCounts),
+            default,
+            _ => new BlobContentId(codeView.Guid, stamp: 0));
+        var image = new BlobBuilder();
+        builder.Serialize(image);
+        File.WriteAllBytes(pdbPath, image.ToArray());
     }
 
     static ImmutableArray<Finding<T>> Findings<T>(FindingInspection<T> inspection)

--- a/tests/ILInspector.Metadata.Tests/MetadataSourceFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataSourceFindingsTests.cs
@@ -114,6 +114,31 @@ public sealed class MetadataSourceFindingsTests
     }
 
     [Fact]
+    public void SourceDocumentIdentity_MatchesSourceLinkPathsCaseInsensitively()
+    {
+        const string sourceLink = """
+            {
+              "documents": {
+                "c:/repo/*": "https://example.test/repository/*"
+              }
+            }
+            """;
+
+        Assert.Equal(
+            "src/Widget.cs",
+            SourceDocumentPath.Canonicalize("C:/Repo/src/Widget.cs", sourceLink));
+    }
+
+    [Fact]
+    public void EmptyPortablePdbDocumentPath_IsMalformedMetadata()
+    {
+        var exception = Assert.Throws<BadImageFormatException>(
+            () => SourceDocumentPath.Canonicalize("", sourceLinkJson: null));
+
+        Assert.Contains("empty path", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void MemberSourceComparison_UsesCanonicalMemberIdentity()
     {
         var anchor = new MemberAnchor(

--- a/tests/ILInspector.Metadata.Tests/MetadataSourceFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataSourceFindingsTests.cs
@@ -18,9 +18,9 @@ public sealed class MetadataSourceFindingsTests
         return adjusted * 2;
     }
 
+#line 100 "Generated/MetadataSourceFindings.g.cs"
     static int MultiDocumentMappedMethod(int value)
     {
-#line 100 "Generated/MetadataSourceFindings.g.cs"
         int adjusted = value + 1;
 #line default
         return adjusted * 2;

--- a/tests/ILInspector.Metadata.Tests/MetadataSourceFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataSourceFindingsTests.cs
@@ -1,0 +1,275 @@
+using System.Collections.Immutable;
+using ILInspector.Findings;
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+
+namespace ILInspector.Metadata.Tests;
+
+public sealed class MetadataSourceFindingsTests
+{
+    static readonly FindingSubject Subject = new("assembly", "Test assembly");
+
+    static int SourceMappedMethod(int value)
+    {
+        int adjusted = value + 1;
+        return adjusted * 2;
+    }
+
+    [Fact]
+    public void SourceDocuments_ReturnCompleteFilteredCensus()
+    {
+        SourceDocument[] documents =
+        [
+            new(
+                "/_/src/System.Text.Json/JsonSerializer.cs",
+                IsEmbedded: false,
+                "https://example.test/repository/commit/src/System.Text.Json/JsonSerializer.cs",
+                [0x01, 0xA2],
+                "SHA256",
+                DocumentRowId: 7,
+                CanonicalPath: "src/System.Text.Json/JsonSerializer.cs"),
+            new(
+                "/_/src/System.Net.Http/HttpClient.cs",
+                IsEmbedded: true,
+                ResolvedUrl: null,
+                DocumentRowId: 9,
+                CanonicalPath: "src/System.Net.Http/HttpClient.cs"),
+            new(
+                "/_/src/Components/App.razor",
+                IsEmbedded: false,
+                ResolvedUrl: "https://example.test/repository/commit/src/Components/App.razor",
+                DocumentRowId: 10,
+                CanonicalPath: "src/Components/App.razor"),
+        ];
+
+        var all = Findings(MetadataFindings.InspectSourceDocuments(documents, Subject));
+        var filtered = Findings(MetadataFindings.InspectSourceDocuments(
+            documents,
+            Subject,
+            new SourceDocumentQuery("text.json")));
+        var missing = Findings(MetadataFindings.InspectSourceDocuments(
+            documents,
+            Subject,
+            new SourceDocumentQuery("does-not-exist")));
+
+        Assert.Equal(3, all.Length);
+        Assert.Contains(all, finding =>
+            finding.Payload.CanonicalPath == "src/Components/App.razor"
+            && !finding.Payload.IsCompilerLanguageSource);
+        var json = Assert.Single(filtered);
+        Assert.Equal("metadata.source-document", json.Descriptor.Id);
+        Assert.Equal("src/System.Text.Json/JsonSerializer.cs", json.Key.IdentityKey);
+        Assert.Equal("01A2", json.Payload.Checksum);
+        Assert.Equal(SourceDocumentStorage.SourceLink, json.Payload.Storage);
+        Assert.Null(json.Ordinal);
+        Assert.Empty(missing);
+    }
+
+    [Fact]
+    public void SourceDocumentComparison_IgnoresPdbRowMovementButReportsContentChanges()
+    {
+        var oldDocument = new SourceDocument(
+            "/_/src/Widget.cs",
+            IsEmbedded: false,
+            "https://example.test/old/src/Widget.cs",
+            [0x01],
+            "SHA256",
+            DocumentRowId: 1,
+            CanonicalPath: "src/Widget.cs");
+        var movedRow = oldDocument with { DocumentRowId = 19 };
+        var changedContent = movedRow with
+        {
+            ResolvedUrl = "https://example.test/new/src/Widget.cs",
+            Checksum = [0x02],
+        };
+
+        var exact = Assert.Single(Pairs(MetadataFindings.CompareSourceDocuments(
+            [oldDocument],
+            [movedRow],
+            Subject)));
+        var changed = Assert.Single(Pairs(MetadataFindings.CompareSourceDocuments(
+            [oldDocument],
+            [changedContent],
+            Subject)));
+
+        Assert.Equal(PairKind.Present, exact.Kind);
+        Assert.Equal(PairKind.Changed, changed.Kind);
+    }
+
+    [Fact]
+    public void SourceDocumentIdentity_UsesMostSpecificSourceLinkMapping()
+    {
+        const string sourceLink = """
+            {
+              "documents": {
+                "/repo/*": "https://example.test/repository/*",
+                "/repo/submodule/*": "https://example.test/submodule/*"
+              }
+            }
+            """;
+
+        Assert.Equal(
+            "Widget.cs",
+            SourceDocumentPath.Canonicalize("/repo/submodule/Widget.cs", sourceLink));
+    }
+
+    [Fact]
+    public void MemberSourceComparison_UsesCanonicalMemberIdentity()
+    {
+        var anchor = new MemberAnchor(
+            "Run~1234567890",
+            "M:Sample.Widget.Run(System.Int32)",
+            "1234567890",
+            "Sample.Widget",
+            "Run");
+        var oldMapping = new MemberSourceInfo(
+            anchor,
+            MetadataToken: 0x06000001,
+            DocumentRowId: 1,
+            "/_/src/Widget.cs",
+            "src/Widget.cs",
+            ResolvedUrl: null,
+            StartLine: 10,
+            EndLine: 12);
+        var renumbered = oldMapping with
+        {
+            MetadataToken = 0x0600000A,
+            DocumentRowId = 8,
+        };
+        var movedLine = renumbered with { StartLine = 20, EndLine = 22 };
+
+        var exact = Assert.Single(Pairs(MetadataFindings.CompareMemberSources(
+            [oldMapping],
+            [renumbered],
+            Subject)));
+        var changed = Assert.Single(Pairs(MetadataFindings.CompareMemberSources(
+            [oldMapping],
+            [movedLine],
+            Subject)));
+
+        Assert.Equal(
+            anchor.CanonicalSignature,
+            Assert.IsType<PairFinding<MemberSourceObservation>.Present>(exact.Value).Old.Key.IdentityKey);
+        Assert.Equal(PairKind.Present, exact.Kind);
+        Assert.Equal(PairKind.Changed, changed.Kind);
+    }
+
+    [Fact]
+    public void MemberSourceQuery_FiltersByMetadataToken()
+    {
+        var anchor = new MemberAnchor(
+            "Run~1234567890",
+            "M:Sample.Widget.Run(System.Int32)",
+            "1234567890",
+            "Sample.Widget",
+            "Run");
+        MemberSourceInfo Mapping(int token) => new(
+            anchor,
+            token,
+            DocumentRowId: token,
+            "/_/src/Widget.cs",
+            "src/Widget.cs",
+            ResolvedUrl: null,
+            StartLine: 10,
+            EndLine: 12);
+
+        var findings = Findings(MetadataFindings.InspectMemberSources(
+            [Mapping(1), Mapping(2)],
+            Subject,
+            new MemberSourceQuery(new HashSet<int> { 2 })));
+
+        Assert.Equal(2, Assert.Single(findings).Payload.MetadataToken);
+    }
+
+    [Fact]
+    public void BuildContextComparisons_PromoteOptionAndReferenceChanges()
+    {
+        var option = Assert.Single(Pairs(MetadataFindings.CompareCompilationOptions(
+            [new CompilationOptionInfo("optimization", "debug")],
+            [new CompilationOptionInfo("optimization", "release")],
+            Subject)));
+        var oldReference = new CompilationReferenceInfo(
+            "System.Runtime.dll",
+            "",
+            CompilationReferenceImageKind.Assembly,
+            EmbedInteropTypes: false,
+            Timestamp: 1,
+            ImageSize: 1024,
+            ModuleVersionId: Guid.Parse("11111111-1111-1111-1111-111111111111"));
+        var reference = Assert.Single(Pairs(MetadataFindings.CompareCompilationReferences(
+            [oldReference],
+            [oldReference with
+            {
+                ModuleVersionId = Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            }],
+            Subject)));
+
+        Assert.Equal(PairKind.Changed, option.Kind);
+        Assert.Equal(PairKind.Changed, reference.Kind);
+    }
+
+    [Fact]
+    public void RealPortablePdb_ProducesAllSourceAndBuildContextFamilies()
+    {
+        using var source = SourceLinkService.Open(typeof(MetadataSourceFindingsTests).Assembly.Location);
+
+        var documents = Findings(MetadataFindings.InspectSourceDocuments(
+            source,
+            Subject,
+            new SourceDocumentQuery(nameof(MetadataSourceFindingsTests))));
+        var members = Findings(MetadataFindings.InspectMemberSources(source, Subject));
+        var options = Findings(MetadataFindings.InspectCompilationOptions(source, Subject));
+        var references = Findings(MetadataFindings.InspectCompilationReferences(source, Subject));
+
+        Assert.Contains(documents, finding =>
+            finding.Payload.CanonicalPath.EndsWith(
+                "tests/ILInspector.Metadata.Tests/MetadataSourceFindingsTests.cs",
+                StringComparison.Ordinal));
+        Assert.Contains(members, finding =>
+            finding.Payload.Anchor.MemberName == nameof(SourceMappedMethod)
+            && finding.Payload.StartLine < finding.Payload.EndLine);
+        Assert.Contains(options, finding => finding.Payload.Name == "language");
+        Assert.Contains(references, finding =>
+            finding.Payload.Name == "ILInspector.Metadata.dll"
+            && finding.Payload.ImageKind == CompilationReferenceImageKind.Assembly);
+    }
+
+    [Fact]
+    public void MissingPortablePdb_IsAbsentForEveryPdbProducer()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"metadata-source-findings-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        string assemblyPath = Path.Combine(directory, "Probe.dll");
+        File.Copy(typeof(MetadataSourceFindingsTests).Assembly.Location, assemblyPath);
+
+        try
+        {
+            using var source = SourceLinkService.Open(assemblyPath);
+
+            Assert.IsType<FindingInspection<SourceDocumentObservation>.Absent>(
+                MetadataFindings.InspectSourceDocuments(source, Subject).Value);
+            Assert.IsType<FindingInspection<MemberSourceObservation>.Absent>(
+                MetadataFindings.InspectMemberSources(source, Subject).Value);
+            Assert.IsType<FindingInspection<CompilationOptionInfo>.Absent>(
+                MetadataFindings.InspectCompilationOptions(source, Subject).Value);
+            Assert.IsType<FindingInspection<CompilationReferenceInfo>.Absent>(
+                MetadataFindings.InspectCompilationReferences(source, Subject).Value);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    static ImmutableArray<Finding<T>> Findings<T>(FindingInspection<T> inspection)
+        where T : notnull
+        => inspection is FindingInspection<T>.Complete complete
+            ? complete.Findings
+            : throw new Xunit.Sdk.XunitException("Expected a complete PDB inspection.");
+
+    static ImmutableArray<PairFinding<T>> Pairs<T>(FindingComparison<T> comparison)
+        where T : notnull
+        => comparison is FindingComparison<T>.Complete complete
+            ? complete.Pairs
+            : throw new Xunit.Sdk.XunitException($"Expected a complete comparison: {comparison.Failure}");
+}


### PR DESCRIPTION
## Summary

- add Metadata Finding producers and comparisons for portable-PDB source documents, member-to-document mappings, compilation options, and compilation references
- support complete source-document censuses with an optional canonical-path substring query, while retaining `Complete([])`, `Absent`, and `Failed`
- migrate SourceLink availability/integrity to the source-document census and member source-location enrichment to metadata-token-scoped mappings
- document producer inputs/outputs, identities, consumer boundaries, and APIs eligible for retirement after migration

## Product boundaries

The new producers are local, SRM-only, NativeAOT-compatible, Roslyn-free, and network-free. Source fetching, checksum verdicts, authored/decompiled correspondence, and rebuild fidelity remain downstream operations.

Low-level PE/PDB extraction remains the authoritative substrate. Once remaining consumers migrate, convenience APIs such as `GetTrackedFiles`, `GetEmbeddedFiles`, and overload-ordinal `ResolveMethodSource` can be removed or made internal; source audit/integrity summaries and the public-type source view remain distinct product projections.

Advances #2673 without closing its SourceLink acquisition or oracle slices.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release --no-build` (459 passed)
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build` (1,817 passed, 10 tool-dependent skips)
- `npx markdownlint-cli docs/design/source-finding-producers.md docs/design/finding-producers.md docs/overview.md docs/architecture.md`
- CI: green

## Review

- Claude Opus 4.8: CLEAN on exact head `bdccf1b5`
- Gemini 3.1 Pro: CLEAN on exact head `bdccf1b5`
- Owner feedback and adversarial findings are reconciled in the PR comments.