### PR TITLE
Unify C# type-keyword escaping onto the product seam (de-C#-ify RTS)

### DIFF
--- a/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
@@ -202,6 +202,14 @@ public sealed class CSharpFormatterTests
     [InlineData("delegate* unmanaged<int>", "delegate* unmanaged<int>")]
     [InlineData("delegate*<ref int, void>", "delegate*<ref int, void>")]
     [InlineData("delegate*<await, void>", "delegate*<@await, void>")]
+    // Pointers to types literally named like a keyword must be escaped, not read as
+    // type syntax: "ref*"/"in*" are pointers to a type named ref/in, and a bare
+    // "delegate*" (not a function-pointer head) is a pointer to a type named delegate.
+    [InlineData("ref*", "@ref*")]
+    [InlineData("in*", "@in*")]
+    [InlineData("readonly*", "@readonly*")]
+    [InlineData("delegate*", "@delegate*")]
+    [InlineData("delegate*[]", "@delegate*[]")]
     // Already-escaped identifiers are left untouched (idempotent).
     [InlineData("@int", "@int")]
     [InlineData("N.@int", "N.@int")]

--- a/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
@@ -168,4 +168,43 @@ public sealed class CSharpFormatterTests
                 NamespacePolicy = (CSharpNamespacePolicy)42
             }));
     }
+
+    [Theory]
+    // Primitive/void aliases stay bare when they name the primitive.
+    [InlineData("int", "int")]
+    [InlineData("string", "string")]
+    [InlineData("void", "void")]
+    [InlineData("int[]", "int[]")]
+    [InlineData("int*", "int*")]
+    [InlineData("System.Int32", "System.Int32")]
+    [InlineData("System.Collections.Generic.List<int>", "System.Collections.Generic.List<int>")]
+    // A type literally named after a primitive keyword (a dotted-name segment) is escaped.
+    [InlineData("N.int", "N.@int")]
+    [InlineData("int.MaxValue", "int.MaxValue")]
+    // Reserved keywords used as identifiers are escaped, including inside generic args.
+    [InlineData("class", "@class")]
+    [InlineData("await", "@await")]
+    [InlineData("record", "@record")]
+    [InlineData("List<await>", "List<@await>")]
+    [InlineData("MyType<class>", "MyType<@class>")]
+    [InlineData("Foo.await", "Foo.@await")]
+    [InlineData("await.Foo", "@await.Foo")]
+    [InlineData("N.readonly", "N.@readonly")]
+    // Parameter/type modifiers stay bare in a leading modifier run.
+    [InlineData("ref int", "ref int")]
+    [InlineData("ref readonly int", "ref readonly int")]
+    [InlineData("scoped ref int", "scoped ref int")]
+    [InlineData("in long", "in long")]
+    [InlineData("out string", "out string")]
+    [InlineData("params byte[]", "params byte[]")]
+    // Function-pointer syntax stays bare, and reserved args inside are still escaped.
+    [InlineData("delegate*<int, void>", "delegate*<int, void>")]
+    [InlineData("delegate* unmanaged<int>", "delegate* unmanaged<int>")]
+    [InlineData("delegate*<ref int, void>", "delegate*<ref int, void>")]
+    [InlineData("delegate*<await, void>", "delegate*<@await, void>")]
+    // Already-escaped identifiers are left untouched (idempotent).
+    [InlineData("@int", "@int")]
+    [InlineData("N.@int", "N.@int")]
+    public void EscapeTypeKeywords_EscapesIdentifiersButNotTypeSyntax(string input, string expected)
+        => Assert.Equal(expected, CSharpFormatter.EscapeTypeKeywords(input));
 }

--- a/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
@@ -210,6 +210,13 @@ public sealed class CSharpFormatterTests
     [InlineData("readonly*", "@readonly*")]
     [InlineData("delegate*", "@delegate*")]
     [InlineData("delegate*[]", "@delegate*[]")]
+    // Whitespace before terminating punctuation is not a modifier/calling-convention
+    // boundary: the keyword names a type and must be escaped.
+    [InlineData("ref *", "@ref *")]
+    [InlineData("Tuple<readonly >", "Tuple<@readonly >")]
+    [InlineData("(delegate* , int)", "(@delegate* , int)")]
+    [InlineData("Tuple<delegate* >", "Tuple<@delegate* >")]
+    [InlineData("delegate* managed<int, void>", "delegate* managed<int, void>")]
     // Already-escaped identifiers are left untouched (idempotent).
     [InlineData("@int", "@int")]
     [InlineData("N.@int", "N.@int")]

