### PR TITLE
Add transitive allocation fanout triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,10 +214,20 @@ dotnet-inspect library MyLib.dll -S "Performance Triage"
 dotnet-inspect library MyLib.dll --loop --min-confidence high --top 20 --tsv
 dotnet-inspect library MyLib.dll --triage-shape scan-method-in-loop-call,linq-scan-in-loop,string-build-in-loop --top 20 --tsv
 dotnet-inspect library MyLib.dll --triage-shape capturing-delegate --top 10 --jsonl
+dotnet-inspect library MyLib.dll --triage-shape allocation-fanout \
+  --order-by "OncePaths desc" --top 20 --tsv
 dotnet-inspect library MyLib.dll --where "Finding=analysis.call-site" --jsonl
 dotnet-inspect member MyType Method:1 --library MyLib.dll -S "Call Graph,Facts"
 dotnet-inspect member MyType Method:1 --library MyLib.dll -S "Caller Graph" --fields "Throw,Catch,Finally"
 ```
+
+`allocation-fanout` is an opt-in aggregate view for construction-heavy
+registries, pipelines, and object graphs that do not match a local rewrite
+shape. It counts direct allocation sites and composes repeated exact
+intra-assembly callsites into `Once Paths`, while keeping conditional, repeated,
+unknown, cached, and opaque paths separate. The counts describe IL-visible
+normal-return paths, not runtime bytes or workload frequency; virtual, external,
+delegate, recursive, and runtime-library effects remain opaque.
 
 Common `--triage-shape` values include `capturing-delegate`,
 `async-state-machine`, `box-value-type`, `small-array`, `linq-scan-in-loop`,

--- a/docs/design/allocation-triage-prefilters.md
+++ b/docs/design/allocation-triage-prefilters.md
@@ -172,7 +172,9 @@ This is not a runtime allocation count. Exceptions can interrupt a
 normal-return path, the JIT can optimize IL-visible constructions, and opaque
 callees can allocate additional objects. The value is structural: it exposes
 how many allocation-producing paths a design creates and where static analysis
-stops.
+stops. Recursive components are condensed into one graph node: their known
+allocation sites and exact outbound effects remain visible as `Unknown Paths`,
+while intra-component recurrence remains opaque.
 
 The aggregate remains opt-in. In an alternating 20-run process-level timing
 against `ILInspector.Analysis.dll`, the default Performance Triage median was

--- a/docs/design/allocation-triage-prefilters.md
+++ b/docs/design/allocation-triage-prefilters.md
@@ -137,3 +137,70 @@ such as `allocation-hotspot` have no exact source occurrence and therefore use
 fields empty. Candidate IDs are checked for uniqueness when an index is built;
 a truncated-prefix collision is deterministically lengthened rather than
 creating an ambiguous join.
+
+## Opt-in allocation fanout
+
+Local rewrite shapes intentionally suppress ordinary once-per-call object
+construction. That is the right default for broad performance triage, but it
+can hide the dominant design cost in registries and fluent pipeline builders:
+one root method repeatedly calls the same generic registration method, and each
+call constructs another runtime entry.
+
+`--triage-shape allocation-fanout` adds one aggregate row per method with known
+IL-visible allocation impact:
+
+```bash
+dotnet-inspect library MyLib.dll \
+  --triage-shape allocation-fanout \
+  --order-by "OncePaths desc" --top 20 --tsv
+```
+
+The fields are deliberately not byte estimates:
+
+| Field | Meaning |
+| --- | --- |
+| `Direct Sites` | Heap-allocation sites in the method body |
+| `Once Paths` | Allocation paths classified once on normally returning control flow; exact intra-assembly callsites compose and repeated callsites count separately |
+| `Conditional Paths` | Allocation paths behind a branch or conditional call |
+| `Repeated Paths` | Allocation paths in a loop or reached through a loop callsite; trip count remains unknown |
+| `Unknown Paths` | Allocation paths whose multiplicity cannot be proven |
+| `Cached Sites` | Compiler-cached sites, deduplicated by method and IL offset across exact paths |
+| `Opaque Paths` | Invocation paths not traversed because the target is external, virtual, indirect, recursive, or unresolved |
+| `Saturated` | A call-path count exceeded the representable range |
+
+This is not a runtime allocation count. Exceptions can interrupt a
+normal-return path, the JIT can optimize IL-visible constructions, and opaque
+callees can allocate additional objects. The value is structural: it exposes
+how many allocation-producing paths a design creates and where static analysis
+stops.
+
+The aggregate remains opt-in. In an alternating 20-run process-level timing
+against `ILInspector.Analysis.dll`, the default Performance Triage median was
+unchanged at 0.370 seconds versus `origin/main`; enabling `allocation-fanout`
+raised the median to 0.400 seconds (+0.030 seconds, about 8%). The measurement
+used `/usr/bin/time` around the built CLI on macOS arm64 and includes process
+startup.
+
+### Registry dogfood
+
+A 2026-07-13 run against the current product and the #2605 registry spike
+surfaced the construction cost that method-scoped allocation diff missed:
+
+| Method/design | Direct sites | Once paths | Conditional paths | Cached sites | Opaque paths |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `LibrarySections.CreatePipeline` | 10 | 53 | 52 | 9 | 493 |
+| `ApiMemberOverloadSectionDescriptors.CreatePipeline` | 16 | 40 | 38 | 16 | 381 |
+| `ApiMemberSectionDescriptors.CreatePipeline` | 6 | 33 | 31 | 6 | 301 |
+| Original spike `CreateCapabilityRegistry` | 1 | 9 | 7 | 1 | 79 |
+| Revised spike `CreateCapabilityRegistry` | 1 | 10 | 14 | 1 | 84 |
+| Original `CapabilitySession` constructor | 3 | 3 | 0 | 0 | 4 |
+| Original `CapabilitySession.ExecutePlanAsync` | 1 | 1 | 0 | 0 | 23 |
+| Revised `CapabilityPlan.ExecuteAsync` | 3 | 0 | 2 | 0 | 14 |
+
+The result changes the registry recommendation. Stateless plan execution removes
+successful normal-path allocation, but the current typed spike does not improve
+registry construction. The production target should therefore generate or
+reuse one registry and its compiled plans rather than rebuilding them per
+command or assembly. Factory-created capability instances remain behind opaque
+delegate/generic activation edges in the original spike, so the table does not
+claim to count them.

--- a/docs/design/row-query-order.md
+++ b/docs/design/row-query-order.md
@@ -164,12 +164,14 @@ Default order:
 Filterable fields:
   Member, Candidate, Finding, Provenance, RootReach, Shape, Operation, Token,
   Evidence, Fix, Confidence, Loop, Allocation, Path, PathConfidence,
-  PostDominance, IL, Weight
+  PostDominance, IL, Weight, DirectSites, OncePaths, ConditionalPaths,
+  RepeatedPaths, UnknownPaths, CachedSites, OpaquePaths, Saturated
 
 Sortable fields:
   Triage, RootReach, Confidence, Loop, Member, Candidate, Finding, Provenance,
   Shape, Operation, Token, IL, Allocation, Path, PathConfidence, PostDominance,
-  Weight
+  Weight, DirectSites, OncePaths, ConditionalPaths, RepeatedPaths, UnknownPaths,
+  CachedSites, OpaquePaths
 ```
 
 This makes the default sort order visible exactly where users and agents already

--- a/skills/performance/SKILL.md
+++ b/skills/performance/SKILL.md
@@ -61,6 +61,22 @@ explicitly: `scan-method-in-loop-call` stays low-confidence because static
 analysis cannot prove that the scanned sequence grows with the caller's loop,
 so a `--min-confidence high` pass intentionally excludes it.
 
+For registry, pipeline, or object-graph construction that does not match a local
+rewrite shape, opt into the aggregate allocation fanout:
+
+```bash
+dnx dotnet-inspect -y -- library MyLib.dll \
+  --triage-shape allocation-fanout \
+  --order-by "OncePaths desc" --top 20 --tsv
+```
+
+`Direct Sites` is local to the method. `Once Paths` composes exact
+intra-assembly callsites and counts repeated callsites separately; conditional,
+repeated, unknown, cached, and opaque paths remain separate columns. Treat this
+as IL-visible normal-return-path quantity, not runtime bytes or observed
+frequency. A high `Opaque Paths` count means virtual, external, delegate,
+recursive, or runtime-library work still needs a drill or profiler.
+
 Exact rows retain machine-readable provenance from the native Analysis producer:
 `Candidate`, `Finding` (`analysis.allocation` or `analysis.call-site`),
 `Provenance=exact`,

--- a/src/ILInspector.Analysis.Tests/AllocationFanoutTests.cs
+++ b/src/ILInspector.Analysis.Tests/AllocationFanoutTests.cs
@@ -157,8 +157,9 @@ public class AllocationFanoutTests
 
         Assert.All(summaries, summary =>
         {
-            Assert.Equal(1, summary.OncePaths);
-            Assert.Equal(1, summary.OpaquePaths);
+            Assert.Equal(0, summary.OncePaths);
+            Assert.Equal(2, summary.UnknownPaths);
+            Assert.Equal(2, summary.OpaquePaths);
         });
     }
 
@@ -182,8 +183,34 @@ public class AllocationFanoutTests
             },
             root);
 
-        Assert.Equal(1, rootSummary.OncePaths);
+        Assert.Equal(0, rootSummary.OncePaths);
+        Assert.Equal(1, rootSummary.UnknownPaths);
         Assert.Equal(1, rootSummary.OpaquePaths);
