### PR TITLE
Make signature limit degradation visible

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,7 +98,10 @@ Extract public API surface using metadata:
 Guarded metadata signature rejection remains fail-closed (`object`/empty
 signature shape), but it is not presented as ordinary metadata:
 `ApiMember.SignatureDecodeStatus` is `Degraded`, and member tables add a
-`Decode: degraded` cell only for affected rows.
+`Decode: degraded` cell only for affected rows. The same status contract covers
+non-rendering signature inspections: spellability rejects a degraded signature
+instead of treating it as spellable, and unsafe-member discovery emits a
+diagnostic row when its pointer-signature scan is incomplete.
 
 ### diff
 

--- a/src/ILInspector.Metadata/AssemblyDetailScanner.cs
+++ b/src/ILInspector.Metadata/AssemblyDetailScanner.cs
@@ -471,10 +471,15 @@ public static class AssemblyDetailScanner
                             var detection = PointerDetection.Combine(
                                 decoded.Value.ReturnType,
                                 decoded.Value.ParameterTypes);
-                            if (decoded.IsDegraded || detection.IsDegraded)
-                                flags.UnsafeSignatureDecodeStatus = SignatureDecodeStatus.Degraded;
                             if (detection.HasPointer)
+                            {
                                 flags.HasUnsafeCode = true;
+                                flags.UnsafeSignatureDecodeStatus = null;
+                            }
+                            else if (decoded.IsDegraded || detection.IsDegraded)
+                            {
+                                flags.UnsafeSignatureDecodeStatus = SignatureDecodeStatus.Degraded;
+                            }
                         }
                         catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
                         {

--- a/src/ILInspector.Metadata/AssemblyDetailScanner.cs
+++ b/src/ILInspector.Metadata/AssemblyDetailScanner.cs
@@ -462,12 +462,24 @@ public static class AssemblyDetailScanner
                     {
                         try
                         {
-                            var sig = GuardedProviderDecode.Method(reader, method, PointerDetector.Instance, (object?)null, false);
-                            if (sig.ReturnType || sig.ParameterTypes.Any(p => p))
+                            var decoded = GuardedProviderDecode.MethodResult(
+                                reader,
+                                method,
+                                PointerDetector.Instance,
+                                (object?)null,
+                                PointerDetection.Degraded);
+                            var detection = PointerDetection.Combine(
+                                decoded.Value.ReturnType,
+                                decoded.Value.ParameterTypes);
+                            if (decoded.IsDegraded || detection.IsDegraded)
+                                flags.UnsafeSignatureDecodeStatus = SignatureDecodeStatus.Degraded;
+                            if (detection.HasPointer)
                                 flags.HasUnsafeCode = true;
                         }
-                        // Skip methods with undecodable signatures
-                        catch { }
+                        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+                        {
+                            flags.UnsafeSignatureDecodeStatus = SignatureDecodeStatus.Degraded;
+                        }
                     }
 
                     if (considerAsync && (!flags.HasRuntimeAsync || !flags.HasStateMachineAsync)
@@ -509,6 +521,7 @@ public class PresenceFlags
     public bool HasExtensionTypes { get; set; }
     public bool HasPInvokeImports { get; set; }
     public bool HasUnsafeCode { get; set; }
+    public SignatureDecodeStatus? UnsafeSignatureDecodeStatus { get; set; }
     public bool HasMethodBodies { get; set; }
     public bool HasManifestResources { get; set; }
     public bool HasAssemblyAttributes { get; set; }

--- a/src/ILInspector.Metadata/GuardedProviderDecode.cs
+++ b/src/ILInspector.Metadata/GuardedProviderDecode.cs
@@ -19,15 +19,32 @@ namespace ILInspector.Metadata;
 /// </summary>
 internal static class GuardedProviderDecode
 {
+    internal readonly record struct DecodeResult<T>(T Value, bool IsDegraded);
+
     public static MethodSignature<T> Method<T, TContext>(
         MetadataReader reader,
         MethodDefinition method,
         ISignatureTypeProvider<T, TContext> provider,
         TContext context,
         T fallbackReturn)
-        => SignatureBlobGuard.IsSafeToDecode(reader, method.Signature, SignatureBlobGuard.Kind.Method)
-            ? method.DecodeSignature(provider, context)
-            : FallbackSignature(fallbackReturn);
+        => MethodResult(reader, method, provider, context, fallbackReturn).Value;
+
+    public static DecodeResult<MethodSignature<T>> MethodResult<T, TContext>(
+        MetadataReader reader,
+        MethodDefinition method,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        T fallbackReturn)
+        => SignatureBlobGuard.IsSafeToDecode(
+                reader,
+                method.Signature,
+                SignatureBlobGuard.Kind.Method)
+            ? new DecodeResult<MethodSignature<T>>(
+                method.DecodeSignature(provider, context),
+                IsDegraded: false)
+            : new DecodeResult<MethodSignature<T>>(
+                FallbackSignature(fallbackReturn),
+                IsDegraded: true);
 
     public static MethodSignature<T> MemberRefMethod<T, TContext>(
         MetadataReader reader,
@@ -45,9 +62,24 @@ internal static class GuardedProviderDecode
         ISignatureTypeProvider<T, TContext> provider,
         TContext context,
         T fallbackReturn)
-        => SignatureBlobGuard.IsSafeToDecode(reader, property.Signature, SignatureBlobGuard.Kind.Method)
-            ? property.DecodeSignature(provider, context)
-            : FallbackSignature(fallbackReturn);
+        => PropertyResult(reader, property, provider, context, fallbackReturn).Value;
+
+    public static DecodeResult<MethodSignature<T>> PropertyResult<T, TContext>(
+        MetadataReader reader,
+        PropertyDefinition property,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        T fallbackReturn)
+        => SignatureBlobGuard.IsSafeToDecode(
+                reader,
+                property.Signature,
+                SignatureBlobGuard.Kind.Method)
+            ? new DecodeResult<MethodSignature<T>>(
+                property.DecodeSignature(provider, context),
+                IsDegraded: false)
+            : new DecodeResult<MethodSignature<T>>(
+                FallbackSignature(fallbackReturn),
+                IsDegraded: true);
 
     public static T Field<T, TContext>(
         MetadataReader reader,
@@ -55,9 +87,24 @@ internal static class GuardedProviderDecode
         ISignatureTypeProvider<T, TContext> provider,
         TContext context,
         T fallback)
-        => SignatureBlobGuard.IsSafeToDecode(reader, field.Signature, SignatureBlobGuard.Kind.Field)
-            ? field.DecodeSignature(provider, context)
-            : fallback;
+        => FieldResult(reader, field, provider, context, fallback).Value;
+
+    public static DecodeResult<T> FieldResult<T, TContext>(
+        MetadataReader reader,
+        FieldDefinition field,
+        ISignatureTypeProvider<T, TContext> provider,
+        TContext context,
+        T fallback)
+        => SignatureBlobGuard.IsSafeToDecode(
+                reader,
+                field.Signature,
+                SignatureBlobGuard.Kind.Field)
+            ? new DecodeResult<T>(
+                field.DecodeSignature(provider, context),
+                IsDegraded: false)
+            : new DecodeResult<T>(
+                fallback,
+                IsDegraded: true);
 
     public static T MemberRefField<T, TContext>(
         MetadataReader reader,

--- a/src/ILInspector.Metadata/PointerDetector.cs
+++ b/src/ILInspector.Metadata/PointerDetector.cs
@@ -5,20 +5,20 @@ namespace ILInspector.Metadata;
 
 /// <summary>
 /// Allocation-free signature type provider that only detects pointer types.
-/// Returns true when any type in the signature is a pointer.
+/// Preserves degraded-decode evidence separately from a definite pointer match.
 /// </summary>
-internal sealed class PointerDetector : ISignatureTypeProvider<bool, object?>
+internal sealed class PointerDetector : ISignatureTypeProvider<PointerDetection, object?>
 {
     public static PointerDetector Instance { get; } = new();
 
-    public bool GetPrimitiveType(PrimitiveTypeCode typeCode) => false;
-    public bool GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => false;
-    public bool GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) => false;
+    public PointerDetection GetPrimitiveType(PrimitiveTypeCode typeCode) => default;
+    public PointerDetection GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => default;
+    public PointerDetection GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) => default;
 
-    public bool GetTypeFromSpecification(MetadataReader reader, object? context, TypeSpecificationHandle handle, byte rawTypeKind)
+    public PointerDetection GetTypeFromSpecification(MetadataReader reader, object? context, TypeSpecificationHandle handle, byte rawTypeKind)
     {
         if (!TypeSpecGuard.TryEnter(reader, handle, out int blobLength))
-            return false;
+            return PointerDetection.Degraded;
         try
         {
             return reader.GetTypeSpecification(handle).DecodeSignature(this, context);
@@ -29,15 +29,40 @@ internal sealed class PointerDetector : ISignatureTypeProvider<bool, object?>
         }
     }
 
-    public bool GetSZArrayType(bool elementType) => elementType;
-    public bool GetArrayType(bool elementType, ArrayShape shape) => elementType;
-    public bool GetByReferenceType(bool elementType) => elementType;
-    public bool GetPointerType(bool elementType) => true;
-    public bool GetGenericInstantiation(bool genericType, ImmutableArray<bool> typeArguments)
-        => genericType || typeArguments.Any(static t => t);
-    public bool GetGenericMethodParameter(object? context, int index) => false;
-    public bool GetGenericTypeParameter(object? context, int index) => false;
-    public bool GetFunctionPointerType(MethodSignature<bool> signature) => true;
-    public bool GetModifiedType(bool modifier, bool unmodifiedType, bool isRequired) => unmodifiedType;
-    public bool GetPinnedType(bool elementType) => elementType;
+    public PointerDetection GetSZArrayType(PointerDetection elementType) => elementType;
+    public PointerDetection GetArrayType(PointerDetection elementType, ArrayShape shape) => elementType;
+    public PointerDetection GetByReferenceType(PointerDetection elementType) => elementType;
+    public PointerDetection GetPointerType(PointerDetection elementType)
+        => new(HasPointer: true, elementType.IsDegraded);
+    public PointerDetection GetGenericInstantiation(
+        PointerDetection genericType,
+        ImmutableArray<PointerDetection> typeArguments)
+        => PointerDetection.Combine(genericType, typeArguments);
+    public PointerDetection GetGenericMethodParameter(object? context, int index) => default;
+    public PointerDetection GetGenericTypeParameter(object? context, int index) => default;
+    public PointerDetection GetFunctionPointerType(MethodSignature<PointerDetection> signature)
+        => new(
+            HasPointer: true,
+            signature.ReturnType.IsDegraded
+                || signature.ParameterTypes.Any(static type => type.IsDegraded));
+    public PointerDetection GetModifiedType(
+        PointerDetection modifier,
+        PointerDetection unmodifiedType,
+        bool isRequired)
+        => new(
+            unmodifiedType.HasPointer,
+            modifier.IsDegraded || unmodifiedType.IsDegraded);
+    public PointerDetection GetPinnedType(PointerDetection elementType) => elementType;
+}
+
+internal readonly record struct PointerDetection(bool HasPointer, bool IsDegraded)
+{
+    public static PointerDetection Degraded => new(HasPointer: false, IsDegraded: true);
+
+    public static PointerDetection Combine(
+        PointerDetection first,
+        ImmutableArray<PointerDetection> rest)
+        => new(
+            first.HasPointer || rest.Any(static type => type.HasPointer),
+            first.IsDegraded || rest.Any(static type => type.IsDegraded));
 }

--- a/src/ILInspector.Metadata/PointerDetector.cs
+++ b/src/ILInspector.Metadata/PointerDetector.cs
@@ -50,7 +50,7 @@ internal sealed class PointerDetector : ISignatureTypeProvider<PointerDetection,
         PointerDetection unmodifiedType,
         bool isRequired)
         => new(
-            unmodifiedType.HasPointer,
+            modifier.HasPointer || unmodifiedType.HasPointer,
             modifier.IsDegraded || unmodifiedType.IsDegraded);
     public PointerDetection GetPinnedType(PointerDetection elementType) => elementType;
 }

