### PR TITLE
Harden signature guard census and receiver indexing

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ClosureDiagnosticEvidenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ClosureDiagnosticEvidenceTests.cs
@@ -39,7 +39,7 @@ public class ClosureDiagnosticEvidenceTests
     [InlineData("CS1061", "class Receiver : System.Collections.IEnumerable { public System.Collections.IEnumerator GetEnumerator() => null; } class C { async System.Threading.Tasks.Task M() { await System.Threading.Tasks.Task.FromResult(new Receiver { 1 }); } }", "Add", "Receiver", null)]
     [InlineData("CS1061", "namespace @for { class @class {} class C { void M(@class value) { value.Missing(); } } }", "Missing", "@for.@class", null)]
     [InlineData("CS1061", "namespace @await { class Receiver {} class C { void M(Receiver value) { value.Missing(); } } }", "Missing", "@await.Receiver", null)]
-    [InlineData("CS1061", "namespace N { class Outer<T> { public class Inner {} } class C { void M(Outer<int>.Inner value) { value.Missing(); } } }", "Missing", "N.Outer.Inner", null)]
+    [InlineData("CS1061", "namespace N { class Outer<T> { public class Inner {} } class C { void M(Outer<int>.Inner value) { value.Missing(); } } }", "Missing", "N.Outer`1.Inner", null)]
     [InlineData("CS0117", "class Receiver {} class C { void M() { Receiver.Missing(); } }", "Missing", "Receiver", null)]
     [InlineData("CS0117", "class Receiver {} class C { Receiver M() => new Receiver { Missing = 1 }; }", "Missing", "Receiver", null)]
     public void Extract_UsesStructuredSyntaxAndSemanticEvidence(
@@ -128,7 +128,7 @@ public class ClosureDiagnosticEvidenceTests
                 "ReceiverEvidence.Derived",
                 "ReceiverEvidence.Base",
                 "System.Object",
-                "ReceiverEvidence.IReceiver",
+                "ReceiverEvidence.IReceiver`1",
             ],
             reference.CompatibleReceiverTypes);
         Assert.True(reference.CompatibleReceiverTypesComplete);

--- a/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
@@ -492,6 +492,73 @@ public class FidelityCheckGeneratedFilterTests
     }
 
     [Fact]
