### PR TITLE
Make Metadata signature rejection explicit

### DIFF
--- a/docs/metadata-primitives.md
+++ b/docs/metadata-primitives.md
@@ -79,6 +79,41 @@ helper is SRM-only. `Analysis` stays independent of `Metadata`.
   metadata *product* surface
 - each consumer's own `TypeRef`/IR model and its `ISignatureTypeProvider<T>`
 
+## Guarded string-signature decoding
+
+String-producing SRM decodes return `SignatureDecodeResult<T>`. `Decoded`
+carries the real field, method, property, method-spec, or TypeSpec value;
+`Rejected` carries a `SignatureDecodeRejectionKind` and detail. Rejection is
+never represented by a plausible `object` type, a default method signature, or
+an empty generic-argument list.
+
+Consumers fail closed according to their operation:
+
+- discovery and classification scanners skip the rejected member;
+- API-surface census construction projects a visible degraded row with
+  `SignatureDecodeStatus.Degraded`;
+- formatting helpers may throw `BadImageFormatException` through
+  `GetValueOrThrow` when their caller already owns a row-level failure boundary.
+
+This contract governs the shared string-signature decoder and is separate from
+the provider-specific `TypeNode` and semantic-tree paths guarded for stack
+safety under #2575. Those providers retain their own result and fallback
+policies.
+
+The safety envelope has two independent limits:
+
+- `SignatureBlobGuard.DefaultMaxDepth` is 512 structural type nodes within one
+  signature blob;
+- `TypeSpecGuard.MaxDepth` is 256 cross-handle TypeSpec re-entries, with
+  `TypeSpecGuard.MaxCumulativeBytes` fixed at 4,096 bytes across the active
+  TypeSpec closure.
+
+A single wide, shallow TypeSpec may consume the full 4,096-byte closure budget.
+There is no separate 1,024-byte per-blob cap. Both
+`GuardedSignatureText.TypeSpecText` and
+`TypeResolver.GetTypeNameFromSpecification` enter through the same
+`TypeSpecGuard`, so legal-input acceptance cannot vary by route.
+
 ## The key finding: it's an entangled cluster, used widely
 
 The shareable primitives are not independent functions — `TypeResolver` and

--- a/docs/metadata-primitives.md
+++ b/docs/metadata-primitives.md
@@ -111,8 +111,10 @@ The safety envelope has two independent limits:
 A single wide, shallow TypeSpec may consume the full 4,096-byte closure budget.
 There is no separate 1,024-byte per-blob cap. Both
 `GuardedSignatureText.TypeSpecText` and
-`TypeResolver.GetTypeNameFromSpecification` enter through the same
-`TypeSpecGuard`, so legal-input acceptance cannot vary by route.
+`TypeResolver.DecodeTypeNameFromSpecification` enter through the same
+`TypeSpecGuard`, so legal-input acceptance cannot vary by route. The
+compatibility API `GetTypeNameFromSpecification` returns a decoded value or
+throws on rejection; it does not restore a plausible fallback.
 
 ## The key finding: it's an entangled cluster, used widely
 

--- a/src/ILInspector.Decompiler.Tests/GuardedSignatureTextTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GuardedSignatureTextTests.cs
@@ -6,12 +6,12 @@ using ILInspector.Decompiler;
 namespace ILInspector.Decompiler.Tests;
 
 // GuardedSignatureText routes the compile-back / type-source composers' string-producing signature
-// decodes through SignatureBlobGuard, so a malformed deeply-nested signature degrades to a
-// placeholder type instead of overflowing the native stack inside SRM.
+// decodes through SignatureBlobGuard, so a malformed deeply-nested signature is rejected
+// explicitly instead of overflowing the native stack inside SRM.
 public class GuardedSignatureTextTests
 {
     [Fact]
-    public void DeepFieldSignature_DegradesToPlaceholder()
+    public void DeepFieldSignature_IsRejected()
     {
         // FIELD header then a 600-deep array (over the 512 guard limit).
         var sig = new BlobBuilder();
@@ -21,9 +21,11 @@ public class GuardedSignatureTextTests
         sig.WriteByte(0x08);     // I4
 
         var (reader, handle) = BuildField(sig);
-        var text = GuardedSignatureText.FieldText(reader, reader.GetFieldDefinition(handle), context: null);
-
-        Assert.Equal("object", text);
+        Assert.Throws<BadImageFormatException>(() =>
+            GuardedSignatureText.FieldText(
+                reader,
+                reader.GetFieldDefinition(handle),
+                context: null));
     }
 
     static (MetadataReader Reader, FieldDefinitionHandle Handle) BuildField(BlobBuilder sig)

--- a/src/ILInspector.Decompiler/GuardedSignatureText.cs
+++ b/src/ILInspector.Decompiler/GuardedSignatureText.cs
@@ -12,37 +12,36 @@ namespace ILInspector.Decompiler;
 /// deeply-nested or huge-count signature would overflow the native stack inside SRM's
 /// <c>SignatureDecoder</c> (an uncatchable <c>StackOverflowException</c>) or trigger a
 /// multi-gigabyte pre-allocation. <see cref="SignatureBlobGuard"/> detects both before decoding,
-/// so these helpers fail closed to an unresolved placeholder type (a parseable <c>object</c>)
-/// instead of crashing. Real signatures are shallow, so the guard only trips on malformed input.
+/// so these helpers reject the member instead of fabricating a parseable <c>object</c> signature.
+/// Real signatures are shallow, so the guard only trips on malformed input.
 /// </summary>
 internal static class GuardedSignatureText
 {
-    // A degraded but syntactically valid C# type keeps composed source parseable; a member whose
-    // signature could not be decoded is already un-reconstructable, so its exact text is moot.
-    const string Unresolved = "object";
-
     public static MethodSignature<string> MethodText(MetadataReader reader, MethodDefinition method, GenericContext? context)
-        => SignatureBlobGuard.IsSafeToDecode(reader, method.Signature, SignatureBlobGuard.Kind.Method)
-            ? method.DecodeSignature(SignatureDecoder.Instance, context)
-            : UnresolvedMethod;
+        => GuardedSignatureDecoder.Decode(
+            reader,
+            method.Signature,
+            SignatureBlobGuard.Kind.Method,
+            () => method.DecodeSignature(SignatureDecoder.Instance, context))
+            .GetValueOrThrow();
 
     public static MethodSignature<string> PropertyText(MetadataReader reader, PropertyDefinition property, GenericContext? context)
-        => SignatureBlobGuard.IsSafeToDecode(reader, property.Signature, SignatureBlobGuard.Kind.Method)
-            ? property.DecodeSignature(SignatureDecoder.Instance, context)
-            : UnresolvedMethod;
+        => GuardedSignatureDecoder.Decode(
+            reader,
+            property.Signature,
+            SignatureBlobGuard.Kind.Method,
+            () => property.DecodeSignature(SignatureDecoder.Instance, context))
+            .GetValueOrThrow();
 
     public static string FieldText(MetadataReader reader, FieldDefinition field, GenericContext? context)
-        => SignatureBlobGuard.IsSafeToDecode(reader, field.Signature, SignatureBlobGuard.Kind.Field)
-            ? field.DecodeSignature(SignatureDecoder.Instance, context)
-            : Unresolved;
+        => GuardedSignatureDecoder.Decode(
+            reader,
+            field.Signature,
+            SignatureBlobGuard.Kind.Field,
+            () => field.DecodeSignature(SignatureDecoder.Instance, context))
+            .GetValueOrThrow();
 
     public static string TypeSpecText(MetadataReader reader, TypeSpecificationHandle handle, GenericContext? context)
-    {
-        var spec = reader.GetTypeSpecification(handle);
-        return SignatureBlobGuard.IsSafeToDecode(reader, spec.Signature, SignatureBlobGuard.Kind.TypeSpecification)
-            ? spec.DecodeSignature(SignatureDecoder.Instance, context)
-            : Unresolved;
-    }
-
-    static readonly MethodSignature<string> UnresolvedMethod = new(default, Unresolved, 0, 0, []);
+        => TypeResolver.GetTypeNameFromSpecification(reader, handle, context)
+            .GetValueOrThrow();
 }

--- a/src/ILInspector.Decompiler/GuardedSignatureText.cs
+++ b/src/ILInspector.Decompiler/GuardedSignatureText.cs
@@ -42,6 +42,6 @@ internal static class GuardedSignatureText
             .GetValueOrThrow();
 
     public static string TypeSpecText(MetadataReader reader, TypeSpecificationHandle handle, GenericContext? context)
-        => TypeResolver.GetTypeNameFromSpecification(reader, handle, context)
+        => TypeResolver.DecodeTypeNameFromSpecification(reader, handle, context)
             .GetValueOrThrow();
 }

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -1509,8 +1509,11 @@ public static class ApiSurfaceExtractor
     private static string? GetFirstParameterType(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)
     {
         var context = GenericContext.ForMethod(reader, typeDef, method);
-        var signature = GuardedSignatureText.MethodText(reader, method, context);
-        return signature.ParameterTypes.Length > 0 ? signature.ParameterTypes[0] : null;
+        return GuardedSignatureText.MethodText(reader, method, context)
+            .TryGetValue(out var signature)
+                && signature.ParameterTypes.Length > 0
+                    ? signature.ParameterTypes[0]
+                    : null;
     }
 
     /// <summary>

