### PR TITLE
Add handle-direct member-body import front door + substrate design note

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Decompiler Inspection & Oracle](design/decompiler-inspection-oracle.md) | Unifies single-method inspection (dump/stages) with the corpus-wide fidelity check oracle; product-vs-tool scoping. |
 | [ReturnToSender: Fact-Planned Compile-Back Harness](design/fact-planned-compile-back-harness.md) | Spec for a fresh tools-side compile-back harness with fact-planned TypeProducer/TypePrinter shells. |
 | [Method Body Inspection](design/method-body-inspection.md) | Target service seam for shared `member` and `library --il-offset` method-body facts and coordinate inspection. |
+| [Member Body Substrate](design/member-body-substrate.md) | One base for skeleton/full/merged/diff body rendering: `ApiType` shape, `MemberAnchor` address, one scope, and `MemberBody`'s scalar (whole-body) and vector (offset-keyed) shapes. |
 | [NuGet API](design/nuget.md) | NuGet API endpoints used by the tool. |
 | [Version Resolution](design/version-resolution.md) | Package/platform version and cache behavior. |
 | [Assembly Inspection Query Model](design/assembly-inspection-query.md) | Target boundary where the CLI forms a query and the metadata/service layer resolves, opens, and returns the final shape (why the CLI should not hold a `PEReader`). |

--- a/docs/design/member-body-substrate.md
+++ b/docs/design/member-body-substrate.md
@@ -78,8 +78,9 @@ Two resolution paths, chosen by scope:
   the very `MetadataReader` the bodies are imported through, so
   `ApiMember.MetadataToken` is an *exact* `MethodDefinitionHandle` — no matching,
   no ambiguity. This is the primary address; the handle-direct front door
-  `IrImporter.Import(MetadataSource, TypeDefinitionHandle, MethodDefinitionHandle)`
-  imports straight from it.
+  `IrImporter.Import(MetadataSource, MethodDefinitionHandle)` imports straight
+  from it (the declaring type is derived from the handle, so the method and its
+  generic scope cannot be mispaired).
 - **Cross reader (surface from build A, bodies from build B).** Here tokens do
   not carry across, so members are matched by a *normalized* canonical
   signature. This is subtle and already solved: there are **two** anchor

