### PR TITLE
Use static plans for library source authorization

### DIFF
--- a/docs/design/capability-section-registry-spike.md
+++ b/docs/design/capability-section-registry-spike.md
@@ -1,12 +1,15 @@
 # Capability-driven section registry spike
 
-Status: **static lambda-table pilot recommendation**.
+Status: **static mechanics validated; source/PDB pilot narrowed to static
+authorization data**.
 
 This is the runnable evaluation for
 [issue #2605](https://github.com/richlander/dotnet-inspect/issues/2605).
-It does not migrate a production command. It compares the current planning
-shape with a reusable registry, measures initialization, lookup, execution, and
-allocations, and records the code-quality tradeoff.
+It compares the current planning shape with a reusable registry, measures
+initialization, lookup, execution, and allocations, and records the
+code-quality tradeoff. The production follow-up in
+[issue #2747](https://github.com/richlander/dotnet-inspect/issues/2747)
+migrates the library source/PDB authorization seam.
 
 ## Current split and drift points
 
@@ -271,6 +274,61 @@ The principal quality gain is one inspectable table:
 - one authorization and execution path;
 - no reusable mutable execution state.
 
+## Production source/PDB pilot
+
+The production pilot found a smaller useful boundary than the complete spike
+design. `LibraryMetadataService.InspectAsync` previously rebuilt the full
+library section pipeline for every inspected assembly, then queried it three
+times to authorize PDB download, SourceLink HEAD auditing, and source-content
+integrity checks. Package inspection repeated that construction for each
+library.
+
+The migrated path uses a seven-row typed static table. Each row references its
+real section descriptor, derives the descriptor name and explicit-only mode,
+and declares four source decisions:
+
+- allow PDB download;
+- run the SourceLink HEAD audit;
+- verify source integrity;
+- collect source files.
+
+The service retains the fixed execution order: PDB acquisition, source metadata
+projection, HEAD audit, integrity verification, and source-file collection.
+The table owns authorization; the service owns orchestration.
+
+The pilot initially modeled those five steps as async operation lambdas and
+bitmask execution plans. That version was rejected:
+
+- it added roughly 200 production lines for one fixed order;
+- retaining span-backed operation data across an async continuation caused
+  later operations to disappear in a combined selection;
+- a generator would add attributes or another declaration form for only five
+  operations and seven sections;
+- generated dispatch would duplicate the service's readable domain sequence
+  without removing another variable execution path.
+
+The static data-only plan is smaller and has no async plan lifetime. Exhaustive
+tests compare all 128 source-section combinations at every verbosity against
+the previous authorization matrix.
+
+Representative managed measurements on .NET 11 preview 5, macOS arm64:
+
+| Scenario | Previous | Static plan |
+| --- | ---: | ---: |
+| First source planning | 19,904 B | 3,512 B |
+| Repeated source planning | 3,780 ns / 5,616 B | 126 ns / 0 B |
+| Allocation-fanout once paths | 53 per `CreatePipeline` | 1 in the static initializer |
+
+The fanout values are structural paths, not object counts. The runtime byte
+measurements supply the allocation quantity. The broader
+`LibrarySections.CreatePipeline` factory remains for rendering and other
+callers; this pilot removes it only from the per-assembly source authorization
+path.
+
+Managed output matched the merge base byte-for-byte for each migrated section
+and for their 884-line combined selection. The NativeAOT binary produced the
+same combined output as the managed binary.
+
 ## NativeAOT and generation
 
 The design uses static lambdas, arrays, dictionaries, and concrete generic
@@ -278,7 +336,8 @@ types. It does not use reflection enumeration, `Activator`, expression
 compilation, runtime code generation, Roslyn, or inspected-assembly loading.
 The spike publishes and runs as an `osx-arm64` NativeAOT binary.
 
-A production generator should emit:
+A broader variable-order registry may eventually justify a generator that
+emits:
 
 - operation entries and noncapturing lambdas;
 - ordered single-section plans;
@@ -286,9 +345,11 @@ A production generator should emit:
 - section rows and the selection-mask switch;
 - diagnostics for missing prerequisites, cycles, duplicate IDs, and names.
 
-Generation is valuable here because it removes runtime graph work and makes the
-single table the source of truth. The checked-in hand-authored table proves the
-runtime shape without making a generator part of this spike.
+Generation is valuable only when it removes real graph work or enough repeated
+declarations to offset another representation. The source/PDB pilot did not
+meet that threshold. Its hand-authored typed rows already provide compile-time
+descriptor name/mode coupling, and invariant tests cover duplicate names and
+the full authorization matrix.
 
 ## Boundaries
 
@@ -305,21 +366,21 @@ assembly loading.
 
 ## Conclusion
 
-Proceed with a static-table production pilot:
+Use the smallest static table that removes repeated construction:
 
 1. Keep `SectionPipeline` as the selection/schema/render-filter authority and
    Markout as the renderer.
-2. Generate one process-wide lambda table and precompiled plans for source/PDB
-   and body-index-backed library sections.
-3. Replace legacy `ScannerKey`, `SectionCapabilities`, and
-   `ProbeEffectiveness` metadata for each migrated section.
-4. A/B product output and actual work counts for every migrated section.
-5. Measure fresh-process initialization and realistic reuse count, not only hot
-   lookup.
-6. Reject the migration if the CLI initializes the table for a single use and
-   cannot recover the cold cost, or if execution loses the measured advantage.
+2. Use typed static authorization data for the source/PDB cluster while its
+   execution order remains fixed and explicit.
+3. Preserve `options.UserVerbosity` as the network authorization input; internal
+   verbosity promotion must not broaden access.
+4. Require output A/B, full authorization-matrix tests, fresh-process
+   initialization, realistic reuse, allocation fanout, and NativeAOT evidence
+   for each production migration.
+5. Add generated lambda dispatch only when a later cluster has enough shared,
+   variable prerequisites to remove more complexity than generation adds.
 
 The dynamic registry was the wrong final shape. The static lambda table
-preserves its semantic gains, removes repeated construction, improves
-steady-state planning and acquisition, and states the remaining cold cost
-explicitly.
+proved the performance model. The production source/PDB result is narrower:
+static typed authorization removes repeated construction and metadata
+duplication, while explicit service orchestration remains the clearest code.

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -634,52 +634,94 @@ public class SectionPipelineTests
     }
 
     [Fact]
-    public void LibraryPipeline_SourceIntegrityAuthorizedOnlyByExplicitSelection()
+    public void LibrarySourcePlan_SourceIntegrityAuthorizedOnlyByExplicitSelection()
     {
-        var pipeline = LibrarySections.CreatePipeline();
         var include = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "SourceLink Integrity" };
 
-        // MayFetchSources is authorized only via explicit include, never by verbosity.
-        Assert.Empty(pipeline.GetAuthorizedSections(SectionCapabilities.MayFetchSources, Verbosity.Detailed, null));
-        Assert.Contains("SourceLink Integrity",
-            pipeline.GetAuthorizedSections(SectionCapabilities.MayFetchSources, Verbosity.Normal, include));
+        Assert.False(LibrarySourcePlans.For(Verbosity.Detailed, null).RunIntegrity);
+        Assert.True(LibrarySourcePlans.For(Verbosity.Normal, include).RunIntegrity);
     }
 
     [Fact]
