### PR TITLE
Add caller-loop census measurement

### DIFF
--- a/eng/prepare-aspire-dashboard-corpus.sh
+++ b/eng/prepare-aspire-dashboard-corpus.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Restores the pinned Aspire Dashboard 9.0.0 assembly used by the original
+# Performance Triage investigation and emits its managed assembly path.
+set -euo pipefail
+
+out="${1:-}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cat > "$tmp/corpus.csproj" <<'EOF'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net11.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Aspire.Dashboard.Sdk.linux-x64" Version="9.0.0" />
+  </ItemGroup>
+</Project>
+EOF
+
+dotnet restore "$tmp/corpus.csproj" --configfile "$root/nuget.config" --verbosity quiet >/dev/null
+
+packages="${NUGET_PACKAGES:-$HOME/.nuget/packages}"
+assembly="$packages/aspire.dashboard.sdk.linux-x64/9.0.0/tools/Aspire.Dashboard.dll"
+if [ ! -f "$assembly" ]; then
+  echo "Missing corpus assembly: $assembly" >&2
+  exit 1
+fi
+
+if [ -n "$out" ]; then
+  printf '%s\n' "$assembly" > "$out"
+else
+  printf '%s\n' "$assembly"
+fi

--- a/eng/prepare-performance-triage-corpus.sh
+++ b/eng/prepare-performance-triage-corpus.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Restores the pinned six-library Performance Triage corpus from #1974 and
+# emits one managed assembly path per line.
+set -euo pipefail
+
+out="${1:-}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cat > "$tmp/corpus.csproj" <<'EOF'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net11.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting" Version="13.4.6" />
+    <PackageReference Include="System.Text.Json" Version="10.0.9" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Polly" Version="8.7.0" />
+    <PackageReference Include="AutoMapper" Version="16.1.1" />
+  </ItemGroup>
+</Project>
+EOF
+
+dotnet restore "$tmp/corpus.csproj" --configfile "$root/nuget.config" --verbosity quiet >/dev/null
+
+packages="${NUGET_PACKAGES:-$HOME/.nuget/packages}"
+
+select_asset() {
+  local package="$1"
+  local version="$2"
+  local assembly="$3"
+  local base="$packages/$package/$version/lib"
+  local tfm
+  for tfm in net11.0 net10.0 net9.0 net8.0 net7.0 net6.0 netstandard2.1 netstandard2.0; do
+    if [ -f "$base/$tfm/$assembly" ]; then
+      printf '%s\n' "$base/$tfm/$assembly"
+      return
+    fi
+  done
+  echo "Missing corpus assembly: $package@$version $assembly" >&2
+  exit 1
+}
+
+assemblies=(
+  "$(select_asset aspire.hosting 13.4.6 Aspire.Hosting.dll)"
+  "$(select_asset system.text.json 10.0.9 System.Text.Json.dll)"
+  "$(select_asset newtonsoft.json 13.0.4 Newtonsoft.Json.dll)"
+  "$(select_asset serilog 4.3.1 Serilog.dll)"
+  "$(select_asset polly 8.7.0 Polly.dll)"
+  "$(select_asset automapper 16.1.1 AutoMapper.dll)"
+)
+
+if [ -n "$out" ]; then
+  printf '%s\n' "${assemblies[@]}" > "$out"
+else
+  printf '%s\n' "${assemblies[@]}"
+fi

--- a/src/ILInspector.Analysis.Tests/CallerLoopCensusTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallerLoopCensusTests.cs
@@ -167,7 +167,9 @@ public class CallerLoopCensusTests
     {
         var report = CallerLoopCensus.Measure(["/not/a/real/assembly.dll"]);
 
+        Assert.Equal(0, report.Opened);
         Assert.Equal(1, report.Failed);
+        Assert.Equal(report.Assemblies, report.Opened + report.Failed);
         Assert.Single(report.Failures);
         Assert.Contains("assembly.dll", report.Failures[0].AssemblyPath, StringComparison.Ordinal);
     }

