### PR TITLE
Add extension-instance soft Finding matches

### DIFF
--- a/docs/design/finding-coordinates.md
+++ b/docs/design/finding-coordinates.md
@@ -10,8 +10,10 @@ different questions and do not share one generic string slot.
 | Subject | `FindingSubject.Key` | The stable thing being inspected, such as one method, member, or document. Sibling producers agree here when Research joins their results. |
 | Correspondence | `FindingKey.IdentityKey` | The exact cross-version candidate identity within one producer stream. |
 | Corroboration | `FindingKey.ScopeKey` | Optional structural evidence used to strengthen an otherwise ambiguous correspondence. It is not identity or provenance. |
+| Soft correspondence | `FindingKey.SoftKeys` | Named producer-owned projections used only after exact matching leaves residual observations. |
 | Producer order | `Finding<T>.Ordinal` | Optional zero-based location retained by an ordered producer for presentation and producer-owned follow-up work. |
 | Provenance | Typed producer payload | Domain coordinates such as `AllocationOccurrence.ILOffset` or `MemberAnchor` retain their native semantics and validation. |
+| Match provenance | `IMatchedPairFinding.Match` | The tier and confidence that established a non-exact old/new correspondence. Null means exact correspondence. |
 
 `FindingMatcher` uses the enumeration order of the collections it receives.
 `Ordinal` does not control alignment or move classification. It lets an ordered
@@ -49,15 +51,18 @@ cross-stream joins should retain an explicit typed provenance relation when a
 producer needs one. A shared anchor belongs on the leaf only after at least two
 producers require the same validated semantics.
 
-## Soft-matching prerequisite
+## Soft-matching contract
 
-Soft matching extends correspondence, not coordinates. Its design must add:
+Soft matching extends correspondence, not coordinates. The shared substrate
+provides:
 
 - structured producer-owned identity projections;
-- typed facet or similarity deltas;
 - explicit match-tier provenance;
-- deterministic tie resolution from input order or a producer's stable sort.
+- exact-first matching and global suppression of ambiguous residual endpoints;
+- consumer-selected acceptance with an exact-only default.
 
 Hard matches remain authoritative and run first. A generic anchor is not a
 substitute for structured identity, and cross-stream provenance must not be
-scored as though it were fuzzy cross-version correspondence.
+scored as though it were fuzzy cross-version correspondence. Producer-owned
+facet details remain typed or explicitly named in the resulting transition;
+future similarity tiers require their own typed delta contract.

--- a/docs/design/finding-nomenclature.md
+++ b/docs/design/finding-nomenclature.md
@@ -24,6 +24,8 @@ the concepts:
 
 - `IFinding` carries observations with different payload types.
 - `IPairFinding` carries transitions with different payload types.
+- `IMatchedPairFinding` exposes optional non-exact match provenance on
+  `Present` and `Changed`; null means exact correspondence.
 
 Neither inspection failures nor transitions implement `IFinding`. Repeated
 properties such as subject, descriptor, or detail do not create an `is-a`
@@ -98,6 +100,12 @@ The governing invariant is:
 
 > An empty match is evidence of a trivial alignment; a manufactured match is a
 > costume.
+
+Exact correspondence is committed before soft correspondence. A soft projection
+is producer-owned identity data on the observation key, while acceptance is a
+consumer fold. At threshold 100, soft candidates remain one `Added` and one
+`Removed`; an accepted soft candidate becomes `Changed` and retains its named
+tier and confidence through `FindingMatchProvenance`.
 
 ## Sparse correlation and onset
 
@@ -217,8 +225,8 @@ coordinates remain typed in their payloads. See
 
 These require explicit design before dependent producers rely on them:
 
-- define structured soft-match projections, typed deltas, and match-tier
-  provenance;
+- define similarity-based soft tiers and typed similarity deltas beyond the
+  landed structured projection contract;
 - define value equality for envelopes containing `ImmutableArray` or
   `ImmutableHashSet` before using them as cache keys or change detectors.
 

--- a/docs/design/finding-producers.md
+++ b/docs/design/finding-producers.md
@@ -101,6 +101,8 @@ The producer owns stable observation identity:
 - `FindingDescriptor` identifies the observation vocabulary entry.
 - `FindingKey.IdentityKey` identifies correspondence candidates.
 - `FindingKey.ScopeKey` constrains correspondence when the domain requires it.
+- `FindingKey.SoftKeys` carries producer-owned identity projections for
+  explicitly named non-exact tiers.
 - `Ordinal` optionally retains the producer's source-stream index. Ordered
   producers populate it when consumers need the source location after matching;
   identity-set producers leave it null.
@@ -127,6 +129,22 @@ implement private matchers, folds, summaries, or equivalence policy.
 
 Consumers select equivalence from the emitted transitions. The producer does
 not collapse a rich transition stream into one universal verdict.
+
+Soft projections are additive to exact identity. The matcher commits exact
+matches first, suppresses ambiguous residual projections, and leaves each
+unique soft correspondence as a deferred candidate. The consumer's acceptance
+threshold selects whether that candidate remains `Added` plus `Removed` or
+becomes `Changed`; the default threshold of 100 remains exact-only. Accepted
+matched transitions retain `FindingMatchProvenance`, including tier and
+confidence.
+
+Metadata's first soft tier is `api.member.extension-instance` at confidence 85.
+It projects structured method receiver, name, generic arity, return type, and
+non-receiver parameters while retaining extension/instance as the variant.
+Same-role relocations, signature near misses, ambiguous endpoints, and
+observations lacking structured signatures do not correlate. `ApiDiffAnalyzer`
+remains the compatibility authority even when an exploratory Finding consumer
+accepts this correspondence.
 
 ## 7. Keep higher rungs separate
 

--- a/src/ILInspector.Findings/Finding.cs
+++ b/src/ILInspector.Findings/Finding.cs
@@ -265,8 +265,25 @@ public sealed record PairFinding<T> : IPairFinding
         string? Detail = null,
         FindingMatchProvenance? Match = null) : IMatchedPairFinding
     {
+        public Present(
+            Finding<T> Old,
+            Finding<T> New,
+            FindingDifferenceKind Difference,
+            string? Detail)
+            : this(Old, New, Difference, Detail, Match: null)
+        {
+        }
+
         public Finding<T> Old { get; } = Old ?? throw new ArgumentNullException(nameof(Old));
         public Finding<T> New { get; } = New ?? throw new ArgumentNullException(nameof(New));
+
+        public void Deconstruct(
+            out Finding<T> Old,
+            out Finding<T> New,
+            out FindingDifferenceKind Difference,
+            out string? Detail)
+            => (Old, New, Difference, Detail)
+                = (this.Old, this.New, this.Difference, this.Detail);
 
         public PairKind Kind => PairKind.Present;
         public FindingSubject Subject => New.Subject;
@@ -283,8 +300,25 @@ public sealed record PairFinding<T> : IPairFinding
         string? Detail = null,
         FindingMatchProvenance? Match = null) : IMatchedPairFinding
     {
+        public Changed(
+            Finding<T> Old,
+            Finding<T> New,
+            FindingDifferenceKind Difference,
+            string? Detail)
+            : this(Old, New, Difference, Detail, Match: null)
+        {
+        }
+
         public Finding<T> Old { get; } = Old ?? throw new ArgumentNullException(nameof(Old));
         public Finding<T> New { get; } = New ?? throw new ArgumentNullException(nameof(New));
+
+        public void Deconstruct(
+            out Finding<T> Old,
+            out Finding<T> New,
+            out FindingDifferenceKind Difference,
+            out string? Detail)
+            => (Old, New, Difference, Detail)
+                = (this.Old, this.New, this.Difference, this.Detail);
 
         public PairKind Kind => PairKind.Changed;
         public FindingSubject Subject => New.Subject;

--- a/src/ILInspector.Findings/Finding.cs
+++ b/src/ILInspector.Findings/Finding.cs
@@ -170,6 +170,15 @@ public interface IPairFinding
 }
 
 /// <summary>
+/// A matched transition that can retain non-exact correspondence provenance. Null
+/// <see cref="Match"/> means the exact hard tier established correspondence.
+/// </summary>
+public interface IMatchedPairFinding : IPairFinding
+{
+    FindingMatchProvenance? Match { get; }
+}
+
+/// <summary>
 /// A classified transition between two <see cref="Finding{T}"/> atoms — the diff row, modeled as a
 /// discriminated union (.NET 11 <c>[Union]</c>) over four nested cases (<see cref="Added"/>,
 /// <see cref="Removed"/>, <see cref="Present"/>, <see cref="Changed"/>). Because each case carries