+    public void ExtensionRootSelection_UsesArityAwareRoslynReceiverEvidence()
+    {
+        var assemblyPath = CompileFixture("""
+            namespace ExtensionReceiverArityEvidenceFixture;
+
+            public interface IReceiver<T> { }
+            public class Result<T> : IReceiver<T> { }
+
+            public static class GenericReceiverExtensions
+            {
+                public static void Add<T>(this IReceiver<T> receiver, int value) { }
+            }
+            """);
+        try
+        {
+            var tree = CSharpSyntaxTree.ParseText(
+                """
+                class Consumer
+                {
+                    void Use(
+                        ExtensionReceiverArityEvidenceFixture.Result<int> value)
+                        => value.Add(1);
+                }
+                """,
+                cancellationToken: TestContext.Current.CancellationToken);
+            var compilation = CSharpCompilation.Create(
+                "extension-receiver-arity-evidence",
+                [tree],
+                [
+                    MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                    MetadataReference.CreateFromFile(assemblyPath),
+                ],
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+            var diagnostic = Assert.Single(
+                compilation.GetDiagnostics(TestContext.Current.CancellationToken),
+                candidate => candidate.Id == "CS1061");
+            var reference = Assert.IsType<ClosureDiagnosticReference>(
+                ClosureDiagnosticEvidence.Extract(
+                    diagnostic,
+                    compilation.GetSemanticModel(tree)));
+
+            Assert.Equal(
+                "ExtensionReceiverArityEvidenceFixture.Result`1",
+                reference.ContainingType);
+            Assert.Contains(
+                "ExtensionReceiverArityEvidenceFixture.IReceiver`1",
+                reference.CompatibleReceiverTypes!);
+
+            var selection = FidelityCheck.SelectExtensionRootsForTest(
+                assemblyPath,
+                reference.Name,
+                reference.ContainingType,
+                reference.CompatibleReceiverTypes,
+                reference.CompatibleReceiverTypesComplete);
+
+            Assert.Equal(
+                ["ExtensionReceiverArityEvidenceFixture.GenericReceiverExtensions"],
+                selection.Roots);
+            Assert.False(selection.UsedFallback, selection.FallbackReason);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void RunMethodDelta_UsesCorpusMetadataForPlatformOutParameters()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
@@ -445,6 +445,53 @@ public class FidelityCheckGeneratedFilterTests
     }
 
     [Fact]
+    public void ExtensionRootSelection_DistinguishesReceiverTypesByGenericArity()
+    {
+        var assemblyPath = CompileFixture("""
+            namespace ExtensionReceiverArityFixture;
+
+            public class NonGenericBase { }
+            public class GenericBase { }
+            public class Result : NonGenericBase { }
+            public class Result<T> : GenericBase { }
+
+            public static class NonGenericExtensions
+            {
+                public static void Add(this NonGenericBase receiver, string value) { }
+            }
+
+            public static class GenericExtensions
+            {
+                public static void Add(this GenericBase receiver, int value) { }
+            }
+            """);
+        try
+        {
+            var nonGeneric = FidelityCheck.SelectExtensionRootsForTest(
+                assemblyPath,
+                "Add",
+                "ExtensionReceiverArityFixture.Result");
+            var generic = FidelityCheck.SelectExtensionRootsForTest(
+                assemblyPath,
+                "Add",
+                "ExtensionReceiverArityFixture.Result<int>");
+
+            Assert.Equal(
+                ["ExtensionReceiverArityFixture.NonGenericExtensions"],
+                nonGeneric.Roots);
+            Assert.False(nonGeneric.UsedFallback, nonGeneric.FallbackReason);
+            Assert.Equal(
+                ["ExtensionReceiverArityFixture.GenericExtensions"],
+                generic.Roots);
+            Assert.False(generic.UsedFallback, generic.FallbackReason);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void RunMethodDelta_UsesCorpusMetadataForPlatformOutParameters()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Instructions/GuardedProviderDecode.cs
+++ b/src/ILInspector.Instructions/GuardedProviderDecode.cs
@@ -185,20 +185,16 @@ internal static class GuardedProviderDecode
         TContext context,
         out T decoded)
     {
-        if (!TypeSpecGuard.TryEnter(reader, handle, out int blobLength))
+        if (!TypeSpecGuard.TryEnter(reader, handle, out var scope))
         {
             decoded = default!;
             return false;
         }
 
-        try
+        using (scope)
         {
             decoded = reader.GetTypeSpecification(handle).DecodeSignature(provider, context);
             return true;
-        }
-        finally
-        {
-            TypeSpecGuard.Exit(blobLength);
         }
     }
 

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -95,15 +95,11 @@ public static class ApiMemberIdentity
 
         public string GetTypeFromSpecification(MetadataReader reader, GenericContext? context, TypeSpecificationHandle handle, byte rawTypeKind)
         {
-            if (!TypeSpecGuard.TryEnter(reader, handle, out int blobLength))
+            if (!TypeSpecGuard.TryEnter(reader, handle, out var scope))
                 return "System.Object";
-            try
+            using (scope)
             {
                 return reader.GetTypeSpecification(handle).DecodeSignature(this, context);
-            }
-            finally
-            {
-                TypeSpecGuard.Exit(blobLength);
             }
         }
 

--- a/src/ILInspector.Metadata/CanonicalIL.cs
+++ b/src/ILInspector.Metadata/CanonicalIL.cs
@@ -47,15 +47,11 @@ public sealed class ILSignatureTypeProvider : ISignatureTypeProvider<string, Gen
 
     public string GetTypeFromSpecification(MetadataReader reader, GenericContext? context, TypeSpecificationHandle handle, byte rawTypeKind)
     {
-        if (!TypeSpecGuard.TryEnter(reader, handle, out int blobLength))
+        if (!TypeSpecGuard.TryEnter(reader, handle, out var scope))
             return "object";
-        try
+        using (scope)
         {
             return reader.GetTypeSpecification(handle).DecodeSignature(this, context);
-        }
-        finally
-        {
-            TypeSpecGuard.Exit(blobLength);
         }
     }
 

--- a/src/ILInspector.Metadata/PointerDetector.cs
+++ b/src/ILInspector.Metadata/PointerDetector.cs
@@ -17,15 +17,11 @@ internal sealed class PointerDetector : ISignatureTypeProvider<PointerDetection,
 
     public PointerDetection GetTypeFromSpecification(MetadataReader reader, object? context, TypeSpecificationHandle handle, byte rawTypeKind)
     {
-        if (!TypeSpecGuard.TryEnter(reader, handle, out int blobLength))
+        if (!TypeSpecGuard.TryEnter(reader, handle, out var scope))
             return PointerDetection.Degraded;
-        try
+        using (scope)
         {
             return reader.GetTypeSpecification(handle).DecodeSignature(this, context);
-        }
-        finally
-        {
-            TypeSpecGuard.Exit(blobLength);
         }
     }
 

--- a/src/ILInspector.Metadata/SignatureSpellability.cs
+++ b/src/ILInspector.Metadata/SignatureSpellability.cs
@@ -219,15 +219,11 @@ public sealed class SignatureSpellability
             TypeSpecificationHandle handle,
             byte rawTypeKind)
         {
-            if (!TypeSpecGuard.TryEnter(reader, handle, out int blobLength))
+            if (!TypeSpecGuard.TryEnter(reader, handle, out var scope))
                 return SpellabilityEvidence.Degraded;
-            try
+            using (scope)
             {
                 return reader.GetTypeSpecification(handle).DecodeSignature(this, context);
-            }
-            finally
-            {
-                TypeSpecGuard.Exit(blobLength);
             }
         }
         public SpellabilityEvidence GetSZArrayType(SpellabilityEvidence elementType) => elementType;

--- a/src/ILInspector.Metadata/TypeNodeProvider.cs
+++ b/src/ILInspector.Metadata/TypeNodeProvider.cs
@@ -37,15 +37,11 @@ internal sealed class TypeNodeProvider : ISignatureTypeProvider<TypeNode, Generi
 
     public TypeNode GetTypeFromSpecification(MetadataReader reader, GenericContext? context, TypeSpecificationHandle handle, byte rawTypeKind)
     {
-        if (!TypeSpecGuard.TryEnter(reader, handle, out int blobLength))
+        if (!TypeSpecGuard.TryEnter(reader, handle, out var scope))
             return new DegradedTypeNode();
-        try
+        using (scope)
         {
             return reader.GetTypeSpecification(handle).DecodeSignature(this, context);
-        }
-        finally
-        {
-            TypeSpecGuard.Exit(blobLength);
         }
     }
 

--- a/src/ILInspector.MetadataPrimitives/SignatureDecodeResult.cs
+++ b/src/ILInspector.MetadataPrimitives/SignatureDecodeResult.cs
@@ -130,7 +130,7 @@ public static class GuardedSignatureDecoder
             if (!TypeSpecGuard.TryEnter(
                 reader,
                 handle,
-                out int blobLength,
+                out var scope,
                 out var rejectionKind))
             {
                 SignatureDecoder.Reject(
@@ -142,14 +142,10 @@ public static class GuardedSignatureDecoder
                 return "object";
             }
 
-            try
+            using (scope)
             {
                 return reader.GetTypeSpecification(handle)
                     .DecodeSignature(SignatureDecoder.Instance, context);
-            }
-            finally
-            {
-                TypeSpecGuard.Exit(blobLength);
             }
         });
 }

