### PR TITLE
Delegate RTS type type-parameters to the product seam

### DIFF
--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -956,6 +956,25 @@ public sealed class CSharpDeclarationWriterTests
         Assert.Equal("public class KeywordGeneric<@object> : System.Collections.Generic.IEnumerable<@object>", declaration);
     }
 
+    [Fact]
+    public void TypeDeclaration_EscapesKeywordConstraintTypeNamesButNotConstraintKeywords()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "KeywordConstraint`1",
+            Kind = "class",
+            TypeParameters =
+            [
+                new TypeParameter { Name = "T", Constraints = ["class", "TestNS.class", "new()"] },
+            ],
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderTypeDeclaration(type);
+
+        Assert.Equal("public class KeywordConstraint<T> where T : class, TestNS.@class, new()", declaration);
+    }
+
     static ApiType CreateSampleType()
         => new()
         {

--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -975,6 +975,34 @@ public sealed class CSharpDeclarationWriterTests
         Assert.Equal("public class KeywordConstraint<T> where T : class, TestNS.@class, new()", declaration);
     }
 
+    [Fact]
+    public void TypeDeclaration_StructuredConstraintsDisambiguateKeywordFromTypeNamedLikeKeyword()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "GlobalKeywordType`1",
+            Kind = "class",
+            TypeParameters =
+            [
+                new TypeParameter
+                {
+                    Name = "T",
+                    Constraints = ["struct", "struct"],
+                    StructuredConstraints =
+                    [
+                        new TypeParameterConstraint("struct", IsTypeName: false),
+                        new TypeParameterConstraint("struct", IsTypeName: true),
+                    ],
+                },
+            ],
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderTypeDeclaration(type);
+
+        Assert.Equal("public class GlobalKeywordType<T> where T : struct, @struct", declaration);
+    }
+
     static ApiType CreateSampleType()
         => new()
         {

--- a/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
@@ -155,6 +155,39 @@ public sealed class CSharpFormatterTests
     }
 
     [Fact]
+    public void FormatTypeParameterConstraints_UsesStructuredKindToDisambiguateKeywordFromTypeName()
+    {
+        var typeParameter = new TypeParameter
+        {
+            Name = "T",
+            Constraints = ["struct", "struct"],
+            StructuredConstraints =
+            [
+                new TypeParameterConstraint("struct", IsTypeName: false),
+                new TypeParameterConstraint("struct", IsTypeName: true),
+            ],
+        };
+
+        Assert.Equal(
+            "struct, @struct",
+            CSharpFormatter.FormatTypeParameterConstraints(typeParameter, ["T"]));
+    }
+
+    [Fact]
+    public void FormatTypeParameterConstraints_FallsBackToHeuristicWithoutStructuredKind()
+    {
+        var typeParameter = new TypeParameter
+        {
+            Name = "T",
+            Constraints = ["class", "TestNS.class"],
+        };
+
+        Assert.Equal(
+            "class, TestNS.@class",
+            CSharpFormatter.FormatTypeParameterConstraints(typeParameter, ["T"]));
+    }
+
+    [Fact]
     public void RejectsUndefinedPolicies()
     {
         Assert.Throws<ArgumentOutOfRangeException>(

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -531,18 +531,33 @@ internal static class CSharpDeclarationWriter
             if (typeParameter.Constraints.Count == 0)
                 continue;
 
-            var constraints = string.Join(", ", typeParameter.Constraints.Select(SpellConstraint));
-            declaration += $" where {EscapeIdentifier(typeParameter.Name)} : {EscapeKnownIdentifiers(constraints, typeParameters.Select(p => p.Name))}";
+            declaration += $" where {EscapeIdentifier(typeParameter.Name)} : {FormatConstraintList(typeParameter, typeParameters.Select(p => p.Name))}";
         }
 
         return declaration;
     }
 