+    }
+
+    [Fact]
+    public void Analyze_PropagatesKnownImpactAcrossMutualRecursion()
+    {
+        var root = Method(1, "Root");
+        var first = Method(2, "First");
+        var allocating = Method(3, "Allocating");
+
+        var rootSummary = Summary(
+            [root, first, allocating],
+            [
+                Call(root, first, 4, AllocationMultiplicity.Once),
+                Call(first, allocating, 4, AllocationMultiplicity.Once),
+                Call(allocating, first, 8, AllocationMultiplicity.Once),
+            ],
+            new Dictionary<int, ImmutableArray<AllocationOccurrence>>
+            {
+                [allocating.MetadataToken] = [Allocation(allocating, AllocationMultiplicity.Once)],
+            },
+            root);
+
+        Assert.Equal(0, rootSummary.OncePaths);
+        Assert.Equal(1, rootSummary.UnknownPaths);
+        Assert.Equal(2, rootSummary.OpaquePaths);
     }
 
     [Fact]

--- a/src/ILInspector.Analysis.Tests/AllocationFanoutTests.cs
+++ b/src/ILInspector.Analysis.Tests/AllocationFanoutTests.cs
@@ -163,6 +163,30 @@ public class AllocationFanoutTests
     }
 
     [Fact]
+    public void Analyze_PropagatesKnownImpactIntoCallersOfRecursiveComponents()
+    {
+        var root = Method(1, "Root");
+        var entry = Method(2, "Entry");
+        var recursive = Method(3, "Recursive");
+
+        var rootSummary = Summary(
+            [root, entry, recursive],
+            [
+                Call(root, entry, 4, AllocationMultiplicity.Once),
+                Call(entry, recursive, 4, AllocationMultiplicity.Once),
+                Call(recursive, recursive, 8, AllocationMultiplicity.Once),
+            ],
+            new Dictionary<int, ImmutableArray<AllocationOccurrence>>
+            {
+                [recursive.MetadataToken] = [Allocation(recursive, AllocationMultiplicity.Once)],
+            },
+            root);
+
+        Assert.Equal(1, rootSummary.OncePaths);
+        Assert.Equal(1, rootSummary.OpaquePaths);
+    }
+
+    [Fact]
     public void Analyze_HandlesDeepCallGraphsWithoutRecursingOnTheNativeStack()
     {
         const int count = 20_000;

--- a/src/ILInspector.Analysis.Tests/AllocationFanoutTests.cs
+++ b/src/ILInspector.Analysis.Tests/AllocationFanoutTests.cs
@@ -1,0 +1,244 @@
+using System.Collections.Immutable;
+
+namespace ILInspector.Analysis.Tests;
+
+public class AllocationFanoutTests
+{
+    static readonly TypeRef s_void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
+    static readonly TypeRef s_type = TypeRef.Definition("Fixture", "Fixtures", "Graph");
+
+    [Fact]
+    public void Analyze_MultipliesRepeatedOnceCallSites()
+    {
+        var root = Method(1, "Root");
+        var leaf = Method(2, "Leaf");
+
+        var rootSummary = Summary(
+            [root, leaf],
+            [
+                Call(root, leaf, 4, AllocationMultiplicity.Once),
+                Call(root, leaf, 8, AllocationMultiplicity.Once),
+                Call(root, leaf, 12, AllocationMultiplicity.Once),
+            ],
+            new Dictionary<int, ImmutableArray<AllocationOccurrence>>
+            {
+                [leaf.MetadataToken] = [Allocation(leaf, AllocationMultiplicity.Once)],
+            },
+            root);
+
+        Assert.Equal(0, rootSummary.DirectSites);
+        Assert.Equal(3, rootSummary.OncePaths);
+        Assert.Equal(0, rootSummary.ConditionalPaths);
+        Assert.Equal(0, rootSummary.OpaquePaths);
+    }
+
+    [Fact]
+    public void Analyze_ComposesMultiplicityAcrossEveryEdge()
+    {
+        var root = Method(1, "Root");
+        var conditional = Method(2, "Conditional");
+        var repeated = Method(3, "Repeated");
+        var unknown = Method(4, "Unknown");
+        var leaf = Method(5, "Leaf");
+
+        var rootSummary = Summary(
+            [root, conditional, repeated, unknown, leaf],
+            [
+                Call(root, conditional, 4, AllocationMultiplicity.Conditional),
+                Call(root, repeated, 8, AllocationMultiplicity.Loop),
+                Call(root, unknown, 12, AllocationMultiplicity.Unknown),
+                Call(conditional, leaf, 4, AllocationMultiplicity.Once),
+                Call(repeated, leaf, 4, AllocationMultiplicity.Once),
+                Call(unknown, leaf, 4, AllocationMultiplicity.Once),
+            ],
+            new Dictionary<int, ImmutableArray<AllocationOccurrence>>
+            {
+                [leaf.MetadataToken] = [Allocation(leaf, AllocationMultiplicity.Once)],
+            },
+            root);
+
+        Assert.Equal(0, rootSummary.OncePaths);
+        Assert.Equal(1, rootSummary.ConditionalPaths);
+        Assert.Equal(1, rootSummary.RepeatedPaths);
+        Assert.Equal(1, rootSummary.UnknownPaths);
+    }
+
+    [Fact]
+    public void Analyze_SeparatesLocalMultiplicityAndCachedAllocations()
+    {
+        var method = Method(1, "Root");
+
+        var summary = Summary(
+            [method],
+            [],
+            new Dictionary<int, ImmutableArray<AllocationOccurrence>>
+            {
+                [method.MetadataToken] =
+                [
+                    Allocation(method, AllocationMultiplicity.Once),
+                    Allocation(method, AllocationMultiplicity.Conditional),
+                    Allocation(method, AllocationMultiplicity.Loop),
+                    Allocation(method, AllocationMultiplicity.Unknown),
+                    Allocation(method, AllocationMultiplicity.Once, cached: true),
+                ],
+            },
+            method);
+
+        Assert.Equal(5, summary.DirectSites);
+        Assert.Equal(1, summary.OncePaths);
+        Assert.Equal(1, summary.ConditionalPaths);
+        Assert.Equal(1, summary.RepeatedPaths);
+        Assert.Equal(1, summary.UnknownPaths);
+        Assert.Equal(1, summary.CachedSites);
+    }
+
+    [Fact]
+    public void Analyze_DeduplicatesCachedSitesAcrossRepeatedCallPaths()
+    {
+        var root = Method(1, "Root");
+        var leaf = Method(2, "Leaf");
+
+        var rootSummary = Summary(
+            [root, leaf],
+            [
+                Call(root, leaf, 4, AllocationMultiplicity.Once),
+                Call(root, leaf, 8, AllocationMultiplicity.Once),
+                Call(root, leaf, 12, AllocationMultiplicity.Once),
+            ],
+            new Dictionary<int, ImmutableArray<AllocationOccurrence>>
+            {
+                [leaf.MetadataToken] = [Allocation(leaf, AllocationMultiplicity.Once, cached: true)],
+            },
+            root);
+
+        Assert.Equal(1, rootSummary.CachedSites);
+        Assert.Equal(0, rootSummary.OncePaths);
+    }
+
+    [Fact]
+    public void Analyze_LeavesUnprovenTargetsOpaque()
+    {
+        var root = Method(1, "Root");
+        var leaf = Method(2, "Leaf");
+        var opaque = Call(root, leaf, 4, AllocationMultiplicity.Once) with { ExactTarget = false };
+
+        var rootSummary = Summary(
+            [root, leaf],
+            [opaque],
+            new Dictionary<int, ImmutableArray<AllocationOccurrence>>
+            {
+                [root.MetadataToken] = [Allocation(root, AllocationMultiplicity.Once)],
+                [leaf.MetadataToken] = [Allocation(leaf, AllocationMultiplicity.Once)],
+            },
+            root);
+
+        Assert.Equal(1, rootSummary.OncePaths);
+        Assert.Equal(1, rootSummary.OpaquePaths);
+    }
+
+    [Fact]
+    public void Analyze_TerminatesRecursiveComponentsWithoutInventingCounts()
+    {
+        var first = Method(1, "First");
+        var second = Method(2, "Second");
+
+        var summaries = AllocationFanout.Analyze(
+            [first, second],
+            [
+                Call(first, second, 4, AllocationMultiplicity.Once),
+                Call(second, first, 4, AllocationMultiplicity.Once),
+            ],
+            new Dictionary<int, ImmutableArray<AllocationOccurrence>>
+            {
+                [first.MetadataToken] = [Allocation(first, AllocationMultiplicity.Once)],
+                [second.MetadataToken] = [Allocation(second, AllocationMultiplicity.Once)],
+            });
+
+        Assert.All(summaries, summary =>
+        {
+            Assert.Equal(1, summary.OncePaths);
+            Assert.Equal(1, summary.OpaquePaths);
+        });
+    }
+
+    [Fact]
+    public void Analyze_HandlesDeepCallGraphsWithoutRecursingOnTheNativeStack()
+    {
+        const int count = 20_000;
+        var methods = Enumerable.Range(1, count)
+            .Select(token => Method(token, $"Method{token}"))
+            .ToImmutableArray();
+        var calls = Enumerable.Range(0, count - 1)
+            .Select(index => Call(methods[index], methods[index + 1], 4, AllocationMultiplicity.Once))
+            .ToImmutableArray();
+
+        var summaries = AllocationFanout.Analyze(
+            methods,
+            calls,
+            new Dictionary<int, ImmutableArray<AllocationOccurrence>>
+            {
+                [methods[^1].MetadataToken] = [Allocation(methods[^1], AllocationMultiplicity.Once)],
+            });
+
+        var root = Assert.Single(summaries, summary => summary.Method.MetadataToken == methods[0].MetadataToken);
+        Assert.Equal(1, root.OncePaths);
+    }
+
+    static AllocationFanoutSummary Summary(
+        ImmutableArray<MethodIdentity> methods,
+        ImmutableArray<DirectCall> calls,
+        IReadOnlyDictionary<int, ImmutableArray<AllocationOccurrence>> occurrences,
+        MethodIdentity method)
+        => Assert.Single(
+            AllocationFanout.Analyze(methods, calls, occurrences),
+            summary => summary.Method.MetadataToken == method.MetadataToken);
+
+    static MethodIdentity Method(int token, string name)
+        => new(
+            "Fixture",
+            Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            s_type,
+            name,
+            [],
+            s_void,
+            token,
+            IsStatic: true);
+
+    static DirectCall Call(
+        MethodIdentity caller,
+        MethodIdentity callee,
+        int offset,
+        AllocationMultiplicity multiplicity)
+        => new(
+            caller,
+            new MemberRef(callee.DeclaringType, callee.Name, callee.ParameterTypes, callee.ReturnType, MemberKind.Method),
+            offset,
+            callee.MetadataToken,
+            callee.MetadataToken,
+            CallKind.Call)
+        {
+            ExactTarget = true,
+            Multiplicity = multiplicity,
+        };
+
+    static AllocationOccurrence Allocation(
+        MethodIdentity method,
+        AllocationMultiplicity multiplicity,
+        bool cached = false)
+        => new(
+            method,
+            ILOffset: 4,
+            OperandToken: null,
+            AllocationKind.Object,
+            s_object,
+            "System.Object",
+            CountsAsHeapAllocation: true,
+            cached ? AllocationFrequency.CachedOnce : AllocationFrequency.Always,
+            InLoop: multiplicity == AllocationMultiplicity.Loop,
+            AllocationEscape.Unknown,
+            AllocationFactSource.Newobj)
+        {
+            Multiplicity = multiplicity,
+        };
+}

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -158,6 +158,22 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void DirectCalls_ClassifyCallsiteMultiplicity()
+    {
+        var index = LibraryBodyIndex.Open(typeof(CallSiteFixtures).Assembly.Location);
+
+        var straight = Assert.Single(index.DirectCalls.Where(call =>
+            call.Caller.Name == nameof(CallSiteFixtures.CallsExactAllocationLeaf)
+            && call.Callee.Name == nameof(CallSiteFixtures.ExactAllocationLeaf)));
+        Assert.Equal(AllocationMultiplicity.Once, straight.Multiplicity);
+
+        var conditional = Assert.Single(index.DirectCalls.Where(call =>
+            call.Caller.Name == nameof(CallSiteFixtures.ConditionallyCallsExactAllocationLeaf)
+            && call.Callee.Name == nameof(CallSiteFixtures.ExactAllocationLeaf)));
+        Assert.Equal(AllocationMultiplicity.Conditional, conditional.Multiplicity);
+    }
+
+    [Fact]
     public void DirectCalls_MarksCallsInsideLoopRegions()
     {
         var index = LibraryBodyIndex.Open(typeof(CallSiteFixtures).Assembly.Location);
@@ -5230,6 +5246,13 @@ public static class CallSiteFixtures
     public static T GenericEcho<T>(T value) => value;
 
     public static int CallsGenericEcho() => GenericEcho(42);
+
+    public static object ExactAllocationLeaf() => new();
+
+    public static object CallsExactAllocationLeaf() => ExactAllocationLeaf();
+
+    public static object? ConditionallyCallsExactAllocationLeaf(bool create)
+        => create ? ExactAllocationLeaf() : null;
 }
 
 public static class GenericDeclaringCallers

--- a/src/ILInspector.Analysis/AllocationFanout.cs
+++ b/src/ILInspector.Analysis/AllocationFanout.cs
@@ -42,76 +42,103 @@ public static class AllocationFanout
                     .ThenBy(static edge => edge.TargetToken)
                     .ToArray());
         var recursiveComponents = FindRecursiveComponents(methods, edgesByCaller);