--- a/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
+++ b/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
@@ -53,7 +53,7 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
         if (!TypeSpecGuard.TryEnter(
             reader,
             handle,
-            out int blobLength,
+            out var scope,
             out var rejectionKind))
         {
             Reject(
@@ -64,13 +64,9 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
                         : "A nested TypeSpec exceeds the re-entry depth or cumulative-byte budget."));
             return Unresolved;
         }
-        try
+        using (scope)
         {
             return reader.GetTypeSpecification(handle).DecodeSignature(this, context);
-        }
-        finally
-        {
-            TypeSpecGuard.Exit(blobLength);
         }
     }
 

--- a/src/ILInspector.MetadataPrimitives/TypeSpecGuard.cs
+++ b/src/ILInspector.MetadataPrimitives/TypeSpecGuard.cs
@@ -24,16 +24,16 @@ public static class TypeSpecGuard
     [ThreadStatic]
     static int s_depth;
 
-    public static bool TryEnter(MetadataReader reader, TypeSpecificationHandle handle, out int blobLength)
-        => TryEnter(reader, handle, out blobLength, out _);
+    public static bool TryEnter(MetadataReader reader, TypeSpecificationHandle handle, out Scope scope)
+        => TryEnter(reader, handle, out scope, out _);
 
     internal static bool TryEnter(
         MetadataReader reader,
         TypeSpecificationHandle handle,
-        out int blobLength,
+        out Scope scope,
         out SignatureDecodeRejectionKind rejectionKind)
     {
-        blobLength = 0;
+        scope = default;
         if (s_depth >= MaxDepth)
         {
             rejectionKind = SignatureDecodeRejectionKind.TypeSpecificationBudget;
@@ -58,14 +58,44 @@ public static class TypeSpecGuard
 
         s_depth++;
         s_cumulativeBytes += length;
-        blobLength = length;
+        scope = new Scope(length, s_depth);
         rejectionKind = default;
         return true;
     }
 
-    public static void Exit(int blobLength)
+    static void Exit(int blobLength, int depth)
     {
+        if (s_depth != depth)
+            throw new InvalidOperationException("TypeSpecGuard scopes must be disposed in entry order.");
+
         s_depth--;
         s_cumulativeBytes -= blobLength;
+    }
+
+    /// <summary>
+    /// Restores the calling thread's TypeSpec decode budget when the guarded
+    /// re-entry completes. The stack-only token cannot escape to another thread.
+    /// </summary>
+    public ref struct Scope
+    {
+        int _blobLength;
+        readonly int _depth;
+        bool _active;
+
+        internal Scope(int blobLength, int depth)
+        {
+            _blobLength = blobLength;
+            _depth = depth;
+            _active = true;
+        }
+
+        public void Dispose()
+        {
+            if (!_active)
+                return;
+
+            Exit(_blobLength, _depth);
+            _active = false;
+        }
     }
 }

--- a/tests/ILInspector.Metadata.Tests/ProviderSignatureDecodeBoundaryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ProviderSignatureDecodeBoundaryTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -12,7 +14,8 @@ namespace ILInspector.Metadata.Tests;
 /// <c>try/catch</c> can contain. Every top-level provider decode must therefore
 /// be prescanned with <c>SignatureBlobGuard.IsSafeToDecode</c> or enter through
 /// <c>GuardedSignatureDecoder</c>, and every nested cross-handle TypeSpec
-/// re-entry must be bounded by <c>TypeSpecGuard</c>.
+/// re-entry must be bounded by the disposable scope returned for that invocation
+/// by <c>TypeSpecGuard</c>.
 ///
 /// This census is a deny-list: any <c>Decode*Signature</c> invocation that is
 /// not one of the three sanctioned guarded forms is a violation. A newly added
@@ -22,12 +25,15 @@ namespace ILInspector.Metadata.Tests;
 ///
 /// The classification is performed on the Roslyn syntax tree, not by string or
 /// regex matching, so it cannot be evaded by comments, line splits, whitespace,
-/// aliasing, or spoofed tokens. It enumerates every occurrence of a decode
+/// aliasing, or spoofed tokens. Negative self-tests freeze those three reviewer
+/// evasions. The census enumerates every occurrence of a decode
 /// method name and requires each to be the invoked member of a sanctioned call,
 /// so null-conditional (`x?.Decode...`), method-group, and delegate forms are
 /// flagged rather than skipped. Form 2 additionally binds the prescan to the
 /// decoded blob (same receiver's `.Signature`), so an unrelated or nil-handle
-/// guard cannot launder an unguarded decode past the census.
+/// guard cannot launder an unguarded decode past the census. Nested TypeSpec
+/// re-entry is likewise bound to a matching TryEnter handle and disposable
+/// scope per invocation; a guard elsewhere in the file proves nothing.
 /// </summary>
 public class ProviderSignatureDecodeBoundaryTests
 {
@@ -54,6 +60,40 @@ public class ProviderSignatureDecodeBoundaryTests
         "DecodeMethodSpecificationSignature",
     };
 
