### PR TITLE
Harden assembly diff metadata graph climbs

### DIFF
--- a/src/ILInspector.Instructions.Tests/ILInspector.Instructions.Tests.csproj
+++ b/src/ILInspector.Instructions.Tests/ILInspector.Instructions.Tests.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="xunit.v3" />
   </ItemGroup>
 

--- a/src/ILInspector.Instructions.Tests/IlAssemblyDiffMetadataGraphSafetyTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlAssemblyDiffMetadataGraphSafetyTests.cs
@@ -4,6 +4,9 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
 namespace ILInspector.Instructions.Tests;
 
 public class IlAssemblyDiffMetadataGraphSafetyTests
@@ -32,7 +35,7 @@ public class IlAssemblyDiffMetadataGraphSafetyTests
     {
         string identity = MemberIdentity(BuildTypeDefinitionImage(depth: 3, cyclic: false));
 
-        Assert.Equal("N.T+T+T::M#static void()", identity);
+        Assert.Equal("N.T+T+T::M#static void([Synthetic]N.T+T+T)", identity);
     }
 
     [Fact]
@@ -47,15 +50,24 @@ public class IlAssemblyDiffMetadataGraphSafetyTests
     public void MetadataGraphEdgeCensus_MatchesBoundedImplementations()
     {
         string sourceDirectory = Path.Combine(FindRepositoryRoot(), "src", "ILInspector.Instructions");
-        var actual = Directory.EnumerateFiles(sourceDirectory, "*.cs")
+        var actual = Directory.EnumerateFiles(sourceDirectory, "*.cs", SearchOption.AllDirectories)
             .Select(path =>
             {
-                string text = File.ReadAllText(path);
+                var root = CSharpSyntaxTree.ParseText(
+                    File.ReadAllText(path),
+                    path: path,
+                    cancellationToken: TestContext.Current.CancellationToken)
+                    .GetRoot(TestContext.Current.CancellationToken);
                 return new GraphEdgeCount(
-                    Path.GetFileName(path),
-                    Count(text, ".GetDeclaringType()"),
-                    Count(text, "(TypeReferenceHandle)type.ResolutionScope")
-                        + Count(text, "(TypeReferenceHandle)scope"));
+                    Path.GetRelativePath(sourceDirectory, path),
+                    root.DescendantNodes()
+                        .OfType<InvocationExpressionSyntax>()
+                        .Count(invocation =>
+                            invocation.Expression is MemberAccessExpressionSyntax member
+                            && member.Name.Identifier.ValueText == "GetDeclaringType"),
+                    root.DescendantNodes()
+                        .OfType<MemberAccessExpressionSyntax>()
+                        .Count(member => member.Name.Identifier.ValueText == "ResolutionScope"));
             })
             .Where(count => count.DeclaringTypeEdges > 0 || count.TypeReferenceEdges > 0)
             .OrderBy(count => count.File, StringComparer.Ordinal)
@@ -63,9 +75,9 @@ public class IlAssemblyDiffMetadataGraphSafetyTests
 
         GraphEdgeCount[] expected =
         [
-            new("BoundedMetadataName.cs", DeclaringTypeEdges: 1, TypeReferenceEdges: 1),
+            new("BoundedMetadataName.cs", DeclaringTypeEdges: 2, TypeReferenceEdges: 2),
             new("IlAssemblyDiff.cs", DeclaringTypeEdges: 1, TypeReferenceEdges: 0),
-            new("IlBodyDiff.cs", DeclaringTypeEdges: 5, TypeReferenceEdges: 2),
+            new("IlBodyDiff.cs", DeclaringTypeEdges: 5, TypeReferenceEdges: 8),
             new("MetadataStackTypeResolver.cs", DeclaringTypeEdges: 2, TypeReferenceEdges: 0),
         ];
         Assert.Equal(expected, actual);
@@ -163,7 +175,7 @@ public class IlAssemblyDiffMetadataGraphSafetyTests
         if (cyclic)
             metadata.AddNestedType(parent, parent);
 
-        var methodBodies = AddMethod(metadata, MethodSignature(metadata, typeReference: default));
+        var methodBodies = AddMethod(metadata, MethodSignature(metadata, parent));
         return Serialize(metadata, methodBodies);
     }
 
@@ -241,16 +253,22 @@ public class IlAssemblyDiffMetadataGraphSafetyTests
             fieldList: MetadataTokens.FieldDefinitionHandle(1),
             methodList: MetadataTokens.MethodDefinitionHandle(1));
 
