### PR TITLE
Address member bodies, attributes, accessors, and IL by metadata handle

### DIFF
--- a/docs/design/member-body-substrate.md
+++ b/docs/design/member-body-substrate.md
@@ -100,6 +100,32 @@ Two resolution paths, chosen by scope:
 makes handle addressing the rule and the two paths above the only way to obtain
 one.
 
+### Caller migration status
+
+The same-reader body-composition callers are migrated onto handle addressing:
+
+- **`TypeSourceComposer`** — whole-type field-initializer collection
+  (`CollectFieldInitializers`) and per-member body composition (`DecompileBody`)
+  import by `MethodDefinitionHandle`. `DecompileBody` resolves
+  `ApiMember.MetadataToken` and validates it against the composing reader (a
+  method of the composed type whose name matches the member) before use; a token
+  that does not validate — e.g. carried over from a type-forwarded surface —
+  falls back to the legacy name+ordinal path rather than mis-addressing.
+- **`CSharpBodyDiff`** — `Decompile` imports each `CSharpMethodEntry` by the
+  `MethodDefinitionHandle` the entry was built from, instead of re-deriving a
+  `(type, method, overloadIndex)` tuple.
+
+This closes an observed correctness bug: the extractor drops some public methods
+from the API surface (e.g. `EditorBrowsable(Never)` overloads) that the by-name
+importer's public-only counting still counts, so a surviving overload's running
+surface index no longer matches its metadata overload index and the ordinal path
+pairs its signature with a *different* overload's body (often referencing
+out-of-scope locals — invalid C#). Handle addressing renders each member's own
+body. Still on the ordinal tuple (follow-up bricks): `ResearchViews`'
+CLI-driven `(type, method, overloadIndex)` entry points, `TypeSourceComposer`
+property/event accessor addressing, and the member **attribute** rendering path
+(`AttributeReader.RenderMethodAttributes`, which drifts the same way).
+
 ## Scope: one load per type
 
 The addressable unit lives in a scope. `MetadataSource : IDisposable` is that

--- a/docs/design/member-body-substrate.md
+++ b/docs/design/member-body-substrate.md
@@ -114,17 +114,33 @@ The same-reader body-composition callers are migrated onto handle addressing:
 - **`CSharpBodyDiff`** — `Decompile` imports each `CSharpMethodEntry` by the
   `MethodDefinitionHandle` the entry was built from, instead of re-deriving a
   `(type, method, overloadIndex)` tuple.
+- **`TypeSourceComposer` attributes + accessors** — `ComposeMembers` resolves the
+  validated member handle once and addresses both the member **body** and its
+  **custom attributes** by it (`AttributeReader.RenderMethodAttributes(reader,
+  handle, ns)`); `ComposeProperty` addresses get/set/init accessors by the
+  property's `GetterToken`/`SetterToken` (fixing indexer `get_Item`/`set_Item`
+  drift, where `overloadIndex:0` always picked the first indexer).
+- **`MemberCodeProvider` (`member` CLI) + `ResearchViews`** — `Collect` resolves
+  the surface member's validated metadata token once and threads it into
+  attributes, generic-parameter names, `HasBody`, decompiled source, the
+  `ResearchViews` mixed IL+C# projection (`MemberProjectionRequest.MethodHandle`),
+  and IL disassembly. Layer overloads were added at each seam
+  (`AttributeReader.GetMethodAttributes`, `ILInstructionPrinter.DisassembleMethod`,
+  `IlProjection.Locate/Project/AnnotatedInstrLines`). Other `ResearchViews` entry
+  points keep the name path (nil handle → fallback) — they are not the CLI's drift
+  surface.
 
 This closes an observed correctness bug: the extractor drops some public methods
 from the API surface (e.g. `EditorBrowsable(Never)` overloads) that the by-name
 importer's public-only counting still counts, so a surviving overload's running
 surface index no longer matches its metadata overload index and the ordinal path
 pairs its signature with a *different* overload's body (often referencing
-out-of-scope locals — invalid C#). Handle addressing renders each member's own
-body. Still on the ordinal tuple (follow-up bricks): `ResearchViews`'
-CLI-driven `(type, method, overloadIndex)` entry points, `TypeSourceComposer`
-property/event accessor addressing, and the member **attribute** rendering path
-(`AttributeReader.RenderMethodAttributes`, which drifts the same way).
+out-of-scope locals — invalid C#), or misattributes the hidden overload's
+attributes (`[EditorBrowsable]`/`[Obsolete]`) onto the survivor. Handle addressing
+renders each member's own body and attributes. Every same-reader body/attribute
+path in whole-type composition and the `member` CLI is now handle-addressed; a
+token that does not validate (type-forwarded surface) falls back to the legacy
+name+ordinal path rather than mis-addressing.
 
 ## Scope: one load per type
 

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerOverloadAddressingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerOverloadAddressingTests.cs
@@ -31,6 +31,29 @@ public class TypeSourceComposerOverloadAddressingTests
         Assert.NotNull(source);
         Assert.Contains("VISIBLE_OVERLOAD_BODY", source);
         Assert.DoesNotContain("HIDDEN_OVERLOAD_BODY", source);
+        // The attribute path drifts on the same running-index mismatch: ordinal
+        // addressing pulls the hidden overload's [EditorBrowsable] onto the
+        // survivor. The hidden overload is not composed, so its attribute must
+        // not appear anywhere in the output.
+        Assert.DoesNotContain("EditorBrowsable", source);
+    }
+
+    [Fact]
+    public void OverloadedIndexers_EachAccessorRendersItsOwnBody()
+    {
+        string assemblyPath = typeof(IndexerDriftSpecimen).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(assemblyPath));
+        var surface = ApiSurfaceExtractor.Extract(pe, includeAll: false);
+        var type = surface.Types.Single(t => t.FullName == typeof(IndexerDriftSpecimen).FullName);
+
+        string? source = TypeSourceComposer.Compose(type, assemblyPath, pdbPath: null);
+
+        Assert.NotNull(source);
+        // Both indexers compile to get_Item accessors; ordinal addressing
+        // (overloadIndex:0) renders the first indexer's body for both. Handle
+        // addressing via the property's GetterToken renders each own body.
+        Assert.Contains("INT_INDEXER_BODY", source);
+        Assert.Contains("STRING_INDEXER_BODY", source);
     }
 }
 
@@ -44,4 +67,14 @@ public class OverloadDriftSpecimen
 
     // Surviving overload: running surface index 0, metadata public index 1.
     public string Describe(string value) => "VISIBLE_OVERLOAD_BODY";
