### PR TITLE
Measure recursive traversal repetition

### DIFF
--- a/src/ILInspector.Analysis.Fixtures/CallerLoopFixtures/CallerLoopFixture.cs
+++ b/src/ILInspector.Analysis.Fixtures/CallerLoopFixtures/CallerLoopFixture.cs
@@ -40,6 +40,78 @@ public class CallerLoopFixture
     public object RecursiveBox(int value)
         => value <= 0 ? value : RecursiveBox(value - 1);
 
+    public object? TraverseRecursively(int[] values, int depth)
+    {
+        object? result = BuildTraversalNode(depth);
+        foreach (int _ in values)
+        {
+            if (depth > 0)
+                result = TraverseRecursively(values, depth - 1);
+        }
+        return result;
+    }
+
+    public object? TraverseConditionally(int[] values, int depth, bool enabled)
+    {
+        object? result = BuildConditionalTraversalNode(enabled, depth);
+        foreach (int _ in values)
+        {
+            if (depth > 0)
+                result = TraverseConditionally(values, depth - 1, enabled);
+        }
+        return result;
+    }
+
+    public object? TraverseMutualA(int[] values, int depth)
+    {
+        object? result = BuildMutualTraversalNode(depth);
+        foreach (int _ in values)
+        {
+            if (depth > 0)
+                result = TraverseMutualB(values, depth - 1);
+        }
+        return result;
+    }
+
+    object? TraverseMutualB(int[] values, int depth)
+    {
+        object? result = null;
+        foreach (int _ in values)
+        {
+            if (depth > 0)
+                result = TraverseMutualA(values, depth - 1);
+        }
+        return result;
+    }
+
+    public virtual object? TraverseVirtually(int[] values, int depth)
+    {
+        object? result = BuildVirtualTraversalNode(depth);
+        foreach (int _ in values)
+        {
+            if (depth > 0)
+                result = TraverseVirtually(values, depth - 1);
+        }
+        return result;
+    }
+
+    public Delegate? LoadSelfFunctionInLoop(int count)
+    {
+        Func<int, Delegate?>? callback = null;
+        for (int i = 0; i < count; i++)
+            callback = LoadSelfFunctionInLoop;
+        return callback;
+    }
+
+    public object BuildTraversalNode(int value) => value;
+
+    public object? BuildConditionalTraversalNode(bool enabled, int value)
+        => enabled ? value : null;
+
+    public object BuildMutualTraversalNode(int value) => value;
+
+    public object BuildVirtualTraversalNode(int value) => value;
+
     public virtual object BoxVirtual(int value) => value;
 
     public object? InvokeVirtualInLoop(int count)

--- a/src/ILInspector.Analysis.Fixtures/CallerLoopFixtures/CallerLoopFixture.cs
+++ b/src/ILInspector.Analysis.Fixtures/CallerLoopFixtures/CallerLoopFixture.cs
@@ -137,3 +137,19 @@ public sealed class CallerLoopConstructorTarget
 
     public object Boxed { get; }
 }
+
+public sealed class GenericTraversalFixture<T>
+{
+    public object? TraverseRecursively(int[] values, int depth)
+    {
+        object? result = BuildTraversalNode(depth);
+        foreach (int _ in values)
+        {
+            if (depth > 0)
+                result = TraverseRecursively(values, depth - 1);
+        }
+        return result;
+    }
+
+    public object BuildTraversalNode(int value) => value;
+}

--- a/src/ILInspector.Analysis.Tests/RecursiveTraversalCensusTests.cs
+++ b/src/ILInspector.Analysis.Tests/RecursiveTraversalCensusTests.cs
@@ -20,11 +20,20 @@ public class RecursiveTraversalCensusTests
             && call.Callee.Name == "TraverseVirtually"
             && call.Kind == CallKind.CallVirtual
             && call.InLoop);
+        Assert.Contains(index.DirectCalls, static call =>
+            call.Caller.DeclaringType.Name == "GenericTraversalFixture`1"
+            && call.Caller.Name == "TraverseRecursively"
+            && call.Callee.Name == "TraverseRecursively"
+            && call.Kind == CallKind.Call
+            && call.InLoop
+            && call.CalleeDefinitionToken != call.Caller.MetadataToken);
 
         Assert.Contains(report.Roots, static root =>
             root.Method.Contains("::TraverseRecursively(", StringComparison.Ordinal));
         Assert.Contains(report.Roots, static root =>
             root.Method.Contains("::TraverseConditionally(", StringComparison.Ordinal));
