### PR TITLE
Bound structured soft candidate matching

### DIFF
--- a/docs/design/finding-nomenclature.md
+++ b/docs/design/finding-nomenclature.md
@@ -107,6 +107,12 @@ consumer fold. At threshold 100, soft candidates remain one `Added` and one
 `Removed`; an accepted soft candidate becomes `Changed` and retains its named
 tier and confidence through `FindingMatchProvenance`.
 
+For structured equality tiers, the matcher blocks on tier plus projected
+identity and summarizes each endpoint's degree without materializing all pairs
+inside a collision bucket. Only mutual degree-one endpoints survive. This keeps
+the false-positive discipline and runtime bound aligned: ambiguity costs input
+size, not the product of both residual streams.
+
 ## Sparse correlation and onset
 
 Neither correlation outcome traverses a version range. The caller chooses which

--- a/docs/design/finding-producers.md
+++ b/docs/design/finding-producers.md
@@ -138,6 +138,13 @@ becomes `Changed`; the default threshold of 100 remains exact-only. Accepted
 matched transitions retain `FindingMatchProvenance`, including tier and
 confidence.
 
+Structured equality tiers are blocked by tier and projected identity. Within
+each bucket the matcher computes only bounded endpoint-degree summaries, not
+the Cartesian candidate graph, then emits mutual degree-one pairs. Candidate
+construction is therefore linear in projected-key memberships even when a
+large collision bucket is wholly ambiguous. Future fuzzy/similarity tiers must
+add their own LSH blocking and explicit comparison cap before they land.
+
 Metadata's first soft tier is `api.member.extension-instance` at confidence 85.
 It projects structured method receiver, name, generic arity, return type, and
 non-receiver parameters while retaining extension/instance as the variant.

--- a/src/ILInspector.Findings/FindingKey.cs
+++ b/src/ILInspector.Findings/FindingKey.cs
@@ -3,8 +3,9 @@ using System.Collections.Immutable;
 namespace ILInspector.Findings;
 
 /// <summary>
