### PR TITLE
RTS ctor chain: emit initializer for array-covariant assignable args (#2726)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1042,6 +1042,75 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_DropsInitializerWhenArrayCovariantArgumentBindsSystemNamespaceUserConversion()
+    {
+        // Issue #2726 guard (adversarial, from PR #2730 round-2 review): a user type
+        // declared in a `System` namespace is NOT corelib and may declare an
+        // implicit conversion operator from an array. Excluding a competitor by
+        // namespace string would be unsound; corelib membership is decided by
+        // assembly identity (TypeRef.Assembly == "corelib"), so `System.MySink`
+        // (defined in the target assembly) stays in play and the chain strips. The
+        // body forces both the conversion operator and the competitor ctor into the
+        // reconstructed shell; [OverloadResolutionPriority(-1)] keeps the original
+        // chain bound to the IEnumerable ctor.
+        var assemblyPath = CompileFixture("""
+            using System.Collections.Generic;
+            using System.Runtime.CompilerServices;
+
+            namespace System
+            {
+                public class MySink
+                {
+                    public static implicit operator MySink(string[] value) => new MySink();
+                }
+            }
+
+            public class C
+            {
+                public C(string tag)
+                    : this(Parse(tag), tag.Length)
+                {
+                    _ = (System.MySink)Parse(tag);
+                    _ = new C(default(System.MySink), 0);
+                }
+
+                public C(IEnumerable<string> labels, int count)
+                {
+                    Count = count;
+                }
+
+                [OverloadResolutionPriority(-1)]
+                public C(System.MySink sink, int count)
+                {
+                    Count = count;
+                }
+
+                public int Count { get; }
+
+                private static string[] Parse(string tag) => tag.Split('.');
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("C", ".ctor", 0,
+                    "(corelib:System.String) -> corelib:System.Void")]));
+
+            // The load-bearing invariant is that the gate STRIPS the unsound chain.
+            // This fixture is deliberately pathological (a user type in `namespace
+            // System` plus an implicit array operator), which RTS cannot round-trip
+            // as a whole shell, so the overall status is not asserted; emitting the
+            // initializer would fail or bind wrong, so stripping is the sound choice.
+            Assert.DoesNotContain(": this(", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_UsesTargetBackingFieldWriteForConstructorAssignment()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -778,6 +778,210 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_PreservesConstructorChainWhenArgumentIsArrayCovariantToInterface()
+    {
+        // Issue #2726: the `(Version, string, string)` ctor chains to
+        // `(Version, IEnumerable<string>, string)` passing a `string[]` argument.
+        // `string[]` is implicitly convertible to `IEnumerable<string>` by array
+        // covariance but is NOT structurally identical to it, so the faithful
+        // check (identity only) declines the chain; the two ctors share arity, so
+        // the unique-arity check declines too. `string[]` cannot bind to the
+        // sibling's second `string` parameter, so the chain binds unambiguously to
+        // `(Version, IEnumerable<string>, string)` and must be preserved.
+        var assemblyPath = CompileFixture("""
+            using System;
+            using System.Collections.Generic;
+
+            public class Ver
+            {
+                public Ver(Version version, string release, string metadata)
+                    : this(version, ParseLabels(release), metadata)
+                {
+                }
+
+                public Ver(Version version, IEnumerable<string> releaseLabels, string metadata)
+                {
+                    Labels = releaseLabels;
+                    Metadata = metadata;
+                }
+
+                public IEnumerable<string> Labels { get; }
+
+                public string Metadata { get; }
+
+                private static string[] ParseLabels(string release) => release.Split('.');
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Ver", ".ctor", 0,
+                    "(corelib:System.Version, corelib:System.String, corelib:System.String) -> corelib:System.Void")]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains(": this(", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_DropsInitializerWhenArrayCovariantArgumentAlsoBindsCovariantSibling()
+    {
+        // Issue #2726 guard: `string[]` is array-covariant to BOTH the chained-to
+        // `IReadOnlyCollection<string>` parameter and the same-arity sibling's
+        // `IEnumerable<string>` parameter, so the chained-to constructor is not the
+        // unique applicable candidate at the array position. The `new C(...)` in the
+        // body forces the sibling into the shell (defeating the unique-arity path),
+        // so the assignability gate must decide — and must strip rather than emit a
+        // chain that could bind to the sibling.
+        var assemblyPath = CompileFixture("""
+            using System.Collections.Generic;
+
+            public class C
+            {
+                public C(string tag)
+                    : this(Parse(tag), tag.Length)
+                {
+                    _ = new C((IEnumerable<string>)null, 0);
+                }
+
+                public C(IReadOnlyCollection<string> labels, int count)
+                {
+                    Count = count;
+                }
+
+                public C(IEnumerable<string> labels, int count)
+                {
+                    Count = count;
+                }
+
+                public int Count { get; }
+
+                private static string[] Parse(string tag) => tag.Split('.');
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("C", ".ctor", 0,
+                    "(corelib:System.String) -> corelib:System.Void")]));
+
+            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.DoesNotContain(": this(", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_DropsInitializerWhenArrayCovariantArgumentAlsoBindsObjectSibling()
+    {
+        // Issue #2726 guard: `string[]` converts to `object`, so a same-arity
+        // sibling taking `object` at the array position cannot be excluded. The
+        // covariance model over-approximates convertibility (so exclusion is only
+        // ever a proof of non-convertibility); an unprovable competitor strips. The
+        // `new C(...)` forces the `object` sibling into the shell so the
+        // assignability gate is the decider.
+        var assemblyPath = CompileFixture("""
+            using System.Collections.Generic;
+
+            public class C
+            {
+                public C(string tag)
+                    : this(Parse(tag), tag.Length)
+                {
+                    _ = new C((object)null, 0);
+                }
+
+                public C(IEnumerable<string> labels, int count)
+                {
+                    Count = count;
+                }
+
+                public C(object marker, int count)
+                {
+                    Count = count;
+                }
+
+                public int Count { get; }
+
+                private static string[] Parse(string tag) => tag.Split('.');
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("C", ".ctor", 0,
+                    "(corelib:System.String) -> corelib:System.Void")]));
+
+            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.DoesNotContain(": this(", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_DropsInitializerWhenArrayCovariantTargetHasParamsConstructor()
+    {
+        // Issue #2726 guard: a `params` constructor absorbs calls of other arities,
+        // so competitor applicability can no longer be decided position-by-position.
+        // The covariance model bails (strips) when any reconstructable constructor
+        // is variadic or has an optional parameter. The `new C("a", "b")` forces the
+        // `params` sibling into the shell so the unique-arity path does not decide.
+        var assemblyPath = CompileFixture("""
+            using System.Collections.Generic;
+
+            public class C
+            {
+                public C(string tag)
+                    : this(Parse(tag), tag.Length)
+                {
+                    _ = new C("a", "b");
+                }
+
+                public C(IEnumerable<string> labels, int count)
+                {
+                    Count = count;
+                }
+
+                public C(params string[] parts)
+                {
+                    Count = parts.Length;
+                }
+
+                public int Count { get; }
+
+                private static string[] Parse(string tag) => tag.Split('.');
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("C", ".ctor", 0,
+                    "(corelib:System.String) -> corelib:System.Void")]));
+
+            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.DoesNotContain(": this(", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_UsesTargetBackingFieldWriteForConstructorAssignment()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1109,6 +1109,75 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_DropsInitializerWhenArrayCovariantArgumentBindsNestedFacadeAssemblyUserConversion()
+    {
+        // Issue #2726 guard (adversarial, from PR #2730 round-4 review, found
+        // independently by both reviewers): a NESTED inspected type has an empty
+        // metadata namespace and a simple metadata name, but the decoder shapes its
+        // TypeRef with the outermost namespace and a `Declaring+Nested` name
+        // (System.Outer+MySink). A flat `namespace + "." + name` inspected-name key
+        // would miss it, so in a facade-simple-named assembly the nested user type
+        // (canonicalized to corelib) would be wrongly excluded and the chain emitted.
+        // InspectedDefinitionKey walks the declaring chain to match the decoder, so
+        // the nested competitor stays in play and the chain strips.
+        var assemblyPath = CompileFixture(
+            """
+            using System.Collections.Generic;
+            using System.Runtime.CompilerServices;
+
+            namespace System
+            {
+                public class Outer
+                {
+                    public class MySink
+                    {
+                        public static implicit operator MySink(string[] value) => new MySink();
+                    }
+                }
+            }
+
+            public class C
+            {
+                public C(string tag)
+                    : this(Parse(tag), tag.Length)
+                {
+                    _ = (System.Outer.MySink)Parse(tag);
+                    _ = new C(default(System.Outer.MySink), 0);
+                }
+
+                public C(IEnumerable<string> labels, int count)
+                {
+                    Count = count;
+                }
+
+                [OverloadResolutionPriority(-1)]
+                public C(System.Outer.MySink sink, int count)
+                {
+                    Count = count;
+                }
+
+                public int Count { get; }
+
+                private static string[] Parse(string tag) => tag.Split('.');
+            }
+            """,
+            assemblyName: "System.Runtime");
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("C", ".ctor", 0,
+                    "(corelib:System.String) -> corelib:System.Void")]));
+
+            Assert.DoesNotContain(": this(", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_DropsInitializerWhenArrayCovariantArgumentBindsSystemNamespaceUserConversion()
     {
         // Issue #2726 guard (adversarial, from PR #2730 round-2 review): a user type

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -935,10 +935,12 @@ public class ReturnToSenderPrototypeTests
     public void CompileBackTargets_DropsInitializerWhenArrayCovariantTargetHasParamsConstructor()
     {
         // Issue #2726 guard: a `params` constructor absorbs calls of other arities,
-        // so competitor applicability can no longer be decided position-by-position.
-        // The covariance model bails (strips) when any reconstructable constructor
-        // is variadic or has an optional parameter. The `new C("a", "b")` forces the
-        // `params` sibling into the shell so the unique-arity path does not decide.
+        // so a `params string[]` sibling is applicable to the two-argument chain.
+        // At the params slot `string[]` binds as the whole array, so the covariance
+        // model cannot exclude it (exclusion requires ruling out both element and
+        // whole-array binding), and the chain must strip. The `new C("a", "b")`
+        // forces the `params` sibling into the shell so the unique-arity path does
+        // not decide.
         var assemblyPath = CompileFixture("""
             using System.Collections.Generic;
 
@@ -958,6 +960,64 @@ public class ReturnToSenderPrototypeTests
                 public C(params string[] parts)
                 {
                     Count = parts.Length;
+                }
+
+                public int Count { get; }
+
+                private static string[] Parse(string tag) => tag.Split('.');
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("C", ".ctor", 0,
+                    "(corelib:System.String) -> corelib:System.Void")]));
+
+            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.DoesNotContain(": this(", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_DropsInitializerWhenArrayCovariantArgumentAlsoBindsSpanSibling()
+    {
+        // Issue #2726 guard (adversarial, from PR #2730 review): a library can use
+        // [OverloadResolutionPriority(-1)] to keep an IEnumerable<string> overload
+        // selected for a string[] argument while ALSO offering a first-class
+        // ReadOnlySpan<string> overload. The original chain then binds to the
+        // IEnumerable ctor (so the covariance emit path is eligible), but `string[]`
+        // implicitly converts to ReadOnlySpan<string> too, and RTS does not re-emit
+        // the priority attribute, so a recompiled `: this(...)` would prefer the span
+        // ctor. `ArrayCanConvertTo` must NOT prove the span competitor
+        // non-convertible; the chain must strip. The `new C(...)` forces the span
+        // sibling into the shell so the assignability gate is the decider.
+        var assemblyPath = CompileFixture("""
+            using System;
+            using System.Collections.Generic;
+            using System.Runtime.CompilerServices;
+
+            public class C
+            {
+                public C(string tag)
+                    : this(Parse(tag), tag.Length)
+                {
+                    _ = new C(default(ReadOnlySpan<string>), 0);
+                }
+
+                public C(IEnumerable<string> labels, int count)
+                {
+                    Count = count;
+                }
+
+                [OverloadResolutionPriority(-1)]
+                public C(ReadOnlySpan<string> labels, int count)
+                {
+                    Count = count;
                 }
 
                 public int Count { get; }

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1042,6 +1042,73 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_DropsInitializerWhenArrayCovariantArgumentBindsFacadeAssemblyUserConversion()
+    {
+        // Issue #2726 guard (adversarial, from PR #2730 round-3 review): when the
+        // inspected assembly's OWN simple name is a corelib facade (System.Runtime,
+        // mscorlib, netstandard, ...), TypeRefDecoder canonicalizes its own
+        // TypeDefinitions' assembly to "corelib". Assembly-identity exclusion alone
+        // would then wrongly rule out `System.MySink` — a type this assembly DEFINES
+        // and which declares an implicit array operator — as if it were corelib.
+        // The gate instead never excludes a competitor whose receiving parameter is
+        // an inspected TypeDefinition, so the unsound chain strips. Recompile status
+        // is environment-dependent for a facade-named shell (see the corelib-facade
+        // interface-seed test), so only the strip invariant is asserted.
+        var assemblyPath = CompileFixture(
+            """
+            using System.Collections.Generic;
+            using System.Runtime.CompilerServices;
+
+            namespace System
+            {
+                public class MySink
+                {
+                    public static implicit operator MySink(string[] value) => new MySink();
+                }
+            }
+
+            public class C
+            {
+                public C(string tag)
+                    : this(Parse(tag), tag.Length)
+                {
+                    _ = (System.MySink)Parse(tag);
+                    _ = new C(default(System.MySink), 0);
+                }
+
+                public C(IEnumerable<string> labels, int count)
+                {
+                    Count = count;
+                }
+
+                [OverloadResolutionPriority(-1)]
+                public C(System.MySink sink, int count)
+                {
+                    Count = count;
+                }
+
+                public int Count { get; }
+
+                private static string[] Parse(string tag) => tag.Split('.');
+            }
+            """,
+            assemblyName: "System.Runtime");
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("C", ".ctor", 0,
+                    "(corelib:System.String) -> corelib:System.Void")]));
+
+            Assert.DoesNotContain(": this(", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_DropsInitializerWhenArrayCovariantArgumentBindsSystemNamespaceUserConversion()
     {
         // Issue #2726 guard (adversarial, from PR #2730 round-2 review): a user type

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1981,21 +1981,42 @@ public static class CompileBackSourceComposer
         return param.Kind switch
         {
             // T[] -> U[] by array covariance when the element is reference-covariant.
-            TypeRefKind.SzArray => param.ElementType is { } targetElement
-                && ElementReferenceCovariant(element, targetElement),
-            // T[] -> IEnumerable<U>/IReadOnlyList<U>/... when element reference-covariant to U.
-            TypeRefKind.GenericInstance => param.TypeArguments.Length == 1
-                && param.ElementType is { } definition
-                && IsCovariantArrayInterfaceDefinition(definition)
-                && ElementReferenceCovariant(element, param.TypeArguments[0]),
-            // object, System.Array, ICloneable, and the non-generic collection /
-            // structural interfaces are the only named types an array converts to.
+            TypeRefKind.SzArray => param.ElementType is not { } targetElement
+                || ElementReferenceCovariant(element, targetElement),
+            // A covariant System.Collections.Generic interface over a
+            // reference-covariant element is convertible; any OTHER generic
+            // instance (Span<T>/ReadOnlySpan<T>/Memory<T>/ReadOnlyMemory<T> with a
+            // built-in array conversion, or a user generic with an implicit
+            // conversion operator we cannot see) is not provably non-convertible,
+            // so it stays in play. Only a covariant interface with a provably
+            // non-covariant element (value-type mismatch) is ruled out.
+            TypeRefKind.GenericInstance =>
+                !(param.TypeArguments.Length == 1
+                    && param.ElementType is { } definition
+                    && IsCovariantArrayInterfaceDefinition(definition))
+                || ElementReferenceCovariant(element, param.TypeArguments[0]),
+            // object, System.Array, ICloneable, the non-generic collection /
+            // structural interfaces, and any user-defined type (which may declare
+            // an implicit conversion from an array) stay in play; only enumerable
+            // corelib types with no array conversion are ruled out.
             TypeRefKind.Definition => IsArrayCompatibleNonGenericType(param),
             // ByRef/Pointer/GenericParameter/Unsupported/etc.: cannot rule out.
             _ => true,
         };
     }
 
+    /// <summary>
+    /// Whether a <c>T[]</c> argument might convert to the non-generic
+    /// <paramref name="type"/>. Over-approximates: returns <c>true</c> for the
+    /// corelib types an array converts to (<c>object</c>, <c>System.Array</c>,
+    /// <c>ICloneable</c>, the non-generic collection / structural interfaces) AND
+    /// for any user-defined type, which could declare an <c>implicit operator</c>
+    /// from an array we cannot observe from the parameter type alone. Returns
+    /// <c>false</c> only for enumerable corelib (<c>System.*</c>) types that
+    /// provably have no array conversion (<c>String</c>, the primitives,
+    /// <c>Version</c>, ...), so a <c>false</c> result stays a proof of
+    /// non-convertibility.
+    /// </summary>
     static bool IsArrayCompatibleNonGenericType(TypeRef type)
     {
         if (type.Kind != TypeRefKind.Definition)
@@ -2009,8 +2030,15 @@ public static class CompileBackSourceComposer
             return true;
         }
 
-        return false;
+        // Corelib/System.* types other than the array-convertible set above have no
+        // implicit conversion from an array, so they can be ruled out. A type in a
+        // non-System namespace is user-defined and may declare a conversion
+        // operator we cannot see, so it must stay in play (fail-closed).
+        return !IsSystemNamespace(type.Namespace);
     }
+
+    static bool IsSystemNamespace(string? ns)
+        => ns is not null && (ns == "System" || ns.StartsWith("System.", StringComparison.Ordinal));
 
     /// <summary>
     /// OVER-approximation of "is there an identity or reference conversion from

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1801,6 +1801,23 @@ public static class CompileBackSourceComposer
         if (!anyArrayCovariant)
             return false;
 
+        // Types the inspected assembly DEFINES (not merely references) can declare
+        // an implicit conversion operator from an array that we cannot see, and the
+        // decoder canonicalizes a facade-simple-named inspected assembly
+        // (System.Runtime, mscorlib, netstandard, ...) to "corelib", so assembly
+        // identity alone cannot prove such a definition non-convertible. Collect the
+        // inspected definitions so competitor exclusion never rules one out.
+        var inspectedTypeNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var definitionHandle in reader.TypeDefinitions)
+        {
+            var definition = reader.GetTypeDefinition(definitionHandle);
+            string definitionNamespace = reader.GetString(definition.Namespace);
+            string definitionName = reader.GetString(definition.Name);
+            inspectedTypeNames.Add(definitionNamespace.Length == 0
+                ? definitionName
+                : definitionNamespace + "." + definitionName);
+        }
+
         // Enumerate the target type's instance constructors from metadata, each
         // with the arity range it can bind (a `params` array or optional parameters
         // let a constructor absorb calls of other declared arities). The metadata
@@ -1846,7 +1863,7 @@ public static class CompileBackSourceComposer
             for (int i = 0; i < paramCount; i++)
             {
                 if (argTypes[i].Kind == TypeRefKind.SzArray
-                    && CompetitorExcludedAtPosition(argTypes[i], shape, i))
+                    && CompetitorExcludedAtPosition(argTypes[i], shape, i, inspectedTypeNames))
                 {
                     excluded = true;
                     break;
@@ -1917,23 +1934,43 @@ public static class CompileBackSourceComposer
     /// which over-approximates convertibility, so a <c>true</c> result here proves
     /// non-applicability.
     /// </summary>
-    static bool CompetitorExcludedAtPosition(TypeRef arrayArg, CtorShape shape, int position)
+    static bool CompetitorExcludedAtPosition(TypeRef arrayArg, CtorShape shape, int position, HashSet<string> inspectedTypeNames)
     {
         var paramTypes = shape.ParamTypes;
         int count = paramTypes.Count;
         if (shape.HasParams && position >= count - 1)
         {
             var paramsArray = paramTypes[count - 1];
+            // A params array or its element defined in the inspected assembly could
+            // declare a conversion operator we cannot see; never rule it out.
+            if (IsInspectedDefinition(paramsArray, inspectedTypeNames)
+                || (paramsArray.ElementType is { } inspectedElement
+                    && IsInspectedDefinition(inspectedElement, inspectedTypeNames)))
+            {
+                return false;
+            }
+
             bool toElement = paramsArray.ElementType is { } element && ArrayCanConvertTo(arrayArg, element);
             bool toArray = ArrayCanConvertTo(arrayArg, paramsArray);
             return !toElement && !toArray;
         }
 
         if (position < count)
+        {
+            // A parameter type defined in the inspected assembly could declare an
+            // implicit array conversion operator; keep it in play (fail-closed).
+            if (IsInspectedDefinition(paramTypes[position], inspectedTypeNames))
+                return false;
             return !ArrayCanConvertTo(arrayArg, paramTypes[position]);
+        }
 
         return true;
     }
+
+    static bool IsInspectedDefinition(TypeRef type, HashSet<string> inspectedTypeNames)
+        => type.Kind == TypeRefKind.Definition
+            && inspectedTypeNames.Contains(
+                type.Namespace.Length == 0 ? type.Name : type.Namespace + "." + type.Name);
 
     /// <summary>
     /// Whether an argument's static type is a single-dimensional array

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1807,6 +1807,16 @@ public static class CompileBackSourceComposer
         // (System.Runtime, mscorlib, netstandard, ...) to "corelib", so assembly
         // identity alone cannot prove such a definition non-convertible. Collect the
         // inspected definitions so competitor exclusion never rules one out.
+        //
+        // Accepted residual (PR #2730 round-5 review): a REFERENCED user assembly
+        // whose simple name is itself a corelib facade (e.g. a dependency literally
+        // named "System.Runtime") also decodes its types as "corelib", and those are
+        // not in reader.TypeDefinitions, so this guard cannot cover them; a proper
+        // fix belongs in the shared TypeRefDecoder (carry TPA/platform provenance
+        // rather than canonicalizing untrusted references by simple name), which is
+        // out of scope for this harness-only gate. This does not corrupt the RTS
+        // corpus metric: the oracle recompiles every emit, so any unsound
+        // `: this(args)` becomes an OpcodeDiff/RecompileFail, never a false Exact.
         var inspectedTypeNames = new HashSet<string>(StringComparer.Ordinal);
         foreach (var definitionHandle in reader.TypeDefinitions)
             inspectedTypeNames.Add(InspectedDefinitionKey(reader, definitionHandle));

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1274,7 +1274,16 @@ public static class CompileBackSourceComposer
             //    constructor even when an argument cannot be typed precisely.
             && (ChainArgumentsAreFaithful(chainCallNode, chainCtor)
                 || targetMembers.Count(member => member.Kind == CompileBackMemberKind.Constructor
-                    && ConstructorCouldBindToArgCount(member, chainCtor.ParameterTypes.Length)) == 1);
+                    && ConstructorCouldBindToArgCount(member, chainCtor.ParameterTypes.Length)) == 1
+                // Assignable-but-not-identical arguments — an argument whose static
+                // type is implicitly convertible to its chained-to parameter by
+                // array covariance (`string[]` -> `IEnumerable<string>`) is not
+                // faithful (identity) and shares arity with the sibling that steals
+                // the unique-arity path, yet still binds unambiguously when every
+                // other same-arity constructor is provably inapplicable at an array
+                // position. Sound and fail-closed: emits only when uniqueness is
+                // proven, strips on any uncertainty.
+                || ChainArgumentsBindViaArrayCovariance(reader, targetTypeDef, chainCallNode, chainCtor));
         if (targetConstructorInitializer is not null && !chainedConstructorReconstructed)
         {
             // The chained-to constructor was not reconstructed in the shell, or the
@@ -1701,24 +1710,283 @@ public static class CompileBackSourceComposer
     }
 
     static bool ChainArgumentIsFaithful(IrExpression argument, TypeRef parameterType)
-        // Box (prints its inner value, dropping the `(object)` cast), Coerce,
-        // Convert, IsInstance, and bare constants can each be spelled at a static
-        // type other than the parameter's, so overload resolution could bind them
-        // elsewhere. Lambdas, collection expressions, tuple literals, and
-        // interpolated strings print in a target-typed form with no intrinsic
-        // static type (a lambda `() => ...` and a collection `[...]` have none; a
-        // tuple `(a, b)` target-types per element; an interpolated string `$"..."`
-        // also converts to FormattableString/IFormattable), so a matching
-        // ResultType does not prove they bind only to the chained-to constructor —
-        // a lambda-, collection-, tuple-, or string-accepting sibling can make the
-        // printed initializer ambiguous (CS0121) or bind it elsewhere. Every other
-        // expression prints at its result type, so it is faithful exactly when
-        // that type matches the parameter type.
-        => argument is not (Box or Coerce or ILInspector.Decompiler.Pipeline.Convert or IsInstance
+        => TryGetFaithfulArgumentType(argument, out var type) && type.Equals(parameterType);
+
+    /// <summary>
+    /// The static type an argument prints at, when that type is intrinsic to the
+    /// printed form (so overload resolution binds it there regardless of the
+    /// other candidates). Box (prints its inner value, dropping the
+    /// <c>(object)</c> cast), Coerce, Convert, IsInstance, and bare constants can
+    /// each be spelled at a static type other than their result type, so overload
+    /// resolution could bind them elsewhere. Lambdas, collection expressions,
+    /// tuple literals, and interpolated strings print in a target-typed form with
+    /// no intrinsic static type, so a matching result type does not prove they
+    /// bind only to one candidate. Every other expression prints at its result
+    /// type. Shared by the faithful-argument check and the array-covariance gate.
+    /// </summary>
+    static bool TryGetFaithfulArgumentType(IrExpression argument, out TypeRef type)
+    {
+        if (argument is not (Box or Coerce or ILInspector.Decompiler.Pipeline.Convert or IsInstance
                 or ILInspector.Decompiler.Pipeline.Constant
                 or Lambda or CollectionExpression or TupleExpression or InterpolatedStringExpression)
-            && argument.ResultType is { } type
-            && type.Equals(parameterType);
+            && argument.ResultType is { } resultType)
+        {
+            type = resultType;
+            return true;
+        }
+
+        type = null!;
+        return false;
+    }
+
+    /// <summary>
+    /// The <c>System.Collections.Generic</c> interfaces a single-dimensional
+    /// zero-based array (<c>T[]</c>) implements via array covariance, keyed by
+    /// their metadata name (arity backtick included).
+    /// </summary>
+    static readonly string[] s_covariantArrayInterfaces =
+        ["IEnumerable`1", "IReadOnlyList`1", "IReadOnlyCollection`1", "IList`1", "ICollection`1"];
+
+    /// <summary>
+    /// Whether a constructor-chain call binds unambiguously to its chained-to
+    /// constructor when one or more arguments are implicitly convertible to their
+    /// parameter by array covariance (<c>string[]</c> to
+    /// <c>IEnumerable&lt;string&gt;</c>) rather than identity-equal. Such an
+    /// argument is not <see cref="ChainArgumentIsFaithful"/> (identity) and shares
+    /// arity with the sibling that defeats the unique-arity path, so neither of the
+    /// two existing conditions accepts it. This returns true only when the chain is
+    /// provably unambiguous: every argument is identity-equal or array-covariant to
+    /// its chained-to parameter, and every OTHER same-arity constructor of the
+    /// target type is provably inapplicable at an array-covariant argument
+    /// position. The model is bounded and fail-closed: it bails (strips) on
+    /// <c>params</c>/optional constructors and on any argument or competitor it
+    /// cannot fully reason about, so it never emits an ambiguous or wrong chain.
+    /// </summary>
+    static bool ChainArgumentsBindViaArrayCovariance(
+        MetadataReader reader,
+        TypeDefinition targetTypeDef,
+        Call chainCall,
+        MethodRef chainCtor)
+    {
+        var arguments = chainCall.Arguments;
+        var chainParams = chainCtor.ParameterTypes;
+        int paramCount = chainParams.Length;
+        // Arguments[0] is the `this` receiver; the ctor arguments follow it.
+        if (arguments.Count - 1 != paramCount)
+            return false;
+
+        // Every argument must carry a known, non-lossy static type and be either
+        // identity-equal to its chained-to parameter or array-covariant-assignable
+        // to it. At least one argument must be the array-covariant (non-identity)
+        // case; otherwise the faithful path already covers this chain.
+        var argTypes = new TypeRef[paramCount];
+        bool anyArrayCovariant = false;
+        for (int i = 0; i < paramCount; i++)
+        {
+            if (!TryGetFaithfulArgumentType(arguments[i + 1], out var argType))
+                return false;
+            argTypes[i] = argType;
+            if (argType.Equals(chainParams[i]))
+                continue;
+            if (IsArrayToCovariantInterface(argType, chainParams[i]))
+            {
+                anyArrayCovariant = true;
+                continue;
+            }
+
+            return false;
+        }
+
+        if (!anyArrayCovariant)
+            return false;
+
+        // Enumerate the target type's instance constructors from metadata. Keep the
+        // model bounded: a `params` array or an optional parameter lets a
+        // constructor bind calls of other arities, so competitor applicability can
+        // no longer be decided position-by-position. Bail (strip) rather than risk
+        // an ambiguous chain.
+        var constructors = new List<IReadOnlyList<TypeRef>>();
+        foreach (var methodHandle in targetTypeDef.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (reader.GetString(method.Name) != ".ctor"
+                || method.Attributes.HasFlag(MethodAttributes.Static))
+            {
+                continue;
+            }
+
+            if (ConstructorHasParamsOrOptional(reader, method))
+                return false;
+            constructors.Add(MethodParameterTypes(reader, targetTypeDef, method));
+        }
+
+        // Competitor exclusion. For every OTHER same-arity constructor, require it
+        // is provably inapplicable at an array-covariant argument position.
+        // `ArrayCanConvertTo` OVER-approximates real convertibility (true = maybe
+        // convertible), so a `false` result PROVES the competitor cannot accept
+        // that array argument. If a same-arity competitor cannot be excluded, the
+        // printed `: this(args)` may be ambiguous (CS0121) or bind elsewhere —
+        // strip. The chained-to constructor must itself appear among the metadata
+        // constructors, so an unresolved chain target never emits.
+        bool sawChainCtor = false;
+        foreach (var ctorParams in constructors)
+        {
+            if (ctorParams.Count != paramCount)
+                continue;
+            if (ParameterTypesEqual(ctorParams, chainParams))
+            {
+                sawChainCtor = true;
+                continue;
+            }
+
+            bool excluded = false;
+            for (int i = 0; i < paramCount; i++)
+            {
+                if (argTypes[i].Kind == TypeRefKind.SzArray
+                    && !ArrayCanConvertTo(argTypes[i], ctorParams[i]))
+                {
+                    excluded = true;
+                    break;
+                }
+            }
+
+            if (!excluded)
+                return false;
+        }
+
+        return sawChainCtor;
+    }
+
+    /// <summary>
+    /// Whether an argument's static type is a single-dimensional array
+    /// (<c>T[]</c>) that is implicitly convertible to <paramref name="param"/> by
+    /// array covariance, where <paramref name="param"/> is one of the
+    /// <c>System.Collections.Generic</c> array-covariant interfaces over the SAME
+    /// element type (<c>string[]</c> to <c>IEnumerable&lt;string&gt;</c>). Only the
+    /// identity-element case is treated as assignable for emission: it is the
+    /// provably sound conversion that needs no element-betterness reasoning.
+    /// </summary>
+    static bool IsArrayToCovariantInterface(TypeRef arg, TypeRef param)
+    {
+        if (arg.Kind != TypeRefKind.SzArray || arg.ElementType is not { } element)
+            return false;
+        if (param.Kind != TypeRefKind.GenericInstance
+            || param.ElementType is not { } definition
+            || param.TypeArguments.Length != 1)
+        {
+            return false;
+        }
+
+        return IsCovariantArrayInterfaceDefinition(definition)
+            && element.Equals(param.TypeArguments[0]);
+    }
+
+    static bool IsCovariantArrayInterfaceDefinition(TypeRef definition)
+        => definition.Kind == TypeRefKind.Definition
+            && definition.Namespace == "System.Collections.Generic"
+            && Array.IndexOf(s_covariantArrayInterfaces, definition.Name) >= 0;
+
+    /// <summary>
+    /// OVER-approximation of "could a <c>T[]</c> argument convert to
+    /// <paramref name="param"/>?". Returns true whenever a conversion exists OR
+    /// cannot be ruled out, so a <c>false</c> result PROVES non-convertibility.
+    /// Used only to EXCLUDE a competing constructor at an array position: any
+    /// uncertainty keeps the competitor in play (which strips the chain).
+    /// </summary>
+    static bool ArrayCanConvertTo(TypeRef arrayType, TypeRef param)
+    {
+        if (arrayType.Kind != TypeRefKind.SzArray || arrayType.ElementType is not { } element)
+            return true;
+        if (arrayType.Equals(param))
+            return true;
+
+        return param.Kind switch
+        {
+            // T[] -> U[] by array covariance when the element is reference-covariant.
+            TypeRefKind.SzArray => param.ElementType is { } targetElement
+                && ElementReferenceCovariant(element, targetElement),
+            // T[] -> IEnumerable<U>/IReadOnlyList<U>/... when element reference-covariant to U.
+            TypeRefKind.GenericInstance => param.TypeArguments.Length == 1
+                && param.ElementType is { } definition
+                && IsCovariantArrayInterfaceDefinition(definition)
+                && ElementReferenceCovariant(element, param.TypeArguments[0]),
+            // object, System.Array, ICloneable, and the non-generic collection /
+            // structural interfaces are the only named types an array converts to.
+            TypeRefKind.Definition => IsArrayCompatibleNonGenericType(param),
+            // ByRef/Pointer/GenericParameter/Unsupported/etc.: cannot rule out.
+            _ => true,
+        };
+    }
+
+    static bool IsArrayCompatibleNonGenericType(TypeRef type)
+    {
+        if (type.Kind != TypeRefKind.Definition)
+            return true;
+        if (type.Namespace == "System" && type.Name is "Object" or "Array" or "ICloneable")
+            return true;
+        if (type.Namespace == "System.Collections"
+            && type.Name is "IEnumerable" or "ICollection" or "IList"
+                or "IStructuralComparable" or "IStructuralEquatable")
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// OVER-approximation of "is there an identity or reference conversion from
+    /// array element <paramref name="source"/> to <paramref name="target"/>?"
+    /// (the precondition for array covariance). Returns false only when provably
+    /// impossible: differing elements where either side is a known value type
+    /// (value-type arrays are invariant). Unknown value-type-ness keeps the
+    /// conversion possible (true), so exclusion stays sound.
+    /// </summary>
+    static bool ElementReferenceCovariant(TypeRef source, TypeRef target)
+    {
+        if (source.Equals(target))
+            return true;
+        if (source.DeclaredValueTypeHint == ValueTypeHint.ValueType
+            || target.DeclaredValueTypeHint == ValueTypeHint.ValueType)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    static bool ParameterTypesEqual(IReadOnlyList<TypeRef> left, IReadOnlyList<TypeRef> right)
+    {
+        if (left.Count != right.Count)
+            return false;
+        for (int i = 0; i < left.Count; i++)
+        {
+            if (!left[i].Equals(right[i]))
+                return false;
+        }
+
+        return true;
+    }
+
+    static bool ConstructorHasParamsOrOptional(MetadataReader reader, MethodDefinition method)
+    {
+        foreach (var parameterHandle in method.GetParameters())
+        {
+            var parameter = reader.GetParameter(parameterHandle);
+            if (parameter.SequenceNumber < 1)
+                continue;
+            if (parameter.Attributes.HasFlag(ParameterAttributes.Optional))
+                return true;
+            var attributes = parameter.GetCustomAttributes();
+            if (AttributeReader.HasAttribute(reader, attributes, "System.ParamArrayAttribute")
+                || AttributeReader.HasAttribute(reader, attributes, "System.Runtime.CompilerServices.ParamCollectionAttribute"))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     /// <summary>
     /// Whether a reconstructed constructor could be an applicable candidate for a

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -2010,9 +2010,9 @@ public static class CompileBackSourceComposer
     /// <paramref name="type"/>. Over-approximates: returns <c>true</c> for the
     /// corelib types an array converts to (<c>object</c>, <c>System.Array</c>,
     /// <c>ICloneable</c>, the non-generic collection / structural interfaces) AND
-    /// for any user-defined type, which could declare an <c>implicit operator</c>
-    /// from an array we cannot observe from the parameter type alone. Returns
-    /// <c>false</c> only for enumerable corelib (<c>System.*</c>) types that
+    /// for any type that does not resolve to corelib, which could declare an
+    /// <c>implicit operator</c> from an array we cannot observe from the parameter
+    /// type alone. Returns <c>false</c> only for enumerable corelib types that
     /// provably have no array conversion (<c>String</c>, the primitives,
     /// <c>Version</c>, ...), so a <c>false</c> result stays a proof of
     /// non-convertibility.
@@ -2030,15 +2030,14 @@ public static class CompileBackSourceComposer
             return true;
         }
 
-        // Corelib/System.* types other than the array-convertible set above have no
-        // implicit conversion from an array, so they can be ruled out. A type in a
-        // non-System namespace is user-defined and may declare a conversion
-        // operator we cannot see, so it must stay in play (fail-closed).
-        return !IsSystemNamespace(type.Namespace);
+        // Corelib types other than the array-convertible set above have no implicit
+        // conversion from an array, so they can be ruled out. Any type that does NOT
+        // resolve to corelib is user-defined (even one spelled in a `System`
+        // namespace) and may declare a conversion operator we cannot see, so it must
+        // stay in play (fail-closed). Assembly identity, not the namespace string,
+        // is the sound corelib test.
+        return type.Assembly != TypeRef.CoreLibrary;
     }
-
-    static bool IsSystemNamespace(string? ns)
-        => ns is not null && (ns == "System" || ns.StartsWith("System.", StringComparison.Ordinal));
 
     /// <summary>
     /// OVER-approximation of "is there an identity or reference conversion from

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1809,14 +1809,7 @@ public static class CompileBackSourceComposer
         // inspected definitions so competitor exclusion never rules one out.
         var inspectedTypeNames = new HashSet<string>(StringComparer.Ordinal);
         foreach (var definitionHandle in reader.TypeDefinitions)
-        {
-            var definition = reader.GetTypeDefinition(definitionHandle);
-            string definitionNamespace = reader.GetString(definition.Namespace);
-            string definitionName = reader.GetString(definition.Name);
-            inspectedTypeNames.Add(definitionNamespace.Length == 0
-                ? definitionName
-                : definitionNamespace + "." + definitionName);
-        }
+            inspectedTypeNames.Add(InspectedDefinitionKey(reader, definitionHandle));
 
         // Enumerate the target type's instance constructors from metadata, each
         // with the arity range it can bind (a `params` array or optional parameters
@@ -1971,6 +1964,25 @@ public static class CompileBackSourceComposer
         => type.Kind == TypeRefKind.Definition
             && inspectedTypeNames.Contains(
                 type.Namespace.Length == 0 ? type.Name : type.Namespace + "." + type.Name);
+
+    /// <summary>
+    /// Builds the same full-name key that <see cref="IsInspectedDefinition"/>
+    /// compares against, mirroring how <c>TypeRefDecoder.GetTypeFromDefinition</c>
+    /// shapes a definition's <see cref="TypeRef"/>: a nested type carries the
+    /// OUTERMOST declaring type's namespace and a <c>Declaring+Nested</c> name
+    /// (chained through every enclosing type), so a flat
+    /// <c>namespace + "." + name</c> would miss nested inspected definitions.
+    /// </summary>
+    static string InspectedDefinitionKey(MetadataReader reader, TypeDefinitionHandle handle)
+    {
+        var definition = reader.GetTypeDefinition(handle);
+        string name = reader.GetString(definition.Name);
+        if (definition.IsNested)
+            return InspectedDefinitionKey(reader, definition.GetDeclaringType()) + "+" + name;
+
+        string ns = reader.GetString(definition.Namespace);
+        return ns.Length == 0 ? name : ns + "." + name;
+    }
 
     /// <summary>
     /// Whether an argument's static type is a single-dimensional array

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1756,11 +1756,12 @@ public static class CompileBackSourceComposer
     /// arity with the sibling that defeats the unique-arity path, so neither of the
     /// two existing conditions accepts it. This returns true only when the chain is
     /// provably unambiguous: every argument is identity-equal or array-covariant to
-    /// its chained-to parameter, and every OTHER same-arity constructor of the
-    /// target type is provably inapplicable at an array-covariant argument
-    /// position. The model is bounded and fail-closed: it bails (strips) on
-    /// <c>params</c>/optional constructors and on any argument or competitor it
-    /// cannot fully reason about, so it never emits an ambiguous or wrong chain.
+    /// its chained-to parameter, and every OTHER constructor of the target type
+    /// that could bind the argument list by arity (accounting for
+    /// <c>params</c>/optional expansion) is provably inapplicable at an
+    /// array-covariant argument position. The model is bounded and fail-closed: it
+    /// strips on any argument or competitor it cannot rule out, so it never emits
+    /// an ambiguous or wrong chain.
     /// </summary>
     static bool ChainArgumentsBindViaArrayCovariance(
         MetadataReader reader,
@@ -1800,12 +1801,13 @@ public static class CompileBackSourceComposer
         if (!anyArrayCovariant)
             return false;
 
-        // Enumerate the target type's instance constructors from metadata. Keep the
-        // model bounded: a `params` array or an optional parameter lets a
-        // constructor bind calls of other arities, so competitor applicability can
-        // no longer be decided position-by-position. Bail (strip) rather than risk
-        // an ambiguous chain.
-        var constructors = new List<IReadOnlyList<TypeRef>>();
+        // Enumerate the target type's instance constructors from metadata, each
+        // with the arity range it can bind (a `params` array or optional parameters
+        // let a constructor absorb calls of other declared arities). The metadata
+        // set is a superset of the reconstructed shell, so ruling out every
+        // arity-applicable metadata constructor conservatively rules out every
+        // shell competitor the recompiled `: this(args)` could bind to.
+        var constructors = new List<CtorShape>();
         foreach (var methodHandle in targetTypeDef.GetMethods())
         {
             var method = reader.GetMethodDefinition(methodHandle);
@@ -1815,35 +1817,36 @@ public static class CompileBackSourceComposer
                 continue;
             }
 
-            if (ConstructorHasParamsOrOptional(reader, method))
-                return false;
-            constructors.Add(MethodParameterTypes(reader, targetTypeDef, method));
+            constructors.Add(GetConstructorShape(reader, targetTypeDef, method));
         }
 
-        // Competitor exclusion. For every OTHER same-arity constructor, require it
-        // is provably inapplicable at an array-covariant argument position.
-        // `ArrayCanConvertTo` OVER-approximates real convertibility (true = maybe
-        // convertible), so a `false` result PROVES the competitor cannot accept
-        // that array argument. If a same-arity competitor cannot be excluded, the
-        // printed `: this(args)` may be ambiguous (CS0121) or bind elsewhere —
-        // strip. The chained-to constructor must itself appear among the metadata
-        // constructors, so an unresolved chain target never emits.
+        // Competitor exclusion. For every constructor other than the chained-to
+        // that could bind the argument count by arity, require it is provably
+        // inapplicable at an array-covariant argument position. `ArrayCanConvertTo`
+        // OVER-approximates real convertibility (true = maybe convertible), so a
+        // `false` result PROVES the competitor cannot accept that array argument. A
+        // competitor that cannot bind the argument count is not a candidate and is
+        // skipped; one that could bind but cannot be excluded strips the chain. The
+        // chained-to constructor must itself appear among the metadata constructors,
+        // so an unresolved chain target never emits.
         bool sawChainCtor = false;
-        foreach (var ctorParams in constructors)
+        foreach (var shape in constructors)
         {
-            if (ctorParams.Count != paramCount)
-                continue;
-            if (ParameterTypesEqual(ctorParams, chainParams))
+            if (ParameterTypesEqual(shape.ParamTypes, chainParams))
             {
                 sawChainCtor = true;
                 continue;
             }
 
+            int maxArgs = shape.HasParams ? int.MaxValue : shape.ParamTypes.Count;
+            if (paramCount < shape.RequiredMin || paramCount > maxArgs)
+                continue;
+
             bool excluded = false;
             for (int i = 0; i < paramCount; i++)
             {
                 if (argTypes[i].Kind == TypeRefKind.SzArray
-                    && !ArrayCanConvertTo(argTypes[i], ctorParams[i]))
+                    && CompetitorExcludedAtPosition(argTypes[i], shape, i))
                 {
                     excluded = true;
                     break;
@@ -1855,6 +1858,81 @@ public static class CompileBackSourceComposer
         }
 
         return sawChainCtor;
+    }
+
+    /// <summary>
+    /// A target constructor's parameter types plus the arity information needed to
+    /// decide whether it could bind an N-argument chain call: the minimum required
+    /// argument count (leading non-optional, non-<c>params</c> parameters) and
+    /// whether the final parameter is a <c>params</c> array.
+    /// </summary>
+    readonly record struct CtorShape(IReadOnlyList<TypeRef> ParamTypes, int RequiredMin, bool HasParams);
+
+    static CtorShape GetConstructorShape(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)
+    {
+        var paramTypes = MethodParameterTypes(reader, typeDef, method);
+        int count = paramTypes.Count;
+        var optional = new bool[count];
+        bool hasParams = false;
+        foreach (var parameterHandle in method.GetParameters())
+        {
+            var parameter = reader.GetParameter(parameterHandle);
+            int sequence = parameter.SequenceNumber;
+            if (sequence < 1 || sequence > count)
+                continue;
+            int index = sequence - 1;
+            if (parameter.Attributes.HasFlag(ParameterAttributes.Optional))
+                optional[index] = true;
+            if (index == count - 1)
+            {
+                var attributes = parameter.GetCustomAttributes();
+                if (AttributeReader.HasAttribute(reader, attributes, "System.ParamArrayAttribute")
+                    || AttributeReader.HasAttribute(reader, attributes, "System.Runtime.CompilerServices.ParamCollectionAttribute"))
+                {
+                    hasParams = true;
+                }
+            }
+        }
+
+        int required = 0;
+        for (int i = 0; i < count; i++)
+        {
+            if (hasParams && i == count - 1)
+                continue;
+            if (optional[i])
+                continue;
+            required++;
+        }
+
+        return new CtorShape(paramTypes, required, hasParams);
+    }
+
+    /// <summary>
+    /// Whether a competing constructor is provably inapplicable to an
+    /// array-covariant argument (<paramref name="arrayArg"/>) at
+    /// <paramref name="position"/>: the argument cannot convert to the parameter
+    /// that would receive it. For a <c>params</c> slot, the argument could bind
+    /// either as a single element (expanded) or as the whole array (non-expanded),
+    /// so exclusion requires ruling out both. Uses <see cref="ArrayCanConvertTo"/>,
+    /// which over-approximates convertibility, so a <c>true</c> result here proves
+    /// non-applicability.
+    /// </summary>
+    static bool CompetitorExcludedAtPosition(TypeRef arrayArg, CtorShape shape, int position)
+    {
+        var paramTypes = shape.ParamTypes;
+        int count = paramTypes.Count;
+        if (shape.HasParams && position >= count - 1)
+        {
+            var paramsArray = paramTypes[count - 1];
+            bool toElement = paramsArray.ElementType is { } element && ArrayCanConvertTo(arrayArg, element);
+            bool toArray = ArrayCanConvertTo(arrayArg, paramsArray);
+            return !toElement && !toArray;
+        }
+
+        if (position < count)
+            return !ArrayCanConvertTo(arrayArg, paramTypes[position]);
+
+        return true;
     }
 
     /// <summary>
@@ -1966,26 +2044,6 @@ public static class CompileBackSourceComposer
         }
 
         return true;
-    }
-
-    static bool ConstructorHasParamsOrOptional(MetadataReader reader, MethodDefinition method)
-    {
-        foreach (var parameterHandle in method.GetParameters())
-        {
-            var parameter = reader.GetParameter(parameterHandle);
-            if (parameter.SequenceNumber < 1)
-                continue;
-            if (parameter.Attributes.HasFlag(ParameterAttributes.Optional))
-                return true;
-            var attributes = parameter.GetCustomAttributes();
-            if (AttributeReader.HasAttribute(reader, attributes, "System.ParamArrayAttribute")
-                || AttributeReader.HasAttribute(reader, attributes, "System.Runtime.CompilerServices.ParamCollectionAttribute"))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /// <summary>


### PR DESCRIPTION
- Advances #2726
- Changes RTS constructor-chain gate to emit `: this(args)` when an argument is array-covariant-assignable (not identity-equal) to its parameter and the chained-to ctor is provably the unique same-arity binder. Harness-only (`tools/DecompilerHarness`); product decompiler output unchanged.
- Evidence revision: `9ef5ca44`

## Change

> Should we accept this harness change?

**Conclusion:** **PASS** — the faithful/unique-arity gate from #2708 could not check `string[]`→`IEnumerable<string>` chain args with a same-arity sibling, so 3 `SemanticVersion` chains stayed `OpcodeDiff`; a bounded, fail-closed array-covariance disjunct proves unique applicability and moves them to `Exact` (NuGet.Versioning probe 18→21 wins), with `RecompileFail` unchanged at 63.

Before (SemanticVersion, `this(version, ParseReleaseLabels(...), metadata)`):

```text
: this(...) stripped — string[] arg is not TypeRef.Equals IEnumerable<string>
and shares arity with the (Version, string, string) sibling  ->  OpcodeDiff
```

After:

```text
: this(version, ParseReleaseLabels(releaseLabel), metadata) emitted  ->  Exact
```

## Scope and safety

- **Root cause:** the gate treats an argument as bindable only when its IR result type *structurally equals* the parameter type (faithful) or the chain is unique by arity. `string[]` does not `TypeRef.Equals` `IEnumerable<string>`, and the arity is shared, so the chain is stripped even though `string[]` genuinely cannot bind the `(Version, string, string)` sibling.
- **Fix shape:** RTS orchestration only. New additive OR-disjunct `ChainArgumentsBindViaArrayCovariance`: every arg is identity- or array→covariant-interface-assignable (same element; the 5 covariant `System.Collections.Generic` interfaces) to its chained-to parameter, ≥1 is the non-identity array case, and every *other* metadata ctor that could bind the argument count by arity is provably inapplicable at an array position. `ArrayCanConvertTo` over-approximates convertibility, so a `false` result *proves* non-applicability — emit only when the chained-to ctor is the unique non-excluded same-arity binder; any uncertainty strips.
- **Product impact:** none. `ReturnToSenderTypePlanner` only shapes the RTS compile-back shell; product decompiler render is untouched.
- **Scope boundary:** limited to array→covariant-interface. General reference up-conversions and user-defined conversions remain a frontier (still stripped).
- **RTS boundary:** RTS only orchestrates closure + Roslyn + opcode compare; the emitted `: this(args)` is round-trip-validated by recompilation.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass (`DecompilerHarness`, `ILInspector.Decompiler.Tests`) |
| Focused tests | `ReturnToSenderPrototypeTests` 111/0 (incl. 1 positive canary + 3 adversarial negatives) |
| Decompiler fast suite | `-notrait "Speed=Slow"` 2409/0 |
| Targeted compile-back | NuGet.Versioning rts-parity 136→**139 exact**, 12→**9 opcode diffs**, **63 RF unchanged** |
| Real witness | `NuGet.Versioning.SemanticVersion::.ctor` (×3 chains) moved `OpcodeDiff` → `Exact` |

## Compile-back quality

**Conclusion:** **PASS** — the 3 changed `SemanticVersion` chains move `OpcodeDiff`→`Exact` and recompile to identical IL; no row regressed (RecompileFail 63 → 63, checked population 211 unchanged).

### Broad assembly context

Run: `NuGet.Versioning.dll` (net8.0), `--corpus-fidelity-cap 500 --corpus-fidelity-oracle return-to-sender --sequential`.

```text
Fidelity (rts-parity, cap 500) over 211 checked

  before:  136 exact, 12 opcode diffs, 63 recompile failures, 0 context failures
  after :  139 exact,  9 opcode diffs, 63 recompile failures, 0 context failures
```

**Broad verdict:** **PASS** — +3 exact, −3 opcode diff, RF/context flat. The broad cap is the load-bearing evidence named in the issue (the 21-wins target).

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| General reference up-conversions (non-array) | Left as frontier | Requires broader overload-applicability reasoning; stays stripped ("can't prove → strip"). |
| User-defined / boxing conversions | Not changed | Out of scope; unsound to admit without full conversion model. |
| `params`-array same-arity siblings | Correctly strips | `string[]` equals the params array type at the params slot, so the sibling is not excludable → strip (adversarial negative `...TargetHasParamsConstructor`). |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| _(pending)_ GPT-5.5 | | isolated worktree |
| _(pending)_ Gemini 3.1 Pro | | isolated worktree |

**Review conclusion:** **REVIEW** — two adversarial reviews requested per decompiler-PR policy (non-Claude roster); results will be reconciled here.

## Validation

```bash
dotnet build tools/DecompilerHarness -c Release --configfile nuget.config
dotnet build src/ILInspector.Decompiler.Tests -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "ILInspector.Decompiler.Tests.ReturnToSenderPrototypeTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -notrait "Speed=Slow"
dotnet run --project tools/DecompilerHarness -c Release --no-build -- \
  "$HOME/.nuget/packages/nuget.versioning/7.3.0/lib/net8.0/NuGet.Versioning.dll" \
  --emit-corpus-snapshot /tmp/out.json --compile-cap 0 --corpus-fidelity-cap 500 \
  --corpus-fidelity-oracle return-to-sender --sequential --max-examples 3
```