-    public void LibraryPipeline_PdbDownloadAuthorizedByDetailedOrInclude()
+    public void LibrarySourcePlan_PdbDownloadAuthorizedByDetailedOrInclude()
     {
-        var pipeline = LibrarySections.CreatePipeline();
-
-        // Signals declares MayDownloadPdb: not authorized at Normal without include...
-        Assert.Empty(pipeline.GetAuthorizedSections(SectionCapabilities.MayDownloadPdb, Verbosity.Normal, null));
-
-        // ...authorized at Detailed (verbosity ceiling)...
-        Assert.Contains("Signals",
-            pipeline.GetAuthorizedSections(SectionCapabilities.MayDownloadPdb, Verbosity.Detailed, null));
-
-        // ...and authorized at Normal when explicitly included.
-        Assert.Contains("Signals",
-            pipeline.GetAuthorizedSections(SectionCapabilities.MayDownloadPdb, Verbosity.Normal,
-                new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Signals" }));
-
-        // SourceLink Integrity also declares MayDownloadPdb but is ExplicitOnly: the verbosity ceiling
-        // must NOT authorize it without an explicit include (regression guard for the ordering of
-        // ExplicitOnly filtering vs. capability authorization).
-        Assert.DoesNotContain("SourceLink Integrity",
-            pipeline.GetAuthorizedSections(SectionCapabilities.MayDownloadPdb, Verbosity.Detailed, null));
+        Assert.False(LibrarySourcePlans.For(Verbosity.Normal, null).AllowPdbDownload);
+        Assert.True(LibrarySourcePlans.For(Verbosity.Detailed, null).AllowPdbDownload);
+        Assert.True(LibrarySourcePlans.For(
+            Verbosity.Normal,
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Signals" })
+            .AllowPdbDownload);
     }
 
     [Fact]
-    public void LibraryPipeline_SourceAuditAuthorizedBySignals()
+    public void LibrarySourcePlan_SourceAuditAuthorizedBySignals()
     {
-        var pipeline = LibrarySections.CreatePipeline();
         var include = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Signals" };
 
-        Assert.Empty(pipeline.GetAuthorizedSections(SectionCapabilities.MayAuditSources, Verbosity.Normal, null));
-        Assert.Contains("Signals",
-            pipeline.GetAuthorizedSections(SectionCapabilities.MayAuditSources, Verbosity.Normal, include));
-        Assert.Contains("Signals",
-            pipeline.GetAuthorizedSections(SectionCapabilities.MayAuditSources, Verbosity.Detailed, null));
+        Assert.False(LibrarySourcePlans.For(Verbosity.Normal, null).RunHeadAudit);
+        Assert.True(LibrarySourcePlans.For(Verbosity.Normal, include).RunHeadAudit);
+        Assert.True(LibrarySourcePlans.For(Verbosity.Detailed, null).RunHeadAudit);
+    }
+
+    [Fact]
+    public void LibrarySourcePlan_PreservesAuthorizationForEverySelection()
+    {
+        string[] sourceSections =
+        [
+            SectionNames.ILOffset,
+            "Source Files",
+            "Symbols",
+            "Signals",
+            "SourceLink Availability",
+            "SourceLink Missing Files",
+            "SourceLink Integrity",
+        ];
+
+        foreach (var verbosity in Enum.GetValues<Verbosity>())
+        {
+            for (int selection = 0; selection < 1 << sourceSections.Length; selection++)
+            {
+                HashSet<string>? include = selection == 0
+                    ? null
+                    : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                for (int index = 0; index < sourceSections.Length; index++)
+                {
+                    if ((selection & (1 << index)) != 0)
+                        include!.Add(sourceSections[index]);
+                }
+
+                var plan = LibrarySourcePlans.For(verbosity, include);
+                bool expectedPdb = include is null
+                    ? verbosity >= Verbosity.Detailed
+                    : include.Overlaps(sourceSections);
+                bool expectedAudit = include is null
+                    ? verbosity >= Verbosity.Detailed
+                    : include.Overlaps(
+                        ["Signals", "SourceLink Availability", "SourceLink Missing Files"]);
+                bool expectedIntegrity = include?.Contains("SourceLink Integrity") == true;
+
+                Assert.Equal(
+                    expectedPdb,
+                    plan.AllowPdbDownload);
+                Assert.Equal(expectedAudit, plan.RunHeadAudit);
+                Assert.Equal(expectedIntegrity, plan.RunIntegrity);
+                Assert.Equal(
+                    include?.Contains("Source Files") == true,
+                    plan.CollectSourceFiles);
+            }
+        }
+    }
+
+    [Fact]
+    public void LibrarySourcePlans_HaveUniqueNamesAndValidModes()
+    {
+        HashSet<string> sectionNames = new(StringComparer.OrdinalIgnoreCase);
+        foreach (var section in LibrarySourcePlans.Sections)
+        {
+            Assert.True(sectionNames.Add(section.Name));
+            Assert.NotEqual(LibrarySourcePlanModes.None, section.Modes);
+            Assert.True(section.DownloadPdb);
+        }
     }
 
     [Fact]

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -189,20 +189,20 @@ internal static class LibraryMetadataService
             inspection.FileSize = pdbContext.FileSize;
             inspection.LastModified = pdbContext.LastWriteTimeUtc;
 
-            // Decide network work from section selection + capability authorization (keyed off the
-            // user's original verbosity, never an internally force-bumped value). PDB download and
-            // source verification are authorized only when a selected section declares the capability.
-            var pipeline = LibrarySections.CreatePipeline();
-            var include = options.IncludeSections;
-            var pdbSections = pipeline.GetAuthorizedSections(
-                SectionCapabilities.MayDownloadPdb, options.UserVerbosity, include);
-            bool allowPdbDownload = pdbSections.Count > 0;
-            bool runHeadAudit = pipeline.GetAuthorizedSections(
-                SectionCapabilities.MayAuditSources, options.UserVerbosity, include).Count > 0;
-            bool runIntegrity = pipeline.GetAuthorizedSections(
-                SectionCapabilities.MayFetchSources, options.UserVerbosity, include).Count > 0;
+            var sourcePlan = LibrarySourcePlans.For(
+                options.UserVerbosity,
+                options.IncludeSections);
 
-            await AuditAsync(service, inspection, path, packageName, packageVersion, logger, httpClient, isPlatformAssembly, allowPdbDownload: allowPdbDownload);
+            await AuditAsync(
+                service,
+                inspection,
+                path,
+                packageName,
+                packageVersion,
+                logger,
+                httpClient,
+                isPlatformAssembly,
+                allowPdbDownload: sourcePlan.AllowPdbDownload);
 
             var sourceSubject = FindingSubjectFor(path);
             inspection.SourceDocumentInspection = MetadataFindings.InspectSourceDocuments(
@@ -218,7 +218,7 @@ internal static class LibraryMetadataService
             if (needsAuditSignals)
                 AuditSignalBuilder.PopulateLibraryAudit(path, inspection, logger);
 
-            if (runHeadAudit && service.HasSourceLink && pdbContext.HasPdb)
+            if (sourcePlan.RunHeadAudit && service.HasSourceLink && pdbContext.HasPdb)
             {
                 // SourceLink URLs are untrusted: probe them with the SSRF-hardened client, not the
                 // shared client used for trusted NuGet/symbol endpoints.
@@ -231,7 +231,7 @@ internal static class LibraryMetadataService
                     AuditSignalBuilder.PopulateLibraryAudit(path, inspection, logger);
             }
 
-            if (runIntegrity && service.HasSourceLink && pdbContext.HasPdb)
+            if (sourcePlan.RunIntegrity && service.HasSourceLink && pdbContext.HasPdb)
             {
                 await SourceIntegrityService.PopulateAsync(
                     inspection.SourceDocumentInspection,
@@ -241,7 +241,7 @@ internal static class LibraryMetadataService
                     AuditSignalBuilder.PopulateLibraryAudit(path, inspection, logger);
             }
 
-            if (include?.Contains("Source Files") == true)
+            if (sourcePlan.CollectSourceFiles)
             {
                 inspection.SourceFiles = await SourceFileCollector.CollectAsync(
                     service,

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -146,7 +146,6 @@ public static class LibrarySections
         public static string Name => SectionNames.ILOffset;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
-        public static SectionCapabilities Capabilities => SectionCapabilities.MayDownloadPdb;
         public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model) => model.ILOffset != null;
     }
@@ -230,7 +229,6 @@ public static class LibrarySections
         public static string Name => "Source Files";
         public static bool IsExpensive => true;
         public static bool ExplicitOnly => true;
-        public static SectionCapabilities Capabilities => SectionCapabilities.MayDownloadPdb;
         public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model) => model.AssemblyInfo != null;
     }
@@ -239,7 +237,6 @@ public static class LibrarySections
     {
         public static string Name => "Symbols";
         public static bool IsExpensive => false;
-        public static SectionCapabilities Capabilities => SectionCapabilities.MayDownloadPdb;
         public static string? ScannerKey => ScannerSymbols;
         public static bool CanRender(LibraryInspection model) => true;
     }
@@ -248,8 +245,6 @@ public static class LibrarySections
     {
         public static string Name => "Signals";
         public static bool IsExpensive => false;
-        public static SectionCapabilities Capabilities =>
-            SectionCapabilities.MayDownloadPdb | SectionCapabilities.MayAuditSources;
         public static string? ScannerKey => ScannerAuditSignals;
         public static bool CanRender(LibraryInspection model)
             => model.AuditSignals is { Count: > 0 };
@@ -422,8 +417,6 @@ public static class LibrarySections
         // Opt-in only: issues one HEAD per source file, which scales with source count and is too
         // slow to render as a full default section. Signals may still summarize this high-value audit.
         public static bool ExplicitOnly => true;
-        public static SectionCapabilities Capabilities =>
-            SectionCapabilities.MayDownloadPdb | SectionCapabilities.MayAuditSources;
         public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model)
             => model.AllSourcesAccessible.HasValue || model.TotalSourceFiles > 0;
@@ -435,8 +428,6 @@ public static class LibrarySections
         public static bool IsExpensive => true;
         // Opt-in only: derived from the same per-file HEAD pass as SourceLink Availability.
         public static bool ExplicitOnly => true;
-        public static SectionCapabilities Capabilities =>
-            SectionCapabilities.MayDownloadPdb | SectionCapabilities.MayAuditSources;
         public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model)
             => model.MissingSourceFiles is { Count: > 0 };
@@ -447,8 +438,6 @@ public static class LibrarySections
         public static string Name => "SourceLink Integrity";
         public static bool IsExpensive => true;
         public static bool ExplicitOnly => true;
-        public static SectionCapabilities Capabilities =>
-            SectionCapabilities.MayDownloadPdb | SectionCapabilities.MayFetchSources;
         public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model) => model.SourceIntegrityChecked;
     }

