### PR TITLE
Measure deferred callback evidence

### DIFF
--- a/src/ILInspector.Analysis.RenderFixtures/ILInspector.Analysis.RenderFixtures.csproj
+++ b/src/ILInspector.Analysis.RenderFixtures/ILInspector.Analysis.RenderFixtures.csproj
@@ -16,6 +16,7 @@
     <IsPackable>false</IsPackable>
     <IsAotCompatible>false</IsAotCompatible>
     <Optimize>true</Optimize>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ILInspector.Analysis.RenderFixtures/RealRenderFixtures.cs
+++ b/src/ILInspector.Analysis.RenderFixtures/RealRenderFixtures.cs
@@ -1,4 +1,5 @@
 using System;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 
 namespace ILInspector.Analysis.RenderFixtures;
@@ -19,4 +20,81 @@ public static class RealRenderFixtures
 
         return total;
     }
+
+    public static void RenderWithDeferredFragmentLoop(RenderTreeBuilder builder, int[] values)
+    {
+        foreach (int value in values)
+        {
+            builder.AddAttribute(
+                0,
+                "ChildContent",
+                (RenderFragment)(nested => nested.AddContent(1, BoxDeferredValue(value))));
+        }
+    }
+
+    public static void RenderWithUnknownConsumerLoop(int[] values)
+    {
+        foreach (int value in values)
+            RegisterUnknown(nested => nested.AddContent(1, BoxDeferredValue(value)));
+    }
+
+    public static RenderFragment BuildLatestFragment(int[] values)
+    {
+        RenderFragment callback = null;
+        foreach (int value in values)
+            callback = nested => nested.AddContent(1, BoxDeferredValue(value));
+        return callback;
+    }
+
+    public static void InvokeLatestFragmentOnce(RenderTreeBuilder builder, int[] values)
+    {
+        RenderFragment callback = null;
+        foreach (int value in values)
+            callback = nested => nested.AddContent(1, BoxDeferredValue(value));
+        callback?.Invoke(builder);
+    }
+
+    public static void RenderWithOutsideCallback(RenderTreeBuilder builder, int[] values)
+    {
+        RenderFragment callback = static nested => nested.AddContent(1, BoxDeferredValue(0));
+        foreach (int value in values)
+            builder.AddAttribute(0, "ChildContent", callback);
+    }
+
+    public static void RenderWithCachedCallbackLoop(RenderTreeBuilder builder, int[] values)
+    {
+        foreach (int value in values)
+        {
+            builder.AddAttribute(
+                0,
+                "ChildContent",
+                (RenderFragment)(static nested => nested.AddContent(1, "cached")));
+        }
+    }
+
+    public static void InvokeConstructedCallbackInLoop(int[] values)
+    {
+        foreach (int value in values)
+            ((Action)(() => GC.KeepAlive(BoxImmediateValue(value))))();
+    }
+
+    public static void InvokeDirectlyInLoop(int[] values)
+    {
+        foreach (int value in values)
+            GC.KeepAlive(BoxDeferredValue(value));
+    }
+
+    public static unsafe nint LoadFunctionPointerInLoop(int count)
+    {
+        delegate*<int, object> callback = null;
+        for (int i = 0; i < count; i++)
+            callback = &BoxDeferredValue;
+        return (nint)callback;
+    }
+
+    public static object BoxDeferredValue(int value) => value;
+
+    static object BoxImmediateValue(int value) => value;
+
+    static void RegisterUnknown(RenderFragment callback) => GC.KeepAlive(callback);
 }

