### PR TITLE
Source body-only modifiers from resolved method facts

### DIFF
--- a/docs/design/member-body-substrate.md
+++ b/docs/design/member-body-substrate.md
@@ -124,7 +124,8 @@ The same-reader body-composition callers are migrated onto handle addressing:
   the surface member's validated metadata token once and threads it into
   attributes, generic-parameter names, `HasBody`, decompiled source, the
   `ResearchViews` mixed IL+C# projection (`MemberProjectionRequest.MethodHandle`),
-  and IL disassembly. Layer overloads were added at each seam
+  body-only modifier classification, and IL disassembly. Layer overloads were
+  added at each seam
   (`AttributeReader.GetMethodAttributes`, `ILInstructionPrinter.DisassembleMethod`,
   `IlProjection.Locate/Project/AnnotatedInstrLines`). Other `ResearchViews` entry
   points keep the name path (nil handle → fallback) — they are not the CLI's drift
@@ -139,8 +140,10 @@ out-of-scope locals — invalid C#), or misattributes the hidden overload's
 attributes (`[EditorBrowsable]`/`[Obsolete]`) onto the survivor. Handle addressing
 renders each member's own body and attributes. Every same-reader body/attribute
 path in whole-type composition and the `member` CLI is now handle-addressed; a
-token that does not validate (type-forwarded surface) falls back to the legacy
-name+ordinal path rather than mis-addressing.
+token that does not validate (type-forwarded surface) resolves the legacy
+name+ordinal selector to its concrete MethodDef before projecting the body,
+attributes, or body-only modifiers, rather than mis-addressing or allowing those
+projections to diverge.
 
 ## Scope: one load per type
 

--- a/docs/design/member-body-substrate.md
+++ b/docs/design/member-body-substrate.md
@@ -273,8 +273,10 @@ sourced from Metadata/Analysis, not from the printed text:
 - **body-only unsafe** (`localloc`, `calli`, pointer deref) — from
   `MethodSignals.Unsafe` (**Analysis**), no Decompiler. Signature-only unsafe is
   already set on `ApiMember.IsUnsafe`. Same body-gating applies: the `unsafe`
-  context is a body concern, forced by the composer today
-  (`RequiresUnsafeMemberContext`).
+  context is a body concern. The current scalar path records the typed IR result
+  as `DecompilerResult.RequiresUnsafeBodyModifier`; both full-body consumers
+  carry it on `CSharpMemberBody`, while the Analysis fact remains the cheap
+  pre-filter for the planned vector path.
 
 ## What lands where
 

--- a/docs/design/member-body-substrate.md
+++ b/docs/design/member-body-substrate.md
@@ -237,31 +237,34 @@ cheapest home rather than recovered from print. Both are **body-gated
 modifiers** — they belong on a member only when a body is emitted, and are
 sourced from Metadata/Analysis, not from the printed text:
 
-- **async / iterator** — sourced from `[AsyncStateMachine]` /
-  `MethodImplAttributes.Async`, classified by
+- **async / iterator** — async method headers are sourced from
+  `[AsyncStateMachine]` / `MethodImplAttributes.Async`, classified by
   `MethodClassificationScanner.ClassifyAsyncMethod` (**Metadata**). `async` is
   *not* part of an API surface — a caller cannot observe it, and reference
   assemblies strip it — so the **skeleton/surface** path deliberately omits it,
   and `ApiMember.IsAsync` (`ApiSurface.cs`) is intentionally left unpopulated
-  there. It matters only on the **full-body** path, and today that path derives
-  the modifier from the printed body rather than from metadata, which has two
-  problems the substrate fixes:
-  - **Signal inconsistency.** `TypeSourceComposer` forces `async` from
-    `ContainsAwaitExpression` alone, while `ApiOutputFormatter` uses
-    `ContainsAwaitExpression || RequiresAsyncBodyModifier`. The latter (set by
-    `ClassicAsyncReconstructionPass`) catches classic-async methods with no
-    reachable `await`; the composer drops `async` on them.
-  - **Runtime async is not reconstructed at all.** For runtime-async methods
-    (`MethodImplAttributes.Async`, no compiler state machine — the shape the
-    preview SDK emitted for the probe fixture, distinct from the classic
-    compiler state-machine async that remains the language default), *neither*
-    signal is set — the reconstruction pass only handles classic state-machine
-    async. Verified: composing an `async Task`/`async Task<int>` fixture built
-    with the preview SDK renders the methods **without** `async` and exposes the
-    raw `AsyncHelpers.UnsafeAwaitAwaiter<...>` lowering instead of `await`.
-    Recovering runtime async is a decompiler raise in its own right (full A/B +
-    adversarial discipline), tracked separately from this substrate as
-    [#2742](https://github.com/richlander/dotnet-inspect/issues/2742).
+  there. It matters only on the **full-body** path. `CSharpTypeProducer`
+  classifies the selected MethodDef, and both full-body consumers carry that
+  body-only fact on `CSharpMemberBody`; skeleton requests remain unchanged.
+  This removes the former signal inconsistency where `TypeSourceComposer`
+  consulted `ContainsAwaitExpression` while `ApiOutputFormatter` also consulted
+  `RequiresAsyncBodyModifier`.
+
+  `[AsyncIteratorStateMachine]` is intentionally not enough to add the modifier:
+  until iterator reconstruction replaces the kickoff's state-machine-return
+  expression with a source `yield` body, adding `async` would make the emitted
+  method invalid. The metadata fact remains available, but the body gate declines
+  it until that upstream reconstruction exists.
+
+  Runtime-async bodies are not yet fully reconstructed. For runtime-async
+  methods (`MethodImplAttributes.Async`, no compiler state machine — the shape
+  the preview SDK emitted for the probe fixture, distinct from the classic
+  compiler state-machine async that remains the language default), metadata now
+  preserves the `async` header, but awaiter-helper shapes still expose the raw
+  `AsyncHelpers.UnsafeAwaitAwaiter<...>` lowering instead of `await`. Recovering
+  runtime async is a decompiler raise in its own right (full A/B + adversarial
+  discipline), tracked separately from this substrate as
+  [#2742](https://github.com/richlander/dotnet-inspect/issues/2742).
 
   The substrate's contract is that this modifier is a **Metadata classification
   fact applied only when the body policy emits a body**, so the surface path is

--- a/docs/design/member-body-substrate.md
+++ b/docs/design/member-body-substrate.md
@@ -110,7 +110,8 @@ The same-reader body-composition callers are migrated onto handle addressing:
   `ApiMember.MetadataToken` and validates it against the composing reader (a
   method of the composed type whose name matches the member) before use; a token
   that does not validate — e.g. carried over from a type-forwarded surface —
-  falls back to the legacy name+ordinal path rather than mis-addressing.
+  resolves the legacy name+ordinal selector to its concrete MethodDef before
+  projection rather than mis-addressing.
 - **`CSharpBodyDiff`** — `Decompile` imports each `CSharpMethodEntry` by the
   `MethodDefinitionHandle` the entry was built from, instead of re-deriving a
   `(type, method, overloadIndex)` tuple.

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -597,6 +597,40 @@ public sealed class CSharpTypePrinterTests
             StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void FullBodyModifiersDoNotLeakIntoSkeletons()
+    {
+        var type = CreateEmptyType("Samples", "Worker");
+        var member = CreateMethod("Run");
+        member.SignatureModel!.ReturnType = "System.Threading.Tasks.Task";
+        type.Members.Add(member);
+        var full = _printer.Print(new CSharpTypePrintRequest(
+            type,
+            memberPolicyOverrides:
+            [
+                new CSharpMemberPolicy(
+                    member,
+                    CSharpBodyPolicy.Full,
+                    new CSharpBlockBody("return;")
+                    {
+                        RequiresAsyncModifier = true,
+                        RequiresUnsafeModifier = true
+                    })
+            ]));
+        var skeleton = _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.Contains(
+            "public unsafe async System.Threading.Tasks.Task Run()",
+            full.Units[0].Source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "public System.Threading.Tasks.Task Run();",
+            skeleton.Units[0].Source,
+            StringComparison.Ordinal);
+        Assert.False(member.IsAsync);
+        Assert.False(member.IsUnsafe);
+    }
+
     [Theory]
     [InlineData(CSharpBodyPolicy.Full)]
     [InlineData(CSharpBodyPolicy.Stub)]

--- a/src/ILInspector.CSharp.Tests/CSharpTypeProducerTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypeProducerTests.cs
@@ -1,7 +1,44 @@
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
 namespace ILInspector.CSharp.Tests;
 
 public sealed class CSharpTypeProducerTests
 {
+    [Fact]
+    public void RequiresAsyncBodyModifier_UsesDefiningMethodMetadata()
+    {
+        using var pe = new PEReader(File.OpenRead(typeof(CSharpTypeProducerTests).Assembly.Location));
+        var reader = pe.GetMetadataReader();
+        var typeHandle = reader.TypeDefinitions
+            .Single(handle => reader.GetString(reader.GetTypeDefinition(handle).Name) == nameof(CSharpTypeProducerTests));
+        var type = reader.GetTypeDefinition(typeHandle);
+        var methods = type.GetMethods()
+            .ToDictionary(
+                handle => reader.GetString(reader.GetMethodDefinition(handle).Name),
+                StringComparer.Ordinal);
+
+        Assert.True(CSharpTypeProducer.RequiresAsyncBodyModifier(
+            reader,
+            methods[nameof(RuntimeAsyncFixture)]));
+        Assert.False(CSharpTypeProducer.RequiresAsyncBodyModifier(
+            reader,
+            methods[nameof(AsyncIteratorFixture)]));
+        Assert.False(CSharpTypeProducer.RequiresAsyncBodyModifier(
+            reader,
+            methods[nameof(IsUnsupportedSurfaceSignature_AllowsOrdinarySignatures)]));
+        Assert.False(CSharpTypeProducer.RequiresAsyncBodyModifier(
+            reader,
+            methods[nameof(IteratorFixture)]));
+        Assert.False(CSharpTypeProducer.RequiresAsyncBodyModifier(
+            reader,
+            MetadataTokens.GetToken(typeHandle)));
+        Assert.False(CSharpTypeProducer.RequiresAsyncBodyModifier(
+            reader,
+            0x0600FFFF));
+    }
+
     [Theory]
     [InlineData("delegate*<int, void>")]
     [InlineData("@delegate*<int, void>")]
@@ -20,5 +57,19 @@ public sealed class CSharpTypeProducerTests
     public void IsUnsupportedSurfaceSignature_AllowsOrdinarySignatures(string signature)
     {
         Assert.False(CSharpTypeProducer.IsUnsupportedSurfaceSignature(signature));
+    }
+
+    static async Task RuntimeAsyncFixture()
+        => await Task.Yield();
+
+    static async IAsyncEnumerable<int> AsyncIteratorFixture()
+    {
+        await Task.Yield();
+        yield return 1;
+    }
+
+    static IEnumerable<int> IteratorFixture()
+    {
+        yield return 1;
     }
 }

--- a/src/ILInspector.CSharp/CSharpFormatter.cs
+++ b/src/ILInspector.CSharp/CSharpFormatter.cs
@@ -69,6 +69,26 @@ public sealed class CSharpFormatter
             methodParameters);
     }
 
