### PR TITLE
Add experimental contextual Repl exploration pilot

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.21" />
     <PackageVersion Include="NuGet.Versioning" Version="7.3.0" />
     <PackageVersion Include="NuGetFetch" Version="0.6.2" />
+    <PackageVersion Include="Repl.Core" Version="0.12.0-dev.3" />
     <PackageVersion Include="ShellComplete" Version="0.1.0" />
     <PackageVersion Include="SourceLinkFetch" Version="0.1.0" />
     <PackageVersion Include="System.CommandLine" Version="3.0.0-preview.5.26302.115" />

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ context for copied DLLs. A future `--deps` source can represent runtime
 | Source mapping | `type`/`library`/`package -S "Source Files"`, `member -S "Source Locations"` / `"Original Source"` | SourceLink URLs, member file/line locations, source fetching, URL verification, token+IL-offset to source-line resolution. |
 | Performance analysis *(experimental)* | `library`/`type`/`member -S "Top Leverage"`, `"Performance Triage"`, `"Call Graph"`, `"Caller Graph"` | Whole-assembly call-graph leverage ranking — direct callers, root reach, fanout, depth, loop calls — with opt-in per-node cost signals (alloc, copy, unsafe, reflection, throw/exception, catch/finally) and actionable rewrite-shape detection. |
 | Decompiler *(experimental)* | `member -S @Source` (`Decompiled Source`, `Annotated Source`, `Original Source`, `Source Diff`, `IL`); `member -S "Fidelity Causes"` | Raises method bodies to C#, interleaves IL and hidden-fact annotations, diffs SourceLink-backed source against decompiled source, and exposes typed `DEC####` fidelity causes rather than emitting plausible-but-wrong source. |
+| Contextual exploration *(experimental)* | `repl` | Interactive package → type → member drill-down that delegates to the existing CLI operations and output pipeline. |
 | Agent-friendly output | global flags | Markdown by default, compact `--table`, normalized `--tsv`, `--jsonl`, `--plaintext`, `--json`, Mermaid diagrams, section/field projection, `--count`, table row limiting, built-in head/tail limiting. |
 
 ## Command inventory
@@ -132,6 +133,7 @@ context for copied DLLs. A future `--deps` source can represent runtime
 | `implements X` | Find concrete implementors or subclasses. |
 | `depends X` | Walk type, package, or library dependency graphs; emits Mermaid diagrams. |
 | `cache` | Inspect or clear dotnet-inspect caches. |
+| `repl` *(experimental)* | Explore one package contextually through its types, members, and decompiled source. |
 | `skill` | Print the base LLM skill; routes to focused skills (`skill list`, `skill source`, `skill performance`). |
 
 Single-type `type X` output is tree-shaped by default. Use `-v:n` or `-v:d`
@@ -177,6 +179,38 @@ configuration switches such as `FeatureSwitchDefinitionAttribute` and
 
 These features are under active development. Their output shapes, section
 names, and signal sets may change between releases.
+
+### Contextual Repl
+
+`dotnet-inspect repl` starts an opt-in interactive pilot built on
+`Repl.Core 0.12.0-dev.3`. It does not replace or change the existing command
+contracts. Each contextual action is translated back into the current
+`package`, `type`, or `member` command graph, so selectors, overload indexes,
+sections, diagnostics, and rendering remain those of the regular CLI.
+
+```text
+$ dotnet-inspect repl
+> package System.Text.Json
+[selected-package]> type System.Text.Json.JsonSerializer
+[selected-package/selected-type]> member Serialize
+[selected-package/selected-type/selected-member]> source 1
+[selected-package/selected-type/selected-member]> back
+[selected-package/selected-type]> back
+[selected-package]>
+```
+
+Use `help` at any prompt and `exit` to end the session. The focused pilot
+supports package `show`, `libraries`, and `types`; type `show` and `members`;
+and member `show` and `source [overload]`. The root token `repl` is reserved for
+this mode; inspect a package literally named `repl` with
+`dotnet-inspect package repl`. See [the interactive workflow](docs/workflows/getting-started/interactive-repl.md)
+for the exact mappings and current limitations.
+
+The working pilot is included in untrimmed managed builds, including the `any`
+tool package. `Repl.Core 0.12.0-dev.3` is not trim-clean, so trimmed and
+RID-specific NativeAOT publishes exclude it and compile a `repl` stub that exits
+with code `1` and a clear managed-build diagnostic. This preserves the existing
+AOT packaging lane without suppressing linker warnings.
 
 ### Performance analysis
 

--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -136,3 +136,34 @@ limitations under the License.
 Used in:
 - src/DotnetInspector.Packages/EncryptionUtility.cs
   DPAPI decryption forked from NuGet.Configuration/Utility/EncryptionUtility.cs
+
+License notice for Repl.Core
+----------------------------
+
+https://github.com/yllibed/repl/tree/d912bcbfd236a62cf696346674d761ac00fc3b96
+
+MIT License
+
+Copyright (c) 2026 Yllibed project / Carl de Billy, All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Used in:
+- src/dotnet-inspect/Commands/ReplCommand.cs
+  Experimental contextual package, type, and member navigation.

--- a/docs/workflows/getting-started/README.md
+++ b/docs/workflows/getting-started/README.md
@@ -1,11 +1,12 @@
 # Getting Started
 
-> Read these first. These three docs tell the complete story of how the tool works.
+> Read these first. These guides tell the complete story of how the tool works.
 
 | Doc | What you'll learn |
 | ----- | ------------------- |
 | [bare-name-routing](bare-name-routing.md) | How names resolve — platform vs NuGet, bare names vs explicit commands |
 | [type-and-member-addressability](type-and-member-addressability.md) | Progressive drill-down: package → type → member |
 | [verbosity-and-tips](verbosity-and-tips.md) | Output control (`-v:q/m/d`, `-S`, `--count`, tips) that applies to every command |
+| [interactive-repl](interactive-repl.md) *(experimental)* | Contextual package → type → member exploration without changing the regular CLI |
 
-After these three, you'll understand the mental model for every other workflow.
+After these guides, you'll understand the mental model for every other workflow.

--- a/docs/workflows/getting-started/interactive-repl.md
+++ b/docs/workflows/getting-started/interactive-repl.md
@@ -1,0 +1,102 @@
+---
+id: interactive-repl
+description: Explore a package contextually through types, members, and source
+commands: [repl, package, type, member]
+areas: [interactive, navigation, experimental]
+---
+
+# Contextual interactive inspection (experimental)
+
+The `repl` command is an opt-in pilot. It leaves every existing CLI command and
+output contract intact, while providing a stateful package → type → member
+navigation layer using `Repl.Core 0.12.0-dev.3`.
+
+The pilot deliberately delegates each action through the existing
+`System.CommandLine` graph. This compatibility bridge avoids duplicating the
+large command orchestration and preserves current parsing, diagnostics,
+overload indexes, sections, and rendering. A future production implementation
+can extract structured operations from the command layer after the interaction
+model has been validated.
+
+## 1. Drill from a package into decompiled member source
+
+> Goal: Browse a real NuGet package without repeatedly spelling its package and
+> type context.
+
+```prompt
+Open System.Text.Json interactively, inspect JsonSerializer.Serialize, and show
+the first overload's decompiled source.
+```
+
+```bash
+dotnet-inspect repl
+```
+
+```usage
+> package System.Text.Json
+[selected-package]> libraries
+[selected-package]> types
+[selected-package]> type System.Text.Json.JsonSerializer
+[selected-package/selected-type]> members
+[selected-package/selected-type]> member Serialize
+[selected-package/selected-type/selected-member]> source 1
+[selected-package/selected-type/selected-member]> back
+[selected-package/selected-type]> back
+[selected-package]> exit
+```
+
+```expect
+System.Text.Json.JsonSerializer
+Serialize
+## Decompiled Source
+```
+
+Selecting a package, type, or member immediately executes its default `show`
+operation. The selected value is stored only after exit code `0`; a failed
+operation leaves the session at its previous prompt and can be retried. Prompts
+show the selected levels, while the delegated output shows the actual values.
+
+## 2. Supported contextual commands
+
+| Prompt | Command delegated to the regular CLI |
+| ------ | ------------------------------------ |
+| root: `package P` | `package P --tips q` |
+| package: `show` | `package P --tips q` |
+| package: `libraries` | `package P -S Libraries --tips q` |
+| package: `types` | `type --package P --tips q` |
+| package: `type T` | `type --package P --tips q -- T` |
+| type: `show` | `type --package P --tips q -- T` |
+| type: `members` | `member --package P --tips q -- T` |
+| type: `member M` | `member --package P --member=M --tips q -- T` |
+| member: `show` | `member --package P --member=M --tips q -- T` |
+| member: `source` | `member --package P --member=M -S "Decompiled Source" --tips q -- T` |
+| member: `source N` | `member --package P --member=M --index N -S "Decompiled Source" --tips q -- T` |
+| type/member: `back` | Navigate to the complete parent selection |
+| any prompt: `help`, `exit` | Repl ambient commands |
+
+`show` always reruns the delegated operation. Selection state changes only
+after the delegated operation returns exit code `0`.
+
+## 3. Current limitations
+
+- This is a focused package → type → member pilot, not a parallel interactive
+  grammar for every dotnet-inspect command.
+- Repl `0.12.0-dev.3` rebuilds absolute navigation from space-split route
+  strings. The pilot therefore keeps user selectors in session state and uses
+  static `selected-*` scopes; `back` moves up one complete selected level.
+- Interactive prompts and navigation are human-facing and do not define a new
+  JSON or automation contract. Scripts should continue to invoke the regular
+  CLI commands directly.
+- Delegated output is capped at 10,000 lines or 1,000,000 characters per
+  stdout/stderr stream. The Repl prints an explicit truncation diagnostic; use
+  the equivalent regular CLI command when you need complete very large output.
+- Ctrl+C cancellation is best effort while a delegated inspection is running.
+  Existing command handlers do not all propagate cancellation through NuGet
+  resolution and decompilation, so the prompt may recover only after that work
+  finishes.
+- `repl` is a reserved root verb. A package literally named `repl` remains
+  inspectable with the explicit command `dotnet-inspect package repl`.
+- The current Repl prerelease is not trim-clean (`IL2104` under full trim
+  analysis with the current SDK). Untrimmed managed builds include the pilot.
+  Trimmed and RID-specific NativeAOT publishes exclude Repl.Core and expose an
+  unavailable stub with exit code `1`.

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -60,7 +60,9 @@ public class CommandLineTests
 
         var processed = CommandLineBuilder.PreprocessArgs(arguments);
 
-        Assert.Equal(["router", "--", "System.Private.CoreLib"], processed);
+        Assert.Equal(
+            ["router", "--", RouterCommandDefinition.LiteralTargetSentinel, "System.Private.CoreLib"],
+            processed);
     }
 
     [Fact]
@@ -70,7 +72,9 @@ public class CommandLineTests
 
         var processed = CommandLineBuilder.PreprocessArgs(arguments);
 
-        Assert.Equal(["router", "--", "System.Private.CoreLib", "-T:q"], processed);
+        Assert.Equal(
+            ["router", "--", RouterCommandDefinition.LiteralTargetSentinel, "System.Private.CoreLib", "-T:q"],
+            processed);
     }
 
     [Fact]