--- a/src/ILInspector.Analysis.Tests/DeferredCallbackCensusTests.cs
+++ b/src/ILInspector.Analysis.Tests/DeferredCallbackCensusTests.cs
@@ -1,0 +1,315 @@
+using System.Collections.Immutable;
+
+using DotnetInspector.Fixtures;
+using ILInspector.AnalysisHarness;
+
+namespace ILInspector.Analysis.Tests;
+
+public class DeferredCallbackCensusTests
+{
+    static readonly TypeRef s_void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
+    static readonly TypeRef s_intPtr = TypeRef.CoreLib("System", "IntPtr");
+    static readonly TypeRef s_action = TypeRef.CoreLib("System", "Action");
+    static readonly TypeRef s_type = TypeRef.Definition("Fixture", "Fixtures", "Graph");
+
+    [Fact]
+    public void Measure_ClassifiesCompiledRegistrationAndNearMisses()
+    {
+        var report = DeferredCallbackCensus.Measure(
+            [FixtureCatalog.AnalysisRender.AssemblyPath()]);
+
+        var registration = Assert.Single(report.Sites, static site =>
+            site.Caller.Contains("::RenderWithDeferredFragmentLoop(", StringComparison.Ordinal));
+        Assert.Equal(DeferredCallbackSiteClassification.FrameworkRegistration, registration.Classification);
+        Assert.Equal("render-tree-registration", registration.ConsumerKind);
+        Assert.False(registration.ConsumptionProven);
+
+        var immediate = Assert.Single(report.Sites, static site =>
+            site.Caller.Contains("::InvokeConstructedCallbackInLoop(", StringComparison.Ordinal));
+        Assert.Equal(DeferredCallbackSiteClassification.ImmediateInvocation, immediate.Classification);
+        Assert.Equal("delegate-invoke", immediate.ConsumerKind);
+        Assert.True(immediate.ConsumptionProven);
+
+        Assert.Contains(report.Sites, static site =>
+            site.Caller.Contains("::RenderWithUnknownConsumerLoop(", StringComparison.Ordinal)
+            && site.Classification == DeferredCallbackSiteClassification.UnknownConsumer
+            && !site.ConsumptionProven);
+        Assert.Contains(report.Sites, static site =>
+            site.Caller.Contains("::BuildLatestFragment(", StringComparison.Ordinal)
+            && site.Classification == DeferredCallbackSiteClassification.ConstructedWithoutImmediateConsumer);
+        Assert.Contains(report.Sites, static site =>
+            site.Caller.Contains("::InvokeLatestFragmentOnce(", StringComparison.Ordinal)
+            && site.Classification == DeferredCallbackSiteClassification.ConstructedWithoutImmediateConsumer
+            && !site.ConsumptionProven);
+        Assert.Contains(report.Sites, static site =>
+            site.Caller.Contains("::RenderWithOutsideCallback(", StringComparison.Ordinal)
+            && site.Classification == DeferredCallbackSiteClassification.ConstructionOutsideLoop);
+        Assert.Contains(report.Sites, static site =>
+            site.Caller.Contains("::LoadFunctionPointerInLoop(", StringComparison.Ordinal)
+            && site.Classification == DeferredCallbackSiteClassification.StandaloneFunctionLoad);
+        Assert.DoesNotContain(report.Sites, static site =>
+            site.Caller.Contains("::InvokeDirectlyInLoop(", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Measure_SeparatesRegisteredOpportunityFromProvenInvocation()
+    {
+        var report = DeferredCallbackCensus.Measure(
+            [FixtureCatalog.AnalysisRender.AssemblyPath()]);
+
+        var registered = Assert.Single(report.Rows, static row =>
+            row.Member.Contains("::BoxDeferredValue(", StringComparison.Ordinal));
+        Assert.Equal(DeferredCallbackReachClassification.Downstream, registered.Classification);
+        Assert.Equal(1, registered.DownstreamDepth);
+        Assert.Equal(
+            DeferredCallbackSiteClassification.FrameworkRegistration,
+            registered.Construction?.Classification);
+        Assert.False(registered.Construction?.ConsumptionProven);
+
+        var invoked = Assert.Single(report.Rows, static row =>
+            row.Member.Contains("::BoxImmediateValue(", StringComparison.Ordinal));
+        Assert.Equal(DeferredCallbackReachClassification.Downstream, invoked.Classification);
+        Assert.Equal(1, invoked.DownstreamDepth);
+        Assert.Equal(
+            DeferredCallbackSiteClassification.ImmediateInvocation,
+            invoked.Construction?.Classification);
+        Assert.True(invoked.Construction?.ConsumptionProven);
+    }
+
+    [Fact]
+    public void Analyze_ReportsDownstreamDepthAndPreservesOpportunitySemantics()
+    {
+        var loop = Method(1, "Loop");
+        var callback = Method(2, "Callback");
+        var wrapper = Method(3, "Wrapper");
+        var target = Method(4, "Target");
+        var opportunity = Opportunity(target, "pt~exact") with
+        {
+            Multiplicity = "conditional",
+            Provenance = PerformanceTriageProvenance.Exact,
+            PathContext = "error path",
+        };
+        var result = DeferredCallbackCensus.Analyze(
+            "Fixture.dll",
+            [loop, callback, wrapper, target],
+            [
+                FunctionLoad(loop, callback, 4, returnAddress: 10),
+                DelegateConstruction(loop, 10, returnAddress: 15),
+                DelegateInvoke(loop, 15),
+                Call(callback, wrapper, 20),
+                Call(wrapper, target, 30),
+            ],
+            Allocations(DelegateAllocation(loop, 10)),
+            [opportunity],
+            maxDepth: 1);
+
+        var site = Assert.Single(result.Sites);
+        Assert.Equal(DeferredCallbackSiteClassification.ImmediateInvocation, site.Classification);
+        Assert.True(site.ConsumptionProven);
+
+        var row = Assert.Single(result.Rows);
+        Assert.Equal(DeferredCallbackReachClassification.BeyondBound, row.Classification);
+        Assert.Equal(2, row.DownstreamDepth);
+        Assert.Equal([20, 30], row.InvocationWitness.Select(static step => step.ILOffset));
+        Assert.Equal("pt~exact", row.Candidate);
+        Assert.Equal("conditional", row.LocalMultiplicity);
+        Assert.False(row.LocalInLoop);
+        Assert.Equal(PerformanceTriageProvenance.Exact, row.Provenance);
+    }
+
+    [Fact]
+    public void Analyze_ClassifiesCachedConstructionWithoutClaimingConsumption()
+    {
+        var loop = Method(1, "Loop");
+        var callback = Method(2, "Callback");
+        var result = DeferredCallbackCensus.Analyze(
+            "Fixture.dll",
+            [loop, callback],
+            [
+                FunctionLoad(loop, callback, 4, returnAddress: 10),
+                DelegateConstruction(loop, 10, returnAddress: 15),
+            ],
+            Allocations(DelegateAllocation(loop, 10, AllocationFrequency.CachedOnce)),
+            []);
+
+        var site = Assert.Single(result.Sites);
+        Assert.Equal(DeferredCallbackSiteClassification.CachedConstruction, site.Classification);
+        Assert.False(site.ConsumptionProven);
+    }
+
+    [Fact]
+    public void Analyze_ProvenInvocationTakesPriorityOverUnknownConsumer()
+    {
+        var unknownCaller = Method(1, "AUnknownCaller");
+        var immediateCaller = Method(2, "ZImmediateCaller");
+        var callback = Method(3, "Callback");
+        var result = DeferredCallbackCensus.Analyze(
+            "Fixture.dll",
+            [unknownCaller, immediateCaller, callback],
+            [
+                FunctionLoad(unknownCaller, callback, 4, returnAddress: 10),
+                DelegateConstruction(unknownCaller, 10, returnAddress: 15),
+                UnknownConsumer(unknownCaller, 15),
+                FunctionLoad(immediateCaller, callback, 20, returnAddress: 25),
+                DelegateConstruction(immediateCaller, 25, returnAddress: 30),
+                DelegateInvoke(immediateCaller, 30),
+            ],
+            Allocations(
+                DelegateAllocation(unknownCaller, 10),
+                DelegateAllocation(immediateCaller, 25)),
+            [Opportunity(callback, "pt~callback")]);
+
+        var row = Assert.Single(result.Rows);
+        Assert.Equal(DeferredCallbackReachClassification.Target, row.Classification);
+        Assert.Equal(
+            DeferredCallbackSiteClassification.ImmediateInvocation,
+            row.Construction?.Classification);
+        Assert.True(row.Construction?.ConsumptionProven);
+    }
+
+    [Fact]
+    public void Measure_ReportsInputFailures()
+    {
+        var report = DeferredCallbackCensus.Measure(["/not/a/real/assembly.dll"]);
+
+        Assert.Equal(0, report.Opened);
+        Assert.Equal(1, report.Failed);
+        Assert.Equal(report.Assemblies, report.Opened + report.Failed);
+        Assert.Single(report.Failures);
+        Assert.Contains("assembly.dll", report.Failures[0].AssemblyPath, StringComparison.Ordinal);
+    }
+
+    static MethodIdentity Method(int token, string name)
+        => new(
+            "Fixture",
+            Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            s_type,
+            name,
+            [],
+            s_void,
+            token,
+            IsStatic: true);
+
+    static DirectCall FunctionLoad(
+        MethodIdentity caller,
+        MethodIdentity callback,
+        int offset,
+        int returnAddress)
+        => Call(caller, callback, offset, CallKind.LoadFunction) with
+        {
+            InLoop = true,
+            ReturnAddress = returnAddress,
+        };
+
+    static DirectCall DelegateConstruction(
+        MethodIdentity caller,
+        int offset,
+        int returnAddress)
+        => new(
+            caller,
+            new MemberRef(
+                s_action,
+                ".ctor",
+                [s_object, s_intPtr],
+                s_void,
+                MemberKind.Constructor)
+            {
+                HasThis = true,
+            },
+            offset,
+            0,
+            0,
+            CallKind.NewObject,
+            InLoop: true)
+        {
+            ReturnAddress = returnAddress,
+        };
+
+    static DirectCall DelegateInvoke(MethodIdentity caller, int offset)
+        => new(
+            caller,
+            new MemberRef(s_action, "Invoke", [], s_void, MemberKind.Method)
+            {
+                HasThis = true,
+            },
+            offset,
+            0,
+            0,
+            CallKind.CallVirtual,
+            InLoop: true);
+
+    static DirectCall UnknownConsumer(MethodIdentity caller, int offset)
+        => new(
+            caller,
+            new MemberRef(
+                TypeRef.Definition("Fixture", "Fixtures", "Consumer"),
+                "Register",
+                [s_action],
+                s_void,
+                MemberKind.Method),
+            offset,
+            0,
+            0,
+            CallKind.Call,
+            InLoop: true);
+
+    static DirectCall Call(
+        MethodIdentity caller,
+        MethodIdentity callee,
+        int offset,
+        CallKind kind = CallKind.Call)
+        => new(
+            caller,
+            new MemberRef(
+                callee.DeclaringType,
+                callee.Name,
+                callee.ParameterTypes,
+                callee.ReturnType,
+                MemberKind.Method),
+            offset,
+            callee.MetadataToken,
+            callee.MetadataToken,
+            kind);
+
+    static IReadOnlyDictionary<int, ImmutableArray<AllocationOccurrence>> Allocations(
+        params AllocationOccurrence[] occurrences)
+        => occurrences
+            .GroupBy(static occurrence => occurrence.Method.MetadataToken)
+            .ToDictionary(
+                static group => group.Key,
+                static group => group.ToImmutableArray());
+
+    static AllocationOccurrence DelegateAllocation(
+        MethodIdentity method,
+        int offset,
+        AllocationFrequency frequency = AllocationFrequency.Always)
+        => new(
+            method,
+            offset,
+            OperandToken: null,
+            AllocationKind.Delegate,
+            s_action,
+            Detail: null,
+            CountsAsHeapAllocation: true,
+            frequency,
+            InLoop: true,
+            AllocationEscape.Unknown,
+            AllocationFactSource.Newobj);
+
+    static OptimizationOpportunity Opportunity(MethodIdentity method, string candidate)
+        => new(
+            method,
+            "box-value-type",
+            "evidence",
+            "fix",
+            "medium",
+            InLoop: false,
+            ILOffset: 4,
+            Caveat: null)
+        {
+            CandidateId = candidate,
+            Multiplicity = "once",
+            Provenance = PerformanceTriageProvenance.Exact,
+        };
+}

--- a/tools/AnalysisHarness/DeferredCallbackCensus.cs
+++ b/tools/AnalysisHarness/DeferredCallbackCensus.cs
@@ -1,0 +1,536 @@
+using System.Collections.Immutable;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using ILInspector.Analysis;
+
+namespace ILInspector.AnalysisHarness;
+
+public enum DeferredCallbackSiteClassification
+{
+    ConstructionOutsideLoop,
+    StandaloneFunctionLoad,
+    CachedConstruction,
+    ConstructedWithoutImmediateConsumer,
+    ImmediateInvocation,
+    UnknownConsumer,
+    FrameworkRegistration,
+}
+
+public enum DeferredCallbackReachClassification
+{
+    None,
+    Target,
+    Downstream,
+    BeyondBound,
+}
+
+public sealed record DeferredCallbackSite(
+    string Assembly,
+    string Caller,
+    int CallerToken,
+    string Target,
+    int TargetToken,
+    int FunctionLoadOffset,
+    CallKind FunctionLoadKind,
+    int? ConstructionOffset,
+    string DelegateType,
+    int? ConsumerOffset,
+    string Consumer,
+    string ConsumerKind,
+    bool ConsumptionProven,
+    DeferredCallbackSiteClassification Classification);
+
+public sealed record DeferredCallbackInvocationStep(
+    string Caller,
+    string Callee,
+    int ILOffset,
+    CallKind Kind);
+
+public sealed record DeferredCallbackCensusRow(
+    string Assembly,
+    string Candidate,
+    string Member,
+    int MethodToken,
+    int? ILOffset,
+    string Shape,
+    string Confidence,
+    string LocalMultiplicity,
+    bool LocalInLoop,
+    PerformanceTriageProvenance Provenance,
+    DeferredCallbackReachClassification Classification,
+    int? DownstreamDepth,
+    DeferredCallbackSite? Construction,
+    IReadOnlyList<DeferredCallbackInvocationStep> InvocationWitness);
+
+public sealed record DeferredCallbackCensusFailure(string AssemblyPath, string Error);
+
+public sealed record DeferredCallbackCensusReport(
+    int MaxDepth,
+    int Assemblies,
+    int Opened,
+    int Failed,
+    int FunctionLoads,
+    int Opportunities,
+    int ReachableOpportunities,
+    int DistinctReachableCandidates,
+    int DistinctReachableMethods,
+    IReadOnlyDictionary<string, int> SitesByClassification,
+    IReadOnlyDictionary<string, int> SitesByConsumer,
+    IReadOnlyDictionary<string, int> RowsByClassification,
+    IReadOnlyDictionary<string, int> OpportunityCross,
+    IReadOnlyList<DeferredCallbackCensusFailure> Failures,
+    IReadOnlyList<DeferredCallbackSite> Sites,
+    IReadOnlyList<DeferredCallbackCensusRow> Rows);
+
+public static class DeferredCallbackCensus
+{
+    const string Empty = "<empty>";
+
+    static readonly JsonSerializerOptions s_json = new()
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    public static DeferredCallbackCensusReport Measure(
+        IReadOnlyList<string> assemblyPaths,
+        int maxDepth = 4)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxDepth, 0);
+
+        var sites = new List<DeferredCallbackSite>();
+        var rows = new List<DeferredCallbackCensusRow>();
+        var failures = new List<DeferredCallbackCensusFailure>();
+        int opened = 0;
+        foreach (string path in assemblyPaths)
+        {
+            try
+            {
+                var index = LibraryBodyIndex.Open(path);
+                var result = Analyze(
+                    Path.GetFileName(path),
+                    index.Methods,
+                    index.DirectCalls,
+                    index.GetAllocationOccurrences(),
+                    index.OptimizationOpportunities,
+                    maxDepth);
+                sites.AddRange(result.Sites);
+                rows.AddRange(result.Rows);
+                opened++;
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or IOException or ArgumentException)
+            {
+                failures.Add(new DeferredCallbackCensusFailure(path, $"{ex.GetType().Name}: {ex.Message}"));
+            }
+        }
+
+        return BuildReport(
+            maxDepth,
+            assemblyPaths.Count,
+            opened,
+            failures,
+            sites,
+            rows);
+    }
+
+    public static (
+        IReadOnlyList<DeferredCallbackSite> Sites,
+        IReadOnlyList<DeferredCallbackCensusRow> Rows) Analyze(
+        string assembly,
+        ImmutableArray<MethodIdentity> methods,
+        ImmutableArray<DirectCall> directCalls,
+        IReadOnlyDictionary<int, ImmutableArray<AllocationOccurrence>> allocations,
+        ImmutableArray<OptimizationOpportunity> opportunities,
+        int maxDepth = 4)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxDepth, 0);
+
+        var callsByCoordinate = directCalls.ToDictionary(
+            static call => (call.Caller.MetadataToken, call.ILOffset));
+        var allocationsByCoordinate = allocations
+            .SelectMany(static pair => pair.Value)
+            .ToDictionary(
+                static occurrence => (occurrence.Method.MetadataToken, occurrence.ILOffset));
+
+        var evidenceSites = directCalls
+            .Where(static call => call.Kind is CallKind.LoadFunction or CallKind.LoadVirtualFunction)
+            .OrderBy(static call => call.Caller.MetadataToken)
+            .ThenBy(static call => call.ILOffset)
+            .Select(call => ClassifySite(
+                assembly,
+                call,
+                callsByCoordinate,
+                allocationsByCoordinate))
+            .ToArray();
+
+        var coherentSites = evidenceSites
+            .Where(static site => site.Row.Classification is
+                DeferredCallbackSiteClassification.ImmediateInvocation
+                or DeferredCallbackSiteClassification.UnknownConsumer
+                or DeferredCallbackSiteClassification.FrameworkRegistration)
+            .ToArray();
+        var siteBySeed = coherentSites.ToDictionary(
+            static site => (site.Load.Caller.MetadataToken, site.Load.ILOffset));
+
+        // Keep evidence classes separate so a nearer unknown consumer cannot hide a proven
+        // invocation or trusted registration. Within each class, the product analysis still
+        // selects the nearest deterministic witness.
+        var nearestByPriority = new[]
+        {
+            FindNearest(
+                methods,
+                directCalls,
+                coherentSites.Where(static site =>
+                    site.Row.Classification == DeferredCallbackSiteClassification.ImmediateInvocation)),
+            FindNearest(
+                methods,
+                directCalls,
+                coherentSites.Where(static site =>
+                    site.Row.Classification == DeferredCallbackSiteClassification.FrameworkRegistration)),
+            FindNearest(
+                methods,
+                directCalls,
+                coherentSites.Where(static site =>
+                    site.Row.Classification == DeferredCallbackSiteClassification.UnknownConsumer)),
+        };
+
+        var rows = opportunities
+            .OrderBy(static opportunity => opportunity.Method.MetadataToken)
+            .ThenBy(static opportunity => opportunity.ILOffset ?? -1)
+            .ThenBy(static opportunity => opportunity.Shape, StringComparer.Ordinal)
+            .Select(opportunity => CreateRow(
+                assembly,
+                opportunity,
+                nearestByPriority,
+                siteBySeed,
+                maxDepth))
+            .ToArray();
+
+        return (evidenceSites.Select(static site => site.Row).ToArray(), rows);
+    }
+
+    public static string ToJson(DeferredCallbackCensusReport report)
+        => JsonSerializer.Serialize(report, s_json);
+
+    public static string FormatCard(DeferredCallbackCensusReport report, int top)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"DEFERRED-CALLBACK CENSUS: {report.Opened}/{report.Assemblies} assemblies opened ({report.Failed} failed), max-downstream-depth={report.MaxDepth}");
+        sb.AppendLine($"  function-loads={report.FunctionLoads} opportunities={report.Opportunities} reachable={report.ReachableOpportunities} distinct-candidates={report.DistinctReachableCandidates} distinct-methods={report.DistinctReachableMethods}");
+        AppendCounts(sb, "sites by classification", report.SitesByClassification);
+        AppendCounts(sb, "sites by consumer", report.SitesByConsumer);
+        AppendCounts(sb, "opportunity rows", report.RowsByClassification);
+        AppendCounts(sb, "callback|consumer|shape|confidence|local-multiplicity|provenance", report.OpportunityCross, top);
+        foreach (var failure in report.Failures)
+            sb.AppendLine($"  failed: {failure.AssemblyPath}: {failure.Error}");
+
+        sb.AppendLine("  examples:");
+        foreach (var row in report.Rows
+            .Where(static row => row.Classification != DeferredCallbackReachClassification.None)
+            .OrderByDescending(static row => row.Construction?.ConsumptionProven)
+            .ThenBy(static row => row.Classification)
+            .ThenBy(static row => row.DownstreamDepth)
+            .ThenBy(static row => row.Assembly, StringComparer.Ordinal)
+            .ThenBy(static row => row.Member, StringComparer.Ordinal)
+            .Take(top))
+        {
+            var site = row.Construction!;
+            sb.AppendLine($"    {Reach(row.Classification)} depth={row.DownstreamDepth}: {row.Assembly} {row.Member} [{row.Shape}, {row.Candidate}]");
+            sb.AppendLine($"      {SiteClass(site.Classification)}: {site.Caller} @ IL_{site.FunctionLoadOffset:X4} -- {site.FunctionLoadKind} --> {site.Target}; newobj IL_{site.ConstructionOffset:X4}; {site.ConsumerKind} {site.Consumer}");
+            foreach (var step in row.InvocationWitness)
+                sb.AppendLine($"      -> {step.Caller} @ IL_{step.ILOffset:X4} -- {step.Kind} --> {step.Callee}");
+        }
+        return sb.ToString();
+    }
+
+    static SiteEvidence ClassifySite(
+        string assembly,
+        DirectCall load,
+        IReadOnlyDictionary<(int MethodToken, int Offset), DirectCall> calls,
+        IReadOnlyDictionary<(int MethodToken, int Offset), AllocationOccurrence> allocations)
+    {
+        DirectCall? construction = null;
+        AllocationOccurrence? allocation = null;
+        DirectCall? consumer = null;
+        if (load.ReturnAddress is { } constructionOffset
+            && calls.TryGetValue((load.Caller.MetadataToken, constructionOffset), out var candidateConstruction)
+            && candidateConstruction.Kind == CallKind.NewObject
+            && allocations.TryGetValue((load.Caller.MetadataToken, constructionOffset), out var candidateAllocation)
+            && candidateAllocation.Source == AllocationFactSource.Newobj
+            && candidateAllocation.CountsAsHeapAllocation
+            && candidateAllocation.AllocatedType?.Equals(candidateConstruction.Callee.DeclaringType) == true
+            && IsDelegateConstructorShape(candidateConstruction.Callee))
+        {
+            construction = candidateConstruction;
+            allocation = candidateAllocation;
+            if (construction.ReturnAddress is { } consumerOffset
+                && calls.TryGetValue((load.Caller.MetadataToken, consumerOffset), out var candidateConsumer)
+                && candidateConsumer.Kind is CallKind.Call or CallKind.CallVirtual)
+            {
+                consumer = candidateConsumer;
+            }
+        }
+
+        DeferredCallbackSiteClassification classification;
+        string consumerKind = Empty;
+        bool consumptionProven = false;
+        if (construction is null || allocation is null)
+        {
+            classification = DeferredCallbackSiteClassification.StandaloneFunctionLoad;
+        }
+        else if (!load.InLoop)
+        {
+            classification = DeferredCallbackSiteClassification.ConstructionOutsideLoop;
+        }
+        else if (!construction.InLoop)
+        {
+            classification = DeferredCallbackSiteClassification.ConstructedWithoutImmediateConsumer;
+        }
+        else if (allocation.Frequency == AllocationFrequency.CachedOnce)
+        {
+            classification = DeferredCallbackSiteClassification.CachedConstruction;
+        }
+        else if (consumer is null)
+        {
+            classification = DeferredCallbackSiteClassification.ConstructedWithoutImmediateConsumer;
+        }
+        else if (!consumer.InLoop)
+        {
+            classification = DeferredCallbackSiteClassification.ConstructedWithoutImmediateConsumer;
+        }
+        else if (IsImmediateInvoke(consumer))
+        {
+            classification = DeferredCallbackSiteClassification.ImmediateInvocation;
+            consumerKind = "delegate-invoke";
+            consumptionProven = true;
+        }
+        else if (IsRenderTreeRegistration(consumer))
+        {
+            classification = DeferredCallbackSiteClassification.FrameworkRegistration;
+            consumerKind = "render-tree-registration";
+        }
+        else
+        {
+            classification = DeferredCallbackSiteClassification.UnknownConsumer;
+            consumerKind = "unknown";
+        }
+
+        var row = new DeferredCallbackSite(
+            assembly,
+            MethodDisplay(load.Caller),
+            load.Caller.MetadataToken,
+            MemberDisplay(load.Callee),
+            load.CalleeDefinitionToken,
+            load.ILOffset,
+            load.Kind,
+            construction?.ILOffset,
+            construction is null ? Empty : construction.Callee.DeclaringType.ToQualifiedDisplayString(),
+            consumer?.ILOffset,
+            consumer is null ? Empty : MemberDisplay(consumer.Callee),
+            consumerKind,
+            consumptionProven,
+            classification);
+        return new SiteEvidence(row, load);
+    }
+
+    static DeferredCallbackCensusRow CreateRow(
+        string assembly,
+        OptimizationOpportunity opportunity,
+        IReadOnlyList<IReadOnlyDictionary<int, CallerLoopEvidence>> nearestByPriority,
+        IReadOnlyDictionary<(int MethodToken, int Offset), SiteEvidence> siteBySeed,
+        int maxDepth)
+    {
+        CallerLoopEvidence? evidence = null;
+        foreach (var nearest in nearestByPriority)
+        {
+            if (nearest.TryGetValue(opportunity.Method.MetadataToken, out evidence))
+                break;
+        }
+        SiteEvidence? site = null;
+        if (evidence is { Witness.IsDefaultOrEmpty: false })
+        {
+            var seed = evidence.Witness[0];
+            siteBySeed.TryGetValue((seed.Caller.MetadataToken, seed.ILOffset), out site);
+        }
+
+        int? downstreamDepth = evidence is null ? null : evidence.Depth - 1;
+        var classification = downstreamDepth is null
+            ? DeferredCallbackReachClassification.None
+            : downstreamDepth == 0
+                ? DeferredCallbackReachClassification.Target
+                : downstreamDepth <= maxDepth
+                    ? DeferredCallbackReachClassification.Downstream
+                    : DeferredCallbackReachClassification.BeyondBound;
+
+        return new DeferredCallbackCensusRow(
+            assembly,
+            opportunity.CandidateId ?? Empty,
+            MethodDisplay(opportunity.Method),
+            opportunity.Method.MetadataToken,
+            opportunity.ILOffset,
+            opportunity.Shape,
+            opportunity.Confidence,
+            Text(opportunity.Multiplicity),
+            opportunity.InLoop,
+            opportunity.Provenance,
+            classification,
+            downstreamDepth,
+            site?.Row,
+            evidence?.Witness.Skip(1).Select(static step => new DeferredCallbackInvocationStep(
+                MethodDisplay(step.Caller),
+                MethodDisplay(step.Callee),
+                step.ILOffset,
+                step.Kind)).ToArray() ?? []);
+    }
+
+    static IReadOnlyDictionary<int, CallerLoopEvidence> FindNearest(
+        ImmutableArray<MethodIdentity> methods,
+        ImmutableArray<DirectCall> directCalls,
+        IEnumerable<SiteEvidence> sites)
+    {
+        var seeds = sites.ToArray();
+        if (seeds.Length == 0)
+            return ImmutableDictionary<int, CallerLoopEvidence>.Empty;
+
+        // Original loop flags are cleared so ordinary loop calls cannot masquerade as
+        // deferred-callback evidence.
+        var graphCalls = directCalls
+            .Select(static call => call with { InLoop = false })
+            .Concat(seeds.Select(static site => site.Load with
+            {
+                Kind = CallKind.Call,
+                InLoop = true,
+            }))
+            .ToImmutableArray();
+        return CallerLoopEvidenceAnalysis.FindNearest(methods, graphCalls);
+    }
+
+    static DeferredCallbackCensusReport BuildReport(
+        int maxDepth,
+        int assemblies,
+        int opened,
+        IReadOnlyList<DeferredCallbackCensusFailure> failures,
+        IReadOnlyList<DeferredCallbackSite> sites,
+        IReadOnlyList<DeferredCallbackCensusRow> rows)
+    {
+        var reachable = rows
+            .Where(static row => row.Classification != DeferredCallbackReachClassification.None)
+            .ToArray();
+        var candidateRows = reachable
+            .GroupBy(
+                static row => row.Candidate == Empty
+                    ? $"{row.Assembly}|{row.MethodToken:X8}|{row.ILOffset?.ToString("X8", System.Globalization.CultureInfo.InvariantCulture) ?? Empty}|{row.Shape}"
+                    : $"{row.Assembly}|{row.Candidate}",
+                StringComparer.Ordinal)
+            .Select(static group => group.First())
+            .ToArray();
+        var methodRows = reachable
+            .GroupBy(static row => $"{row.Assembly}|{row.MethodToken:X8}", StringComparer.Ordinal)
+            .Select(static group => group.First())
+            .ToArray();
+        return new DeferredCallbackCensusReport(
+            maxDepth,
+            assemblies,
+            opened,
+            failures.Count,
+            sites.Count,
+            rows.Count,
+            reachable.Length,
+            candidateRows.Length,
+            methodRows.Length,
+            Counts(sites, static site => SiteClass(site.Classification)),
+            Counts(sites, static site => site.ConsumerKind),
+            Counts(rows, static row => Reach(row.Classification)),
+            Counts(reachable, static row =>
+                $"{SiteClass(row.Construction!.Classification)}|{row.Construction.ConsumerKind}|{row.Shape}|{row.Confidence}|{row.LocalMultiplicity}|{row.Provenance.ToString().ToLowerInvariant()}"),
+            failures,
+            sites,
+            rows);
+    }
+
+    static bool IsImmediateInvoke(DirectCall consumer)
+        => consumer.Callee.HasThis
+            && consumer.Callee.Name == "Invoke"
+            && consumer.Callee.ParameterTypes.Length == 0;
+
+    static bool IsDelegateConstructorShape(MemberRef constructor)
+        => constructor.Kind == MemberKind.Constructor
+            && constructor.ParameterTypes.Length == 2
+            && constructor.ParameterTypes[0].Equals(TypeRef.CoreLib("System", "Object"))
+            && constructor.ParameterTypes[1].Equals(TypeRef.CoreLib("System", "IntPtr"));
+
+    static bool IsRenderTreeRegistration(DirectCall consumer)
+    {
+        var type = consumer.Callee.DeclaringType.Kind == TypeRefKind.GenericInstance
+            ? consumer.Callee.DeclaringType.ElementType ?? consumer.Callee.DeclaringType
+            : consumer.Callee.DeclaringType;
+        return type.TrustedFrameworkAssembly
+            && type.Assembly == "Microsoft.AspNetCore.Components"
+            && type.Namespace == "Microsoft.AspNetCore.Components.Rendering"
+            && type.Name == "RenderTreeBuilder"
+            && consumer.Callee.Name == "AddAttribute"
+            && consumer.Callee.HasThis
+            && consumer.Callee.ParameterTypes.SequenceEqual(
+                [
+                    TypeRef.CoreLib("System", "Int32"),
+                    TypeRef.CoreLib("System", "String"),
+                    TypeRef.CoreLib("System", "MulticastDelegate"),
+                ]);
+    }
+
+    static string MethodDisplay(MethodIdentity method)
+        => $"{method.DeclaringType.ToQualifiedDisplayString()}::{method.Name}({string.Join(", ", method.ParameterTypes.Select(static type => type.ToQualifiedDisplayString()))})";
+
+    static string MemberDisplay(MemberRef member)
+        => $"{member.DeclaringType.ToQualifiedDisplayString()}::{member.Name}({string.Join(", ", member.ParameterTypes.Select(static type => type.ToQualifiedDisplayString()))})";
+
+    static string Text(string? value)
+        => string.IsNullOrWhiteSpace(value) ? Empty : value;
+
+    static string SiteClass(DeferredCallbackSiteClassification value)
+        => value switch
+        {
+            DeferredCallbackSiteClassification.ConstructionOutsideLoop => "construction-outside-loop",
+            DeferredCallbackSiteClassification.StandaloneFunctionLoad => "standalone-function-load",
+            DeferredCallbackSiteClassification.CachedConstruction => "cached-construction",
+            DeferredCallbackSiteClassification.ConstructedWithoutImmediateConsumer => "constructed-without-immediate-consumer",
+            DeferredCallbackSiteClassification.ImmediateInvocation => "immediate-invocation",
+            DeferredCallbackSiteClassification.UnknownConsumer => "unknown-consumer",
+            _ => "framework-registration",
+        };
+
+    static string Reach(DeferredCallbackReachClassification value)
+        => value switch
+        {
+            DeferredCallbackReachClassification.Target => "target",
+            DeferredCallbackReachClassification.Downstream => "downstream",
+            DeferredCallbackReachClassification.BeyondBound => "beyond-bound",
+            _ => "none",
+        };
+
+    static IReadOnlyDictionary<string, int> Counts<T>(
+        IEnumerable<T> values,
+        Func<T, string> key)
+        => values
+            .GroupBy(key, StringComparer.Ordinal)
+            .OrderByDescending(static group => group.Count())
+            .ThenBy(static group => group.Key, StringComparer.Ordinal)
+            .ToDictionary(static group => group.Key, static group => group.Count(), StringComparer.Ordinal);
+
+    static void AppendCounts(
+        StringBuilder sb,
+        string title,
+        IReadOnlyDictionary<string, int> counts,
+        int top = int.MaxValue)
+    {
+        sb.AppendLine($"  {title}:");
+        foreach (var (key, value) in counts.Take(top))
+            sb.AppendLine($"    {key}={value}");
+        if (counts.Count > top)
+            sb.AppendLine($"    ... {counts.Count - top} more");
+    }
+
+    sealed record SiteEvidence(DeferredCallbackSite Row, DirectCall Load);
+}

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -36,6 +36,11 @@ const string Usage =
           loop invocation. Reports direct/transitive/none/beyond-bound populations, nearest depth,
           deterministic witness paths, provenance, and shape/confidence/local-multiplicity cross-tabs.
 