+    public string FormatMemberWithBody(
+        ApiType type,
+        ApiMember member,
+        CSharpMemberBody body,
+        IReadOnlyList<string>? methodParameters = null)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        ArgumentNullException.ThrowIfNull(member);
+        ArgumentNullException.ThrowIfNull(body);
+        return CSharpDeclarationWriter.RenderMemberDeclaration(
+            type,
+            member,
+            _declarationOptions with
+            {
+                ForceAsync = _declarationOptions.ForceAsync || body.RequiresAsyncModifier,
+                ForceUnsafe = _declarationOptions.ForceUnsafe || body.RequiresUnsafeModifier
+            },
+            methodParameters);
+    }
+
     public CSharpFormattedDeclaration FormatMemberUnit(
         ApiType type,
         ApiMember member,

--- a/src/ILInspector.CSharp/CSharpTypePrintContracts.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrintContracts.cs
@@ -10,7 +10,20 @@ public enum CSharpBodyPolicy
     Stub
 }
 
-public abstract record CSharpMemberBody;
+public abstract record CSharpMemberBody
+{
+    /// <summary>
+    /// True when this body must be emitted under a C# <c>async</c> modifier.
+    /// This is a body-only fact: skeleton declarations deliberately ignore it.
+    /// </summary>
+    public bool RequiresAsyncModifier { get; init; }
+
+    /// <summary>
+    /// True when this body requires an <c>unsafe</c> member context beyond any
+    /// unsafe signature already represented by <see cref="ApiMember.IsUnsafe"/>.
+    /// </summary>
+    public bool RequiresUnsafeModifier { get; init; }
+}
 
 public enum CSharpConstructorInitializerKind
 {

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -253,7 +253,9 @@ public sealed class CSharpTypePrinter
         if (member.Member.Kind == "property")
             return RenderProperty(type, member, formatter, propertyFormatter, indent);
 
-        string memberDeclaration = formatter.FormatMember(type.Type, member.Member);
+        string memberDeclaration = member.Body is null
+            ? formatter.FormatMember(type.Type, member.Member)
+            : formatter.FormatMemberWithBody(type.Type, member.Member, member.Body);
         if (type.Type.Kind == "interface"
             || member.Member.IsAbstract
             || member.Policy == CSharpBodyPolicy.Skeleton)
@@ -292,7 +294,10 @@ public sealed class CSharpTypePrinter
         }
 
         var body = (CSharpPropertyBody)member.Body!;
