### PR TITLE
Fix --rows window validation leaking a stack trace (follow-up to #2704)

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1406,6 +1406,9 @@ public class CommandExecutionTests
         Assert.Equal(1, exit);
         Assert.Empty(output);
         Assert.Contains("--rows cannot combine -n/--head with --tail", error);
+        // Pin the failure shape, not just the message: a swallowed BuildRowWindow
+        // throw would dump a stack trace that also contains the message and exits 1.
+        Assert.DoesNotContain("Unhandled exception", error);
     }
 
     [Fact]
@@ -1417,6 +1420,8 @@ public class CommandExecutionTests
         Assert.Equal(1, exit);
         Assert.Empty(output);
         Assert.Contains("--rows requires -n/--head N or --tail N", error);
+        // Pin the failure shape, not just the message (see above).
+        Assert.DoesNotContain("Unhandled exception", error);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -399,13 +399,28 @@ public class CommandExecutionTests
         {
             args = CommandLineBuilder.PreprocessArgs(args);
             var root = CommandLineBuilder.CreateRootCommand();
+            var result = root.Parse(args);
+            // Mirror Program.cs: surface parse/validation errors (including the --rows
+            // head/tail window validator) as a clean "Error: ..." line on stderr with
+            // exit 1, instead of letting InvokeAsync print usage help.
+            if (result.Errors.Count > 0)
+            {
+                foreach (var error in result.Errors)
+                {
+                    var message = error.Message.StartsWith("Error:", StringComparison.OrdinalIgnoreCase)
+                        ? error.Message
+                        : $"Error: {error.Message}";
+                    Console.Error.WriteLine(message);
+                }
+                return 1;
+            }
             try
             {
-                return await root.Parse(args).InvokeAsync();
+                return await result.InvokeAsync();
             }
             catch (RowWindowValidationException ex)
             {
-                // Mirror Program.cs so --rows window validation surfaces as exit 1 + stderr.
+                // Defensive: matches the Program.cs safety-net catch.
                 Console.Error.WriteLine($"Error: {ex.Message}");
                 return 1;
             }

--- a/src/dotnet-inspect/Program.cs
+++ b/src/dotnet-inspect/Program.cs
@@ -114,10 +114,11 @@ if (showTraceMermaid && args.Length > 0 && argsBeforePreprocess.FirstOrDefault()
     RequestTelemetry.Breadcrumb("preprocess", $"{string.Join(' ', argsBeforePreprocess)} -> {string.Join(' ', args)}");
 
 // Install line-limiting writer when -NN shorthand was used (e.g. -30).
-// With --rows, -n/-NN is interpreted by commands as per-table row limits, and the
-// head/tail conflict is validated by SharedOptions.BuildRowWindow against the real
-// System.CommandLine parse (see the RowWindowValidationException catch below), not
-// the token scan here — the scan misses =-syntax and concatenated forms.
+// With --rows, -n/-NN is interpreted by commands as per-table row limits. The
+// head/tail conflict is validated at parse time by the command validator in
+// SharedOptions.AddOutputOptionsTo against the real System.CommandLine parse (so it
+// covers =-syntax and concatenated forms the arg-preprocessor token scan misses),
+// which is why no --rows gate remains here.
 var rowLimitMode = args.Any(a => a == "--rows");
 // Line/tail windows apply only outside --rows mode; in --rows mode the count is a
 // per-table data-row window rendered by the commands, not an output-line window.
@@ -148,6 +149,10 @@ try
 }
 catch (RowWindowValidationException ex)
 {
+    // Defensive: the --rows head/tail window is rejected at parse time by the
+    // command validator (SharedOptions.AddOutputOptionsTo), so this is not the
+    // primary path. It converts any escaped validation throw into the clean CLI
+    // error contract instead of an unhandled-exception stack trace.
     Console.Error.WriteLine($"Error: {ex.Message}");
     return 1;
 }

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -159,6 +159,24 @@ public class SharedOptions
         command.Options.Add(Limit);
         command.Options.Add(Rows);
         command.Options.Add(Tail);
+
+        // Validate the --rows head/tail window at parse time so an invalid combination
+        // surfaces as a clean System.CommandLine error (one line on stderr, exit 1)
+        // rather than a RowWindowValidationException thrown inside the invocation
+        // pipeline, which SCL prints as an unhandled-exception stack trace. Reading the
+        // parse results here (not the arg-preprocessor token scan) covers =-syntax and
+        // concatenated forms the scanner misses.
+        command.Validators.Add(result =>
+        {
+            if (!result.GetValue(Rows))
+                return;
+            var hasHead = result.GetValue(Limit) is not null;
+            var hasTail = result.GetValue(Tail) is not null;
+            if (hasHead && hasTail)
+                result.AddError("--rows cannot combine -n/--head with --tail; choose one row window.");
+            else if (!hasHead && !hasTail)
+                result.AddError("--rows requires -n/--head N or --tail N.");
+        });
     }
 
     /// <summary>
