### PR TITLE
Add Finding-backed implementation and authored-source evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ context for copied DLLs. A future `--deps` source can represent runtime
 | Project skills | `project` | Direct dependency `Skills` rows from package `skills/**/SKILL.md` files, plus version-resolved package README/PROJECT docs from restored projects. |
 | Library audit | `library` | Assembly identity, public key token, trim/AOT metadata, unsafe/interoperability signals, OpenTelemetry support, symbols/PDBs, SourceLink and determinism audit, references, resources, async method classification. |
 | API discovery | `type`, `member`, `find` | Type search, member tables, docs, overload selection, generics, obsolete-member markers, direct calls and callers, source/decompiled/IL drill-in. Add `--project` to resolve type/member queries in the project's restored dependency context. |
-| API compatibility | `diff` | Version ranges, package or platform diffs, breaking/additive/potentially-breaking classification, type and member filters. |
+| API compatibility | `diff` | Version ranges, package or platform diffs, breaking/additive/potentially-breaking classification, type and member filters, plus opt-in decompiled C#/IL/checksum-verified authored Source evidence. |
 | Relationships | `depends`, `extensions`, `implements` | Type hierarchies, package dependencies, library reference graphs, extension methods/properties, implementors and subclasses. Add `--project` to search project-referenced packages. |
 | Source mapping | `type`/`library`/`package -S "Source Files"`, `member -S "Source Locations"` / `"Original Source"` | SourceLink URLs, member file/line locations, source fetching, URL verification, token+IL-offset to source-line resolution. |
 | Performance analysis *(experimental)* | `library`/`type`/`member -S "Top Leverage"`, `"Performance Triage"`, `"Call Graph"`, `"Caller Graph"` | Whole-assembly call-graph leverage ranking — direct callers, root reach, fanout, depth, loop calls — with opt-in per-node cost signals (alloc, copy, unsafe, reflection, throw/exception, catch/finally) and actionable rewrite-shape detection. |
@@ -127,7 +127,7 @@ context for copied DLLs. A future `--deps` source can represent runtime
 | `type X` | Discover types or render a single type shape. |
 | `member X` | Inspect members, docs, overloads, decompiled/lowered C#, SourceLink-backed original source, and IL. |
 | `find X` | Search for types across packages, frameworks, projects, and local assets. |
-| `diff X` | Compare API surfaces by default; opt into analysis or C# + IL implementation evidence. |
+| `diff X` | Compare API surfaces by default; opt into analysis or peer decompiled C#, IL, and checksum-verified authored Source implementation evidence. |
 | `extensions X` | Find extension methods and C# extension properties for a type. |
 | `implements X` | Find concrete implementors or subclasses. |
 | `depends X` | Walk type, package, or library dependency graphs; emits Mermaid diagrams. |

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ dotnet-inspect library System.Text.Json --il-offset 0x06000004+0x15
 dotnet-inspect diff --package System.Text.Json@9.0.0..10.0.0 --breaking
 dotnet-inspect timeline --package System.Text.Json@8.0.0..9.0.0 --type System.Text.Json.JsonSerializer --members --at all
 dotnet-inspect timeline --package MyLib@1.0.0..2.0.0 --type MyType --member Parse --finding analysis.unsafety --at all
-dotnet-inspect diff --library old/Foo.dll..new/Foo.dll -S "Implementation Diff" -m MyType.HotPath
+dotnet-inspect diff --library old/Foo.dll..new/Foo.dll -S "Implementation Diff" --authored-source -m MyType.HotPath
 dotnet-inspect depends Stream --markdown --mermaid
 dotnet-inspect implements IEquatable --project ./src/App -v:q
 dotnet-inspect extensions string --project ./src/App -v:n

--- a/docs/design/fact-planned-compile-back-harness.md
+++ b/docs/design/fact-planned-compile-back-harness.md
@@ -24,6 +24,20 @@ The important distinction is artifact production vs proof:
 - ReturnToSender owns artifact requests, compilation, product diff invocation,
   and failure reporting.
 
+The harness also has a strict two-oracle invariant:
+
+- decompiled **B→IL** answers whether product-decompiled C# rebuilds to shipped
+  IL;
+- checksum-verified authored **A→IL** measures authored-source rebuild fidelity;
+- neither verdict changes, rescues, or declassifies the other.
+
+PDB checksum verification proves that fetched authored bytes correspond to the
+PDB. It is not the A→IL verdict. Determinism, compilation options, references,
+compiler version, generators, and project context are reported separately as
+build-context evidence. `--authored-rebuild-fidelity` substitutes the acquired
+authored body into the same final `ArtifactRequest`, invokes product IL diff,
+and prints both oracle results plus checksum, determinism, and context status.
+
 The existing `CB_CLUSTER=1` path already has a strong generic answer for closure
 membership: compile, read the compiler's missing-symbol diagnostics, add the
 named same-assembly roots, and repeat until the closure stops growing or hits a

--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -28,7 +28,8 @@ family.
   Source comparisons retain `FindingComparison<string>` with the `text.line`
   descriptor. Research
   cross-checks their exactness against the richer semantic projections for
-  members present on both sides.
+  members present on both sides. A disagreement is retained as a per-member
+  `Failed` diagnostic; it does not abort healthy members in the same diff.
 
 ## Research comparison model
 
@@ -38,7 +39,7 @@ type-centric groups from that collection; grouped and flat consumers therefore
 cannot observe divergent copies of the same result.
 
 Each `ResearchChange` carries one mechanism, a `FindingDescriptor`, an
-added/removed/changed classification, its subject, and any native producer
+added/removed/changed/failed classification, its subject, and any native producer
 payload needed for typed presentation. It is deliberately not a
 `PairFinding<T>`. Metadata now exposes genuine API type/member comparisons and
 `ResearchComparison.ApiComparison` retains that producer-owned envelope. C#,
@@ -50,6 +51,24 @@ their semantic rows remain because they carry richer producer-owned evidence,
 while retained comparisons expose the exact census transitions. `Source` never
 replaces or changes the meaning of `CSharp`: one describes checksum-verified
 authored text and the other describes product-decompiled text.
+
+### Deliberate dual-representation decision
+
+This design revises the earlier plan to retire the C# and IL semantic
+projections immediately after Finding adoption. The two retained
+representations have different durable payloads:
+
+- native Finding comparisons own inspection outcomes, stable census identity,
+  and added/removed/present/changed transitions;
+- `CSharpBodyDiff` and `IlBodyDiff` own aligned hunks, typed display failures,
+  old/new offsets, and richer producer-formatted evidence.
+
+The semantic projections therefore remain deliberately rather than by
+accretion. Every overlapping member is cross-validated against the native
+comparison, and divergence becomes a visible per-member `Failed` diagnostic.
+If the Finding producers later carry equivalent aligned hunk and typed display
+payloads, the semantic projections should be deleted rather than matched a
+third time.
 
 ## Consumer contract
 
@@ -69,6 +88,10 @@ Use `CompareMembersWithAuthoredSource` when the caller also has old/new
 `WithAuthoredSourceComparisons` to enrich an assembly comparison. These APIs
 preserve `Complete`, `Absent`, and `Failed` independently and retain the native
 line comparison. Research does not fetch source.
+
+Finding acquisition and cross-validation failures use
+`ResearchChangeKind.Failed`; they are operational diagnostics, never semantic
+`Changed` rows in table, TSV, JSONL, or programmatic consumers.
 
 The `diff --finding csharp.line` and `diff --finding il.op` focused lenses read
 those retained comparisons and render native `PairFinding` cases. Missing
@@ -97,6 +120,10 @@ endpoint PDB and
 SourceLink body, verifies the document checksum, and adds a separately labeled
 `Source` lane. Missing mappings and acquisition failures remain visible rather
 than falling back to decompiled C#.
+The authored A→IL lane reuses the final RTS shell/request but compiles with
+portable-PDB-recorded options when available; the decompiled B→IL lane uses the
+RTS compile context. `BuildContext` and determinism verdicts therefore remain
+part of interpreting any Exact/IlDifferent disagreement.
 Package, platform, and local-library ranges use the same acquisition path as the
 default API diff; `--type`, `--member`, row limits, table, TSV, and JSONL
 projection continue to apply. The CLI consumes this product component and does

--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -1,6 +1,7 @@
 # Implementation Diff Boundary
 
-`ImplementationDiff` is the product-side C# + IL/body diff projection in
+`ImplementationDiff` is the product-side decompiled C# + IL/body + authored
+Source diff projection in
 `ILInspector.Research`. It is the reusable implementation-diff component for
 the CLI, ReturnToSender, harnesses, and other consumers that need one
 member-centric change model instead of separate C# and IL renderers.
@@ -17,12 +18,15 @@ family.
 - `ILInspector.Instructions` owns IL/body diff production and display rows
   through `IlBodyDiff`, `IlAssemblyDiff`, and `IlDiffPrinter`.
 - `ILInspector.Research` owns the join. `ImplementationDiff` compares assemblies
-  with C# and IL/body mechanisms, groups changes by `ResearchSubjectKey`, and
+  with decompiled C# and IL/body mechanisms, accepts checksum-gated authored
+  line inspections from Services, groups changes by `ResearchSubjectKey`, and
   exposes typed display rows and unified lines without reformatting producer
   wording.
 - `ResearchComparison.RetainedComparisons` keeps the native
   `FindingComparison<CSharpCanonicalLine>` and
-  `FindingComparison<CanonicalIlOperation>` envelopes when requested. Research
+  `FindingComparison<CanonicalIlOperation>` envelopes when requested. Authored
+  Source comparisons retain `FindingComparison<string>` with the `text.line`
+  descriptor. Research
   cross-checks their exactness against the richer semantic projections for
   members present on both sides.
 
@@ -43,7 +47,9 @@ old/new Finding censuses yet, so the cross-mechanism `ResearchChange` projection
 must not manufacture Finding atoms or misuse `PairKind`. `ResearchChange` is a Research-owned migration projection, not the seed of a
 parallel generic `EvidenceRow` spine. C# and IL now have native comparisons;
 their semantic rows remain because they carry richer producer-owned evidence,
-while retained comparisons expose the exact census transitions.
+while retained comparisons expose the exact census transitions. `Source` never
+replaces or changes the meaning of `CSharp`: one describes checksum-verified
+authored text and the other describes product-decompiled text.
 
 ## Consumer contract
 
@@ -57,6 +63,12 @@ old/new `MethodDefinitionHandle` values in live `MetadataSource` instances. The
 member result keeps the typed C# diff, typed IL diff, joined implementation
 changes, and a single `ResearchSubjectKey`; exact members return an empty
 change list with `IsExact` set.
+
+Use `CompareMembersWithAuthoredSource` when the caller also has old/new
+`FindingInspection<string>` envelopes from Services. Use
+`WithAuthoredSourceComparisons` to enrich an assembly comparison. These APIs
+preserve `Complete`, `Absent`, and `Failed` independently and retain the native
+line comparison. Research does not fetch source.
 
 The `diff --finding csharp.line` and `diff --finding il.op` focused lenses read
 those retained comparisons and render native `PairFinding` cases. Missing
@@ -80,6 +92,10 @@ third implementation-specific row family.
 The `diff` command exposes this component through the explicit-only
 `Implementation Diff` section. The CLI projects one row per producer-owned
 unified line with `Member`, `Mechanism`, `Change`, and `Evidence` columns.
+For changed implementation members, it acquires each endpoint's PDB and
+SourceLink body, verifies the document checksum, and adds a separately labeled
+`Source` lane. Missing mappings and acquisition failures remain visible rather
+than falling back to decompiled C#.
 Package, platform, and local-library ranges use the same acquisition path as the
 default API diff; `--type`, `--member`, row limits, table, TSV, and JSONL
 projection continue to apply. The CLI consumes this product component and does

--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -92,6 +92,10 @@ line comparison. Research does not fetch source.
 Finding acquisition and cross-validation failures use
 `ResearchChangeKind.Failed`; they are operational diagnostics, never semantic
 `Changed` rows in table, TSV, JSONL, or programmatic consumers.
+When a semantic projection carries the corresponding typed failure, Research
+keeps that richer row and suppresses the duplicate generic Finding failure.
+Synthetic add/remove rows from the same failed C# hunk are omitted; genuine
+body absence and independently decoded partial IL evidence remain visible.
 
 The `diff --finding csharp.line` and `diff --finding il.op` focused lenses read
 those retained comparisons and render native `PairFinding` cases. Missing

--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -20,6 +20,11 @@ family.
   with C# and IL/body mechanisms, groups changes by `ResearchSubjectKey`, and
   exposes typed display rows and unified lines without reformatting producer
   wording.
+- `ResearchComparison.RetainedComparisons` keeps the native
+  `FindingComparison<CSharpCanonicalLine>` and
+  `FindingComparison<CanonicalIlOperation>` envelopes when requested. Research
+  cross-checks their exactness against the richer semantic projections for
+  members present on both sides.
 
 ## Research comparison model
 
@@ -35,11 +40,10 @@ payload needed for typed presentation. It is deliberately not a
 `ResearchComparison.ApiComparison` retains that producer-owned envelope. C#,
 IL/body, body-signal, and ReturnToSender mechanisms do not all expose equivalent
 old/new Finding censuses yet, so the cross-mechanism `ResearchChange` projection
-must not manufacture Finding atoms or misuse `PairKind`. `ResearchChange` is a
-Research-owned migration projection, not the seed of a parallel generic
-`EvidenceRow` spine. As each mechanism gains honest observations and
-transitions, Research should retain those producer-owned values and retire the
-corresponding projection fields.
+must not manufacture Finding atoms or misuse `PairKind`. `ResearchChange` is a Research-owned migration projection, not the seed of a
+parallel generic `EvidenceRow` spine. C# and IL now have native comparisons;
+their semantic rows remain because they carry richer producer-owned evidence,
+while retained comparisons expose the exact census transitions.
 
 ## Consumer contract
 
@@ -53,6 +57,14 @@ old/new `MethodDefinitionHandle` values in live `MetadataSource` instances. The
 member result keeps the typed C# diff, typed IL diff, joined implementation
 changes, and a single `ResearchSubjectKey`; exact members return an empty
 change list with `IsExact` set.
+
+The `diff --finding csharp.line` and `diff --finding il.op` focused lenses read
+those retained comparisons and render native `PairFinding` cases. Missing
+members and methods without bodies remain distinct inspection states. IL
+retention pairs the union of declared method identities, so added, removed, and
+signature-changed methods are not lost by the semantic body-diff intersection.
+Failed inspections render explicit failure rows instead of becoming empty
+comparisons.
 
 Use `ImplementationDiff.ToIlChanges` when a caller already has a scoped
 `IlMemberDiffResult`, such as ReturnToSender comparing one original method to a

--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -92,7 +92,8 @@ third implementation-specific row family.
 The `diff` command exposes this component through the explicit-only
 `Implementation Diff` section. The CLI projects one row per producer-owned
 unified line with `Member`, `Mechanism`, `Change`, and `Evidence` columns.
-For changed implementation members, it acquires each endpoint's PDB and
+With `--authored-source`, it acquires each changed implementation member's
+endpoint PDB and
 SourceLink body, verifies the document checksum, and adds a separately labeled
 `Source` lane. Missing mappings and acquisition failures remain visible rather
 than falling back to decompiled C#.

--- a/docs/design/source-finding-producers.md
+++ b/docs/design/source-finding-producers.md
@@ -64,8 +64,8 @@ presentation folds, not additional Metadata Findings.
 token. `AuthoredSourceAcquisition` consumes the same token-scoped mapping and
 document census, fetches exact bytes through the SSRF-hardened Services path,
 verifies the portable-PDB checksum, extracts the member body, and returns a
-`FindingInspection<string>`. It keeps missing PDB/mapping/URL as `Absent` and
-fetch/checksum/extraction errors as `Failed`.
+`FindingInspection<string>`. It keeps missing PDB/mapping/URL/checksum metadata
+as `Absent` and fetch/checksum mismatch/extraction errors as `Failed`.
 
 Compilation options and references describe available rebuild context. They do
 not claim that the context is complete enough to reproduce the original build.

--- a/docs/design/source-finding-producers.md
+++ b/docs/design/source-finding-producers.md
@@ -61,11 +61,21 @@ census. Their reachability and checksum statuses are operation results and
 presentation folds, not additional Metadata Findings.
 
 `MemberSourceLocationCollector` consumes member-source Findings by metadata
-token. The decompiler SourceLink oracle can later consume the same mappings,
-then join a complete source acquisition with the selected member observation.
+token. `AuthoredSourceAcquisition` consumes the same token-scoped mapping and
+document census, fetches exact bytes through the SSRF-hardened Services path,
+verifies the portable-PDB checksum, extracts the member body, and returns a
+`FindingInspection<string>`. It keeps missing PDB/mapping/URL as `Absent` and
+fetch/checksum/extraction errors as `Failed`.
 
 Compilation options and references describe available rebuild context. They do
 not claim that the context is complete enough to reproduce the original build.
+The authored rebuild harness reports `Recorded`, `Incomplete`, `Drift`, or
+`Failed` context beside—never folded into—the A-to-IL result.
+
+Product `ImplementationDiff` consumes acquired line envelopes for its `Source`
+mechanism; Research remains network-free. Decompiled `CSharp` and authored
+`Source` are peers, so Source absence never changes or suppresses decompiler
+evidence.
 
 ## Migration and API retirement
 

--- a/docs/workflows/discovery/api-diff.md
+++ b/docs/workflows/discovery/api-diff.md
@@ -183,6 +183,20 @@ only the supplied pair; it does not traverse the version range. Use
 `PairFinding.Present` means the target exists at both endpoints, while
 `PairFinding.Removed` means only the old endpoint contains it.
 
+Select an implementation producer to inspect the exact C# line or IL operation
+census for one method:
+
+```bash
+dotnet-inspect diff --library old/Foo.dll..new/Foo.dll \
+  --type Foo.Parser --member Parse:1 --finding csharp.line
+dotnet-inspect diff --library old/Foo.dll..new/Foo.dll \
+  --type Foo.Parser --member Parse:1 --finding il.op
+```
+
+These lenses preserve complete, absent, and failed inspection outcomes.
+One-sided methods therefore render added or removed native pairs rather than
+disappearing from an intersection-only body diff.
+
 This focused endpoint-confirmation lens must be selected by itself. It does not
 compose with the comparison sections or `-S @All`; select `Changes`,
 `Analysis Diff`, and `Implementation Diff` explicitly when composing those

--- a/skills/compatibility/SKILL.md
+++ b/skills/compatibility/SKILL.md
@@ -83,12 +83,15 @@ Rows identify unsafe operation kinds and details. `PairFinding.Added` confirms
 introduction; `Present` and `Removed` distinguish persistence from
 disappearance without treating endpoint-local IL offsets as identity.
 
-## Did the implementation change? (C# + IL)
+## Did the implementation change? (decompiled C# + IL + authored Source)
 
 `-S "Implementation Diff"` selects Research-composed body evidence instead of
-the default API compatibility view. Rows identify the member, producer (`C#` or
-`IL`), change kind, and producer-owned evidence. Narrow with `-t` and `-m`; use
-`--table`, `--tsv`, or `--jsonl` for columnar output.
+the default API compatibility view. Rows identify the member, producer (`C#`,
+`IL`, or `Source`), change kind, and producer-owned evidence. `C#` is
+decompiled text; `Source` is checksum-verified authored SourceLink text. The
+lanes are peers: Source absence or failure stays visible and never replaces the
+C# lane. Narrow with `-t` and `-m`; use `--table`, `--tsv`, or `--jsonl` for
+columnar output.
 
 ```bash
 dnx dotnet-inspect -y -- diff --library old/Foo.dll..new/Foo.dll -S "Implementation Diff" -t MyType -m HotPath

--- a/skills/compatibility/SKILL.md
+++ b/skills/compatibility/SKILL.md
@@ -162,3 +162,6 @@ for a type target, no row means it exists at neither. Use `-m Type.Member:1` for
 an API member boundary. Use `--finding analysis.allocation`,
 `--finding analysis.call-site`, or `--finding analysis.unsafety` with exactly
 one method target for the corresponding Analysis boundary.
+Use `--finding csharp.line` or `--finding il.op` with exactly one method target
+to inspect native implementation-census transitions. Those lenses preserve
+complete, absent, and failed outcomes, including added or removed methods.

--- a/skills/compatibility/SKILL.md
+++ b/skills/compatibility/SKILL.md
@@ -94,7 +94,8 @@ C# lane. Narrow with `-t` and `-m`; use `--table`, `--tsv`, or `--jsonl` for
 columnar output.
 
 ```bash