--- a/src/ILInspector.Metadata/SignatureSpellability.cs
+++ b/src/ILInspector.Metadata/SignatureSpellability.cs
@@ -7,6 +7,10 @@ using System.Threading;
 
 namespace ILInspector.Metadata;
 
+public readonly record struct SignatureSpellabilityResult(
+    bool CanSpell,
+    SignatureDecodeStatus? DecodeStatus);
+
 /// <summary>
 /// Answers whether metadata signatures can be spelled from a generated C#
 /// assembly. Public metadata can expose non-public referenced types, especially
@@ -22,30 +26,87 @@ public sealed class SignatureSpellability
         => _resolver = resolver;
 
     public bool CanSpellField(MetadataReader reader, FieldDefinition field, GenericContext context)
+        => InspectField(reader, field, context).CanSpell;
+
+    public SignatureSpellabilityResult InspectField(
+        MetadataReader reader,
+        FieldDefinition field,
+        GenericContext context)
     {
-        try { return !GuardedProviderDecode.Field(reader, field, new InaccessibleTypeDetector(this), context, false); }
-        catch (Exception ex) when (IsDecodeException(ex)) { return true; }
+        try
+        {
+            var decoded = GuardedProviderDecode.FieldResult(
+                reader,
+                field,
+                new InaccessibleTypeDetector(this),
+                context,
+                SpellabilityEvidence.Degraded);
+            return Result(decoded.Value, decoded.IsDegraded);
+        }
+        catch (Exception ex) when (IsDecodeException(ex))
+        {
+            return DegradedResult;
+        }
     }
 
     public bool CanSpellProperty(MetadataReader reader, PropertyDefinition property, GenericContext context)