--- a/docs/design/member-body-substrate.md
+++ b/docs/design/member-body-substrate.md
@@ -1,0 +1,248 @@
+# Member Body Substrate
+
+How the product renders a type and its member bodies through **one** base, so
+that skeleton source, full source, the merged IL+C# view, and the implementation
+diff are all projections of the same shape instead of four parallel stacks. This
+is a design note about the intended contract, not a tour of the current code. It
+records the layering, the addressing, the two body shapes, and the one open
+granularity decision, so the four experiences can be built against a settled
+base rather than converged after the fact.
+
+See [rendering-model.md](rendering-model.md) for how printed text becomes
+sections, [method-body-inspection.md](method-body-inspection.md) and
+[implementation-diff.md](implementation-diff.md) for two of the consumers,
+[decompiler-substrate.md](decompiler-substrate.md) for the raising layer the
+bodies come from, and [member-target-resolution.md](member-target-resolution.md)
+for how a member is named on the way in.
+
+## The problem
+
+Four experiences render member bodies, and today each carries its own stack:
+
+| Experience | Entry point | Body form |
+| --- | --- | --- |
+| Skeleton source | `CSharpTypePrinter.Print` | declarations, no bodies |
+| Full source | `TypeSourceComposer.Compose` | full C# bodies |
+| Merged IL + C# | `ResearchViews.RenderMixedCore` | C# spine, IL beneath |
+| Implementation diff | `ImplementationDiff.CompareMembers` | per-member C#/IL/source diff |
+
+They already agree on the bottom: every C# or IL body path calls
+`IrImporter.Import(MetadataSource, …) → IrFunction` and then projects it. But
+they disagree on everything above that — how a member is addressed, how a body
+is shaped, and whether facts (unsafe, throws, allocations) can select regions of
+a body. Three different member-addressing schemes funnel into one positional
+`(methodName, overloadIndex, publicOnly)` tuple and can *disagree* on which
+overload or visibility resolves. That disagreement is the fragmentation this
+substrate removes.
+
+## The layering
+
+The substrate respects the existing dependency direction — data flows **down**
+the arrows, nothing flows up:
+
+```text
+Research (aggregator)  ── merged view, diff
+   │
+Decompiler ── MemberBody, body text, offset-anchored rows
+   │
+CSharp ── ApiType shape, skeleton/full/mixed printer
+   │
+Metadata ── ApiType/ApiMember, MemberAnchor, cheap shape facts
+   │
+Analysis ── offset-keyed body facts (unsafe, throws, allocations)
+```
+
+The consequence that pins the design: **CSharp owns the type shape and the
+printer; Decompiler owns body text.** CSharp never references Decompiler, so it
+cannot decompile — it *consumes* body data (`CSharpMemberBody`) that Decompiler
+hands down. That is why a mix of skeletal and full-bodied members is a Decompiler
+concern (it supplies the bodies) while the *shape* and *member subset* are a
+CSharp concern (it owns `ApiType` and the printer). Analysis sits to the side of
+Decompiler: it derives body-level facts (`MethodSignals.Unsafe`, throw sites,
+allocation offsets) directly over `Instructions` + `ControlFlow` without the
+Decompiler, so "which members/regions are unsafe" is answerable cheaply, before
+any IR import.
+
+## Address: identity, not an ordinal
+
+Every experience addresses a member, and the substrate replaces the positional
+`(methodName, overloadIndex, publicOnly)` tuple — recomputed independently in
+`TypeSourceComposer`, `CSharpBodyDiff.CreateMethodEntry`, and `ResearchViews`,
+where the recomputations can drift — with a stable identity address. Member
+**selection** (which members to render) is therefore an identity filter over
+`ApiType.Members`, never an index.
+
+Two resolution paths, chosen by scope:
+
+- **Same reader (the substrate's normal case).** The surface is extracted from
+  the very `MetadataReader` the bodies are imported through, so
+  `ApiMember.MetadataToken` is an *exact* `MethodDefinitionHandle` — no matching,
+  no ambiguity. This is the primary address; the handle-direct front door
+  `IrImporter.Import(MetadataSource, TypeDefinitionHandle, MethodDefinitionHandle)`
+  imports straight from it.
+- **Cross reader (surface from build A, bodies from build B).** Here tokens do
+  not carry across, so members are matched by a *normalized* canonical
+  signature. This is subtle and already solved: there are **two** anchor
+  spellings — the API-flavored `MemberAnchor` from `ApiMemberIdentity`
+  (`int`, `object?`, `IReadOnlyList<string>`) and the metadata-flavored anchor
+  from `CreateMethodAnchor` (`System.Int32`, `System.Object`,
+  `IReadOnlyList` with an arity tick) — and **their fingerprints do not match**.
+  The reconciling bridge is `ResearchMemberIdentity.BodyMemberIdentity`, which
+  normalizes the surface spelling to the metadata spelling (`ParameterPrimitiveName`,
+  strip nullable `?`, `out`/`ref` → `&`, `Foo<T>` → `` Foo`1<T> ``) so a surface
+  member and a metadata method produce the *same* `StableSelector`.
+  `ImplementationDiff`/`ResearchDiff` already resolve members this way; the
+  substrate reuses that bridge rather than comparing raw `MemberAnchor`
+  fingerprints, which would silently never match across the two spelling worlds.
+
+`ImplementationDiff` already takes a `MethodDefinitionHandle`; the substrate
+makes handle addressing the rule and the two paths above the only way to obtain
+one.
+
+## Scope: one load per type
+
+The addressable unit lives in a scope. `MetadataSource : IDisposable` is that
+scope: it loads the PE once and builds its type maps once (`EnsureTypeMaps`),
+and `Compose` already reuses it across every member of a type. The substrate
+formalizes it: open a scope per type (a `TypeAnchor`), resolve each selected
+`MemberAnchor` to a handle within it, and import bodies through the one scope —
+never load the assembly per member.
+
+## Shape: `MemberBody`, scalar and vector
+
+`MemberBody` is the printable unit: an `IrFunction` over a `MetadataSource`
+scope, addressed by a `MemberAnchor`. It exposes **two** shapes, and the choice
+between them is the whole design.
+
+### Scalar — no offsets
+
+> "Just give me everything, IL or C#."
+
+```csharp
+string Print(BodyLanguage language)   // skeleton | full C# | full IL
+```
+
+A whole body in one language, with no offset axis. This is the cheap, common
+case: skeleton declarations, full source, a single IL dump. Skeleton is the
+degenerate scalar where the body is empty.
+
+### Vector — offset-keyed
+
+The vector is a sequence of rows on the **IL-offset axis**. It generalizes the
+row that already exists — `FactRow(Member, ILOffset, CSharpLine, Anchor,
+Category, Id, Detail, Conditionality)` in `ResearchViews` — from carrying only
+fact metadata to also carrying the C# and IL text for that offset:
+
+```csharp
+BodyRow { IlOffsetRange Range; string? CSharp; IReadOnlyList<string> Il; IReadOnlyList<Fact> Facts; }
+IReadOnlyList<BodyRow> Rows { get; }
+```
+
+A row is the **join of three offset-keyed streams**, all of which exist today:
+
+| Stream | Source | Offset carrier |
+| --- | --- | --- |
+| C# statements | `CSharpPrinter.PrintRaised(out statementLines)` | `IrNode.SourceOffset` |
+| IL instructions | `IlProjection.AnnotatedInstrLines(…)` | instruction `.Offset` |
+| Facts | `MethodSignals`, annotations | `EvidenceOffsets`, `SourceOffset` |
+
+The join engine also exists: `AnnotationAnchor.ComputeSpans` buckets any
+offset-keyed item onto the owning C# statement **by IL-offset range**, not exact
+match. That is what lets the three streams line up on one axis.
+
+Because the axis is shared, **every view is `filter → render` over the vector**:
+
+| View | Operation |
+| --- | --- |
+| Merged IL + C# (interleave) | render C# + IL columns per row (today's `RenderMixedCore`) |
+| Single language | render one column across all rows |
+| Body subset — "just the unsafe blocks" | keep rows where `offset ∈ MethodSignals.Evidence` and `Unsafe` |
+| Body subset — "where exception X is thrown" | keep rows whose span contains a `Throw` (`IrNodes.cs`) whose operand type is X |
+| Implementation diff | pair rows across two vectors and render deltas |
+
+Interleave is therefore *one* vector view, not the point of the vector. The
+offset axis is a general join key; that is why it must be **first-class /
+co-equal** rather than "C# spine with IL overlays." The scalar shape is the
+deliberate opt-out of the axis for the cheap whole-body case.
+
+## Member subset vs body subset
+
+The two filtering granularities are symmetric and use different tiers of fact:
+
+- **Member subset** — which `ApiMember`s to render. An identity filter at the
+  type level. It can use **method-level** facts (`MethodSignals.Unsafe`,
+  `ExceptionTypes`, `Throws`) as a cheap pre-filter so "show every unsafe block
+  in the type" does not import IR for members that cannot match.
+- **Body subset** — which rows within a member. An offset-predicate at the body
+  level. It needs **site-level** facts (`EvidenceOffsets`, the `Throw` node's
+  operand type) to pick individual rows.
+
+## The one open decision
+
+The two-tier fact granularity above is the single point to nail before writing
+the vector's filter signature: method-level facts are cheap and answer *does
+this member qualify at all*, while site-level facts require the IR and answer
+*which rows*. The contract should make the method-level pre-filter explicit so
+that a type-wide body-subset query (e.g. every `localloc` in an assembly) does
+not decompile every member to discover most do not qualify. Everything else in
+this note is settled; this is the knob that changes the public filter shape.
+
+## Shape facts owed by the layers below
+
+Two Metadata/Analysis facts feed the shape and should be sourced from their
+cheapest home rather than recovered from print. Both are **body-gated
+modifiers** — they belong on a member only when a body is emitted, and are
+sourced from Metadata/Analysis, not from the printed text:
+
+- **async / iterator** — sourced from `[AsyncStateMachine]` /
+  `MethodImplAttributes.Async`, classified by
+  `MethodClassificationScanner.ClassifyAsyncMethod` (**Metadata**). `async` is
+  *not* part of an API surface — a caller cannot observe it, and reference
+  assemblies strip it — so the **skeleton/surface** path deliberately omits it,
+  and `ApiMember.IsAsync` (`ApiSurface.cs`) is intentionally left unpopulated
+  there. It matters only on the **full-body** path, and today that path derives
+  the modifier from the printed body rather than from metadata, which has two
+  problems the substrate fixes:
+  - **Signal inconsistency.** `TypeSourceComposer` forces `async` from
+    `ContainsAwaitExpression` alone, while `ApiOutputFormatter` uses
+    `ContainsAwaitExpression || RequiresAsyncBodyModifier`. The latter (set by
+    `ClassicAsyncReconstructionPass`) catches classic-async methods with no
+    reachable `await`; the composer drops `async` on them.
+  - **Runtime async is not reconstructed at all.** For runtime-async methods
+    (`MethodImplAttributes.Async`, no compiler state machine — the shape the
+    preview SDK emitted for the probe fixture, distinct from the classic
+    compiler state-machine async that remains the language default), *neither*
+    signal is set — the reconstruction pass only handles classic state-machine
+    async. Verified: composing an `async Task`/`async Task<int>` fixture built
+    with the preview SDK renders the methods **without** `async` and exposes the
+    raw `AsyncHelpers.UnsafeAwaitAwaiter<...>` lowering instead of `await`.
+    Recovering runtime async is a decompiler raise in its own right (full A/B +
+    adversarial discipline), tracked separately from this substrate as
+    [#2742](https://github.com/richlander/dotnet-inspect/issues/2742).
+
+  The substrate's contract is that this modifier is a **Metadata classification
+  fact applied only when the body policy emits a body**, so the surface path is
+  unchanged and both full-body renderers agree — but the runtime-async *body*
+  fidelity gap is upstream of that contract and out of its scope.
+- **body-only unsafe** (`localloc`, `calli`, pointer deref) — from
+  `MethodSignals.Unsafe` (**Analysis**), no Decompiler. Signature-only unsafe is
+  already set on `ApiMember.IsUnsafe`. Same body-gating applies: the `unsafe`
+  context is a body concern, forced by the composer today
+  (`RequiresUnsafeMemberContext`).
+
+## What lands where
+
+| Layer | Adds |
+| --- | --- |
+| Metadata | keep identity addressing the rule (`MetadataToken` same-reader, `ResearchMemberIdentity` cross-reader); expose async classification for the body path |
+| Analysis | expose offset-keyed body facts (unsafe/throw/alloc) for filtering |
+| CSharp | `ApiType` shape + printer; identity-addressed member subset; carry async/unsafe flags on `CSharpMemberBody` |
+| Decompiler | `MemberBody` (scalar `Print` + vector `Rows`) over a `MetadataSource` scope; collapse `TypeSourceComposer`'s duplicate declaration rendering onto the CSharp printer |
+| Research | re-express `RenderMixedCore` and `ImplementationDiff` as vector views |
+
+The end state: **shape** (`ApiType` / `ApiMember`, fact-enriched) → **address**
+(identity: `MetadataToken` same-reader, normalized `ResearchMemberIdentity`
+cross-reader) → **scope** (`MetadataSource`, one load) → **`MemberBody`**
+(scalar `Print`, vector `Rows`) → **views** (skeleton, full, interleaved,
+subsetted, diff), with Analysis facts joining on the offset axis. No experience
+owns a body stack of its own.

--- a/src/ILInspector.Decompiler.Tests/IrImporterHandleAddressingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterHandleAddressingTests.cs
@@ -8,7 +8,7 @@ using ILInspector.MetadataPrimitives;
 namespace ILInspector.Decompiler.Tests;
 
 /// <summary>
-/// The handle-direct <see cref="IrImporter.Import(MetadataSource, TypeDefinitionHandle, MethodDefinitionHandle)"/>
+/// The handle-direct <see cref="IrImporter.Import(MetadataSource, MethodDefinitionHandle)"/>
 /// front door — the canonical addressing the member-body substrate builds on —
 /// must resolve to the same body the by-name/overload-index front door does for
 /// the same method. These tests prove that equivalence broadly over a real
@@ -45,7 +45,7 @@ public class IrImporterHandleAddressingTests
                 ordinals[name] = ordinal + 1;
 
                 var byName = Render(IrImporter.Import(source, typeFullName, name, ordinal, publicOnly: false));
-                var byHandle = Render(IrImporter.Import(source, typeDefHandle, methodHandle));
+                var byHandle = Render(IrImporter.Import(source, methodHandle));
 
                 Assert.Equal(byName, byHandle);
                 compared++;
@@ -82,13 +82,26 @@ public class IrImporterHandleAddressingTests
             if (reader.GetString(method.Name) != nameof(InterleavedVisibilityOverloads.Marker))
                 continue;
 
-            var body = Render(IrImporter.Import(source, typeDefHandle, methodHandle));
+            var body = Render(IrImporter.Import(source, methodHandle));
             Assert.NotNull(body);
             bodies.Add(body!);
         }
 
         Assert.Equal(3, bodies.Count);
         Assert.Equal(3, new HashSet<string>(bodies).Count);
+    }
+
+    [Fact]
+    public void HandleDirect_NullSource_ReturnsCrashFunction_NeverThrows()
+    {
+        // No-crash guarantee parity with the by-name front door: a null/faulted
+        // source must surface as a diagnosed crash function, not an escaping throw
+        // (the reader is read inside the try for exactly this reason). Passing a
+        // null source reproduces the fault before the handle is ever dereferenced.
+        var crash = IrImporter.Import(null!, default(MethodDefinitionHandle));
+
+        Assert.NotNull(crash);
+        Assert.Contains(crash!.Diagnostics, d => d.Id == DiagnosticIds.InternalError);
     }
 
     [Fact]
@@ -121,7 +134,6 @@ public class IrImporterHandleAddressingTests
 
                 var methodHandle = (MethodDefinitionHandle)handle;
                 var method = reader.GetMethodDefinition(methodHandle);
-                var typeHandle = method.GetDeclaringType();
 
                 // The token points at the right method: its metadata name matches
                 // the member (constructors carry the metadata name ".ctor").
@@ -131,7 +143,7 @@ public class IrImporterHandleAddressingTests
 
                 // Handle-direct import yields a body exactly when the method has IL.
                 bool hasBody = method.RelativeVirtualAddress != 0;
-                var imported = IrImporter.Import(source, typeHandle, methodHandle);
+                var imported = IrImporter.Import(source, methodHandle);
                 Assert.Equal(hasBody, imported is not null);
 
                 resolved++;

--- a/src/ILInspector.Decompiler.Tests/IrImporterHandleAddressingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterHandleAddressingTests.cs
@@ -1,0 +1,198 @@
+using System.Collections.Generic;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The handle-direct <see cref="IrImporter.Import(MetadataSource, TypeDefinitionHandle, MethodDefinitionHandle)"/>
+/// front door — the canonical addressing the member-body substrate builds on —
+/// must resolve to the same body the by-name/overload-index front door does for
+/// the same method. These tests prove that equivalence broadly over a real
+/// assembly and on the interleaved-visibility overload shape the positional
+/// <c>publicOnly</c> index is fragile against.
+/// </summary>
+public class IrImporterHandleAddressingTests
+{
+    static string? Render(IrFunction? function)
+        => function is null ? null : CSharpPrinter.PrintRaised(function).Output;
+
+    [Fact]
+    public void HandleDirect_MatchesByName_AcrossRealAssembly()
+    {
+        var source = MetadataSource.Open(typeof(AllocSampleClass).Assembly.Location);
+        var reader = source.Reader;
+
+        int compared = 0;
+        int bodies = 0;
+        foreach (var typeDefHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeDefHandle);
+            string typeFullName = reader.GetFullTypeName(typeDef);
+
+            // The by-name front door counts every same-name overload in metadata
+            // order at publicOnly:false, so the ordinal for a handle is the number
+            // of same-name methods that precede it.
+            var ordinals = new Dictionary<string, int>(System.StringComparer.Ordinal);
+            foreach (var methodHandle in typeDef.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                string name = reader.GetString(method.Name);
+                int ordinal = ordinals.TryGetValue(name, out var seen) ? seen : 0;
+                ordinals[name] = ordinal + 1;
+
+                var byName = Render(IrImporter.Import(source, typeFullName, name, ordinal, publicOnly: false));
+                var byHandle = Render(IrImporter.Import(source, typeDefHandle, methodHandle));
+
+                Assert.Equal(byName, byHandle);
+                compared++;
+                if (byHandle is not null)
+                    bodies++;
+            }
+        }
+
+        Assert.True(compared > 100, $"expected a broad sweep, only compared {compared} methods");
+        Assert.True(bodies > 0, "expected at least one method with a body");
+    }
+
+    [Fact]
+    public void HandleDirect_SelectsCorrectOverload_WhenPublicAndPrivateInterleave()
+    {
+        var source = MetadataSource.Open(typeof(InterleavedVisibilityOverloads).Assembly.Location);
+        var reader = source.Reader;
+
+        var typeDefHandle = System.Linq.Enumerable.Single(
+            reader.TypeDefinitions,
+            h => reader.GetFullTypeName(reader.GetTypeDefinition(h))
+                == typeof(InterleavedVisibilityOverloads).FullName);
+        var typeDef = reader.GetTypeDefinition(typeDefHandle);
+
+        // Each Marker() overload returns a distinct literal, so the rendered body
+        // identifies which method was resolved. Import each by its own handle; the
+        // three bodies must all be present and distinct — proving handle-direct
+        // addressing reaches the private overload interleaved between the public
+        // ones, which a publicOnly index would skip or misplace.
+        var bodies = new List<string>();
+        foreach (var methodHandle in typeDef.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (reader.GetString(method.Name) != nameof(InterleavedVisibilityOverloads.Marker))
+                continue;
+
+            var body = Render(IrImporter.Import(source, typeDefHandle, methodHandle));
+            Assert.NotNull(body);
+            bodies.Add(body!);
+        }
+
+        Assert.Equal(3, bodies.Count);
+        Assert.Equal(3, new HashSet<string>(bodies).Count);
+    }
+
+    [Fact]
+    public void MetadataToken_ResolvesExactHandle_ForSurfaceMethodMembers()
+    {
+        // The substrate's same-reader address is ApiMember.MetadataToken: because
+        // the surface is extracted from the same reader the bodies import through,
+        // the token is an exact MethodDefinitionHandle. This proves that primitive
+        // end-to-end over a real surface — every method-bearing member's token
+        // points at a method whose metadata name matches the member, and the
+        // handle-direct import produces a body exactly when the method has IL.
+        string path = typeof(AllocSampleClass).Assembly.Location;
+        var surface = AssemblyReader.ExtractApiSurface(path, includeAll: true);
+        Assert.NotNull(surface);
+
+        var source = MetadataSource.Open(path);
+        var reader = source.Reader;
+
+        int resolved = 0;
+        foreach (var type in surface!.Types)
+        {
+            foreach (var member in type.Members)
+            {
+                if (member.MetadataToken is not int token)
+                    continue;
+
+                var handle = MetadataTokens.EntityHandle(token);
+                if (handle.Kind != HandleKind.MethodDefinition)
+                    continue;
+
+                var methodHandle = (MethodDefinitionHandle)handle;
+                var method = reader.GetMethodDefinition(methodHandle);
+                var typeHandle = method.GetDeclaringType();
+
+                // The token points at the right method: its metadata name matches
+                // the member (constructors carry the metadata name ".ctor").
+                string metadataName = reader.GetString(method.Name);
+                string expectedName = member.Kind == "constructor" ? ".ctor" : member.Name;
+                Assert.Equal(expectedName, metadataName);
+
+                // Handle-direct import yields a body exactly when the method has IL.
+                bool hasBody = method.RelativeVirtualAddress != 0;
+                var imported = IrImporter.Import(source, typeHandle, methodHandle);
+                Assert.Equal(hasBody, imported is not null);
+
+                resolved++;
+            }
+        }
+
+        Assert.True(resolved > 20, $"expected a broad sweep, only resolved {resolved} members");
+    }
+
+    [Fact]
+    public void SurfaceAndMetadataAnchors_UseDistinctSpellings()
+    {
+        // Characterization guard: the API-flavored surface anchor (GetMemberAnchor,
+        // int/object?/generic-<>) and the metadata-flavored anchor (CreateMethodAnchor,
+        // System.Int32/generic-`n) are DELIBERATELY distinct spelling spaces whose
+        // fingerprints do not cross-match. The substrate must NOT resolve cross-reader
+        // members by comparing these raw fingerprints; it uses MetadataToken
+        // (same-reader) or the normalizing ResearchMemberIdentity bridge instead.
+        // This test pins that drift so a future "unification" that silently makes the
+        // two fingerprints equal (or diverge differently) is caught.
+        string path = typeof(AllocSampleClass).Assembly.Location;
+        var surface = AssemblyReader.ExtractApiSurface(path, includeAll: true);
+        Assert.NotNull(surface);
+
+        var source = MetadataSource.Open(path);
+        var reader = source.Reader;
+
+        int spellingDivergences = 0;
+        foreach (var type in surface!.Types)
+        {
+            foreach (var member in type.Members)
+            {
+                if (member.MetadataToken is not int token)
+                    continue;
+
+                var handle = MetadataTokens.EntityHandle(token);
+                if (handle.Kind != HandleKind.MethodDefinition)
+                    continue;
+
+                var method = reader.GetMethodDefinition((MethodDefinitionHandle)handle);
+                var typeHandle = method.GetDeclaringType();
+
+                MemberAnchor surfaceAnchor = ApiMemberIdentity.GetMemberAnchor(type, member);
+                MemberAnchor metadataAnchor = ApiMemberIdentity.CreateMethodAnchor(
+                    reader, typeHandle, method, member.IsExtension);
+
+                if (surfaceAnchor.CanonicalSignature != metadataAnchor.CanonicalSignature)
+                    spellingDivergences++;
+            }
+        }
+
+        Assert.True(
+            spellingDivergences > 0,
+            "expected the API-flavored and metadata-flavored anchor spellings to diverge; " +
+            "if they now agree, the substrate's cross-reader resolution assumptions must be revisited");
+    }
+}
+
+public class InterleavedVisibilityOverloads
+{
+    public int Marker() => 10;
+    private int Marker(int a) => 20 + a;
+    public int Marker(int a, int b) => 30 + a + b;
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -142,10 +142,52 @@ public static class IrImporter
     }
 
     /// <summary>