--- a/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
@@ -219,6 +219,9 @@ public sealed class CSharpFormatterTests
     [InlineData("delegate* managed<int, void>", "delegate* managed<int, void>")]
     // Whitespace between "delegate*" and '<' is still a function-pointer head.
     [InlineData("delegate* <int, void>", "delegate* <int, void>")]
+    // A qualified "delegate" segment is a type name, never a function-pointer head.
+    [InlineData("N.delegate*<int, void>", "N.@delegate*<int, void>")]
+    [InlineData("N.delegate", "N.@delegate")]
     // Already-escaped identifiers are left untouched (idempotent).
     [InlineData("@int", "@int")]
     [InlineData("N.@int", "N.@int")]

--- a/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
@@ -217,6 +217,8 @@ public sealed class CSharpFormatterTests
     [InlineData("(delegate* , int)", "(@delegate* , int)")]
     [InlineData("Tuple<delegate* >", "Tuple<@delegate* >")]
     [InlineData("delegate* managed<int, void>", "delegate* managed<int, void>")]
+    // Whitespace between "delegate*" and '<' is still a function-pointer head.
+    [InlineData("delegate* <int, void>", "delegate* <int, void>")]
     // Already-escaped identifiers are left untouched (idempotent).
     [InlineData("@int", "@int")]
     [InlineData("N.@int", "N.@int")]

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -700,30 +700,48 @@ internal static class CSharpDeclarationWriter
             return start == 0 || type[start - 1] != '.';
 
         // Function-pointer type head: "delegate*<...>" or "delegate* unmanaged<...>".
-        // A real function-pointer head is "delegate*" followed by '<' or by a
-        // calling-convention run (whitespace). A bare "delegate*" with anything else
-        // after the '*' (end of string, '[', ',', '>' ...) is instead a pointer to a
-        // type literally named "delegate" and must be escaped ("@delegate*").
+        // A real function-pointer head is "delegate*" followed immediately by '<', or
+        // by a calling-convention run (whitespace then an identifier such as
+        // "managed"/"unmanaged"). A "delegate*" followed by anything else — end of
+        // string, terminating punctuation ('[', ',', '>', ')'), or whitespace that
+        // does not introduce a calling convention — is a pointer to a type literally
+        // named "delegate" and must be escaped ("@delegate*").
         if (identifier == "delegate")
         {
             if (end >= type.Length || type[end] != '*')
                 return false;
             int afterStar = end + 1;
-            return afterStar < type.Length
-                && (type[afterStar] == '<' || char.IsWhiteSpace(type[afterStar]));
+            if (afterStar >= type.Length)
+                return false;
+            if (type[afterStar] == '<')
+                return true;
+            if (!char.IsWhiteSpace(type[afterStar]))
+                return false;
+            int convStart = afterStar;
+            while (convStart < type.Length && char.IsWhiteSpace(type[convStart]))
+                convStart++;
+            return convStart < type.Length && IsIdentifierStart(type[convStart]);
         }
 
         // Parameter/type modifiers are bare in a leading modifier run — at the start
         // of the string or of a type slot ("ref int", "ref readonly int",
         // "scoped ref int", "in long", "params byte[]"), and inside a function
         // pointer signature ("delegate*<ref int, void>", "delegate* unmanaged<...>").
-        // Whitespace is the only valid trailing boundary: a modifier can never
-        // immediately precede a pointer '*' in C# type syntax, so "ref*" is a pointer
-        // to a type named "ref" and must be escaped ("@ref*").
+        // A modifier is only type syntax when a type actually follows it: it must be
+        // separated by whitespace from a following type start (identifier, '@', or a
+        // tuple '('), and never immediately precedes a pointer '*' or terminating
+        // punctuation. So "ref int" stays bare while "ref*"/"ref ," are pointers to /
+        // uses of a type named "ref" and must be escaped ("@ref*").
         if (identifier is "ref" or "in" or "out" or "params" or "readonly" or "scoped" or "unmanaged")
         {
-            bool followedByBoundary = end < type.Length && char.IsWhiteSpace(type[end]);
-            return followedByBoundary && InModifierPosition(type, start);
+            if (end >= type.Length || !char.IsWhiteSpace(type[end]))
+                return false;
+            int typeStart = end;
+            while (typeStart < type.Length && char.IsWhiteSpace(type[typeStart]))
+                typeStart++;
+            bool typeFollows = typeStart < type.Length
+                && (IsIdentifierStart(type[typeStart]) || type[typeStart] is '@' or '(');
+            return typeFollows && InModifierPosition(type, start);
         }
 
         return false;

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -699,18 +699,30 @@ internal static class CSharpDeclarationWriter
         if (IsPrimitiveOrVoidKeyword(identifier))
             return start == 0 || type[start - 1] != '.';
 