+}
+
+public class IndexerDriftSpecimen
+{
+    // Two indexers, both emitted as get_Item accessors. Ordinal accessor
+    // addressing (overloadIndex:0) selects the first for both; handle addressing
+    // keys each accessor by the property's own GetterToken.
+    public string this[int index] => "INT_INDEXER_BODY";
+
+    public string this[string key] => "STRING_INDEXER_BODY";
 }

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerOverloadAddressingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerOverloadAddressingTests.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Reflection.PortableExecutable;
+using ILInspector.Metadata;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Pins whole-type composition to metadata-handle member addressing rather than
+/// name+overload-ordinal counting. The extractor drops some public methods from
+/// the API surface (here, an <see cref="EditorBrowsableAttribute"/>-hidden
+/// overload) that the by-name importer's public-only counting still counts, so
+/// the surviving overload's running surface index no longer matches its metadata
+/// overload index. Ordinal addressing then pairs the survivor's signature with
+/// the hidden overload's body (invalid); handle addressing renders each member's
+/// own body. See docs/design/member-body-substrate.md.
+/// </summary>
+public class TypeSourceComposerOverloadAddressingTests
+{
+    [Fact]
+    public void EditorBrowsableHiddenOverload_DoesNotStealVisibleBody()
+    {
+        string assemblyPath = typeof(OverloadDriftSpecimen).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(assemblyPath));
+        var surface = ApiSurfaceExtractor.Extract(pe, includeAll: false);
+        var type = surface.Types.Single(t => t.FullName == typeof(OverloadDriftSpecimen).FullName);
+
+        string? source = TypeSourceComposer.Compose(type, assemblyPath, pdbPath: null);
+
+        Assert.NotNull(source);
+        Assert.Contains("VISIBLE_OVERLOAD_BODY", source);
+        Assert.DoesNotContain("HIDDEN_OVERLOAD_BODY", source);
+    }
+}
+
+public class OverloadDriftSpecimen
+{
+    // First public overload in metadata order — hidden from the API surface, so
+    // it is not composed but still occupies a public overload slot the by-name
+    // importer counts.
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public string Describe(int value) => "HIDDEN_OVERLOAD_BODY";
+
+    // Surviving overload: running surface index 0, metadata public index 1.
+    public string Describe(string value) => "VISIBLE_OVERLOAD_BODY";
+}

--- a/src/ILInspector.Decompiler/CSharpBodyDiff.cs
+++ b/src/ILInspector.Decompiler/CSharpBodyDiff.cs
@@ -400,7 +400,7 @@ public static class CSharpBodyDiff
         if (!entry.HasBody)
             return new CSharpMethodRender(CSharpRenderState.Absent, ["/* no method body */"], DecompilationFidelity.IlOnly);
 
-        var function = IrImporter.Import(source, entry.TypeFullName, entry.MethodName, entry.OverloadIndex, publicOnly: false);
+        var function = IrImporter.Import(source, entry.MethodHandle);
         if (function is null)
             return new CSharpMethodRender(CSharpRenderState.Absent, ["/* no method body */"], DecompilationFidelity.IlOnly);
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IlProjection.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IlProjection.cs
@@ -53,12 +53,23 @@ public static class IlProjection
         MetadataSource source, string typeFullName, string methodName,
         IlProjectionDepth depth, int overloadIndex = 0, bool publicOnly = false)
         => DecompilerResult.Run(
-            () => Render(source, typeFullName, methodName, depth, overloadIndex, publicOnly),
+            () => Render(source, Locate(source.Reader, typeFullName, methodName, overloadIndex, publicOnly), depth),
             emptyOutputIsFailure: true);
 
-    static string Render(MetadataSource source, string type, string method, IlProjectionDepth depth, int overloadIndex, bool publicOnly)
+    /// <summary>
+    /// Handle-addressed projection: the caller already holds the method's own
+    /// <see cref="MethodDefinitionHandle"/> (see docs/design/member-body-substrate.md),
+    /// bypassing the name+overload-ordinal walk and its drift.
+    /// </summary>
+    public static DecompilerResult Project(
+        MetadataSource source, MethodDefinitionHandle methodHandle, IlProjectionDepth depth)
+        => DecompilerResult.Run(
+            () => Render(source, Locate(source.Reader, methodHandle), depth),
+            emptyOutputIsFailure: true);
+
+    static string Render(MetadataSource source, (TypeDefinition Type, MethodDefinition Method, MethodDefinitionHandle Handle) located, IlProjectionDepth depth)
     {
-        var (typeDef, methodDef, methodHandle) = Locate(source.Reader, type, method, overloadIndex, publicOnly);
+        var (typeDef, methodDef, methodHandle) = located;
         var imported = MethodImporter.Import(source, (TypeDefinitionHandle)methodDef.GetDeclaringType(), methodHandle);
         var scope = IrImporter.CallerScope(source.Reader, typeDef, methodDef);
         var instructions = Decode(source.Reader, scope, imported.Body.IL.AsSpan());
@@ -92,6 +103,16 @@ public static class IlProjection
             sb.AppendLine(Format(i) + types);
         }
         return sb.ToString();