@@ -253,7 +262,8 @@ public sealed record PairFinding<T> : IPairFinding
         Finding<T> Old,
         Finding<T> New,
         FindingDifferenceKind Difference = FindingDifferenceKind.None,
-        string? Detail = null) : IPairFinding
+        string? Detail = null,
+        FindingMatchProvenance? Match = null) : IMatchedPairFinding
     {
         public Finding<T> Old { get; } = Old ?? throw new ArgumentNullException(nameof(Old));
         public Finding<T> New { get; } = New ?? throw new ArgumentNullException(nameof(New));
@@ -270,7 +280,8 @@ public sealed record PairFinding<T> : IPairFinding
         Finding<T> Old,
         Finding<T> New,
         FindingDifferenceKind Difference = FindingDifferenceKind.None,
-        string? Detail = null) : IPairFinding
+        string? Detail = null,
+        FindingMatchProvenance? Match = null) : IMatchedPairFinding
     {
         public Finding<T> Old { get; } = Old ?? throw new ArgumentNullException(nameof(Old));
         public Finding<T> New { get; } = New ?? throw new ArgumentNullException(nameof(New));

--- a/src/ILInspector.Findings/FindingComparison.cs
+++ b/src/ILInspector.Findings/FindingComparison.cs
@@ -84,7 +84,9 @@ public sealed record FindingComparison<T> where T : notnull
             if (pairs.IsDefault)
                 throw new ArgumentException("Pairs must be initialized.", nameof(pairs));
             ArgumentNullException.ThrowIfNull(match);
-            if (match.Edges.IsDefault || match.MoveCandidates.IsDefault)
+            if (match.Edges.IsDefault
+                || match.MoveCandidates.IsDefault
+                || match.SoftCandidates.IsDefault)
                 throw new ArgumentException("Match arrays must be initialized.", nameof(match));
             ArgumentNullException.ThrowIfNull(oldInspection);
             ArgumentNullException.ThrowIfNull(newInspection);

--- a/src/ILInspector.Findings/FindingComparison.cs
+++ b/src/ILInspector.Findings/FindingComparison.cs
@@ -202,6 +202,14 @@ public sealed record FindingComparison<T> where T : notnull
                     $"Transformed pair {i} must preserve its old and new atoms.",
                     nameof(transformed));
             }
+            if (original[i].Value is IMatchedPairFinding { Match: not null } matchedBefore
+                && (transformed[i].Value is not IMatchedPairFinding matchedAfter
+                    || matchedAfter.Match != matchedBefore.Match))
+            {
+                throw new ArgumentException(
+                    $"Transformed pair {i} must preserve its match provenance.",
+                    nameof(transformed));
+            }
         }
     }
 }

--- a/src/ILInspector.Findings/FindingFold.cs
+++ b/src/ILInspector.Findings/FindingFold.cs
@@ -34,12 +34,13 @@ public static class FindingFold
 
     static ImmutableArray<FindingEdge> ApplyAcceptance(FindingMatch match, int threshold)
     {
-        if (threshold > 99 || match.MoveCandidates.IsDefaultOrEmpty)
+        if (threshold > 99
+            || (match.MoveCandidates.IsDefaultOrEmpty && match.SoftCandidates.IsDefaultOrEmpty))
             return match.Edges;
 
         var usedOld = new HashSet<int>();
         var usedNew = new HashSet<int>();
-        var accepted = new List<FindingMoveCandidate>();
+        var acceptedMoves = new List<FindingMoveCandidate>();
         foreach (var candidate in match.MoveCandidates
             .OrderByDescending(c => c.Confidence)
             .ThenBy(c => c.OldIndex)
@@ -55,10 +56,29 @@ public static class FindingFold
                 continue;
             }
 
-            accepted.Add(candidate);
+            acceptedMoves.Add(candidate);
         }
 
-        if (accepted.Count == 0)
+        var acceptedSoft = new List<FindingSoftMatchCandidate>();
+        foreach (var candidate in match.SoftCandidates
+            .OrderByDescending(c => c.Match.Confidence)
+            .ThenBy(c => c.OldIndex)
+            .ThenBy(c => c.NewIndex))
+        {
+            if (candidate.Match.Confidence < threshold)
+                continue;
+            if (!usedOld.Add(candidate.OldIndex))
+                continue;
+            if (!usedNew.Add(candidate.NewIndex))
+            {
+                usedOld.Remove(candidate.OldIndex);
+                continue;
+            }
+
+            acceptedSoft.Add(candidate);
+        }
+
+        if (acceptedMoves.Count == 0 && acceptedSoft.Count == 0)
             return match.Edges;
 
         var result = ImmutableArray.CreateBuilder<FindingEdge>();
@@ -72,8 +92,17 @@ public static class FindingFold
             result.Add(edge);
         }
 
-        foreach (var candidate in accepted)
+        foreach (var candidate in acceptedMoves)
             result.Add(new FindingEdge(FindingEdgeKind.Moved, candidate.OldIndex, candidate.NewIndex, candidate.Confidence));
+        foreach (var candidate in acceptedSoft)
+        {
+            result.Add(new FindingEdge(
+                FindingEdgeKind.Changed,
+                candidate.OldIndex,
+                candidate.NewIndex,
+                candidate.Match.Confidence,
+                candidate.Match));
+        }
 
         return result.ToImmutable();
     }
@@ -98,6 +127,17 @@ public static class FindingFold
                     FindingDifferenceKind.Moved,
                     Detail: $"moved {delta:+#;-#;0}");
             }
+
+            case FindingEdgeKind.Changed when edge.Match is { } match:
+                return new PairFinding<T>.Changed(
+                    oldStream[edge.OldIndex],
+                    newStream[edge.NewIndex],
+                    Detail: $"soft match: {match.Tier.Id}",
+                    Match: match);
+
+            case FindingEdgeKind.Changed:
+                throw new InvalidOperationException(
+                    "A changed match edge requires soft-match provenance.");
 
             case FindingEdgeKind.Added:
                 return new PairFinding<T>.Added(newStream[edge.NewIndex]);

--- a/src/ILInspector.Findings/FindingKey.cs
+++ b/src/ILInspector.Findings/FindingKey.cs
@@ -1,4 +1,50 @@
+using System.Collections.Immutable;
+
 namespace ILInspector.Findings;
