### PR TITLE
De-C#-ify RTS: move remaining C# spelling/shape decisions to the product seam

### DIFF
--- a/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
@@ -227,4 +227,97 @@ public sealed class CSharpFormatterTests
     [InlineData("N.@int", "N.@int")]
     public void EscapeTypeKeywords_EscapesIdentifiersButNotTypeSyntax(string input, string expected)
         => Assert.Equal(expected, CSharpFormatter.EscapeTypeKeywords(input));
+
+    [Theory]
+    // Every CLR primitive full name aliases to its C# keyword, including the native
+    // ints (nint/nuint) and decimal, matching the product decompiler's spelling.
+    [InlineData("System.Boolean", "bool")]
+    [InlineData("System.Byte", "byte")]
+    [InlineData("System.SByte", "sbyte")]
+    [InlineData("System.Char", "char")]
+    [InlineData("System.Decimal", "decimal")]
+    [InlineData("System.Double", "double")]
+    [InlineData("System.Single", "float")]
+    [InlineData("System.Int16", "short")]
+    [InlineData("System.UInt16", "ushort")]
+    [InlineData("System.Int32", "int")]
+    [InlineData("System.UInt32", "uint")]
+    [InlineData("System.Int64", "long")]
+    [InlineData("System.UInt64", "ulong")]
+    [InlineData("System.IntPtr", "nint")]
+    [InlineData("System.UIntPtr", "nuint")]
+    [InlineData("System.Object", "object")]
+    [InlineData("System.String", "string")]
+    [InlineData("System.Void", "void")]
+    // Primitives nested in generics, arrays, pointers, and by-ref forms are aliased.
+    [InlineData("System.Collections.Generic.List<System.Int32>", "System.Collections.Generic.List<int>")]
+    [InlineData("System.Collections.Generic.Dictionary<System.String,System.Boolean>", "System.Collections.Generic.Dictionary<string,bool>")]
+    [InlineData("System.Int32[]", "int[]")]
+    [InlineData("System.Int32[,]", "int[,]")]
+    [InlineData("System.Int32&", "int&")]
+    [InlineData("System.Int32*", "int*")]
+    [InlineData("System.Nullable<System.Int32>[]", "System.Nullable<int>[]")]
+    // A longer name that merely contains a primitive as a substring is left alone.
+    [InlineData("System.Int32Enum", "System.Int32Enum")]
+    [InlineData("A.System.Int32", "A.System.Int32")]
+    [InlineData("System.Int32.MaxValue", "System.Int32.MaxValue")]
+    [InlineData("System.Collections.Generic.List<System.Guid>", "System.Collections.Generic.List<System.Guid>")]
+    // Non-System text and already-keyword spellings pass through unchanged.
+    [InlineData("int", "int")]
+    [InlineData("MyNamespace.MyType", "MyNamespace.MyType")]
+    [InlineData("", "")]
+    public void AliasPrimitiveTypeNames_RewritesClrPrimitivesToKeywords(string input, string expected)
+        => Assert.Equal(expected, CSharpFormatter.AliasPrimitiveTypeNames(input));
+
+    [Theory]
+    [InlineData("this(x)", CSharpConstructorInitializerKind.This, "x")]
+    [InlineData("base(a, b)", CSharpConstructorInitializerKind.Base, "a, b")]
+    // A leading ": " (the emitted form) is accepted and stripped.
+    [InlineData(": this(1)", CSharpConstructorInitializerKind.This, "1")]
+    [InlineData(": base()", CSharpConstructorInitializerKind.Base, null)]
+    // Nested calls are carried verbatim as a single argument (no top-level split).
+    [InlineData("base(Wrap(a, b), c)", CSharpConstructorInitializerKind.Base, "Wrap(a, b), c")]
+    public void ParseConstructorInitializer_ParsesThisAndBaseChains(
+        string chain,
+        CSharpConstructorInitializerKind expectedKind,
+        string? expectedArgument)
+    {
+        var initializer = CSharpFormatter.ParseConstructorInitializer(chain);
+        Assert.NotNull(initializer);
+        Assert.Equal(expectedKind, initializer!.Kind);
+        Assert.Equal(
+            expectedArgument is null ? [] : new[] { expectedArgument },
+            initializer.Arguments);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("SomeMethod(x)")]
+    [InlineData("this")]
+    public void ParseConstructorInitializer_ReturnsNullForNonChains(string? chain)
+        => Assert.Null(CSharpFormatter.ParseConstructorInitializer(chain));
+
+    [Fact]
+    public void ParseConstructorInitializer_RoundTripsFormatConstructorInitializer()
+    {
+        var initializer = new CSharpConstructorInitializer(
+            CSharpConstructorInitializerKind.This,
+            ["a, b"]);
+        string formatted = CSharpFormatter.FormatConstructorInitializer(initializer);
+        var parsed = CSharpFormatter.ParseConstructorInitializer(formatted);
+        Assert.NotNull(parsed);
+        Assert.Equal(initializer.Kind, parsed!.Kind);
+        Assert.Equal(initializer.Arguments, parsed.Arguments);
+    }
+
+    [Theory]
+    [InlineData("int*", true)]
+    [InlineData("delegate*<int, void>", true)]
+    [InlineData("stackalloc int[4]", true)]
+    [InlineData("int", false)]
+    [InlineData("System.Collections.Generic.List<int>", false)]
+    [InlineData("a + b", false)]
+    public void RequiresUnsafeModifier_DetectsPointerAndStackalloc(string csharp, bool expected)
+        => Assert.Equal(expected, CSharpFormatter.RequiresUnsafeModifier(csharp));
 }