+        => InspectProperty(reader, property, context).CanSpell;
+
+    public SignatureSpellabilityResult InspectProperty(
+        MetadataReader reader,
+        PropertyDefinition property,
+        GenericContext context)
     {
         try
         {
-            var signature = GuardedProviderDecode.Property(reader, property, new InaccessibleTypeDetector(this), context, false);
-            return !signature.ReturnType && !signature.ParameterTypes.Any(inaccessible => inaccessible);
+            var decoded = GuardedProviderDecode.PropertyResult(
+                reader,
+                property,
+                new InaccessibleTypeDetector(this),
+                context,
+                SpellabilityEvidence.Degraded);
+            return Result(SpellabilityEvidence.Combine(decoded.Value), decoded.IsDegraded);
         }
-        catch (Exception ex) when (IsDecodeException(ex)) { return true; }
+        catch (Exception ex) when (IsDecodeException(ex))
+        {
+            return DegradedResult;
+        }
     }
 
     public bool CanSpellMethod(MetadataReader reader, MethodDefinition method, GenericContext context)
+        => InspectMethod(reader, method, context).CanSpell;
+
+    public SignatureSpellabilityResult InspectMethod(
+        MetadataReader reader,
+        MethodDefinition method,
+        GenericContext context)
     {
         try
         {
-            var signature = GuardedProviderDecode.Method(reader, method, new InaccessibleTypeDetector(this), context, false);
-            return !signature.ReturnType && !signature.ParameterTypes.Any(inaccessible => inaccessible);
+            var decoded = GuardedProviderDecode.MethodResult(
+                reader,
+                method,
+                new InaccessibleTypeDetector(this),
+                context,
+                SpellabilityEvidence.Degraded);
+            return Result(SpellabilityEvidence.Combine(decoded.Value), decoded.IsDegraded);
         }
-        catch (Exception ex) when (IsDecodeException(ex)) { return true; }
+        catch (Exception ex) when (IsDecodeException(ex))
+        {
+            return DegradedResult;
+        }
     }