-/// A named soft-correspondence tier. Confidence is below 100 by construction so the default
-/// acceptance threshold remains exact-only.
+/// A named soft-correspondence tier. <see cref="Id"/> uniquely names the tier and therefore its
+/// configured confidence; two projections with the same ID are not distinct tiers. Confidence is
+/// below 100 by construction so the default acceptance threshold remains exact-only.
 /// </summary>
 public sealed record FindingMatchTier
 {

--- a/src/ILInspector.Findings/FindingMatcher.cs
+++ b/src/ILInspector.Findings/FindingMatcher.cs
@@ -495,74 +495,39 @@ public static class FindingMatcher
         IReadOnlySet<int>? blockedOld = null,
         IReadOnlySet<int>? blockedNew = null)
     {
-        var newByProjection = new Dictionary<SoftProjectionKey, List<(int Index, FindingSoftKey Key)>>();
-        foreach (int newIndex in residualNew)
-        {
-            if (blockedNew?.Contains(newIndex) == true)
-                continue;
-
-            foreach (var softKey in newStream[newIndex].SoftKeys)
-            {
-                var projection = new SoftProjectionKey(
-                    softKey.Tier.Id,
-                    softKey.Tier.Confidence,
-                    softKey.IdentityKey);
-                if (!newByProjection.TryGetValue(projection, out var bucket))
-                    newByProjection.Add(projection, bucket = []);
-                bucket.Add((newIndex, softKey));
-            }
-        }
+        var oldBuckets = BuildSoftProjectionBuckets(oldStream, residualOld, blockedOld);
+        var newBuckets = BuildSoftProjectionBuckets(newStream, residualNew, blockedNew);
+        var oldCandidates = BuildEndpointCandidates(
+            oldStream,
+            residualOld,
+            blockedOld,
+            newBuckets);
+        var newCandidates = BuildEndpointCandidates(
+            newStream,
+            residualNew,
+            blockedNew,
+            oldBuckets);
 
         var candidates = new List<FindingSoftMatchCandidate>();
         foreach (int oldIndex in residualOld)
         {
-            if (blockedOld?.Contains(oldIndex) == true)
-                continue;
-
-            foreach (var oldSoftKey in oldStream[oldIndex].SoftKeys)
+            if (!oldCandidates[oldIndex].TryGetSingle(out int newIndex)
+                || !newCandidates[newIndex].TryGetSingle(out int candidateOldIndex)
+                || candidateOldIndex != oldIndex)
             {
-                var projection = new SoftProjectionKey(
-                    oldSoftKey.Tier.Id,
-                    oldSoftKey.Tier.Confidence,
-                    oldSoftKey.IdentityKey);
-                if (!newByProjection.TryGetValue(projection, out var newEntries))
-                    continue;
-
-                foreach (var (newIndex, newSoftKey) in newEntries)
-                {
-                    if (string.Equals(oldSoftKey.Variant, newSoftKey.Variant, StringComparison.Ordinal))
-                        continue;
-
-                    candidates.Add(new FindingSoftMatchCandidate(
-                        oldIndex,
-                        newIndex,
-                        new FindingMatchProvenance(oldSoftKey.Tier, oldSoftKey.Tier.Confidence)));
-                }
+                continue;
             }
-        }
 
-        // Multiple tiers may independently project the same pair. Keep only its strongest tier,
-        // then suppress every endpoint that still participates in more than one pair. Under-match
-        // is safer than choosing among ambiguous near misses.
-        var distinctPairs = candidates
-            .GroupBy(candidate => (candidate.OldIndex, candidate.NewIndex))
-            .Select(group => group
-                .OrderByDescending(candidate => candidate.Match.Confidence)
-                .ThenBy(candidate => candidate.Match.Tier.Id, StringComparer.Ordinal)
-                .First())
-            .ToArray();
-        var oldCounts = distinctPairs
-            .GroupBy(candidate => candidate.OldIndex)
-            .ToDictionary(group => group.Key, group => group.Count());
-        var newCounts = distinctPairs
-            .GroupBy(candidate => candidate.NewIndex)
-            .ToDictionary(group => group.Key, group => group.Count());
+            var match = FindStrongestSoftMatch(
+                oldStream[oldIndex].SoftKeys,
+                newStream[newIndex].SoftKeys);
+            if (match is not null)
+                candidates.Add(new FindingSoftMatchCandidate(oldIndex, newIndex, match));
+        }
 
         return
         [
-            .. distinctPairs
-                .Where(candidate => oldCounts[candidate.OldIndex] == 1)
-                .Where(candidate => newCounts[candidate.NewIndex] == 1)
+            .. candidates
                 .OrderByDescending(candidate => candidate.Match.Confidence)
                 .ThenBy(candidate => candidate.OldIndex)
                 .ThenBy(candidate => candidate.NewIndex),
@@ -573,6 +538,153 @@ public static class FindingMatcher
         string TierId,
         int Confidence,
         string IdentityKey);