-        // Function-pointer type head: "delegate*<...>".
+        // Function-pointer type head: "delegate*<...>" or "delegate* unmanaged<...>".
+        // A real function-pointer head is "delegate*" followed by '<' or by a
+        // calling-convention run (whitespace). A bare "delegate*" with anything else
+        // after the '*' (end of string, '[', ',', '>' ...) is instead a pointer to a
+        // type literally named "delegate" and must be escaped ("@delegate*").
         if (identifier == "delegate")
-            return end < type.Length && type[end] == '*';
+        {
+            if (end >= type.Length || type[end] != '*')
+                return false;
+            int afterStar = end + 1;
+            return afterStar < type.Length
+                && (type[afterStar] == '<' || char.IsWhiteSpace(type[afterStar]));
+        }
 
         // Parameter/type modifiers are bare in a leading modifier run — at the start
         // of the string or of a type slot ("ref int", "ref readonly int",
         // "scoped ref int", "in long", "params byte[]"), and inside a function
         // pointer signature ("delegate*<ref int, void>", "delegate* unmanaged<...>").
+        // Whitespace is the only valid trailing boundary: a modifier can never
+        // immediately precede a pointer '*' in C# type syntax, so "ref*" is a pointer
+        // to a type named "ref" and must be escaped ("@ref*").
         if (identifier is "ref" or "in" or "out" or "params" or "readonly" or "scoped" or "unmanaged")
         {
-            bool followedByBoundary = end < type.Length
-                && (char.IsWhiteSpace(type[end]) || type[end] == '*');
+            bool followedByBoundary = end < type.Length && char.IsWhiteSpace(type[end]);
             return followedByBoundary && InModifierPosition(type, start);
         }
 

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -653,7 +653,15 @@ internal static class CSharpDeclarationWriter
             : $"[{string.Join(", ", parameter.Attributes)}] {declaration}";
     }
 