-    static BlobHandle MethodSignature(MetadataBuilder metadata, TypeReferenceHandle typeReference)
+    static BlobHandle MethodSignature(MetadataBuilder metadata, EntityHandle parameterType)
     {
         var signature = new BlobBuilder();
         signature.WriteByte(0x00); // default, static
-        signature.WriteCompressedInteger(typeReference.IsNil ? 0 : 1);
+        signature.WriteCompressedInteger(parameterType.IsNil ? 0 : 1);
         signature.WriteByte(0x01); // void
-        if (!typeReference.IsNil)
+        if (!parameterType.IsNil)
         {
             signature.WriteByte(0x12); // class
-            signature.WriteCompressedInteger((MetadataTokens.GetRowNumber(typeReference) << 2) | 1);
+            int tag = parameterType.Kind switch
+            {
+                HandleKind.TypeDefinition => 0,
+                HandleKind.TypeReference => 1,
+                _ => throw new ArgumentException($"Unsupported signature type {parameterType.Kind}.", nameof(parameterType)),
+            };
+            signature.WriteCompressedInteger((MetadataTokens.GetRowNumber(parameterType) << 2) | tag);
         }
         return metadata.GetOrAddBlob(signature);
     }
@@ -293,18 +311,6 @@ public class IlAssemblyDiffMetadataGraphSafetyTests
         }
 
         throw new InvalidOperationException("Method M not found.");
-    }
-
-    static int Count(string text, string value)
-    {
-        int count = 0;
-        int start = 0;
-        while ((start = text.IndexOf(value, start, StringComparison.Ordinal)) >= 0)
-        {
-            count++;
-            start += value.Length;
-        }
-        return count;
     }
 
     static string FindRepositoryRoot()