@@ -237,10 +255,11 @@ public class SharedOptions
 
     /// <summary>
     /// Resolves the <c>--rows</c> data-row window from the parsed head/tail values.
-    /// Validation lives here (not in the arg preprocessor) so it sees the real
-    /// System.CommandLine parse — including <c>=</c>-syntax and concatenated forms
-    /// the token scanner misses. Throws <see cref="RowWindowValidationException"/>
-    /// when <c>--rows</c> is given both windows or neither.
+    /// The primary user-facing validation is the parse-time command validator in
+    /// <see cref="AddOutputOptionsTo"/>, which fails cleanly during parsing before
+    /// this runs. The throws here are a defensive invariant guard for direct callers
+    /// (and are unit-tested); in the CLI path the invalid both/neither combinations
+    /// are already rejected, so they are not expected to fire.
     /// </summary>
     public static RowWindow? BuildRowWindow(bool rows, int? head, int? tail)
     {


### PR DESCRIPTION
## Summary

Follow-up fix to #2704 (merged as d1d6222c). That PR shipped a real user-facing
regression that adversarial review caught **after** the squash-merge: the
`--rows` head/tail window validation threw `RowWindowValidationException` from
`SharedOptions.BuildRowWindow`, which runs inside the command `SetAction` during
`System.CommandLine`'s `InvokeAsync`. SCL's invocation pipeline catches that
throw and prints a raw **"Unhandled exception" stack trace** (exit 1) instead of
the intended clean `Error: ...` one-liner. The `catch` in `Program.cs` was
therefore dead code.

### Before (on current `main`)

```console
$ dotnet-inspect type System.String -S "Member Index" --rows --head=3 --tail 2
Unhandled exception: DotnetInspector.Output.RowWindowValidationException: --rows cannot combine -n/--head with --tail; choose one row window.
   at DotnetInspector.Services.SharedOptions.BuildRowWindow(...)
   ...
   at System.CommandLine.Invocation.InvocationPipeline.InvokeAsync(...)
```

### After

```console
$ dotnet-inspect type System.String -S "Member Index" --rows --head=3 --tail 2
Error: --rows cannot combine -n/--head with --tail; choose one row window.   # stderr, exit 1, empty stdout, no stack trace

$ dotnet-inspect type System.String -S "Member Index" --rows
Error: --rows requires -n/--head N or --tail N.                              # stderr, exit 1
```

## Fix

Validate the `--rows` head/tail window at **parse time** via a command validator
in `SharedOptions.AddOutputOptionsTo` (`command.Validators.Add(result => ...
result.AddError(...))`). It reads the real `System.CommandLine` parse values
(Rows/Limit/Tail), so it covers `=`-syntax (`--head=3`) and concatenated forms
(`-n3`) that the arg-preprocessor token scan misses. `Program.cs` already checks
`result.Errors` after `Parse` and prints clean `Error: ...` lines before
`InvokeAsync`, so no code path change is needed there.

`BuildRowWindow`'s throws remain as a defensive, unit-tested invariant guard (the
validator gates the CLI path first); the `Program.cs` catch is likewise
defensive.

Test-harness fidelity: `RunAppAsync` now mirrors `Program.cs` by surfacing
`result.Errors` as clean `Error: ...` stderr lines before `InvokeAsync`, so the
e2e grammar tests reflect the real CLI contract instead of SCL's usage-help dump
(this is why the original #2704 e2e tests passed falsely — the stack-trace text
happened to contain the message string).

## Validation

- `dotnet build src/dotnet-inspect -c Release` — succeeds.
- Full test suite (`dotnet run --project src/dotnet-inspect.Tests -c Release`):
  **1852 total, 0 failed, 10 skipped**.
- Manual CLI checks across forms: `--head=3 --tail 2`, `-n3 --tail 2`,
  `-3 --tail 2` (all rejected, exit 1, clean error); `--tail=2`, `-n 2` (valid,
  exit 0); cross-command probes (`type`, `member`, `cache`, `timeline`, `diff`,
  …) all emit the clean parse-time error with no stack trace.

## Adversarial review

Both **GPT-5.5** and **Gemini 3.1 Pro** independently found the swallowed-exception
bug on the pre-fix head, and both re-reviewed this fix at head `0eb0f233`
(cherry-picked here as `d49466b5`) and returned **CLEAN** with real-run evidence,
including confirmation that `Rows`/`Tail` options are only ever added through
`AddOutputOptionsTo` (so no command has the options without the validator).