-        string declaration = propertyFormatter.FormatMember(type.Type, member.Member);
+        string declaration = propertyFormatter.FormatMemberWithBody(
+            type.Type,
+            member.Member,
+            member.Body!);
         if (AllAuto(body))
         {
             var accessors = new List<string>();

--- a/src/ILInspector.CSharp/CSharpTypeProducer.cs
+++ b/src/ILInspector.CSharp/CSharpTypeProducer.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using ILInspector.Metadata;
 
 namespace ILInspector.CSharp;
@@ -18,6 +19,54 @@ namespace ILInspector.CSharp;
 /// </summary>
 public static class CSharpTypeProducer
 {
+    /// <summary>
+    /// True when the selected method's emitted body requires a C# <c>async</c>
+    /// modifier. Runtime async is identified by <see cref="MethodImplAttributes.Async"/>;
+    /// classic async by its state-machine attribute.
+    ///
+    /// This fact belongs only to full-body production. API skeletons deliberately
+    /// omit <c>async</c> because it is not part of the callable surface. Async
+    /// iterators are also withheld until their kickoff is reconstructed to a
+    /// source iterator body; adding <c>async</c> to the raw state-machine-return
+    /// expression would make otherwise-compilable output invalid.
+    /// </summary>
+    public static bool RequiresAsyncBodyModifier(
+        MetadataReader reader,
+        MethodDefinitionHandle methodHandle)
+    {
+        if (methodHandle.IsNil)
+            return false;
+
+        var method = reader.GetMethodDefinition(methodHandle);
+        var classification = MethodClassificationScanner.ClassifyAsyncMethod(reader, method);
+        return classification == MethodClassification.RuntimeAsync
+            || classification == MethodClassification.StateMachineAsync
+                && AttributeReader.HasAttribute(
+                    reader,
+                    method.GetCustomAttributes(),
+                    KnownAttributeNames.AsyncStateMachineAttribute);
+    }
+
+    /// <summary>
+    /// Token-addressed form for an <see cref="ApiMember"/> extracted from the same
+    /// reader. Non-MethodDef and invalid tokens fail closed.
+    /// </summary>
+    public static bool RequiresAsyncBodyModifier(
+        MetadataReader reader,
+        int metadataToken)
+    {
+        try
+        {
+            var handle = MetadataTokens.EntityHandle(metadataToken);
+            return handle.Kind == HandleKind.MethodDefinition
+                && RequiresAsyncBodyModifier(reader, (MethodDefinitionHandle)handle);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            return false;
+        }
+    }
+
     /// <summary>
     /// True when a C# type display name cannot be represented on a skeletal type
     /// surface (function pointers, compiler-generated <c>&lt;&gt;</c> names, or

--- a/src/ILInspector.Decompiler.Fixtures.ClassicAsync/AsyncFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.ClassicAsync/AsyncFixtures.cs
@@ -52,4 +52,10 @@ public static class AsyncFixtures
 
     public static async Task<int> AwaitConditional(Task<int> a, bool flag)
         => flag ? await a : 0;
+
+#pragma warning disable CS1998 // Pins async metadata when no await survives into the body.
+    public static async Task NoAwait()
+    {
+    }
+#pragma warning restore CS1998
 }

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerAsyncTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerAsyncTests.cs
@@ -8,12 +8,13 @@ public sealed class TypeSourceComposerAsyncTests
     [Fact]
     public void ClassicAsyncWithoutAwait_UsesMetadataBodyModifier()
     {
+        string configuration = new DirectoryInfo(AppContext.BaseDirectory).Name;
         string path = Path.GetFullPath(Path.Combine(
             AppContext.BaseDirectory,
             "..",
             "..",
             "ILInspector.Decompiler.Fixtures.ClassicAsync",
-            "release",
+            configuration,
             "ILInspector.Decompiler.Fixtures.ClassicAsync.dll"));
         using var pe = new PEReader(File.OpenRead(path));
         var surface = ApiSurfaceExtractor.Extract(pe);

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerAsyncTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerAsyncTests.cs
@@ -5,8 +5,11 @@ namespace ILInspector.Decompiler.Tests;
 
 public sealed class TypeSourceComposerAsyncTests
 {
-    [Fact]
-    public void ClassicAsyncWithoutAwait_UsesMetadataBodyModifier()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ClassicAsyncWithoutAwait_UsesResolvedMethodBodyModifier(
+        bool invalidateMetadataToken)
     {
         string configuration = new DirectoryInfo(AppContext.BaseDirectory).Name;
         string path = Path.GetFullPath(Path.Combine(
@@ -21,6 +24,13 @@ public sealed class TypeSourceComposerAsyncTests
         var type = Assert.Single(
             surface.Types,
             candidate => candidate.FullName == "ILInspector.Decompiler.Fixtures.ClassicAsync.AsyncFixtures");
+        if (invalidateMetadataToken)
+        {
+            var member = Assert.Single(
+                type.Members,
+                candidate => candidate.Name == "NoAwait");
+            member.MetadataToken = 0x02000001;
+        }
 
         var source = TypeSourceComposer.Compose(type, path, pdbPath: null);
 

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerAsyncTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerAsyncTests.cs
@@ -1,0 +1,29 @@
+using System.Reflection.PortableExecutable;
+using ILInspector.Metadata;
+
+namespace ILInspector.Decompiler.Tests;
+
+public sealed class TypeSourceComposerAsyncTests
+{
+    [Fact]
+    public void ClassicAsyncWithoutAwait_UsesMetadataBodyModifier()
+    {
+        string path = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "ILInspector.Decompiler.Fixtures.ClassicAsync",
+            "release",
+            "ILInspector.Decompiler.Fixtures.ClassicAsync.dll"));
+        using var pe = new PEReader(File.OpenRead(path));
+        var surface = ApiSurfaceExtractor.Extract(pe);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.FullName == "ILInspector.Decompiler.Fixtures.ClassicAsync.AsyncFixtures");
+
+        var source = TypeSourceComposer.Compose(type, path, pdbPath: null);
+
+        Assert.NotNull(source);
+        Assert.Contains("public static async Task NoAwait()", source, StringComparison.Ordinal);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -29,12 +29,17 @@ namespace ILInspector.Decompiler.Tests;
 /// </summary>
 public class UnsafeEmitterTests
 {
-    static string Decompile(string assemblyPath, string typeFullName, string method)
+    static DecompilerResult DecompileResult(string assemblyPath, string typeFullName, string method)
     {
         var source = MetadataSource.Open(assemblyPath);
         var function = IrImporter.Import(source, typeFullName, method);
         Assert.NotNull(function);
-        var result = CSharpPrinter.PrintRaised(function!);
+        return CSharpPrinter.PrintRaised(function!);
+    }
+
+    static string Decompile(string assemblyPath, string typeFullName, string method)
+    {
+        var result = DecompileResult(assemblyPath, typeFullName, method);
         Assert.NotNull(result.Output);
         return result.Output!;
     }
@@ -255,6 +260,55 @@ public class UnsafeEmitterTests
         // `scoped` to stay clean (otherwise CS9081). A stackalloc result is
         // always scoped, so this is mode-independent correctness, not a guess.
         Assert.Contains("scoped Span<int> s", output);
+    }
+
+    [Fact]
+    public void UnsafeBodyModifierFact_TracksSkipLocalsInitStackAlloc()
+    {
+        var unsafeResult = DecompileResult(
+            typeof(NewFixtures).Assembly.Location,
+            typeof(NewFixtures).FullName!,
+            nameof(NewFixtures.StackAllocSkipInit));
+        var safeResult = DecompileResult(
+            typeof(NewFixtures).Assembly.Location,
+            typeof(NewFixtures).FullName!,
+            nameof(NewFixtures.StackAllocDefault));
+
+        Assert.True(unsafeResult.RequiresUnsafeBodyModifier);
+        Assert.False(safeResult.RequiresUnsafeBodyModifier);
+    }
+
+    [Fact]
+    public void UnsafeBodyModifierFact_ExcludesStructThisInitialization()
+    {
+        var structType = TypeRef.Definition(
+            "Synthetic",
+            "Synthetic",
+            "Value",
+            ValueTypeHint.ValueType);
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var block = new Block(0);
+        block.Add(new InitObject(
+            structType,
+            new LoadArgument(0, "this", structType)));
+        block.Add(new Return(null));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "Reset",
+            structType,
+            new MethodSignature(
+                voidType,
+                [],
+                HasThis: true,
+                GenericParameterCount: 0),
+            [],
+            body);
+
+        var result = CSharpPrinter.Print(function);
+
+        Assert.NotNull(result.Output);
+        Assert.False(result.RequiresUnsafeBodyModifier);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -222,6 +222,13 @@ public sealed record DecompilerResult(
     /// </summary>
     public bool RequiresAsyncBodyModifier { get; init; }
 
+    /// <summary>
+    /// True when the rendered body contains operations that require an unsafe
+    /// member context. Full-body consumers carry this typed projection fact to
+    /// the C# declaration formatter instead of recovering it from rendered text.
+    /// </summary>
+    public bool RequiresUnsafeBodyModifier { get; init; }
+
     /// <summary>True when the rendered IR contains at least one recovered <c>await</c> expression.</summary>
     public bool ContainsAwaitExpression { get; init; }
 
@@ -260,6 +267,7 @@ public sealed record DecompilerResult(
             && EqualityComparer<string?>.Default.Equals(ConstructorChain, other.ConstructorChain)
             && EqualityComparer<IReadOnlyList<(string Field, string Value)>>.Default.Equals(FieldInitializers, other.FieldInitializers)
             && RequiresAsyncBodyModifier == other.RequiresAsyncBodyModifier
+            && RequiresUnsafeBodyModifier == other.RequiresUnsafeBodyModifier
             && ContainsAwaitExpression == other.ContainsAwaitExpression
             && EqualityComparer<DecompilerTrace?>.Default.Equals(Trace, other.Trace);
 
@@ -272,6 +280,7 @@ public sealed record DecompilerResult(
         hash.Add(ConstructorChain);
         hash.Add(FieldInitializers);
         hash.Add(RequiresAsyncBodyModifier);
+        hash.Add(RequiresUnsafeBodyModifier);
         hash.Add(ContainsAwaitExpression);
         hash.Add(Trace);
         return hash.ToHashCode();

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -215,10 +215,10 @@ public sealed record DecompilerResult(
     public IReadOnlyList<(string Field, string Value)> FieldInitializers { get; init; } = [];
 
     /// <summary>
-    /// True when the body must be emitted under a C# <c>async</c> method modifier
-    /// to recompile to equivalent IL. Classic async state-machine reconstruction
-    /// sets this; runtime-async helper-call recovery does not, because compiling it
-    /// as C# async would emit a different lowering.
+    /// True when classic state-machine reconstruction installed an async body
+    /// contract. The printer uses this to shape fallback returns. Final C# member
+    /// modifiers are body-gated metadata facts owned by <c>ILInspector.CSharp</c>,
+    /// not inferred from this projection result.
     /// </summary>
     public bool RequiresAsyncBodyModifier { get; init; }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -219,9 +219,29 @@ public sealed partial class CSharpPrinter
             ConstructorChain = _constructorChain,
             FieldInitializers = _fieldInitializers,
             RequiresAsyncBodyModifier = function.RequiresAsyncBodyModifier,
+            RequiresUnsafeBodyModifier = RequiresUnsafeBodyModifier(function),
             ContainsAwaitExpression = function.Descendants.OfType<AwaitExpression>().Any(),
             Metadata = new DecompilerResultMetadata(EffectiveDecompilerOptions(), [.. _decisions]),
         };
+
+    static bool RequiresUnsafeBodyModifier(IrFunction function)
+        => function.Descendants.Prepend(function).Any(IsUnsafeBodyModifierOperation);
+
+    static bool IsUnsafeBodyModifierOperation(IrNode node) => node switch
+    {
+        CallIndirect => true,
+        StackAllocate => true,
+        StackAllocArray => false,
+        Call c => c.Callee.RequiresUnsafe || SignatureRequiresUnsafe(c.Callee),
+        NewObject n => n.Constructor.RequiresUnsafe || SignatureRequiresUnsafe(n.Constructor),
+        LoadIndirect l => BodyOperationRendersAsPointerDeref(l.Address),
+        StoreIndirect s => BodyOperationRendersAsPointerDeref(s.Address),
+        InitObject o => BodyOperationRendersAsPointerDeref(o.Address),
+        _ => false,
+    };
+
+    static bool BodyOperationRendersAsPointerDeref(IrExpression address)
+        => address.ResultType?.Kind != TypeRefKind.ByRef;
 
     DecompilerOptions EffectiveDecompilerOptions()
         => new()

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -219,29 +219,10 @@ public sealed partial class CSharpPrinter
             ConstructorChain = _constructorChain,
             FieldInitializers = _fieldInitializers,
             RequiresAsyncBodyModifier = function.RequiresAsyncBodyModifier,
-            RequiresUnsafeBodyModifier = RequiresUnsafeBodyModifier(function),
+            RequiresUnsafeBodyModifier = function.Descendants.Prepend(function).Any(NeedsUnsafeContext),
             ContainsAwaitExpression = function.Descendants.OfType<AwaitExpression>().Any(),
             Metadata = new DecompilerResultMetadata(EffectiveDecompilerOptions(), [.. _decisions]),
         };
-
-    static bool RequiresUnsafeBodyModifier(IrFunction function)
-        => function.Descendants.Prepend(function).Any(IsUnsafeBodyModifierOperation);
-
-    static bool IsUnsafeBodyModifierOperation(IrNode node) => node switch
-    {
-        CallIndirect => true,
-        StackAllocate => true,
-        StackAllocArray => false,
-        Call c => c.Callee.RequiresUnsafe || SignatureRequiresUnsafe(c.Callee),
-        NewObject n => n.Constructor.RequiresUnsafe || SignatureRequiresUnsafe(n.Constructor),
-        LoadIndirect l => BodyOperationRendersAsPointerDeref(l.Address),
-        StoreIndirect s => BodyOperationRendersAsPointerDeref(s.Address),
-        InitObject o => BodyOperationRendersAsPointerDeref(o.Address),
-        _ => false,
-    };
-
-    static bool BodyOperationRendersAsPointerDeref(IrExpression address)
-        => address.ResultType?.Kind != TypeRefKind.ByRef;
 
     DecompilerOptions EffectiveDecompilerOptions()
         => new()

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -103,42 +103,89 @@ public static class IrImporter
         try
         {
             var reader = source.Reader;
-            foreach (var typeDefHandle in reader.TypeDefinitions)
+            if (ResolveMethodHandle(
+                reader,
+                typeFullName,
+                methodName,
+                overloadIndex,
+                publicOnly) is not { } methodHandle)
             {
-                var typeDef = reader.GetTypeDefinition(typeDefHandle);
-                // Nested-aware: a nested type has a nil namespace and a leaf
-                // Name, so the full name must thread its declaring types
-                // (Outer.Inner). The product passes such names; a raw ns+name
-                // would never match and the body would silently disappear.
-                if (reader.GetFullTypeName(typeDef) != typeFullName)
-                    continue;
-
-                // Overload indices count name matches at the requested
-                // visibility, body or not (parity with legacy selection); a
-                // selected overload without a body is null, not silently the
-                // next one with a body.
-                int seen = 0;
-                foreach (var methodHandle in typeDef.GetMethods())
-                {
-                    var method = reader.GetMethodDefinition(methodHandle);
-                    if (reader.GetString(method.Name) != methodName)
-                        continue;
-                    if (publicOnly && (method.Attributes & System.Reflection.MethodAttributes.MemberAccessMask) != System.Reflection.MethodAttributes.Public)
-                        continue;
-                    if (seen++ != overloadIndex)
-                        continue;
-                    if (method.RelativeVirtualAddress == 0)
-                        return null;
-                    return Build(source, MethodImporter.Import(source, typeDefHandle, methodHandle), CallerScope(reader, typeDef, method));
-                }
                 return null;
             }
-            return null;
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (method.RelativeVirtualAddress == 0)
+                return null;
+            var typeDefHandle = method.GetDeclaringType();
+            var typeDef = reader.GetTypeDefinition(typeDefHandle);
+            return Build(
+                source,
+                MethodImporter.Import(source, typeDefHandle, methodHandle),
+                CallerScope(reader, typeDef, method));
         }
         catch (Exception ex)
         {
             return CrashFunction(methodName, typeFullName, ex);
         }
+    }
+
+    /// <summary>
+    /// Resolves the same name/ordinal selector used by
+    /// <see cref="Import(MetadataSource, string, string, int, bool)"/> to its
+    /// concrete method definition. This lets callers keep declaration facts,
+    /// attributes, and bodies on one identity when a carried metadata token
+    /// does not validate against the current reader.
+    /// </summary>
+    public static MethodDefinitionHandle? ResolveMethodHandle(
+        MetadataReader reader,
+        string typeFullName,
+        string methodName,
+        int overloadIndex = 0,
+        bool publicOnly = false)
+    {
+        foreach (var typeDefHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeDefHandle);
+            // Nested-aware: a nested type has a nil namespace and a leaf Name.
+            if (reader.GetFullTypeName(typeDef) != typeFullName)
+                continue;
+            return ResolveMethodHandle(
+                reader,
+                typeDefHandle,
+                methodName,
+                overloadIndex,
+                publicOnly);
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Type-handle form of <see cref="ResolveMethodHandle(MetadataReader, string, string, int, bool)"/>.
+    /// Overload ordinals count matching methods at the requested visibility,
+    /// including methods without an IL body.
+    /// </summary>
+    public static MethodDefinitionHandle? ResolveMethodHandle(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        string methodName,
+        int overloadIndex = 0,
+        bool publicOnly = false)
+    {
+        int seen = 0;
+        foreach (var methodHandle in reader.GetTypeDefinition(typeHandle).GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (reader.GetString(method.Name) != methodName)
+                continue;
+            if (publicOnly
+                && (method.Attributes & System.Reflection.MethodAttributes.MemberAccessMask)
+                    != System.Reflection.MethodAttributes.Public)
+            {
+                continue;
+            }
+            if (seen++ == overloadIndex)
+                return methodHandle;
+        }
+        return null;
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -285,11 +285,10 @@ public sealed class IrFunction : IrNode
     public bool SkipLocalsInit { get; set; }
 
     /// <summary>
-    /// True when a pass reconstructed a body whose compile-back shell must carry
-    /// the C# <c>async</c> modifier to re-emit equivalent IL. Runtime-async
-    /// <see cref="AwaitExpression"/> bodies deliberately leave this false: compiling
-    /// those as C# async would produce classic state-machine IL, not the original
-    /// runtime-async helper-call form.
+    /// True when classic state-machine reconstruction installed an async body
+    /// contract. The printer uses this while shaping returns and unsupported
+    /// fallbacks. Final member modifiers come from defining-method metadata in
+    /// the C# producer rather than from this pass-local state.
     /// </summary>
     public bool RequiresAsyncBodyModifier { get; set; }
 

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -384,12 +384,21 @@ public static class TypeSourceComposer
                     any = true;
 
                     bool publicOnly = member.Kind != "explicit-interface-implementation";
+                    bool bodyPublicOnly = publicOnly
+                        && !(member.Kind == "constructor" && member.DeclaringOverloadIndex is not null)
+                        && member.Accessibility is null;
                     // Resolve the member's metadata handle once (validated
                     // against this reader) and address both its attributes and
-                    // its body by it, so neither drifts onto a different
-                    // overload. A non-validating token falls back to the
-                    // name+ordinal path.
-                    var memberHandle = ResolveMemberHandle(reader, typeHandle, member);
+                    // its body by it, so neither drifts onto a different overload.
+                    // A non-validating token resolves the legacy name+ordinal
+                    // selector to its concrete handle before any projection.
+                    var memberHandle = ResolveMemberHandle(reader, typeHandle, member)
+                        ?? Pipeline.IrImporter.ResolveMethodHandle(
+                            reader,
+                            member.DeclaringType ?? type.FullName,
+                            member.Name,
+                            index,
+                            bodyPublicOnly);
                     var attributes = memberHandle is { } attrHandle
                         ? AttributeReader.RenderMethodAttributes(reader, attrHandle, bodyNamespaces)
                         : AttributeReader.RenderMethodAttributes(reader, typeHandle, member.Name, index, publicOnly, bodyNamespaces);

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -1019,40 +1019,12 @@ public static class TypeSourceComposer
         if (function is null)
             return null;
         CollectNamespaces(function, bodyNamespaces);
-        requiresUnsafeContext = RequiresUnsafeMemberContext(function);
         var result = Pipeline.CSharpPrinter.PrintRaised(
             function, importMethodBody: method => Pipeline.IrImporter.Import(pipelineSource, method));
         constructorChain = result.ConstructorChain;
+        requiresUnsafeContext = result.RequiresUnsafeBodyModifier;
         return result.Output?.TrimEnd() ?? DiagnosticComment(result);
     }
-
-    static bool RequiresUnsafeMemberContext(Pipeline.IrFunction function)
-        => function.Descendants.Prepend(function).Any(IsUnsafeContextOperation);
-
-    static bool IsUnsafeContextOperation(Pipeline.IrNode node) => node switch
-    {
-        Pipeline.CallIndirect => true,
-        Pipeline.StackAllocate => true,
-        Pipeline.StackAllocArray => false,
-        Pipeline.Call c => c.Callee.RequiresUnsafe || SignatureRequiresUnsafe(c.Callee),
-        Pipeline.NewObject n => n.Constructor.RequiresUnsafe || SignatureRequiresUnsafe(n.Constructor),
-        Pipeline.LoadIndirect l => RendersAsPointerDeref(l.Address),
-        Pipeline.StoreIndirect s => RendersAsPointerDeref(s.Address),
-        Pipeline.InitObject o => RendersAsPointerDeref(o.Address),
-        _ => false,
-    };
-
-    static bool SignatureRequiresUnsafe(Pipeline.MethodRef callee)
-        => ContainsPointer(callee.ReturnType) || callee.ParameterTypes.Any(ContainsPointer);
-
-    static bool ContainsPointer(Pipeline.TypeRef? type)
-        => type is not null
-            && (type.Kind is Pipeline.TypeRefKind.Pointer or Pipeline.TypeRefKind.FunctionPointer
-                || ContainsPointer(type.ElementType)
-                || type.TypeArguments.Any(ContainsPointer));
-
-    static bool RendersAsPointerDeref(Pipeline.IrExpression address)
-        => address.ResultType?.Kind != Pipeline.TypeRefKind.ByRef;
 
     /// <summary>
     /// Unions the namespaces of every definition type the function references

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -19,9 +19,6 @@ namespace ILInspector.Decompiler;
 public static class TypeSourceComposer
 {
     static readonly CSharpFormatter DefaultDeclarationFormatter = CreateDeclarationFormatter();
-    static readonly CSharpFormatter UnsafeDeclarationFormatter = CreateDeclarationFormatter(forceUnsafe: true);
-    static readonly CSharpFormatter AsyncDeclarationFormatter = CreateDeclarationFormatter(forceAsync: true);
-    static readonly CSharpFormatter AsyncUnsafeDeclarationFormatter = CreateDeclarationFormatter(forceUnsafe: true, forceAsync: true);
     static readonly CSharpFormatter TerminatedDeclarationFormatter = CreateDeclarationFormatter(terminateMemberDeclaration: true);
 
     /// <summary>
@@ -185,27 +182,14 @@ public static class TypeSourceComposer
     }
 
     static CSharpFormatter CreateDeclarationFormatter(
-        bool forceUnsafe = false,
-        bool forceAsync = false,
         bool terminateMemberDeclaration = false)
         => new(new CSharpFormatOptions
         {
-            ForceAsync = forceAsync,
-            ForceUnsafe = forceUnsafe,
             IncludeCustomAttributes = false,
             IncludeObsoleteAttribute = false,
             OmitInterfaceMemberModifiers = true,
             TerminateMemberDeclaration = terminateMemberDeclaration
         });
-
-    static CSharpFormatter DeclarationFormatter(bool forceUnsafe, bool forceAsync)
-        => (forceUnsafe, forceAsync) switch
-        {
-            (false, false) => DefaultDeclarationFormatter,
-            (true, false) => UnsafeDeclarationFormatter,
-            (false, true) => AsyncDeclarationFormatter,
-            (true, true) => AsyncUnsafeDeclarationFormatter
-        };
 
     static string DisplayName(ApiType type)
     {
@@ -413,11 +397,10 @@ public static class TypeSourceComposer
                         sb.AppendLine($"    [{attribute}]");
 
                     string? constructorChain = null;
-                    bool requiresAsync = false;
                     bool requiresUnsafeContext = false;
                     string? body = member.IsAbstract
                         ? null
-                        : DecompileBody(pipelineSource, memberHandle, type.FullName, member, index, bodyNamespaces, out constructorChain, out requiresAsync, out requiresUnsafeContext);
+                        : DecompileBody(pipelineSource, memberHandle, type.FullName, member, index, bodyNamespaces, out constructorChain, out requiresUnsafeContext);
 
                     // An explicit interface property implementation surfaces
                     // as its accessor method (Iface.get_X). Render the
@@ -466,8 +449,17 @@ public static class TypeSourceComposer
                         break;
                     }
 
-                    var declaration = DeclarationFormatter(requiresUnsafeContext, requiresAsync)
-                        .FormatMember(type, member);
+                    var bodyShape = body is null
+                        ? null
+                        : new CSharpBlockBody(body)
+                        {
+                            RequiresAsyncModifier = memberHandle is { } asyncHandle
+                                && CSharpTypeProducer.RequiresAsyncBodyModifier(reader, asyncHandle),
+                            RequiresUnsafeModifier = requiresUnsafeContext
+                        };
+                    var declaration = bodyShape is null
+                        ? DefaultDeclarationFormatter.FormatMember(type, member)
+                        : DefaultDeclarationFormatter.FormatMemberWithBody(type, member, bodyShape);
                     AppendMember(sb, declaration, body, constructorChain);
                     break;
                 }
@@ -789,7 +781,10 @@ public static class TypeSourceComposer
 
         if (!requiresUnsafeContext && accessors.Any(a => a.RequiresUnsafeContext))
         {
-            signature = UnsafeDeclarationFormatter.FormatMember(type, member);
+            signature = DefaultDeclarationFormatter.FormatMemberWithBody(
+                type,
+                member,
+                new CSharpPropertyBody(null, null) { RequiresUnsafeModifier = true });
             accessorList = signature.IndexOf('{');
             head = accessorList >= 0 ? signature[..accessorList].TrimEnd() : signature;
         }
@@ -891,7 +886,7 @@ public static class TypeSourceComposer
     static string? DecompileBody(
         Pipeline.MetadataSource pipelineSource, MethodDefinitionHandle? memberHandle,
         string typeFullName, ApiMember member, int overloadIndex,
-        SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresAsync, out bool requiresUnsafeContext)
+        SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresUnsafeContext)
     {
         // Prefer the member's own metadata handle — the canonical same-reader
         // addressing (see docs/design/member-body-substrate.md). The caller has
@@ -902,7 +897,7 @@ public static class TypeSourceComposer
         if (memberHandle is { } methodHandle)
             return DecompileFunction(pipelineSource,
                 Pipeline.IrImporter.Import(pipelineSource, methodHandle),
-                bodyNamespaces, out constructorChain, out requiresAsync, out requiresUnsafeContext);
+                bodyNamespaces, out constructorChain, out requiresUnsafeContext);
 
         // Public-only overload counting, except explicit interface
         // implementations (non-public by nature) — matching the API surface
@@ -911,7 +906,7 @@ public static class TypeSourceComposer
             publicOnly: member.Kind != "explicit-interface-implementation"
                 && !(member.Kind == "constructor" && member.DeclaringOverloadIndex is not null)
                 && member.Accessibility is null,
-            bodyNamespaces, out constructorChain, out requiresAsync, out requiresUnsafeContext);
+            bodyNamespaces, out constructorChain, out requiresUnsafeContext);
     }
 
     /// <summary>
@@ -990,9 +985,9 @@ public static class TypeSourceComposer
         => accessorHandle is { } handle
             ? DecompileFunction(pipelineSource,
                 Pipeline.IrImporter.Import(pipelineSource, handle),
-                bodyNamespaces, out _, out _, out requiresUnsafeContext)
+                bodyNamespaces, out _, out requiresUnsafeContext)
             : DecompileMethod(pipelineSource, typeFullName, accessorName, overloadIndex: 0,
-            publicOnly: false, bodyNamespaces, out _, out _, out requiresUnsafeContext);
+            publicOnly: false, bodyNamespaces, out _, out requiresUnsafeContext);
 
     /// <summary>
     /// Imports one method to typed IR, runs the raising passes, and prints the