--- a/src/ILInspector.Metadata/EcosystemIntegrationScanner.cs
+++ b/src/ILInspector.Metadata/EcosystemIntegrationScanner.cs
@@ -614,7 +614,8 @@ public static class EcosystemIntegrationScanner
             MethodSignature<string> signature;
             try
             {
-                signature = GuardedSignatureText.MethodText(reader, method, context);
+                signature = GuardedSignatureText.MethodText(reader, method, context)
+                    .GetValueOrThrow();
             }
             catch (BadImageFormatException)
             {

--- a/src/ILInspector.Metadata/ExtensionMethodScanner.cs
+++ b/src/ILInspector.Metadata/ExtensionMethodScanner.cs
@@ -125,7 +125,11 @@ public static class ExtensionMethodScanner
                 // Decode signature to get first parameter type
                 {
                     var context = GenericContext.ForMethod(reader, typeDef, method);
-                    var signature = GuardedSignatureText.MethodText(reader, method, context);
+                    if (!GuardedSignatureText.MethodText(reader, method, context)
+                        .TryGetValue(out var signature))
+                    {
+                        continue;
+                    }
                     if (signature.ParameterTypes.Length == 0) continue;
 
                     var extendedType = signature.ParameterTypes[0];
@@ -222,7 +226,11 @@ public static class ExtensionMethodScanner
 
                 {
                     var context = GenericContext.ForMethod(reader, typeDef, method);
-                    var signature = GuardedSignatureText.MethodText(reader, method, context);
+                    if (!GuardedSignatureText.MethodText(reader, method, context)
+                        .TryGetValue(out var signature))
+                    {
+                        continue;
+                    }
                     if (signature.ParameterTypes.Length == 0) continue;
 
                     var extendedType = signature.ParameterTypes[0];
@@ -331,7 +339,8 @@ public static class ExtensionMethodScanner
 
                     try
                     {
-                        var sig = GuardedSignatureText.PropertyText(reader, prop, context);
+                        var sig = GuardedSignatureText.PropertyText(reader, prop, context)
+                            .GetValueOrThrow();
                         var propType = UnwrapAsyncType(sig.ReturnType);
 
                         if (!string.IsNullOrEmpty(propType) && !IsPrimitiveType(propType) && visited.Add(propType))
@@ -360,7 +369,8 @@ public static class ExtensionMethodScanner
                     try
                     {
                         var methodContext = GenericContext.ForMethod(reader, typeDef, method);
-                        var sig = GuardedSignatureText.MethodText(reader, method, methodContext);
+                        var sig = GuardedSignatureText.MethodText(reader, method, methodContext)
+                            .GetValueOrThrow();
                         var retType = UnwrapAsyncType(sig.ReturnType);
 
                         if (!string.IsNullOrEmpty(retType) && retType != "void" &&
@@ -487,18 +497,24 @@ public static class ExtensionMethodScanner
                     continue;
 
                 var displayContext = GenericContext.ForType(reader, markerType);
-                var markerSignature = GuardedSignatureText.MethodText(
+                if (!GuardedSignatureText.MethodText(
                     reader,
                     markerMethod,
-                    displayContext);
+                    displayContext).TryGetValue(out var markerSignature))
+                {
+                    continue;
+                }
                 if (markerSignature.ParameterTypes.Length != 1)
                     throw new BadImageFormatException(
                         "An extension marker must have exactly one receiver parameter.");
 
-                var propertySignature = GuardedSignatureText.PropertyText(
+                if (!GuardedSignatureText.PropertyText(
                     reader,
                     property,
-                    displayContext);
+                    displayContext).TryGetValue(out var propertySignature))
+                {
+                    continue;
+                }
                 string propertyName = reader.GetString(property.Name);
                 string parameterText = propertySignature.ParameterTypes.Length == 0
                     ? ""
@@ -565,7 +581,8 @@ public static class ExtensionMethodScanner
         GenericContext? context)
     {
         string name = reader.GetString(method.Name);
-        var signature = GuardedSignatureText.MethodText(reader, method, context);
+        var signature = GuardedSignatureText.MethodText(reader, method, context)
+            .GetValueOrThrow();
 
         // First parameter is the extension receiver, rendered with a 'this ' prefix.
         return SignatureRenderer.RenderDecodedSignature(reader, method, name, signature, extensionThis: true);

--- a/src/ILInspector.Metadata/GuardedSignatureText.cs
+++ b/src/ILInspector.Metadata/GuardedSignatureText.cs
@@ -64,5 +64,5 @@ internal static class GuardedSignatureText
         MetadataReader reader,
         TypeSpecificationHandle handle,
         GenericContext? context)
-        => TypeResolver.GetTypeNameFromSpecification(reader, handle, context);
+        => TypeResolver.DecodeTypeNameFromSpecification(reader, handle, context);
 }

--- a/src/ILInspector.Metadata/GuardedSignatureText.cs
+++ b/src/ILInspector.Metadata/GuardedSignatureText.cs
@@ -4,149 +4,65 @@ using System.Reflection.Metadata;
 namespace ILInspector.Metadata;
 
 /// <summary>
-/// Top-level prescan gateway for string-producing signature decodes in Metadata.
-/// Nested TypeSpec re-entry is guarded by <see cref="SignatureDecoder"/>.
+/// Top-level result gateway for string-producing signature decodes in Metadata.
+/// Nested TypeSpec rejection is retained by <see cref="SignatureDecoder"/> and projected as a
+/// rejected result rather than a plausible signature value.
 /// </summary>
 internal static class GuardedSignatureText
 {
-    const string Unresolved = "object";
-    static readonly MethodSignature<string> UnresolvedMethod = new(default, Unresolved, 0, 0, []);
-
-    internal readonly record struct DecodeResult<T>(T Value, bool IsDegraded);
-
-    sealed class TrackingSignatureDecoder
-        : SignatureDecoder, ISignatureTypeProvider<string, GenericContext?>
-    {
-        public bool IsDegraded { get; private set; }
-
-        public T Reject<T>(T fallback)
-        {
-            IsDegraded = true;
-            return fallback;
-        }
-
-        string ISignatureTypeProvider<string, GenericContext?>.GetTypeFromSpecification(
-            MetadataReader reader,
-            GenericContext? context,
-            TypeSpecificationHandle handle,
-            byte rawTypeKind)
-        {
-            if (!TypeSpecGuard.TryEnter(reader, handle, out int blobLength))
-            {
-                IsDegraded = true;
-                return Unresolved;
-            }
-
-            try
-            {
-                return reader.GetTypeSpecification(handle).DecodeSignature(this, context);
-            }
-            finally
-            {
-                TypeSpecGuard.Exit(blobLength);
-            }
-        }
-    }
-
-    public static MethodSignature<string> MethodText(
+    public static SignatureDecodeResult<MethodSignature<string>> MethodText(
         MetadataReader reader,
         MethodDefinition method,
         GenericContext? context)
-        => SignatureBlobGuard.IsSafeToDecode(reader, method.Signature, SignatureBlobGuard.Kind.Method)
-            ? method.DecodeSignature(SignatureDecoder.Instance, context)
-            : UnresolvedMethod;
-
-    public static DecodeResult<MethodSignature<string>> MethodTextResult(
-        MetadataReader reader,
-        MethodDefinition method,
-        GenericContext? context)
-    {
-        var provider = new TrackingSignatureDecoder();
-        var signature = SignatureBlobGuard.IsSafeToDecode(
+        => GuardedSignatureDecoder.Decode(
             reader,
             method.Signature,
-            SignatureBlobGuard.Kind.Method)
-            ? method.DecodeSignature(provider, context)
-            : provider.Reject(UnresolvedMethod);
-        return new DecodeResult<MethodSignature<string>>(signature, provider.IsDegraded);
-    }
+            SignatureBlobGuard.Kind.Method,
+            () => method.DecodeSignature(SignatureDecoder.Instance, context));
 
-    public static MethodSignature<string> MemberRefMethodText(
+    public static SignatureDecodeResult<MethodSignature<string>> MemberRefMethodText(
         MetadataReader reader,
         MemberReference member,
         GenericContext? context)
-        => SignatureBlobGuard.IsSafeToDecode(reader, member.Signature, SignatureBlobGuard.Kind.Method)
-            ? member.DecodeMethodSignature(SignatureDecoder.Instance, context)
-            : UnresolvedMethod;
+        => GuardedSignatureDecoder.Decode(
+            reader,
+            member.Signature,
+            SignatureBlobGuard.Kind.Method,
+            () => member.DecodeMethodSignature(SignatureDecoder.Instance, context));
 
-    public static MethodSignature<string> PropertyText(
+    public static SignatureDecodeResult<MethodSignature<string>> PropertyText(
         MetadataReader reader,
         PropertyDefinition property,
         GenericContext? context)
-        => SignatureBlobGuard.IsSafeToDecode(reader, property.Signature, SignatureBlobGuard.Kind.Method)
-            ? property.DecodeSignature(SignatureDecoder.Instance, context)
-            : UnresolvedMethod;
-
-    public static DecodeResult<MethodSignature<string>> PropertyTextResult(
-        MetadataReader reader,
-        PropertyDefinition property,
-        GenericContext? context)
-    {
-        var provider = new TrackingSignatureDecoder();
-        var signature = SignatureBlobGuard.IsSafeToDecode(
+        => GuardedSignatureDecoder.Decode(
             reader,
             property.Signature,
-            SignatureBlobGuard.Kind.Method)
-            ? property.DecodeSignature(provider, context)
-            : provider.Reject(UnresolvedMethod);
-        return new DecodeResult<MethodSignature<string>>(signature, provider.IsDegraded);
-    }
+            SignatureBlobGuard.Kind.Method,
+            () => property.DecodeSignature(SignatureDecoder.Instance, context));
 
-    public static string FieldText(
+    public static SignatureDecodeResult<string> FieldText(
         MetadataReader reader,
         FieldDefinition field,
         GenericContext? context)
-        => SignatureBlobGuard.IsSafeToDecode(reader, field.Signature, SignatureBlobGuard.Kind.Field)
-            ? field.DecodeSignature(SignatureDecoder.Instance, context)
-            : Unresolved;
-
-    public static DecodeResult<string> FieldTextResult(
-        MetadataReader reader,
-        FieldDefinition field,
-        GenericContext? context)
-    {
-        var provider = new TrackingSignatureDecoder();
-        var type = SignatureBlobGuard.IsSafeToDecode(
+        => GuardedSignatureDecoder.Decode(
             reader,
             field.Signature,
-            SignatureBlobGuard.Kind.Field)
-            ? field.DecodeSignature(provider, context)
-            : provider.Reject(Unresolved);
-        return new DecodeResult<string>(type, provider.IsDegraded);
-    }
+            SignatureBlobGuard.Kind.Field,
+            () => field.DecodeSignature(SignatureDecoder.Instance, context));
 
-    public static ImmutableArray<string> MethodSpecTypeArgs(
+    public static SignatureDecodeResult<ImmutableArray<string>> MethodSpecTypeArgs(
         MetadataReader reader,
         MethodSpecification specification,
         GenericContext? context)
-        => SignatureBlobGuard.IsSafeToDecode(
+        => GuardedSignatureDecoder.Decode(
             reader,
             specification.Signature,
-            SignatureBlobGuard.Kind.MethodSpecification)
-            ? specification.DecodeSignature(SignatureDecoder.Instance, context)
-            : [];
+            SignatureBlobGuard.Kind.MethodSpecification,
+            () => specification.DecodeSignature(SignatureDecoder.Instance, context));
 
-    public static string TypeSpecText(
+    public static SignatureDecodeResult<string> TypeSpecText(
         MetadataReader reader,
         TypeSpecificationHandle handle,
         GenericContext? context)
-    {
-        var specification = reader.GetTypeSpecification(handle);
-        return SignatureBlobGuard.IsSafeToDecode(
-            reader,
-            specification.Signature,
-            SignatureBlobGuard.Kind.TypeSpecification)
-            ? specification.DecodeSignature(SignatureDecoder.Instance, context)
-            : Unresolved;
-    }
+        => TypeResolver.GetTypeNameFromSpecification(reader, handle, context);
 }

--- a/src/ILInspector.Metadata/ILTokenResolver.cs
+++ b/src/ILInspector.Metadata/ILTokenResolver.cs
@@ -110,7 +110,8 @@ public static class ILTokenResolver
 
         try
         {
-            var sig = GuardedSignatureText.MethodText(reader, method, context: null);
+            var sig = GuardedSignatureText.MethodText(reader, method, context: null)
+                .GetValueOrThrow();
             return $"{baseName}({string.Join(", ", sig.ParameterTypes)})";
         }
         catch
@@ -131,7 +132,8 @@ public static class ILTokenResolver
             if (memberRef.GetKind() == MemberReferenceKind.Method)
             {
                 var genericCtx = BuildGenericContext(reader, memberRef);
-                var sig = GuardedSignatureText.MemberRefMethodText(reader, memberRef, genericCtx);
+                var sig = GuardedSignatureText.MemberRefMethodText(reader, memberRef, genericCtx)
+                    .GetValueOrThrow();
                 return $"{baseName}({string.Join(", ", sig.ParameterTypes)})";
             }
         }
@@ -155,7 +157,8 @@ public static class ILTokenResolver
 
         try
         {
-            var typeArgs = GuardedSignatureText.MethodSpecTypeArgs(reader, spec, context: null);
+            var typeArgs = GuardedSignatureText.MethodSpecTypeArgs(reader, spec, context: null)
+                .GetValueOrThrow();
             return $"{baseName}<{string.Join(", ", typeArgs)}>";
         }
         catch
@@ -182,7 +185,10 @@ public static class ILTokenResolver
         {
             if (memberRef.Parent.Kind == HandleKind.TypeSpecification)
             {
-                var parentType = GuardedSignatureText.TypeSpecText(reader, (TypeSpecificationHandle)memberRef.Parent, context: null);
+                var parentType = GuardedSignatureText.TypeSpecText(
+                    reader,
+                    (TypeSpecificationHandle)memberRef.Parent,
+                    context: null).GetValueOrThrow();
                 var typeArgs = ExtractGenericArguments(parentType);
                 if (typeArgs.Count > 0)
                     return new GenericContext(typeArgs, []);

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -60,6 +60,10 @@ public sealed record MetadataFieldDeclaration(
 /// </summary>
 public static class MetadataDeclarationQuery
 {
+    const string DegradedType = "object";
+    static readonly MethodSignature<string> DegradedMethodSignature =
+        new(default, DegradedType, requiredParameterCount: 0, genericParameterCount: 0, []);
+
     public static ApiType GetTypeSurface(
         MetadataReader reader,
         TypeDefinitionHandle typeHandle,
@@ -201,10 +205,14 @@ public static class MetadataDeclarationQuery
         TypeDefinition typeDef,
         MethodDefinition method)
     {
-        var result = GuardedSignatureText.MethodTextResult(reader, method, GenericContext.ForMethod(reader, typeDef, method));
-        return GetMethod(reader, typeDef, method, result.Value) with
+        var result = GuardedSignatureText.MethodText(
+            reader,
+            method,
+            GenericContext.ForMethod(reader, typeDef, method));
+        var signature = ProjectDecode(result, DegradedMethodSignature, out var status);
+        return GetMethod(reader, typeDef, method, signature) with
         {
-            SignatureDecodeStatus = DecodeStatus(result.IsDegraded),
+            SignatureDecodeStatus = status,
         };
     }
 
@@ -213,7 +221,11 @@ public static class MetadataDeclarationQuery
         TypeDefinition typeDef,
         MethodDefinition method)
     {
-        var signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, typeDef, method));
+        var signature = GuardedSignatureText.MethodText(
+            reader,
+            method,
+            GenericContext.ForMethod(reader, typeDef, method))
+            .GetValueOrThrow();
         return FormatMethodReturnType(reader, signature.ReturnType, method.GetParameters());
     }
 
@@ -266,9 +278,24 @@ public static class MetadataDeclarationQuery
         TypeDefinition typeDef,
         PropertyDefinition property)
     {
+        var result = GuardedSignatureText.PropertyText(
+            reader,
+            property,
+            GenericContext.ForType(reader, typeDef));
+        var signature = ProjectDecode(result, DegradedMethodSignature, out var status);
+        return GetProperty(reader, typeDef, property, signature) with
+        {
+            SignatureDecodeStatus = status,
+        };
+    }
+
+    static MetadataPropertyDeclaration GetProperty(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        PropertyDefinition property,
+        MethodSignature<string> signature)
+    {
         var accessors = property.GetAccessors();
-        var result = GuardedSignatureText.PropertyTextResult(reader, property, GenericContext.ForType(reader, typeDef));
-        var signature = result.Value;
         var getter = accessors.Getter.IsNil ? default : reader.GetMethodDefinition(accessors.Getter);
         var setter = accessors.Setter.IsNil ? default : reader.GetMethodDefinition(accessors.Setter);
 
@@ -340,10 +367,7 @@ public static class MetadataDeclarationQuery
             },
             RenderMemberAttributes(reader, property.GetCustomAttributes()),
             accessors.Getter,
-            accessors.Setter)
-        {
-            SignatureDecodeStatus = DecodeStatus(result.IsDegraded),
-        };
+            accessors.Setter);
     }
 
     public static MetadataFieldDeclaration GetField(
@@ -351,9 +375,25 @@ public static class MetadataDeclarationQuery
         TypeDefinition typeDef,
         FieldDefinition field)
     {
+        var result = GuardedSignatureText.FieldText(
+            reader,
+            field,
+            GenericContext.ForType(reader, typeDef));
+        var fieldType = ProjectDecode(result, DegradedType, out var status);
+        return GetField(reader, typeDef, field, fieldType) with
+        {
+            SignatureDecodeStatus = status,
+        };
+    }
+
+    static MetadataFieldDeclaration GetField(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        FieldDefinition field,
+        string fieldType)
+    {
         var attributes = field.Attributes;
         var access = attributes & FieldAttributes.FieldAccessMask;
-        var result = GuardedSignatureText.FieldTextResult(reader, field, GenericContext.ForType(reader, typeDef));
         return new MetadataFieldDeclaration(
             reader.GetString(field.Name),
             EscapeIdentifier(reader.GetString(field.Name)),
@@ -361,11 +401,8 @@ public static class MetadataDeclarationQuery
             (attributes & FieldAttributes.Static) != 0,
             (attributes & FieldAttributes.InitOnly) != 0,
             (attributes & FieldAttributes.Literal) != 0,
-            result.Value,
-            RenderMemberAttributes(reader, field.GetCustomAttributes()))
-        {
-            SignatureDecodeStatus = DecodeStatus(result.IsDegraded),
-        };
+            fieldType,
+            RenderMemberAttributes(reader, field.GetCustomAttributes()));
     }
 
     /// <summary>
@@ -680,7 +717,12 @@ public static class MetadataDeclarationQuery
         {
             HandleKind.TypeDefinition => TypeResolver.GetFullName(reader, reader.GetTypeDefinition((TypeDefinitionHandle)handle)),
             HandleKind.TypeReference => TypeResolver.GetTypeNameFromReference(reader, (TypeReferenceHandle)handle),
-            HandleKind.TypeSpecification => GuardedSignatureText.TypeSpecText(reader, (TypeSpecificationHandle)handle, context),
+            HandleKind.TypeSpecification => GuardedSignatureText.TypeSpecText(
+                reader,
+                (TypeSpecificationHandle)handle,
+                context).TryGetValue(out var typeName)
+                    ? typeName
+                    : null,
             _ => null,
         };
 
@@ -739,8 +781,21 @@ public static class MetadataDeclarationQuery
     static string? NonPublicAccessibility(string accessibility)
         => accessibility == "public" ? null : accessibility;
 
-    static SignatureDecodeStatus? DecodeStatus(bool isDegraded)
-        => isDegraded ? SignatureDecodeStatus.Degraded : null;
+    static T ProjectDecode<T>(
+        SignatureDecodeResult<T> result,
+        T degradedValue,
+        out SignatureDecodeStatus? status)
+        where T : notnull
+    {
+        if (result.TryGetValue(out var value))
+        {
+            status = null;
+            return value;
+        }
+
+        status = SignatureDecodeStatus.Degraded;
+        return degradedValue;
+    }
 
     static (string? Namespace, string Name) GetApiTypeNameParts(MetadataReader reader, TypeDefinition typeDef)
     {

--- a/src/ILInspector.Metadata/MethodClassificationScanner.cs
+++ b/src/ILInspector.Metadata/MethodClassificationScanner.cs
@@ -165,7 +165,8 @@ public static class MethodClassificationScanner
                 try
                 {
                     var context = GenericContext.ForMethod(reader, typeDef, method);
-                    var sig = GuardedSignatureText.MethodText(reader, method, context);
+                    var sig = GuardedSignatureText.MethodText(reader, method, context)
+                        .GetValueOrThrow();
                     if (HasPointerType(sig))
                     {
                         var signature = SignatureRenderer.RenderDecodedSignature(reader, method, methodName, sig);
@@ -255,7 +256,8 @@ public static class MethodClassificationScanner
         try
         {
             var context = GenericContext.ForMethod(reader, typeDef, method);
-            var sig = GuardedSignatureText.MethodText(reader, method, context);
+            var sig = GuardedSignatureText.MethodText(reader, method, context)
+                .GetValueOrThrow();
             string methodName = reader.GetString(method.Name);
             return SignatureRenderer.RenderDecodedSignature(reader, method, methodName, sig);
         }

--- a/src/ILInspector.Metadata/OpenTelemetryScanner.cs
+++ b/src/ILInspector.Metadata/OpenTelemetryScanner.cs
@@ -88,7 +88,8 @@ public static class OpenTelemetryScanner
 
                 try
                 {
-                    var signature = GuardedSignatureText.PropertyText(reader, property, context);
+                    var signature = GuardedSignatureText.PropertyText(reader, property, context)
+                        .GetValueOrThrow();
                     if (signature.ReturnType != "bool")
                         continue;
                 }
@@ -132,7 +133,8 @@ public static class OpenTelemetryScanner
                 try
                 {
                     var context = GenericContext.ForMethod(metadataReader, typeDefinition, method);
-                    signature = GuardedSignatureText.MethodText(metadataReader, method, context);
+                    signature = GuardedSignatureText.MethodText(metadataReader, method, context)
+                        .GetValueOrThrow();
                 }
                 catch (BadImageFormatException)
                 {
@@ -256,7 +258,8 @@ public static class OpenTelemetryScanner
 
             try
             {
-                if (GuardedSignatureText.PropertyText(reader, property, context).ReturnType == "bool")
+                if (GuardedSignatureText.PropertyText(reader, property, context)
+                    .GetValueOrThrow().ReturnType == "bool")
                     return true;
             }
             catch (BadImageFormatException)
@@ -292,7 +295,8 @@ public static class OpenTelemetryScanner
             try
             {
                 var context = GenericContext.ForMethod(reader, typeDefinition, method);
-                var signature = GuardedSignatureText.MethodText(reader, method, context);
+                var signature = GuardedSignatureText.MethodText(reader, method, context)
+                    .GetValueOrThrow();
                 if (TryClassifyTelemetryBuilderMethod(signature, out _))
                     return true;
             }

--- a/src/ILInspector.Metadata/PdbContext.cs
+++ b/src/ILInspector.Metadata/PdbContext.cs
@@ -622,7 +622,8 @@ public class PdbContext : IDisposable
         try
         {
             var context = GenericContext.ForMethod(reader, type, method);
-            var signature = GuardedSignatureText.MethodText(reader, method, context);
+            var signature = GuardedSignatureText.MethodText(reader, method, context)
+                .GetValueOrThrow();
             return SignatureRenderer.RenderDecodedSignature(reader, method, methodName, signature);
         }
         catch

--- a/src/ILInspector.Metadata/UnionTypeScanner.cs
+++ b/src/ILInspector.Metadata/UnionTypeScanner.cs
@@ -69,7 +69,11 @@ public static class UnionTypeScanner
             MethodSignature<string> signature;
             try
             {
-                signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, typeDef, method));
+                signature = GuardedSignatureText.MethodText(
+                    reader,
+                    method,
+                    GenericContext.ForMethod(reader, typeDef, method))
+                    .GetValueOrThrow();
             }
             catch
             {

--- a/src/ILInspector.MetadataPrimitives/SignatureBlobGuard.cs
+++ b/src/ILInspector.MetadataPrimitives/SignatureBlobGuard.cs
@@ -16,7 +16,7 @@ namespace ILInspector.Metadata;
 ///
 /// This guard walks the blob *iteratively* (an explicit heap work-stack, never the native stack),
 /// computing the maximum type-nesting depth, and reports whether it exceeds a safe limit so the
-/// caller can fail closed (skip the decode and degrade to an unresolved shape) instead of crashing.
+/// caller can fail closed with an explicit rejection instead of crashing.
 /// A raw blob-length cap is deliberately avoided: a legitimately <i>wide</i> method signature (many
 /// parameters or generic arguments) is long but structurally shallow, so length would false-reject
 /// real code. Depth does not.

--- a/src/ILInspector.MetadataPrimitives/SignatureDecodeResult.cs
+++ b/src/ILInspector.MetadataPrimitives/SignatureDecodeResult.cs
@@ -108,15 +108,13 @@ public static class GuardedSignatureDecoder
         where T : notnull
     {
         ArgumentNullException.ThrowIfNull(decode);
-        if (!SignatureBlobGuard.IsSafeToDecode(reader, signature, kind))
-        {
-            return new SignatureDecodeResult<T>.Rejected(
-                new SignatureDecodeRejection(
+        return SignatureDecoder.Decode(
+            decode,
+            () => SignatureBlobGuard.IsSafeToDecode(reader, signature, kind)
+                ? null
+                : new SignatureDecodeRejection(
                     SignatureDecodeRejectionKind.UnsafeStructure,
                     $"The {kind} signature exceeds the structural safety limit."));
-        }
-
-        return SignatureDecoder.Decode(decode);
     }
 
     /// <summary>

--- a/src/ILInspector.MetadataPrimitives/SignatureDecodeResult.cs
+++ b/src/ILInspector.MetadataPrimitives/SignatureDecodeResult.cs
@@ -1,0 +1,157 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata;
+
+/// <summary>Why a guarded string-signature decode did not produce a value.</summary>
+public enum SignatureDecodeRejectionKind
+{
+    /// <summary>The iterative prescan found unsafe structural depth or counts.</summary>
+    UnsafeStructure,
+
+    /// <summary>The active TypeSpec closure exceeded its depth or cumulative-byte budget.</summary>
+    TypeSpecificationBudget,
+
+    /// <summary>SRM rejected malformed metadata during the bounded decode.</summary>
+    MalformedMetadata,
+}
+
+/// <summary>Inspectable detail for a rejected guarded signature decode.</summary>
+public sealed record SignatureDecodeRejection
+{
+    public SignatureDecodeRejection(
+        SignatureDecodeRejectionKind kind,
+        string detail)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(detail);
+        Kind = kind;
+        Detail = detail;
+    }
+
+    public SignatureDecodeRejectionKind Kind { get; }
+    public string Detail { get; }
+}
+
+/// <summary>
+/// The outcome of a guarded string-signature decode. A rejected decode never carries a
+/// success-shaped placeholder.
+/// </summary>
+public abstract record SignatureDecodeResult<T>
+    where T : notnull
+{
+    private protected SignatureDecodeResult()
+    {
+    }
+
+    /// <summary>The signature decoded successfully.</summary>
+    public sealed record Decoded : SignatureDecodeResult<T>
+    {
+        public Decoded(T value)
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            Value = value;
+        }
+
+        public T Value { get; }
+    }
+
+    /// <summary>The signature was rejected before a trustworthy value could be produced.</summary>
+    public sealed record Rejected : SignatureDecodeResult<T>
+    {
+        public Rejected(SignatureDecodeRejection rejection)
+        {
+            ArgumentNullException.ThrowIfNull(rejection);
+            Rejection = rejection;
+        }
+
+        public SignatureDecodeRejection Rejection { get; }
+    }
+
+    /// <summary>Returns whether this outcome carries a decoded value.</summary>
+    public bool TryGetValue([MaybeNullWhen(false)] out T value)
+    {
+        if (this is Decoded decoded)
+        {
+            value = decoded.Value;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the decoded value or throws <see cref="BadImageFormatException"/> at a caller-owned
+    /// failure boundary.
+    /// </summary>
+    public T GetValueOrThrow()
+        => this switch
+        {
+            Decoded decoded => decoded.Value,
+            Rejected rejected => throw new BadImageFormatException(
+                $"Signature decode rejected ({rejected.Rejection.Kind}): "
+                + rejected.Rejection.Detail),
+            _ => throw new InvalidOperationException(
+                "Unknown signature decode result."),
+        };
+}
+
+/// <summary>Shared guarded entry points for string-producing SRM signature decodes.</summary>
+public static class GuardedSignatureDecoder
+{
+    /// <summary>Prescans and decodes a field, method, property, or method-spec signature.</summary>
+    public static SignatureDecodeResult<T> Decode<T>(
+        MetadataReader reader,
+        BlobHandle signature,
+        SignatureBlobGuard.Kind kind,
+        Func<T> decode)
+        where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(decode);
+        if (!SignatureBlobGuard.IsSafeToDecode(reader, signature, kind))
+        {
+            return new SignatureDecodeResult<T>.Rejected(
+                new SignatureDecodeRejection(
+                    SignatureDecodeRejectionKind.UnsafeStructure,
+                    $"The {kind} signature exceeds the structural safety limit."));
+        }
+
+        return SignatureDecoder.Decode(decode);
+    }
+
+    /// <summary>
+    /// Decodes a TypeSpec through the same cross-handle depth and cumulative-byte envelope used by
+    /// nested string-provider re-entry.
+    /// </summary>
+    public static SignatureDecodeResult<string> DecodeTypeSpecification(
+        MetadataReader reader,
+        TypeSpecificationHandle handle,
+        GenericContext? context = null)
+        => SignatureDecoder.Decode(() =>
+        {
+            if (!TypeSpecGuard.TryEnter(
+                reader,
+                handle,
+                out int blobLength,
+                out var rejectionKind))
+            {
+                SignatureDecoder.Reject(
+                    new SignatureDecodeRejection(
+                        rejectionKind,
+                        rejectionKind == SignatureDecodeRejectionKind.UnsafeStructure
+                            ? "The TypeSpec exceeds the structural safety limit."
+                            : "The TypeSpec exceeds the re-entry depth or cumulative-byte budget."));
+                return "object";
+            }
+
+            try
+            {
+                return reader.GetTypeSpecification(handle)
+                    .DecodeSignature(SignatureDecoder.Instance, context);
+            }
+            finally
+            {
+                TypeSpecGuard.Exit(blobLength);
+            }
+        });
+}

--- a/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
+++ b/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
@@ -11,6 +11,9 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
 {
     const string Unresolved = "object";
 
+    [ThreadStatic]
+    static SignatureDecodeRejection? s_rejection;
+
     /// <summary>
     /// Shared instance for common use cases.
     /// </summary>
@@ -47,8 +50,20 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
 
     public string GetTypeFromSpecification(MetadataReader reader, GenericContext? context, TypeSpecificationHandle handle, byte rawTypeKind)
     {
-        if (!TypeSpecGuard.TryEnter(reader, handle, out int blobLength))
+        if (!TypeSpecGuard.TryEnter(
+            reader,
+            handle,
+            out int blobLength,
+            out var rejectionKind))
+        {
+            Reject(
+                new SignatureDecodeRejection(
+                    rejectionKind,
+                    rejectionKind == SignatureDecodeRejectionKind.UnsafeStructure
+                        ? "A nested TypeSpec exceeds the structural safety limit."
+                        : "A nested TypeSpec exceeds the re-entry depth or cumulative-byte budget."));
             return Unresolved;
+        }
         try
         {
             return reader.GetTypeSpecification(handle).DecodeSignature(this, context);
@@ -58,6 +73,46 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
             TypeSpecGuard.Exit(blobLength);
         }
     }
+
+    internal static SignatureDecodeResult<T> Decode<T>(Func<T> decode)
+        where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(decode);
+        var previousRejection = s_rejection;
+        s_rejection = null;
+        try
+        {
+            T value = decode();
+            return s_rejection is null
+                ? new SignatureDecodeResult<T>.Decoded(value)
+                : new SignatureDecodeResult<T>.Rejected(s_rejection);
+        }
+        catch (BadImageFormatException ex)
+        {
+            return Malformed<T>(ex);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            return Malformed<T>(ex);
+        }
+        finally
+        {
+            s_rejection = previousRejection;
+        }
+    }
+
+    internal static void Reject(SignatureDecodeRejection rejection)
+    {
+        ArgumentNullException.ThrowIfNull(rejection);
+        s_rejection ??= rejection;
+    }
+
+    static SignatureDecodeResult<T> Malformed<T>(Exception exception)
+        where T : notnull
+        => new SignatureDecodeResult<T>.Rejected(
+            new SignatureDecodeRejection(
+                SignatureDecodeRejectionKind.MalformedMetadata,
+                exception.Message));
 
     public string GetSZArrayType(string elementType) => $"{elementType}[]";
     

--- a/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
+++ b/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
@@ -74,7 +74,9 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
         }
     }
 
-    internal static SignatureDecodeResult<T> Decode<T>(Func<T> decode)
+    internal static SignatureDecodeResult<T> Decode<T>(
+        Func<T> decode,
+        Func<SignatureDecodeRejection?>? preflight = null)
         where T : notnull
     {
         ArgumentNullException.ThrowIfNull(decode);
@@ -82,6 +84,9 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
         s_rejection = null;
         try
         {
+            if (preflight?.Invoke() is { } preflightRejection)
+                return new SignatureDecodeResult<T>.Rejected(preflightRejection);
+
             T value = decode();
             return s_rejection is null
                 ? new SignatureDecodeResult<T>.Decoded(value)

--- a/src/ILInspector.MetadataPrimitives/TypeResolver.cs
+++ b/src/ILInspector.MetadataPrimitives/TypeResolver.cs
@@ -20,7 +20,7 @@ public static class TypeResolver
         {
             HandleKind.TypeReference => GetTypeNameFromReference(reader, (TypeReferenceHandle)handle),
             HandleKind.TypeDefinition => GetTypeNameFromDefinition(reader, (TypeDefinitionHandle)handle),
-            HandleKind.TypeSpecification => GetTypeNameFromSpecification(
+            HandleKind.TypeSpecification => DecodeTypeNameFromSpecification(
                 reader,
                 (TypeSpecificationHandle)handle,
                 context).TryGetValue(out var name)
@@ -53,9 +53,18 @@ public static class TypeResolver
         => GetFullName(reader, reader.GetTypeDefinition(handle));
 
     /// <summary>
+    /// Gets the type name from a TypeSpecification handle (generic instantiations).
+    /// </summary>
+    public static string GetTypeNameFromSpecification(
+        MetadataReader reader,
+        TypeSpecificationHandle handle,
+        GenericContext? context = null)
+        => DecodeTypeNameFromSpecification(reader, handle, context).GetValueOrThrow();
+
+    /// <summary>
     /// Gets the guarded decode outcome for a TypeSpecification handle (generic instantiations).
     /// </summary>
-    public static SignatureDecodeResult<string> GetTypeNameFromSpecification(
+    public static SignatureDecodeResult<string> DecodeTypeNameFromSpecification(
         MetadataReader reader,
         TypeSpecificationHandle handle,
         GenericContext? context = null)

--- a/src/ILInspector.MetadataPrimitives/TypeResolver.cs
+++ b/src/ILInspector.MetadataPrimitives/TypeResolver.cs
@@ -20,7 +20,12 @@ public static class TypeResolver
         {
             HandleKind.TypeReference => GetTypeNameFromReference(reader, (TypeReferenceHandle)handle),
             HandleKind.TypeDefinition => GetTypeNameFromDefinition(reader, (TypeDefinitionHandle)handle),
-            HandleKind.TypeSpecification => GetTypeNameFromSpecification(reader, (TypeSpecificationHandle)handle, context),
+            HandleKind.TypeSpecification => GetTypeNameFromSpecification(
+                reader,
+                (TypeSpecificationHandle)handle,
+                context).TryGetValue(out var name)
+                    ? name
+                    : null,
             _ => null
         };
     }
@@ -48,21 +53,13 @@ public static class TypeResolver
         => GetFullName(reader, reader.GetTypeDefinition(handle));
 
     /// <summary>
-    /// Gets the type name from a TypeSpecification handle (generic instantiations).
+    /// Gets the guarded decode outcome for a TypeSpecification handle (generic instantiations).
     /// </summary>
-    public static string GetTypeNameFromSpecification(MetadataReader reader, TypeSpecificationHandle handle, GenericContext? context = null)
-    {
-        if (!TypeSpecGuard.TryEnter(reader, handle, out int blobLength))
-            return "object";
-        try
-        {
-            return reader.GetTypeSpecification(handle).DecodeSignature(SignatureDecoder.Instance, context);
-        }
-        finally
-        {
-            TypeSpecGuard.Exit(blobLength);
-        }
-    }
+    public static SignatureDecodeResult<string> GetTypeNameFromSpecification(
+        MetadataReader reader,
+        TypeSpecificationHandle handle,
+        GenericContext? context = null)
+        => GuardedSignatureDecoder.DecodeTypeSpecification(reader, handle, context);
 
     /// <summary>
     /// Gets the full name of a type definition (Namespace.Name), qualifying a

--- a/src/ILInspector.MetadataPrimitives/TypeSpecGuard.cs
+++ b/src/ILInspector.MetadataPrimitives/TypeSpecGuard.cs
@@ -9,9 +9,14 @@ namespace ILInspector.Metadata;
 /// </summary>
 public static class TypeSpecGuard
 {
-    const int MaxBlobLength = 1024;
-    const int MaxCumulativeBytes = 4096;
-    const int MaxDepth = 256;
+    /// <summary>
+    /// Maximum bytes across the active TypeSpec re-entry closure. A single wide,
+    /// shallow TypeSpec may use the entire budget.
+    /// </summary>
+    public const int MaxCumulativeBytes = 4096;
+
+    /// <summary>Maximum cross-handle TypeSpec re-entry depth.</summary>
+    public const int MaxDepth = 256;
 
     [ThreadStatic]
     static int s_cumulativeBytes;
@@ -20,23 +25,41 @@ public static class TypeSpecGuard
     static int s_depth;
 
     public static bool TryEnter(MetadataReader reader, TypeSpecificationHandle handle, out int blobLength)
+        => TryEnter(reader, handle, out blobLength, out _);
+
+    internal static bool TryEnter(
+        MetadataReader reader,
+        TypeSpecificationHandle handle,
+        out int blobLength,
+        out SignatureDecodeRejectionKind rejectionKind)
     {
         blobLength = 0;
         if (s_depth >= MaxDepth)
+        {
+            rejectionKind = SignatureDecodeRejectionKind.TypeSpecificationBudget;
             return false;
+        }
 
         var signature = reader.GetTypeSpecification(handle).Signature;
         int length = reader.GetBlobReader(signature).Length;
-        if (length > MaxBlobLength
-            || s_cumulativeBytes + length > MaxCumulativeBytes
-            || !SignatureBlobGuard.IsSafeToDecode(reader, signature, SignatureBlobGuard.Kind.TypeSpecification))
+        if ((long)s_cumulativeBytes + length > MaxCumulativeBytes)
         {
+            rejectionKind = SignatureDecodeRejectionKind.TypeSpecificationBudget;
+            return false;
+        }
+        if (!SignatureBlobGuard.IsSafeToDecode(
+            reader,
+            signature,
+            SignatureBlobGuard.Kind.TypeSpecification))
+        {
+            rejectionKind = SignatureDecodeRejectionKind.UnsafeStructure;
             return false;
         }
 
         s_depth++;
         s_cumulativeBytes += length;
         blobLength = length;
+        rejectionKind = default;
         return true;
     }
 

--- a/tests/ILInspector.Metadata.Tests/ProviderSignatureDecodeBoundaryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ProviderSignatureDecodeBoundaryTests.cs
@@ -10,11 +10,12 @@ namespace ILInspector.Metadata.Tests;
 /// stack for every nested element <em>before</em> the first provider callback,
 /// so a single over-deep blob overflows the stack in a way no managed
 /// <c>try/catch</c> can contain. Every top-level provider decode must therefore
-/// be prescanned with <c>SignatureBlobGuard.IsSafeToDecode</c>, and every nested
-/// cross-handle TypeSpec re-entry must be bounded by <c>TypeSpecGuard</c>.
+/// be prescanned with <c>SignatureBlobGuard.IsSafeToDecode</c> or enter through
+/// <c>GuardedSignatureDecoder</c>, and every nested cross-handle TypeSpec
+/// re-entry must be bounded by <c>TypeSpecGuard</c>.
 ///
 /// This census is a deny-list: any <c>Decode*Signature</c> invocation that is
-/// not one of the two sanctioned guarded forms is a violation. A newly added
+/// not one of the three sanctioned guarded forms is a violation. A newly added
 /// provider, an un-gated site, or a decode routed through a local alias fails
 /// this test rather than shipping an unguarded same-mechanism hole. This is the
 /// anti-ratchet closure proof.
@@ -68,7 +69,9 @@ public class ProviderSignatureDecodeBoundaryTests
                 // delegate reference, or a call whose name node is not the invoked
                 // member — is an unguarded escape and a violation.
                 if (TryGetInvokedDecode(name, out var invocation)
-                    && (IsNestedTypeSpecReentry(invocation) || IsPrescanGuardedTernary(invocation)))
+                    && (IsNestedTypeSpecReentry(invocation)
+                        || IsPrescanGuardedTernary(invocation)
+                        || IsGuardedSignatureDecoderGateway(invocation)))
                 {
                     // Sanctioned form 1: a nested cross-handle TypeSpec re-entry,
                     // `reader.GetTypeSpecification(handle).Decode*Signature(...)`,
@@ -77,6 +80,9 @@ public class ProviderSignatureDecodeBoundaryTests
                     // Sanctioned form 2: the decode is the true-branch of a
                     // `SignatureBlobGuard.IsSafeToDecode(reader, <recv>.Signature,
                     // ...) ? decode : fallback` prescan ternary.
+                    // Sanctioned form 3: the decode is the value factory of
+                    // `GuardedSignatureDecoder.Decode(reader, <recv>.Signature,
+                    // ..., () => decode)`, bound to the same signature blob.
                     continue;
                 }
 
@@ -88,7 +94,8 @@ public class ProviderSignatureDecodeBoundaryTests
         Assert.True(
             violations.Count == 0,
             "Every top-level provider signature decode must be the true-branch of a "
-            + "SignatureBlobGuard.IsSafeToDecode prescan ternary or a "
+            + "SignatureBlobGuard.IsSafeToDecode prescan ternary, the value factory "
+            + "of a matching GuardedSignatureDecoder.Decode call, or a "
             + "TypeSpecGuard-bounded nested GetTypeSpecification re-entry. "
             + "Unguarded raw decodes:\n  " + string.Join("\n  ", violations));
     }
@@ -212,6 +219,34 @@ public class ProviderSignatureDecodeBoundaryTests
                     a.Expression is MemberAccessExpressionSyntax blob
                     && blob.Name.Identifier.Text == "Signature"
                     && blob.Expression.ToString() == decodeReceiver));
+
+    // `GuardedSignatureDecoder.Decode(reader, <recv>.Signature, ..., () =>
+    // <recv>.Decode*Signature(...))`: the decode must be inside the supplied
+    // value factory and the gateway must prescan the same receiver's blob.
+    static bool IsGuardedSignatureDecoderGateway(InvocationExpressionSyntax invocation)
+    {
+        if (invocation.Expression is not MemberAccessExpressionSyntax decodeMember)
+            return false;
+        var decodeReceiver = decodeMember.Expression.ToString();
+
+        var valueFactory = invocation.Ancestors()
+            .OfType<AnonymousFunctionExpressionSyntax>()
+            .FirstOrDefault();
+        if (valueFactory?.Parent is not ArgumentSyntax valueArgument
+            || valueArgument.Parent?.Parent is not InvocationExpressionSyntax gateway
+            || gateway.Expression is not MemberAccessExpressionSyntax gatewayMember
+            || gatewayMember.Name.Identifier.Text != "Decode"
+            || gatewayMember.Expression is not IdentifierNameSyntax gatewayType
+            || gatewayType.Identifier.Text != "GuardedSignatureDecoder")
+        {
+            return false;
+        }
+
+        return gateway.ArgumentList.Arguments.Any(a =>
+            a.Expression is MemberAccessExpressionSyntax blob
+            && blob.Name.Identifier.Text == "Signature"
+            && blob.Expression.ToString() == decodeReceiver);
+    }
 
     static IEnumerable<string> EnumerateSourceFiles(string root)
     {

--- a/tests/ILInspector.Metadata.Tests/SignatureDecoderSafetyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SignatureDecoderSafetyTests.cs
@@ -116,11 +116,11 @@ public class SignatureDecoderSafetyTests
             signature.WriteByte(0x08); // I4
         });
 
-        Assert.Equal(
-            "int",
+        AssertRejected(
             TypeResolver.GetTypeNameFromSpecification(
                 reader,
-                MetadataTokens.TypeSpecificationHandle(1)));
+                MetadataTokens.TypeSpecificationHandle(1)),
+            SignatureDecodeRejectionKind.TypeSpecificationBudget);
     }
 
     [Fact]
@@ -136,11 +136,11 @@ public class SignatureDecoderSafetyTests
             signature.WriteByte(0x08);     // I4
         });
 
-        Assert.Equal(
-            "object",
+        AssertRejected(
             TypeResolver.GetTypeNameFromSpecification(
                 reader,
-                MetadataTokens.TypeSpecificationHandle(1)));
+                MetadataTokens.TypeSpecificationHandle(1)),
+            SignatureDecodeRejectionKind.TypeSpecificationBudget);
     }
 
     [Fact]
@@ -176,12 +176,202 @@ public class SignatureDecoderSafetyTests
                 methodHandle);
         });
 