+    public static TheoryData<string, string> ReviewerEvasions => new()
+    {
+        {
+            "provider local alias",
+            """
+            object Decode()
+            {
+                var provider = TypeNodeProvider.Instance;
+                return method.DecodeSignature(provider, context);
+            }
+            """
+        },
+        {
+            "newline-split invocation",
+            """
+            object Decode()
+            {
+                return method.
+                    DecodeSignature(TypeNodeProvider.Instance, context);
+            }
+            """
+        },
+        {
+            "guard token in comment",
+            """
+            object Decode()
+            {
+                // SignatureBlobGuard.IsSafeToDecode(reader, method.Signature)
+                return method.DecodeSignature(TypeNodeProvider.Instance, context);
+            }
+            """
+        },
+    };
+
     [Fact]
     public void EveryProviderDecode_IsGuarded()
     {
@@ -62,30 +102,8 @@ public class ProviderSignatureDecodeBoundaryTests
 
         foreach (var file in EnumerateSourceFiles(root))
         {
-            foreach (var name in DecodeNameOccurrences(file))
+            foreach (var name in FindDecodeViolations(ParseFileRoot(file)))
             {
-                // A decode method name may appear ONLY as the invoked method of a
-                // sanctioned decode call. Any other occurrence — a method-group /
-                // delegate reference, or a call whose name node is not the invoked
-                // member — is an unguarded escape and a violation.
-                if (TryGetInvokedDecode(name, out var invocation)
-                    && (IsNestedTypeSpecReentry(invocation)
-                        || IsPrescanGuardedTernary(invocation)
-                        || IsGuardedSignatureDecoderGateway(invocation)))
-                {
-                    // Sanctioned form 1: a nested cross-handle TypeSpec re-entry,
-                    // `reader.GetTypeSpecification(handle).Decode*Signature(...)`,
-                    // bounded by TypeSpecGuard in its enclosing provider file
-                    // (asserted by NestedTypeSpecReentry_IsBoundedByTypeSpecGuard).
-                    // Sanctioned form 2: the decode is the true-branch of a
-                    // `SignatureBlobGuard.IsSafeToDecode(reader, <recv>.Signature,
-                    // ...) ? decode : fallback` prescan ternary.
-                    // Sanctioned form 3: the decode is the value factory of
-                    // `GuardedSignatureDecoder.Decode(reader, <recv>.Signature,
-                    // ..., () => decode)`, bound to the same signature blob.
-                    continue;
-                }
-
                 var line = name.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
                 violations.Add($"{Path.GetRelativePath(root, file)}:{line}");
             }
@@ -100,49 +118,109 @@ public class ProviderSignatureDecodeBoundaryTests
             + "Unguarded raw decodes:\n  " + string.Join("\n  ", violations));
     }
 
+    [Theory]
+    [MemberData(nameof(ReviewerEvasions))]
+    public void Census_RejectsReviewerEvasion(string evasion, string source)
+    {
+        var violations = FindDecodeViolations(ParseSourceRoot(source));
+
+        Assert.True(violations.Count == 1, $"{evasion}: expected one violation, found {violations.Count}");
+    }
+
     [Fact]
-    public void NestedTypeSpecReentry_IsBoundedByTypeSpecGuard()
+    public void NestedTypeSpecReentry_IsBoundedPerInvocation()
     {
         var root = FindRepoRoot();
         var unguarded = new List<string>();
 
         foreach (var file in EnumerateSourceFiles(root))
         {
-            var invocations = AllInvocations(file);
-
-            bool hasNestedReentry = invocations.Any(i => IsDecodeInvocation(i) && IsNestedTypeSpecReentry(i));
-            if (!hasNestedReentry)
-                continue;
-
-            bool boundsWithTypeSpecGuard = invocations.Any(i =>
-                i.Expression is MemberAccessExpressionSyntax member
-                && member.Name.Identifier.Text == "TryEnter"
-                && member.Expression is IdentifierNameSyntax id
-                && id.Identifier.Text == "TypeSpecGuard");
-
-            if (!boundsWithTypeSpecGuard)
-                unguarded.Add(Path.GetRelativePath(root, file));
+            foreach (var invocation in AllInvocations(ParseFileRoot(file))
+                         .Where(i => IsDecodeInvocation(i)
+                             && IsNestedTypeSpecReentry(i)
+                             && !IsBoundedByTypeSpecGuardScope(i)))
+            {
+                var line = invocation.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+                unguarded.Add($"{Path.GetRelativePath(root, file)}:{line}");
+            }
         }
 
         Assert.True(
             unguarded.Count == 0,
-            "Every file that re-enters a nested TypeSpec decode must bound it with "
-            + "TypeSpecGuard.TryEnter:\n  " + string.Join("\n  ", unguarded));
+            "Every nested TypeSpec decode must be inside the disposable scope from "
+            + "a matching TypeSpecGuard.TryEnter invocation:\n  "
+            + string.Join("\n  ", unguarded));
     }
 
-    static IEnumerable<SimpleNameSyntax> DecodeNameOccurrences(string file)
-        => ParseRoot(file).DescendantNodes()
+    [Fact]
+    public void NestedTypeSpecFact_RejectsGuardElsewhereInFile()
+    {
+        var root = ParseSourceRoot("""
+            object Guarded()
+            {
+                if (!TypeSpecGuard.TryEnter(reader, first, out var scope))
+                    return null;
+                using (scope)
+                {
+                    return reader.GetTypeSpecification(first).DecodeSignature(provider, context);
+                }
+            }
+
+            object Unguarded()
+                => reader.GetTypeSpecification(second).DecodeSignature(provider, context);
+            """);
+
+        var violation = Assert.Single(FindDecodeViolations(root));
+        Assert.Equal("DecodeSignature", violation.Identifier.Text);
+        Assert.Contains("second", violation.Parent!.Parent!.ToString());
+    }
+
+    [Fact]
+    public void TypeSpecGuard_ExposesDisposableScopeInsteadOfUnpairedExit()
+    {
+        Assert.Null(typeof(TypeSpecGuard).GetMethod(
+            "Exit",
+            BindingFlags.Public | BindingFlags.Static));
+
+        var tryEnter = Assert.Single(
+            typeof(TypeSpecGuard).GetMethods(BindingFlags.Public | BindingFlags.Static),
+            method => method.Name == nameof(TypeSpecGuard.TryEnter));
+        Assert.Equal(
+            typeof(TypeSpecGuard.Scope).MakeByRefType(),
+            tryEnter.GetParameters()[2].ParameterType);
+        Assert.NotNull(typeof(TypeSpecGuard.Scope).GetMethod(
+            nameof(TypeSpecGuard.Scope.Dispose),
+            BindingFlags.Public | BindingFlags.Instance));
+    }
+
+    static IReadOnlyList<SimpleNameSyntax> FindDecodeViolations(SyntaxNode root)
+        => DecodeNameOccurrences(root)
+            .Where(name => !TryGetInvokedDecode(name, out var invocation)
+                || !(IsPrescanGuardedTernary(invocation)
+                    || IsGuardedSignatureDecoderGateway(invocation)
+                    || (IsNestedTypeSpecReentry(invocation)
+                        && IsBoundedByTypeSpecGuardScope(invocation))))
+            .ToArray();
+
+    static IEnumerable<SimpleNameSyntax> DecodeNameOccurrences(SyntaxNode root)
+        => root.DescendantNodes()
             .OfType<SimpleNameSyntax>()
             .Where(name => DecodeMethodNames.Contains(name.Identifier.Text));
 