--- a/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
@@ -262,6 +262,9 @@ public sealed class CSharpFormatterTests
     [InlineData("A.System.Int32", "A.System.Int32")]
     [InlineData("System.Int32.MaxValue", "System.Int32.MaxValue")]
     [InlineData("System.Collections.Generic.List<System.Guid>", "System.Collections.Generic.List<System.Guid>")]
+    // An explicitly-escaped identifier (leading '@') is not a primitive reference.
+    [InlineData("@System.Int32", "@System.Int32")]
+    [InlineData("List<@System.Int32>", "List<@System.Int32>")]
     // Non-System text and already-keyword spellings pass through unchanged.
     [InlineData("int", "int")]
     [InlineData("MyNamespace.MyType", "MyNamespace.MyType")]

--- a/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
@@ -320,4 +320,16 @@ public sealed class CSharpFormatterTests
     [InlineData("a + b", false)]
     public void RequiresUnsafeModifier_DetectsPointerAndStackalloc(string csharp, bool expected)
         => Assert.Equal(expected, CSharpFormatter.RequiresUnsafeModifier(csharp));
+
+    [Theory]
+    [InlineData("int*", true)]
+    [InlineData("delegate*<int, void>", true)]
+    [InlineData("System.Int32*", true)]
+    [InlineData("int", false)]
+    [InlineData("System.Collections.Generic.List<int>", false)]
+    [InlineData("stackalloc", false)]
+    [InlineData("@stackalloc", false)]
+    [InlineData("N.stackalloc", false)]
+    public void TypeRequiresUnsafeModifier_MatchesPointersButNotStackallocIdentifiers(string typeDisplayName, bool expected)
+        => Assert.Equal(expected, CSharpFormatter.TypeRequiresUnsafeModifier(typeDisplayName));
 }

--- a/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
+++ b/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
@@ -59,6 +59,20 @@ public sealed class TypeShellProducerTests
         Assert.False(TypeShellProducer.IsUnsupportedSurfaceSignature(signature));
     }
 
+    [Fact]
+    public void IsStaticType_DistinguishesStaticClassesFromOtherKinds()
+    {
+        using var pe = new PEReader(File.OpenRead(typeof(TypeShellProducerTests).Assembly.Location));
+        var reader = pe.GetMetadataReader();
+
+        TypeDefinition Type(string name) => reader.GetTypeDefinition(reader.TypeDefinitions
+            .Single(handle => reader.GetString(reader.GetTypeDefinition(handle).Name) == name));
+
+        Assert.True(TypeShellProducer.IsStaticType(Type(nameof(StaticFixture))));
+        Assert.False(TypeShellProducer.IsStaticType(Type(nameof(InstanceFixture))));
+        Assert.False(TypeShellProducer.IsStaticType(Type(nameof(IInterfaceFixture))));
+    }
+
     static async Task RuntimeAsyncFixture()
         => await Task.Yield();
 