+
+/// <summary>
+/// A named soft-correspondence tier. Confidence is below 100 by construction so the default
+/// acceptance threshold remains exact-only.
+/// </summary>
+public sealed record FindingMatchTier
+{
+    public FindingMatchTier(string Id, int Confidence)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(Id);
+        if (Confidence is <= 0 or >= 100)
+            throw new ArgumentOutOfRangeException(
+                nameof(Confidence),
+                Confidence,
+                "Soft match confidence must be between 1 and 99.");
+
+        this.Id = Id;
+        this.Confidence = Confidence;
+    }
+
+    public string Id { get; }
+    public int Confidence { get; }
+}
+
+/// <summary>
+/// One producer-owned projection of a structured identity. Two residual observations are soft
+/// candidates when tier and projected identity agree while the dropped-facet variant differs.
+/// The matcher treats <see cref="Variant"/> as opaque data; its meaning belongs to the producer.
+/// </summary>
+public sealed record FindingSoftKey
+{
+    public FindingSoftKey(FindingMatchTier Tier, string IdentityKey, string Variant)
+    {
+        this.Tier = Tier ?? throw new ArgumentNullException(nameof(Tier));
+        ArgumentException.ThrowIfNullOrWhiteSpace(IdentityKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(Variant);
+        this.IdentityKey = IdentityKey;
+        this.Variant = Variant;
+    }
+
+    public FindingMatchTier Tier { get; }
+    public string IdentityKey { get; }
+    public string Variant { get; }
+}
 
 /// <summary>
 /// The domain-free alignment key the <see cref="FindingMatcher"/> operates on: a content
@@ -22,14 +68,49 @@ namespace ILInspector.Findings;
 public readonly record struct FindingKey
 {
     public FindingKey(string IdentityKey, string? ScopeKey = null)
+        : this(IdentityKey, ScopeKey, [])
+    {
+    }
+
+    public FindingKey(
+        string IdentityKey,
+        string? ScopeKey,
+        IEnumerable<FindingSoftKey> SoftKeys)
     {
         ArgumentNullException.ThrowIfNull(IdentityKey);
+        ArgumentNullException.ThrowIfNull(SoftKeys);
+
+        var softKeys = SoftKeys.ToImmutableArray();
+        if (softKeys.Any(key => key is null))
+            throw new ArgumentException("Soft keys must not contain null values.", nameof(SoftKeys));
+        if (softKeys
+            .GroupBy(key => key.Tier.Id, StringComparer.Ordinal)
+            .Any(group => group.Count() > 1))
+        {
+            throw new ArgumentException(
+                "A finding key may carry at most one projection per soft tier.",
+                nameof(SoftKeys));
+        }
+
         this.IdentityKey = IdentityKey;
         this.ScopeKey = ScopeKey;
+        this.SoftKeys = softKeys;
     }
 
     public string IdentityKey { get; }
     public string? ScopeKey { get; }
+    public ImmutableArray<FindingSoftKey> SoftKeys { get; }
+
+    public bool Equals(FindingKey other)
+        => string.Equals(IdentityKey, other.IdentityKey, StringComparison.Ordinal)
+            && string.Equals(ScopeKey, other.ScopeKey, StringComparison.Ordinal)
+            && FindingValueEquality.SequenceEqual(SoftKeys, other.SoftKeys);
+
+    public override int GetHashCode()
+        => HashCode.Combine(
+            StringComparer.Ordinal.GetHashCode(IdentityKey),
+            ScopeKey is null ? 0 : StringComparer.Ordinal.GetHashCode(ScopeKey),
+            FindingValueEquality.SequenceHashCode(SoftKeys));
 
     public void Deconstruct(out string identityKey, out string? scopeKey)
         => (identityKey, scopeKey) = (IdentityKey, ScopeKey);

--- a/src/ILInspector.Findings/FindingMatcher.cs
+++ b/src/ILInspector.Findings/FindingMatcher.cs
@@ -11,6 +11,9 @@ public enum FindingEdgeKind
     /// <summary>Content match recovered out of order by the move pass (a relocation).</summary>
     Moved,
 
+    /// <summary>Content correspondence accepted from a non-exact identity tier.</summary>
+    Changed,
+
     /// <summary>Present only on the new side.</summary>
     Added,
 
@@ -23,7 +26,30 @@ public enum FindingEdgeKind
 /// <see cref="NewIndex"/> is -1 for <see cref="FindingEdgeKind.Removed"/>. <see cref="Confidence"/>
 /// is 100 for the committed matching; lower values are reserved for accepted fringe.
 /// </summary>
-public sealed record FindingEdge(FindingEdgeKind Kind, int OldIndex, int NewIndex, int Confidence);
+public sealed record FindingEdge(
+    FindingEdgeKind Kind,
+    int OldIndex,
+    int NewIndex,
+    int Confidence,
+    FindingMatchProvenance? Match = null);
+
+/// <summary>Typed provenance retained when a non-exact tier establishes correspondence.</summary>
+public sealed record FindingMatchProvenance
+{
+    public FindingMatchProvenance(FindingMatchTier Tier, int Confidence)
+    {
+        this.Tier = Tier ?? throw new ArgumentNullException(nameof(Tier));
+        if (Confidence is <= 0 or >= 100)
+            throw new ArgumentOutOfRangeException(
+                nameof(Confidence),
+                Confidence,
+                "Soft match confidence must be between 1 and 99.");
+        this.Confidence = Confidence;
+    }
+
+    public FindingMatchTier Tier { get; }
+    public int Confidence { get; }
+}
 
 /// <summary>
 /// A deferred, ambiguous match the committed core did not commit (a content-equal
@@ -32,6 +58,15 @@ public sealed record FindingEdge(FindingEdgeKind Kind, int OldIndex, int NewInde
 /// threshold. The default (100) accepts none, so these stay Added+Removed.
 /// </summary>
 public sealed record FindingMoveCandidate(int OldIndex, int NewIndex, int Confidence, string Reason);
+
+/// <summary>
+/// A deferred non-exact correspondence between two residual observations. The candidate remains
+/// an add/remove pair until a consumer accepts its tier confidence.
+/// </summary>
+public sealed record FindingSoftMatchCandidate(
+    int OldIndex,
+    int NewIndex,
+    FindingMatchProvenance Match);
 
 /// <summary>The result of matching two key streams (see FindingKey).</summary>
 /// <param name="Edges">
@@ -49,6 +84,7 @@ public sealed record FindingMatch(
     ImmutableArray<FindingEdge> _edges = Validate(Edges, nameof(Edges));
     ImmutableArray<FindingMoveCandidate> _moveCandidates
         = Validate(MoveCandidates, nameof(MoveCandidates));
+    ImmutableArray<FindingSoftMatchCandidate> _softCandidates = [];
 
     public ImmutableArray<FindingEdge> Edges
     {
@@ -62,15 +98,23 @@ public sealed record FindingMatch(
         init => _moveCandidates = Validate(value, nameof(MoveCandidates));
     }
 
+    public ImmutableArray<FindingSoftMatchCandidate> SoftCandidates
+    {
+        get => _softCandidates;
+        init => _softCandidates = Validate(value, nameof(SoftCandidates));
+    }
+
     public bool Equals(FindingMatch? other)
         => other is not null
             && FindingValueEquality.SequenceEqual(Edges, other.Edges)
-            && FindingValueEquality.SequenceEqual(MoveCandidates, other.MoveCandidates);
+            && FindingValueEquality.SequenceEqual(MoveCandidates, other.MoveCandidates)
+            && FindingValueEquality.SequenceEqual(SoftCandidates, other.SoftCandidates);
 
     public override int GetHashCode()
         => HashCode.Combine(
             FindingValueEquality.SequenceHashCode(Edges),
-            FindingValueEquality.SequenceHashCode(MoveCandidates));
+            FindingValueEquality.SequenceHashCode(MoveCandidates),
+            FindingValueEquality.SequenceHashCode(SoftCandidates));
 
     static ImmutableArray<TItem> Validate<TItem>(
         ImmutableArray<TItem> items,
@@ -187,6 +231,7 @@ public static class FindingMatcher
         for (int j = 0; j < newKeys.Length; j++)
             Bucket(newByKey, newKeys[j].IdentityKey).Enqueue(j);
 
+        var matchedOld = new bool[oldKeys.Length];
         var matchedNew = new bool[newKeys.Length];
         var edges = ImmutableArray.CreateBuilder<FindingEdge>();
 
@@ -197,14 +242,18 @@ public static class FindingMatcher
             if (queue is { Count: > 0 })
             {
                 int j = queue.Dequeue();
+                matchedOld[i] = true;
                 matchedNew[j] = true;
                 edges.Add(new FindingEdge(FindingEdgeKind.Matched, i, j, 100));
             }
-            else
-            {
-                edges.Add(new FindingEdge(FindingEdgeKind.Removed, i, -1, 100));
-            }
         }
+
+        var residualOld = ResidualIndices(matchedOld);
+        var residualNew = ResidualIndices(matchedNew);
+        var softCandidates = BuildSoftCandidates(oldKeys, newKeys, residualOld, residualNew);
+
+        foreach (int i in residualOld)
+            edges.Add(new FindingEdge(FindingEdgeKind.Removed, i, -1, 100));
 
         for (int j = 0; j < newKeys.Length; j++)
         {
@@ -212,7 +261,10 @@ public static class FindingMatcher
                 edges.Add(new FindingEdge(FindingEdgeKind.Added, -1, j, 100));
         }
 
-        return new FindingMatch(edges.ToImmutable(), ImmutableArray<FindingMoveCandidate>.Empty);
+        return new FindingMatch(edges.ToImmutable(), ImmutableArray<FindingMoveCandidate>.Empty)
+        {
+            SoftCandidates = softCandidates,
+        };
 
         static Queue<int> Bucket(Dictionary<string, Queue<int>> byKey, string key)
         {
@@ -256,6 +308,19 @@ public static class FindingMatcher
 
         // 4. Leftover residual: score singleton content matches as fringe, emit the rest as add/remove.
         var fringe = BuildFringe(oldKeys, newKeys, residualOld, residualNew, committedOld, committedNew);
+        var unmatchedOld = residualOld
+            .Where((_, localIndex) => !committedOld[localIndex])
+            .ToArray();
+        var unmatchedNew = residualNew
+            .Where((_, localIndex) => !committedNew[localIndex])
+            .ToArray();
+        var softCandidates = BuildSoftCandidates(
+            oldKeys,
+            newKeys,
+            unmatchedOld,
+            unmatchedNew,
+            fringe.Select(candidate => candidate.OldIndex).ToHashSet(),
+            fringe.Select(candidate => candidate.NewIndex).ToHashSet());
 
         foreach (var (localIndex, oldIndex) in Indexed(residualOld))
         {
@@ -269,7 +334,10 @@ public static class FindingMatcher
                 edges.Add(new FindingEdge(FindingEdgeKind.Added, -1, newIndex, 100));
         }
 
-        return new FindingMatch(edges.ToImmutable(), fringe);
+        return new FindingMatch(edges.ToImmutable(), fringe)
+        {
+            SoftCandidates = softCandidates,
+        };
     }
 
     static int[] ResidualIndices(bool[] matched)
@@ -400,6 +468,93 @@ public static class FindingMatcher
 
         return fringe.ToImmutable();
     }
+
+    static ImmutableArray<FindingSoftMatchCandidate> BuildSoftCandidates(
+        FindingKey[] oldStream,
+        FindingKey[] newStream,
+        int[] residualOld,
+        int[] residualNew,
+        IReadOnlySet<int>? blockedOld = null,
+        IReadOnlySet<int>? blockedNew = null)
+    {
+        var newByProjection = new Dictionary<SoftProjectionKey, List<(int Index, FindingSoftKey Key)>>();
+        foreach (int newIndex in residualNew)
+        {
+            if (blockedNew?.Contains(newIndex) == true)
+                continue;
+
+            foreach (var softKey in newStream[newIndex].SoftKeys)
+            {
+                var projection = new SoftProjectionKey(
+                    softKey.Tier.Id,
+                    softKey.Tier.Confidence,
+                    softKey.IdentityKey);
+                if (!newByProjection.TryGetValue(projection, out var bucket))
+                    newByProjection.Add(projection, bucket = []);
+                bucket.Add((newIndex, softKey));
+            }
+        }
+
+        var candidates = new List<FindingSoftMatchCandidate>();
+        foreach (int oldIndex in residualOld)
+        {
+            if (blockedOld?.Contains(oldIndex) == true)
+                continue;
+
+            foreach (var oldSoftKey in oldStream[oldIndex].SoftKeys)
+            {
+                var projection = new SoftProjectionKey(
+                    oldSoftKey.Tier.Id,
+                    oldSoftKey.Tier.Confidence,
+                    oldSoftKey.IdentityKey);
+                if (!newByProjection.TryGetValue(projection, out var newEntries))
+                    continue;
+
+                foreach (var (newIndex, newSoftKey) in newEntries)
+                {
+                    if (string.Equals(oldSoftKey.Variant, newSoftKey.Variant, StringComparison.Ordinal))
+                        continue;
+
+                    candidates.Add(new FindingSoftMatchCandidate(
+                        oldIndex,
+                        newIndex,
+                        new FindingMatchProvenance(oldSoftKey.Tier, oldSoftKey.Tier.Confidence)));
+                }
+            }
+        }
+
+        // Multiple tiers may independently project the same pair. Keep only its strongest tier,
+        // then suppress every endpoint that still participates in more than one pair. Under-match
+        // is safer than choosing among ambiguous near misses.
+        var distinctPairs = candidates
+            .GroupBy(candidate => (candidate.OldIndex, candidate.NewIndex))
+            .Select(group => group
+                .OrderByDescending(candidate => candidate.Match.Confidence)
+                .ThenBy(candidate => candidate.Match.Tier.Id, StringComparer.Ordinal)
+                .First())
+            .ToArray();
+        var oldCounts = distinctPairs
+            .GroupBy(candidate => candidate.OldIndex)
+            .ToDictionary(group => group.Key, group => group.Count());
+        var newCounts = distinctPairs
+            .GroupBy(candidate => candidate.NewIndex)
+            .ToDictionary(group => group.Key, group => group.Count());
+
+        return
+        [
+            .. distinctPairs
+                .Where(candidate => oldCounts[candidate.OldIndex] == 1)
+                .Where(candidate => newCounts[candidate.NewIndex] == 1)
+                .OrderByDescending(candidate => candidate.Match.Confidence)
+                .ThenBy(candidate => candidate.OldIndex)
+                .ThenBy(candidate => candidate.NewIndex),
+        ];
+    }
+
+    readonly record struct SoftProjectionKey(
+        string TierId,
+        int Confidence,
+        string IdentityKey);
 
     // Same construction and tiebreak as ILInspector.Instructions.IlBodyDiff so the committed
     // core reproduces the existing IL sequence diff exactly on move-free inputs.

--- a/src/ILInspector.Findings/FindingMatcher.cs
+++ b/src/ILInspector.Findings/FindingMatcher.cs
@@ -31,7 +31,25 @@ public sealed record FindingEdge(
     int OldIndex,
     int NewIndex,
     int Confidence,
-    FindingMatchProvenance? Match = null);
+    FindingMatchProvenance? Match = null)
+{
+    public FindingEdge(
+        FindingEdgeKind Kind,
+        int OldIndex,
+        int NewIndex,
+        int Confidence)
+        : this(Kind, OldIndex, NewIndex, Confidence, Match: null)
+    {
+    }
+
+    public void Deconstruct(
+        out FindingEdgeKind Kind,
+        out int OldIndex,
+        out int NewIndex,
+        out int Confidence)
+        => (Kind, OldIndex, NewIndex, Confidence)
+            = (this.Kind, this.OldIndex, this.NewIndex, this.Confidence);
+}
 
 /// <summary>Typed provenance retained when a non-exact tier establishes correspondence.</summary>
 public sealed record FindingMatchProvenance

--- a/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
@@ -284,6 +284,45 @@ public class FindingPilotTests
     }
 
     [Fact]
+    public void FindingComparison_TransformationMustPreserveSoftMatchProvenance()
+    {
+        FindingInspection<string> oldInspection =
+            new FindingInspection<string>.Complete(
+            [
+                new Finding<string>(
+                    Subject,
+                    Descriptor,
+                    SoftKey("old", "same", "extension"),
+                    "old"),
+            ]);
+        FindingInspection<string> newInspection =
+            new FindingInspection<string>.Complete(
+            [
+                new Finding<string>(
+                    Subject,
+                    Descriptor,
+                    SoftKey("new", "same", "instance"),
+                    "new"),
+            ]);
+        var comparison = FindingComparison.Compare(
+            oldInspection,
+            newInspection,
+            acceptanceThreshold: 85);
+
+        Assert.Throws<ArgumentException>(() => comparison.TransformPairs(
+            pairs =>
+            [
+                pairs[0] is PairFinding<string>.Changed changed
+                    ? new PairFinding<string>.Changed(
+                        changed.Old,
+                        changed.New,
+                        changed.Difference,
+                        changed.Detail)
+                    : throw new Xunit.Sdk.XunitException("Expected a changed pair."),
+            ]));
+    }
+
+    [Fact]
     public void FindingComparison_FailedDerivesBothInspectionErrors()
     {
         FindingInspection<string> oldFailed =

--- a/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
@@ -20,6 +20,8 @@ public class FindingPilotTests
 
     // Matcher-only tests need just the alignment keys.
     static FindingKey[] Keys(params string[] keys) => [.. keys.Select(k => new FindingKey(k))];
+    static FindingKey SoftKey(string exact, string projected, string variant)
+        => new(exact, null, [new FindingSoftKey(SoftTier, projected, variant)]);
 
     // Fold tests need atoms: payload is the key string, ordinal is retained observation metadata.
     static ImmutableArray<Finding<string>> Atoms(params string[] keys)
@@ -496,6 +498,7 @@ public class FindingPilotTests
         => Assert.Throws<ArgumentNullException>(() => FindingMatcher.Match(null!, Keys("a")));
 
     static readonly FindingMatchOptions IdentitySet = new() { MatchMode = FindingMatchMode.IdentitySet };
+    static readonly FindingMatchTier SoftTier = new("test.role-change", 85);
 
     [Fact]
     public void IdentitySet_Permutation_IsAllMatched_NoAddRemoveOrMove()
@@ -538,6 +541,83 @@ public class FindingPilotTests
         Assert.Equal(2, Count(match, FindingEdgeKind.Matched));
         Assert.Equal(1, Count(match, FindingEdgeKind.Removed));
         Assert.Equal(0, Count(match, FindingEdgeKind.Added));
+    }
+
+    [Fact]
+    public void IdentitySet_SoftTier_DoesNotMatchSameVariant()
+    {
+        var match = FindingMatcher.Match(
+            [SoftKey("old", "shared", "extension")],
+            [SoftKey("new", "shared", "extension")],
+            IdentitySet);
+
+        Assert.Empty(match.SoftCandidates);
+        Assert.Equal(1, Count(match, FindingEdgeKind.Removed));
+        Assert.Equal(1, Count(match, FindingEdgeKind.Added));
+    }
+
+    [Fact]
+    public void IdentitySet_SoftTier_SuppressesAmbiguousEndpoints()
+    {
+        var match = FindingMatcher.Match(
+            [
+                SoftKey("old-a", "shared", "extension"),
+                SoftKey("old-b", "shared", "extension"),
+            ],
+            [SoftKey("new", "shared", "instance")],
+            IdentitySet);
+
+        Assert.Empty(match.SoftCandidates);
+        Assert.Equal(2, Count(match, FindingEdgeKind.Removed));
+        Assert.Equal(1, Count(match, FindingEdgeKind.Added));
+    }
+
+    [Fact]
+    public void IdentitySet_ExactMatchCannotBeDisplacedBySoftTier()
+    {
+        var match = FindingMatcher.Match(
+            [
+                SoftKey("exact", "shared", "instance"),
+                SoftKey("extension", "shared", "extension"),
+            ],
+            [SoftKey("exact", "shared", "instance")],
+            IdentitySet);
+
+        Assert.Empty(match.SoftCandidates);
+        Assert.Equal(1, Count(match, FindingEdgeKind.Matched));
+        Assert.Equal(1, Count(match, FindingEdgeKind.Removed));
+        Assert.Equal(0, Count(match, FindingEdgeKind.Added));
+    }
+
+    [Fact]
+    public void IdentitySet_SoftTier_IsDeferredAndRetainsProvenanceWhenAccepted()
+    {
+        var old = ImmutableArray.Create(
+            new Finding<string>(
+                Subject,
+                Descriptor,
+                SoftKey("old", "shared", "extension"),
+                "old"));
+        var @new = ImmutableArray.Create(
+            new Finding<string>(
+                Subject,
+                Descriptor,
+                SoftKey("new", "shared", "instance"),
+                "new"));
+        var match = FindingMatcher.Match(old.Keys(), @new.Keys(), IdentitySet);
+
+        var candidate = Assert.Single(match.SoftCandidates);
+        Assert.Equal(SoftTier, candidate.Match.Tier);
+        Assert.Equal(85, candidate.Match.Confidence);
+
+        var strict = FindingFold.ToPairs(match, old, @new);
+        Assert.Contains(strict, pair => pair.Kind == PairKind.Removed);
+        Assert.Contains(strict, pair => pair.Kind == PairKind.Added);
+
+        var accepted = Assert.IsType<PairFinding<string>.Changed>(
+            Assert.Single(FindingFold.ToPairs(match, old, @new, acceptanceThreshold: 85)).Value);
+        Assert.Equal(SoftTier, accepted.Match?.Tier);
+        Assert.Equal(85, accepted.Match?.Confidence);
     }
 
     [Fact]

--- a/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
@@ -738,6 +738,31 @@ public class FindingPilotTests
     }
 
     [Fact]