-dnx dotnet-inspect -y -- diff --library old/Foo.dll..new/Foo.dll -S "Implementation Diff" -t MyType -m HotPath
+dnx dotnet-inspect -y -- diff --library old/Foo.dll..new/Foo.dll \
+  -S "Implementation Diff" --authored-source -t MyType -m HotPath
 ```
 
 Treat these rows as implementation evidence, not semantic-equivalence proof.

--- a/src/DotnetInspector.Services.Tests/AuthoredSourceAcquisitionTests.cs
+++ b/src/DotnetInspector.Services.Tests/AuthoredSourceAcquisitionTests.cs
@@ -82,7 +82,7 @@ public class AuthoredSourceAcquisitionTests
     }
 
     [Fact]
-    public void FromContent_MissingChecksumIsNotAuthoredEvidence()
+    public void FromContent_MissingChecksumIsAbsentEvidence()
     {
         byte[] content = Encoding.UTF8.GetBytes(Source);
         var document = Document(content) with
@@ -98,10 +98,13 @@ public class AuthoredSourceAcquisitionTests
             "M",
             Subject);
 
-        Assert.True(result.Lines.Value is FindingInspection<string>.Failed);
+        Assert.IsType<FindingInspection<string>.Absent>(result.Lines.Value);
         Assert.Equal(
             SourceChecksumVerification.Unavailable,
             result.ChecksumVerification);
+        Assert.NotNull(result.Mapping);
+        Assert.NotNull(result.Document);
+        Assert.Null(result.Text);
     }
 
     [Fact]

--- a/src/DotnetInspector.Services.Tests/AuthoredSourceAcquisitionTests.cs
+++ b/src/DotnetInspector.Services.Tests/AuthoredSourceAcquisitionTests.cs
@@ -1,12 +1,15 @@
 using System.Security.Cryptography;
 using System.Text;
 
+using DotnetInspector.Core;
+
 using ILInspector.Findings;
 using ILInspector.Metadata;
 using ILInspector.MetadataPrimitives;
 
 namespace DotnetInspector.Services.Tests;
 
+[Collection(CoreCacheCollection.Name)]
 public class AuthoredSourceAcquisitionTests
 {
     static readonly FindingSubject Subject = new("M~source", "Sample.M");
@@ -101,6 +104,52 @@ public class AuthoredSourceAcquisitionTests
             result.ChecksumVerification);
     }
 
+    [Fact]
+    public async Task FetchValidatedSourceBytes_InvalidCacheRetriesAndRepairsFromNetwork()
+    {
+        string cachePath = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-source-cache-{Guid.NewGuid():N}");
+        CoreCache.Initialize("dotnet-inspect-test", cachePath);
+        byte[] invalid = Encoding.UTF8.GetBytes("invalid");
+        byte[] expected = Encoding.UTF8.GetBytes(Source);
+        var handler = new QueueHandler(invalid, expected);
+        using var client = new HttpClient(handler);
+        const string Url = "https://example.test/Sample.cs";
+
+        try
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var firstFetcher = new SourceFetcher(client);
+            Assert.Equal(
+                invalid,
+                await firstFetcher.FetchSourceBytesAsync(Url, cancellationToken));
+
+            var secondFetcher = new SourceFetcher(client);
+            var repaired = await secondFetcher.FetchValidatedSourceBytesAsync(
+                Url,
+                bytes => bytes.Span.SequenceEqual(expected),
+                cancellationToken);
+
+            Assert.Equal(expected, repaired);
+            Assert.Equal(2, handler.RequestCount);
+
+            var thirdFetcher = new SourceFetcher(client);
+            var cached = await thirdFetcher.FetchValidatedSourceBytesAsync(
+                Url,
+                bytes => bytes.Span.SequenceEqual(expected),
+                cancellationToken);
+
+            Assert.Equal(expected, cached);
+            Assert.Equal(2, handler.RequestCount);
+        }
+        finally
+        {
+            if (Directory.Exists(cachePath))
+                Directory.Delete(cachePath, recursive: true);
+        }
+    }
+
     static MemberSourceObservation Mapping()
         => new(
             new MemberAnchor(
@@ -127,4 +176,22 @@ public class AuthoredSourceAcquisitionTests
             ResolvedUrl: "https://example.test/Sample.cs",
             ChecksumAlgorithm: "SHA256",
             Checksum: Convert.ToHexString(SHA256.HashData(content)));
+
+    sealed class QueueHandler(params byte[][] responses) : HttpMessageHandler
+    {
+        readonly Queue<byte[]> _responses = new(responses);
+
+        public int RequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(_responses.Dequeue()),
+            });
+        }
+    }
 }

--- a/src/DotnetInspector.Services.Tests/AuthoredSourceAcquisitionTests.cs
+++ b/src/DotnetInspector.Services.Tests/AuthoredSourceAcquisitionTests.cs
@@ -1,0 +1,130 @@
+using System.Security.Cryptography;
+using System.Text;
+
+using ILInspector.Findings;
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+
+namespace DotnetInspector.Services.Tests;
+
+public class AuthoredSourceAcquisitionTests
+{
+    static readonly FindingSubject Subject = new("M~source", "Sample.M");
+    const string Source = """
+        class Sample
+        {
+            public int M()
+            {
+                return 1;
+            }
+        }
+        """;
+
+    [Fact]
+    public void FromContent_VerifiedSourceProducesCompleteLineCensus()
+    {
+        byte[] content = Encoding.UTF8.GetBytes(Source);
+        var result = AuthoredSourceAcquisition.FromContent(
+            Mapping(),
+            Document(content),
+            content,
+            "M",
+            Subject);
+
+        var complete = Assert.IsType<FindingInspection<string>.Complete>(
+            result.Lines.Value);
+        Assert.Equal(SourceChecksumVerification.Exact, result.ChecksumVerification);
+        Assert.Contains(
+            complete.Findings,
+            finding => finding.Payload.Contains(
+                "public int M()",
+                StringComparison.Ordinal));
+        Assert.Contains(
+            complete.Findings,
+            finding => finding.Payload.Contains(
+                "return 1;",
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FromContent_MismatchedChecksumProducesFailedInspection()
+    {
+        byte[] content = Encoding.UTF8.GetBytes(Source);
+        var result = AuthoredSourceAcquisition.FromContent(
+            Mapping(),
+            Document(Encoding.UTF8.GetBytes(Source + "changed")),
+            content,
+            "M",
+            Subject);
+
+        var failed = Assert.IsType<FindingInspection<string>.Failed>(
+            result.Lines.Value);
+        Assert.Equal(SourceChecksumVerification.Mismatch, result.ChecksumVerification);
+        Assert.Contains("does not match", failed.Error.Reason);
+    }
+
+    [Fact]
+    public void VerifyChecksum_AcceptsLineEndingNormalization()
+    {
+        byte[] expected = Encoding.UTF8.GetBytes(Source.ReplaceLineEndings("\n"));
+        byte[] actual = Encoding.UTF8.GetBytes(Source.ReplaceLineEndings("\r\n"));
+
+        var verification = AuthoredSourceAcquisition.VerifyChecksum(
+            Document(expected),
+            actual);
+
+        Assert.Equal(
+            SourceChecksumVerification.LineEndingNormalized,
+            verification);
+    }
+
+    [Fact]
+    public void FromContent_MissingChecksumIsNotAuthoredEvidence()
+    {
+        byte[] content = Encoding.UTF8.GetBytes(Source);
+        var document = Document(content) with
+        {
+            ChecksumAlgorithm = null,
+            Checksum = null,
+        };
+
+        var result = AuthoredSourceAcquisition.FromContent(
+            Mapping(),
+            document,
+            content,
+            "M",
+            Subject);
+
+        Assert.True(result.Lines.Value is FindingInspection<string>.Failed);
+        Assert.Equal(
+            SourceChecksumVerification.Unavailable,
+            result.ChecksumVerification);
+    }
+
+    static MemberSourceObservation Mapping()
+        => new(
+            new MemberAnchor(
+                "M~1234567890",
+                "M:Sample.M",
+                "1234567890",
+                "Sample",
+                "M"),
+            MetadataToken: 0x06000001,
+            DocumentRowId: 1,
+            CanonicalPath: "Sample.cs",
+            OriginalPath: "/_/Sample.cs",
+            ResolvedUrl: "https://example.test/Sample.cs",
+            StartLine: 5,
+            EndLine: 5,
+            IsPrimaryDocument: true);
+
+    static SourceDocumentObservation Document(byte[] content)
+        => new(
+            CanonicalPath: "Sample.cs",
+            OriginalPath: "/_/Sample.cs",
+            DocumentRowId: 1,
+            Storage: SourceDocumentStorage.SourceLink,
+            ResolvedUrl: "https://example.test/Sample.cs",
+            ChecksumAlgorithm: "SHA256",
+            Checksum: Convert.ToHexString(SHA256.HashData(content)));
+}

--- a/src/DotnetInspector.Services/AuthoredSourceAcquisition.cs
+++ b/src/DotnetInspector.Services/AuthoredSourceAcquisition.cs
@@ -91,8 +91,12 @@ public static class AuthoredSourceAcquisition
                 : "The selected source document has no fetchable SourceLink URL.");
         }
 
-        var bytes = await fetcher.FetchSourceBytesAsync(url, cancellationToken)
-            .ConfigureAwait(false);
+        var bytes = await fetcher.FetchValidatedSourceBytesAsync(
+            url,
+            content => VerifyChecksum(document, content.Span)
+                is SourceChecksumVerification.Exact
+                    or SourceChecksumVerification.LineEndingNormalized,
+            cancellationToken).ConfigureAwait(false);
         if (bytes is null)
         {
             return Failed(

--- a/src/DotnetInspector.Services/AuthoredSourceAcquisition.cs
+++ b/src/DotnetInspector.Services/AuthoredSourceAcquisition.cs
@@ -1,0 +1,302 @@
+using System.Collections.Immutable;
+using System.Security.Cryptography;
+using System.Text;
+
+using ILInspector.Findings;
+using ILInspector.Metadata;
+using ILInspector.Text;
+
+namespace DotnetInspector.Services;
+
+public enum SourceChecksumVerification
+{
+    Exact,
+    LineEndingNormalized,
+    Unavailable,
+    Unsupported,
+    Mismatch,
+}
+
+public sealed record AuthoredMemberSourceInspection(
+    FindingInspection<string> Lines,
+    string? Text,
+    MemberSourceObservation? Mapping,
+    SourceDocumentObservation? Document,
+    SourceChecksumVerification? ChecksumVerification)
+{
+    public bool IsComplete => Lines.Value is FindingInspection<string>.Complete;
+}
+
+/// <summary>
+/// Acquires one authored member from SourceLink and verifies the portable-PDB checksum before
+/// exposing its text as evidence.
+/// </summary>
+public static class AuthoredSourceAcquisition
+{
+    public static async Task<AuthoredMemberSourceInspection> AcquireMemberAsync(
+        SourceLinkService source,
+        int metadataToken,
+        string methodName,
+        FindingSubject subject,
+        SourceFetcher fetcher,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrWhiteSpace(methodName);
+        ArgumentNullException.ThrowIfNull(subject);
+        ArgumentNullException.ThrowIfNull(fetcher);
+
+        var memberInspection = MetadataFindings.InspectMemberSources(
+            source,
+            subject,
+            new MemberSourceQuery(new HashSet<int> { metadataToken }));
+        if (memberInspection.Value is FindingInspection<MemberSourceObservation>.Absent absent)
+            return Absent(absent.Detail ?? "Authored source mapping is unavailable.");
+        if (memberInspection.Value is FindingInspection<MemberSourceObservation>.Failed failed)
+            return Failed(failed.Error);
+
+        var memberComplete = (FindingInspection<MemberSourceObservation>.Complete)
+            memberInspection.Value;
+        var mapping = memberComplete.Findings
+            .Select(static finding => finding.Payload)
+            .OrderByDescending(static candidate => candidate.IsPrimaryDocument)
+            .ThenBy(static candidate => candidate.DocumentRowId)
+            .FirstOrDefault();
+        if (mapping is null)
+            return Absent("The selected member has no portable-PDB source mapping.");
+
+        var documentInspection = MetadataFindings.InspectSourceDocuments(
+            source,
+            subject,
+            new SourceDocumentQuery(mapping.CanonicalPath));
+        if (documentInspection.Value is FindingInspection<SourceDocumentObservation>.Absent documentAbsent)
+            return Absent(documentAbsent.Detail ?? "Authored source document is unavailable.");
+        if (documentInspection.Value is FindingInspection<SourceDocumentObservation>.Failed documentFailed)
+            return Failed(documentFailed.Error);
+
+        var documentComplete = (FindingInspection<SourceDocumentObservation>.Complete)
+            documentInspection.Value;
+        var document = documentComplete.Findings
+            .Select(static finding => finding.Payload)
+            .FirstOrDefault(candidate => string.Equals(
+                candidate.CanonicalPath,
+                mapping.CanonicalPath,
+                StringComparison.OrdinalIgnoreCase));
+        if (document is null)
+            return Absent("The selected member's source document is not in the portable PDB.");
+        if (document.ResolvedUrl is not { Length: > 0 } url)
+        {
+            return Absent(document.Storage == SourceDocumentStorage.Embedded
+                ? "Embedded authored-source retrieval is not available."
+                : "The selected source document has no fetchable SourceLink URL.");
+        }
+
+        var bytes = await fetcher.FetchSourceBytesAsync(url, cancellationToken)
+            .ConfigureAwait(false);
+        if (bytes is null)
+        {
+            return Failed(
+                subject,
+                $"Could not fetch authored source from '{url}'.");
+        }
+
+        return FromContent(mapping, document, bytes, methodName, subject);
+    }
+
+    public static AuthoredMemberSourceInspection FromContent(
+        MemberSourceObservation mapping,
+        SourceDocumentObservation document,
+        byte[] content,
+        string methodName,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(mapping);
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentException.ThrowIfNullOrWhiteSpace(methodName);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        var verification = VerifyChecksum(document, content);
+        if (verification is SourceChecksumVerification.Unavailable
+            or SourceChecksumVerification.Unsupported
+            or SourceChecksumVerification.Mismatch)
+        {
+            return Failed(
+                subject,
+                verification switch
+                {
+                    SourceChecksumVerification.Unavailable =>
+                        "The portable PDB does not provide a usable source checksum.",
+                    SourceChecksumVerification.Unsupported =>
+                        $"The source checksum algorithm '{document.ChecksumAlgorithm}' is unsupported.",
+                    _ => "Fetched authored source does not match the portable-PDB checksum.",
+                },
+                mapping,
+                document,
+                verification);
+        }
+
+        try
+        {
+            string sourceText = Encoding.UTF8.GetString(content);
+            if (sourceText.Length > 0 && sourceText[0] == '\uFEFF')
+                sourceText = sourceText[1..];
+            string memberText = SourceLinkResolver.ExtractMethodBody(
+                sourceText,
+                mapping.StartLine,
+                mapping.EndLine,
+                methodName);
+            var lines = TextFindings.Inspect(memberText, subject).ToImmutableArray();
+            return new AuthoredMemberSourceInspection(
+                new FindingInspection<string>.Complete(lines),
+                memberText,
+                mapping,
+                document,
+                verification);
+        }
+        catch (Exception ex) when (ex is ArgumentException
+            or IndexOutOfRangeException
+            or InvalidOperationException)
+        {
+            return Failed(
+                subject,
+                $"Could not extract the authored member source: {ex.Message}",
+                mapping,
+                document,
+                verification);
+        }
+    }
+
+    public static SourceChecksumVerification VerifyChecksum(
+        SourceDocumentObservation document,
+        ReadOnlySpan<byte> content)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        if (document.ChecksumAlgorithm is not { Length: > 0 }
+            || document.Checksum is not { Length: > 0 })
+        {
+            return SourceChecksumVerification.Unavailable;
+        }
+
+        byte[] expected;
+        try
+        {
+            expected = Convert.FromHexString(document.Checksum);
+        }
+        catch (FormatException)
+        {
+            return SourceChecksumVerification.Unsupported;
+        }
+
+        if (HashMatches(document.ChecksumAlgorithm, content, expected))
+            return SourceChecksumVerification.Exact;
+        if (HashMatchesAfterLineEndingNormalization(
+            document.ChecksumAlgorithm,
+            content,
+            expected))
+        {
+            return SourceChecksumVerification.LineEndingNormalized;
+        }
+
+        return IsSupportedAlgorithm(document.ChecksumAlgorithm)
+            ? SourceChecksumVerification.Mismatch
+            : SourceChecksumVerification.Unsupported;
+    }
+
+    static AuthoredMemberSourceInspection Absent(string detail)
+        => new(
+            new FindingInspection<string>.Absent(detail),
+            Text: null,
+            Mapping: null,
+            Document: null,
+            ChecksumVerification: null);
+
+    static AuthoredMemberSourceInspection Failed(
+        InspectionError error)
+        => new(
+            new FindingInspection<string>.Failed(error),
+            Text: null,
+            Mapping: null,
+            Document: null,
+            ChecksumVerification: null);
+
+    static AuthoredMemberSourceInspection Failed(
+        FindingSubject subject,
+        string reason,
+        MemberSourceObservation? mapping = null,
+        SourceDocumentObservation? document = null,
+        SourceChecksumVerification? verification = null)
+        => new(
+            new FindingInspection<string>.Failed(
+                new InspectionError(subject, TextFindings.LineDescriptor, reason)),
+            Text: null,
+            mapping,
+            document,
+            verification);
+
+    static bool HashMatches(
+        string algorithm,
+        ReadOnlySpan<byte> content,
+        ReadOnlySpan<byte> expected)
+        => ComputeHash(algorithm, content).AsSpan().SequenceEqual(expected);
+
+    static bool HashMatchesAfterLineEndingNormalization(
+        string algorithm,
+        ReadOnlySpan<byte> content,
+        ReadOnlySpan<byte> expected)
+    {
+        if (!content.Contains((byte)'\n') && !content.Contains((byte)'\r'))
+            return false;
+
+        return HashMatches(algorithm, NormalizeLineEndings(content, crlf: false), expected)
+            || HashMatches(algorithm, NormalizeLineEndings(content, crlf: true), expected);
+    }
+
+    static byte[] NormalizeLineEndings(ReadOnlySpan<byte> content, bool crlf)
+    {
+        List<byte> lf = new(content.Length);
+        for (int i = 0; i < content.Length; i++)
+        {
+            if (content[i] == '\r')
+            {
+                if (i + 1 < content.Length && content[i + 1] == '\n')
+                    continue;
+
+                lf.Add((byte)'\n');
+                continue;
+            }
+
+            lf.Add(content[i]);
+        }
+
+        if (!crlf)
+            return [.. lf];
+
+        List<byte> result = new(lf.Count);
+        foreach (byte value in lf)
+        {
+            if (value == '\n')
+            {
+                result.Add((byte)'\r');
+                result.Add((byte)'\n');
+            }
+            else
+            {
+                result.Add(value);
+            }
+        }
+
+        return [.. result];
+    }
+
+    static byte[] ComputeHash(string algorithm, ReadOnlySpan<byte> content)
+        => algorithm switch
+        {
+            "SHA256" => SHA256.HashData(content),
+            "SHA1" => SHA1.HashData(content),
+            _ => [],
+        };
+
+    static bool IsSupportedAlgorithm(string algorithm)
+        => algorithm is "SHA256" or "SHA1";
+}

--- a/src/DotnetInspector.Services/AuthoredSourceAcquisition.cs
+++ b/src/DotnetInspector.Services/AuthoredSourceAcquisition.cs
@@ -84,6 +84,15 @@ public static class AuthoredSourceAcquisition
                 StringComparison.OrdinalIgnoreCase));
         if (document is null)
             return Absent("The selected member's source document is not in the portable PDB.");
+        if (document.ChecksumAlgorithm is not { Length: > 0 }
+            || document.Checksum is not { Length: > 0 })
+        {
+            return Absent(
+                "The portable PDB does not provide a usable source checksum.",
+                mapping,
+                document,
+                SourceChecksumVerification.Unavailable);
+        }
         if (document.ResolvedUrl is not { Length: > 0 } url)
         {
             return Absent(document.Storage == SourceDocumentStorage.Embedded
@@ -121,16 +130,21 @@ public static class AuthoredSourceAcquisition
         ArgumentNullException.ThrowIfNull(subject);
 
         var verification = VerifyChecksum(document, content);
-        if (verification is SourceChecksumVerification.Unavailable
-            or SourceChecksumVerification.Unsupported
+        if (verification == SourceChecksumVerification.Unavailable)
+        {
+            return Absent(
+                "The portable PDB does not provide a usable source checksum.",
+                mapping,
+                document,
+                verification);
+        }
+        if (verification is SourceChecksumVerification.Unsupported
             or SourceChecksumVerification.Mismatch)
         {
             return Failed(
                 subject,
                 verification switch
                 {
-                    SourceChecksumVerification.Unavailable =>
-                        "The portable PDB does not provide a usable source checksum.",
                     SourceChecksumVerification.Unsupported =>
                         $"The source checksum algorithm '{document.ChecksumAlgorithm}' is unsupported.",
                     _ => "Fetched authored source does not match the portable-PDB checksum.",
@@ -214,6 +228,18 @@ public static class AuthoredSourceAcquisition
             Mapping: null,
             Document: null,
             ChecksumVerification: null);
+
+    static AuthoredMemberSourceInspection Absent(
+        string detail,
+        MemberSourceObservation mapping,
+        SourceDocumentObservation document,
+        SourceChecksumVerification verification)
+        => new(
+            new FindingInspection<string>.Absent(detail),
+            Text: null,
+            mapping,
+            document,
+            verification);
 
     static AuthoredMemberSourceInspection Failed(
         InspectionError error)

--- a/src/DotnetInspector.Services/DotnetInspector.Services.csproj
+++ b/src/DotnetInspector.Services/DotnetInspector.Services.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../ILInspector.Metadata/ILInspector.Metadata.csproj" />
+    <ProjectReference Include="../ILInspector.Text/ILInspector.Text.csproj" />
     <ProjectReference Include="../DotnetInspector.Core/DotnetInspector.Core.csproj" />
     <ProjectReference Include="../DotnetInspector.Packages/DotnetInspector.Packages.csproj" />
   </ItemGroup>

--- a/src/DotnetInspector.Services/SourceFetcher.cs
+++ b/src/DotnetInspector.Services/SourceFetcher.cs
@@ -9,7 +9,9 @@ namespace DotnetInspector.Services;
 public class SourceFetcher(HttpClient httpClient)
 {
     private readonly Dictionary<string, string> _memoryCache = new();
+    private readonly Dictionary<string, byte[]> _byteMemoryCache = new();
     private readonly HttpClient _httpClient = httpClient;
+    private const string ByteCacheCategory = "source-bytes-v1";
 
     /// <summary>
     /// Fetches source content from a URL, with caching.
@@ -56,6 +58,71 @@ public class SourceFetcher(HttpClient httpClient)
             return content;
         }
         catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Fetches the exact source bytes. This path has a byte-preserving cache so callers can verify
+    /// portable-PDB checksums before treating fetched content as authored-source evidence.
+    /// </summary>
+    public async Task<byte[]?> FetchSourceBytesAsync(
+        string url,
+        CancellationToken cancellationToken = default)
+    {
+        using var trafficScope = NetworkTelemetry.Scope(NetworkTrafficKind.SourceFetch);
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var parsed)
+            || (parsed.Scheme != Uri.UriSchemeHttps
+                && parsed.Scheme != Uri.UriSchemeHttp))
+        {
+            return null;
+        }
+
+        if (_byteMemoryCache.TryGetValue(url, out var memoryBytes))
+            return memoryBytes;
+
+        string? encoded = CoreCache.TryGet(
+            ByteCacheCategory,
+            url,
+            extension: "base64");
+        if (encoded is not null)
+        {
+            try
+            {
+                var cachedBytes = Convert.FromBase64String(encoded);
+                _byteMemoryCache[url] = cachedBytes;
+                return cachedBytes;
+            }
+            catch (FormatException)
+            {
+                // A corrupt cache entry is replaced by the network result below.
+            }
+        }
+
+        try
+        {
+            var bytes = await HttpRetryHelper.GetBytesWithRetryAsync(
+                _httpClient,
+                url,
+                cancellationToken: cancellationToken,
+                trafficKind: NetworkTrafficKind.SourceFetch).ConfigureAwait(false);
+            if (bytes is null)
+                return null;
+
+            _byteMemoryCache[url] = bytes;
+            CoreCache.Set(
+                ByteCacheCategory,
+                url,
+                Convert.ToBase64String(bytes),
+                extension: "base64");
+            return bytes;
+        }
+        catch (HttpRequestException)
+        {
+            return null;
+        }
+        catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
             return null;
         }

--- a/src/DotnetInspector.Services/SourceFetcher.cs
+++ b/src/DotnetInspector.Services/SourceFetcher.cs
@@ -67,9 +67,35 @@ public class SourceFetcher(HttpClient httpClient)
     /// Fetches the exact source bytes. This path has a byte-preserving cache so callers can verify
     /// portable-PDB checksums before treating fetched content as authored-source evidence.
     /// </summary>
-    public async Task<byte[]?> FetchSourceBytesAsync(
+    public Task<byte[]?> FetchSourceBytesAsync(
         string url,
         CancellationToken cancellationToken = default)
+        => FetchSourceBytesCoreAsync(
+            url,
+            cacheValidator: null,
+            cancellationToken);
+
+    /// <summary>
+    /// Fetches exact source bytes while accepting cached bytes only when they satisfy
+    /// <paramref name="cacheValidator"/>. Invalid cached bytes are bypassed and replaced by a
+    /// valid network result; an invalid network result is returned but is not cached.
+    /// </summary>
+    public Task<byte[]?> FetchValidatedSourceBytesAsync(
+        string url,
+        Func<ReadOnlyMemory<byte>, bool> cacheValidator,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(cacheValidator);
+        return FetchSourceBytesCoreAsync(
+            url,
+            cacheValidator,
+            cancellationToken);
+    }
+
+    private async Task<byte[]?> FetchSourceBytesCoreAsync(
+        string url,
+        Func<ReadOnlyMemory<byte>, bool>? cacheValidator,
+        CancellationToken cancellationToken)
     {
         using var trafficScope = NetworkTelemetry.Scope(NetworkTrafficKind.SourceFetch);
         if (!Uri.TryCreate(url, UriKind.Absolute, out var parsed)
@@ -80,7 +106,12 @@ public class SourceFetcher(HttpClient httpClient)
         }
 
         if (_byteMemoryCache.TryGetValue(url, out var memoryBytes))
-            return memoryBytes;
+        {
+            if (cacheValidator is null || cacheValidator(memoryBytes))
+                return memoryBytes;
+
+            _byteMemoryCache.Remove(url);
+        }
 
         string? encoded = CoreCache.TryGet(
             ByteCacheCategory,
@@ -91,8 +122,11 @@ public class SourceFetcher(HttpClient httpClient)
             try
             {
                 var cachedBytes = Convert.FromBase64String(encoded);
-                _byteMemoryCache[url] = cachedBytes;
-                return cachedBytes;
+                if (cacheValidator is null || cacheValidator(cachedBytes))
+                {
+                    _byteMemoryCache[url] = cachedBytes;
+                    return cachedBytes;
+                }
             }
             catch (FormatException)
             {
@@ -110,12 +144,15 @@ public class SourceFetcher(HttpClient httpClient)
             if (bytes is null)
                 return null;
 
-            _byteMemoryCache[url] = bytes;
-            CoreCache.Set(
-                ByteCacheCategory,
-                url,
-                Convert.ToBase64String(bytes),
-                extension: "base64");
+            if (cacheValidator is null || cacheValidator(bytes))
+            {
+                _byteMemoryCache[url] = bytes;
+                CoreCache.Set(
+                    ByteCacheCategory,
+                    url,
+                    Convert.ToBase64String(bytes),
+                    extension: "base64");
+            }
             return bytes;
         }
         catch (HttpRequestException)

--- a/src/DotnetInspector.Services/SourceFetcher.cs
+++ b/src/DotnetInspector.Services/SourceFetcher.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+
 using DotnetInspector.Core;
 using DotnetInspector.Packages;
 
@@ -8,8 +10,8 @@ namespace DotnetInspector.Services;
 /// </summary>
 public class SourceFetcher(HttpClient httpClient)
 {
-    private readonly Dictionary<string, string> _memoryCache = new();
-    private readonly Dictionary<string, byte[]> _byteMemoryCache = new();
+    private readonly ConcurrentDictionary<string, string> _memoryCache = new();
+    private readonly ConcurrentDictionary<string, byte[]> _byteMemoryCache = new();
     private readonly HttpClient _httpClient = httpClient;
     private const string ByteCacheCategory = "source-bytes-v1";
 
@@ -110,7 +112,7 @@ public class SourceFetcher(HttpClient httpClient)
             if (cacheValidator is null || cacheValidator(memoryBytes))
                 return memoryBytes;
 
-            _byteMemoryCache.Remove(url);
+            _byteMemoryCache.TryRemove(url, out _);
         }
 
         string? encoded = CoreCache.TryGet(

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -29,6 +29,20 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void DeclaredMethods_PreservesMethodsWithoutBodies()
+    {
+        var index = LibraryBodyIndex.Open(
+            FixtureCatalog.DiffPair.OldAssemblyPath());
+
+        Assert.Contains(index.DeclaredMethods, method =>
+            method.DeclaringType.Name == "BodyStateSample"
+            && method.Name == "BodyState");
+        Assert.DoesNotContain(index.Methods, method =>
+            method.DeclaringType.Name == "BodyStateSample"
+            && method.Name == "BodyState");
+    }
+
+    [Fact]
     public void CrossAssemblyMetadataResolver_ResolvesFrameworkTypeDefinition()
     {
         string targetPath = typeof(Console).Assembly.Location;

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -16,6 +16,7 @@ public sealed class LibraryBodyIndex
 {
     LibraryBodyIndex(
         string path,
+        ImmutableArray<MethodIdentity> declaredMethods,
         ImmutableArray<MethodIdentity> methods,
         ImmutableArray<DirectCall> directCalls,
         ImmutableArray<UnsafeEvidence> unsafeEvidence,
@@ -34,6 +35,7 @@ public sealed class LibraryBodyIndex
         bool opportunitiesComputed)
     {
         Path = path;
+        DeclaredMethods = declaredMethods;
         Methods = methods;
         DirectCalls = directCalls;
         UnsafeEvidence = unsafeEvidence;
@@ -53,6 +55,9 @@ public sealed class LibraryBodyIndex
     }
 
     public string Path { get; }
+    /// <summary>Every decoded method identity, including abstract and extern members.</summary>
+    public ImmutableArray<MethodIdentity> DeclaredMethods { get; }
+    /// <summary>Method identities whose definitions carry IL bodies.</summary>
     public ImmutableArray<MethodIdentity> Methods { get; }
     public ImmutableArray<DirectCall> DirectCalls { get; }
     public ImmutableArray<UnsafeEvidence> UnsafeEvidence { get; }
@@ -881,7 +886,8 @@ public sealed class LibraryBodyIndex
         IReadOnlyDictionary<int, ImmutableArray<UnsafetyOccurrence>>? unsafetyOccurrences = null)
         => new(
             path: "",
-            methods,
+            declaredMethods: methods,
+            methods: methods,
             directCalls: [],
             unsafeEvidence,
             diagnostics: [],
@@ -923,7 +929,7 @@ public sealed class LibraryBodyIndex
         // hotspots), so requesting opportunities implies computing allocations.
         var index = builder.Build(includeAllocations || includeOpportunities, includeOpportunities, bodyScope, bodyTypeScope);
         return new LibraryBodyIndex(
-            path, index.Methods, index.DirectCalls, index.UnsafeEvidence, index.Diagnostics,
+            path, index.DeclaredMethods, index.Methods, index.DirectCalls, index.UnsafeEvidence, index.Diagnostics,
             index.OptimizationOpportunities, index.UnsafeLeverageMethods, builder.MemorySafetyRulesEnabled, index.UnsafeModes,
             index.BodySignals, index.AllocationOccurrences, index.UnsafetyOccurrences, index.InAssemblyTypeIsException, index.SuppressedOpportunityTokens, index.ExceptionTypeNames,
             index.NonHeapNewObjOperandTokens,
@@ -2145,8 +2151,9 @@ public sealed class LibraryBodyIndex
                 && HasAttributeNamed(_reader.GetAssemblyDefinition().GetCustomAttributes(), "MemorySafetyRulesAttribute", ns);
         }
 
-        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics, ImmutableArray<OptimizationOpportunity> OptimizationOpportunities, ImmutableArray<MethodIdentity> UnsafeLeverageMethods, UnsafeModeBreakdown UnsafeModes, IReadOnlyDictionary<int, BodySignals> BodySignals, IReadOnlyDictionary<int, ImmutableArray<AllocationOccurrence>> AllocationOccurrences, IReadOnlyDictionary<int, ImmutableArray<UnsafetyOccurrence>> UnsafetyOccurrences, IReadOnlyDictionary<(string Namespace, string Name), bool> InAssemblyTypeIsException, IReadOnlySet<int> SuppressedOpportunityTokens, IReadOnlySet<string> ExceptionTypeNames,         IReadOnlySet<int> NonHeapNewObjOperandTokens) Build(bool includeAllocations, bool includeOpportunities, IReadOnlySet<int>? bodyScope = null, Func<TypeRef, bool>? bodyTypeScope = null)
+        public (ImmutableArray<MethodIdentity> DeclaredMethods, ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics, ImmutableArray<OptimizationOpportunity> OptimizationOpportunities, ImmutableArray<MethodIdentity> UnsafeLeverageMethods, UnsafeModeBreakdown UnsafeModes, IReadOnlyDictionary<int, BodySignals> BodySignals, IReadOnlyDictionary<int, ImmutableArray<AllocationOccurrence>> AllocationOccurrences, IReadOnlyDictionary<int, ImmutableArray<UnsafetyOccurrence>> UnsafetyOccurrences, IReadOnlyDictionary<(string Namespace, string Name), bool> InAssemblyTypeIsException, IReadOnlySet<int> SuppressedOpportunityTokens, IReadOnlySet<string> ExceptionTypeNames,         IReadOnlySet<int> NonHeapNewObjOperandTokens) Build(bool includeAllocations, bool includeOpportunities, IReadOnlySet<int>? bodyScope = null, Func<TypeRef, bool>? bodyTypeScope = null)
         {
+            var declaredMethods = ImmutableArray.CreateBuilder<MethodIdentity>();
             var methods = ImmutableArray.CreateBuilder<MethodIdentity>();
             var unsafeLeverageMethods = ImmutableArray.CreateBuilder<MethodIdentity>();
             var calls = ImmutableArray.CreateBuilder<DirectCall>();
@@ -2224,6 +2231,7 @@ public sealed class LibraryBodyIndex
                     case CallerUnsafeMode.Implicit: impl++; break;
                     default: none++; break;
                 }
+                declaredMethods.Add(r.Caller!);
                 if (!r.UnsafeEvidence.IsDefaultOrEmpty)
                     unsafeEvidence.AddRange(r.UnsafeEvidence);
                 if (r.IsLeverage)
@@ -2248,7 +2256,7 @@ public sealed class LibraryBodyIndex
 
             var directCalls = calls.ToImmutable();
             var nonHeapNewObjOperandTokens = ComputeNonHeapNewObjOperandTokens(directCalls);
-            return (methods.ToImmutable(), directCalls, unsafeEvidence.ToImmutable(), diagnostics.ToImmutable(),
+            return (declaredMethods.ToImmutable(), methods.ToImmutable(), directCalls, unsafeEvidence.ToImmutable(), diagnostics.ToImmutable(),
                 optimizationOpportunities.ToImmutable(), unsafeLeverageMethods.ToImmutable(), new UnsafeModeBreakdown(none, impl, expl), bodySignals, allocationOccurrences, unsafetyOccurrences,
                 BuildInAssemblyExceptionMap(), suppressedOpportunityTokens, exceptionTypeNames, nonHeapNewObjOperandTokens);
         }

--- a/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
@@ -128,6 +128,36 @@ public sealed class AuthoredRebuildFidelityTests
         Assert.Contains("return 2;", body, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void AuthoredMemberSource_PrefersQualifiedExplicitInterfaceMethod()
+    {
+        Assert.True(AuthoredRebuildFidelity.TryExtractTargetBody(
+            "int I1.M() { return 1; } int N.I1.M() { return 2; }",
+            "N.I1.M",
+            out string body));
+        Assert.Contains("return 2;", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AuthoredMemberSource_MatchesGenericExplicitInterfaceProperty()
+    {
+        Assert.True(AuthoredRebuildFidelity.TryExtractTargetBody(
+            "int ICustom<int>.Value { get { return 3; } }",
+            "ICustom<System.Int32>.get_Value",
+            out string body));
+        Assert.Contains("return 3;", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AuthoredMemberSource_ExtractsIndexerBody()
+    {
+        Assert.True(AuthoredRebuildFidelity.TryExtractTargetBody(
+            "public int this[int index] { get { return index; } }",
+            "get_Item",
+            out string body));
+        Assert.Contains("return index;", body, StringComparison.Ordinal);
+    }
+
     static FindingInspection<CompilationOptionInfo> CompleteOptions(
         params CompilationOptionInfo[] options)
         => MetadataFindings.InspectCompilationOptions(options, Subject);

--- a/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
@@ -108,6 +108,26 @@ public sealed class AuthoredRebuildFidelityTests
             out _));
     }
 
+    [Fact]
+    public void AuthoredMemberSource_FindsTargetAfterNeighboringProperty()
+    {
+        Assert.True(AuthoredRebuildFidelity.TryExtractTargetBody(
+            "public int Other { get { return 1; } } public int Value { get { return 2; } }",
+            "get_Value",
+            out string body));
+        Assert.Contains("return 2;", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AuthoredMemberSource_DistinguishesExplicitInterfaceMethod()
+    {
+        Assert.True(AuthoredRebuildFidelity.TryExtractTargetBody(
+            "public int M() { return 1; } int IFoo.M() { return 2; }",
+            "Sample.IFoo.M",
+            out string body));
+        Assert.Contains("return 2;", body, StringComparison.Ordinal);
+    }
+
     static FindingInspection<CompilationOptionInfo> CompleteOptions(
         params CompilationOptionInfo[] options)
         => MetadataFindings.InspectCompilationOptions(options, Subject);

--- a/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
@@ -149,6 +149,27 @@ public sealed class AuthoredRebuildFidelityTests
     }
 
     [Fact]
+    public void AuthoredMemberSource_DistinguishesConstructedGenericInterfaces()
+    {
+        Assert.True(AuthoredRebuildFidelity.TryExtractTargetBody(
+            "int ICustom<int>.Value { get { return 1; } } "
+                + "int ICustom<string>.Value { get { return 2; } }",
+            "ICustom<System.String>.get_Value",
+            out string body));
+        Assert.Contains("return 2;", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AuthoredMemberSource_AllowsUnresolvedNamespaceAlias()
+    {
+        Assert.True(AuthoredRebuildFidelity.TryExtractTargetBody(
+            "int Alias::I1.Value { get { return 4; } }",
+            "N.I1.get_Value",
+            out string body));
+        Assert.Contains("return 4;", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void AuthoredMemberSource_ExtractsIndexerBody()
     {
         Assert.True(AuthoredRebuildFidelity.TryExtractTargetBody(

--- a/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
@@ -1,0 +1,106 @@
+using DotnetInspector.Fixtures;
+using DotnetInspector.Services;
+using ILInspector.Findings;
+using ILInspector.Metadata;
+
+using Microsoft.CodeAnalysis;
+
+namespace ILInspector.DecompilerHarness;
+
+public sealed class AuthoredRebuildFidelityTests
+{
+    static readonly FindingSubject Subject = new("test", "test");
+
+    [Fact]
+    public void BuildContextAssessment_KeepsDeterminismSeparateFromRecordedContext()
+    {
+        string runtimePath = typeof(object).Assembly.Location;
+        var assessment = AuthoredRebuildFidelity.AssessBuildContext(
+            isDeterministic: false,
+            CompleteOptions(
+                new CompilationOptionInfo("optimization", "release"),
+                new CompilationOptionInfo("unsafe", "true")),
+            CompleteReferences(new CompilationReferenceInfo(
+                Path.GetFileName(runtimePath),
+                Aliases: "",
+                CompilationReferenceImageKind.Assembly,
+                EmbedInteropTypes: false,
+                Timestamp: 0,
+                ImageSize: 0,
+                ModuleVersionId: Guid.Empty)),
+            [MetadataReference.CreateFromFile(runtimePath)]);
+
+        Assert.Equal(AuthoredBuildContextStatus.Recorded, assessment.Status);
+        Assert.False(assessment.IsDeterministic);
+    }
+
+    [Fact]
+    public void BuildContextAssessment_ReportsContextDriftIndependently()
+    {
+        var assessment = AuthoredRebuildFidelity.AssessBuildContext(
+            isDeterministic: true,
+            CompleteOptions(new CompilationOptionInfo("optimization", "debug")),
+            CompleteReferences(new CompilationReferenceInfo(
+                "Missing.Reference.dll",
+                Aliases: "",
+                CompilationReferenceImageKind.Assembly,
+                EmbedInteropTypes: false,
+                Timestamp: 0,
+                ImageSize: 0,
+                ModuleVersionId: Guid.Empty)),
+            []);
+
+        Assert.Equal(AuthoredBuildContextStatus.Drift, assessment.Status);
+        Assert.True(assessment.IsDeterministic);
+        Assert.Contains("optimization=debug", assessment.Detail, StringComparison.Ordinal);
+        Assert.Contains("Missing.Reference.dll", assessment.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AuthoredBody_ReusesFinalRtsRequestAndProductIlDiff()
+    {
+        var decompiler = ReturnToSender.CompileBackFirstPropertyGetter(
+            FixtureCatalog.DiffPair.OldAssemblyPath());
+        var context = new AuthoredBuildContextAssessment(
+            AuthoredBuildContextStatus.Incomplete,
+            IsDeterministic: true,
+            "test context");
+
+        var result = AuthoredRebuildFidelity.CompileAuthoredBody(
+            decompiler,
+            decompiler.TargetBody,
+            SourceChecksumVerification.Exact,
+            context);
+
+        Assert.True(
+            result.Outcome is AuthoredRebuildOutcome.Exact or AuthoredRebuildOutcome.IlDifferent,
+            result.Detail);
+        Assert.NotNull(result.ImplementationDiff);
+        Assert.Equal(SourceChecksumVerification.Exact, result.ChecksumVerification);
+        Assert.Equal(decompiler, result.DecompilerLane);
+    }
+
+    [Theory]
+    [InlineData("public int Value { get { return 1; } }", "get_Value", "return 1;")]
+    [InlineData("public int Value => 2;", "get_Value", "return 2;")]
+    [InlineData("public int M() { return 3; }", "M", "return 3;")]
+    public void AuthoredMemberSource_ExtractsRtsTargetBody(
+        string memberSource,
+        string methodName,
+        string expected)
+    {
+        Assert.True(AuthoredRebuildFidelity.TryExtractTargetBody(
+            memberSource,
+            methodName,
+            out string body));
+        Assert.Contains(expected, body, StringComparison.Ordinal);
+    }
+
+    static FindingInspection<CompilationOptionInfo> CompleteOptions(
+        params CompilationOptionInfo[] options)
+        => MetadataFindings.InspectCompilationOptions(options, Subject);
+
+    static FindingInspection<CompilationReferenceInfo> CompleteReferences(
+        params CompilationReferenceInfo[] references)
+        => MetadataFindings.InspectCompilationReferences(references, Subject);
+}

--- a/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
@@ -85,6 +85,8 @@ public sealed class AuthoredRebuildFidelityTests
     [InlineData("public int Value { get { return 1; } }", "get_Value", "return 1;")]
     [InlineData("public int Value => 2;", "get_Value", "return 2;")]
     [InlineData("public int M() { return 3; }", "M", "return 3;")]
+    [InlineData("int IFoo.Value { get { return 4; } }", "Sample.IFoo.get_Value", "return 4;")]
+    [InlineData("int IFoo.M() { return 5; }", "Sample.IFoo.M", "return 5;")]
     public void AuthoredMemberSource_ExtractsRtsTargetBody(
         string memberSource,
         string methodName,
@@ -95,6 +97,15 @@ public sealed class AuthoredRebuildFidelityTests
             methodName,
             out string body));
         Assert.Contains(expected, body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AuthoredMemberSource_DoesNotUseDifferentPropertyBody()
+    {
+        Assert.False(AuthoredRebuildFidelity.TryExtractTargetBody(
+            "public int Value { get { return 1; } }",
+            "get_Other",
+            out _));
     }
 
     static FindingInspection<CompilationOptionInfo> CompleteOptions(

--- a/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
@@ -179,6 +179,25 @@ public sealed class AuthoredRebuildFidelityTests
         Assert.Contains("return index;", body, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void AuthoredMemberSource_RejectsEqualRankGenericFallbacks()
+    {
+        Assert.False(AuthoredRebuildFidelity.TryExtractTargetBody(
+            "int ICustom<(int, string)>.Value { get { return 1; } } "
+                + "int ICustom<(int, int)>.Value { get { return 2; } }",
+            "ICustom<System.ValueTuple<System.Byte,System.Byte>>.get_Value",
+            out _));
+    }
+
+    [Fact]
+    public void AuthoredMemberSource_RejectsMultipleConstructorsWithoutArity()
+    {
+        Assert.False(AuthoredRebuildFidelity.TryExtractTargetBody(
+            "public Sample() { } public Sample(int value) { }",
+            ".ctor",
+            out _));
+    }
+
     static FindingInspection<CompilationOptionInfo> CompleteOptions(
         params CompilationOptionInfo[] options)
         => MetadataFindings.InspectCompilationOptions(options, Subject);

--- a/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
@@ -57,6 +57,7 @@ public sealed class AuthoredRebuildFidelityTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public void AuthoredBody_ReusesFinalRtsRequestAndProductIlDiff()
     {
         var decompiler = ReturnToSender.CompileBackFirstPropertyGetter(

--- a/src/ILInspector.Decompiler.Tests/CSharpFindingsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpFindingsTests.cs
@@ -46,6 +46,23 @@ public class CSharpFindingsTests
     }
 
     [Fact]
+    public void CSharpFindings_WhitespaceOnlyPayloadChange_IsChanged()
+    {
+        var old = Statements("    int value = 1;");
+        var @new = Statements("        int value = 1;");
+
+        var result = CompleteComparison(
+            CSharpFindings.CompareCanonicalized(old, @new, Subject));
+
+        var changed = Assert.Single(result.Pairs);
+        var pair = Assert.IsType<PairFinding<CSharpCanonicalLine>.Changed>(
+            changed.Value);
+        Assert.Equal("    int value = 1;", pair.Old.Payload.Text);
+        Assert.Equal("        int value = 1;", pair.New.Payload.Text);
+        Assert.False(result.IsExact);
+    }
+
+    [Fact]
     public void CSharpFindings_RelocatedBlock_IsDetectedAsMoved()
     {
         var old = Statements(

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -81,6 +81,8 @@
              Link="ReturnToSenderClosureEvidence.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\ReturnToSenderSourceProbe.cs"
              Link="ReturnToSenderSourceProbe.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\AuthoredRebuildFidelity.cs"
+             Link="AuthoredRebuildFidelity.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\CSharpSourceIdentity.cs"
              Link="CSharpSourceIdentity.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\SignatureIdentity.cs"

--- a/src/ILInspector.Decompiler/CSharpBodyDiff.cs
+++ b/src/ILInspector.Decompiler/CSharpBodyDiff.cs
@@ -224,8 +224,18 @@ public static class CSharpBodyDiff
 {
     internal const int MaxLcsLines = 4096;
 
-    public static CSharpBodyDiffResult CompareAssemblies(string oldPath, string newPath, bool includeNonPublic = false, IReadOnlySet<string>? typeFilters = null)
-        => CompareAssemblies([oldPath], [newPath], includeNonPublic, typeFilters);
+    public static CSharpBodyDiffResult CompareAssemblies(
+        string oldPath,
+        string newPath,
+        bool includeNonPublic = false,
+        IReadOnlySet<string>? typeFilters = null,
+        IReadOnlySet<string>? memberTargetIdentities = null)
+        => CompareAssemblies(
+            [oldPath],
+            [newPath],
+            includeNonPublic,
+            typeFilters,
+            memberTargetIdentities);
 
     public static CSharpBodyDiffResult CompareMembers(
         MetadataSource oldSource,
@@ -287,7 +297,12 @@ public static class CSharpBodyDiff
         }
     }
 
-    public static CSharpBodyDiffResult CompareAssemblies(IReadOnlyList<string> oldPaths, IReadOnlyList<string> newPaths, bool includeNonPublic = false, IReadOnlySet<string>? typeFilters = null)
+    public static CSharpBodyDiffResult CompareAssemblies(
+        IReadOnlyList<string> oldPaths,
+        IReadOnlyList<string> newPaths,
+        bool includeNonPublic = false,
+        IReadOnlySet<string>? typeFilters = null,
+        IReadOnlySet<string>? memberTargetIdentities = null)
     {
         ArgumentNullException.ThrowIfNull(oldPaths);
         ArgumentNullException.ThrowIfNull(newPaths);
@@ -305,6 +320,13 @@ public static class CSharpBodyDiff
             {
                 oldMethods.TryGetValue(key, out var oldMethod);
                 newMethods.TryGetValue(key, out var newMethod);
+                var representative = newMethod ?? oldMethod!;
+                if (memberTargetIdentities is { Count: > 0 }
+                    && !memberTargetIdentities.Contains(
+                        representative.Anchor.StableSelector))
+                {
+                    continue;
+                }
 
                 if (oldMethod is null)
                 {
@@ -332,7 +354,10 @@ public static class CSharpBodyDiff
         return new CSharpBodyDiffResult(rows.ToImmutable(), failureRows.ToImmutable());
     }
 
-    static Dictionary<string, CSharpMethodEntry> BuildMethodIndex(IReadOnlyList<string> paths, bool includeNonPublic, IReadOnlySet<string>? typeFilters)
+    internal static Dictionary<string, CSharpMethodEntry> BuildMethodIndex(
+        IReadOnlyList<string> paths,
+        bool includeNonPublic,
+        IReadOnlySet<string>? typeFilters)
     {
         var entries = new List<CSharpMethodEntry>();
         var assemblyOccurrences = new Dictionary<string, int>(StringComparer.Ordinal);
@@ -457,6 +482,7 @@ public static class CSharpBodyDiff
             display,
             typeFullName,
             methodName,
+            methodHandle,
             overloadIndex ?? OverloadIndex(reader, type, methodHandle, methodName),
             method.RelativeVirtualAddress != 0,
             BodyFingerprint(source, method));
@@ -1787,7 +1813,7 @@ public static class CSharpBodyDiff
         return text.Trim();
     }
 
-    sealed record CSharpMethodEntry(
+    internal sealed record CSharpMethodEntry(
         string Path,
         string AssemblyName,
         string StableAssemblyKey,
@@ -1798,13 +1824,14 @@ public static class CSharpBodyDiff
         string Display,
         string TypeFullName,
         string MethodName,
+        MethodDefinitionHandle MethodHandle,
         int OverloadIndex,
         bool HasBody,
         string BodyFingerprint);
 
     sealed record CSharpMethodRender(CSharpRenderState State, string[] Lines, DecompilationFidelity Fidelity);
 
-    sealed class SourceCache : IDisposable
+    internal sealed class SourceCache : IDisposable
     {
         readonly Dictionary<string, MetadataSource> _sources = new(StringComparer.Ordinal);
 

--- a/src/ILInspector.Decompiler/CSharpFindings.cs
+++ b/src/ILInspector.Decompiler/CSharpFindings.cs
@@ -3,8 +3,17 @@ using System.Reflection.Metadata;
 
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Findings;
+using ILInspector.MetadataPrimitives;
 
 namespace ILInspector.Decompiler;
+
+public sealed record CSharpMemberFindingComparison(
+    string StableMemberKey,
+    MemberAnchor Anchor,
+    string Member,
+    bool OldMemberPresent,
+    bool NewMemberPresent,
+    FindingComparison<CSharpCanonicalLine> Comparison);
 
 /// <summary>
 /// Adapts decompiled C# method bodies onto the domain-free finding substrate. It reuses
@@ -65,6 +74,54 @@ public static class CSharpFindings
         return CompareInspections(oldInspection, newInspection, acceptanceThreshold);
     }
 
+    public static ImmutableArray<CSharpMemberFindingComparison> CompareAssemblies(
+        IReadOnlyList<string> oldPaths,
+        IReadOnlyList<string> newPaths,
+        bool includeNonPublic = false,
+        IReadOnlySet<string>? typeFilters = null,
+        IReadOnlySet<string>? memberTargetIdentities = null,
+        int acceptanceThreshold = 100)
+    {
+        ArgumentNullException.ThrowIfNull(oldPaths);
+        ArgumentNullException.ThrowIfNull(newPaths);
+
+        var oldMethods = CSharpBodyDiff.BuildMethodIndex(oldPaths, includeNonPublic, typeFilters);
+        var newMethods = CSharpBodyDiff.BuildMethodIndex(newPaths, includeNonPublic, typeFilters);
+        var comparisons = ImmutableArray.CreateBuilder<CSharpMemberFindingComparison>();
+        using var sources = new CSharpBodyDiff.SourceCache();
+
+        foreach (string key in oldMethods.Keys.Union(newMethods.Keys).Order(StringComparer.Ordinal))
+        {
+            oldMethods.TryGetValue(key, out var oldMethod);
+            newMethods.TryGetValue(key, out var newMethod);
+            var representative = newMethod ?? oldMethod!;
+            if (memberTargetIdentities is { Count: > 0 }
+                && !memberTargetIdentities.Contains(representative.Anchor.StableSelector))
+            {
+                continue;
+            }
+
+            var subject = new FindingSubject(
+                representative.Anchor.StableSelector,
+                representative.Display);
+            var oldInspection = oldMethod is null
+                ? new FindingInspection<CSharpCanonicalLine>.Absent("Member is absent.")
+                : Inspect(sources.Open(oldMethod.Path), oldMethod.MethodHandle, subject);
+            var newInspection = newMethod is null
+                ? new FindingInspection<CSharpCanonicalLine>.Absent("Member is absent.")
+                : Inspect(sources.Open(newMethod.Path), newMethod.MethodHandle, subject);
+            comparisons.Add(new CSharpMemberFindingComparison(
+                key,
+                representative.Anchor,
+                representative.Display,
+                oldMethod is not null,
+                newMethod is not null,
+                CompareInspections(oldInspection, newInspection, acceptanceThreshold)));
+        }
+
+        return comparisons.ToImmutable();
+    }
+
     internal static FindingComparison<CSharpCanonicalLine> CompareCanonicalized(
         ImmutableArray<CSharpCanonicalLine> oldLines,
         ImmutableArray<CSharpCanonicalLine> newLines,
@@ -82,7 +139,30 @@ public static class CSharpFindings
         => FindingComparison.Compare(
             oldInspection,
             newInspection,
-            acceptanceThreshold: acceptanceThreshold);
+            acceptanceThreshold: acceptanceThreshold)
+            .TransformPairs(PromoteRawTextChanges);
+
+    static ImmutableArray<PairFinding<CSharpCanonicalLine>> PromoteRawTextChanges(
+        ImmutableArray<PairFinding<CSharpCanonicalLine>> pairs)
+    {
+        var builder = ImmutableArray.CreateBuilder<PairFinding<CSharpCanonicalLine>>(
+            pairs.Length);
+        foreach (var pair in pairs)
+        {
+            builder.Add(pair is PairFinding<CSharpCanonicalLine>.Present present
+                && !StringComparer.Ordinal.Equals(
+                    present.Old.Payload.Text,
+                    present.New.Payload.Text)
+                    ? new PairFinding<CSharpCanonicalLine>.Changed(
+                        present.Old,
+                        present.New,
+                        present.Difference,
+                        "Canonical line text changed.")
+                    : pair);
+        }
+
+        return builder.MoveToImmutable();
+    }
 
     static InspectionError CreateInspectionError(FindingSubject subject, string reason)
         => new(subject, InspectionDescriptor, reason);

--- a/src/ILInspector.Instructions/IlFindings.cs
+++ b/src/ILInspector.Instructions/IlFindings.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 
 using ILInspector.Findings;
 
@@ -78,6 +79,98 @@ public static class IlFindings
 
         var oldInspection = Inspect(oldBody, oldReader, subject);
         var newInspection = Inspect(newBody, newReader, subject);
+        return CompareInspections(
+            oldInspection,
+            newInspection,
+            oldBody,
+            newBody,
+            acceptanceThreshold);
+    }
+
+    /// <summary>
+    /// Inspects a method definition directly from its PE and metadata readers.
+    /// </summary>
+    public static FindingInspection<CanonicalIlOperation> Inspect(
+        PEReader pe,
+        MetadataReader reader,
+        MethodDefinitionHandle method,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(pe);
+        ArgumentNullException.ThrowIfNull(reader);
+        ArgumentNullException.ThrowIfNull(subject);
+        if (method.IsNil)
+            throw new ArgumentException("Method handle must not be nil.", nameof(method));
+
+        return InspectMethod(pe, reader, method, subject, out _);
+    }
+
+    /// <summary>
+    /// Compares already-acquired inspections. This overload preserves explicit absent sides for
+    /// added and removed methods; branch validation is unnecessary unless both sides have bodies.
+    /// </summary>
+    public static FindingComparison<CanonicalIlOperation> Compare(
+        FindingInspection<CanonicalIlOperation> oldInspection,
+        FindingInspection<CanonicalIlOperation> newInspection,
+        int acceptanceThreshold = 100)
+    {
+        ArgumentNullException.ThrowIfNull(oldInspection);
+        ArgumentNullException.ThrowIfNull(newInspection);
+        return CompareInspections(
+            oldInspection,
+            newInspection,
+            oldBody: null,
+            newBody: null,
+            acceptanceThreshold);
+    }
+
+    public static FindingComparison<CanonicalIlOperation> Compare(
+        PEReader oldPe,
+        MetadataReader oldReader,
+        MethodDefinitionHandle oldMethod,
+        PEReader newPe,
+        MetadataReader newReader,
+        MethodDefinitionHandle newMethod,
+        FindingSubject subject,
+        int acceptanceThreshold = 100)
+    {
+        ArgumentNullException.ThrowIfNull(oldPe);
+        ArgumentNullException.ThrowIfNull(oldReader);
+        ArgumentNullException.ThrowIfNull(newPe);
+        ArgumentNullException.ThrowIfNull(newReader);
+        ArgumentNullException.ThrowIfNull(subject);
+        if (oldMethod.IsNil)
+            throw new ArgumentException("Old method handle must not be nil.", nameof(oldMethod));
+        if (newMethod.IsNil)
+            throw new ArgumentException("New method handle must not be nil.", nameof(newMethod));
+
+        var oldInspection = InspectMethod(
+            oldPe,
+            oldReader,
+            oldMethod,
+            subject,
+            out var oldBody);
+        var newInspection = InspectMethod(
+            newPe,
+            newReader,
+            newMethod,
+            subject,
+            out var newBody);
+        return CompareInspections(
+            oldInspection,
+            newInspection,
+            oldBody,
+            newBody,
+            acceptanceThreshold);
+    }
+
+    static FindingComparison<CanonicalIlOperation> CompareInspections(
+        FindingInspection<CanonicalIlOperation> oldInspection,
+        FindingInspection<CanonicalIlOperation> newInspection,
+        MethodInstructions? oldBody,
+        MethodInstructions? newBody,
+        int acceptanceThreshold)
+    {
         var comparison = FindingComparison.Compare(
             oldInspection,
             newInspection,
@@ -98,6 +191,33 @@ public static class IlFindings
             [.. complete.OldAtoms.Select(static atom => atom.Payload)],
             newBody.Instructions,
             [.. complete.NewAtoms.Select(static atom => atom.Payload)]));
+    }
+
+    static FindingInspection<CanonicalIlOperation> InspectMethod(
+        PEReader pe,
+        MetadataReader reader,
+        MethodDefinitionHandle methodHandle,
+        FindingSubject subject,
+        out MethodInstructions? body)
+    {
+        body = null;
+        try
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (method.RelativeVirtualAddress == 0)
+                return Inspect(null, reader, subject);
+
+            body = MethodInstructions.Decode(pe.GetMethodBody(method.RelativeVirtualAddress));
+            return Inspect(body, reader, subject);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException
+            or InvalidOperationException
+            or ArgumentException
+            or NotSupportedException)
+        {
+            return new FindingInspection<CanonicalIlOperation>.Failed(
+                new InspectionError(subject, InspectionDescriptor, ex.Message));
+        }
     }
 
     // IdentityKey deliberately ignores a branch/switch operation's targets (matching CanonicalEquals),

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -509,6 +509,7 @@ public class ResearchDiffTests
             failure =>
             {
                 Assert.Equal("il.diff.unsupported-boundary", failure.Descriptor.Id);
+                Assert.Equal(ResearchChangeKind.Failed, failure.Kind);
                 Assert.NotNull(failure.IlFailureRow);
                 Assert.Null(failure.IlRow);
             },
@@ -568,6 +569,44 @@ public class ResearchDiffTests
         Assert.Contains(diff.Changes, row =>
             row.CSharpRow is not null
             && row.Descriptor.Id == "csharp.method.body-added");
+    }
+
+    [Fact]
+    public void FromCSharpBodyDiff_OperationalFailureOmitsSyntheticChangeRows()
+    {
+        var template = Assert.Single(CSharpBodyDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ConstructorSample" }).Rows,
+            row => row.ChangeId == "csharp.line.removed");
+        var failure = new CSharpDiffFailureRow(
+            template.AssemblyIdentity,
+            template.StableMemberKey,
+            template.Anchor,
+            template.Member,
+            CSharpDiffFailureKind.OldDecompileFailure,
+            "Old method body decompilation failed.",
+            Side: "old",
+            Detail: "invalid IL",
+            HunkId: 42);
+        var synthetic = template with
+        {
+            ChangeId = "csharp.decompile.failed",
+            HunkId = 42,
+            Kind = CSharpDiffKind.Remove,
+            Message = "Old method body decompilation failed.",
+            Text = "invalid IL",
+        };
+
+        var diff = ResearchDiff.FromCSharpBodyDiff(
+            new CSharpBodyDiffResult([synthetic], [failure]));
+
+        var change = Assert.Single(diff.Changes);
+        Assert.Equal(ResearchChangeKind.Failed, change.Kind);
+        Assert.Equal("csharp.diff.old-decompile-failure", change.Descriptor.Id);
+        Assert.Same(failure, change.CSharpFailureRow);
+        Assert.DoesNotContain(diff.Changes, row =>
+            row.Descriptor.Id == "csharp.decompile.failed");
     }
 
     [Fact]
@@ -1684,6 +1723,7 @@ public class ResearchDiffTests
 
         var row = Assert.Single(changes);
         Assert.Equal("il.diff.new-body-missing", row.Descriptor.Id);
+        Assert.Equal(ResearchChangeKind.Removed, row.Kind);
         Assert.Equal("method has no body", row.Detail);
         Assert.Same(failure, row.IlDisplayFailureRow);
         Assert.Null(row.IlMemberDiff);

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -925,6 +925,164 @@ public class ResearchDiffTests
     }
 
     [Fact]
+    public void CompareAssemblies_CSharp_RetainsNativeLineComparison()
+    {
+        var diff = ResearchDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            new ResearchDiffOptions(
+                ResearchChangeMechanism.CSharp,
+                TypeFilters: new HashSet<string>(StringComparer.Ordinal)
+                {
+                    "DiffFixtureSample.DiffSample",
+                })
+            {
+                RetainedComparisonDescriptorIds = ImmutableHashSet.Create(
+                    StringComparer.Ordinal,
+                    CSharpFindings.LineDescriptor.Id),
+            });
+
+        var retained = Assert.Single(
+            diff.RetainedComparisons.Get<CSharpCanonicalLine>(
+                CSharpFindings.LineDescriptor),
+            comparison => comparison.Subject.MemberName == "ConstantValue");
+        var comparison = retained.Comparison switch
+        {
+            FindingComparison<CSharpCanonicalLine>.Complete complete => complete,
+            _ => throw new InvalidOperationException("Expected a complete C# comparison."),
+        };
+        Assert.Contains(comparison.Pairs, pair =>
+            pair is PairFinding<CSharpCanonicalLine>.Removed removed
+            && removed.Old.Payload.Text == "return 1;");
+        Assert.Contains(comparison.Pairs, pair =>
+            pair is PairFinding<CSharpCanonicalLine>.Added added
+            && added.New.Payload.Text == "return 2;");
+        Assert.Contains(diff.Changes, change =>
+            change.Subject.MemberName == "ConstantValue"
+            && change.Mechanism == ResearchChangeMechanism.CSharp);
+    }
+
+    [Fact]
+    public void CompareAssemblies_IlBody_RetainsNativeOperationComparison()
+    {
+        var diff = ResearchDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            new ResearchDiffOptions(
+                ResearchChangeMechanism.IlBody,
+                TypeFilters: new HashSet<string>(StringComparer.Ordinal)
+                {
+                    "DiffFixtureSample.DiffSample",
+                })
+            {
+                RetainedComparisonDescriptorIds = ImmutableHashSet.Create(
+                    StringComparer.Ordinal,
+                    IlFindings.OperationDescriptor.Id),
+            });
+
+        var retained = Assert.Single(
+            diff.RetainedComparisons.Get<CanonicalIlOperation>(
+                IlFindings.OperationDescriptor),
+            comparison => comparison.Subject.MemberName == "ConstantValue");
+        var comparison = retained.Comparison switch
+        {
+            FindingComparison<CanonicalIlOperation>.Complete complete => complete,
+            _ => throw new InvalidOperationException("Expected a complete IL comparison."),
+        };
+        Assert.Contains(comparison.Pairs, pair =>
+            pair is PairFinding<CanonicalIlOperation>.Removed removed
+            && removed.Old.Payload.Display == "ldc.i4 1");
+        Assert.Contains(comparison.Pairs, pair =>
+            pair is PairFinding<CanonicalIlOperation>.Added added
+            && added.New.Payload.Display == "ldc.i4 2");
+        Assert.Contains(diff.Changes, change =>
+            change.Subject.MemberName == "ConstantValue"
+            && change.Mechanism == ResearchChangeMechanism.IlBody);
+    }
+
+    [Theory]
+    [InlineData(false, PairKind.Removed)]
+    [InlineData(true, PairKind.Added)]
+    public void CompareAssemblies_IlBody_RetainsOneSidedMethodComparisons(
+        bool reverse,
+        PairKind expectedKind)
+    {
+        string oldPath = reverse
+            ? FixtureCatalog.DiffPair.NewAssemblyPath()
+            : FixtureCatalog.DiffPair.OldAssemblyPath();
+        string newPath = reverse
+            ? FixtureCatalog.DiffPair.OldAssemblyPath()
+            : FixtureCatalog.DiffPair.NewAssemblyPath();
+        var diff = ResearchDiff.CompareAssemblies(
+            oldPath,
+            newPath,
+            new ResearchDiffOptions(
+                ResearchChangeMechanism.IlBody,
+                TypeFilters: new HashSet<string>(StringComparer.Ordinal)
+                {
+                    "DiffFixtureSample.MethodRemovalSample",
+                })
+            {
+                RetainedComparisonDescriptorIds = ImmutableHashSet.Create(
+                    StringComparer.Ordinal,
+                    IlFindings.OperationDescriptor.Id),
+            });
+
+        var retained = diff.RetainedComparisons
+            .Get<CanonicalIlOperation>(IlFindings.OperationDescriptor)
+            .Where(comparison => comparison.Subject.MemberName == "Removed")
+            .ToImmutableArray();
+
+        Assert.Equal(2, retained.Length);
+        Assert.All(retained, comparison =>
+        {
+            var complete = Assert.IsType<
+                FindingComparison<CanonicalIlOperation>.Complete>(
+                comparison.Comparison.Value);
+            Assert.All(
+                complete.Pairs,
+                pair => Assert.Equal(expectedKind, pair.Kind));
+            Assert.True(reverse
+                ? complete.OldInspection
+                    is FindingInspection<CanonicalIlOperation>.Absent
+                : complete.NewInspection
+                    is FindingInspection<CanonicalIlOperation>.Absent);
+        });
+    }
+
+    [Fact]
+    public void CompareAssemblies_IlBody_PreservesAbsentBodyAgainstPresentBody()
+    {
+        var diff = ResearchDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            new ResearchDiffOptions(
+                ResearchChangeMechanism.IlBody,
+                TypeFilters: new HashSet<string>(StringComparer.Ordinal)
+                {
+                    "DiffFixtureSample.BodyStateSample",
+                })
+            {
+                RetainedComparisonDescriptorIds = ImmutableHashSet.Create(
+                    StringComparer.Ordinal,
+                    IlFindings.OperationDescriptor.Id),
+            });
+
+        var retained = Assert.Single(diff.RetainedComparisons
+            .Get<CanonicalIlOperation>(IlFindings.OperationDescriptor),
+            comparison => comparison.Subject.MemberName == "BodyState");
+        var complete = Assert.IsType<
+            FindingComparison<CanonicalIlOperation>.Complete>(
+            retained.Comparison.Value);
+
+        Assert.True(
+            complete.OldInspection is FindingInspection<CanonicalIlOperation>.Absent);
+        Assert.True(
+            complete.NewInspection is FindingInspection<CanonicalIlOperation>.Complete);
+        Assert.All(complete.Pairs, pair => Assert.Equal(PairKind.Added, pair.Kind));
+    }
+
+    [Fact]
     public void CompareAssemblies_IlBody_QueryImplementationChanges()
     {
         var diff = ResearchDiff.CompareAssemblies(
@@ -1287,6 +1445,10 @@ public class ResearchDiffTests
         Assert.NotNull(diff.IlDiff);
         Assert.True(diff.IlDiff.Diff.IsExact);
         Assert.Empty(diff.Changes);
+        Assert.True(Assert.Single(diff.RetainedComparisons.Get<CSharpCanonicalLine>(
+            CSharpFindings.LineDescriptor)).IsExact);
+        Assert.True(Assert.Single(diff.RetainedComparisons.Get<CanonicalIlOperation>(
+            IlFindings.OperationDescriptor)).IsExact);
     }
 
     [Fact]
@@ -1309,6 +1471,10 @@ public class ResearchDiffTests
         Assert.Contains(diff.Changes, change =>
             change.Mechanism == ResearchChangeMechanism.IlBody
             && ImplementationDiff.UnifiedLines(change).Any(line => line.Contains("ldc.i4 1", StringComparison.Ordinal)));
+        Assert.False(Assert.Single(diff.RetainedComparisons.Get<CSharpCanonicalLine>(
+            CSharpFindings.LineDescriptor)).IsExact);
+        Assert.False(Assert.Single(diff.RetainedComparisons.Get<CanonicalIlOperation>(
+            IlFindings.OperationDescriptor)).IsExact);
     }
 
     [Fact]

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -8,6 +8,7 @@ using ILInspector.Findings;
 using ILInspector.Metadata;
 using ILInspector.MetadataPrimitives;
 using ILInspector.Instructions;
+using ILInspector.Text;
 using DecompilerMetadataSource = ILInspector.Decompiler.Pipeline.MetadataSource;
 
 namespace ILInspector.Research.Tests;
@@ -1475,6 +1476,65 @@ public class ResearchDiffTests
             CSharpFindings.LineDescriptor)).IsExact);
         Assert.False(Assert.Single(diff.RetainedComparisons.Get<CanonicalIlOperation>(
             IlFindings.OperationDescriptor)).IsExact);
+    }
+
+    [Fact]
+    public void ImplementationDiff_AuthoredSourceIsIndependentPeerMechanism()
+    {
+        using var source = DecompilerMetadataSource.OpenWithoutSymbols(FixtureCatalog.DiffPair.OldAssemblyPath());
+        var stable = FindMethodHandle(FixtureCatalog.DiffPair.OldAssemblyPath(), "DiffFixtureSample.DiffSample", "Stable");
+        var oldInspection = new FindingInspection<string>.Complete(
+            [.. TextFindings.Inspect("return 1;", new FindingSubject("old", "old"))]);
+        var newInspection = new FindingInspection<string>.Complete(
+            [.. TextFindings.Inspect("return 2;", new FindingSubject("new", "new"))]);
+        var result = ImplementationDiff.CompareMembersWithAuthoredSource(
+            source,
+            stable,
+            source,
+            stable,
+            oldInspection,
+            newInspection);
+
+        Assert.True(result.HasSourceChanges);
+        Assert.False(result.HasCSharpChanges);
+        Assert.False(result.HasIlChanges);
+        Assert.NotNull(result.SourceComparison);
+        Assert.Contains(result.Changes, change =>
+            change.Mechanism == ResearchChangeMechanism.Source
+            && ImplementationDiff.UnifiedLines(change).Any(line =>
+                line.Contains("return 2", StringComparison.Ordinal)));
+        Assert.Single(result.RetainedComparisons.Get<string>(TextFindings.LineDescriptor));
+        Assert.Single(result.RetainedComparisons.Get<CSharpCanonicalLine>(
+            CSharpFindings.LineDescriptor));
+        Assert.Single(result.RetainedComparisons.Get<CanonicalIlOperation>(
+            IlFindings.OperationDescriptor));
+    }
+
+    [Fact]
+    public void ImplementationDiff_AuthoredSourcePreservesAbsentStateWithoutChangingCSharp()
+    {
+        var subject = new ResearchSubjectKey(
+            ResearchSubjectKind.Member,
+            "M~1234567890",
+            "Sample.M()",
+            "Sample",
+            "M");
+        var result = ImplementationDiff.WithAuthoredSourceComparisons(
+            new ImplementationDiffResult(
+                [],
+                new ResearchComparison([])),
+            [
+                new AuthoredSourceComparisonInput(
+                    subject,
+                    new FindingInspection<string>.Absent("old source unavailable"),
+                    new FindingInspection<string>.Absent("new source unavailable"))
+            ]);
+
+        var member = Assert.Single(result.Members);
+        Assert.Empty(member.Changes);
+        Assert.True(member.SourceComparison!.IsExact);
+        Assert.IsType<FindingInspection<string>.Absent>(member.SourceComparison.OldInspection.Value);
+        Assert.IsType<FindingInspection<string>.Absent>(member.SourceComparison.NewInspection.Value);
     }
 
     [Fact]

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -1538,6 +1538,82 @@ public class ResearchDiffTests
     }
 
     [Fact]
+    public void ImplementationDiff_FindingFailureIsNotSemanticChange()
+    {
+        var subject = new ResearchSubjectKey(
+            ResearchSubjectKind.Member,
+            "M~1234567890",
+            "Sample.M()",
+            "Sample",
+            "M");
+
+        var change = ImplementationDiff.FindingFailureChange(
+            subject,
+            ResearchChangeMechanism.CSharp,
+            ResearchChangeCategory.CSharp,
+            CSharpFindings.InspectionDescriptor,
+            "render failed");
+
+        Assert.Equal(ResearchChangeKind.Failed, change.Kind);
+        Assert.Equal("render failed", change.Detail);
+    }
+
+    [Fact]
+    public void ImplementationDiff_FindingDivergenceIsScopedFailure()
+    {
+        var subject = new ResearchSubjectKey(
+            ResearchSubjectKind.Member,
+            "M~1234567890",
+            "Sample.M()",
+            "Sample",
+            "M");
+
+        var divergence = ImplementationDiff.FindingDivergenceChange(
+            subject,
+            ResearchChangeMechanism.CSharp,
+            ResearchChangeCategory.CSharp,
+            ImplementationDiff.CSharpFindingDivergenceDescriptor,
+            findingExact: true,
+            semanticExact: false);
+
+        Assert.NotNull(divergence);
+        Assert.Equal(ResearchChangeKind.Failed, divergence.Kind);
+        Assert.Contains("diverged", divergence.Detail, StringComparison.Ordinal);
+        Assert.Null(ImplementationDiff.FindingDivergenceChange(
+            subject,
+            ResearchChangeMechanism.CSharp,
+            ResearchChangeCategory.CSharp,
+            ImplementationDiff.CSharpFindingDivergenceDescriptor,
+            findingExact: true,
+            semanticExact: true));
+    }
+
+    [Fact]
+    public void ImplementationDiff_AuthoredSourceFailureIsNotSemanticChange()
+    {
+        var subject = new ResearchSubjectKey(
+            ResearchSubjectKind.Member,
+            "M~1234567890",
+            "Sample.M()",
+            "Sample",
+            "M");
+        var comparison = FindingComparison.Compare<string>(
+            new FindingInspection<string>.Failed(
+                new InspectionError(
+                    new FindingSubject(subject.Id, subject.Display),
+                    TextFindings.LineDescriptor,
+                    "checksum failed")),
+            new FindingInspection<string>.Complete([]));
+
+        var change = Assert.Single(ImplementationDiff.ToSourceChanges(
+            comparison,
+            subject));
+
+        Assert.Equal(ResearchChangeKind.Failed, change.Kind);
+        Assert.Contains("checksum failed", change.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ImplementationDiff_ToIlChanges_ProjectsTypedMemberDiffRows()
     {
         var typedDiff = new IlMemberDiffResult(

--- a/src/ILInspector.Research/ILInspector.Research.csproj
+++ b/src/ILInspector.Research/ILInspector.Research.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\ILInspector.Findings\ILInspector.Findings.csproj" />
     <ProjectReference Include="..\ILInspector.Instructions\ILInspector.Instructions.csproj" />
     <ProjectReference Include="..\ILInspector.Metadata\ILInspector.Metadata.csproj" />
+    <ProjectReference Include="..\ILInspector.Text\ILInspector.Text.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ILInspector.Research/ImplementationDiff.cs
+++ b/src/ILInspector.Research/ImplementationDiff.cs
@@ -89,6 +89,10 @@ public static class ImplementationDiff
 {
     public static readonly FindingDescriptor AuthoredSourceFailureDescriptor =
         new("source.authored.failed", "Authored source acquisition failed");
+    internal static readonly FindingDescriptor CSharpFindingDivergenceDescriptor =
+        new("csharp.finding.diverged", "C# Finding comparison diverged");
+    internal static readonly FindingDescriptor IlFindingDivergenceDescriptor =
+        new("il.finding.diverged", "IL Finding comparison diverged");
 
     public static ImplementationDiffResult CompareAssemblies(
         string oldAssemblyPath,
@@ -147,10 +151,15 @@ public static class ImplementationDiff
                     CSharpFindings.InspectionDescriptor,
                     failed.Failure));
             }
-            else if (comparison.IsExact != csharpDiff.IsExact)
+            else if (FindingDivergenceChange(
+                subject,
+                ResearchChangeMechanism.CSharp,
+                ResearchChangeCategory.CSharp,
+                CSharpFindingDivergenceDescriptor,
+                comparison.IsExact,
+                csharpDiff.IsExact) is { } divergence)
             {
-                throw new InvalidOperationException(
-                    $"C# Finding comparison diverged from the semantic C# diff for '{subject.Display}'.");
+                changes.Add(divergence);
             }
         }
 
@@ -192,10 +201,15 @@ public static class ImplementationDiff
             }
             else if (MethodHasBody(oldSource, oldMethod)
                 && MethodHasBody(newSource, newMethod)
-                && comparison.IsExact != ilDiff.Diff.IsExact)
+                && FindingDivergenceChange(
+                    subject,
+                    ResearchChangeMechanism.IlBody,
+                    ResearchChangeCategory.IlBody,
+                    IlFindingDivergenceDescriptor,
+                    comparison.IsExact,
+                    ilDiff.Diff.IsExact) is { } divergence)
             {
-                throw new InvalidOperationException(
-                    $"IL Finding comparison diverged from the semantic IL diff for '{subject.Display}'.");
+                changes.Add(divergence);
             }
         }
 
@@ -356,7 +370,7 @@ public static class ImplementationDiff
                     subject,
                     ResearchChangeMechanism.Source,
                     AuthoredSourceFailureDescriptor,
-                    ResearchChangeKind.Changed,
+                    ResearchChangeKind.Failed,
                     detail: failed.Failure,
                     category: ResearchChangeCategory.Source)
             ];
@@ -596,7 +610,7 @@ public static class ImplementationDiff
            || memberTargetIdentities.Count == 0
            || memberTargetIdentities.Contains(subject.Id);
 
-    static ResearchChange FindingFailureChange(
+    internal static ResearchChange FindingFailureChange(
         ResearchSubjectKey subject,
         ResearchChangeMechanism mechanism,
         ResearchChangeCategory category,
@@ -606,9 +620,25 @@ public static class ImplementationDiff
             subject,
             mechanism,
             descriptor,
-            ResearchChangeKind.Changed,
+            ResearchChangeKind.Failed,
             detail: failure,
             category: category);
+
+    internal static ResearchChange? FindingDivergenceChange(
+        ResearchSubjectKey subject,
+        ResearchChangeMechanism mechanism,
+        ResearchChangeCategory category,
+        FindingDescriptor descriptor,
+        bool findingExact,
+        bool semanticExact)
+        => findingExact == semanticExact
+            ? null
+            : FindingFailureChange(
+                subject,
+                mechanism,
+                category,
+                descriptor,
+                $"{descriptor.Title} from the semantic projection for '{subject.Display}'.");
 
     static bool MethodHasBody(MetadataSource source, MethodDefinitionHandle method)
         => source.Reader.GetMethodDefinition(method).RelativeVirtualAddress != 0;

--- a/src/ILInspector.Research/ImplementationDiff.cs
+++ b/src/ILInspector.Research/ImplementationDiff.cs
@@ -131,7 +131,8 @@ public static class ImplementationDiff
         if (mechanisms.HasFlag(ImplementationDiffMechanism.CSharp))
         {
             csharpDiff = CSharpBodyDiff.CompareMembers(oldSource, oldMethod, newSource, newMethod);
-            changes.AddRange(ToCSharpChanges(csharpDiff, subject));
+            var semanticChanges = ToCSharpChanges(csharpDiff, subject);
+            changes.AddRange(semanticChanges);
             var comparison = CSharpFindings.Compare(
                 oldSource,
                 oldMethod,
@@ -144,12 +145,15 @@ public static class ImplementationDiff
                 comparison));
             if (comparison is FindingComparison<CSharpCanonicalLine>.Failed failed)
             {
-                changes.Add(FindingFailureChange(
-                    subject,
-                    ResearchChangeMechanism.CSharp,
-                    ResearchChangeCategory.CSharp,
-                    CSharpFindings.InspectionDescriptor,
-                    failed.Failure));
+                if (!semanticChanges.Any(change => change.Kind == ResearchChangeKind.Failed))
+                {
+                    changes.Add(FindingFailureChange(
+                        subject,
+                        ResearchChangeMechanism.CSharp,
+                        ResearchChangeCategory.CSharp,
+                        CSharpFindings.InspectionDescriptor,
+                        failed.Failure));
+                }
             }
             else if (FindingDivergenceChange(
                 subject,
@@ -177,7 +181,8 @@ public static class ImplementationDiff
                 newMethod,
                 oldLabel: label,
                 newLabel: label);
-            changes.AddRange(ToIlChanges(ilDiff, subject));
+            var semanticChanges = ToIlChanges(ilDiff, subject);
+            changes.AddRange(semanticChanges);
             var comparison = IlFindings.Compare(
                 oldSource.Pe,
                 oldSource.Reader,
@@ -192,12 +197,15 @@ public static class ImplementationDiff
                 comparison));
             if (comparison is FindingComparison<CanonicalIlOperation>.Failed failed)
             {
-                changes.Add(FindingFailureChange(
-                    subject,
-                    ResearchChangeMechanism.IlBody,
-                    ResearchChangeCategory.IlBody,
-                    IlFindings.InspectionDescriptor,
-                    failed.Failure));
+                if (!semanticChanges.Any(change => change.Kind == ResearchChangeKind.Failed))
+                {
+                    changes.Add(FindingFailureChange(
+                        subject,
+                        ResearchChangeMechanism.IlBody,
+                        ResearchChangeCategory.IlBody,
+                        IlFindings.InspectionDescriptor,
+                        failed.Failure));
+                }
             }
             else if (MethodHasBody(oldSource, oldMethod)
                 && MethodHasBody(newSource, newMethod)
@@ -451,7 +459,7 @@ public static class ImplementationDiff
                 subject,
                 ResearchChangeMechanism.IlBody,
                 new FindingDescriptor(descriptorId, failureRow.Kind.ToString()),
-                ResearchChangeKind.Changed,
+                ResearchDiff.Direction(failureRow.Kind),
                 detail: failureRow.Detail ?? failureRow.Message,
                 category: ResearchChangeCategory.IlBody,
                 ilDisplayFailureRow: failureRow,
@@ -464,7 +472,7 @@ public static class ImplementationDiff
                 subject,
                 ResearchChangeMechanism.IlBody,
                 new FindingDescriptor("il.diff.failed", "IL diff failed"),
-                ResearchChangeKind.Changed,
+                ResearchChangeKind.Failed,
                 detail: failure,
                 category: ResearchChangeCategory.IlBody,
                 ilMemberDiff: diff));
@@ -547,14 +555,11 @@ public static class ImplementationDiff
             return [];
 
         var changes = ImmutableArray.CreateBuilder<ResearchChange>();
-        foreach (var failure in diff.FailureRows.IsDefault ? [] : diff.FailureRows)
+        var failureRows = diff.FailureRows.IsDefault ? [] : diff.FailureRows;
+        var operationalFailureHunks = ResearchDiff.OperationalCSharpFailureHunks(failureRows);
+        foreach (var failure in failureRows)
         {
-            var kind = failure.Kind switch
-            {
-                CSharpDiffFailureKind.OldBodyMissing => ResearchChangeKind.Added,
-                CSharpDiffFailureKind.NewBodyMissing => ResearchChangeKind.Removed,
-                _ => ResearchChangeKind.Changed,
-            };
+            var kind = ResearchDiff.Direction(failure.Kind);
             string descriptorId = $"csharp.diff.{ResearchDiff.ToChangeIdPart(failure.Kind.ToString())}";
             changes.Add(new ResearchChange(
                 subject,
@@ -570,6 +575,9 @@ public static class ImplementationDiff
 
         foreach (var row in diff.Rows.IsDefault ? [] : diff.Rows)
         {
+            if (operationalFailureHunks.Contains(row.HunkId))
+                continue;
+
             var kind = row.Kind switch
             {
                 CSharpDiffKind.Add => ResearchChangeKind.Added,

--- a/src/ILInspector.Research/ImplementationDiff.cs
+++ b/src/ILInspector.Research/ImplementationDiff.cs
@@ -46,7 +46,8 @@ public sealed record ImplementationMemberDiffResult(
     ResearchSubjectKey Subject,
     CSharpBodyDiffResult? CSharpDiff,
     IlMemberDiffResult? IlDiff,
-    IReadOnlyList<ResearchChange> Changes)
+    IReadOnlyList<ResearchChange> Changes,
+    RetainedFindingComparisonSet RetainedComparisons)
 {
     public bool HasCSharpChanges
         => Changes.Any(change => change.Mechanism == ResearchChangeMechanism.CSharp);
@@ -57,7 +58,8 @@ public sealed record ImplementationMemberDiffResult(
     public bool IsExact
         => Changes.Count == 0
            && (CSharpDiff is null || CSharpDiff.IsExact)
-           && (IlDiff is null || IlDiff.Diff.IsExact);
+           && (IlDiff is null || IlDiff.Diff.IsExact)
+           && RetainedComparisons.Items.All(comparison => comparison.IsExact);
 }
 
 /// <summary>
@@ -98,11 +100,36 @@ public static class ImplementationDiff
         CSharpBodyDiffResult? csharpDiff = null;
         IlMemberDiffResult? ilDiff = null;
         var changes = ImmutableArray.CreateBuilder<ResearchChange>();
+        var retainedComparisons = ImmutableArray.CreateBuilder<RetainedFindingComparison>();
 
         if (mechanisms.HasFlag(ImplementationDiffMechanism.CSharp))
         {
             csharpDiff = CSharpBodyDiff.CompareMembers(oldSource, oldMethod, newSource, newMethod);
             changes.AddRange(ToCSharpChanges(csharpDiff, subject));
+            var comparison = CSharpFindings.Compare(
+                oldSource,
+                oldMethod,
+                newSource,
+                newMethod,
+                new FindingSubject(subject.Id, subject.Display));
+            retainedComparisons.Add(new RetainedFindingComparison<CSharpCanonicalLine>(
+                subject,
+                CSharpFindings.LineDescriptor,
+                comparison));
+            if (comparison is FindingComparison<CSharpCanonicalLine>.Failed failed)
+            {
+                changes.Add(FindingFailureChange(
+                    subject,
+                    ResearchChangeMechanism.CSharp,
+                    ResearchChangeCategory.CSharp,
+                    CSharpFindings.InspectionDescriptor,
+                    failed.Failure));
+            }
+            else if (comparison.IsExact != csharpDiff.IsExact)
+            {
+                throw new InvalidOperationException(
+                    $"C# Finding comparison diverged from the semantic C# diff for '{subject.Display}'.");
+            }
         }
 
         if (mechanisms.HasFlag(ImplementationDiffMechanism.IlBody))
@@ -120,9 +147,42 @@ public static class ImplementationDiff
                 oldLabel: label,
                 newLabel: label);
             changes.AddRange(ToIlChanges(ilDiff, subject));
+            var comparison = IlFindings.Compare(
+                oldSource.Pe,
+                oldSource.Reader,
+                oldMethod,
+                newSource.Pe,
+                newSource.Reader,
+                newMethod,
+                new FindingSubject(subject.Id, subject.Display));
+            retainedComparisons.Add(new RetainedFindingComparison<CanonicalIlOperation>(
+                subject,
+                IlFindings.OperationDescriptor,
+                comparison));
+            if (comparison is FindingComparison<CanonicalIlOperation>.Failed failed)
+            {
+                changes.Add(FindingFailureChange(
+                    subject,
+                    ResearchChangeMechanism.IlBody,
+                    ResearchChangeCategory.IlBody,
+                    IlFindings.InspectionDescriptor,
+                    failed.Failure));
+            }
+            else if (MethodHasBody(oldSource, oldMethod)
+                && MethodHasBody(newSource, newMethod)
+                && comparison.IsExact != ilDiff.Diff.IsExact)
+            {
+                throw new InvalidOperationException(
+                    $"IL Finding comparison diverged from the semantic IL diff for '{subject.Display}'.");
+            }
         }
 
-        return new ImplementationMemberDiffResult(subject, csharpDiff, ilDiff, changes.ToImmutable());
+        return new ImplementationMemberDiffResult(
+            subject,
+            csharpDiff,
+            ilDiff,
+            changes.ToImmutable(),
+            new RetainedFindingComparisonSet(retainedComparisons));
     }
 
     public static ImplementationDiffResult Compare(
@@ -336,6 +396,23 @@ public static class ImplementationDiff
         => memberTargetIdentities is null
            || memberTargetIdentities.Count == 0
            || memberTargetIdentities.Contains(subject.Id);
+
+    static ResearchChange FindingFailureChange(
+        ResearchSubjectKey subject,
+        ResearchChangeMechanism mechanism,
+        ResearchChangeCategory category,
+        FindingDescriptor descriptor,
+        string failure)
+        => new(
+            subject,
+            mechanism,
+            descriptor,
+            ResearchChangeKind.Changed,
+            detail: failure,
+            category: category);
+
+    static bool MethodHasBody(MetadataSource source, MethodDefinitionHandle method)
+        => source.Reader.GetMethodDefinition(method).RelativeVirtualAddress != 0;
 
     static ResearchSubjectKey SubjectFromMethod(MetadataSource source, MethodDefinitionHandle methodHandle)
     {

--- a/src/ILInspector.Research/ImplementationDiff.cs
+++ b/src/ILInspector.Research/ImplementationDiff.cs
@@ -7,6 +7,7 @@ using ILInspector.Findings;
 using ILInspector.Instructions;
 using ILInspector.Metadata;
 using ILInspector.MetadataPrimitives;
+using ILInspector.Text;
 
 namespace ILInspector.Research;
 
@@ -16,7 +17,9 @@ public enum ImplementationDiffMechanism
     None = 0,
     CSharp = 1,
     IlBody = 2,
+    Source = 4,
     All = CSharp | IlBody,
+    AllAvailable = All | Source,
 }
 
 public sealed record ImplementationDiffOptions(
@@ -35,12 +38,22 @@ public sealed record ImplementationDiffMember(
     ResearchSubjectKey Subject,
     IReadOnlyList<ResearchChange> Changes)
 {
+    public FindingComparison<string>? SourceComparison { get; init; }
+
     public bool HasCSharpChanges
         => Changes.Any(change => change.Mechanism == ResearchChangeMechanism.CSharp);
 
     public bool HasIlChanges
         => Changes.Any(change => change.Mechanism == ResearchChangeMechanism.IlBody);
+
+    public bool HasSourceChanges
+        => Changes.Any(change => change.Mechanism == ResearchChangeMechanism.Source);
 }
+
+public sealed record AuthoredSourceComparisonInput(
+    ResearchSubjectKey Subject,
+    FindingInspection<string> OldInspection,
+    FindingInspection<string> NewInspection);
 
 public sealed record ImplementationMemberDiffResult(
     ResearchSubjectKey Subject,
@@ -49,17 +62,23 @@ public sealed record ImplementationMemberDiffResult(
     IReadOnlyList<ResearchChange> Changes,
     RetainedFindingComparisonSet RetainedComparisons)
 {
+    public FindingComparison<string>? SourceComparison { get; init; }
+
     public bool HasCSharpChanges
         => Changes.Any(change => change.Mechanism == ResearchChangeMechanism.CSharp);
 
     public bool HasIlChanges
         => Changes.Any(change => change.Mechanism == ResearchChangeMechanism.IlBody);
 
+    public bool HasSourceChanges
+        => Changes.Any(change => change.Mechanism == ResearchChangeMechanism.Source);
+
     public bool IsExact
         => Changes.Count == 0
            && (CSharpDiff is null || CSharpDiff.IsExact)
            && (IlDiff is null || IlDiff.Diff.IsExact)
-           && RetainedComparisons.Items.All(comparison => comparison.IsExact);
+           && RetainedComparisons.Items.All(comparison => comparison.IsExact)
+           && (SourceComparison is null || SourceComparison.IsExact);
 }
 
 /// <summary>
@@ -68,6 +87,9 @@ public sealed record ImplementationMemberDiffResult(
 /// </summary>
 public static class ImplementationDiff
 {
+    public static readonly FindingDescriptor AuthoredSourceFailureDescriptor =
+        new("source.authored.failed", "Authored source acquisition failed");
+
     public static ImplementationDiffResult CompareAssemblies(
         string oldAssemblyPath,
         string newAssemblyPath,
@@ -185,6 +207,45 @@ public static class ImplementationDiff
             new RetainedFindingComparisonSet(retainedComparisons));
     }
 
+    public static ImplementationMemberDiffResult CompareMembersWithAuthoredSource(
+        MetadataSource oldSource,
+        MethodDefinitionHandle oldMethod,
+        MetadataSource newSource,
+        MethodDefinitionHandle newMethod,
+        FindingInspection<string> oldAuthoredSource,
+        FindingInspection<string> newAuthoredSource,
+        ImplementationDiffMechanism mechanisms = ImplementationDiffMechanism.AllAvailable,
+        ResearchSubjectKey? subject = null)
+    {
+        ArgumentNullException.ThrowIfNull(oldAuthoredSource);
+        ArgumentNullException.ThrowIfNull(newAuthoredSource);
+
+        var result = CompareMembers(
+            oldSource,
+            oldMethod,
+            newSource,
+            newMethod,
+            mechanisms & ~ImplementationDiffMechanism.Source,
+            subject);
+        if (!mechanisms.HasFlag(ImplementationDiffMechanism.Source))
+            return result;
+
+        var comparison = FindingComparison.Compare(
+            oldAuthoredSource,
+            newAuthoredSource);
+        var retained = result.RetainedComparisons.Items.ToBuilder();
+        retained.Add(new RetainedFindingComparison<string>(
+            result.Subject,
+            TextFindings.LineDescriptor,
+            comparison));
+        return result with
+        {
+            Changes = [.. result.Changes, .. ToSourceChanges(comparison, result.Subject)],
+            RetainedComparisons = new RetainedFindingComparisonSet(retained),
+            SourceComparison = comparison,
+        };
+    }
+
     public static ImplementationDiffResult Compare(
         ResearchDiffInput oldInput,
         ResearchDiffInput newInput,
@@ -208,18 +269,133 @@ public static class ImplementationDiff
         ArgumentNullException.ThrowIfNull(research);
         options ??= new ImplementationDiffOptions();
 
-        var members = research.MembersWhere(member => member.ImplementationChanged)
+        var sourceComparisons = research.RetainedComparisons.Items
+            .Where(comparison => comparison.Descriptor.Id == TextFindings.LineDescriptor.Id)
+            .OfType<RetainedFindingComparison<string>>()
+            .GroupBy(comparison => comparison.Subject.Id, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+        var changedMembers = research.BySubject()
+            .Where(member => member.Subject.Kind == ResearchSubjectKind.Member)
+            .ToDictionary(member => member.Subject.Id, StringComparer.Ordinal);
+        var subjects = changedMembers.Values
+            .Select(member => member.Subject)
+            .Concat(sourceComparisons.Values.Select(comparison => comparison.Subject))
+            .DistinctBy(subject => subject.Id, StringComparer.Ordinal);
+        var members = subjects
+            .Select(subject => (
+                Subject: subject,
+                Changes: changedMembers.TryGetValue(subject.Id, out var member)
+                    ? member.Changes
+                    : ImmutableArray<ResearchChange>.Empty))
+            .Where(item => item.Changes.Any(change =>
+                    change.Mechanism is ResearchChangeMechanism.CSharp
+                        or ResearchChangeMechanism.IlBody
+                        or ResearchChangeMechanism.Source)
+                || sourceComparisons.ContainsKey(item.Subject.Id))
             .Select(member => new ImplementationDiffMember(
                 member.Subject,
                 [.. member.Changes.Where(change =>
                     change.Mechanism is ResearchChangeMechanism.CSharp
-                        or ResearchChangeMechanism.IlBody)]))
-            .Where(member => member.Changes.Count > 0)
+                        or ResearchChangeMechanism.IlBody
+                        or ResearchChangeMechanism.Source)])
+                {
+                    SourceComparison = sourceComparisons.GetValueOrDefault(member.Subject.Id)?.Comparison,
+                })
+            .Where(member => member.Changes.Count > 0 || member.SourceComparison is not null)
             .Where(member => ResearchDiff.MatchesTypeFilters(member.Subject.TypeName ?? "", options.TypeFilters))
             .Where(member => MatchesMemberTargets(member.Subject, options.MemberTargetIdentities))
             .ToArray();
 
         return new ImplementationDiffResult(members, research);
+    }
+
+    public static ImplementationDiffResult WithAuthoredSourceComparisons(
+        ImplementationDiffResult result,
+        IEnumerable<AuthoredSourceComparisonInput> inputs,
+        ImplementationDiffOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentNullException.ThrowIfNull(inputs);
+        options ??= new ImplementationDiffOptions();
+
+        var changes = result.Research.Changes.ToBuilder();
+        var retained = result.Research.RetainedComparisons.Items.ToBuilder();
+        foreach (var input in inputs)
+        {
+            ArgumentNullException.ThrowIfNull(input);
+            var comparison = FindingComparison.Compare(
+                input.OldInspection,
+                input.NewInspection);
+            retained.Add(new RetainedFindingComparison<string>(
+                input.Subject,
+                TextFindings.LineDescriptor,
+                comparison));
+            changes.AddRange(ToSourceChanges(comparison, input.Subject));
+        }
+
+        var research = new ResearchComparison(
+            changes.ToImmutable(),
+            result.Research.ApiDiff,
+            result.Research.ApiComparison,
+            new RetainedFindingComparisonSet(retained));
+        return FromResearchComparison(research, options);
+    }
+
+    public static ImmutableArray<ResearchChange> ToSourceChanges(
+        FindingComparison<string> comparison,
+        ResearchSubjectKey subject)
+    {
+        ArgumentNullException.ThrowIfNull(comparison);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        if (comparison is FindingComparison<string>.Failed failed)
+        {
+            return
+            [
+                new ResearchChange(
+                    subject,
+                    ResearchChangeMechanism.Source,
+                    AuthoredSourceFailureDescriptor,
+                    ResearchChangeKind.Changed,
+                    detail: failed.Failure,
+                    category: ResearchChangeCategory.Source)
+            ];
+        }
+
+        var complete = (FindingComparison<string>.Complete)comparison.Value;
+        var changes = ImmutableArray.CreateBuilder<ResearchChange>();
+        foreach (var pair in complete.Pairs)
+        {
+            switch (pair)
+            {
+                case PairFinding<string>.Added added:
+                    changes.Add(SourceChange(
+                        subject,
+                        ResearchChangeKind.Added,
+                        newValue: added.New.Payload,
+                        detail: added.Detail));
+                    break;
+                case PairFinding<string>.Removed removed:
+                    changes.Add(SourceChange(
+                        subject,
+                        ResearchChangeKind.Removed,
+                        oldValue: removed.Old.Payload,
+                        detail: removed.Detail));
+                    break;
+                case PairFinding<string>.Changed changed:
+                    changes.Add(SourceChange(
+                        subject,
+                        ResearchChangeKind.Changed,
+                        changed.Old.Payload,
+                        changed.New.Payload,
+                        changed.Detail));
+                    break;
+                case PairFinding<string>.Present:
+                    break;
+            }
+        }
+
+        return changes.ToImmutable();
     }
 
     public static ImmutableArray<ResearchChange> ToIlChanges(
@@ -322,8 +498,31 @@ public static class ImplementationDiff
             lines.Add(change.IlDisplayFailureRow.UnifiedLine);
         if (!change.IlDisplayRows.IsDefaultOrEmpty)
             lines.AddRange(change.IlDisplayRows.Select(row => row.UnifiedLine));
+        if (change.Mechanism == ResearchChangeMechanism.Source)
+        {
+            if (change.OldValue is { } oldValue)
+                lines.Add($"- {oldValue}");
+            if (change.NewValue is { } newValue)
+                lines.Add($"+ {newValue}");
+        }
         return lines.ToImmutable();
     }
+
+    static ResearchChange SourceChange(
+        ResearchSubjectKey subject,
+        ResearchChangeKind kind,
+        string? oldValue = null,
+        string? newValue = null,
+        string? detail = null)
+        => new(
+            subject,
+            ResearchChangeMechanism.Source,
+            TextFindings.LineDescriptor,
+            kind,
+            oldValue,
+            newValue,
+            detail: detail,
+            category: ResearchChangeCategory.Source);
 
     static ImmutableArray<ResearchChange> ToCSharpChanges(
         CSharpBodyDiffResult diff,

--- a/src/ILInspector.Research/ResearchChanges.cs
+++ b/src/ILInspector.Research/ResearchChanges.cs
@@ -319,6 +319,8 @@ public abstract record RetainedFindingComparison
 
     public ResearchSubjectKey Subject { get; }
     public FindingDescriptor Descriptor { get; }
+    public abstract bool IsExact { get; }
+    public abstract string? Failure { get; }
 }
 
 public sealed record RetainedFindingComparison<T> : RetainedFindingComparison
@@ -334,6 +336,8 @@ public sealed record RetainedFindingComparison<T> : RetainedFindingComparison
     }
 
     public FindingComparison<T> Comparison { get; }
+    public override bool IsExact => Comparison.IsExact;
+    public override string? Failure => Comparison.Failure;
 }
 
 public sealed class RetainedFindingComparisonSet

--- a/src/ILInspector.Research/ResearchChanges.cs
+++ b/src/ILInspector.Research/ResearchChanges.cs
@@ -31,6 +31,7 @@ public enum ResearchChangeKind
     Added,
     Removed,
     Changed,
+    Failed,
 }
 
 public enum ResearchChangeCategory

--- a/src/ILInspector.Research/ResearchChanges.cs
+++ b/src/ILInspector.Research/ResearchChanges.cs
@@ -16,7 +16,8 @@ public enum ResearchChangeMechanism
     IlBody = 4,
     CSharp = 8,
     ReturnToSender = 16,
-    AllAvailable = Api | BodySignals | IlBody | CSharp | ReturnToSender,
+    Source = 32,
+    AllAvailable = Api | BodySignals | IlBody | CSharp | ReturnToSender | Source,
 }
 
 public enum ResearchSubjectKind
@@ -40,6 +41,7 @@ public enum ResearchChangeCategory
     BodySignal,
     IlBody,
     CSharp,
+    Source,
     RoundTrip,
 }
 
@@ -290,7 +292,8 @@ public sealed record ResearchSubjectChanges
         => Changes.Any(change =>
             change.Mechanism is ResearchChangeMechanism.BodySignals
                 or ResearchChangeMechanism.IlBody
-                or ResearchChangeMechanism.CSharp);
+                or ResearchChangeMechanism.CSharp
+                or ResearchChangeMechanism.Source);
 
     public bool HasMechanism(ResearchChangeMechanism mechanism)
         => Changes.Any(change => change.Mechanism == mechanism);

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -223,10 +223,26 @@ public static class ResearchDiff
         }
 
         if (options.Mechanisms.HasFlag(ResearchChangeMechanism.IlBody))
-            AddIlBodyDiff(builder, oldInput, newInput, options.TypeFilters, options.MemberTargetIdentities);
+        {
+            AddIlBodyDiff(
+                builder,
+                oldInput,
+                newInput,
+                options.TypeFilters,
+                options.MemberTargetIdentities,
+                options.RetainedComparisonDescriptorIds);
+        }
 
         if (options.Mechanisms.HasFlag(ResearchChangeMechanism.CSharp))
-            AddCSharpDiff(builder, oldInput, newInput, options.TypeFilters, options.MemberTargetIdentities);
+        {
+            AddCSharpDiff(
+                builder,
+                oldInput,
+                newInput,
+                options.TypeFilters,
+                options.MemberTargetIdentities,
+                options.RetainedComparisonDescriptorIds);
+        }
 
         return builder.ToResult();
     }
@@ -720,8 +736,21 @@ public static class ResearchDiff
         ResearchDiffInput oldInput,
         ResearchDiffInput newInput,
         IReadOnlySet<string>? typeFilters,
-        IReadOnlySet<string>? memberTargetIdentities)
+        IReadOnlySet<string>? memberTargetIdentities,
+        IReadOnlySet<string> retainedComparisonDescriptorIds)
     {
+        bool retainOperations = retainedComparisonDescriptorIds.Contains(
+            IlFindings.OperationDescriptor.Id);
+        var retainedComparisons = retainOperations
+            ? AddRetainedIlOperationComparisons(
+                builder,
+                oldInput,
+                newInput,
+                typeFilters,
+                memberTargetIdentities)
+            : new Dictionary<string, FindingComparison<CanonicalIlOperation>>(
+                StringComparer.Ordinal);
+
         foreach (var pair in PairedBodyIndexEntries(oldInput, newInput))
         {
             var oldMethods = MethodLookup(pair.Old.Index);
@@ -739,6 +768,11 @@ public static class ResearchDiff
                     continue;
                 if (!MatchesMemberTargets(subject, memberTargetIdentities))
                     continue;
+
+                retainedComparisons.TryGetValue(
+                    RetainedIlComparisonKey(pair.Old.Key, key),
+                    out var findingComparison);
+
                 var oldAvailable = oldBodies.TryDecode(oldMethod.MetadataToken, out var oldBody, out var oldReason);
                 var newAvailable = newBodies.TryDecode(newMethod.MetadataToken, out var newBody, out var newReason);
 
@@ -760,6 +794,12 @@ public static class ResearchDiff
                     oldBody!,
                     newBodies.MetadataReader,
                     newBody!);
+                if (findingComparison is FindingComparison<CanonicalIlOperation>.Complete complete
+                    && complete.IsExact != diff.IsExact)
+                {
+                    throw new InvalidOperationException(
+                        $"IL Finding comparison diverged from the semantic IL diff for '{subject.Display}'.");
+                }
                 if (diff.IsExact)
                     continue;
                 if (!diff.FailureRows.IsDefaultOrEmpty)
@@ -811,6 +851,124 @@ public static class ResearchDiff
         }
     }
 
+    static Dictionary<string, FindingComparison<CanonicalIlOperation>>
+        AddRetainedIlOperationComparisons(
+            ResultBuilder builder,
+            ResearchDiffInput oldInput,
+            ResearchDiffInput newInput,
+            IReadOnlySet<string>? typeFilters,
+            IReadOnlySet<string>? memberTargetIdentities)
+    {
+        var retained = new Dictionary<string, FindingComparison<CanonicalIlOperation>>(
+            StringComparer.Ordinal);
+        foreach (var pair in UnionBodyIndexEntries(oldInput, newInput))
+        {
+            var oldMethods = pair.Old is null
+                ? new Dictionary<string, IlRetentionMethod>(StringComparer.Ordinal)
+                : IlRetentionMethodLookup(pair.Old);
+            var newMethods = pair.New is null
+                ? new Dictionary<string, IlRetentionMethod>(StringComparer.Ordinal)
+                : IlRetentionMethodLookup(pair.New);
+            using var oldBodies = pair.Old is null
+                ? null
+                : new MethodBodyLookup(pair.Old.Path);
+            using var newBodies = pair.New is null
+                ? null
+                : new MethodBodyLookup(pair.New.Path);
+
+            foreach (string key in oldMethods.Keys
+                .Union(newMethods.Keys, StringComparer.Ordinal)
+                .Order(StringComparer.Ordinal))
+            {
+                oldMethods.TryGetValue(key, out var oldMethod);
+                newMethods.TryGetValue(key, out var newMethod);
+                var representative = newMethod ?? oldMethod!;
+                var subject = representative.Subject;
+                if (!MatchesTypeFilters(subject.TypeName ?? "", typeFilters)
+                    || !MatchesMemberTargets(subject, memberTargetIdentities))
+                {
+                    continue;
+                }
+
+                var findingSubject = new FindingSubject(subject.Id, subject.Display);
+                FindingComparison<CanonicalIlOperation> comparison;
+                if (oldMethod is not null && newMethod is not null)
+                {
+                    comparison = IlFindings.Compare(
+                        oldBodies!.PeReader,
+                        oldBodies.MetadataReader,
+                        MethodHandle(oldMethod.MetadataToken),
+                        newBodies!.PeReader,
+                        newBodies.MetadataReader,
+                        MethodHandle(newMethod.MetadataToken),
+                        findingSubject);
+                }
+                else
+                {
+                    var oldInspection = oldMethod is null
+                        ? new FindingInspection<CanonicalIlOperation>.Absent(
+                            "Member is absent.")
+                        : IlFindings.Inspect(
+                            oldBodies!.PeReader,
+                            oldBodies.MetadataReader,
+                            MethodHandle(oldMethod.MetadataToken),
+                            findingSubject);
+                    var newInspection = newMethod is null
+                        ? new FindingInspection<CanonicalIlOperation>.Absent(
+                            "Member is absent.")
+                        : IlFindings.Inspect(
+                            newBodies!.PeReader,
+                            newBodies.MetadataReader,
+                            MethodHandle(newMethod.MetadataToken),
+                            findingSubject);
+                    comparison = IlFindings.Compare(oldInspection, newInspection);
+                }
+
+                AddRetainedComparison(
+                    builder,
+                    subject,
+                    IlFindings.OperationDescriptor,
+                    comparison);
+                retained.Add(
+                    RetainedIlComparisonKey(pair.Key, key),
+                    comparison);
+                if (comparison is FindingComparison<CanonicalIlOperation>.Failed failed)
+                {
+                    AddFindingComparisonFailure(
+                        builder,
+                        subject,
+                        ResearchChangeMechanism.IlBody,
+                        ResearchChangeCategory.IlBody,
+                        IlFindings.InspectionDescriptor,
+                        failed.Failure);
+                }
+            }
+        }
+
+        return retained;
+    }
+
+    static Dictionary<string, IlRetentionMethod> IlRetentionMethodLookup(
+        BodyIndexEntry entry)
+    {
+        var methods = new Dictionary<string, IlRetentionMethod>(StringComparer.Ordinal);
+        foreach (var method in entry.Index.DeclaredMethods)
+        {
+            var subject = SubjectFromMethod(method);
+            methods.TryAdd(
+                MethodMatchKey(method),
+                new IlRetentionMethod(subject, method.MetadataToken));
+        }
+
+        return methods;
+    }
+
+    static MethodDefinitionHandle MethodHandle(int metadataToken)
+        => (MethodDefinitionHandle)MetadataTokens.EntityHandle(metadataToken);
+
+    static string RetainedIlComparisonKey(string assemblyKey, string methodKey)
+        => $"{assemblyKey}\u001f{methodKey}";
+
     static void AddIlFailureEvidence(ResultBuilder builder, ResearchSubjectKey subject, IlDiffFailureRow failure)
     {
         var kind = failure.Kind switch
@@ -838,12 +996,17 @@ public static class ResearchDiff
         ResearchDiffInput oldInput,
         ResearchDiffInput newInput,
         IReadOnlySet<string>? typeFilters,
-        IReadOnlySet<string>? memberTargetIdentities)
+        IReadOnlySet<string>? memberTargetIdentities,
+        IReadOnlySet<string> retainedComparisonDescriptorIds)
     {
         if (oldInput.AssemblyPaths.Count == 0 || newInput.AssemblyPaths.Count == 0)
             return;
 
-        var diff = CSharpBodyDiff.CompareAssemblies(oldInput.AssemblyPaths, newInput.AssemblyPaths, typeFilters: typeFilters);
+        var diff = CSharpBodyDiff.CompareAssemblies(
+            oldInput.AssemblyPaths,
+            newInput.AssemblyPaths,
+            typeFilters: typeFilters,
+            memberTargetIdentities: memberTargetIdentities);
         foreach (var failure in diff.FailureRows.IsDefault ? [] : diff.FailureRows)
         {
             var subject = ResearchMemberIdentity.SubjectFromAnchor(failure.Anchor, failure.Member);
@@ -876,7 +1039,82 @@ public static class ResearchDiff
                 cSharpRow: row,
                 cSharpDisplayRows: [CSharpDiffPrinter.ToDisplayRow(row)]));
         }
+
+        if (!retainedComparisonDescriptorIds.Contains(CSharpFindings.LineDescriptor.Id))
+            return;
+
+        foreach (var retained in CSharpFindings.CompareAssemblies(
+            oldInput.AssemblyPaths,
+            newInput.AssemblyPaths,
+            typeFilters: typeFilters,
+            memberTargetIdentities: memberTargetIdentities))
+        {
+            var subject = ResearchMemberIdentity.SubjectFromAnchor(
+                retained.Anchor,
+                retained.Member);
+            AddRetainedComparison(
+                builder,
+                subject,
+                CSharpFindings.LineDescriptor,
+                retained.Comparison);
+            if (retained.Comparison is FindingComparison<CSharpCanonicalLine>.Failed failed)
+            {
+                AddFindingComparisonFailure(
+                    builder,
+                    subject,
+                    ResearchChangeMechanism.CSharp,
+                    ResearchChangeCategory.CSharp,
+                    CSharpFindings.InspectionDescriptor,
+                    failed.Failure);
+                continue;
+            }
+
+            if (!retained.OldMemberPresent || !retained.NewMemberPresent)
+                continue;
+
+            bool semanticExact = !diff.Rows.Any(row =>
+                    string.Equals(
+                        row.Anchor.StableSelector,
+                        retained.Anchor.StableSelector,
+                        StringComparison.Ordinal))
+                && !(diff.FailureRows.IsDefault ? [] : diff.FailureRows).Any(failure =>
+                    string.Equals(
+                        failure.Anchor.StableSelector,
+                        retained.Anchor.StableSelector,
+                        StringComparison.Ordinal));
+            if (retained.Comparison.IsExact != semanticExact)
+            {
+                throw new InvalidOperationException(
+                    $"C# Finding comparison diverged from the semantic C# diff for '{subject.Display}'.");
+            }
+        }
     }
+
+    static void AddFindingComparisonFailure(
+        ResultBuilder builder,
+        ResearchSubjectKey subject,
+        ResearchChangeMechanism mechanism,
+        ResearchChangeCategory category,
+        FindingDescriptor descriptor,
+        string failure)
+        => builder.Add(new ResearchChange(
+            subject,
+            mechanism,
+            descriptor,
+            ResearchChangeKind.Changed,
+            detail: failure,
+            category: category));
+
+    static void AddRetainedComparison<T>(
+        ResultBuilder builder,
+        ResearchSubjectKey subject,
+        FindingDescriptor descriptor,
+        FindingComparison<T> comparison)
+        where T : notnull
+        => builder.Add(new RetainedFindingComparison<T>(
+            subject,
+            descriptor,
+            comparison));
 
     static void AddCSharpFailureEvidence(ResultBuilder builder, ResearchSubjectKey subject, CSharpDiffFailureRow failure)
     {
@@ -929,6 +1167,26 @@ public static class ResearchDiff
         var newIndexes = BodyIndexEntries(newInput).ToDictionary(entry => entry.Key, StringComparer.Ordinal);
         foreach (var key in oldIndexes.Keys.Intersect(newIndexes.Keys, StringComparer.Ordinal).Order(StringComparer.Ordinal))
             yield return (oldIndexes[key], newIndexes[key]);
+    }
+
+    static IEnumerable<UnionBodyIndexEntry> UnionBodyIndexEntries(
+        ResearchDiffInput oldInput,
+        ResearchDiffInput newInput)
+    {
+        var oldIndexes = BodyIndexEntries(oldInput).ToDictionary(
+            entry => entry.Key,
+            StringComparer.Ordinal);
+        var newIndexes = BodyIndexEntries(newInput).ToDictionary(
+            entry => entry.Key,
+            StringComparer.Ordinal);
+        foreach (string key in oldIndexes.Keys
+            .Union(newIndexes.Keys, StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal))
+        {
+            oldIndexes.TryGetValue(key, out var oldIndex);
+            newIndexes.TryGetValue(key, out var newIndex);
+            yield return new UnionBodyIndexEntry(key, oldIndex, newIndex);
+        }
     }
 
     static IEnumerable<BodyIndexEntry> BodyIndexEntries(ResearchDiffInput input)
@@ -1194,6 +1452,13 @@ public static class ResearchDiff
         };
 
     sealed record BodyIndexEntry(string Key, string Path, LibraryBodyIndex Index);
+    sealed record UnionBodyIndexEntry(
+        string Key,
+        BodyIndexEntry? Old,
+        BodyIndexEntry? New);
+    sealed record IlRetentionMethod(
+        ResearchSubjectKey Subject,
+        int MetadataToken);
 
     sealed record ResearchAnalysisMethod(
         ResearchSubjectKey Subject,
@@ -1238,6 +1503,7 @@ public static class ResearchDiff
         }
 
         public MetadataReader MetadataReader => _metadataReader;
+        public PEReader PeReader => _peReader;
 
         public bool TryDecode(int metadataToken, out MethodBodyBlock? body, out string? unavailableReason)
         {

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -97,7 +97,7 @@ public static class ResearchDiff
                 subject,
                 ResearchChangeMechanism.IlBody,
                 Descriptor("il.diff.failed", "IL diff failed"),
-                ResearchChangeKind.Changed,
+                ResearchChangeKind.Failed,
                 detail: failure,
                 category: ResearchChangeCategory.IlBody));
         }
@@ -132,9 +132,11 @@ public static class ResearchDiff
     {
         ArgumentNullException.ThrowIfNull(diff);
         var changes = ImmutableArray.CreateBuilder<ResearchChange>();
-        if (!diff.FailureRows.IsDefaultOrEmpty)
+        var failureRows = diff.FailureRows.IsDefault ? [] : diff.FailureRows;
+        var operationalFailureHunks = OperationalCSharpFailureHunks(failureRows);
+        if (!failureRows.IsEmpty)
         {
-            changes.AddRange(diff.FailureRows.Select(row =>
+            changes.AddRange(failureRows.Select(row =>
             {
                 string descriptorId = $"csharp.diff.{ToKebabCase(row.Kind.ToString())}";
                 return new ResearchChange(
@@ -153,7 +155,9 @@ public static class ResearchDiff
 
         if (!diff.Rows.IsDefaultOrEmpty)
         {
-            changes.AddRange(diff.Rows.Select(row =>
+            changes.AddRange(diff.Rows
+                .Where(row => !operationalFailureHunks.Contains(row.HunkId))
+                .Select(row =>
             {
                 var kind = Direction(row.Kind);
                 return new ResearchChange(
@@ -976,12 +980,14 @@ public static class ResearchDiff
 
     static void AddIlFailureEvidence(ResultBuilder builder, ResearchSubjectKey subject, IlDiffFailureRow failure)
     {
-        var kind = failure.Kind switch
+        var kind = Direction(failure.Kind);
+        if (kind == ResearchChangeKind.Failed)
         {
-            IlDiffFailureKind.OldBodyMissing => ResearchChangeKind.Added,
-            IlDiffFailureKind.NewBodyMissing => ResearchChangeKind.Removed,
-            _ => ResearchChangeKind.Changed,
-        };
+            builder.RemoveFailure(
+                subject,
+                ResearchChangeMechanism.IlBody,
+                IlFindings.InspectionDescriptor);
+        }
         string descriptorId = $"il.diff.{ToKebabCase(failure.Kind.ToString())}";
         builder.Add(new ResearchChange(
             subject,
@@ -1012,7 +1018,9 @@ public static class ResearchDiff
             newInput.AssemblyPaths,
             typeFilters: typeFilters,
             memberTargetIdentities: memberTargetIdentities);
-        foreach (var failure in diff.FailureRows.IsDefault ? [] : diff.FailureRows)
+        var failureRows = diff.FailureRows.IsDefault ? [] : diff.FailureRows;
+        var operationalFailureHunks = OperationalCSharpFailureHunks(failureRows);
+        foreach (var failure in failureRows)
         {
             var subject = ResearchMemberIdentity.SubjectFromAnchor(failure.Anchor, failure.Member);
             if (MatchesMemberTargets(subject, memberTargetIdentities))
@@ -1021,6 +1029,9 @@ public static class ResearchDiff
 
         foreach (var row in diff.Rows)
         {
+            if (operationalFailureHunks.Contains(row.HunkId))
+                continue;
+
             var subject = ResearchMemberIdentity.SubjectFromAnchor(row.Anchor, row.Member);
             if (!MatchesMemberTargets(subject, memberTargetIdentities))
                 continue;
@@ -1064,13 +1075,16 @@ public static class ResearchDiff
                 retained.Comparison);
             if (retained.Comparison is FindingComparison<CSharpCanonicalLine>.Failed failed)
             {
-                AddFindingComparisonFailure(
-                    builder,
-                    subject,
-                    ResearchChangeMechanism.CSharp,
-                    ResearchChangeCategory.CSharp,
-                    CSharpFindings.InspectionDescriptor,
-                    failed.Failure);
+                if (!builder.HasFailure(subject, ResearchChangeMechanism.CSharp))
+                {
+                    AddFindingComparisonFailure(
+                        builder,
+                        subject,
+                        ResearchChangeMechanism.CSharp,
+                        ResearchChangeCategory.CSharp,
+                        CSharpFindings.InspectionDescriptor,
+                        failed.Failure);
+                }
                 continue;
             }
 
@@ -1128,12 +1142,7 @@ public static class ResearchDiff
 
     static void AddCSharpFailureEvidence(ResultBuilder builder, ResearchSubjectKey subject, CSharpDiffFailureRow failure)
     {
-        var kind = failure.Kind switch
-        {
-            CSharpDiffFailureKind.OldBodyMissing => ResearchChangeKind.Added,
-            CSharpDiffFailureKind.NewBodyMissing => ResearchChangeKind.Removed,
-            _ => ResearchChangeKind.Changed,
-        };
+        var kind = Direction(failure.Kind);
         string descriptorId = $"csharp.diff.{ToKebabCase(failure.Kind.ToString())}";
         builder.Add(new ResearchChange(
             subject,
@@ -1304,12 +1313,12 @@ public static class ResearchDiff
             _ => ResearchChangeKind.Changed,
         };
 
-    static ResearchChangeKind Direction(IlDiffFailureKind kind)
+    internal static ResearchChangeKind Direction(IlDiffFailureKind kind)
         => kind switch
         {
             IlDiffFailureKind.OldBodyMissing => ResearchChangeKind.Added,
             IlDiffFailureKind.NewBodyMissing => ResearchChangeKind.Removed,
-            _ => ResearchChangeKind.Changed,
+            _ => ResearchChangeKind.Failed,
         };
 
     static ResearchChangeKind Direction(CSharpDiffKind kind)
@@ -1320,13 +1329,21 @@ public static class ResearchDiff
             _ => ResearchChangeKind.Changed,
         };
 
-    static ResearchChangeKind Direction(CSharpDiffFailureKind kind)
+    internal static ResearchChangeKind Direction(CSharpDiffFailureKind kind)
         => kind switch
         {
             CSharpDiffFailureKind.OldBodyMissing => ResearchChangeKind.Added,
             CSharpDiffFailureKind.NewBodyMissing => ResearchChangeKind.Removed,
-            _ => ResearchChangeKind.Changed,
+            _ => ResearchChangeKind.Failed,
         };
+
+    internal static ImmutableHashSet<int> OperationalCSharpFailureHunks(
+        ImmutableArray<CSharpDiffFailureRow> failureRows)
+        => failureRows
+            .Where(failure => Direction(failure.Kind) == ResearchChangeKind.Failed
+                && failure.HunkId is not null)
+            .Select(failure => failure.HunkId!.Value)
+            .ToImmutableHashSet();
 
     static ResearchChangeCategory ToResearchCategory(ApiChangeCategory category)
         => category switch
@@ -1489,6 +1506,24 @@ public static class ResearchDiff
 
         public void Add(RetainedFindingComparison comparison)
             => _retainedComparisons.Add(comparison);
+
+        public bool HasFailure(
+            ResearchSubjectKey subject,
+            ResearchChangeMechanism mechanism)
+            => _changes.Any(change =>
+                change.Subject.Id == subject.Id
+                && change.Mechanism == mechanism
+                && change.Kind == ResearchChangeKind.Failed);
+
+        public void RemoveFailure(
+            ResearchSubjectKey subject,
+            ResearchChangeMechanism mechanism,
+            FindingDescriptor descriptor)
+            => _changes.RemoveAll(change =>
+                change.Subject.Id == subject.Id
+                && change.Mechanism == mechanism
+                && change.Descriptor == descriptor
+                && change.Kind == ResearchChangeKind.Failed);
 
         public ResearchComparison ToResult()
             => new(

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -795,10 +795,15 @@ public static class ResearchDiff
                     newBodies.MetadataReader,
                     newBody!);
                 if (findingComparison is FindingComparison<CanonicalIlOperation>.Complete complete
-                    && complete.IsExact != diff.IsExact)
+                    && ImplementationDiff.FindingDivergenceChange(
+                        subject,
+                        ResearchChangeMechanism.IlBody,
+                        ResearchChangeCategory.IlBody,
+                        ImplementationDiff.IlFindingDivergenceDescriptor,
+                        complete.IsExact,
+                        diff.IsExact) is { } divergence)
                 {
-                    throw new InvalidOperationException(
-                        $"IL Finding comparison diverged from the semantic IL diff for '{subject.Display}'.");
+                    builder.Add(divergence);
                 }
                 if (diff.IsExact)
                     continue;
@@ -1082,10 +1087,15 @@ public static class ResearchDiff
                         failure.Anchor.StableSelector,
                         retained.Anchor.StableSelector,
                         StringComparison.Ordinal));
-            if (retained.Comparison.IsExact != semanticExact)
+            if (ImplementationDiff.FindingDivergenceChange(
+                subject,
+                ResearchChangeMechanism.CSharp,
+                ResearchChangeCategory.CSharp,
+                ImplementationDiff.CSharpFindingDivergenceDescriptor,
+                retained.Comparison.IsExact,
+                semanticExact) is { } divergence)
             {
-                throw new InvalidOperationException(
-                    $"C# Finding comparison diverged from the semantic C# diff for '{subject.Display}'.");
+                builder.Add(divergence);
             }
         }
     }
@@ -1101,7 +1111,7 @@ public static class ResearchDiff
             subject,
             mechanism,
             descriptor,
-            ResearchChangeKind.Changed,
+            ResearchChangeKind.Failed,
             detail: failure,
             category: category));
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1644,6 +1644,51 @@ public class CommandExecutionTests
         Assert.Contains("present", output);
     }
 
+    [Theory]
+    [InlineData("csharp.line", "return 1;", "return 2;")]
+    [InlineData("il.op", "ldc.i4 1", "ldc.i4 2")]
+    public async Task Diff_FindingTransitions_ConfirmsImplementationOccurrenceChanges(
+        string descriptor,
+        string oldEvidence,
+        string newEvidence)
+    {
+        var oldPath = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var newPath = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var (exit, output, error) = await RunAppAsync(
+            "diff", "--library", $"{oldPath}..{newPath}",
+            "-t", "DiffFixtureSample.DiffSample",
+            "-m", "ConstantValue",
+            "--finding", descriptor,
+            "--table", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("PairFinding.Removed", output);
+        Assert.Contains("PairFinding.Added", output);
+        Assert.Contains(descriptor, output);
+        Assert.Contains(oldEvidence, output);
+        Assert.Contains(newEvidence, output);
+    }
+
+    [Theory]
+    [InlineData("csharp.line")]
+    [InlineData("il.op")]
+    public async Task Diff_FindingTransitions_ImplementationFindingsRequireOneMemberBeforeAcquisition(
+        string descriptor)
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "diff", "--library", "missing-old.dll..missing-new.dll",
+            "-t", "Sample.Widget",
+            "--finding", descriptor,
+            "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains($"--finding {descriptor} requires exactly one --member", error);
+        Assert.DoesNotContain("not found", error, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Fact]
     public async Task Diff_FindingTransitions_AllocationRequiresOneMemberBeforeAcquisition()
     {

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -805,6 +805,16 @@ public class CommandLineTests
     }
 
     [Fact]
+    public void DiffCommand_WithAuthoredSource_ParsesCorrectly()
+    {
+        var result = CommandLineBuilder.CreateRootCommand().Parse(
+            ["diff", "--library", "old/Foo.dll..new/Foo.dll", "-S", "Implementation Diff", "--authored-source"]);
+
+        Assert.Empty(result.Errors);
+        Assert.Equal("diff", result.CommandResult.Command.Name);
+    }
+
+    [Fact]
     public void DiffCommand_WithChangedOption_ParsesCorrectly()
     {
         var result = CommandLineBuilder.CreateRootCommand().Parse(["diff", "--library", "old/Foo.dll..new/Foo.dll", "-S", "Analysis Diff", "--changed"]);

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -8,6 +8,7 @@ using ILInspector.Instructions;
 using ILInspector.Metadata;
 using ILInspector.MetadataPrimitives;
 using ILInspector.Research;
+using ILInspector.Text;
 using DotnetInspector.Commands;
 using DotnetInspector.Output;
 using DotnetInspector.Views;
@@ -1309,6 +1310,101 @@ public class DiffCommandTests
     }
 
     [Fact]
+    public void BuildImplementationDiffView_LabelsAuthoredSourceAsIndependentLane()
+    {
+        var subject = new ResearchSubjectKey(
+            ResearchSubjectKind.Member,
+            "M~1234567890",
+            "Sample.M()",
+            "Sample",
+            "M");
+        var oldInspection = new FindingInspection<string>.Complete(
+            [.. TextFindings.Inspect("return 1;", new FindingSubject("old", "old"))]);
+        var newInspection = new FindingInspection<string>.Complete(
+            [.. TextFindings.Inspect("return 2;", new FindingSubject("new", "new"))]);
+        var result = ImplementationDiff.WithAuthoredSourceComparisons(
+            new ImplementationDiffResult([], new ResearchComparison([])),
+            [new AuthoredSourceComparisonInput(subject, oldInspection, newInspection)]);
+
+        var view = DiffOutputFormatter.BuildImplementationDiffView(
+            "Sample",
+            result,
+            "old",
+            "new");
+
+        Assert.Contains(view.Rows!, row =>
+            row.Mechanism == "Source"
+            && row.Evidence.Contains("return 2", StringComparison.Ordinal));
+        Assert.Contains("authored Source", view.Summary, StringComparison.Ordinal);
+        Assert.Contains("C# is decompiled", view.Status.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildImplementationDiffView_RendersAuthoredSourceAbsence()
+    {
+        var subject = new ResearchSubjectKey(
+            ResearchSubjectKind.Member,
+            "M~1234567890",
+            "Sample.M()",
+            "Sample",
+            "M");
+        var result = ImplementationDiff.WithAuthoredSourceComparisons(
+            new ImplementationDiffResult([], new ResearchComparison([])),
+            [
+                new AuthoredSourceComparisonInput(
+                    subject,
+                    new FindingInspection<string>.Absent("old PDB unavailable"),
+                    new FindingInspection<string>.Absent("new PDB unavailable"))
+            ]);
+
+        var view = DiffOutputFormatter.BuildImplementationDiffView(
+            "Sample",
+            result,
+            "old",
+            "new");
+
+        var row = Assert.Single(view.Rows!);
+        Assert.Equal("Source", row.Mechanism);
+        Assert.Equal("unavailable", row.Change);
+        Assert.Contains("old PDB unavailable", row.Evidence, StringComparison.Ordinal);
+        Assert.Contains("new PDB unavailable", row.Evidence, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildImplementationDiffView_RendersAuthoredSourceFailure()
+    {
+        var subject = new ResearchSubjectKey(
+            ResearchSubjectKind.Member,
+            "M~1234567890",
+            "Sample.M()",
+            "Sample",
+            "M");
+        var failure = new FindingInspection<string>.Failed(new InspectionError(
+            new FindingSubject(subject.Id, subject.Display),
+            TextFindings.LineDescriptor,
+            "checksum mismatch"));
+        var result = ImplementationDiff.WithAuthoredSourceComparisons(
+            new ImplementationDiffResult([], new ResearchComparison([])),
+            [
+                new AuthoredSourceComparisonInput(
+                    subject,
+                    failure,
+                    new FindingInspection<string>.Absent("new source unavailable"))
+            ]);
+
+        var view = DiffOutputFormatter.BuildImplementationDiffView(
+            "Sample",
+            result,
+            "old",
+            "new");
+
+        var row = Assert.Single(view.Rows!);
+        Assert.Equal("Source", row.Mechanism);
+        Assert.Equal("failed", row.Change);
+        Assert.Contains("checksum mismatch", row.Evidence, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void BuildImplementationDiff_MemberFilter_UsesResolverBackedTarget()
     {
         var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
@@ -1421,7 +1517,7 @@ public class DiffCommandTests
             output,
             StringComparison.Ordinal);
         Assert.Contains(
-            "C# and IL implementation evidence is body-level evidence, not public API compatibility.",
+            "C# is decompiled evidence; Source is checksum-verified authored evidence; IL is shipped body evidence. These peer lanes do not replace one another and are not public API compatibility.",
             output,
             StringComparison.Ordinal);
     }
@@ -1472,7 +1568,7 @@ public class DiffCommandTests
             "Analysis signal changes are body-level evidence, not public API compatibility changes.",
             document.RootElement.GetProperty("analysis_diff_note").GetString());
         Assert.Equal(
-            "C# and IL implementation evidence is body-level evidence, not public API compatibility.",
+            "C# is decompiled evidence; Source is checksum-verified authored evidence; IL is shipped body evidence. These peer lanes do not replace one another and are not public API compatibility.",
             document.RootElement.GetProperty("implementation_diff_note").GetString());
         Assert.DoesNotContain(analysis.EnumerateArray(), row =>
             row.GetProperty("member").GetString()!.Contains("<code>", StringComparison.Ordinal)

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -1492,6 +1492,23 @@ public class DiffCommandTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_AuthoredSourceWithoutImplementationDiff_ReturnsError()
+    {
+        var (exitCode, output, error) = await ConsoleCapture.RunAsync(() =>
+            DiffCommand.ExecuteAsync(new DiffOptions
+            {
+                IncludeAuthoredSource = true
+            }));
+
+        Assert.Equal(1, exitCode);
+        Assert.Empty(output);
+        Assert.Contains(
+            "--authored-source requires the Implementation Diff section",
+            error,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_MultipleSelectedSections_ComposesMarkdown()
     {
         var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
@@ -1517,7 +1534,7 @@ public class DiffCommandTests
             output,
             StringComparison.Ordinal);
         Assert.Contains(
-            "C# is decompiled evidence; Source is checksum-verified authored evidence; IL is shipped body evidence. These peer lanes do not replace one another and are not public API compatibility.",
+            "C# and IL implementation evidence is body-level evidence, not public API compatibility.",
             output,
             StringComparison.Ordinal);
     }
@@ -1568,7 +1585,7 @@ public class DiffCommandTests
             "Analysis signal changes are body-level evidence, not public API compatibility changes.",
             document.RootElement.GetProperty("analysis_diff_note").GetString());
         Assert.Equal(
-            "C# is decompiled evidence; Source is checksum-verified authored evidence; IL is shipped body evidence. These peer lanes do not replace one another and are not public API compatibility.",
+            "C# and IL implementation evidence is body-level evidence, not public API compatibility.",
             document.RootElement.GetProperty("implementation_diff_note").GetString());
         Assert.DoesNotContain(analysis.EnumerateArray(), row =>
             row.GetProperty("member").GetString()!.Contains("<code>", StringComparison.Ordinal)

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -2,6 +2,9 @@ using System.CommandLine;
 using DotnetInspector.CommandLine;
 using DotnetInspector.Fixtures;
 using ILInspector.Analysis;
+using ILInspector.Decompiler;
+using ILInspector.Findings;
+using ILInspector.Instructions;
 using ILInspector.Metadata;
 using ILInspector.MetadataPrimitives;
 using ILInspector.Research;
@@ -436,6 +439,127 @@ public class DiffCommandTests
     }
 
     [Fact]
+    public void BuildCSharpFindingTransitions_ChangedLine_UsesNativePairs()
+    {
+        var rows = BuildCSharpFindingTransitions("ConstantValue");
+
+        Assert.Contains(rows, row =>
+            row.Transition == "PairFinding.Removed"
+            && row.Finding == "csharp.line"
+            && row.Old == "return 1;"
+            && row.New == "absent");
+        Assert.Contains(rows, row =>
+            row.Transition == "PairFinding.Added"
+            && row.Finding == "csharp.line"
+            && row.Old == "absent"
+            && row.New == "return 2;");
+    }
+
+    [Fact]
+    public void BuildIlFindingTransitions_ChangedOperation_UsesNativePairs()
+    {
+        var rows = BuildIlFindingTransitions("ConstantValue");
+
+        Assert.Contains(rows, row =>
+            row.Transition == "PairFinding.Removed"
+            && row.Finding == "il.op"
+            && row.Old.Contains("ldc.i4 1", StringComparison.Ordinal)
+            && row.New == "absent");
+        Assert.Contains(rows, row =>
+            row.Transition == "PairFinding.Added"
+            && row.Finding == "il.op"
+            && row.Old == "absent"
+            && row.New.Contains("ldc.i4 2", StringComparison.Ordinal));
+        Assert.Contains(rows, row => row.Transition == "PairFinding.Present");
+    }
+
+    [Fact]
+    public void BuildIlFindingTransitions_RemovedMethods_UseNativePairs()
+    {
+        var rows = BuildIlFindingTransitions(
+            "Removed:1",
+            "DiffFixtureSample.MethodRemovalSample");
+
+        Assert.NotEmpty(rows);
+        Assert.All(
+            rows,
+            row => Assert.Equal("PairFinding.Removed", row.Transition));
+    }
+
+    [Fact]
+    public void BuildIlFindingTransitions_AbsentBodyToBody_UsesAddedPairs()
+    {
+        var rows = BuildIlFindingTransitions(
+            "BodyState",
+            "DiffFixtureSample.BodyStateSample");
+
+        Assert.NotEmpty(rows);
+        Assert.All(
+            rows,
+            row => Assert.Equal("PairFinding.Added", row.Transition));
+    }
+
+    [Fact]
+    public void RetainedComparisonRows_EmptyComparison_PreservesInspectionStates()
+    {
+        var subject = new ResearchSubjectKey(
+            ResearchSubjectKind.Member,
+            "member",
+            "Sample.Widget.Empty");
+        var comparison = FindingComparison.Compare<CSharpCanonicalLine>(
+            new FindingInspection<CSharpCanonicalLine>.Complete([]),
+            new FindingInspection<CSharpCanonicalLine>.Absent("no body"));
+        var retained = new RetainedFindingComparison<CSharpCanonicalLine>(
+            subject,
+            CSharpFindings.LineDescriptor,
+            comparison);
+
+        var row = Assert.Single(DiffCommand.RetainedComparisonRows(
+            retained,
+            "v1",
+            "v2",
+            emitEmptyComparison: true,
+            static (_, _, _, _) => throw new InvalidOperationException()));
+
+        Assert.Equal("FindingComparison.Complete", row.Transition);
+        Assert.Equal("complete", row.Old);
+        Assert.Equal("absent", row.New);
+    }
+
+    [Fact]
+    public void RetainedComparisonRows_FailedComparison_PreservesFailure()
+    {
+        var subject = new ResearchSubjectKey(
+            ResearchSubjectKind.Member,
+            "member",
+            "Sample.Widget.Broken");
+        var findingSubject = new FindingSubject(subject.Id, subject.Display);
+        var comparison = FindingComparison.Compare<CSharpCanonicalLine>(
+            new FindingInspection<CSharpCanonicalLine>.Failed(
+                new InspectionError(
+                    findingSubject,
+                    CSharpFindings.InspectionDescriptor,
+                    "render failed")),
+            new FindingInspection<CSharpCanonicalLine>.Complete([]));
+        var retained = new RetainedFindingComparison<CSharpCanonicalLine>(
+            subject,
+            CSharpFindings.LineDescriptor,
+            comparison);
+
+        var row = Assert.Single(DiffCommand.RetainedComparisonRows(
+            retained,
+            "v1",
+            "v2",
+            emitEmptyComparison: true,
+            static (_, _, _, _) => throw new InvalidOperationException()));
+
+        Assert.Equal("FindingComparison.Failed", row.Transition);
+        Assert.Equal("failed", row.Old);
+        Assert.Equal("complete", row.New);
+        Assert.Contains("render failed", row.Detail);
+    }
+
+    [Fact]
     public void RenderFindingTransitionsMarkdown_LabelsPairBoundary()
     {
         var view = DiffOutputFormatter.BuildFindingTransitionsView(
@@ -665,6 +789,51 @@ public class DiffCommandTests
             {
                 Finding = AnalysisFindings.UnsafetyDescriptor.Id,
                 TypeFilter = ["DiffFixtureSample.DiffSample"],
+                MemberFilter = [member],
+            });
+    }
+
+    private static IReadOnlyList<FindingTransitionRow> BuildCSharpFindingTransitions(
+        string member)
+    {
+        var oldPath = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var newPath = FixtureCatalog.DiffPair.NewAssemblyPath();
+        var oldSurface = AssemblyReader.ExtractApiSurface(oldPath)!;
+        var newSurface = AssemblyReader.ExtractApiSurface(newPath)!;
+        return DiffCommand.BuildCSharpFindingTransitions(
+            [oldPath],
+            [newPath],
+            oldSurface,
+            newSurface,
+            "v1",
+            "v2",
+            new DiffOptions
+            {
+                Finding = CSharpFindings.LineDescriptor.Id,
+                TypeFilter = ["DiffFixtureSample.DiffSample"],
+                MemberFilter = [member],
+            });
+    }
+
+    private static IReadOnlyList<FindingTransitionRow> BuildIlFindingTransitions(
+        string member,
+        string type = "DiffFixtureSample.DiffSample")
+    {
+        var oldPath = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var newPath = FixtureCatalog.DiffPair.NewAssemblyPath();
+        var oldSurface = AssemblyReader.ExtractApiSurface(oldPath)!;
+        var newSurface = AssemblyReader.ExtractApiSurface(newPath)!;
+        return DiffCommand.BuildIlFindingTransitions(
+            [oldPath],
+            [newPath],
+            oldSurface,
+            newSurface,
+            "v1",
+            "v2",
+            new DiffOptions
+            {
+                Finding = IlFindings.OperationDescriptor.Id,
+                TypeFilter = [type],
                 MemberFilter = [member],
             });
     }

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -1405,6 +1405,43 @@ public class DiffCommandTests
     }
 
     [Fact]
+    public void BuildImplementationDiffView_RendersCSharpFailure()
+    {
+        var subject = new ResearchSubjectKey(
+            ResearchSubjectKind.Member,
+            "M~1234567890",
+            "Sample.M()",
+            "Sample",
+            "M");
+        var result = new ImplementationDiffResult(
+            [
+                new ImplementationDiffMember(
+                    subject,
+                    [
+                        new ResearchChange(
+                            subject,
+                            ResearchChangeMechanism.CSharp,
+                            CSharpFindings.InspectionDescriptor,
+                            ResearchChangeKind.Failed,
+                            detail: "render failed",
+                            category: ResearchChangeCategory.CSharp)
+                    ])
+            ],
+            new ResearchComparison([]));
+
+        var view = DiffOutputFormatter.BuildImplementationDiffView(
+            "Sample",
+            result,
+            "old",
+            "new");
+
+        var row = Assert.Single(view.Rows!);
+        Assert.Equal("C#", row.Mechanism);
+        Assert.Equal("failed", row.Change);
+        Assert.Equal("render failed", row.Evidence);
+    }
+
+    [Fact]
     public void BuildImplementationDiff_MemberFilter_UsesResolverBackedTarget()
     {
         var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -202,6 +202,7 @@ public static class InspectionCommandDefinitions
         var additiveOption = new Option<bool>("--additive") { Description = "Show only additive changes" };
         var changedOption = new Option<bool>("--changed") { Description = "Analysis Diff only: show only in-place changes to members present in both versions (drop added/removed members)" };
         var allocRegressionsOption = new Option<bool>("--alloc-regressions") { Description = "Analysis Diff focus: show only allocation increases on members present in both versions (the file-able set), in-loop (hot) ones first" };
+        var authoredSourceOption = new Option<bool>("--authored-source") { Description = "Implementation Diff only: acquire checksum-verified authored SourceLink evidence" };
         var findingOption = new Option<string?>("--finding") { Description = "Finding Transitions producer: api.type, api.member, api.attribute, analysis.allocation, or analysis.call-site" };
         var legendOption = new Option<bool>("--legend") { Description = "Show legend explaining change symbols" };
 
@@ -222,6 +223,7 @@ public static class InspectionCommandDefinitions
         diffCommand.Options.Add(additiveOption);
         diffCommand.Options.Add(changedOption);
         diffCommand.Options.Add(allocRegressionsOption);
+        diffCommand.Options.Add(authoredSourceOption);
         diffCommand.Options.Add(findingOption);
         diffCommand.Options.Add(legendOption);
         opts.AddOutputOptionsTo(diffCommand);
@@ -232,7 +234,7 @@ public static class InspectionCommandDefinitions
 
         var commandArgs = new DiffOptionsParser.DiffCommandArgs(
             argsArg, packageOption, platformOption, libraryOption, frameworkOption, tfmOption, allOption,
-            typeFilterOption, memberFilterOption, opts.NoHeaders, nameOnlyOption, breakingOption, additiveOption, changedOption, allocRegressionsOption, findingOption, legendOption);
+            typeFilterOption, memberFilterOption, opts.NoHeaders, nameOnlyOption, breakingOption, additiveOption, changedOption, allocRegressionsOption, authoredSourceOption, findingOption, legendOption);
 
         diffCommand.SetAction(async (parseResult, ct) =>
         {

--- a/src/dotnet-inspect/CommandLine/Parsers/DiffOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/DiffOptionsParser.cs
@@ -32,6 +32,7 @@ public static class DiffOptionsParser
         Option<bool> AdditiveOption,
         Option<bool> ChangedOption,
         Option<bool> AllocRegressionsOption,
+        Option<bool> AuthoredSourceOption,
         Option<string?> FindingOption,
         Option<bool> LegendOption);
 
@@ -127,6 +128,7 @@ public static class DiffOptionsParser
             Additive = parseResult.GetValue(args.AdditiveOption),
             ChangedOnly = parseResult.GetValue(args.ChangedOption),
             AllocRegressionsOnly = parseResult.GetValue(args.AllocRegressionsOption),
+            IncludeAuthoredSource = parseResult.GetValue(args.AuthoredSourceOption),
             Finding = parseResult.GetValue(args.FindingOption),
             Legend = parseResult.GetValue(args.LegendOption),
             SourceOptions = opts.ParseNuGetSourceOptions(parseResult),

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -63,6 +63,13 @@ public class DiffCommand
                 options.IncludeSections))
             return 1;
 
+        if (options.IncludeAuthoredSource && !SelectsImplementationDiff(options))
+        {
+            Console.Error.WriteLine(
+                "Error: --authored-source requires the Implementation Diff section.");
+            return 1;
+        }
+
         if (!hasPlatform && !hasPackage && !hasLibrary)
         {
             Console.Error.WriteLine("Error: --package, --platform, or --library with version range required.");
@@ -866,7 +873,7 @@ public class DiffCommand
             options,
             fromSurface,
             toSurface);
-        if (result.Members.Count == 0)
+        if (!options.IncludeAuthoredSource || result.Members.Count == 0)
             return result;
 
         var subjects = result.Members
@@ -2046,6 +2053,7 @@ public record DiffOptions
     public bool Additive { get; init; }
     public bool ChangedOnly { get; init; }
     public bool AllocRegressionsOnly { get; init; }
+    public bool IncludeAuthoredSource { get; init; }
     public string? Finding { get; init; }
     public bool Legend { get; init; }
     public string[]? Discover { get; init; }

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -7,7 +7,9 @@ using DotnetInspector.Sections;
 using DotnetInspector.Services;
 using DotnetInspector.Views;
 using ILInspector.Analysis;
+using ILInspector.Decompiler;
 using ILInspector.Findings;
+using ILInspector.Instructions;
 using ILInspector.Research;
 using Markout;
 using System.Collections.Immutable;
@@ -99,9 +101,7 @@ public class DiffCommand
                 Console.Error.WriteLine($"Error: {findingError}");
                 return 1;
             }
-            if (findingDescriptor == AnalysisFindings.AllocationDescriptor.Id
-                || findingDescriptor == AnalysisFindings.CallSiteDescriptor.Id
-                || findingDescriptor == AnalysisFindings.UnsafetyDescriptor.Id)
+            if (IsMemberBodyFindingDescriptor(findingDescriptor))
             {
                 if (options.MemberFilter.Count != 1)
                 {
@@ -579,8 +579,20 @@ public class DiffCommand
             error = null;
             return true;
         }
+        if (string.Equals(descriptor, CSharpFindings.LineDescriptor.Id, StringComparison.OrdinalIgnoreCase))
+        {
+            descriptor = CSharpFindings.LineDescriptor.Id;
+            error = null;
+            return true;
+        }
+        if (string.Equals(descriptor, IlFindings.OperationDescriptor.Id, StringComparison.OrdinalIgnoreCase))
+        {
+            descriptor = IlFindings.OperationDescriptor.Id;
+            error = null;
+            return true;
+        }
 
-        error = $"Unsupported Finding descriptor '{descriptor}'. Supported descriptors: api.type, api.member, api.attribute, analysis.allocation, analysis.call-site, analysis.unsafety.";
+        error = $"Unsupported Finding descriptor '{descriptor}'. Supported descriptors: api.type, api.member, api.attribute, analysis.allocation, analysis.call-site, analysis.unsafety, csharp.line, il.op.";
         return false;
     }
 
@@ -625,6 +637,24 @@ public class DiffCommand
                     inputs.FromVersion,
                     inputs.ToVersion,
                     options),
+            var descriptor when descriptor == CSharpFindings.LineDescriptor.Id =>
+                BuildCSharpFindingTransitions(
+                    inputs.FromPaths,
+                    inputs.ToPaths,
+                    inputs.FromSurface,
+                    inputs.ToSurface,
+                    inputs.FromVersion,
+                    inputs.ToVersion,
+                    options),
+            var descriptor when descriptor == IlFindings.OperationDescriptor.Id =>
+                BuildIlFindingTransitions(
+                    inputs.FromPaths,
+                    inputs.ToPaths,
+                    inputs.FromSurface,
+                    inputs.ToSurface,
+                    inputs.FromVersion,
+                    inputs.ToVersion,
+                    options),
             _ => BuildFindingTransitions(
                 inputs.FromSurface,
                 inputs.ToSurface,
@@ -632,6 +662,13 @@ public class DiffCommand
                 inputs.ToVersion,
                 options),
         };
+
+    static bool IsMemberBodyFindingDescriptor(string descriptor)
+        => descriptor == AnalysisFindings.AllocationDescriptor.Id
+            || descriptor == AnalysisFindings.CallSiteDescriptor.Id
+            || descriptor == AnalysisFindings.UnsafetyDescriptor.Id
+            || descriptor == CSharpFindings.LineDescriptor.Id
+            || descriptor == IlFindings.OperationDescriptor.Id;
 
     private static bool SelectsImplementationDiff(DiffOptions options)
         => options.IncludeSections?.Contains(DiffSections.ImplementationDiff.Name) == true;
@@ -1060,7 +1097,7 @@ public class DiffCommand
         string fromVersion,
         string toVersion,
         DiffOptions options)
-        => BuildAnalysisFindingTransitions<AllocationOccurrence>(
+        => BuildRetainedFindingTransitions<AllocationOccurrence>(
             fromPaths,
             toPaths,
             fromSurface,
@@ -1068,6 +1105,8 @@ public class DiffCommand
             fromVersion,
             toVersion,
             options,
+            ResearchChangeMechanism.BodySignals,
+            emitEmptyComparison: false,
             AnalysisFindings.AllocationDescriptor,
             ToAllocationTransitionRow);
 
@@ -1079,7 +1118,7 @@ public class DiffCommand
         string fromVersion,
         string toVersion,
         DiffOptions options)
-        => BuildAnalysisFindingTransitions<DirectCall>(
+        => BuildRetainedFindingTransitions<DirectCall>(
             fromPaths,
             toPaths,
             fromSurface,
@@ -1087,6 +1126,8 @@ public class DiffCommand
             fromVersion,
             toVersion,
             options,
+            ResearchChangeMechanism.BodySignals,
+            emitEmptyComparison: false,
             AnalysisFindings.CallSiteDescriptor,
             ToCallSiteTransitionRow);
 
@@ -1098,7 +1139,7 @@ public class DiffCommand
         string fromVersion,
         string toVersion,
         DiffOptions options)
-        => BuildAnalysisFindingTransitions<UnsafetyOccurrence>(
+        => BuildRetainedFindingTransitions<UnsafetyOccurrence>(
             fromPaths,
             toPaths,
             fromSurface,
@@ -1106,10 +1147,54 @@ public class DiffCommand
             fromVersion,
             toVersion,
             options,
+            ResearchChangeMechanism.BodySignals,
+            emitEmptyComparison: false,
             AnalysisFindings.UnsafetyDescriptor,
             ToUnsafetyTransitionRow);
 
-    static IReadOnlyList<FindingTransitionRow> BuildAnalysisFindingTransitions<T>(
+    internal static IReadOnlyList<FindingTransitionRow> BuildCSharpFindingTransitions(
+        IReadOnlyList<string> fromPaths,
+        IReadOnlyList<string> toPaths,
+        ApiSurface fromSurface,
+        ApiSurface toSurface,
+        string fromVersion,
+        string toVersion,
+        DiffOptions options)
+        => BuildRetainedFindingTransitions<CSharpCanonicalLine>(
+            fromPaths,
+            toPaths,
+            fromSurface,
+            toSurface,
+            fromVersion,
+            toVersion,
+            options,
+            ResearchChangeMechanism.CSharp,
+            emitEmptyComparison: true,
+            CSharpFindings.LineDescriptor,
+            ToCSharpTransitionRow);
+
+    internal static IReadOnlyList<FindingTransitionRow> BuildIlFindingTransitions(
+        IReadOnlyList<string> fromPaths,
+        IReadOnlyList<string> toPaths,
+        ApiSurface fromSurface,
+        ApiSurface toSurface,
+        string fromVersion,
+        string toVersion,
+        DiffOptions options)
+        => BuildRetainedFindingTransitions<CanonicalIlOperation>(
+            fromPaths,
+            toPaths,
+            fromSurface,
+            toSurface,
+            fromVersion,
+            toVersion,
+            options,
+            ResearchChangeMechanism.IlBody,
+            emitEmptyComparison: true,
+            IlFindings.OperationDescriptor,
+            ToIlTransitionRow);
+
+    static IReadOnlyList<FindingTransitionRow> BuildRetainedFindingTransitions<T>(
         IReadOnlyList<string> fromPaths,
         IReadOnlyList<string> toPaths,
         ApiSurface fromSurface,
@@ -1117,6 +1202,8 @@ public class DiffCommand
         string fromVersion,
         string toVersion,
         DiffOptions options,
+        ResearchChangeMechanism mechanism,
+        bool emitEmptyComparison,
         FindingDescriptor descriptor,
         Func<ResearchSubjectKey, PairFinding<T>, string, string, FindingTransitionRow>
             toTransitionRow)
@@ -1139,25 +1226,89 @@ public class DiffCommand
             ResearchDiffInput.FromAssemblies(fromPaths),
             ResearchDiffInput.FromAssemblies(toPaths),
             new ResearchDiffOptions(
-                ResearchChangeMechanism.BodySignals,
+                mechanism,
                 TypeFilters: options.TypeFilter,
                 MemberTargetIdentities: targets.MemberIdentities)
             {
                 RetainedComparisonDescriptorIds =
                     ImmutableHashSet.Create(StringComparer.Ordinal, descriptor.Id),
             });
-
         return research.RetainedComparisons.Get<T>(descriptor)
-            .SelectMany(comparison => CompletePairs(comparison.Comparison)
-                .Select(pair => toTransitionRow(
-                    comparison.Subject,
-                    pair,
-                    fromVersion,
-                    toVersion)))
+            .SelectMany(comparison => RetainedComparisonRows(
+                comparison,
+                fromVersion,
+                toVersion,
+                emitEmptyComparison,
+                toTransitionRow))
             .OrderBy(row => row.Target, StringComparer.Ordinal)
             .ThenBy(row => row.Transition, StringComparer.Ordinal)
             .ToList();
     }
+
+    internal static IEnumerable<FindingTransitionRow> RetainedComparisonRows<T>(
+        RetainedFindingComparison<T> retained,
+        string fromVersion,
+        string toVersion,
+        bool emitEmptyComparison,
+        Func<ResearchSubjectKey, PairFinding<T>, string, string, FindingTransitionRow>
+            toTransitionRow)
+        where T : notnull
+    {
+        if (retained.Comparison is FindingComparison<T>.Failed failed)
+        {
+            yield return new FindingTransitionRow(
+                "FindingComparison.Failed",
+                retained.Descriptor.Id,
+                retained.Subject.Display,
+                fromVersion,
+                toVersion,
+                InspectionState(failed.OldInspection),
+                InspectionState(failed.NewInspection),
+                failed.Failure);
+            yield break;
+        }
+
+        var complete = retained.Comparison switch
+        {
+            FindingComparison<T>.Complete value => value,
+            FindingComparison<T>.Failed => throw new InvalidOperationException(
+                "Failed comparisons are handled before completed comparisons."),
+        };
+        if (complete.Pairs.IsEmpty)
+        {
+            if (!emitEmptyComparison)
+                yield break;
+
+            yield return new FindingTransitionRow(
+                "FindingComparison.Complete",
+                retained.Descriptor.Id,
+                retained.Subject.Display,
+                fromVersion,
+                toVersion,
+                InspectionState(complete.OldInspection),
+                InspectionState(complete.NewInspection),
+                null);
+            yield break;
+        }
+
+        foreach (var pair in complete.Pairs)
+        {
+            yield return toTransitionRow(
+                retained.Subject,
+                pair,
+                fromVersion,
+                toVersion);
+        }
+    }
+
+    static string InspectionState<T>(FindingInspection<T> inspection)
+        where T : notnull
+        => inspection switch
+        {
+            FindingInspection<T>.Complete => "complete",
+            FindingInspection<T>.Absent => "absent",
+            FindingInspection<T>.Failed => "failed",
+        };
 
     static IReadOnlyList<PairFinding<T>> CompletePairs<T>(FindingComparison<T> comparison)
         where T : notnull
@@ -1322,6 +1473,59 @@ public class DiffCommand
             : $" {occurrence.Detail}";
         return $"{subject.Display} :: {occurrence.Kind}{detail}";
     }
+
+    static FindingTransitionRow ToCSharpTransitionRow(
+        ResearchSubjectKey subject,
+        PairFinding<CSharpCanonicalLine> pair,
+        string fromVersion,
+        string toVersion)
+    {
+        var oldFinding = OldSide(pair);
+        var newFinding = NewSide(pair);
+        return new FindingTransitionRow(
+            $"PairFinding.{pair.Kind}",
+            pair.Descriptor.Id,
+            CSharpLineTarget(subject, newFinding ?? oldFinding!),
+            fromVersion,
+            toVersion,
+            oldFinding?.Payload.Text ?? "absent",
+            newFinding?.Payload.Text ?? "absent",
+            pair.Detail);
+    }
+
+    static string CSharpLineTarget(
+        ResearchSubjectKey subject,
+        Finding<CSharpCanonicalLine> finding)
+        => $"{subject.Display} :: line {finding.Payload.Line}";
+
+    static FindingTransitionRow ToIlTransitionRow(
+        ResearchSubjectKey subject,
+        PairFinding<CanonicalIlOperation> pair,
+        string fromVersion,
+        string toVersion)
+    {
+        var oldFinding = OldSide(pair);
+        var newFinding = NewSide(pair);
+        return new FindingTransitionRow(
+            $"PairFinding.{pair.Kind}",
+            pair.Descriptor.Id,
+            IlOperationTarget(subject, newFinding ?? oldFinding!),
+            fromVersion,
+            toVersion,
+            FormatIlFinding(oldFinding),
+            FormatIlFinding(newFinding),
+            pair.Detail);
+    }
+
+    static string IlOperationTarget(
+        ResearchSubjectKey subject,
+        Finding<CanonicalIlOperation> finding)
+        => $"{subject.Display} :: IL_{finding.Payload.Offset:X4}";
+
+    static string FormatIlFinding(Finding<CanonicalIlOperation>? finding)
+        => finding is null
+            ? "absent"
+            : $"IL_{finding.Payload.Offset:X4} {finding.Payload.Display}";
 
     static string TypeTarget(PairFinding<ApiTypeHandle> pair)
         => (NewSide(pair) ?? OldSide(pair))!.Payload.TypeFullName;

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -184,7 +184,11 @@ public class DiffCommand
             {
                 if (options.JsonOutput || options.IncludeSections is { Count: > 1 })
                 {
-                    WriteSelectedDocument(inputs, options);
+                    await WriteSelectedDocumentAsync(
+                        inputs,
+                        options,
+                        context.HttpClient,
+                        logger);
                     return 0;
                 }
 
@@ -214,10 +218,12 @@ public class DiffCommand
 
                 if (SelectsImplementationDiff(options) && !SelectsAnalysisDiff(options))
                 {
-                    var implementation = BuildImplementationDiff(
+                    var implementation = await BuildImplementationDiffWithSourceAsync(
                         inputs.FromPaths,
                         inputs.ToPaths,
                         options,
+                        context.HttpClient,
+                        logger,
                         inputs.FromSurface,
                         inputs.ToSurface);
                     var view = DiffOutputFormatter.BuildImplementationDiffView(
@@ -676,7 +682,11 @@ public class DiffCommand
     private static bool SelectsDetailedChanges(DiffOptions options)
         => options.IncludeSections?.Contains(DiffSections.Changes.Name) == true;
 
-    private static void WriteSelectedDocument(DiffInputs inputs, DiffOptions options)
+    private static async Task WriteSelectedDocumentAsync(
+        DiffInputs inputs,
+        DiffOptions options,
+        HttpClient httpClient,
+        VerboseLogger logger)
     {
         var selected = options.IncludeSections
             ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -718,10 +728,12 @@ public class DiffCommand
         ImplementationDiffView? implementationView = null;
         if (selected.Contains(DiffSections.ImplementationDiff.Name))
         {
-            var implementation = BuildImplementationDiff(
+            var implementation = await BuildImplementationDiffWithSourceAsync(
                 inputs.FromPaths,
                 inputs.ToPaths,
                 options,
+                httpClient,
+                logger,
                 inputs.FromSurface,
                 inputs.ToSurface);
             implementationView = DiffOutputFormatter.BuildImplementationDiffView(
@@ -837,6 +849,157 @@ public class DiffCommand
             new ImplementationDiffOptions(
                 TypeFilters: options.TypeFilter,
                 MemberTargetIdentities: memberTargetIdentities));
+    }
+
+    internal static async Task<ImplementationDiffResult> BuildImplementationDiffWithSourceAsync(
+        IReadOnlyList<string> fromPaths,
+        IReadOnlyList<string> toPaths,
+        DiffOptions options,
+        HttpClient httpClient,
+        VerboseLogger logger,
+        ApiSurface? fromSurface = null,
+        ApiSurface? toSurface = null)
+    {
+        var result = BuildImplementationDiff(
+            fromPaths,
+            toPaths,
+            options,
+            fromSurface,
+            toSurface);
+        if (result.Members.Count == 0)
+            return result;
+
+        var subjects = result.Members
+            .Select(member => member.Subject)
+            .ToDictionary(subject => subject.Id, StringComparer.Ordinal);
+        var from = await AcquireAuthoredSourceInspectionsAsync(
+            fromPaths,
+            subjects,
+            options,
+            oldSide: true,
+            httpClient,
+            logger);
+        var to = await AcquireAuthoredSourceInspectionsAsync(
+            toPaths,
+            subjects,
+            options,
+            oldSide: false,
+            httpClient,
+            logger);
+        var comparisons = subjects.Values.Select(subject =>
+            new AuthoredSourceComparisonInput(
+                subject,
+                from.GetValueOrDefault(subject.Id)
+                    ?? new FindingInspection<string>.Absent(
+                        "The member is unavailable in the old endpoint."),
+                to.GetValueOrDefault(subject.Id)
+                    ?? new FindingInspection<string>.Absent(
+                        "The member is unavailable in the new endpoint.")));
+        return ImplementationDiff.WithAuthoredSourceComparisons(
+            result,
+            comparisons,
+            new ImplementationDiffOptions(
+                TypeFilters: options.TypeFilter,
+                MemberTargetIdentities: subjects.Keys.ToHashSet(StringComparer.Ordinal)));
+    }
+
+    static async Task<Dictionary<string, FindingInspection<string>>> AcquireAuthoredSourceInspectionsAsync(
+        IReadOnlyList<string> paths,
+        IReadOnlyDictionary<string, ResearchSubjectKey> subjects,
+        DiffOptions options,
+        bool oldSide,
+        HttpClient httpClient,
+        VerboseLogger logger)
+    {
+        var results = new Dictionary<string, FindingInspection<string>>(StringComparer.Ordinal);
+        var fetcher = new SourceFetcher(DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch);
+        var (packageName, packageVersion) = DiffPackageIdentity(options, oldSide);
+
+        foreach (string path in paths)
+        {
+            LibraryBodyIndex index;
+            try
+            {
+                index = LibraryBodyIndex.Open(
+                    path,
+                    includeAllocations: false,
+                    includeOpportunities: false);
+            }
+            catch (Exception ex) when (ex is IOException
+                or UnauthorizedAccessException
+                or BadImageFormatException
+                or InvalidOperationException)
+            {
+                logger.Log($"Could not index authored-source targets in '{path}': {ex.Message}");
+                continue;
+            }
+
+            var targets = index.DeclaredMethods
+                .Select(method => (
+                    Method: method,
+                    Subject: ResearchMemberIdentity.SubjectFromMethod(method)))
+                .Where(item => subjects.ContainsKey(item.Subject.Id))
+                .Where(item => !results.ContainsKey(item.Subject.Id))
+                .ToArray();
+            if (targets.Length == 0)
+                continue;
+
+            try
+            {
+                using var source = SourceLinkService.Open(path, logger.Log);
+                if (source.Context.NeedsPdb)
+                {
+                    await SourceEnricher.AcquirePdbAsync(
+                        source.Context,
+                        httpClient,
+                        packageName,
+                        packageVersion,
+                        isPlatformAssembly: options.PlatformVersionRange is not null,
+                        logger.Log);
+                }
+
+                foreach (var target in targets)
+                {
+                    var subject = subjects[target.Subject.Id];
+                    var inspection = await AuthoredSourceAcquisition.AcquireMemberAsync(
+                        source,
+                        target.Method.MetadataToken,
+                        target.Method.Name,
+                        new FindingSubject(subject.Id, subject.Display),
+                        fetcher);
+                    results[subject.Id] = inspection.Lines;
+                }
+            }
+            catch (Exception ex) when (ex is IOException
+                or UnauthorizedAccessException
+                or BadImageFormatException
+                or InvalidOperationException
+                or HttpRequestException)
+            {
+                foreach (var target in targets)
+                {
+                    var subject = subjects[target.Subject.Id];
+                    results[subject.Id] = new FindingInspection<string>.Failed(
+                        new InspectionError(
+                            new FindingSubject(subject.Id, subject.Display),
+                            ILInspector.Text.TextFindings.LineDescriptor,
+                            $"Authored-source acquisition failed ({ex.GetType().Name}): {ex.Message}"));
+                }
+            }
+        }
+
+        return results;
+    }
+
+    static (string? PackageName, string? PackageVersion) DiffPackageIdentity(
+        DiffOptions options,
+        bool oldSide)
+    {
+        if (options.PackageVersionRange is null)
+            return (null, null);
+
+        var (name, fromVersion, toVersion) = ParseVersionRange(options.PackageVersionRange);
+        return (name, oldSide ? fromVersion : toVersion);
     }
 
     // Applies the changed-only / allocation-regression filters, ranks rows (in-place

--- a/src/dotnet-inspect/Output/DiffOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/DiffOutputFormatter.cs
@@ -377,11 +377,16 @@ public static class DiffOutputFormatter
         var csharpCount = rows.Count(row => row.Mechanism == "C#");
         var ilCount = rows.Count(row => row.Mechanism == "IL");
         var sourceCount = rows.Count(row => row.Mechanism == "Source");
+        bool hasSourceLane = diff.Members.Any(member =>
+            member.SourceComparison is not null);
         var summary = rows.Count == 0
             ? "No implementation differences detected."
-            : $"{diff.Members.Count} changed member{(diff.Members.Count == 1 ? "" : "s")}; "
-              + $"{csharpCount} decompiled C#, {ilCount} IL, and {sourceCount} authored Source "
-              + $"evidence row{(rows.Count == 1 ? "" : "s")}.";
+            : !hasSourceLane
+                ? $"{diff.Members.Count} changed member{(diff.Members.Count == 1 ? "" : "s")}; "
+                  + $"{csharpCount} C# and {ilCount} IL evidence row{(rows.Count == 1 ? "" : "s")}."
+                : $"{diff.Members.Count} changed member{(diff.Members.Count == 1 ? "" : "s")}; "
+                  + $"{csharpCount} decompiled C#, {ilCount} IL, and {sourceCount} authored Source "
+                  + $"evidence row{(rows.Count == 1 ? "" : "s")}.";
 
         return new ImplementationDiffView
         {
@@ -392,7 +397,9 @@ public static class DiffOutputFormatter
                 ? new Callout(CalloutSeverity.Note, summary)
                 : new Callout(
                     CalloutSeverity.Note,
-                    "C# is decompiled evidence; Source is checksum-verified authored evidence; IL is shipped body evidence. These peer lanes do not replace one another and are not public API compatibility."),
+                    hasSourceLane
+                        ? "C# is decompiled evidence; Source is checksum-verified authored evidence; IL is shipped body evidence. These peer lanes do not replace one another and are not public API compatibility."
+                        : "C# and IL implementation evidence is body-level evidence, not public API compatibility."),
             Rows = rows.Count > 0 ? rows : null
         };
     }

--- a/src/dotnet-inspect/Output/DiffOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/DiffOutputFormatter.cs
@@ -334,11 +334,7 @@ public static class DiffOutputFormatter
                     _ => change.Mechanism.ToString()
                 };
                 var evidenceLines = ImplementationDiff.UnifiedLines(change);
-                string changeKind = change.Mechanism == ResearchChangeMechanism.Source
-                    && change.Descriptor.Id
-                        == ImplementationDiff.AuthoredSourceFailureDescriptor.Id
-                    ? "failed"
-                    : change.Kind.ToString().ToLowerInvariant();
+                string changeKind = change.Kind.ToString().ToLowerInvariant();
                 if (evidenceLines.IsDefaultOrEmpty)
                 {
                     rows.Add(new ImplementationDiffRow(

--- a/src/dotnet-inspect/Output/DiffOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/DiffOutputFormatter.cs
@@ -330,15 +330,21 @@ public static class DiffOutputFormatter
                 {
                     ResearchChangeMechanism.CSharp => "C#",
                     ResearchChangeMechanism.IlBody => "IL",
+                    ResearchChangeMechanism.Source => "Source",
                     _ => change.Mechanism.ToString()
                 };
                 var evidenceLines = ImplementationDiff.UnifiedLines(change);
+                string changeKind = change.Mechanism == ResearchChangeMechanism.Source
+                    && change.Descriptor.Id
+                        == ImplementationDiff.AuthoredSourceFailureDescriptor.Id
+                    ? "failed"
+                    : change.Kind.ToString().ToLowerInvariant();
                 if (evidenceLines.IsDefaultOrEmpty)
                 {
                     rows.Add(new ImplementationDiffRow(
                         member.Subject.Display,
                         mechanism,
-                        change.Kind.ToString().ToLowerInvariant(),
+                        changeKind,
                         change.Detail ?? change.Descriptor.Title));
                     continue;
                 }
@@ -348,18 +354,34 @@ public static class DiffOutputFormatter
                     rows.Add(new ImplementationDiffRow(
                         member.Subject.Display,
                         mechanism,
-                        change.Kind.ToString().ToLowerInvariant(),
+                        changeKind,
                         evidence));
+                }
+            }
+
+            var sourceComparison = member.SourceComparison;
+            if (sourceComparison is not null && !member.HasSourceChanges)
+            {
+                string? sourceState = SourceState(sourceComparison);
+                if (sourceState is not null)
+                {
+                    rows.Add(new ImplementationDiffRow(
+                        member.Subject.Display,
+                        "Source",
+                        sourceComparison.IsExact ? "unavailable" : "changed",
+                        sourceState));
                 }
             }
         }
 
         var csharpCount = rows.Count(row => row.Mechanism == "C#");
         var ilCount = rows.Count(row => row.Mechanism == "IL");
+        var sourceCount = rows.Count(row => row.Mechanism == "Source");
         var summary = rows.Count == 0
             ? "No implementation differences detected."
             : $"{diff.Members.Count} changed member{(diff.Members.Count == 1 ? "" : "s")}; "
-              + $"{csharpCount} C# and {ilCount} IL evidence row{(rows.Count == 1 ? "" : "s")}.";
+              + $"{csharpCount} decompiled C#, {ilCount} IL, and {sourceCount} authored Source "
+              + $"evidence row{(rows.Count == 1 ? "" : "s")}.";
 
         return new ImplementationDiffView
         {
@@ -370,9 +392,32 @@ public static class DiffOutputFormatter
                 ? new Callout(CalloutSeverity.Note, summary)
                 : new Callout(
                     CalloutSeverity.Note,
-                    "C# and IL implementation evidence is body-level evidence, not public API compatibility."),
+                    "C# is decompiled evidence; Source is checksum-verified authored evidence; IL is shipped body evidence. These peer lanes do not replace one another and are not public API compatibility."),
             Rows = rows.Count > 0 ? rows : null
         };
+    }
+
+    static string? SourceState(ILInspector.Findings.FindingComparison<string> comparison)
+    {
+        if (comparison is ILInspector.Findings.FindingComparison<string>.Failed failed)
+            return failed.Failure;
+
+        bool oldAbsent = comparison.OldInspection.Value
+            is ILInspector.Findings.FindingInspection<string>.Absent;
+        bool newAbsent = comparison.NewInspection.Value
+            is ILInspector.Findings.FindingInspection<string>.Absent;
+        if (!oldAbsent && !newAbsent)
+            return null;
+
+        string oldState = oldAbsent
+            ? ((ILInspector.Findings.FindingInspection<string>.Absent)
+                comparison.OldInspection.Value).Detail ?? "unavailable"
+            : "complete";
+        string newState = newAbsent
+            ? ((ILInspector.Findings.FindingInspection<string>.Absent)
+                comparison.NewInspection.Value).Detail ?? "unavailable"
+            : "complete";
+        return $"old: {oldState}; new: {newState}";
     }
 
     public static string RenderImplementationDiffView(ImplementationDiffView view)

--- a/src/dotnet-inspect/Services/SourceIntegrityService.cs
+++ b/src/dotnet-inspect/Services/SourceIntegrityService.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Security.Cryptography;
 using DotnetInspector.Core;
 using ILInspector.Findings;
 using ILInspector.Metadata;
@@ -77,7 +76,6 @@ internal static class SourceIntegrityService
                 new ParallelOptions { MaxDegreeOfParallelism = 16, CancellationToken = cancellationToken },
                 async (doc, ct) =>
                 {
-                    byte[] checksum = Convert.FromHexString(doc.Checksum!);
                     string cacheKey = $"{doc.ResolvedUrl}|{doc.ChecksumAlgorithm}|{doc.Checksum}";
                     bool immutable = SourceLinkUrls.IsImmutable(doc.ResolvedUrl!);
 
@@ -112,24 +110,32 @@ internal static class SourceIntegrityService
                         return;
                     }
 
-                    if (HashMatches(doc.ChecksumAlgorithm!, body, checksum))
+                    var verification = AuthoredSourceAcquisition.VerifyChecksum(
+                        doc,
+                        body);
+                    if (verification == SourceChecksumVerification.Exact)
                     {
                         Interlocked.Increment(ref verified);
                         if (immutable)
                             CoreCache.Set(CacheCategory, cacheKey, "1", extension: "verified");
                     }
-                    else if (HashMatchesAfterLineEndingNormalization(doc.ChecksumAlgorithm!, body, checksum))
+                    else if (verification
+                        == SourceChecksumVerification.LineEndingNormalized)
                     {
                         Interlocked.Increment(ref verified);
                         Interlocked.Increment(ref lineEndingNormalized);
                         if (immutable)
                             CoreCache.Set(CacheCategory, cacheKey, "1", extension: "normalized");
                     }
-                    else
+                    else if (verification == SourceChecksumVerification.Mismatch)
                     {
                         Interlocked.Increment(ref mismatched);
                         mismatches.Add(doc.OriginalPath);
                         logger.Log($"Integrity MISMATCH: {doc.OriginalPath} ({doc.ResolvedUrl})");
+                    }
+                    else
+                    {
+                        Interlocked.Increment(ref unverifiable);
                     }
                 });
         }
@@ -145,59 +151,4 @@ internal static class SourceIntegrityService
     private static string? SafeHost(string url) =>
         Uri.TryCreate(url, UriKind.Absolute, out var uri) ? uri.Host : null;
 
-    private static bool HashMatches(string algorithm, byte[] content, byte[] expected)
-        => ComputeHash(algorithm, content).AsSpan().SequenceEqual(expected);
-
-    private static bool HashMatchesAfterLineEndingNormalization(string algorithm, byte[] content, byte[] expected)
-    {
-        if (!content.Contains((byte)'\n') && !content.Contains((byte)'\r'))
-            return false;
-
-        return HashMatches(algorithm, NormalizeLineEndings(content, crlf: false), expected)
-            || HashMatches(algorithm, NormalizeLineEndings(content, crlf: true), expected);
-    }
-
-    private static byte[] NormalizeLineEndings(byte[] content, bool crlf)
-    {
-        List<byte> lf = new(content.Length);
-        for (var i = 0; i < content.Length; i++)
-        {
-            if (content[i] == '\r')
-            {
-                if (i + 1 < content.Length && content[i + 1] == '\n')
-                    continue;
-
-                lf.Add((byte)'\n');
-                continue;
-            }
-
-            lf.Add(content[i]);
-        }
-
-        if (!crlf)
-            return [.. lf];
-
-        List<byte> result = new(lf.Count);
-        foreach (var b in lf)
-        {
-            if (b == '\n')
-            {
-                result.Add((byte)'\r');
-                result.Add((byte)'\n');
-            }
-            else
-            {
-                result.Add(b);
-            }
-        }
-
-        return [.. result];
-    }
-
-    private static byte[] ComputeHash(string algorithm, byte[] content) => algorithm switch
-    {
-        "SHA256" => SHA256.HashData(content),
-        "SHA1" => SHA1.HashData(content),
-        _ => [],
-    };
 }

--- a/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
+++ b/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
@@ -212,64 +212,132 @@ static class AuthoredRebuildFidelity
         var root = CSharpSyntaxTree.ParseText(
             $"class __AuthoredSourceHost {{{Environment.NewLine}{memberSource}{Environment.NewLine}}}")
             .GetCompilationUnitRoot();
-        var member = root.DescendantNodes()
+        var identity = MetadataMethodIdentity.Parse(metadataMethodName);
+        foreach (var member in root.DescendantNodes()
             .OfType<MemberDeclarationSyntax>()
-            .FirstOrDefault(candidate => candidate.Parent is ClassDeclarationSyntax);
-        string simpleMethodName = SimpleMetadataMethodName(metadataMethodName);
-        body = member switch
+            .Where(candidate => candidate.Parent is ClassDeclarationSyntax))
+        {
+            body = MemberBodyText(member, identity);
+            if (body.Length > 0)
+                return true;
+        }
+
+        body = "";
+        return false;
+    }
+
+    static string MemberBodyText(
+        MemberDeclarationSyntax member,
+        MetadataMethodIdentity identity)
+        => member switch
         {
             MethodDeclarationSyntax method
                 when string.Equals(
                     method.Identifier.ValueText,
-                    simpleMethodName,
+                    identity.SimpleName,
                     StringComparison.Ordinal)
+                    && ExplicitInterfaceMatches(
+                        method.ExplicitInterfaceSpecifier,
+                        identity.ExplicitInterface)
                 => BodyText(method.Body, method.ExpressionBody, ReturnsVoid(method.ReturnType)),
             ConstructorDeclarationSyntax constructor
-                when metadataMethodName is ".ctor" or ".cctor"
+                when identity.SimpleName is ".ctor" or ".cctor"
+                    && identity.ExplicitInterface is null
                 => BodyText(constructor.Body, constructor.ExpressionBody, returnsVoid: true),
             PropertyDeclarationSyntax property
-                when AccessorMatches(simpleMethodName, "get_", property.Identifier.ValueText)
+                when AccessorMatches(
+                    identity,
+                    "get_",
+                    property.Identifier.ValueText,
+                    property.ExplicitInterfaceSpecifier)
                 => AccessorBodyText(property, SyntaxKind.GetAccessorDeclaration),
             PropertyDeclarationSyntax property
-                when AccessorMatches(simpleMethodName, "set_", property.Identifier.ValueText)
+                when AccessorMatches(
+                    identity,
+                    "set_",
+                    property.Identifier.ValueText,
+                    property.ExplicitInterfaceSpecifier)
                 => AccessorBodyText(property, SyntaxKind.SetAccessorDeclaration),
             EventDeclarationSyntax eventDeclaration
                 when AccessorMatches(
-                    simpleMethodName,
+                    identity,
                     "add_",
-                    eventDeclaration.Identifier.ValueText)
+                    eventDeclaration.Identifier.ValueText,
+                    eventDeclaration.ExplicitInterfaceSpecifier)
                 => AccessorBodyText(eventDeclaration, SyntaxKind.AddAccessorDeclaration),
             EventDeclarationSyntax eventDeclaration
                 when AccessorMatches(
-                    simpleMethodName,
+                    identity,
                     "remove_",
-                    eventDeclaration.Identifier.ValueText)
+                    eventDeclaration.Identifier.ValueText,
+                    eventDeclaration.ExplicitInterfaceSpecifier)
                 => AccessorBodyText(eventDeclaration, SyntaxKind.RemoveAccessorDeclaration),
             _ => "",
         };
-        return body.Length > 0;
-    }
-
-    static string SimpleMetadataMethodName(string metadataMethodName)
-    {
-        if (metadataMethodName is ".ctor" or ".cctor")
-            return metadataMethodName;
-
-        int separator = metadataMethodName.LastIndexOf('.');
-        return separator >= 0
-            ? metadataMethodName[(separator + 1)..]
-            : metadataMethodName;
-    }
 
     static bool AccessorMatches(
-        string methodName,
+        MetadataMethodIdentity identity,
         string prefix,
-        string memberName)
-        => methodName.StartsWith(prefix, StringComparison.Ordinal)
+        string memberName,
+        ExplicitInterfaceSpecifierSyntax? explicitInterface)
+        => identity.SimpleName.StartsWith(prefix, StringComparison.Ordinal)
            && string.Equals(
-               methodName[prefix.Length..],
+               identity.SimpleName[prefix.Length..],
                memberName,
-               StringComparison.Ordinal);
+               StringComparison.Ordinal)
+           && ExplicitInterfaceMatches(
+               explicitInterface,
+               identity.ExplicitInterface);
+
+    static bool ExplicitInterfaceMatches(
+        ExplicitInterfaceSpecifierSyntax? syntax,
+        string? metadataInterface)
+    {
+        if (syntax is null || metadataInterface is null)
+            return syntax is null && metadataInterface is null;
+
+        string sourceInterface = MetadataInterfaceName(syntax.Name);
+        return string.Equals(
+                   metadataInterface,
+                   sourceInterface,
+                   StringComparison.Ordinal)
+               || metadataInterface.EndsWith(
+                   $".{sourceInterface}",
+                   StringComparison.Ordinal);
+    }
+
+    static string MetadataInterfaceName(NameSyntax name)
+        => name switch
+        {
+            IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
+            GenericNameSyntax generic => generic.Identifier.ValueText,
+            QualifiedNameSyntax qualified =>
+                $"{MetadataInterfaceName(qualified.Left)}.{MetadataInterfaceName(qualified.Right)}",
+            AliasQualifiedNameSyntax alias
+                when alias.Alias.Identifier.ValueText == "global"
+                => MetadataInterfaceName(alias.Name),
+            AliasQualifiedNameSyntax alias =>
+                $"{alias.Alias.Identifier.ValueText}.{MetadataInterfaceName(alias.Name)}",
+            _ => name.ToString(),
+        };
+
+    readonly record struct MetadataMethodIdentity(
+        string SimpleName,
+        string? ExplicitInterface)
+    {
+        public static MetadataMethodIdentity Parse(string metadataMethodName)
+        {
+            if (metadataMethodName is ".ctor" or ".cctor")
+                return new(metadataMethodName, ExplicitInterface: null);
+
+            int separator = metadataMethodName.LastIndexOf('.');
+            return separator >= 0
+                ? new(
+                    metadataMethodName[(separator + 1)..],
+                    metadataMethodName[..separator])
+                : new(metadataMethodName, ExplicitInterface: null);
+        }
+    }
 
     static string AccessorBodyText(
         BasePropertyDeclarationSyntax declaration,

--- a/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
+++ b/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
@@ -256,6 +256,8 @@ static class AuthoredRebuildFidelity
             ConstructorDeclarationSyntax constructor
                 when identity.SimpleName is ".ctor" or ".cctor"
                     && identity.ExplicitInterface is null
+                // Metadata names do not encode constructor arity. Multiple constructors in the
+                // checksum-verified sequence-point window tie and are rejected as ambiguous.
                 => (2, BodyText(
                     constructor.Body,
                     constructor.ExpressionBody,

--- a/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
+++ b/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
@@ -80,7 +80,9 @@ static class AuthoredRebuildFidelity
                 or BadImageFormatException
                 or InvalidOperationException)
             {
-                _ = ex;
+                Console.Error.WriteLine(
+                    $"Warning: authored rebuild skipped '{assemblyPath}' "
+                    + $"({ex.GetType().Name}: {ex.Message}).");
                 continue;
             }
 

--- a/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
+++ b/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
@@ -1,0 +1,584 @@
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using System.Reflection;
+
+using DotnetInspector.Core;
+using DotnetInspector.Packages;
+using DotnetInspector.Services;
+using ILInspector.Findings;
+using ILInspector.Metadata;
+using ILInspector.Research;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace ILInspector.DecompilerHarness;
+
+enum AuthoredRebuildOutcome
+{
+    Exact,
+    IlDifferent,
+    RecompileFailed,
+    ContextFailed,
+    SourceAbsent,
+    SourceFailed,
+}
+
+enum AuthoredBuildContextStatus
+{
+    Recorded,
+    Incomplete,
+    Drift,
+    Failed,
+}
+
+sealed record AuthoredBuildContextAssessment(
+    AuthoredBuildContextStatus Status,
+    bool IsDeterministic,
+    string Detail,
+    IReadOnlyDictionary<string, string>? RecordedOptions = null);
+
+sealed record AuthoredRebuildFidelityResult(
+    ReturnToSender.Result DecompilerLane,
+    AuthoredRebuildOutcome Outcome,
+    SourceChecksumVerification? ChecksumVerification,
+    AuthoredBuildContextAssessment BuildContext,
+    string? Detail,
+    ImplementationMemberDiffResult? ImplementationDiff);
+
+static class AuthoredRebuildFidelity
+{
+    public static int Run(IReadOnlyList<string> assemblies, int cap, int maxExamples)
+        => RunAsync(assemblies, cap, maxExamples).GetAwaiter().GetResult();
+
+    static async Task<int> RunAsync(
+        IReadOnlyList<string> assemblies,
+        int cap,
+        int maxExamples)
+    {
+        HttpClientFactory.Initialize();
+        using var httpClient = HttpClientFactory.CreateNew();
+        var fetcher = new SourceFetcher(HttpClientFactory.SharedUntrustedFetch);
+        List<AuthoredRebuildFidelityResult> results = [];
+
+        foreach (string assemblyPath in assemblies)
+        {
+            if (results.Count >= cap)
+                break;
+
+            IReadOnlyList<ReturnToSender.Result> decompilerResults;
+            try
+            {
+                decompilerResults = ReturnToSender.CompileBackPropertyGetters(
+                    assemblyPath,
+                    cap - results.Count);
+            }
+            catch (Exception ex) when (ex is IOException
+                or UnauthorizedAccessException
+                or BadImageFormatException
+                or InvalidOperationException)
+            {
+                _ = ex;
+                continue;
+            }
+
+            using var source = SourceLinkService.Open(assemblyPath);
+            await AcquirePdbAsync(source, httpClient);
+            var buildContext = AssessBuildContext(
+                AssemblyInspector.InspectDll(assemblyPath).IsDeterministic,
+                MetadataFindings.InspectCompilationOptions(
+                    source,
+                    new FindingSubject(assemblyPath, Path.GetFileName(assemblyPath))),
+                MetadataFindings.InspectCompilationReferences(
+                    source,
+                    new FindingSubject(assemblyPath, Path.GetFileName(assemblyPath))),
+                ReturnToSender.CompilationReferences(assemblyPath));
+
+            foreach (var decompilerResult in decompilerResults)
+            {
+                if (results.Count >= cap)
+                    break;
+
+                results.Add(await EvaluateAsync(
+                    source,
+                    fetcher,
+                    decompilerResult,
+                    buildContext));
+            }
+        }
+
+        WriteReport(results, maxExamples);
+        return results.Any(result =>
+            result.Outcome is AuthoredRebuildOutcome.RecompileFailed
+                or AuthoredRebuildOutcome.ContextFailed
+                or AuthoredRebuildOutcome.SourceFailed)
+            ? 1
+            : 0;
+    }
+
+    internal static async Task<AuthoredRebuildFidelityResult> EvaluateAsync(
+        SourceLinkService source,
+        SourceFetcher fetcher,
+        ReturnToSender.Result decompilerResult,
+        AuthoredBuildContextAssessment buildContext)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(fetcher);
+        ArgumentNullException.ThrowIfNull(decompilerResult);
+        ArgumentNullException.ThrowIfNull(buildContext);
+
+        if (decompilerResult.FinalRequest is not { } request)
+        {
+            return new AuthoredRebuildFidelityResult(
+                decompilerResult,
+                AuthoredRebuildOutcome.ContextFailed,
+                ChecksumVerification: null,
+                buildContext,
+                "RTS did not produce a final artifact request.",
+                ImplementationDiff: null);
+        }
+
+        var subject = new FindingSubject(
+            decompilerResult.MemberAnchor?.StableSelector
+                ?? $"{request.FullType}.{request.MethodName}",
+            $"{request.FullType}.{request.MethodName}");
+        var authored = await AuthoredSourceAcquisition.AcquireMemberAsync(
+            source,
+            MetadataTokens.GetToken(request.TargetMethod),
+            request.MethodName,
+            subject,
+            fetcher);
+        if (authored.Lines.Value is FindingInspection<string>.Absent absent)
+        {
+            return new AuthoredRebuildFidelityResult(
+                decompilerResult,
+                AuthoredRebuildOutcome.SourceAbsent,
+                authored.ChecksumVerification,
+                buildContext,
+                absent.Detail,
+                ImplementationDiff: null);
+        }
+        if (authored.Lines.Value is FindingInspection<string>.Failed failed)
+        {
+            return new AuthoredRebuildFidelityResult(
+                decompilerResult,
+                AuthoredRebuildOutcome.SourceFailed,
+                authored.ChecksumVerification,
+                buildContext,
+                failed.Error.Reason,
+                ImplementationDiff: null);
+        }
+        if (authored.Text is not { } authoredBody)
+        {
+            return new AuthoredRebuildFidelityResult(
+                decompilerResult,
+                AuthoredRebuildOutcome.SourceFailed,
+                authored.ChecksumVerification,
+                buildContext,
+                "Authored-source acquisition completed without body text.",
+                ImplementationDiff: null);
+        }
+
+        if (!TryExtractTargetBody(authoredBody, request.MethodName, out string targetBody))
+        {
+            return new AuthoredRebuildFidelityResult(
+                decompilerResult,
+                AuthoredRebuildOutcome.SourceFailed,
+                authored.ChecksumVerification,
+                buildContext,
+                "Checksum-verified authored member source did not contain the target body.",
+                ImplementationDiff: null);
+        }
+
+        return CompileAuthoredBody(
+            decompilerResult,
+            targetBody,
+            authored.ChecksumVerification,
+            buildContext);
+    }
+
+    internal static bool TryExtractTargetBody(
+        string memberSource,
+        string metadataMethodName,
+        out string body)
+    {
+        ArgumentNullException.ThrowIfNull(memberSource);
+        ArgumentException.ThrowIfNullOrWhiteSpace(metadataMethodName);
+
+        var root = CSharpSyntaxTree.ParseText(
+            $"class __AuthoredSourceHost {{{Environment.NewLine}{memberSource}{Environment.NewLine}}}")
+            .GetCompilationUnitRoot();
+        var member = root.DescendantNodes()
+            .OfType<MemberDeclarationSyntax>()
+            .FirstOrDefault(candidate => candidate.Parent is ClassDeclarationSyntax);
+        body = member switch
+        {
+            MethodDeclarationSyntax method
+                when string.Equals(
+                    method.Identifier.ValueText,
+                    metadataMethodName,
+                    StringComparison.Ordinal)
+                => BodyText(method.Body, method.ExpressionBody, ReturnsVoid(method.ReturnType)),
+            ConstructorDeclarationSyntax constructor
+                when metadataMethodName is ".ctor" or ".cctor"
+                => BodyText(constructor.Body, constructor.ExpressionBody, returnsVoid: true),
+            PropertyDeclarationSyntax property
+                when metadataMethodName.StartsWith("get_", StringComparison.Ordinal)
+                => AccessorBodyText(property, SyntaxKind.GetAccessorDeclaration),
+            PropertyDeclarationSyntax property
+                when metadataMethodName.StartsWith("set_", StringComparison.Ordinal)
+                => AccessorBodyText(property, SyntaxKind.SetAccessorDeclaration),
+            EventDeclarationSyntax eventDeclaration
+                when metadataMethodName.StartsWith("add_", StringComparison.Ordinal)
+                => AccessorBodyText(eventDeclaration, SyntaxKind.AddAccessorDeclaration),
+            EventDeclarationSyntax eventDeclaration
+                when metadataMethodName.StartsWith("remove_", StringComparison.Ordinal)
+                => AccessorBodyText(eventDeclaration, SyntaxKind.RemoveAccessorDeclaration),
+            _ => "",
+        };
+        return body.Length > 0;
+    }
+
+    static string AccessorBodyText(
+        BasePropertyDeclarationSyntax declaration,
+        SyntaxKind accessorKind)
+    {
+        var accessor = declaration.AccessorList?.Accessors
+            .FirstOrDefault(candidate => candidate.IsKind(accessorKind));
+        if (accessor is not null)
+        {
+            return BodyText(
+                accessor.Body,
+                accessor.ExpressionBody,
+                returnsVoid: accessorKind is SyntaxKind.SetAccessorDeclaration
+                    or SyntaxKind.AddAccessorDeclaration
+                    or SyntaxKind.RemoveAccessorDeclaration);
+        }
+
+        if (accessorKind == SyntaxKind.GetAccessorDeclaration
+            && declaration is PropertyDeclarationSyntax
+                { ExpressionBody: { } expressionBody })
+        {
+            return $"return {expressionBody.Expression};";
+        }
+
+        return "";
+    }
+
+    static string BodyText(
+        BlockSyntax? block,
+        ArrowExpressionClauseSyntax? expressionBody,
+        bool returnsVoid)
+    {
+        if (block is not null)
+        {
+            return string.Join(
+                Environment.NewLine,
+                block.Statements.Select(statement => statement.ToFullString()))
+                .Trim();
+        }
+        if (expressionBody is null)
+            return "";
+
+        return returnsVoid
+            ? $"{expressionBody.Expression};"
+            : $"return {expressionBody.Expression};";
+    }
+
+    static bool ReturnsVoid(TypeSyntax type)
+        => type is PredefinedTypeSyntax predefined
+           && predefined.Keyword.IsKind(SyntaxKind.VoidKeyword);
+
+    internal static AuthoredRebuildFidelityResult CompileAuthoredBody(
+        ReturnToSender.Result decompilerResult,
+        string authoredBody,
+        SourceChecksumVerification? checksumVerification,
+        AuthoredBuildContextAssessment buildContext)
+    {
+        ArgumentNullException.ThrowIfNull(decompilerResult);
+        ArgumentNullException.ThrowIfNull(authoredBody);
+        ArgumentNullException.ThrowIfNull(buildContext);
+        if (decompilerResult.FinalRequest is not { } request)
+        {
+            return new AuthoredRebuildFidelityResult(
+                decompilerResult,
+                AuthoredRebuildOutcome.ContextFailed,
+                checksumVerification,
+                buildContext,
+                "RTS did not produce a final artifact request.",
+                ImplementationDiff: null);
+        }
+
+        try
+        {
+            using var originalPe = new PEReader(File.OpenRead(request.AssemblyPath));
+            var originalReader = originalPe.GetMetadataReader();
+            request = ReturnToSender.WithReader(request, originalReader);
+            var authoredRequest = ReturnToSender.WithTargetBody(
+                request,
+                new ProductTargetBody(authoredBody, []));
+            var artifact = CompileBackSourceComposer.Compose(authoredRequest);
+            var parseOptions = ParseOptions(buildContext.RecordedOptions);
+            var compileOptions = CompilationOptions(buildContext.RecordedOptions);
+            var references = ReturnToSender.CompilationReferences(
+                request.AssemblyPath).ToArray();
+            var compilation = CSharpCompilation.Create(
+                "return-to-sender",
+                [CSharpSyntaxTree.ParseText(artifact.Source, parseOptions)],
+                references,
+                compileOptions);
+            using var stream = new MemoryStream();
+            var emit = compilation.Emit(stream);
+            if (!emit.Success)
+            {
+                var error = emit.Diagnostics.FirstOrDefault(diagnostic =>
+                    diagnostic.Severity == DiagnosticSeverity.Error);
+                return new AuthoredRebuildFidelityResult(
+                    decompilerResult,
+                    AuthoredRebuildOutcome.RecompileFailed,
+                    checksumVerification,
+                    buildContext,
+                    error is null
+                        ? "The authored body did not compile in the RTS shell."
+                        : $"{error.Id}: {error.GetMessage()}",
+                    ImplementationDiff: null);
+            }
+
+            var originalMethod = MetadataTokens.MethodDefinitionHandle(
+                MetadataTokens.GetRowNumber(request.TargetMethod));
+            var implementationDiff = ReturnToSender.BuildImplementationDiff(
+                request.AssemblyPath,
+                originalReader,
+                originalMethod,
+                stream.ToArray(),
+                request.FullType,
+                request.MethodName,
+                overload: 0,
+                ImplementationDiffMechanism.IlBody);
+            if (implementationDiff is null)
+            {
+                return new AuthoredRebuildFidelityResult(
+                    decompilerResult,
+                    AuthoredRebuildOutcome.ContextFailed,
+                    checksumVerification,
+                    buildContext,
+                    "The authored rebuild target could not be compared to shipped IL.",
+                    ImplementationDiff: null);
+            }
+
+            return new AuthoredRebuildFidelityResult(
+                decompilerResult,
+                implementationDiff.IsExact
+                    ? AuthoredRebuildOutcome.Exact
+                    : AuthoredRebuildOutcome.IlDifferent,
+                checksumVerification,
+                buildContext,
+                Detail: null,
+                implementationDiff);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException
+            or InvalidOperationException
+            or ArgumentException
+            or IOException)
+        {
+            return new AuthoredRebuildFidelityResult(
+                decompilerResult,
+                AuthoredRebuildOutcome.ContextFailed,
+                checksumVerification,
+                buildContext,
+                $"{ex.GetType().Name}: {ex.Message}",
+                ImplementationDiff: null);
+        }
+    }
+
+    internal static AuthoredBuildContextAssessment AssessBuildContext(
+        bool isDeterministic,
+        FindingInspection<CompilationOptionInfo> options,
+        FindingInspection<CompilationReferenceInfo> references,
+        IEnumerable<MetadataReference> actualReferences)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(references);
+        ArgumentNullException.ThrowIfNull(actualReferences);
+
+        if (options.Value is FindingInspection<CompilationOptionInfo>.Failed optionFailure)
+        {
+            return new AuthoredBuildContextAssessment(
+                AuthoredBuildContextStatus.Failed,
+                isDeterministic,
+                $"Compilation options: {optionFailure.Error.Reason}");
+        }
+        if (references.Value is FindingInspection<CompilationReferenceInfo>.Failed referenceFailure)
+        {
+            return new AuthoredBuildContextAssessment(
+                AuthoredBuildContextStatus.Failed,
+                isDeterministic,
+                $"Compilation references: {referenceFailure.Error.Reason}");
+        }
+        if (options.Value is not FindingInspection<CompilationOptionInfo>.Complete optionComplete
+            || references.Value is not FindingInspection<CompilationReferenceInfo>.Complete referenceComplete
+            || optionComplete.Findings.IsEmpty
+            || referenceComplete.Findings.IsEmpty)
+        {
+            return new AuthoredBuildContextAssessment(
+                AuthoredBuildContextStatus.Incomplete,
+                isDeterministic,
+                "Portable-PDB compilation options or references are incomplete.");
+        }
+
+        var drift = new List<string>();
+        var optionValues = optionComplete.Findings
+            .Select(finding => finding.Payload)
+            .ToDictionary(option => option.Name, option => option.Value, StringComparer.OrdinalIgnoreCase);
+        CheckOption(optionValues, "optimization", "release", drift);
+        CheckOption(optionValues, "unsafe", "true", drift, missingIsDrift: false);
+        CheckOption(optionValues, "language-version", "preview", drift, missingIsDrift: false);
+        CheckOption(
+            optionValues,
+            "compiler-version",
+            typeof(CSharpCompilation).Assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                ?.InformationalVersion
+                ?? typeof(CSharpCompilation).Assembly.GetName().Version?.ToString()
+                ?? "unknown",
+            drift,
+            missingIsDrift: false);
+
+        var actualNames = actualReferences
+            .Select(reference => Path.GetFileName(reference.Display))
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var missingReferences = referenceComplete.Findings
+            .Select(finding => finding.Payload.Name)
+            .Select(Path.GetFileName)
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Where(name => !actualNames.Contains(name!))
+            .Take(3)
+            .ToArray();
+        if (missingReferences.Length > 0)
+            drift.Add($"references missing from RTS context: {string.Join(", ", missingReferences)}");
+
+        return drift.Count == 0
+            ? new AuthoredBuildContextAssessment(
+                AuthoredBuildContextStatus.Recorded,
+                isDeterministic,
+                "Portable-PDB options and reference names agree with the RTS context.",
+                optionValues)
+            : new AuthoredBuildContextAssessment(
+                AuthoredBuildContextStatus.Drift,
+                isDeterministic,
+                string.Join("; ", drift),
+                optionValues);
+    }
+
+    static CSharpParseOptions ParseOptions(
+        IReadOnlyDictionary<string, string>? options)
+    {
+        var languageVersion = LanguageVersion.Preview;
+        if (options?.TryGetValue("language-version", out string? language) == true
+            && LanguageVersionFacts.TryParse(language, out var parsedLanguage))
+        {
+            languageVersion = parsedLanguage;
+        }
+
+        var symbols = options?.TryGetValue("define", out string? define) == true
+            ? define.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            : [];
+        return new CSharpParseOptions(
+            languageVersion,
+            preprocessorSymbols: symbols);
+    }
+
+    static CSharpCompilationOptions CompilationOptions(
+        IReadOnlyDictionary<string, string>? options)
+    {
+        bool release = options?.TryGetValue("optimization", out string? optimization) != true
+            || string.Equals(optimization, "release", StringComparison.OrdinalIgnoreCase);
+        bool allowUnsafe = options?.TryGetValue("unsafe", out string? unsafeValue) != true
+            || bool.TryParse(unsafeValue, out bool parsedUnsafe) && parsedUnsafe;
+        bool checkOverflow = options?.TryGetValue("checked", out string? checkedValue) == true
+            && bool.TryParse(checkedValue, out bool parsedChecked) && parsedChecked;
+        return new CSharpCompilationOptions(
+            OutputKind.DynamicallyLinkedLibrary,
+            optimizationLevel: release ? OptimizationLevel.Release : OptimizationLevel.Debug,
+            nullableContextOptions: NullableContextOptions.Disable,
+            allowUnsafe: allowUnsafe,
+            checkOverflow: checkOverflow);
+    }
+
+    static void CheckOption(
+        IReadOnlyDictionary<string, string> options,
+        string name,
+        string expected,
+        ICollection<string> drift,
+        bool missingIsDrift = true)
+    {
+        if (!options.TryGetValue(name, out string? actual))
+        {
+            if (missingIsDrift)
+                drift.Add($"{name} is not recorded");
+            return;
+        }
+
+        if (!string.Equals(actual, expected, StringComparison.OrdinalIgnoreCase))
+            drift.Add($"{name}={actual} (RTS uses {expected})");
+    }
+
+    static async Task AcquirePdbAsync(
+        SourceLinkService source,
+        HttpClient httpClient)
+    {
+        if (!source.Context.NeedsPdb || source.Context.PdbId is not { } pdb)
+            return;
+
+        var result = await new SymbolPackageDownloader(httpClient).DownloadPdbAsync(
+            pdb.Guid,
+            pdb.Age,
+            pdb.PdbFileName,
+            pdb.IsPortable,
+            source.Context.AssemblyPath);
+        if (result.PdbFilePath is not null)
+            source.LoadPdb(result.PdbFilePath, "Symbol Package", result.SymbolServer);
+    }
+
+    static void WriteReport(
+        IReadOnlyList<AuthoredRebuildFidelityResult> results,
+        int maxExamples)
+    {
+        Console.WriteLine($"AUTHORED-SOURCE REBUILD FIDELITY over {results.Count} target(s)");
+        Console.WriteLine();
+        foreach (AuthoredRebuildOutcome outcome in Enum.GetValues<AuthoredRebuildOutcome>())
+            Console.WriteLine($"  {outcome,-16}: {results.Count(result => result.Outcome == outcome)}");
+        Console.WriteLine();
+        Console.WriteLine("Build context:");
+        foreach (AuthoredBuildContextStatus status in Enum.GetValues<AuthoredBuildContextStatus>())
+            Console.WriteLine($"  {status,-16}: {results.Count(result => result.BuildContext.Status == status)}");
+        Console.WriteLine($"  {"Deterministic",-16}: {results.Count(result => result.BuildContext.IsDeterministic)}");
+
+        var examples = results
+            .Where(result => result.Outcome != AuthoredRebuildOutcome.Exact
+                || result.BuildContext.Status != AuthoredBuildContextStatus.Recorded
+                || !result.BuildContext.IsDeterministic)
+            .Take(maxExamples)
+            .ToArray();
+        if (examples.Length == 0)
+            return;
+
+        Console.WriteLine();
+        Console.WriteLine("Examples:");
+        foreach (var result in examples)
+        {
+            var target = result.DecompilerLane.Plan.TargetMethod;
+            Console.WriteLine($"  {target.Type}::{target.Method}");
+            Console.WriteLine($"    decompiled : {result.DecompilerLane.Status}");
+            Console.WriteLine($"    authored   : {result.Outcome}");
+            Console.WriteLine($"    checksum   : {result.ChecksumVerification?.ToString() ?? "unavailable"}");
+            Console.WriteLine($"    deterministic: {result.BuildContext.IsDeterministic}");
+            Console.WriteLine($"    context    : {result.BuildContext.Status} — {result.BuildContext.Detail}");
+            if (!string.IsNullOrWhiteSpace(result.Detail))
+                Console.WriteLine($"    detail     : {result.Detail}");
+        }
+    }
+}

--- a/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
+++ b/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
@@ -332,20 +332,30 @@ static class AuthoredRebuildFidelity
         string? metadataInterface)
     {
         if (syntax is null || metadataInterface is null)
-            return syntax is null && metadataInterface is null ? 2 : -1;
+            return syntax is null && metadataInterface is null ? 4 : -1;
 
         string sourceInterface = MetadataInterfaceName(syntax.Name);
-        string normalizedMetadata = NormalizeMetadataInterfaceName(metadataInterface);
         if (string.Equals(
-                   normalizedMetadata,
+                   metadataInterface,
                    sourceInterface,
                    StringComparison.Ordinal))
         {
-            return 2;
+            return 4;
+        }
+        if (metadataInterface.EndsWith(
+            $".{sourceInterface}",
+            StringComparison.Ordinal))
+        {
+            return 3;
         }
 
-        return normalizedMetadata.EndsWith(
-            $".{sourceInterface}",
+        string erasedSource = EraseGenericArguments(sourceInterface);
+        string erasedMetadata = EraseGenericArguments(metadataInterface);
+        if (string.Equals(erasedMetadata, erasedSource, StringComparison.Ordinal))
+            return 2;
+
+        return erasedMetadata.EndsWith(
+            $".{erasedSource}",
             StringComparison.Ordinal)
             ? 1
             : -1;
@@ -355,22 +365,55 @@ static class AuthoredRebuildFidelity
         => name switch
         {
             IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
-            GenericNameSyntax generic => generic.Identifier.ValueText,
+            GenericNameSyntax generic =>
+                $"{generic.Identifier.ValueText}<"
+                + $"{string.Join(",", generic.TypeArgumentList.Arguments.Select(MetadataTypeName))}>",
             QualifiedNameSyntax qualified =>
                 $"{MetadataInterfaceName(qualified.Left)}.{MetadataInterfaceName(qualified.Right)}",
             AliasQualifiedNameSyntax alias
                 when alias.Alias.Identifier.ValueText == "global"
                 => MetadataInterfaceName(alias.Name),
-            AliasQualifiedNameSyntax alias =>
-                $"{alias.Alias.Identifier.ValueText}.{MetadataInterfaceName(alias.Name)}",
+            AliasQualifiedNameSyntax alias => MetadataInterfaceName(alias.Name),
             _ => name.ToString(),
         };
 
-    static string NormalizeMetadataInterfaceName(string metadataInterface)
+    static string MetadataTypeName(TypeSyntax type)
+        => type switch
+        {
+            PredefinedTypeSyntax predefined => predefined.Keyword.Kind() switch
+            {
+                SyntaxKind.BoolKeyword => "System.Boolean",
+                SyntaxKind.ByteKeyword => "System.Byte",
+                SyntaxKind.SByteKeyword => "System.SByte",
+                SyntaxKind.ShortKeyword => "System.Int16",
+                SyntaxKind.UShortKeyword => "System.UInt16",
+                SyntaxKind.IntKeyword => "System.Int32",
+                SyntaxKind.UIntKeyword => "System.UInt32",
+                SyntaxKind.LongKeyword => "System.Int64",
+                SyntaxKind.ULongKeyword => "System.UInt64",
+                SyntaxKind.CharKeyword => "System.Char",
+                SyntaxKind.FloatKeyword => "System.Single",
+                SyntaxKind.DoubleKeyword => "System.Double",
+                SyntaxKind.DecimalKeyword => "System.Decimal",
+                SyntaxKind.StringKeyword => "System.String",
+                SyntaxKind.ObjectKeyword => "System.Object",
+                _ => predefined.Keyword.ValueText,
+            },
+            NullableTypeSyntax nullable =>
+                $"System.Nullable<{MetadataTypeName(nullable.ElementType)}>",
+            ArrayTypeSyntax array =>
+                MetadataTypeName(array.ElementType)
+                + string.Concat(array.RankSpecifiers.Select(rank =>
+                    rank.Rank == 1 ? "[]" : $"[{new string(',', rank.Rank - 1)}]")),
+            NameSyntax name => MetadataInterfaceName(name),
+            _ => type.WithoutTrivia().ToString(),
+        };
+
+    static string EraseGenericArguments(string name)
     {
-        StringBuilder normalized = new(metadataInterface.Length);
+        StringBuilder normalized = new(name.Length);
         int genericDepth = 0;
-        foreach (char value in metadataInterface)
+        foreach (char value in name)
         {
             switch (value)
             {

--- a/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
+++ b/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
@@ -215,33 +215,61 @@ static class AuthoredRebuildFidelity
         var member = root.DescendantNodes()
             .OfType<MemberDeclarationSyntax>()
             .FirstOrDefault(candidate => candidate.Parent is ClassDeclarationSyntax);
+        string simpleMethodName = SimpleMetadataMethodName(metadataMethodName);
         body = member switch
         {
             MethodDeclarationSyntax method
                 when string.Equals(
                     method.Identifier.ValueText,
-                    metadataMethodName,
+                    simpleMethodName,
                     StringComparison.Ordinal)
                 => BodyText(method.Body, method.ExpressionBody, ReturnsVoid(method.ReturnType)),
             ConstructorDeclarationSyntax constructor
                 when metadataMethodName is ".ctor" or ".cctor"
                 => BodyText(constructor.Body, constructor.ExpressionBody, returnsVoid: true),
             PropertyDeclarationSyntax property
-                when metadataMethodName.StartsWith("get_", StringComparison.Ordinal)
+                when AccessorMatches(simpleMethodName, "get_", property.Identifier.ValueText)
                 => AccessorBodyText(property, SyntaxKind.GetAccessorDeclaration),
             PropertyDeclarationSyntax property
-                when metadataMethodName.StartsWith("set_", StringComparison.Ordinal)
+                when AccessorMatches(simpleMethodName, "set_", property.Identifier.ValueText)
                 => AccessorBodyText(property, SyntaxKind.SetAccessorDeclaration),
             EventDeclarationSyntax eventDeclaration
-                when metadataMethodName.StartsWith("add_", StringComparison.Ordinal)
+                when AccessorMatches(
+                    simpleMethodName,
+                    "add_",
+                    eventDeclaration.Identifier.ValueText)
                 => AccessorBodyText(eventDeclaration, SyntaxKind.AddAccessorDeclaration),
             EventDeclarationSyntax eventDeclaration
-                when metadataMethodName.StartsWith("remove_", StringComparison.Ordinal)
+                when AccessorMatches(
+                    simpleMethodName,
+                    "remove_",
+                    eventDeclaration.Identifier.ValueText)
                 => AccessorBodyText(eventDeclaration, SyntaxKind.RemoveAccessorDeclaration),
             _ => "",
         };
         return body.Length > 0;
     }
+
+    static string SimpleMetadataMethodName(string metadataMethodName)
+    {
+        if (metadataMethodName is ".ctor" or ".cctor")
+            return metadataMethodName;
+
+        int separator = metadataMethodName.LastIndexOf('.');
+        return separator >= 0
+            ? metadataMethodName[(separator + 1)..]
+            : metadataMethodName;
+    }
+
+    static bool AccessorMatches(
+        string methodName,
+        string prefix,
+        string memberName)
+        => methodName.StartsWith(prefix, StringComparison.Ordinal)
+           && string.Equals(
+               methodName[prefix.Length..],
+               memberName,
+               StringComparison.Ordinal);
 
     static string AccessorBodyText(
         BasePropertyDeclarationSyntax declaration,

--- a/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
+++ b/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
@@ -2,6 +2,7 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Reflection;
+using System.Text;
 
 using DotnetInspector.Core;
 using DotnetInspector.Packages;
@@ -213,20 +214,32 @@ static class AuthoredRebuildFidelity
             $"class __AuthoredSourceHost {{{Environment.NewLine}{memberSource}{Environment.NewLine}}}")
             .GetCompilationUnitRoot();
         var identity = MetadataMethodIdentity.Parse(metadataMethodName);
+        int bestScore = -1;
+        bool ambiguous = false;
+        body = "";
         foreach (var member in root.DescendantNodes()
             .OfType<MemberDeclarationSyntax>()
             .Where(candidate => candidate.Parent is ClassDeclarationSyntax))
         {
-            body = MemberBodyText(member, identity);
-            if (body.Length > 0)
-                return true;
+            var candidate = MemberBody(member, identity);
+            if (candidate.Score < bestScore)
+                continue;
+            if (candidate.Score == bestScore)
+            {
+                if (candidate.Score >= 0)
+                    ambiguous = true;
+                continue;
+            }
+
+            bestScore = candidate.Score;
+            body = candidate.Body;
+            ambiguous = false;
         }
 
-        body = "";
-        return false;
+        return bestScore >= 0 && !ambiguous && body.Length > 0;
     }
 
-    static string MemberBodyText(
+    static (int Score, string Body) MemberBody(
         MemberDeclarationSyntax member,
         MetadataMethodIdentity identity)
         => member switch
@@ -236,74 +249,106 @@ static class AuthoredRebuildFidelity
                     method.Identifier.ValueText,
                     identity.SimpleName,
                     StringComparison.Ordinal)
-                    && ExplicitInterfaceMatches(
-                        method.ExplicitInterfaceSpecifier,
-                        identity.ExplicitInterface)
-                => BodyText(method.Body, method.ExpressionBody, ReturnsVoid(method.ReturnType)),
+                => ScoredBody(
+                    method.ExplicitInterfaceSpecifier,
+                    identity,
+                    BodyText(method.Body, method.ExpressionBody, ReturnsVoid(method.ReturnType))),
             ConstructorDeclarationSyntax constructor
                 when identity.SimpleName is ".ctor" or ".cctor"
                     && identity.ExplicitInterface is null
-                => BodyText(constructor.Body, constructor.ExpressionBody, returnsVoid: true),
+                => (2, BodyText(
+                    constructor.Body,
+                    constructor.ExpressionBody,
+                    returnsVoid: true)),
             PropertyDeclarationSyntax property
-                when AccessorMatches(
+                when AccessorNameMatches(
                     identity,
                     "get_",
-                    property.Identifier.ValueText,
-                    property.ExplicitInterfaceSpecifier)
-                => AccessorBodyText(property, SyntaxKind.GetAccessorDeclaration),
+                    property.Identifier.ValueText)
+                => ScoredBody(
+                    property.ExplicitInterfaceSpecifier,
+                    identity,
+                    AccessorBodyText(property, SyntaxKind.GetAccessorDeclaration)),
             PropertyDeclarationSyntax property
-                when AccessorMatches(
+                when AccessorNameMatches(
                     identity,
                     "set_",
-                    property.Identifier.ValueText,
-                    property.ExplicitInterfaceSpecifier)
-                => AccessorBodyText(property, SyntaxKind.SetAccessorDeclaration),
+                    property.Identifier.ValueText)
+                => ScoredBody(
+                    property.ExplicitInterfaceSpecifier,
+                    identity,
+                    AccessorBodyText(property, SyntaxKind.SetAccessorDeclaration)),
+            IndexerDeclarationSyntax indexer
+                when AccessorNameMatches(identity, "get_", "Item")
+                => ScoredBody(
+                    indexer.ExplicitInterfaceSpecifier,
+                    identity,
+                    AccessorBodyText(indexer, SyntaxKind.GetAccessorDeclaration)),
+            IndexerDeclarationSyntax indexer
+                when AccessorNameMatches(identity, "set_", "Item")
+                => ScoredBody(
+                    indexer.ExplicitInterfaceSpecifier,
+                    identity,
+                    AccessorBodyText(indexer, SyntaxKind.SetAccessorDeclaration)),
             EventDeclarationSyntax eventDeclaration
-                when AccessorMatches(
+                when AccessorNameMatches(
                     identity,
                     "add_",
-                    eventDeclaration.Identifier.ValueText,
-                    eventDeclaration.ExplicitInterfaceSpecifier)
-                => AccessorBodyText(eventDeclaration, SyntaxKind.AddAccessorDeclaration),
+                    eventDeclaration.Identifier.ValueText)
+                => ScoredBody(
+                    eventDeclaration.ExplicitInterfaceSpecifier,
+                    identity,
+                    AccessorBodyText(eventDeclaration, SyntaxKind.AddAccessorDeclaration)),
             EventDeclarationSyntax eventDeclaration
-                when AccessorMatches(
+                when AccessorNameMatches(
                     identity,
                     "remove_",
-                    eventDeclaration.Identifier.ValueText,
-                    eventDeclaration.ExplicitInterfaceSpecifier)
-                => AccessorBodyText(eventDeclaration, SyntaxKind.RemoveAccessorDeclaration),
-            _ => "",
+                    eventDeclaration.Identifier.ValueText)
+                => ScoredBody(
+                    eventDeclaration.ExplicitInterfaceSpecifier,
+                    identity,
+                    AccessorBodyText(eventDeclaration, SyntaxKind.RemoveAccessorDeclaration)),
+            _ => (-1, ""),
         };
 
-    static bool AccessorMatches(
+    static (int Score, string Body) ScoredBody(
+        ExplicitInterfaceSpecifierSyntax? syntax,
+        MetadataMethodIdentity identity,
+        string body)
+        => (ExplicitInterfaceMatchScore(syntax, identity.ExplicitInterface), body);
+
+    static bool AccessorNameMatches(
         MetadataMethodIdentity identity,
         string prefix,
-        string memberName,
-        ExplicitInterfaceSpecifierSyntax? explicitInterface)
+        string memberName)
         => identity.SimpleName.StartsWith(prefix, StringComparison.Ordinal)
            && string.Equals(
                identity.SimpleName[prefix.Length..],
                memberName,
-               StringComparison.Ordinal)
-           && ExplicitInterfaceMatches(
-               explicitInterface,
-               identity.ExplicitInterface);
+               StringComparison.Ordinal);
 
-    static bool ExplicitInterfaceMatches(
+    static int ExplicitInterfaceMatchScore(
         ExplicitInterfaceSpecifierSyntax? syntax,
         string? metadataInterface)
     {
         if (syntax is null || metadataInterface is null)
-            return syntax is null && metadataInterface is null;
+            return syntax is null && metadataInterface is null ? 2 : -1;
 
         string sourceInterface = MetadataInterfaceName(syntax.Name);
-        return string.Equals(
-                   metadataInterface,
+        string normalizedMetadata = NormalizeMetadataInterfaceName(metadataInterface);
+        if (string.Equals(
+                   normalizedMetadata,
                    sourceInterface,
-                   StringComparison.Ordinal)
-               || metadataInterface.EndsWith(
-                   $".{sourceInterface}",
-                   StringComparison.Ordinal);
+                   StringComparison.Ordinal))
+        {
+            return 2;
+        }
+
+        return normalizedMetadata.EndsWith(
+            $".{sourceInterface}",
+            StringComparison.Ordinal)
+            ? 1
+            : -1;
     }
 
     static string MetadataInterfaceName(NameSyntax name)
@@ -320,6 +365,30 @@ static class AuthoredRebuildFidelity
                 $"{alias.Alias.Identifier.ValueText}.{MetadataInterfaceName(alias.Name)}",
             _ => name.ToString(),
         };
+
+    static string NormalizeMetadataInterfaceName(string metadataInterface)
+    {
+        StringBuilder normalized = new(metadataInterface.Length);
+        int genericDepth = 0;
+        foreach (char value in metadataInterface)
+        {
+            switch (value)
+            {
+                case '<':
+                    genericDepth++;
+                    break;
+                case '>':
+                    genericDepth--;
+                    break;
+                default:
+                    if (genericDepth == 0)
+                        normalized.Append(value);
+                    break;
+            }
+        }
+
+        return normalized.ToString();
+    }
 
     readonly record struct MetadataMethodIdentity(
         string SimpleName,

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -71,6 +71,7 @@ static class Program
         bool returnToSenderCatalog = false;
         bool returnToSenderMarkout = false;
         bool returnToSenderSourceProbe = false;
+        bool authoredRebuildFidelity = false;
         string? returnToSenderFixtureGroup = null;
         bool fidelityTimings = false;
         int fidelityZeroSignalGuard = 0;
@@ -179,6 +180,7 @@ static class Program
                     case "--return-to-sender-markout": returnToSenderMarkout = true; break;
                     case "--return-to-sender-source-probe": returnToSenderSourceProbe = true; break;
                     case "--source-correspondence-census": returnToSenderSourceProbe = true; break;
+                    case "--authored-rebuild-fidelity": authoredRebuildFidelity = true; break;
                     case "--return-to-sender-fixtures": returnToSenderFixtureGroup = NextArg(args, ref i, flag); break;
                     case "--return-to-sender-catalog":
                         returnToSenderCatalog = true;
@@ -293,9 +295,9 @@ static class Program
         }
 
         if (returnToSenderFixtureGroup is not null
-            && !(returnToSender || returnToSenderAb || returnToSenderSourceProbe))
+            && !(returnToSender || returnToSenderAb || returnToSenderSourceProbe || authoredRebuildFidelity))
         {
-            return Fail("--return-to-sender-fixtures requires --return-to-sender, --return-to-sender-ab, --return-to-sender-source-probe, or --source-correspondence-census.");
+            return Fail("--return-to-sender-fixtures requires a ReturnToSender or authored rebuild operation.");
         }
 
         using var packageInputs = ResolvePackageAssemblies(packages, packageVersion, packageTfm, packageAssembly);
@@ -381,6 +383,9 @@ static class Program
 
         if (returnToSenderSourceProbe)
             return ReturnToSenderSourceProbe.Run(assemblies, cap, maxExamples, json);
+
+        if (authoredRebuildFidelity)
+            return AuthoredRebuildFidelity.Run(assemblies, cap, maxExamples);
 
         if (typeCheck)
             return TypeSourceCheck.Run(assemblies, cap, maxExamples);
@@ -1695,6 +1700,11 @@ static class Program
                                 alias for --return-to-sender-source-probe that
                                 emphasizes the Finding-style source-correspondence
                                 projection emitted in --json output.
+          --authored-rebuild-fidelity
+                                checksum-verify authored SourceLink bodies, rebuild
+                                each in the same RTS shell, and compare authored
+                                A->IL beside the independent decompiled B->IL lane;
+                                reports determinism and build-context drift separately.
           --return-to-sender-fixtures <group>
                                 add built fixture assemblies from a FixtureCatalog
                                 group (for example rts.candidates) as inputs for

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -160,7 +160,8 @@ The `rts.*` fixtures are focused ReturnToSender parity-burndown probes; for
 example `rts.attribute-shell` protects attribute type shells that must preserve a
 spellable `System.Attribute` base before attribute usages can compile.
 Use `--return-to-sender-fixtures rts.candidates` with `--return-to-sender`,
-`--return-to-sender-ab`, or `--return-to-sender-source-probe` to add built
+`--return-to-sender-ab`, `--return-to-sender-source-probe`, or
+`--authored-rebuild-fidelity` to add built
 fixture assemblies from `FixtureCatalog` as inputs without generating source.
 The source probe reuses RTS target discovery/import/render/compile-back plumbing
 and, for catalog fixtures, compares the decompiled target body against the
@@ -200,6 +201,14 @@ such as `source.correspondence.valid_different.known_taste`, a coarse category
 whether opcode-diff evidence is attached. The finding projection intentionally
 uses source file names rather than absolute source paths so the census can be
 shared without leaking local checkout paths.
+
+`--authored-rebuild-fidelity` is the SourceLink-backed second oracle. It
+checksum-verifies the authored body, substitutes it into the same final RTS
+artifact request, compiles it, and compares emitted IL through product
+`ImplementationDiff`. The report keeps authored A→IL beside decompiled B→IL and
+reports deterministic-build and portable-PDB option/reference context
+separately. `SourceAbsent` is missing evidence; `SourceFailed` is an acquisition
+or integrity failure.
 
 The generated fixture ladder is intentionally staged:
 

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -51,6 +51,7 @@ static class ReturnToSender
         FaultIsolationResult? FaultIsolation = null)
     {
         public bool UsedCompileBackFloor => CompileBackFloor is not null;
+        internal ArtifactRequest? FinalRequest { get; init; }
     }
 
     public sealed record RequestedTarget(string Type, string Method, int Overload, string? Signature = null);
@@ -1023,7 +1024,10 @@ static class ReturnToSender
                     $"{identityDiagnostic.Reason}: {identityDiagnostic.Detail}",
                     TargetBody: targetBody.Source,
                     MemberAnchor: memberAnchor,
-                    Decisions: targetBody.Decisions);
+                    Decisions: targetBody.Decisions)
+                {
+                    FinalRequest = sourceResult.Request,
+                };
             }
 
             string unit = sourceResult.Source;
@@ -1054,7 +1058,10 @@ static class ReturnToSender
                         "method-not-found",
                         TargetBody: targetBody.Source,
                         MemberAnchor: memberAnchor,
-                        Decisions: targetBody.Decisions);
+                        Decisions: targetBody.Decisions)
+                    {
+                        FinalRequest = sourceResult.Request,
+                    };
                 }
 
                 return new Result(
@@ -1070,7 +1077,10 @@ static class ReturnToSender
                     IlDiffDiagnostic: ilDiffDiagnostic,
                     IlDiff: ilDiff,
                     MemberAnchor: memberAnchor,
-                    Decisions: targetBody.Decisions);
+                    Decisions: targetBody.Decisions)
+                {
+                    FinalRequest = sourceResult.Request,
+                };
             }
 
             var errors = emit.Diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
@@ -1103,7 +1113,10 @@ static class ReturnToSender
                     TargetBody: targetBody.Source,
                     MemberAnchor: memberAnchor,
                     Decisions: targetBody.Decisions,
-                    FaultIsolation: faultIsolation);
+                    FaultIsolation: faultIsolation)
+                {
+                    FinalRequest = sourceResult.Request,
+                };
             }
         }
 
@@ -1121,7 +1134,10 @@ static class ReturnToSender
                 TargetBody: targetBody.Source,
                 MemberAnchor: memberAnchor,
                 Decisions: targetBody.Decisions,
-                FaultIsolation: faultIsolation);
+                FaultIsolation: faultIsolation)
+            {
+                FinalRequest = sourceResult.Request,
+            };
         }
     }
 
@@ -1413,7 +1429,7 @@ static class ReturnToSender
         return display.IsEmpty ? null : display;
     }
 
-    static IEnumerable<MetadataReference> CompilationReferences(string targetPath)
+    internal static IEnumerable<MetadataReference> CompilationReferences(string targetPath)
     {
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var resolver = new AssemblyDependencyResolver(new AssemblyDependencyResolutionOptions(targetPath)
@@ -1501,12 +1517,21 @@ static class ReturnToSender
         }
     }
 
-    static ArtifactRequest WithTargetBody(ArtifactRequest request, ProductTargetBody targetBody)
+    internal static ArtifactRequest WithTargetBody(ArtifactRequest request, ProductTargetBody targetBody)
         => request switch
         {
             MethodArtifactRequest method => method with { TargetBody = targetBody },
             PropertyGetterArtifactRequest getter => getter with { TargetBody = targetBody },
             PropertySetterArtifactRequest setter => setter with { TargetBody = targetBody },
+            _ => throw new ArgumentException($"Unknown artifact request type '{request.GetType().FullName}'.", nameof(request)),
+        };
+
+    internal static ArtifactRequest WithReader(ArtifactRequest request, MetadataReader reader)
+        => request switch
+        {
+            MethodArtifactRequest method => method with { Reader = reader },
+            PropertyGetterArtifactRequest getter => getter with { Reader = reader },
+            PropertySetterArtifactRequest setter => setter with { Reader = reader },
             _ => throw new ArgumentException($"Unknown artifact request type '{request.GetType().FullName}'.", nameof(request)),
         };
 


### PR DESCRIPTION
Advances #2673

- Adopts native C# and IL Finding comparisons through Research and product
  `ImplementationDiff`.
- Adds checksum-gated authored-source rebuild fidelity beside the independent
  decompiler lane.
- Adds opt-in authored `Source` as a peer product mechanism.
- Evidence revision: `f8ebc0b2`

## Change

> Should we accept these implementation-evidence lanes?

**Conclusion:** **PASS** — the product and harness now retain producer-owned
C#, IL, and authored Source evidence without blending checksum integrity,
decompiler fidelity, authored rebuild fidelity, determinism, or build-context
drift.

Before:

```text
ImplementationDiff reconstructed C#/IL rows after discarding native Finding
envelopes; authored SourceLink bytes could prove integrity but could not be
rebuilt or compared as product implementation evidence.
```

After:

```text
DiffFixtureSample.DiffSample.ConstantValue()
  IL      changed  ldc.i4 1 -> ldc.i4 2
  C#      changed  return 1 -> return 2
  Source  removed  public static int ConstantValue() => 1;
  Source  added    public static int ConstantValue() => 2;