-        var decoded = MetadataDeclarationQuery.GetMethodReturnType(
-            reader,
-            reader.GetTypeDefinition(typeHandle),
-            reader.GetMethodDefinition(methodHandle));
+        Assert.Throws<BadImageFormatException>(() =>
+            MetadataDeclarationQuery.GetMethodReturnType(
+                reader,
+                reader.GetTypeDefinition(typeHandle),
+                reader.GetMethodDefinition(methodHandle)));
+    }
 
-        Assert.Equal("object", decoded);
+    [Fact]
+    public void WideTypeSpec_AboveLegacyPerBlobCap_IsDecoded()
+    {
+        const int argumentCount = 1_500;
+        var reader = BuildTypeSpec(signature =>
+        {
+            signature.WriteByte(0x15); // GENERICINST
+            signature.WriteByte(0x12); // CLASS
+            signature.WriteByte(0x04); // TypeDef row 1
+            signature.WriteCompressedInteger(argumentCount);
+            for (int i = 0; i < argumentCount; i++)
+                signature.WriteByte(0x08); // I4
+        });
+
+        var handle = MetadataTokens.TypeSpecificationHandle(1);
+        var decoded = Assert.IsType<SignatureDecodeResult<string>.Decoded>(
+            TypeResolver.GetTypeNameFromSpecification(
+                reader,
+                handle));
+        var gateway = Assert.IsType<SignatureDecodeResult<string>.Decoded>(
+            GuardedSignatureText.TypeSpecText(reader, handle, context: null));
+
+        Assert.StartsWith("<Module><int, int", decoded.Value, StringComparison.Ordinal);
+        Assert.Equal(decoded.Value, gateway.Value);
+        Assert.True(
+            reader.GetBlobReader(
+                reader.GetTypeSpecification(MetadataTokens.TypeSpecificationHandle(1)).Signature)
+                .Length > 1_024);
+    }
+
+    [Fact]
+    public void TypeSpec_AboveCumulativeBudget_IsRejected()
+    {
+        var reader = BuildTypeSpec(signature =>
+        {
+            signature.WriteByte(0x15); // GENERICINST
+            signature.WriteByte(0x12); // CLASS
+            signature.WriteByte(0x04); // TypeDef row 1
+            signature.WriteCompressedInteger(TypeSpecGuard.MaxCumulativeBytes);
+            for (int i = 0; i < TypeSpecGuard.MaxCumulativeBytes; i++)
+                signature.WriteByte(0x08); // I4
+        });
+
+        var handle = MetadataTokens.TypeSpecificationHandle(1);
+        AssertRejected(
+            TypeResolver.GetTypeNameFromSpecification(
+                reader,
+                handle),
+            SignatureDecodeRejectionKind.TypeSpecificationBudget);
+        AssertRejected(
+            GuardedSignatureText.TypeSpecText(reader, handle, context: null),
+            SignatureDecodeRejectionKind.TypeSpecificationBudget);
+    }
+
+    [Fact]
+    public void MalformedTypeSpecHandle_IsRejected()
+    {
+        var reader = BuildTypeSpec(signature =>
+        {
+            signature.WriteByte(0x12); // CLASS
+            signature.WriteByte(0x05); // TypeRef row 1, which does not exist
+        });
+
+        AssertRejected(
+            TypeResolver.GetTypeNameFromSpecification(
+                reader,
+                MetadataTokens.TypeSpecificationHandle(1)),
+            SignatureDecodeRejectionKind.MalformedMetadata);
+        AssertRejected(
+            GuardedSignatureText.TypeSpecText(
+                reader,
+                MetadataTokens.TypeSpecificationHandle(1),
+                context: null),
+            SignatureDecodeRejectionKind.MalformedMetadata);
+    }
+
+    [Fact]
+    public void GuardedGateways_RejectEveryUnsafeSignatureKind()
+    {
+        MethodDefinitionHandle methodHandle = default;
+        FieldDefinitionHandle fieldHandle = default;
+        PropertyDefinitionHandle propertyHandle = default;
+        MethodSpecificationHandle methodSpecHandle = default;
+        TypeSpecificationHandle typeSpecHandle = default;
+        var reader = BuildAssembly(metadata =>
+        {
+            methodHandle = metadata.AddMethodDefinition(
+                MethodAttributes.Public | MethodAttributes.Static,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("M"),
+                metadata.GetOrAddBlob(DeepMethodSignature()),
+                bodyOffset: -1,
+                parameterList: MetadataTokens.ParameterHandle(1));
+
+            var fieldSignature = new BlobBuilder();
+            fieldSignature.WriteByte(0x06); // FIELD
+            WriteDeepType(fieldSignature);
+            fieldHandle = metadata.AddFieldDefinition(
+                FieldAttributes.Public,
+                metadata.GetOrAddString("F"),
+                metadata.GetOrAddBlob(fieldSignature));
+
+            var propertySignature = new BlobBuilder();
+            propertySignature.WriteByte(0x08); // PROPERTY
+            propertySignature.WriteByte(0x00); // zero parameters
+            WriteDeepType(propertySignature);
+            propertyHandle = metadata.AddProperty(
+                PropertyAttributes.None,
+                metadata.GetOrAddString("P"),
+                metadata.GetOrAddBlob(propertySignature));
+
+            var methodSpecSignature = new BlobBuilder();
+            methodSpecSignature.WriteByte(0x0a); // GENERICINST
+            methodSpecSignature.WriteByte(0x01); // one argument
+            WriteDeepType(methodSpecSignature);
+            methodSpecHandle = metadata.AddMethodSpecification(
+                methodHandle,
+                metadata.GetOrAddBlob(methodSpecSignature));
+
+            var typeSpecSignature = new BlobBuilder();
+            for (int i = 0; i < 600; i++)
+                typeSpecSignature.WriteByte(0x1d); // SZARRAY
+            typeSpecSignature.WriteByte(0x08);     // I4
+            typeSpecHandle = metadata.AddTypeSpecification(
+                metadata.GetOrAddBlob(typeSpecSignature));
+        });
+
+        AssertRejected(
+            GuardedSignatureText.MethodText(
+                reader,
+                reader.GetMethodDefinition(methodHandle),
+                context: null),
+            SignatureDecodeRejectionKind.UnsafeStructure);
+        AssertRejected(
+            GuardedSignatureText.FieldText(
+                reader,
+                reader.GetFieldDefinition(fieldHandle),
+                context: null),
+            SignatureDecodeRejectionKind.UnsafeStructure);
+        AssertRejected(
+            GuardedSignatureText.PropertyText(
+                reader,
+                reader.GetPropertyDefinition(propertyHandle),
+                context: null),
+            SignatureDecodeRejectionKind.UnsafeStructure);
+        AssertRejected(
+            GuardedSignatureText.MethodSpecTypeArgs(
+                reader,
+                reader.GetMethodSpecification(methodSpecHandle),
+                context: null),
+            SignatureDecodeRejectionKind.UnsafeStructure);
+        AssertRejected(
+            GuardedSignatureText.TypeSpecText(reader, typeSpecHandle, context: null),
+            SignatureDecodeRejectionKind.UnsafeStructure);
+    }
+
+    [Fact]
+    public void NestedTypeSpecRejection_RejectsContainingMethod()
+    {
+        MethodDefinitionHandle methodHandle = default;
+        var reader = BuildAssembly(metadata =>
+        {
+            var cyclicTypeSpec = new BlobBuilder();
+            cyclicTypeSpec.WriteByte(0x1f); // CMOD_REQD
+            cyclicTypeSpec.WriteByte(0x06); // TypeSpec row 1
+            cyclicTypeSpec.WriteByte(0x08); // I4
+            metadata.AddTypeSpecification(metadata.GetOrAddBlob(cyclicTypeSpec));
+
+            var methodSignature = new BlobBuilder();
+            methodSignature.WriteByte(0x00); // default method signature
+            methodSignature.WriteByte(0x00); // zero parameters
+            methodSignature.WriteByte(0x1f); // CMOD_REQD
+            methodSignature.WriteByte(0x06); // TypeSpec row 1
+            methodSignature.WriteByte(0x08); // I4
+            methodHandle = metadata.AddMethodDefinition(
+                MethodAttributes.Public | MethodAttributes.Static,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("M"),
+                metadata.GetOrAddBlob(methodSignature),
+                bodyOffset: -1,
+                parameterList: MetadataTokens.ParameterHandle(1));
+        });
+
+        AssertRejected(
+            GuardedSignatureText.MethodText(
+                reader,
+                reader.GetMethodDefinition(methodHandle),
+                context: null),
+            SignatureDecodeRejectionKind.TypeSpecificationBudget);
     }
 
     [Fact]