+    public void MatchedPairCases_PreserveFourParameterConstructors()
+    {
+        foreach (var type in (Type[])
+        [
+            typeof(PairFinding<string>.Present),
+            typeof(PairFinding<string>.Changed),
+            typeof(FindingEdge),
+        ])
+        {
+            var parameterCounts = type.GetConstructors()
+                .Select(constructor => constructor.GetParameters().Length)
+                .ToHashSet();
+            Assert.Contains(4, parameterCounts);
+            Assert.Contains(5, parameterCounts);
+
+            var deconstructParameterCounts = type.GetMethods()
+                .Where(method => method.Name == "Deconstruct")
+                .Select(method => method.GetParameters().Length)
+                .ToHashSet();
+            Assert.Contains(4, deconstructParameterCounts);
+            Assert.Contains(5, deconstructParameterCounts);
+        }
+    }
+
+    [Fact]
     public void PairFinding_Cases_RejectNullAtoms_FailClosed()
     {
         var a = new Finding<string>(Subject, Descriptor, new FindingKey("k"), "k", Ordinal: 0);

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -456,6 +456,13 @@ public static class ApiMemberIdentity
             variant = "";
             return false;
         }
+        if (signature.Parameters.Any(parameter =>
+                string.IsNullOrWhiteSpace(parameter.TypeWithModifier)))
+        {
+            identityKey = "";
+            variant = "";
+            return false;
+        }
 
         string receiver = isExtension
             ? member.ExtendedType ?? signature.Parameters[0].TypeWithModifier

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -465,7 +465,7 @@ public static class ApiMemberIdentity
         }
 
         string receiver = isExtension