--- a/src/dotnet-inspect/Sections/LibrarySourcePlan.cs
+++ b/src/dotnet-inspect/Sections/LibrarySourcePlan.cs
@@ -1,0 +1,98 @@
+using DotnetInspector.Models;
+using DotnetInspector.Options;
+
+namespace DotnetInspector.Sections;
+
+[Flags]
+internal enum LibrarySourcePlanModes
+{
+    None = 0,
+    Detailed = 1 << 0,
+    Explicit = 1 << 1,
+    All = Detailed | Explicit,
+}
+
+internal readonly record struct LibrarySourcePlan(
+    bool AllowPdbDownload,
+    bool RunHeadAudit,
+    bool RunIntegrity,
+    bool CollectSourceFiles);
+
+internal readonly record struct LibrarySourceSectionPlan(
+    string Name,
+    LibrarySourcePlanModes Modes,
+    bool DownloadPdb,
+    bool AuditSources,
+    bool VerifyIntegrity,
+    bool CollectSourceFiles);
+
+internal static class LibrarySourcePlans
+{
+    private static readonly LibrarySourceSectionPlan[] s_sections =
+    [
+        Section<LibrarySections.ILOffset>(downloadPdb: true),
+        Section<LibrarySections.SourceFiles>(downloadPdb: true, collectSourceFiles: true),
+        Section<LibrarySections.Symbols>(downloadPdb: true),
+        Section<LibrarySections.Signals>(downloadPdb: true, auditSources: true),
+        Section<LibrarySections.SourceLinkAudit>(downloadPdb: true, auditSources: true),
+        Section<LibrarySections.MissingSourceFiles>(downloadPdb: true, auditSources: true),
+        Section<LibrarySections.SourceIntegrity>(downloadPdb: true, verifyIntegrity: true),
+    ];
+
+    internal static ReadOnlySpan<LibrarySourceSectionPlan> Sections => s_sections;
+
+    internal static LibrarySourcePlan For(
+        Verbosity userVerbosity,
+        HashSet<string>? include)
+    {
+        bool downloadPdb = false;
+        bool auditSources = false;
+        bool verifyIntegrity = false;
+        bool collectSourceFiles = false;
+        bool hasExplicitSelection = include is { Count: > 0 };
+        var mode = hasExplicitSelection
+            ? LibrarySourcePlanModes.Explicit
+            : userVerbosity >= Verbosity.Detailed
+                ? LibrarySourcePlanModes.Detailed
+                : LibrarySourcePlanModes.None;
+
+        if (mode == LibrarySourcePlanModes.None)
+            return default;
+
+        foreach (var section in s_sections)
+        {
+            bool selected = hasExplicitSelection
+                ? include!.Contains(section.Name)
+                : (section.Modes & LibrarySourcePlanModes.Detailed) != 0;
+            if (!selected || (section.Modes & mode) == 0)
+                continue;
+
+            downloadPdb |= section.DownloadPdb;
+            auditSources |= section.AuditSources;
+            verifyIntegrity |= section.VerifyIntegrity;
+            collectSourceFiles |= section.CollectSourceFiles;
+        }
+
+        return new LibrarySourcePlan(
+            downloadPdb,
+            auditSources,
+            verifyIntegrity,
+            collectSourceFiles);
+    }
+
+    private static LibrarySourceSectionPlan Section<TDescriptor>(
+        bool downloadPdb = false,
+        bool auditSources = false,
+        bool verifyIntegrity = false,
+        bool collectSourceFiles = false)
+        where TDescriptor : ISectionDescriptor<LibraryInspection>
+        => new(
+            TDescriptor.Name,
+            TDescriptor.ExplicitOnly
+                ? LibrarySourcePlanModes.Explicit
+                : LibrarySourcePlanModes.All,
+            downloadPdb,
+            auditSources,
+            verifyIntegrity,
+            collectSourceFiles);
+}