@@ -386,6 +576,27 @@ public class SignatureDecoderSafetyTests
         signature.WriteByte(0x0f);     // PTR
         signature.WriteByte(0x08);     // I4
         return signature;
+    }
+
+    static void WriteDeepType(BlobBuilder signature)
+    {
+        for (int i = 0; i < 100_000; i++)
+            signature.WriteByte(0x1d); // SZARRAY
+        signature.WriteByte(0x08);     // I4
+    }
+
+    static void AssertRejected<T>(
+        SignatureDecodeResult<T> result,
+        SignatureDecodeRejectionKind kind)
+        where T : notnull
+    {
+        var rejected = Assert.IsType<SignatureDecodeResult<T>.Rejected>(result);
+        Assert.Equal(kind, rejected.Rejection.Kind);
+        Assert.False(string.IsNullOrWhiteSpace(rejected.Rejection.Detail));
+        Assert.False(result.TryGetValue(out _));
+        var exception = Assert.Throws<BadImageFormatException>(
+            () => result.GetValueOrThrow());
+        Assert.Contains(rejected.Rejection.Detail, exception.Message, StringComparison.Ordinal);
     }
 
     static (MetadataReader Reader, TypeDefinitionHandle TypeHandle, MethodDefinitionHandle MethodHandle)