+      --deferred-callback-census <file> [--max-depth N] [--top N] [--json]
+          Measurement-only census of in-loop function loads that form an exact delegate construction
+          and immediate consumer/registration shape. Separates proven immediate Invoke calls from
+          trusted framework registration and unknown consumers, then reports downstream triage rows.
+
       --allocation-parity <expected-annotations.json> <actual-annotations.json> [--json]
           Compare allocation annotations from the legacy decompiler classifier and a candidate
           occurrence-derived projection. The gate is exact on id, IL offset, detail, and
@@ -92,6 +97,7 @@ string? referenceFile = null;
 string? precisionAssembly = null;
 string? allocationReadoutList = null;
 string? callerLoopCensusList = null;
+string? deferredCallbackCensusList = null;
 string? allocationParityExpected = null;
 string? allocationParityActual = null;
 string? annotationParityCategory = null;
@@ -134,6 +140,9 @@ for (int i = 0; i < args.Length; i++)
             break;
         case "--caller-loop-census":
             callerLoopCensusList = NextValue(args, ref i);
+            break;
+        case "--deferred-callback-census":
+            deferredCallbackCensusList = NextValue(args, ref i);
             break;
         case "--allocation-parity":
             allocationParityExpected = NextPathValue(args, ref i);
@@ -212,6 +221,9 @@ if (allocationReadoutList is not null)
 
 if (callerLoopCensusList is not null)
     return RunCallerLoopCensus(callerLoopCensusList, maxDepth, top, json);
