### PR TITLE
Fix RTS constructor-chain opcode loss (#2678)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -571,11 +571,11 @@ public class ReturnToSenderPrototypeTests
     {
         // Issue #2678 guard: the printer can render chain arguments without a
         // disambiguating cast (a `box` to `object` prints without `(object)`), so
-        // when two same-arity siblings are reconstructed the emitted
-        // `: this(args)` could silently bind to the wrong overload. The guard
-        // requires a unique same-arity sibling; here `C(object)` and `C(int)` are
-        // both present (the latter pulled in by `new C(2)`), so the initializer
-        // must be stripped rather than emit a wrong-binding chain.
+        // any second reconstructed constructor could silently hijack the
+        // `: this(args)` binding. The guard emits the initializer only when the
+        // chained-to constructor is the sole reconstructed sibling; here
+        // `C(object)` and `C(int)` are both present (the latter pulled in by
+        // `new C(2)`), so the initializer must be stripped.
         var assemblyPath = CompileFixture("""
             public class C
             {
@@ -590,6 +590,47 @@ public class ReturnToSenderPrototypeTests
                 public C(string z) : this((object)1)
                 {
                     _ = new C(2);
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("C", ".ctor", 2)]));
+
+            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.DoesNotContain(": this(", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_DropsInitializerWhenSiblingConstructorCrossesArity()
+    {
+        // Issue #2678 guard: overload resolution can bind a chain-call argument
+        // list to a constructor of a DIFFERENT IL arity (a `params` array absorbs
+        // extra arguments). A same-arity check alone would miss this, so the guard
+        // requires the chained-to constructor to be the sole reconstructed
+        // sibling. Here `C(params int[])` and `C(int, int)` are both present, so
+        // `: this(1, 2)` could bind to either; the initializer must be stripped.
+        var assemblyPath = CompileFixture("""
+            public class C
+            {
+                public C(params int[] xs)
+                {
+                }
+
+                public C(int a, int b)
+                {
+                }
+
+                public C(string z) : this(1, 2)
+                {
+                    _ = new C(9);
                 }
             }
             """);

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -482,6 +482,47 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_PreservesThisConstructorChainOpcodes()
+    {
+        // Issue #2678: RTS used to reconstruct target constructors with empty
+        // bodies, dropping the `: this(...)` chain call. The recompiled ctor then
+        // emitted `ldarg call ret` instead of the original `ldarg ldarg call call
+        // ret`, producing an OpcodeDiff. The chain must be preserved so the ctor
+        // round-trips Exact.
+        var assemblyPath = CompileFixture("""
+            public class Versioned
+            {
+                public Versioned(string text) : this(Parse(text))
+                {
+                }
+
+                public Versioned(int value)
+                {
+                    Value = value;
+                }
+
+                public int Value { get; }
+
+                private static int Parse(string text) => text.Length;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Versioned", ".ctor", 0,
+                    "(corelib:System.String) -> corelib:System.Void")]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains(": this(", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_UsesTargetBackingFieldWriteForConstructorAssignment()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -570,12 +570,12 @@ public class ReturnToSenderPrototypeTests
     public void CompileBackTargets_DropsInitializerWhenChainedConstructorIsOverloadAmbiguous()
     {
         // Issue #2678 guard: the printer can render chain arguments without a
-        // disambiguating cast (a `box` to `object` prints without `(object)`), so
-        // any second reconstructed constructor could silently hijack the
-        // `: this(args)` binding. The guard emits the initializer only when the
-        // chained-to constructor is the sole reconstructed sibling; here
-        // `C(object)` and `C(int)` are both present (the latter pulled in by
-        // `new C(2)`), so the initializer must be stripped.
+        // disambiguating cast (a `box` to `object` prints as its inner value), and
+        // C# overload resolution — including the target constructor — can then
+        // re-bind the call. A boxed argument is never faithful, and here three
+        // same-arity constructors (`C(object)`, `C(int)`, the target `C(string)`)
+        // share the callee's arity, so unique-arity binding does not hold either.
+        // The initializer must be stripped rather than emit a wrong-binding chain.
         var assemblyPath = CompileFixture("""
             public class C
             {
@@ -609,28 +609,25 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
-    public void CompileBackTargets_DropsInitializerWhenSiblingConstructorCrossesArity()
+    public void CompileBackTargets_DropsInitializerWhenChainBindsToTargetConstructor()
     {
-        // Issue #2678 guard: overload resolution can bind a chain-call argument
-        // list to a constructor of a DIFFERENT IL arity (a `params` array absorbs
-        // extra arguments). A same-arity check alone would miss this, so the guard
-        // requires the chained-to constructor to be the sole reconstructed
-        // sibling. Here `C(params int[])` and `C(int, int)` are both present, so
-        // `: this(1, 2)` could bind to either; the initializer must be stripped.
+        // Issue #2678 guard: overload resolution also considers the target
+        // constructor itself. The printer drops the `(object)` cast from
+        // `: this((object)text)`, printing `: this(text)`; with the target
+        // `C(string)` in the shell, `text` (a string) binds back to the target
+        // constructor — `C(string)` calling itself (CS0516). The argument is not
+        // faithful (its printed string type differs from the `object` parameter)
+        // and the callee shares the target's arity, so the initializer must be
+        // stripped.
         var assemblyPath = CompileFixture("""
             public class C
             {
-                public C(params int[] xs)
+                public C(object value)
                 {
                 }
 
-                public C(int a, int b)
+                public C(string text) : this((object)text)
                 {
-                }
-
-                public C(string z) : this(1, 2)
-                {
-                    _ = new C(9);
                 }
             }
             """);
@@ -638,10 +635,49 @@ public class ReturnToSenderPrototypeTests
         {
             var result = Assert.Single(ReturnToSender.CompileBackTargets(
                 assemblyPath,
-                [new ReturnToSender.RequestedTarget("C", ".ctor", 2)]));
+                [new ReturnToSender.RequestedTarget("C", ".ctor", 1)]));
 
             Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
             Assert.DoesNotContain(": this(", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_PreservesConstructorChainWhenArityIsUnique()
+    {
+        // Issue #2678: a chain whose arguments the printer cannot type precisely (a
+        // bare `null`) is still safe to emit when exactly one constructor in the
+        // shell has the chain's argument count — a normal-form exact-arity match
+        // has no competing overload, so `: this(1, 2, null)` binds unambiguously to
+        // the sole three-argument constructor. The initializer must be preserved so
+        // the constructor round-trips Exact.
+        var assemblyPath = CompileFixture("""
+            public class C
+            {
+                public C(int a, int b, string s)
+                {
+                    S = s;
+                }
+
+                public C(string z) : this(1, 2, null)
+                {
+                }
+
+                public string S { get; }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("C", ".ctor", 1)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains(": this(", result.Source);
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -686,6 +686,50 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_DropsInitializerWhenCrossArityParamsSiblingCanBind()
+    {
+        // Issue #2678 guard (Gemini R5): unique *declared* arity is not enough — a
+        // cross-arity `params` (or optional) sibling can absorb an N-argument call
+        // and, for a lossy argument the printer cannot type precisely, offer a
+        // better conversion that steals the bind. Here `C()` chains
+        // `: this((object)null)`; the printer drops the `(object)` cast, printing
+        // `: this(null)`. `C(object)` is the only one-parameter constructor, but
+        // `C(string, params int[])` is also applicable to a one-argument call and
+        // `null` binds to `string` (more derived than `object`) via params
+        // expansion — the wrong overload. The initializer must be stripped.
+        var assemblyPath = CompileFixture("""
+            public class C
+            {
+                public C(object x)
+                {
+                }
+
+                public C(string x, params int[] y)
+                {
+                }
+
+                public C() : this((object)null)
+                {
+                    _ = new C("hello");
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("C", ".ctor", 2)]));
+
+            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.DoesNotContain(": this(", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_UsesTargetBackingFieldWriteForConstructorAssignment()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -730,6 +730,54 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_DropsInitializerWhenChainArgumentIsAmbiguousLambda()
+    {
+        // Issue #2678 guard (Gemini R6): a lambda argument prints typeless
+        // (`() => ...`) and relies on C# target-typing, so its IR result type
+        // matching the parameter does NOT prove an unambiguous bind. Here `C()`
+        // chains `: this((Func<int>)(() => 1))`; the shell also contains
+        // `C(Expression<Func<int>>)` (pulled in by the body). Both constructors
+        // accept `() => 1`, so the printed `: this(() => 1)` is ambiguous (CS0121).
+        // The lambda must not be treated as faithful; with a same-arity sibling in
+        // the shell, unique-arity does not hold either, so the initializer is
+        // stripped and the body (which references the sibling through a typed local,
+        // so it stays unambiguous) still compiles.
+        var assemblyPath = CompileFixture("""
+            using System;
+            using System.Linq.Expressions;
+            public class C
+            {
+                public C(Func<int> x)
+                {
+                }
+
+                public C(Expression<Func<int>> y)
+                {
+                }
+
+                public C() : this((Func<int>)(() => 1))
+                {
+                    Expression<Func<int>> e = () => 2;
+                    _ = new C(e);
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("C", ".ctor", 2)]));
+
+            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.DoesNotContain(": this(", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_UsesTargetBackingFieldWriteForConstructorAssignment()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -567,6 +567,48 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_DropsInitializerWhenChainedConstructorIsOverloadAmbiguous()
+    {
+        // Issue #2678 guard: the printer can render chain arguments without a
+        // disambiguating cast (a `box` to `object` prints without `(object)`), so
+        // when two same-arity siblings are reconstructed the emitted
+        // `: this(args)` could silently bind to the wrong overload. The guard
+        // requires a unique same-arity sibling; here `C(object)` and `C(int)` are
+        // both present (the latter pulled in by `new C(2)`), so the initializer
+        // must be stripped rather than emit a wrong-binding chain.
+        var assemblyPath = CompileFixture("""
+            public class C
+            {
+                public C(object x)
+                {
+                }
+
+                public C(int x)
+                {
+                }
+
+                public C(string z) : this((object)1)
+                {
+                    _ = new C(2);
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("C", ".ctor", 2)]));
+
+            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.DoesNotContain(": this(", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_UsesTargetBackingFieldWriteForConstructorAssignment()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -523,6 +523,50 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_DropsInitializerWhenChainedConstructorUnreconstructable()
+    {
+        // Issue #2678 guard: when the chained-to constructor has an unsupported
+        // signature (a function pointer), the planner drops it from the shell. A
+        // same-arity sibling ctor pulled in by another dependency must NOT be
+        // mistaken for the chained-to ctor: emitting `: this(args)` would bind to
+        // the wrong overload and fail with CS1503. The initializer must be
+        // stripped, falling back to an (empty) body that still compiles.
+        var assemblyPath = CompileFixture(
+            """
+            public unsafe class Chained
+            {
+                public Chained(int value) : this((delegate*<void>)value)
+                {
+                    _ = new Chained(true);
+                }
+
+                public Chained(delegate*<void> callback)
+                {
+                }
+
+                public Chained(bool flag)
+                {
+                }
+            }
+            """,
+            allowUnsafe: true);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Chained", ".ctor", 0,
+                    "(corelib:System.Int32) -> corelib:System.Void")]));
+
+            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.DoesNotContain(": this(", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_UsesTargetBackingFieldWriteForConstructorAssignment()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler/Pipeline/Ir/ConsumedMemberEvidence.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/ConsumedMemberEvidence.cs
@@ -44,7 +44,12 @@ public readonly record struct ConsumedMemberEvidence(
         switch (node)
         {
             case Call call:
-                evidence.Add(new(Method: call.Callee));
+                // A Call (not NewObject) to a constructor is a base(...)/this(...)
+                // chain (or an explicit struct ctor call) — a construction context
+                // that legitimately re-seeds the target root's own constructor, just
+                // like NewObject/ObjectInitializer below. Without this a this(...)
+                // self-chain reconstruction omits the chained-to ctor overload.
+                evidence.Add(new(Method: call.Callee, AllowTargetRoot: call.Callee.Name is ".ctor"));
                 break;
             case NewObject creation:
                 evidence.Add(new(Method: creation.Constructor, AllowTargetRoot: true));

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1246,16 +1246,23 @@ public static class CompileBackSourceComposer
             // is fully supported (an unsupported parameter such as a function
             // pointer makes the planner drop it, mirroring MethodRequirement).
             && chainCtor.ParameterTypes.All(type => !IsUnsupportedChainParameterType(type))
-            && targetMembers.Any(member => member.Kind == CompileBackMemberKind.Constructor
+            // Exactly one same-arity non-target constructor must be present. The
+            // printer can render chain arguments without disambiguating casts
+            // (e.g. a `box` to `object` prints without the `(object)` cast), so if
+            // two same-arity siblings exist the emitted `: this(args)` could
+            // silently bind to the wrong overload. Requiring a unique same-arity
+            // sibling keeps binding unambiguous; otherwise fall back to an empty
+            // body.
+            && targetMembers.Count(member => member.Kind == CompileBackMemberKind.Constructor
                 && member.StubBody != CompileBackStubBodyKind.TargetBody
-                && member.Parameters.Count == chainCtor.ParameterTypes.Length);
+                && member.Parameters.Count == chainCtor.ParameterTypes.Length) == 1;
         if (targetConstructorInitializer is not null && !chainedConstructorReconstructed)
         {
             // The chained-to sibling constructor was not reconstructed in the
-            // shell, so `: this(args)` would not bind (it would either fail to
-            // resolve or, worse, silently bind to a same-arity sibling of a
-            // different signature and fail with CS1503). Drop the initializer and
-            // keep the body rather than emit an uncompilable chain.
+            // shell (or is ambiguous with another same-arity sibling), so
+            // `: this(args)` might not bind, or could silently bind to the wrong
+            // overload (CS1503 or a semantic mismatch). Drop the initializer and
+            // keep the body rather than emit an uncompilable or wrong chain.
             int targetIndex = targetMembers.FindIndex(member =>
                 member.Kind == CompileBackMemberKind.Constructor
                 && member.StubBody == CompileBackStubBodyKind.TargetBody);

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1704,9 +1704,19 @@ public static class CompileBackSourceComposer
         // Box (prints its inner value, dropping the `(object)` cast), Coerce,
         // Convert, IsInstance, and bare constants can each be spelled at a static
         // type other than the parameter's, so overload resolution could bind them
-        // elsewhere. Every other expression prints at its result type, so it is
-        // faithful exactly when that type matches the parameter type.
-        => argument is not (Box or Coerce or ILInspector.Decompiler.Pipeline.Convert or IsInstance or ILInspector.Decompiler.Pipeline.Constant)
+        // elsewhere. Lambdas, collection expressions, tuple literals, and
+        // interpolated strings print in a target-typed form with no intrinsic
+        // static type (a lambda `() => ...` and a collection `[...]` have none; a
+        // tuple `(a, b)` target-types per element; an interpolated string `$"..."`
+        // also converts to FormattableString/IFormattable), so a matching
+        // ResultType does not prove they bind only to the chained-to constructor —
+        // a lambda-, collection-, tuple-, or string-accepting sibling can make the
+        // printed initializer ambiguous (CS0121) or bind it elsewhere. Every other
+        // expression prints at its result type, so it is faithful exactly when
+        // that type matches the parameter type.
+        => argument is not (Box or Coerce or ILInspector.Decompiler.Pipeline.Convert or IsInstance
+                or ILInspector.Decompiler.Pipeline.Constant
+                or Lambda or CollectionExpression or TupleExpression or InterpolatedStringExpression)
             && argument.ResultType is { } type
             && type.Equals(parameterType);
 

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -476,7 +476,8 @@ public sealed record CompileBackMemberRequirement(
     bool IsSealed = false,
     bool IsAsync = false,
     bool IsExtension = false,
-    CompileBackAccessibility Accessibility = CompileBackAccessibility.Public)
+    CompileBackAccessibility Accessibility = CompileBackAccessibility.Public,
+    string? ConstructorInitializer = null)
 {
     public string Name => Identity.Method;
     public string Type => ReturnType?.DisplayName ?? "";
@@ -485,7 +486,10 @@ public sealed record CompileBackMemberRequirement(
 
 public sealed record CompileBackPlanningDiagnostic(string Layer, string Reason, string Detail);
 
-internal sealed record ProductTargetBody(string Source, IReadOnlyList<DecompilerDecision> Decisions);
+internal sealed record ProductTargetBody(
+    string Source,
+    IReadOnlyList<DecompilerDecision> Decisions,
+    string? ConstructorChain = null);
 
 public static class CompileBackSourceComposer
 {
@@ -498,7 +502,12 @@ public static class CompileBackSourceComposer
         var printed = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
         if (printed.Output is null)
             throw new InvalidOperationException($"Could not print {fullType}::{methodName}.");
-        return new ProductTargetBody(printed.Output, printed.Decisions);
+        // The printer lifts an explicit base(...)/this(...) constructor-chain call
+        // out of the body into ConstructorChain (chain calls are invalid as body
+        // statements). Carry it so the reconstructed target constructor re-emits
+        // the initializer; dropping it silently compiles an empty body and loses
+        // the constructor-chain opcodes (issue #2678).
+        return new ProductTargetBody(printed.Output, printed.Decisions, printed.ConstructorChain);
     }
 
     internal static ProductArtifact Compose(ArtifactRequest request)
@@ -549,7 +558,8 @@ public static class CompileBackSourceComposer
                 request.SignatureText,
                 closure.Roots,
                 closure.Facts,
-                closure.MemberRequirements),
+                closure.MemberRequirements,
+                request.TargetBody.ConstructorChain),
             _ => throw new ArgumentException($"Unknown artifact request type '{request.GetType().FullName}'.", nameof(request)),
         };
 
@@ -1138,7 +1148,8 @@ public static class CompileBackSourceComposer
         string signatureText,
         IReadOnlySet<TypeDefinitionHandle> closureRoots,
         IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
-        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements)
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements,
+        string? constructorChain = null)
     {
         var targetTypeDef = reader.GetTypeDefinition(targetType);
         var method = reader.GetMethodDefinition(targetMethod);
@@ -1158,6 +1169,17 @@ public static class CompileBackSourceComposer
         };
         if (closureFacts.TryGetValue(targetType, out var targetClosureFacts))
             targetFacts.AddRange(targetClosureFacts);
+
+        var chainCallee = isConstructor ? ConstructorChainCallee(function) : null;
+        // Only this(...) self-chains are re-emitted as constructor initializers.
+        // RTS shells are flat (object-based, no reconstructed base class), so a
+        // base(args) initializer has no base constructor to bind to and would
+        // fail to compile (CS1729). Leaving those bodies empty keeps the prior
+        // implicit-base() behavior instead of introducing a recompile failure.
+        string? targetConstructorInitializer =
+            constructorChain is { } chain && chain.StartsWith("this(", StringComparison.Ordinal)
+                ? constructorChain
+                : null;
 
         var targetMembers = isConstructor && primaryConstructor is not null
             ? primaryConstructor.FieldInitializers.ToList()
@@ -1179,7 +1201,8 @@ public static class CompileBackSourceComposer
                 IsVirtual: !isConstructor && IsVirtualMethod(method),
                 IsOverride: false,
                 IsSealed: false,
-                IsAsync: !isConstructor && function.RequiresAsyncBodyModifier)
+                IsAsync: !isConstructor && function.RequiresAsyncBodyModifier,
+                ConstructorInitializer: targetConstructorInitializer)
         ];
         bool includeRecordSurface = false;
         if (!isConstructor && IsRecordGeneratedFieldReadHelper(reader, targetTypeDef, targetIdentity, methodName, signature, function))
@@ -1217,6 +1240,22 @@ public static class CompileBackSourceComposer
             targetMembers.Add(typedEqualsSibling);
         }
         AddRequiredMembers(targetMembers, closureMemberRequirements, targetType, primaryConstructor);
+        if (targetConstructorInitializer is not null
+            && chainCallee is { } chainCtor
+            && !targetMembers.Any(member => member.Kind == CompileBackMemberKind.Constructor
+                && member.StubBody != CompileBackStubBodyKind.TargetBody
+                && member.Parameters.Count == chainCtor.ParameterTypes.Length))
+        {
+            // The chained-to sibling constructor was not reconstructed in the
+            // shell (e.g. an unsupported parameter signature was dropped), so
+            // `: this(args)` would not bind. Drop the initializer and keep the
+            // body rather than emit an uncompilable chain.
+            int targetIndex = targetMembers.FindIndex(member =>
+                member.Kind == CompileBackMemberKind.Constructor
+                && member.StubBody == CompileBackStubBodyKind.TargetBody);
+            if (targetIndex >= 0)
+                targetMembers[targetIndex] = targetMembers[targetIndex] with { ConstructorInitializer = null };
+        }
         if (includeRecordSurface)
         {
             // AddRequiredMembers above preserves every IR-gathered dependency (including a user
@@ -1512,6 +1551,12 @@ public static class CompileBackSourceComposer
                         new CSharpConstructorInitializer(
                             CSharpConstructorInitializerKind.This,
                             Enumerable.Repeat("default", primaryConstructorParameterCount).ToArray()))),
+            CompileBackStubBodyKind.TargetBody when requirement.Kind == CompileBackMemberKind.Constructor
+                && ParseConstructorInitializer(requirement.ConstructorInitializer) is { } capturedInitializer
+                => new(
+                    member,
+                    CSharpBodyPolicy.Full,
+                    new CSharpBlockBody(requirement.TargetBody!, capturedInitializer)),
             CompileBackStubBodyKind.TargetBody
                 => new(member, CSharpBodyPolicy.Full, new CSharpBlockBody(requirement.TargetBody!)),
             CompileBackStubBodyKind.TargetGetterWithSetter
@@ -1541,6 +1586,61 @@ public static class CompileBackSourceComposer
         => requirement.Kind == CompileBackMemberKind.PropertyGet
             ? new CSharpPropertyBody(body, null)
             : new CSharpPropertyBody(null, body);
+
+    /// <summary>
+    /// Parses a printer-form constructor-chain string (<c>this(args)</c> or
+    /// <c>base(args)</c>, with no leading <c>: </c> or trailing <c>;</c>) into a
+    /// <see cref="CSharpConstructorInitializer"/>. The whole argument list is
+    /// carried as a single initializer argument — the printer already rendered
+    /// it, so no top-level comma split is needed (and splitting would break
+    /// nested calls). Returns null when there is no captured chain.
+    /// </summary>
+    static CSharpConstructorInitializer? ParseConstructorInitializer(string? chain)
+    {
+        if (string.IsNullOrEmpty(chain))
+            return null;
+        var kind = chain.StartsWith("this(", StringComparison.Ordinal)
+            ? CSharpConstructorInitializerKind.This
+            : chain.StartsWith("base(", StringComparison.Ordinal)
+                ? CSharpConstructorInitializerKind.Base
+                : (CSharpConstructorInitializerKind?)null;
+        if (kind is null)
+            return null;
+        int open = chain.IndexOf('(', StringComparison.Ordinal);
+        int close = chain.LastIndexOf(')');
+        if (open < 0 || close <= open)
+            return null;
+        string arguments = chain[(open + 1)..close];
+        return new CSharpConstructorInitializer(
+            kind.Value,
+            arguments.Length == 0 ? [] : [arguments]);
+    }
+
+    /// <summary>
+    /// The base/this <c>.ctor</c> chain call's callee in the entry block, or null
+    /// when the constructor body has no chain call (a struct ctor, or a body that
+    /// never chains). Mirrors the printer's chain-call detection so the shell can
+    /// verify the chained-to constructor was reconstructed before emitting the
+    /// initializer.
+    /// </summary>
+    static MethodRef? ConstructorChainCallee(IrFunction function)
+    {
+        if (function.Body.Blocks is not [{ } entry, ..])
+            return null;
+        foreach (var child in entry.Children)
+        {
+            if (child is ExpressionStatement
+                {
+                    Expression: Call { Callee: { Name: ".ctor", HasThis: true } callee } call
+                }
+                && call.Arguments is [_, ..])
+            {
+                return callee;
+            }
+        }
+
+        return null;
+    }
 
     static CompileBackParameter ToCompileBackParameter(ApiParameter parameter)
         => new(

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1170,7 +1170,8 @@ public static class CompileBackSourceComposer
         if (closureFacts.TryGetValue(targetType, out var targetClosureFacts))
             targetFacts.AddRange(targetClosureFacts);
 
-        var chainCallee = isConstructor ? ConstructorChainCallee(function) : null;
+        var chainCall = isConstructor ? ConstructorChainCall(function) : null;
+        var chainCallee = chainCall?.Callee;
         // Only this(...) self-chains are re-emitted as constructor initializers.
         // RTS shells are flat (object-based, no reconstructed base class), so a
         // base(args) initializer has no base constructor to bind to and would
@@ -1240,34 +1241,42 @@ public static class CompileBackSourceComposer
             targetMembers.Add(typedEqualsSibling);
         }
         AddRequiredMembers(targetMembers, closureMemberRequirements, targetType, primaryConstructor);
-        int nonTargetConstructorCount = targetMembers.Count(member =>
-            member.Kind == CompileBackMemberKind.Constructor
-            && member.StubBody != CompileBackStubBodyKind.TargetBody);
         bool chainedConstructorReconstructed =
             chainCallee is { } chainCtor
+            && chainCall is { } chainCallNode
             // The chained-to constructor is reconstructed only when its signature
             // is fully supported (an unsupported parameter such as a function
             // pointer makes the planner drop it, mirroring MethodRequirement).
             && chainCtor.ParameterTypes.All(type => !IsUnsupportedChainParameterType(type))
-            // The chained-to constructor must be the ONLY reconstructed
-            // constructor in the shell. The printer can render chain arguments
-            // without a disambiguating cast (e.g. a `box` to `object` prints
-            // without the `(object)` cast), and C# overload resolution can bind
-            // across arities (params arrays, optional parameters), so any other
-            // reconstructed constructor — regardless of arity — could silently
-            // hijack the `: this(args)` binding. Emitting only when it is
-            // unambiguous keeps the chain faithful; otherwise fall back to an
-            // empty body.
-            && nonTargetConstructorCount == 1
+            // A same-arity non-target constructor must actually be present in the
+            // shell for `: this(args)` to have a binding target.
             && targetMembers.Any(member => member.Kind == CompileBackMemberKind.Constructor
                 && member.StubBody != CompileBackStubBodyKind.TargetBody
-                && member.Parameters.Count == chainCtor.ParameterTypes.Length);
+                && member.Parameters.Count == chainCtor.ParameterTypes.Length)
+            // The printed `: this(args)` must bind to exactly the chained-to
+            // constructor. Two independent conditions each guarantee that:
+            //
+            //  * Faithful arguments — every argument's printed form already carries
+            //    its parameter's exact type. The printer can drop a disambiguating
+            //    cast (a `box` to `object` prints as its inner value; a reference
+            //    upcast prints bare), so only faithful arguments bind unambiguously
+            //    regardless of the other constructors in the shell (this also
+            //    excludes binding back to the target constructor itself, CS0516).
+            //
+            //  * Unique-arity binding — exactly one constructor in the whole shell
+            //    (the target constructor included) has the chained-to constructor's
+            //    argument count. A normal-form exact-arity match beats any
+            //    params/optional expansion, so `: this(a1..aN)` binds to that sole
+            //    N-arg constructor even when an argument is a bare constant or
+            //    `null` the printer cannot type precisely.
+            && (ChainArgumentsAreFaithful(chainCallNode, chainCtor)
+                || targetMembers.Count(member => member.Kind == CompileBackMemberKind.Constructor
+                    && member.Parameters.Count == chainCtor.ParameterTypes.Length) == 1);
         if (targetConstructorInitializer is not null && !chainedConstructorReconstructed)
         {
-            // The chained-to sibling constructor was not reconstructed in the
-            // shell (or another reconstructed constructor could hijack overload
-            // resolution), so `: this(args)` might not bind, or could silently
-            // bind to the wrong overload (CS1503 or a semantic mismatch). Drop the
+            // The chained-to constructor was not reconstructed in the shell, or the
+            // printed `: this(args)` could not be proven to bind to it (a lossy
+            // argument could bind to a sibling or the target constructor). Drop the
             // initializer and keep the body rather than emit an uncompilable or
             // wrong chain.
             int targetIndex = targetMembers.FindIndex(member =>
@@ -1637,13 +1646,13 @@ public static class CompileBackSourceComposer
     }
 
     /// <summary>
-    /// The base/this <c>.ctor</c> chain call's callee in the entry block, or null
-    /// when the constructor body has no chain call (a struct ctor, or a body that
-    /// never chains). Mirrors the printer's chain-call detection so the shell can
-    /// verify the chained-to constructor was reconstructed before emitting the
-    /// initializer.
+    /// The base/this <c>.ctor</c> chain call in the entry block, or null when the
+    /// constructor body has no chain call (a struct ctor, or a body that never
+    /// chains). Mirrors the printer's chain-call detection so the shell can verify
+    /// the chained-to constructor was reconstructed and its arguments bind
+    /// faithfully before emitting the initializer.
     /// </summary>
-    static MethodRef? ConstructorChainCallee(IrFunction function)
+    static Call? ConstructorChainCall(IrFunction function)
     {
         if (function.Body.Blocks is not [{ } entry, ..])
             return null;
@@ -1651,16 +1660,52 @@ public static class CompileBackSourceComposer
         {
             if (child is ExpressionStatement
                 {
-                    Expression: Call { Callee: { Name: ".ctor", HasThis: true } callee } call
+                    Expression: Call { Callee: { Name: ".ctor", HasThis: true } } call
                 }
                 && call.Arguments is [_, ..])
             {
-                return callee;
+                return call;
             }
         }
 
         return null;
     }
+
+    /// <summary>
+    /// Whether every argument of a constructor-chain call prints in a form that
+    /// binds to exactly the chained-to constructor. The C# printer can drop a
+    /// disambiguating cast (a <c>box</c> to <c>object</c> prints as its inner
+    /// value; a reference upcast prints bare), so a lossy argument could re-bind
+    /// to a different reconstructed constructor — a sibling or the target
+    /// constructor itself. An argument is faithful only when its printed form
+    /// already carries the parameter's exact type: a non-lossy expression whose
+    /// result type structurally equals the parameter type. Faithful arguments
+    /// bind unambiguously regardless of the other constructors in the shell.
+    /// </summary>
+    static bool ChainArgumentsAreFaithful(Call chainCall, MethodRef callee)
+    {
+        var arguments = chainCall.Arguments;
+        // Arguments[0] is the `this` receiver; the ctor arguments follow it.
+        if (arguments.Count - 1 != callee.ParameterTypes.Length)
+            return false;
+        for (int i = 0; i < callee.ParameterTypes.Length; i++)
+        {
+            if (!ChainArgumentIsFaithful(arguments[i + 1], callee.ParameterTypes[i]))
+                return false;
+        }
+
+        return true;
+    }
+
+    static bool ChainArgumentIsFaithful(IrExpression argument, TypeRef parameterType)
+        // Box (prints its inner value, dropping the `(object)` cast), Coerce,
+        // Convert, IsInstance, and bare constants can each be spelled at a static
+        // type other than the parameter's, so overload resolution could bind them
+        // elsewhere. Every other expression prints at its result type, so it is
+        // faithful exactly when that type matches the parameter type.
+        => argument is not (Box or Coerce or ILInspector.Decompiler.Pipeline.Convert or IsInstance or ILInspector.Decompiler.Pipeline.Constant)
+            && argument.ResultType is { } type
+            && type.Equals(parameterType);
 
     /// <summary>
     /// Whether a constructor-chain parameter type would be dropped from the

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1240,29 +1240,36 @@ public static class CompileBackSourceComposer
             targetMembers.Add(typedEqualsSibling);
         }
         AddRequiredMembers(targetMembers, closureMemberRequirements, targetType, primaryConstructor);
+        int nonTargetConstructorCount = targetMembers.Count(member =>
+            member.Kind == CompileBackMemberKind.Constructor
+            && member.StubBody != CompileBackStubBodyKind.TargetBody);
         bool chainedConstructorReconstructed =
             chainCallee is { } chainCtor
             // The chained-to constructor is reconstructed only when its signature
             // is fully supported (an unsupported parameter such as a function
             // pointer makes the planner drop it, mirroring MethodRequirement).
             && chainCtor.ParameterTypes.All(type => !IsUnsupportedChainParameterType(type))
-            // Exactly one same-arity non-target constructor must be present. The
-            // printer can render chain arguments without disambiguating casts
-            // (e.g. a `box` to `object` prints without the `(object)` cast), so if
-            // two same-arity siblings exist the emitted `: this(args)` could
-            // silently bind to the wrong overload. Requiring a unique same-arity
-            // sibling keeps binding unambiguous; otherwise fall back to an empty
-            // body.
-            && targetMembers.Count(member => member.Kind == CompileBackMemberKind.Constructor
+            // The chained-to constructor must be the ONLY reconstructed
+            // constructor in the shell. The printer can render chain arguments
+            // without a disambiguating cast (e.g. a `box` to `object` prints
+            // without the `(object)` cast), and C# overload resolution can bind
+            // across arities (params arrays, optional parameters), so any other
+            // reconstructed constructor — regardless of arity — could silently
+            // hijack the `: this(args)` binding. Emitting only when it is
+            // unambiguous keeps the chain faithful; otherwise fall back to an
+            // empty body.
+            && nonTargetConstructorCount == 1
+            && targetMembers.Any(member => member.Kind == CompileBackMemberKind.Constructor
                 && member.StubBody != CompileBackStubBodyKind.TargetBody
-                && member.Parameters.Count == chainCtor.ParameterTypes.Length) == 1;
+                && member.Parameters.Count == chainCtor.ParameterTypes.Length);
         if (targetConstructorInitializer is not null && !chainedConstructorReconstructed)
         {
             // The chained-to sibling constructor was not reconstructed in the
-            // shell (or is ambiguous with another same-arity sibling), so
-            // `: this(args)` might not bind, or could silently bind to the wrong
-            // overload (CS1503 or a semantic mismatch). Drop the initializer and
-            // keep the body rather than emit an uncompilable or wrong chain.
+            // shell (or another reconstructed constructor could hijack overload
+            // resolution), so `: this(args)` might not bind, or could silently
+            // bind to the wrong overload (CS1503 or a semantic mismatch). Drop the
+            // initializer and keep the body rather than emit an uncompilable or
+            // wrong chain.
             int targetIndex = targetMembers.FindIndex(member =>
                 member.Kind == CompileBackMemberKind.Constructor
                 && member.StubBody == CompileBackStubBodyKind.TargetBody);

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1264,14 +1264,17 @@ public static class CompileBackSourceComposer
             //    excludes binding back to the target constructor itself, CS0516).
             //
             //  * Unique-arity binding — exactly one constructor in the whole shell
-            //    (the target constructor included) has the chained-to constructor's
-            //    argument count. A normal-form exact-arity match beats any
-            //    params/optional expansion, so `: this(a1..aN)` binds to that sole
-            //    N-arg constructor even when an argument is a bare constant or
-            //    `null` the printer cannot type precisely.
+            //    (the target constructor included) can bind to a call with the
+            //    chained-to constructor's argument count. Applicability accounts for
+            //    `params`/optional expansion, not just declared arity: a cross-arity
+            //    `params`/optional sibling can absorb an N-argument call and, for a
+            //    lossy argument (a bare constant or `null`), offer a better
+            //    conversion that steals the bind. Requiring a single applicable
+            //    candidate guarantees `: this(a1..aN)` binds to the chained-to
+            //    constructor even when an argument cannot be typed precisely.
             && (ChainArgumentsAreFaithful(chainCallNode, chainCtor)
                 || targetMembers.Count(member => member.Kind == CompileBackMemberKind.Constructor
-                    && member.Parameters.Count == chainCtor.ParameterTypes.Length) == 1);
+                    && ConstructorCouldBindToArgCount(member, chainCtor.ParameterTypes.Length)) == 1);
         if (targetConstructorInitializer is not null && !chainedConstructorReconstructed)
         {
             // The chained-to constructor was not reconstructed in the shell, or the
@@ -1706,6 +1709,38 @@ public static class CompileBackSourceComposer
         => argument is not (Box or Coerce or ILInspector.Decompiler.Pipeline.Convert or IsInstance or ILInspector.Decompiler.Pipeline.Constant)
             && argument.ResultType is { } type
             && type.Equals(parameterType);
+
+    /// <summary>
+    /// Whether a reconstructed constructor could be an applicable candidate for a
+    /// call with <paramref name="argCount"/> arguments. This is stronger than a
+    /// declared-arity match: a <c>params</c> array absorbs any number of trailing
+    /// arguments (including zero), and optional parameters may be omitted, so a
+    /// constructor of a different nominal arity can still bind an N-argument call.
+    /// The unique-arity guard uses this so a cross-arity <c>params</c>/optional
+    /// sibling that could steal a lossy-argument bind is counted as a competing
+    /// candidate rather than ignored.
+    /// </summary>
+    static bool ConstructorCouldBindToArgCount(CompileBackMemberRequirement member, int argCount)
+    {
+        var parameters = member.Parameters;
+        int total = parameters.Count;
+        bool hasParams = total > 0 && parameters[total - 1].Modifier == "params";
+        // Minimum required arguments: leading parameters that are neither optional
+        // (C# requires all parameters after the first optional to be optional too)
+        // nor the trailing `params` array (which is satisfied by zero arguments).
+        int required = 0;
+        for (int i = 0; i < total; i++)
+        {
+            if (hasParams && i == total - 1)
+                break;
+            if (parameters[i].HasDefault)
+                break;
+            required++;
+        }
+
+        int max = hasParams ? int.MaxValue : total;
+        return argCount >= required && argCount <= max;
+    }
 
     /// <summary>
     /// Whether a constructor-chain parameter type would be dropped from the

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1240,16 +1240,22 @@ public static class CompileBackSourceComposer
             targetMembers.Add(typedEqualsSibling);
         }
         AddRequiredMembers(targetMembers, closureMemberRequirements, targetType, primaryConstructor);
-        if (targetConstructorInitializer is not null
-            && chainCallee is { } chainCtor
-            && !targetMembers.Any(member => member.Kind == CompileBackMemberKind.Constructor
+        bool chainedConstructorReconstructed =
+            chainCallee is { } chainCtor
+            // The chained-to constructor is reconstructed only when its signature
+            // is fully supported (an unsupported parameter such as a function
+            // pointer makes the planner drop it, mirroring MethodRequirement).
+            && chainCtor.ParameterTypes.All(type => !IsUnsupportedChainParameterType(type))
+            && targetMembers.Any(member => member.Kind == CompileBackMemberKind.Constructor
                 && member.StubBody != CompileBackStubBodyKind.TargetBody
-                && member.Parameters.Count == chainCtor.ParameterTypes.Length))
+                && member.Parameters.Count == chainCtor.ParameterTypes.Length);
+        if (targetConstructorInitializer is not null && !chainedConstructorReconstructed)
         {
             // The chained-to sibling constructor was not reconstructed in the
-            // shell (e.g. an unsupported parameter signature was dropped), so
-            // `: this(args)` would not bind. Drop the initializer and keep the
-            // body rather than emit an uncompilable chain.
+            // shell, so `: this(args)` would not bind (it would either fail to
+            // resolve or, worse, silently bind to a same-arity sibling of a
+            // different signature and fail with CS1503). Drop the initializer and
+            // keep the body rather than emit an uncompilable chain.
             int targetIndex = targetMembers.FindIndex(member =>
                 member.Kind == CompileBackMemberKind.Constructor
                 && member.StubBody == CompileBackStubBodyKind.TargetBody);
@@ -1640,6 +1646,21 @@ public static class CompileBackSourceComposer
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Whether a constructor-chain parameter type would be dropped from the
+    /// reconstructed shell (mirrors <c>IsUnsupportedSurfaceSignature</c>): a
+    /// function pointer or a compiler-generated/anonymous type has no faithful
+    /// C# surface, so the chained-to constructor is not reconstructed and a
+    /// <c>: this(args)</c> initializer targeting it cannot bind.
+    /// </summary>
+    static bool IsUnsupportedChainParameterType(TypeRef type)
+    {
+        string display = type.ToDisplayString();
+        return display.Contains("delegate*", StringComparison.Ordinal)
+            || display.Contains("<>", StringComparison.Ordinal)
+            || display.Contains('{', StringComparison.Ordinal);
     }
 
     static CompileBackParameter ToCompileBackParameter(ApiParameter parameter)


### PR DESCRIPTION
- Closes #2678
- Changes ReturnToSender to preserve `this(...)` constructor-chain opcodes; product change to `ConsumedMemberEvidence` is RTS-only (decompiler render output unchanged)
- Evidence revision: `229436cd`

## Change

> Should we accept this harness change?

**Conclusion:** **PASS** — RTS reconstructed target ctors with empty bodies, dropping the chain call the printer lifts into `DecompilerResult.ConstructorChain`; re-emitting it as a `this(...)` initializer, gated by a sound overload-safety predicate, moves 18 ctor rows `OpcodeDiff -> Exact` with zero regressions.

Before (recompiled `NuGetVersion(string)` ctor):

```text
ldarg call ret            # empty body, chain dropped -> Exact -> OpcodeDiff
```

After:

```text
ldarg ldarg call call ret # : this(Parse(version)) preserved -> Exact
```

## Scope and safety

- **Root cause:** `CompileBackSourceComposer.CreateTargetBody` kept only `printed.Output` and discarded `printed.ConstructorChain`, so the target ctor requirement rendered a bare `CSharpBlockBody` with no initializer.
- **Fix shape:** RTS orchestration — thread `ConstructorChain` through `ProductTargetBody` and the target `CompileBackMemberRequirement`, re-emit via `CSharpConstructorInitializer`. Restrict to `this(...)` self-chains (flat shells have no reconstructed base class, so `base(args)` -> CS1729).
- **Overload-safety gate (the core of adversarial rounds 1–7):** the printer can drop disambiguating casts (`CSharpPrinter.Numerics.cs` `CoerceText`, unmodified here), so a re-emitted `: this(args)` could bind to the wrong constructor (a sibling, or the target itself -> CS0516). The initializer is emitted **only** when the chained-to ctor's parameter types are all supported, a same-arity non-target ctor is present, **and either**:
  1. **Faithful args** — every argument is a non-lossy, non-target-typed expression whose result type structurally equals its parameter type (excludes `Box`/`Coerce`/`Convert`/`IsInstance`/`Constant`, which the printer can spell at a different static type, and the target-typed `Lambda`/`CollectionExpression`/`TupleExpression`/`InterpolatedStringExpression`, whose `ResultType` proves nothing about binding); **or**
  2. **Unique applicable candidate** — exactly one constructor in the whole shell (target included) is *applicable* to an N-argument call, modelling `params` absorption and optional-parameter omission (`ConstructorCouldBindToArgCount`), not just declared arity.
  The failure direction is conservative throughout: can't prove the bind -> drop the initializer -> the pre-PR empty-body OpcodeDiff, never a wrong bind.
- **Product impact:** `ConsumedMemberEvidence` now seeds `.ctor` Call callees with `AllowTargetRoot` so the flat shell reconstructs the chained-to sibling ctor. This layer is consumed only by ReturnToSender — decompiler render output is unchanged.
- **RTS boundary:** RTS only orchestrates closure + Roslyn + opcode compare; the printer/shared code owns chain lifting and C# source generation.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `ReturnToSenderPrototypeTests` (107), `ConsumedMemberEvidenceTests` (8) passed |
| Regression tests | `PreservesThisConstructorChainOpcodes`, `PreservesConstructorChainWhenArityIsUnique` (Exact); `DropsInitializerWhenChainedConstructorUnreconstructable` / `...IsOverloadAmbiguous` / `...ChainBindsToTargetConstructor` / `...CrossArityParamsSiblingCanBind` / `...ChainArgumentIsAmbiguousLambda` (strip) passed |
| Deterministic probe | `OpcodeDiff -> Exact: 18`; total `OpcodeDiff` 30 -> 12; `RecompileFail` 63 -> 63 (no regressions) |

## Compile-back quality

**Conclusion:** **PASS** — 18 ctor `OpcodeDiff -> Exact`, zero new `RecompileFail`.

Run at head `229436cd`: `NuGet.Versioning.dll` (7.3.0 net8.0), `--corpus-fidelity-cap 500 --corpus-fidelity-oracle return-to-sender --sequential`.

```text
BASE: Exact 118, OpcodeDiff 30, RecompileFail 63, not-sampled 98
FIX : Exact 136, OpcodeDiff 12, RecompileFail 63, not-sampled 98

ctor BASE: OpcodeDiff 24, Exact 12, RecompileFail 3, not-sampled 14
ctor FIX : OpcodeDiff  6, Exact 30, RecompileFail 3, not-sampled 14

Transitions: OpcodeDiff -> Exact: 18   (no other transitions)
```

### Why 18, not the 21 of the first head

The first head (`1c121952`) emitted the chain from a weaker guard and scored 21 wins. Adversarial rounds 1–7 proved that guard could bind to the wrong overload (sibling hijack, self-referential CS0516, cross-arity `params` hijack, typeless-lambda ambiguity), so the gate was tightened to the sound faithful-args / unique-applicable-candidate predicate above. That stricter proof preserves **18** of the 21 (their arguments are provably faithful, e.g. `this(Parse(version))` where `Parse` returns the parameter type exactly, or their arity is uniquely applicable) and conservatively declines **3** `SemanticVersion` chains that pass a `string[]` argument to an `IEnumerable<string>` parameter alongside a same-arity `(Version, string, string)` sibling — not faithful (`string[]` != `IEnumerable<string>`) and not unique-applicable. Those 3 stay at the **pre-PR OpcodeDiff baseline** (they were OpcodeDiff before, still OpcodeDiff now) — a documented sound miss, **not a regression**. Proving `string[]` cannot bind to the sibling's `string` parameter would need a full type model.

Remaining ctor OpcodeDiffs at head (all pre-existing / by design / sound-miss — none are regressions):

```text
NuGet.SimplePool`1::.ctor                                                    # field-initializer lift (out of scope)
NuGet.StringBuilderPool::.ctor                                              # field-initializer lift (out of scope)
NuGet.Versioning.NuGetVersion(Version, IEnumerable<string>, string, string) # base(...) chain, flat shell -> left empty
NuGet.Versioning.SemanticVersion(int, int, int, string, ...)  x2            # string[] -> IEnumerable<string> sound miss
NuGet.Versioning.SemanticVersion(Version, string, string)                   # string[] -> IEnumerable<string> sound miss
```

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `base(...)` chains in flat shells | Left as frontier | RTS shells are object-based; no base class to bind `base(args)` to (CS1729). Left empty as before. |
| Field-initializer ctors (`SimplePool`, `StringBuilderPool`) | Not changed | Different lifting (`FieldInitializers`); would need separate support. |
| `string[]` -> `IEnumerable<string>` chains (3 `SemanticVersion` ctors) | Conservative miss | Not provably faithful and not unique-applicable; stays at pre-PR OpcodeDiff baseline. No correctness risk; proving safety needs a full type model. |

## Review

Adversarial review per policy — two reviewers from model families other than my own (Claude Opus 4.8). Both **CLEAN on the final head `229436cd`**; every finding across rounds 1–7 was verified and resolved by a commit (`fc4065dc`, `fdc86627`, `9e4f805a`, `1128d5c8`, `d2a50bd9`, `229436cd`). See the round-5→7 reconciliation comment for the full trail.

| Reviewer | Result | Notes |
| --- | --- | --- |
| GPT-5.5 | CLEAN | Forced rebuilds; 107 RTS + 8 CME tests; probe `OpcodeDiff -> Exact: 18`, RF 63; stackalloc/span + target-typed probes clean |
| Gemini 3.1 Pro | CLEAN | Verified target-typed exclusion set complete; adversarial `decimal.One` (preserved Exact) + lossy `short` (stripped) fixtures; both branches sound |

**Review conclusion:** **PASS** — two CLEAN reviews on the final head.

## Validation

```bash
dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config
dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "ILInspector.Decompiler.Tests.ReturnToSenderPrototypeTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "ILInspector.Decompiler.Tests.ConsumedMemberEvidenceTests"
dotnet run --project tools/DecompilerHarness -c Release --no-build -- "$HOME/.nuget/packages/nuget.versioning/7.3.0/lib/net8.0/NuGet.Versioning.dll" --emit-corpus-snapshot /tmp/out.json --compile-cap 0 --corpus-fidelity-cap 500 --corpus-fidelity-oracle return-to-sender --sequential --max-examples 3
```