+        Assert.Contains(report.Roots, static root =>
+            root.Method.Contains("GenericTraversalFixture", StringComparison.Ordinal));
         Assert.DoesNotContain(report.Roots, static root =>
             root.Method.Contains("::RecursiveBox(", StringComparison.Ordinal)
             || root.Method.Contains("::TraverseMutual", StringComparison.Ordinal)
@@ -32,7 +41,7 @@ public class RecursiveTraversalCensusTests
             || root.Method.Contains("::LoadSelfFunctionInLoop(", StringComparison.Ordinal));
 
         var direct = Assert.Single(report.Rows, static row =>
-            row.Member.Contains("::BuildTraversalNode(", StringComparison.Ordinal));
+            row.Member.Contains("CallerLoopFixture::BuildTraversalNode(", StringComparison.Ordinal));
         Assert.Equal(RecursiveTraversalClassification.Direct, direct.Classification);
         Assert.Equal(1, direct.DownstreamDepth);
         Assert.Equal("once", direct.LocalMultiplicity);
@@ -47,6 +56,12 @@ public class RecursiveTraversalCensusTests
         Assert.Equal(RecursiveTraversalClassification.Direct, conditional.Classification);
         Assert.Equal("conditional", conditional.LocalMultiplicity);
         Assert.False(conditional.LocalInLoop);
