### PR TITLE
Match authored bodies by parameter count

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
@@ -222,6 +222,22 @@ public sealed class AuthoredRebuildFidelityTests
         Assert.Contains("return 1;", body, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData(".ctor", "Value = 1;")]
+    [InlineData(".cctor", "Value = 2;")]
+    public void AuthoredMemberSource_DistinguishesConstructorKind(
+        string methodName,
+        string expected)
+    {
+        Assert.True(AuthoredRebuildFidelity.TryExtractTargetBody(
+            "public Sample() { Value = 1; } "
+                + "static Sample() { Value = 2; }",
+            methodName,
+            expectedParameterCount: 0,
+            out string body));
+        Assert.Contains(expected, body, StringComparison.Ordinal);
+    }
+
     static FindingInspection<CompilationOptionInfo> CompleteOptions(
         params CompilationOptionInfo[] options)
         => MetadataFindings.InspectCompilationOptions(options, Subject);

--- a/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
@@ -198,6 +198,30 @@ public sealed class AuthoredRebuildFidelityTests
             out _));
     }
 
+    [Fact]
+    public void AuthoredMemberSource_UsesConstructorArity()
+    {
+        Assert.True(AuthoredRebuildFidelity.TryExtractTargetBody(
+            "public Sample() { Value = 1; } "
+                + "public Sample(int value) { Value = value; }",
+            ".ctor",
+            expectedParameterCount: 1,
+            out string body));
+        Assert.Contains("Value = value;", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AuthoredMemberSource_UsesMethodArity()
+    {
+        Assert.True(AuthoredRebuildFidelity.TryExtractTargetBody(
+            "public int M() { return 1; } "
+                + "public int M(int value) { return value; }",
+            "M",
+            expectedParameterCount: 0,
+            out string body));
+        Assert.Contains("return 1;", body, StringComparison.Ordinal);
+    }
+
     static FindingInspection<CompilationOptionInfo> CompleteOptions(
         params CompilationOptionInfo[] options)
         => MetadataFindings.InspectCompilationOptions(options, Subject);

--- a/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
+++ b/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
@@ -184,7 +184,11 @@ static class AuthoredRebuildFidelity
                 ImplementationDiff: null);
         }
 