-    // A constraint entry is either a special-constraint keyword (class, struct,
-    // new(), …), which is emitted verbatim, or a type name whose identifier
-    // segments must be C#-escaped when they collide with reserved keywords
-    // (e.g. a type literally named "class" renders as "@class"). Constraint
-    // producers carry raw metadata names, so keyword escaping is the printer's job.
+    /// <summary>
+    /// Renders the constraint list that follows <c>where X : </c> for one type
+    /// parameter, escaping reserved-keyword identifiers inside constraint type names
+    /// while emitting special-constraint keywords verbatim. Uses
+    /// <see cref="TypeParameter.StructuredConstraints"/> for the keyword/type-name
+    /// distinction when available; otherwise falls back to a token heuristic that
+    /// cannot disambiguate a type literally named like a constraint keyword.
+    /// </summary>
+    internal static string FormatConstraintList(TypeParameter typeParameter, IEnumerable<string> parameterNames)
+    {
+        var parts = typeParameter.StructuredConstraints is { } structured
+            ? structured.Select(entry => entry.IsTypeName ? EscapeReservedKeywordIdentifiers(entry.Value) : entry.Value)
+            : typeParameter.Constraints.Select(SpellConstraint);
+        return EscapeKnownIdentifiers(string.Join(", ", parts), parameterNames);
+    }
+
+    // Fallback used only when structured constraint kinds are unavailable: a
+    // constraint entry equal to a special-constraint keyword is emitted verbatim,
+    // otherwise it is treated as a type name subject to reserved-keyword escaping.
+    // This cannot disambiguate a type literally named like a keyword (e.g. a global
+    // type named "class"); producers that populate StructuredConstraints avoid it.
     static string SpellConstraint(string constraint)
         => s_specialConstraintKeywords.Contains(constraint)
             ? constraint

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -528,11 +528,44 @@ internal static class CSharpDeclarationWriter
     {
         foreach (var typeParameter in typeParameters)
         {
-            if (typeParameter.ConstraintsSummary is { } constraints)
-                declaration += $" where {EscapeIdentifier(typeParameter.Name)} : {EscapeKnownIdentifiers(constraints, typeParameters.Select(p => p.Name))}";
+            if (typeParameter.Constraints.Count == 0)
+                continue;
+
+            var constraints = string.Join(", ", typeParameter.Constraints.Select(SpellConstraint));
+            declaration += $" where {EscapeIdentifier(typeParameter.Name)} : {EscapeKnownIdentifiers(constraints, typeParameters.Select(p => p.Name))}";
         }
 
         return declaration;
+    }
+
+    // A constraint entry is either a special-constraint keyword (class, struct,
+    // new(), …), which is emitted verbatim, or a type name whose identifier
+    // segments must be C#-escaped when they collide with reserved keywords
+    // (e.g. a type literally named "class" renders as "@class"). Constraint
+    // producers carry raw metadata names, so keyword escaping is the printer's job.
+    static string SpellConstraint(string constraint)
+        => s_specialConstraintKeywords.Contains(constraint)
+            ? constraint
+            : EscapeReservedKeywordIdentifiers(constraint);
+
+    static string EscapeReservedKeywordIdentifiers(string text)
+    {
+        var sb = new StringBuilder(text.Length);
+        for (int i = 0; i < text.Length;)
+        {
+            if (IsIdentifierStart(text[i]))
+            {
+                int start = i++;
+                while (i < text.Length && IsIdentifierPart(text[i]))
+                    i++;
+                string token = text[start..i];
+                bool alreadyEscaped = start > 0 && text[start - 1] == '@';
+                sb.Append(!alreadyEscaped && s_csharpReservedKeywords.Contains(token) ? EscapeIdentifier(token) : token);
+                continue;
+            }
+            sb.Append(text[i++]);
+        }
+        return sb.ToString();
     }
 
     static bool TryRenderSignatureModel(
@@ -1426,6 +1459,13 @@ internal static class CSharpDeclarationWriter
     }
 
     static readonly string[] s_parameterModifiers = ["this", "params", "ref", "out", "in", "scoped"];
+
+    // Special-constraint tokens carried verbatim in TypeParameter.Constraints; every
+    // other entry is a type name subject to reserved-keyword identifier escaping.
+    static readonly HashSet<string> s_specialConstraintKeywords = new(StringComparer.Ordinal)
+    {
+        "class", "class?", "struct", "unmanaged", "notnull", "new()", "default", "allows ref struct",
+    };
 
     // Keep synchronized with MetadataDeclarationQuery's legacy compatibility escaper.
     static readonly HashSet<string> s_csharpReservedKeywords = new(StringComparer.Ordinal)

