### PR TITLE
Route the RTS chain-parameter surface check through the CSharpTypeProducer seam (#2613)

### DIFF
--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1669,12 +1669,10 @@ public static class CompileBackSourceComposer
     /// <c>: this(args)</c> initializer targeting it cannot bind.
     /// </summary>
     static bool IsUnsupportedChainParameterType(TypeRef type)
-    {
-        string display = type.ToDisplayString();
-        return display.Contains("delegate*", StringComparison.Ordinal)
-            || display.Contains("<>", StringComparison.Ordinal)
-            || display.Contains('{', StringComparison.Ordinal);
-    }
+        // Route surface-representability through the product seam (CSharpTypeProducer)
+        // so every RTS consumer judges droppable surfaces identically, instead of
+        // re-inlining the delegate*/<>/{ heuristic here.
+        => CSharpTypeProducer.IsUnsupportedSurfaceSignature(type.ToDisplayString());
 
     static CompileBackParameter ToCompileBackParameter(ApiParameter parameter)
         => new(
@@ -2308,8 +2306,7 @@ public static class CompileBackSourceComposer
                 return null;
             }
 
-            if (fieldType.Contains("delegate*", StringComparison.Ordinal)
-                || fieldType.Contains("@delegate*", StringComparison.Ordinal))
+            if (CSharpTypeProducer.IsUnsupportedSurfaceSignature(fieldType))
                 return null;
 
             parameters.Add(new CompileBackParameter(

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -2306,7 +2306,8 @@ public static class CompileBackSourceComposer
                 return null;
             }
 
-            if (CSharpTypeProducer.IsUnsupportedSurfaceSignature(fieldType))
+            if (fieldType.Contains("delegate*", StringComparison.Ordinal)
+                || fieldType.Contains("@delegate*", StringComparison.Ordinal))
                 return null;
 
             parameters.Add(new CompileBackParameter(


### PR DESCRIPTION
## Summary

RTS reversal increment 2 (follows #2737, #2739). The compile-back harness
re-inlined the "surface not representable in C# source" heuristic
(`delegate*` / `<>` / `{` substring checks) that #2737 relocated into the product
as `CSharpTypeProducer.IsUnsupportedSurfaceSignature`. This routes the
chain-parameter site through the product seam:

- `IsUnsupportedChainParameterType` — the `: this(args)` chain-arg gate.

Every RTS consumer that judges chain-arg surface now shares the product's
definition, and one more piece of C# knowledge moves out of the orchestrator and
into `ILInspector.CSharp`, where recompilation validates it. This is the ongoing
#2613 goal: RTS as a C#-free orchestrator between the product and Roslyn.

### Scope note (single site — see reconciliation below)

This increment initially migrated a second site (the primary-ctor backing-field
gate), but adversarial review showed that site passed **raw** signature text to a
seam whose contract expects a normalized C# display name, turning a duplicate
consolidation into an arm-set change. It was reverted (commit `8c17ab57`); only
the chain-parameter site ships here. A correct routing of the field-type gate
needs display-form normalization and is tracked with the other #2613 roadmap
items (generic base chains #2746, type-shell header, member-closure composition,
`CompileBackCSharpNames.Clean`).

## Neutrality

Provably neutral. `IsUnsupportedChainParameterType` already fed the seam a
normalized `type.ToDisplayString()`; its old arms (`delegate*` / `<>` / `{`) are
exactly the seam's arms, and the only extra seam arm (`@delegate*`) is subsumed
by `delegate*` (dead). The seam performs no normalization. Same input, same
truth-space.

**Corpus RTS-parity A/B** (14 assemblies, snapshots cap 200):

| ref | Exact | OpcodeDiff | RecompileFail | changed methods |
|---|---|---|---|---|
| base (`origin/main`) | 1357 | 194 | 581 | — |
| head | 1357 | 194 | 581 | **0 / 89,065** |

`ReturnToSenderPrototypeTests`: **114 passed**.

## Scope

Does **not** close #2731 / #2745 (interface projection). Those need product-path
consumed-member / receiver-type evidence, not a surface relocation — tracked
separately.

## Testing

- `dotnet build tools/DecompilerHarness -c Release` ✅
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "…ReturnToSenderPrototypeTests"` → 114 passed ✅
- 14-asm corpus RTS-parity A/B → 0 changed / 89,065 ✅

Two CLEAN adversarial reviews (GPT-5.5 + Gemini 3.1 Pro) on the scoped-down head; see reconciliation comments.