+    }
+
+    static (TypeDefinition Type, MethodDefinition Method, MethodDefinitionHandle Handle) Locate(
+        MetadataReader reader, MethodDefinitionHandle methodHandle)
+    {
+        var method = reader.GetMethodDefinition(methodHandle);
+        if (method.RelativeVirtualAddress == 0)
+            throw new InvalidOperationException($"0x{MetadataTokens.GetToken(methodHandle):X8} has no IL body");
+        var typeDef = reader.GetTypeDefinition(method.GetDeclaringType());
+        return (typeDef, method, methodHandle);
     }
 
     static (TypeDefinition Type, MethodDefinition Method, MethodDefinitionHandle Handle) Locate(
@@ -443,8 +464,21 @@ public static class IlProjection
     /// </summary>
     public static IReadOnlyList<AnnotatedInstrLine> AnnotatedInstrLines(
         MetadataSource source, string type, string method, int overloadIndex, bool publicOnly)
+        => AnnotatedInstrLines(source, Locate(source.Reader, type, method, overloadIndex, publicOnly));
+
+    /// <summary>
+    /// Handle-addressed annotated IL lines: the caller already holds the
+    /// method's own <see cref="MethodDefinitionHandle"/>, bypassing the
+    /// name+overload-ordinal walk and its drift.
+    /// </summary>
+    public static IReadOnlyList<AnnotatedInstrLine> AnnotatedInstrLines(
+        MetadataSource source, MethodDefinitionHandle methodHandle)
+        => AnnotatedInstrLines(source, Locate(source.Reader, methodHandle));
+
+    static IReadOnlyList<AnnotatedInstrLine> AnnotatedInstrLines(
+        MetadataSource source, (TypeDefinition Type, MethodDefinition Method, MethodDefinitionHandle Handle) located)
     {
-        var (typeDef, methodDef, methodHandle) = Locate(source.Reader, type, method, overloadIndex, publicOnly);
+        var (typeDef, methodDef, methodHandle) = located;
         var imported = MethodImporter.Import(source, (TypeDefinitionHandle)methodDef.GetDeclaringType(), methodHandle);
         var scope = IrImporter.CallerScope(source.Reader, typeDef, methodDef);
         var instructions = Decode(source.Reader, scope, imported.Body.IL.AsSpan());

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -772,8 +772,8 @@ public static class TypeSourceComposer
         string head = accessorList >= 0 ? signature[..accessorList].TrimEnd() : signature;
         bool requiresUnsafeContext = member.IsUnsafe || signature.Contains('*', StringComparison.Ordinal);
 
-        var getterHandle = ResolveMethodHandle(reader, typeHandle, member.GetterToken);
-        var setterHandle = ResolveMethodHandle(reader, typeHandle, member.SetterToken);
+        var getterHandle = ResolveAccessorHandle(reader, typeHandle, member.GetterToken, $"get_{member.Name}");
+        var setterHandle = ResolveAccessorHandle(reader, typeHandle, member.SetterToken, $"set_{member.Name}");
 
         var accessors = new List<(string Keyword, string? Body, bool RequiresUnsafeContext)>();
         if (accessorList >= 0)
@@ -957,6 +957,25 @@ public static class TypeSourceComposer
             return null;
         }
         return method.GetDeclaringType() == typeHandle ? methodHandle : null;
+    }
+
+    /// <summary>
+    /// Resolves a property accessor token to its <see cref="MethodDefinitionHandle"/>,
+    /// applying the same rigor as <see cref="ResolveMemberHandle"/>: the token must
+    /// resolve to a method of <paramref name="typeHandle"/> whose name equals the
+    /// expected accessor name (e.g. <c>get_Item</c>). A stale token carried over
+    /// from a type-forwarded or round-tripped surface that lands on a different
+    /// method of the same type — a private helper or a sibling property's accessor —
+    /// is rejected, asking the caller to fall back to name+ordinal addressing rather
+    /// than decompiling an unrelated body as the accessor.
+    /// </summary>
+    static MethodDefinitionHandle? ResolveAccessorHandle(MetadataReader reader, TypeDefinitionHandle typeHandle, int? token, string accessorName)
+    {
+        if (ResolveMethodHandle(reader, typeHandle, token) is not { } handle)
+            return null;
+        if (reader.GetString(reader.GetMethodDefinition(handle).Name) != accessorName)
+            return null;
+        return handle;
     }
 
     static string? DecompileAccessor(

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -131,7 +131,7 @@ public static class TypeSourceComposer
                     else
                     {
                         ComposeFields(sb, reader, typeHandle, bodyNamespaces,
-                            CollectFieldInitializers(pipelineSource, type.FullName, reader, typeHandle), ref any);
+                            CollectFieldInitializers(pipelineSource, reader, typeHandle), ref any);
                         ComposeMembers(sb, type, pipelineSource, reader, typeHandle, union, bodyNamespaces, ref any);
                     }
 
@@ -409,7 +409,7 @@ public static class TypeSourceComposer
                     bool requiresUnsafeContext = false;
                     string? body = member.IsAbstract
                         ? null
-                        : DecompileBody(pipelineSource, type.FullName, member, index, bodyNamespaces, out constructorChain, out requiresAsync, out requiresUnsafeContext);
+                        : DecompileBody(pipelineSource, reader, typeHandle, type.FullName, member, index, bodyNamespaces, out constructorChain, out requiresAsync, out requiresUnsafeContext);
 
                     // An explicit interface property implementation surfaces
                     // as its accessor method (Iface.get_X). Render the