+
+    static SignatureSpellabilityResult Result(SpellabilityEvidence evidence, bool topLevelDegraded)
+    {
+        bool isDegraded = topLevelDegraded || evidence.IsDegraded;
+        return new SignatureSpellabilityResult(
+            CanSpell: !evidence.IsInaccessible && !isDegraded,
+            isDegraded ? SignatureDecodeStatus.Degraded : null);
+    }
+
+    static SignatureSpellabilityResult DegradedResult =>
+        new(CanSpell: false, SignatureDecodeStatus.Degraded);
 
     static bool IsDecodeException(Exception ex)
         => ex is BadImageFormatException or InvalidOperationException or ArgumentException;
@@ -146,16 +207,20 @@ public sealed class SignatureSpellability
     sealed record NonPublicTypeSet(HashSet<string>? Types);
 
     sealed class InaccessibleTypeDetector(SignatureSpellability spellability)
-        : ISignatureTypeProvider<bool, GenericContext?>
+        : ISignatureTypeProvider<SpellabilityEvidence, GenericContext?>
     {
-        public bool GetPrimitiveType(PrimitiveTypeCode typeCode) => false;
-        public bool GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => false;
-        public bool GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
-            => spellability.IsInaccessible(reader, handle);
-        public bool GetTypeFromSpecification(MetadataReader reader, GenericContext? context, TypeSpecificationHandle handle, byte rawTypeKind)
+        public SpellabilityEvidence GetPrimitiveType(PrimitiveTypeCode typeCode) => default;
+        public SpellabilityEvidence GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => default;
+        public SpellabilityEvidence GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+            => new(spellability.IsInaccessible(reader, handle), IsDegraded: false);
+        public SpellabilityEvidence GetTypeFromSpecification(
+            MetadataReader reader,
+            GenericContext? context,
+            TypeSpecificationHandle handle,
+            byte rawTypeKind)
         {
             if (!TypeSpecGuard.TryEnter(reader, handle, out int blobLength))
-                return false;
+                return SpellabilityEvidence.Degraded;
             try
             {
                 return reader.GetTypeSpecification(handle).DecodeSignature(this, context);
@@ -165,17 +230,41 @@ public sealed class SignatureSpellability
                 TypeSpecGuard.Exit(blobLength);
             }
         }
-        public bool GetSZArrayType(bool elementType) => elementType;
-        public bool GetArrayType(bool elementType, ArrayShape shape) => elementType;
-        public bool GetByReferenceType(bool elementType) => elementType;
-        public bool GetPointerType(bool elementType) => elementType;
-        public bool GetGenericInstantiation(bool genericType, ImmutableArray<bool> typeArguments)
-            => genericType || typeArguments.Any(inaccessible => inaccessible);
-        public bool GetGenericMethodParameter(GenericContext? context, int index) => false;
-        public bool GetGenericTypeParameter(GenericContext? context, int index) => false;
-        public bool GetFunctionPointerType(MethodSignature<bool> signature)
-            => signature.ReturnType || signature.ParameterTypes.Any(inaccessible => inaccessible);
-        public bool GetModifiedType(bool modifier, bool unmodifiedType, bool isRequired) => unmodifiedType;
-        public bool GetPinnedType(bool elementType) => elementType;
+        public SpellabilityEvidence GetSZArrayType(SpellabilityEvidence elementType) => elementType;
+        public SpellabilityEvidence GetArrayType(SpellabilityEvidence elementType, ArrayShape shape) => elementType;
+        public SpellabilityEvidence GetByReferenceType(SpellabilityEvidence elementType) => elementType;
+        public SpellabilityEvidence GetPointerType(SpellabilityEvidence elementType) => elementType;
+        public SpellabilityEvidence GetGenericInstantiation(
+            SpellabilityEvidence genericType,
+            ImmutableArray<SpellabilityEvidence> typeArguments)
+            => SpellabilityEvidence.Combine(genericType, typeArguments);
+        public SpellabilityEvidence GetGenericMethodParameter(GenericContext? context, int index) => default;
+        public SpellabilityEvidence GetGenericTypeParameter(GenericContext? context, int index) => default;
+        public SpellabilityEvidence GetFunctionPointerType(MethodSignature<SpellabilityEvidence> signature)
+            => SpellabilityEvidence.Combine(signature);
+        public SpellabilityEvidence GetModifiedType(
+            SpellabilityEvidence modifier,
+            SpellabilityEvidence unmodifiedType,
+            bool isRequired)
+            => new(
+                unmodifiedType.IsInaccessible,
+                modifier.IsDegraded || unmodifiedType.IsDegraded);
+        public SpellabilityEvidence GetPinnedType(SpellabilityEvidence elementType) => elementType;
+    }
+
+    readonly record struct SpellabilityEvidence(bool IsInaccessible, bool IsDegraded)
+    {
+        public static SpellabilityEvidence Degraded =>
+            new(IsInaccessible: false, IsDegraded: true);
+
+        public static SpellabilityEvidence Combine(
+            SpellabilityEvidence first,
+            ImmutableArray<SpellabilityEvidence> rest)
+            => new(
+                first.IsInaccessible || rest.Any(static type => type.IsInaccessible),
+                first.IsDegraded || rest.Any(static type => type.IsDegraded));
+
+        public static SpellabilityEvidence Combine(MethodSignature<SpellabilityEvidence> signature)
+            => Combine(signature.ReturnType, signature.ParameterTypes);
     }
 }