@@ -71,5 +85,17 @@ public sealed class TypeShellProducerTests
     static IEnumerable<int> IteratorFixture()
     {
         yield return 1;
+    }
+
+    static class StaticFixture
+    {
+    }
+
+    sealed class InstanceFixture
+    {
+    }
+
+    interface IInterfaceFixture
+    {
     }
 }

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -654,6 +654,51 @@ internal static class CSharpDeclarationWriter
     }
 
     /// <summary>
+    /// Rewrites CLR primitive full names (<c>System.Int32</c>, <c>System.Boolean</c>,
+    /// <c>System.IntPtr</c>, …) to their C# keyword spelling (<c>int</c>, <c>bool</c>,
+    /// <c>nint</c>, …) wherever they appear as a complete type-name segment inside a
+    /// type string, including nested in generics, arrays, pointers, and by-ref forms
+    /// (e.g. <c>System.Collections.Generic.List&lt;System.Int32&gt;[]</c> →
+    /// <c>System.Collections.Generic.List&lt;int&gt;[]</c>). Only whole dotted-name
+    /// runs are considered, so a longer name that merely contains a primitive as a
+    /// substring (<c>System.Int32Enum</c>, <c>A.System.Int32</c>) is left untouched.
+    /// The keyword pairs are the single source of truth in
+    /// <see cref="PrimitiveTypeNames"/>, so this spelling always matches the rest of
+    /// the C# layer. This is the authoritative primitive-alias rewriter; consumers
+    /// must not reimplement it.
+    /// </summary>
+    internal static string AliasPrimitiveTypeNames(string type)
+    {
+        if (type.IndexOf("System.", StringComparison.Ordinal) < 0)
+            return type;
+
+        var builder = new StringBuilder(type.Length);
+        for (int index = 0; index < type.Length;)
+        {
+            if (!IsTypeNameSegmentChar(type[index]))
+            {
+                builder.Append(type[index++]);
+                continue;
+            }
+
+            int end = index + 1;
+            while (end < type.Length && IsTypeNameSegmentChar(type[end]))
+                end++;
+
+            string run = type[index..end];
+            builder.Append(PrimitiveTypeNames.TryToKeyword(run, out var keyword) ? keyword : run);
+            index = end;
+        }
+        return builder.ToString();
+    }
+
+    // A dotted type-name run: identifier characters plus the '.' segment separator.
+    // Type-syntax delimiters ('<', '>', ',', '[', ']', '*', '&', whitespace) break
+    // the run, so an embedded primitive full name is isolated as its own run.
+    static bool IsTypeNameSegmentChar(char c)
+        => char.IsLetterOrDigit(c) || c is '_' or '.';
+
+    /// <summary>
     /// Escapes C# reserved keywords that appear as identifiers (type or namespace
     /// name segments) inside a type string, while leaving keywords that are C# type
     /// <em>syntax</em> bare (primitive aliases, parameter/type modifiers, and

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -661,7 +661,8 @@ internal static class CSharpDeclarationWriter
     /// (e.g. <c>System.Collections.Generic.List&lt;System.Int32&gt;[]</c> →
     /// <c>System.Collections.Generic.List&lt;int&gt;[]</c>). Only whole dotted-name
     /// runs are considered, so a longer name that merely contains a primitive as a
-    /// substring (<c>System.Int32Enum</c>, <c>A.System.Int32</c>) is left untouched.
+    /// substring (<c>System.Int32Enum</c>, <c>A.System.Int32</c>) is left untouched,
+    /// as is an explicitly-escaped identifier (<c>@System.Int32</c>).
     /// The keyword pairs are the single source of truth in
     /// <see cref="PrimitiveTypeNames"/>, so this spelling always matches the rest of
     /// the C# layer. This is the authoritative primitive-alias rewriter; consumers
@@ -686,7 +687,11 @@ internal static class CSharpDeclarationWriter
                 end++;
 
             string run = type[index..end];