--- a/src/ILInspector.Instructions.Tests/IlAssemblyDiffMetadataGraphSafetyTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlAssemblyDiffMetadataGraphSafetyTests.cs
@@ -1,0 +1,326 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Instructions.Tests;
+
+public class IlAssemblyDiffMetadataGraphSafetyTests
+{
+    const string WorkerVariable = "DOTNET_INSPECT_INSTRUCTIONS_METADATA_GRAPH_WORKER";
+    const int DeepGraphLength = 100_000;
+
+    [Fact]
+    public void CyclicAndDeepMetadataGraphs_ThroughPublicAssemblyDiffPaths_AreContainedInChildProcess()
+        => RunWorker(nameof(MetadataGraphWorker));
+
+    [Fact]
+    public void MetadataGraphWorker()
+    {
+        if (!IsSelectedWorker(nameof(MetadataGraphWorker)))
+            return;
+
+        AssertContained(BuildTypeDefinitionImage(depth: 1, cyclic: true));
+        AssertContained(BuildTypeDefinitionImage(DeepGraphLength, cyclic: false));
+        AssertContained(BuildTypeReferenceImage(depth: 1, cyclic: true));
+        AssertContained(BuildTypeReferenceImage(DeepGraphLength, cyclic: false));
+    }
+
+    [Fact]
+    public void ValidNestedTypeDefinitionIdentity_IsPreserved()
+    {
+        string identity = MemberIdentity(BuildTypeDefinitionImage(depth: 3, cyclic: false));
+
+        Assert.Equal("N.T+T+T::M#static void()", identity);
+    }
+
+    [Fact]
+    public void ValidCoreLibTypeReferenceIdentity_IsPreserved()
+    {
+        string identity = MemberIdentity(BuildTypeReferenceImage(depth: 1, cyclic: false));
+
+        Assert.Equal("C::M#static void([System.Private.CoreLib]System.String)", identity);
+    }
+
+    [Fact]
+    public void MetadataGraphEdgeCensus_MatchesBoundedImplementations()
+    {
+        string sourceDirectory = Path.Combine(FindRepositoryRoot(), "src", "ILInspector.Instructions");
+        var actual = Directory.EnumerateFiles(sourceDirectory, "*.cs")
+            .Select(path =>
+            {
+                string text = File.ReadAllText(path);
+                return new GraphEdgeCount(
+                    Path.GetFileName(path),
+                    Count(text, ".GetDeclaringType()"),
+                    Count(text, "(TypeReferenceHandle)type.ResolutionScope")
+                        + Count(text, "(TypeReferenceHandle)scope"));
+            })
+            .Where(count => count.DeclaringTypeEdges > 0 || count.TypeReferenceEdges > 0)
+            .OrderBy(count => count.File, StringComparer.Ordinal)
+            .ToArray();
+
+        GraphEdgeCount[] expected =
+        [
+            new("BoundedMetadataName.cs", DeclaringTypeEdges: 1, TypeReferenceEdges: 1),
+            new("IlAssemblyDiff.cs", DeclaringTypeEdges: 1, TypeReferenceEdges: 0),
+            new("IlBodyDiff.cs", DeclaringTypeEdges: 5, TypeReferenceEdges: 2),
+            new("MetadataStackTypeResolver.cs", DeclaringTypeEdges: 2, TypeReferenceEdges: 0),
+        ];
+        Assert.Equal(expected, actual);
+    }
+
+    static bool IsSelectedWorker(string methodName)
+        => Environment.GetEnvironmentVariable(WorkerVariable) == methodName;
+
+    static void RunWorker(string workerMethod)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add(typeof(IlAssemblyDiffMetadataGraphSafetyTests).Assembly.Location);
+        startInfo.ArgumentList.Add("-method");
+        startInfo.ArgumentList.Add($"*{workerMethod}*");
+        startInfo.Environment[WorkerVariable] = workerMethod;
+
+        using var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+        var standardOutputTask = process.StandardOutput.ReadToEndAsync();
+        var standardErrorTask = process.StandardError.ReadToEndAsync();
+        process.WaitForExit();
+        string standardOutput = standardOutputTask.GetAwaiter().GetResult();
+        string standardError = standardErrorTask.GetAwaiter().GetResult();
+
+        Assert.True(
+            process.ExitCode == 0,
+            $"Child worker {workerMethod} exited {process.ExitCode}.\nstdout:\n{standardOutput}\nstderr:\n{standardError}");
+    }
+
+    static void AssertContained(byte[] image)
+    {
+        using (var oldStream = new MemoryStream(image))
+        using (var newStream = new MemoryStream(image))
+        {
+            var assemblyResult = IlAssemblyDiff.CompareStreams(
+                oldStream,
+                "old.dll",
+                newStream,
+                "new.dll");
+
+            Assert.Equal(1, assemblyResult.Diff.ComparedBodyCount);
+            Assert.Equal(1, assemblyResult.Diff.PairExactCount);
+            Assert.Equal(0, assemblyResult.Diff.FailureCount);
+        }
+
+        using var pe = new PEReader(new MemoryStream(image));
+        var reader = pe.GetMetadataReader();
+        var method = FindMethod(reader);
+        var memberResult = IlAssemblyDiff.CompareMembers(
+            pe,
+            reader,
+            method,
+            pe,
+            reader,
+            method);
+
+        Assert.True(memberResult.Diff.IsExact);
+        Assert.Equal(memberResult.Old.Identity, memberResult.New.Identity);
+        Assert.InRange(memberResult.Old.Identity.Length, 1, 4096);
+    }
+
+    static string MemberIdentity(byte[] image)
+    {
+        using var pe = new PEReader(new MemoryStream(image));
+        var reader = pe.GetMetadataReader();
+        var method = FindMethod(reader);
+        return IlAssemblyDiff.CompareMembers(pe, reader, method, pe, reader, method).Old.Identity;
+    }
+
+    static byte[] BuildTypeDefinitionImage(int depth, bool cyclic)
+    {
+        var metadata = CreateMetadata();
+        AddModuleType(metadata);
+
+        TypeDefinitionHandle parent = default;
+        for (int i = 0; i < depth; i++)
+        {
+            var current = metadata.AddTypeDefinition(
+                i == 0 ? TypeAttributes.Public : TypeAttributes.NestedPublic,
+                i == 0 ? metadata.GetOrAddString("N") : default,
+                metadata.GetOrAddString("T"),
+                baseType: default,
+                fieldList: MetadataTokens.FieldDefinitionHandle(1),
+                methodList: MetadataTokens.MethodDefinitionHandle(1));
+            if (!parent.IsNil)
+                metadata.AddNestedType(current, parent);
+            parent = current;
+        }
+
+        if (cyclic)
+            metadata.AddNestedType(parent, parent);
+
+        var methodBodies = AddMethod(metadata, MethodSignature(metadata, typeReference: default));
+        return Serialize(metadata, methodBodies);
+    }
+
+    static byte[] BuildTypeReferenceImage(int depth, bool cyclic)
+    {
+        var metadata = CreateMetadata();
+        AddModuleType(metadata);
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            default,
+            metadata.GetOrAddString("C"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        TypeReferenceHandle typeReference;
+        if (cyclic)
+        {
+            typeReference = metadata.AddTypeReference(
+                MetadataTokens.TypeReferenceHandle(1),
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("Loop"));
+        }
+        else
+        {
+            var coreLib = metadata.AddAssemblyReference(
+                metadata.GetOrAddString("System.Private.CoreLib"),
+                new Version(11, 0, 0, 0),
+                culture: default,
+                publicKeyOrToken: default,
+                flags: default,
+                hashValue: default);
+            typeReference = metadata.AddTypeReference(
+                coreLib,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("String"));
+            for (int i = 1; i < depth; i++)
+            {
+                typeReference = metadata.AddTypeReference(
+                    typeReference,
+                    default,
+                    metadata.GetOrAddString("T"));
+            }
+        }
+
+        var methodBodies = AddMethod(metadata, MethodSignature(metadata, typeReference));
+        return Serialize(metadata, methodBodies);
+    }
+
+    static MetadataBuilder CreateMetadata()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("Synthetic.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Synthetic"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        return metadata;
+    }
+
+    static void AddModuleType(MetadataBuilder metadata)
+        => metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+    static BlobHandle MethodSignature(MetadataBuilder metadata, TypeReferenceHandle typeReference)
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x00); // default, static
+        signature.WriteCompressedInteger(typeReference.IsNil ? 0 : 1);
+        signature.WriteByte(0x01); // void
+        if (!typeReference.IsNil)
+        {
+            signature.WriteByte(0x12); // class
+            signature.WriteCompressedInteger((MetadataTokens.GetRowNumber(typeReference) << 2) | 1);
+        }
+        return metadata.GetOrAddBlob(signature);
+    }
+
+    static BlobBuilder AddMethod(MetadataBuilder metadata, BlobHandle signature)
+    {
+        var il = new BlobBuilder();
+        var instructions = new InstructionEncoder(il, new ControlFlowBuilder());
+        instructions.OpCode(ILOpCode.Ret);
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = new MethodBodyStreamEncoder(methodBodies).AddMethodBody(instructions, maxStack: 0);
+        metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Static,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("M"),
+            signature,
+            bodyOffset,
+            MetadataTokens.ParameterHandle(1));
+        return methodBodies;
+    }
+
+    static byte[] Serialize(MetadataBuilder metadata, BlobBuilder methodBodies)
+    {
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            methodBodies,
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    static MethodDefinitionHandle FindMethod(MetadataReader reader)
+    {
+        foreach (var handle in reader.MethodDefinitions)
+        {
+            if (reader.GetString(reader.GetMethodDefinition(handle).Name) == "M")
+                return handle;
+        }
+
+        throw new InvalidOperationException("Method M not found.");
+    }
+
+    static int Count(string text, string value)
+    {
+        int count = 0;
+        int start = 0;
+        while ((start = text.IndexOf(value, start, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            start += value.Length;
+        }
+        return count;
+    }
+
+    static string FindRepositoryRoot()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
+        {
+            string sourceDirectory = Path.Combine(directory.FullName, "src", "ILInspector.Instructions");
+            if (Directory.Exists(sourceDirectory))
+                return directory.FullName;
+        }
+
+        throw new DirectoryNotFoundException("Could not find repository root containing src/ILInspector.Instructions.");
+    }
+
+    readonly record struct GraphEdgeCount(
+        string File,
+        int DeclaringTypeEdges,
+        int TypeReferenceEdges);
+}

--- a/src/ILInspector.Instructions/BoundedMetadataName.cs
+++ b/src/ILInspector.Instructions/BoundedMetadataName.cs
@@ -11,25 +11,38 @@ static class BoundedMetadataName
         TypeDefinitionHandle handle,
         bool includeAssembly)
     {
-        var segments = new List<string>();
-        var visited = new HashSet<TypeDefinitionHandle>();
-        string ns = "";
-        var current = handle;
+        var first = reader.GetTypeDefinition(handle);
+        string firstName = reader.GetString(first.Name);
+        string ns = reader.GetString(first.Namespace);
+        var declaring = first.GetDeclaringType();
+        if (declaring.IsNil)
+            return QualifyDefinition(reader, ns, firstName, includeAssembly);
 
+        var segments = new List<string> { firstName };
+        var visited = new HashSet<TypeDefinitionHandle> { handle };
+        var current = declaring;
         while (segments.Count < MaxSegments && visited.Add(current))
         {
             var type = reader.GetTypeDefinition(current);
             segments.Add(reader.GetString(type.Name));
             ns = reader.GetString(type.Namespace);
 
-            var declaring = type.GetDeclaringType();
+            declaring = type.GetDeclaringType();
             if (declaring.IsNil)
                 break;
             current = declaring;
         }
 
         segments.Reverse();
-        string name = string.Join("+", segments);
+        return QualifyDefinition(reader, ns, string.Join("+", segments), includeAssembly);
+    }
+
+    static string QualifyDefinition(
+        MetadataReader reader,
+        string ns,
+        string name,
+        bool includeAssembly)
+    {
         string fullName = ns.Length == 0 ? name : $"{ns}.{name}";
         if (!includeAssembly)
             return fullName;
@@ -42,11 +55,17 @@ static class BoundedMetadataName
         MetadataReader reader,
         TypeReferenceHandle handle)
     {
-        var segments = new List<string>();
-        var visited = new HashSet<TypeReferenceHandle>();
-        EntityHandle scope = default;
-        var current = handle;
+        var first = reader.GetTypeReference(handle);
+        string firstName = reader.GetString(first.Name);
+        string firstNamespace = reader.GetString(first.Namespace);
+        string firstFullName = firstNamespace.Length == 0 ? firstName : $"{firstNamespace}.{firstName}";
+        var scope = first.ResolutionScope;
+        if (scope.Kind != HandleKind.TypeReference)
+            return QualifyReference(reader, scope, firstFullName);
 
+        var segments = new List<string> { firstFullName };
+        var visited = new HashSet<TypeReferenceHandle> { handle };
+        var current = (TypeReferenceHandle)scope;
         while (segments.Count < MaxSegments && visited.Add(current))
         {
             var type = reader.GetTypeReference(current);
@@ -61,7 +80,14 @@ static class BoundedMetadataName
         }
 
         segments.Reverse();
-        string fullName = string.Join("+", segments);
+        return QualifyReference(reader, scope, string.Join("+", segments));
+    }
+
+    static string QualifyReference(
+        MetadataReader reader,
+        EntityHandle scope,
+        string fullName)
+    {
         return scope.Kind == HandleKind.AssemblyReference
             ? $"[{reader.GetString(reader.GetAssemblyReference((AssemblyReferenceHandle)scope).Name)}]{fullName}"
             : fullName;

--- a/src/ILInspector.Instructions/BoundedMetadataName.cs
+++ b/src/ILInspector.Instructions/BoundedMetadataName.cs
@@ -1,0 +1,69 @@
+using System.Reflection.Metadata;
+
+namespace ILInspector.Instructions;
+
+static class BoundedMetadataName
+{
+    const int MaxSegments = 256;
+
+    public static string TypeDefinition(
+        MetadataReader reader,
+        TypeDefinitionHandle handle,
+        bool includeAssembly)
+    {
+        var segments = new List<string>();
+        var visited = new HashSet<TypeDefinitionHandle>();
+        string ns = "";
+        var current = handle;
+
+        while (segments.Count < MaxSegments && visited.Add(current))
+        {
+            var type = reader.GetTypeDefinition(current);
+            segments.Add(reader.GetString(type.Name));
+            ns = reader.GetString(type.Namespace);
+
+            var declaring = type.GetDeclaringType();
+            if (declaring.IsNil)
+                break;
+            current = declaring;
+        }
+
+        segments.Reverse();
+        string name = string.Join("+", segments);
+        string fullName = ns.Length == 0 ? name : $"{ns}.{name}";
+        if (!includeAssembly)
+            return fullName;
+
+        string assembly = reader.IsAssembly ? reader.GetString(reader.GetAssemblyDefinition().Name) : "";
+        return $"[{assembly}]{fullName}";
+    }
+
+    public static string TypeReference(
+        MetadataReader reader,
+        TypeReferenceHandle handle)
+    {
+        var segments = new List<string>();
+        var visited = new HashSet<TypeReferenceHandle>();
+        EntityHandle scope = default;
+        var current = handle;
+
+        while (segments.Count < MaxSegments && visited.Add(current))
+        {
+            var type = reader.GetTypeReference(current);
+            string name = reader.GetString(type.Name);
+            string ns = reader.GetString(type.Namespace);
+            segments.Add(ns.Length == 0 ? name : $"{ns}.{name}");
+            scope = type.ResolutionScope;
+
+            if (scope.Kind != HandleKind.TypeReference)
+                break;
+            current = (TypeReferenceHandle)scope;
+        }
+
+        segments.Reverse();
+        string fullName = string.Join("+", segments);
+        return scope.Kind == HandleKind.AssemblyReference
+            ? $"[{reader.GetString(reader.GetAssemblyReference((AssemblyReferenceHandle)scope).Name)}]{fullName}"
+            : fullName;
+    }
+}

--- a/src/ILInspector.Instructions/IlAssemblyDiff.cs
+++ b/src/ILInspector.Instructions/IlAssemblyDiff.cs
@@ -289,15 +289,7 @@ public static class IlAssemblyDiff
     }
 
     static string TypeName(MetadataReader reader, TypeDefinitionHandle handle)