--- a/src/ILInspector.Metadata/SignatureSpellability.cs
+++ b/src/ILInspector.Metadata/SignatureSpellability.cs
@@ -247,7 +247,7 @@ public sealed class SignatureSpellability
             SpellabilityEvidence unmodifiedType,
             bool isRequired)
             => new(
-                unmodifiedType.IsInaccessible,
+                (isRequired && modifier.IsInaccessible) || unmodifiedType.IsInaccessible,
                 modifier.IsDegraded || unmodifiedType.IsDegraded);
         public SpellabilityEvidence GetPinnedType(SpellabilityEvidence elementType) => elementType;
     }

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -18,6 +18,21 @@ namespace DotnetInspector.Tests;
 public class OutputFormatterTests
 {
     [Fact]
+    public void UnsafeMembersSection_RendersDegradedSignatureScan()
+    {
+        var view = new LibraryInspectionView(new LibraryInspection
+        {
+            AssemblyInfo = new AssemblyInfo(),
+            UnsafeSignatureDecodeStatus = SignatureDecodeStatus.Degraded,
+        });
+
+        Assert.True(view.HasUnsafeMembers);
+        var row = Assert.Single(view.UnsafeMembersSection!);
+        Assert.Equal("Decode degraded", row.Reason);
+        Assert.Contains("unsafe-code presence may be incomplete", row.Detail);
+    }
+
+    [Fact]
     public void WriteTable_WithoutRowLimit_MatchesRenderThenWrite()
     {
         // The uncapped path serializes straight to the writer instead of materializing the

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -903,6 +903,24 @@ public class SectionPipelineTests
     }
 
     [Fact]
+    public void CanRender_UnsafeMembers_UsesDegradedDecodeStatus()
+    {
+        var pipeline = LibrarySections.CreatePipeline();
+        var model = new LibraryInspection
+        {
+            AssemblyInfo = new AssemblyInfo(),
+            UnsafeSignatureDecodeStatus = SignatureDecodeStatus.Degraded
+        };
+
+        var effective = pipeline.GetEffectiveSections(
+            model,
+            Verbosity.Detailed,
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Unsafe Members" });
+
+        Assert.Contains("Unsafe Members", effective);
+    }
+
+    [Fact]
     public void CanRender_PInvokeMethods_UsesPresenceFlag()
     {
         var pipeline = LibrarySections.CreatePipeline();

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -86,6 +86,7 @@ internal static class LibraryMetadataService
             inspection.HasExtensionTypes = presenceFlags.HasExtensionTypes;
             inspection.HasPInvokeImports = presenceFlags.HasPInvokeImports;
             inspection.HasUnsafeCode = presenceFlags.HasUnsafeCode;
+            inspection.UnsafeSignatureDecodeStatus = presenceFlags.UnsafeSignatureDecodeStatus;
             inspection.HasMethodBodies = presenceFlags.HasMethodBodies;
             inspection.HasRuntimeAsync = presenceFlags.HasRuntimeAsync;
             inspection.HasStateMachineAsync = presenceFlags.HasStateMachineAsync;

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -680,6 +680,10 @@ public class LibraryInspection
     [JsonIgnore]
     public bool HasUnsafeCode { get; set; }
 
+    /// <summary>Set when unsafe-signature detection could not inspect every signature completely.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public SignatureDecodeStatus? UnsafeSignatureDecodeStatus { get; set; }
+
     /// <summary>True when the assembly has at least one method with an IL body (not a pure ref/abstract assembly).</summary>
     [JsonIgnore]
     public bool HasMethodBodies { get; set; }

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -680,7 +680,7 @@ public class LibraryInspection
     [JsonIgnore]
     public bool HasUnsafeCode { get; set; }
 
-    /// <summary>Set when unsafe-signature detection could not inspect every signature completely.</summary>
+    /// <summary>Set when guarded decoding prevents unsafe-code presence from being determined.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public SignatureDecodeStatus? UnsafeSignatureDecodeStatus { get; set; }
 

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -492,7 +492,9 @@ public static class LibrarySections
         public static bool ExplicitOnly => true;
         public static string? ScannerKey => ScannerUnsafeMembers;
         public static bool CanRender(LibraryInspection model)
-            => model.UnsafeMembers is { Count: > 0 } || model.HasUnsafeCode;
+            => model.UnsafeMembers is { Count: > 0 }
+                || model.HasUnsafeCode
+                || model.UnsafeSignatureDecodeStatus is not null;
     }
 
     public sealed class TopLeverage : ISectionDescriptor<LibraryInspection>

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -728,11 +728,13 @@ public class LibraryInspectionView
             .ToList() is { Count: > 0 } rows ? rows : null;
 
     [MarkoutIgnore]
-    public bool HasUnsafeMembers => _data.UnsafeMembers is { Count: > 0 };
+    public bool HasUnsafeMembers =>
+        _data.UnsafeMembers is { Count: > 0 }
+        || _data.UnsafeSignatureDecodeStatus is SignatureDecodeStatus.Degraded;
 
     [MarkoutSection(Name = "Unsafe Members", ShowWhenProperty = nameof(HasUnsafeMembers))]
     public List<UnsafeMemberRow>? UnsafeMembersSection =>
-        _data.UnsafeMembers?
+        (_data.UnsafeMembers ?? [])
             .OrderBy(m => m.Member, StringComparer.OrdinalIgnoreCase)
             .ThenBy(m => m.IL, StringComparer.OrdinalIgnoreCase)
             .ThenBy(m => m.Reason, StringComparer.OrdinalIgnoreCase)
@@ -740,6 +742,15 @@ public class LibraryInspectionView
             .Select(m => new UnsafeMemberRow(
                 MarkoutInline.Code(m.Member), m.Reason, MarkoutInline.Code(m.Detail), m.Kind,
                 m.IL is null ? null : MarkoutInline.Code(m.IL), m.Token is null ? null : MarkoutInline.Code(m.Token)))
+            .Concat(_data.UnsafeSignatureDecodeStatus is SignatureDecodeStatus.Degraded
+                ? [new UnsafeMemberRow(
+                    MarkoutInline.Code("signature scan"),
+                    "Decode degraded",
+                    MarkoutInline.Code("unsafe-code presence may be incomplete"),
+                    "Diagnostic",
+                    null,
+                    null)]
+                : [])
             .ToList();
 
     public bool HasTopLeverage => _data.TopLeverage is { Count: > 0 };

--- a/tests/ILInspector.Metadata.Tests/SignatureDecoderSafetyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SignatureDecoderSafetyTests.cs
@@ -56,6 +56,23 @@ public class SignatureDecoderSafetyTests
         => RunWorker(nameof(DeepEnumFieldThroughAttributeDecoderWorker));
 
     [Fact]
+    public void ValidPointerSignature_IsDetectedWithoutDegradation()
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x00); // default method signature
+        signature.WriteByte(0x00); // zero parameters
+        signature.WriteByte(0x0f); // PTR return type
+        signature.WriteByte(0x08); // I4
+        var image = BuildSurfacePe(fieldSignature: null, methodSignature: signature);
+        using var peReader = new PEReader(new MemoryStream(image));
+
+        var flags = AssemblyDetailScanner.ScanPresenceFlags(peReader);
+
+        Assert.True(flags.HasUnsafeCode);
+        Assert.Null(flags.UnsafeSignatureDecodeStatus);
+    }
+
+    [Fact]
     public void SignatureBlobGuard_OldAssemblyIdentity_IsForwarded()
         => Assert.Equal(
             typeof(SignatureBlobGuard),
@@ -225,9 +242,12 @@ public class SignatureDecoderSafetyTests
         if (!IsSelectedWorker(nameof(DeepMethodSignatureThroughPointerDetectorWorker)))
             return;
 
-        var image = BuildSurfacePe(fieldSignature: null, methodSignature: DeepMethodSignature());
+        var image = BuildSurfacePe(fieldSignature: null, methodSignature: DeepPointerMethodSignature());
         using var peReader = new PEReader(new MemoryStream(image));
-        _ = AssemblyDetailScanner.ScanPresenceFlags(peReader);
+        var flags = AssemblyDetailScanner.ScanPresenceFlags(peReader);
+
+        Assert.False(flags.HasUnsafeCode);
+        Assert.Equal(SignatureDecodeStatus.Degraded, flags.UnsafeSignatureDecodeStatus);
     }
 
     [Fact]
