### PR TITLE
Pin initializer-only projection flow

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1758,7 +1758,7 @@ public class CSharpPrinterTests
     }
 
     [Fact]
-    public void Constructor_ImplicitBaseCall_IsSuppressed()
+    public void Constructor_InitializerOnlyResult_RemainsSuccessful()
     {
         // A no-argument base-constructor call is implicit in C#, and the field
         // initializer (`_shadowed = 1`) the compiler emits before that base call
@@ -1770,6 +1770,9 @@ public class CSharpPrinterTests
         Assert.NotNull(function);
         var result = CSharpPrinter.Print(function);
         string output = result.Output!;
+        Assert.True(result.Succeeded);
+        Assert.Equal(DecompilationFidelity.Full, result.Fidelity);
+        Assert.Empty(output);
         Assert.DoesNotContain("base(", output);
         Assert.DoesNotContain(".ctor", output);
         Assert.DoesNotContain("_shadowed", output);

--- a/src/ILInspector.Decompiler.Tests/TypeSourceCheckTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceCheckTests.cs
@@ -502,6 +502,20 @@ public class TypeSourceCheckTests
     }
 
     [Fact]
+    public void Evaluate_OnInitializerOnlyFixture_RendersCompilableInitializer()
+    {
+        string path = typeof(TypeSourceInitializerOnlyFixture).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(path));
+        var api = ApiSurfaceExtractor.Extract(pe);
+        var type = Assert.Single(api.Types, t => t.FullName == typeof(TypeSourceInitializerOnlyFixture).FullName);
+        var source = TypeSourceComposer.Compose(type, path, pdbPath: null);
+        Assert.NotNull(source);
+
+        Assert.Contains("public int Value = 42;", source);
+        AssertCompiles(type.FullName, source);
+    }
+
+    [Fact]
     public void Evaluate_OnUnsafeFieldFixture_RendersCompilableUnsafeBlocks()
     {
         string path = typeof(TypeSourceUnsafeFieldFixture).Assembly.Location;
@@ -652,6 +666,11 @@ public sealed class TypeSourcePrivateCtorInitFixture
     private TypeSourcePrivateCtorInitFixture() { }
 
     public static TypeSourcePrivateCtorInitFixture Create() => new();
+}
+
+public sealed class TypeSourceInitializerOnlyFixture
+{
+    public int Value = 42;
 }
 
 public unsafe interface ITypeSourceUnsafeConsumer

--- a/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
@@ -101,22 +101,6 @@ public class ResearchFactRegistryTests
     }
 
     [Fact]
-    public void RunProjection_AllowsInitializerOnlyResult()
-    {
-        var projected = DecompilerResult.Success("") with
-        {
-            FieldInitializers = [("Value", "42")]
-        };
-
-        var result = ResearchViews.RunProjection(
-            () => projected,
-            emptyOutputIsFailure: true);
-
-        Assert.Same(projected, result);
-        Assert.Empty(result.Diagnostics);
-    }
-
-    [Fact]
     public void EmptyRegistry_ProducesNoOverlayFacts()
     {
         using var source = MetadataSource.Open(typeof(ResearchFixture).Assembly.Location);

--- a/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
@@ -44,6 +44,35 @@ public class ResearchFactRegistryTests
     }
 
     [Fact]
+    public void MemberProjection_PreservesInitializerOnlyConstructorMetadata()
+    {
+        using var source = MetadataSource.Open(typeof(ResearchInitializerOnlyFixture).Assembly.Location);
+
+        var projection = ResearchViews.ProjectMember(new ResearchViews.MemberProjectionRequest(
+            source,
+            typeof(ResearchInitializerOnlyFixture).FullName!,
+            ".ctor",
+            AnnotatedSource: true,
+            CostOverlay: true,
+            SemanticsOverlay: true));
+
+        var results = new[]
+        {
+            Assert.IsType<DecompilerResult>(projection.AnnotatedSource),
+            Assert.IsType<DecompilerResult>(projection.CostOverlay?.Body),
+            Assert.IsType<DecompilerResult>(projection.SemanticsOverlay)
+        };
+        Assert.All(results, result =>
+        {
+            Assert.True(result.Succeeded, string.Join(Environment.NewLine, result.Diagnostics));
+            Assert.Equal(DecompilationFidelity.Full, result.Fidelity);
+            Assert.Contains((nameof(ResearchInitializerOnlyFixture.Value), "42"), result.FieldInitializers);
+            Assert.DoesNotContain(nameof(ResearchInitializerOnlyFixture.Value), result.Output);
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == DiagnosticIds.EmptyOutput);
+        });
+    }
+
+    [Fact]
     public void RunProjection_PreservesFailureDiagnostics()
     {
         var failure = DecompilerResult.Failure(
@@ -68,6 +97,22 @@ public class ResearchFactRegistryTests
 
         Assert.True(result.Succeeded);
         Assert.Equal("", result.Output);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void RunProjection_AllowsInitializerOnlyResult()
+    {
+        var projected = DecompilerResult.Success("") with
+        {
+            FieldInitializers = [("Value", "42")]
+        };
+
+        var result = ResearchViews.RunProjection(
+            () => projected,
+            emptyOutputIsFailure: true);
+
+        Assert.Same(projected, result);
         Assert.Empty(result.Diagnostics);
     }
 
@@ -466,4 +511,9 @@ public sealed class ResearchConstructorFixture
     {
         GC.KeepAlive(value);
     }
+}
+
+public sealed class ResearchInitializerOnlyFixture
+{
+    public int Value = 42;
 }

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -486,7 +486,6 @@ public static class ResearchViews
         return emptyOutputIsFailure
             && string.IsNullOrWhiteSpace(result.Output)
             && result.ConstructorChain is null
-            && result.FieldInitializers.Count == 0
             ? DecompilerResult.Failure(DiagnosticIds.EmptyOutput, "projection produced no output for a method with a body")
             : result;
     }

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -486,6 +486,7 @@ public static class ResearchViews
         return emptyOutputIsFailure
             && string.IsNullOrWhiteSpace(result.Output)
             && result.ConstructorChain is null