@@ -1004,10 +999,10 @@ public static class TypeSourceComposer
     /// </summary>
     static string? DecompileMethod(
         Pipeline.MetadataSource pipelineSource, string typeFullName, string methodName, int overloadIndex,
-        bool publicOnly, SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresAsync, out bool requiresUnsafeContext)
+        bool publicOnly, SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresUnsafeContext)
         => DecompileFunction(pipelineSource,
             Pipeline.IrImporter.Import(pipelineSource, typeFullName, methodName, overloadIndex, publicOnly),
-            bodyNamespaces, out constructorChain, out requiresAsync, out requiresUnsafeContext);
+            bodyNamespaces, out constructorChain, out requiresUnsafeContext);
 
     /// <summary>
     /// Runs the raising passes and prints an already-imported function. A null
@@ -1017,10 +1012,9 @@ public static class TypeSourceComposer
     /// </summary>
     static string? DecompileFunction(
         Pipeline.MetadataSource pipelineSource, Pipeline.IrFunction? function,
-        SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresAsync, out bool requiresUnsafeContext)
+        SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresUnsafeContext)
     {
         constructorChain = null;
-        requiresAsync = false;
         requiresUnsafeContext = false;
         if (function is null)
             return null;
@@ -1029,7 +1023,6 @@ public static class TypeSourceComposer
         var result = Pipeline.CSharpPrinter.PrintRaised(
             function, importMethodBody: method => Pipeline.IrImporter.Import(pipelineSource, method));
         constructorChain = result.ConstructorChain;
-        requiresAsync = result.ContainsAwaitExpression;
         return result.Output?.TrimEnd() ?? DiagnosticComment(result);
     }
 

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -199,6 +199,30 @@ public class ApiOutputFormatterTests
         Assert.Equal(requiresAsyncBodyModifier, declaration.Contains(" async ", StringComparison.Ordinal));
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void FormatSourceWithDeclaration_UsesTypedUnsafeBodyFact(
+        bool requiresUnsafeBodyModifier)
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Worker", Kind = "class" };
+        var member = Method("Run");
+        var result = DecompilerResult.Success("return;") with
+        {
+            RequiresUnsafeBodyModifier = requiresUnsafeBodyModifier
+        };
+
+        var source = ApiOutputFormatter.FormatSourceWithDeclaration(
+            type,
+            member,
+            methodGenericParameters: null,
+            result);
+        var declaration = Declaration(source);
+
+        Assert.Equal(requiresUnsafeBodyModifier, declaration.Contains(" unsafe ", StringComparison.Ordinal));
+        Assert.False(member.IsUnsafe);
+    }
+
     [Fact]
     public void FormatSourceWithDeclaration_PreservesObsoleteAttribute()
     {
@@ -239,11 +263,14 @@ public class ApiOutputFormatterTests
     }
 
     [Fact]