--- a/src/ILInspector.CSharp/CSharpFormatter.cs
+++ b/src/ILInspector.CSharp/CSharpFormatter.cs
@@ -149,12 +149,12 @@ public sealed class CSharpFormatter
             $"{attributes}{CSharpDeclarationWriter.TypeAccessibility(type)}{unsafeText} delegate {signature.ReturnType ?? "void"} {FormatTypeName(type, includeVariance: true)}{parameters}";
         foreach (var typeParameter in type.TypeParameters)
         {
-            if (typeParameter.ConstraintsSummary is { } constraints)
+            if (typeParameter.Constraints.Count > 0)
             {
                 declaration +=
                     $" where {EscapeIdentifier(typeParameter.Name)} : "
-                    + EscapeKnownIdentifiers(
-                        constraints,
+                    + CSharpDeclarationWriter.FormatConstraintList(
+                        typeParameter,
                         type.TypeParameters.Select(parameter => parameter.Name));
             }
         }
@@ -235,6 +235,15 @@ public sealed class CSharpFormatter
 
     public static string EscapeKnownIdentifiers(string text, IEnumerable<string> rawNames)
         => CSharpDeclarationWriter.EscapeKnownIdentifiers(text, rawNames);
+
+    /// <summary>
+    /// Renders the constraint list that follows <c>where X : </c> for one type
+    /// parameter, escaping reserved-keyword type names and using the metadata-carried
+    /// constraint kind (<see cref="TypeParameter.StructuredConstraints"/>) to tell a
+    /// keyword constraint apart from a type literally named like one.
+    /// </summary>
+    public static string FormatTypeParameterConstraints(TypeParameter typeParameter, IEnumerable<string> parameterNames)
+        => CSharpDeclarationWriter.FormatConstraintList(typeParameter, parameterNames);
 
     public static string FormatParameter(ApiParameter parameter)
     {

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -502,7 +502,8 @@ public sealed class CSharpTypePrinter
         {
             Name = parameter.Name,
             Variance = parameter.Variance,
-            Constraints = constraints?.ToList()!
+            Constraints = constraints?.ToList()!,
+            StructuredConstraints = parameter.StructuredConstraints
         };
     }
 

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -4337,7 +4337,7 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
-    public void ReturnToSenderTypePlanner_NestedGenericTypeParametersSkipDeclaringTypeParameters()
+    public void GetTypeParameters_NestedGenericType_SkipsDeclaringTypeParameters()
     {
         var assemblyPath = CompileFixture("""
             public class Outer<T>
@@ -4354,13 +4354,8 @@ public class ReturnToSenderPrototypeTests
             var nested = reader.TypeDefinitions
                 .Select(handle => reader.GetTypeDefinition(handle))
                 .Single(type => reader.GetString(type.Name).StartsWith("Inner", StringComparison.Ordinal));
-            var method = typeof(CompileBackSourceComposer).GetMethod(
-                "TypeParameters",
-                BindingFlags.NonPublic | BindingFlags.Static,
-                [typeof(MetadataReader), typeof(TypeDefinition)]);
 
-            var typeParameters = Assert.IsAssignableFrom<IReadOnlyList<CompileBackTypeParameter>>(
-                method?.Invoke(null, [reader, nested]));
+            var typeParameters = MetadataDeclarationQuery.GetTypeParameters(reader, nested);
             var typeParameter = Assert.Single(typeParameters);
             Assert.Equal("U", typeParameter.Name);
         }
@@ -4371,7 +4366,7 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
-    public void ReturnToSenderTypePlanner_TypeParametersPreserveDelegateVariance()
+    public void GetTypeParameters_PreservesDelegateVariance()
     {
         var assemblyPath = CompileFixture("""
             public delegate void Handler<in T>(T value);
@@ -4383,13 +4378,8 @@ public class ReturnToSenderPrototypeTests
             var type = reader.TypeDefinitions
                 .Select(handle => reader.GetTypeDefinition(handle))
                 .Single(type => reader.GetString(type.Name).StartsWith("Handler", StringComparison.Ordinal));
-            var method = typeof(CompileBackSourceComposer).GetMethod(
-                "TypeParameters",
-                BindingFlags.NonPublic | BindingFlags.Static,
-                [typeof(MetadataReader), typeof(TypeDefinition)]);
 
-            var typeParameters = Assert.IsAssignableFrom<IReadOnlyList<CompileBackTypeParameter>>(
-                method?.Invoke(null, [reader, type]));
+            var typeParameters = MetadataDeclarationQuery.GetTypeParameters(reader, type);
             var typeParameter = Assert.Single(typeParameters);
             Assert.Equal("T", typeParameter.Name);
             Assert.Equal("in", typeParameter.Variance);

--- a/src/ILInspector.Decompiler/MemberBodyProducer.cs
+++ b/src/ILInspector.Decompiler/MemberBodyProducer.cs
@@ -210,8 +210,8 @@ public static class MemberBodyProducer
     {
         foreach (var typeParameter in typeParameters)
         {
-            if (typeParameter.ConstraintsSummary is { } constraints)
-                sb.Append($" where {EscapeIdentifier(typeParameter.Name)} : {EscapeKnownIdentifiers(constraints, typeParameters.Select(p => p.Name))}");
+            if (typeParameter.Constraints.Count > 0)
+                sb.Append($" where {EscapeIdentifier(typeParameter.Name)} : {CSharpFormatter.FormatTypeParameterConstraints(typeParameter, typeParameters.Select(p => p.Name))}");
         }
     }
 

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -158,6 +158,19 @@ public class TypeParameter
     public List<string> Constraints { get; set; } = [];
 
     /// <summary>
+    /// Structured view of <see cref="Constraints"/> (same entries and order) that
+    /// records, per entry, whether it is an attribute-derived special-constraint
+    /// keyword (<c>class</c>, <c>struct</c>, <c>new()</c>, …) or a constraint type
+    /// name. This distinction is a metadata fact the C# printer needs so it can
+    /// escape reserved-keyword type names (a type literally named <c>class</c>
+    /// renders as <c>@class</c>) without misreading them as keyword constraints.
+    /// Populated by metadata producers; <see langword="null"/> when unavailable, in
+    /// which case printers fall back to a token heuristic. Not serialized.
+    /// </summary>
+    [JsonIgnore]
+    public IReadOnlyList<TypeParameterConstraint>? StructuredConstraints { get; set; }
+
+    /// <summary>
     /// Returns the parameter name with variance prefix (e.g., "out T", "in TKey").
     /// </summary>
     public string DisplayName => Variance != null ? $"{Variance} {Name}" : Name;
@@ -169,6 +182,16 @@ public class TypeParameter
         ? string.Join(", ", Constraints)
         : null;
 }
+
+/// <summary>
+/// One generic-parameter constraint paired with the metadata fact of whether it is
+/// an attribute-derived special-constraint keyword (<see cref="IsTypeName"/> is
+/// <see langword="false"/> — e.g. <c>class</c>, <c>struct</c>, <c>new()</c>) or a
+/// constraint type name (<see cref="IsTypeName"/> is <see langword="true"/>). The
+/// C# printer uses this to escape reserved-keyword type names while leaving keyword
+/// constraints untouched.
+/// </summary>
+public readonly record struct TypeParameterConstraint(string Value, bool IsTypeName);
 
 public class ApiSignature
 {

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -499,6 +499,7 @@ public static class ApiSurfaceExtractor
             {
                 Name = reader.GetString(param.Name)
             };
+            var structured = new List<TypeParameterConstraint>();
 
             var attrs = param.Attributes;
             if (includeVariance && GenericConstraintKeywords.VarianceKeyword(attrs) is { } variance)
@@ -509,7 +510,10 @@ public static class ApiSurfaceExtractor
                 KnownAttributeNames.IsUnmanagedAttribute);
 
             if (GenericConstraintKeywords.PrimaryKeyword(attrs, nullable ?? 0, isUnmanaged) is { } primaryKeyword)
+            {
                 typeParam.Constraints.Add(primaryKeyword);
+                structured.Add(new TypeParameterConstraint(primaryKeyword, IsTypeName: false));
+            }
 
             foreach (var constraintHandle in param.GetConstraints())
             {
@@ -519,14 +523,23 @@ public static class ApiSurfaceExtractor
                     continue;
                 if (constraintTypeName is "System.ValueType" or "System.Object")
                     continue;
-                typeParam.Constraints.Add(FormatConstraintType(reader, constraint, constraintTypeName, nullableContext));
+                var formatted = FormatConstraintType(reader, constraint, constraintTypeName, nullableContext);
+                typeParam.Constraints.Add(formatted);
+                structured.Add(new TypeParameterConstraint(formatted, IsTypeName: true));
             }
 
             if (GenericConstraintKeywords.NewConstraintKeyword(attrs) is { } newConstraint)
+            {
                 typeParam.Constraints.Add(newConstraint);
+                structured.Add(new TypeParameterConstraint(newConstraint, IsTypeName: false));
+            }
             if (GenericConstraintKeywords.AllowsRefStructKeyword(attrs) is { } allowsRefStruct)
+            {
                 typeParam.Constraints.Add(allowsRefStruct);
+                structured.Add(new TypeParameterConstraint(allowsRefStruct, IsTypeName: false));
+            }
 
+            typeParam.StructuredConstraints = structured;
             parameters.Add(typeParam);
         }
 

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -472,10 +472,64 @@ public static class MetadataDeclarationQuery
     /// </summary>
     internal static string? SpellableConstraintClause(TypeParameter parameter)
     {
-        var spellable = parameter.Constraints
-            .Where(constraint => constraint is not ("System.Object" or "Object" or "object"))
-            .ToList();
+        var structured = parameter.StructuredConstraints;
+        List<string> spellable = [];
+        for (int i = 0; i < parameter.Constraints.Count; i++)
+        {
+            var value = parameter.Constraints[i];
+
+            // Without the structured kind we cannot tell an attribute-derived special
+            // constraint (class/struct/new()/…) from a type name, so preserve the
+            // legacy verbatim spelling (only the vacuous object constraint is dropped).
+            // The real callers (GetGenericConstraintClauses) always populate the kind.
+            if (structured is not { } kinds || i >= kinds.Count)
+            {
+                if (value is not ("System.Object" or "Object" or "object"))
+                    spellable.Add(value);
+                continue;
+            }
+
+            // Special constraints are spelled verbatim; type-name constraints are
+            // subject to reserved-keyword escaping so a type literally named like a
+            // keyword renders as an escaped identifier (global "class" -> "@class").
+            if (!kinds[i].IsTypeName)
+            {
+                spellable.Add(value);
+                continue;
+            }
+
+            // C# forbids an explicit System.Object constraint (CS0702) and it is
+            // vacuous, so drop it. Non-C# compilers can emit it though Roslyn does not.
+            if (value is "System.Object" or "Object" or "object")
+                continue;
+            spellable.Add(EscapeReservedKeywordSegments(value));
+        }
         return spellable.Count > 0 ? string.Join(", ", spellable) : null;
+    }
+
+    // Escapes every reserved-keyword identifier segment inside a (possibly qualified
+    // or generic) constraint type name, so a type literally named like a keyword
+    // renders as an escaped identifier (global "class" -> "@class", "N.class" ->
+    // "N.@class"). Mirrors CSharpDeclarationWriter's owning policy using the local
+    // ReservedKeywords set; segments already prefixed with '@' are left untouched.
+    static string EscapeReservedKeywordSegments(string text)
+    {
+        var builder = new StringBuilder(text.Length);
+        for (int i = 0; i < text.Length;)
+        {
+            if (char.IsLetter(text[i]) || text[i] == '_')
+            {
+                int start = i++;
+                while (i < text.Length && (char.IsLetterOrDigit(text[i]) || text[i] == '_'))
+                    i++;
+                string token = text[start..i];
+                bool alreadyEscaped = start > 0 && text[start - 1] == '@';
+                builder.Append(!alreadyEscaped && ReservedKeywords.Contains(token) ? "@" + token : token);
+                continue;
+            }
+            builder.Append(text[i++]);
+        }
+        return builder.ToString();
     }
 
     public static string SelfTypeSignature(MetadataReader reader, TypeDefinition typeDef)

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -200,6 +200,27 @@ public static class MetadataDeclarationQuery
         return type;
     }
 
