### PR TITLE
Harden Instructions signature decoding against deep blobs

### DIFF
--- a/src/ILInspector.Instructions.Tests/SignatureDecoderSafetyTests.cs
+++ b/src/ILInspector.Instructions.Tests/SignatureDecoderSafetyTests.cs
@@ -1,0 +1,409 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Instructions.Tests;
+
+public class SignatureDecoderSafetyTests
+{
+    const string WorkerVariable = "DOTNET_INSPECT_INSTRUCTIONS_SIGNATURE_WORKER";
+
+    [Fact]
+    public void DeepAndCyclicSignatures_ThroughAssemblyDiff_AreContainedInChildProcess()
+        => RunWorker(nameof(AssemblyDiffWorker));
+
+    [Fact]
+    public void DeepAndCyclicSignatures_ThroughStackResolver_AreContainedInChildProcess()
+        => RunWorker(nameof(StackResolverWorker));
+
+    [Fact]
+    public void AssemblyDiffWorker()
+    {
+        if (!IsSelectedWorker(nameof(AssemblyDiffWorker)))
+            return;
+
+        var image = BuildAdversarialImage();
+        using var oldStream = new MemoryStream(image);
+        using var newStream = new MemoryStream(image);
+
+        var result = IlAssemblyDiff.CompareStreams(
+            oldStream,
+            "old.dll",
+            newStream,
+            "new.dll");
+
+        Assert.True(result.Diff.ComparedBodyCount > 0);
+        Assert.Equal(0, result.Diff.FailureCount);
+
+        using var oneOverload = new MemoryStream(BuildRejectedOverloadImage(methodCount: 1));
+        using var twoOverloads = new MemoryStream(BuildRejectedOverloadImage(methodCount: 2));
+        var overloadResult = IlAssemblyDiff.CompareStreams(
+            oneOverload,
+            "one.dll",
+            twoOverloads,
+            "two.dll");
+
+        Assert.Equal(1, overloadResult.Diff.FailureCount);
+
+        var unshifted = BuildShiftedGuardedMethodImage(addPrefixMethod: false);
+        var shifted = BuildShiftedGuardedMethodImage(addPrefixMethod: true);
+        using var unshiftedStream = new MemoryStream(unshifted);
+        using var shiftedStream = new MemoryStream(shifted);
+        var shiftedResult = IlAssemblyDiff.CompareStreams(
+            unshiftedStream,
+            "unshifted.dll",
+            shiftedStream,
+            "shifted.dll");
+
+        Assert.Equal(1, shiftedResult.Diff.FailureCount);
+        Assert.Equal(1, shiftedResult.Diff.PairExactCount);
+
+        using var oldPe = new PEReader(new MemoryStream(unshifted));
+        using var newPe = new PEReader(new MemoryStream(shifted));
+        var oldReader = oldPe.GetMetadataReader();
+        var newReader = newPe.GetMetadataReader();
+        var memberResult = IlAssemblyDiff.CompareMembers(
+            oldPe,
+            oldReader,
+            FindMethod(oldReader, "Caller"),
+            newPe,
+            newReader,
+            FindMethod(newReader, "Caller"));
+
+        Assert.True(memberResult.Diff.IsExact);
+    }
+
+    [Fact]
+    public void StackResolverWorker()
+    {
+        if (!IsSelectedWorker(nameof(StackResolverWorker)))
+            return;
+
+        var image = BuildAdversarialImage();
+        using var pe = new PEReader(new MemoryStream(image));
+        var reader = pe.GetMetadataReader();
+        var entryHandle = FindMethod(reader, "Entry");
+        var entry = reader.GetMethodDefinition(entryHandle);
+        var body = pe.GetMethodBody(entry.RelativeVirtualAddress);
+        var resolver = MetadataStackTypeResolver.Create(reader, entryHandle, body);
+
+        Assert.Equal(StackType.Unknown, resolver.Field(MetadataTokens.GetToken(MetadataTokens.FieldDefinitionHandle(1))));
+        Assert.Equal(StackType.Unknown, resolver.Field(MetadataTokens.GetToken(MetadataTokens.MemberReferenceHandle(2))));
+        _ = resolver.TypeOfToken(MetadataTokens.GetToken(MetadataTokens.TypeSpecificationHandle(1)));
+        Assert.False(resolver.TryResolveCall(
+            MetadataTokens.GetToken(MetadataTokens.MethodDefinitionHandle(1)),
+            isNewObj: false,
+            out _,
+            out _,
+            out _));
+        Assert.False(resolver.TryResolveCall(
+            MetadataTokens.GetToken(MetadataTokens.MemberReferenceHandle(1)),
+            isNewObj: false,
+            out _,
+            out _,
+            out _));
+        Assert.False(resolver.TryResolveCalli(
+            MetadataTokens.GetToken(MetadataTokens.StandaloneSignatureHandle(2)),
+            out _,
+            out _,
+            out _));
+
+        var stack = MethodInstructions.Decode(body).InterpretStack(reader, entryHandle, body);
+        Assert.False(stack.IsComplete);
+        Assert.Contains("Unresolved Call signature", stack.IncompleteReason, StringComparison.Ordinal);
+    }
+
+    static bool IsSelectedWorker(string methodName)
+        => Environment.GetEnvironmentVariable(WorkerVariable) == methodName;
+
+    static void RunWorker(string workerMethod)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add(typeof(SignatureDecoderSafetyTests).Assembly.Location);
+        startInfo.ArgumentList.Add("-method");
+        startInfo.ArgumentList.Add($"*{workerMethod}*");
+        startInfo.Environment[WorkerVariable] = workerMethod;
+
+        using var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+        var standardOutputTask = process.StandardOutput.ReadToEndAsync();
+        var standardErrorTask = process.StandardError.ReadToEndAsync();
+        process.WaitForExit();
+        string standardOutput = standardOutputTask.GetAwaiter().GetResult();
+        string standardError = standardErrorTask.GetAwaiter().GetResult();
+
+        Assert.True(
+            process.ExitCode == 0,
+            $"Child worker {workerMethod} exited {process.ExitCode}.\nstdout:\n{standardOutput}\nstderr:\n{standardError}");
+    }
+
+    static byte[] BuildAdversarialImage()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("Synthetic.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Synthetic"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        var type = metadata.AddTypeDefinition(
+            TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed,
+            default,
+            metadata.GetOrAddString("C"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        var cyclicTypeSpec = new BlobBuilder();
+        cyclicTypeSpec.WriteByte(0x1f); // CMOD_REQD
+        cyclicTypeSpec.WriteByte(0x06); // TypeDefOrRefOrSpec: TypeSpec row 1
+        cyclicTypeSpec.WriteByte(0x08); // I4
+        var cyclicTypeSpecHandle = metadata.AddTypeSpecification(metadata.GetOrAddBlob(cyclicTypeSpec));
+
+        var deepFieldSignature = DeepSignature(header: 0x06, count: null);
+        var field = metadata.AddFieldDefinition(
+            FieldAttributes.Public | FieldAttributes.Static,
+            metadata.GetOrAddString("DeepField"),
+            metadata.GetOrAddBlob(deepFieldSignature));
+
+        var deepMethodSignature = DeepSignature(header: 0x00, count: 0);
+        var deepMethod = metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Static,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("DeepMethod"),
+            metadata.GetOrAddBlob(deepMethodSignature),
+            bodyOffset: -1,
+            parameterList: MetadataTokens.ParameterHandle(1));
+
+        var cyclicMethodSignature = new BlobBuilder();
+        cyclicMethodSignature.WriteByte(0x00); // default method signature
+        cyclicMethodSignature.WriteByte(0x00); // zero parameters
+        cyclicMethodSignature.WriteByte(0x1f); // CMOD_REQD
+        cyclicMethodSignature.WriteByte(0x06); // TypeDefOrRefOrSpec: TypeSpec row 1
+        cyclicMethodSignature.WriteByte(0x08); // I4
+        var cyclicMethod = metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Static,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("CyclicMethod"),
+            metadata.GetOrAddBlob(cyclicMethodSignature),
+            bodyOffset: -1,
+            parameterList: MetadataTokens.ParameterHandle(1));
+
+        var deepMember = metadata.AddMemberReference(
+            type,
+            metadata.GetOrAddString("DeepMember"),
+            metadata.GetOrAddBlob(DeepSignature(header: 0x00, count: 0)));
+        var deepFieldMember = metadata.AddMemberReference(
+            type,
+            metadata.GetOrAddString("DeepFieldMember"),
+            metadata.GetOrAddBlob(DeepSignature(header: 0x06, count: null)));
+
+        var deepMethodSpecSignature = DeepSignature(header: 0x0a, count: 1);
+        var methodSpec = metadata.AddMethodSpecification(
+            deepMethod,
+            metadata.GetOrAddBlob(deepMethodSpecSignature));
+
+        var deepLocalSignature = DeepSignature(header: 0x07, count: 1);
+        var localSignature = metadata.AddStandaloneSignature(metadata.GetOrAddBlob(deepLocalSignature));
+        var calliSignature = metadata.AddStandaloneSignature(metadata.GetOrAddBlob(DeepSignature(header: 0x00, count: 0)));
+
+        var il = new BlobBuilder();
+        var instructions = new InstructionEncoder(il, new ControlFlowBuilder());
+        instructions.OpCode(ILOpCode.Ldsfld);
+        instructions.Token(field);
+        instructions.OpCode(ILOpCode.Pop);
+        instructions.Call(deepMethod);
+        instructions.OpCode(ILOpCode.Pop);
+        instructions.Call(cyclicMethod);
+        instructions.OpCode(ILOpCode.Pop);
+        instructions.Call(deepMember);
+        instructions.OpCode(ILOpCode.Pop);
+        instructions.OpCode(ILOpCode.Ldsfld);
+        instructions.Token(deepFieldMember);
+        instructions.OpCode(ILOpCode.Pop);
+        instructions.Call(methodSpec);
+        instructions.OpCode(ILOpCode.Pop);
+        instructions.OpCode(ILOpCode.Ldtoken);
+        instructions.Token(cyclicTypeSpecHandle);
+        instructions.OpCode(ILOpCode.Pop);
+        instructions.OpCode(ILOpCode.Ldc_i4_0);
+        instructions.OpCode(ILOpCode.Conv_i);
+        instructions.OpCode(ILOpCode.Calli);
+        instructions.Token(calliSignature);
+        instructions.OpCode(ILOpCode.Ret);
+
+        var methodBodies = new BlobBuilder();
+        var bodyEncoder = new MethodBodyStreamEncoder(methodBodies);
+        int entryBodyOffset = bodyEncoder.AddMethodBody(
+            instructions,
+            maxStack: 8,
+            localSignature,
+            MethodBodyAttributes.InitLocals);
+        metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Static,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("Entry"),
+            metadata.GetOrAddBlob(new byte[] { 0x00, 0x00, 0x01 }),
+            entryBodyOffset,
+            MetadataTokens.ParameterHandle(1));
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            methodBodies,
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    static BlobBuilder DeepSignature(byte header, int? count)
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(header);
+        if (count is int value)
+            signature.WriteCompressedInteger(value);
+        for (int i = 0; i < 100_000; i++)
+            signature.WriteByte(0x1d); // SZARRAY
+        signature.WriteByte(0x08); // I4
+        return signature;
+    }
+
+    static byte[] BuildRejectedOverloadImage(int methodCount)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("Overloads.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Overloads"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed,
+            default,
+            metadata.GetOrAddString("C"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        for (int i = 0; i < methodCount; i++)
+        {
+            metadata.AddMethodDefinition(
+                MethodAttributes.Public | MethodAttributes.Static,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("M"),
+                metadata.GetOrAddBlob(DeepSignature(header: 0x00, count: 0)),
+                bodyOffset: -1,
+                parameterList: MetadataTokens.ParameterHandle(1));
+        }
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    static byte[] BuildShiftedGuardedMethodImage(bool addPrefixMethod)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("Shifted.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Shifted"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed,
+            default,
+            metadata.GetOrAddString("C"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        if (addPrefixMethod)
+        {
+            metadata.AddMethodDefinition(
+                MethodAttributes.Public | MethodAttributes.Static,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Dummy"),
+                metadata.GetOrAddBlob(new byte[] { 0x00, 0x00, 0x01 }),
+                bodyOffset: -1,
+                parameterList: MetadataTokens.ParameterHandle(1));
+        }
+
+        var guarded = metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Static,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("Guarded"),
+            metadata.GetOrAddBlob(DeepSignature(header: 0x00, count: 0)),
+            bodyOffset: -1,
+            parameterList: MetadataTokens.ParameterHandle(1));
+
+        var il = new BlobBuilder();
+        var instructions = new InstructionEncoder(il, new ControlFlowBuilder());
+        instructions.Call(guarded);
+        instructions.OpCode(ILOpCode.Pop);
+        instructions.OpCode(ILOpCode.Ret);
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = new MethodBodyStreamEncoder(methodBodies).AddMethodBody(instructions, maxStack: 1);
+        metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Static,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("Caller"),
+            metadata.GetOrAddBlob(new byte[] { 0x00, 0x00, 0x01 }),
+            bodyOffset,
+            MetadataTokens.ParameterHandle(1));
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            methodBodies,
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    static MethodDefinitionHandle FindMethod(MetadataReader reader, string name)
+    {
+        foreach (var handle in reader.MethodDefinitions)
+        {
+            if (reader.GetString(reader.GetMethodDefinition(handle).Name) == name)
+                return handle;
+        }
+
+        throw new InvalidOperationException($"Method {name} not found.");
+    }
+}

--- a/src/ILInspector.Instructions/GuardedProviderDecode.cs
+++ b/src/ILInspector.Instructions/GuardedProviderDecode.cs
@@ -1,0 +1,214 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Security.Cryptography;
+
+using ILInspector.Metadata;
+
+namespace ILInspector.Instructions;
+
+/// <summary>
+/// Prescans top-level signature blobs and bounds nested TypeSpec re-entry before
+/// handing attacker-controlled metadata to SRM's recursive signature decoder.
+/// </summary>
+internal static class GuardedProviderDecode
+{
+    public static MethodSignature<T> Method<T, TContext>(
+        MetadataReader reader,
+        MethodDefinition method,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        T fallbackReturn)
+        => TryMethod(reader, method, provider, context, out var signature)
+            ? signature
+            : FallbackSignature(fallbackReturn);
+
+    public static bool TryMethod<T, TContext>(
+        MetadataReader reader,
+        MethodDefinition method,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        out MethodSignature<T> signature)
+    {
+        var result = SignatureBlobGuard.IsSafeToDecode(reader, method.Signature, SignatureBlobGuard.Kind.Method)
+            ? (Safe: true, Signature: method.DecodeSignature(provider, context))
+            : (Safe: false, Signature: default(MethodSignature<T>));
+        signature = result.Signature;
+        return result.Safe;
+    }
+
+    public static MethodSignature<T> MemberRefMethod<T, TContext>(
+        MetadataReader reader,
+        MemberReference member,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        T fallbackReturn)
+        => TryMemberRefMethod(reader, member, provider, context, out var signature)
+            ? signature
+            : FallbackSignature(fallbackReturn);
+
+    public static bool TryMemberRefMethod<T, TContext>(
+        MetadataReader reader,
+        MemberReference member,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        out MethodSignature<T> signature)
+    {
+        var result = SignatureBlobGuard.IsSafeToDecode(reader, member.Signature, SignatureBlobGuard.Kind.Method)
+            ? (Safe: true, Signature: member.DecodeMethodSignature(provider, context))
+            : (Safe: false, Signature: default(MethodSignature<T>));
+        signature = result.Signature;
+        return result.Safe;
+    }
+
+    public static MethodSignature<T> StandaloneMethod<T, TContext>(
+        MetadataReader reader,
+        StandaloneSignature signature,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        T fallbackReturn)
+        => TryStandaloneMethod(reader, signature, provider, context, out var decoded)
+            ? decoded
+            : FallbackSignature(fallbackReturn);
+
+    public static bool TryStandaloneMethod<T, TContext>(
+        MetadataReader reader,
+        StandaloneSignature signature,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        out MethodSignature<T> decoded)
+    {
+        var result = SignatureBlobGuard.IsSafeToDecode(reader, signature.Signature, SignatureBlobGuard.Kind.Method)
+            ? (Safe: true, Signature: signature.DecodeMethodSignature(provider, context))
+            : (Safe: false, Signature: default(MethodSignature<T>));
+        decoded = result.Signature;
+        return result.Safe;
+    }
+
+    public static T Field<T, TContext>(
+        MetadataReader reader,
+        FieldDefinition field,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        T fallback)
+        => TryField(reader, field, provider, context, out var decoded)
+            ? decoded
+            : fallback;
+
+    public static bool TryField<T, TContext>(
+        MetadataReader reader,
+        FieldDefinition field,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        out T decoded)
+    {
+        var result = SignatureBlobGuard.IsSafeToDecode(reader, field.Signature, SignatureBlobGuard.Kind.Field)
+            ? (Safe: true, Value: field.DecodeSignature(provider, context))
+            : (Safe: false, Value: default(T)!);
+        decoded = result.Value;
+        return result.Safe;
+    }
+
+    public static T MemberRefField<T, TContext>(
+        MetadataReader reader,
+        MemberReference member,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        T fallback)
+        => TryMemberRefField(reader, member, provider, context, out var decoded)
+            ? decoded
+            : fallback;
+
+    public static bool TryMemberRefField<T, TContext>(
+        MetadataReader reader,
+        MemberReference member,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        out T decoded)
+    {
+        var result = SignatureBlobGuard.IsSafeToDecode(reader, member.Signature, SignatureBlobGuard.Kind.Field)
+            ? (Safe: true, Value: member.DecodeFieldSignature(provider, context))
+            : (Safe: false, Value: default(T)!);
+        decoded = result.Value;
+        return result.Safe;
+    }
+
+    public static ImmutableArray<T> LocalVariables<T, TContext>(
+        MetadataReader reader,
+        StandaloneSignature signature,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context)
+        => SignatureBlobGuard.IsSafeToDecode(reader, signature.Signature, SignatureBlobGuard.Kind.LocalVariables)
+            ? signature.DecodeLocalSignature(provider, context)
+            : ImmutableArray<T>.Empty;
+
+    public static ImmutableArray<T> MethodSpec<T, TContext>(
+        MetadataReader reader,
+        MethodSpecification specification,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        ImmutableArray<T> fallback)
+        => TryMethodSpec(reader, specification, provider, context, out var decoded)
+            ? decoded
+            : fallback;
+
+    public static bool TryMethodSpec<T, TContext>(
+        MetadataReader reader,
+        MethodSpecification specification,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        out ImmutableArray<T> decoded)
+    {
+        var result = SignatureBlobGuard.IsSafeToDecode(
+                reader,
+                specification.Signature,
+                SignatureBlobGuard.Kind.MethodSpecification)
+            ? (Safe: true, Value: specification.DecodeSignature(provider, context))
+            : (Safe: false, Value: ImmutableArray<T>.Empty);
+        decoded = result.Value;
+        return result.Safe;
+    }
+
+    public static T TypeSpec<T, TContext>(
+        MetadataReader reader,
+        TypeSpecificationHandle handle,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        T fallback)
+        => TryTypeSpec(reader, handle, provider, context, out var decoded)
+            ? decoded
+            : fallback;
+
+    public static bool TryTypeSpec<T, TContext>(
+        MetadataReader reader,
+        TypeSpecificationHandle handle,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        out T decoded)
+    {
+        if (!TypeSpecGuard.TryEnter(reader, handle, out int blobLength))
+        {
+            decoded = default!;
+            return false;
+        }
+
+        try
+        {
+            decoded = reader.GetTypeSpecification(handle).DecodeSignature(provider, context);
+            return true;
+        }
+        finally
+        {
+            TypeSpecGuard.Exit(blobLength);
+        }
+    }
+
+    public static string RejectedIdentity(MetadataReader reader, BlobHandle signature)
+    {
+        Span<byte> hash = stackalloc byte[32];
+        SHA256.HashData(reader.GetBlobBytes(signature), hash);
+        return $"<unsupported-signature:{Convert.ToHexString(hash)}>";
+    }
+
+    public static MethodSignature<T> FallbackSignature<T>(T fallbackReturn)
+        => new(default, fallbackReturn, requiredParameterCount: 0, genericParameterCount: 0, ImmutableArray<T>.Empty);
+}

--- a/src/ILInspector.Instructions/ILInspector.Instructions.csproj
+++ b/src/ILInspector.Instructions/ILInspector.Instructions.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ILInspector.Findings\ILInspector.Findings.csproj" />
     <ProjectReference Include="..\ILInspector.ControlFlow\ILInspector.ControlFlow.csproj" />
+    <ProjectReference Include="..\ILInspector.MetadataPrimitives\ILInspector.MetadataPrimitives.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ILInspector.Instructions/IlAssemblyDiff.cs
+++ b/src/ILInspector.Instructions/IlAssemblyDiff.cs
@@ -39,6 +39,11 @@ public sealed record IlMemberDiffResult(
 /// </summary>
 public static class IlAssemblyDiff
 {
+    readonly record struct MethodMapKey(string Identity, int Occurrence)
+    {
+        public string Display => Occurrence == 1 ? Identity : $"{Identity}#occurrence:{Occurrence}";
+    }
+
     public static IlAssemblyDiffPairResult CompareFiles(
         string oldPath,
         string newPath,
@@ -86,7 +91,11 @@ public static class IlAssemblyDiff
 
         var oldMethods = MethodMap(oldReader);
         var newMethods = MethodMap(newReader);
-        var keys = oldMethods.Keys.Union(newMethods.Keys, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray();
+        var keys = oldMethods.Keys
+            .Union(newMethods.Keys)
+            .OrderBy(key => key.Identity, StringComparer.Ordinal)
+            .ThenBy(key => key.Occurrence)
+            .ToArray();
         var failures = new Dictionary<string, int>(StringComparer.Ordinal);
         var hunkKinds = new Dictionary<string, int>(StringComparer.Ordinal);
         var opcodeFamilies = new Dictionary<string, int>(StringComparer.Ordinal);
@@ -97,7 +106,7 @@ public static class IlAssemblyDiff
         int changed = 0;
         int selfDiffExact = 0;
 
-        foreach (string key in keys)
+        foreach (var key in keys)
         {
             if (!oldMethods.TryGetValue(key, out var oldHandle))
             {
@@ -173,7 +182,7 @@ public static class IlAssemblyDiff
             }
 
             if (examples.Count < maxExamples)
-                examples.Add(new IlAssemblyDiffExample(key, diff));
+                examples.Add(new IlAssemblyDiffExample(key.Display, diff));
         }
 
         return new IlAssemblyDiffResult(
@@ -244,14 +253,17 @@ public static class IlAssemblyDiff
         }
     }
 
-    static Dictionary<string, MethodDefinitionHandle> MethodMap(MetadataReader reader)
+    static Dictionary<MethodMapKey, MethodDefinitionHandle> MethodMap(MetadataReader reader)
     {
-        var methods = new Dictionary<string, MethodDefinitionHandle>(StringComparer.Ordinal);
+        var methods = new Dictionary<MethodMapKey, MethodDefinitionHandle>();
+        var occurrences = new Dictionary<string, int>(StringComparer.Ordinal);
         foreach (var handle in reader.MethodDefinitions)
         {
             var method = reader.GetMethodDefinition(handle);
-            string key = MethodKey(reader, method);
-            methods.TryAdd(key, handle);
+            string identity = MethodKey(reader, method);
+            int occurrence = occurrences.TryGetValue(identity, out int count) ? count + 1 : 1;
+            occurrences[identity] = occurrence;
+            methods.Add(new MethodMapKey(identity, occurrence), handle);
         }
 
         return methods;
@@ -261,7 +273,15 @@ public static class IlAssemblyDiff
     {
         string type = TypeName(reader, method.GetDeclaringType());
         string name = reader.GetString(method.Name);
-        var signature = method.DecodeSignature(SignatureIdentityProvider.Instance, genericContext: null);
+        if (!GuardedProviderDecode.TryMethod(
+            reader,
+            method,
+            SignatureIdentityProvider.Instance,
+            context: null,
+            out var signature))
+        {
+            return $"{type}::{name}#{GuardedProviderDecode.RejectedIdentity(reader, method.Signature)}";
+        }
         string instance = signature.Header.IsInstance ? "instance" : "static";
         string genericArity = signature.GenericParameterCount > 0 ? $"<{signature.GenericParameterCount}>" : "";
         string signatureText = $"{instance} {signature.ReturnType}({string.Join(", ", signature.ParameterTypes)})";
@@ -349,7 +369,17 @@ sealed class SignatureIdentityProvider : ISignatureTypeProvider<string, object?>
     }
 
     public string GetTypeFromSpecification(MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
-        => reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+    {
+        var specification = reader.GetTypeSpecification(handle);
+        return GuardedProviderDecode.TryTypeSpec(
+            reader,
+            handle,
+            this,
+            genericContext,
+            out var decoded)
+            ? decoded
+            : GuardedProviderDecode.RejectedIdentity(reader, specification.Signature);
+    }
 
     public string GetSZArrayType(string elementType) => $"{elementType}[]";
     public string GetArrayType(string elementType, ArrayShape shape) => $"{elementType}[{new string(',', Math.Max(shape.Rank - 1, 0))}]";

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -577,7 +577,15 @@ public static class IlBodyDiff
         string FormatMethodDefinition(MethodDefinitionHandle handle)
         {
             var method = reader.GetMethodDefinition(handle);
-            var signature = method.DecodeSignature(SignatureIdentityProvider.Instance, genericContext: null);
+            var signature = GuardedProviderDecode.TryMethod(
+                reader,
+                method,
+                SignatureIdentityProvider.Instance,
+                context: null,
+                out var decoded)
+                ? decoded
+                : GuardedProviderDecode.FallbackSignature(
+                    GuardedProviderDecode.RejectedIdentity(reader, method.Signature));
             return FormatCall(signature, FormatType(method.GetDeclaringType()), reader.GetString(method.Name), genericArgs: null);
         }
 
@@ -587,14 +595,29 @@ public static class IlBodyDiff
             if (member.GetKind() != MemberReferenceKind.Method)
                 throw new BadImageFormatException("Expected method member reference.");
 
-            var signature = member.DecodeMethodSignature(SignatureIdentityProvider.Instance, genericContext: null);
+            var signature = GuardedProviderDecode.TryMemberRefMethod(
+                reader,
+                member,
+                SignatureIdentityProvider.Instance,
+                context: null,
+                out var decoded)
+                ? decoded
+                : GuardedProviderDecode.FallbackSignature(
+                    GuardedProviderDecode.RejectedIdentity(reader, member.Signature));
             return FormatCall(signature, FormatMemberParent(member.Parent), reader.GetString(member.Name), genericArgs: null);
         }
 
         string FormatMethodSpecification(MethodSpecificationHandle handle)
         {
             var spec = reader.GetMethodSpecification(handle);
-            var typeArguments = spec.DecodeSignature(SignatureIdentityProvider.Instance, genericContext: null);
+            var typeArguments = GuardedProviderDecode.TryMethodSpec(
+                reader,
+                spec,
+                SignatureIdentityProvider.Instance,
+                context: null,
+                out var decoded)
+                ? decoded
+                : [GuardedProviderDecode.RejectedIdentity(reader, spec.Signature)];
             string genericArgs = $"<{string.Join(", ", typeArguments)}>";
 
             return spec.Method.Kind switch
@@ -608,21 +631,44 @@ public static class IlBodyDiff
         string FormatMethodSpecificationDefinition(MethodDefinitionHandle handle, string genericArgs)
         {
             var method = reader.GetMethodDefinition(handle);
-            var signature = method.DecodeSignature(SignatureIdentityProvider.Instance, genericContext: null);
+            var signature = GuardedProviderDecode.TryMethod(
+                reader,
+                method,
+                SignatureIdentityProvider.Instance,
+                context: null,
+                out var decoded)
+                ? decoded
+                : GuardedProviderDecode.FallbackSignature(
+                    GuardedProviderDecode.RejectedIdentity(reader, method.Signature));
             return FormatCall(signature, FormatType(method.GetDeclaringType()), reader.GetString(method.Name), genericArgs);
         }
 
         string FormatMethodSpecificationReference(MemberReferenceHandle handle, string genericArgs)
         {
             var member = reader.GetMemberReference(handle);
-            var signature = member.DecodeMethodSignature(SignatureIdentityProvider.Instance, genericContext: null);
+            var signature = GuardedProviderDecode.TryMemberRefMethod(
+                reader,
+                member,
+                SignatureIdentityProvider.Instance,
+                context: null,
+                out var decoded)
+                ? decoded
+                : GuardedProviderDecode.FallbackSignature(
+                    GuardedProviderDecode.RejectedIdentity(reader, member.Signature));
             return FormatCall(signature, FormatMemberParent(member.Parent), reader.GetString(member.Name), genericArgs);
         }
 
         string FormatFieldDefinition(FieldDefinitionHandle handle)
         {
             var field = reader.GetFieldDefinition(handle);
-            string fieldType = field.DecodeSignature(SignatureIdentityProvider.Instance, genericContext: null);
+            string fieldType = GuardedProviderDecode.TryField(
+                reader,
+                field,
+                SignatureIdentityProvider.Instance,
+                context: null,
+                out var decoded)
+                ? decoded
+                : GuardedProviderDecode.RejectedIdentity(reader, field.Signature);
             return $"{fieldType} {FormatType(field.GetDeclaringType())}::{reader.GetString(field.Name)}";
         }
 
@@ -632,7 +678,14 @@ public static class IlBodyDiff
             if (member.GetKind() != MemberReferenceKind.Field)
                 throw new BadImageFormatException("Expected field member reference.");
 
-            string fieldType = member.DecodeFieldSignature(SignatureIdentityProvider.Instance, genericContext: null);
+            string fieldType = GuardedProviderDecode.TryMemberRefField(
+                reader,
+                member,
+                SignatureIdentityProvider.Instance,
+                context: null,
+                out var decoded)
+                ? decoded
+                : GuardedProviderDecode.RejectedIdentity(reader, member.Signature);
             return $"{fieldType} {FormatMemberParent(member.Parent)}::{reader.GetString(member.Name)}";
         }
 
@@ -659,10 +712,22 @@ public static class IlBodyDiff
             {
                 HandleKind.TypeDefinition => FormatTypeDefinition((TypeDefinitionHandle)handle),
                 HandleKind.TypeReference => FormatTypeReference((TypeReferenceHandle)handle),
-                HandleKind.TypeSpecification => reader.GetTypeSpecification((TypeSpecificationHandle)handle)
-                    .DecodeSignature(SignatureIdentityProvider.Instance, null),
+                HandleKind.TypeSpecification => FormatTypeSpecification((TypeSpecificationHandle)handle),
                 _ => throw new BadImageFormatException($"Unsupported type handle {handle.Kind}."),
             };
+
+        string FormatTypeSpecification(TypeSpecificationHandle handle)
+        {
+            var specification = reader.GetTypeSpecification(handle);
+            return GuardedProviderDecode.TryTypeSpec(
+                reader,
+                handle,
+                SignatureIdentityProvider.Instance,
+                null,
+                out var decoded)
+                ? decoded
+                : GuardedProviderDecode.RejectedIdentity(reader, specification.Signature);
+        }
 
         string FormatTypeDefinition(TypeDefinitionHandle handle)
         {
@@ -707,6 +772,7 @@ public static class IlBodyDiff
 
         static string Escape(string value)
             => value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal);
+
     }
 
     sealed class SignatureIdentityProvider : ISignatureTypeProvider<string, object?>
@@ -752,7 +818,17 @@ public static class IlBodyDiff
             => TypeName(reader, handle);
 
         public string GetTypeFromSpecification(MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
-            => reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+        {
+            var specification = reader.GetTypeSpecification(handle);
+            return GuardedProviderDecode.TryTypeSpec(
+                reader,
+                handle,
+                this,
+                genericContext,
+                out var decoded)
+                ? decoded
+                : GuardedProviderDecode.RejectedIdentity(reader, specification.Signature);
+        }
 
         public string GetSZArrayType(string elementType) => $"{elementType}[]";
         public string GetArrayType(string elementType, ArrayShape shape) => $"{elementType}[{new string(',', Math.Max(shape.Rank - 1, 0))}]";

--- a/src/ILInspector.Instructions/MetadataStackTypeResolver.cs
+++ b/src/ILInspector.Instructions/MetadataStackTypeResolver.cs
@@ -42,7 +42,8 @@ public sealed class MetadataStackTypeResolver : IStackTypeResolver
         ArgumentNullException.ThrowIfNull(body);
         var provider = new StackTypeSignatureProvider(reader);
         var definition = reader.GetMethodDefinition(method);
-        var signature = definition.DecodeSignature(provider, null);
+        if (!GuardedProviderDecode.TryMethod(reader, definition, provider, null, out var signature))
+            throw new BadImageFormatException("Method signature exceeds the safe structural depth.");
 
         var arguments = ImmutableArray.CreateBuilder<StackType>();
         if (signature.Header.IsInstance && !signature.Header.HasExplicitThis)
@@ -55,7 +56,11 @@ public sealed class MetadataStackTypeResolver : IStackTypeResolver
         var locals = ImmutableArray<StackType>.Empty;
         if (!body.LocalSignature.IsNil)
         {
-            var localSig = reader.GetStandaloneSignature(body.LocalSignature).DecodeLocalSignature(provider, null);
+            var localSig = GuardedProviderDecode.LocalVariables(
+                reader,
+                reader.GetStandaloneSignature(body.LocalSignature),
+                provider,
+                null);
             locals = [.. localSig.Select(t => t.Stack)];
         }
 
@@ -73,8 +78,18 @@ public sealed class MetadataStackTypeResolver : IStackTypeResolver
             var handle = MetadataTokens.EntityHandle(fieldToken);
             return handle.Kind switch
             {
-                HandleKind.FieldDefinition => _reader.GetFieldDefinition((FieldDefinitionHandle)handle).DecodeSignature(_provider, null).Stack,
-                HandleKind.MemberReference => _reader.GetMemberReference((MemberReferenceHandle)handle).DecodeFieldSignature(_provider, null).Stack,
+                HandleKind.FieldDefinition => GuardedProviderDecode.Field(
+                    _reader,
+                    _reader.GetFieldDefinition((FieldDefinitionHandle)handle),
+                    _provider,
+                    null,
+                    SigType.Of(StackType.Unknown)).Stack,
+                HandleKind.MemberReference => GuardedProviderDecode.MemberRefField(
+                    _reader,
+                    _reader.GetMemberReference((MemberReferenceHandle)handle),
+                    _provider,
+                    null,
+                    SigType.Of(StackType.Unknown)).Stack,
                 _ => StackType.Unknown,
             };
         }
@@ -133,7 +148,15 @@ public sealed class MetadataStackTypeResolver : IStackTypeResolver
             var handle = MetadataTokens.EntityHandle(signatureToken);
             if (handle.Kind != HandleKind.StandaloneSignature)
                 return false;
-            var signature = _reader.GetStandaloneSignature((StandaloneSignatureHandle)handle).DecodeMethodSignature(_provider, null);
+            if (!GuardedProviderDecode.TryStandaloneMethod(
+                _reader,
+                _reader.GetStandaloneSignature((StandaloneSignatureHandle)handle),
+                _provider,
+                null,
+                out var signature))
+            {
+                return false;
+            }
             popCount = signature.ParameterTypes.Length + (signature.Header.IsInstance && !signature.Header.HasExplicitThis ? 1 : 0);
             pushes = !signature.ReturnType.IsVoid;
             pushType = signature.ReturnType.Stack;
@@ -160,7 +183,8 @@ public sealed class MetadataStackTypeResolver : IStackTypeResolver
             case HandleKind.MethodDefinition:
             {
                 var definition = _reader.GetMethodDefinition((MethodDefinitionHandle)handle);
-                var signature = definition.DecodeSignature(_provider, null);
+                if (!GuardedProviderDecode.TryMethod(_reader, definition, _provider, null, out var signature))
+                    return false;
                 paramCount = signature.ParameterTypes.Length;
                 hasThis = signature.Header.IsInstance && !signature.Header.HasExplicitThis;
                 returnType = signature.ReturnType;
@@ -170,7 +194,8 @@ public sealed class MetadataStackTypeResolver : IStackTypeResolver
             case HandleKind.MemberReference:
             {
                 var member = _reader.GetMemberReference((MemberReferenceHandle)handle);
-                var signature = member.DecodeMethodSignature(_provider, null);
+                if (!GuardedProviderDecode.TryMemberRefMethod(_reader, member, _provider, null, out var signature))
+                    return false;
                 paramCount = signature.ParameterTypes.Length;
                 hasThis = signature.Header.IsInstance && !signature.Header.HasExplicitThis;
                 returnType = signature.ReturnType;

--- a/src/ILInspector.Instructions/StackTypeSignatureProvider.cs
+++ b/src/ILInspector.Instructions/StackTypeSignatureProvider.cs
@@ -44,7 +44,7 @@ internal sealed class StackTypeSignatureProvider : ISignatureTypeProvider<SigTyp
         => SigType.Of(StackType.ObjectReference);
 
     public SigType GetTypeFromSpecification(MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
-        => reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+        => GuardedProviderDecode.TypeSpec(reader, handle, this, genericContext, SigType.Of(StackType.Unknown));
 
     public SigType GetSZArrayType(SigType elementType) => SigType.Of(StackType.ObjectReference);
     public SigType GetArrayType(SigType elementType, ArrayShape shape) => SigType.Of(StackType.ObjectReference);
@@ -62,7 +62,12 @@ internal sealed class StackTypeSignatureProvider : ISignatureTypeProvider<SigTyp
     {
         HandleKind.TypeDefinition => ClassifyDefinition((TypeDefinitionHandle)handle),
         HandleKind.TypeReference => StackType.ObjectReference,
-        HandleKind.TypeSpecification => _reader.GetTypeSpecification((TypeSpecificationHandle)handle).DecodeSignature(this, null).Stack,
+        HandleKind.TypeSpecification => GuardedProviderDecode.TypeSpec(
+            _reader,
+            (TypeSpecificationHandle)handle,
+            this,
+            null,
+            SigType.Of(StackType.Unknown)).Stack,
         _ => StackType.Unknown,
     };
 

--- a/tests/ILInspector.Metadata.Tests/ProviderSignatureDecodeBoundaryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ProviderSignatureDecodeBoundaryTests.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace ILInspector.Metadata.Tests;
 
 /// <summary>
-/// Freezes the signature-provider closure contract for issue #2575 across both
+/// Freezes the signature-provider closure contract for issue #2575 across the
 /// SRM-only assemblies. SRM's <c>DecodeSignature</c> recurses on the native
 /// stack for every nested element <em>before</em> the first provider callback,
 /// so a single over-deep blob overflows the stack in a way no managed
@@ -34,6 +34,7 @@ public class ProviderSignatureDecodeBoundaryTests
     {
         Path.Combine("src", "ILInspector.Metadata"),
         Path.Combine("src", "ILInspector.MetadataPrimitives"),
+        Path.Combine("src", "ILInspector.Instructions"),
     };
 
     // The complete set of SRM top-level signature-blob decoders that recurse on


### PR DESCRIPTION
## Summary

Closes #2490's final signature-decoder exposure by routing every
`ILInspector.Instructions` provider decode through a shared structural prescan
and every nested TypeSpec re-entry through `TypeSpecGuard`.

- unsafe method/calli signatures fail unresolved instead of fabricating stack effects
- rejected diff identities remain stable across metadata-token shifts
- the provider-decode AST census now covers `ILInspector.Instructions`
- process-isolated fixtures cover deep method, field, member-ref, local,
  method-spec, standalone/calli, and cyclic TypeSpec paths

The separate cyclic type-name graph mechanism found during the census is tracked
in #2710.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `ILInspector.Instructions.Tests`: 116 passed
- signature safety + provider census: 23 passed
- CoreLib return-address A/B: normalized snapshots byte-identical
  (36,846 matched; 8,980 agree; 27,866 diverge; 7,015 unmatched)

## Adversarial review

Exact head `7a463017` received two clean isolated-checkout reviews:

- Claude Opus 4.8: **CLEAN**
- Gemini 3.1 Pro: **CLEAN**

Both verified the complete decode census, guard-kind mapping, balanced TypeSpec
re-entry, fail-unresolved stack behavior, stable rejected identities, duplicate
row handling, process-isolated fixtures, and SRM/NativeAOT layering. Neither
reported an actionable finding, so no review-resolution commit applies.

Closes #2490