+
+    static Dictionary<SoftProjectionKey, SoftProjectionBucket> BuildSoftProjectionBuckets(
+        FindingKey[] stream,
+        int[] residual,
+        IReadOnlySet<int>? blocked)
+    {
+        var buckets = new Dictionary<SoftProjectionKey, SoftProjectionBucket>();
+        foreach (int index in residual)
+        {
+            if (blocked?.Contains(index) == true)
+                continue;
+
+            foreach (var softKey in stream[index].SoftKeys)
+            {
+                var projection = ToProjectionKey(softKey);
+                if (!buckets.TryGetValue(projection, out var bucket))
+                    buckets.Add(projection, bucket = new SoftProjectionBucket());
+                bucket.Add(index, softKey.Variant);
+            }
+        }
+
+        return buckets;
+    }
+
+    static EndpointCandidateSet[] BuildEndpointCandidates(
+        FindingKey[] stream,
+        int[] residual,
+        IReadOnlySet<int>? blocked,
+        IReadOnlyDictionary<SoftProjectionKey, SoftProjectionBucket> oppositeBuckets)
+    {
+        var candidates = new EndpointCandidateSet[stream.Length];
+        foreach (int index in residual)
+        {
+            if (blocked?.Contains(index) == true)
+                continue;
+
+            foreach (var softKey in stream[index].SoftKeys)
+            {
+                if (!oppositeBuckets.TryGetValue(ToProjectionKey(softKey), out var bucket))
+                    continue;
+
+                int count = bucket.CountExcept(softKey.Variant);
+                if (count == 1)
+                    candidates[index].Add(bucket.SoleIndexExcept(softKey.Variant));
+                else if (count > 1)
+                    candidates[index].MarkAmbiguous();
+            }
+        }
+
+        return candidates;
+    }
+
+    static FindingMatchProvenance? FindStrongestSoftMatch(
+        ImmutableArray<FindingSoftKey> oldKeys,
+        ImmutableArray<FindingSoftKey> newKeys)
+    {
+        var newByProjection = new Dictionary<SoftProjectionKey, FindingSoftKey>();
+        foreach (var newKey in newKeys)
+            newByProjection.Add(ToProjectionKey(newKey), newKey);
+
+        FindingSoftKey? best = null;
+        foreach (var oldKey in oldKeys)
+        {
+            if (!newByProjection.TryGetValue(ToProjectionKey(oldKey), out var newKey)
+                || string.Equals(oldKey.Variant, newKey.Variant, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (best is null
+                || oldKey.Tier.Confidence > best.Tier.Confidence
+                || (oldKey.Tier.Confidence == best.Tier.Confidence
+                    && string.CompareOrdinal(oldKey.Tier.Id, best.Tier.Id) < 0))
+            {
+                best = oldKey;
+            }
+        }
+
+        return best is null
+            ? null
+            : new FindingMatchProvenance(best.Tier, best.Tier.Confidence);
+    }
+
+    static SoftProjectionKey ToProjectionKey(FindingSoftKey key)
+        => new(key.Tier.Id, key.Tier.Confidence, key.IdentityKey);
+
+    sealed class SoftProjectionBucket
+    {
+        readonly Dictionary<string, VariantAggregate> _variants =
+            new(StringComparer.Ordinal);
+        int _indexXor;
+
+        public int Count { get; private set; }
+
+        public void Add(int index, string variant)
+        {
+            Count++;
+            _indexXor ^= index;
+            _variants.TryGetValue(variant, out var aggregate);
+            _variants[variant] = new VariantAggregate(
+                aggregate.Count + 1,
+                aggregate.IndexXor ^ index);
+        }
+
+        public int CountExcept(string variant)
+            => Count - (_variants.TryGetValue(variant, out var aggregate)
+                ? aggregate.Count
+                : 0);
+
+        public int SoleIndexExcept(string variant)
+        {
+            _variants.TryGetValue(variant, out var aggregate);
+            return _indexXor ^ aggregate.IndexXor;
+        }
+    }
+
+    readonly record struct VariantAggregate(int Count, int IndexXor);
+
+    struct EndpointCandidateSet
+    {
+        int _index;
+        bool _hasCandidate;
+        bool _ambiguous;
+
+        public void Add(int index)
+        {
+            if (_ambiguous)
+                return;
+            if (!_hasCandidate)
+            {
+                _index = index;
+                _hasCandidate = true;
+            }
+            else if (_index != index)
+            {
+                _ambiguous = true;
+            }
+        }
+
+        public void MarkAmbiguous() => _ambiguous = true;
+
+        public readonly bool TryGetSingle(out int index)
+        {
+            index = _index;
+            return _hasCandidate && !_ambiguous;
+        }
+    }
 
     // Same construction and tiebreak as ILInspector.Instructions.IlBodyDiff so the committed
     // core reproduces the existing IL sequence diff exactly on move-free inputs.

--- a/src/ILInspector.Findings/FindingMatcher.cs
+++ b/src/ILInspector.Findings/FindingMatcher.cs
@@ -511,18 +511,17 @@ public static class FindingMatcher
         var candidates = new List<FindingSoftMatchCandidate>();
         foreach (int oldIndex in residualOld)
         {
-            if (!oldCandidates[oldIndex].TryGetSingle(out int newIndex)
-                || !newCandidates[newIndex].TryGetSingle(out int candidateOldIndex)
+            if (!oldCandidates[oldIndex].TryGetSingle(out int newIndex, out var tier)
+                || !newCandidates[newIndex].TryGetSingle(out int candidateOldIndex, out _)
                 || candidateOldIndex != oldIndex)
             {
                 continue;
             }
 
-            var match = FindStrongestSoftMatch(
-                oldStream[oldIndex].SoftKeys,
-                newStream[newIndex].SoftKeys);
-            if (match is not null)
-                candidates.Add(new FindingSoftMatchCandidate(oldIndex, newIndex, match));
+            candidates.Add(new FindingSoftMatchCandidate(
+                oldIndex,
+                newIndex,
+                new FindingMatchProvenance(tier, tier.Confidence)));
         }
 
         return
@@ -581,44 +580,15 @@ public static class FindingMatcher
 
                 int count = bucket.CountExcept(softKey.Variant);
                 if (count == 1)
-                    candidates[index].Add(bucket.SoleIndexExcept(softKey.Variant));
+                    candidates[index].Add(
+                        bucket.SoleIndexExcept(softKey.Variant),
+                        softKey.Tier);
                 else if (count > 1)
                     candidates[index].MarkAmbiguous();
             }
         }
 
         return candidates;
-    }
-
-    static FindingMatchProvenance? FindStrongestSoftMatch(
-        ImmutableArray<FindingSoftKey> oldKeys,
-        ImmutableArray<FindingSoftKey> newKeys)
-    {
-        var newByProjection = new Dictionary<SoftProjectionKey, FindingSoftKey>();
-        foreach (var newKey in newKeys)
-            newByProjection.Add(ToProjectionKey(newKey), newKey);
-
-        FindingSoftKey? best = null;
-        foreach (var oldKey in oldKeys)
-        {
-            if (!newByProjection.TryGetValue(ToProjectionKey(oldKey), out var newKey)
-                || string.Equals(oldKey.Variant, newKey.Variant, StringComparison.Ordinal))
-            {
-                continue;
-            }
-
-            if (best is null
-                || oldKey.Tier.Confidence > best.Tier.Confidence
-                || (oldKey.Tier.Confidence == best.Tier.Confidence
-                    && string.CompareOrdinal(oldKey.Tier.Id, best.Tier.Id) < 0))
-            {
-                best = oldKey;
-            }
-        }
-
-        return best is null
-            ? null
-            : new FindingMatchProvenance(best.Tier, best.Tier.Confidence);
     }
 
     static SoftProjectionKey ToProjectionKey(FindingSoftKey key)