-            builder.Append(PrimitiveTypeNames.TryToKeyword(run, out var keyword) ? keyword : run);
+            // A run immediately preceded by '@' is an explicitly-escaped identifier
+            // (e.g. `@System.Int32`), not a primitive type reference; leave it as-is
+            // rather than emitting a malformed `@int`.
+            bool escaped = index > 0 && type[index - 1] == '@';
+            builder.Append(!escaped && PrimitiveTypeNames.TryToKeyword(run, out var keyword) ? keyword : run);
             index = end;
         }
         return builder.ToString();

--- a/src/ILInspector.CSharp/CSharpFormatter.cs
+++ b/src/ILInspector.CSharp/CSharpFormatter.cs
@@ -199,19 +199,38 @@ public sealed class CSharpFormatter
         => CSharpDeclarationWriter.AliasPrimitiveTypeNames(type);
 
     /// <summary>
-    /// True when a C# type or member-body fragment requires the <c>unsafe</c>
-    /// modifier — it contains pointer syntax (including function pointers, which
-    /// carry a <c>*</c>) or a <c>stackalloc</c>. This over-approximates (a body
-    /// using <c>*</c> as multiplication also reports true), which is safe because
-    /// an unnecessary <c>unsafe</c> modifier still compiles. This is the
-    /// authoritative unsafe-requirement predicate for the C# layer; consumers must
-    /// not reimplement it.
+    /// True when a C# code fragment (typically a member body) requires the
+    /// <c>unsafe</c> modifier — it contains pointer syntax (including function
+    /// pointers, which carry a <c>*</c>) or a <c>stackalloc</c> expression. This
+    /// over-approximates (a body using <c>*</c> as multiplication also reports
+    /// true); an unnecessary <c>unsafe</c> is normally harmless, but callers that
+    /// may also emit <c>async</c> must not feed it type names — see
+    /// <see cref="TypeRequiresUnsafeModifier"/>. This is the authoritative
+    /// unsafe-requirement predicate for C# fragments; consumers must not
+    /// reimplement it.
     /// </summary>
     public static bool RequiresUnsafeModifier(string csharp)
     {
         ArgumentNullException.ThrowIfNull(csharp);
         return csharp.Contains('*', StringComparison.Ordinal)
             || csharp.Contains("stackalloc", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// True when a C# <em>type</em> display name requires the <c>unsafe</c>
+    /// modifier — it denotes a pointer or function-pointer type (both carry a
+    /// <c>*</c>). Unlike <see cref="RequiresUnsafeModifier"/> this deliberately
+    /// does not look for <c>stackalloc</c>, which is an expression construct that
+    /// can never appear in a type name (matching it against a type name — e.g. an
+    /// escaped identifier <c>@stackalloc</c> — would be a false positive, and a
+    /// spurious <c>unsafe</c> on an <c>async</c> member fails to compile). This is
+    /// the authoritative unsafe-requirement predicate for C# type names; consumers
+    /// must not reimplement it.
+    /// </summary>
+    public static bool TypeRequiresUnsafeModifier(string typeDisplayName)
+    {
+        ArgumentNullException.ThrowIfNull(typeDisplayName);
+        return typeDisplayName.Contains('*', StringComparison.Ordinal);
     }
 
     public static string EscapeKnownIdentifiers(string text, IEnumerable<string> rawNames)

--- a/src/ILInspector.CSharp/CSharpFormatter.cs
+++ b/src/ILInspector.CSharp/CSharpFormatter.cs
@@ -188,6 +188,32 @@ public sealed class CSharpFormatter
     public static string EscapeTypeKeywords(string type)
         => CSharpDeclarationWriter.EscapeTypeKeywords(type);
 
+    /// <summary>
+    /// Rewrites CLR primitive full names (e.g. <c>System.Int32</c>, <c>System.IntPtr</c>)
+    /// to their C# keyword spelling (<c>int</c>, <c>nint</c>) wherever they appear as a
+    /// complete type-name segment inside a type string — including nested in generics,
+    /// arrays, pointers, and by-ref forms. This is the authoritative primitive-alias
+    /// rewriter for the C# layer; consumers must not reimplement it.
+    /// </summary>
+    public static string AliasPrimitiveTypeNames(string type)
+        => CSharpDeclarationWriter.AliasPrimitiveTypeNames(type);
+
+    /// <summary>
+    /// True when a C# type or member-body fragment requires the <c>unsafe</c>
+    /// modifier — it contains pointer syntax (including function pointers, which
+    /// carry a <c>*</c>) or a <c>stackalloc</c>. This over-approximates (a body
+    /// using <c>*</c> as multiplication also reports true), which is safe because
+    /// an unnecessary <c>unsafe</c> modifier still compiles. This is the
+    /// authoritative unsafe-requirement predicate for the C# layer; consumers must
+    /// not reimplement it.
+    /// </summary>
+    public static bool RequiresUnsafeModifier(string csharp)
+    {
+        ArgumentNullException.ThrowIfNull(csharp);
+        return csharp.Contains('*', StringComparison.Ordinal)
+            || csharp.Contains("stackalloc", StringComparison.Ordinal);
+    }
+
     public static string EscapeKnownIdentifiers(string text, IEnumerable<string> rawNames)
         => CSharpDeclarationWriter.EscapeKnownIdentifiers(text, rawNames);
 
@@ -250,6 +276,42 @@ public sealed class CSharpFormatter
                 "Unknown constructor initializer kind.")
         };
         return $": {target}({string.Join(", ", initializer.Arguments)})";