@@ -850,24 +850,20 @@ public static class TypeSourceComposer
     /// is skipped: its stores are not lifted (no base chain, no <c>this</c>).
     /// </summary>
     static Dictionary<string, string> CollectFieldInitializers(
-        Pipeline.MetadataSource pipelineSource, string typeFullName,
+        Pipeline.MetadataSource pipelineSource,
         MetadataReader reader, TypeDefinitionHandle typeHandle)
     {
         var initializers = new Dictionary<string, string>(StringComparer.Ordinal);
         var typeDef = reader.GetTypeDefinition(typeHandle);
 
-        // The overload index counts every '.ctor' in metadata order at
-        // publicOnly: false — the same order this loop walks — so it selects the
-        // matching constructor regardless of accessibility.
-        int constructorIndex = 0;
+        // Address each constructor by its metadata handle directly — the
+        // canonical same-reader addressing (see docs/design/member-body-substrate.md).
         foreach (var methodHandle in typeDef.GetMethods())
         {
             if (reader.GetString(reader.GetMethodDefinition(methodHandle).Name) != ".ctor")
                 continue;
 
-            var function = Pipeline.IrImporter.Import(
-                pipelineSource, typeFullName, ".ctor", constructorIndex, publicOnly: false);
-            constructorIndex++;
+            var function = Pipeline.IrImporter.Import(pipelineSource, methodHandle);
             if (function is null)
                 continue;
 
@@ -881,16 +877,61 @@ public static class TypeSourceComposer
     }
 
     static string? DecompileBody(
-        Pipeline.MetadataSource pipelineSource, string typeFullName, ApiMember member, int overloadIndex,
+        Pipeline.MetadataSource pipelineSource, MetadataReader reader, TypeDefinitionHandle typeHandle,
+        string typeFullName, ApiMember member, int overloadIndex,
         SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresAsync, out bool requiresUnsafeContext)
+    {
+        // Prefer the member's own metadata handle — the canonical same-reader
+        // addressing (see docs/design/member-body-substrate.md). The token is
+        // validated against this reader (a method of this type with this name)
+        // before use, so a stale token from a type-forwarded surface falls back
+        // to the name+ordinal path rather than mis-addressing.
+        if (ResolveMemberHandle(reader, typeHandle, member) is { } methodHandle)
+            return DecompileFunction(pipelineSource,
+                Pipeline.IrImporter.Import(pipelineSource, methodHandle),
+                bodyNamespaces, out constructorChain, out requiresAsync, out requiresUnsafeContext);
+
         // Public-only overload counting, except explicit interface
         // implementations (non-public by nature) — matching the API surface
         // ordering the running index is built from.
-        => DecompileMethod(pipelineSource, member.DeclaringType ?? typeFullName, member.Name, overloadIndex,
+        return DecompileMethod(pipelineSource, member.DeclaringType ?? typeFullName, member.Name, overloadIndex,
             publicOnly: member.Kind != "explicit-interface-implementation"
                 && !(member.Kind == "constructor" && member.DeclaringOverloadIndex is not null)
                 && member.Accessibility is null,
             bodyNamespaces, out constructorChain, out requiresAsync, out requiresUnsafeContext);
+    }
+
+    /// <summary>
+    /// Resolves a member to its <see cref="MethodDefinitionHandle"/> in
+    /// <paramref name="reader"/>, or null when the member carries no metadata
+    /// token or the token does not validate to a method of
+    /// <paramref name="typeHandle"/> with the member's name (e.g. a token
+    /// carried over from a type-forwarded surface). A null result asks the
+    /// caller to fall back to name+ordinal addressing.
+    /// </summary>
+    static MethodDefinitionHandle? ResolveMemberHandle(MetadataReader reader, TypeDefinitionHandle typeHandle, ApiMember member)
+    {
+        if (member.MetadataToken is not { } token)
+            return null;
+        var handle = MetadataTokens.EntityHandle(token);
+        if (handle.Kind != HandleKind.MethodDefinition)
+            return null;
+        var methodHandle = (MethodDefinitionHandle)handle;
+        MethodDefinition method;
+        try
+        {
+            method = reader.GetMethodDefinition(methodHandle);
+        }
+        catch
+        {
+            return null;
+        }
+        if (method.GetDeclaringType() != typeHandle)
+            return null;
+        if (reader.GetString(method.Name) != member.Name)
+            return null;
+        return methodHandle;
+    }
 
     static string? DecompileAccessor(
         Pipeline.MetadataSource pipelineSource, string typeFullName, string accessorName,
@@ -911,11 +952,23 @@ public static class TypeSourceComposer
     static string? DecompileMethod(
         Pipeline.MetadataSource pipelineSource, string typeFullName, string methodName, int overloadIndex,
         bool publicOnly, SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresAsync, out bool requiresUnsafeContext)
+        => DecompileFunction(pipelineSource,
+            Pipeline.IrImporter.Import(pipelineSource, typeFullName, methodName, overloadIndex, publicOnly),
+            bodyNamespaces, out constructorChain, out requiresAsync, out requiresUnsafeContext);
+
+    /// <summary>
+    /// Runs the raising passes and prints an already-imported function. A null
+    /// function means no IL body (abstract/extern) — nothing to render, not an
+    /// error. The two addressing front doors (handle-direct and name+ordinal)
+    /// share this body so they render identically.
+    /// </summary>
+    static string? DecompileFunction(
+        Pipeline.MetadataSource pipelineSource, Pipeline.IrFunction? function,
+        SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresAsync, out bool requiresUnsafeContext)
     {
         constructorChain = null;
         requiresAsync = false;
         requiresUnsafeContext = false;
-        var function = Pipeline.IrImporter.Import(pipelineSource, typeFullName, methodName, overloadIndex, publicOnly);
         if (function is null)
             return null;
         CollectNamespaces(function, bodyNamespaces);

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -400,8 +400,16 @@ public static class TypeSourceComposer
                     any = true;
 
                     bool publicOnly = member.Kind != "explicit-interface-implementation";
-                    foreach (var attribute in AttributeReader.RenderMethodAttributes(
-                        reader, typeHandle, member.Name, index, publicOnly, bodyNamespaces))
+                    // Resolve the member's metadata handle once (validated
+                    // against this reader) and address both its attributes and
+                    // its body by it, so neither drifts onto a different
+                    // overload. A non-validating token falls back to the
+                    // name+ordinal path.
+                    var memberHandle = ResolveMemberHandle(reader, typeHandle, member);
+                    var attributes = memberHandle is { } attrHandle
+                        ? AttributeReader.RenderMethodAttributes(reader, attrHandle, bodyNamespaces)
+                        : AttributeReader.RenderMethodAttributes(reader, typeHandle, member.Name, index, publicOnly, bodyNamespaces);
+                    foreach (var attribute in attributes)
                         sb.AppendLine($"    [{attribute}]");
 
                     string? constructorChain = null;
@@ -409,7 +417,7 @@ public static class TypeSourceComposer
                     bool requiresUnsafeContext = false;
                     string? body = member.IsAbstract
                         ? null
-                        : DecompileBody(pipelineSource, reader, typeHandle, type.FullName, member, index, bodyNamespaces, out constructorChain, out requiresAsync, out requiresUnsafeContext);
+                        : DecompileBody(pipelineSource, memberHandle, type.FullName, member, index, bodyNamespaces, out constructorChain, out requiresAsync, out requiresUnsafeContext);
 
                     // An explicit interface property implementation surfaces
                     // as its accessor method (Iface.get_X). Render the
@@ -472,7 +480,7 @@ public static class TypeSourceComposer
                     foreach (var attribute in AttributeReader.RenderPropertyAttributes(
                         reader, typeHandle, member.Name, bodyNamespaces))
                         sb.AppendLine($"    [{attribute}]");
-                    ComposeProperty(sb, pipelineSource, type, member, bodyNamespaces);
+                    ComposeProperty(sb, pipelineSource, reader, typeHandle, type, member, bodyNamespaces);
                     break;
                 }
 
@@ -754,7 +762,8 @@ public static class TypeSourceComposer
     }
 
     static void ComposeProperty(
-        StringBuilder sb, Pipeline.MetadataSource pipelineSource, ApiType type, ApiMember member,
+        StringBuilder sb, Pipeline.MetadataSource pipelineSource,
+        MetadataReader reader, TypeDefinitionHandle typeHandle, ApiType type, ApiMember member,
         SortedSet<string> bodyNamespaces)
     {
         string typeFullName = type.FullName;
@@ -763,16 +772,19 @@ public static class TypeSourceComposer
         string head = accessorList >= 0 ? signature[..accessorList].TrimEnd() : signature;
         bool requiresUnsafeContext = member.IsUnsafe || signature.Contains('*', StringComparison.Ordinal);
 
+        var getterHandle = ResolveMethodHandle(reader, typeHandle, member.GetterToken);
+        var setterHandle = ResolveMethodHandle(reader, typeHandle, member.SetterToken);
+
         var accessors = new List<(string Keyword, string? Body, bool RequiresUnsafeContext)>();
         if (accessorList >= 0)
         {
             string list = signature[accessorList..];
             if (list.Contains("get;", StringComparison.Ordinal))
-                accessors.Add(("get", DecompileAccessor(pipelineSource, typeFullName, $"get_{member.Name}", bodyNamespaces, out var getRequiresUnsafe), getRequiresUnsafe));
+                accessors.Add(("get", DecompileAccessor(pipelineSource, getterHandle, typeFullName, $"get_{member.Name}", bodyNamespaces, out var getRequiresUnsafe), getRequiresUnsafe));
             if (list.Contains("set;", StringComparison.Ordinal))
-                accessors.Add(("set", DecompileAccessor(pipelineSource, typeFullName, $"set_{member.Name}", bodyNamespaces, out var setRequiresUnsafe), setRequiresUnsafe));
+                accessors.Add(("set", DecompileAccessor(pipelineSource, setterHandle, typeFullName, $"set_{member.Name}", bodyNamespaces, out var setRequiresUnsafe), setRequiresUnsafe));
             if (list.Contains("init;", StringComparison.Ordinal))
-                accessors.Add(("init", DecompileAccessor(pipelineSource, typeFullName, $"set_{member.Name}", bodyNamespaces, out var initRequiresUnsafe), initRequiresUnsafe));
+                accessors.Add(("init", DecompileAccessor(pipelineSource, setterHandle, typeFullName, $"set_{member.Name}", bodyNamespaces, out var initRequiresUnsafe), initRequiresUnsafe));
         }
 
         if (!requiresUnsafeContext && accessors.Any(a => a.RequiresUnsafeContext))
@@ -877,16 +889,17 @@ public static class TypeSourceComposer
     }
 
     static string? DecompileBody(
-        Pipeline.MetadataSource pipelineSource, MetadataReader reader, TypeDefinitionHandle typeHandle,
+        Pipeline.MetadataSource pipelineSource, MethodDefinitionHandle? memberHandle,
         string typeFullName, ApiMember member, int overloadIndex,
         SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresAsync, out bool requiresUnsafeContext)
     {
         // Prefer the member's own metadata handle — the canonical same-reader
-        // addressing (see docs/design/member-body-substrate.md). The token is
-        // validated against this reader (a method of this type with this name)
-        // before use, so a stale token from a type-forwarded surface falls back
-        // to the name+ordinal path rather than mis-addressing.
-        if (ResolveMemberHandle(reader, typeHandle, member) is { } methodHandle)
+        // addressing (see docs/design/member-body-substrate.md). The caller has
+        // already validated the token against this reader (a method of this type
+        // with this name); a stale token from a type-forwarded surface resolves
+        // to null and falls back to the name+ordinal path rather than
+        // mis-addressing.
+        if (memberHandle is { } methodHandle)
             return DecompileFunction(pipelineSource,
                 Pipeline.IrImporter.Import(pipelineSource, methodHandle),
                 bodyNamespaces, out constructorChain, out requiresAsync, out requiresUnsafeContext);
@@ -911,9 +924,26 @@ public static class TypeSourceComposer
     /// </summary>
     static MethodDefinitionHandle? ResolveMemberHandle(MetadataReader reader, TypeDefinitionHandle typeHandle, ApiMember member)
     {
-        if (member.MetadataToken is not { } token)
+        if (ResolveMethodHandle(reader, typeHandle, member.MetadataToken) is not { } handle)
             return null;
-        var handle = MetadataTokens.EntityHandle(token);
+        if (reader.GetString(reader.GetMethodDefinition(handle).Name) != member.Name)
+            return null;
+        return handle;
+    }
+
+    /// <summary>
+    /// Resolves a raw metadata token to a <see cref="MethodDefinitionHandle"/>
+    /// that belongs to <paramref name="typeHandle"/> in
+    /// <paramref name="reader"/>, or null when the token is absent, is not a
+    /// method definition, or does not belong to the type (e.g. carried over from
+    /// a type-forwarded surface). The shared validation behind member and
+    /// accessor handle addressing.
+    /// </summary>
+    static MethodDefinitionHandle? ResolveMethodHandle(MetadataReader reader, TypeDefinitionHandle typeHandle, int? token)
+    {
+        if (token is not { } value)
+            return null;
+        var handle = MetadataTokens.EntityHandle(value);
         if (handle.Kind != HandleKind.MethodDefinition)
             return null;
         var methodHandle = (MethodDefinitionHandle)handle;
@@ -926,19 +956,23 @@ public static class TypeSourceComposer
         {
             return null;
         }
-        if (method.GetDeclaringType() != typeHandle)
-            return null;
-        if (reader.GetString(method.Name) != member.Name)
-            return null;
-        return methodHandle;
+        return method.GetDeclaringType() == typeHandle ? methodHandle : null;
     }
 
     static string? DecompileAccessor(
-        Pipeline.MetadataSource pipelineSource, string typeFullName, string accessorName,
+        Pipeline.MetadataSource pipelineSource, MethodDefinitionHandle? accessorHandle,
+        string typeFullName, string accessorName,
         SortedSet<string> bodyNamespaces, out bool requiresUnsafeContext)
-        // Accessors are non-public special-name methods; count across all
-        // visibilities (a property has one get_/set_ per name anyway).
-        => DecompileMethod(pipelineSource, typeFullName, accessorName, overloadIndex: 0,
+        // Prefer the accessor's own handle (fixes indexer get_Item/set_Item
+        // drift, where name+index:0 always selects the first indexer's
+        // accessor). Fall back to the by-name path — accessors are non-public
+        // special-name methods, counted across all visibilities — when no valid
+        // handle is available.
+        => accessorHandle is { } handle
+            ? DecompileFunction(pipelineSource,
+                Pipeline.IrImporter.Import(pipelineSource, handle),
+                bodyNamespaces, out _, out _, out requiresUnsafeContext)
+            : DecompileMethod(pipelineSource, typeFullName, accessorName, overloadIndex: 0,
             publicOnly: false, bodyNamespaces, out _, out _, out requiresUnsafeContext);
 
     /// <summary>

--- a/src/ILInspector.Metadata/AttributeReader.cs
+++ b/src/ILInspector.Metadata/AttributeReader.cs
@@ -504,6 +504,16 @@ public static class AttributeReader
         return handle.IsNil ? [] : RenderAttributes(reader, handle, namespaces);
     }
 
+    /// <summary>
+    /// Renders the attributes on a method addressed directly by its
+    /// <see cref="MethodDefinitionHandle"/> — the canonical same-reader address
+    /// (see docs/design/member-body-substrate.md), free of the overload-ordinal
+    /// drift the name+index overload is subject to.
+    /// </summary>
+    public static List<string> RenderMethodAttributes(
+        MetadataReader reader, MethodDefinitionHandle handle, SortedSet<string>? namespaces = null)
+        => handle.IsNil ? [] : RenderAttributes(reader, handle, namespaces);
+
     /// <summary>Renders the attributes on a property, found by name within the type.</summary>
     public static List<string> RenderPropertyAttributes(
         MetadataReader reader, TypeDefinitionHandle typeHandle, string propertyName, SortedSet<string>? namespaces = null)

--- a/src/ILInspector.Metadata/AttributeReader.cs
+++ b/src/ILInspector.Metadata/AttributeReader.cs
@@ -235,6 +235,16 @@ public static class AttributeReader
         MetadataReader reader, TypeDefinitionHandle typeHandle, string methodName, int overloadIndex, bool publicOnly = true)
         => ReadMethodAttributes(reader, FindMethodHandleInType(reader, typeHandle, methodName, overloadIndex, publicOnly));
 
+    /// <summary>
+    /// Overload for callers that already hold the method's own
+    /// <see cref="MethodDefinitionHandle"/> — the canonical same-reader address
+    /// (see docs/design/member-body-substrate.md), free of the overload-ordinal
+    /// drift the name+index overloads are subject to.
+    /// </summary>
+    public static List<(string Name, string? Value)> GetMethodAttributes(
+        MetadataReader reader, MethodDefinitionHandle methodHandle)
+        => ReadMethodAttributes(reader, methodHandle);
+
     private static List<(string Name, string? Value)> ReadMethodAttributes(MetadataReader reader, MethodDefinitionHandle methodHandle)
     {
         List<(string Name, string? Value)> results = [];

--- a/src/ILInspector.Metadata/ILInstructionPrinter.cs
+++ b/src/ILInspector.Metadata/ILInstructionPrinter.cs
@@ -148,6 +148,15 @@ public static class ILInstructionPrinter
         return null;
     }
 
+    /// <summary>
+    /// Handle-addressed disassembly: the caller already holds the method's own
+    /// <see cref="MethodDefinitionHandle"/> (see docs/design/member-body-substrate.md),
+    /// bypassing the name+overload-ordinal walk and its drift.
+    /// </summary>
+    public static List<ILInstructionText>? DisassembleMethod(
+        PEReader peReader, MetadataReader reader, MethodDefinitionHandle methodHandle)
+        => Disassemble(peReader, reader, reader.GetMethodDefinition(methodHandle));
+
     static string? FormatOperand(DecodedInstruction instruction, MetadataReader reader, ILSyntax syntax)
     {
         bool canonical = syntax == ILSyntax.Canonical;

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -1,3 +1,4 @@
+using System.Reflection.Metadata;
 using System.Text;
 using ILInspector.Analysis;
 using ILInspector.Decompiler;
@@ -33,7 +34,8 @@ public static class ResearchViews
         bool SemanticsOverlay = false,
         bool FactRows = false,
         AnnotationStage AnnotatedStage = AnnotationStage.Raised,
-        ResearchFactRegistry? Registry = null);
+        ResearchFactRegistry? Registry = null,
+        MethodDefinitionHandle MethodHandle = default);
 
     public sealed record MemberProjectionResult(
         DecompilerResult? AnnotatedSource,
@@ -46,12 +48,14 @@ public static class ResearchViews
     {
         try
         {
-            var imported = IrImporter.Import(
-                request.Source,
-                request.Type,
-                request.Method,
-                request.OverloadIndex,
-                request.PublicOnly)
+            var imported = (request.MethodHandle.IsNil
+                ? IrImporter.Import(
+                    request.Source,
+                    request.Type,
+                    request.Method,
+                    request.OverloadIndex,
+                    request.PublicOnly)
+                : IrImporter.Import(request.Source, request.MethodHandle))
                 ?? throw new InvalidOperationException($"{request.Type}::{request.Method} has no IL body");
 
             var assembly = imported.AssemblyPath is { Length: > 0 } path
@@ -76,7 +80,8 @@ public static class ResearchViews
                         facts,
                         request.AnnotatedStage,
                         request.OverloadIndex,
-                        request.PublicOnly),
+                        request.PublicOnly,
+                        request.MethodHandle),
                         emptyOutputIsFailure: false),
                     request.Source);
             }