```

## Scope and safety

- **Finding adoption:** Research retains native `csharp.line` and `il.op`
  comparisons, descriptor-gates them, and preserves one-sided, bodiless,
  `Absent`, and `Failed` outcomes.
- **Authored acquisition:** `DotnetInspector.Services` fetches and caches exact
  bytes, verifies SHA-1/SHA-256 portable-PDB checksums before decoding, and
  returns token-scoped member/document Finding envelopes.
- **Harness oracle:** authored A→IL substitutes only the target body into the
  same final RTS `ArtifactRequest`; the independent decompiled B→IL verdict is
  unchanged.
- **Product impact:** `diff -S "Implementation Diff" --authored-source` adds
  checksum-verified authored `Source` beside decompiled `CSharp` and shipped
  `IL`. Network acquisition is explicit; without the flag, existing C#/IL-only
  output is unchanged.
- **Boundary:** Services and Research remain network/Roslyn separated; Roslyn
  rebuild and body extraction stay in `DecompilerHarness`; inspected
  assemblies use SRM rather than runtime loading.

## Evidence

| Check | Result |
| --- | --- |
| Release solution build | Pass; 3 pre-existing Metadata nullable warnings |
| Product suite | 1,865 total; 1,855 passed, 10 expected tool skips |
| Services suite | 259 passed |
| Research suite | 106 passed |
| Authored rebuild focus | 16 passed |
| Product diff focus | 286 passed |
| Decompiler fast suite | 2,403 passed |
| Markdownlint | Pass |
| Real product Source witness | `ConstantValue`: 2 authored Source rows beside 3 decompiled C# and 2 IL rows |

## Oracle separation

Real SourceLink-backed run over
`DiffFixtureSample.ConstructorSample::get_Value`:

| Evidence lane | Verdict |
| --- | --- |
| PDB checksum integrity | `Exact` |
| Decompiled B→IL | `Exact` |
| Authored A→IL | `IlDifferent` |
| Deterministic build | `False` |
| Build context | `Drift` — compiler version differs from the current RTS compiler |

The authored mismatch is therefore reported as build/compiler drift, not a
decompiler defect and not an integrity failure.

## Compile-back quality

> Did this add a second oracle without weakening the first?

**Conclusion:** **PASS** — the authored body reuses the final typed RTS request
while keeping its verdict and context labels separate from decompiler
compile-back. This PR does not change importer, raise, typing, or printer
behavior, so render-text A/B and a decompiler quality-diff card are not
applicable.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Nondeterministic or compiler-drifted A→IL | Explicit context verdict | Not clean evidence of authored-source fidelity |
| Missing SourceLink coverage | `Absent` | Missing evidence is not a failure |
| Source acquisition/checksum error | `Failed` | Never rendered as a semantic change |
| Assembly-wide source-only census | Not added | Product enrichment is bounded to members already changed by C#/IL |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Clean on `f8ebc0b2` | Verified the whole PR, real SRM generic-interface names, 24 identity probes, cache repair, boundaries, and targeted tests |
| Gemini 3.1 Pro | Clean on `f8ebc0b2` | Verified constructed-generic, alias, ambiguity, cache, comparison, and lifetime adversarial cases |

Earlier rounds found and resolved:

1. Valid-Base64 cache poisoning could persist after checksum mismatch;
   `6aa335b9` now bypasses invalid memory/disk bytes, repairs from valid network
   bytes, and never caches an invalid network payload.
2. Source caches were not concurrency-safe; `deae7342` uses
   `ConcurrentDictionary`.
3. Authored extraction could miss or select neighboring explicit-interface
   declarations; `d66a637e` searches all members and preserves qualifiers.
4. Generic, qualified, alias, and same-name interface identities needed ranked
   matching; `3672851a` and `f8ebc0b2` add full-identity scoring, conservative
   ambiguity rejection, CLR generic-name normalization, and adversarial tests.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config
dotnet run --project src/DotnetInspector.Services.Tests -c Release --no-build
dotnet run --project src/ILInspector.Research.Tests -c Release --no-build
dotnet run --project src/dotnet-inspect.Tests -c Release --no-build
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- \
  -trait- "Speed=Slow"
npx markdownlint-cli README.md docs/design/implementation-diff.md \
  docs/design/source-finding-producers.md \
  docs/design/fact-planned-compile-back-harness.md \
  skills/compatibility/SKILL.md

dotnet run --project tools/DecompilerHarness -c Release --no-build -- \
  artifacts/bin/DiffFixtures.V1/release/DiffFixtureSample.dll \
  --authored-rebuild-fidelity --cap 1 --max-examples 3

dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll diff \
  --library artifacts/bin/DiffFixtures.V1/release/DiffFixtureSample.dll..artifacts/bin/DiffFixtures.V2/release/DiffFixtureSample.dll \
  -S "Implementation Diff" --authored-source \
  -t DiffSample -m ConstantValue
```
