### PR TITLE
Remove dead RTS self-type parameter normalization

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -906,7 +906,7 @@ public class GeneratedFixtureCatalogTests
             GeneratedFixtureCatalog.Select("minimal.property.literal").Select(fixture => fixture.Id).ToArray());
 
         Assert.Equal(
-            ["rts.attribute-shell"],
+            ["rts.attribute-shell", "rts.shifted-sibling-nested-generic"],
             GeneratedFixtureCatalog.Select("rts").Select(fixture => fixture.Id).Order(StringComparer.Ordinal).ToArray());
 
         Assert.Equal(
@@ -1440,6 +1440,21 @@ public class GeneratedFixtureCatalogTests
             result.FixtureId == "rts.attribute-shell" &&
             result.Method == "get_FeatureType");
         Assert.DoesNotContain("CS0641", report);
+    }
+
+    [Fact]
+    public void ReturnToSenderRtsCatalog_KeepsShiftedSiblingNestedGenericParameter()
+    {
+        var run = GeneratedFixtureRunner.RunReturnToSenderCatalog(
+            GeneratedFixtureCatalog.Select("rts.shifted-sibling-nested-generic"));
+        string report = GeneratedFixtureRunner.FormatReturnToSenderCatalogReport(run, maxExamples: 10);
+
+        Assert.True(run.Passed, report);
+        var result = Assert.Single(run.Results);
+        Assert.Equal(GeneratedFixtureReturnToSenderStatus.Pass, result.Status);
+        Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.ActualStatus);
+        Assert.Equal("ShiftedSiblingOuter`1.Inner`3", result.Type);
+        Assert.Equal("ReadShifted", result.Method);
     }
 
     [Fact]

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -1481,6 +1481,38 @@ internal static class GeneratedFixtureCatalog
         ],
         ["rts", "attribute", "shell", "return-to-sender"]);
 
