### PR TITLE
Reconstruct base classes in RTS shells (#2527)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -17,6 +17,120 @@ namespace ILInspector.Decompiler.Tests;
 public class ReturnToSenderPrototypeTests
 {
     [Fact]
+    public void CompileBackTargets_SynthesizesParameterlessConstructorForNestedDerivedType()
+    {
+        // Issue #2527 guard (Gemini review of #2732): nested types are emitted from
+        // their enclosing requirement and are absent from the top-level requirement
+        // map, so the synthetic-parameterless-base-constructor scan must also walk
+        // nested types. Here `Outer.Nested : Base` is emitted even though it is never
+        // consumed; `Base` (reconstructed with only a parameterized constructor) must
+        // still receive a synthetic parameterless constructor so Nested's implicit
+        // `: base()` binds natively, without relying on the compile-back floor.
+        var assemblyPath = CompileFixture("""
+            using System;
+
+            public class Base
+            {
+                public Base(int seed)
+                {
+                    Seed = seed;
+                }
+
+                public int Seed { get; }
+            }
+
+            public class Outer
+            {
+                public Outer()
+                {
+                }
+
+                public class Nested : Base
+                {
+                    public Nested() : base(1)
+                    {
+                    }
+                }
+            }
+
+            public static class Use
+            {
+                public static void Run()
+                {
+                    Console.WriteLine(new Base(1));
+                    Console.WriteLine(new Outer());
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Use", "Run", 0)]));
+
+            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_DoesNotReconstructGenericBaseClass()
+    {
+        // Issue #2527 guard (Gemini review of #2732): a closed generic base
+        // instantiation (`Derived : Base<int>`) is a TypeSpecification, which the
+        // flat shell cannot carry and cannot own a synthetic constructor for. It must
+        // be dropped rather than emitted, so the derived stub does not fail on an
+        // implicit `: base()` with no parameterless target.
+        var assemblyPath = CompileFixture("""
+            using System;
+
+            public class Base<T>
+            {
+                public Base(int seed)
+                {
+                    Seed = seed;
+                }
+
+                public int Seed { get; }
+            }
+
+            public class Derived : Base<int>
+            {
+                public Derived() : base(1)
+                {
+                }
+            }
+
+            public static class Use
+            {
+                public static void Run()
+                {
+                    Console.WriteLine(new Base<int>(1));
+                    Console.WriteLine(new Derived());
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Use", "Run", 0)]));
+
+            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.DoesNotContain(": Base", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_RoundTripsMinimalClassProperty()
     {
         var assemblyPath = CompileFixture("""
@@ -883,6 +997,62 @@ public class ReturnToSenderPrototypeTests
 
             Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
             Assert.Contains("class Widget : Base", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_DoesNotReconstructExternalBaseClass()
+    {
+        // Issue #2527 guard (GPT-5.5 review of #2732): base-class reconstruction must
+        // stay same-assembly. An external (referenced-assembly) base whose only
+        // constructor is parameterized cannot receive a synthesized parameterless
+        // constructor (the shell does not own it), so reconstructing `Derived : Base`
+        // would make the derived stub's implicit `: base()` fail with CS7036 where the
+        // baseline dropped the base and compiled. The shell must not declare the
+        // external base.
+        var directory = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var dependencyPath = CompileFixture("""
+            namespace External;
+
+            public class Base
+            {
+                public Base(int seed)
+                {
+                    Seed = seed;
+                }
+
+                public int Seed { get; }
+            }
+            """, directory, "ExternalLib");
+        var assemblyPath = CompileFixture("""
+            using External;
+
+            public class Derived : Base
+            {
+                public Derived(int seed) : base(seed)
+                {
+                }
+            }
+
+            public static class Factory
+            {
+                public static Derived Make(Derived value) => value;
+            }
+            """, directory, "Fixture", [MetadataReference.CreateFromFile(dependencyPath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Factory", "Make", 0)]));
+
+            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.DoesNotContain(": Base", result.Source);
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -81,31 +81,41 @@ public class ReturnToSenderPrototypeTests
     [Fact]
     public void CompileBackFirstPropertyGetter_FallsBackToCompileBackFloorForAttributeShellStall()
     {
+        // Issue #2527: base-class reconstruction restores same-assembly base classes,
+        // so the old dropped-base attribute stall no longer occurs. A concrete shell
+        // that inherits an abstract member it does not itself consume still cannot
+        // satisfy that obligation (CS0534) — the growth loop does not synthesize
+        // abstract/interface member implementations. The shell stalls with a complete
+        // payload; the compile-back floor (which compiles the decompiled member
+        // against the full original assembly) rescues it.
         var assemblyPath = CompileFixture("""
-            using System;
-
-            public abstract class BaseMarkerAttribute : Attribute
+            public abstract class Shape
             {
+                protected abstract int Corners();
             }
 
-            [AttributeUsage(AttributeTargets.Class)]
-            public sealed class MarkerAttribute : BaseMarkerAttribute
+            public sealed class Triangle : Shape
             {
-                public bool Flag => true;
+                protected override int Corners() => 3;
+
+                public int First => Corners();
             }
             """);
         try
         {
             var result = ReturnToSender.CompileBackFirstPropertyGetter(assemblyPath);
 
-            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
             Assert.True(result.UsedCompileBackFloor, result.Detail);
             Assert.NotNull(result.CompileBackFloor);
-            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.CompileBackFloor.Status);
+            Assert.True(
+                result.Status is FidelityCheck.CompileBackStatus.Exact
+                    or FidelityCheck.CompileBackStatus.OpcodeDiff,
+                result.Detail);
+            Assert.Equal(result.CompileBackFloor.Status, result.Status);
             Assert.Contains("compile-back-floor", result.Detail);
-            Assert.Contains("CS0641", result.Detail);
-            Assert.Contains("return true;", result.TargetBody);
-            Assert.Contains("return true;", result.Source);
+            Assert.Contains("CS0534", result.Detail);
+            Assert.Contains("Corners", result.TargetBody);
+            Assert.Contains("Corners", result.Source);
             Assert.NotNull(result.MemberAnchor);
         }
         finally
@@ -118,21 +128,21 @@ public class ReturnToSenderPrototypeTests
     public void CorpusParity_DoesNotApplyCompileBackFloorToRtsFailure()
     {
         var assemblyPath = CompileFixture("""
-            using System;
-
-            public abstract class BaseMarkerAttribute : Attribute
+            public abstract class Shape
             {
+                protected abstract int Corners();
             }
 
-            [AttributeUsage(AttributeTargets.Class)]
-            public sealed class MarkerAttribute : BaseMarkerAttribute
+            public sealed class Triangle : Shape
             {
-                public bool Flag => true;
+                protected override int Corners() => 3;
+
+                public int First => Corners();
             }
             """);
         try
         {
-            var target = new ReturnToSender.RequestedTarget("MarkerAttribute", "get_Flag", 0);
+            var target = new ReturnToSender.RequestedTarget("Triangle", "get_First", 0);
             var floored = Assert.Single(ReturnToSender.CompileBackTargets(assemblyPath, [target]));
             Assert.True(floored.UsedCompileBackFloor, floored.Detail);
             var reference = Assert.IsType<FidelityCheck.CompileBackResult>(floored.CompileBackFloor);
@@ -770,6 +780,109 @@ public class ReturnToSenderPrototypeTests
 
             Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
             Assert.DoesNotContain(": this(", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_ReconstructsBaseClassForCovariantArgument()
+    {
+        // Issue #2527: RTS minimal shells used to drop base classes entirely
+        // (BaseTypeSignature emitted only System.Attribute). A body that relies on
+        // an implicit derived->base conversion — passing a `Dog` where an `Animal`
+        // is expected — then failed to compile (CS1503) because the shell declared
+        // `Dog` with no base. Reconstructing the real base class restores the
+        // covariant conversion so the method round-trips.
+        var assemblyPath = CompileFixture("""
+            public class Animal
+            {
+                public Animal(string name)
+                {
+                    Name = name;
+                }
+
+                public string Name { get; }
+            }
+
+            public class Dog : Animal
+            {
+                public Dog(string name) : base(name)
+                {
+                }
+            }
+
+            public static class Shelter
+            {
+                public static string Describe(Dog dog) => Name(dog);
+
+                private static string Name(Animal animal) => animal.Name;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Shelter", "Describe", 0)]));
+
+            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.Contains("class Dog : Animal", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_SynthesizesParameterlessConstructorForReconstructedBase()
+    {
+        // Issue #2527: once base classes are reconstructed, a derived stub emits an
+        // implicit `: base()`. When the base shell carries only a parameterized
+        // constructor (its base(...) chain is left empty in the flat shell), that
+        // implicit call has nothing to bind to (CS7036/CS1729). The planner
+        // synthesizes an accessible parameterless constructor on the reconstructed
+        // base so base-class reconstruction never breaks the derived shell. Here the
+        // body constructs a `Base` directly (so `Base(int)` is reconstructed with no
+        // parameterless sibling) and a `Widget : Base` (whose stub needs `: base()`).
+        var assemblyPath = CompileFixture("""
+            public class Base
+            {
+                public Base(int seed)
+                {
+                    Seed = seed;
+                }
+
+                public int Seed { get; }
+            }
+
+            public class Widget : Base
+            {
+                public Widget(int seed) : base(seed)
+                {
+                }
+            }
+
+            public static class Factory
+            {
+                public static Widget Create()
+                {
+                    Base b = new Base(1);
+                    _ = b.Seed;
+                    return new Widget(21);
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Factory", "Create", 0)]));
+
+            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.Contains("class Widget : Base", result.Source);
         }
         finally
         {

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -3229,6 +3229,19 @@ public static class CompileBackSourceComposer
             bool includeMemberSurface = requirement.IncludeMemberSurface;
             if (includeMemberSurface && kind != CompileBackTypeKind.Delegate)
                 AddClosureMemberSurface(reader, typeDef, requirement, members, diagnostics);
+            // When this class is reconstructed as the base of another shell type, a
+            // derived stub constructor emits an implicit `: base()`. If the class has
+            // only parameterized constructors (no accessible parameterless one), that
+            // implicit call fails to bind (CS7036/CS1729). Synthesize a parameterless
+            // constructor so base-class reconstruction never breaks the derived shell;
+            // at worst the derived constructor stays at its pre-existing opcode diff.
+            if (kind == CompileBackTypeKind.Class
+                && members.Any(member => member.Kind == CompileBackMemberKind.Constructor)
+                && !members.Any(member => member.Kind == CompileBackMemberKind.Constructor && member.Parameters.Count == 0)
+                && IsReconstructedBaseOfAnotherType(reader, requirement, requirementsByMetadataName))
+            {
+                members.Add(SyntheticParameterlessConstructor(requirement.Type));
+            }
             var producedRequirement = requirement with { RequiredMembers = members };
             producedRequirements.Add(producedRequirement);
 
@@ -3244,7 +3257,7 @@ public static class CompileBackSourceComposer
                 Name = requirement.Type.MetadataName,
                 MetadataName = requirement.Type.MetadataName,
                 Kind = TypeKindText(kind),
-                BaseType = BaseTypeSignature(reader, typeDef)?.DisplayName,
+                BaseType = BaseTypeSignature(reader, typeDef, kind)?.DisplayName,
                 TypeParameters = TypeParameters(reader, typeDef)
                     .Select(ToApiTypeParameter)
                     .ToList(),
@@ -3422,18 +3435,89 @@ public static class CompileBackSourceComposer
         static IReadOnlyList<string> TypeAttributeList(MetadataReader reader, TypeDefinition typeDef)
             => AttributeReader.RenderAttributes(reader, typeDef.GetCustomAttributes(), qualifyNames: true);
 
-        static CompileBackTypeSignature? BaseTypeSignature(MetadataReader reader, TypeDefinition typeDef)
+        static CompileBackTypeSignature? BaseTypeSignature(MetadataReader reader, TypeDefinition typeDef, CompileBackTypeKind kind)
         {
             if ((typeDef.Attributes & TypeAttributes.Interface) != 0)
                 return null;
             if (typeDef.BaseType.IsNil)
                 return null;
 
-            string? baseType = TypeResolver.GetTypeName(reader, typeDef.BaseType, GenericContext.ForType(reader, typeDef));
-            return baseType is "System.Attribute"
-                ? CompileBackTypeSignature.Display(baseType)
-                : null;
+            string? baseType;
+            try
+            {
+                baseType = TypeResolver.GetTypeName(reader, typeDef.BaseType, GenericContext.ForType(reader, typeDef));
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+            {
+                return null;
+            }
+
+            if (baseType is null)
+                return null;
+            // Attributes must derive from System.Attribute (existing behavior).
+            if (baseType is "System.Attribute")
+                return CompileBackTypeSignature.Display(baseType);
+            // Only plain classes reconstruct a real base class; records/structs/enums/
+            // delegates keep their compiler-implied base to avoid primary-constructor
+            // and value-type conflicts. A generic type's base can reference its own
+            // type parameters, which the flat shell does not carry, so skip it.
+            if (kind != CompileBackTypeKind.Class || typeDef.GetGenericParameters().Count != 0)
+                return null;
+            if (baseType is "System.Object" or "System.ValueType" or "System.Enum"
+                or "System.Delegate" or "System.MulticastDelegate")
+                return null;
+            if (IsUnsupportedSurfaceSignature(baseType))
+                return null;
+            return CompileBackTypeSignature.Display(baseType);
         }
+
+        // True when some other reconstructed shell type derives from this class via a
+        // reconstructed (same-assembly) base declaration, so its implicit `: base()`
+        // depends on this class exposing an accessible parameterless constructor.
+        static bool IsReconstructedBaseOfAnotherType(
+            MetadataReader reader,
+            CompileBackTypeRequirement requirement,
+            IReadOnlyDictionary<string, CompileBackTypeRequirement> requirementsByMetadataName)
+        {
+            string metadataFullName = requirement.Type.MetadataFullName;
+            foreach (var other in requirementsByMetadataName.Values)
+            {
+                if (other.Type.MetadataFullName == metadataFullName)
+                    continue;
+                if (FindType(reader, other.Type.MetadataFullName) is not { } otherHandle)
+                    continue;
+                if (ReconstructedSameAssemblyBaseName(reader, otherHandle, other.RequiredKind) == metadataFullName)
+                    return true;
+            }
+
+            return false;
+        }
+
+        // The metadata full name of the class's reconstructed same-assembly base, or
+        // null when the base is not reconstructed (external base, or a kind that keeps
+        // its compiler-implied base).
+        static string? ReconstructedSameAssemblyBaseName(MetadataReader reader, TypeDefinitionHandle handle, CompileBackTypeKind kind)
+        {
+            var typeDef = reader.GetTypeDefinition(handle);
+            if (typeDef.BaseType.Kind != HandleKind.TypeDefinition)
+                return null;
+            if (BaseTypeSignature(reader, typeDef, kind) is null)
+                return null;
+            var baseDef = reader.GetTypeDefinition((TypeDefinitionHandle)typeDef.BaseType);
+            return CompileBackTypeIdentity.FromDefinition(reader, baseDef).MetadataFullName;
+        }
+
+        static CompileBackMemberRequirement SyntheticParameterlessConstructor(CompileBackTypeIdentity typeIdentity)
+            => new(
+                new CompileBackMethodIdentity(typeIdentity.FullName, ".ctor", 0, "synthetic-base-parameterless-constructor()"),
+                CompileBackMemberKind.Constructor,
+                IsStatic: false,
+                Parameters: [],
+                ReturnType: null,
+                TypeParameters: [],
+                CompileBackStubBodyKind.Throw,
+                TargetBody: null,
+                [new CompileBackFact("synthetic", "base-parameterless-constructor", typeIdentity.MetadataFullName)]);
 
         static IReadOnlyList<CompileBackTypeSignature> InterfaceSignatures(MetadataReader reader, TypeDefinition typeDef)
         {

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -3457,6 +3457,14 @@ public static class CompileBackSourceComposer
             // Attributes must derive from System.Attribute (existing behavior).
             if (baseType is "System.Attribute")
                 return CompileBackTypeSignature.Display(baseType);
+            // Only reconstruct same-assembly base classes. External (TypeReference)
+            // and generic-instantiation (TypeSpecification) bases are dropped as
+            // before: the shell cannot own their construction, so an external base
+            // whose only constructor is parameterized would make the derived stub's
+            // implicit `: base()` fail (CS7036) where the baseline compiled without
+            // a base. This mirrors ReconstructedSameAssemblyBaseName's own gate.
+            if (typeDef.BaseType.Kind != HandleKind.TypeDefinition)
+                return null;
             // Only plain classes reconstruct a real base class; records/structs/enums/
             // delegates keep their compiler-implied base to avoid primary-constructor
             // and value-type conflicts. A generic type's base can reference its own
@@ -3471,9 +3479,12 @@ public static class CompileBackSourceComposer
             return CompileBackTypeSignature.Display(baseType);
         }
 
-        // True when some other reconstructed shell type derives from this class via a
-        // reconstructed (same-assembly) base declaration, so its implicit `: base()`
-        // depends on this class exposing an accessible parameterless constructor.
+        // True when some other reconstructed shell type — top-level or nested —
+        // derives from this class via a reconstructed (same-assembly) base
+        // declaration, so its implicit `: base()` depends on this class exposing an
+        // accessible parameterless constructor. Nested types are emitted by
+        // NestedTypes() from their enclosing requirement and are not present in
+        // requirementsByMetadataName, so each requirement's nested tree is walked.
         static bool IsReconstructedBaseOfAnotherType(
             MetadataReader reader,
             CompileBackTypeRequirement requirement,
@@ -3482,11 +3493,27 @@ public static class CompileBackSourceComposer
             string metadataFullName = requirement.Type.MetadataFullName;
             foreach (var other in requirementsByMetadataName.Values)
             {
-                if (other.Type.MetadataFullName == metadataFullName)
-                    continue;
                 if (FindType(reader, other.Type.MetadataFullName) is not { } otherHandle)
                     continue;
-                if (ReconstructedSameAssemblyBaseName(reader, otherHandle, other.RequiredKind) == metadataFullName)
+                if (TypeOrNestedDerivesFrom(reader, otherHandle, metadataFullName))
+                    return true;
+            }
+
+            return false;
+        }
+
+        static bool TypeOrNestedDerivesFrom(MetadataReader reader, TypeDefinitionHandle handle, string baseMetadataFullName)
+        {
+            var typeDef = reader.GetTypeDefinition(handle);
+            if (CompileBackTypeIdentity.FromDefinition(reader, typeDef).MetadataFullName != baseMetadataFullName
+                && ReconstructedSameAssemblyBaseName(reader, handle, ShellKind(reader, typeDef)) == baseMetadataFullName)
+            {
+                return true;
+            }
+
+            foreach (var nestedHandle in typeDef.GetNestedTypes())
+            {
+                if (TypeOrNestedDerivesFrom(reader, nestedHandle, baseMetadataFullName))
                     return true;
             }
 


### PR DESCRIPTION
- Advances #2527 (follow-up gap tracked as #2731)
- Changes RTS shell base-type reconstruction (harness-only; product decompiler output unchanged)
- Evidence revision: `2bf7f313` (rebased onto `origin/main`)

## Change

> Should we accept this harness change?

**Conclusion:** **PASS** — RTS minimal shells dropped base classes, so decompiled bodies relying on a derived→base conversion could not recompile (CS1503) and attribute hierarchies lost their derives-from-`Attribute` chain; reconstructing the real same-assembly base class turns 22 NuGet.Versioning targets from RecompileFail into Exact/OpcodeDiff with zero regressions.

Before (shell body fails to recompile):

```text
NuGet.Versioning.VersionRange::get_MinVersion  RecompileFail  (base class dropped)
```

After:

```text
NuGet.Versioning.VersionRange::get_MinVersion  Exact
```

## Scope and safety

- **Root cause:** `BaseTypeSignature` emitted only `System.Attribute`, so every other base class was dropped from the shell. Bodies that pass a derived instance where a base type is expected then failed with CS1503, and multi-level attribute shells lost the chain to `System.Attribute`.
- **Fix shape:** Reconstruct the real same-assembly, non-generic base class for plain **class** shells (records/structs/enums/delegates keep their compiler-implied base; generic bases are skipped because the flat shell cannot carry the base's type parameters). To keep it sound, synthesize an accessible parameterless constructor on a reconstructed base that carries only parameterized constructors, so a derived stub's implicit `: base()` never fails (CS7036/CS1729).
- **Product impact:** None. Change is confined to `tools/DecompilerHarness/ReturnToSenderTypePlanner.cs` (RTS shell planning); product decompilation is unchanged.
- **Scope boundary:** The generic-base-**interface** / CS0176 inherited-member gap (empty interface shells, e.g. `FloatRange::Equals#0`) is intentionally left as a frontier and tracked in #2731. The compile-back floor still rescues those shells.
- **RTS boundary:** RTS only orchestrates closure + Roslyn + opcode compare; product/shared code owns C# source generation. This PR touches only the shell type planner.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `ReturnToSenderPrototypeTests` (109) passed |
| Targeted compile-back | NuGet.Versioning RTS parity: Exact 136→153, RecompileFail 63→41 |
| ReturnToSender A/B (per-method vs `origin/main`) | 22 wins, 0 regressions |
| Real witness | `VersionRange::get_MinVersion` moved RecompileFail → Exact |

## Compile-back quality

> Did this increase the checkable population without hiding a product defect?

**Conclusion:** **PASS** — 22 measured RecompileFail/OpcodeDiff → Exact/OpcodeDiff transitions on the deterministic NuGet.Versioning probe, zero regressions, verified by a per-method diff against `origin/main` (not just aggregate bucket counts).

### Deterministic NuGet.Versioning probe

Command:

```text
dotnet run --project tools/DecompilerHarness -c Release -- \
  <nuget.versioning/7.3.0/lib/net8.0/NuGet.Versioning.dll> \
  --emit-corpus-snapshot out.json --compile-cap 0 --corpus-fidelity-cap 500 \
  --corpus-fidelity-oracle return-to-sender --sequential --max-examples 3
```

| Bucket (goal) | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Exact (+) | 136 | 153 | +17 |
| OpcodeDiff | 12 | 17 | +5 |
| RecompileFail (-) | 63 | 41 | -22 |
| ContextFail | 0 | 0 | 0 |

Per-method diff vs `origin/main`: **22 wins, 0 regressions**. The one case that base-class reconstruction alone would regress (`NuGetVersion::.ctor#10`, CS7036 from a missing base parameterless ctor) is held at its pre-existing OpcodeDiff by the synthetic-parameterless-constructor guard.

## Tests

- `CompileBackTargets_ReconstructsBaseClassForCovariantArgument` — derived→base covariant argument now recompiles; shell declares `class Dog : Animal`.
- `CompileBackTargets_SynthesizesParameterlessConstructorForReconstructedBase` — reconstructed base carrying only a parameterized ctor gets a synthetic parameterless ctor so the derived stub's implicit `: base()` binds.
- `CompileBackFirstPropertyGetter_FallsBackToCompileBackFloorForAttributeShellStall` / `CorpusParity_DoesNotApplyCompileBackFloorToRtsFailure` — re-pointed from the (now natively-compiling) dropped-base attribute stall to a CS0534 abstract-member stall, preserving compile-back-floor coverage.

## Adversarial review

Requested from two non-Opus models per policy; results reconciled in a follow-up comment.