+    /// Imports a method body addressed directly by its
+    /// <see cref="MethodDefinitionHandle"/> within <paramref name="typeDefHandle"/>
+    /// — the canonical addressing the member-body substrate uses. A caller that
+    /// holds a handle (resolved from an <c>ApiMember.MetadataToken</c> same-reader,
+    /// or a <c>MemberAnchor</c> match cross-reader) avoids the by-name overload's
+    /// positional <c>overloadIndex</c>/<c>publicOnly</c> selection, which cannot
+    /// distinguish overloads that differ only by visibility ordering. Carries the
+    /// same no-crash guarantee as the by-name front door: any importer bug or
+    /// malformed-metadata read surfaces as a diagnosed crash function, never a
+    /// thrown exception. Returns <see langword="null"/> for a bodyless method
+    /// (abstract/extern/interface, RVA 0), matching the by-name overload.
+    /// </summary>
+    public static IrFunction? Import(MetadataSource source, TypeDefinitionHandle typeDefHandle, MethodDefinitionHandle methodHandle)
+    {
+        var reader = source.Reader;
+        try
+        {
+            var typeDef = reader.GetTypeDefinition(typeDefHandle);
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (method.RelativeVirtualAddress == 0)
+                return null;
+            return Build(source, MethodImporter.Import(source, typeDefHandle, methodHandle), CallerScope(reader, typeDef, method));
+        }
+        catch (Exception ex)
+        {
+            return CrashFunction(SafeName(reader, methodHandle), SafeTypeName(reader, typeDefHandle), ex);
+        }
+    }
+
+    static string SafeName(MetadataReader reader, MethodDefinitionHandle handle)
+    {
+        try { return reader.GetString(reader.GetMethodDefinition(handle).Name); }
+        catch { return "<method>"; }
+    }
+
+    static string SafeTypeName(MetadataReader reader, TypeDefinitionHandle handle)
+    {
+        try { return reader.GetFullTypeName(reader.GetTypeDefinition(handle)); }
+        catch { return "<type>"; }
+    }
+
+    /// <summary>
     /// Every same-name overload on the type, in metadata order, with its decoded
     /// signature and whether it carries an IL body. The harness uses this to
     /// disambiguate <c>--dump</c> when a name resolves to more than one method —