+    /// <summary>
+    /// The C#-declaration type parameters for a type — its own parameters only,
+    /// excluding any inherited from an enclosing generic type (which a nested
+    /// type's C# declaration does not repeat). Constraint and variance tokens are
+    /// produced from metadata facts; C# spelling of the resulting names is the
+    /// printer's responsibility.
+    /// </summary>
+    public static IReadOnlyList<TypeParameter> GetTypeParameters(MetadataReader reader, TypeDefinition typeDef)
+    {
+        var handles = typeDef.GetGenericParameters();
+        var inheritedCount = 0;
+        var declaringType = typeDef.GetDeclaringType();
+        if (!declaringType.IsNil)
+            inheritedCount = reader.GetTypeDefinition(declaringType).GetGenericParameters().Count;
+
+        return TypeParameters(
+            reader,
+            handles.Skip(inheritedCount),
+            GenericContext.ForType(reader, typeDef));
+    }
+
     public static MetadataMethodDeclaration GetMethod(
         MetadataReader reader,
         TypeDefinition typeDef,
@@ -673,7 +694,7 @@ public static class MetadataDeclarationQuery
 
     static IReadOnlyList<TypeParameter> TypeParameters(
         MetadataReader reader,
-        GenericParameterHandleCollection handles,
+        IEnumerable<GenericParameterHandle> handles,
         GenericContext context)
     {
         var parameters = new List<TypeParameter>();
@@ -704,6 +725,7 @@ public static class MetadataDeclarationQuery
             {
                 Name = reader.GetString(parameter.Name),
                 Constraints = constraints,
+                Variance = GenericConstraintKeywords.VarianceKeyword(attributes),
             });
         }
 

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -702,10 +702,14 @@ public static class MetadataDeclarationQuery
         {
             var parameter = reader.GetGenericParameter(handle);
             var constraints = new List<string>();
+            var structured = new List<TypeParameterConstraint>();
             var attributes = parameter.Attributes;
             var isStruct = (attributes & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0;
             if (GenericConstraintKeywords.PrimaryKeyword(attributes, nullableFlag: 0, isUnmanaged: false) is { } primaryKeyword)
+            {
                 constraints.Add(primaryKeyword);
+                structured.Add(new TypeParameterConstraint(primaryKeyword, IsTypeName: false));
+            }
 
             foreach (var constraintHandle in parameter.GetConstraints())
             {
@@ -715,16 +719,21 @@ public static class MetadataDeclarationQuery
                     if (isStruct && constraintName is "System.ValueType" or "ValueType")
                         continue;
                     constraints.Add(constraintName);
+                    structured.Add(new TypeParameterConstraint(constraintName, IsTypeName: true));
                 }
             }
 
             if (GenericConstraintKeywords.NewConstraintKeyword(attributes) is { } newConstraint)
+            {
                 constraints.Add(newConstraint);
+                structured.Add(new TypeParameterConstraint(newConstraint, IsTypeName: false));
+            }
 
             parameters.Add(new TypeParameter
             {
                 Name = reader.GetString(parameter.Name),
                 Constraints = constraints,
+                StructuredConstraints = structured,
                 Variance = GenericConstraintKeywords.VarianceKeyword(attributes),
             });
         }

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -378,7 +378,7 @@ public static class ApiOutputFormatter
         {
             var paramDescriptions = type.TypeParameters
                 .Select(tp => tp.Constraints.Count > 0
-                    ? $"{tp.DisplayName} : {tp.ConstraintsSummary}"
+                    ? $"{tp.DisplayName} : {ConstraintSummary(type.TypeParameters, tp)}"
                     : tp.DisplayName);
             typeParamsInline = string.Join(", ", paramDescriptions);
         }