--- a/tests/ILInspector.Metadata.Tests/SignatureDecoderSafetyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SignatureDecoderSafetyTests.cs
@@ -117,7 +117,7 @@ public class SignatureDecoderSafetyTests
         });
 
         AssertRejected(
-            TypeResolver.GetTypeNameFromSpecification(
+            TypeResolver.DecodeTypeNameFromSpecification(
                 reader,
                 MetadataTokens.TypeSpecificationHandle(1)),
             SignatureDecodeRejectionKind.TypeSpecificationBudget);
@@ -137,7 +137,7 @@ public class SignatureDecoderSafetyTests
         });
 
         AssertRejected(
-            TypeResolver.GetTypeNameFromSpecification(
+            TypeResolver.DecodeTypeNameFromSpecification(
                 reader,
                 MetadataTokens.TypeSpecificationHandle(1)),
             SignatureDecodeRejectionKind.TypeSpecificationBudget);
@@ -199,7 +199,7 @@ public class SignatureDecoderSafetyTests
 
         var handle = MetadataTokens.TypeSpecificationHandle(1);
         var decoded = Assert.IsType<SignatureDecodeResult<string>.Decoded>(
-            TypeResolver.GetTypeNameFromSpecification(
+            TypeResolver.DecodeTypeNameFromSpecification(
                 reader,
                 handle));
         var gateway = Assert.IsType<SignatureDecodeResult<string>.Decoded>(
@@ -207,6 +207,9 @@ public class SignatureDecoderSafetyTests
 
         Assert.StartsWith("<Module><int, int", decoded.Value, StringComparison.Ordinal);
         Assert.Equal(decoded.Value, gateway.Value);
+        Assert.Equal(
+            decoded.Value,
+            TypeResolver.GetTypeNameFromSpecification(reader, handle));
         Assert.True(
             reader.GetBlobReader(
                 reader.GetTypeSpecification(MetadataTokens.TypeSpecificationHandle(1)).Signature)
@@ -228,13 +231,15 @@ public class SignatureDecoderSafetyTests
 
         var handle = MetadataTokens.TypeSpecificationHandle(1);
         AssertRejected(
-            TypeResolver.GetTypeNameFromSpecification(
+            TypeResolver.DecodeTypeNameFromSpecification(
                 reader,
                 handle),
             SignatureDecodeRejectionKind.TypeSpecificationBudget);
         AssertRejected(
             GuardedSignatureText.TypeSpecText(reader, handle, context: null),
             SignatureDecodeRejectionKind.TypeSpecificationBudget);
+        Assert.Throws<BadImageFormatException>(
+            () => TypeResolver.GetTypeNameFromSpecification(reader, handle));
     }
 
     [Fact]
@@ -247,7 +252,7 @@ public class SignatureDecoderSafetyTests
         });
 
         AssertRejected(
-            TypeResolver.GetTypeNameFromSpecification(
+            TypeResolver.DecodeTypeNameFromSpecification(
                 reader,
                 MetadataTokens.TypeSpecificationHandle(1)),
             SignatureDecodeRejectionKind.MalformedMetadata);
@@ -257,6 +262,26 @@ public class SignatureDecoderSafetyTests
                 MetadataTokens.TypeSpecificationHandle(1),
                 context: null),
             SignatureDecodeRejectionKind.MalformedMetadata);
+    }
+
+    [Fact]
+    public void MalformedSignatureBlobHandle_IsRejectedBeforeDecode()
+    {
+        var reader = BuildAssembly(_ => { });
+        bool decodeCalled = false;
+
+        var result = GuardedSignatureDecoder.Decode(
+            reader,
+            MetadataTokens.BlobHandle(0x1000),
+            SignatureBlobGuard.Kind.Field,
+            () =>
+            {
+                decodeCalled = true;
+                return "int";
+            });
+
+        AssertRejected(result, SignatureDecodeRejectionKind.MalformedMetadata);
+        Assert.False(decodeCalled);
     }
 
     [Fact]