+
+        var generic = Assert.Single(report.Rows, static row =>
+            row.Member.Contains("GenericTraversalFixture", StringComparison.Ordinal)
+            && row.Member.Contains("::BuildTraversalNode(", StringComparison.Ordinal));
+        Assert.Equal(RecursiveTraversalClassification.Direct, generic.Classification);
+        Assert.Equal(1, generic.DownstreamDepth);
 
         Assert.DoesNotContain(report.Rows, static row =>
             (row.Member.Contains("::BuildMutualTraversalNode(", StringComparison.Ordinal)

--- a/src/ILInspector.Analysis.Tests/RecursiveTraversalCensusTests.cs
+++ b/src/ILInspector.Analysis.Tests/RecursiveTraversalCensusTests.cs
@@ -1,0 +1,200 @@
+using DotnetInspector.Fixtures;
+using ILInspector.AnalysisHarness;
+
+namespace ILInspector.Analysis.Tests;
+
+public class RecursiveTraversalCensusTests
+{
+    static readonly TypeRef s_void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef s_type = TypeRef.Definition("Fixture", "Fixtures", "Graph");
+
+    [Fact]
+    public void Measure_ClassifiesCompiledTraversalAndNearMisses()
+    {
+        string assemblyPath = FixtureCatalog.AnalysisCallerLoop.AssemblyPath();
+        var report = RecursiveTraversalCensus.Measure([assemblyPath]);
+        var index = LibraryBodyIndex.Open(assemblyPath);
+
+        Assert.Contains(index.DirectCalls, static call =>
+            call.Caller.Name == "TraverseVirtually"
+            && call.Callee.Name == "TraverseVirtually"
+            && call.Kind == CallKind.CallVirtual
+            && call.InLoop);
+
+        Assert.Contains(report.Roots, static root =>
+            root.Method.Contains("::TraverseRecursively(", StringComparison.Ordinal));
+        Assert.Contains(report.Roots, static root =>
+            root.Method.Contains("::TraverseConditionally(", StringComparison.Ordinal));
+        Assert.DoesNotContain(report.Roots, static root =>
+            root.Method.Contains("::RecursiveBox(", StringComparison.Ordinal)
+            || root.Method.Contains("::TraverseMutual", StringComparison.Ordinal)
+            || root.Method.Contains("::TraverseVirtually(", StringComparison.Ordinal)
+            || root.Method.Contains("::LoadSelfFunctionInLoop(", StringComparison.Ordinal));
+
+        var direct = Assert.Single(report.Rows, static row =>
+            row.Member.Contains("::BuildTraversalNode(", StringComparison.Ordinal));
+        Assert.Equal(RecursiveTraversalClassification.Direct, direct.Classification);
+        Assert.Equal(1, direct.DownstreamDepth);
+        Assert.Equal("once", direct.LocalMultiplicity);
+        Assert.False(direct.LocalInLoop);
+        Assert.Contains("::TraverseRecursively(", direct.Root?.Method, StringComparison.Ordinal);
+        Assert.Equal(2, direct.Witness.Count);
+        Assert.True(direct.Witness[0].InLoop);
+        Assert.False(direct.Witness[1].InLoop);
+
+        var conditional = Assert.Single(report.Rows, static row =>
+            row.Member.Contains("::BuildConditionalTraversalNode(", StringComparison.Ordinal));
+        Assert.Equal(RecursiveTraversalClassification.Direct, conditional.Classification);
+        Assert.Equal("conditional", conditional.LocalMultiplicity);
+        Assert.False(conditional.LocalInLoop);
+
+        Assert.DoesNotContain(report.Rows, static row =>
+            (row.Member.Contains("::BuildMutualTraversalNode(", StringComparison.Ordinal)
+            || row.Member.Contains("::BuildVirtualTraversalNode(", StringComparison.Ordinal))
+            && row.Classification != RecursiveTraversalClassification.None);
+    }
+
+    [Fact]
+    public void Analyze_ReportsBoundedDepthAndPreservesOpportunitySemantics()
+    {
+        var root = Method(1, "Root");
+        var wrapper = Method(2, "Wrapper");
+        var target = Method(3, "Target");
+        var opportunity = Opportunity(target, "pt~exact") with
+        {
+            Multiplicity = "conditional",
+            Provenance = PerformanceTriageProvenance.Exact,
+            PathContext = "error path",
+        };
+        var result = RecursiveTraversalCensus.Analyze(
+            "Fixture.dll",
+            [root, wrapper, target],
+            [
+                Call(root, wrapper, 4),
+                Call(root, root, 8, inLoop: true),
+                Call(wrapper, target, 12),
+            ],
+            [opportunity],
+            maxDepth: 1);
+
+        var traversal = Assert.Single(result.Roots);
+        Assert.Equal(8, traversal.RecursionOffset);
+
+        var row = Assert.Single(result.Rows);
+        Assert.Equal(RecursiveTraversalClassification.BeyondBound, row.Classification);
+        Assert.Equal(2, row.DownstreamDepth);
+        Assert.Equal([8, 4, 12], row.Witness.Select(static step => step.ILOffset));
+        Assert.Equal("pt~exact", row.Candidate);
+        Assert.Equal("conditional", row.LocalMultiplicity);
+        Assert.False(row.LocalInLoop);
+        Assert.Equal(PerformanceTriageProvenance.Exact, row.Provenance);
+    }
+
+    [Fact]
+    public void Analyze_RejectsNonBranchingRecursionAndFunctionLoads()
+    {
+        var recursive = Method(1, "Recursive");
+        var mutualA = Method(2, "MutualA");
+        var mutualB = Method(3, "MutualB");
+        var functionTarget = Method(4, "FunctionTarget");
+        var virtualRecursive = Method(5, "VirtualRecursive");
+        var result = RecursiveTraversalCensus.Analyze(
+            "Fixture.dll",
+            [recursive, mutualA, mutualB, functionTarget, virtualRecursive],
+            [
+                Call(recursive, recursive, 4),
+                Call(mutualA, mutualB, 8, inLoop: true),
+                Call(mutualB, mutualA, 12),
+                Call(functionTarget, functionTarget, 16, inLoop: true, CallKind.LoadFunction),
+                Call(virtualRecursive, virtualRecursive, 20, inLoop: true, CallKind.CallVirtual),
+            ],
+            [
+                Opportunity(recursive, "pt~recursive"),
+                Opportunity(mutualA, "pt~mutual"),
+                Opportunity(functionTarget, "pt~function"),
+                Opportunity(virtualRecursive, "pt~virtual"),
+            ]);
+
+        Assert.Empty(result.Roots);
+        Assert.All(result.Rows, static row =>
+            Assert.Equal(RecursiveTraversalClassification.None, row.Classification));
+    }
+
+    [Fact]
+    public void Analyze_UsesStableRecursionSite()
+    {
+        var root = Method(1, "Root");
+        var row = Assert.Single(RecursiveTraversalCensus.Analyze(
+            "Fixture.dll",
+            [root],
+            [
+                Call(root, root, 12, inLoop: true),
+                Call(root, root, 4, inLoop: true),
+            ],
+            [Opportunity(root, "pt~root")]).Rows);
+
+        Assert.Equal(RecursiveTraversalClassification.TraversalRoot, row.Classification);
+        Assert.Equal(0, row.DownstreamDepth);
+        Assert.Equal(4, row.Root?.RecursionOffset);
+        Assert.Equal(4, Assert.Single(row.Witness).ILOffset);
+    }
+
+    [Fact]
+    public void Measure_ReportsInputFailures()
+    {
+        var report = RecursiveTraversalCensus.Measure(["/not/a/real/assembly.dll"]);
+
+        Assert.Equal(0, report.Opened);
+        Assert.Equal(1, report.Failed);
+        Assert.Equal(report.Assemblies, report.Opened + report.Failed);
+        Assert.Single(report.Failures);
+        Assert.Contains("assembly.dll", report.Failures[0].AssemblyPath, StringComparison.Ordinal);
+    }
+
+    static MethodIdentity Method(int token, string name)
+        => new(
+            "Fixture",
+            Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            s_type,
+            name,
+            [],
+            s_void,
+            token,
+            IsStatic: true);
+
+    static DirectCall Call(
+        MethodIdentity caller,
+        MethodIdentity callee,
+        int offset,
+        bool inLoop = false,
+        CallKind kind = CallKind.Call)
+        => new(
+            caller,
+            new MemberRef(
+                callee.DeclaringType,
+                callee.Name,
+                callee.ParameterTypes,
+                callee.ReturnType,
+                MemberKind.Method),
+            offset,
+            callee.MetadataToken,
+            callee.MetadataToken,
+            kind,
+            inLoop);
+
+    static OptimizationOpportunity Opportunity(MethodIdentity method, string candidate)
+        => new(
+            method,
+            "box-value-type",
+            "evidence",
+            "fix",
+            "medium",
+            InLoop: false,
+            ILOffset: 4,
+            Caveat: null)
+        {
+            CandidateId = candidate,
+            Multiplicity = "once",
+            Provenance = PerformanceTriageProvenance.Exact,
+        };
+}

--- a/src/ILInspector.Analysis/ILInspector.Analysis.csproj
+++ b/src/ILInspector.Analysis/ILInspector.Analysis.csproj
@@ -16,6 +16,7 @@
   <!-- System.Reflection.Metadata is part of net10.0 BCL -->
 
   <ItemGroup>
+    <InternalsVisibleTo Include="analysis-harness" />
     <InternalsVisibleTo Include="ILInspector.Analysis.Tests" />
     <InternalsVisibleTo Include="ILInspector.Research.Tests" />
   </ItemGroup>

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -41,6 +41,11 @@ const string Usage =
           and immediate consumer/registration shape. Separates proven immediate Invoke calls from
           trusted framework registration and unknown consumers, then reports downstream triage rows.
 
+      --recursive-traversal-census <file> [--max-depth N] [--top N] [--json]
+          Measurement-only census of Performance Triage rows reached from methods with an exact
+          in-loop self-recursive call. Reports the recursion edge, downstream invocation witness,
+          depth, provenance, and unchanged local multiplicity/loop semantics.
+
       --allocation-parity <expected-annotations.json> <actual-annotations.json> [--json]
           Compare allocation annotations from the legacy decompiler classifier and a candidate
           occurrence-derived projection. The gate is exact on id, IL offset, detail, and
@@ -98,6 +103,7 @@ string? precisionAssembly = null;
 string? allocationReadoutList = null;
 string? callerLoopCensusList = null;
 string? deferredCallbackCensusList = null;
+string? recursiveTraversalCensusList = null;
 string? allocationParityExpected = null;
 string? allocationParityActual = null;
 string? annotationParityCategory = null;
@@ -143,6 +149,9 @@ for (int i = 0; i < args.Length; i++)
             break;
         case "--deferred-callback-census":
             deferredCallbackCensusList = NextValue(args, ref i);
+            break;
+        case "--recursive-traversal-census":
+            recursiveTraversalCensusList = NextValue(args, ref i);
             break;
         case "--allocation-parity":
             allocationParityExpected = NextPathValue(args, ref i);
@@ -224,6 +233,9 @@ if (callerLoopCensusList is not null)
 
 if (deferredCallbackCensusList is not null)
     return RunDeferredCallbackCensus(deferredCallbackCensusList, maxDepth, top, json);
+
+if (recursiveTraversalCensusList is not null)
+    return RunRecursiveTraversalCensus(recursiveTraversalCensusList, maxDepth, top, json);
 
 if (allocationParityExpected is not null)
     return RunAnnotationParity("Allocation", allocationParityExpected, allocationParityActual, json);
@@ -344,6 +356,31 @@ static int RunDeferredCallbackCensus(string corpusList, int maxDepth, int top, b
 
     var report = DeferredCallbackCensus.Measure(paths, maxDepth);
     Console.Write(json ? DeferredCallbackCensus.ToJson(report) : DeferredCallbackCensus.FormatCard(report, top));
+    if (json)
+        Console.WriteLine();
+    return report.Failed == 0 ? 0 : 1;
+}
+
+static int RunRecursiveTraversalCensus(string corpusList, int maxDepth, int top, bool json)
+{
+    if (!File.Exists(corpusList))
+    {
+        Console.Error.WriteLine($"Corpus list not found: {corpusList}");
+        return 2;
+    }
+
+    var paths = File.ReadAllLines(corpusList)
+        .Select(line => line.Trim())
+        .Where(line => line.Length > 0 && !line.StartsWith('#'))
+        .ToList();
+    if (paths.Count == 0)
+    {
+        Console.Error.WriteLine($"Corpus list is empty: {corpusList}");
+        return 2;
+    }
+
+    var report = RecursiveTraversalCensus.Measure(paths, maxDepth);
+    Console.Write(json ? RecursiveTraversalCensus.ToJson(report) : RecursiveTraversalCensus.FormatCard(report, top));
     if (json)
         Console.WriteLine();
     return report.Failed == 0 ? 0 : 1;

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -164,6 +164,46 @@ is useful diagnostic provenance, but is not strong enough for a product-side
 caller-loop projection or ranking change without runtime evidence or a stronger
 framework invocation contract.
 
+A recursive-traversal census measures a different repetition boundary: an exact
+resolved self-call that occurs structurally inside the caller's loop.
+
+```bash
+dotnet run --project tools/AnalysisHarness -c Release -- \
+  --recursive-traversal-census /tmp/performance-triage-assemblies.txt \
+  --max-depth 4 --top 20
+dotnet run --project tools/AnalysisHarness -c Release -- \
+  --recursive-traversal-census /tmp/aspire-dashboard-assemblies.txt \
+  --max-depth 4 --json
+```
+
+The in-loop self-call identifies branching traversal potential. It does not
+prove runtime heat, recursion depth, collection size, or that either the loop or
+recursive branch executes. The discriminator rejects ordinary recursion,
+mutual recursion, `callvirt` self-dispatch, and function loads. From each
+qualifying root, the census reuses the typed invocation graph to report exact
+downstream Performance Triage rows as traversal-root, direct, transitive,
+beyond-bound, or none. Candidate identity, local `Loop`, multiplicity,
+confidence, weight, and product ranking remain unchanged.
+
+The pinned six-library run opened all six assemblies and found 29 traversal
+roots among 2,459 opportunity rows. Seventy-five rows were reachable: 11 on a
+traversal root, nine direct, 20 transitive within depth four, and 35 beyond the
+bound. The separately pinned Aspire Dashboard run was much narrower: one root
+and one reachable row among 488 opportunities. The root was
+`TraceDetail.AddSelfAndChildren`; its direct call to
+`OtlpSpan.GetChildSpans` remained candidate `pt~6756cfa4ed4130d8`, local
+multiplicity `once`, and `LocalInLoop=false`. The witness records the root's
+in-loop self-call followed by its direct, non-loop call to `GetChildSpans`.
+
+Recent registry improvements are orthogonal controls. The allocation-fanout
+view still distinguishes 53 once paths in `LibrarySections.CreatePipeline`
+from one in `LibrarySourcePlans..cctor`, and 34 in `SpikeSections..cctor` from
+zero in `PlanFor`, `CompilePlan`, and `CapabilityPlan.ExecuteAsync`. Those
+registry methods have no recursive-traversal evidence. This is therefore a
+selective static receipt, not a product ranking change: use runtime allocation
+evidence to decide whether a reachable row is hot before changing production
+code.
+
 A 2026-07-01 fixed-corpus run (`14/14` assemblies opened) showed 41,890
 allocation occurrences and 6,587 optimization opportunities. `return-post-dominates`
 was common (29,175 occurrences; 4,817 opportunities), but not selective by

--- a/tools/AnalysisHarness/RecursiveTraversalCensus.cs
+++ b/tools/AnalysisHarness/RecursiveTraversalCensus.cs
@@ -128,11 +128,12 @@ public static class RecursiveTraversalCensus
         var methodTokens = methods
             .Select(static method => method.MetadataToken)
             .ToHashSet();
+        var methodMap = MethodDefinitionMap.Create(methods);
         var rootEvidence = directCalls
             .Where(call =>
                 call.Kind == CallKind.Call
                 && call.InLoop
-                && call.CalleeDefinitionToken == call.Caller.MetadataToken
+                && methodMap.Resolve(call) == call.Caller.MetadataToken
                 && methodTokens.Contains(call.Caller.MetadataToken))
             .OrderBy(static call => call.Caller.MetadataToken)
             .ThenBy(static call => call.ILOffset)

--- a/tools/AnalysisHarness/RecursiveTraversalCensus.cs
+++ b/tools/AnalysisHarness/RecursiveTraversalCensus.cs
@@ -1,0 +1,367 @@
+using System.Collections.Immutable;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using ILInspector.Analysis;
+
+namespace ILInspector.AnalysisHarness;
+
+public enum RecursiveTraversalClassification
+{
+    None,
+    TraversalRoot,
+    Direct,
+    Transitive,
+    BeyondBound,
+}
+
+public sealed record RecursiveTraversalRoot(
+    string Assembly,
+    string Method,
+    int MethodToken,
+    int RecursionOffset,
+    CallKind RecursionKind);
+
+public sealed record RecursiveTraversalWitnessStep(
+    string Caller,
+    string Callee,
+    int ILOffset,
+    CallKind Kind,
+    bool InLoop);
+
+public sealed record RecursiveTraversalCensusRow(
+    string Assembly,
+    string Candidate,
+    string Member,
+    int MethodToken,
+    int? ILOffset,
+    string Shape,
+    string Confidence,
+    string LocalMultiplicity,
+    bool LocalInLoop,
+    PerformanceTriageProvenance Provenance,
+    RecursiveTraversalClassification Classification,
+    int? DownstreamDepth,
+    RecursiveTraversalRoot? Root,
+    IReadOnlyList<RecursiveTraversalWitnessStep> Witness);
+
+public sealed record RecursiveTraversalCensusFailure(string AssemblyPath, string Error);
+
+public sealed record RecursiveTraversalCensusReport(
+    int MaxDepth,
+    int Assemblies,
+    int Opened,
+    int Failed,
+    int TraversalRoots,
+    int Opportunities,
+    int ReachableOpportunities,
+    int DistinctReachableCandidates,
+    int DistinctReachableMethods,
+    IReadOnlyDictionary<string, int> RowsByClassification,
+    IReadOnlyDictionary<string, int> OpportunityCross,
+    IReadOnlyList<RecursiveTraversalCensusFailure> Failures,
+    IReadOnlyList<RecursiveTraversalRoot> Roots,
+    IReadOnlyList<RecursiveTraversalCensusRow> Rows);
+
+public static class RecursiveTraversalCensus
+{
+    const string Empty = "<empty>";
+
+    static readonly JsonSerializerOptions s_json = new()
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    public static RecursiveTraversalCensusReport Measure(
+        IReadOnlyList<string> assemblyPaths,
+        int maxDepth = 4)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxDepth, 0);
+
+        var roots = new List<RecursiveTraversalRoot>();
+        var rows = new List<RecursiveTraversalCensusRow>();
+        var failures = new List<RecursiveTraversalCensusFailure>();
+        int opened = 0;
+        foreach (string path in assemblyPaths)
+        {
+            try
+            {
+                var index = LibraryBodyIndex.Open(path);
+                var result = Analyze(
+                    Path.GetFileName(path),
+                    index.Methods,
+                    index.DirectCalls,
+                    index.OptimizationOpportunities,
+                    maxDepth);
+                roots.AddRange(result.Roots);
+                rows.AddRange(result.Rows);
+                opened++;
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or IOException or ArgumentException)
+            {
+                failures.Add(new RecursiveTraversalCensusFailure(path, $"{ex.GetType().Name}: {ex.Message}"));
+            }
+        }
+
+        return BuildReport(
+            maxDepth,
+            assemblyPaths.Count,
+            opened,
+            failures,
+            roots,
+            rows);
+    }
+
+    public static (
+        IReadOnlyList<RecursiveTraversalRoot> Roots,
+        IReadOnlyList<RecursiveTraversalCensusRow> Rows) Analyze(
+        string assembly,
+        ImmutableArray<MethodIdentity> methods,
+        ImmutableArray<DirectCall> directCalls,
+        ImmutableArray<OptimizationOpportunity> opportunities,
+        int maxDepth = 4)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxDepth, 0);
+
+        var methodTokens = methods
+            .Select(static method => method.MetadataToken)
+            .ToHashSet();
+        var rootEvidence = directCalls
+            .Where(call =>
+                call.Kind == CallKind.Call
+                && call.InLoop
+                && call.CalleeDefinitionToken == call.Caller.MetadataToken
+                && methodTokens.Contains(call.Caller.MetadataToken))
+            .OrderBy(static call => call.Caller.MetadataToken)
+            .ThenBy(static call => call.ILOffset)
+            .GroupBy(static call => call.Caller.MetadataToken)
+            .Select(static group => group.First())
+            .Select((call, index) => CreateRootEvidence(assembly, call, index))
+            .ToArray();
+        var rootBySeed = rootEvidence.ToDictionary(
+            static root => (root.Seed.Caller.MetadataToken, root.Seed.ILOffset));
+
+        var graphCalls = directCalls
+            .Select(static call => call with { InLoop = false })
+            .Concat(rootEvidence.Select(static root => root.Seed))
+            .ToImmutableArray();
+        var nearest = rootEvidence.Length == 0
+            ? ImmutableDictionary<int, CallerLoopEvidence>.Empty
+            : CallerLoopEvidenceAnalysis.FindNearest(methods, graphCalls);
+
+        var rows = opportunities
+            .OrderBy(static opportunity => opportunity.Method.MetadataToken)
+            .ThenBy(static opportunity => opportunity.ILOffset ?? -1)
+            .ThenBy(static opportunity => opportunity.Shape, StringComparer.Ordinal)
+            .Select(opportunity => CreateRow(
+                assembly,
+                opportunity,
+                nearest,
+                rootBySeed,
+                maxDepth))
+            .ToArray();
+
+        return (
+            rootEvidence.Select(static root => root.Row).ToArray(),
+            rows);
+    }
+
+    public static string ToJson(RecursiveTraversalCensusReport report)
+        => JsonSerializer.Serialize(report, s_json);
+
+    public static string FormatCard(RecursiveTraversalCensusReport report, int top)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"RECURSIVE-TRAVERSAL CENSUS: {report.Opened}/{report.Assemblies} assemblies opened ({report.Failed} failed), max-downstream-depth={report.MaxDepth}");
+        sb.AppendLine($"  roots={report.TraversalRoots} opportunities={report.Opportunities} reachable={report.ReachableOpportunities} distinct-candidates={report.DistinctReachableCandidates} distinct-methods={report.DistinctReachableMethods}");
+        AppendCounts(sb, "opportunity rows", report.RowsByClassification);
+        AppendCounts(sb, "recursion|shape|confidence|local-multiplicity|provenance", report.OpportunityCross, top);
+        foreach (var failure in report.Failures)
+            sb.AppendLine($"  failed: {failure.AssemblyPath}: {failure.Error}");
+
+        sb.AppendLine("  examples:");
+        foreach (var row in report.Rows
+            .Where(static row => row.Classification != RecursiveTraversalClassification.None)
+            .OrderBy(static row => row.Classification)
+            .ThenBy(static row => row.DownstreamDepth)
+            .ThenBy(static row => row.Assembly, StringComparer.Ordinal)
+            .ThenBy(static row => row.Member, StringComparer.Ordinal)
+            .ThenBy(static row => row.Candidate, StringComparer.Ordinal)
+            .Take(top))
+        {
+            sb.AppendLine($"    {Classification(row.Classification)} depth={row.DownstreamDepth}: {row.Assembly} {row.Member} [{row.Shape}, {row.Candidate}]");
+            foreach (var step in row.Witness)
+                sb.AppendLine($"      -> {step.Caller} @ IL_{step.ILOffset:X4} -- {step.Kind}{(step.InLoop ? " in-loop" : "")} --> {step.Callee}");
+        }
+        return sb.ToString();
+    }
+
+    static RootEvidence CreateRootEvidence(
+        string assembly,
+        DirectCall recursion,
+        int index)
+    {
+        var row = new RecursiveTraversalRoot(
+            assembly,
+            MethodDisplay(recursion.Caller),
+            recursion.Caller.MetadataToken,
+            recursion.ILOffset,
+            recursion.Kind);
+        var syntheticCaller = recursion.Caller with
+        {
+            MetadataToken = int.MinValue + index,
+        };
+        var seed = recursion with
+        {
+            Caller = syntheticCaller,
+            InLoop = true,
+        };
+        return new RootEvidence(row, recursion, seed);
+    }
+
+    static RecursiveTraversalCensusRow CreateRow(
+        string assembly,
+        OptimizationOpportunity opportunity,
+        IReadOnlyDictionary<int, CallerLoopEvidence> nearest,
+        IReadOnlyDictionary<(int MethodToken, int Offset), RootEvidence> rootBySeed,
+        int maxDepth)
+    {
+        nearest.TryGetValue(opportunity.Method.MetadataToken, out var evidence);
+        RootEvidence? root = null;
+        if (evidence is { Witness.IsDefaultOrEmpty: false })
+        {
+            var seed = evidence.Witness[0];
+            rootBySeed.TryGetValue((seed.Caller.MetadataToken, seed.ILOffset), out root);
+        }
+
+        int? downstreamDepth = evidence is null ? null : evidence.Depth - 1;
+        var classification = downstreamDepth is null
+            ? RecursiveTraversalClassification.None
+            : downstreamDepth == 0
+                ? RecursiveTraversalClassification.TraversalRoot
+                : downstreamDepth == 1
+                    ? RecursiveTraversalClassification.Direct
+                    : downstreamDepth <= maxDepth
+                        ? RecursiveTraversalClassification.Transitive
+                        : RecursiveTraversalClassification.BeyondBound;
+        var witness = new List<RecursiveTraversalWitnessStep>();
+        if (root is not null)
+        {
+            witness.Add(new RecursiveTraversalWitnessStep(
+                MethodDisplay(root.Recursion.Caller),
+                MethodDisplay(root.Recursion.Caller),
+                root.Recursion.ILOffset,
+                root.Recursion.Kind,
+                InLoop: true));
+            witness.AddRange(evidence!.Witness.Skip(1).Select(static step =>
+                new RecursiveTraversalWitnessStep(
+                    MethodDisplay(step.Caller),
+                    MethodDisplay(step.Callee),
+                    step.ILOffset,
+                    step.Kind,
+                    InLoop: false)));
+        }
+
+        return new RecursiveTraversalCensusRow(
+            assembly,
+            opportunity.CandidateId ?? Empty,
+            MethodDisplay(opportunity.Method),
+            opportunity.Method.MetadataToken,
+            opportunity.ILOffset,
+            opportunity.Shape,
+            opportunity.Confidence,
+            Text(opportunity.Multiplicity),
+            opportunity.InLoop,
+            opportunity.Provenance,
+            classification,
+            downstreamDepth,
+            root?.Row,
+            witness);
+    }
+
+    static RecursiveTraversalCensusReport BuildReport(
+        int maxDepth,
+        int assemblies,
+        int opened,
+        IReadOnlyList<RecursiveTraversalCensusFailure> failures,
+        IReadOnlyList<RecursiveTraversalRoot> roots,
+        IReadOnlyList<RecursiveTraversalCensusRow> rows)
+    {
+        var reachable = rows
+            .Where(static row => row.Classification != RecursiveTraversalClassification.None)
+            .ToArray();
+        var candidateRows = reachable
+            .GroupBy(
+                static row => row.Candidate == Empty
+                    ? $"{row.Assembly}|{row.MethodToken:X8}|{row.ILOffset?.ToString("X8", System.Globalization.CultureInfo.InvariantCulture) ?? Empty}|{row.Shape}"
+                    : $"{row.Assembly}|{row.Candidate}",
+                StringComparer.Ordinal)
+            .Select(static group => group.First())
+            .ToArray();
+        var methodRows = reachable
+            .GroupBy(static row => $"{row.Assembly}|{row.MethodToken:X8}", StringComparer.Ordinal)
+            .Select(static group => group.First())
+            .ToArray();
+        return new RecursiveTraversalCensusReport(
+            maxDepth,
+            assemblies,
+            opened,
+            failures.Count,
+            roots.Count,
+            rows.Count,
+            reachable.Length,
+            candidateRows.Length,
+            methodRows.Length,
+            Counts(rows, static row => Classification(row.Classification)),
+            Counts(reachable, static row =>
+                $"{Classification(row.Classification)}|{row.Shape}|{row.Confidence}|{row.LocalMultiplicity}|{row.Provenance.ToString().ToLowerInvariant()}"),
+            failures,
+            roots,
+            rows);
+    }
+
+    static string MethodDisplay(MethodIdentity method)
+        => $"{method.DeclaringType.ToQualifiedDisplayString()}::{method.Name}({string.Join(", ", method.ParameterTypes.Select(static type => type.ToQualifiedDisplayString()))})";
+
+    static string Text(string? value)
+        => string.IsNullOrWhiteSpace(value) ? Empty : value;
+
+    static string Classification(RecursiveTraversalClassification value)
+        => value switch
+        {
+            RecursiveTraversalClassification.TraversalRoot => "traversal-root",
+            RecursiveTraversalClassification.Direct => "direct",
+            RecursiveTraversalClassification.Transitive => "transitive",
+            RecursiveTraversalClassification.BeyondBound => "beyond-bound",
+            _ => "none",
+        };
+
+    static IReadOnlyDictionary<string, int> Counts<T>(
+        IEnumerable<T> values,
+        Func<T, string> key)
+        => values
+            .GroupBy(key, StringComparer.Ordinal)
+            .OrderByDescending(static group => group.Count())
+            .ThenBy(static group => group.Key, StringComparer.Ordinal)
+            .ToDictionary(static group => group.Key, static group => group.Count(), StringComparer.Ordinal);
+
+    static void AppendCounts(
+        StringBuilder sb,
+        string title,
+        IReadOnlyDictionary<string, int> counts,
+        int top = int.MaxValue)
+    {
+        sb.AppendLine($"  {title}:");
+        foreach (var (key, value) in counts.Take(top))
+            sb.AppendLine($"    {key}={value}");
+        if (counts.Count > top)
+            sb.AppendLine($"    ... {counts.Count - top} more");
+    }
+
+    sealed record RootEvidence(
+        RecursiveTraversalRoot Row,
+        DirectCall Recursion,
+        DirectCall Seed);
+}