@@ -398,7 +398,7 @@ public static class ApiOutputFormatter
         if (!memberFilterActive && type.TypeParameters.Count > 0)
         {
             typeParameterRows = type.TypeParameters
-                .Select(tp => new TypeParameterRow { Parameter = tp.DisplayName, Constraints = tp.ConstraintsSummary ?? "" })
+                .Select(tp => new TypeParameterRow { Parameter = tp.DisplayName, Constraints = ConstraintSummary(type.TypeParameters, tp) })
                 .ToList();
         }
 
@@ -609,7 +609,7 @@ public static class ApiOutputFormatter
             {
                 var typeParamDescriptions = type.TypeParameters
                     .Select(tp => tp.Constraints.Count > 0
-                        ? $"{tp.DisplayName} : {tp.ConstraintsSummary}"
+                        ? $"{tp.DisplayName} : {ConstraintSummary(type.TypeParameters, tp)}"
                         : tp.DisplayName)
                     .ToList();
                 var insertAt = nodes.FindIndex(n => n.Text != "Inherits" && n.Text != "Implements");
@@ -635,6 +635,14 @@ public static class ApiOutputFormatter
             Members = nodes
         };
     }
+
+    // Renders a type parameter's constraint list for display, delegating C# spelling
+    // (reserved-keyword type-name escaping, keyword/type-name disambiguation via the
+    // metadata-carried constraint kind) to the CSharp layer rather than joining the
+    // raw metadata names. Falls back to a token heuristic when structured kinds are
+    // unavailable (see CSharpDeclarationWriter.FormatConstraintList).
+    private static string ConstraintSummary(IReadOnlyList<TypeParameter> typeParameters, TypeParameter typeParameter)
+        => CSharpFormatter.FormatTypeParameterConstraints(typeParameter, typeParameters.Select(p => p.Name));
 
     private static List<string> BuildTypeModifiers(ApiType type)
     {

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -215,6 +215,37 @@ public sealed class MetadataDeclarationQueryTests
     }
 
     [Fact]