+    }
+
+    /// <summary>
+    /// Parses a printer-form constructor-chain string — <c>this(args)</c> or
+    /// <c>base(args)</c>, with an optional leading <c>: </c> and no trailing
+    /// <c>;</c> — back into a <see cref="CSharpConstructorInitializer"/>. The inverse
+    /// of <see cref="FormatConstructorInitializer"/>. The whole argument list is
+    /// carried as a single initializer argument: the printer already rendered it, so
+    /// there is no top-level comma split (splitting would break nested calls). Returns
+    /// <see langword="null"/> when there is no <c>this</c>/<c>base</c> chain. This is
+    /// the authoritative constructor-initializer parser for the C# layer; consumers
+    /// must not reimplement it.
+    /// </summary>
+    public static CSharpConstructorInitializer? ParseConstructorInitializer(string? chain)
+    {
+        if (string.IsNullOrEmpty(chain))
+            return null;
+
+        string text = chain.StartsWith(": ", StringComparison.Ordinal) ? chain[2..] : chain;
+        CSharpConstructorInitializerKind? kind = text.StartsWith("this(", StringComparison.Ordinal)
+            ? CSharpConstructorInitializerKind.This
+            : text.StartsWith("base(", StringComparison.Ordinal)
+                ? CSharpConstructorInitializerKind.Base
+                : null;
+        if (kind is null)
+            return null;
+
+        int open = text.IndexOf('(', StringComparison.Ordinal);
+        int close = text.LastIndexOf(')');
+        if (open < 0 || close <= open)
+            return null;
+
+        string arguments = text[(open + 1)..close];
+        return new CSharpConstructorInitializer(
+            kind.Value,
+            arguments.Length == 0 ? [] : [arguments]);
     }
 
     static CSharpDeclarationOptions ToDeclarationOptions(

--- a/src/ILInspector.CSharp/TypeShellProducer.cs
+++ b/src/ILInspector.CSharp/TypeShellProducer.cs
@@ -140,4 +140,15 @@ public static class TypeShellProducer
         // generated `<>`-named base). This method owns only the metadata-level gates.
         return baseType;
     }