-            ? member.ExtendedType ?? signature.Parameters[0].TypeWithModifier
+            ? signature.Parameters[0].TypeWithModifier
             : type.FullName;
         if (string.IsNullOrWhiteSpace(receiver)
             || string.IsNullOrWhiteSpace(member.Name)

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -434,6 +434,64 @@ public static class ApiMemberIdentity
         return true;
     }
 
+    internal static bool TryGetExtensionInstanceProjection(
+        ApiType type,
+        ApiMember member,
+        out string identityKey,
+        out string variant)
+    {
+        bool isExtension = member.Kind == "method" && member.IsExtension && member.IsStatic;
+        bool isInstance = member.Kind == "method" && !member.IsExtension && !member.IsStatic;
+        if ((!isExtension && !isInstance)
+            || member.SignatureModel is not { ReturnType: not null } signature)
+        {
+            identityKey = "";
+            variant = "";
+            return false;
+        }
+
+        if (isExtension && signature.Parameters.Count == 0)
+        {
+            identityKey = "";
+            variant = "";
+            return false;
+        }
+
+        string receiver = isExtension
+            ? member.ExtendedType ?? signature.Parameters[0].TypeWithModifier
+            : type.FullName;
+        if (string.IsNullOrWhiteSpace(receiver)
+            || string.IsNullOrWhiteSpace(member.Name)
+            || string.IsNullOrWhiteSpace(signature.ReturnType))
+        {
+            identityKey = "";
+            variant = "";
+            return false;
+        }
+
+        var parameters = isExtension
+            ? signature.Parameters.Skip(1)
+            : signature.Parameters;
+        var facets = new List<string>
+        {
+            NormalizeCorrespondenceType(receiver),
+            member.Name,
+            signature.TypeParameters.Count.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            NormalizeCorrespondenceType(signature.ReturnType),
+        };
+        facets.AddRange(parameters.Select(parameter =>
+            NormalizeCorrespondenceType(parameter.TypeWithModifier)));
+
+        identityKey = string.Concat(facets.Select(facet => $"{facet.Length}:{facet}"));
+        variant = isExtension ? "extension" : "instance";
+        return true;
+    }
+
+    static string NormalizeCorrespondenceType(string type)
+        => type.Trim()
+            .Replace("+", ".", StringComparison.Ordinal)
+            .Replace(", ", ",", StringComparison.Ordinal);
+
     // Preserve the v1 Member Index digest contract for members that already have
     // compatibility signature text. The legacy parser had edge-case behavior
     // around method names inside generic parameter names, and published stable

--- a/src/ILInspector.Metadata/MetadataFindings.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.cs
@@ -13,6 +13,8 @@ public static partial class MetadataFindings
     public static readonly FindingDescriptor TypeDescriptor = new("api.type", "API type");
     public static readonly FindingDescriptor MemberDescriptor = new("api.member", "API member");
     public static readonly FindingDescriptor AttributeDescriptor = new("api.attribute", "API attribute");
+    public static readonly FindingMatchTier ExtensionInstanceMatchTier =
+        new("api.member.extension-instance", 85);
 
     static readonly FindingMatchOptions IdentitySetOptions = new()
     {
@@ -51,9 +53,7 @@ public static partial class MetadataFindings
                 return new Finding<ApiMemberHandle>(
                     subject,
                     MemberDescriptor,
-                    new FindingKey(
-                        handle.CanonicalSignature ?? handle.Identity,
-                        item.Type.FullName),
+                    CreateMemberFindingKey(item.Type, item.Member, handle),
                     handle);
             }),
         ]);
@@ -103,9 +103,7 @@ public static partial class MetadataFindings
                     return new Finding<ApiMemberHandle>(
                         subject,
                         MemberDescriptor,
-                        new FindingKey(
-                            handle.CanonicalSignature ?? handle.Identity,
-                            item.Type.FullName),
+                        CreateMemberFindingKey(item.Type, item.Member, handle),
                         handle);
                 }),
             ]);
@@ -166,7 +164,8 @@ public static partial class MetadataFindings
         ApiSurface oldSurface,
         ApiSurface newSurface,
         FindingSubject subject,