-        var impactByToken = new Dictionary<int, Impact>();
+        int NodeForToken(int token)
+            => recursiveComponents.TryGetValue(token, out int component)
+                ? -component - 1
+                : token;
 
-        Impact ImpactFor(int token)
+        var tokensByNode = methods
+            .GroupBy(method => NodeForToken(method.MetadataToken))
+            .ToDictionary(
+                static group => group.Key,
+                static group => group.Select(static method => method.MetadataToken).ToArray());
+        var edgesByNode = edgesByCaller
+            .SelectMany(static pair => pair.Value)
+            .GroupBy(edge => NodeForToken(edge.Call.Caller.MetadataToken))
+            .ToDictionary(
+                static group => group.Key,
+                static group => group.ToArray());
+        var impactByNode = new Dictionary<int, Impact>();
+
+        Impact ImpactFor(int node)
         {
-            if (impactByToken.TryGetValue(token, out var cached))
+            if (impactByNode.TryGetValue(node, out var cached))
                 return cached;
 
-            var pending = new Stack<(int Token, bool Compose)>();
-            pending.Push((token, false));
+            var pending = new Stack<(int Node, bool Compose)>();
+            pending.Push((node, false));
             while (pending.TryPop(out var item))
             {
-                if (impactByToken.ContainsKey(item.Token))
+                if (impactByNode.ContainsKey(item.Node))
                     continue;
 
                 if (!item.Compose)
                 {
-                    pending.Push((item.Token, true));
-                    if (edgesByCaller.TryGetValue(item.Token, out var dependencies))
+                    pending.Push((item.Node, true));
+                    if (edgesByNode.TryGetValue(item.Node, out var dependencies))
                     {
                         for (int i = dependencies.Length - 1; i >= 0; i--)
                         {
                             var dependency = dependencies[i];
+                            int targetNode = dependency.TargetToken == 0
+                                ? 0
+                                : NodeForToken(dependency.TargetToken);
                             if (dependency.Call.ExactTarget
-                                && dependency.TargetToken != 0
-                                && !InSameRecursiveComponent(
-                                    item.Token,
-                                    dependency.TargetToken,
-                                    recursiveComponents)
-                                && !impactByToken.ContainsKey(dependency.TargetToken))
+                                && targetNode != 0
+                                && targetNode != item.Node
+                                && !impactByNode.ContainsKey(targetNode))
                             {
-                                pending.Push((dependency.TargetToken, false));
+                                pending.Push((targetNode, false));
                             }
                         }
                     }
                     continue;
                 }
 
-                var impact = LocalImpact(
-                    item.Token,
-                    allocationOccurrences.TryGetValue(item.Token, out var occurrences)
-                        ? occurrences
-                        : []);
-                if (edgesByCaller.TryGetValue(item.Token, out var edges))
+                var impact = new Impact();
+                bool recursiveNode = item.Node < 0;
+                foreach (int methodToken in tokensByNode[item.Node])
+                {
+                    var local = LocalImpact(
+                        methodToken,
+                        allocationOccurrences.TryGetValue(methodToken, out var occurrences)
+                            ? occurrences
+                            : []);
+                    impact.Add(
+                        local,
+                        recursiveNode ? AllocationMultiplicity.Unknown : AllocationMultiplicity.Once);
+                }
+
+                if (edgesByNode.TryGetValue(item.Node, out var edges))
                 {
                     foreach (var edge in edges)
                     {
+                        int targetNode = edge.TargetToken == 0
+                            ? 0
+                            : NodeForToken(edge.TargetToken);
                         if (!edge.Call.ExactTarget
-                            || edge.TargetToken == 0
-                            || InSameRecursiveComponent(
-                                item.Token,
-                                edge.TargetToken,
-                                recursiveComponents))
+                            || targetNode == 0
+                            || targetNode == item.Node)
                         {
                             impact.AddOpaque();
                             continue;
                         }
 
-                        impact.Add(impactByToken[edge.TargetToken], edge.Call.Multiplicity);
+                        impact.Add(
+                            impactByNode[targetNode],
+                            recursiveNode ? AllocationMultiplicity.Unknown : edge.Call.Multiplicity);
                     }
                 }
-                impactByToken[item.Token] = impact;
+                impactByNode[item.Node] = impact;
             }
 