-    /// the index lines up 1:1 with the <c>overloadIndex</c> of <see cref="Import"/>.
+    /// the index lines up 1:1 with the <c>overloadIndex</c> of <see cref="Import(MetadataSource, string, string, int, bool)"/>.
     /// Returns an empty list when the type or name is not found.
     /// </summary>
     public static IReadOnlyList<OverloadInfo> Overloads(MetadataSource source, string typeFullName, string methodName)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -143,31 +143,39 @@ public static class IrImporter
 
     /// <summary>
     /// Imports a method body addressed directly by its
-    /// <see cref="MethodDefinitionHandle"/> within <paramref name="typeDefHandle"/>
-    /// — the canonical addressing the member-body substrate uses. A caller that
-    /// holds a handle (resolved from an <c>ApiMember.MetadataToken</c> same-reader,
-    /// or a <c>MemberAnchor</c> match cross-reader) avoids the by-name overload's
-    /// positional <c>overloadIndex</c>/<c>publicOnly</c> selection, which cannot
-    /// distinguish overloads that differ only by visibility ordering. Carries the
-    /// same no-crash guarantee as the by-name front door: any importer bug or
+    /// <see cref="MethodDefinitionHandle"/> — the canonical addressing the
+    /// member-body substrate uses. A caller that holds a handle (resolved from an
+    /// <c>ApiMember.MetadataToken</c> same-reader, or a <c>MemberAnchor</c> match
+    /// cross-reader) avoids the by-name overload's positional
+    /// <c>overloadIndex</c>/<c>publicOnly</c> selection, which cannot distinguish
+    /// overloads that differ only by visibility ordering. The declaring type is
+    /// derived from the handle (<see cref="MethodDefinition.GetDeclaringType"/>),
+    /// so the method and its generic scope cannot be mispaired. Carries the same
+    /// no-crash guarantee as the by-name front door: any importer bug or
     /// malformed-metadata read surfaces as a diagnosed crash function, never a
     /// thrown exception. Returns <see langword="null"/> for a bodyless method
     /// (abstract/extern/interface, RVA 0), matching the by-name overload.
     /// </summary>