--- a/tests/ILInspector.Metadata.Tests/StringSignatureDecodeBoundaryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/StringSignatureDecodeBoundaryTests.cs
@@ -14,6 +14,7 @@ public class StringSignatureDecodeBoundaryTests
         var allowedFiles = new HashSet<string>(StringComparer.Ordinal)
         {
             "GuardedSignatureText.cs",
+            "SignatureDecodeResult.cs",
             "SignatureDecoder.cs",
             "TypeResolver.cs",
             // TypeNodeProvider delegates leaf-name callbacks to the string provider for


### PR DESCRIPTION
Closes #2689.

Guarded Metadata string-signature decodes now return a typed `Decoded` or `Rejected` outcome instead of silently presenting `object`, an empty method-spec argument list, or a default method/property signature as genuine metadata.

This preserves #2709 and #2715 provenance behavior: API census consumers project rejected signatures as `SignatureDecodeStatus.Degraded`, while discovery consumers skip rejected rows and direct rendering boundaries throw through their existing row-level containment. Nested TypeSpec rejection propagates to the enclosing decode.

TypeSpec acceptance is now route-independent. The legacy 1,024-byte per-blob cap is removed; both typed gateways use the documented 4,096-byte active-closure budget, 256 cross-handle depth limit, and 512 structural-depth guard. A valid 1,500-argument shallow TypeSpec proves the widened legal envelope. The existing public `TypeResolver.GetTypeNameFromSpecification` signature remains compatible; `DecodeTypeNameFromSpecification` exposes the typed outcome.

Validation:
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release` (474 passed after the final main rebase)
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.GuardedSignatureTextTests"` (1 passed)
- full Decompiler suite before the final main rebases (2,528 passed, 1 SDK-dependent skip)
- `npx markdownlint-cli docs/metadata-primitives.md`
- GitHub Actions: all merge-blocking jobs passed

Adversarial review: Gemini 3.1 Pro and Claude Opus 4.8 both reported CLEAN on fixed head `a879869a`; round-1 findings and their resolution are reconciled in PR comments.