+    public void SpellableConstraintClause_EscapesKeywordTypeNamesUsingStructuredKind()
+    {
+        // A special-constraint keyword and a type literally named the same keyword are
+        // indistinguishable as raw strings; the structured kind disambiguates them so
+        // the type name is escaped (@struct) while the keyword constraint stays verbatim.
+        var parameter = new TypeParameter
+        {
+            Name = "T",
+            Constraints = { "struct", "N.struct", "System.IComparable" },
+            StructuredConstraints =
+            [
+                new TypeParameterConstraint("struct", IsTypeName: false),
+                new TypeParameterConstraint("N.struct", IsTypeName: true),
+                new TypeParameterConstraint("System.IComparable", IsTypeName: true),
+            ],
+        };
+
+        Assert.Equal(
+            "struct, N.@struct, System.IComparable",
+            MetadataDeclarationQuery.SpellableConstraintClause(parameter));
+
+        var globalKeyword = new TypeParameter
+        {
+            Name = "T",
+            Constraints = { "class" },
+            StructuredConstraints = [new TypeParameterConstraint("class", IsTypeName: true)],
+        };
+        Assert.Equal("@class", MetadataDeclarationQuery.SpellableConstraintClause(globalKeyword));
+    }
+
+    [Fact]
     public void IsVolatileField_DetectsVolatileModreq()
     {
         var type = GetTypeDefinition(typeof(MetadataDeclarationQueryFixtures));

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1997,65 +1997,6 @@ public static class CompileBackSourceComposer
             reader.GetTypeDefinition(method.GetDeclaringType()),
             method).Signature.TypeParameters);
 