@@ -250,8 +270,11 @@ public class SignatureDecoderSafetyTests
         var (reader, typeHandle, methodHandle) = BuildTypeWithMethod(DeepMethodSignature());
         var method = reader.GetMethodDefinition(methodHandle);
         var spellability = new SignatureSpellability(new NullReferenceResolver());
-        _ = spellability.CanSpellMethod(
+        var result = spellability.InspectMethod(
             reader, method, GenericContext.ForMethod(reader, reader.GetTypeDefinition(typeHandle), method));
+
+        Assert.False(result.CanSpell);
+        Assert.Equal(SignatureDecodeStatus.Degraded, result.DecodeStatus);
     }
 
     [Fact]
@@ -324,6 +347,18 @@ public class SignatureDecoderSafetyTests
         signature.WriteByte(0x00); // zero parameters
         for (int i = 0; i < 100_000; i++)
             signature.WriteByte(0x1d); // SZARRAY return type
+        signature.WriteByte(0x08);     // I4
+        return signature;
+    }
+
+    static BlobBuilder DeepPointerMethodSignature()
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x00); // default method signature
+        signature.WriteByte(0x00); // zero parameters
+        for (int i = 0; i < 100_000; i++)
+            signature.WriteByte(0x1d); // SZARRAY return type
+        signature.WriteByte(0x0f);     // PTR
         signature.WriteByte(0x08);     // I4
         return signature;
     }

