### PR TITLE
De-C#-ify RTS: dedupe generic-constraint keyword spelling into Metadata

### DIFF
--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -501,29 +501,15 @@ public static class ApiSurfaceExtractor
             };
 
             var attrs = param.Attributes;
-            if (includeVariance)
-            {
-                if ((attrs & GenericParameterAttributes.Covariant) != 0)
-                    typeParam.Variance = "out";
-                else if ((attrs & GenericParameterAttributes.Contravariant) != 0)
-                    typeParam.Variance = "in";
-            }
+            if (includeVariance && GenericConstraintKeywords.VarianceKeyword(attrs) is { } variance)
+                typeParam.Variance = variance;
 
             var nullable = GetEffectiveNullable(reader, param.GetCustomAttributes(), nullableContext);
-            var hasReferenceTypeConstraint = (attrs & GenericParameterAttributes.ReferenceTypeConstraint) != 0;
-            var hasValueTypeConstraint = (attrs & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0;
-            var hasDefaultConstructorConstraint = (attrs & GenericParameterAttributes.DefaultConstructorConstraint) != 0;
             var isUnmanaged = AttributeReader.HasAttribute(reader, param.GetCustomAttributes(),
                 KnownAttributeNames.IsUnmanagedAttribute);
 
-            if (hasReferenceTypeConstraint)
-                typeParam.Constraints.Add(nullable == 2 ? "class?" : "class");
-            else if (isUnmanaged)
-                typeParam.Constraints.Add("unmanaged");
-            else if (hasValueTypeConstraint)
-                typeParam.Constraints.Add("struct");
-            else if (nullable == 1)
-                typeParam.Constraints.Add("notnull");
+            if (GenericConstraintKeywords.PrimaryKeyword(attrs, nullable ?? 0, isUnmanaged) is { } primaryKeyword)
+                typeParam.Constraints.Add(primaryKeyword);
 
             foreach (var constraintHandle in param.GetConstraints())
             {
@@ -536,10 +522,10 @@ public static class ApiSurfaceExtractor
                 typeParam.Constraints.Add(FormatConstraintType(reader, constraint, constraintTypeName, nullableContext));
             }
 
-            if (hasDefaultConstructorConstraint && !hasValueTypeConstraint)
-                typeParam.Constraints.Add("new()");
-            if ((attrs & GenericParameterAttributes.AllowByRefLike) != 0)
-                typeParam.Constraints.Add("allows ref struct");
+            if (GenericConstraintKeywords.NewConstraintKeyword(attrs) is { } newConstraint)
+                typeParam.Constraints.Add(newConstraint);
+            if (GenericConstraintKeywords.AllowsRefStructKeyword(attrs) is { } allowsRefStruct)
+                typeParam.Constraints.Add(allowsRefStruct);
 
             parameters.Add(typeParam);
         }