-    public void PopulateCSharpSections_AppliesBodyAsyncMetadataToAllOverlays()
+    public void PopulateCSharpSections_AppliesBodyModifierFactsToAllOverlays()
     {
         var type = new ApiType { Namespace = "Samples", Name = "Worker", Kind = "class" };
         var member = Method("Run");
-        var result = DecompilerResult.Success("await Task.Yield();");
+        var result = DecompilerResult.Success("await Task.Yield();") with
+        {
+            RequiresUnsafeBodyModifier = true
+        };
         var code = new MemberCodeProvider.Item(
             DecompiledResult: null,
             MethodGenericParameters: null,
@@ -259,9 +286,12 @@ public class ApiOutputFormatterTests
 
         Assert.True(ApiOutputFormatter.PopulateCSharpSections(sections, type, member, code));
         Assert.Contains(" async ", Declaration(sections.AnnotatedSourceCode.Content));
+        Assert.Contains(" unsafe ", Declaration(sections.AnnotatedSourceCode.Content));
         Assert.Contains(" async ", Declaration(sections.CostOverlayCode.Content));
+        Assert.Contains(" unsafe ", Declaration(sections.CostOverlayCode.Content));
         Assert.Contains("// cost evidence", sections.CostOverlayCode.Content);
         Assert.Contains(" async ", Declaration(sections.SemanticsOverlayCode.Content));
+        Assert.Contains(" unsafe ", Declaration(sections.SemanticsOverlayCode.Content));
     }
 
     [Fact]
@@ -306,6 +336,56 @@ public class ApiOutputFormatterTests
         Assert.NotNull(typeSource);
         Assert.Contains(
             "public static async Task<int> YieldAsync",
+            typeSource,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnsafeBodyConsumers_UseTypedBodyModifier()
+    {
+        string path = typeof(RuntimeAsyncHeaderFixture).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(path));
+        var surface = ApiSurfaceExtractor.Extract(pe);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.FullName == typeof(RuntimeAsyncHeaderFixture).FullName);
+        var member = Assert.Single(
+            type.Members,
+            candidate => candidate.Name == nameof(RuntimeAsyncHeaderFixture.ReadAddress));
+        Assert.False(member.IsUnsafe);
+
+        var collected = Assert.Single(MemberCodeProvider.Collect(
+            type,
+            [member],
+            path,
+            overloadIndex: 0,
+            new MemberCodeProvider.Request(
+                DecompiledSource: true,
+                AnnotatedSource: false,
+                CostOverlay: false,
+                SemanticsOverlay: false,
+                IL: false,
+                Attributes: false,
+                Calls: false,
+                Callers: false,
+                CallGraph: false,
+                UnsafeOperations: false)));
+        var sections = new MemberCodeView();
+
+        Assert.True(ApiOutputFormatter.PopulateCSharpSections(
+            sections,
+            type,
+            member,
+            collected.Code));
+        Assert.Contains(
+            "public static unsafe int ReadAddress",
+            sections.DecompiledSourceCode.Content,
+            StringComparison.Ordinal);
+
+        var typeSource = TypeSourceComposer.Compose(type, path, pdbPath: null);
+        Assert.NotNull(typeSource);
+        Assert.Contains(
+            "public static unsafe int ReadAddress",
             typeSource,
             StringComparison.Ordinal);
     }