-    public static IrFunction? Import(MetadataSource source, TypeDefinitionHandle typeDefHandle, MethodDefinitionHandle methodHandle)
+    public static IrFunction? Import(MetadataSource source, MethodDefinitionHandle methodHandle)
     {
-        var reader = source.Reader;
+        // Read the reader inside the try so a null/faulted source surfaces as a
+        // diagnosed crash function too, at parity with the by-name front door.
+        MetadataReader? reader = null;
         try
         {
-            var typeDef = reader.GetTypeDefinition(typeDefHandle);
+            reader = source.Reader;
             var method = reader.GetMethodDefinition(methodHandle);
+            var typeDefHandle = method.GetDeclaringType();
+            var typeDef = reader.GetTypeDefinition(typeDefHandle);
             if (method.RelativeVirtualAddress == 0)
                 return null;
             return Build(source, MethodImporter.Import(source, typeDefHandle, methodHandle), CallerScope(reader, typeDef, method));
         }
         catch (Exception ex)
         {
-            return CrashFunction(SafeName(reader, methodHandle), SafeTypeName(reader, typeDefHandle), ex);
+            return reader is null
+                ? CrashFunction("<method>", "<type>", ex)
+                : CrashFunction(SafeName(reader, methodHandle), SafeTypeName(reader, methodHandle), ex);
         }
     }
 