@@ -80,7 +84,20 @@ public class CommandLineTests
 
         var processed = CommandLineBuilder.PreprocessArgs(arguments);
 
-        Assert.Equal(["router", "--", "System.Private.CoreLib", "-S", "Libraries"], processed);
+        Assert.Equal(
+            [
+                "router", "--", RouterCommandDefinition.LiteralTargetSentinel,
+                "System.Private.CoreLib", "-S", "Libraries"
+            ],
+            processed);
+    }
+
+    [Fact]
+    public void Preprocessor_RoutesBareSectionDiscoveryWithoutTreatingValueAsTarget()
+    {
+        var processed = CommandLineBuilder.PreprocessArgs(["-S", "Methods", "--help"]);
+
+        Assert.Equal(["router", "-S", "Methods", "--help"], processed);
     }
 
     [Fact]
@@ -91,7 +108,10 @@ public class CommandLineTests
         var processed = CommandLineBuilder.PreprocessArgs(arguments);
 
         Assert.Equal(
-            ["router", "--", "System.Private.CoreLib", RouterCommandDefinition.EndOfOptionsSentinel, "--offline"],
+            [
+                "router", "--", RouterCommandDefinition.LiteralTargetSentinel, "System.Private.CoreLib",
+                RouterCommandDefinition.EndOfOptionsSentinel, "--offline"
+            ],
             processed);
     }
 
@@ -128,6 +148,20 @@ public class CommandLineTests
         Assert.Equal(
             ["type", "-T:q", "--", "--offline"],
             EarlyGlobalOptions.InsertBeforeEndOfOptions(afterOnly, "-T:q"));
+    }
+
+    [Fact]
+    public void EarlyGlobalOptions_ParseInlineBooleanValuesBeforeDoubleDash()
+    {
+        string[] arguments =
+            ["--offline=false", "--offline=true", "type", "--trace-mermaid=False", "--", "--offline=true"];
+
+        Assert.True(EarlyGlobalOptions.GetBooleanValueBeforeEndOfOptions(arguments, "--offline"));
+        Assert.False(EarlyGlobalOptions.GetBooleanValueBeforeEndOfOptions(arguments, "--trace-mermaid"));
+        Assert.Null(EarlyGlobalOptions.GetBooleanValueBeforeEndOfOptions(arguments, "--info"));
+        Assert.Equal(
+            ["type", "--trace-mermaid=False", "--", "--offline=true"],
+            EarlyGlobalOptions.RemoveBooleanBeforeEndOfOptions(arguments, "--offline"));
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -24,6 +24,113 @@ public class CommandLineTests
     }
 
     [Fact]
+    public void ReplCommand_ParsesAndIsReserved()
+    {
+        var result = CommandLineBuilder.CreateRootCommand().Parse(["repl"]);
+
+        Assert.Empty(result.Errors);
+        Assert.Equal("repl", result.CommandResult.Command.Name);
+        Assert.Contains("repl", ArgumentPreprocessor.KnownCommands);
+    }
+
+    [Fact]
+    public void PackageCommand_WithReservedReplPackage_ParsesExplicitly()
+    {
+        var result = CommandLineBuilder.CreateRootCommand().Parse(["package", "repl"]);
+
+        Assert.Empty(result.Errors);
+        Assert.Equal("package", result.CommandResult.Command.Name);
+    }
+
+    [Fact]
+    public void Preprocessor_DoesNotRewriteDashNumericAfterDoubleDash()
+    {
+        string[] arguments = ["type", "--platform", "System.Private.CoreLib", "--", "-30"];
+
+        var processed = CommandLineBuilder.PreprocessArgs(arguments);
+
+        Assert.Equal(arguments, processed);
+        Assert.Null(ArgumentPreprocessor.HeadLines);
+    }
+
+    [Fact]
+    public void Preprocessor_RoutesImplicitTargetAfterDoubleDashWithoutRewritingSuffix()
+    {
+        string[] arguments = ["--", "System.Private.CoreLib"];
+
+        var processed = CommandLineBuilder.PreprocessArgs(arguments);
+
+        Assert.Equal(["router", "--", "System.Private.CoreLib"], processed);
+    }
+
+    [Fact]
+    public void Preprocessor_RoutesImplicitTargetAfterGlobalOptionsWithoutRewritingSuffix()
+    {
+        string[] arguments = ["-T:q", "--", "System.Private.CoreLib"];
+
+        var processed = CommandLineBuilder.PreprocessArgs(arguments);
+
+        Assert.Equal(["router", "--", "System.Private.CoreLib", "-T:q"], processed);
+    }
+
+    [Fact]
+    public void Preprocessor_RoutesImplicitTargetAfterCommandOptionsWithoutTreatingOptionValueAsTarget()
+    {
+        string[] arguments = ["-S", "Libraries", "--", "System.Private.CoreLib"];
+
+        var processed = CommandLineBuilder.PreprocessArgs(arguments);
+
+        Assert.Equal(["router", "--", "System.Private.CoreLib", "-S", "Libraries"], processed);
+    }
+
+    [Fact]
+    public void Preprocessor_PreservesOptionShapedSuffixAfterImplicitTarget()
+    {
+        string[] arguments = ["--", "System.Private.CoreLib", "--offline"];
+
+        var processed = CommandLineBuilder.PreprocessArgs(arguments);
+
+        Assert.Equal(
+            ["router", "--", "System.Private.CoreLib", RouterCommandDefinition.EndOfOptionsSentinel, "--offline"],
+            processed);
+    }
+
+    [Fact]
+    public async Task ImplicitRouter_PreservesOptionsBeforeDoubleDashDuringExecution()
+    {
+        var arguments = CommandLineBuilder.PreprocessArgs(["-v:q", "--", "System.Private.CoreLib"]);
+        var root = CommandLineBuilder.CreateRootCommand();
+
+        var (exitCode, output, error) = await ConsoleCapture.RunAsync(
+            () => root.Parse(arguments).InvokeAsync());
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(error);
+        Assert.Contains("# System.Private.CoreLib.dll", output);
+        Assert.DoesNotContain("## Library Info", output);
+    }
+
+    [Fact]
+    public void EarlyGlobalOptions_StopAtDoubleDash()
+    {
+        string[] beforeAndAfter = ["type", "--offline", "--", "--offline"];
+        string[] afterOnly = ["type", "--", "--offline"];
+
+        Assert.True(EarlyGlobalOptions.ContainsBeforeEndOfOptions(beforeAndAfter, "--offline"));
+        Assert.Equal(1, EarlyGlobalOptions.IndexOfBeforeEndOfOptions(beforeAndAfter, "--offline"));
+        Assert.Equal(
+            ["type", "--", "--offline"],
+            EarlyGlobalOptions.RemoveAllBeforeEndOfOptions(beforeAndAfter, "--offline"));
+
+        Assert.False(EarlyGlobalOptions.ContainsBeforeEndOfOptions(afterOnly, "--offline"));
+        Assert.Equal(-1, EarlyGlobalOptions.IndexOfBeforeEndOfOptions(afterOnly, "--offline"));
+        Assert.Equal(afterOnly, EarlyGlobalOptions.RemoveAllBeforeEndOfOptions(afterOnly, "--offline"));
+        Assert.Equal(
+            ["type", "-T:q", "--", "--offline"],
+            EarlyGlobalOptions.InsertBeforeEndOfOptions(afterOnly, "-T:q"));
+    }
+
+    [Fact]
     public void RootCommand_WithVerbosityQuiet_ParsesCorrectly()
     {
         var result = CommandLineBuilder.CreateRootCommand().Parse(["-v:q"]);

--- a/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
@@ -120,6 +120,20 @@ public class MemberOptionsParserTests
     }
 
     [Fact]