@@ -483,4 +563,6 @@ public static class RuntimeAsyncHeaderFixture
         await Task.Yield();
         return value;
     }
+
+    public static unsafe int ReadAddress(nint address) => *(int*)address;
 }

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -170,13 +170,10 @@ public class ApiOutputFormatterTests
     }
 
     [Theory]
-    [InlineData(false, false, false)]
-    [InlineData(true, false, true)]
-    [InlineData(false, true, true)]
-    public void FormatSourceWithDeclaration_UsesTypedAsyncEvidence(
-        bool containsAwaitExpression,
-        bool requiresAsyncBodyModifier,
-        bool expectedAsync)
+    [InlineData(false)]
+    [InlineData(true)]
+    public void FormatSourceWithDeclaration_UsesBodyAsyncMetadata(
+        bool requiresAsyncBodyModifier)
     {
         var type = new ApiType { Namespace = "Samples", Name = "Worker", Kind = "class" };
         var member = new ApiMember
@@ -189,20 +186,33 @@ public class ApiOutputFormatterTests
                 ReturnType = "System.Threading.Tasks.Task"
             }
         };
-        var result = DecompilerResult.Success("Console.WriteLine(\"await\");") with
-        {
-            ContainsAwaitExpression = containsAwaitExpression,
-            RequiresAsyncBodyModifier = requiresAsyncBodyModifier
-        };
+        var result = DecompilerResult.Success("Console.WriteLine(\"await\");");
 
         var source = ApiOutputFormatter.FormatSourceWithDeclaration(
             type,
             member,
             methodGenericParameters: null,
-            result);
+            result,
+            requiresAsyncBodyModifier: requiresAsyncBodyModifier);
         var declaration = source.ReplaceLineEndings("\n").Split('\n')[0];
 