@@ -177,9 +185,9 @@ public static class IrImporter
         catch { return "<method>"; }
     }
 
-    static string SafeTypeName(MetadataReader reader, TypeDefinitionHandle handle)
+    static string SafeTypeName(MetadataReader reader, MethodDefinitionHandle handle)
     {
-        try { return reader.GetFullTypeName(reader.GetTypeDefinition(handle)); }
+        try { return reader.GetFullTypeName(reader.GetTypeDefinition(reader.GetMethodDefinition(handle).GetDeclaringType())); }
         catch { return "<type>"; }
     }
 


### PR DESCRIPTION
## Summary

First brick of the **member-body substrate** (`docs/design/member-body-substrate.md`): a handle-direct front door that addresses a method body by its `MethodDefinitionHandle`, retiring the fragile positional `(methodName, overloadIndex, publicOnly)` address the four body-rendering surfaces (skeleton source, full source, merged IL+C#, implementation diff) recompute independently.

Additive only — **no product caller is migrated, so no rendered output changes.** Render A/B is therefore N/A to this step.

## What lands

- **`IrImporter.Import(MetadataSource, MethodDefinitionHandle)`** — factored from the by-name overload's core (`Build(source, MethodImporter.Import(...), CallerScope(...))`), so it is equivalent *by construction*. The declaring type is derived from the handle (`MethodDefinition.GetDeclaringType()`), so the method and its generic scope cannot be mispaired. Preserves the `RVA==0 → null` bodyless guard and the no-crash guarantee (importer/malformed-metadata faults surface as a diagnosed crash function, never a throw).
- **`IrImporterHandleAddressingTests`** (5 tests) —
  - handle-direct == by-name across a real assembly (>100 methods);
  - correct resolution on an interleaved public/private overload shape the positional `publicOnly` index is fragile against;
  - `ApiMember.MetadataToken` resolves an exact handle (body iff `RVA≠0`);
  - null-source → diagnosed crash function, never a throw;
  - characterization pinning that the API-flavored (`GetMemberAnchor`) and metadata-flavored (`CreateMethodAnchor`) anchor spellings are **distinct** and must not be cross-matched.
- **`docs/design/member-body-substrate.md`** — the substrate contract (layering, address, scope, scalar/vector `MemberBody`, member-vs-body subset, the one open granularity decision). The *Address* section records that same-reader resolution uses `ApiMember.MetadataToken` and cross-reader uses the normalizing `ResearchMemberIdentity` bridge — **not** raw `MemberAnchor` fingerprints, which never match across the two spelling worlds.

## Design finding baked into the note

A probe test disproved the initial "one canonical `MemberAnchor` resolves directly to a handle" premise: the API-flavored anchor (`int`, `object?`, `IReadOnlyList<string>`) and the metadata-flavored anchor (`System.Int32`, `` IReadOnlyList`1<...> ``) produce fingerprints that never cross-match. The reconciling bridge that `ImplementationDiff`/`ResearchDiff` already use is `ResearchMemberIdentity.BodyMemberIdentity`. The note's addressing section now reflects this.

## Validation

- `dotnet build src/ILInspector.Decompiler.Tests -c Release --configfile nuget.config` — 0 warnings, 0 errors.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "…IrImporterHandleAddressingTests"` — **5/5 pass**.
- `markdownlint` clean on changed docs.

## Adversarial review

Two independent reviewers in isolated worktrees, per policy (I authored as Opus 4.8, so reviewers are from other model families):

| Reviewer | First pass (`56bb4401`) | Re-review (`ff7973c8`) |
| --- | --- | --- |
| **GPT-5.5** | CLEAN | CLEAN |
| **Gemini 3.1 Pro** | 2 findings (below) | CLEAN |

**Where they diverged:** GPT-5.5 accepted the original as clean; Gemini 3.1 Pro found two issues GPT missed. Both were verified and fixed in `ff7973c8`:

1. **No-crash parity gap (High).** `var reader = source.Reader;` sat *outside* the try, so a null/faulted source threw a `NullReferenceException` instead of returning a crash function (Gemini reproduced it). Fixed: reader read moved inside the try, catch made reader-null-safe. Locked by `HandleDirect_NullSource_ReturnsCrashFunction_NeverThrows`. (commit `ff7973c8`)
2. **Redundant/mispair-prone type handle (Medium).** The overload took both a `TypeDefinitionHandle` and a `MethodDefinitionHandle` with no consistency check; a mispair would draw the generic scope from the wrong type. Fixed: dropped the `TypeDefinitionHandle` parameter and derive it internally via `GetDeclaringType()`. (commit `ff7973c8`)

Both reviewers re-reviewed the fixed head and returned **CLEAN** (build 0/0, 5/5 tests, clean trees).