-    static InvocationExpressionSyntax[] AllInvocations(string file)
-        => ParseRoot(file).DescendantNodes().OfType<InvocationExpressionSyntax>().ToArray();
+    static InvocationExpressionSyntax[] AllInvocations(SyntaxNode root)
+        => root.DescendantNodes().OfType<InvocationExpressionSyntax>().ToArray();
 
-    static SyntaxNode ParseRoot(string file)
+    static SyntaxNode ParseFileRoot(string file)
     {
         var token = TestContext.Current.CancellationToken;
         var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(file), cancellationToken: token);
         return tree.GetRoot(token);
+    }
+
+    static SyntaxNode ParseSourceRoot(string source)
+    {
+        var token = TestContext.Current.CancellationToken;
+        return CSharpSyntaxTree.ParseText(source, cancellationToken: token).GetRoot(token);
     }
 
     // Resolves a decode-method name occurrence to the invocation that invokes it,
@@ -179,10 +257,100 @@ public class ProviderSignatureDecodeBoundaryTests
     // `<expr>.GetTypeSpecification(...).Decode*Signature(...)`: the decode's
     // immediate receiver is itself a GetTypeSpecification invocation.
     static bool IsNestedTypeSpecReentry(InvocationExpressionSyntax invocation)
-        => invocation.Expression is MemberAccessExpressionSyntax member
-            && member.Expression is InvocationExpressionSyntax receiver
-            && receiver.Expression is MemberAccessExpressionSyntax receiverMember
-            && receiverMember.Name.Identifier.Text == "GetTypeSpecification";
+        => TryGetNestedTypeSpecReceiver(invocation, out _);
+
+    static bool TryGetNestedTypeSpecReceiver(
+        InvocationExpressionSyntax invocation,
+        out InvocationExpressionSyntax receiver)
+    {
+        if (invocation.Expression is MemberAccessExpressionSyntax member
+            && member.Expression is InvocationExpressionSyntax typeSpecReceiver
+            && typeSpecReceiver.Expression is MemberAccessExpressionSyntax receiverMember
+            && receiverMember.Name.Identifier.Text == "GetTypeSpecification")
+        {
+            receiver = typeSpecReceiver;
+            return true;
+        }
+
+        receiver = null!;
+        return false;
+    }
+
+    static bool IsBoundedByTypeSpecGuardScope(InvocationExpressionSyntax invocation)
+    {
+        if (!TryGetNestedTypeSpecReceiver(invocation, out var receiver)
+            || receiver.ArgumentList.Arguments.Count == 0)
+        {
+            return false;
+        }
+
+        var handle = receiver.ArgumentList.Arguments[0].Expression;
+        foreach (var usingStatement in invocation.Ancestors().OfType<UsingStatementSyntax>())
+        {
+            if (usingStatement.Expression is not IdentifierNameSyntax scope
+                || usingStatement.Parent is not BlockSyntax block)
+            {
+                continue;
+            }
+
+            int usingIndex = block.Statements.IndexOf(usingStatement);
+            if (usingIndex <= 0
+                || block.Statements[usingIndex - 1] is not IfStatementSyntax guard
+                || !GuardReturnsWhenEntryFails(guard, scope.Identifier.Text, handle))
+            {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    static bool GuardReturnsWhenEntryFails(
+        IfStatementSyntax guard,
+        string scopeName,
+        ExpressionSyntax handle)
+    {
+        var condition = UnwrapParentheses(guard.Condition);
+        if (condition is not PrefixUnaryExpressionSyntax
+            {
+                OperatorToken.RawKind: (int)SyntaxKind.ExclamationToken
+            } negation
+            || UnwrapParentheses(negation.Operand) is not InvocationExpressionSyntax tryEnter
+            || tryEnter.Expression is not MemberAccessExpressionSyntax
+            {
+                Expression: IdentifierNameSyntax { Identifier.Text: "TypeSpecGuard" },
+                Name.Identifier.Text: "TryEnter",
+            }
+            || tryEnter.ArgumentList.Arguments.Count < 3
+            || !SyntaxFactory.AreEquivalent(
+                tryEnter.ArgumentList.Arguments[1].Expression,
+                handle)
+            || tryEnter.ArgumentList.Arguments[2].Expression is not DeclarationExpressionSyntax
+            {
+                Designation: SingleVariableDesignationSyntax designation,
+            }
+            || designation.Identifier.Text != scopeName)
+        {
+            return false;
+        }
+
+        return guard.Statement switch
+        {
+            ReturnStatementSyntax or ThrowStatementSyntax => true,
+            BlockSyntax block when block.Statements.LastOrDefault()
+                is ReturnStatementSyntax or ThrowStatementSyntax => true,
+            _ => false,
+        };
+    }
+
+    static ExpressionSyntax UnwrapParentheses(ExpressionSyntax expression)
+    {
+        while (expression is ParenthesizedExpressionSyntax parentheses)
+            expression = parentheses.Expression;
+        return expression;
+    }
 
     // `SignatureBlobGuard.IsSafeToDecode(reader, <recv>.Signature, ...) ?
     // <recv>.Decode*Signature(...) : <fallback>`: some enclosing conditional
@@ -194,7 +362,7 @@ public class ProviderSignatureDecodeBoundaryTests
     {
         if (invocation.Expression is not MemberAccessExpressionSyntax decodeMember)
             return false;
-        var decodeReceiver = decodeMember.Expression.ToString();
+        var decodeReceiver = decodeMember.Expression;
 
         foreach (var ancestor in invocation.Ancestors())
         {
@@ -208,7 +376,9 @@ public class ProviderSignatureDecodeBoundaryTests
         return false;
     }
 
-    static bool ConditionGuardsReceiverSignature(ExpressionSyntax condition, string decodeReceiver)
+    static bool ConditionGuardsReceiverSignature(
+        ExpressionSyntax condition,
+        ExpressionSyntax decodeReceiver)
         => condition.DescendantNodesAndSelf()
             .OfType<InvocationExpressionSyntax>()
             .Any(i => i.Expression is MemberAccessExpressionSyntax member
@@ -218,7 +388,7 @@ public class ProviderSignatureDecodeBoundaryTests
                 && i.ArgumentList.Arguments.Any(a =>
                     a.Expression is MemberAccessExpressionSyntax blob
                     && blob.Name.Identifier.Text == "Signature"
-                    && blob.Expression.ToString() == decodeReceiver));
+                    && SyntaxFactory.AreEquivalent(blob.Expression, decodeReceiver)));
 
     // `GuardedSignatureDecoder.Decode(reader, <recv>.Signature, ..., () =>
     // <recv>.Decode*Signature(...))`: the decode must be inside the supplied
@@ -227,7 +397,7 @@ public class ProviderSignatureDecodeBoundaryTests
     {
         if (invocation.Expression is not MemberAccessExpressionSyntax decodeMember)
             return false;
-        var decodeReceiver = decodeMember.Expression.ToString();
+        var decodeReceiver = decodeMember.Expression;
 
         var valueFactory = invocation.Ancestors()
             .OfType<AnonymousFunctionExpressionSyntax>()
@@ -235,17 +405,17 @@ public class ProviderSignatureDecodeBoundaryTests
         if (valueFactory?.Parent is not ArgumentSyntax valueArgument
             || valueArgument.Parent?.Parent is not InvocationExpressionSyntax gateway
             || gateway.Expression is not MemberAccessExpressionSyntax gatewayMember
-            || gatewayMember.Name.Identifier.Text != "Decode"
+            || gatewayMember.Name.Identifier.ValueText != "Decode"
             || gatewayMember.Expression is not IdentifierNameSyntax gatewayType
-            || gatewayType.Identifier.Text != "GuardedSignatureDecoder")
+            || gatewayType.Identifier.ValueText != "GuardedSignatureDecoder")
         {
             return false;
         }
 
         return gateway.ArgumentList.Arguments.Any(a =>
             a.Expression is MemberAccessExpressionSyntax blob
-            && blob.Name.Identifier.Text == "Signature"
-            && blob.Expression.ToString() == decodeReceiver);
+            && blob.Name.Identifier.ValueText == "Signature"
+            && SyntaxFactory.AreEquivalent(blob.Expression, decodeReceiver));
     }
 
     static IEnumerable<string> EnumerateSourceFiles(string root)