+    public static readonly GeneratedFixtureDefinition RtsShiftedSiblingNestedGeneric = new(
+        "rts.shifted-sibling-nested-generic",
+        """
+        public class ShiftedSiblingOuter<T>
+        {
+            public class Inner<A, B>
+            {
+                public int Marker => 123;
+            }
+
+            public class Inner<A, B, C>
+            {
+                public int ReadShifted(ShiftedSiblingOuter<A>.Inner<B, C> shifted) => shifted.Marker;
+            }
+        }
+        """,
+        [
+            new(
+                "ShiftedSiblingOuter`1.Inner`3",
+                "ReadShifted",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "ShiftedSiblingOuter<A>.Inner<B, C> shifted",
+                ],
+                ExpectedTargetBodyFragments:
+                [
+                    "return shifted.Marker;",
+                ]),
+        ],
+        ["rts", "nested", "generic", "shifted", "return-to-sender"]);
+
     public static readonly GeneratedFixtureDefinition AssertionNodeCoverage = new(
         "assertion.inverse-node-coverage",
         """
@@ -1952,6 +1984,7 @@ internal static class GeneratedFixtureCatalog
     public static IReadOnlyList<GeneratedFixtureDefinition> ReturnToSenderParity { get; } =
     [
         RtsAttributeShell,
+        RtsShiftedSiblingNestedGeneric,
     ];
 
     public static IReadOnlyList<GeneratedFixtureDefinition> AssertionCoverage { get; } =

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1622,46 +1622,11 @@ public static class CompileBackSourceComposer
         MethodSignature<string> signature)
     {
         var declaringType = reader.GetTypeDefinition(method.GetDeclaringType());
-        var parameters = ToCompileBackParameters(MetadataDeclarationQuery.GetMethod(
+        return ToCompileBackParameters(MetadataDeclarationQuery.GetMethod(
             reader,
             declaringType,
             method,
             signature).Signature.Parameters);
-        return NormalizeSelfTypeParameters(reader, declaringType, parameters);
-    }
-
-    static IReadOnlyList<CompileBackParameter> NormalizeSelfTypeParameters(
-        MetadataReader reader,
-        TypeDefinition declaringType,
-        IReadOnlyList<CompileBackParameter> parameters)
-    {
-        if (parameters.Count == 0 || declaringType.GetDeclaringType().IsNil)
-            return parameters;
-
-        string selfType = MetadataDeclarationQuery.SelfTypeSignature(reader, declaringType);
-        string directSelfType = DirectSelfTypeSignature(reader, declaringType);
-        if (directSelfType == selfType || parameters.All(parameter => parameter.Type.DisplayName != directSelfType))
-            return parameters;
-
-        return parameters
-            .Select(parameter => parameter.Type.DisplayName == directSelfType
-                ? parameter with { Type = CompileBackTypeSignature.Display(selfType) }
-                : parameter)
-            .ToArray();
-    }
-
-    static string DirectSelfTypeSignature(MetadataReader reader, TypeDefinition type)
-    {
-        var handles = type.GetGenericParameters();
-        int inheritedCount = 0;
-        var declaringType = type.GetDeclaringType();
-        if (!declaringType.IsNil)
-            inheritedCount = reader.GetTypeDefinition(declaringType).GetGenericParameters().Count;
-        var directNames = handles
-            .Skip(inheritedCount)
-            .Select(handle => reader.GetString(reader.GetGenericParameter(handle).Name))
-            .ToArray();
-        return TypeResolver.ApplyGenericArguments(TypeResolver.GetFullName(reader, type), directNames);
     }
 
     static IReadOnlyList<string> MethodReturnAttributes(MetadataReader reader, MethodDefinition method)


### PR DESCRIPTION
## Summary

Removes `NormalizeSelfTypeParameters` (and its `DirectSelfTypeSignature` helper) from the ReturnToSender type planner. This continues the "de-C#-ify RTS" arc by deleting harness-side metadata reconstruction in favour of the product-owned parameter spelling — **and fixes a latent parameter-corruption bug** surfaced during adversarial review.

> **Correction:** the first commit describes this as "dead code / behaviorally identical". Adversarial review (below) proved that is inaccurate — the transform **is reachable** and the deletion is a **bug fix**. This description is the authoritative narrative.

## What the normalization did — and why it was wrong

`NormalizeSelfTypeParameters` rewrote any method parameter whose display name equalled a locally-computed "direct" self-type (`DirectSelfTypeSignature`) to the full self-type (`MetadataDeclarationQuery.SelfTypeSignature`).

- **For compiler-emitted simple nested self-types it was a no-op.** For `Outer<T>.Inner<U>`, the product already spells a `self` parameter as `NS.Outer<T>.Inner<U>` (identical to `SelfTypeSignature`), while `DirectSelfTypeSignature` produces the malformed `NS.Outer<U>.Inner<>`, which never matches. Confirmed by probe + 199 RTS oracle tests + a framework corpus run (CoreLib/Collections/Linq), all with **zero fires**.
- **But it actively corrupted legitimate shifted-sibling nested-generic parameters.** For `Outer<T>.Inner<A,B,C>.ReadShifted(Outer<A>.Inner<B,C> shifted)`, `DirectSelfTypeSignature` produces the *well-formed* `Outer<A>.Inner<B,C>` — which matches the real parameter. The old code then rewrote it to `Outer<T>.Inner<A,B,C>` (a different, wrong type), corrupting the reconstructed shell (`shifted.Marker` → CS1061). Deleting the normalization preserves the correct spelling.

## Regression coverage

Added generated fixture `rts.shifted-sibling-nested-generic` (`GeneratedFixtures.cs`) + a catalog test that reconstructs `ReadShifted` and asserts, via an expected source fragment, that the parameter is preserved as `ShiftedSiblingOuter<A>.Inner<B, C> shifted`.

**Guard verified both ways:** with the old normalization reintroduced the fixture fails `source-fragment-missing`; with it removed it passes `Exact`.

## Validation

- `GeneratedFixtureCatalogTests`, `ReturnToSenderEvidenceTests`, `ReturnToSenderFixtureCatalogTests`, `ReturnToSenderPrototypeTests`: **216 pass, 0 fail**.
- Framework RTS corpus (CoreLib/Collections/Linq): verdicts unchanged (48 Exact / 1 OpcodeDiff / 2 RecompileFail / 1 ContextFail).
- Built on .NET 11 preview 6 (`11.0.100-preview.6.26359.118`).

## Risk

Harness-only (`tools/DecompilerHarness`). The behaviour change is strictly a fidelity improvement (removes a corruption); no regression in the 216-test suite or the framework corpus. Two adversarial reviews reconciled below.