--- a/src/ILInspector.Analysis.Tests/CallerLoopCensusTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallerLoopCensusTests.cs
@@ -1,0 +1,216 @@
+using System.Collections.Immutable;
+
+using ILInspector.AnalysisHarness;
+
+namespace ILInspector.Analysis.Tests;
+
+public class CallerLoopCensusTests
+{
+    static readonly TypeRef s_void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef s_type = TypeRef.Definition("Fixture", "Fixtures", "Graph");
+
+    [Fact]
+    public void Analyze_ClassifiesDirectAndTransitiveWitnesses()
+    {
+        var loop = Method(1, "Loop");
+        var wrapper = Method(2, "Wrapper");
+        var target = Method(3, "Target");
+        var rows = CallerLoopCensus.Analyze(
+            "Fixture.dll",
+            [loop, wrapper, target],
+            [Call(loop, wrapper, 4, inLoop: true), Call(wrapper, target, 8)],
+            [Opportunity(wrapper, "c1"), Opportunity(target, "c2")],
+            maxDepth: 4);
+
+        Assert.Equal(CallerLoopClassification.Direct, rows[0].Classification);
+        Assert.Equal(1, rows[0].NearestDepth);
+        Assert.Equal(CallerLoopClassification.Transitive, rows[1].Classification);
+        Assert.Equal(2, rows[1].NearestDepth);
+        Assert.Equal([4, 8], rows[1].Witness.Select(static step => step.ILOffset));
+    }
+
+    [Fact]
+    public void Analyze_RejectsNonInvocationAndNonLoopEdges()
+    {
+        var caller = Method(1, "Caller");
+        var functionLoadTarget = Method(2, "FunctionLoadTarget");
+        var straightTarget = Method(3, "StraightTarget");
+        var rows = CallerLoopCensus.Analyze(
+            "Fixture.dll",
+            [caller, functionLoadTarget, straightTarget],
+            [
+                Call(caller, functionLoadTarget, 4, inLoop: true, CallKind.LoadFunction),
+                Call(caller, straightTarget, 8),
+            ],
+            [Opportunity(functionLoadTarget, "c1"), Opportunity(straightTarget, "c2")]);
+
+        Assert.All(rows, static row => Assert.Equal(CallerLoopClassification.None, row.Classification));
+    }
+
+    [Fact]
+    public void Analyze_DoesNotTreatSelfRecursionAsCallerLoop()
+    {
+        var recursive = Method(1, "Recursive");
+        var row = Assert.Single(CallerLoopCensus.Analyze(
+            "Fixture.dll",
+            [recursive],
+            [Call(recursive, recursive, 4, inLoop: true)],
+            [Opportunity(recursive, "c1")]));
+
+        Assert.Equal(CallerLoopClassification.None, row.Classification);
+    }
+
+    [Fact]
+    public void Analyze_ReportsWitnessBeyondConfiguredBound()
+    {
+        var loop = Method(1, "Loop");
+        var first = Method(2, "First");
+        var second = Method(3, "Second");
+        var target = Method(4, "Target");
+        var row = Assert.Single(CallerLoopCensus.Analyze(
+            "Fixture.dll",
+            [loop, first, second, target],
+            [
+                Call(loop, first, 4, inLoop: true),
+                Call(first, second, 8),
+                Call(second, target, 12),
+            ],
+            [Opportunity(target, "c1")],
+            maxDepth: 2));
+
+        Assert.Equal(CallerLoopClassification.BeyondBound, row.Classification);
+        Assert.Equal(3, row.NearestDepth);
+        Assert.Equal(3, row.Witness.Count);
+    }
+
+    [Fact]
+    public void Analyze_UsesStableShortestWitnessTieBreak()
+    {
+        var zCaller = Method(1, "ZCaller");
+        var aCaller = Method(2, "ACaller");
+        var target = Method(3, "Target");
+        var row = Assert.Single(CallerLoopCensus.Analyze(
+            "Fixture.dll",
+            [zCaller, aCaller, target],
+            [
+                Call(zCaller, target, 4, inLoop: true),
+                Call(aCaller, target, 12, inLoop: true),
+            ],
+            [Opportunity(target, "c1")]));
+
+        Assert.Contains("ACaller", Assert.Single(row.Witness).Caller, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Analyze_CycleTerminatesAtNearestDepth()
+    {
+        var loop = Method(1, "Loop");
+        var first = Method(2, "First");
+        var second = Method(3, "Second");
+        var row = Assert.Single(CallerLoopCensus.Analyze(
+            "Fixture.dll",
+            [loop, first, second],
+            [
+                Call(loop, first, 4, inLoop: true),
+                Call(first, second, 8),
+                Call(second, first, 12),
+            ],
+            [Opportunity(second, "c1")]));
+
+        Assert.Equal(CallerLoopClassification.Transitive, row.Classification);
+        Assert.Equal(2, row.NearestDepth);
+    }
+
+    [Fact]
+    public void Analyze_DoesNotPropagateRecursiveCycleBackToLoopOwner()
+    {
+        var loopOwner = Method(1, "LoopOwner");
+        var wrapper = Method(2, "Wrapper");
+        var row = Assert.Single(CallerLoopCensus.Analyze(
+            "Fixture.dll",
+            [loopOwner, wrapper],
+            [
+                Call(loopOwner, wrapper, 4, inLoop: true),
+                Call(wrapper, loopOwner, 8),
+            ],
+            [Opportunity(loopOwner, "c1")]));
+
+        Assert.Equal(CallerLoopClassification.None, row.Classification);
+    }
+
+    [Fact]
+    public void Analyze_PreservesCandidateAndLocalSemantics()
+    {
+        var loop = Method(1, "Loop");
+        var target = Method(2, "Target");
+        var opportunity = Opportunity(target, "pt~exact") with
+        {
+            Multiplicity = "conditional",
+            Provenance = PerformanceTriageProvenance.Exact,
+            PathContext = "error path",
+        };
+        var row = Assert.Single(CallerLoopCensus.Analyze(
+            "Fixture.dll",
+            [loop, target],
+            [Call(loop, target, 4, inLoop: true)],
+            [opportunity]));
+
+        Assert.Equal("pt~exact", row.Candidate);
+        Assert.Equal("conditional", row.LocalMultiplicity);
+        Assert.False(row.LocalInLoop);
+        Assert.Equal("error path", row.Path);
+        Assert.Equal(PerformanceTriageProvenance.Exact, row.Provenance);
+    }
+
+    [Fact]
+    public void Measure_ReportsInputFailures()
+    {
+        var report = CallerLoopCensus.Measure(["/not/a/real/assembly.dll"]);
+
+        Assert.Equal(1, report.Failed);
+        Assert.Single(report.Failures);
+        Assert.Contains("assembly.dll", report.Failures[0].AssemblyPath, StringComparison.Ordinal);
+    }
+
+    static MethodIdentity Method(int token, string name)
+        => new(
+            "Fixture",
+            Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            s_type,
+            name,
+            [],
+            s_void,
+            token,
+            IsStatic: true);
+
+    static DirectCall Call(
+        MethodIdentity caller,
+        MethodIdentity callee,
+        int offset,
+        bool inLoop = false,
+        CallKind kind = CallKind.Call)
+        => new(
+            caller,
+            new MemberRef(callee.DeclaringType, callee.Name, callee.ParameterTypes, callee.ReturnType, MemberKind.Method),
+            offset,
+            callee.MetadataToken,
+            callee.MetadataToken,
+            kind,
+            inLoop);
+
+    static OptimizationOpportunity Opportunity(MethodIdentity method, string candidate)
+        => new(
+            method,
+            "instance-method-group-delegate",
+            "evidence",
+            "fix",
+            "low",
+            InLoop: false,
+            ILOffset: 4,
+            Caveat: null)
+        {
+            CandidateId = candidate,
+            Multiplicity = "once",
+            Provenance = PerformanceTriageProvenance.Exact,
+        };
+}

--- a/src/ILInspector.Analysis/ILInspector.Analysis.csproj
+++ b/src/ILInspector.Analysis/ILInspector.Analysis.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="ILInspector.Analysis.Tests" />
     <InternalsVisibleTo Include="ILInspector.Research.Tests" />
+    <InternalsVisibleTo Include="analysis-harness" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/AnalysisHarness/CallerLoopCensus.cs
+++ b/tools/AnalysisHarness/CallerLoopCensus.cs
@@ -79,13 +79,13 @@ public static class CallerLoopCensus
             try
             {
                 var index = LibraryBodyIndex.Open(path);
-                opened++;
                 rows.AddRange(Analyze(
                     Path.GetFileName(path),
                     index.Methods,
                     index.DirectCalls,
                     index.OptimizationOpportunities,
                     maxDepth));
+                opened++;
             }
             catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or IOException or ArgumentException)
             {
@@ -269,7 +269,7 @@ public static class CallerLoopCensus
             maxDepth,
             assemblies,
             opened,
-            assemblies - opened,
+            failures.Count,
             rows.Count,
             candidateRows.Length,
             methodRows.Length,

--- a/tools/AnalysisHarness/CallerLoopCensus.cs
+++ b/tools/AnalysisHarness/CallerLoopCensus.cs
@@ -1,0 +1,372 @@
+using System.Collections.Immutable;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using ILInspector.Analysis;
+
+namespace ILInspector.AnalysisHarness;
+
+public enum CallerLoopClassification
+{
+    None,
+    Direct,
+    Transitive,
+    BeyondBound,
+}
+
+public sealed record CallerLoopWitnessStep(
+    string Caller,
+    string Callee,
+    int ILOffset,
+    CallKind Kind,
+    bool InLoop);
+
+public sealed record CallerLoopCensusRow(
+    string Assembly,
+    string Candidate,
+    string Member,
+    int MethodToken,
+    int? ILOffset,
+    string Shape,
+    string Confidence,
+    string LocalMultiplicity,
+    bool LocalInLoop,
+    string Path,
+    PerformanceTriageProvenance Provenance,
+    CallerLoopClassification Classification,
+    int? NearestDepth,
+    IReadOnlyList<CallerLoopWitnessStep> Witness);
+
+public sealed record CallerLoopCensusFailure(string AssemblyPath, string Error);
+
+public sealed record CallerLoopCensusReport(
+    int MaxDepth,
+    int Assemblies,
+    int Opened,
+    int Failed,
+    int Opportunities,
+    int DistinctCandidates,
+    int DistinctMethods,
+    IReadOnlyDictionary<string, int> RowsByClassification,
+    IReadOnlyDictionary<string, int> CandidatesByClassification,
+    IReadOnlyDictionary<string, int> MethodsByClassification,
+    IReadOnlyDictionary<string, int> RowsByDepth,
+    IReadOnlyDictionary<string, int> ProvenanceCross,
+    IReadOnlyDictionary<string, int> OpportunityCross,
+    IReadOnlyList<CallerLoopCensusFailure> Failures,
+    IReadOnlyList<CallerLoopCensusRow> Rows);
+
+public static class CallerLoopCensus
+{
+    const string Empty = "<empty>";
+
+    static readonly JsonSerializerOptions s_json = new()
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    public static CallerLoopCensusReport Measure(IReadOnlyList<string> assemblyPaths, int maxDepth = 4)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxDepth, 1);
+
+        var rows = new List<CallerLoopCensusRow>();
+        var failures = new List<CallerLoopCensusFailure>();
+        int opened = 0;
+        foreach (string path in assemblyPaths)
+        {
+            try
+            {
+                var index = LibraryBodyIndex.Open(path);
+                opened++;
+                rows.AddRange(Analyze(
+                    Path.GetFileName(path),
+                    index.Methods,
+                    index.DirectCalls,
+                    index.OptimizationOpportunities,
+                    maxDepth));
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or IOException or ArgumentException)
+            {
+                failures.Add(new CallerLoopCensusFailure(path, $"{ex.GetType().Name}: {ex.Message}"));
+            }
+        }
+
+        return BuildReport(maxDepth, assemblyPaths.Count, opened, failures, rows);
+    }
+
+    public static IReadOnlyList<CallerLoopCensusRow> Analyze(
+        string assembly,
+        ImmutableArray<MethodIdentity> methods,
+        ImmutableArray<DirectCall> directCalls,
+        ImmutableArray<OptimizationOpportunity> opportunities,
+        int maxDepth = 4)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxDepth, 1);
+
+        var methodByToken = methods.ToDictionary(static method => method.MetadataToken);
+        var methodMap = MethodDefinitionMap.Create(methods);
+        var edges = directCalls
+            .Where(IsInvocation)
+            .Select(call => new GraphEdge(call, methodMap.Resolve(call)))
+            .Where(static edge => edge.CalleeToken != 0)
+            .OrderBy(edge => EdgeKey(edge.Call, methodByToken[edge.CalleeToken]), StringComparer.Ordinal)
+            .ToArray();
+
+        var adjacency = edges
+            .GroupBy(static edge => edge.Call.Caller.MetadataToken)
+            .ToDictionary(
+                static group => group.Key,
+                static group => group.ToArray());
+
+        var bestByToken = NearestLoopWitnesses(edges, adjacency);
+        return opportunities
+            .OrderBy(static opportunity => opportunity.Method.MetadataToken)
+            .ThenBy(static opportunity => opportunity.ILOffset ?? -1)
+            .ThenBy(static opportunity => opportunity.Shape, StringComparer.Ordinal)
+            .Select(opportunity => CreateRow(assembly, opportunity, bestByToken, methodByToken, maxDepth))
+            .ToArray();
+    }
+
+    public static string ToJson(CallerLoopCensusReport report)
+        => JsonSerializer.Serialize(report, s_json);
+
+    public static string FormatCard(CallerLoopCensusReport report, int top)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"CALLER-LOOP CENSUS: {report.Opened}/{report.Assemblies} assemblies opened ({report.Failed} failed), max-depth={report.MaxDepth}");
+        sb.AppendLine($"  opportunities={report.Opportunities} candidates={report.DistinctCandidates} methods={report.DistinctMethods}");
+        AppendCounts(sb, "rows", report.RowsByClassification);
+        AppendCounts(sb, "distinct candidates", report.CandidatesByClassification);
+        AppendCounts(sb, "distinct methods", report.MethodsByClassification);
+        AppendCounts(sb, "nearest depth", report.RowsByDepth);
+        AppendCounts(sb, "provenance|caller-loop", report.ProvenanceCross);
+        AppendCounts(sb, "caller-loop|shape|confidence|local-multiplicity", report.OpportunityCross, top);
+        foreach (var failure in report.Failures)
+            sb.AppendLine($"  failed: {failure.AssemblyPath}: {failure.Error}");
+
+        sb.AppendLine("  examples:");
+        foreach (var row in report.Rows
+            .Where(static row => row.Classification != CallerLoopClassification.None)
+            .OrderBy(static row => row.Classification)
+            .ThenBy(static row => row.NearestDepth)
+            .ThenBy(static row => row.Assembly, StringComparer.Ordinal)
+            .ThenBy(static row => row.Member, StringComparer.Ordinal)
+            .ThenBy(static row => row.Candidate, StringComparer.Ordinal)
+            .Take(top))
+        {
+            string witness = string.Join(" -> ", row.Witness.Select(static step => $"{step.Caller} @ IL_{step.ILOffset:X4}"));
+            if (row.Witness.Count > 0)
+                witness += $" -> {row.Witness[^1].Callee}";
+            sb.AppendLine($"    {Classification(row.Classification)} depth={row.NearestDepth}: {row.Assembly} {row.Member} [{row.Shape}, {row.Candidate}]");
+            sb.AppendLine($"      {witness}");
+        }
+        return sb.ToString();
+    }
+
+    static Dictionary<int, WitnessState> NearestLoopWitnesses(
+        IReadOnlyList<GraphEdge> edges,
+        IReadOnlyDictionary<int, GraphEdge[]> adjacency)
+    {
+        var best = new Dictionary<int, WitnessState>();
+        var seeds = new List<WitnessState>();
+        foreach (var edge in edges.Where(static edge =>
+            edge.Call.InLoop
+            && edge.Call.Caller.MetadataToken != edge.CalleeToken))
+        {
+            if (best.ContainsKey(edge.CalleeToken))
+                continue;
+            var state = WitnessState.Seed(edge);
+            best[edge.CalleeToken] = state;
+            seeds.Add(state);
+        }
+
+        WitnessState[] frontier = [.. seeds];
+        while (frontier.Length > 0)
+        {
+            var next = new Dictionary<int, WitnessState>();
+            var orderedNext = new List<WitnessState>();
+            foreach (var state in frontier)
+            {
+                if (!adjacency.TryGetValue(state.Token, out var outgoing))
+                    continue;
+                foreach (var edge in outgoing)
+                {
+                    if (best.ContainsKey(edge.CalleeToken))
+                        continue;
+                    // Returning to the loop owner is recursive repetition, not evidence that
+                    // a distinct upstream caller loop repeats the method.
+                    if (edge.CalleeToken == state.LoopCallerToken)
+                        continue;
+                    if (next.ContainsKey(edge.CalleeToken))
+                        continue;
+                    var candidate = state.Append(edge);
+                    next[edge.CalleeToken] = candidate;
+                    orderedNext.Add(candidate);
+                }
+            }
+
+            frontier = [.. orderedNext];
+            foreach (var state in frontier)
+                best[state.Token] = state;
+        }
+        return best;
+    }
+
+    static CallerLoopCensusRow CreateRow(
+        string assembly,
+        OptimizationOpportunity opportunity,
+        IReadOnlyDictionary<int, WitnessState> bestByToken,
+        IReadOnlyDictionary<int, MethodIdentity> methodByToken,
+        int maxDepth)
+    {
+        bestByToken.TryGetValue(opportunity.Method.MetadataToken, out var witness);
+        var classification = witness is null
+            ? CallerLoopClassification.None
+            : witness.Depth == 1
+                ? CallerLoopClassification.Direct
+                : witness.Depth <= maxDepth
+                    ? CallerLoopClassification.Transitive
+                    : CallerLoopClassification.BeyondBound;
+        return new CallerLoopCensusRow(
+            assembly,
+            opportunity.CandidateId ?? Empty,
+            MethodDisplay(opportunity.Method),
+            opportunity.Method.MetadataToken,
+            opportunity.ILOffset,
+            opportunity.Shape,
+            opportunity.Confidence,
+            Text(opportunity.Multiplicity),
+            opportunity.InLoop,
+            Text(opportunity.PathContext),
+            opportunity.Provenance,
+            classification,
+            witness?.Depth,
+            witness?.BuildSteps(methodByToken) ?? []);
+    }
+
+    static CallerLoopCensusReport BuildReport(
+        int maxDepth,
+        int assemblies,
+        int opened,
+        IReadOnlyList<CallerLoopCensusFailure> failures,
+        IReadOnlyList<CallerLoopCensusRow> rows)
+    {
+        var candidateRows = rows
+            .GroupBy(
+                static row => row.Candidate == Empty
+                    ? $"{row.Assembly}|{row.MethodToken:X8}|{row.ILOffset?.ToString("X8", System.Globalization.CultureInfo.InvariantCulture) ?? Empty}|{row.Shape}"
+                    : $"{row.Assembly}|{row.Candidate}",
+                StringComparer.Ordinal)
+            .Select(static group => group.First())
+            .ToArray();
+        var methodRows = rows
+            .GroupBy(static row => $"{row.Assembly}|{row.MethodToken:X8}", StringComparer.Ordinal)
+            .Select(static group => group.First())
+            .ToArray();
+        return new CallerLoopCensusReport(
+            maxDepth,
+            assemblies,
+            opened,
+            assemblies - opened,
+            rows.Count,
+            candidateRows.Length,
+            methodRows.Length,
+            Counts(rows, static row => Classification(row.Classification)),
+            Counts(candidateRows, static row => Classification(row.Classification)),
+            Counts(methodRows, static row => Classification(row.Classification)),
+            Counts(rows, static row => row.NearestDepth?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? Empty),
+            Counts(rows, static row => $"{row.Provenance.ToString().ToLowerInvariant()}|{Classification(row.Classification)}"),
+            Counts(rows, static row => $"{Classification(row.Classification)}|{row.Shape}|{row.Confidence}|{row.LocalMultiplicity}"),
+            failures,
+            rows);
+    }
+
+    static bool IsInvocation(DirectCall call)
+        => call.Kind is CallKind.Call or CallKind.CallVirtual or CallKind.NewObject;
+
+    static string EdgeKey(DirectCall call, MethodIdentity callee)
+        => $"{MethodKey(call.Caller)}|{call.ILOffset:X8}|{MethodKey(callee)}|{call.Kind}";
+
+    static string MethodKey(MethodIdentity method)
+        => $"{method.AssemblyName}|{GenericMemberIdentity.KeyFragment(method.DeclaringType)}|{method.Name}|{string.Join(",", method.ParameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(method.ReturnType)}";
+
+    static string MethodDisplay(MethodIdentity method)
+        => $"{method.DeclaringType.ToQualifiedDisplayString()}::{method.Name}({string.Join(", ", method.ParameterTypes.Select(static type => type.ToQualifiedDisplayString()))})";
+
+    static string MethodDisplay(MemberRef member)
+        => $"{member.DeclaringType.ToQualifiedDisplayString()}::{member.Name}({string.Join(", ", member.ParameterTypes.Select(static type => type.ToQualifiedDisplayString()))})";
+
+    static string Text(string? value)
+        => string.IsNullOrWhiteSpace(value) ? Empty : value;
+
+    static string Classification(CallerLoopClassification value)
+        => value switch
+        {
+            CallerLoopClassification.Direct => "direct",
+            CallerLoopClassification.Transitive => "transitive",
+            CallerLoopClassification.BeyondBound => "beyond-bound",
+            _ => "none",
+        };
+
+    static IReadOnlyDictionary<string, int> Counts<T>(IEnumerable<T> values, Func<T, string> key)
+        => values
+            .GroupBy(key, StringComparer.Ordinal)
+            .OrderByDescending(static group => group.Count())
+            .ThenBy(static group => group.Key, StringComparer.Ordinal)
+            .ToDictionary(static group => group.Key, static group => group.Count(), StringComparer.Ordinal);
+
+    static void AppendCounts(StringBuilder sb, string title, IReadOnlyDictionary<string, int> counts, int top = int.MaxValue)
+    {
+        sb.AppendLine($"  {title}:");
+        foreach (var (key, value) in counts.Take(top))
+            sb.AppendLine($"    {key}={value}");
+        if (counts.Count > top)
+            sb.AppendLine($"    ... {counts.Count - top} more");
+    }
+
+    sealed record GraphEdge(DirectCall Call, int CalleeToken);
+
+    sealed record WitnessState(
+        int Token,
+        int Depth,
+        int LoopCallerToken,
+        GraphEdge Incoming,
+        WitnessState? Previous)
+    {
+        public static WitnessState Seed(GraphEdge edge)
+            => new(
+                edge.CalleeToken,
+                1,
+                edge.Call.Caller.MetadataToken,
+                edge,
+                null);
+
+        public WitnessState Append(GraphEdge edge)
+            => new(
+                edge.CalleeToken,
+                Depth + 1,
+                LoopCallerToken,
+                edge,
+                this);
+
+        public IReadOnlyList<CallerLoopWitnessStep> BuildSteps(IReadOnlyDictionary<int, MethodIdentity> methodByToken)
+        {
+            var reversed = new List<GraphEdge>(Depth);
+            for (WitnessState? state = this; state is not null; state = state.Previous)
+                reversed.Add(state.Incoming);
+            reversed.Reverse();
+            return reversed.Select(edge =>
+            {
+                var callee = methodByToken[edge.CalleeToken];
+                return new CallerLoopWitnessStep(
+                    MethodDisplay(edge.Call.Caller),
+                    MethodDisplay(callee),
+                    edge.Call.ILOffset,
+                    edge.Call.Kind,
+                    edge.Call.InLoop);
+            }).ToArray();
+        }
+    }
+}

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -31,6 +31,11 @@ const string Usage =
           distributions: allocation, path, path confidence, post dominance, escape, shape, and
           cross-tabs. Text output prints the top-N buckets per dimension; JSON emits every bucket.
 