@@ -661,8 +631,9 @@ public static class FindingMatcher
         int _index;
         bool _hasCandidate;
         bool _ambiguous;
+        FindingMatchTier? _tier;
 
-        public void Add(int index)
+        public void Add(int index, FindingMatchTier tier)
         {
             if (_ambiguous)
                 return;
@@ -670,18 +641,28 @@ public static class FindingMatcher
             {
                 _index = index;
                 _hasCandidate = true;
+                _tier = tier;
             }
             else if (_index != index)
             {
                 _ambiguous = true;
             }
+            else if (tier.Confidence > _tier!.Confidence
+                || (tier.Confidence == _tier.Confidence
+                    && string.CompareOrdinal(tier.Id, _tier.Id) < 0))
+            {
+                _tier = tier;
+            }
         }
 
         public void MarkAmbiguous() => _ambiguous = true;
 
-        public readonly bool TryGetSingle(out int index)
+        public readonly bool TryGetSingle(
+            out int index,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out FindingMatchTier? tier)
         {
             index = _index;
+            tier = _tier;
             return _hasCandidate && !_ambiguous;
         }
     }

--- a/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
@@ -542,6 +542,24 @@ public class FindingPilotTests
     static readonly FindingMatchTier FaintSoftTier = new("test.faint-role-change", 60);
 
     [Fact]