-            return impactByToken[token];
+            return impactByNode[node];
         }
 
         var summaries = ImmutableArray.CreateBuilder<AllocationFanoutSummary>();
         foreach (var method in methods.OrderBy(static method => method.MetadataToken))
         {
-            var impact = ImpactFor(method.MetadataToken);
+            var impact = ImpactFor(NodeForToken(method.MetadataToken));
             int directSites = DirectSiteCount(
                 allocationOccurrences.TryGetValue(method.MetadataToken, out var occurrences)
                     ? occurrences
@@ -241,14 +268,6 @@ public static class AllocationFanout
         bool HasExactSelfEdge(int token)
             => adjacency[token].Contains(token);
     }
-
-    static bool InSameRecursiveComponent(
-        int callerToken,
-        int targetToken,
-        IReadOnlyDictionary<int, int> recursiveComponents)
-        => recursiveComponents.TryGetValue(callerToken, out int callerComponent)
-            && recursiveComponents.TryGetValue(targetToken, out int targetComponent)
-            && callerComponent == targetComponent;
 
     sealed record Edge(DirectCall Call, int TargetToken);
 

--- a/src/ILInspector.Analysis/AllocationFanout.cs
+++ b/src/ILInspector.Analysis/AllocationFanout.cs
@@ -1,0 +1,345 @@
+using System.Collections.Immutable;
+
+namespace ILInspector.Analysis;
+
+/// <summary>
+/// Known IL-visible allocation impact for one method invocation. Once-path counts compose only
+/// through exact call sites and allocation sites classified once on normally returning control
+/// flow; every uncertain path remains separate.
+/// </summary>
+public sealed record AllocationFanoutSummary(
+    MethodIdentity Method,
+    int DirectSites,
+    long OncePaths,
+    long ConditionalPaths,
+    long RepeatedPaths,
+    long UnknownPaths,
+    long CachedSites,
+    long OpaquePaths,
+    bool Saturated);
+
+public static class AllocationFanout
+{
+    public static ImmutableArray<AllocationFanoutSummary> Analyze(
+        ImmutableArray<MethodIdentity> methods,
+        ImmutableArray<DirectCall> directCalls,
+        IReadOnlyDictionary<int, ImmutableArray<AllocationOccurrence>> allocationOccurrences)
+    {
+        if (methods.IsDefault)
+            throw new ArgumentException("Method census must be initialized.", nameof(methods));
+        if (directCalls.IsDefault)
+            throw new ArgumentException("Call census must be initialized.", nameof(directCalls));
+
+        var methodMap = MethodDefinitionMap.Create(methods);
+        var edgesByCaller = directCalls
+            .Where(IsInvocation)
+            .Select(call => new Edge(call, methodMap.Resolve(call)))
+            .GroupBy(static edge => edge.Call.Caller.MetadataToken)
+            .ToDictionary(
+                static group => group.Key,
+                static group => group
+                    .OrderBy(static edge => edge.Call.ILOffset)
+                    .ThenBy(static edge => edge.TargetToken)
+                    .ToArray());
+        var recursiveTokens = FindRecursiveTokens(methods, edgesByCaller);
+        var impactByToken = new Dictionary<int, Impact>();
+
+        Impact ImpactFor(int token)
+        {
+            if (impactByToken.TryGetValue(token, out var cached))
+                return cached;
+
+            var pending = new Stack<(int Token, bool Compose)>();
+            pending.Push((token, false));
+            while (pending.TryPop(out var item))
+            {
+                if (impactByToken.ContainsKey(item.Token))
+                    continue;
+
+                if (!item.Compose)
+                {
+                    pending.Push((item.Token, true));
+                    if (edgesByCaller.TryGetValue(item.Token, out var dependencies))
+                    {
+                        for (int i = dependencies.Length - 1; i >= 0; i--)
+                        {
+                            var dependency = dependencies[i];
+                            if (dependency.Call.ExactTarget
+                                && dependency.TargetToken != 0
+                                && !recursiveTokens.Contains(dependency.TargetToken)
+                                && !impactByToken.ContainsKey(dependency.TargetToken))
+                            {
+                                pending.Push((dependency.TargetToken, false));
+                            }
+                        }
+                    }
+                    continue;
+                }
+
+                var impact = LocalImpact(
+                    item.Token,
+                    allocationOccurrences.TryGetValue(item.Token, out var occurrences)
+                        ? occurrences
+                        : []);
+                if (edgesByCaller.TryGetValue(item.Token, out var edges))
+                {
+                    foreach (var edge in edges)
+                    {
+                        if (!edge.Call.ExactTarget
+                            || edge.TargetToken == 0
+                            || recursiveTokens.Contains(edge.TargetToken))
+                        {
+                            impact.AddOpaque();
+                            continue;
+                        }
+
+                        impact.Add(impactByToken[edge.TargetToken], edge.Call.Multiplicity);
+                    }
+                }
+                impactByToken[item.Token] = impact;
+            }
+
+            return impactByToken[token];
+        }
+
+        var summaries = ImmutableArray.CreateBuilder<AllocationFanoutSummary>();
+        foreach (var method in methods.OrderBy(static method => method.MetadataToken))
+        {
+            var impact = ImpactFor(method.MetadataToken);
+            int directSites = DirectSiteCount(
+                allocationOccurrences.TryGetValue(method.MetadataToken, out var occurrences)
+                    ? occurrences
+                    : []);
+            if (directSites == 0 && !impact.HasKnownAllocation)
+                continue;
+
+            summaries.Add(new AllocationFanoutSummary(
+                method,
+                directSites,
+                impact.OncePaths,
+                impact.ConditionalPaths,
+                impact.RepeatedPaths,
+                impact.UnknownPaths,
+                impact.CachedSites,
+                impact.OpaquePaths,
+                impact.Saturated));
+        }
+        return summaries.ToImmutable();
+    }
+
+    static Impact LocalImpact(int methodToken, ImmutableArray<AllocationOccurrence> occurrences)
+    {
+        var impact = new Impact();
+        foreach (var occurrence in occurrences)
+        {
+            if (!IsHeapAllocation(occurrence))
+                continue;
+            if (occurrence.Frequency == AllocationFrequency.CachedOnce)
+            {
+                impact.AddCached(methodToken, occurrence.ILOffset);
+                continue;
+            }
+
+            impact.AddLocal(occurrence.Multiplicity);
+        }
+        return impact;
+    }
+
+    static int DirectSiteCount(ImmutableArray<AllocationOccurrence> occurrences)
+        => occurrences.Count(IsHeapAllocation);
+
+    static bool IsHeapAllocation(AllocationOccurrence occurrence)
+        => occurrence.CountsAsHeapAllocation || occurrence.Kind == AllocationKind.Enumerator;
+
+    static bool IsInvocation(DirectCall call)
+        => call.Kind is CallKind.Call or CallKind.CallVirtual or CallKind.NewObject or CallKind.CallIndirect;
+
+    static HashSet<int> FindRecursiveTokens(
+        ImmutableArray<MethodIdentity> methods,
+        IReadOnlyDictionary<int, Edge[]> edgesByCaller)
+    {
+        var adjacency = methods.ToDictionary(
+            static method => method.MetadataToken,
+            method => edgesByCaller.TryGetValue(method.MetadataToken, out var edges)
+                ? edges
+                    .Where(static edge => edge.Call.ExactTarget && edge.TargetToken != 0)
+                    .Select(static edge => edge.TargetToken)
+                    .Distinct()
+                    .ToArray()
+                : []);
+        var reverse = methods.ToDictionary(
+            static method => method.MetadataToken,
+            static _ => new List<int>());
+        foreach (var (caller, targets) in adjacency)
+        {
+            foreach (int target in targets)
+                reverse[target].Add(caller);
+        }
+
+        var visited = new HashSet<int>();
+        var finishingOrder = new List<int>(methods.Length);
+        foreach (var method in methods)
+        {
+            if (visited.Contains(method.MetadataToken))
+                continue;
+
+            var pending = new Stack<(int Token, bool Finish)>();
+            pending.Push((method.MetadataToken, false));
+            while (pending.TryPop(out var item))
+            {
+                if (item.Finish)
+                {
+                    finishingOrder.Add(item.Token);
+                    continue;
+                }
+                if (!visited.Add(item.Token))
+                    continue;
+
+                pending.Push((item.Token, true));
+                var targets = adjacency[item.Token];
+                for (int i = targets.Length - 1; i >= 0; i--)
+                    pending.Push((targets[i], false));
+            }
+        }
+
+        var recursive = new HashSet<int>();
+        visited.Clear();
+        for (int i = finishingOrder.Count - 1; i >= 0; i--)
+        {
+            int start = finishingOrder[i];
+            if (!visited.Add(start))
+                continue;
+            var component = new List<int>();
+            var pending = new Stack<int>();
+            pending.Push(start);
+            while (pending.TryPop(out int member))
+            {
+                component.Add(member);
+                foreach (int caller in reverse[member])
+                {
+                    if (visited.Add(caller))
+                        pending.Push(caller);
+                }
+            }
+
+            if (component.Count > 1 || HasExactSelfEdge(component[0]))
+                recursive.UnionWith(component);
+        }
+        return recursive;
+
+        bool HasExactSelfEdge(int token)
+            => adjacency[token].Contains(token);
+    }
+
+    sealed record Edge(DirectCall Call, int TargetToken);
+
+    struct Impact
+    {
+        HashSet<long>? _cachedSiteKeys;
+
+        public long OncePaths;
+        public long ConditionalPaths;
+        public long RepeatedPaths;
+        public long UnknownPaths;
+        public long OpaquePaths;
+        public bool Saturated;
+
+        public readonly long CachedSites => _cachedSiteKeys?.Count ?? 0;
+
+        public readonly bool HasKnownAllocation =>
+            OncePaths > 0
+            || ConditionalPaths > 0
+            || RepeatedPaths > 0
+            || UnknownPaths > 0
+            || CachedSites > 0;
+
+        public void AddLocal(AllocationMultiplicity multiplicity)
+        {
+            switch (multiplicity)
+            {
+                case AllocationMultiplicity.Once:
+                    AddTo(ref OncePaths, 1);
+                    break;
+                case AllocationMultiplicity.Conditional:
+                    AddTo(ref ConditionalPaths, 1);
+                    break;
+                case AllocationMultiplicity.Loop:
+                    AddTo(ref RepeatedPaths, 1);
+                    break;
+                default:
+                    AddTo(ref UnknownPaths, 1);
+                    break;
+            }
+        }
+
+        public void AddCached(int methodToken, int ilOffset)
+        {
+            _cachedSiteKeys ??= [];
+            _cachedSiteKeys.Add(((long)(uint)methodToken << 32) | (uint)ilOffset);
+        }
+
+        public void AddOpaque() => AddTo(ref OpaquePaths, 1);
+
+        public void Add(Impact callee, AllocationMultiplicity callMultiplicity)
+        {
+            Saturated |= callee.Saturated;
+            if (callee._cachedSiteKeys is not null)
+            {
+                _cachedSiteKeys ??= [];
+                _cachedSiteKeys.UnionWith(callee._cachedSiteKeys);
+            }
+            AddTo(ref OpaquePaths, callee.OpaquePaths);
+            switch (callMultiplicity)
+            {
+                case AllocationMultiplicity.Once:
+                    AddTo(ref OncePaths, callee.OncePaths);
+                    AddTo(ref ConditionalPaths, callee.ConditionalPaths);
+                    AddTo(ref RepeatedPaths, callee.RepeatedPaths);
+                    AddTo(ref UnknownPaths, callee.UnknownPaths);
+                    break;
+                case AllocationMultiplicity.Conditional:
+                    AddTo(ref ConditionalPaths, Sum(callee.OncePaths, callee.ConditionalPaths));
+                    AddTo(ref RepeatedPaths, callee.RepeatedPaths);
+                    AddTo(ref UnknownPaths, callee.UnknownPaths);
+                    break;
+                case AllocationMultiplicity.Loop:
+                    AddTo(ref RepeatedPaths, Sum(callee.OncePaths, callee.ConditionalPaths, callee.RepeatedPaths));
+                    AddTo(ref UnknownPaths, callee.UnknownPaths);
+                    break;
+                default:
+                    AddTo(ref UnknownPaths, Sum(
+                        callee.OncePaths,
+                        callee.ConditionalPaths,
+                        callee.RepeatedPaths,
+                        callee.UnknownPaths));
+                    break;
+            }
+        }
+
+        long Sum(params long[] values)
+        {
+            long result = 0;
+            foreach (long value in values)
+            {
+                if (long.MaxValue - result < value)
+                {
+                    Saturated = true;
+                    return long.MaxValue;
+                }
+                result += value;
+            }
+            return result;
+        }
+
+        void AddTo(ref long target, long value)
+        {
+            if (long.MaxValue - target < value)
+            {
+                target = long.MaxValue;
+                Saturated = true;
+                return;
+            }
+            target += value;
+        }
+    }
+}

--- a/src/ILInspector.Analysis/AllocationFanout.cs
+++ b/src/ILInspector.Analysis/AllocationFanout.cs
@@ -41,7 +41,7 @@ public static class AllocationFanout
                     .OrderBy(static edge => edge.Call.ILOffset)
                     .ThenBy(static edge => edge.TargetToken)
                     .ToArray());