+            && result.FieldInitializers.Count == 0
             ? DecompilerResult.Failure(DiagnosticIds.EmptyOutput, "projection produced no output for a method with a body")
             : result;
     }

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -143,6 +143,32 @@ public class ApiOutputFormatterTests
         Assert.Contains("    : base(42)", lines);
     }
 
+    [Fact]
+    public void FormatSourceWithDeclaration_AllowsInitializerOnlyConstructorBody()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Widget", Kind = "class" };
+        var constructor = new ApiMember
+        {
+            Name = ".ctor",
+            Kind = "constructor",
+            SignatureModel = new ApiSignature { MemberName = "#ctor" }
+        };
+        var result = DecompilerResult.Success("") with
+        {
+            FieldInitializers = [("Value", "42")]
+        };
+
+        var source = ApiOutputFormatter.FormatSourceWithDeclaration(
+            type,
+            constructor,
+            methodGenericParameters: null,
+            result);
+
+        Assert.StartsWith("public Widget()", source);
+        Assert.DoesNotContain("Value = 42", source);
+        Assert.DoesNotContain(DiagnosticIds.EmptyOutput, source);
+    }
+
     [Theory]
     [InlineData(false, false, false)]
     [InlineData(true, false, true)]

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -720,6 +720,33 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task InitializerOnlyConstructor_ProjectsThroughMemberAndTypeCommands()
+    {
+        string typeName = typeof(CommandInitializerOnlyFixture).FullName!;
+        var member = await RunAppAsync(
+            "member", typeName, ".ctor:1",
+            "--library", TestAssemblyPath,
+            "-S", "Decompiled Source",
+            "--tips", "q");
+        var type = await RunAppAsync(
+            "type", typeName,
+            "--library", TestAssemblyPath,
+            "-S", "Decompiled Source",
+            "--tips", "q");
+
+        Assert.Equal(0, member.Exit);
+        Assert.Empty(member.Error);
+        Assert.Contains("CommandInitializerOnlyFixture()", member.Output);
+        Assert.DoesNotContain("Value = 42", member.Output);
+        Assert.DoesNotContain("DEC0003", member.Output);
+
+        Assert.Equal(0, type.Exit);
+        Assert.Empty(type.Error);
+        Assert.Contains("public int Value = 42;", type.Output);
+        Assert.DoesNotContain("DEC0003", type.Output);
+    }
+
+    [Fact]
     public async Task MemberCommand_DoesNotInferAsyncFromRenderedText()
     {
         var (exit, output, error) = await RunAppAsync(
@@ -9512,6 +9539,11 @@ public sealed class CommandExecutionSourceDiffFixture
     {
         return value + 1;
     }
+}
+
+public sealed class CommandInitializerOnlyFixture
+{
+    public int Value = 42;
 }
 
 public static class FactsTableFixture


### PR DESCRIPTION
Closes #2688

- Confirms current production paths already preserve initializer-only constructor
  results without `DEC0003`.
- Pins raw decompilation, Research overlays, member/type CLI output, and
  whole-type compile-back with compiled fixtures.
- Card revision: `d0d0d550`

## Change

**Conclusion:** **PASS** — the reported production gap is not reachable.
Initializer-only constructors already remain successful, member views keep
declaration-owned initializers out of body text, and whole-type composition emits
them on fields.

Pinned output:

```csharp
public int Value = 42;

public InitializerOnly()
{
}
```

## Evidence

| Check | Result |
| --- | --- |
| Product/test/fixture solution build | Pass |
| Raw compiled fixture | Empty body, `Full`, `FieldInitializers = [("Value", "42")]` |
| Research annotated/cost/semantics projections | Typed initializer preserved; no `DEC0003` |
| CLI member/type projections | Empty member body; initializer emitted on type field |
| Type artifact boss | Composed initializer source compiles with Roslyn |
| Decompiler fast suite | 2,388 passed |
| Research suite | 101 passed |
| CLI fast suite | 1,343 passed, 10 tool-dependent skips |

## Decompiler quality

**Conclusion:** **PASS** — this is behavior-neutral regression coverage; no
raise, structuring, typing, printer, or corpus rendering behavior changes.
Render A/B and a corpus quality card are not applicable; the highest relevant
proof is the type artifact boss.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | CLEAN | Exact-head re-review confirmed behavior-neutral coverage and correct ownership |
| Gemini 3.1 Pro | CLEAN | Exact-head re-review confirmed its first-round dead-code finding is resolved |

**Review conclusion:** **PASS** — Gemini identified that the proposed Research
guard change was unreachable in production; `d0d0d550` removes that dead change
and its synthetic test. Both isolated reviewers returned CLEAN on the revised
exact head.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile ./nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -trait- "Speed=Slow"
dotnet run --project src/ILInspector.Research.Tests -c Release --no-build
dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- -trait- "Speed=Slow"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "ILInspector.Decompiler.Tests.TypeSourceCheckTests"
dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- -method "*InitializerOnlyConstructor_ProjectsThroughMemberAndTypeCommands*"
```