-        ApiDiffOptions? options = null)
+        ApiDiffOptions? options = null,
+        int acceptanceThreshold = 100)
     {
         ArgumentNullException.ThrowIfNull(oldSurface);
         ArgumentNullException.ThrowIfNull(newSurface);
@@ -174,7 +173,13 @@ public static partial class MetadataFindings
         options ??= ApiDiffOptions.Default;
 
         var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface, options);
-        return CompareApiMembers(oldSurface, newSurface, subject, options, diff);
+        return CompareApiMembers(
+            oldSurface,
+            newSurface,
+            subject,
+            options,
+            diff,
+            acceptanceThreshold);
     }
 
     public static FindingComparison<ApiTypeHandle> CompareApiType(
@@ -208,7 +213,8 @@ public static partial class MetadataFindings
         ApiSurface? newSurface,
         FindingSubject subject,
         string typeFullName,
-        ApiDiffOptions? options = null)
+        ApiDiffOptions? options = null,
+        int acceptanceThreshold = 100)
     {
         ArgumentNullException.ThrowIfNull(subject);
         ArgumentException.ThrowIfNullOrEmpty(typeFullName);
@@ -217,7 +223,8 @@ public static partial class MetadataFindings
         var comparison = FindingComparison.Compare(
             InspectApiMembers(oldSurface, subject, typeFullName),
             InspectApiMembers(newSurface, subject, typeFullName),
-            IdentitySetOptions);
+            IdentitySetOptions,
+            acceptanceThreshold);
         if (oldSurface is null || newSurface is null)
             return comparison;
 
@@ -248,7 +255,8 @@ public static partial class MetadataFindings
         ApiSurface oldSurface,
         ApiSurface newSurface,
         FindingSubject subject,
-        ApiDiffOptions? options = null)
+        ApiDiffOptions? options = null,
+        int memberAcceptanceThreshold = 100)
     {
         ArgumentNullException.ThrowIfNull(oldSurface);
         ArgumentNullException.ThrowIfNull(newSurface);
@@ -258,7 +266,13 @@ public static partial class MetadataFindings
         var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface, options);
         return new ApiFindingComparison(
             CompareApiTypes(oldSurface, newSurface, subject, options, diff),
-            CompareApiMembers(oldSurface, newSurface, subject, options, diff),
+            CompareApiMembers(
+                oldSurface,
+                newSurface,
+                subject,
+                options,
+                diff,
+                memberAcceptanceThreshold),
             diff);
     }
 
@@ -283,14 +297,16 @@ public static partial class MetadataFindings
         ApiSurface newSurface,
         FindingSubject subject,
         ApiDiffOptions options,
-        ApiDiff diff)
+        ApiDiff diff,
+        int acceptanceThreshold = 100)
     {
         var oldInspection = InspectApiMembers(oldSurface, subject);
         var newInspection = InspectApiMembers(newSurface, subject);
         return FindingComparison.Compare(
             oldInspection,
             newInspection,
-            IdentitySetOptions)
+            IdentitySetOptions,
+            acceptanceThreshold)
             .TransformPairs(pairs => ApplyMemberFacetChanges(pairs, diff, options.Scope));
     }
 
@@ -351,6 +367,30 @@ public static partial class MetadataFindings
                         present.New,
                         present.Difference,
                         string.Join("; ", details.Distinct(StringComparer.Ordinal))));
+            }
+            else if (pair is PairFinding<ApiMemberHandle>.Changed changed
+                && changed.Match is not null)
+            {
+                var details = new List<string>();
+                if (!string.IsNullOrWhiteSpace(changed.Detail))
+                    details.Add(changed.Detail);
+                AddMemberFacetDetails(
+                    changed.Old.Payload.Member,
+                    changed.New.Payload.Member,
+                    scope,
+                    details);
+                AddFacetDetail(
+                    details,
+                    "declaring type",
+                    changed.Old.Payload.TypeFullName,
+                    changed.New.Payload.TypeFullName);
+
+                builder.Add(new PairFinding<ApiMemberHandle>.Changed(
+                    changed.Old,
+                    changed.New,
+                    changed.Difference,
+                    string.Join("; ", details.Distinct(StringComparer.Ordinal)),
+                    changed.Match));
             }
             else
             {
@@ -538,6 +578,30 @@ public static partial class MetadataFindings
     {
         foreach (var member in type.Members)
             yield return (type, member);
+    }
+
+    static FindingKey CreateMemberFindingKey(
+        ApiType type,
+        ApiMember member,
+        ApiMemberHandle handle)
+    {
+        var softKeys = ApiMemberIdentity.TryGetExtensionInstanceProjection(
+            type,
+            member,
+            out var identityKey,
+            out var variant)
+                ? (IEnumerable<FindingSoftKey>)
+                [
+                    new FindingSoftKey(
+                        ExtensionInstanceMatchTier,
+                        identityKey,
+                        variant),
+                ]
+                : [];
+        return new FindingKey(
+            handle.CanonicalSignature ?? handle.Identity,
+            type.FullName,
+            softKeys);
     }
 
     static ApiType? FindType(ApiSurface surface, string typeFullName)

--- a/tests/ILInspector.Metadata.Tests/Fixtures/ExtensionInstanceNew/Api.cs
+++ b/tests/ILInspector.Metadata.Tests/Fixtures/ExtensionInstanceNew/Api.cs
@@ -1,0 +1,6 @@
+namespace ExtensionInstanceFixture;
+
+public sealed class Widget
+{
+    public int Measure(int count) => count;
+}

--- a/tests/ILInspector.Metadata.Tests/Fixtures/ExtensionInstanceNew/ILInspector.Metadata.ExtensionInstanceNew.csproj
+++ b/tests/ILInspector.Metadata.Tests/Fixtures/ExtensionInstanceNew/ILInspector.Metadata.ExtensionInstanceNew.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <AssemblyName>ILInspector.Metadata.ExtensionInstanceNew</AssemblyName>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/tests/ILInspector.Metadata.Tests/Fixtures/ExtensionInstanceOld/Api.cs
+++ b/tests/ILInspector.Metadata.Tests/Fixtures/ExtensionInstanceOld/Api.cs
@@ -1,0 +1,8 @@
+namespace ExtensionInstanceFixture;
+
+public sealed class Widget;
+
+public static class WidgetExtensions
+{
+    public static int Measure(this Widget value, int count) => count;
+}

--- a/tests/ILInspector.Metadata.Tests/Fixtures/ExtensionInstanceOld/ILInspector.Metadata.ExtensionInstanceOld.csproj
+++ b/tests/ILInspector.Metadata.Tests/Fixtures/ExtensionInstanceOld/ILInspector.Metadata.ExtensionInstanceOld.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <AssemblyName>ILInspector.Metadata.ExtensionInstanceOld</AssemblyName>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/tests/ILInspector.Metadata.Tests/ILInspector.Metadata.Tests.csproj
+++ b/tests/ILInspector.Metadata.Tests/ILInspector.Metadata.Tests.csproj
@@ -28,6 +28,12 @@
     <ProjectReference Include="../../src/ILInspector.Metadata/ILInspector.Metadata.csproj" />
     <ProjectReference Include="Fixtures/SignatureSpellabilityConsumer/ILInspector.Metadata.SpellabilityConsumer.csproj" />
     <ProjectReference Include="Fixtures/SignatureSpellabilityReference/ILInspector.Metadata.SpellabilityReference.csproj" />
+    <ProjectReference Include="Fixtures/ExtensionInstanceOld/ILInspector.Metadata.ExtensionInstanceOld.csproj">
+      <Aliases>extensionold</Aliases>
+    </ProjectReference>
+    <ProjectReference Include="Fixtures/ExtensionInstanceNew/ILInspector.Metadata.ExtensionInstanceNew.csproj">
+      <Aliases>extensionnew</Aliases>
+    </ProjectReference>
     <!-- New-rules unsafe fixture: a member declared `unsafe` with no pointer in
          its signature is stamped [RequiresUnsafeAttribute]; used to verify the
          API surface marks it unsafe. -->

--- a/tests/ILInspector.Metadata.Tests/MetadataFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataFindingsTests.cs
@@ -288,6 +288,78 @@ public class MetadataFindingsTests
     }
 
     [Fact]