-        var recursiveTokens = FindRecursiveTokens(methods, edgesByCaller);
+        var recursiveComponents = FindRecursiveComponents(methods, edgesByCaller);
         var impactByToken = new Dictionary<int, Impact>();
 
         Impact ImpactFor(int token)
@@ -66,7 +66,10 @@ public static class AllocationFanout
                             var dependency = dependencies[i];
                             if (dependency.Call.ExactTarget
                                 && dependency.TargetToken != 0
-                                && !recursiveTokens.Contains(dependency.TargetToken)
+                                && !InSameRecursiveComponent(
+                                    item.Token,
+                                    dependency.TargetToken,
+                                    recursiveComponents)
                                 && !impactByToken.ContainsKey(dependency.TargetToken))
                             {
                                 pending.Push((dependency.TargetToken, false));
@@ -87,7 +90,10 @@ public static class AllocationFanout
                     {
                         if (!edge.Call.ExactTarget
                             || edge.TargetToken == 0
-                            || recursiveTokens.Contains(edge.TargetToken))
+                            || InSameRecursiveComponent(
+                                item.Token,
+                                edge.TargetToken,
+                                recursiveComponents))
                         {
                             impact.AddOpaque();
                             continue;
@@ -154,7 +160,7 @@ public static class AllocationFanout
     static bool IsInvocation(DirectCall call)
         => call.Kind is CallKind.Call or CallKind.CallVirtual or CallKind.NewObject or CallKind.CallIndirect;
 
-    static HashSet<int> FindRecursiveTokens(
+    static Dictionary<int, int> FindRecursiveComponents(
         ImmutableArray<MethodIdentity> methods,
         IReadOnlyDictionary<int, Edge[]> edgesByCaller)
     {
@@ -202,7 +208,8 @@ public static class AllocationFanout
             }
         }
 
-        var recursive = new HashSet<int>();
+        var recursiveComponents = new Dictionary<int, int>();
+        int nextComponent = 0;
         visited.Clear();
         for (int i = finishingOrder.Count - 1; i >= 0; i--)
         {
@@ -223,13 +230,25 @@ public static class AllocationFanout
             }
 
             if (component.Count > 1 || HasExactSelfEdge(component[0]))
-                recursive.UnionWith(component);
+            {
+                int componentId = nextComponent++;
+                foreach (int token in component)
+                    recursiveComponents[token] = componentId;
+            }
         }
-        return recursive;
+        return recursiveComponents;
 
         bool HasExactSelfEdge(int token)
             => adjacency[token].Contains(token);
     }
+
+    static bool InSameRecursiveComponent(
+        int callerToken,
+        int targetToken,
+        IReadOnlyDictionary<int, int> recursiveComponents)
+        => recursiveComponents.TryGetValue(callerToken, out int callerComponent)
+            && recursiveComponents.TryGetValue(targetToken, out int targetComponent)
+            && callerComponent == targetComponent;
 
     sealed record Edge(DirectCall Call, int TargetToken);
 

--- a/src/ILInspector.Analysis/AnalysisFindings.cs
+++ b/src/ILInspector.Analysis/AnalysisFindings.cs
@@ -98,8 +98,8 @@ public static class AnalysisFindings
 
     /// <summary>
     /// Projects one method's direct calls into IL order. The callee signature establishes exact
-    /// correspondence; call opcode, dispatch kind, loop context, and version-local coordinates
-    /// remain payload facets or provenance.
+    /// correspondence; call opcode, dispatch kind, loop/multiplicity context, and version-local
+    /// coordinates remain payload facets or provenance.
     /// </summary>
     public static ImmutableArray<Finding<DirectCall>> InspectCallSites(
         IEnumerable<DirectCall> calls,
@@ -130,7 +130,8 @@ public static class AnalysisFindings
 
     /// <summary>
     /// Compares two direct-call censuses. Exact correspondence requires the same instantiated
-    /// callee signature; dispatch, opcode, and loop-context changes remain classified transitions.
+    /// callee signature; dispatch, opcode, multiplicity, and loop-context changes remain
+    /// classified transitions.
     /// </summary>
     public static FindingComparison<DirectCall> CompareCallSites(
         IEnumerable<DirectCall> oldCalls,
@@ -375,6 +376,7 @@ public static class AnalysisFindings
         // explicitly opted into transition classification here.
         => oldCall.Kind == newCall.Kind
             && oldCall.InLoop == newCall.InLoop
+            && oldCall.Multiplicity == newCall.Multiplicity
             && string.Equals(oldCall.Opcode, newCall.Opcode, StringComparison.Ordinal);
 
     static string DescribeCallSiteFacetChanges(DirectCall oldCall, DirectCall newCall)
@@ -382,6 +384,7 @@ public static class AnalysisFindings
         var changes = new List<string>();
         AddChange(changes, "kind", oldCall.Kind, newCall.Kind);
         AddChange(changes, "in loop", oldCall.InLoop, newCall.InLoop);
+        AddChange(changes, "multiplicity", oldCall.Multiplicity, newCall.Multiplicity);
         AddChange(changes, "opcode", oldCall.Opcode, newCall.Opcode);
         return changes.Count == 0 ? "other facets changed" : string.Join("; ", changes);
     }

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -67,6 +67,8 @@ public sealed class LibraryBodyIndex
     readonly bool _opportunitiesComputed;
     readonly ImmutableArray<MethodIdentity> _unsafeLeverageMethods;
     ImmutableArray<OptimizationOpportunity> _opportunities;
+    ImmutableArray<OptimizationOpportunity> _allocationFanoutOpportunities;
+    Dictionary<int, int>? _rootReachByToken;
     IReadOnlyDictionary<int, ImmutableArray<DirectCall>>? _directCallsByCaller;
     IReadOnlyDictionary<int, ImmutableArray<UnsafeEvidence>>? _unsafeEvidenceByMember;
 
@@ -84,9 +86,7 @@ public sealed class LibraryBodyIndex
                 return ImmutableArray<OptimizationOpportunity>.Empty;
             if (_opportunities.IsDefault)
             {
-                var reachByToken = new Dictionary<int, int>();
-                foreach (var entry in TopLeverage(int.MaxValue))
-                    reachByToken[entry.Method.MetadataToken] = entry.RootReach;
+                var reachByToken = RootReachByToken;
                 _opportunities = AttachFindingProvenance(
                 [
                     .. _rawOpportunities.Select(opportunity =>
@@ -109,6 +109,111 @@ public sealed class LibraryBodyIndex
             }
             return _opportunities;
         }
+    }
+
+    /// <summary>
+    /// Opt-in allocation fanout rows. Each row carries a sound IL-visible lower bound through
+    /// exact intra-assembly call targets; uncertain, recursive, virtual, and external calls are
+    /// counted as opaque rather than assigned invented targets.
+    /// </summary>
+    public ImmutableArray<OptimizationOpportunity> AllocationFanoutOpportunities
+    {
+        get
+        {
+            if (!_opportunitiesComputed)
+                return ImmutableArray<OptimizationOpportunity>.Empty;
+            if (_allocationFanoutOpportunities.IsDefault)
+            {
+                var reachByToken = RootReachByToken;
+
+                _allocationFanoutOpportunities = AttachFindingProvenance(
+                [
+                    .. AllocationFanout.Analyze(
+                            Methods,
+                            ClassifyExactCallTargets(Path, DirectCalls, Methods),
+                            _allocationOccurrences)
+                        .Select(summary => new OptimizationOpportunity(
+                            summary.Method,
+                            "allocation-fanout",
+                            $"Known IL-visible impact: direct-sites={summary.DirectSites}, once-paths={summary.OncePaths}, conditional-paths={summary.ConditionalPaths}, repeated-paths={summary.RepeatedPaths}, unknown-paths={summary.UnknownPaths}, cached-sites={summary.CachedSites}, opaque-paths={summary.OpaquePaths}.",
+                            "Inspect the exact allocation findings and call paths; consolidate repeated setup or dispatch object construction when lifecycle measurements show it is unnecessary.",
+                            summary.UnknownPaths == 0 && summary.OpaquePaths == 0 && !summary.Saturated ? "high" : "medium",
+                            summary.RepeatedPaths > 0,
+                            ILOffset: null,
+                            "This is a static lower bound over IL-visible allocations. External, virtual, delegate, recursive, and runtime-library allocation effects remain opaque.",
+                            reachByToken.GetValueOrDefault(summary.Method.MetadataToken))
+                        {
+                            CandidateId = null,
+                            Provenance = PerformanceTriageProvenance.Aggregate,
+                            DirectAllocationSites = summary.DirectSites,
+                            OnceAllocationPaths = summary.OncePaths,
+                            ConditionalAllocationPaths = summary.ConditionalPaths,
+                            RepeatedAllocationPaths = summary.RepeatedPaths,
+                            UnknownAllocationPaths = summary.UnknownPaths,
+                            CachedAllocationSites = summary.CachedSites,
+                            OpaqueCallPaths = summary.OpaquePaths,
+                            AllocationCountSaturated = summary.Saturated,
+                        }),
+                ]);
+            }
+            return _allocationFanoutOpportunities;
+        }
+    }
+
+    Dictionary<int, int> RootReachByToken
+    {
+        get
+        {
+            if (_rootReachByToken is null)
+            {
+                var reachByToken = new Dictionary<int, int>();
+                foreach (var entry in TopLeverage(int.MaxValue))
+                    reachByToken[entry.Method.MetadataToken] = entry.RootReach;
+                _rootReachByToken = reachByToken;
+            }
+            return _rootReachByToken;
+        }
+    }
+
+    static ImmutableArray<DirectCall> ClassifyExactCallTargets(
+        string path,
+        ImmutableArray<DirectCall> calls,
+        ImmutableArray<MethodIdentity> methods)
+    {
+        using var stream = File.OpenRead(path);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var methodMap = MethodDefinitionMap.Create(methods);
+        return
+        [
+            .. calls.Select(call =>
+            {
+                int targetToken = methodMap.Resolve(call);
+                bool exact = targetToken != 0 && call.Kind switch
+                {
+                    CallKind.Call or CallKind.NewObject => true,
+                    CallKind.CallVirtual => IsExactVirtualTarget(reader, targetToken),
+                    _ => false,
+                };
+                return call with { ExactTarget = exact };
+            }),
+        ];
+    }
+
+    static bool IsExactVirtualTarget(MetadataReader reader, int methodToken)
+    {
+        var handle = MetadataTokens.EntityHandle(methodToken);
+        if (handle.Kind != HandleKind.MethodDefinition)
+            return false;
+        var method = reader.GetMethodDefinition((MethodDefinitionHandle)handle);
+        if ((method.Attributes & MethodAttributes.Virtual) == 0
+            || (method.Attributes & MethodAttributes.Final) != 0)
+        {
+            return true;
+        }
+
+        var declaringType = reader.GetTypeDefinition(method.GetDeclaringType());
+        return (declaringType.Attributes & TypeAttributes.Sealed) != 0;
     }
 
     ImmutableArray<OptimizationOpportunity> AttachFindingProvenance(
@@ -160,7 +265,7 @@ public sealed class LibraryBodyIndex
                 }
             }
 
-            string? sourceFinding = allocation?.Descriptor.Id ?? callSite?.Descriptor.Id;
+            string? sourceFinding = allocation?.Descriptor.Id ?? callSite?.Descriptor.Id ?? opportunity.SourceFinding;
             FindingKey? findingKey = allocation?.Key ?? callSite?.Key;
             int? ordinal = allocation?.Ordinal ?? callSite?.Ordinal;
             int fingerprintLength = PerformanceTriageCandidateId.InitialFingerprintLength;
@@ -193,11 +298,13 @@ public sealed class LibraryBodyIndex
                     ? CallOperation(callSite?.Payload)
                     : AllocationOperation(allocation.Payload),
                 OperandToken = allocation?.Payload.OperandToken ?? callSite?.Payload.OperandToken,
-                Provenance = sourceFinding is not null
-                    ? PerformanceTriageProvenance.Exact
-                    : opportunity.ILOffset is null
-                        ? PerformanceTriageProvenance.Aggregate
-                        : PerformanceTriageProvenance.Unmatched,
+                Provenance = opportunity.Provenance != PerformanceTriageProvenance.Unknown
+                    ? opportunity.Provenance
+                    : sourceFinding is not null
+                        ? PerformanceTriageProvenance.Exact
+                        : opportunity.ILOffset is null
+                            ? PerformanceTriageProvenance.Aggregate
+                            : PerformanceTriageProvenance.Unmatched,
             });
         }
 