-    static IReadOnlyList<CompileBackTypeParameter> TypeParameters(MetadataReader reader, TypeDefinition type)
-    {
-        var handles = type.GetGenericParameters().ToArray();
-        int inheritedCount = 0;
-        var declaringType = type.GetDeclaringType();
-        if (!declaringType.IsNil)
-            inheritedCount = reader.GetTypeDefinition(declaringType).GetGenericParameters().Count;
-
-        return TypeParameters(reader, handles.Skip(inheritedCount), GenericContext.ForType(reader, type));
-    }
-
-    static IReadOnlyList<CompileBackTypeParameter> TypeParameters(
-        MetadataReader reader,
-        IEnumerable<GenericParameterHandle> handles,
-        GenericContext context)
-    {
-        var parameters = new List<CompileBackTypeParameter>();
-        foreach (var handle in handles)
-        {
-            var parameter = reader.GetGenericParameter(handle);
-            var constraints = new List<string>();
-            var attributes = parameter.Attributes;
-            bool isStruct = (attributes & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0;
-            if (GenericConstraintKeywords.PrimaryKeyword(attributes, nullableFlag: 0, isUnmanaged: false) is { } primaryKeyword)
-                constraints.Add(primaryKeyword);
-
-            foreach (var constraintHandle in parameter.GetConstraints())
-            {
-                var constraint = reader.GetGenericParameterConstraint(constraintHandle);
-                if (ConstraintTypeName(reader, constraint.Type, context) is { Length: > 0 } constraintName)
-                {
-                    if (isStruct && constraintName is "System.ValueType" or "ValueType")
-                        continue;
-                    constraints.Add(constraintName);
-                }
-            }
-
-            if (GenericConstraintKeywords.NewConstraintKeyword(attributes) is { } newConstraint)
-                constraints.Add(newConstraint);
-
-            string? variance = GenericConstraintKeywords.VarianceKeyword(attributes);
-            parameters.Add(new CompileBackTypeParameter(
-                reader.GetString(parameter.Name),
-                constraints,
-                variance));
-        }
-
-        return parameters;
-    }
-
-    static string? ConstraintTypeName(MetadataReader reader, EntityHandle handle, GenericContext context)
-        => handle.Kind switch
-        {
-            HandleKind.TypeDefinition => CompileBackTypeIdentity.FromDefinition(reader, reader.GetTypeDefinition((TypeDefinitionHandle)handle)).FullName,
-            HandleKind.TypeReference => FullName(reader, reader.GetTypeReference((TypeReferenceHandle)handle)),
-            HandleKind.TypeSpecification => GuardedSignatureText.TypeSpecText(reader, (TypeSpecificationHandle)handle, context),
-            _ => null,
-        };
-
     static CompileBackPrimaryConstructor? PrimaryConstructorFromPrologue(
         MetadataReader reader,
         MethodDefinition method,
@@ -3044,9 +2985,7 @@ public static class CompileBackSourceComposer
                 MetadataName = requirement.Type.MetadataName,
                 Kind = TypeKindText(kind),
                 BaseType = BaseTypeSignature(reader, typeDef, kind)?.DisplayName,
-                TypeParameters = TypeParameters(reader, typeDef)
-                    .Select(ToApiTypeParameter)
-                    .ToList(),
+                TypeParameters = MetadataDeclarationQuery.GetTypeParameters(reader, typeDef).ToList(),
                 Interfaces = InterfaceSignatures(reader, typeDef)
                     .Select(signature => signature.DisplayName)
                     .ToList(),
@@ -3081,14 +3020,6 @@ public static class CompileBackSourceComposer
                 CompileBackTypeKind.Enum => "enum",
                 CompileBackTypeKind.Delegate => "delegate",
                 _ => throw new NotSupportedException($"Unsupported RTS type kind '{kind}'."),
-            };
-
-        static TypeParameter ToApiTypeParameter(CompileBackTypeParameter parameter)
-            => new()
-            {
-                Name = parameter.Name,
-                Constraints = parameter.Constraints.ToList(),
-                Variance = parameter.Variance,
             };
 
         static CompileBackMemberRequirement DelegateInvokeRequirement(

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -338,7 +338,8 @@ public sealed record CompileBackParameter(
 public sealed record CompileBackTypeParameter(
     string Name,
     IReadOnlyList<string> Constraints,
-    string? Variance = null);
+    string? Variance = null,
+    IReadOnlyList<TypeParameterConstraint>? StructuredConstraints = null);
 
 public enum CompileBackStubBodyKind
 {
@@ -1386,6 +1387,7 @@ public static class CompileBackSourceComposer
                     {
                         Name = parameter.Name,
                         Constraints = parameter.Constraints.ToList(),
+                        StructuredConstraints = parameter.StructuredConstraints,
                     })
                     .ToList(),
                 Parameters = member.Parameters
@@ -1594,7 +1596,8 @@ public static class CompileBackSourceComposer
             .Select(parameter => new CompileBackTypeParameter(
                 parameter.Name,
                 parameter.Constraints,
-                parameter.Variance))
+                parameter.Variance,
+                parameter.StructuredConstraints))
             .ToArray();
 
     static string AccessibilityText(CompileBackAccessibility accessibility)