-        Assert.Equal(expectedAsync, declaration.Contains(" async ", StringComparison.Ordinal));
+        Assert.Equal(requiresAsyncBodyModifier, declaration.Contains(" async ", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FormatSourceWithDeclaration_PreservesObsoleteAttribute()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Worker", Kind = "class" };
+        var member = Method("Run");
+        member.IsObsolete = true;
+
+        var source = ApiOutputFormatter.FormatSourceWithDeclaration(
+            type,
+            member,
+            methodGenericParameters: null,
+            DecompilerResult.Success("return;"));
+
+        Assert.StartsWith("[Obsolete] public", source, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -229,28 +239,22 @@ public class ApiOutputFormatterTests
     }
 
     [Fact]
-    public void PopulateCSharpSections_AppliesTypedAsyncEvidenceToAllOverlays()
+    public void PopulateCSharpSections_AppliesBodyAsyncMetadataToAllOverlays()
     {
         var type = new ApiType { Namespace = "Samples", Name = "Worker", Kind = "class" };
         var member = Method("Run");
-        var containsAwait = DecompilerResult.Success("await Task.Yield();") with
-        {
-            ContainsAwaitExpression = true
-        };
-        var requiresAsync = DecompilerResult.Success("await Task.Yield();") with
-        {
-            RequiresAsyncBodyModifier = true
-        };
+        var result = DecompilerResult.Success("await Task.Yield();");
         var code = new MemberCodeProvider.Item(
             DecompiledResult: null,
             MethodGenericParameters: null,
-            AnnotatedResult: containsAwait,
-            CostOverlayResult: containsAwait,
+            AnnotatedResult: result,
+            CostOverlayResult: result,
             CostOverlayHeaderComments: ["// cost evidence"],
-            SemanticsOverlayResult: requiresAsync,
+            SemanticsOverlayResult: result,
             ILText: null,
             ILDiagnostic: null,
-            Attributes: null);
+            Attributes: null,
+            RequiresAsyncBodyModifier: true);
         var sections = new MemberCodeView();
 
         Assert.True(ApiOutputFormatter.PopulateCSharpSections(sections, type, member, code));
@@ -258,6 +262,52 @@ public class ApiOutputFormatterTests
         Assert.Contains(" async ", Declaration(sections.CostOverlayCode.Content));
         Assert.Contains("// cost evidence", sections.CostOverlayCode.Content);
         Assert.Contains(" async ", Declaration(sections.SemanticsOverlayCode.Content));
+    }
+
+    [Fact]
+    public void RuntimeAsyncBodyConsumers_UseMetadataModifier()
+    {
+        string path = typeof(RuntimeAsyncHeaderFixture).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(path));
+        var surface = ApiSurfaceExtractor.Extract(pe);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.FullName == typeof(RuntimeAsyncHeaderFixture).FullName);
+        var member = Assert.Single(type.Members, candidate => candidate.Name == nameof(RuntimeAsyncHeaderFixture.YieldAsync));
+        var collected = Assert.Single(MemberCodeProvider.Collect(
+            type,
+            [member],
+            path,
+            overloadIndex: 0,
+            new MemberCodeProvider.Request(
+                DecompiledSource: true,
+                AnnotatedSource: false,
+                CostOverlay: false,
+                SemanticsOverlay: false,
+                IL: false,
+                Attributes: false,
+                Calls: false,
+                Callers: false,
+                CallGraph: false,
+                UnsafeOperations: false)));
+        var sections = new MemberCodeView();
+
+        Assert.True(ApiOutputFormatter.PopulateCSharpSections(
+            sections,
+            type,
+            member,
+            collected.Code));
+        Assert.Contains(
+            "public static async System.Threading.Tasks.Task<int> YieldAsync",
+            sections.DecompiledSourceCode.Content,
+            StringComparison.Ordinal);
+
+        var typeSource = TypeSourceComposer.Compose(type, path, pdbPath: null);
+        Assert.NotNull(typeSource);
+        Assert.Contains(
+            "public static async Task<int> YieldAsync",
+            typeSource,
+            StringComparison.Ordinal);
     }
 
     static ApiMember Method(string name)
@@ -424,4 +474,13 @@ public class ApiOutputFormatterTests
 public class PlusFixtureOuter
 {
     public class Inner { }
+}
+
+public static class RuntimeAsyncHeaderFixture
+{
+    public static async Task<int> YieldAsync(int value)
+    {
+        await Task.Yield();
+        return value;
+    }
 }

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -294,8 +294,11 @@ public class ApiOutputFormatterTests
         Assert.Contains(" unsafe ", Declaration(sections.SemanticsOverlayCode.Content));
     }
 
-    [Fact]
-    public void RuntimeAsyncBodyConsumers_UseMetadataModifier()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void RuntimeAsyncBodyConsumers_UseResolvedMethodModifier(
+        bool invalidateMetadataToken)
     {
         string path = typeof(RuntimeAsyncHeaderFixture).Assembly.Location;
         using var pe = new PEReader(File.OpenRead(path));
@@ -304,6 +307,8 @@ public class ApiOutputFormatterTests
             surface.Types,
             candidate => candidate.FullName == typeof(RuntimeAsyncHeaderFixture).FullName);
         var member = Assert.Single(type.Members, candidate => candidate.Name == nameof(RuntimeAsyncHeaderFixture.YieldAsync));