-    static string EscapeTypeKeywords(string type)
+    /// <summary>
+    /// Escapes C# reserved keywords that appear as identifiers (type or namespace
+    /// name segments) inside a type string, while leaving keywords that are C# type
+    /// <em>syntax</em> bare (primitive aliases, parameter/type modifiers, and
+    /// function-pointer syntax). This is the single authoritative type-keyword
+    /// escaper for the C# layer; consumers reach it through
+    /// <see cref="CSharpFormatter.EscapeTypeKeywords"/>.
+    /// </summary>
+    internal static string EscapeTypeKeywords(string type)
     {
         var builder = new StringBuilder(type.Length);
         for (int index = 0; index < type.Length;)
@@ -684,26 +692,61 @@ internal static class CSharpDeclarationWriter
 
     static bool IsTypeSyntaxKeyword(string type, string identifier, int start, int end)
     {
-        if (identifier is "bool" or "byte" or "sbyte" or "char" or "decimal" or "double"
-            or "float" or "int" or "uint" or "nint" or "nuint" or "long" or "ulong"
-            or "object" or "short" or "ushort" or "string" or "void")
-        {
-            return end == type.Length || type[end] != '.';
-        }
+        // Primitive/void aliases are bare when they name the primitive, and escaped
+        // only when they are a segment of a dotted qualified name (a type literally
+        // named e.g. "int" under some namespace: "N.int" -> "N.@int"). Being
+        // followed by '.' is member access, not a name segment, so it stays bare.
+        if (IsPrimitiveOrVoidKeyword(identifier))
+            return start == 0 || type[start - 1] != '.';
 
+        // Function-pointer type head: "delegate*<...>".
         if (identifier == "delegate")
             return end < type.Length && type[end] == '*';
 
-        if (type.StartsWith("delegate*", StringComparison.Ordinal)
-            && identifier is "ref" or "in" or "out" or "readonly" or "unmanaged")
+        // Parameter/type modifiers are bare in a leading modifier run — at the start
+        // of the string or of a type slot ("ref int", "ref readonly int",
+        // "scoped ref int", "in long", "params byte[]"), and inside a function
+        // pointer signature ("delegate*<ref int, void>", "delegate* unmanaged<...>").
+        if (identifier is "ref" or "in" or "out" or "params" or "readonly" or "scoped" or "unmanaged")
         {
-            return true;
+            bool followedByBoundary = end < type.Length
+                && (char.IsWhiteSpace(type[end]) || type[end] == '*');
+            return followedByBoundary && InModifierPosition(type, start);
         }
 
-        return start == 0
-            && end < type.Length
-            && char.IsWhiteSpace(type[end])
-            && identifier is "ref" or "in" or "out" or "params" or "readonly" or "scoped";
+        return false;
+    }
+
+    static bool IsPrimitiveOrVoidKeyword(string identifier)
+        => identifier is "bool" or "byte" or "sbyte" or "char" or "decimal" or "double"
+            or "float" or "int" or "uint" or "nint" or "nuint" or "long" or "ulong"
+            or "object" or "short" or "ushort" or "string" or "void";
+
+    // A modifier keyword is in modifier position when everything preceding it in the
+    // current type slot is only other modifiers and whitespace — i.e. walking back
+    // reaches the start of the string or a slot boundary ('<', ',', '(', '*') after
+    // skipping intervening modifier tokens.
+    static bool InModifierPosition(string type, int start)
+    {
+        int i = start - 1;
+        while (i >= 0)
+        {
+            while (i >= 0 && char.IsWhiteSpace(type[i]))
+                i--;
+            if (i < 0)
+                return true;
+            if (type[i] is '<' or ',' or '(' or '*')
+                return true;
+
+            int wordEnd = i + 1;
+            while (i >= 0 && IsIdentifierPart(type[i]))
+                i--;
+            string word = type[(i + 1)..wordEnd];
+            if (word is "ref" or "in" or "out" or "params" or "readonly" or "scoped" or "unmanaged")
+                continue;
+            return false;
+        }
+        return true;
     }
 
     static string FormatTypeDisplayName(string name, IReadOnlyList<TypeParameter> typeParameters)

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -705,9 +705,13 @@ internal static class CSharpDeclarationWriter
         // identifier such as "managed"/"unmanaged"). A "delegate*" followed by
         // anything else — end of string, or terminating punctuation ('[', ',', '>',
         // ')') after whitespace — is a pointer to a type literally named "delegate"
-        // and must be escaped ("@delegate*").
+        // and must be escaped ("@delegate*"). A function-pointer head is also never a
+        // qualified name segment, so a dotted "N.delegate*<...>" is a pointer to a
+        // type named "delegate" and is escaped ("N.@delegate*<...>").
         if (identifier == "delegate")
         {
+            if (start > 0 && type[start - 1] == '.')
+                return false;
             if (end >= type.Length || type[end] != '*')
                 return false;
             int afterStar = end + 1;

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -700,12 +700,12 @@ internal static class CSharpDeclarationWriter
             return start == 0 || type[start - 1] != '.';
 
         // Function-pointer type head: "delegate*<...>" or "delegate* unmanaged<...>".
-        // A real function-pointer head is "delegate*" followed immediately by '<', or
-        // by a calling-convention run (whitespace then an identifier such as
-        // "managed"/"unmanaged"). A "delegate*" followed by anything else — end of
-        // string, terminating punctuation ('[', ',', '>', ')'), or whitespace that
-        // does not introduce a calling convention — is a pointer to a type literally
-        // named "delegate" and must be escaped ("@delegate*").
+        // A real function-pointer head is "delegate*" followed (after optional
+        // whitespace) by '<', or by a calling-convention run (whitespace then an
+        // identifier such as "managed"/"unmanaged"). A "delegate*" followed by
+        // anything else — end of string, or terminating punctuation ('[', ',', '>',
+        // ')') after whitespace — is a pointer to a type literally named "delegate"
+        // and must be escaped ("@delegate*").
         if (identifier == "delegate")
         {
             if (end >= type.Length || type[end] != '*')
@@ -720,7 +720,8 @@ internal static class CSharpDeclarationWriter
             int convStart = afterStar;
             while (convStart < type.Length && char.IsWhiteSpace(type[convStart]))
                 convStart++;
-            return convStart < type.Length && IsIdentifierStart(type[convStart]);
+            return convStart < type.Length
+                && (IsIdentifierStart(type[convStart]) || type[convStart] == '<');
         }
 
         // Parameter/type modifiers are bare in a leading modifier run — at the start

--- a/src/ILInspector.CSharp/CSharpFormatter.cs
+++ b/src/ILInspector.CSharp/CSharpFormatter.cs
@@ -179,6 +179,15 @@ public sealed class CSharpFormatter
     public static string EscapeNamespace(string @namespace)
         => CSharpDeclarationWriter.EscapeNamespace(@namespace);
 
+    /// <summary>
+    /// Escapes C# reserved keywords used as identifiers within a type string while
+    /// leaving type-syntax keywords (primitive aliases, parameter/type modifiers,
+    /// function-pointer syntax) bare. This is the authoritative type-keyword escaper;
+    /// consumers must not reimplement it.
+    /// </summary>
+    public static string EscapeTypeKeywords(string type)
+        => CSharpDeclarationWriter.EscapeTypeKeywords(type);
+
     public static string EscapeKnownIdentifiers(string text, IEnumerable<string> rawNames)
         => CSharpDeclarationWriter.EscapeKnownIdentifiers(text, rawNames);
 

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -32,7 +32,7 @@ static class CompileBackCSharpNames
             _ => type,
         };
 
-        return EscapeTypeKeywords(type);
+        return CSharpFormatter.EscapeTypeKeywords(type);
     }
 
     static string SanitizeGeneratedTypeSegments(string type)