+
+    /// <summary>
+    /// True when <paramref name="typeDef"/> is a C# <c>static class</c> — a type that
+    /// is both <c>abstract</c> and <c>sealed</c> and is not an interface. Interfaces
+    /// are also abstract, so they are excluded explicitly to avoid misreading an
+    /// interface as a static class.
+    /// </summary>
+    public static bool IsStaticType(TypeDefinition typeDef)
+        => (typeDef.Attributes & TypeAttributes.Abstract) != 0
+            && (typeDef.Attributes & TypeAttributes.Sealed) != 0
+            && (typeDef.Attributes & TypeAttributes.Interface) == 0;
 }

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -434,7 +434,7 @@ public class ReturnToSenderFixtureCatalogTests
     {
         Assert.Equal("A.B.@delegate*", CompileBackCSharpNames.Clean("A.B.delegate*"));
         Assert.Equal("@delegate*", CompileBackCSharpNames.Clean("delegate*"));
-        Assert.Equal("delegate*<System.Int32, System.Int32>", CompileBackCSharpNames.Clean("delegate*<System.Int32, System.Int32>"));
+        Assert.Equal("delegate*<int, int>", CompileBackCSharpNames.Clean("delegate*<System.Int32, System.Int32>"));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -3110,7 +3110,7 @@ public class ReturnToSenderPrototypeTests
                 result =>
                 {
                     Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
-                    Assert.Contains("public System.Decimal DecimalDefault(System.Decimal value = 1.25m)", result.Source);
+                    Assert.Contains("public decimal DecimalDefault(decimal value = 1.25m)", result.Source);
                 },
                 result =>
                 {

--- a/src/ILInspector.Metadata/PrimitiveTypeNames.cs
+++ b/src/ILInspector.Metadata/PrimitiveTypeNames.cs
@@ -30,6 +30,9 @@ public static class PrimitiveTypeNames
         ["void"] = "System.Void",
     };
 
+    private static readonly Dictionary<string, string> ReverseMap =
+        Map.ToDictionary(static pair => pair.Value, static pair => pair.Key, StringComparer.Ordinal);
+
     /// <summary>Returns the CLR full name for a primitive keyword, or the input unchanged.</summary>
     public static string ToClrFullName(string keyword)
         => Map.TryGetValue(keyword, out var full) ? full : keyword;
@@ -37,4 +40,12 @@ public static class PrimitiveTypeNames
     /// <summary>Tries to map a primitive keyword to its CLR full name.</summary>
     public static bool TryToClrFullName(string keyword, out string fullName)
         => Map.TryGetValue(keyword, out fullName!);
+
+    /// <summary>
+    /// Tries to map a CLR primitive full name (e.g. <c>System.Int32</c>) back to its
+    /// C# keyword (e.g. <c>int</c>). The inverse of <see cref="ToClrFullName"/>; the
+    /// single source of truth for both directions so the two never disagree.
+    /// </summary>
+    public static bool TryToKeyword(string clrFullName, out string keyword)
+        => ReverseMap.TryGetValue(clrFullName, out keyword!);
 }

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -3061,7 +3061,7 @@ public static class CompileBackSourceComposer
                 IsAbstract = (typeDef.Attributes & TypeAttributes.Abstract) != 0
                     && (typeDef.Attributes & TypeAttributes.Interface) == 0,
                 IsSealed = (typeDef.Attributes & TypeAttributes.Sealed) != 0,
-                IsStatic = IsStaticType(typeDef),
+                IsStatic = TypeShellProducer.IsStaticType(typeDef),
             };
             return new CSharpTypePrintRequest(
                 type,
@@ -3218,11 +3218,6 @@ public static class CompileBackSourceComposer
                     yield return handle;
             }
         }
-
-        static bool IsStaticType(TypeDefinition typeDef)
-            => (typeDef.Attributes & TypeAttributes.Abstract) != 0
-               && (typeDef.Attributes & TypeAttributes.Sealed) != 0
-               && (typeDef.Attributes & TypeAttributes.Interface) == 0;
 
         static IReadOnlyList<string> TypeAttributeList(MetadataReader reader, TypeDefinition typeDef)
             => AttributeReader.RenderAttributes(reader, typeDef.GetCustomAttributes(), qualifyNames: true);
@@ -3548,7 +3543,7 @@ public static class CompileBackSourceComposer
             }
 
             if (requirement.RequiredKind == CompileBackTypeKind.Class
-                && !IsStaticType(typeDef)
+                && !TypeShellProducer.IsStaticType(typeDef)
                 && requirement.PrimaryConstructor is null
                 && !members.Any(member => member.Kind == CompileBackMemberKind.Constructor && member.Parameters.Count == 0)
                 && !HasParameterlessInstanceConstructor(reader, typeDef))

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1607,9 +1607,9 @@ public static class CompileBackSourceComposer
 
     static bool RequiresUnsafe(CompileBackMemberRequirement member)
         => (member.ReturnType is { } returnType
-                && CSharpFormatter.RequiresUnsafeModifier(returnType.DisplayName))
+                && CSharpFormatter.TypeRequiresUnsafeModifier(returnType.DisplayName))
             || member.Parameters.Any(parameter =>
-                CSharpFormatter.RequiresUnsafeModifier(parameter.Type.DisplayName))
+                CSharpFormatter.TypeRequiresUnsafeModifier(parameter.Type.DisplayName))
             || (member.TargetBody is { } body && CSharpFormatter.RequiresUnsafeModifier(body));
 
 

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -24,13 +24,7 @@ static class CompileBackCSharpNames
             .Replace(")", "", StringComparison.Ordinal)
             .Trim();
 