+        if (invalidateMetadataToken)
+            member.MetadataToken = 0x02000001;
         var collected = Assert.Single(MemberCodeProvider.Collect(
             type,
             [member],

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -97,9 +97,16 @@ internal static class MemberCodeProvider
             // this reader) and address every section by it, so none drifts onto
             // a different overload. A non-validating token — e.g. carried over
             // from a type-forwarded surface — falls back to the name+ordinal
-            // path. This is the same drift class the whole-type composition path
-            // fixes (see docs/design/member-body-substrate.md).
-            var memberHandle = ResolveMethodHandle(reader, typeHandle, method.MetadataToken, method.Name);
+            // path, resolved to its concrete handle before any projection. This
+            // is the same drift class the whole-type composition path fixes
+            // (see docs/design/member-body-substrate.md).
+            var memberHandle = ResolveMethodHandle(reader, typeHandle, method.MetadataToken, method.Name)
+                ?? IrImporter.ResolveMethodHandle(
+                    reader,
+                    typeHandle,
+                    method.Name,
+                    lookupOverloadIndex,
+                    publicOnly);
 
             IReadOnlyList<(string Name, string? Value)>? attributes = null;
             if (request.Attributes)

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -1,6 +1,7 @@
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using DotnetInspector.Services;
+using ILInspector.CSharp;
 using ILInspector.Metadata;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Findings;
@@ -36,7 +37,8 @@ internal static class MemberCodeProvider
         string? ILDiagnostic,
         IReadOnlyList<(string Name, string? Value)>? Attributes,
         IReadOnlyList<ILInspector.Research.ResearchViews.FactRow>? Facts = null,
-        FindingInspection<Decompiler.DecompilerFidelityCause>? FidelityCauses = null);
+        FindingInspection<Decompiler.DecompilerFidelityCause>? FidelityCauses = null,
+        bool RequiresAsyncBodyModifier = false);
 
     internal static List<(ApiMember Member, Item Code)> Collect(
         ApiType type, List<ApiMember> methods, string dllPath, int? overloadIndex,
@@ -122,6 +124,8 @@ internal static class MemberCodeProvider
                 ? SelectedMethodHasBody(reader, bodyHandle)
                 : SelectedMethodHasBody(
                     reader, typeHandle, method.Name, lookupOverloadIndex, publicOnly);
+            bool requiresAsyncBodyModifier = memberHandle is { } asyncHandle
+                && CSharpTypeProducer.RequiresAsyncBodyModifier(reader, asyncHandle);
 
             // Decompiled source: raised C# only, without annotations or interleaved IL.
             Decompiler.DecompilerResult? decompiledResult = null;
@@ -253,7 +257,8 @@ internal static class MemberCodeProvider
                 ilDiagnostic,
                 attributes,
                 facts,
-                fidelityCauses)));
+                fidelityCauses,
+                requiresAsyncBodyModifier)));
         }
 
         return results;

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -2315,7 +2315,8 @@ public static class ApiOutputFormatter
             ?? throw new ArgumentException("A successful decompiler result is required.", nameof(result));
         var bodyShape = new CSharpBlockBody(lowered)
         {
-            RequiresAsyncModifier = requiresAsyncBodyModifier
+            RequiresAsyncModifier = requiresAsyncBodyModifier,
+            RequiresUnsafeModifier = result.RequiresUnsafeBodyModifier
         };
         var declaration = DefaultCSharpFormatter.FormatMemberWithBody(
             type,

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1549,7 +1549,8 @@ public static class ApiOutputFormatter
                 member,
                 code.MethodGenericParameters,
                 decompiledResult,
-                preferExpressionBodied: true);
+                preferExpressionBodied: true,
+                requiresAsyncBodyModifier: code.RequiresAsyncBodyModifier);
             hasCode = true;
         }
 
@@ -1560,7 +1561,8 @@ public static class ApiOutputFormatter
                 type,
                 member,
                 code.MethodGenericParameters,
-                annotatedResult);
+                annotatedResult,
+                requiresAsyncBodyModifier: code.RequiresAsyncBodyModifier);
             hasCode = true;
         }
 
@@ -1572,7 +1574,8 @@ public static class ApiOutputFormatter
                 member,
                 code.MethodGenericParameters,
                 costOverlayResult,
-                leadingBodyComments: code.CostOverlayHeaderComments);
+                leadingBodyComments: code.CostOverlayHeaderComments,
+                requiresAsyncBodyModifier: code.RequiresAsyncBodyModifier);
             hasCode = true;
         }
 
@@ -1583,7 +1586,8 @@ public static class ApiOutputFormatter
                 type,
                 member,
                 code.MethodGenericParameters,
-                semanticsOverlayResult);
+                semanticsOverlayResult,
+                requiresAsyncBodyModifier: code.RequiresAsyncBodyModifier);
             hasCode = true;
         }
 
@@ -2271,7 +2275,8 @@ public static class ApiOutputFormatter
         IReadOnlyList<string>? methodGenericParameters,
         Decompiler.DecompilerResult result,
         bool preferExpressionBodied = false,
-        IReadOnlyList<string>? leadingBodyComments = null)
+        IReadOnlyList<string>? leadingBodyComments = null,
+        bool requiresAsyncBodyModifier = false)
     {
         if (!result.Succeeded)
             return new CodeSection("csharp", DiagnosticComment(result));
@@ -2286,7 +2291,8 @@ public static class ApiOutputFormatter
                     methodGenericParameters,
                     result,
                     preferExpressionBodied,
-                    leadingBodyComments));
+                    leadingBodyComments,
+                    requiresAsyncBodyModifier));
         }
         catch (Exception ex)
         {
@@ -2302,16 +2308,20 @@ public static class ApiOutputFormatter
         IReadOnlyList<string>? methodGenericParameters,
         Decompiler.DecompilerResult result,
         bool preferExpressionBodied = false,
-        IReadOnlyList<string>? leadingBodyComments = null)
+        IReadOnlyList<string>? leadingBodyComments = null,
+        bool requiresAsyncBodyModifier = false)
     {
         var lowered = result.Output
             ?? throw new ArgumentException("A successful decompiler result is required.", nameof(result));
-        var declaration = FormatMemberDeclaration(
+        var bodyShape = new CSharpBlockBody(lowered)
+        {
+            RequiresAsyncModifier = requiresAsyncBodyModifier
+        };
+        var declaration = DefaultCSharpFormatter.FormatMemberWithBody(
             type,
             member,
-            abbreviate: false,
-            methodGenericParameters,
-            forceAsync: result.ContainsAwaitExpression || result.RequiresAsyncBodyModifier);
+            bodyShape,
+            methodGenericParameters);
         if (result.ConstructorChain is { } constructorChain
             && !string.IsNullOrWhiteSpace(declaration))
         {


### PR DESCRIPTION
Advances #2742. Follow-up to #2737 and #2750.

## Change

**Conclusion: PASS** — full-body C# declarations now source body-only `async`
and `unsafe` modifiers from resolved method/body facts, while API skeletons
remain unchanged.

Before:

```csharp
public static Task<int> PlainAsyncTask(int value)
```

After:

```csharp
public static async Task<int> PlainAsyncTask(int value)
```

The same contract now drives `TypeSourceComposer`, member decompiled source, and
annotated/cost/semantics overlays:

- `CSharpMemberBody` carries body-only async/unsafe requirements.
- `CSharpTypeProducer` classifies runtime async and classic async from the
  resolved defining MethodDef.
- Async-iterator kickoff methods remain without `async` until their bodies are
  reconstructed to source `yield` forms.
- Invalid carried tokens resolve the legacy name/ordinal selector to its concrete
  MethodDef before body, attribute, overlay, IL, or modifier projection.
- `DecompilerResult` carries typed unsafe-body evidence from the printer's
  existing unsafe-context discriminator.

This does not implement #2742's runtime awaiter-helper body reconstruction.

## Evidence

| Check | Result |
| --- | --- |
| Solution build | Pass |
| CSharp tests | 100 passed |
| Type-source tests | 61 passed |
| Unsafe-emitter tests | 38 passed |
| IrImporter tests | 65 passed |
| Product tests | 1,902 passed; 10 expected external-tool skips |
| Debug classic-async canary | 2 passed |
| Markdown lint | Pass |

Latest-merge-base targeted A/B:

- `OptimizationOpportunityFixtures.PlainAsyncTask`: only the `async` header was
  added.
- `RuntimeAsyncHeaderFixture.YieldAsync`: only the `async` header was added.
- `AsyncStream` and `YieldsPlainObjectAsync`: unchanged async-iterator near
  misses.

Render-text A/B evaluated 89,065 methods: **0 changed, 0 added, 0 removed**.
This is expected because the behavior change is in outer member declarations,
not decompiler body text.

## Review

| Reviewer | Result | Reconciliation |
| --- | --- | --- |
| Gemini 3.1 Pro | Clean on `3317c828` | Re-attacked resolved handles, token fallback, iterator gating, unsafe polarity, overlays, and skeleton isolation |
| MAI-Code-1-Flash | Clean on `3317c828` | Rebuilt and reran focused CSharp, decompiler addressing, and product rendering coverage |

Earlier adversarial findings were resolved as follows:

- MAI found that product member views dropped body-only unsafe evidence. Fixed
  in `13e5a0e7` by carrying the typed fact through every result/overlay.
- Gemini found struct-`this` false positives, `[SkipLocalsInit]` stackalloc false
  negatives, and a Release-specific fixture path. Fixed in `76e37cc7` with
  polarity tests and Debug/Release path resolution.
- Gemini found declaration/body drift when an invalid token fell back to a
  name/ordinal body but not async classification. Fixed in `700eb5cb` by
  resolving that selector to the concrete MethodDef before every projection.
- MAI suggested removing async iterators from
  `MethodClassificationScanner.StateMachineAsync`. No change: that scanner is
  intentionally a coarse async/iterator classifier; `CSharpTypeProducer` is the
  sharper body-capability gate and explicitly excludes iterator-only metadata.

**Review conclusion: PASS** — both required reviewers are clean on the final
head with no outstanding findings.