@@ -2303,9 +2410,10 @@ public sealed class LibraryBodyIndex
                     diagnostics.Add(r.Diagnostic);
             }
 
+            var methodArray = methods.ToImmutable();
             var directCalls = calls.ToImmutable();
             var nonHeapNewObjOperandTokens = ComputeNonHeapNewObjOperandTokens(directCalls);
-            return (declaredMethods.ToImmutable(), methods.ToImmutable(), directCalls, unsafeEvidence.ToImmutable(), diagnostics.ToImmutable(),
+            return (declaredMethods.ToImmutable(), methodArray, directCalls, unsafeEvidence.ToImmutable(), diagnostics.ToImmutable(),
                 optimizationOpportunities.ToImmutable(), unsafeLeverageMethods.ToImmutable(), new UnsafeModeBreakdown(none, impl, expl), bodySignals, allocationOccurrences, unsafetyOccurrences,
                 BuildInAssemblyExceptionMap(), suppressedOpportunityTokens, exceptionTypeNames, nonHeapNewObjOperandTokens);
         }
@@ -2412,7 +2520,7 @@ public sealed class LibraryBodyIndex
                     result.Signals = signals;
                     result.HasSignals = true;
                 }
-                ScanBody(decodedBody.Instructions, caller, scope, calls, evidence,
+                ScanBody(decodedBody, caller, scope, calls, evidence,
                     includeIndirectOpcodes: hasUnsafeApiMember || hasUnsafeSignature || hasUnsafeLocals,
                     loopRegions);
             }
@@ -5420,13 +5528,13 @@ public sealed class LibraryBodyIndex
         }
 
 
-        void ScanBody(ImmutableArray<DecodedInstruction> instructions, MethodIdentity caller, GenericScope callerScope,
+        void ScanBody(DecodedBody decodedBody, MethodIdentity caller, GenericScope callerScope,
             ImmutableArray<DirectCall>.Builder calls,
             ImmutableArray<UnsafeEvidence>.Builder unsafeEvidence,
             bool includeIndirectOpcodes,
             IReadOnlyList<(int Start, int End)> loopRegions)
         {
-            foreach (var instruction in instructions)
+            foreach (var instruction in decodedBody.Instructions)
             {
                 int offset = instruction.Offset;
                 var opcode = instruction.OpCode;
@@ -5451,7 +5559,12 @@ public sealed class LibraryBodyIndex
                             inLoop)
                         {
                             Opcode = FormatCallOpcode(opcode),
-                            ReturnAddress = instruction.NextOffset
+                            ReturnAddress = instruction.NextOffset,
+                            Multiplicity = AllocationMultiplicityFor(
+                                decodedBody,
+                                offset,
+                                loopRegions,
+                                AllocationEscape.Unknown),
                         });
                         if (IsUnsafeCall(callee))
                         {
@@ -5478,7 +5591,12 @@ public sealed class LibraryBodyIndex
                             IsInLoopRegion(offset, loopRegions))
                         {
                             Opcode = FormatCallOpcode(opcode),
-                            ReturnAddress = instruction.NextOffset
+                            ReturnAddress = instruction.NextOffset,
+                            Multiplicity = AllocationMultiplicityFor(
+                                decodedBody,
+                                offset,
+                                loopRegions,
+                                AllocationEscape.Unknown),
                         });
                         unsafeEvidence.Add(new UnsafeEvidence(caller, "Unsafe operation", "calli", "calli", offset, token));
                         break;

--- a/src/ILInspector.Analysis/MemberIdentity.cs
+++ b/src/ILInspector.Analysis/MemberIdentity.cs
@@ -283,6 +283,8 @@ public sealed record DirectCall(
 {
     public string Opcode { get; init; } = "";
     public int? ReturnAddress { get; init; }
+    public AllocationMultiplicity Multiplicity { get; init; }
+    public bool ExactTarget { get; init; }
 }
 
 public sealed record CalledTypeSummary(

--- a/src/ILInspector.Analysis/OptimizationOpportunity.cs
+++ b/src/ILInspector.Analysis/OptimizationOpportunity.cs
@@ -56,4 +56,20 @@ public sealed record OptimizationOpportunity(
 
     /// <summary>Whether this row has exact, aggregate, or unresolved producer provenance.</summary>
     public PerformanceTriageProvenance Provenance { get; init; }
+
+    /// <summary>Direct IL-visible heap-allocation sites in the declaring method.</summary>
+    public int? DirectAllocationSites { get; init; }
+
+    /// <summary>
+    /// IL-visible allocation paths classified once on normally returning control flow, including
+    /// exact intra-assembly callees reached only through call sites with the same classification.
+    /// </summary>
+    public long? OnceAllocationPaths { get; init; }
+
+    public long? ConditionalAllocationPaths { get; init; }
+    public long? RepeatedAllocationPaths { get; init; }
+    public long? UnknownAllocationPaths { get; init; }
+    public long? CachedAllocationSites { get; init; }
+    public long? OpaqueCallPaths { get; init; }
+    public bool AllocationCountSaturated { get; init; }
 }

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -464,6 +464,41 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task PerformanceTriageAllocationFanout_ReportsOncePathQuantity()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "--triage-shape", "allocation-fanout",
+            "--where", "Member=*CreateAllocationFanout*",
+            "--where", "OncePaths>=4",
+            "--order-by", "OncePaths desc",
+            "--jsonl",
+            "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("\"shape\":\"allocation-fanout\"", output);
+        Assert.Contains("\"provenance\":\"aggregate\"", output);
+        Assert.Contains("\"direct_sites\":\"1\"", output);
+        Assert.Contains("\"once_paths\":\"4\"", output);
+    }
+
+    [Fact]
+    public async Task PerformanceTriageAllocationFanout_IsOptIn()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "Performance Triage",
+            "--where", "Member=*CreateAllocationFanout*",
+            "--jsonl",
+            "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.DoesNotContain("\"shape\":\"allocation-fanout\"", output);
+    }
+
+    [Fact]
     public async Task PerformanceTriageWhere_FiltersRowsByField()
     {
         var (exit, output, error) = await RunAppAsync(
@@ -5640,6 +5675,8 @@ public class CommandExecutionTests
         Assert.Contains("| Loop desc | order-step |", output);
         Assert.Contains("| Allocation | filterable |", output);
         Assert.Contains("| RootReach | sortable |", output);
+        Assert.Contains("| Once Paths | column |", output);
+        Assert.Contains("| OncePaths | sortable |", output);
         Assert.Contains("| IL | column |", output);
     }
 

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -138,6 +138,34 @@ public class OutputFormatterTests
     }
 
     [Fact]