-    {
-        var type = reader.GetTypeDefinition(handle);
-        string name = reader.GetString(type.Name);
-        var declaring = type.GetDeclaringType();
-        if (!declaring.IsNil)
-            return $"{TypeName(reader, declaring)}+{name}";
-        string ns = reader.GetString(type.Namespace);
-        return ns.Length == 0 ? name : $"{ns}.{name}";
-    }
+        => BoundedMetadataName.TypeDefinition(reader, handle, includeAssembly: false);
 
     static ImmutableArray<IlDiffBucket> Buckets(Dictionary<string, int> counts)
         => [.. counts
@@ -350,23 +342,10 @@ sealed class SignatureIdentityProvider : ISignatureTypeProvider<string, object?>
         };
 
     public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
-        => TypeDefinitionName(reader, handle);
+        => BoundedMetadataName.TypeDefinition(reader, handle, includeAssembly: true);
 
     public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
-    {
-        var type = reader.GetTypeReference(handle);
-        string name = reader.GetString(type.Name);
-        string ns = reader.GetString(type.Namespace);
-        string fullName = ns.Length == 0 ? name : $"{ns}.{name}";
-        return type.ResolutionScope.Kind switch
-        {
-            HandleKind.AssemblyReference =>
-                $"[{reader.GetString(reader.GetAssemblyReference((AssemblyReferenceHandle)type.ResolutionScope).Name)}]{fullName}",
-            HandleKind.TypeReference =>
-                $"{GetTypeFromReference(reader, (TypeReferenceHandle)type.ResolutionScope, rawTypeKind)}+{fullName}",
-            _ => fullName,
-        };
-    }
+        => BoundedMetadataName.TypeReference(reader, handle);
 
     public string GetTypeFromSpecification(MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
     {
@@ -395,15 +374,4 @@ sealed class SignatureIdentityProvider : ISignatureTypeProvider<string, object?>
     public string GetFunctionPointerType(MethodSignature<string> signature)
         => $"method {signature.ReturnType} *({string.Join(", ", signature.ParameterTypes)})";
 
-    static string TypeDefinitionName(MetadataReader reader, TypeDefinitionHandle handle)
-    {
-        var type = reader.GetTypeDefinition(handle);
-        string name = reader.GetString(type.Name);
-        var declaring = type.GetDeclaringType();
-        if (!declaring.IsNil)
-            return $"{TypeDefinitionName(reader, declaring)}+{name}";
-        string ns = reader.GetString(type.Namespace);
-        string assembly = reader.IsAssembly ? reader.GetString(reader.GetAssemblyDefinition().Name) : "";
-        return $"[{assembly}]{(ns.Length == 0 ? name : $"{ns}.{name}")}";
-    }
 }


### PR DESCRIPTION
## Summary

- replace unbounded TypeDef and TypeRef name recursion in `IlAssemblyDiff` with bounded, cycle-aware iteration
- preserve valid nested-type and CoreLib signature identities
- add process-isolated cyclic/deep fixtures through `CompareStreams` and `CompareMembers`, plus a graph-edge census

## Validation

- `dotnet run --project src/ILInspector.Instructions.Tests -c Release --no-build` (121 passed)
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`

Fixes #2710