-        if (!TryExtractTargetBody(authoredBody, request.MethodName, out string targetBody))
+        if (!TryExtractTargetBody(
+            authoredBody,
+            request.MethodName,
+            request.Function.Signature.Parameters.Length,
+            out string targetBody))
         {
             return new AuthoredRebuildFidelityResult(
                 decompilerResult,
@@ -206,6 +210,28 @@ static class AuthoredRebuildFidelity
         string memberSource,
         string metadataMethodName,
         out string body)
+        => TryExtractTargetBody(
+            memberSource,
+            metadataMethodName,
+            expectedParameterCount: null,
+            out body);
+
+    internal static bool TryExtractTargetBody(
+        string memberSource,
+        string metadataMethodName,
+        int expectedParameterCount,
+        out string body)
+        => TryExtractTargetBody(
+            memberSource,
+            metadataMethodName,
+            (int?)expectedParameterCount,
+            out body);
+
+    static bool TryExtractTargetBody(
+        string memberSource,
+        string metadataMethodName,
+        int? expectedParameterCount,
+        out string body)
     {
         ArgumentNullException.ThrowIfNull(memberSource);
         ArgumentException.ThrowIfNullOrWhiteSpace(metadataMethodName);
@@ -221,7 +247,7 @@ static class AuthoredRebuildFidelity
             .OfType<MemberDeclarationSyntax>()
             .Where(candidate => candidate.Parent is ClassDeclarationSyntax))
         {
-            var candidate = MemberBody(member, identity);
+            var candidate = MemberBody(member, identity, expectedParameterCount);
             if (candidate.Score < bestScore)
                 continue;
             if (candidate.Score == bestScore)
@@ -241,7 +267,8 @@ static class AuthoredRebuildFidelity
 
     static (int Score, string Body) MemberBody(
         MemberDeclarationSyntax member,
-        MetadataMethodIdentity identity)
+        MetadataMethodIdentity identity,
+        int? expectedParameterCount)
         => member switch
         {
             MethodDeclarationSyntax method
@@ -249,6 +276,9 @@ static class AuthoredRebuildFidelity
                     method.Identifier.ValueText,
                     identity.SimpleName,
                     StringComparison.Ordinal)
+                    && ParameterCountMatches(
+                        method.ParameterList.Parameters.Count,
+                        expectedParameterCount)
                 => ScoredBody(
                     method.ExplicitInterfaceSpecifier,
                     identity,
@@ -256,8 +286,9 @@ static class AuthoredRebuildFidelity
             ConstructorDeclarationSyntax constructor
                 when identity.SimpleName is ".ctor" or ".cctor"
                     && identity.ExplicitInterface is null
-                // Metadata names do not encode constructor arity. Multiple constructors in the
-                // checksum-verified sequence-point window tie and are rejected as ambiguous.
+                    && ParameterCountMatches(
+                        constructor.ParameterList.Parameters.Count,
+                        expectedParameterCount)
                 => (2, BodyText(
                     constructor.Body,
                     constructor.ExpressionBody,
@@ -312,6 +343,9 @@ static class AuthoredRebuildFidelity
                     AccessorBodyText(eventDeclaration, SyntaxKind.RemoveAccessorDeclaration)),
             _ => (-1, ""),
         };
+
+    static bool ParameterCountMatches(int actual, int? expected)
+        => expected is null || actual == expected.Value;
 
     static (int Score, string Body) ScoredBody(
         ExplicitInterfaceSpecifierSyntax? syntax,

--- a/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
+++ b/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
@@ -286,6 +286,7 @@ static class AuthoredRebuildFidelity
             ConstructorDeclarationSyntax constructor
                 when identity.SimpleName is ".ctor" or ".cctor"
                     && identity.ExplicitInterface is null
+                    && ConstructorKindMatches(constructor, identity.SimpleName)
                     && ParameterCountMatches(
                         constructor.ParameterList.Parameters.Count,
                         expectedParameterCount)
@@ -346,6 +347,13 @@ static class AuthoredRebuildFidelity
 
     static bool ParameterCountMatches(int actual, int? expected)
         => expected is null || actual == expected.Value;
+
+    static bool ConstructorKindMatches(
+        ConstructorDeclarationSyntax constructor,
+        string metadataMethodName)
+        => constructor.Modifiers.Any(SyntaxKind.StaticKeyword)
+            ? metadataMethodName == ".cctor"
+            : metadataMethodName == ".ctor";
 
     static (int Score, string Body) ScoredBody(
         ExplicitInterfaceSpecifierSyntax? syntax,


### PR DESCRIPTION
- Advances #2673
- Follow-up to #2717
- Changes harness-only authored-body identity matching; product output is unchanged
- Evidence revision: `a2e97373`

## Change

**Conclusion:** **PASS** — authored rebuild fidelity now uses RTS request signature arity plus constructor kind to select overloaded methods and constructors instead of rejecting or misidentifying same-name candidates.

Before:

```text
Multiple `.ctor` declarations in the checksum-verified source window tied on name and produced SourceFailed.
```

After:

```text
Metadata parameter count selects the matching overload; `.ctor` and `.cctor` select instance and static constructors respectively.
```

## Scope and safety

- **Root cause:** metadata method names do not encode overload arity, but `ArtifactRequest.Function.Signature.Parameters` already carries it.
- **Fix shape:** pass expected parameter count into the Roslyn-only harness matcher and gate method/constructor candidates on arity and constructor kind.
- **Product impact:** none; this changes only `tools/DecompilerHarness` authored-source evidence.
- **Scope boundary:** parameter types are intentionally not matched; equal-arity overloads remain ambiguous and fail closed.
- **RTS boundary:** RTS still owns closure/request orchestration; authored evidence remains a sidecar and cannot alter the independent decompiler verdict.

## Evidence

| Check | Result |
| --- | --- |
| Product/test build | Pass |
| Focused tests | `AuthoredRebuildFidelityTests`: 22 passed |
| Decompiler fast suite | 2,411 passed at `7ada4f10`; focused constructor-kind coverage passed at `a2e97373` |
| CI | Pass |
| Targeted identity cases | constructor/method overload arity and `.ctor`/`.cctor` kind select the intended body |
| Near miss | no-arity compatibility overload still rejects multiple same-kind constructors |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | CLEAN | Verified metadata arity semantics and 18 real matcher probes, including ctor kind, generics, ref/out, params, ambiguity, and compatibility behavior. |
| Gemini 3.1 Pro | CLEAN | Verified ctor kind, explicit parameter-count equivalence, equal-arity fail-closed behavior, accessor isolation, and sidecar-only scope. |

**Review conclusion:** **PASS** — both isolated reviewers were clean on exact head `a2e97373`; there were no actionable findings, so no resolution commit applies.