+      --caller-loop-census <file> [--max-depth N] [--top N] [--json]
+          Measurement-only census of Performance Triage rows reachable downstream from a caller's
+          loop invocation. Reports direct/transitive/none/beyond-bound populations, nearest depth,
+          deterministic witness paths, provenance, and shape/confidence/local-multiplicity cross-tabs.
+
       --allocation-parity <expected-annotations.json> <actual-annotations.json> [--json]
           Compare allocation annotations from the legacy decompiler classifier and a candidate
           occurrence-derived projection. The gate is exact on id, IL offset, detail, and
@@ -86,6 +91,7 @@ string? recallAssembly = null;
 string? referenceFile = null;
 string? precisionAssembly = null;
 string? allocationReadoutList = null;
+string? callerLoopCensusList = null;
 string? allocationParityExpected = null;
 string? allocationParityActual = null;
 string? annotationParityCategory = null;
@@ -97,6 +103,7 @@ string? memoryPoolLifecycleList = null;
 bool tsv = false;
 bool jsonl = false;
 int top = 20;
+int maxDepth = 4;
 
 for (int i = 0; i < args.Length; i++)
 {
@@ -124,6 +131,9 @@ for (int i = 0; i < args.Length; i++)
             break;
         case "--allocation-readout":
             allocationReadoutList = NextValue(args, ref i);
+            break;
+        case "--caller-loop-census":
+            callerLoopCensusList = NextValue(args, ref i);
             break;
         case "--allocation-parity":
             allocationParityExpected = NextPathValue(args, ref i);
@@ -154,6 +164,15 @@ for (int i = 0; i < args.Length; i++)
             break;
         case "--top":
             if (NextValue(args, ref i) is { } t && int.TryParse(t, out int n)) top = n;
+            break;
+        case "--max-depth":
+            if (NextValue(args, ref i) is not { } depth
+                || !int.TryParse(depth, out maxDepth)
+                || maxDepth < 1)
+            {
+                Console.Error.WriteLine("--max-depth requires a positive integer.");
+                return 2;
+            }
             break;
         case "list":
             list = true;
@@ -190,6 +209,9 @@ if (precisionAssembly is not null)
 
 if (allocationReadoutList is not null)
     return RunAllocationReadout(allocationReadoutList, top, json);
+
+if (callerLoopCensusList is not null)
+    return RunCallerLoopCensus(callerLoopCensusList, maxDepth, top, json);
 
 if (allocationParityExpected is not null)
     return RunAnnotationParity("Allocation", allocationParityExpected, allocationParityActual, json);
@@ -263,6 +285,31 @@ static int RunAllocationReadout(string corpusList, int top, bool json)
     if (json)
         Console.WriteLine();
     return 0;
+}
+
+static int RunCallerLoopCensus(string corpusList, int maxDepth, int top, bool json)
+{
+    if (!File.Exists(corpusList))
+    {
+        Console.Error.WriteLine($"Corpus list not found: {corpusList}");
+        return 2;
+    }
+
+    var paths = File.ReadAllLines(corpusList)
+        .Select(line => line.Trim())
+        .Where(line => line.Length > 0 && !line.StartsWith('#'))
+        .ToList();
+    if (paths.Count == 0)
+    {
+        Console.Error.WriteLine($"Corpus list is empty: {corpusList}");
+        return 2;
+    }
+
+    var report = CallerLoopCensus.Measure(paths, maxDepth);
+    Console.Write(json ? CallerLoopCensus.ToJson(report) : CallerLoopCensus.FormatCard(report, top));
+    if (json)
+        Console.WriteLine();
+    return report.Failed == 0 ? 0 : 1;
 }
 
 static int RunLeakTriage(string corpusList, int top, bool tsv, bool jsonl)

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -85,6 +85,43 @@ cross-tabs. Text output caps each bucket with `--top`; JSON keeps all buckets.
 Use it before changing confidence/ranking so the proposal names its measured
 population.
 