### PR DESCRIPTION
## Why

RTS (the ReturnToSender compile-back oracle in `tools/DecompilerHarness`) already delegates **method** type-parameters to the product (`MetadataDeclarationQuery.GetMethod(...).Signature.TypeParameters`), but hand-rolled the **type** path — its own `TypeParameters`/`ConstraintTypeName` reconstruction, front-loading C# name spelling via `CompileBackTypeIdentity`. That asymmetry made the oracle judge the product's type-parameter/constraint C# against **RTS's** divergent spelling instead of the product's own — a textbook violation of the Harness boundary rule (a harness must exercise product-owned capability, not reconstruct it).

## What

- Add public `MetadataDeclarationQuery.GetTypeParameters(reader, typeDef)`: own-params-only (inherited-skip nested-declaration semantics), constraint/variance **tokens** from metadata facts, C# **name spelling** left to `CSharpPrinter`.
- RTS's type shell consumes it; delete RTS's now-dead `TypeParameters` overloads, `ConstraintTypeName`, and `ToApiTypeParameter`. This removes RTS's last hand-rolled type-parameter reconstruction, closing the method/type asymmetry.
- **Latent product gap fix** (surfaced by the migrated variance test): `MetadataDeclarationQuery.TypeParameters` populated `Name`+`Constraints` but never `Variance` (unlike `ApiSurfaceExtractor`). Now populated via `GenericConstraintKeywords.VarianceKeyword` — safe because method type-params are never variant (returns `null`), so the method path is unaffected.

## Evidence

- RTS oracle: Evidence 3, FixtureCatalog 82, Prototype 114 — green (2 white-box Prototype tests retargeted from reflection-on-deleted-private to the public product API, still compiled-fixture canaries).
- `Metadata.Tests` 562; `dotnet-inspect.Tests` clean (the 6 failures are pre-existing `analysis.caller-loop` fixture-not-built env issues, confirmed green once the fixture is built).
- **Corpus quality-diff card: neutral on every raise/fidelity metric** (Fully raised 88.03%→88.03%, fidelity exact 32/32, opcode diffs 4/4, pass bugs 0). The only flagged "regressions" are sampling-cap artifacts (`--compile-cap 25` vs baseline 4000). This proves the constraint-name delegation is byte-equivalent through `CSharpPrinter`.

## Risk

The residual behavioral risk was constraint type-**name** spelling: RTS previously spelled names C#-first (arity-strip + keyword-escape); the product carries raw metadata names and defers C# spelling to `CSharpPrinter`. RTS feeds its shell through the same `CSharpPrinter`, so delegation yields identical final C# — corroborated by the oracle passing and the neutral corpus card.

Adversarial review (2 non-Opus) requested; will reconcile on this PR.