@@ -269,7 +274,8 @@ public static class ResearchViews
         IReadOnlyList<Annotation> annotations,
         AnnotationStage stage,
         int overloadIndex,
-        bool publicOnly)
+        bool publicOnly,
+        MethodDefinitionHandle methodHandle = default)
     {
 
         IrFunction? ImportMethodBody(MethodRef target) => IrImporter.Import(source, target);
@@ -295,7 +301,10 @@ public static class ResearchViews
 
         var ilByLine = new Dictionary<int, List<string>>();
         var factsByOffset = FactsByOffset(annotations);
-        foreach (var instr in IlProjection.AnnotatedInstrLines(source, type, method, overloadIndex, publicOnly))
+        var annotatedInstrLines = methodHandle.IsNil
+            ? IlProjection.AnnotatedInstrLines(source, type, method, overloadIndex, publicOnly)
+            : IlProjection.AnnotatedInstrLines(source, methodHandle);
+        foreach (var instr in annotatedInstrLines)
         {
             if (AnnotationAnchor.Best(spans, instr.Offset) is not { } owner)
                 continue;

--- a/src/dotnet-inspect.Tests/MemberCodeProviderOverloadAddressingTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCodeProviderOverloadAddressingTests.cs
@@ -1,0 +1,68 @@
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Reflection.PortableExecutable;
+using DotnetInspector.Inspectors;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Tests;
+
+/// <summary>
+/// Pins the member-command code path (<see cref="MemberCodeProvider"/>) to
+/// metadata-handle member addressing rather than name+overload-ordinal counting.
+/// The extractor drops some public methods from the API surface (here, an
+/// <see cref="EditorBrowsableAttribute"/>-hidden overload) that the by-name
+/// importer's public-only counting still counts, so a surviving overload's
+/// surface index no longer matches its metadata overload index. Ordinal
+/// addressing then pairs the survivor's selector with the hidden overload's
+/// body/attributes; handle addressing (via the surface member's own metadata
+/// token) renders each member's own body. See docs/design/member-body-substrate.md.
+/// </summary>
+public class MemberCodeProviderOverloadAddressingTests
+{
+    [Fact]
+    public void SelectedOverload_RendersOwnBodyAndAttributes_NotHiddenSibling()
+    {
+        string assemblyPath = typeof(MemberOverloadDriftSpecimen).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(assemblyPath));
+        var surface = ApiSurfaceExtractor.Extract(pe, includeAll: false);
+        var type = surface.Types.Single(t => t.FullName == typeof(MemberOverloadDriftSpecimen).FullName);
+        var describeOverloads = type.Members.Where(m => m.Name == "Describe").ToList();
+
+        var request = new MemberCodeProvider.Request(
+            DecompiledSource: true,
+            AnnotatedSource: false,
+            CostOverlay: false,
+            SemanticsOverlay: false,
+            IL: false,
+            Attributes: true,
+            Calls: false,
+            Callers: false,
+            CallGraph: false,
+            UnsafeOperations: false);
+
+        var results = MemberCodeProvider.Collect(
+            type, describeOverloads, assemblyPath, overloadIndex: 0, request);
+
+        var (_, code) = Assert.Single(results);
+        Assert.NotNull(code.DecompiledResult?.Output);
+        Assert.Contains("VISIBLE_MEMBER_BODY", code.DecompiledResult!.Output);
+        Assert.DoesNotContain("HIDDEN_MEMBER_BODY", code.DecompiledResult.Output);
+        // The hidden overload's [EditorBrowsable] must not drift onto the survivor.
+        Assert.True(
+            code.Attributes is null || code.Attributes.All(a => a.Name != "EditorBrowsable"),
+            "EditorBrowsable must not be misattributed onto the surviving overload.");
+    }
+}
+
+public class MemberOverloadDriftSpecimen
+{
+    // First public overload in metadata order — hidden from the API surface, so
+    // it is not composed but still occupies a public overload slot the by-name
+    // importer counts.
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public string Describe(int value) => "HIDDEN_MEMBER_BODY";
+
+    // Surviving overload: surface index 0, metadata public index 1.
+    public string Describe(string value) => "VISIBLE_MEMBER_BODY";
+}

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -91,11 +91,21 @@ internal static class MemberCodeProvider
             if (!typeIndex.TryGetValue(lookupType, out var typeHandle))
                 continue;
 
+            // Resolve the member's own metadata handle once (validated against
+            // this reader) and address every section by it, so none drifts onto
+            // a different overload. A non-validating token — e.g. carried over
+            // from a type-forwarded surface — falls back to the name+ordinal
+            // path. This is the same drift class the whole-type composition path
+            // fixes (see docs/design/member-body-substrate.md).
+            var memberHandle = ResolveMethodHandle(reader, typeHandle, method.MetadataToken, method.Name);
+
             IReadOnlyList<(string Name, string? Value)>? attributes = null;
             if (request.Attributes)
             {
-                var found = AttributeReader.GetMethodAttributes(
-                    reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
+                var found = memberHandle is { } attrHandle
+                    ? AttributeReader.GetMethodAttributes(reader, attrHandle)
+                    : AttributeReader.GetMethodAttributes(
+                        reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
                 if (found.Count > 0)
                     attributes = found.Select(a => (a.Name, a.Value)).ToList();
             }
@@ -104,10 +114,14 @@ internal static class MemberCodeProvider
             // the decompiled-source declaration formatter. Sourced here (not from
             // a decompiler pass) so it is available whenever a method body is
             // shown, independent of which sections were requested.
-            var methodGenericParameters = MethodGenericParameterNames(
-                reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
-            var methodHasBody = SelectedMethodHasBody(
-                reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
+            var methodGenericParameters = memberHandle is { } genHandle
+                ? MethodGenericParameterNames(reader, genHandle)
+                : MethodGenericParameterNames(
+                    reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
+            var methodHasBody = memberHandle is { } bodyHandle
+                ? SelectedMethodHasBody(reader, bodyHandle)
+                : SelectedMethodHasBody(
+                    reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
 
             // Decompiled source: raised C# only, without annotations or interleaved IL.
             Decompiler.DecompilerResult? decompiledResult = null;
@@ -121,6 +135,7 @@ internal static class MemberCodeProvider
                     method.Name,
                     lookupOverloadIndex,
                     publicOnly,
+                    memberHandle ?? default,
                     out raisedFunction));
                 projectionResult = projectionResult with
                 {
@@ -173,7 +188,8 @@ internal static class MemberCodeProvider
                         AnnotatedSource: request.AnnotatedSource,
                         CostOverlay: request.CostOverlay,
                         SemanticsOverlay: request.SemanticsOverlay,
-                        FactRows: request.Facts));
+                        FactRows: request.Facts,
+                        MethodHandle: memberHandle ?? default));
             }
 
             // Annotated source: raised C# with hidden-fact comments and the
@@ -207,8 +223,10 @@ internal static class MemberCodeProvider
             {
                 try
                 {
-                    var instructions = ILInstructionPrinter.DisassembleMethod(
-                        peReader, reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
+                    var instructions = memberHandle is { } ilHandle
+                        ? ILInstructionPrinter.DisassembleMethod(peReader, reader, ilHandle)
+                        : ILInstructionPrinter.DisassembleMethod(
+                            peReader, reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
                     if (instructions is { Count: > 0 })
                         ilText = string.Join(Environment.NewLine, instructions.Select(i => i.ToString()));
                 }
@@ -277,6 +295,17 @@ internal static class MemberCodeProvider
         return null;
     }
 
+    /// <summary>
+    /// Handle-addressed generic parameter names: reads directly from the
+    /// method's own definition, free of the name+overload-ordinal drift.
+    /// </summary>
+    static IReadOnlyList<string>? MethodGenericParameterNames(
+        MetadataReader reader, MethodDefinitionHandle methodHandle)
+    {
+        var handles = reader.GetMethodDefinition(methodHandle).GetGenericParameters();
+        return handles.Count == 0 ? null : handles.Select(reader.GetGenericParameterName).ToList();
+    }
+
     static bool SelectedMethodHasBody(
         MetadataReader reader, TypeDefinitionHandle typeHandle, string methodName, int overloadIndex, bool publicOnly)
     {
@@ -294,6 +323,41 @@ internal static class MemberCodeProvider
             return method.RelativeVirtualAddress != 0;
         }
         return false;
+    }
+
+    static bool SelectedMethodHasBody(MetadataReader reader, MethodDefinitionHandle methodHandle)
+        => reader.GetMethodDefinition(methodHandle).RelativeVirtualAddress != 0;
+
+    /// <summary>
+    /// Validates a surface member's metadata token to a
+    /// <see cref="MethodDefinitionHandle"/> that belongs to
+    /// <paramref name="typeHandle"/> in <paramref name="reader"/> and carries
+    /// the member's name, or null when the token is absent, is not a method
+    /// definition, or does not validate (e.g. a type-forwarded surface whose
+    /// token points into another assembly). A null result asks the caller to
+    /// fall back to name+ordinal addressing.
+    /// </summary>
+    static MethodDefinitionHandle? ResolveMethodHandle(
+        MetadataReader reader, TypeDefinitionHandle typeHandle, int? token, string memberName)
+    {
+        if (token is not { } value)
+            return null;
+        var entity = System.Reflection.Metadata.Ecma335.MetadataTokens.EntityHandle(value);
+        if (entity.Kind != HandleKind.MethodDefinition)
+            return null;
+        var methodHandle = (MethodDefinitionHandle)entity;
+        MethodDefinition method;
+        try
+        {
+            method = reader.GetMethodDefinition(methodHandle);
+        }
+        catch
+        {
+            return null;
+        }
+        if (method.GetDeclaringType() != typeHandle)
+            return null;
+        return reader.GetString(method.Name) == memberName ? methodHandle : null;
     }
 
     internal static FindingInspection<Decompiler.DecompilerFidelityCause> BuildFidelityCauseInspection(
@@ -355,12 +419,15 @@ internal static class MemberCodeProvider
         string method,
         int overloadIndex,
         bool publicOnly,
+        MethodDefinitionHandle methodHandle,
         out IrFunction? imported)
     {
         imported = null;
         try
         {
-            imported = IrImporter.Import(source, type, method, overloadIndex, publicOnly)
+            imported = (methodHandle.IsNil
+                ? IrImporter.Import(source, type, method, overloadIndex, publicOnly)
+                : IrImporter.Import(source, methodHandle))
                 ?? throw new InvalidOperationException($"{type}::{method} has no IL body");
             var result = Decompiler.Pipeline.CSharpPrinter.PrintRaised(
                 imported,


### PR DESCRIPTION
- Advances the member-body substrate: retires name+overload-ordinal member
  addressing in favor of canonical `MethodDefinitionHandle` addressing.
- Changes: a selected member's decompiled source, custom attributes, and IL now
  resolve to that member's own metadata row instead of a recomputed positional
  index, fixing silent mis-addressing of overloaded members.
- Card revision: not applicable (member-selection fix; no raising/structuring or
  corpus-delta change).

## Change

> Should we accept this change?

**Conclusion:** **PASS** — every same-reader body/attribute/accessor/IL path in
whole-type composition and the `member` command is now addressed by the member's
own handle, and a base-vs-head A/B shows only corrections and zero regressions.

**Root cause.** `ApiSurfaceExtractor` walks `typeDef.GetMethods()` in metadata
order but *skips* some public methods (`EditorBrowsable(Never)`, accessors,
compiler-generated). The by-name body importer counts overloads with
`publicOnly=true`, which counts *all* public methods including the skipped ones.
So a surviving overload's running **surface** index no longer matches its
metadata public overload index, and the ordinal path pairs a survivor's selector
with a **different** overload's body/attributes/IL.

Before (survivor `Describe(string)` selected, but the hidden first overload's
body/attribute drift in):

```csharp
[EditorBrowsable(EditorBrowsableState.Never)] // drifted from the hidden overload
public string Describe(string value)
{
    return "HIDDEN_MEMBER_BODY"; // body of Describe(int)
}
```

After (each member renders its own row):

```csharp
public string Describe(string value)
{
    return "VISIBLE_MEMBER_BODY";
}
```

Real-world witnesses from the base-vs-head A/B on the `member` command
(NuGet.Versioning / Roslyn corpus): `SyntaxFactory.ParseTypeName`,
`EmitBaseline.CreateInitialBaseline`, and `SourceText.From:1/:3` were corrected
across source, attributes, **and** IL (base misattributed
`[EditorBrowsable]`/`[Obsolete]` and rendered a different overload's body, at
times referencing out-of-scope locals — invalid C#). Neutral controls
(`From:2/:4`, `GetSubText`, `Location.Create`) are byte-identical.

## How it works

Each caller resolves the surface member's own `ApiMember.MetadataToken`
(rehydrated to `MethodDefinitionHandle`) **once**, validated against the
composing reader — the token must be a `MethodDef` whose declaring type is the
resolved type, and whose name matches — then threads that handle into
attributes, generic-parameter names, `HasBody`, decompiled source, the
`ResearchViews` mixed IL+C# projection, and IL disassembly. A token that does not
validate (type-forwarded / round-tripped surface) or is null (older serialized
surfaces) falls back to the legacy name+ordinal path rather than mis-addressing.

Layer overloads added at each seam: `AttributeReader.GetMethodAttributes(reader,
handle)`, `ILInstructionPrinter.DisassembleMethod(peReader, reader, handle)`,
`IlProjection.Locate/Project/AnnotatedInstrLines(handle)` (refactored to share
located-tuple cores so the name path is byte-for-byte unchanged), and
`ResearchViews.MemberProjectionRequest.MethodHandle`. Property/indexer accessors
resolve via `GetterToken`/`SetterToken` through a name-checked
`ResolveAccessorHandle`.

## Evidence

| Check | Result |
| --- | --- |
| Product build (`dotnet-inspect.slnx`) | Pass |
| Focused tests | `MemberCodeProviderOverloadAddressingTests`, `TypeSourceComposerOverloadAddressingTests` passed |
| Decompiler fast suite | Pass (2424) |
| `dotnet-inspect.Tests` | Pass (1895, 10 skipped = ilasm/ildasm) |
| `ILInspector.Research.Tests` | Pass (111) |
| Member-command base-vs-head A/B | Corrections on drift members; byte-identical neutral controls; zero regressions |
| Whole-type base-vs-head A/B (14 assemblies) | 46 hunks, all corrections, zero regressions |
| Real witnesses | `SyntaxFactory.ParseTypeName`, `EmitBaseline.CreateInitialBaseline`, `SourceText.From` |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS (not applicable)** — this changes which member's body is
selected, not how any body is raised or structured. There is no corpus-delta or
quality-diff card; correctness is established by the member-selection A/B above
(only corrections, zero regressions).

## Review

Two adversarial reviews (author is Claude Opus 4.8 → two non-Opus reviewers),
each in an isolated worktree at the PR head.

| Reviewer | Result | Notes |
| --- | --- | --- |
| GPT-5.5 | No blocking findings | CLEAN both rounds; ran non-slow suites + CLI drift specimens, all green |
| Gemini 3.1 Pro | Findings resolved | 3 findings → 1 adopted, 2 dismissed with accepted rationale; CLEAN on re-review |

**Reconciliation.** All three Gemini findings targeted the **cross-reader
defensive fallback** (tokens always come from the same reader that extracted
them — `ApiSurfaceExtractor.cs:185` — so the tested same-reader path is
unaffected):

1. **Accessor validation asymmetry — ADOPTED** (commit `b0336919`). Accessors
   used bare `ResolveMethodHandle` (no name check), unlike `ResolveMemberHandle`.
   `ResolveAccessorHandle` now requires the resolved method name to equal
   `get_/set_{Name}` (`member.Name == "Item"` for indexers, so same-reader
   `get_Item` still resolves; both reviewers confirmed no over-rejection).
2. **Member-path signature check — dismissed.** Would require `SignatureModel`,
   which is `[JsonIgnore]` and absent on exactly the round-tripped surfaces it
   would guard; the name check is the established guard; not reproduced.
3. **Accessor fallback `overloadIndex:0` — dismissed.** Byte-identical to
   pre-fix behavior, only reached when no valid handle exists.

**Review conclusion:** **PASS** — two CLEAN reviews on the fixed head
`b0336919`.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config
dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- -class "DotnetInspector.Tests.MemberCodeProviderOverloadAddressingTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "ILInspector.Decompiler.Tests.TypeSourceComposerOverloadAddressingTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -notrait "Speed=Slow"
```