--- a/tests/ILInspector.Metadata.Tests/SignatureDecoderSafetyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SignatureDecoderSafetyTests.cs
@@ -73,6 +73,31 @@ public class SignatureDecoderSafetyTests
     }
 
     [Fact]
+    public void PointerInCustomModifier_IsDetectedWithoutDegradation()
+    {
+        var typeSpecification = new BlobBuilder();
+        typeSpecification.WriteByte(0x0f); // PTR
+        typeSpecification.WriteByte(0x08); // I4
+
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x00); // default method signature
+        signature.WriteByte(0x00); // zero parameters
+        signature.WriteByte(0x20); // CMOD_OPT
+        signature.WriteByte(0x06); // TypeDefOrRefOrSpec: TypeSpec row 1
+        signature.WriteByte(0x01); // VOID
+        var image = BuildSurfacePe(
+            fieldSignature: null,
+            methodSignature: signature,
+            typeSpecification: typeSpecification);
+        using var peReader = new PEReader(new MemoryStream(image));
+
+        var flags = AssemblyDetailScanner.ScanPresenceFlags(peReader);
+
+        Assert.True(flags.HasUnsafeCode);
+        Assert.Null(flags.UnsafeSignatureDecodeStatus);
+    }
+
+    [Fact]
     public void SignatureBlobGuard_OldAssemblyIdentity_IsForwarded()
         => Assert.Equal(
             typeof(SignatureBlobGuard),
@@ -394,7 +419,10 @@ public class SignatureDecoderSafetyTests
     /// PE-level scanners (ApiSurfaceExtractor, AssemblyDetailScanner) reach the
     /// crafted signature through their real entry points.
     /// </summary>
-    static byte[] BuildSurfacePe(BlobBuilder? fieldSignature, BlobBuilder? methodSignature)
+    static byte[] BuildSurfacePe(
+        BlobBuilder? fieldSignature,
+        BlobBuilder? methodSignature,
+        BlobBuilder? typeSpecification = null)
     {
         var metadata = new MetadataBuilder();
         metadata.AddModule(
@@ -424,6 +452,9 @@ public class SignatureDecoderSafetyTests
             default,
             MetadataTokens.FieldDefinitionHandle(1),
             MetadataTokens.MethodDefinitionHandle(1));
+
+        if (typeSpecification is not null)
+            metadata.AddTypeSpecification(metadata.GetOrAddBlob(typeSpecification));
 
         if (fieldSignature is not null)
         {

--- a/tests/ILInspector.Metadata.Tests/SignatureSpellabilityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SignatureSpellabilityTests.cs
@@ -12,14 +12,19 @@ public sealed class SignatureSpellabilityTests
     {
         using var fixture = OpenFixture();
 
-        Assert.False(fixture.Spellability.CanSpellField(
+        var hidden = fixture.Spellability.InspectField(
             fixture.Reader,
             GetField(fixture.Reader, fixture.Type, "HiddenField"),
-            GenericContext.ForType(fixture.Reader, fixture.Type)));
-        Assert.True(fixture.Spellability.CanSpellField(
+            GenericContext.ForType(fixture.Reader, fixture.Type));
+        var visible = fixture.Spellability.InspectField(
             fixture.Reader,
             GetField(fixture.Reader, fixture.Type, "VisibleField"),
-            GenericContext.ForType(fixture.Reader, fixture.Type)));
+            GenericContext.ForType(fixture.Reader, fixture.Type));
+
+        Assert.False(hidden.CanSpell);
+        Assert.Null(hidden.DecodeStatus);
+        Assert.True(visible.CanSpell);
+        Assert.Null(visible.DecodeStatus);
     }
 
     [Fact]

--- a/tests/ILInspector.Metadata.Tests/SignatureSpellabilityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SignatureSpellabilityTests.cs
@@ -1,4 +1,6 @@
+using System.Reflection;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using ILInspector.Metadata.Tests.SpellabilityConsumer;
 using ILInspector.Metadata.Tests.SpellabilityReference;
@@ -79,6 +81,21 @@ public sealed class SignatureSpellabilityTests
             GenericContext.ForType(fixture.Reader, fixture.Type)));
     }
 