-        type = type switch
-        {
-            "System.String" => "string",
-            "System.Int32" => "int",
-            "System.Void" => "void",
-            _ => type,
-        };
+        type = CSharpFormatter.AliasPrimitiveTypeNames(type);
 
         return CSharpFormatter.EscapeTypeKeywords(type);
     }
@@ -1495,7 +1489,7 @@ public static class CompileBackSourceComposer
                             CSharpConstructorInitializerKind.This,
                             Enumerable.Repeat("default", primaryConstructorParameterCount).ToArray()))),
             CompileBackStubBodyKind.TargetBody when requirement.Kind == CompileBackMemberKind.Constructor
-                && ParseConstructorInitializer(requirement.ConstructorInitializer) is { } capturedInitializer
+                && CSharpFormatter.ParseConstructorInitializer(requirement.ConstructorInitializer) is { } capturedInitializer
                 => new(
                     member,
                     CSharpBodyPolicy.Full,
@@ -1529,35 +1523,6 @@ public static class CompileBackSourceComposer
         => requirement.Kind == CompileBackMemberKind.PropertyGet
             ? new CSharpPropertyBody(body, null)
             : new CSharpPropertyBody(null, body);
-
-    /// <summary>
-    /// Parses a printer-form constructor-chain string (<c>this(args)</c> or
-    /// <c>base(args)</c>, with no leading <c>: </c> or trailing <c>;</c>) into a
-    /// <see cref="CSharpConstructorInitializer"/>. The whole argument list is
-    /// carried as a single initializer argument — the printer already rendered
-    /// it, so no top-level comma split is needed (and splitting would break
-    /// nested calls). Returns null when there is no captured chain.
-    /// </summary>
-    static CSharpConstructorInitializer? ParseConstructorInitializer(string? chain)
-    {
-        if (string.IsNullOrEmpty(chain))
-            return null;
-        var kind = chain.StartsWith("this(", StringComparison.Ordinal)
-            ? CSharpConstructorInitializerKind.This
-            : chain.StartsWith("base(", StringComparison.Ordinal)
-                ? CSharpConstructorInitializerKind.Base
-                : (CSharpConstructorInitializerKind?)null;
-        if (kind is null)
-            return null;
-        int open = chain.IndexOf('(', StringComparison.Ordinal);
-        int close = chain.LastIndexOf(')');
-        if (open < 0 || close <= open)
-            return null;
-        string arguments = chain[(open + 1)..close];
-        return new CSharpConstructorInitializer(
-            kind.Value,
-            arguments.Length == 0 ? [] : [arguments]);
-    }
 
     /// <summary>
     /// The base/this <c>.ctor</c> chain call in the entry block, or null when the
@@ -1641,15 +1606,11 @@ public static class CompileBackSourceComposer
         };
 
     static bool RequiresUnsafe(CompileBackMemberRequirement member)