+A caller-loop census measures whether an otherwise once-per-call Performance
+Triage row can be repeated by an upstream caller's loop:
+
+```bash
+eng/prepare-performance-triage-corpus.sh /tmp/performance-triage-assemblies.txt
+dotnet run --project tools/AnalysisHarness -c Release -- \
+  --caller-loop-census /tmp/performance-triage-assemblies.txt --max-depth 4 --top 20
+dotnet run --project tools/AnalysisHarness -c Release -- \
+  --caller-loop-census /tmp/performance-triage-assemblies.txt --max-depth 4 --json
+```
+
+The census is measurement-only and does not alter product rows, ranking, local
+`Loop`, multiplicity, or confidence. It builds one invocation-only graph per
+assembly (`call`, `callvirt`, and `newobj`; function loads and unresolved
+`calli` signatures are excluded), then records the nearest deterministic path
+from a loop invocation to each triage method. Results separate direct,
+transitive, beyond-bound, and no-witness rows and report both row and distinct
+method denominators, provenance, and
+caller-loop/shape/confidence/local-multiplicity cross-tabs. JSON includes every
+row and its exact witness path for classification.
+
+The original Aspire Dashboard acceptance target is separately pinned because it
+ships in the platform-specific Dashboard SDK package rather than
+`Aspire.Hosting`:
+
+```bash
+eng/prepare-aspire-dashboard-corpus.sh /tmp/aspire-dashboard-assemblies.txt
+dotnet run --project tools/AnalysisHarness -c Release -- \
+  --caller-loop-census /tmp/aspire-dashboard-assemblies.txt --max-depth 4 --json
+```
+
+That run is also an invocation-edge near miss: the current Caller Graph path to
+`ColorGenerator.GetColorIndex` crosses an in-loop `ldftn` that creates a
+`RenderFragment`; it is not a call. The invocation-only census therefore
+correctly reports no witness. Proving that callback is repeatedly consumed
+requires a separate deferred-callback discriminator.
+
 A 2026-07-01 fixed-corpus run (`14/14` assemblies opened) showed 41,890
 allocation occurrences and 6,587 optimization opportunities. `return-post-dominates`
 was common (29,175 occurrences; 4,817 opportunities), but not selective by