+    public void ExtensionReceiverRefnessMismatch_DoesNotSoftMatch()
+    {
+        var oldSurface = Surface(
+            Type("Widget"),
+            Type("WidgetExtensions", members:
+            [
+                StructuredMethod(
+                    "Run",
+                    "void Run(ref TestNamespace.Widget value, int count)",
+                    "System.Void",
+                    [
+                        Parameter("TestNamespace.Widget", "ref"),
+                        Parameter("System.Int32"),
+                    ],
+                    isStatic: true,
+                    isExtension: true,
+                    extendedType: "TestNamespace.Widget"),
+            ]));
+        var newSurface = Surface(Type("Widget", members:
+        [
+            StructuredMethod(
+                "Run",
+                "void Run(int count)",
+                "System.Void",
+                [Parameter("System.Int32")]),
+        ]));
+
+        var comparison = MetadataFindings.CompareApiMembers(
+            oldSurface,
+            newSurface,
+            Subject,
+            acceptanceThreshold: 85);
+
+        Assert.Equal(2, Pairs(comparison).Length);
+        Assert.DoesNotContain(Pairs(comparison), pair => pair.Kind == PairKind.Changed);
+    }
+
+    [Fact]
+    public void ExtensionMethodGenericArityMismatch_DoesNotSoftMatch()
+    {
+        var extension = StructuredMethod(
+            "Run",
+            "void Run<T>(TestNamespace.Widget value, int count)",
+            "System.Void",
+            [Parameter("TestNamespace.Widget"), Parameter("System.Int32")],
+            isStatic: true,
+            isExtension: true,
+            extendedType: "TestNamespace.Widget");
+        extension.SignatureModel!.TypeParameters.Add(new TypeParameter { Name = "T" });
+        var oldSurface = Surface(
+            Type("Widget"),
+            Type("WidgetExtensions", members: [extension]));
+        var newSurface = Surface(Type("Widget", members:
+        [
+            StructuredMethod(
+                "Run",
+                "void Run(int count)",
+                "System.Void",
+                [Parameter("System.Int32")]),
+        ]));
+
+        var comparison = MetadataFindings.CompareApiMembers(
+            oldSurface,
+            newSurface,
+            Subject,
+            acceptanceThreshold: 85);
+
+        Assert.Equal(2, Pairs(comparison).Length);
+        Assert.DoesNotContain(Pairs(comparison), pair => pair.Kind == PairKind.Changed);
+    }
+
+    [Fact]
     public void AmbiguousExtensionInstanceEndpoints_DoNotSoftMatch()
     {
         var oldSurface = Surface(

--- a/tests/ILInspector.Metadata.Tests/MetadataFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataFindingsTests.cs
@@ -253,6 +253,41 @@ public class MetadataFindingsTests
     }
 
     [Fact]
+    public void MalformedExtensionInstanceParameter_DoesNotSoftMatch()
+    {
+        var oldSurface = Surface(
+            Type("Widget"),
+            Type("WidgetExtensions", members:
+            [
+                StructuredMethod(
+                    "Run",
+                    "void Run(TestNamespace.Widget value, object value)",
+                    "System.Void",
+                    [Parameter("TestNamespace.Widget"), Parameter("")],
+                    isStatic: true,
+                    isExtension: true,
+                    extendedType: "TestNamespace.Widget"),
+            ]));
+        var newSurface = Surface(Type("Widget", members:
+        [
+            StructuredMethod(
+                "Run",
+                "void Run(object value)",
+                "System.Void",
+                [Parameter("")]),
+        ]));
+
+        var comparison = MetadataFindings.CompareApiMembers(
+            oldSurface,
+            newSurface,
+            Subject,
+            acceptanceThreshold: 85);
+
+        Assert.Equal(2, Pairs(comparison).Length);
+        Assert.DoesNotContain(Pairs(comparison), pair => pair.Kind == PairKind.Changed);
+    }
+
+    [Fact]
     public void AmbiguousExtensionInstanceEndpoints_DoNotSoftMatch()
     {
         var oldSurface = Surface(

--- a/tests/ILInspector.Metadata.Tests/MetadataFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataFindingsTests.cs
@@ -1,3 +1,6 @@
+extern alias extensionnew;
+extern alias extensionold;
+
 using System.Collections.Immutable;
 using System.Reflection.PortableExecutable;
 using ILInspector.Findings;
@@ -174,6 +177,250 @@ public class MetadataFindingsTests
     }
 
     [Fact]
+    public void SameRoleExtensionRelocation_DoesNotSoftMatch()
+    {
+        var oldSurface = Surface(
+            Type("Widget"),
+            Type("OldExtensions", members:
+            [
+                StructuredMethod(
+                    "Run",
+                    "void Run(TestNamespace.Widget value, int count)",
+                    "System.Void",
+                    [Parameter("TestNamespace.Widget"), Parameter("System.Int32")],
+                    isStatic: true,
+                    isExtension: true,
+                    extendedType: "TestNamespace.Widget"),
+            ]));
+        var newSurface = Surface(
+            Type("Widget"),
+            Type("NewExtensions", members:
+            [
+                StructuredMethod(
+                    "Run",
+                    "void Run(TestNamespace.Widget value, int count)",
+                    "System.Void",
+                    [Parameter("TestNamespace.Widget"), Parameter("System.Int32")],
+                    isStatic: true,
+                    isExtension: true,
+                    extendedType: "TestNamespace.Widget"),
+            ]));
+
+        var comparison = MetadataFindings.CompareApiMembers(
+            oldSurface,
+            newSurface,
+            Subject,
+            acceptanceThreshold: 85);
+
+        Assert.Equal(2, Pairs(comparison).Length);
+        Assert.Contains(Pairs(comparison), pair => pair.Kind == PairKind.Added);
+        Assert.Contains(Pairs(comparison), pair => pair.Kind == PairKind.Removed);
+    }
+
+    [Fact]
+    public void ExtensionInstanceParameterMismatch_DoesNotSoftMatch()
+    {
+        var oldSurface = Surface(
+            Type("Widget"),
+            Type("WidgetExtensions", members:
+            [
+                StructuredMethod(
+                    "Run",
+                    "void Run(TestNamespace.Widget value, int count)",
+                    "System.Void",
+                    [Parameter("TestNamespace.Widget"), Parameter("System.Int32")],
+                    isStatic: true,
+                    isExtension: true,
+                    extendedType: "TestNamespace.Widget"),
+            ]));
+        var newSurface = Surface(Type("Widget", members:
+        [
+            StructuredMethod(
+                "Run",
+                "void Run(string count)",
+                "System.Void",
+                [Parameter("System.String")]),
+        ]));
+
+        var comparison = MetadataFindings.CompareApiMembers(
+            oldSurface,
+            newSurface,
+            Subject,
+            acceptanceThreshold: 85);
+
+        Assert.Equal(2, Pairs(comparison).Length);
+        Assert.DoesNotContain(Pairs(comparison), pair => pair.Kind == PairKind.Changed);
+    }
+
+    [Fact]
+    public void AmbiguousExtensionInstanceEndpoints_DoNotSoftMatch()
+    {
+        var oldSurface = Surface(
+            Type("Widget"),
+            Type("WidgetExtensions", members:
+            [
+                StructuredMethod(
+                    "Run",
+                    "void Run(TestNamespace.Widget value, int count)",
+                    "System.Void",
+                    [Parameter("TestNamespace.Widget"), Parameter("System.Int32")],
+                    isStatic: true,
+                    isExtension: true,
+                    extendedType: "TestNamespace.Widget"),
+            ]));
+        var newSurface = Surface(Type("Widget", members:
+        [
+            StructuredMethod(
+                "Run",
+                "void Run(int count)",
+                "System.Void",
+                [Parameter("System.Int32")]),
+            StructuredMethod(
+                "Run",
+                "void Run(int count)",
+                "System.Void",
+                [Parameter("System.Int32")]),
+        ]));
+
+        var comparison = MetadataFindings.CompareApiMembers(
+            oldSurface,
+            newSurface,
+            Subject,
+            acceptanceThreshold: 85);
+
+        Assert.Equal(3, Pairs(comparison).Length);
+        Assert.DoesNotContain(Pairs(comparison), pair => pair.Kind == PairKind.Changed);
+    }
+
+    [Fact]
+    public void ExtensionSoftMatch_CannotDisplaceExactMemberMatch()
+    {
+        var instance = StructuredMethod(
+            "Run",
+            "void Run(int count)",
+            "System.Void",
+            [Parameter("System.Int32")]);
+        var oldSurface = Surface(
+            Type("Widget", members: [instance]),
+            Type("WidgetExtensions", members:
+            [
+                StructuredMethod(
+                    "Run",
+                    "void Run(TestNamespace.Widget value, int count)",
+                    "System.Void",
+                    [Parameter("TestNamespace.Widget"), Parameter("System.Int32")],
+                    isStatic: true,
+                    isExtension: true,
+                    extendedType: "TestNamespace.Widget"),
+            ]));
+        var newSurface = Surface(Type("Widget", members:
+        [
+            StructuredMethod(
+                "Run",
+                "void Run(int count)",
+                "System.Void",
+                [Parameter("System.Int32")]),
+        ]));
+
+        var comparison = MetadataFindings.CompareApiMembers(
+            oldSurface,
+            newSurface,
+            Subject,
+            acceptanceThreshold: 85);
+
+        Assert.Equal(2, Pairs(comparison).Length);
+        Assert.Single(Pairs(comparison), pair => pair.Kind == PairKind.Present);
+        Assert.Single(Pairs(comparison), pair => pair.Kind == PairKind.Removed);
+    }
+
+    [Fact]
+    public void ExtensionToInstance_DefaultIsConservativeAndOptInIsChanged()
+    {
+        var oldSurface = Surface(
+            Type("Widget"),
+            Type("WidgetExtensions", members:
+            [
+                StructuredMethod(
+                    "Run",
+                    "void Run(TestNamespace.Widget value, int count)",
+                    "System.Void",
+                    [Parameter("TestNamespace.Widget"), Parameter("System.Int32")],
+                    isStatic: true,
+                    isExtension: true,
+                    extendedType: "TestNamespace.Widget"),
+            ]));
+        var newSurface = Surface(Type("Widget", members:
+        [
+            StructuredMethod(
+                "Run",
+                "void Run(int count)",
+                "System.Void",
+                [Parameter("System.Int32")]),
+        ]));
+
+        var conservative = MetadataFindings.CompareApiMembers(oldSurface, newSurface, Subject);
+        Assert.Equal(2, Pairs(conservative).Length);
+        Assert.Contains(Pairs(conservative), pair => pair.Kind == PairKind.Added);
+        Assert.Contains(Pairs(conservative), pair => pair.Kind == PairKind.Removed);
+
+        var accepted = MetadataFindings.CompareApiMembers(
+            oldSurface,
+            newSurface,
+            Subject,
+            acceptanceThreshold: 85);
+
+        var changed = Assert.IsType<PairFinding<ApiMemberHandle>.Changed>(
+            Assert.Single(Pairs(accepted)).Value);
+        Assert.NotNull(changed.Match);
+        Assert.Equal(MetadataFindings.ExtensionInstanceMatchTier, changed.Match.Tier);
+        Assert.Equal(85, changed.Match.Confidence);
+        Assert.Contains("soft match: api.member.extension-instance", changed.Detail, StringComparison.Ordinal);
+        Assert.Contains("signature:", changed.Detail, StringComparison.Ordinal);
+        Assert.Contains("static: true -> false", changed.Detail, StringComparison.Ordinal);
+        Assert.Contains("extension: true -> false", changed.Detail, StringComparison.Ordinal);
+        Assert.Contains(
+            "declaring type: TestNamespace.WidgetExtensions -> TestNamespace.Widget",
+            changed.Detail,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InstanceToExtension_SoftMatchIsSymmetric()
+    {
+        var oldSurface = Surface(Type("Widget", members:
+        [
+            StructuredMethod(
+                "Run",
+                "void Run(int count)",
+                "System.Void",
+                [Parameter("System.Int32")]),
+        ]));
+        var newSurface = Surface(
+            Type("Widget"),
+            Type("WidgetExtensions", members:
+            [
+                StructuredMethod(
+                    "Run",
+                    "void Run(TestNamespace.Widget value, int count)",
+                    "System.Void",
+                    [Parameter("TestNamespace.Widget"), Parameter("System.Int32")],
+                    isStatic: true,
+                    isExtension: true,
+                    extendedType: "TestNamespace.Widget"),
+            ]));
+
+        var comparison = MetadataFindings.CompareApiMembers(
+            oldSurface,
+            newSurface,
+            Subject,
+            acceptanceThreshold: 85);
+
+        var changed = Assert.IsType<PairFinding<ApiMemberHandle>.Changed>(
+            Assert.Single(Pairs(comparison)).Value);
+        Assert.Contains("extension: false -> true", changed.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ApiSurfaceMembersAreNotFilteredByNameHeuristics()
     {
         var oldSurface = Surface(Type("Widget"));
@@ -284,6 +531,29 @@ public class MetadataFindingsTests
         Assert.True(Pairs(result.Members).Length > 50);
     }
 
+    [Fact]
+    public void CompiledExtensionToInstance_ProducesSoftChangedCandidate()
+    {
+        var oldSurface = ExtractSurface(typeof(extensionold::ExtensionInstanceFixture.Widget).Assembly.Location);
+        var newSurface = ExtractSurface(typeof(extensionnew::ExtensionInstanceFixture.Widget).Assembly.Location);
+
+        var comparison = MetadataFindings.CompareApiMembers(
+            oldSurface,
+            newSurface,
+            Subject,
+            acceptanceThreshold: 85);
+
+        var changed = Assert.Single(
+            Pairs(comparison),
+            pair => pair is PairFinding<ApiMemberHandle>.Changed
+            {
+                Old.Payload.Member.Name: "Measure",
+                New.Payload.Member.Name: "Measure",
+            });
+        var matched = Assert.IsAssignableFrom<IMatchedPairFinding>(changed.Value);
+        Assert.Equal(MetadataFindings.ExtensionInstanceMatchTier, matched.Match?.Tier);
+    }
+
     static ImmutableArray<PairFinding<T>> Pairs<T>(FindingComparison<T> comparison)
         where T : notnull
         => comparison is FindingComparison<T>.Complete complete
@@ -334,6 +604,13 @@ public class MetadataFindingsTests
     static ApiSurface Surface(params ApiType[] types)
         => new() { Types = [.. types] };
 
+    static ApiSurface ExtractSurface(string assemblyPath)
+    {
+        using var stream = File.OpenRead(assemblyPath);
+        using var reader = new PEReader(stream);
+        return ApiSurfaceExtractor.Extract(reader);
+    }
+
     static ApiType Type(
         string name,
         string kind = "class",
@@ -369,6 +646,33 @@ public class MetadataFindingsTests
 
     static ApiMember Property(string name, string signature)
         => new() { Name = name, Kind = "property", Signature = signature };
+
+    static ApiMember StructuredMethod(
+        string name,
+        string signature,
+        string returnType,
+        List<ApiParameter> parameters,
+        bool isStatic = false,
+        bool isExtension = false,
+        string? extendedType = null)
+        => new()
+        {
+            Name = name,
+            Kind = "method",
+            Signature = signature,
+            SignatureModel = new ApiSignature
+            {
+                MemberName = name,
+                ReturnType = returnType,
+                Parameters = parameters,
+            },
+            IsStatic = isStatic,
+            IsExtension = isExtension,
+            ExtendedType = extendedType,
+        };
+
+    static ApiParameter Parameter(string type, string? modifier = null)
+        => new() { Type = type, Modifier = modifier };
 
     sealed record ExpectedMembers(string[] Added, string[] Removed);
 }


### PR DESCRIPTION
Advances #2585 with the first Rung 2 soft-correspondence tier.

## Change

- Adds producer-owned soft identity projections, deferred candidates, consumer-selected acceptance, and typed tier/confidence provenance to the shared Finding substrate.
- Adds Metadata's `api.member.extension-instance` tier at confidence 85 using structured receiver, name, generic arity, return type, and non-receiver parameters.
- Keeps threshold 100 exactly conservative: soft correspondence remains Added + Removed unless a consumer opts in.
- Preserves exact-match dominance, suppresses ambiguous and same-role endpoints, fails closed on incomplete signatures, and keeps `ApiDiffAnalyzer` as compatibility authority.
- Preserves existing public constructors and deconstruction shapes alongside the provenance-aware forms.

## Evidence

- Full `dotnet-inspect.slnx` Release build passes.
- `FindingPilotTests`: 62 passed.
- `MetadataFindingsTests`: 24 passed, including a compiled SRM importer fixture.
- Changed Finding design docs pass markdownlint.

## Adversarial review

- **MAI first pass:** found malformed blank parameter facets could correlate. Fixed in `482ff810` with fail-closed validation and a regression test.
- **Gemini first pass:** found `TransformPairs` could drop accepted match provenance. Fixed in `bb1b4df8` with invariant enforcement and a regression test. Its suggestion to strip receiver refness/nullability and coalesce generic arity was not applied because this tier intentionally drops only extension/instance kind; explicit near-miss tests now pin those facets as gates.
- **Final compatibility pass:** found the new optional provenance parameters changed emitted constructor signatures. Fixed in `fa1cb8f2`, including the corresponding four-parameter `Deconstruct` forms and compatibility coverage.
- **Final head `fa1cb8f2`: Gemini CLEAN; MAI CLEAN.**