### PR DESCRIPTION
## Summary

Adds a measurement-only recursive-traversal census and records a selective
static receipt for Aspire's `OtlpSpan.GetChildSpans`. No product rows, ranking,
or local allocation semantics change.

- recognizes only an exact resolved `call` to the same MethodDef inside a loop
- reuses typed invocation traversal for deterministic downstream witnesses
- rejects ordinary recursion, mutual recursion, `callvirt` self-dispatch, and
  function loads
- preserves candidate identity, Finding provenance, local `Loop`,
  multiplicity, confidence, and weight
- adds compiled positive and near-miss fixtures

## Measured result

| Corpus | Roots | Opportunities | Reachable |
| --- | ---: | ---: | ---: |
| Pinned six-library corpus | 29 | 2,459 | 75 |
| Aspire Dashboard 9.0.0 | 1 | 488 | 1 |

The six-library reachable population is 11 traversal-root rows, nine direct,
20 transitive within depth four, and 35 beyond the bound.

Aspire is exact and narrow:

```text
AddSelfAndChildren @ IL_006A -- call in-loop --> AddSelfAndChildren
AddSelfAndChildren @ IL_001A -- callvirt --> OtlpSpan.GetChildSpans
```

`GetChildSpans` remains candidate `pt~6756cfa4ed4130d8`, shape
`instance-method-group-delegate`, local multiplicity `once`, and
`LocalInLoop=false`.

This proves branching traversal potential, not runtime heat, recursion depth,
collection size, or guaranteed execution. The result is an explicit product
non-action pending runtime evidence or a stronger use case.

## Orthogonal registry controls

The recent registry improvements retain their allocation-fanout distinction:

| Method | Once paths |
| --- | ---: |
| `LibrarySections.CreatePipeline` | 53 |
| `LibrarySourcePlans..cctor` | 1 |
| `SpikeSections..cctor` | 34 |
| `PlanFor` / `CompilePlan` / `CapabilityPlan.ExecuteAsync` | 0 |

Those methods have no recursive-traversal evidence, confirming that this census
does not act as a generic known-performance-win classifier.

## Validation

- Release solution build
- `ILInspector.Analysis.Tests`: 471 passed
- pinned six-library, Aspire Dashboard, and registry control measurements
- markdownlint

Closes #2754. Related to #2724, #2733, #2749.