--- a/tests/ILInspector.Metadata.Tests/ProviderSignatureDecodeBoundaryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ProviderSignatureDecodeBoundaryTests.cs
@@ -60,7 +60,7 @@ public class ProviderSignatureDecodeBoundaryTests
         "DecodeMethodSpecificationSignature",
     };
 
-    public static TheoryData<string, string> ReviewerEvasions => new()
+    public static TheoryData<string, string> CensusEvasions => new()
     {
         {
             "provider local alias",
@@ -92,6 +92,38 @@ public class ProviderSignatureDecodeBoundaryTests
             }
             """
         },
+        {
+            "verbatim decode identifier",
+            """
+            object Decode()
+            {
+                return method.@DecodeSignature(TypeNodeProvider.Instance, context);
+            }
+            """
+        },
+        {
+            "unicode-escaped decode identifier",
+            """
+            object Decode()
+            {
+                return method.\u0044ecodeSignature(TypeNodeProvider.Instance, context);
+            }
+            """
+        },
+        {
+            "short-circuited prescan",
+            """
+            object Decode()
+            {
+                return SignatureBlobGuard.IsSafeToDecode(
+                        reader,
+                        method.Signature,
+                        SignatureBlobGuard.Kind.Method) || true
+                    ? method.DecodeSignature(TypeNodeProvider.Instance, context)
+                    : fallback;
+            }
+            """
+        },
     };
 
     [Fact]
@@ -119,7 +151,7 @@ public class ProviderSignatureDecodeBoundaryTests
     }
 
     [Theory]
-    [MemberData(nameof(ReviewerEvasions))]
+    [MemberData(nameof(CensusEvasions))]
     public void Census_RejectsReviewerEvasion(string evasion, string source)
     {
         var violations = FindDecodeViolations(ParseSourceRoot(source));
@@ -205,7 +237,7 @@ public class ProviderSignatureDecodeBoundaryTests
     static IEnumerable<SimpleNameSyntax> DecodeNameOccurrences(SyntaxNode root)
         => root.DescendantNodes()
             .OfType<SimpleNameSyntax>()
-            .Where(name => DecodeMethodNames.Contains(name.Identifier.Text));
+            .Where(name => DecodeMethodNames.Contains(name.Identifier.ValueText));
 
     static InvocationExpressionSyntax[] AllInvocations(SyntaxNode root)
         => root.DescendantNodes().OfType<InvocationExpressionSyntax>().ToArray();
@@ -252,7 +284,7 @@ public class ProviderSignatureDecodeBoundaryTests
 
     static bool IsDecodeInvocation(InvocationExpressionSyntax invocation)
         => invocation.Expression is MemberAccessExpressionSyntax member
-            && DecodeMethodNames.Contains(member.Name.Identifier.Text);
+            && DecodeMethodNames.Contains(member.Name.Identifier.ValueText);
 
     // `<expr>.GetTypeSpecification(...).Decode*Signature(...)`: the decode's
     // immediate receiver is itself a GetTypeSpecification invocation.
@@ -266,7 +298,7 @@ public class ProviderSignatureDecodeBoundaryTests
         if (invocation.Expression is MemberAccessExpressionSyntax member
             && member.Expression is InvocationExpressionSyntax typeSpecReceiver
             && typeSpecReceiver.Expression is MemberAccessExpressionSyntax receiverMember
-            && receiverMember.Name.Identifier.Text == "GetTypeSpecification")
+            && receiverMember.Name.Identifier.ValueText == "GetTypeSpecification")
         {
             receiver = typeSpecReceiver;
             return true;
@@ -296,7 +328,7 @@ public class ProviderSignatureDecodeBoundaryTests
             int usingIndex = block.Statements.IndexOf(usingStatement);
             if (usingIndex <= 0
                 || block.Statements[usingIndex - 1] is not IfStatementSyntax guard
-                || !GuardReturnsWhenEntryFails(guard, scope.Identifier.Text, handle))
+                || !GuardReturnsWhenEntryFails(guard, scope.Identifier.ValueText, handle))
             {
                 continue;
             }
@@ -320,8 +352,8 @@ public class ProviderSignatureDecodeBoundaryTests
             || UnwrapParentheses(negation.Operand) is not InvocationExpressionSyntax tryEnter
             || tryEnter.Expression is not MemberAccessExpressionSyntax
             {
-                Expression: IdentifierNameSyntax { Identifier.Text: "TypeSpecGuard" },
-                Name.Identifier.Text: "TryEnter",
+                Expression: IdentifierNameSyntax { Identifier.ValueText: "TypeSpecGuard" },
+                Name.Identifier.ValueText: "TryEnter",
             }
             || tryEnter.ArgumentList.Arguments.Count < 3
             || !SyntaxFactory.AreEquivalent(
@@ -331,7 +363,7 @@ public class ProviderSignatureDecodeBoundaryTests
             {
                 Designation: SingleVariableDesignationSyntax designation,
             }
-            || designation.Identifier.Text != scopeName)
+            || designation.Identifier.ValueText != scopeName)
         {
             return false;
         }
@@ -379,16 +411,25 @@ public class ProviderSignatureDecodeBoundaryTests
     static bool ConditionGuardsReceiverSignature(
         ExpressionSyntax condition,
         ExpressionSyntax decodeReceiver)
-        => condition.DescendantNodesAndSelf()
-            .OfType<InvocationExpressionSyntax>()
-            .Any(i => i.Expression is MemberAccessExpressionSyntax member
-                && member.Name.Identifier.Text == "IsSafeToDecode"
+    {
+        condition = UnwrapParentheses(condition);
+        if (condition is BinaryExpressionSyntax binary
+            && binary.IsKind(SyntaxKind.LogicalAndExpression))
+        {
+            return ConditionGuardsReceiverSignature(binary.Left, decodeReceiver)
+                || ConditionGuardsReceiverSignature(binary.Right, decodeReceiver);
+        }
+
+        return condition is InvocationExpressionSyntax i
+            && i.Expression is MemberAccessExpressionSyntax member
+                && member.Name.Identifier.ValueText == "IsSafeToDecode"
                 && member.Expression is IdentifierNameSyntax id
-                && id.Identifier.Text == "SignatureBlobGuard"
+                && id.Identifier.ValueText == "SignatureBlobGuard"
                 && i.ArgumentList.Arguments.Any(a =>
                     a.Expression is MemberAccessExpressionSyntax blob
-                    && blob.Name.Identifier.Text == "Signature"
-                    && SyntaxFactory.AreEquivalent(blob.Expression, decodeReceiver)));
+                    && blob.Name.Identifier.ValueText == "Signature"
+                    && SyntaxFactory.AreEquivalent(blob.Expression, decodeReceiver));
+    }
 
     // `GuardedSignatureDecoder.Decode(reader, <recv>.Signature, ..., () =>
     // <recv>.Decode*Signature(...))`: the decode must be inside the supplied

--- a/tests/ILInspector.Metadata.Tests/SignatureBlobGuardTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SignatureBlobGuardTests.cs
@@ -129,6 +129,19 @@ public class SignatureBlobGuardTests
     }
 
     [Fact]
+    public void TypeSpecScope_EmptyBlob_DoesNotLeakBudget()
+    {
+        var (reader, handle) = BuildTypeSpec([]);
+
+        for (int i = 0; i < 300; i++)
+        {
+            Assert.True(TypeSpecGuard.TryEnter(reader, handle, out var scope));
+            scope.Dispose();
+            scope.Dispose();
+        }
+    }
+
+    [Fact]
     public void DeepPrefixChains_AreUnsafe()
     {
         // SRM recurses natively through by-ref, pinned, and custom-modifier prefixes, so a long

--- a/tools/DecompilerHarness/ClosureDiagnosticEvidence.cs
+++ b/tools/DecompilerHarness/ClosureDiagnosticEvidence.cs
@@ -248,7 +248,7 @@ internal static class ClosureDiagnosticEvidence
         var (types, complete) = CompatibleReceiverTypes(receiver);
         return new ClosureDiagnosticReference(
             name,
-            TypeName(receiver),
+            TypeName(receiver, includeGenericArity: true),
             CompatibleReceiverTypes: types,
             CompatibleReceiverTypesComplete: complete);
     }
@@ -284,7 +284,7 @@ internal static class ClosureDiagnosticEvidence
 
         void Add(ITypeSymbol type)
         {
-            types.Add(TypeName(type));
+            types.Add(TypeName(type, includeGenericArity: true));
             complete &= !ContainsErrorType(type);
         }
     }
@@ -324,16 +324,21 @@ internal static class ClosureDiagnosticEvidence
         };
     }
 
-    static string TypeName(ITypeSymbol type)
+    static string TypeName(ITypeSymbol type, bool includeGenericArity = false)
     {
         if (type is IArrayTypeSymbol array)
-            return $"{TypeName(array.ElementType)}[{new string(',', array.Rank - 1)}]";
+            return $"{TypeName(array.ElementType, includeGenericArity)}[{new string(',', array.Rank - 1)}]";
         if (type is not INamedTypeSymbol named)
             return type.Name;
 
         var names = new Stack<string>();
         for (INamedTypeSymbol? current = named.OriginalDefinition; current is not null; current = current.ContainingType)
-            names.Push(CompileBackCSharpNames.Identifier(current.Name));
+        {
+            string name = CompileBackCSharpNames.Identifier(current.Name);
+            names.Push(includeGenericArity && current.Arity > 0
+                ? $"{name}`{current.Arity}"
+                : name);
+        }
 
         string typeName = string.Join(".", names);
         string ns = named.ContainingNamespace is { IsGlobalNamespace: false } containingNamespace

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1850,28 +1850,29 @@ static class FidelityCheck
             value = value[4..];
 
         var normalized = new StringBuilder(value.Length);
-        int genericDepth = 0;
         for (int i = 0; i < value.Length; i++)
         {
             char ch = value[i];
             if (ch == '<')
             {
-                genericDepth++;
+                int end = FindGenericListEnd(value, i);
+                if (end > i)
+                {
+                    normalized.Append('`');
+                    normalized.Append(GenericArity(value.AsSpan(i + 1, end - i - 1)));
+                    i = end;
+                    continue;
+                }
+            }
+            if (ch == '`')
+            {
+                normalized.Append(ch);
+                while (i + 1 < value.Length && char.IsAsciiDigit(value[i + 1]))
+                    normalized.Append(value[++i]);
                 continue;
             }
             if (ch == '>')
-            {
-                genericDepth--;
                 continue;
-            }
-            if (genericDepth > 0)
-                continue;
-            if (ch == '`')
-            {
-                while (i + 1 < value.Length && char.IsAsciiDigit(value[i + 1]))
-                    i++;
-                continue;
-            }
             if (ch is '@' or ' ')
                 continue;
             normalized.Append(ch == '+' ? '.' : ch);
@@ -1897,6 +1898,57 @@ static class FidelityCheck
             "nuint" => "System.UIntPtr",
             var result => result,
         };
+    }
+
+    static int FindGenericListEnd(string value, int start)
+    {
+        int depth = 0;
+        for (int i = start; i < value.Length; i++)
+        {
+            if (value[i] == '<')
+            {
+                depth++;
+            }
+            else if (value[i] == '>' && --depth == 0)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    static int GenericArity(ReadOnlySpan<char> arguments)
+    {
+        int arity = 1;
+        int depth = 0;
+        bool hasContent = false;
+        foreach (char ch in arguments)
+        {
+            if (!char.IsWhiteSpace(ch))
+                hasContent = true;
+
+            switch (ch)
+            {
+                case '<':
+                case '(':
+                case '[':
+                case '{':
+                    depth++;
+                    break;
+                case '>':
+                case ')':
+                case ']':
+                case '}':
+                    depth--;
+                    break;
+                case ',' when depth == 0:
+                    arity++;
+                    break;
+            }
+        }
+
+        return hasContent ? arity : 0;
     }
 
     static CompileBackResult Classify(string fullType, Entry e, IReadOnlyList<string> rOps) =>


### PR DESCRIPTION
## Summary

Evidence revision: `8b9c9a54`

- replace `TypeSpecGuard`'s public unpaired `Exit(int)` with a stack-only
  disposable scope and migrate nested TypeSpec re-entry in Metadata,
  MetadataPrimitives, and Instructions
- strengthen the provider-decode census with durable negative tests for the
  three reviewer evasions and bind every nested decode to its own matching
  guard invocation
- preserve generic arity across the DecompilerHarness receiver-type index and
  Roslyn receiver evidence so `Result` and `Result<T>` cannot collide without
  silently excluding generic receiver extensions

The token migration preserves the explicit signature rejection behavior added
on main: nested TypeSpec failures still report their typed rejection kind, and
existing degraded provider results remain unchanged.

## Safety

- scopes are stack-only, idempotent on repeated disposal, and enforce LIFO
  restoration of the thread-local depth and cumulative-byte budgets
- an empty TypeSpec blob is pinned through 300 enter/dispose cycles so zero
  length cannot be confused with an inactive scope
- the census binds the `TryEnter` handle, returned scope name, terminating
  failure branch, and enclosing `using` to the exact nested decode
- receiver keys canonicalize both `Result<int>` and metadata `Result`1` to the
  same arity-aware identity while keeping non-generic `Result` distinct;
  production-shaped CS1061 evidence pins generic interface receiver selection

## Validation

| Check | Result |
| --- | --- |
| Solution build | Pass |
| Metadata suite | 483 passed |
| Instructions suite | 121 passed |
| `FidelityCheckGeneratedFilterTests` | 24 passed |
| `ClosureDiagnosticEvidenceTests` | 37 passed |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | CLEAN | Verified typed rejection preservation, scope lifetime, census probes, and arity normalization on `8b9c9a54`. |
| Gemini 3.1 Pro | CLEAN | Reproduced the post-rebase generic-receiver exclusion, verified its fix with independent probes, and found no remaining issues on `8b9c9a54`. |

Earlier review rounds found census identifier/boolean evasions and, after the
#2718 conflict resolution, an arity mismatch between metadata keys and Roslyn
receiver evidence. The fixes are pinned by negative syntax tests and a
production-shaped generic receiver test. Both reviewers returned clean on the
final exact head.