+    public void FindingKey_SoftTierIdUniquelyNamesItsConfidence()
+    {
+        Assert.Throws<ArgumentException>(() => new FindingKey(
+            "exact",
+            null,
+            [
+                new FindingSoftKey(
+                    new FindingMatchTier("same-tier", 85),
+                    "first",
+                    "extension"),
+                new FindingSoftKey(
+                    new FindingMatchTier("same-tier", 70),
+                    "second",
+                    "extension"),
+            ]));
+    }
+
+    [Fact]
     public void IdentitySet_Permutation_IsAllMatched_NoAddRemoveOrMove()
     {
         // Order is not semantic for a set: a permutation is a non-event, unlike the ordered matcher

--- a/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingPilotTests.cs
@@ -538,6 +538,8 @@ public class FindingPilotTests
 
     static readonly FindingMatchOptions IdentitySet = new() { MatchMode = FindingMatchMode.IdentitySet };
     static readonly FindingMatchTier SoftTier = new("test.role-change", 85);
+    static readonly FindingMatchTier WeakSoftTier = new("test.weak-role-change", 70);
+    static readonly FindingMatchTier FaintSoftTier = new("test.faint-role-change", 60);
 
     [Fact]
     public void IdentitySet_Permutation_IsAllMatched_NoAddRemoveOrMove()
@@ -609,6 +611,171 @@ public class FindingPilotTests
         Assert.Empty(match.SoftCandidates);
         Assert.Equal(2, Count(match, FindingEdgeKind.Removed));
         Assert.Equal(1, Count(match, FindingEdgeKind.Added));
+    }
+
+    [Fact]
+    public void IdentitySet_SoftTier_LargeCollisionBucketDoesNotMaterializeCandidateGraph()
+    {
+        const int count = 9000;
+        var old = Enumerable.Range(0, count)
+            .Select(index => SoftKey($"old-{index}", "shared", "extension"))
+            .ToArray();
+        var @new = Enumerable.Range(0, count)
+            .Select(index => SoftKey($"new-{index}", "shared", "instance"))
+            .ToArray();
+
+        var first = FindingMatcher.Match(old, @new, IdentitySet);
+        var second = FindingMatcher.Match(old, @new, IdentitySet);
+
+        Assert.Empty(first.SoftCandidates);
+        Assert.Equal(count, Count(first, FindingEdgeKind.Removed));
+        Assert.Equal(count, Count(first, FindingEdgeKind.Added));
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void IdentitySet_SoftTier_MultipleTiersForSamePairKeepStrongest()
+    {
+        var old = new FindingKey(
+            "old",
+            null,
+            [
+                new FindingSoftKey(WeakSoftTier, "weak", "extension"),
+                new FindingSoftKey(SoftTier, "strong", "extension"),
+            ]);
+        var @new = new FindingKey(
+            "new",
+            null,
+            [
+                new FindingSoftKey(WeakSoftTier, "weak", "instance"),
+                new FindingSoftKey(SoftTier, "strong", "instance"),
+            ]);
+
+        var candidate = Assert.Single(
+            FindingMatcher.Match([old], [@new], IdentitySet).SoftCandidates);
+
+        Assert.Equal(0, candidate.OldIndex);
+        Assert.Equal(0, candidate.NewIndex);
+        Assert.Equal(SoftTier, candidate.Match.Tier);
+    }
+
+    [Fact]
+    public void SoftTier_CompressedConstructionMatchesBruteForce()
+    {
+        var random = new Random(2585);
+        foreach (var options in (FindingMatchOptions[])[IdentitySet, FindingMatchOptions.Default])
+        {
+            for (int iteration = 0; iteration < 250; iteration++)
+            {
+                var old = RandomSoftKeys(random, random.Next(9));
+                var @new = RandomSoftKeys(random, random.Next(9));
+
+                var match = FindingMatcher.Match(old, @new, options);
+                var expected = BruteForceSoftCandidates(
+                    old,
+                    @new,
+                    match.Edges,
+                    match.MoveCandidates);
+
+                Assert.Equal(expected, match.SoftCandidates);
+            }
+        }
+    }
+
+    static FindingKey[] RandomSoftKeys(Random random, int count)
+    {
+        FindingMatchTier[] tiers = [SoftTier, WeakSoftTier, FaintSoftTier];
+        var keys = new FindingKey[count];
+        for (int index = 0; index < count; index++)
+        {
+            var softKeys = new List<FindingSoftKey>();
+            foreach (var tier in tiers)
+            {
+                if (random.Next(3) == 0)
+                    continue;
+                softKeys.Add(new FindingSoftKey(
+                    tier,
+                    $"projection-{random.Next(3)}",
+                    $"variant-{random.Next(3)}"));
+            }
+
+            keys[index] = new FindingKey(
+                $"exact-{random.Next(5)}",
+                null,
+                softKeys);
+        }
+
+        return keys;
+    }
+
+    static ImmutableArray<FindingSoftMatchCandidate> BruteForceSoftCandidates(
+        FindingKey[] old,
+        FindingKey[] @new,
+        ImmutableArray<FindingEdge> edges,
+        ImmutableArray<FindingMoveCandidate> moveCandidates)
+    {
+        var blockedOld = moveCandidates
+            .Select(candidate => candidate.OldIndex)
+            .ToHashSet();
+        var blockedNew = moveCandidates
+            .Select(candidate => candidate.NewIndex)
+            .ToHashSet();
+        var residualOld = edges
+            .Where(edge => edge.Kind == FindingEdgeKind.Removed)
+            .Select(edge => edge.OldIndex)
+            .Where(index => !blockedOld.Contains(index));
+        var residualNew = edges
+            .Where(edge => edge.Kind == FindingEdgeKind.Added)
+            .Select(edge => edge.NewIndex)
+            .Where(index => !blockedNew.Contains(index))
+            .ToArray();
+        var candidates = new List<FindingSoftMatchCandidate>();
+        foreach (int oldIndex in residualOld)
+        {
+            foreach (int newIndex in residualNew)
+            {
+                foreach (var oldKey in old[oldIndex].SoftKeys)
+                {
+                    foreach (var newKey in @new[newIndex].SoftKeys)
+                    {
+                        if (oldKey.Tier != newKey.Tier
+                            || !string.Equals(oldKey.IdentityKey, newKey.IdentityKey, StringComparison.Ordinal)
+                            || string.Equals(oldKey.Variant, newKey.Variant, StringComparison.Ordinal))
+                        {
+                            continue;
+                        }
+
+                        candidates.Add(new FindingSoftMatchCandidate(
+                            oldIndex,
+                            newIndex,
+                            new FindingMatchProvenance(oldKey.Tier, oldKey.Tier.Confidence)));
+                    }
+                }
+            }
+        }
+
+        var distinct = candidates
+            .GroupBy(candidate => (candidate.OldIndex, candidate.NewIndex))
+            .Select(group => group
+                .OrderByDescending(candidate => candidate.Match.Confidence)
+                .ThenBy(candidate => candidate.Match.Tier.Id, StringComparer.Ordinal)
+                .First())
+            .ToArray();
+        var oldCounts = distinct
+            .GroupBy(candidate => candidate.OldIndex)
+            .ToDictionary(group => group.Key, group => group.Count());
+        var newCounts = distinct
+            .GroupBy(candidate => candidate.NewIndex)
+            .ToDictionary(group => group.Key, group => group.Count());
+        return
+        [
+            .. distinct
+                .Where(candidate => oldCounts[candidate.OldIndex] == 1)
+                .Where(candidate => newCounts[candidate.NewIndex] == 1)
+                .OrderByDescending(candidate => candidate.Match.Confidence)
+                .ThenBy(candidate => candidate.OldIndex)
+                .ThenBy(candidate => candidate.NewIndex),
+        ];
     }
 
     [Fact]


### PR DESCRIPTION
Advances #2585 by closing the structured-soft-pass scaling gap before another tier lands.

## Change

- Replaces Cartesian soft-candidate materialization with exact-projection buckets and bounded endpoint-degree summaries.
- Emits only mutual degree-one pairs while preserving ambiguity suppression, exact/move dominance, strongest-tier provenance, and deterministic ordering.
- Carries strongest-tier provenance in endpoint state, so candidate construction is linear in projected-key memberships and allocations.
- Clarifies that a tier ID uniquely names its configured confidence; distinct IDs are distinct tiers.
- Keeps future fuzzy/similarity tiers gated on LSH blocking and an explicit comparison cap.

## Evidence

- A 9,000 × 9,000 shared-projection collision bucket completes without materializing its 81 million possible pairs and remains conservatively unmatched.
- 500 deterministic randomized cases compare compressed output to the prior brute-force candidate graph across both ordered and identity-set modes.
- Full `dotnet-inspect.slnx` Release build passes.
- `FindingPilotTests`: 66 passed.
- `MetadataFindingsTests`: 24 passed.
- Changed Finding design docs pass markdownlint.

## Adversarial review

- **Gemini first pass:** CLEAN.
- **MAI first pass:** identified per-accepted-pair projection dictionary churn. Fixed in `deed5e14` by retaining strongest-tier provenance directly in the bounded endpoint state.
- **Final contract pass:** a same-ID/different-confidence suggestion was not adopted because one ID names one semantic tier and confidence; `86ce540f` makes that invariant explicit and adds coverage.
- **Final head `86ce540f`: Gemini CLEAN; MAI CLEAN.**