### PR DESCRIPTION
## Summary

- replace per-assembly library-pipeline construction and three authorization
  queries with one typed static source plan
- keep the existing explicit PDB/source operation order and hardened HTTP
  boundary
- remove migrated capability declarations from section descriptors
- document why the measured production design is static authorization data,
  not generated async dispatch

Closes #2747.

## Performance

Managed .NET 11 preview 5, macOS arm64:

| Scenario | Before | After |
| --- | ---: | ---: |
| First source planning | 19,904 B | 3,512 B |
| Repeated source planning | 3,780 ns / 5,616 B | 126 ns / 0 B |
| Allocation-fanout once paths | 53 per `CreatePipeline` | 1 in static initializer |

The fanout values are structural paths rather than object counts. Fresh-process
and repeated managed measurements provide the runtime allocation quantities.

## Correctness

- all 128 source-section combinations at every verbosity match the previous
  authorization matrix
- individual output matches merge base for Symbols, Signals, Source Files,
  SourceLink Availability, SourceLink Missing Files, and SourceLink Integrity
- the 884-line combined selection matches merge base byte-for-byte
- managed and NativeAOT combined output match byte-for-byte
- authorization continues to use original user verbosity
- SourceLink Integrity remains explicit-only
- source HEAD requests continue to use the untrusted-fetch client

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release`
  (1,896 total, 0 failed, 10 tool-dependent skips)
- `dotnet publish src/dotnet-inspect/dotnet-inspect.csproj -c Release -p:PublishAot=true`
- markdownlint on the changed design document

## Design decision

The initial prototype used five static async operation lambdas and bitmask
execution plans. It added roughly 200 production lines for one fixed sequence
and exposed an async-lifetime hazard when span-backed operation data crossed a
continuation. A generator would add a third declaration form for only five
operations and seven rows.

The final design keeps the measured construction win with a seven-row typed
authorization table. Descriptor names and explicit-only modes are compile-time
coupled; the service keeps the readable domain sequence. Generation remains an
option for a later cluster with variable shared prerequisites.