@@ -89,84 +89,6 @@ static class CompileBackCSharpNames
 
     public static string EscapeNamespace(string ns)
         => CSharpFormatter.EscapeNamespace(ns);
-
-    static string EscapeTypeKeywords(string type)
-    {
-        var sb = new StringBuilder(type.Length);
-        int i = 0;
-        while (i < type.Length)
-        {
-            char c = type[i];
-            if (char.IsLetter(c) || c == '_')
-            {
-                int start = i;
-                while (i < type.Length && (char.IsLetterOrDigit(type[i]) || type[i] == '_'))
-                    i++;
-
-                string word = type[start..i];
-                bool alreadyEscaped = start > 0 && type[start - 1] == '@';
-                bool qualifiedSegment = start > 0 && type[start - 1] == '.';
-                bool functionPointerKeyword = !qualifiedSegment
-                    && word == "delegate"
-                    && i + 1 < type.Length
-                    && type[i] == '*'
-                    && (type[i + 1] == '<' || char.IsWhiteSpace(type[i + 1]));
-                bool bareSpelling = ((word is "void" or "ref" || IsPrimitiveTypeName(word)) && !qualifiedSegment)
-                    || (word == "readonly" && !qualifiedSegment && PreviousWordIsRef(type, start) && HasFollowingWord(type, i))
-                    || functionPointerKeyword;
-                if (!alreadyEscaped && !bareSpelling && IsCSharpKeyword(word))
-                    sb.Append('@');
-                sb.Append(word);
-            }
-            else
-            {
-                sb.Append(c);
-                i++;
-            }
-        }
-
-        return sb.ToString();
-    }
-
-    static bool PreviousWordIsRef(string text, int wordStart)
-    {
-        int i = wordStart - 1;
-        while (i >= 0 && char.IsWhiteSpace(text[i]))
-            i--;
-        int end = i + 1;
-        while (i >= 0 && (char.IsLetterOrDigit(text[i]) || text[i] == '_'))
-            i--;
-        return end > i + 1 && text[(i + 1)..end] == "ref";
-    }
-
-    static bool HasFollowingWord(string text, int wordEnd)
-    {
-        int i = wordEnd;
-        while (i < text.Length && char.IsWhiteSpace(text[i]))
-            i++;
-        return i < text.Length && (char.IsLetter(text[i]) || text[i] == '_' || text[i] == '@');
-    }
-
-    static bool IsPrimitiveTypeName(string name)
-        => name is "bool" or "byte" or "sbyte" or "char" or "decimal" or "double"
-            or "float" or "int" or "uint" or "nint" or "nuint" or "long" or "ulong"
-            or "object" or "short" or "ushort" or "string";
-
-    static bool IsCSharpKeyword(string word)
-        => word is "abstract" or "as" or "base" or "bool" or "break" or "byte"
-            or "case" or "catch" or "char" or "checked" or "class" or "const"
-            or "continue" or "decimal" or "default" or "delegate" or "do"
-            or "double" or "else" or "enum" or "event" or "explicit" or "extern"
-            or "false" or "finally" or "fixed" or "float" or "for" or "foreach"
-            or "goto" or "if" or "implicit" or "in" or "int" or "interface"
-            or "internal" or "is" or "lock" or "long" or "namespace" or "new"
-            or "null" or "object" or "operator" or "out" or "override" or "params"
-            or "private" or "protected" or "public" or "readonly" or "ref"
-            or "return" or "sbyte" or "sealed" or "short" or "sizeof" or "stackalloc"
-            or "static" or "string" or "struct" or "switch" or "this" or "throw"
-            or "true" or "try" or "typeof" or "uint" or "ulong" or "unchecked"
-            or "unsafe" or "ushort" or "using" or "virtual" or "void" or "volatile"
-            or "while" or "record" or "required" or "init" or "file" or "scoped";
 }
 
 internal abstract record ArtifactRequest(


### PR DESCRIPTION
## Why

RTS (ReturnToSender) is the compile-back **oracle** that declares the product decompiler's C# output valid/passing. It had reimplemented C# reserved-keyword escaping in `CompileBackCSharpNames`, and that duplicate had **drifted** from the product's authoritative rules in *both* directions:

- RTS's local `IsCSharpKeyword` list **omitted `await`**, so a type named `await` emitted bare `await` — while the product correctly emits `@await`.
- The product's own `EscapeTypeKeywords` wrongly escaped `ref readonly int` (as `ref @readonly int`), `int.MaxValue` (as `@int.MaxValue`), and left dotted `N.int` bare instead of `N.@int`.

Because RTS judges the product against *its own* spelling, any such drift silently contaminates the pass/fail verdict in both directions — the oracle can bless invalid product output or fail valid output. Removing C# knowledge from RTS so it defers to the product's C# layer is a standing goal; this is the escaping slice of it.

## What this enables

- **One authoritative type-keyword escaper.** `CSharpDeclarationWriter.EscapeTypeKeywords` is now the single implementation, surfaced through `CSharpFormatter.EscapeTypeKeywords`. There is no second copy to drift.
- **A trustworthy oracle for this dimension.** RTS now escapes exactly as the product does, so its valid/passing verdict reflects the product's real C# layer rather than RTS's divergent guess.
- **A template for the rest of the RTS de-C#-ification.** RTS still carries `Clean`'s `System.X` primitive aliasing, a local `TypeProducer`, `ToMemberPolicy`, and `ParseConstructorInitializer`. This PR establishes the pattern (product owns the seam, RTS delegates) those follow-ups will reuse.

## Change

- `src/ILInspector.CSharp/CSharpDeclarationWriter.cs` — `EscapeTypeKeywords` made `internal`; `IsTypeSyntaxKeyword` rewritten with a corrected, unified model plus helpers `IsPrimitiveOrVoidKeyword` and `InModifierPosition`:
  - primitive/void aliases bare unless a dotted-name segment (`N.int` → `N.@int`);
  - parameter/type modifiers (`ref/in/out/params/readonly/scoped/unmanaged`) bare only in a leading modifier run followed by a real type;
  - `delegate*` bare only as a genuine function-pointer head (`<` or a calling-convention run after the `*`).
- `src/ILInspector.CSharp/CSharpFormatter.cs` — new public facade `EscapeTypeKeywords`.
- `tools/DecompilerHarness/ReturnToSenderTypePlanner.cs` — `CompileBackCSharpNames.Clean` delegates to the product; local escaping helpers (`EscapeTypeKeywords`, `PreviousWordIsRef`, `HasFollowingWord`, `IsPrimitiveTypeName`, `IsCSharpKeyword`) deleted.
- `src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs` — new theory covering the union of both old behaviors plus the pointer/keyword edge cases surfaced in review.

## Validation

- `ILInspector.CSharp.Tests`: 140 pass (incl. the new escaping theory).
- Core RTS oracle tests (`ReturnToSenderPrototypeTests`, `ReturnToSenderEvidenceTests`): 117 pass.
- Corpus quality-diff card: **neutral on every raise/fidelity metric** (escaping-only change; the only movement is more-correct escaping where a keyword-named type appears). Card was run with reduced sampling caps (`--compile-cap 25`, fidelity cap 3) for turnaround, so its "regressions" line reflects only the lower caps vs baseline, not behavior.

## Review

Adversarial review per policy — two reviewers from non-Opus families (I authored as Opus): **GPT-5.5** and **Gemini 3.1 Pro**, in isolated worktrees, plus an **MAI** pass for extra rigor on this central-file + oracle change. Reviews drove four rounds of real fixes (pointer-to-keyword-typed names: `ref*`→`@ref*`, `delegate*`→`@delegate*`, whitespace-then-punctuation, and preserving `delegate* <...>`). Reconciliation posted below once all sign-offs land.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