+    public async Task QualifiedType_DashPrefixedTrailingValueBeforeDoubleDash_IsRejected()
+    {
+        ArgumentPreprocessor.Reset();
+        var (root, opts, cmdArgs) = CreateTestCommand();
+        var parseResult = root.Parse(["member", "System.Text.Json.JsonDocument", "--bogus"]);
+        Assert.Empty(parseResult.Errors);
+
+        var result = await MemberOptionsParser.ParseAsync(parseResult, opts, cmdArgs);
+
+        var unrecognized = Assert.IsType<MemberOptionsParser.UnrecognizedOption>(result);
+        Assert.Equal("--bogus", unrecognized.Option);
+    }
+
+    [Fact]
     public async Task PackageRangeAddress_IsPreservedForLazyResolution()
     {
         var options = await ParseSuccessAsync(

--- a/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
@@ -110,6 +110,16 @@ public class MemberOptionsParserTests
     }
 
     [Fact]
+    public async Task ExplicitPackage_DashPrefixedMemberAfterDoubleDash_IsLiteral()
+    {
+        var options = await ParseSuccessAsync(
+            "member", "--package", "System.Text.Json", "--", "JsonSerializer", "-Foo");
+
+        Assert.Equal("JsonSerializer", options.TypeName);
+        Assert.Equal(["-Foo"], options.MemberFilter);
+    }
+
+    [Fact]
     public async Task PackageRangeAddress_IsPreservedForLazyResolution()
     {
         var options = await ParseSuccessAsync(

--- a/src/dotnet-inspect.Tests/Parsers/TypeOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/TypeOptionsParserTests.cs
@@ -120,6 +120,29 @@ public class TypeOptionsParserTests
     }
 
     [Fact]
+    public async Task DashPrefixedTypeAfterDoubleDash_IsPositional()
+    {
+        var options = await ParseSuccessAsync(
+            "type", "--package", "System.Text.Json", "--", "-Foo");
+
+        Assert.Equal("-Foo", options.TypeName);
+    }
+
+    [Fact]
+    public async Task UnknownOptionBeforeDoubleDash_RemainsUnrecognized()
+    {
+        ArgumentPreprocessor.Reset();
+        var (root, opts, cmdArgs) = CreateTestCommand();
+        var parseResult = root.Parse(
+            ["type", "--platform", "System.Private.CoreLib", "--bogus", "--", "-Foo"]);
+        Assert.Empty(parseResult.Errors);
+
+        var result = await TypeOptionsParser.ParseAsync(parseResult, opts, cmdArgs);
+        var error = Assert.IsType<TypeOptionsParser.UnrecognizedOption>(result);
+        Assert.Equal("--bogus", error.Option);
+    }
+
+    [Fact]
     public async Task ProjectCannotCombineWithExplicitSource()
     {
         ArgumentPreprocessor.Reset();

--- a/src/dotnet-inspect.Tests/ReplCommandTests.cs
+++ b/src/dotnet-inspect.Tests/ReplCommandTests.cs
@@ -266,6 +266,51 @@ public class ReplCommandTests
     }
 
     [Fact]
+    public async Task EntryPoint_InlineOfflineTrue_EnforcesOfflineMode()
+    {
+        var cacheDirectory = Path.Combine(Path.GetTempPath(), $"dotnet-inspect-inline-offline-{Guid.NewGuid():N}");
+        try
+        {
+            var result = await RunProductAsync(
+                ["--offline=true", "--no-nuget-cache", "package", "DotnetInspect.Offline.Probe.7f3a9d", "-v:q"],
+                new Dictionary<string, string?>
+                {
+                    ["DOTNET_INSPECT_CACHE_DIR"] = cacheDirectory,
+                    ["DOTNET_INSPECT_OFFLINE"] = "0",
+                });
+
+            Assert.Equal(1, result.ExitCode);
+            Assert.Empty(result.Output);
+            Assert.Contains("is not available offline", result.Error);
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDirectory))
+                Directory.Delete(cacheDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task EntryPoint_OptionsBeforeDoubleDash_AreApplied()
+    {
+        var result = await RunProductAsync(["-v:q", "--", "System.Private.CoreLib"]);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        Assert.Contains("# System.Private.CoreLib.dll", result.Output);
+        Assert.DoesNotContain("## Library Info", result.Output);
+    }
+
+    [Fact]
+    public async Task EntryPoint_OptionAfterDoubleDash_RemainsLiteral()
+    {
+        var result = await RunProductAsync(["--", "System.Private.CoreLib", "--offline"]);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("Unrecognized command or argument '--offline'.", result.Error);
+    }
+
+    [Fact]
     public async Task CliRouting_StreamsAndPreservesStdoutStderrInterleaving()
     {
         var io = new RecordingIoContext();
@@ -345,7 +390,9 @@ public class ReplCommandTests
         Assert.Same(originalError, Console.Error);
     }
 
-    private static async Task<(int ExitCode, string Output, string Error)> RunProductAsync(string[] arguments)
+    private static async Task<(int ExitCode, string Output, string Error)> RunProductAsync(
+        string[] arguments,
+        IReadOnlyDictionary<string, string?>? environment = null)
     {
         var dotnet = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? "dotnet";
         var runtimeConfig = Path.Combine(AppContext.BaseDirectory, "dotnet-inspect.Tests.runtimeconfig.json");
@@ -363,6 +410,12 @@ public class ReplCommandTests
         startInfo.ArgumentList.Add(typeof(ReplCommand).Assembly.Location);
         foreach (var argument in arguments)
             startInfo.ArgumentList.Add(argument);
+
+        if (environment is not null)
+        {
+            foreach (var (name, value) in environment)
+                startInfo.Environment[name] = value;
+        }
 
         using var process = Process.Start(startInfo) ?? throw new InvalidOperationException("Could not start dotnet-inspect.");
         var outputTask = process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken);

--- a/src/dotnet-inspect.Tests/ReplCommandTests.cs
+++ b/src/dotnet-inspect.Tests/ReplCommandTests.cs
@@ -1,0 +1,496 @@
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Text.Json;
+using DotnetInspector.Commands;
+using Repl;
+
+namespace DotnetInspector.Tests;
+
+[Collection("Console")]
+public class ReplCommandTests
+{
+    [Fact]
+    public async Task Repl_NavigatesPackageTypeMember_UsingExistingCliOperations()
+    {
+        List<string[]> calls = [];
+        Task<int> ExecuteAsync(string[] arguments, IReplIoContext io, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            calls.Add(arguments);
+            io.Output.WriteLine($"ran {string.Join(" ", arguments)}");
+            return Task.FromResult(0);
+        }
+
+        var result = await RunAsync(ReplCommand.CreateApp(ExecuteAsync), """
+            package Example.Package
+            libraries
+            types
+            type Example.Type
+            members
+            member Run
+            source
+            source 2
+            show
+            back
+            back
+            exit
+            """);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(
+        [
+            "package Example.Package --tips q",
+            "package Example.Package -S Libraries --tips q",
+            "type --package Example.Package --tips q",
+            "type --package Example.Package --tips q -- Example.Type",
+            "member --package Example.Package --tips q -- Example.Type",
+            "member --package Example.Package --member=Run --tips q -- Example.Type",
+            "member --package Example.Package --member=Run -S Decompiled Source --tips q -- Example.Type",
+            "member --package Example.Package --member=Run --index 2 -S Decompiled Source --tips q -- Example.Type",
+            "member --package Example.Package --member=Run --tips q -- Example.Type",
+        ],
+        calls.Select(arguments => string.Join(" ", arguments)));
+        Assert.Contains("[selected-package/selected-type/selected-member]>", result.Output);
+        Assert.Contains("[selected-package/selected-type]>", result.Output);
+        Assert.Contains("[selected-package]>", result.Output);
+        Assert.DoesNotContain(Environment.NewLine + "0" + Environment.NewLine, result.Output);
+    }
+
+    [Fact]
+    public async Task Repl_DefaultExecutor_TraversesLocalPackageTypeMemberAndSource()
+    {
+        var tempDirectory = Directory.CreateTempSubdirectory("repl-integration-").FullName;
+        try
+        {
+            var packageRoot = Path.Combine(tempDirectory, "package");
+            var libraryDirectory = Path.Combine(packageRoot, "lib", "net11.0");
+            Directory.CreateDirectory(libraryDirectory);
+            File.Copy(
+                typeof(ReplCommandTests).Assembly.Location,
+                Path.Combine(libraryDirectory, "Repl.Integration.dll"));
+            var packagePath = Path.Combine(tempDirectory, "Repl.Integration.1.0.0.nupkg");
+            ZipFile.CreateFromDirectory(packageRoot, packagePath);
+
+            var result = await RunAsync(ReplCommand.CreateApp(), $$"""
+                package "{{packagePath}}"
+                type DotnetInspector.Tests.ReplCommandTests
+                member Repl_OneShotActionFailure_PropagatesExitCode
+                source 1
+                exit
+                """);
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Empty(result.Error);
+            Assert.Contains("[selected-package/selected-type/selected-member]>", result.Output);
+            Assert.Contains("Decompiled Source", result.Output);
+            Assert.Contains("Repl_OneShotActionFailure_PropagatesExitCode", result.Output);
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Repl_FailedContextValidation_IsRetried()
+    {
+        var callCount = 0;
+        Task<int> ExecuteAsync(string[] arguments, IReplIoContext io, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            callCount++;
+            io.Error.WriteLine($"attempt {callCount}: {string.Join(" ", arguments)}");
+            return Task.FromResult(callCount == 1 ? 1 : 0);
+        }
+
+        var result = await RunAsync(ReplCommand.CreateApp(ExecuteAsync), """
+            package Missing.Package
+            package Missing.Package
+            exit
+            """);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(2, callCount);
+        Assert.Contains("[selected-package]>", result.Output);
+        Assert.Contains("attempt 1", result.Error);
+        Assert.Contains("attempt 2", result.Error);
+    }
+
+    [Fact]
+    public async Task Repl_OneShotActionFailure_PropagatesExitCode()
+    {
+        var callCount = 0;
+        Task<int> ExecuteAsync(string[] arguments, IReplIoContext io, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            callCount++;
+            return Task.FromResult(7);
+        }
+
+        var result = await ConsoleCapture.RunAsync(
+            () => ReplCommand.CreateApp(ExecuteAsync)
+                .RunAsync(["package", "Example.Package"])
+                .AsTask());
+
+        Assert.Equal(1, callCount);
+        Assert.Equal(7, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task Repl_ActionFailure_ProducesExplicitExitResult()
+    {
+        Task<int> ExecuteAsync(string[] arguments, IReplIoContext io, CancellationToken cancellationToken) =>
+            Task.FromResult(7);
+
+        var result = await ReplCommand.ExecuteAsResultAsync(
+            ["show"],
+            new RecordingIoContext(),
+            ExecuteAsync,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(7, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task Repl_BackPreservesSelectorContainingWhitespace()
+    {
+        List<string[]> calls = [];
+        Task<int> ExecuteAsync(string[] arguments, IReplIoContext io, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            calls.Add(arguments);
+            return Task.FromResult(0);
+        }
+
+        var result = await RunAsync(ReplCommand.CreateApp(ExecuteAsync), """
+            package Example.Package
+            type "Example Type"
+            member Run
+            back
+            show
+            exit
+            """);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(2, calls.Count(arguments => arguments.Length > 1 && arguments[0] == "type" && arguments.Contains("--") && arguments[^1] == "Example Type"));
+        Assert.Contains("[selected-package/selected-type]>", result.Output);
+    }
+
+    [Fact]
+    public async Task Repl_DistinctSlashDelimitedSelectors_DoNotShareContextState()
+    {
+        List<string[]> calls = [];
+        Task<int> ExecuteAsync(string[] arguments, IReplIoContext io, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            calls.Add(arguments);
+            return Task.FromResult(0);
+        }
+
+        var result = await RunAsync(ReplCommand.CreateApp(ExecuteAsync), """
+            package Example.Package
+            type A/B
+            member C
+            back
+            back
+            type A
+            member B/C
+            exit
+            """);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains(calls, arguments => arguments.Contains("--member=C"));
+        Assert.Contains(calls, arguments => arguments.Contains("--member=B/C"));
+    }
+
+    [Fact]
+    public async Task Repl_DashPrefixedType_UsesUnambiguousCliArguments()
+    {
+        List<string[]> calls = [];
+        Task<int> ExecuteAsync(string[] arguments, IReplIoContext io, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            calls.Add(arguments);
+            return Task.FromResult(0);
+        }
+
+        var result = await RunAsync(ReplCommand.CreateApp(ExecuteAsync), """
+            package Example.Package
+            type "-Foo"
+            members
+            member Run
+            source
+            exit
+            """);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains(calls, arguments => arguments[0] == "type" && arguments.Contains("--") && arguments[^1] == "-Foo");
+        Assert.All(calls.Where(arguments => arguments[0] == "member"), arguments =>
+        {
+            var separator = Array.IndexOf(arguments, "--");
+            Assert.True(separator >= 0, string.Join(' ', arguments));
+            Assert.Equal("-Foo", arguments[separator + 1]);
+        });
+    }
+
+    [Fact]
+    public async Task ReplFeatureGate_DisablesTrimmedAndRidAotBuilds()
+    {
+        (string Name, string[] Properties, bool Expected)[] cases =
+        [
+            ("managed development", [], true),
+            ("managed any", ["-p:PublishAot=false", "-p:RuntimeIdentifier=any"], true),
+            ("inferred RID AOT publish", ["-p:_IsPublishing=true"], false),
+            ("RID AOT", ["-p:PublishAot=true", "-p:RuntimeIdentifier=linux-x64"], false),
+            ("official RID AOT", ["-p:OfficialAotBuild=true", "-p:RuntimeIdentifier=linux-x64"], false),
+            ("trimmed managed", ["-p:PublishAot=false", "-p:PublishTrimmed=true"], false),
+        ];
+
+        foreach (var testCase in cases)
+        {
+            var gate = await EvaluateExperimentalReplGateAsync(testCase.Properties);
+            Assert.Equal(testCase.Expected, gate.Enabled);
+            Assert.Equal(testCase.Expected, gate.HasCompilationSymbol);
+            Assert.Equal(testCase.Expected, gate.HasPackageReference);
+        }
+    }
+
+    [Fact]
+    public async Task EntryPoint_IsolatedWithoutValueBeforeDoubleDash_Fails()
+    {
+        var result = await RunProductAsync(["--isolated", "--", "System.Private.CoreLib"]);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Empty(result.Output);
+        Assert.Equal("Error: --isolated requires a session name before '--'.", result.Error.Trim());
+    }
+
+    [Fact]
+    public async Task CliRouting_StreamsAndPreservesStdoutStderrInterleaving()
+    {
+        var io = new RecordingIoContext();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var originalOut = Console.Out;
+        var originalError = Console.Error;
+
+        var execution = ReplCommand.ExecuteWithConsoleRoutingAsync(io, TestContext.Current.CancellationToken, async _ =>
+        {
+            Console.Out.Write("first");
+            Console.Error.Write("second");
+            await release.Task;
+            Console.Out.Write("third");
+            return 0;
+        });
+
+        try
+        {
+            await io.FirstWrite.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+            Assert.False(execution.IsCompleted);
+            Assert.Equal(["out:first", "err:second"], io.Events);
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+
+        Assert.Equal(0, await execution);
+        Assert.Equal(["out:first", "err:second", "out:third"], io.Events);
+        Assert.Same(originalOut, Console.Out);
+        Assert.Same(originalError, Console.Error);
+    }
+
+    [Fact]
+    public async Task CliRouting_BoundsLargeOutputAndReportsTruncation()
+    {
+        var io = new RecordingIoContext();
+        var payload = new string('x', ReplCommand.OutputCharacterLimit + 1);
+
+        var exitCode = await ReplCommand.ExecuteWithConsoleRoutingAsync(
+            io,
+            TestContext.Current.CancellationToken,
+            _ =>
+            {
+                Console.Out.Write(payload);
+                return Task.FromResult(0);
+            });
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(
+            ReplCommand.OutputCharacterLimit,
+            io.Events.Where(entry => entry.StartsWith("out:", StringComparison.Ordinal)).Sum(entry => entry.Length - 4));
+        Assert.Contains(io.Events, entry => entry.Contains("Repl output truncated", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task CliRouting_RestoresConsoleAndKeepsPartialOutputWhenOperationThrows()
+    {
+        var io = new RecordingIoContext();
+        var originalOut = Console.Out;
+        var originalError = Console.Error;
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            ReplCommand.ExecuteWithConsoleRoutingAsync(
+                io,
+                TestContext.Current.CancellationToken,
+                async _ =>
+                {
+                    Console.Out.Write("partial");
+                    Console.Error.Write("diagnostic");
+                    await Task.Yield();
+                    throw new InvalidOperationException("test failure");
+                }));
+
+        Assert.Equal(["out:partial", "err:diagnostic"], io.Events);
+        Assert.Same(originalOut, Console.Out);
+        Assert.Same(originalError, Console.Error);
+    }
+
+    private static async Task<(int ExitCode, string Output, string Error)> RunProductAsync(string[] arguments)
+    {
+        var dotnet = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? "dotnet";
+        var runtimeConfig = Path.Combine(AppContext.BaseDirectory, "dotnet-inspect.Tests.runtimeconfig.json");
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = dotnet,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = FindRepositoryRoot(),
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(runtimeConfig);
+        startInfo.ArgumentList.Add(typeof(ReplCommand).Assembly.Location);
+        foreach (var argument in arguments)
+            startInfo.ArgumentList.Add(argument);
+
+        using var process = Process.Start(startInfo) ?? throw new InvalidOperationException("Could not start dotnet-inspect.");
+        var outputTask = process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken);
+        var errorTask = process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+        await process.WaitForExitAsync(TestContext.Current.CancellationToken);
+        return (process.ExitCode, await outputTask, await errorTask);
+    }
+
+    private static async Task<ExperimentalReplGate> EvaluateExperimentalReplGateAsync(string[] properties)
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var dotnet = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? "dotnet";
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = dotnet,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = repositoryRoot,
+        };
+        startInfo.ArgumentList.Add("msbuild");
+        startInfo.ArgumentList.Add(Path.Combine(repositoryRoot, "src", "dotnet-inspect", "dotnet-inspect.csproj"));
+        startInfo.ArgumentList.Add("-nologo");
+        startInfo.ArgumentList.Add("-getProperty:EnableExperimentalRepl,DefineConstants");
+        startInfo.ArgumentList.Add("-getItem:PackageReference");
+        foreach (var property in properties)
+            startInfo.ArgumentList.Add(property);
+
+        using var process = Process.Start(startInfo) ?? throw new InvalidOperationException("Could not start dotnet msbuild.");
+        var outputTask = process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken);
+        var errorTask = process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+        await process.WaitForExitAsync(TestContext.Current.CancellationToken);
+        var output = await outputTask;
+        var error = await errorTask;
+        Assert.True(process.ExitCode == 0, $"dotnet msbuild exited {process.ExitCode}: {error}");
+
+        var jsonStart = output.IndexOf('{');
+        Assert.True(jsonStart >= 0, $"Expected JSON from dotnet msbuild: {output}");
+
+        using var document = JsonDocument.Parse(output[jsonStart..]);
+        var propertiesElement = document.RootElement.GetProperty("Properties");
+        var enabled = string.Equals(
+            propertiesElement.GetProperty("EnableExperimentalRepl").GetString(),
+            "true",
+            StringComparison.OrdinalIgnoreCase);
+        var constants = propertiesElement.GetProperty("DefineConstants").GetString() ?? string.Empty;
+        var hasCompilationSymbol = constants.Split(';', StringSplitOptions.RemoveEmptyEntries)
+            .Contains("DOTNET_INSPECT_EXPERIMENTAL_REPL", StringComparer.Ordinal);
+        var hasPackageReference = document.RootElement
+            .GetProperty("Items")
+            .GetProperty("PackageReference")
+            .EnumerateArray()
+            .Any(item => string.Equals(
+                item.GetProperty("Identity").GetString(),
+                "Repl.Core",
+                StringComparison.OrdinalIgnoreCase));
+        return new ExperimentalReplGate(enabled, hasCompilationSymbol, hasPackageReference);
+    }
+
+    private sealed record ExperimentalReplGate(
+        bool Enabled,
+        bool HasCompilationSymbol,
+        bool HasPackageReference);
+
+    private static string FindRepositoryRoot()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "dotnet-inspect.slnx")))
+                return directory.FullName;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the dotnet-inspect repository root.");
+    }
+
+    private sealed class RecordingIoContext : IReplIoContext
+    {
+        private readonly List<string> _events = [];
+        private readonly object _gate = new();
+
+        public RecordingIoContext()
+        {
+            Output = new RecordingWriter("out", _events, _gate, FirstWrite);
+            Error = new RecordingWriter("err", _events, _gate, FirstWrite);
+        }
+
+        public TaskCompletionSource FirstWrite { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public IReadOnlyList<string> Events
+        {
+            get
+            {
+                lock (_gate)
+                    return [.. _events];
+            }
+        }
+
+        public TextReader Input => TextReader.Null;
+        public TextWriter Output { get; }
+        public TextWriter Error { get; }
+        public bool IsHostedSession => false;
+        public string? SessionId => null;
+    }
+
+    private sealed class RecordingWriter(
+        string channel,
+        List<string> events,
+        object gate,
+        TaskCompletionSource firstWrite) : StringWriter
+    {
+        public override void Write(string? value)
+        {
+            lock (gate)
+                events.Add($"{channel}:{value}");
+            firstWrite.TrySetResult();
+        }
+    }
+
+    private static async Task<(int ExitCode, string Output, string Error)> RunAsync(CoreReplApp app, string input)
+    {
+        var originalIn = Console.In;
+        Console.SetIn(new StringReader(input));
+        try
+        {
+            return await ConsoleCapture.RunAsync(() => app.RunAsync([]).AsTask());
+        }
+        finally
+        {
+            Console.SetIn(originalIn);
+        }
+    }
+}

--- a/src/dotnet-inspect/CommandLine/Commands/ReplCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/ReplCommandDefinition.cs
@@ -1,0 +1,17 @@
+using System.CommandLine;
+using DotnetInspector.Commands;
+
+namespace DotnetInspector.CommandLine;
+
+/// <summary>
+/// Defines the experimental interactive Repl command.
+/// </summary>
+internal static class ReplCommandDefinition
+{
+    internal static Command Create()
+    {
+        var command = new Command("repl", "Start the experimental contextual inspection Repl");
+        command.SetAction((_, cancellationToken) => ReplCommand.ExecuteAsync(cancellationToken));
+        return command;
+    }
+}

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -17,6 +17,7 @@ namespace DotnetInspector.CommandLine;
 public static class RouterCommandDefinition
 {
     internal const string EndOfOptionsSentinel = "\0dotnet-inspect-end-of-options";
+    internal const string LiteralTargetSentinel = "\0dotnet-inspect-literal-target";
 
     public static Command Create(RootCommand rootCommand)
     {
@@ -37,6 +38,10 @@ public static class RouterCommandDefinition
         routerCommand.SetAction(async (parseResult, ct) =>
         {
             var tokens = parseResult.GetValue(tokensArg) ?? [];
+            var literalTarget = tokens.FirstOrDefault() == LiteralTargetSentinel;
+            if (literalTarget)
+                tokens = tokens[1..];
+
             var endOfOptionsIndex = Array.IndexOf(tokens, EndOfOptionsSentinel);
             string[] protectedTail = [];
             if (endOfOptionsIndex >= 0)
@@ -68,7 +73,7 @@ public static class RouterCommandDefinition
             }
 
             RequestTelemetry.Breadcrumb("router-hit", string.Join(' ', tokens));
-            var rewritten = await RouterTokenRewriter.RewriteAsync(tokens);
+            var rewritten = await RouterTokenRewriter.RewriteAsync(tokens, literalTarget);
             RequestTelemetry.Breadcrumb(
                 "router-rewrite",
                 $"{string.Join(' ', tokens)} -> {string.Join(' ', rewritten)}");
@@ -141,13 +146,15 @@ public static class RouterCommandDefinition
 
     private static class RouterTokenRewriter
     {
-        public static async Task<string[]> RewriteAsync(string[] tokens)
+        public static async Task<string[]> RewriteAsync(string[] tokens, bool literalTarget)
         {
             var target = tokens[0];
             var tail = tokens[1..];
 
-            // A target placed after `--` is literal even when it looks like an option.
-            if (target.StartsWith('-', StringComparison.Ordinal))
+            // A target explicitly marked as coming after `--` is literal even when
+            // it looks like an option. Ordinary router options (for example -S)
+            // must not be mistaken for such a target.
+            if (literalTarget && target.StartsWith('-', StringComparison.Ordinal))
                 return ["package", .. tail, "--", target];
 
             if (CommandLineHelpers.TryClassifyAsFilePath(target, out var dllPath, out var nupkgPath))

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -16,6 +16,8 @@ namespace DotnetInspector.CommandLine;
 /// </summary>
 public static class RouterCommandDefinition
 {
+    internal const string EndOfOptionsSentinel = "\0dotnet-inspect-end-of-options";
+
     public static Command Create(RootCommand rootCommand)
     {
         var routerCommand = new Command("router", "Auto-route bare input to a real command")
@@ -35,6 +37,14 @@ public static class RouterCommandDefinition
         routerCommand.SetAction(async (parseResult, ct) =>
         {
             var tokens = parseResult.GetValue(tokensArg) ?? [];
+            var endOfOptionsIndex = Array.IndexOf(tokens, EndOfOptionsSentinel);
+            string[] protectedTail = [];
+            if (endOfOptionsIndex >= 0)
+            {
+                protectedTail = tokens[(endOfOptionsIndex + 1)..];
+                tokens = tokens[..endOfOptionsIndex];
+            }
+
             if (tokens.Length == 0)
             {
                 HelpWriter.WriteHelp(rootCommand);
@@ -67,6 +77,13 @@ public static class RouterCommandDefinition
             {
                 Console.Error.WriteLine($"Error: Could not route '{tokens[0]}'.");
                 return 1;
+            }
+
+            if (protectedTail.Length > 0)
+            {
+                rewritten = rewritten.Contains("--", StringComparer.Ordinal)
+                    ? [.. rewritten, .. protectedTail]
+                    : [.. rewritten, "--", .. protectedTail];
             }
 
             return await rootCommand.Parse(rewritten).InvokeAsync();
@@ -129,6 +146,10 @@ public static class RouterCommandDefinition
             var target = tokens[0];
             var tail = tokens[1..];
 
+            // A target placed after `--` is literal even when it looks like an option.
+            if (target.StartsWith('-', StringComparison.Ordinal))
+                return ["package", .. tail, "--", target];
+
             if (CommandLineHelpers.TryClassifyAsFilePath(target, out var dllPath, out var nupkgPath))
             {
                 if (dllPath != null)
@@ -137,10 +158,10 @@ public static class RouterCommandDefinition
                     return ["package", target, .. tail];
             }
 
-            if (ContainsOption(tokens, "--member") || ContainsOption(tokens, "-m"))
+            if (ContainsOption(tail, "--member") || ContainsOption(tail, "-m"))
                 return ["member", target, .. tail];
 
-            if (ContainsOption(tokens, "--library"))
+            if (ContainsOption(tail, "--library"))
                 return ["package", .. tokens];
 
             if (tokens.Length >= 2
@@ -150,9 +171,9 @@ public static class RouterCommandDefinition
                 return ["type", tokens[1], "--package", target, .. tokens[2..]];
             }
 
-            var hasVersionQuery = ContainsOption(tokens, "--version")
-                || ContainsOption(tokens, "--latest-version")
-                || ContainsOption(tokens, "--versions");
+            var hasVersionQuery = ContainsOption(tail, "--version")
+                || ContainsOption(tail, "--latest-version")
+                || ContainsOption(tail, "--versions");
             if (hasVersionQuery || target.Contains('@'))
                 return ["package", .. tokens];
 

--- a/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
+++ b/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
@@ -25,7 +25,7 @@ public static class ArgumentPreprocessor
     public static readonly HashSet<string> KnownCommands = new(StringComparer.OrdinalIgnoreCase)
     {
         "audit", // removed command, reserved so it is not treated as an implicit package target
-        "package", "project", "library", "api", "type", "member", "diff", "timeline", "find", "source", "list", "ls", "skill", "extensions", "implements", "depends", "cache", "help", "--help", "-h", "-?", "--version", "--flavor"
+        "package", "project", "library", "api", "type", "member", "repl", "diff", "timeline", "find", "source", "list", "ls", "skill", "extensions", "implements", "depends", "cache", "help", "--help", "-h", "-?", "--version", "--flavor"
     };
 
     /// <summary>
@@ -46,6 +46,55 @@ public static class ArgumentPreprocessor
         HeadLines = null;
         TailLines = null;
 
+        var endOfOptionsIndex = Array.IndexOf(args, "--");
+        if (endOfOptionsIndex < 0)
+            return PreprocessOptionsAndRouting(args);
+
+        var processedPrefix = PreprocessOptions(args[..endOfOptionsIndex]);
+        var suffix = args[(endOfOptionsIndex + 1)..];
+        var firstPositional = FindFirstPositionalIndex(processedPrefix);
+        if (firstPositional >= 0)
+        {
+            var routedPrefix = RouteImplicitTarget(processedPrefix);
+            if (routedPrefix.Length > 0
+                && routedPrefix[0] == "router"
+                && suffix.Length > 0)
+            {
+                return
+                [
+                    "router", "--", .. routedPrefix[1..],
+                    RouterCommandDefinition.EndOfOptionsSentinel, .. suffix
+                ];
+            }
+
+            return [.. routedPrefix, "--", .. suffix];
+        }
+
+        if (suffix.Length == 0)
+            return [.. processedPrefix, "--"];
+
+        var target = suffix[0];
+        if (CommandLineHelpers.TryClassifyAsFilePath(target, out var dllPath, out var nupkgPath))
+        {
+            var command = dllPath != null ? "library" : nupkgPath != null ? "package" : "router";
+            return [command, .. processedPrefix, "--", .. suffix];
+        }
+
+        RequestTelemetry.Breadcrumb("implicit-router", target);
+        return suffix.Length == 1
+            ? ["router", "--", target, .. processedPrefix]
+            :
+            [
+                "router", "--", target, .. processedPrefix,
+                RouterCommandDefinition.EndOfOptionsSentinel, .. suffix[1..]
+            ];
+    }
+
+    private static string[] PreprocessOptionsAndRouting(string[] args)
+        => RouteImplicitTarget(PreprocessOptions(args));
+
+    private static string[] PreprocessOptions(string[] args)
+    {
         // These options are single-valued (comma/semicolon-separated), so a natural `-S A -S B`
         // otherwise errors with "expects a single argument". Collapse repeated occurrences into one
         // ';'-joined token so repeated and separated forms behave the same.
@@ -91,26 +140,13 @@ public static class ArgumentPreprocessor
             }
         }
 
-        // Find the first positional argument, skipping any leading options
-        int firstPositional = -1;
-        for (int i = 0; i < args.Length; i++)
-        {
-            var token = args[i];
-            if (!token.StartsWith('-'))
-            {
-                firstPositional = i;
-                break;
-            }
+        return args;
+    }
 
-            var optionName = token.Split('=', 2)[0];
-            if (OptionsWithFollowingValue.Contains(optionName)
-                && !token.Contains('=', StringComparison.Ordinal)
-                && i + 1 < args.Length
-                && !args[i + 1].StartsWith("-", StringComparison.Ordinal))
-            {
-                i++;
-            }
-        }
+    private static string[] RouteImplicitTarget(string[] args)
+    {
+        // Find the first positional argument, skipping any leading options.
+        int firstPositional = FindFirstPositionalIndex(args);
 
         if (firstPositional >= 0 && !KnownCommands.Contains(args[firstPositional]))
         {
@@ -133,6 +169,27 @@ public static class ArgumentPreprocessor
         }
 
         return args;
+    }
+
+    private static int FindFirstPositionalIndex(string[] args)
+    {
+        for (int i = 0; i < args.Length; i++)
+        {
+            var token = args[i];
+            if (!token.StartsWith('-'))
+                return i;
+
+            var optionName = token.Split('=', 2)[0];
+            if (OptionsWithFollowingValue.Contains(optionName)
+                && !token.Contains('=', StringComparison.Ordinal)
+                && i + 1 < args.Length
+                && !args[i + 1].StartsWith("-", StringComparison.Ordinal))
+            {
+                i++;
+            }
+        }
+
+        return -1;
     }
 
     private static readonly string[] SelectAliases = ["-S", "-s", "--select", "--section"];

--- a/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
+++ b/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
@@ -82,10 +82,10 @@ public static class ArgumentPreprocessor
 
         RequestTelemetry.Breadcrumb("implicit-router", target);
         return suffix.Length == 1
-            ? ["router", "--", target, .. processedPrefix]
+            ? ["router", "--", RouterCommandDefinition.LiteralTargetSentinel, target, .. processedPrefix]
             :
             [
-                "router", "--", target, .. processedPrefix,
+                "router", "--", RouterCommandDefinition.LiteralTargetSentinel, target, .. processedPrefix,
                 RouterCommandDefinition.EndOfOptionsSentinel, .. suffix[1..]
             ];
     }

--- a/src/dotnet-inspect/CommandLine/Helpers/EarlyGlobalOptions.cs
+++ b/src/dotnet-inspect/CommandLine/Helpers/EarlyGlobalOptions.cs
@@ -1,0 +1,38 @@
+namespace DotnetInspector.CommandLine;
+
+/// <summary>
+/// Handles options that must be consumed before the command graph is invoked.
+/// </summary>
+internal static class EarlyGlobalOptions
+{
+    internal static bool ContainsBeforeEndOfOptions(string[] arguments, string option) =>
+        IndexOfBeforeEndOfOptions(arguments, option) >= 0;
+
+    internal static int IndexOfBeforeEndOfOptions(string[] arguments, string option)
+    {
+        var boundary = GetEndOfOptionsIndex(arguments);
+        return Array.IndexOf(arguments, option, 0, boundary);
+    }
+
+    internal static string[] RemoveAllBeforeEndOfOptions(string[] arguments, string option)
+    {
+        var boundary = GetEndOfOptionsIndex(arguments);
+        return
+        [
+            .. arguments[..boundary].Where(argument => argument != option),
+            .. arguments[boundary..],
+        ];
+    }
+
+    internal static string[] InsertBeforeEndOfOptions(string[] arguments, params string[] values)
+    {
+        var boundary = GetEndOfOptionsIndex(arguments);
+        return [.. arguments[..boundary], .. values, .. arguments[boundary..]];
+    }
+
+    internal static int GetEndOfOptionsIndex(string[] arguments)
+    {
+        var index = Array.IndexOf(arguments, "--");
+        return index < 0 ? arguments.Length : index;
+    }
+}

--- a/src/dotnet-inspect/CommandLine/Helpers/EarlyGlobalOptions.cs
+++ b/src/dotnet-inspect/CommandLine/Helpers/EarlyGlobalOptions.cs
@@ -14,12 +14,45 @@ internal static class EarlyGlobalOptions
         return Array.IndexOf(arguments, option, 0, boundary);
     }
 
+    internal static bool? GetBooleanValueBeforeEndOfOptions(string[] arguments, string option)
+    {
+        bool? value = null;
+        var boundary = GetEndOfOptionsIndex(arguments);
+        for (var index = 0; index < boundary; index++)
+        {
+            if (arguments[index] == option)
+            {
+                value = true;
+                continue;
+            }
+
+            var prefix = $"{option}=";
+            if (arguments[index].StartsWith(prefix, StringComparison.Ordinal)
+                && bool.TryParse(arguments[index][prefix.Length..], out var inlineValue))
+            {
+                value = inlineValue;
+            }
+        }
+
+        return value;
+    }
+
     internal static string[] RemoveAllBeforeEndOfOptions(string[] arguments, string option)
     {
         var boundary = GetEndOfOptionsIndex(arguments);
         return
         [
             .. arguments[..boundary].Where(argument => argument != option),
+            .. arguments[boundary..],
+        ];
+    }
+
+    internal static string[] RemoveBooleanBeforeEndOfOptions(string[] arguments, string option)
+    {
+        var boundary = GetEndOfOptionsIndex(arguments);
+        return
+        [
+            .. arguments[..boundary].Where(argument => !IsBooleanOption(argument, option)),
             .. arguments[boundary..],
         ];
     }
@@ -34,5 +67,15 @@ internal static class EarlyGlobalOptions
     {
         var index = Array.IndexOf(arguments, "--");
         return index < 0 ? arguments.Length : index;
+    }
+
+    private static bool IsBooleanOption(string argument, string option)
+    {
+        if (argument == option)
+            return true;
+
+        var prefix = $"{option}=";
+        return argument.StartsWith(prefix, StringComparison.Ordinal)
+            && bool.TryParse(argument[prefix.Length..], out _);
     }
 }

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -104,6 +104,27 @@ public static class MemberOptionsParser
         else if (!sourceInputs.HasExplicitSource && sourceInputs.Args.Length >= 3)
             positionalMembers.AddRange(sourceInputs.Args[2..]);
 
+        // A double dash marks subsequent positional values as literals. Capture only
+        // the raw member tokens before that marker for unknown-option validation;
+        // source/type values and members after the marker must remain valid selectors.
+        var argumentsAfterEndOfOptions = 0;
+        var afterEndOfOptions = false;
+        foreach (var token in parseResult.Tokens)
+        {
+            if (token.Type == TokenType.DoubleDash)
+            {
+                afterEndOfOptions = true;
+            }
+            else if (afterEndOfOptions && token.Type == TokenType.Argument)
+            {
+                argumentsAfterEndOfOptions++;
+            }
+        }
+
+        var positionalMembersBeforeEndOfOptions = positionalMembers
+            .Take(Math.Max(0, positionalMembers.Count - argumentsAfterEndOfOptions))
+            .ToArray();
+
         // Resolve source
         SharedParsers.SourceSelection sourceSelection;
         SourceResolver.ResolvedSource source;
@@ -218,8 +239,8 @@ public static class MemberOptionsParser
             }
         }
 
-        // Check for unrecognized options in positional args
-        var badOption = positionalMembers.FirstOrDefault(m => m.StartsWith('-'));
+        // Check for unrecognized options only among positional members before '--'.
+        var badOption = positionalMembersBeforeEndOfOptions.FirstOrDefault(m => m.StartsWith('-'));
         if (badOption != null)
             return new UnrecognizedOption(badOption);
 

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -121,10 +121,6 @@ public static class MemberOptionsParser
             }
         }
 
-        var positionalMembersBeforeEndOfOptions = positionalMembers
-            .Take(Math.Max(0, positionalMembers.Count - argumentsAfterEndOfOptions))
-            .ToArray();
-
         // Resolve source
         SharedParsers.SourceSelection sourceSelection;
         SourceResolver.ResolvedSource source;
@@ -240,6 +236,10 @@ public static class MemberOptionsParser
         }
 
         // Check for unrecognized options only among positional members before '--'.
+        // Calculate this after qualified-type/member transformations because they can
+        // move a raw argument into positionalMembers while preserving its boundary order.
+        var positionalMembersBeforeEndOfOptions = positionalMembers
+            .Take(Math.Max(0, positionalMembers.Count - argumentsAfterEndOfOptions));
         var badOption = positionalMembersBeforeEndOfOptions.FirstOrDefault(m => m.StartsWith('-'));
         if (badOption != null)
             return new UnrecognizedOption(badOption);

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -94,8 +94,26 @@ public static class TypeOptionsParser
         if (hasProjectSource && hasNonProjectSource)
             return new VersionError("Error: --project cannot be combined with --package, --library, or --platform.");
 
-        // Check for unrecognized options in positional args
-        var badOption = sourceInputs.Args.FirstOrDefault(a => a.StartsWith('-'));
+        // A double dash marks only subsequent tokens as positional. Continue to
+        // reject dash-prefixed positional values that occur before the marker.
+        var argumentsAfterEndOfOptions = 0;
+        var afterEndOfOptions = false;
+        foreach (var token in parseResult.Tokens)
+        {
+            if (token.Type == TokenType.DoubleDash)
+            {
+                afterEndOfOptions = true;
+            }
+            else if (afterEndOfOptions && token.Type == TokenType.Argument)
+            {
+                argumentsAfterEndOfOptions++;
+            }
+        }
+
+        var argumentsToValidate = Math.Max(0, sourceInputs.Args.Length - argumentsAfterEndOfOptions);
+        var badOption = sourceInputs.Args
+            .Take(argumentsToValidate)
+            .FirstOrDefault(argument => argument.StartsWith('-'));
         if (badOption != null)
             return new UnrecognizedOption(badOption);
 

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -104,6 +104,9 @@ public static class CommandLineBuilder
         // Project command
         rootCommand.Subcommands.Add(ProjectCommandDefinitions.CreateProjectCommand(opts));
 
+        // Experimental Repl mode
+        rootCommand.Subcommands.Add(ReplCommandDefinition.Create());
+
         // Router command (hidden, implicit default for bare names)
         rootCommand.Subcommands.Add(RouterCommandDefinition.Create(rootCommand));
 

--- a/src/dotnet-inspect/Commands/ReplCommand.cs
+++ b/src/dotnet-inspect/Commands/ReplCommand.cs
@@ -1,0 +1,437 @@
+#if DOTNET_INSPECT_EXPERIMENTAL_REPL
+using System.CommandLine;
+using System.Globalization;
+using System.Text;
+using Repl;
+
+namespace DotnetInspector.Commands;
+
+/// <summary>
+/// Runs the experimental contextual inspection Repl.
+/// </summary>
+internal static class ReplCommand
+{
+    private const string CurrentPackageKey = "dotnet-inspect.repl.package";
+    private const string CurrentTypeKey = "dotnet-inspect.repl.type";
+    private const string CurrentMemberKey = "dotnet-inspect.repl.member";
+    private const string PackageScope = "selected-package";
+    private const string TypeScope = "selected-package selected-type";
+    private const string MemberScope = "selected-package selected-type selected-member";
+    internal const int OutputLineLimit = 10_000;
+    internal const int OutputCharacterLimit = 1_000_000;
+    private static readonly SemaphoreSlim CliExecutionLock = new(1, 1);
+
+    internal delegate Task<int> ReplInspectionExecutor(
+        string[] arguments,
+        IReplIoContext io,
+        CancellationToken cancellationToken);
+
+    internal static Task<int> ExecuteAsync(CancellationToken cancellationToken = default) =>
+        CreateApp().RunAsync([], cancellationToken).AsTask();
+
+    internal static CoreReplApp CreateApp(ReplInspectionExecutor? executor = null)
+    {
+        executor ??= ExecuteExistingCliAsync;
+
+        var app = CoreReplApp.Create()
+            .WithDescription("Explore NuGet packages, .NET types, and members contextually.")
+            .WithBanner("Experimental mode. Enter package <id> to begin; use help for commands and back to leave contexts.");
+
+        Func<IReplSessionState, bool> hasPackage = state => state.TryGet<string>(CurrentPackageKey, out _);
+        Func<IReplSessionState, bool> hasType = state => state.TryGet<string>(CurrentTypeKey, out _);
+        Func<IReplSessionState, bool> hasMember = state => state.TryGet<string>(CurrentMemberKey, out _);
+
+        app.Map("package {package}", async (
+            string package,
+            IReplSessionState state,
+            IReplIoContext io,
+            CancellationToken cancellationToken) =>
+            await SelectContextAsync(
+                CurrentPackageKey,
+                package,
+                [CurrentTypeKey, CurrentMemberKey],
+                PackageScope,
+                PackageArguments(package),
+                state,
+                io,
+                executor,
+                cancellationToken));
+
+        app.Context(PackageScope, packageScope =>
+        {
+            packageScope.Map("show", async (
+                IReplSessionState state,
+                IReplIoContext io,
+                CancellationToken cancellationToken) =>
+                await ExecuteAsResultAsync(
+                    PackageArguments(GetSelected(state, CurrentPackageKey, "package")),
+                    io,
+                    executor,
+                    cancellationToken));
+            packageScope.Map("libraries", async (
+                IReplSessionState state,
+                IReplIoContext io,
+                CancellationToken cancellationToken) =>
+                await ExecuteAsResultAsync(
+                    PackageArguments(GetSelected(state, CurrentPackageKey, "package"), "-S", "Libraries"),
+                    io,
+                    executor,
+                    cancellationToken));
+            packageScope.Map("types", async (
+                IReplSessionState state,
+                IReplIoContext io,
+                CancellationToken cancellationToken) =>
+                await ExecuteAsResultAsync(
+                    TypeArguments(GetSelected(state, CurrentPackageKey, "package")),
+                    io,
+                    executor,
+                    cancellationToken));
+            packageScope.Map("back", () => Results.NavigateUp());
+            packageScope.Map("type {type}", async (
+                string type,
+                IReplSessionState state,
+                IReplIoContext io,
+                CancellationToken cancellationToken) =>
+            {
+                var package = GetSelected(state, CurrentPackageKey, "package");
+                return await SelectContextAsync(
+                    CurrentTypeKey,
+                    type,
+                    [CurrentMemberKey],
+                    TypeScope,
+                    TypeArguments(package, type),
+                    state,
+                    io,
+                    executor,
+                    cancellationToken);
+            });
+
+            packageScope.Context("selected-type", typeScope =>
+            {
+                typeScope.Map("show", async (
+                    IReplSessionState state,
+                    IReplIoContext io,
+                    CancellationToken cancellationToken) =>
+                    await ExecuteAsResultAsync(
+                        TypeArguments(
+                            GetSelected(state, CurrentPackageKey, "package"),
+                            GetSelected(state, CurrentTypeKey, "type")),
+                        io,
+                        executor,
+                        cancellationToken));
+                typeScope.Map("members", async (
+                    IReplSessionState state,
+                    IReplIoContext io,
+                    CancellationToken cancellationToken) =>
+                    await ExecuteAsResultAsync(
+                        MemberArguments(
+                            GetSelected(state, CurrentPackageKey, "package"),
+                            GetSelected(state, CurrentTypeKey, "type")),
+                        io,
+                        executor,
+                        cancellationToken));
+                typeScope.Map("back", () => Results.NavigateUp());
+                typeScope.Map("member {member}", async (
+                    string member,
+                    IReplSessionState state,
+                    IReplIoContext io,
+                    CancellationToken cancellationToken) =>
+                {
+                    var package = GetSelected(state, CurrentPackageKey, "package");
+                    var type = GetSelected(state, CurrentTypeKey, "type");
+                    return await SelectContextAsync(
+                        CurrentMemberKey,
+                        member,
+                        [],
+                        MemberScope,
+                        MemberArguments(package, type, member),
+                        state,
+                        io,
+                        executor,
+                        cancellationToken);
+                });
+
+                typeScope.Context("selected-member", memberScope =>
+                {
+                    memberScope.Map("show", async (
+                        IReplSessionState state,
+                        IReplIoContext io,
+                        CancellationToken cancellationToken) =>
+                        await ExecuteAsResultAsync(
+                            MemberArguments(
+                                GetSelected(state, CurrentPackageKey, "package"),
+                                GetSelected(state, CurrentTypeKey, "type"),
+                                GetSelected(state, CurrentMemberKey, "member")),
+                            io,
+                            executor,
+                            cancellationToken));
+                    memberScope.Map("source", async (
+                        IReplSessionState state,
+                        IReplIoContext io,
+                        CancellationToken cancellationToken) =>
+                        await ExecuteAsResultAsync(
+                            MemberSourceArguments(
+                                GetSelected(state, CurrentPackageKey, "package"),
+                                GetSelected(state, CurrentTypeKey, "type"),
+                                GetSelected(state, CurrentMemberKey, "member"),
+                                overload: null),
+                            io,
+                            executor,
+                            cancellationToken));
+                    memberScope.Map("source {overload:int}", async (
+                        int overload,
+                        IReplSessionState state,
+                        IReplIoContext io,
+                        CancellationToken cancellationToken) =>
+                        await ExecuteAsResultAsync(
+                            MemberSourceArguments(
+                                GetSelected(state, CurrentPackageKey, "package"),
+                                GetSelected(state, CurrentTypeKey, "type"),
+                                GetSelected(state, CurrentMemberKey, "member"),
+                                overload),
+                            io,
+                            executor,
+                            cancellationToken));
+                    memberScope.Map("back", () => Results.NavigateUp());
+                }, validation: hasMember);
+            }, validation: hasType);
+        }, validation: hasPackage);
+
+        return app;
+    }
+
+    internal static async Task<IExitResult> ExecuteAsResultAsync(
+        string[] arguments,
+        IReplIoContext io,
+        ReplInspectionExecutor executor,
+        CancellationToken cancellationToken) =>
+        Results.Exit(await executor(arguments, io, cancellationToken));
+
+    internal static async Task<int> ExecuteWithConsoleRoutingAsync(
+        IReplIoContext io,
+        CancellationToken cancellationToken,
+        Func<IReplIoContext, Task<int>> operation)
+    {
+        ArgumentNullException.ThrowIfNull(io);
+        ArgumentNullException.ThrowIfNull(operation);
+
+        await CliExecutionLock.WaitAsync(cancellationToken);
+        var originalOut = Console.Out;
+        var originalError = Console.Error;
+        var boundedIo = new BoundedReplIoContext(io);
+
+        try
+        {
+            Console.SetOut(boundedIo.Output);
+            Console.SetError(boundedIo.Error);
+            cancellationToken.ThrowIfCancellationRequested();
+            return await operation(boundedIo);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+            try
+            {
+                if (boundedIo.LimitReached)
+                {
+                    io.Error.WriteLine(
+                        $"Repl output truncated after {OutputLineLimit:N0} lines or " +
+                        $"{OutputCharacterLimit:N0} characters per stream. " +
+                        "Run the equivalent regular CLI command with explicit output controls.");
+                }
+            }
+            finally
+            {
+                CliExecutionLock.Release();
+            }
+        }
+    }
+
+    private static string[] PackageArguments(string package, params string[] additionalArguments) =>
+        ["package", package, .. additionalArguments, "--tips", "q"];
+
+    private static string[] TypeArguments(string package, string? type = null) =>
+        type is null
+            ? ["type", "--package", package, "--tips", "q"]
+            : ["type", "--package", package, "--tips", "q", "--", type];
+
+    private static string[] MemberArguments(string package, string type, string? member = null) =>
+        member is null
+            ? ["member", "--package", package, "--tips", "q", "--", type]
+            : ["member", "--package", package, $"--member={member}", "--tips", "q", "--", type];
+
+    private static string[] MemberSourceArguments(string package, string type, string member, int? overload) =>
+        overload is null
+            ? ["member", "--package", package, $"--member={member}", "-S", "Decompiled Source", "--tips", "q", "--", type]
+            : ["member", "--package", package, $"--member={member}", "--index", overload.Value.ToString(CultureInfo.InvariantCulture), "-S", "Decompiled Source", "--tips", "q", "--", type];
+
+    private static string GetSelected(IReplSessionState state, string key, string name) =>
+        state.Get<string>(key) ?? throw new InvalidOperationException($"No {name} is selected.");
+
+    private static async Task<object> SelectContextAsync(
+        string stateKey,
+        string value,
+        IReadOnlyList<string> staleStateKeys,
+        string targetPath,
+        string[] arguments,
+        IReplSessionState state,
+        IReplIoContext io,
+        ReplInspectionExecutor executor,
+        CancellationToken cancellationToken)
+    {
+        var exitCode = await executor(arguments, io, cancellationToken);
+        if (exitCode != 0)
+            return Results.Exit(exitCode);
+
+        state.Set(stateKey, value);
+        foreach (var staleStateKey in staleStateKeys)
+            state.Remove(staleStateKey);
+
+        return Results.NavigateTo(targetPath);
+    }
+
+    private sealed class BoundedReplIoContext : IReplIoContext
+    {
+        private readonly BoundedTextWriter _output;
+        private readonly BoundedTextWriter _error;
+
+        public BoundedReplIoContext(IReplIoContext inner)
+        {
+            Input = inner.Input;
+            _output = new BoundedTextWriter(inner.Output, OutputLineLimit, OutputCharacterLimit);
+            _error = new BoundedTextWriter(inner.Error, OutputLineLimit, OutputCharacterLimit);
+            Output = TextWriter.Synchronized(_output);
+            Error = TextWriter.Synchronized(_error);
+            IsHostedSession = inner.IsHostedSession;
+            SessionId = inner.SessionId;
+        }
+
+        public TextReader Input { get; }
+        public TextWriter Output { get; }
+        public TextWriter Error { get; }
+        public bool IsHostedSession { get; }
+        public string? SessionId { get; }
+        public bool LimitReached => _output.LimitReached || _error.LimitReached;
+    }
+
+    private sealed class BoundedTextWriter(TextWriter inner, int maxLines, int maxCharacters) : TextWriter
+    {
+        private readonly object _gate = new();
+        private int _charactersWritten;
+        private int _linesWritten;
+
+        public override Encoding Encoding => inner.Encoding;
+        public bool LimitReached { get; private set; }
+
+        public override void Write(char value)
+        {
+            lock (_gate)
+            {
+                if (LimitReached)
+                    return;
+
+                if (_charactersWritten >= maxCharacters || (value == '\n' && _linesWritten >= maxLines))
+                {
+                    LimitReached = true;
+                    return;
+                }
+
+                inner.Write(value);
+                _charactersWritten++;
+                if (value == '\n')
+                {
+                    _linesWritten++;
+                    if (_linesWritten >= maxLines)
+                        LimitReached = true;
+                }
+            }
+        }
+
+        public override void Write(string? value)
+        {
+            if (value is null)
+                return;
+
+            lock (_gate)
+            {
+                if (LimitReached)
+                    return;
+
+                var allowedLength = Math.Min(value.Length, maxCharacters - _charactersWritten);
+                var lines = 0;
+                for (var i = 0; i < allowedLength; i++)
+                {
+                    if (value[i] != '\n')
+                        continue;
+
+                    lines++;
+                    if (_linesWritten + lines >= maxLines)
+                    {
+                        allowedLength = i + 1;
+                        break;
+                    }
+                }
+
+                if (allowedLength > 0)
+                {
+                    var allowed = value[..allowedLength];
+                    inner.Write(allowed);
+                    _charactersWritten += allowedLength;
+                    _linesWritten += allowed.Count(character => character == '\n');
+                }
+
+                if (allowedLength < value.Length
+                    || _charactersWritten >= maxCharacters
+                    || _linesWritten >= maxLines)
+                {
+                    LimitReached = true;
+                }
+            }
+        }
+
+        public override void WriteLine(string? value)
+        {
+            Write(value);
+            Write(NewLine);
+        }
+
+        public override void WriteLine() => Write(NewLine);
+        public override void Flush() => inner.Flush();
+    }
+
+    private static Task<int> ExecuteExistingCliAsync(
+        string[] arguments,
+        IReplIoContext io,
+        CancellationToken cancellationToken) =>
+        ExecuteWithConsoleRoutingAsync(io, cancellationToken, async boundedIo =>
+        {
+            var processedArguments = CommandLineBuilder.PreprocessArgs(arguments);
+            var root = CommandLineBuilder.CreateRootCommand();
+            var invocationConfiguration = new InvocationConfiguration
+            {
+                Output = boundedIo.Output,
+                Error = boundedIo.Error,
+            };
+            return await root.Parse(processedArguments)
+                .InvokeAsync(invocationConfiguration, cancellationToken);
+        });
+}
+#else
+namespace DotnetInspector.Commands;
+
+/// <summary>
+/// Reports that the experimental Repl is unavailable in trimmed or NativeAOT builds.
+/// </summary>
+internal static class ReplCommand
+{
+    internal static Task<int> ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Console.Error.WriteLine(
+            "The experimental Repl is unavailable in trimmed or NativeAOT builds. " +
+            "Use an untrimmed managed dotnet-inspect build or the managed 'any' tool package.");
+        return Task.FromResult(1);
+    }
+}
+#endif

--- a/src/dotnet-inspect/Program.cs
+++ b/src/dotnet-inspect/Program.cs
@@ -1,33 +1,35 @@
 using DotnetInspector;
 using DotnetInspector.Core;
+using DotnetInspector.CommandLine;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
 using DotnetInspector.Views;
 using Markout;
 
 // Parse --offline early (before command parsing) to configure HttpClientFactory
-bool offline = args.Contains("--offline")
+bool offline = EarlyGlobalOptions.ContainsBeforeEndOfOptions(args, "--offline")
     || string.Equals(Environment.GetEnvironmentVariable("DOTNET_INSPECT_OFFLINE"), "1");
 if (offline)
-    args = args.Where(a => a != "--offline").ToArray();
+    args = EarlyGlobalOptions.RemoveAllBeforeEndOfOptions(args, "--offline");
 
 // Parse --info early (before command parsing) to install counting writer
-bool showInfo = args.Contains("--info")
+bool showInfo = EarlyGlobalOptions.ContainsBeforeEndOfOptions(args, "--info")
     || string.Equals(Environment.GetEnvironmentVariable("DOTNET_INSPECT_INFO"), "1");
 if (showInfo)
-    args = args.Where(a => a != "--info").ToArray();
+    args = EarlyGlobalOptions.RemoveAllBeforeEndOfOptions(args, "--info");
 
 // Parse --trace-mermaid early to subscribe before any request/cache/network breadcrumbs.
-bool showTraceMermaid = args.Contains("--trace-mermaid")
+bool showTraceMermaid = EarlyGlobalOptions.ContainsBeforeEndOfOptions(args, "--trace-mermaid")
     || string.Equals(Environment.GetEnvironmentVariable("DOTNET_INSPECT_TRACE_MERMAID"), "1");
 if (showTraceMermaid)
-    args = args.Where(a => a != "--trace-mermaid").ToArray();
+    args = EarlyGlobalOptions.RemoveAllBeforeEndOfOptions(args, "--trace-mermaid");
 
 // Parse --isolated <name> and --no-nuget-cache early
 string? sessionName = null;
 var argList = new List<string>(args);
-int isolatedIdx = argList.IndexOf("--isolated");
-if (isolatedIdx >= 0 && isolatedIdx + 1 < argList.Count)
+int isolatedIdx = EarlyGlobalOptions.IndexOfBeforeEndOfOptions(args, "--isolated");
+int endOfOptionsIdx = EarlyGlobalOptions.GetEndOfOptionsIndex(args);
+if (isolatedIdx >= 0 && isolatedIdx + 1 < endOfOptionsIdx)
 {
     sessionName = argList[isolatedIdx + 1];
     argList.RemoveAt(isolatedIdx + 1);
@@ -35,7 +37,8 @@ if (isolatedIdx >= 0 && isolatedIdx + 1 < argList.Count)
 }
 else if (isolatedIdx >= 0)
 {
-    argList.RemoveAt(isolatedIdx);
+    Console.Error.WriteLine("Error: --isolated requires a session name before '--'.");
+    return 1;
 }
 sessionName ??= Environment.GetEnvironmentVariable("DOTNET_INSPECT_ISOLATED");
 if (string.IsNullOrWhiteSpace(sessionName))
@@ -43,9 +46,9 @@ if (string.IsNullOrWhiteSpace(sessionName))
 bool isolated = sessionName != null;
 args = argList.ToArray();
 
-bool noNuGetCache = args.Contains("--no-nuget-cache") || isolated;
-if (args.Contains("--no-nuget-cache"))
-    args = args.Where(a => a != "--no-nuget-cache").ToArray();
+bool noNuGetCache = EarlyGlobalOptions.ContainsBeforeEndOfOptions(args, "--no-nuget-cache") || isolated;
+if (EarlyGlobalOptions.ContainsBeforeEndOfOptions(args, "--no-nuget-cache"))
+    args = EarlyGlobalOptions.RemoveAllBeforeEndOfOptions(args, "--no-nuget-cache");
 
 // Resolve cache base path: explicit env var > named session dir > default
 string? cacheBasePath = Environment.GetEnvironmentVariable("DOTNET_INSPECT_CACHE_DIR");
@@ -65,7 +68,7 @@ if (showInfo)
 {
     InfoTracker.Start();
     // Suppress tips when --info is active (show info instead)
-    args = [.. args, "-T:q"];
+    args = EarlyGlobalOptions.InsertBeforeEndOfOptions(args, "-T:q");
 }
 
 #if DEBUG

--- a/src/dotnet-inspect/Program.cs
+++ b/src/dotnet-inspect/Program.cs
@@ -7,22 +7,25 @@ using DotnetInspector.Views;
 using Markout;
 
 // Parse --offline early (before command parsing) to configure HttpClientFactory
-bool offline = EarlyGlobalOptions.ContainsBeforeEndOfOptions(args, "--offline")
+bool? offlineOption = EarlyGlobalOptions.GetBooleanValueBeforeEndOfOptions(args, "--offline");
+bool offline = offlineOption == true
     || string.Equals(Environment.GetEnvironmentVariable("DOTNET_INSPECT_OFFLINE"), "1");
-if (offline)
-    args = EarlyGlobalOptions.RemoveAllBeforeEndOfOptions(args, "--offline");
+if (offlineOption.HasValue)
+    args = EarlyGlobalOptions.RemoveBooleanBeforeEndOfOptions(args, "--offline");
 
 // Parse --info early (before command parsing) to install counting writer
-bool showInfo = EarlyGlobalOptions.ContainsBeforeEndOfOptions(args, "--info")
+bool? infoOption = EarlyGlobalOptions.GetBooleanValueBeforeEndOfOptions(args, "--info");
+bool showInfo = infoOption == true
     || string.Equals(Environment.GetEnvironmentVariable("DOTNET_INSPECT_INFO"), "1");
-if (showInfo)
-    args = EarlyGlobalOptions.RemoveAllBeforeEndOfOptions(args, "--info");
+if (infoOption.HasValue)
+    args = EarlyGlobalOptions.RemoveBooleanBeforeEndOfOptions(args, "--info");
 
 // Parse --trace-mermaid early to subscribe before any request/cache/network breadcrumbs.
-bool showTraceMermaid = EarlyGlobalOptions.ContainsBeforeEndOfOptions(args, "--trace-mermaid")
+bool? traceMermaidOption = EarlyGlobalOptions.GetBooleanValueBeforeEndOfOptions(args, "--trace-mermaid");
+bool showTraceMermaid = traceMermaidOption == true
     || string.Equals(Environment.GetEnvironmentVariable("DOTNET_INSPECT_TRACE_MERMAID"), "1");
-if (showTraceMermaid)
-    args = EarlyGlobalOptions.RemoveAllBeforeEndOfOptions(args, "--trace-mermaid");
+if (traceMermaidOption.HasValue)
+    args = EarlyGlobalOptions.RemoveBooleanBeforeEndOfOptions(args, "--trace-mermaid");
 
 // Parse --isolated <name> and --no-nuget-cache early
 string? sessionName = null;
@@ -46,9 +49,10 @@ if (string.IsNullOrWhiteSpace(sessionName))
 bool isolated = sessionName != null;
 args = argList.ToArray();
 
-bool noNuGetCache = EarlyGlobalOptions.ContainsBeforeEndOfOptions(args, "--no-nuget-cache") || isolated;
-if (EarlyGlobalOptions.ContainsBeforeEndOfOptions(args, "--no-nuget-cache"))
-    args = EarlyGlobalOptions.RemoveAllBeforeEndOfOptions(args, "--no-nuget-cache");
+bool? noNuGetCacheOption = EarlyGlobalOptions.GetBooleanValueBeforeEndOfOptions(args, "--no-nuget-cache");
+bool noNuGetCache = noNuGetCacheOption == true || isolated;
+if (noNuGetCacheOption.HasValue)
+    args = EarlyGlobalOptions.RemoveBooleanBeforeEndOfOptions(args, "--no-nuget-cache");
 
 // Resolve cache base path: explicit env var > named session dir > default
 string? cacheBasePath = Environment.GetEnvironmentVariable("DOTNET_INSPECT_CACHE_DIR");

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -34,6 +34,22 @@
     <PublishAot>true</PublishAot>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Repl.Core 0.12.0-dev.3 is not trim/AOT clean. Keep the experimental mode in
+         untrimmed managed builds, and compile an unavailable stub otherwise. -->
+    <ExperimentalReplBuildSupported Condition="'$(PublishTrimmed)' != 'true' and ('$(PublishAot)' != 'true' or ('$(_IsPublishing)' != 'true' and '$(RuntimeIdentifier)' == ''))">true</ExperimentalReplBuildSupported>
+    <ExperimentalReplBuildSupported Condition="'$(ExperimentalReplBuildSupported)' == ''">false</ExperimentalReplBuildSupported>
+    <EnableExperimentalRepl Condition="'$(EnableExperimentalRepl)' == ''">$(ExperimentalReplBuildSupported)</EnableExperimentalRepl>
+    <DefineConstants Condition="'$(EnableExperimentalRepl)' == 'true'">$(DefineConstants);DOTNET_INSPECT_EXPERIMENTAL_REPL</DefineConstants>
+  </PropertyGroup>
+
+  <Target Name="ValidateExperimentalReplConfiguration" BeforeTargets="PrepareForBuild">
+    <Error Condition="'$(EnableExperimentalRepl)' == 'true' and '$(ExperimentalReplBuildSupported)' != 'true' and '$(PublishTrimmed)' == 'true'"
+           Text="EnableExperimentalRepl cannot be true when PublishTrimmed is explicitly enabled." />
+    <Error Condition="'$(EnableExperimentalRepl)' == 'true' and '$(PublishAot)' == 'true' and ('$(_IsPublishing)' == 'true' or '$(RuntimeIdentifier)' != '')"
+           Text="EnableExperimentalRepl cannot be true for a NativeAOT publish." />
+  </Target>
+
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <DebugType>embedded</DebugType>
@@ -76,6 +92,7 @@
     <PackageReference Include="MarkdownTable.Formatting" />
     <PackageReference Include="Markout" />
     <PackageReference Include="NuGet.Versioning" />
+    <PackageReference Include="Repl.Core" Condition="'$(EnableExperimentalRepl)' == 'true'" />
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 


### PR DESCRIPTION
## Context: unsolicited exploratory proposal

This is an **unsolicited exploratory contribution** proposing that dotnet-inspect add a contextual Repl pilot. It was not requested, sponsored, or pre-approved by the dotnet-inspect maintainers, and the proposing contributor is also involved in Repl's development.

The goal is to provide a concrete prototype for evaluation—not to imply that the project has selected Repl, committed to this direction, or placed it on its roadmap. There is no expectation that this proposal be accepted; declining or closing it is a completely valid outcome if the dependency, maintenance cost, or interaction model does not fit the project.

## What does this PR do?

Adds an opt-in experimental command without replacing the existing `System.CommandLine` CLI:

```bash
dotnet-inspect repl
```

The pilot:

- pins `Repl.Core` to prerelease `0.12.0-dev.3`
- adds contextual `package → type → member → source` navigation
- delegates every inspection through the existing `System.CommandLine` graph so current parsing, diagnostics, sections, overload indexes, and rendering remain authoritative
- changes selection state only after the delegated command returns exit code `0`
- preserves literal selectors and option-shaped suffixes across `--`
- supports standalone and `=true|false` forms for early global boolean options before `--`
- streams delegated stdout/stderr through bounded writers while restoring the process console after success, error, or cancellation
- caps each delegated stdout/stderr stream at 10,000 lines or 1,000,000 characters and reports truncation explicitly
- reserves `repl` as a root verb while keeping a package named `repl` available through `dotnet-inspect package repl`
- documents the workflow, compatibility boundary, operational limits, and third-party MIT notice

Example session:

```text
> package System.Text.Json
[selected-package]> type System.Text.Json.JsonSerializer
[selected-package/selected-type]> member Serialize
[selected-package/selected-type/selected-member]> source 1
```

## Packaging and compatibility boundary

- Untrimmed managed builds and the managed `any` tool package include the pilot.
- Trimmed and RID-specific NativeAOT builds exclude `Repl.Core` and expose an explicit unavailable stub returning exit code `1`.
- An unsafe explicit Repl + trimming/AOT override fails the build rather than silently producing an unsupported configuration.
- Existing non-Repl commands and output contracts remain the primary automation surface; the interactive prompts do not define a new JSON or scripting contract.

## Current limitations

- This is a focused package/type/member exploration pilot, not a second grammar for every dotnet-inspect command.
- Repl `0.12.0-dev.3` currently rebuilds absolute navigation from space-split route strings, so the bridge stores user selectors in session state and navigates through static selected scopes.
- Ctrl+C cancellation is best effort because not every existing NuGet/decompilation handler propagates cancellation all the way down.
- Very large delegated output is intentionally truncated; users needing complete output should invoke the equivalent regular CLI command.
- The current Repl prerelease is not trim-clean, which is why the pilot is excluded from trimmed/NativeAOT artifacts.

## Verification

Validated locally with .NET SDK `11.0.100-preview.6.26359.118`:

- `dotnet-inspect.Tests`: **1,933 total, 0 failed, 10 skipped**
- targeted entry-point/parser/router regressions: **7 passed**
- Release build of the product/test graph: **0 warnings, 0 errors**
- real managed `any` package created and installed as a local .NET tool
- installed-package smoke test completed `package → type → member → source`
- package inspection confirmed `Repl.Core.dll` is present in the managed `any` package
- integrated RID/AOT build completed successfully; its `repl` stub returned `1` and `Repl.Core.dll` was absent
- whitespace/static secret and shell-execution scans passed

Managed package exercised locally:

```text
PackageId: dotnet-inspect.any
Version:   0.16.0
SHA-256:   44ac3cdcdbda4b09d42cae9e85cbe8364d06c54a1c0d2cc20233a5b3284d526f
```

## Review posture

The intended review question is whether this interaction model and dependency are useful enough to pursue—not whether the project is already committed to adopting them. Feedback that the prototype should be narrowed, redesigned, moved upstream, or closed is welcome.