+    public void PopulateOptimizationOpportunities_AllocationFanoutCountsRepeatedCallSites()
+    {
+        var type = new ApiType
+        {
+            Namespace = typeof(OutputFormatterTests).Namespace,
+            Name = nameof(OutputFormatterTests),
+            Kind = "class"
+        };
+        var view = new TypeView();
+
+        ApiOutputFormatter.PopulateOptimizationOpportunities(
+            view,
+            type,
+            ApiOutputFormatter.OpenTypeAnalysisIndex(typeof(OutputFormatterTests).Assembly.Location),
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { SectionNames.PerformanceTriage },
+            new PerformanceTriageOptions { Shapes = ["allocation-fanout"] });
+
+        var row = Assert.Single(
+            Assert.IsType<List<OptimizationOpportunityRow>>(view.OptimizationOpportunityRows),
+            row => row.Member.Contains(nameof(CreateAllocationFanout), StringComparison.Ordinal));
+        Assert.Equal("allocation-fanout", row.Shape);
+        Assert.Null(row.Finding);
+        Assert.Equal("aggregate", row.Provenance);
+        Assert.Equal("1", row.DirectSites);
+        Assert.Equal("4", row.OncePaths);
+    }
+
+    [Fact]
     public void RenderTypeSectionsMarkdown_PopulatesOptimizationOpportunitiesWhenRequested()
     {
         var type = new ApiType
@@ -217,6 +245,15 @@ public class OutputFormatterTests
         byte[] bytes = new byte[4];
         _ = bytes.Length;
     }
+
+    private static object[] CreateAllocationFanout() =>
+    [
+        CreateFanoutLeaf(),
+        CreateFanoutLeaf(),
+        CreateFanoutLeaf(),
+    ];
+
+    private static object CreateFanoutLeaf() => new();
 
     // The local function compiles to a compiler-generated method (<...>g__Make|...)
     // declared on this type, carrying the small-array opportunity from `new int[3]`.
@@ -388,6 +425,27 @@ public class OutputFormatterTests
             .ToList();
 
         Assert.Equal(["BoxLoop"], filtered);
+    }
+
+    [Fact]
+    public void FilterAndOrderTriageOpportunities_DoesNotMatchMissingNumericFields()
+    {
+        var opportunities = new[]
+        {
+            Opp("Fanout", inLoop: false, confidence: "high", rootReach: 1, shape: "allocation-fanout") with
+            {
+                OnceAllocationPaths = 4,
+            },
+            Opp("Local", inLoop: false, confidence: "high", rootReach: 1, shape: "allocation-hotspot"),
+        };
+
+        var filtered = LibraryMetadataService.FilterAndOrderTriageOpportunities(
+                opportunities,
+                new PerformanceTriageOptions { Where = ["OncePaths!=5"] })
+            .Select(opportunity => opportunity.Method.Name)
+            .ToList();
+
+        Assert.Equal(["Fanout"], filtered);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -785,7 +785,7 @@ internal static class LibraryMetadataService
             var index = openIndex();
             var generatedFrameworkTypes = index.GeneratedFrameworkTypeNames;
             var rows = FilterAndOrderTriageOpportunities(
-                    index.OptimizationOpportunities
+                    TriageOpportunities(index, options)
                         .Where(opportunity => !IsGeneratedMethod(opportunity.Method, generatedFrameworkTypes)),
                     options)
                 .Select(opportunity => new OptimizationOpportunitySummary
@@ -808,6 +808,14 @@ internal static class LibraryMetadataService
                     PostDominance = opportunity.PostDominance,
                     IL = opportunity.ILOffset is { } offset ? $"IL_{offset:X4}" : null,
                     Weight = opportunity.Weight,
+                    DirectSites = opportunity.DirectAllocationSites,
+                    OncePaths = opportunity.OnceAllocationPaths,
+                    ConditionalPaths = opportunity.ConditionalAllocationPaths,
+                    RepeatedPaths = opportunity.RepeatedAllocationPaths,
+                    UnknownPaths = opportunity.UnknownAllocationPaths,
+                    CachedSites = opportunity.CachedAllocationSites,
+                    OpaquePaths = opportunity.OpaqueCallPaths,
+                    Saturated = opportunity.AllocationCountSaturated ? "yes" : null,
                 })
                 .ToList();
             return rows.Count > 0 ? rows : null;
@@ -881,11 +889,24 @@ internal static class LibraryMetadataService
                 filtered = filtered.Where(opportunity => MatchesTriagePredicate(opportunity, predicate));
         }
 
-        var ordered = options.TryGetOrderTerms(out var orderTerms, out _)
-            ? OrderTriageRows(filtered, orderTerms)
-            : OrderByTriagePriority(filtered);
+        var ordered = options.OrderBy is null && options.IncludesAllocationFanout
+            ? filtered
+                .OrderByDescending(opportunity => opportunity.OnceAllocationPaths ?? -1)
+                .ThenByDescending(opportunity => opportunity.RepeatedAllocationPaths ?? -1)
+                .ThenByDescending(opportunity => opportunity.ConditionalAllocationPaths ?? -1)
+                .ThenBy(opportunity => FormatMethod(opportunity.Method), StringComparer.Ordinal)
+            : options.TryGetOrderTerms(out var orderTerms, out _)
+                ? OrderTriageRows(filtered, orderTerms)
+                : OrderByTriagePriority(filtered);
         return options.Top is { } top ? ordered.Take(top) : ordered;
     }