-        => member.ReturnType?.DisplayName.Contains('*', StringComparison.Ordinal) == true
-            || member.Parameters.Any(parameter => parameter.Type.DisplayName.Contains('*', StringComparison.Ordinal))
-            || MemberBodyRequiresUnsafe(member);
-
-    static bool MemberBodyRequiresUnsafe(CompileBackMemberRequirement member)
-        => member.TargetBody is { } body
-            && (body.Contains("delegate*", StringComparison.Ordinal)
-                || body.Contains("stackalloc", StringComparison.Ordinal)
-                || body.Contains('*', StringComparison.Ordinal));
+        => (member.ReturnType is { } returnType
+                && CSharpFormatter.RequiresUnsafeModifier(returnType.DisplayName))
+            || member.Parameters.Any(parameter =>
+                CSharpFormatter.RequiresUnsafeModifier(parameter.Type.DisplayName))
+            || (member.TargetBody is { } body && CSharpFormatter.RequiresUnsafeModifier(body));
 
 
     static IReadOnlyList<CompileBackParameter> MethodParameters(


### PR DESCRIPTION
## Summary

Move the last of RTS's re-implemented C# spelling/shape decisions into the
product's C# seam, so the compile-back oracle judges the product decompiler
against the **product's** C# spelling instead of RTS's own divergent copy.

## Why this matters

RTS (ReturnToSender) is the compile-back oracle: it takes the product
decompiler's reconstructed C#, compiles it, and compares IL to declare the
product's output valid. That verdict is only trustworthy if RTS reproduces the
product's C# faithfully. Where RTS re-implemented its own spelling/shape rules,
it was silently grading the product against a *different* dialect — a
load-bearing conflict of interest in the thing that certifies the decompiler as
correct. Every rule RTS owns independently is a way for the oracle to disagree
with the product for reasons that have nothing to do with the decompiler.

This PR removes that duplication for the remaining cases:

- **Primitive spelling** — RTS aliased only `String`/`Int32`/`Void`; everything
  else (`System.Decimal`, `System.IntPtr`, …) stayed fully-qualified, unlike the
  product which spells them `decimal`/`nint`/etc. Now a single product aliaser
  (driven by the one `PrimitiveTypeNames` map that also feeds the decompiler)
  covers all 18 primitives.
- **Constructor-initializer parsing**, **unsafe-modifier detection**, and the
  **`static class` shape predicate** — each had a private RTS copy; each now
  delegates to the product seam (`CSharpFormatter` / `TypeShellProducer`).

## What it enables

- **A trustworthy oracle.** RTS's "the product's C# is valid" claim is no longer
  contaminated by RTS's own spelling divergence — the oracle and the product
  read spelling/shape from the same source of truth.
- **A proven source-fidelity win.** Unifying primitive aliasing improves the
  reconstructed source (`System.Decimal DecimalDefault(System.Decimal…)` →
  `decimal DecimalDefault(decimal…)`), still `Exact` under compile-back.
- **Reusable product API.** `CSharpFormatter.AliasPrimitiveTypeNames` /
  `ParseConstructorInitializer` / `RequiresUnsafeModifier` /
  `TypeRequiresUnsafeModifier`, `TypeShellProducer.IsStaticType`, and
  `PrimitiveTypeNames.TryToKeyword` are general, SRM-only, Roslyn-free seam
  operations any future consumer (not just RTS) can reuse — a further step
  toward RTS being a pure compile-back *planner* rather than a C# re-implementer.

## Scope / non-goals

The remaining `TypeProducer` in RTS is **not** re-implemented C# spelling — it is
closure-aware compile-back planning (dependency-closure roots, stub-body policy)
and its base-type gate depends on RTS's own `Clean` sanitization. That is RTS's
irreducible job and deliberately stays in RTS; see the in-file note near the
base-type gate. This PR is spelling/shape only.

## Validation

- Full `dotnet-inspect.slnx` build clean.
- `ILInspector.CSharp.Tests` (incl. new `AliasPrimitiveTypeNames`,
  `ParseConstructorInitializer`, `RequiresUnsafeModifier`,
  `TypeRequiresUnsafeModifier`, `IsStaticType` cases) green.
- RTS oracle tests (`ReturnToSenderPrototypeTests`, `ReturnToSenderEvidenceTests`,
  `ReturnToSenderFixtureCatalogTests`, fast subset) green after updating two
  stale `System.X`→keyword assertions.
- Corpus quality-diff card: **neutral on every raise/fidelity metric** (fidelity
  is opcode-based, so `System.Decimal`↔`decimal` is the same IL — the change is a
  source-spelling improvement, not a fidelity delta). The only flagged rows are
  sampling-cap artifacts from `--compile-cap 25`.

## Adversarial review

Two reviewers from a different model family than the author (Opus), plus an
additional MAI pass given RTS's load-bearing role — reconciliation posted below.