### PR DESCRIPTION
## Summary

Adds a measurement-only caller-loop census to `AnalysisHarness` for issue #2724.

- builds an invocation-only same-assembly graph from resolved `call`, `callvirt`,
  and `newobj` edges
- reports deterministic nearest direct, transitive, beyond-bound, or absent
  witnesses without changing Performance Triage candidates, ranking, confidence,
  or the existing local `Loop` field
- includes row, candidate, and distinct-method denominators plus provenance
  cross-tabs
- pins repeatable corpus preparation for the six-library Performance Triage set
  and Aspire Dashboard 9.0.0

## Result

| Corpus | Rows with caller-loop witness | Methods with witness | Classification |
| --- | ---: | ---: | --- |
| Six-library Performance Triage | 247 / 2,459 (10.0%) | 163 / 1,568 (10.4%) | 125 direct, 109 transitive, 13 beyond bound |
| Broader local 14-assembly set | 2,490 / 6,589 (37.8%) | 1,106 / 3,174 (34.8%) | 807 direct, 1,207 transitive, 476 beyond bound |
| Aspire Dashboard 9.0.0 | 38 / 488 (7.8%) | 25 / 261 (9.6%) | 32 direct, 5 transitive, 1 beyond bound |

The signal is selective, but the proposed `ColorGenerator.GetColorIndex`
acceptance example is a near miss: the loop uses `ldftn` to capture a deferred
callback rather than invoking `GetColorIndex`. Caller Graph currently traverses
that function-load edge; this census intentionally does not. Product work should
therefore use a true invocation acceptance fixture, while `ColorGenerator`
requires a separate callback-consumption discriminator.

The historical "44-assembly" corpus is described in prose but has no exact
package/version/assembly manifest in the repository, so this PR does not claim a
reproduction of that result.

## Validation

- Release solution build
- full `ILInspector.Analysis.Tests`: 446 passed
- focused `CallerLoopCensusTests`: 9 passed
- markdownlint
- six-library, broader 14-assembly, and Aspire Dashboard census runs

Relates to #2724.