+
+if (deferredCallbackCensusList is not null)
+    return RunDeferredCallbackCensus(deferredCallbackCensusList, maxDepth, top, json);
 
 if (allocationParityExpected is not null)
     return RunAnnotationParity("Allocation", allocationParityExpected, allocationParityActual, json);
@@ -307,6 +319,31 @@ static int RunCallerLoopCensus(string corpusList, int maxDepth, int top, bool js
 
     var report = CallerLoopCensus.Measure(paths, maxDepth);
     Console.Write(json ? CallerLoopCensus.ToJson(report) : CallerLoopCensus.FormatCard(report, top));
+    if (json)
+        Console.WriteLine();
+    return report.Failed == 0 ? 0 : 1;
+}
+
+static int RunDeferredCallbackCensus(string corpusList, int maxDepth, int top, bool json)
+{
+    if (!File.Exists(corpusList))
+    {
+        Console.Error.WriteLine($"Corpus list not found: {corpusList}");
+        return 2;
+    }
+
+    var paths = File.ReadAllLines(corpusList)
+        .Select(line => line.Trim())
+        .Where(line => line.Length > 0 && !line.StartsWith('#'))
+        .ToList();
+    if (paths.Count == 0)
+    {
+        Console.Error.WriteLine($"Corpus list is empty: {corpusList}");
+        return 2;
+    }
+
+    var report = DeferredCallbackCensus.Measure(paths, maxDepth);
+    Console.Write(json ? DeferredCallbackCensus.ToJson(report) : DeferredCallbackCensus.FormatCard(report, top));
     if (json)
         Console.WriteLine();
     return report.Failed == 0 ? 0 : 1;

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -127,6 +127,43 @@ That run is also an invocation-edge near miss: the current Caller Graph path to
 correctly reports no witness. Proving that callback is repeatedly consumed
 requires a separate deferred-callback discriminator.
 
+A deferred-callback census measures that separate construction boundary:
+
+```bash
+dotnet run --project tools/AnalysisHarness -c Release -- \
+  --deferred-callback-census /tmp/performance-triage-assemblies.txt \
+  --max-depth 4 --top 20
+dotnet run --project tools/AnalysisHarness -c Release -- \
+  --deferred-callback-census /tmp/aspire-dashboard-assemblies.txt \
+  --max-depth 4 --json
+```
+
+The census joins an in-loop function load to an adjacent delegate constructor
+and immediate consumer, then reuses the typed invocation graph downstream from
+the callback target. It distinguishes cached or unconsumed constructions,
+unknown consumers, trusted `RenderTreeBuilder.AddAttribute` registration, and
+an immediately constructed parameterless delegate invocation. Only the last
+classification sets `ConsumptionProven=true`. Framework registration proves
+which callback object was passed to which API, but not whether, when, or how
+often the framework invokes it. This measurement does not alter Performance
+Triage candidates, local `Loop`, multiplicity, confidence, weight, or ranking.
+When more than one callback path reaches a row, the report keeps the strongest
+available class (`Invoke`, registration, then unknown) and the nearest
+deterministic witness within that class.
+
+The 2026-07-14 pinned run found no statically proven callback consumption. The
+six-library corpus had 2,176 function loads and 2,459 opportunities; 10
+opportunity rows were reachable through 39 unknown consumers, and none had
+proven consumption. Aspire Dashboard had 1,019 function loads and 488
+opportunities; 12 sites were trusted framework registrations, eight
+opportunity rows were reachable, and none had proven consumption.
+`ColorGenerator.GetColorIndex` is reached at downstream depth 2 through the
+expected `RenderFragment` registration, with `ConsumptionProven=false`.
+Consequently this census records an explicit non-action: registration evidence
+is useful diagnostic provenance, but is not strong enough for a product-side
+caller-loop projection or ranking change without runtime evidence or a stronger
+framework invocation contract.
+
 A 2026-07-01 fixed-corpus run (`14/14` assemblies opened) showed 41,890
 allocation occurrences and 6,587 optimization opportunities. `return-post-dominates`
 was common (29,175 occurrences; 4,817 opportunities), but not selective by


### PR DESCRIPTION
## Summary

Records an explicit non-action for deferred callback evidence: callback
registration is machine-readable diagnostic provenance, but it is not proof of
invocation frequency or runtime heat.

- adds a measurement-only AnalysisHarness census for exact
  `ldftn -> delegate .ctor -> consumer` shapes
- separates proven immediate invocation, trusted Blazor registration, unknown
  consumers, cached/unconsumed construction, and required near misses
- reuses typed invocation resolution downstream without relabeling function
  loads as calls or changing Performance Triage behavior

## Evidence

| Corpus | Function loads | Opportunities | Reachable | Proven consumption |
| --- | ---: | ---: | ---: | ---: |
| Pinned six-library corpus | 2,176 | 2,459 | 10 | 0 |
| Aspire Dashboard 9.0.0 | 1,019 | 488 | 8 | 0 |

Aspire contains 12 trusted `RenderTreeBuilder.AddAttribute` registration sites.
`ColorGenerator.GetColorIndex` is reached at downstream depth 2 through the
expected `RenderFragment` construction and registration witness, with
`ConsumptionProven=false`.

No candidate identity, local `Loop`, multiplicity, confidence, weight, ranking,
or default product output changes.

## Validation

- Release solution build
- 466 Analysis tests
- pinned six-library and Aspire Dashboard census runs
- markdownlint

Closes #2738