+
+    internal static IEnumerable<Analysis.OptimizationOpportunity> TriageOpportunities(
+        Analysis.LibraryBodyIndex index,
+        PerformanceTriageOptions? options)
+        => options?.IncludesAllocationFanout == true
+            ? index.OptimizationOpportunities.Concat(index.AllocationFanoutOpportunities)
+            : index.OptimizationOpportunities;
 
     static IEnumerable<Analysis.OptimizationOpportunity> OrderTriageRows(
         IEnumerable<Analysis.OptimizationOpportunity> opportunities,
@@ -919,13 +940,15 @@ internal static class LibraryMetadataService
 
     static bool MatchesTriagePredicate(Analysis.OptimizationOpportunity opportunity, PerformanceTriageOptions.RowPredicate predicate)
     {
-        if (predicate.Field == "RootReach")
+        if (NumericTriageField(opportunity, predicate.Field) is { } actualNumber)
         {
-            if (!int.TryParse(predicate.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value))
+            if (!long.TryParse(predicate.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out long value))
                 return false;
-            int compare = opportunity.RootReach.CompareTo(value);
+            int compare = actualNumber.CompareTo(value);
             return MatchCompare(compare, predicate.Operator);
         }
+        if (PerformanceTriageOptions.IsNumericField(predicate.Field))
+            return false;
 
         if (predicate.Field == "Confidence")
         {
@@ -999,8 +1022,11 @@ internal static class LibraryMetadataService
 
     static int CompareTriageField(Analysis.OptimizationOpportunity left, Analysis.OptimizationOpportunity right, string field)
     {
-        if (field == "RootReach")
-            return left.RootReach.CompareTo(right.RootReach);
+        if (NumericTriageField(left, field) is { } leftNumber
+            && NumericTriageField(right, field) is { } rightNumber)
+        {
+            return leftNumber.CompareTo(rightNumber);
+        }
         if (field == "Confidence")
             return ConfidenceRank(left.Confidence).CompareTo(ConfidenceRank(right.Confidence));
         if (field == "Weight")
@@ -1034,8 +1060,30 @@ internal static class LibraryMetadataService
             "PathConfidence" => opportunity.PathConfidence,
             "PostDominance" => opportunity.PostDominance,
             "Weight" => opportunity.Weight,
+            "DirectSites" => opportunity.DirectAllocationSites?.ToString(CultureInfo.InvariantCulture),
+            "OncePaths" => opportunity.OnceAllocationPaths?.ToString(CultureInfo.InvariantCulture),
+            "ConditionalPaths" => opportunity.ConditionalAllocationPaths?.ToString(CultureInfo.InvariantCulture),
+            "RepeatedPaths" => opportunity.RepeatedAllocationPaths?.ToString(CultureInfo.InvariantCulture),
+            "UnknownPaths" => opportunity.UnknownAllocationPaths?.ToString(CultureInfo.InvariantCulture),
+            "CachedSites" => opportunity.CachedAllocationSites?.ToString(CultureInfo.InvariantCulture),
+            "OpaquePaths" => opportunity.OpaqueCallPaths?.ToString(CultureInfo.InvariantCulture),
+            "Saturated" => opportunity.AllocationCountSaturated ? "yes" : null,
             "IL" => opportunity.ILOffset is { } offset ? $"IL_{offset:X4}" : null,
             "RootReach" => opportunity.RootReach.ToString(CultureInfo.InvariantCulture),
+            _ => null,
+        };
+
+    static long? NumericTriageField(Analysis.OptimizationOpportunity opportunity, string field)
+        => field switch
+        {
+            "RootReach" => opportunity.RootReach,
+            "DirectSites" => opportunity.DirectAllocationSites,
+            "OncePaths" => opportunity.OnceAllocationPaths,
+            "ConditionalPaths" => opportunity.ConditionalAllocationPaths,
+            "RepeatedPaths" => opportunity.RepeatedAllocationPaths,
+            "UnknownPaths" => opportunity.UnknownAllocationPaths,
+            "CachedSites" => opportunity.CachedAllocationSites,
+            "OpaquePaths" => opportunity.OpaqueCallPaths,
             _ => null,
         };
 

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -1112,6 +1112,22 @@ public record class OptimizationOpportunitySummary
     public string? IL { get; init; }
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Weight { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? DirectSites { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? OncePaths { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? ConditionalPaths { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? RepeatedPaths { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? UnknownPaths { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? CachedSites { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? OpaquePaths { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Saturated { get; init; }
 }
 
 /// <summary>

--- a/src/dotnet-inspect/Options/PerformanceTriageOptions.cs
+++ b/src/dotnet-inspect/Options/PerformanceTriageOptions.cs
@@ -38,6 +38,14 @@ public sealed record PerformanceTriageOptions
         "PostDominance",
         "IL",
         "Weight",
+        "DirectSites",
+        "OncePaths",
+        "ConditionalPaths",
+        "RepeatedPaths",
+        "UnknownPaths",
+        "CachedSites",
+        "OpaquePaths",
+        "Saturated",
     ];
 
     public static readonly string[] SortableFields =
@@ -59,11 +67,19 @@ public sealed record PerformanceTriageOptions
         "PathConfidence",
         "PostDominance",
         "Weight",
+        "DirectSites",
+        "OncePaths",
+        "ConditionalPaths",
+        "RepeatedPaths",
+        "UnknownPaths",
+        "CachedSites",
+        "OpaquePaths",
     ];
 
     public static readonly string[] KnownShapes =
     [
         "allocation-hotspot",
+        "allocation-fanout",
         "async-state-machine",
         "box-value-type",
         "capturing-delegate",
@@ -93,6 +109,9 @@ public sealed record PerformanceTriageOptions
         || Top.HasValue
         || Where.Length > 0
         || !string.IsNullOrWhiteSpace(OrderBy);
+
+    public bool IncludesAllocationFanout =>
+        Shapes.Contains("allocation-fanout", StringComparer.OrdinalIgnoreCase);
 
     public bool TryGetPredicates(out RowPredicate[] predicates, out string error)
     {
@@ -247,15 +266,16 @@ public sealed record PerformanceTriageOptions
             }
 
             if (op is RowOperator.GreaterOrEqual or RowOperator.LessOrEqual
-                && field is not ("RootReach" or "Confidence" or "Weight"))
+                && !IsNumericField(field)
+                && field is not ("Confidence" or "Weight"))
             {
                 error = $"Error: Field '{field}' supports only = and != predicates.";
                 return false;
             }
-            if (field == "RootReach"
-                && !int.TryParse(value, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out _))
+            if (IsNumericField(field)
+                && !long.TryParse(value, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out _))
             {
-                error = $"Error: Field 'RootReach' expects an integer value in --where predicate '{expression}'.";
+                error = $"Error: Field '{field}' expects an integer value in --where predicate '{expression}'.";
                 return false;
             }
             if (field is "Confidence" or "Weight" && !IsKnownConfidence(value))
@@ -301,6 +321,16 @@ public sealed record PerformanceTriageOptions
         => value.Equals("low", StringComparison.OrdinalIgnoreCase)
            || value.Equals("medium", StringComparison.OrdinalIgnoreCase)
            || value.Equals("high", StringComparison.OrdinalIgnoreCase);
+
+    internal static bool IsNumericField(string field)
+        => field is "RootReach"
+            or "DirectSites"
+            or "OncePaths"
+            or "ConditionalPaths"
+            or "RepeatedPaths"
+            or "UnknownPaths"
+            or "CachedSites"
+            or "OpaquePaths";
 
     static string? NormalizeField(string field, IReadOnlyList<string> knownFields)
     {

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -2009,7 +2009,7 @@ public static class ApiOutputFormatter
             ? type.Members.Where(m => m.MetadataToken is not null).Select(m => m.MetadataToken!.Value).ToHashSet()
             : null;
         var rows = LibraryMetadataService.FilterAndOrderTriageOpportunities(
-                index.OptimizationOpportunities
+                LibraryMetadataService.TriageOpportunities(index, options)
                     .Where(opportunity => SameType(opportunity.Method.DeclaringType, type))
                     .Where(opportunity => !LibraryMetadataService.IsGeneratedMethod(opportunity.Method, index.GeneratedFrameworkTypeNames))
                     .Where(opportunity => memberTokens is null || memberTokens.Contains(opportunity.Method.MetadataToken)),
@@ -2032,7 +2032,15 @@ public static class ApiOutputFormatter
                 opportunity.PathConfidence,
                 opportunity.PostDominance,
                 opportunity.ILOffset is { } offset ? MarkoutInline.Code($"IL_{offset:X4}") : null,
-                opportunity.Weight))
+                opportunity.Weight,
+                opportunity.DirectAllocationSites?.ToString(),
+                opportunity.OnceAllocationPaths?.ToString(),
+                opportunity.ConditionalAllocationPaths?.ToString(),
+                opportunity.RepeatedAllocationPaths?.ToString(),
+                opportunity.UnknownAllocationPaths?.ToString(),
+                opportunity.CachedAllocationSites?.ToString(),
+                opportunity.OpaqueCallPaths?.ToString(),
+                opportunity.AllocationCountSaturated ? "yes" : null))
             .ToList();
 
         if (rows.Count > 0 || explicitSections is not null && explicitSections.Contains(SectionNames.PerformanceTriage))

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -922,7 +922,22 @@ public record OptimizationOpportunityRow(
     [property: MarkoutPropertyName("Post Dominance")]
     [property: MarkoutSkipNull] string? PostDominance,
     [property: MarkoutSkipNull] string? IL,
-    [property: MarkoutSkipNull] string? Weight);
+    [property: MarkoutSkipNull] string? Weight,
+    [property: MarkoutPropertyName("Direct Sites")]
+    [property: MarkoutSkipNull] string? DirectSites,
+    [property: MarkoutPropertyName("Once Paths")]
+    [property: MarkoutSkipNull] string? OncePaths,
+    [property: MarkoutPropertyName("Conditional Paths")]
+    [property: MarkoutSkipNull] string? ConditionalPaths,
+    [property: MarkoutPropertyName("Repeated Paths")]
+    [property: MarkoutSkipNull] string? RepeatedPaths,
+    [property: MarkoutPropertyName("Unknown Paths")]
+    [property: MarkoutSkipNull] string? UnknownPaths,
+    [property: MarkoutPropertyName("Cached Sites")]
+    [property: MarkoutSkipNull] string? CachedSites,
+    [property: MarkoutPropertyName("Opaque Paths")]
+    [property: MarkoutSkipNull] string? OpaquePaths,
+    [property: MarkoutSkipNull] string? Saturated);
 
 [MarkoutSerializable]
 public record TopLeverageRow(

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -801,7 +801,15 @@ public class LibraryInspectionView
                 o.PathConfidence,
                 o.PostDominance,
                 o.IL is null ? null : MarkoutInline.Code(o.IL),
-                o.Weight))
+                o.Weight,
+                o.DirectSites?.ToString(),
+                o.OncePaths?.ToString(),
+                o.ConditionalPaths?.ToString(),
+                o.RepeatedPaths?.ToString(),
+                o.UnknownPaths?.ToString(),
+                o.CachedSites?.ToString(),
+                o.OpaquePaths?.ToString(),
+                o.Saturated))
             .ToList();
 
     public static bool TopLeverageVisibilityEmpty(List<TopLeverageRow>? rows) => rows is null || rows.All(r => string.IsNullOrEmpty(r.Visibility));


### PR DESCRIPTION
**Summary**
- Add an opt-in `allocation-fanout` Performance Triage shape that composes IL-visible allocation paths through exact intra-assembly calls.
- Separate direct, once, conditional, repeated, unknown, cached, and opaque quantities without claiming runtime bytes or frequency.
- Condense recursive SCCs so known component effects remain visible as `UnknownPaths` while recurrence remains opaque.
- Use the census to show that production pipeline creation exposes 28-53 once paths and that the #2605 registry spike improves successful plan execution, not registry construction.

**Measured cost**
Alternating 20-run process timings against `ILInspector.Analysis.dll` kept default Performance Triage at a 0.370 s median on both `origin/main` and this branch. Opting into `allocation-fanout` measured 0.400 s (+0.030 s, about 8%, including process startup). Default candidate rows and values were unchanged after excluding the new empty schema columns.

**Registry dogfood**
| Method/design | Direct sites | Once paths | Conditional paths | Cached sites | Opaque paths |
| --- | ---: | ---: | ---: | ---: | ---: |
| `LibrarySections.CreatePipeline` | 10 | 53 | 52 | 9 | 493 |
| Original spike `CreateCapabilityRegistry` | 1 | 9 | 7 | 1 | 79 |
| Revised spike `CreateCapabilityRegistry` | 1 | 10 | 14 | 1 | 84 |
| Original `CapabilitySession.ExecutePlanAsync` | 1 | 1 | 0 | 0 | 23 |
| Revised `CapabilityPlan.ExecuteAsync` | 3 | 0 | 2 | 0 | 14 |

**Local evidence**
- Release solution build
- `ILInspector.Analysis.Tests`: 456 passed
- `dotnet-inspect.Tests`: 1,876 passed, 10 tool-dependent skips
- NativeAOT publish (`osx-arm64`)
- markdownlint on all changed Markdown
- Final-head adversarial reviews: Claude Opus 4.8 CLEAN; Gemini 3.1 Pro CLEAN

Related to #2605 and #2733.