### PR TITLE
Reject --rows on cache command

### DIFF
--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -41,6 +41,23 @@ public class CommandLineTests
     }
 
     [Fact]
+    public void CacheCommand_WithRowsMode_ReportsUnsupportedOption()
+    {
+        var result = CommandLineBuilder.CreateRootCommand().Parse(["cache", "--rows", "--tail", "5"]);
+
+        var error = Assert.Single(result.Errors);
+        Assert.Equal("--rows is not supported by the 'cache' command.", error.Message);
+    }
+
+    [Fact]
+    public void CacheCommand_WithTailLineLimit_Parses()
+    {
+        var result = CommandLineBuilder.CreateRootCommand().Parse(["cache", "--tail", "5"]);
+
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
     public void RootCommand_DoesNotExposeRemovedUtilityCommands()
     {
         var rootCommand = CommandLineBuilder.CreateRootCommand();

--- a/src/dotnet-inspect/CommandLine/Commands/UtilityCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/UtilityCommandDefinitions.cs
@@ -18,7 +18,7 @@ public static class UtilityCommandDefinitions
         var cleanOption = new Option<bool>("--clean", "--clear") { Hidden = true };
 
         cacheCommand.Options.Add(cleanOption);
-        opts.AddOutputOptionsTo(cacheCommand);
+        opts.AddOutputOptionsTo(cacheCommand, supportsRowWindows: false);
 
         // Subcommand: clear
         var clearCommand = new Command("clear", "Clear the cache");

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -149,7 +149,7 @@ public class SharedOptions
     /// <summary>
     /// Adds core output options to a command (verbose, verbosity, tips, limit).
     /// </summary>
-    public void AddOutputOptionsTo(Command command)
+    public void AddOutputOptionsTo(Command command, bool supportsRowWindows = true)
     {
         command.Options.Add(Verbose);
         command.Options.Add(Verbosity);
@@ -158,6 +158,14 @@ public class SharedOptions
         command.Options.Add(Limit);
         command.Options.Add(Rows);
         command.Options.Add(Tail);
+        if (!supportsRowWindows)
+        {
+            command.Validators.Add(result =>
+            {
+                if (result.GetValue(Rows))
+                    result.AddError($"--rows is not supported by the '{command.Name}' command.");
+            });
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Fixes #2712 by rejecting `--rows` on `cache`, where row-window mode cannot be honored. `cache` still accepts `-n`/`--head` and `--tail` as normal global output-line limits; only row-window mode is unsupported.

This is separate from #2714: that PR validates malformed row windows (`--rows` with both/neither head/tail), but `cache --rows --tail 5` can still be well-formed and inert unless `cache` explicitly opts out of row-window support.

## Fix

- Added an optional `supportsRowWindows` parameter to `SharedOptions.AddOutputOptionsTo`.
- Marked `cache` as `supportsRowWindows: false`.
- Added parser regressions for:
  - `cache --rows --tail 5` -> parse error
  - `cache --tail 5` -> still parses

## Validation

- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -class DotnetInspector.Tests.CommandLineTests`
- `dotnet build src/dotnet-inspect/dotnet-inspect.csproj -c Release --configfile nuget.config --verbosity quiet`
- `dotnet restore src/dotnet-inspect/dotnet-inspect.csproj --configfile nuget.config -p:DefaultTargetFramework=net10.0 --verbosity quiet && dotnet build src/dotnet-inspect/dotnet-inspect.csproj -c Release --configfile nuget.config --verbosity quiet -p:DefaultTargetFramework=net10.0`
- Manual: `dotnet run --project src/dotnet-inspect -c Release --no-build -- cache --rows --tail 5` exits 1 with `Error: --rows is not supported by the 'cache' command.` and no stack trace.