--- a/src/ILInspector.Metadata/GenericConstraintKeywords.cs
+++ b/src/ILInspector.Metadata/GenericConstraintKeywords.cs
@@ -1,0 +1,71 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Canonical tokens for the generic-parameter constraint and variance facts
+/// carried by <see cref="GenericParameterAttributes"/>. These flags are CLI
+/// metadata facts; their canonical names (<c>struct</c>, <c>class</c>,
+/// <c>new()</c>, <c>in</c>, <c>out</c>, …) are the single source of truth used to
+/// populate <see cref="TypeParameter.Constraints"/> and
+/// <see cref="TypeParameter.Variance"/>. Any producer of constraint tokens —
+/// including compile-back harnesses — must derive them here rather than
+/// reimplementing the flag-to-token mapping.
+/// </summary>
+public static class GenericConstraintKeywords
+{
+    /// <summary>
+    /// The leading primary constraint token for a generic parameter, or
+    /// <see langword="null"/> when none applies. Reference- and value-type
+    /// constraints are mutually exclusive in metadata, so their evaluation order
+    /// is immaterial. <paramref name="nullableFlag"/> is the parameter's
+    /// nullable-context flag (2 → nullable reference, 1 → non-nullable) and
+    /// <paramref name="isUnmanaged"/> reflects an <c>IsUnmanagedAttribute</c>;
+    /// callers without that context pass <c>0</c> and <see langword="false"/> to
+    /// obtain the plain <c>class</c>/<c>struct</c> tokens.
+    /// </summary>
+    public static string? PrimaryKeyword(GenericParameterAttributes attributes, int nullableFlag, bool isUnmanaged)
+    {
+        if ((attributes & GenericParameterAttributes.ReferenceTypeConstraint) != 0)
+            return nullableFlag == 2 ? "class?" : "class";
+        if (isUnmanaged)
+            return "unmanaged";
+        if ((attributes & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0)
+            return "struct";
+        if (nullableFlag == 1)
+            return "notnull";
+        return null;
+    }
+
+    /// <summary>
+    /// The <c>new()</c> constraint token when the parameter has a default
+    /// constructor constraint that is not already implied by a value-type
+    /// constraint, otherwise <see langword="null"/>.
+    /// </summary>
+    public static string? NewConstraintKeyword(GenericParameterAttributes attributes)
+        => (attributes & GenericParameterAttributes.DefaultConstructorConstraint) != 0
+            && (attributes & GenericParameterAttributes.NotNullableValueTypeConstraint) == 0
+            ? "new()"
+            : null;
+
+    /// <summary>
+    /// The variance token (<c>out</c> for covariant, <c>in</c> for contravariant)
+    /// or <see langword="null"/> when the parameter is invariant.
+    /// </summary>
+    public static string? VarianceKeyword(GenericParameterAttributes attributes)
+        => (attributes & GenericParameterAttributes.Covariant) != 0
+            ? "out"
+            : (attributes & GenericParameterAttributes.Contravariant) != 0
+                ? "in"
+                : null;
+
+    /// <summary>
+    /// The <c>allows ref struct</c> anti-constraint token when the parameter
+    /// permits by-ref-like type arguments, otherwise <see langword="null"/>.
+    /// </summary>
+    public static string? AllowsRefStructKeyword(GenericParameterAttributes attributes)
+        => (attributes & GenericParameterAttributes.AllowByRefLike) != 0
+            ? "allows ref struct"
+            : null;
+}

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -683,10 +683,8 @@ public static class MetadataDeclarationQuery
             var constraints = new List<string>();
             var attributes = parameter.Attributes;
             var isStruct = (attributes & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0;
-            if (isStruct)
-                constraints.Add("struct");
-            else if ((attributes & GenericParameterAttributes.ReferenceTypeConstraint) != 0)
-                constraints.Add("class");
+            if (GenericConstraintKeywords.PrimaryKeyword(attributes, nullableFlag: 0, isUnmanaged: false) is { } primaryKeyword)
+                constraints.Add(primaryKeyword);
 
             foreach (var constraintHandle in parameter.GetConstraints())
             {
@@ -699,8 +697,8 @@ public static class MetadataDeclarationQuery
                 }
             }
 
-            if (!isStruct && (attributes & GenericParameterAttributes.DefaultConstructorConstraint) != 0)
-                constraints.Add("new()");
+            if (GenericConstraintKeywords.NewConstraintKeyword(attributes) is { } newConstraint)
+                constraints.Add(newConstraint);
 
             parameters.Add(new TypeParameter
             {

--- a/tests/ILInspector.Metadata.Tests/GenericConstraintKeywordsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/GenericConstraintKeywordsTests.cs
@@ -1,0 +1,55 @@
+using System.Reflection;
+
+namespace ILInspector.Metadata.Tests;
+
+public sealed class GenericConstraintKeywordsTests
+{
+    [Theory]
+    [InlineData(GenericParameterAttributes.ReferenceTypeConstraint, 0, false, "class")]
+    [InlineData(GenericParameterAttributes.ReferenceTypeConstraint, 2, false, "class?")]
+    [InlineData(GenericParameterAttributes.NotNullableValueTypeConstraint, 0, false, "struct")]
+    [InlineData(GenericParameterAttributes.NotNullableValueTypeConstraint, 0, true, "unmanaged")]
+    [InlineData(GenericParameterAttributes.None, 0, true, "unmanaged")]
+    [InlineData(GenericParameterAttributes.None, 1, false, "notnull")]
+    [InlineData(GenericParameterAttributes.None, 0, false, null)]
+    [InlineData(GenericParameterAttributes.None, 2, false, null)]
+    public void PrimaryKeyword_MapsMutuallyExclusiveConstraints(
+        GenericParameterAttributes attributes,
+        int nullableFlag,
+        bool isUnmanaged,
+        string? expected)
+        => Assert.Equal(expected, GenericConstraintKeywords.PrimaryKeyword(attributes, nullableFlag, isUnmanaged));
+
+    [Fact]
+    public void PrimaryKeyword_ReferenceConstraintWinsOverUnmanagedContext()
+        => Assert.Equal("class", GenericConstraintKeywords.PrimaryKeyword(
+            GenericParameterAttributes.ReferenceTypeConstraint, nullableFlag: 0, isUnmanaged: true));
+
+    [Theory]
+    [InlineData(GenericParameterAttributes.DefaultConstructorConstraint, "new()")]
+    [InlineData(
+        GenericParameterAttributes.DefaultConstructorConstraint | GenericParameterAttributes.NotNullableValueTypeConstraint,
+        null)]
+    [InlineData(GenericParameterAttributes.None, null)]
+    public void NewConstraintKeyword_SuppressedByValueTypeConstraint(
+        GenericParameterAttributes attributes,
+        string? expected)
+        => Assert.Equal(expected, GenericConstraintKeywords.NewConstraintKeyword(attributes));
+
+    [Theory]
+    [InlineData(GenericParameterAttributes.Covariant, "out")]
+    [InlineData(GenericParameterAttributes.Contravariant, "in")]
+    [InlineData(GenericParameterAttributes.None, null)]
+    public void VarianceKeyword_MapsCovarianceAndContravariance(
+        GenericParameterAttributes attributes,
+        string? expected)
+        => Assert.Equal(expected, GenericConstraintKeywords.VarianceKeyword(attributes));
+
+    [Theory]
+    [InlineData(GenericParameterAttributes.AllowByRefLike, "allows ref struct")]
+    [InlineData(GenericParameterAttributes.None, null)]
+    public void AllowsRefStructKeyword_MapsByRefLike(
+        GenericParameterAttributes attributes,
+        string? expected)
+        => Assert.Equal(expected, GenericConstraintKeywords.AllowsRefStructKeyword(attributes));
+}

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -2020,10 +2020,8 @@ public static class CompileBackSourceComposer
             var constraints = new List<string>();
             var attributes = parameter.Attributes;
             bool isStruct = (attributes & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0;
-            if (isStruct)
-                constraints.Add("struct");
-            else if ((attributes & GenericParameterAttributes.ReferenceTypeConstraint) != 0)
-                constraints.Add("class");
+            if (GenericConstraintKeywords.PrimaryKeyword(attributes, nullableFlag: 0, isUnmanaged: false) is { } primaryKeyword)
+                constraints.Add(primaryKeyword);
 
             foreach (var constraintHandle in parameter.GetConstraints())
             {
@@ -2036,14 +2034,10 @@ public static class CompileBackSourceComposer
                 }
             }
 
-            if (!isStruct && (attributes & GenericParameterAttributes.DefaultConstructorConstraint) != 0)
-                constraints.Add("new()");
+            if (GenericConstraintKeywords.NewConstraintKeyword(attributes) is { } newConstraint)
+                constraints.Add(newConstraint);
 
-            string? variance = (attributes & GenericParameterAttributes.Covariant) != 0
-                ? "out"
-                : (attributes & GenericParameterAttributes.Contravariant) != 0
-                    ? "in"
-                    : null;
+            string? variance = GenericConstraintKeywords.VarianceKeyword(attributes);
             parameters.Add(new CompileBackTypeParameter(
                 reader.GetString(parameter.Name),
                 constraints,


### PR DESCRIPTION
## Why

RTS (ReturnToSender, the compile-back oracle in `tools/DecompilerHarness`) is
supposed to judge whether the **product** decompiler emits valid, faithful C#.
But it re-implemented the CLI generic-parameter constraint/variance
flag-to-token mapping (`struct`/`class`/`new()`/`in`/`out`) itself — so its
verdict measured the product against **RTS's own** spelling, not the product's.
That is exactly the contamination this de-C#-ification arc removes.

The same mapping was **duplicated a third time**: `MetadataDeclarationQuery`
(simple form) and `ApiSurfaceExtractor` (richer superset with
`class?`/`notnull`/`unmanaged`/`allows ref struct`) each carried their own copy.
RTS being an adversarial consumer flushed out a real product gap: three drifting
implementations of one fact.

## What this enables

One authoritative seam — `ILInspector.Metadata.GenericConstraintKeywords` with
`PrimaryKeyword` / `NewConstraintKeyword` / `VarianceKeyword` /
`AllowsRefStructKeyword`. All three callers now delegate:

- RTS derives constraint tokens from the product seam it judges, so the oracle
  measures the product against the product.
- `MetadataDeclarationQuery` and `ApiSurfaceExtractor` share one source of
  truth; adding a future constraint token (or fixing a spelling) is a one-line
  change in one place instead of three.

These flags are CLI **metadata facts**, so their canonical tokens are
Metadata-owned naming — and Metadata is the only layer every caller reaches
(`CSharp` references `Metadata`, not vice versa). C#-specific aliasing stays in
`CSharp` (already de-C#-ified in #2763).

## Behavior-preserving

Reference- and value-type constraints are mutually exclusive in metadata, so the
two simple callers pass `nullableFlag: 0, isUnmanaged: false` to reproduce their
exact `class`/`struct`/`new()` output byte-for-byte. The `ApiSurfaceExtractor`
richer path keeps its `class?`/`notnull`/`unmanaged`/`allows ref struct`
precedence unchanged (verified by diff and unit tests).

`TypeKindText` is intentionally **left in RTS**: it is a boundary translator over
RTS's internal `CompileBackTypeKind` planning enum, not re-implemented C#
spelling — migrating it would be layering-awkward churn for no correctness gain.

## Evidence

- New unit tests: `GenericConstraintKeywordsTests` (17) — mutual exclusion,
  `class?`/`notnull`/`unmanaged` precedence, variance, `allows ref struct`.
- `ApiSurfaceExtractorTests` 40, RTS oracle Evidence 3 / FixtureCatalog 82 /
  Prototype 114 — all pass.
- Corpus quality-diff card **neutral** on every raise/fidelity metric (0 count
  deltas); the only flagged rows are sampling-cap artifacts (`--compile-cap 25`
  vs baseline 4000), as in prior PRs in this arc.

Adversarial review (two non-Opus reviewers) to follow; PR opened before reviews
finish per policy.