+    [Fact]
+    public void InspectMethod_RejectsInaccessibleRequiredModifier()
+    {
+        using var fixture = OpenRequiredModifierFixture();
+        var method = GetMethod(fixture.Reader, fixture.Type, "M");
+
+        var result = fixture.Spellability.InspectMethod(
+            fixture.Reader,
+            method,
+            GenericContext.ForMethod(fixture.Reader, fixture.Type, method));
+
+        Assert.False(result.CanSpell);
+        Assert.Null(result.DecodeStatus);
+    }
+
     static Fixture OpenFixture(IAssemblyReferenceResolver? resolver = null)
     {
         var stream = File.OpenRead(typeof(SignatureSpellabilityConsumerFixtures).Assembly.Location);
@@ -86,6 +103,84 @@ public sealed class SignatureSpellabilityTests
         var reader = pe.GetMetadataReader();
         var type = GetTypeDefinition(reader, typeof(SignatureSpellabilityConsumerFixtures));
         resolver ??= new MapResolver(typeof(VisibleReferenceType).Assembly.Location);
+        return new Fixture(stream, pe, reader, type, new SignatureSpellability(resolver));
+    }
+
+    static Fixture OpenRequiredModifierFixture()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString("Synthetic.dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Synthetic"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+
+        var referenceName = typeof(VisibleReferenceType).Assembly.GetName();
+        var reference = metadata.AddAssemblyReference(
+            metadata.GetOrAddString(referenceName.Name!),
+            referenceName.Version!,
+            referenceName.CultureName is { Length: > 0 } culture
+                ? metadata.GetOrAddString(culture)
+                : default,
+            metadata.GetOrAddBlob(referenceName.GetPublicKeyToken() ?? []),
+            default,
+            default);
+        var modifier = metadata.AddTypeReference(
+            reference,
+            metadata.GetOrAddString("ILInspector.Metadata.Tests.SpellabilityReference"),
+            metadata.GetOrAddString("HiddenReferenceType"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var typeHandle = metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            metadata.GetOrAddString("N"),
+            metadata.GetOrAddString("C"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        int modifierIndex = CodedIndex.TypeDefOrRefOrSpec(modifier);
+        Assert.InRange(modifierIndex, 1, byte.MaxValue);
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x00); // default method signature
+        signature.WriteByte(0x00); // zero parameters
+        signature.WriteByte(0x1f); // CMOD_REQD
+        signature.WriteByte((byte)modifierIndex);
+        signature.WriteByte(0x01); // VOID
+        metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Static,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("M"),
+            metadata.GetOrAddBlob(signature),
+            bodyOffset: -1,
+            parameterList: MetadataTokens.ParameterHandle(1));
+
+        var peBuilder = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        peBuilder.Serialize(image);
+        var stream = new MemoryStream(image.ToArray());
+        var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+        var type = reader.GetTypeDefinition(typeHandle);
+        var resolver = new MapResolver(typeof(VisibleReferenceType).Assembly.Location);
         return new Fixture(stream, pe, reader, type, new SignatureSpellability(resolver));
     }
 


### PR DESCRIPTION
## Summary

- carry guarded-decode degradation through unsafe pointer detection instead of collapsing it to `HasUnsafeCode = false`
- fail signature spellability closed and expose `SignatureSpellabilityResult.DecodeStatus`
- render unresolved unsafe signature presence as a `Decode degraded` diagnostic
- preserve pointer and required-modifier evidence through custom-modifier combinators

## Evidence

- process-isolated 100,000-level pointer-bearing and spellability fixtures report `Degraded`
- real TypeSpec-backed `modopt(pointer)` and external-internal `modreq` fixtures pin modifier behavior
- ordinary pointer and accessible/inaccessible signatures retain their existing results with no decode marker
- Metadata tests: 468 passed
- CLI tests: 1,844 passed, 10 tool-dependent skips
- linux-x64 NativeAOT publish succeeded
- changed Markdown passes markdownlint

Follow-up to #2700 and #2709.