### PR TITLE
Add Resource Triage for exception-path pool churn

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,11 +219,13 @@ exception-path pool-churn candidates. It currently reports `ArrayPool<T>`
 acquisitions whose exact def-use path reaches an external-input boundary before
 modeled cleanup. These are triage candidates, not permanent-memory-leak or
 memory-corruption accusations: the impact is pooled-array churn if the boundary
-throws, and static analysis does not establish runtime frequency. Each row
-retains its `analysis.resource-lifecycle` Finding, stable `Candidate`, exact
-acquire and boundary IL offsets, and the resolved boundary operation. Trusted
-in-memory transforms and unknown boundaries remain available to corpus
-measurement but are not exposed in this curated section.
+throws, and static analysis does not establish runtime frequency. Each boundary
+is one row that retains its `analysis.resource-lifecycle` Finding, stable
+`Candidate`, exact acquire and boundary IL offsets, and resolved operation.
+Candidates with multiple boundaries repeat their candidate and acquisition
+fields so each operation remains paired with its own offset. Trusted in-memory
+transforms and unknown boundaries remain available to corpus measurement but
+are not exposed in this curated section.
 
 ```bash
 dotnet-inspect library MyLib.dll -S "Top Leverage"

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ context for copied DLLs. A future `--deps` source can represent runtime
 | API compatibility | `diff` | Version ranges, package or platform diffs, breaking/additive/potentially-breaking classification, type and member filters, plus opt-in decompiled C#/IL/checksum-verified authored Source evidence. |
 | Relationships | `depends`, `extensions`, `implements` | Type hierarchies, package dependencies, library reference graphs, extension methods/properties, implementors and subclasses. Add `--project` to search project-referenced packages. |
 | Source mapping | `type`/`library`/`package -S "Source Files"`, `member -S "Source Locations"` / `"Original Source"` | SourceLink URLs, member file/line locations, source fetching, URL verification, token+IL-offset to source-line resolution. |
-| Performance analysis *(experimental)* | `library`/`type`/`member -S "Top Leverage"`, `"Performance Triage"`, `"Call Graph"`, `"Caller Graph"` | Whole-assembly call-graph leverage ranking — direct callers, root reach, fanout, depth, loop calls — with opt-in per-node cost signals (alloc, copy, unsafe, reflection, throw/exception, catch/finally) and actionable rewrite-shape detection. |
+| Performance analysis *(experimental)* | `library`/`type`/`member -S "Top Leverage"`, `"Performance Triage"`, `"Resource Triage"`, `"Call Graph"`, `"Caller Graph"` | Whole-assembly call-graph leverage ranking — direct callers, root reach, fanout, depth, loop calls — with opt-in per-node cost signals (alloc, copy, unsafe, reflection, throw/exception, catch/finally), actionable rewrite-shape detection, and exception-path resource-lifecycle candidates. |
 | Decompiler *(experimental)* | `member -S @Source` (`Decompiled Source`, `Annotated Source`, `Original Source`, `Source Diff`, `IL`); `member -S "Fidelity Causes"` | Raises method bodies to C#, interleaves IL and hidden-fact annotations, diffs SourceLink-backed source against decompiled source, and exposes typed `DEC####` fidelity causes rather than emitting plausible-but-wrong source. |
 | Agent-friendly output | global flags | Markdown by default, compact `--table`, normalized `--tsv`, `--jsonl`, `--plaintext`, `--json`, Mermaid diagrams, section/field projection, `--count`, table row limiting, built-in head/tail limiting. |
 
@@ -214,10 +214,22 @@ the allocation's local `Loop`, multiplicity, confidence, weight, or ranking,
 and it does not claim runtime heat. Function loads such as `ldftn` are not
 invocations and do not produce this evidence.
 
+`Resource Triage` is an explicit library section for high-confidence
+exception-path pool-churn candidates. It currently reports `ArrayPool<T>`
+acquisitions whose exact def-use path reaches an external-input boundary before
+modeled cleanup. These are triage candidates, not permanent-memory-leak or
+memory-corruption accusations: the impact is pooled-array churn if the boundary
+throws, and static analysis does not establish runtime frequency. Each row
+retains its `analysis.resource-lifecycle` Finding, stable `Candidate`, exact
+acquire and boundary IL offsets, and the resolved boundary operation. Trusted
+in-memory transforms and unknown boundaries remain available to corpus
+measurement but are not exposed in this curated section.
+
 ```bash
 dotnet-inspect library MyLib.dll -S "Top Leverage"
 dotnet-inspect type MyType --library MyLib.dll --all -S "Top Leverage"
 dotnet-inspect library MyLib.dll -S "Performance Triage"
+dotnet-inspect library MyLib.dll -S "Resource Triage" --jsonl
 dotnet-inspect library MyLib.dll --loop --min-confidence high --top 20 --tsv
 dotnet-inspect library MyLib.dll --triage-shape scan-method-in-loop-call,linq-scan-in-loop,string-build-in-loop --top 20 --tsv
 dotnet-inspect library MyLib.dll --triage-shape capturing-delegate --top 10 --jsonl

--- a/docs/analysis-baselines.md
+++ b/docs/analysis-baselines.md
@@ -42,7 +42,7 @@ are the cheapest "found something interesting" wins.
 | # | Analysis type | Command | Volume (44 asm) | Precision | Actionability | Verdict |
 | - | ------------- | ------- | --------------- | --------- | ------------- | ------- |
 | 1 | Algorithmic scan-in-loop | `Performance Triage` (`scan-method-in-loop-call`, `linq-scan-in-loop`, `string-build-in-loop`, `allocation-hotspot`) | 155 | High | **Very high** (quadratic) | **Headline** |
-| 2 | Leak-after-exception | harness `--leak-triage` + `--leak-actionability` | 5 actionable | **Very high (9/9 confirmed)** | High (`try/finally`) | **Headline** |
+| 2 | Leak-after-exception | `Resource Triage` (harness `--leak-actionability` for the full census) | 2 current framework / 9 historical confirmed | **Very high** | High (`try/finally`) | **Headline** |
 | 3 | Delegate allocation | `Performance Triage` (`instance-method-group-delegate`, `capturing-delegate`) | 3,327 raw / 128 hot | High (real) / High in loops | High in loops | **Worthy w/ ranking** |
 | 4 | Enumerator allocation | `Performance Triage` (`enumerator-allocation`) | 121 / 117 hot | High | Med–High | **Worthy** |
 | 5 | Reach / leverage | `Top Leverage` | ranking | — | Impact multiplier for 1,3,4 | **Worthy as a lens** |
@@ -70,14 +70,21 @@ where each `CalculateDepth` step re-scans all spans) — the O(N·D·N) waterfal
 
 ### 2. Leak-after-exception — highest-precision lane
 
-Pooled-buffer leak on the exception path (see catalog issue #2572 and #2439). Harness sensors classify
-the exception-path `ArrayPool` candidates by whether the throwing boundary consumes external input.
+Pooled-buffer churn on the exception path (see catalog issue #2572 and #2439). Analysis classifies
+exact def-use-attributed `ArrayPool` boundaries by whether they consume external input;
+`Resource Triage` exposes the untrusted-actionable candidates.
 
-- Broadened packages (44 asm): 12 exception-path candidates → **5 untrusted-actionable, all confirmed**
+- Historical broadened-package sensor (44 asm): 12 exception-path candidates →
+  **5 untrusted-actionable, all confirmed**
   (MessagePack `ReadStringSlow`, MimeKit `Rfc2047.DecodePhrase`/`DecodeText`, Npgsql
   `TextConverter.GetChars`, Pipelines.Sockets `AsyncPipeStream.ReadByte`).
-- Framework (308 asm): 4 untrusted-actionable, all confirmed.
-- **9/9 confirmed real leaks**, IL-verified. Lowest volume, highest precision, clean `try/finally` fix.
+- Historical framework sensor (308 asm): 4 untrusted-actionable, all confirmed.
+- **9/9 confirmed exception-path pool-retention defects**, IL-verified. Lowest volume,
+  highest precision, clean `try/finally` fix.
+- Current exact product contract (.NET 11 daily, 314 assemblies): 49 lifecycle
+  candidates → 2 untrusted-actionable
+  (`MessagePackReader.ReadStringSlow`, `BinaryReader.FillBuffer`), 1 trusted,
+  and 46 unknown.
 
 ### 3–4. Delegate & enumerator allocation
 

--- a/docs/design/analysis-ux-scopes.md
+++ b/docs/design/analysis-ux-scopes.md
@@ -202,6 +202,7 @@ Future semantic sections should use the same facts and nouns across scopes.
 | Exception | `Exception Context` | `Exception Regions` | `Exception Regions` with member column | optional `Exception Triage` |
 | Callsite | `Callsite Context` / `Return Address Context` | `Calls` | `Calls` with member column | `Top Leverage` / call graph summaries |
 | Allocation | `Allocation Context` | `Allocation Facts` | `Allocation Facts` with member column | `Performance Triage` |
+| Resource lifecycle | optional `Resource Context` | optional `Resource Facts` | resource rows with member column | `Resource Triage` |
 | Safety | `Safety Context` | `Safety Facts` | `Safety Facts` with member column | `Safety Triage` or `Correctness Triage` |
 | Cost | `Cost Context` | `Cost Facts` / `Cost Overlay` | cost rows with member column | `Performance Triage` |
 

--- a/docs/design/finding-adoption.md
+++ b/docs/design/finding-adoption.md
@@ -219,9 +219,10 @@ deliberately have no exact source Finding.
 `Resource Triage` follows the same rule. Its pool-churn impact and cleanup
 direction are downstream judgments over exact
 `analysis.resource-lifecycle` observations; rows retain the native descriptor,
-candidate identity, resolved boundaries, and acquisition/boundary IL offsets.
-The harness measures all actionability classes from that same inspection, while
-the product section selects the untrusted-actionable subset.
+candidate identity, resolved boundary, and acquisition/boundary IL offsets.
+Multi-boundary candidates expand into one row per typed operation/offset pair.
+The harness measures all actionability classes from that same inspection,
+while the product section selects the untrusted-actionable subset.
 
 ## Adoption review
 

--- a/docs/design/finding-adoption.md
+++ b/docs/design/finding-adoption.md
@@ -216,6 +216,13 @@ therefore useful for a runtime/static join within one build, while
 correspondence paths. Aggregate judgments such as `allocation-hotspot`
 deliberately have no exact source Finding.
 
+`Resource Triage` follows the same rule. Its pool-churn impact and cleanup
+direction are downstream judgments over exact
+`analysis.resource-lifecycle` observations; rows retain the native descriptor,
+candidate identity, resolved boundaries, and acquisition/boundary IL offsets.
+The harness measures all actionability classes from that same inspection, while
+the product section selects the untrusted-actionable subset.
+
 ## Adoption review
 
 Before calling a consumer migration complete, verify:

--- a/docs/design/finding-producers.md
+++ b/docs/design/finding-producers.md
@@ -212,6 +212,15 @@ Allocation, call-site, and unsafety comparisons share one descriptor-keyed
 retention container; new descriptors do not add parallel flags, lists,
 constructors, or merge branches.
 
+Resource lifecycle observations are a single-version Analysis producer under
+`analysis.resource-lifecycle`. Each occurrence retains one acquisition and its
+exact unprotected boundary set; boundary kinds and aggregate actionability are
+producer-owned API-shape facets. The explicit `Resource Triage` section keeps
+the complete `FindingInspection<ResourceLifecycleOccurrence>`, exposes only
+untrusted-actionable candidates, and adds impact/fix language downstream.
+`Complete([])` and `Failed` remain distinct, and the corpus harness consumes the
+same inspection rather than resolving tokens or classifying boundaries itself.
+
 The same three Analysis censuses now compose with the N-address correlation
 tier. `timeline --member M --finding analysis.*` uses Metadata only to resolve
 the structural method focus, then correlates the producer-native Analysis

--- a/skills/performance/SKILL.md
+++ b/skills/performance/SKILL.md
@@ -118,6 +118,22 @@ prove realized depth or frequency. Do not infer either case into caller-loop
 evidence; require runtime evidence or a stronger product-owned invocation
 contract.
 
+## Triage exception-path pool churn
+
+Select the explicit `Resource Triage` library section to find `ArrayPool<T>`
+acquisitions whose exact def-use path reaches an external-input boundary before
+modeled cleanup:
+
+```bash
+dnx dotnet-inspect -y -- library MyLib.dll -S "Resource Triage" --jsonl
+```
+
+Treat `pool-churn-on-exception` as a profiling and hardening candidate, not a
+permanent-memory-leak or memory-corruption accusation. Static analysis proves
+the unprotected boundary shape and API evidence, not runtime frequency. Use
+`Candidate`, `Finding=analysis.resource-lifecycle`, `Acquire IL`, `Boundary IL`,
+and `Boundary` to retain exact provenance while drilling the method.
+
 Not every shape is a pure hot-path win. `async-state-machine` is reported as
 amortized (low confidence) unless the allocation sits in a loop: async lowering
 moves work into a state object rather than eliminating it, often once per

--- a/skills/performance/SKILL.md
+++ b/skills/performance/SKILL.md
@@ -132,7 +132,9 @@ Treat `pool-churn-on-exception` as a profiling and hardening candidate, not a
 permanent-memory-leak or memory-corruption accusation. Static analysis proves
 the unprotected boundary shape and API evidence, not runtime frequency. Use
 `Candidate`, `Finding=analysis.resource-lifecycle`, `Acquire IL`, `Boundary IL`,
-and `Boundary` to retain exact provenance while drilling the method.
+and `Boundary` to retain exact provenance while drilling the method. Each
+boundary is one row; a multi-boundary candidate repeats its candidate and
+acquisition fields so every operation stays paired with its own IL offset.
 
 Not every shape is a pure hot-path win. `async-state-machine` is reported as
 amortized (low confidence) unless the allocation sits in a loop: async lowering

--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -123,6 +123,38 @@ public sealed class LeakTriageAnalyzerTests
             boundary.Operation.Name == "GetChars"
             && boundary.Kind == ResourceBoundaryKind.ExternalInput);
 
+        var throughStringArgument = Assert.Single(candidates.Where(candidate =>
+            candidate.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.ExternalParseThroughSpanWithTag)));
+        Assert.Equal(
+            ResourceActionability.UntrustedActionable,
+            throughStringArgument.Source.Payload.Actionability);
+        Assert.Contains(
+            throughStringArgument.Source.Payload.Boundaries,
+            boundary =>
+                boundary.Operation.Name == "Parse"
+                && boundary.Kind == ResourceBoundaryKind.ExternalInput);
+
+        var unrelatedReader = Assert.Single(candidates.Where(candidate =>
+            candidate.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.UnrelatedTextReaderReadBeforeReturn)));
+        Assert.Equal(
+            ResourceActionability.Unknown,
+            unrelatedReader.Source.Payload.Actionability);
+        Assert.Equal(
+            ResourceBoundaryKind.Unknown,
+            Assert.Single(unrelatedReader.Source.Payload.Boundaries).Kind);
+
+        var frameworkReader = Assert.Single(candidates.Where(candidate =>
+            candidate.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.FrameworkTextReaderReadBeforeReturn)));
+        Assert.Equal(
+            ResourceActionability.UntrustedActionable,
+            frameworkReader.Source.Payload.Actionability);
+        Assert.Equal(
+            ResourceBoundaryKind.ExternalInput,
+            Assert.Single(frameworkReader.Source.Payload.Boundaries).Kind);
+
         var trusted = Assert.Single(candidates.Where(candidate =>
             candidate.Source.Payload.Method.Name
                 == nameof(ArrayPoolLeakFixtures.TrustedTransformWithUnrelatedReadAfterReturn)));
@@ -843,6 +875,33 @@ internal sealed class ArrayPoolLeakFixtures
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int ExternalParseThroughSpanWithTag()
+    {
+        var chars = ArrayPool<char>.Shared.Rent(16);
+        int written = ExternalInputReader.Parse(chars.AsSpan(), "wire");
+        ArrayPool<char>.Shared.Return(chars);
+        return written;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int UnrelatedTextReaderReadBeforeReturn(TextReader reader)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        int read = reader.Read(buffer);
+        ArrayPool<byte>.Shared.Return(buffer);
+        return read;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int FrameworkTextReaderReadBeforeReturn(System.IO.TextReader reader)
+    {
+        var buffer = ArrayPool<char>.Shared.Rent(16);
+        int read = reader.Read(buffer, 0, 16);
+        ArrayPool<char>.Shared.Return(buffer);
+        return read;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static int TrustedTransformWithUnrelatedReadAfterReturn(Stream stream)
     {
         var buffer = ArrayPool<byte>.Shared.Rent(16);
@@ -875,6 +934,19 @@ internal sealed class ArrayPoolLeakFixtures
             ArrayPool<byte>.Shared.Return(buffer);
             throw;
         }
+    }
+
+    internal sealed class TextReader
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Read(byte[] buffer) => buffer.Length;
+    }
+
+    internal static class ExternalInputReader
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static int Parse(Span<char> destination, string tag)
+            => destination.Length + tag.Length;
     }
 
     // Same shape with `catch (Exception)`, which also runs for every managed exception type.

--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -5,6 +5,8 @@ using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
 
 using ILInspector.Analysis;
+using ILInspector.AnalysisHarness;
+using ILInspector.Findings;
 
 namespace ILInspector.Analysis.Tests;
 
@@ -72,6 +74,130 @@ public sealed class LeakTriageAnalyzerTests
         Assert.Empty(ForMethod(result.Findings, nameof(ArrayPoolLeakFixtures.RentCrossCallCatchAllReturn)));
         Assert.Empty(ForMethod(result.Findings, nameof(ArrayPoolLeakFixtures.RentCrossCallCatchExceptionReturn)));
         Assert.Empty(ForMethod(result.Findings, nameof(ArrayPoolLeakFixtures.RentCrossCallTypedCatchReturn)));
+    }
+
+    [Fact]
+    public void ResourceLifecycleAnalysis_ClassifiesExactBoundaryEvidence()
+    {
+        var inspection = ResourceLifecycleAnalysis.InspectAssembly(
+            typeof(ArrayPoolLeakFixtures).Assembly.Location,
+            new FindingSubject("fixtures", "fixtures"));
+        var complete =
+            Assert.IsType<FindingInspection<ResourceLifecycleOccurrence>.Complete>(
+                inspection.Value);
+        var candidates = ResourceLifecycleAnalysis.SelectCandidates(complete);
+
+        var external = Assert.Single(candidates.Where(candidate =>
+            candidate.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.ExternalReadBeforeReturn)));
+        Assert.Equal("analysis.resource-lifecycle", external.Source.Descriptor.Id);
+        Assert.StartsWith("rt~", external.CandidateId);
+        Assert.Equal(
+            ResourceActionability.UntrustedActionable,
+            external.Source.Payload.Actionability);
+        var externalBoundary = Assert.Single(external.Source.Payload.Boundaries);
+        Assert.Equal("Read", externalBoundary.Operation.Name);
+        Assert.Equal(ResourceBoundaryKind.ExternalInput, externalBoundary.Kind);
+        Assert.True(
+            externalBoundary.ILOffset > external.Source.Payload.AcquireOffset);
+
+        var throughSetup = Assert.Single(candidates.Where(candidate =>
+            candidate.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.ExternalDecodeThroughSpan)));
+        Assert.Equal(
+            ResourceActionability.UntrustedActionable,
+            throughSetup.Source.Payload.Actionability);
+        Assert.Contains(throughSetup.Source.Payload.Boundaries, boundary =>
+            boundary.Operation.Name == "GetChars"
+            && boundary.Kind == ResourceBoundaryKind.ExternalInput);
+        Assert.DoesNotContain(throughSetup.Source.Payload.Boundaries, boundary =>
+            boundary.Operation.Name == "AsSpan");
+
+        var throughLocal = Assert.Single(candidates.Where(candidate =>
+            candidate.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.ExternalDecodeThroughSpanLocal)));
+        Assert.Equal(
+            ResourceActionability.UntrustedActionable,
+            throughLocal.Source.Payload.Actionability);
+        Assert.Contains(throughLocal.Source.Payload.Boundaries, boundary =>
+            boundary.Operation.Name == "GetChars"
+            && boundary.Kind == ResourceBoundaryKind.ExternalInput);
+
+        var trusted = Assert.Single(candidates.Where(candidate =>
+            candidate.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.TrustedTransformWithUnrelatedReadAfterReturn)));
+        Assert.Equal(
+            ResourceActionability.TrustedLowActionability,
+            trusted.Source.Payload.Actionability);
+        var trustedBoundary = Assert.Single(trusted.Source.Payload.Boundaries);
+        Assert.Equal("GetBytes", trustedBoundary.Operation.Name);
+        Assert.Equal(
+            ResourceBoundaryKind.InMemoryTransform,
+            trustedBoundary.Kind);
+
+        var actionable = ResourceLifecycleAnalysis.SelectCandidates(
+            complete,
+            ResourceActionability.UntrustedActionable);
+        Assert.Contains(actionable, candidate =>
+            candidate.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.ExternalReadBeforeReturn));
+        Assert.DoesNotContain(actionable, candidate =>
+            candidate.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.TrustedTransformWithUnrelatedReadAfterReturn));
+
+        var clone = external.Source.Payload with
+        {
+            Boundaries = [.. external.Source.Payload.Boundaries],
+        };
+        Assert.Equal(external.Source.Payload, clone);
+        Assert.Equal(external.Source.Payload.GetHashCode(), clone.GetHashCode());
+    }
+
+    [Fact]
+    public void ResourceLifecycleAnalysis_ReportsInspectionFailure()
+    {
+        var subject = new FindingSubject("missing", "missing");
+        var inspection = ResourceLifecycleAnalysis.InspectAssembly(
+            Path.Combine(
+                Path.GetTempPath(),
+                $"{Guid.NewGuid():N}.dll"),
+            subject);
+
+        var failed =
+            Assert.IsType<FindingInspection<ResourceLifecycleOccurrence>.Failed>(
+                inspection.Value);
+        Assert.Equal(subject, failed.Error.Subject);
+        Assert.Equal(
+            AnalysisFindings.ResourceLifecycleDescriptor,
+            failed.Error.Descriptor);
+        Assert.Contains("FileNotFoundException", failed.Error.Reason);
+    }
+
+    [Fact]
+    public void LeakActionabilitySensor_ConsumesProductClassification()
+    {
+        var report = LeakActionabilitySensor.Measure(
+            [typeof(ArrayPoolLeakFixtures).Assembly.Location],
+            examplesPerAssembly: 1000);
+        var assembly = Assert.Single(report.Assemblies);
+
+        Assert.True(assembly.Opened);
+        Assert.Contains(assembly.Examples, example =>
+            example.Class == LeakActionabilitySensor.Untrusted
+            && example.Method.EndsWith(
+                $"::{nameof(ArrayPoolLeakFixtures.ExternalReadBeforeReturn)}",
+                StringComparison.Ordinal)
+            && example.BoundarySet.Contains(
+                "Stream::Read",
+                StringComparison.Ordinal));
+        Assert.Contains(assembly.Examples, example =>
+            example.Class == LeakActionabilitySensor.Trusted
+            && example.Method.EndsWith(
+                $"::{nameof(ArrayPoolLeakFixtures.TrustedTransformWithUnrelatedReadAfterReturn)}",
+                StringComparison.Ordinal)
+            && !example.BoundarySet.Contains(
+                "ReadByte",
+                StringComparison.Ordinal));
     }
 
     [Fact]
@@ -676,6 +802,59 @@ internal sealed class ArrayPoolLeakFixtures
     {
         var buffer = ArrayPool<byte>.Shared.Rent(16);
         throw new InvalidOperationException(buffer.Length.ToString());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int ExternalReadBeforeReturn(Stream stream)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        int read = stream.Read(buffer, 0, 16);
+        ArrayPool<byte>.Shared.Return(buffer);
+        return read;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int ExternalDecodeThroughSpan(byte[] source)
+    {
+        var chars = ArrayPool<char>.Shared.Rent(16);
+        int written = System.Text.Encoding.UTF8
+            .GetDecoder()
+            .GetChars(
+                source.AsSpan(),
+                chars.AsSpan(),
+                flush: true);
+        ArrayPool<char>.Shared.Return(chars);
+        return written;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int ExternalDecodeThroughSpanLocal(byte[] source)
+    {
+        var chars = ArrayPool<char>.Shared.Rent(16);
+        Span<char> destination = chars.AsSpan();
+        int written = System.Text.Encoding.UTF8
+            .GetDecoder()
+            .GetChars(
+                source.AsSpan(),
+                destination,
+                flush: true);
+        ArrayPool<char>.Shared.Return(chars);
+        return written;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int TrustedTransformWithUnrelatedReadAfterReturn(Stream stream)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        int written = System.Text.Encoding.UTF8.GetBytes(
+            "value",
+            0,
+            5,
+            buffer,
+            0);
+        ArrayPool<byte>.Shared.Return(buffer);
+        _ = stream.ReadByte();
+        return written;
     }
 
     // A cross-method throwing boundary returned on both the normal path and a catch-ALL cleanup

--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -135,6 +135,44 @@ public sealed class LeakTriageAnalyzerTests
                 boundary.Operation.Name == "Parse"
                 && boundary.Kind == ResourceBoundaryKind.ExternalInput);
 
+        var throughConstructedArgument = Assert.Single(candidates.Where(candidate =>
+            candidate.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.ExternalParseThroughSpanWithConstructedTag)));
+        Assert.Equal(
+            ResourceActionability.UntrustedActionable,
+            throughConstructedArgument.Source.Payload.Actionability);
+        Assert.Contains(
+            throughConstructedArgument.Source.Payload.Boundaries,
+            boundary =>
+                boundary.Operation.Name == "Parse"
+                && boundary.Kind == ResourceBoundaryKind.ExternalInput);
+        Assert.DoesNotContain(
+            throughConstructedArgument.Source.Payload.Boundaries,
+            boundary => boundary.Operation.Name == ".ctor");
+
+        var throughStaticArgument = Assert.Single(candidates.Where(candidate =>
+            candidate.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.ExternalParseThroughSpanWithStaticTag)));
+        Assert.Equal(
+            ResourceActionability.UntrustedActionable,
+            throughStaticArgument.Source.Payload.Actionability);
+        Assert.Contains(
+            throughStaticArgument.Source.Payload.Boundaries,
+            boundary =>
+                boundary.Operation.Name == "Parse"
+                && boundary.Kind == ResourceBoundaryKind.ExternalInput);
+
+        var constructorBoundary = Assert.Single(candidates.Where(candidate =>
+            candidate.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.SpanConsumedByConstructor)));
+        Assert.Equal(
+            ResourceActionability.Unknown,
+            constructorBoundary.Source.Payload.Actionability);
+        Assert.Equal(
+            ".ctor",
+            Assert.Single(constructorBoundary.Source.Payload.Boundaries)
+                .Operation.Name);
+
         var unrelatedReader = Assert.Single(candidates.Where(candidate =>
             candidate.Source.Payload.Method.Name
                 == nameof(ArrayPoolLeakFixtures.UnrelatedTextReaderReadBeforeReturn)));
@@ -693,6 +731,7 @@ internal static class Synthetic
 internal sealed class ArrayPoolLeakFixtures
 {
     static byte[]? s_field;
+    static readonly string s_tag = "wire";
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void CorrectRentReturn()
@@ -884,6 +923,35 @@ internal sealed class ArrayPoolLeakFixtures
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int ExternalParseThroughSpanWithConstructedTag()
+    {
+        var chars = ArrayPool<char>.Shared.Rent(16);
+        int written = ExternalInputReader.Parse(
+            chars.AsSpan(),
+            new string('a', 5));
+        ArrayPool<char>.Shared.Return(chars);
+        return written;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int ExternalParseThroughSpanWithStaticTag()
+    {
+        var chars = ArrayPool<char>.Shared.Rent(16);
+        int written = ExternalInputReader.Parse(chars.AsSpan(), s_tag);
+        ArrayPool<char>.Shared.Return(chars);
+        return written;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int SpanConsumedByConstructor()
+    {
+        var chars = ArrayPool<char>.Shared.Rent(16);
+        var consumer = new SpanConsumer(chars.AsSpan());
+        ArrayPool<char>.Shared.Return(chars);
+        return consumer.Length;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static int UnrelatedTextReaderReadBeforeReturn(TextReader reader)
     {
         var buffer = ArrayPool<byte>.Shared.Rent(16);
@@ -947,6 +1015,16 @@ internal sealed class ArrayPoolLeakFixtures
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static int Parse(Span<char> destination, string tag)
             => destination.Length + tag.Length;
+    }
+
+    internal sealed class SpanConsumer
+    {
+        public SpanConsumer(Span<char> value)
+        {
+            Length = value.Length;
+        }
+
+        public int Length { get; }
     }
 
     // Same shape with `catch (Exception)`, which also runs for every managed exception type.

--- a/src/ILInspector.Analysis/AnalysisFindings.cs
+++ b/src/ILInspector.Analysis/AnalysisFindings.cs
@@ -20,6 +20,9 @@ public static class AnalysisFindings
     public static readonly FindingDescriptor UnsafeEvidenceDescriptor =
         new("analysis.unsafe-evidence", "Unsafe evidence");
 
+    public static readonly FindingDescriptor ResourceLifecycleDescriptor =
+        new("analysis.resource-lifecycle", "Resource lifecycle occurrence");
+
     /// <summary>
     /// Projects one method's allocation occurrences into IL order. An empty occurrence sequence is
     /// a complete empty census; acquisition failures belong to the caller that builds the body index.
@@ -168,17 +171,64 @@ public static class AnalysisFindings
             return key.ToString();
         }
 
-        AppendKeyPart(key, ((int)callee.Kind).ToString(System.Globalization.CultureInfo.InvariantCulture));
-        AppendKeyPart(key, GenericMemberIdentity.KeyFragment(callee.DeclaringType));
-        AppendKeyPart(key, callee.Name);
-        AppendKeyPart(key, callee.HasThis ? "instance" : "static");
-        AppendKeyPart(key, callee.SignatureHeader.ToString(System.Globalization.CultureInfo.InvariantCulture));
-        AppendKeyPart(key, callee.GenericArity.ToString(System.Globalization.CultureInfo.InvariantCulture));
-        AppendTypes(key, callee.TypeArguments);
-        AppendTypes(key, callee.ParameterTypes);
-        AppendKeyPart(key, GenericMemberIdentity.KeyFragment(callee.ReturnType));
-        AppendTypes(key, callee.OpenSignatureParameters);
-        AppendKeyPart(key, GenericMemberIdentity.KeyFragment(callee.OpenSignatureReturn));
+        AppendMemberIdentity(key, callee);
+        return key.ToString();
+    }
+
+    /// <summary>
+    /// Projects exception-path resource lifecycle observations into acquisition order. Identity
+    /// uses the containing method and exact boundary operations; version-local IL coordinates
+    /// remain payload evidence rather than correspondence.
+    /// </summary>
+    public static ImmutableArray<Finding<ResourceLifecycleOccurrence>> InspectResourceLifecycles(
+        IEnumerable<ResourceLifecycleOccurrence> occurrences,
+        FindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(occurrences);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        var ordered = occurrences
+            .OrderBy(static occurrence => occurrence.Method.MetadataToken)
+            .ThenBy(static occurrence => occurrence.AcquireOffset)
+            .ThenBy(GetResourceLifecycleIdentityKey, StringComparer.Ordinal)
+            .ToImmutableArray();
+        var findings =
+            ImmutableArray.CreateBuilder<Finding<ResourceLifecycleOccurrence>>(ordered.Length);
+        for (int i = 0; i < ordered.Length; i++)
+        {
+            ResourceLifecycleOccurrence occurrence = ordered[i];
+            findings.Add(new Finding<ResourceLifecycleOccurrence>(
+                subject,
+                ResourceLifecycleDescriptor,
+                new FindingKey(GetResourceLifecycleIdentityKey(occurrence)),
+                occurrence,
+                Ordinal: i,
+                Detail: occurrence.Shape));
+        }
+
+        return findings.MoveToImmutable();
+    }
+
+    public static string GetResourceLifecycleIdentityKey(
+        ResourceLifecycleOccurrence occurrence)
+    {
+        ArgumentNullException.ThrowIfNull(occurrence);
+
+        var key = new StringBuilder();
+        MethodIdentity method = occurrence.Method;
+        AppendKeyPart(key, method.AssemblyName);
+        AppendKeyPart(key, GenericMemberIdentity.KeyFragment(method.DeclaringType));
+        AppendKeyPart(key, method.Name);
+        AppendTypes(key, method.ParameterTypes);
+        AppendKeyPart(key, GenericMemberIdentity.KeyFragment(method.ReturnType));
+        AppendKeyPart(key, occurrence.Resource);
+        AppendKeyPart(key, occurrence.Shape);
+        AppendKeyPart(
+            key,
+            occurrence.Boundaries.Length.ToString(
+                System.Globalization.CultureInfo.InvariantCulture));
+        foreach (ResourceBoundaryEvidence boundary in occurrence.Boundaries)
+            AppendMemberIdentity(key, boundary.Operation);
         return key.ToString();
     }
 
@@ -402,6 +452,30 @@ public static class AnalysisFindings
         AppendKeyPart(key, types.Length.ToString(System.Globalization.CultureInfo.InvariantCulture));
         foreach (TypeRef type in types)
             AppendKeyPart(key, GenericMemberIdentity.KeyFragment(type));
+    }
+
+    static void AppendMemberIdentity(StringBuilder key, MemberRef member)
+    {
+        AppendKeyPart(
+            key,
+            ((int)member.Kind).ToString(
+                System.Globalization.CultureInfo.InvariantCulture));
+        AppendKeyPart(key, GenericMemberIdentity.KeyFragment(member.DeclaringType));
+        AppendKeyPart(key, member.Name);
+        AppendKeyPart(key, member.HasThis ? "instance" : "static");
+        AppendKeyPart(
+            key,
+            member.SignatureHeader.ToString(
+                System.Globalization.CultureInfo.InvariantCulture));
+        AppendKeyPart(
+            key,
+            member.GenericArity.ToString(
+                System.Globalization.CultureInfo.InvariantCulture));
+        AppendTypes(key, member.TypeArguments);
+        AppendTypes(key, member.ParameterTypes);
+        AppendKeyPart(key, GenericMemberIdentity.KeyFragment(member.ReturnType));
+        AppendTypes(key, member.OpenSignatureParameters);
+        AppendKeyPart(key, GenericMemberIdentity.KeyFragment(member.OpenSignatureReturn));
     }
 
     static void AppendKeyPart(StringBuilder key, string part)

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -806,7 +806,7 @@ public static class LeakTriageAnalyzer
             var instruction = instructions[i];
             if (instruction.OpCode == ILOpCode.Nop)
                 continue;
-            if (IsSimpleArgumentPush(instruction.OpCode))
+            if (IsSetupArgumentPush(instruction.OpCode))
             {
                 extraArguments++;
                 continue;
@@ -962,16 +962,21 @@ public static class LeakTriageAnalyzer
         => opcode is ILOpCode.Ldc_i4_m1 or ILOpCode.Ldc_i4_0 or ILOpCode.Ldc_i4_1 or ILOpCode.Ldc_i4_2
             or ILOpCode.Ldc_i4_3 or ILOpCode.Ldc_i4_4 or ILOpCode.Ldc_i4_5 or ILOpCode.Ldc_i4_6
             or ILOpCode.Ldc_i4_7 or ILOpCode.Ldc_i4_8 or ILOpCode.Ldc_i4_s or ILOpCode.Ldc_i4
-            or ILOpCode.Ldc_i8 or ILOpCode.Ldc_r4 or ILOpCode.Ldc_r8
             or ILOpCode.Ldarg_0 or ILOpCode.Ldarg_1 or ILOpCode.Ldarg_2 or ILOpCode.Ldarg_3
-            or ILOpCode.Ldarg_s or ILOpCode.Ldarg or ILOpCode.Ldarga_s or ILOpCode.Ldarga
+            or ILOpCode.Ldarg_s or ILOpCode.Ldarg
             or ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2 or ILOpCode.Ldloc_3
-            or ILOpCode.Ldloc_s or ILOpCode.Ldloc or ILOpCode.Ldloca_s or ILOpCode.Ldloca
-            or ILOpCode.Ldnull
-            or ILOpCode.Ldstr
-            or ILOpCode.Ldsfld or ILOpCode.Ldsflda
-            or ILOpCode.Ldtoken or ILOpCode.Ldftn
-            or ILOpCode.Sizeof or ILOpCode.Arglist;
+            or ILOpCode.Ldloc_s or ILOpCode.Ldloc
+            or ILOpCode.Ldnull;
+
+    static bool IsSetupArgumentPush(ILOpCode opcode)
+        => IsSimpleArgumentPush(opcode)
+            || opcode is ILOpCode.Ldc_i8 or ILOpCode.Ldc_r4 or ILOpCode.Ldc_r8
+                or ILOpCode.Ldarga_s or ILOpCode.Ldarga
+                or ILOpCode.Ldloca_s or ILOpCode.Ldloca
+                or ILOpCode.Ldstr
+                or ILOpCode.Ldsfld or ILOpCode.Ldsflda
+                or ILOpCode.Ldtoken or ILOpCode.Ldftn
+                or ILOpCode.Sizeof or ILOpCode.Arglist;
 
     static bool IsElementRead(ILOpCode opcode)
         => opcode is ILOpCode.Ldelem or ILOpCode.Ldelem_i or ILOpCode.Ldelem_i1 or ILOpCode.Ldelem_i2

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -23,9 +23,50 @@ public sealed record LeakTriageCandidate(
     int? RentOffset,
     int? ILOffset);
 
+public readonly record struct ArrayPoolExceptionBoundary(
+    int ILOffset,
+    MemberRef Operation);
+
+public sealed record ArrayPoolExceptionPathCandidate
+{
+    public ArrayPoolExceptionPathCandidate(
+        MethodIdentity Method,
+        int RentOffset,
+        ImmutableArray<ArrayPoolExceptionBoundary> Boundaries)
+    {
+        this.Method = Method ?? throw new ArgumentNullException(nameof(Method));
+        if (RentOffset < 0)
+            throw new ArgumentOutOfRangeException(nameof(RentOffset));
+        this.RentOffset = RentOffset;
+        this.Boundaries = Boundaries.IsDefault ? [] : Boundaries;
+    }
+
+    public MethodIdentity Method { get; }
+    public int RentOffset { get; }
+    public ImmutableArray<ArrayPoolExceptionBoundary> Boundaries { get; }
+
+    public bool Equals(ArrayPoolExceptionPathCandidate? other)
+        => other is not null
+            && Method == other.Method
+            && RentOffset == other.RentOffset
+            && ImmutableArrayValueEquality.SequenceEqual(Boundaries, other.Boundaries);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Method);
+        hash.Add(RentOffset);
+        ImmutableArrayValueEquality.AddToHash(ref hash, Boundaries);
+        return hash.ToHashCode();
+    }
+}
+
 public sealed record LeakTriageResult(
     ImmutableArray<LeakTriageFinding> Findings,
-    ImmutableArray<LeakTriageCandidate> Candidates);
+    ImmutableArray<LeakTriageCandidate> Candidates)
+{
+    public ImmutableArray<ArrayPoolExceptionPathCandidate> ExceptionPathCandidates { get; init; } = [];
+}
 
 public static class LeakTriageAnalyzer
 {
@@ -44,6 +85,7 @@ public static class LeakTriageAnalyzer
         var mvid = reader.GetGuid(reader.GetModuleDefinition().Mvid);
         var findings = ImmutableArray.CreateBuilder<LeakTriageFinding>();
         var candidates = ImmutableArray.CreateBuilder<LeakTriageCandidate>();
+        var exceptionPathCandidates = ImmutableArray.CreateBuilder<ArrayPoolExceptionPathCandidate>();
 
         foreach (var typeHandle in reader.TypeDefinitions)
         {
@@ -78,6 +120,7 @@ public static class LeakTriageAnalyzer
                         token => ResolveCatchTypeRef(reader, MetadataTokens.EntityHandle(token), scope));
                     findings.AddRange(result.Findings);
                     candidates.AddRange(result.Candidates);
+                    exceptionPathCandidates.AddRange(result.ExceptionPathCandidates);
                 }
                 catch (Exception ex) when (IsRecoverable(ex))
                 {
@@ -87,7 +130,10 @@ public static class LeakTriageAnalyzer
             }
         }
 
-        return new LeakTriageResult(findings.ToImmutable(), candidates.ToImmutable());
+        return new LeakTriageResult(findings.ToImmutable(), candidates.ToImmutable())
+        {
+            ExceptionPathCandidates = exceptionPathCandidates.ToImmutable(),
+        };
     }
 
     public static ImmutableArray<LeakTriageFinding> AnalyzeMethod(
@@ -146,15 +192,32 @@ public static class LeakTriageAnalyzer
 
             var catchAllCleanup = ComputeCreditableCatchCleanup(exceptionRegions, resolveCatchType);
             var candidates = ImmutableArray.CreateBuilder<LeakTriageCandidate>();
+            var exceptionPathCandidates = ImmutableArray.CreateBuilder<ArrayPoolExceptionPathCandidate>();
             var rents = FindRents(method, instructions, graph, reaching, calls, candidates).ToImmutableArray();
             if (rents.Length == 0)
                 return new LeakTriageResult([], candidates.ToImmutable());
 
             var findings = ImmutableArray.CreateBuilder<LeakTriageFinding>();
             foreach (var rent in rents)
-                AnalyzeRent(method, instructions, graph, reaching, calls, exceptionRegions, catchAllCleanup, rent, findings, candidates);
+            {
+                AnalyzeRent(
+                    method,
+                    instructions,
+                    graph,
+                    reaching,
+                    calls,
+                    exceptionRegions,
+                    catchAllCleanup,
+                    rent,
+                    findings,
+                    candidates,
+                    exceptionPathCandidates);
+            }
 
-            return new LeakTriageResult(findings.ToImmutable(), candidates.ToImmutable());
+            return new LeakTriageResult(findings.ToImmutable(), candidates.ToImmutable())
+            {
+                ExceptionPathCandidates = exceptionPathCandidates.ToImmutable(),
+            };
         }
         catch (Exception ex) when (IsRecoverable(ex))
         {
@@ -179,11 +242,15 @@ public static class LeakTriageAnalyzer
         IReadOnlySet<(int TryOffset, int TryLength, int HandlerOffset)> catchAllCleanup,
         RentedLocal rent,
         ImmutableArray<LeakTriageFinding>.Builder findings,
-        ImmutableArray<LeakTriageCandidate>.Builder candidates)
+        ImmutableArray<LeakTriageCandidate>.Builder candidates,
+        ImmutableArray<ArrayPoolExceptionPathCandidate>.Builder exceptionPathCandidates)
     {
         var releases = ImmutableArray.CreateBuilder<int>();
         var safeUses = ImmutableArray.CreateBuilder<int>();
-        var throwingBoundaries = ImmutableArray.CreateBuilder<int>();
+        var throwingBoundaries = ImmutableArray.CreateBuilder<ArrayPoolExceptionBoundary>();
+        var directThrowingBoundaries =
+            ImmutableArray.CreateBuilder<ArrayPoolExceptionBoundary>();
+        var directUseOffsets = new Dictionary<int, int>();
         AmbiguousUse? firstAmbiguous = null;
 
         foreach (var use in reaching.UsesOf(rent.Definition))
@@ -214,8 +281,24 @@ public static class LeakTriageAnalyzer
                         AddCandidate(candidates, method, classification.CandidateShape, classification.Evidence, rent.RentOffset, use.Offset);
                         firstAmbiguous = new AmbiguousUse(use.Offset, classification.CandidateShape);
                     }
-                    if (classification.CandidateShape == "cross-method-suppressed" && !classification.NonThrowingSetupBoundary)
-                        throwingBoundaries.Add(use.Offset);
+                    if (classification.CandidateShape == "cross-method-suppressed"
+                        && classification.Boundary is { } boundary)
+                    {
+                        if (!classification.NonThrowingSetupBoundary)
+                        {
+                            throwingBoundaries.Add(boundary);
+                            directThrowingBoundaries.Add(boundary);
+                            directUseOffsets.TryAdd(boundary.ILOffset, use.Offset);
+                        }
+                        else if (FindBoundaryAfterSetup(
+                            instructions,
+                            reaching,
+                            calls,
+                            boundary) is { } downstream)
+                        {
+                            throwingBoundaries.Add(downstream);
+                        }
+                    }
                     break;
             }
         }
@@ -226,15 +309,41 @@ public static class LeakTriageAnalyzer
         if (firstAmbiguous is { } ambiguous)
         {
             if (ambiguous.Shape == "cross-method-suppressed"
-                && FirstUnprotectedThrowingBoundary(graph, exceptionRegions, catchAllCleanup, releaseOffsets, throwingBoundaries.ToImmutable()) is { } throwingBoundary)
+                && UnprotectedThrowingBoundaries(
+                    graph,
+                    exceptionRegions,
+                    catchAllCleanup,
+                    releaseOffsets,
+                    throwingBoundaries.ToImmutable()) is { Length: > 0 } unprotectedBoundaries)
             {
-                AddCandidate(
-                    candidates,
-                    method,
-                    "exception-path-leak-candidate",
-                    $"Rented array crosses a method boundary at IL_{throwingBoundary:X4} before a modeled cleanup; an exception can bypass Return.",
-                    rent.RentOffset,
-                    throwingBoundary);
+                var directUnprotectedBoundaries =
+                    UnprotectedThrowingBoundaries(
+                        graph,
+                        exceptionRegions,
+                        catchAllCleanup,
+                        releaseOffsets,
+                        directThrowingBoundaries.ToImmutable());
+                if (directUnprotectedBoundaries is { Length: > 0 })
+                {
+                    int throwingBoundary =
+                        directUnprotectedBoundaries[0].ILOffset;
+                    int candidateOffset =
+                        directUseOffsets.GetValueOrDefault(
+                            throwingBoundary,
+                            throwingBoundary);
+                    AddCandidate(
+                        candidates,
+                        method,
+                        "exception-path-leak-candidate",
+                        $"Rented array crosses a method boundary at IL_{candidateOffset:X4} before a modeled cleanup; an exception can bypass Return.",
+                        rent.RentOffset,
+                        candidateOffset);
+                }
+                exceptionPathCandidates.Add(
+                    new ArrayPoolExceptionPathCandidate(
+                        method,
+                        rent.RentOffset,
+                        unprotectedBoundaries));
             }
             return;
         }
@@ -253,6 +362,11 @@ public static class LeakTriageAnalyzer
                 $"ArrayPool<T>.Shared.Rent at IL_{rent.RentOffset:X4} reaches an unreleased {(exitKind == LeakExitKind.Exception ? "exception" : "normal")} exit.",
                 rent.RentOffset,
                 rent.RentOffset);
+            if (exitKind == LeakExitKind.Exception)
+            {
+                exceptionPathCandidates.Add(
+                    new ArrayPoolExceptionPathCandidate(method, rent.RentOffset, []));
+            }
             findings.Add(new LeakTriageFinding(
                 method,
                 "arraypool-rent-not-returned",
@@ -405,23 +519,30 @@ public static class LeakTriageAnalyzer
     static bool ReleasedBeforeUseInSameBlock(BlockGraph graph, ImmutableArray<int> releases, int useOffset)
         => releases.Any(release => ReachesInSameBlock(graph, release, useOffset));
 
-    static int? FirstUnprotectedThrowingBoundary(
+    static ImmutableArray<ArrayPoolExceptionBoundary> UnprotectedThrowingBoundaries(
         BlockGraph graph,
         IReadOnlyCollection<ExceptionRegion> exceptionRegions,
         IReadOnlySet<(int TryOffset, int TryLength, int HandlerOffset)> catchAllCleanup,
         ImmutableArray<int> releases,
-        ImmutableArray<int> throwingBoundaries)
+        ImmutableArray<ArrayPoolExceptionBoundary> throwingBoundaries)
     {
-        foreach (int boundary in throwingBoundaries)
+        var result = ImmutableArray.CreateBuilder<ArrayPoolExceptionBoundary>();
+        var seenOffsets = new HashSet<int>();
+        foreach (var boundary in throwingBoundaries.OrderBy(static boundary => boundary.ILOffset))
         {
-            if (!ReleasedBeforeUseInSameBlock(graph, releases, boundary)
-                && !HasCleanupReleaseForUse(exceptionRegions, catchAllCleanup, releases, boundary))
+            if (seenOffsets.Add(boundary.ILOffset)
+                && !ReleasedBeforeUseInSameBlock(graph, releases, boundary.ILOffset)
+                && !HasCleanupReleaseForUse(
+                    exceptionRegions,
+                    catchAllCleanup,
+                    releases,
+                    boundary.ILOffset))
             {
-                return boundary;
+                result.Add(boundary);
             }
         }
 
-        return null;
+        return result.ToImmutable();
     }
 
     static bool HasCleanupReleaseForUse(
@@ -627,7 +748,8 @@ public static class LeakTriageAnalyzer
                     return UseClassification.Release;
                 return UseClassification.CrossMethod(
                     $"Rented array is passed to {callee.DeclaringType.Name}::{callee.Name}.",
-                    IsNonThrowingSetupBoundary(instructions, calls, i, callee));
+                    IsNonThrowingSetupBoundary(instructions, calls, i, callee),
+                    new ArrayPoolExceptionBoundary(instruction.Offset, callee));
             }
             return UseClassification.OwnershipTransfer($"Rented array reaches unsupported opcode {opcode}.");
         }
@@ -647,6 +769,125 @@ public static class LeakTriageAnalyzer
             calls[instruction.Offset] = resolveMethod(checked((int)instruction.OperandValue));
         }
         return calls;
+    }
+
+    static ArrayPoolExceptionBoundary? FindBoundaryAfterSetup(
+        ImmutableArray<DecodedInstruction> instructions,
+        ReachingDefinitionsResult reaching,
+        IReadOnlyDictionary<int, MemberRef> calls,
+        ArrayPoolExceptionBoundary setup,
+        int depth = 0)
+    {
+        if (depth >= 4)
+            return null;
+
+        if (FrameworkIdentity.IsCoreLibraryType(
+            setup.Operation.ReturnType,
+            "System",
+            "Void"))
+        {
+            return null;
+        }
+
+        if (!TryFindInstruction(
+            instructions,
+            setup.ILOffset,
+            out int setupIndex,
+            out _))
+        {
+            return null;
+        }
+
+        int extraArguments = 0;
+        for (int i = setupIndex + 1;
+            i < instructions.Length && i <= setupIndex + 16;
+            i++)
+        {
+            var instruction = instructions[i];
+            if (instruction.OpCode == ILOpCode.Nop)
+                continue;
+            if (IsSimpleArgumentPush(instruction.OpCode))
+            {
+                extraArguments++;
+                continue;
+            }
+
+            if (extraArguments == 0
+                && TryReadStoreLocal(instruction, out int slot))
+            {
+                var definition = reaching.Definitions.FirstOrDefault(candidate =>
+                    !candidate.IsArgument
+                    && candidate.Slot == slot
+                    && candidate.Offset == instruction.Offset);
+                if (definition is null)
+                    return null;
+
+                foreach (var use in reaching.UsesOf(definition)
+                    .OrderBy(static use => use.Offset))
+                {
+                    if (use.Address)
+                        return null;
+
+                    var classification = ClassifyUse(
+                        instructions,
+                        calls,
+                        use.Offset,
+                        slot);
+                    if (classification.CandidateShape
+                            != "cross-method-suppressed"
+                        || classification.Boundary is not { } localBoundary)
+                    {
+                        continue;
+                    }
+
+                    if (!classification.NonThrowingSetupBoundary)
+                        return localBoundary;
+
+                    if (FindBoundaryAfterSetup(
+                            instructions,
+                            reaching,
+                            calls,
+                            localBoundary,
+                            depth + 1) is { } downstream)
+                    {
+                        return downstream;
+                    }
+                }
+
+                return null;
+            }
+
+            if (!calls.TryGetValue(instruction.Offset, out var callee))
+                return null;
+
+            int consumedArguments =
+                callee.ParameterTypes.Length + (callee.HasThis ? 1 : 0);
+            if (consumedArguments <= extraArguments)
+                return null;
+
+            var boundary =
+                new ArrayPoolExceptionBoundary(instruction.Offset, callee);
+            if (!IsNonThrowingSetupBoundary(
+                instructions,
+                calls,
+                i,
+                callee))
+            {
+                return boundary;
+            }
+
+            if (FrameworkIdentity.IsCoreLibraryType(
+                callee.ReturnType,
+                "System",
+                "Void"))
+            {
+                return null;
+            }
+
+            extraArguments = 0;
+        }
+
+        return null;
     }
 
     static bool TryFindNextNonNop(ImmutableArray<DecodedInstruction> instructions, int offset, out DecodedInstruction instruction)
@@ -777,6 +1018,9 @@ public static class LeakTriageAnalyzer
         if (member.Name == "Clear" && FrameworkIdentity.IsCoreLibraryType(member.DeclaringType, "System", "Array"))
             return true;
 
+        if (member.Name == "CopyTo" && IsSpanType(member.DeclaringType))
+            return true;
+
         if (member.Name == "AsSpan"
             && (FrameworkIdentity.IsCoreLibraryType(member.DeclaringType, "System", "MemoryExtensions")
                 || FrameworkIdentity.IsKnownFrameworkType(member.DeclaringType, "System.Memory", "System", "MemoryExtensions")))
@@ -866,12 +1110,26 @@ public static class LeakTriageAnalyzer
         Ambiguous,
     }
 
-    readonly record struct UseClassification(UseKind Kind, string CandidateShape, string Evidence, bool NonThrowingSetupBoundary = false)
+    readonly record struct UseClassification(
+        UseKind Kind,
+        string CandidateShape,
+        string Evidence,
+        bool NonThrowingSetupBoundary = false,
+        ArrayPoolExceptionBoundary? Boundary = null)
     {
         public static UseClassification Release { get; } = new(UseKind.Release, "", "");
         public static UseClassification LocalUse { get; } = new(UseKind.LocalUse, "", "");
         public static UseClassification AliasOrField(string evidence) => new(UseKind.Ambiguous, "alias-or-field-suppressed", evidence);
-        public static UseClassification CrossMethod(string evidence, bool nonThrowingSetupBoundary) => new(UseKind.Ambiguous, "cross-method-suppressed", evidence, nonThrowingSetupBoundary);
+        public static UseClassification CrossMethod(
+            string evidence,
+            bool nonThrowingSetupBoundary,
+            ArrayPoolExceptionBoundary boundary)
+            => new(
+                UseKind.Ambiguous,
+                "cross-method-suppressed",
+                evidence,
+                nonThrowingSetupBoundary,
+                boundary);
         public static UseClassification OwnershipTransfer(string evidence) => new(UseKind.Ambiguous, "ownership-transfer-suppressed", evidence);
     }
 

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -951,7 +951,8 @@ public static class LeakTriageAnalyzer
             or ILOpCode.Ldarg_s or ILOpCode.Ldarg
             or ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2 or ILOpCode.Ldloc_3
             or ILOpCode.Ldloc_s or ILOpCode.Ldloc
-            or ILOpCode.Ldnull;
+            or ILOpCode.Ldnull
+            or ILOpCode.Ldstr;
 
     static bool IsElementRead(ILOpCode opcode)
         => opcode is ILOpCode.Ldelem or ILOpCode.Ldelem_i or ILOpCode.Ldelem_i1 or ILOpCode.Ldelem_i2

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -861,9 +861,24 @@ public static class LeakTriageAnalyzer
                 return null;
 
             int consumedArguments =
-                callee.ParameterTypes.Length + (callee.HasThis ? 1 : 0);
+                callee.ParameterTypes.Length
+                + (instruction.OpCode != ILOpCode.Newobj && callee.HasThis
+                    ? 1
+                    : 0);
             if (consumedArguments <= extraArguments)
-                return null;
+            {
+                extraArguments -= consumedArguments;
+                if (instruction.OpCode == ILOpCode.Newobj
+                    || !FrameworkIdentity.IsCoreLibraryType(
+                        callee.ReturnType,
+                        "System",
+                        "Void"))
+                {
+                    extraArguments++;
+                }
+
+                continue;
+            }
 
             var boundary =
                 new ArrayPoolExceptionBoundary(instruction.Offset, callee);
@@ -947,12 +962,16 @@ public static class LeakTriageAnalyzer
         => opcode is ILOpCode.Ldc_i4_m1 or ILOpCode.Ldc_i4_0 or ILOpCode.Ldc_i4_1 or ILOpCode.Ldc_i4_2
             or ILOpCode.Ldc_i4_3 or ILOpCode.Ldc_i4_4 or ILOpCode.Ldc_i4_5 or ILOpCode.Ldc_i4_6
             or ILOpCode.Ldc_i4_7 or ILOpCode.Ldc_i4_8 or ILOpCode.Ldc_i4_s or ILOpCode.Ldc_i4
+            or ILOpCode.Ldc_i8 or ILOpCode.Ldc_r4 or ILOpCode.Ldc_r8
             or ILOpCode.Ldarg_0 or ILOpCode.Ldarg_1 or ILOpCode.Ldarg_2 or ILOpCode.Ldarg_3
-            or ILOpCode.Ldarg_s or ILOpCode.Ldarg
+            or ILOpCode.Ldarg_s or ILOpCode.Ldarg or ILOpCode.Ldarga_s or ILOpCode.Ldarga
             or ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2 or ILOpCode.Ldloc_3
-            or ILOpCode.Ldloc_s or ILOpCode.Ldloc
+            or ILOpCode.Ldloc_s or ILOpCode.Ldloc or ILOpCode.Ldloca_s or ILOpCode.Ldloca
             or ILOpCode.Ldnull
-            or ILOpCode.Ldstr;
+            or ILOpCode.Ldstr
+            or ILOpCode.Ldsfld or ILOpCode.Ldsflda
+            or ILOpCode.Ldtoken or ILOpCode.Ldftn
+            or ILOpCode.Sizeof or ILOpCode.Arglist;
 
     static bool IsElementRead(ILOpCode opcode)
         => opcode is ILOpCode.Ldelem or ILOpCode.Ldelem_i or ILOpCode.Ldelem_i1 or ILOpCode.Ldelem_i2

--- a/src/ILInspector.Analysis/MemberIdentity.cs
+++ b/src/ILInspector.Analysis/MemberIdentity.cs
@@ -194,6 +194,9 @@ public sealed record MemberRef(
 
     public TypeRef OpenSignatureReturn => OpenReturnType ?? ReturnType;
 
+    public string ToQualifiedDisplayString()
+        => $"{DeclaringType.ToQualifiedDisplayString()}::{Name}";
+
     public bool Equals(MemberRef? other)
         => other is not null
             && Equals(DeclaringType, other.DeclaringType)

--- a/src/ILInspector.Analysis/ResourceLifecycleAnalysis.cs
+++ b/src/ILInspector.Analysis/ResourceLifecycleAnalysis.cs
@@ -1,0 +1,303 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
+using ILInspector.Findings;
+
+namespace ILInspector.Analysis;
+
+public enum ResourceBoundaryKind
+{
+    Unknown,
+    ExternalInput,
+    InMemoryTransform,
+}
+
+public enum ResourceActionability
+{
+    Unknown,
+    TrustedLowActionability,
+    UntrustedActionable,
+}
+
+public readonly record struct ResourceBoundaryEvidence(
+    int ILOffset,
+    MemberRef Operation,
+    ResourceBoundaryKind Kind);
+
+public sealed record ResourceLifecycleOccurrence
+{
+    ImmutableArray<ResourceBoundaryEvidence> _boundaries;
+
+    public ResourceLifecycleOccurrence(
+        MethodIdentity Method,
+        string Resource,
+        string Shape,
+        int AcquireOffset,
+        ImmutableArray<ResourceBoundaryEvidence> Boundaries,
+        ResourceActionability Actionability)
+    {
+        this.Method = Method ?? throw new ArgumentNullException(nameof(Method));
+        ArgumentException.ThrowIfNullOrWhiteSpace(Resource);
+        ArgumentException.ThrowIfNullOrWhiteSpace(Shape);
+        if (AcquireOffset < 0)
+            throw new ArgumentOutOfRangeException(nameof(AcquireOffset));
+
+        this.Resource = Resource;
+        this.Shape = Shape;
+        this.AcquireOffset = AcquireOffset;
+        _boundaries = ImmutableArrayValueEquality.RequireInitialized(
+            Boundaries,
+            nameof(Boundaries));
+        this.Actionability = Actionability;
+    }
+
+    public MethodIdentity Method { get; }
+    public string Resource { get; }
+    public string Shape { get; }
+    public int AcquireOffset { get; }
+    public ImmutableArray<ResourceBoundaryEvidence> Boundaries
+    {
+        get => _boundaries;
+        init => _boundaries = ImmutableArrayValueEquality.RequireInitialized(
+            value,
+            nameof(Boundaries));
+    }
+    public ResourceActionability Actionability { get; }
+
+    public bool Equals(ResourceLifecycleOccurrence? other)
+        => other is not null
+            && Method == other.Method
+            && string.Equals(Resource, other.Resource, StringComparison.Ordinal)
+            && string.Equals(Shape, other.Shape, StringComparison.Ordinal)
+            && AcquireOffset == other.AcquireOffset
+            && ImmutableArrayValueEquality.SequenceEqual(Boundaries, other.Boundaries)
+            && Actionability == other.Actionability;
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Method);
+        hash.Add(Resource, StringComparer.Ordinal);
+        hash.Add(Shape, StringComparer.Ordinal);
+        hash.Add(AcquireOffset);
+        ImmutableArrayValueEquality.AddToHash(ref hash, Boundaries);
+        hash.Add(Actionability);
+        return hash.ToHashCode();
+    }
+}
+
+public sealed record ResourceTriageCandidate(
+    string CandidateId,
+    Finding<ResourceLifecycleOccurrence> Source);
+
+public static class ResourceLifecycleAnalysis
+{
+    public static FindingInspection<ResourceLifecycleOccurrence> InspectAssembly(
+        string path,
+        FindingSubject subject)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(subject);
+
+        try
+        {
+            var occurrences = LeakTriageAnalyzer
+                .AnalyzeAssemblyDetailed(path)
+                .ExceptionPathCandidates
+                .Select(Classify);
+            return new FindingInspection<ResourceLifecycleOccurrence>.Complete(
+                AnalysisFindings.InspectResourceLifecycles(occurrences, subject));
+        }
+        catch (Exception ex) when (
+            ex is IOException
+                or UnauthorizedAccessException
+                or BadImageFormatException
+                or InvalidOperationException
+                or ArgumentException
+                or OverflowException
+                or IndexOutOfRangeException)
+        {
+            return new FindingInspection<ResourceLifecycleOccurrence>.Failed(
+                new InspectionError(
+                    subject,
+                    AnalysisFindings.ResourceLifecycleDescriptor,
+                    $"{ex.GetType().Name}: {ex.Message}"));
+        }
+    }
+
+    public static ImmutableArray<ResourceTriageCandidate> SelectCandidates(
+        FindingInspection<ResourceLifecycleOccurrence>.Complete inspection,
+        ResourceActionability? actionability = null)
+    {
+        ArgumentNullException.ThrowIfNull(inspection);
+
+        var candidateIds = new HashSet<string>(StringComparer.Ordinal);
+        var candidates =
+            ImmutableArray.CreateBuilder<ResourceTriageCandidate>(
+                inspection.Findings.Length);
+        foreach (var finding in inspection.Findings)
+        {
+            int fingerprintLength = InitialFingerprintLength;
+            string candidateId;
+            while (true)
+            {
+                candidateId = CreateCandidateId(
+                    finding,
+                    fingerprintLength);
+                if (candidateIds.Add(candidateId))
+                    break;
+                if (fingerprintLength == MaximumFingerprintLength)
+                {
+                    throw new InvalidOperationException(
+                        $"Duplicate Resource Triage candidate identity '{candidateId}'.");
+                }
+
+                fingerprintLength = Math.Min(
+                    fingerprintLength + 8,
+                    MaximumFingerprintLength);
+            }
+
+            candidates.Add(
+                new ResourceTriageCandidate(candidateId, finding));
+        }
+
+        return actionability is null
+            ? candidates.MoveToImmutable()
+            : candidates
+                .Where(candidate =>
+                    candidate.Source.Payload.Actionability
+                        == actionability)
+                .ToImmutableArray();
+    }
+
+    static ResourceLifecycleOccurrence Classify(ArrayPoolExceptionPathCandidate candidate)
+    {
+        var boundaries = candidate.Boundaries
+            .Select(boundary => new ResourceBoundaryEvidence(
+                boundary.ILOffset,
+                boundary.Operation,
+                ClassifyBoundary(boundary.Operation)))
+            .ToImmutableArray();
+
+        ResourceActionability actionability = boundaries.Any(
+            static boundary => boundary.Kind == ResourceBoundaryKind.ExternalInput)
+                ? ResourceActionability.UntrustedActionable
+                : boundaries.Any(
+                    static boundary => boundary.Kind == ResourceBoundaryKind.Unknown)
+                    || boundaries.Length == 0
+                    ? ResourceActionability.Unknown
+                    : ResourceActionability.TrustedLowActionability;
+
+        return new ResourceLifecycleOccurrence(
+            candidate.Method,
+            "ArrayPool<T>",
+            "pool-churn-on-exception",
+            candidate.RentOffset,
+            boundaries,
+            actionability);
+    }
+
+    static ResourceBoundaryKind ClassifyBoundary(MemberRef member)
+    {
+        string type = TypeName(member.DeclaringType);
+        string method = member.Name;
+
+        if ((IsStreamLike(type)
+                && method.StartsWith("Read", StringComparison.Ordinal))
+            || ((type is "Decoder"
+                    || type.EndsWith("Decoder", StringComparison.Ordinal))
+                && method is "GetChars" or "GetString" or "Convert")
+            || ((type is "Encoding"
+                    || type.EndsWith("Encoding", StringComparison.Ordinal))
+                && method is "GetChars" or "GetString")
+            || (type == "Socket"
+                && method.StartsWith("Receive", StringComparison.Ordinal))
+            || (type is "TextReader" or "StreamReader" or "BinaryReader"
+                && method.StartsWith("Read", StringComparison.Ordinal))
+            || method.StartsWith("Deserialize", StringComparison.Ordinal)
+            || method.StartsWith("Tokenize", StringComparison.Ordinal)
+            || method == "Decode"
+            || ((method is "Parse" or "TryParse"
+                    || method.StartsWith("Parse", StringComparison.Ordinal))
+                && (type.Contains("Document", StringComparison.Ordinal)
+                    || type.Contains("Reader", StringComparison.Ordinal)
+                    || type.Contains("Parser", StringComparison.Ordinal))))
+        {
+            return ResourceBoundaryKind.ExternalInput;
+        }
+
+        if (method.StartsWith("Escape", StringComparison.Ordinal)
+            || ((type is "Encoding"
+                    || type.EndsWith("Encoding", StringComparison.Ordinal))
+                && method is "GetBytes" or "GetByteCount")
+            || method.StartsWith("Encode", StringComparison.Ordinal)
+            || method.StartsWith("Transcode", StringComparison.Ordinal)
+            || method is "ToUtf8" or "EncodeHelper"
+            || (type == "Array"
+                && method is "Copy" or "Clear" or "Resize" or "Fill")
+            || (type == "Buffer"
+                && method.StartsWith("Block", StringComparison.Ordinal))
+            || type is "Unsafe" or "MemoryMarshal"
+            || (type == "String" && method == ".ctor")
+            || (!IsStreamLike(type)
+                && method == "CopyTo")
+            || method.StartsWith("TryFormat", StringComparison.Ordinal)
+            || method.StartsWith("Format", StringComparison.Ordinal)
+            || method.StartsWith("WriteString", StringComparison.Ordinal)
+            || method.StartsWith("WriteValue", StringComparison.Ordinal)
+            || method is "WriteStringByOptions" or "WriteStringByOptionsPropertyName")
+        {
+            return ResourceBoundaryKind.InMemoryTransform;
+        }
+
+        return ResourceBoundaryKind.Unknown;
+    }
+
+    static bool IsStreamLike(string type)
+        => type == "Stream"
+            || type.EndsWith("Stream", StringComparison.Ordinal);
+
+    static string TypeName(TypeRef type)
+    {
+        TypeRef definition =
+            type.Kind == TypeRefKind.GenericInstance
+                ? type.ElementType ?? type
+                : type;
+        int tick = definition.Name.IndexOf('`');
+        return tick >= 0
+            ? definition.Name[..tick]
+            : definition.Name;
+    }
+
+    const int InitialFingerprintLength = 16;
+    const int MaximumFingerprintLength = 64;
+
+    static string CreateCandidateId(
+        Finding<ResourceLifecycleOccurrence> finding,
+        int fingerprintLength)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(
+            fingerprintLength,
+            InitialFingerprintLength);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(
+            fingerprintLength,
+            MaximumFingerprintLength);
+
+        const string fingerprintNamespace = "dotnet-inspect.resource-triage.v1\n";
+        ResourceLifecycleOccurrence occurrence = finding.Payload;
+        string coordinate =
+            $"0x{occurrence.Method.MetadataToken:X8}+0x{occurrence.AcquireOffset:X4}";
+        byte[] input = Encoding.UTF8.GetBytes(
+            $"{fingerprintNamespace}{Part(finding.Descriptor.Id)}\n"
+            + $"{Part(finding.Key.IdentityKey)}\n"
+            + $"{Part(coordinate)}");
+        string fingerprint = Convert.ToHexString(SHA256.HashData(input))
+            .ToLowerInvariant();
+        return $"rt~{fingerprint[..fingerprintLength]}";
+    }
+
+    static string Part(string value)
+        => $"{value.Length.ToString(CultureInfo.InvariantCulture)}:{value}";
+}

--- a/src/ILInspector.Analysis/ResourceLifecycleAnalysis.cs
+++ b/src/ILInspector.Analysis/ResourceLifecycleAnalysis.cs
@@ -201,20 +201,23 @@ public static class ResourceLifecycleAnalysis
 
     static ResourceBoundaryKind ClassifyBoundary(MemberRef member)
     {
-        string type = TypeName(member.DeclaringType);
+        TypeRef declaringType = member.DeclaringType;
+        string type = SimpleTypeName(declaringType);
         string method = member.Name;
 
-        if ((IsStreamLike(type)
+        if ((IsStreamLike(declaringType)
                 && method.StartsWith("Read", StringComparison.Ordinal))
-            || ((type is "Decoder"
-                    || type.EndsWith("Decoder", StringComparison.Ordinal))
+            || ((IsType(declaringType, "System.Text", "Decoder")
+                    || HasTypeNameSuffix(declaringType, "Decoder"))
                 && method is "GetChars" or "GetString" or "Convert")
-            || ((type is "Encoding"
-                    || type.EndsWith("Encoding", StringComparison.Ordinal))
+            || ((IsType(declaringType, "System.Text", "Encoding")
+                    || HasTypeNameSuffix(declaringType, "Encoding"))
                 && method is "GetChars" or "GetString")
-            || (type == "Socket"
+            || (IsType(declaringType, "System.Net.Sockets", "Socket")
                 && method.StartsWith("Receive", StringComparison.Ordinal))
-            || (type is "TextReader" or "StreamReader" or "BinaryReader"
+            || ((IsType(declaringType, "System.IO", "TextReader")
+                    || IsType(declaringType, "System.IO", "StreamReader")
+                    || IsType(declaringType, "System.IO", "BinaryReader"))
                 && method.StartsWith("Read", StringComparison.Ordinal))
             || method.StartsWith("Deserialize", StringComparison.Ordinal)
             || method.StartsWith("Tokenize", StringComparison.Ordinal)
@@ -229,19 +232,27 @@ public static class ResourceLifecycleAnalysis
         }
 
         if (method.StartsWith("Escape", StringComparison.Ordinal)
-            || ((type is "Encoding"
-                    || type.EndsWith("Encoding", StringComparison.Ordinal))
+            || ((IsType(declaringType, "System.Text", "Encoding")
+                    || HasTypeNameSuffix(declaringType, "Encoding"))
                 && method is "GetBytes" or "GetByteCount")
             || method.StartsWith("Encode", StringComparison.Ordinal)
             || method.StartsWith("Transcode", StringComparison.Ordinal)
             || method is "ToUtf8" or "EncodeHelper"
-            || (type == "Array"
+            || (IsType(declaringType, "System", "Array")
                 && method is "Copy" or "Clear" or "Resize" or "Fill")
-            || (type == "Buffer"
+            || (IsType(declaringType, "System", "Buffer")
                 && method.StartsWith("Block", StringComparison.Ordinal))
-            || type is "Unsafe" or "MemoryMarshal"
-            || (type == "String" && method == ".ctor")
-            || (!IsStreamLike(type)
+            || IsType(
+                declaringType,
+                "System.Runtime.CompilerServices",
+                "Unsafe")
+            || IsType(
+                declaringType,
+                "System.Runtime.InteropServices",
+                "MemoryMarshal")
+            || (IsType(declaringType, "System", "String")
+                && method == ".ctor")
+            || (!IsStreamLike(declaringType)
                 && method == "CopyTo")
             || method.StartsWith("TryFormat", StringComparison.Ordinal)
             || method.StartsWith("Format", StringComparison.Ordinal)
@@ -255,21 +266,40 @@ public static class ResourceLifecycleAnalysis
         return ResourceBoundaryKind.Unknown;
     }
 
-    static bool IsStreamLike(string type)
-        => type == "Stream"
-            || type.EndsWith("Stream", StringComparison.Ordinal);
+    static bool IsStreamLike(TypeRef type)
+        => IsType(type, "System.IO", "Stream")
+            || HasTypeNameSuffix(type, "Stream");
 
-    static string TypeName(TypeRef type)
+    static bool IsType(TypeRef type, string @namespace, string name)
     {
-        TypeRef definition =
-            type.Kind == TypeRefKind.GenericInstance
-                ? type.ElementType ?? type
-                : type;
+        TypeRef definition = TypeDefinition(type);
+        return string.Equals(
+                definition.Namespace,
+                @namespace,
+                StringComparison.Ordinal)
+            && string.Equals(definition.Name, name, StringComparison.Ordinal);
+    }
+
+    static bool HasTypeNameSuffix(TypeRef type, string suffix)
+    {
+        string name = SimpleTypeName(type);
+        return name.Length > suffix.Length
+            && name.EndsWith(suffix, StringComparison.Ordinal);
+    }
+
+    static string SimpleTypeName(TypeRef type)
+    {
+        TypeRef definition = TypeDefinition(type);
         int tick = definition.Name.IndexOf('`');
         return tick >= 0
             ? definition.Name[..tick]
             : definition.Name;
     }
+
+    static TypeRef TypeDefinition(TypeRef type)
+        => type.Kind == TypeRefKind.GenericInstance
+            ? type.ElementType ?? type
+            : type;
 
     const int InitialFingerprintLength = 16;
     const int MaximumFingerprintLength = 64;

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.IO.Compression;
 using System.Reflection;
 using System.Reflection.Metadata;
@@ -27,6 +28,31 @@ public class CommandExecutionTests
 {
     private static readonly string TestAssemblyPath =
         typeof(CommandExecutionTests).Assembly.Location;
+
+    private static class ResourceTriageFixture
+    {
+        public static int ReadBeforeReturn(Stream stream)
+        {
+            var buffer = ArrayPool<byte>.Shared.Rent(16);
+            int read = stream.Read(buffer, 0, 16);
+            ArrayPool<byte>.Shared.Return(buffer);
+            return read;
+        }
+
+        public static int TransformWithUnrelatedReadAfterReturn(Stream stream)
+        {
+            var buffer = ArrayPool<byte>.Shared.Rent(16);
+            int written = System.Text.Encoding.UTF8.GetBytes(
+                "value",
+                0,
+                5,
+                buffer,
+                0);
+            ArrayPool<byte>.Shared.Return(buffer);
+            _ = stream.ReadByte();
+            return written;
+        }
+    }
 
     private static void WriteFidelityFailureAssembly(string path)
     {
@@ -516,6 +542,81 @@ public class CommandExecutionTests
         Assert.Contains("\"caller_loop\":\"direct\"", output);
         Assert.Contains("\"caller_loop_depth\":\"1\"", output);
         Assert.Contains("\"direct_sites\":\"1\"", output);
+    }
+
+    [Fact]
+    public async Task ResourceTriage_IsExplicitAndUsesExactBoundaryEvidence()
+    {
+        var defaultResult = await RunAppAsync(
+            "library",
+            TestAssemblyPath,
+            "-v:m",
+            "--tips",
+            "q");
+        var markdown = await RunAppAsync(
+            "library",
+            TestAssemblyPath,
+            "-S",
+            SectionNames.ResourceTriage,
+            "--tips",
+            "q");
+        var jsonl = await RunAppAsync(
+            "library",
+            TestAssemblyPath,
+            "-S",
+            SectionNames.ResourceTriage,
+            "--jsonl",
+            "--tips",
+            "q");
+        var tsv = await RunAppAsync(
+            "library",
+            TestAssemblyPath,
+            "-S",
+            SectionNames.ResourceTriage,
+            "--tsv",
+            "--tips",
+            "q");
+        var empty = await RunAppAsync(
+            "library",
+            FixtureCatalog.AnalysisCallerLoop.AssemblyPath(),
+            "-S",
+            SectionNames.ResourceTriage,
+            "--tips",
+            "q");
+
+        Assert.Equal(0, defaultResult.Exit);
+        Assert.DoesNotContain(SectionNames.ResourceTriage, defaultResult.Output);
+
+        Assert.Equal(0, markdown.Exit);
+        Assert.Empty(markdown.Error);
+        Assert.Contains("## Resource Triage", markdown.Output);
+        Assert.Contains("ReadBeforeReturn", markdown.Output);
+        Assert.DoesNotContain(
+            nameof(ResourceTriageFixture.TransformWithUnrelatedReadAfterReturn),
+            markdown.Output);
+        Assert.Contains("analysis.resource-lifecycle", markdown.Output);
+        Assert.Contains("pool-churn-on-exception", markdown.Output);
+        Assert.Contains("System.IO.Stream::Read", markdown.Output);
+
+        Assert.Equal(0, jsonl.Exit);
+        Assert.Empty(jsonl.Error);
+        Assert.Contains("\"finding\":\"analysis.resource-lifecycle\"", jsonl.Output);
+        Assert.Contains("\"provenance\":\"exact\"", jsonl.Output);
+        Assert.Contains("\"actionability\":\"untrusted-input boundary\"", jsonl.Output);
+        Assert.Contains("\"acquire_il\":\"IL_", jsonl.Output);
+        Assert.Contains("\"boundary_il\":\"IL_", jsonl.Output);
+
+        Assert.Equal(0, tsv.Exit);
+        Assert.Empty(tsv.Error);
+        Assert.StartsWith(
+            "member\tcandidate\tfinding\tprovenance\tresource\tshape\timpact\tactionability\tboundary\tacquire_il\tboundary_il",
+            tsv.Output);
+
+        Assert.Equal(0, empty.Exit);
+        Assert.Empty(empty.Error);
+        Assert.Contains(
+            "No actionable resource lifecycle candidates found.",
+            empty.Output);
     }
 
     [Fact]
@@ -5715,6 +5816,7 @@ public class CommandExecutionTests
                 "OpenTelemetry",
                 "Options",
                 "Performance Triage",
+                "Resource Triage",
                 "Resources",
                 "Return Address Context",
                 "Safety Context",
@@ -5755,6 +5857,28 @@ public class CommandExecutionTests
         Assert.Contains("| Once Paths | column |", output);
         Assert.Contains("| OncePaths | sortable |", output);
         Assert.Contains("| IL | column |", output);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_DiscoverResourceTriage_ListsRenderableColumns()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library",
+            TestAssemblyPath,
+            "-D",
+            SectionNames.ResourceTriage,
+            "--tips",
+            "q");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("not found", error);
+        Assert.Contains("| Member | column |", output);
+        Assert.Contains("| Candidate | column |", output);
+        Assert.Contains("| Finding | column |", output);
+        Assert.Contains("| Actionability | column |", output);
+        Assert.Contains("| Boundary | column |", output);
+        Assert.Contains("| Acquire IL | column |", output);
+        Assert.Contains("| Boundary IL | column |", output);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -48,6 +48,12 @@ public class OutputFormatterTests
                 {
                     Member = "Fixture.ReadTwice",
                     Candidate = "rt~fixture",
+                    Finding = "analysis.resource-lifecycle",
+                    Provenance = "exact",
+                    Resource = "ArrayPool<T>",
+                    Shape = "pool-churn-on-exception",
+                    Impact = "pool churn if boundary throws",
+                    Actionability = "untrusted-input boundary",
                     AcquireOffset = 0x0007,
                     Boundaries =
                     [
@@ -58,6 +64,11 @@ public class OutputFormatterTests
                             "System.IO.Stream::Read",
                             0x001A),
                     ],
+                    Evidence =
+                        "An exact external-input boundary is reached before modeled cleanup; an exception can bypass Return.",
+                    Direction =
+                        "Return the pooled array from finally or catch-all cleanup.",
+                    Confidence = "medium",
                 },
             ],
         }).ResourceTriageSection;

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -38,6 +38,47 @@ public class OutputFormatterTests
     }
 
     [Fact]
+    public void ResourceTriageSection_PreservesRepeatedOperationBoundaryOffsets()
+    {
+        var rows = new LibraryInspectionView(new LibraryInspection
+        {
+            ResourceTriage =
+            [
+                new ResourceTriageSummary
+                {
+                    Member = "Fixture.ReadTwice",
+                    Candidate = "rt~fixture",
+                    AcquireOffset = 0x0007,
+                    Boundaries =
+                    [
+                        new ResourceBoundarySummary(
+                            "System.IO.Stream::Read",
+                            0x0011),
+                        new ResourceBoundarySummary(
+                            "System.IO.Stream::Read",
+                            0x001A),
+                    ],
+                },
+            ],
+        }).ResourceTriageSection;
+
+        Assert.Collection(
+            rows,
+            row =>
+            {
+                Assert.Contains("System.IO.Stream::Read", row.Boundary);
+                Assert.Contains("IL_0011", row.BoundaryIL);
+            },
+            row =>
+            {
+                Assert.Contains("System.IO.Stream::Read", row.Boundary);
+                Assert.Contains("IL_001A", row.BoundaryIL);
+            });
+        Assert.All(rows, row => Assert.Contains("IL_0007", row.AcquireIL));
+        Assert.Single(rows.Select(row => row.Candidate).Distinct());
+    }
+
+    [Fact]
     public void UnsafeMembersSection_RendersDegradedSignatureScan()
     {
         var view = new LibraryInspectionView(new LibraryInspection

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -18,6 +18,26 @@ namespace DotnetInspector.Tests;
 public class OutputFormatterTests
 {
     [Fact]
+    public void ResourceTriageFailure_IsVisible()
+    {
+        var subject = new FindingSubject("fixture", "fixture");
+        var inspection = new LibraryInspection
+        {
+            ResourceLifecycleInspection =
+                new FindingInspection<ResourceLifecycleOccurrence>.Failed(
+                    new InspectionError(
+                        subject,
+                        AnalysisFindings.ResourceLifecycleDescriptor,
+                        "fixture failure")),
+        };
+
+        var failure = Assert.Single(inspection.InspectionFailures!);
+        Assert.Equal(SectionNames.ResourceTriage, failure.Section);
+        Assert.Equal("Resource lifecycle occurrence", failure.Finding);
+        Assert.Equal("fixture failure", failure.Reason);
+    }
+
+    [Fact]
     public void UnsafeMembersSection_RendersDegradedSignatureScan()
     {
         var view = new LibraryInspectionView(new LibraryInspection

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -298,7 +298,7 @@ public class SectionPipelineTests
     {
         var pipeline = LibrarySections.CreatePipeline();
 
-        Assert.Equal(46, pipeline.AllSectionNames.Length);
+        Assert.Equal(47, pipeline.AllSectionNames.Length);
         Assert.Contains("AI", pipeline.AllSectionNames);
         Assert.Contains("ASP.NET Core", pipeline.AllSectionNames);
         Assert.Contains("Aspire", pipeline.AllSectionNames);
@@ -329,6 +329,7 @@ public class SectionPipelineTests
         Assert.Contains("Switches", pipeline.AllSectionNames);
         Assert.Contains("Top Leverage", pipeline.AllSectionNames);
         Assert.Contains("Performance Triage", pipeline.AllSectionNames);
+        Assert.Contains("Resource Triage", pipeline.AllSectionNames);
         Assert.Contains("Return Address Context", pipeline.AllSectionNames);
         Assert.Contains("Union Types", pipeline.AllSectionNames);
     }

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -875,18 +875,13 @@ internal static class LibraryMetadataService
                     Shape = occurrence.Shape,
                     Impact = "pool churn if boundary throws",
                     Actionability = "untrusted-input boundary",
-                    Boundary = string.Join(
-                        " + ",
-                        occurrence.Boundaries
-                            .Select(boundary =>
-                                $"{boundary.Operation.DeclaringType.ToQualifiedDisplayString()}::{boundary.Operation.Name}")
-                            .Distinct(StringComparer.Ordinal)),
-                    AcquireIL = $"IL_{occurrence.AcquireOffset:X4}",
-                    BoundaryIL = string.Join(
-                        " + ",
-                        occurrence.Boundaries
-                            .Select(boundary => $"IL_{boundary.ILOffset:X4}")
-                            .Distinct(StringComparer.Ordinal)),
+                    AcquireOffset = occurrence.AcquireOffset,
+                    Boundaries = occurrence.Boundaries
+                        .Select(boundary => new ResourceBoundarySummary(
+                            boundary.Operation.ToQualifiedDisplayString(),
+                            boundary.ILOffset))
+                        .Distinct()
+                        .ToList(),
                     Evidence =
                         "An exact external-input boundary is reached before modeled cleanup; an exception can bypass Return.",
                     Direction = "Return the pooled array from finally or catch-all cleanup.",
@@ -900,11 +895,11 @@ internal static class LibraryMetadataService
                 static row => row.Member,
                 StringComparer.Ordinal)
             .ThenBy(
-                static row => row.AcquireIL,
-                StringComparer.Ordinal)
+                static row => row.AcquireOffset)
             .ThenBy(
-                static row => row.BoundaryIL,
-                StringComparer.Ordinal)
+                static row => row.Boundaries.Count > 0
+                    ? row.Boundaries[0].ILOffset
+                    : -1)
             .ToList();
     }
 

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -830,6 +830,84 @@ internal static class LibraryMetadataService
         }
     }
 
+    internal static void ScanResourceTriage(
+        string path,
+        LibraryInspection inspection,
+        VerboseLogger logger)
+    {
+        var result = Analysis.ResourceLifecycleAnalysis.InspectAssembly(
+            path,
+            new FindingSubject(Path.GetFullPath(path), Path.GetFileName(path)));
+        inspection.ResourceLifecycleInspection = result;
+        inspection.ResourceTriage =
+            result.Value
+                is FindingInspection<Analysis.ResourceLifecycleOccurrence>.Complete complete
+                ? ProjectResourceTriage(
+                    path,
+                    complete,
+                    logger)
+                : null;
+    }
+
+    static List<ResourceTriageSummary> ProjectResourceTriage(
+        string path,
+        FindingInspection<Analysis.ResourceLifecycleOccurrence>.Complete inspection,
+        VerboseLogger logger)
+    {
+        var drillByToken = BuildLibraryDrillMap(path, logger);
+        return Analysis.ResourceLifecycleAnalysis
+            .SelectCandidates(
+                inspection,
+                Analysis.ResourceActionability.UntrustedActionable)
+            .Select(candidate =>
+            {
+                var occurrence = candidate.Source.Payload;
+                drillByToken.TryGetValue(
+                    occurrence.Method.MetadataToken,
+                    out var drill);
+                return new ResourceTriageSummary
+                {
+                    Member = FormatMethod(occurrence.Method),
+                    Candidate = candidate.CandidateId,
+                    Finding = candidate.Source.Descriptor.Id,
+                    Provenance = "exact",
+                    Resource = occurrence.Resource,
+                    Shape = occurrence.Shape,
+                    Impact = "pool churn if boundary throws",
+                    Actionability = "untrusted-input boundary",
+                    Boundary = string.Join(
+                        " + ",
+                        occurrence.Boundaries
+                            .Select(boundary =>
+                                $"{boundary.Operation.DeclaringType.ToQualifiedDisplayString()}::{boundary.Operation.Name}")
+                            .Distinct(StringComparer.Ordinal)),
+                    AcquireIL = $"IL_{occurrence.AcquireOffset:X4}",
+                    BoundaryIL = string.Join(
+                        " + ",
+                        occurrence.Boundaries
+                            .Select(boundary => $"IL_{boundary.ILOffset:X4}")
+                            .Distinct(StringComparer.Ordinal)),
+                    Evidence =
+                        "An exact external-input boundary is reached before modeled cleanup; an exception can bypass Return.",
+                    Direction = "Return the pooled array from finally or catch-all cleanup.",
+                    Confidence = "medium",
+                    Visibility = drill.Visibility,
+                    Stable = drill.Stable,
+                    Selector = drill.Selector,
+                };
+            })
+            .OrderBy(
+                static row => row.Member,
+                StringComparer.Ordinal)
+            .ThenBy(
+                static row => row.AcquireIL,
+                StringComparer.Ordinal)
+            .ThenBy(
+                static row => row.BoundaryIL,
+                StringComparer.Ordinal)
+            .ToList();
+    }
+
     // Performance Triage ordering: surface pay-dirt first. In-loop (repeated, hot)
     // allocations lead, then by confidence, then by call-graph leverage (root reach),
     // then a stable structural tie-break. This is distinct from Top Leverage, which ranks

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 using DotnetInspector.Options;
 using ILInspector.Findings;
 using ILInspector.Metadata;
+using ILInspector.Analysis;
 
 namespace DotnetInspector.Models;
 
@@ -332,6 +333,24 @@ public class LibraryInspection
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<OptimizationOpportunitySummary>? OptimizationOpportunities { get; set; }
 
+    private FindingInspection<ResourceLifecycleOccurrence>?
+        _resourceLifecycleInspection;
+
+    [JsonIgnore]
+    public FindingInspection<ResourceLifecycleOccurrence>?
+        ResourceLifecycleInspection
+    {
+        get => _resourceLifecycleInspection;
+        set
+        {
+            _resourceLifecycleInspection = value;
+            ResetFindingProjectionCaches();
+        }
+    }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<ResourceTriageSummary>? ResourceTriage { get; set; }
+
     [JsonIgnore]
     public PerformanceTriageOptions PerformanceTriageOptions { get; set; } = PerformanceTriageOptions.Default;
 
@@ -523,6 +542,10 @@ public class LibraryInspection
             AddFailure(failures, "Type Forwarders", TypeForwarderInspection);
             AddFailure(failures, "Union Types", UnionTypeInspection);
             AddFailure(failures, "Switches", SwitchInspection);
+            AddFailure(
+                failures,
+                DotnetInspector.Sections.SectionNames.ResourceTriage,
+                ResourceLifecycleInspection);
             return NullIfEmpty(failures);
             });
 
@@ -1134,6 +1157,30 @@ public record class OptimizationOpportunitySummary
     public long? OpaquePaths { get; init; }
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Saturated { get; init; }
+}
+
+/// <summary>
+/// A curated exception-path resource lifecycle candidate backed by exact Analysis evidence.
+/// </summary>
+public record class ResourceTriageSummary
+{
+    public string Member { get; init; } = "";
+    public string Candidate { get; init; } = "";
+    public string Finding { get; init; } = "";
+    public string Provenance { get; init; } = "";
+    public string Resource { get; init; } = "";
+    public string Shape { get; init; } = "";
+    public string Impact { get; init; } = "";
+    public string Actionability { get; init; } = "";
+    public string Boundary { get; init; } = "";
+    public string AcquireIL { get; init; } = "";
+    public string BoundaryIL { get; init; } = "";
+    public string Evidence { get; init; } = "";
+    public string Direction { get; init; } = "";
+    public string Confidence { get; init; } = "";
+    public string? Visibility { get; init; }
+    public string? Stable { get; init; }
+    public string? Selector { get; init; }
 }
 
 /// <summary>

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -1172,9 +1172,8 @@ public record class ResourceTriageSummary
     public string Shape { get; init; } = "";
     public string Impact { get; init; } = "";
     public string Actionability { get; init; } = "";
-    public string Boundary { get; init; } = "";
-    public string AcquireIL { get; init; } = "";
-    public string BoundaryIL { get; init; } = "";
+    public int AcquireOffset { get; init; }
+    public List<ResourceBoundarySummary> Boundaries { get; init; } = [];
     public string Evidence { get; init; } = "";
     public string Direction { get; init; } = "";
     public string Confidence { get; init; } = "";
@@ -1182,6 +1181,10 @@ public record class ResourceTriageSummary
     public string? Stable { get; init; }
     public string? Selector { get; init; }
 }
+
+public sealed record ResourceBoundarySummary(
+    string Operation,
+    int ILOffset);
 
 /// <summary>
 /// Summary of a dependency age window.

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -1164,19 +1164,19 @@ public record class OptimizationOpportunitySummary
 /// </summary>
 public record class ResourceTriageSummary
 {
-    public string Member { get; init; } = "";
-    public string Candidate { get; init; } = "";
-    public string Finding { get; init; } = "";
-    public string Provenance { get; init; } = "";
-    public string Resource { get; init; } = "";
-    public string Shape { get; init; } = "";
-    public string Impact { get; init; } = "";
-    public string Actionability { get; init; } = "";
-    public int AcquireOffset { get; init; }
-    public List<ResourceBoundarySummary> Boundaries { get; init; } = [];
-    public string Evidence { get; init; } = "";
-    public string Direction { get; init; } = "";
-    public string Confidence { get; init; } = "";
+    public required string Member { get; init; }
+    public required string Candidate { get; init; }
+    public required string Finding { get; init; }
+    public required string Provenance { get; init; }
+    public required string Resource { get; init; }
+    public required string Shape { get; init; }
+    public required string Impact { get; init; }
+    public required string Actionability { get; init; }
+    public required int AcquireOffset { get; init; }
+    public required List<ResourceBoundarySummary> Boundaries { get; init; }
+    public required string Evidence { get; init; }
+    public required string Direction { get; init; }
+    public required string Confidence { get; init; }
     public string? Visibility { get; init; }
     public string? Stable { get; init; }
     public string? Selector { get; init; }

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -27,6 +27,7 @@ public static class LibrarySections
     public const string ScannerUnsafeMembers = "UnsafeMembers";
     public const string ScannerTopLeverage = "TopLeverage";
     public const string ScannerOptimizationOpportunities = "OptimizationOpportunities";
+    public const string ScannerResourceTriage = "ResourceTriage";
 
     /// <summary>Builds the section pipeline with all library sections registered.</summary>
     public static SectionPipeline<LibraryInspection> CreatePipeline()
@@ -71,6 +72,7 @@ public static class LibrarySections
             .Add<UnsafeMembers>()
             .Add<TopLeverage>()
             .Add<OptimizationOpportunities>()
+            .Add<ResourceTriage>()
             .Add<PInvokeMethods>()
             .Add<AsyncMethods>()
             .Add<Resources>()
@@ -115,6 +117,11 @@ public static class LibrarySections
             .Add(ScannerOptimizationOpportunities, ctx =>
                 ctx.Model.OptimizationOpportunities = LibraryMetadataService.ScanOptimizationOpportunities(
                     ctx.BodyIndex, ctx.AssemblyPath, ctx.Logger, ctx.Model.PerformanceTriageOptions))
+            .Add(ScannerResourceTriage, ctx =>
+                LibraryMetadataService.ScanResourceTriage(
+                    ctx.AssemblyPath,
+                    ctx.Model,
+                    ctx.Logger))
             .Add(ScannerIntegrations, ctx =>
                 LibraryMetadataService.ScanIntegrations(ctx.AssemblyPath, ctx.Model, ctx.Logger))
             .Add(ScannerIntegrationOpportunities, ctx =>
@@ -504,6 +511,19 @@ public static class LibrarySections
         public static string? ScannerKey => ScannerOptimizationOpportunities;
         public static bool CanRender(LibraryInspection model)
             => model.OptimizationOpportunities is { Count: > 0 } || model.HasMethodBodies;
+    }
+
+    public sealed class ResourceTriage : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => SectionNames.ResourceTriage;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static string? ScannerKey => ScannerResourceTriage;
+        public static bool CanRender(LibraryInspection model)
+            => model.ResourceLifecycleInspection?.Value
+                    is ILInspector.Findings.FindingInspection<
+                        ILInspector.Analysis.ResourceLifecycleOccurrence>.Complete
+                || model.HasMethodBodies;
     }
 
     public sealed class PInvokeMethods : ISectionDescriptor<LibraryInspection>

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -178,6 +178,9 @@ public static class SectionNames
     /// <summary>Section for safe, local optimization opportunities inferred from IL/body evidence.</summary>
     public const string PerformanceTriage = "Performance Triage";
 
+    /// <summary>Section for curated exception-path resource lifecycle candidates.</summary>
+    public const string ResourceTriage = "Resource Triage";
+
     /// <summary>Section for unsafe-relevant evidence from the selected member body.</summary>
     public const string UnsafeOperations = "Unsafe Operations";
 

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -448,6 +448,7 @@ public record PackageSourceFileRow(
 [MarkoutContext(typeof(ClassifiedMethodRow))]
 [MarkoutContext(typeof(PInvokeMethodRow))]
 [MarkoutContext(typeof(ResourceRow))]
+[MarkoutContext(typeof(ResourceTriageRow))]
 [MarkoutContext(typeof(CustomAttributeRow))]
 [MarkoutContext(typeof(TypeForwarderRow))]
 [MarkoutContext(typeof(AuditSignalRow))]

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -815,6 +815,38 @@ public class LibraryInspectionView
                 o.Saturated))
             .ToList();
 
+    [MarkoutIgnore]
+    public bool HasResourceTriage =>
+        _data.ResourceLifecycleInspection?.Value
+            is ILInspector.Findings.FindingInspection<
+                ILInspector.Analysis.ResourceLifecycleOccurrence>.Complete;
+
+    [MarkoutSection(
+        Name = SectionNames.ResourceTriage,
+        ShowWhenProperty = nameof(HasResourceTriage),
+        EmptyText = "No actionable resource lifecycle candidates found.")]
+    public List<ResourceTriageRow> ResourceTriageSection =>
+        (_data.ResourceTriage ?? [])
+            .Select(row => new ResourceTriageRow(
+                MarkoutInline.Code(row.Member),
+                MarkoutInline.Code(row.Candidate),
+                row.Finding,
+                row.Provenance,
+                row.Resource,
+                row.Shape,
+                row.Impact,
+                row.Actionability,
+                MarkoutInline.Code(row.Boundary),
+                MarkoutInline.Code(row.AcquireIL),
+                MarkoutInline.Code(row.BoundaryIL),
+                row.Evidence,
+                row.Direction,
+                row.Confidence,
+                row.Visibility,
+                row.Stable is null ? null : MarkoutInline.Code(row.Stable),
+                row.Selector is null ? null : MarkoutInline.Code(row.Selector)))
+            .ToList();
+
     public static bool TopLeverageVisibilityEmpty(List<TopLeverageRow>? rows) => rows is null || rows.All(r => string.IsNullOrEmpty(r.Visibility));
     public static bool TopLeverageGeneratedEmpty(List<TopLeverageRow>? rows) => rows is null || rows.All(r => string.IsNullOrEmpty(r.Generated));
     public static bool TopLeverageStableEmpty(List<TopLeverageRow>? rows) => rows is null || rows.All(r => string.IsNullOrEmpty(r.Stable));
@@ -1115,6 +1147,26 @@ public record ResourceRow(
     string Name,
     string Visibility,
     string Size);
+
+[MarkoutSerializable]
+public record ResourceTriageRow(
+    string Member,
+    string Candidate,
+    string Finding,
+    string Provenance,
+    string Resource,
+    string Shape,
+    string Impact,
+    string Actionability,
+    string Boundary,
+    [property: MarkoutPropertyName("Acquire IL")] string AcquireIL,
+    [property: MarkoutPropertyName("Boundary IL")] string BoundaryIL,
+    string Evidence,
+    string Direction,
+    string Confidence,
+    string? Visibility,
+    string? Stable,
+    string? Selector);
 
 [MarkoutSerializable]
 public record CustomAttributeRow(

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -827,24 +827,25 @@ public class LibraryInspectionView
         EmptyText = "No actionable resource lifecycle candidates found.")]
     public List<ResourceTriageRow> ResourceTriageSection =>
         (_data.ResourceTriage ?? [])
-            .Select(row => new ResourceTriageRow(
-                MarkoutInline.Code(row.Member),
-                MarkoutInline.Code(row.Candidate),
-                row.Finding,
-                row.Provenance,
-                row.Resource,
-                row.Shape,
-                row.Impact,
-                row.Actionability,
-                MarkoutInline.Code(row.Boundary),
-                MarkoutInline.Code(row.AcquireIL),
-                MarkoutInline.Code(row.BoundaryIL),
-                row.Evidence,
-                row.Direction,
-                row.Confidence,
-                row.Visibility,
-                row.Stable is null ? null : MarkoutInline.Code(row.Stable),
-                row.Selector is null ? null : MarkoutInline.Code(row.Selector)))
+            .SelectMany(row => row.Boundaries.Select(boundary =>
+                new ResourceTriageRow(
+                    MarkoutInline.Code(row.Member),
+                    MarkoutInline.Code(row.Candidate),
+                    row.Finding,
+                    row.Provenance,
+                    row.Resource,
+                    row.Shape,
+                    row.Impact,
+                    row.Actionability,
+                    MarkoutInline.Code(boundary.Operation),
+                    MarkoutInline.Code($"IL_{row.AcquireOffset:X4}"),
+                    MarkoutInline.Code($"IL_{boundary.ILOffset:X4}"),
+                    row.Evidence,
+                    row.Direction,
+                    row.Confidence,
+                    row.Visibility,
+                    row.Stable is null ? null : MarkoutInline.Code(row.Stable),
+                    row.Selector is null ? null : MarkoutInline.Code(row.Selector))))
             .ToList();
 
     public static bool TopLeverageVisibilityEmpty(List<TopLeverageRow>? rows) => rows is null || rows.All(r => string.IsNullOrEmpty(r.Visibility));

--- a/tools/AnalysisHarness/LeakActionabilitySensor.cs
+++ b/tools/AnalysisHarness/LeakActionabilitySensor.cs
@@ -1,14 +1,8 @@
-using System.Reflection.Metadata;
-using System.Reflection.Metadata.Ecma335;
-using System.Reflection.PortableExecutable;
-using System.Collections.Immutable;
-using System.Runtime.InteropServices;
-
 using Markout;
 using Markout.Formatting;
 
 using ILInspector.Analysis;
-using ILInspector.Instructions;
+using ILInspector.Findings;
 
 namespace ILInspector.AnalysisHarness;
 
@@ -35,30 +29,10 @@ public sealed record LeakActionabilityReport(
 public enum LeakActionabilityFormat { Markdown, Tsv, Jsonl }
 
 /// <summary>
-/// The leak-actionability corpus sensor (#2439): a measurement-only classifier for the
-/// <see cref="LeakTriageAnalyzer"/> <c>exception-path-leak-candidate</c> bucket. It changes no
-/// analyzer behavior and wires no product surface - it reads the analyzer's public candidates and,
-/// per candidate, re-resolves via SRM every call the rented array flows into between Rent and the
-/// method's end, then classifies the boundary set by what it touches:
-/// <list type="bullet">
-/// <item><b>Untrusted</b> - a boundary reads/decodes/parses <i>external</i> input (Stream.Read,
-/// Decoder.GetChars, Encoding.GetString, Parse/Tokenize/Deserialize): genuinely actionable, since
-/// the exception is one a caller commonly catches.</item>
-/// <item><b>Trusted</b> - every boundary is an in-memory transform of already-validated data
-/// (Escape, Encode/Transcode, Array.Copy, format/write, new string): low actionability - the
-/// deliberate high-perf no-<c>finally</c> BCL idiom that leaks only on a rare/invariant-violating
-/// exception.</item>
-/// <item><b>Unknown</b> - unclassified boundary; stays measurement-only.</item>
-/// </list>
-/// A candidate is Untrusted if <i>any</i> boundary is untrusted, else Trusted if any is a known
-/// in-memory transform, else Unknown. This is the evidence engine for the #2439 Slice-4 decision
-/// about which exception-path candidates could graduate toward findings; the split is deliberately
-/// separate from the analyzer so it never affects a user-facing accusation.
-///
-/// <para>Precision note: boundary attribution is a Rent-to-end window scan, coarser than the
-/// analyzer's def-use set (it can include an unrelated call in the window). It is exact for the
-/// small single-rent methods this bucket is dominated by; a def-use-precise attribution is the
-/// natural follow-up.</para>
+/// Corpus orchestration and reporting over the Analysis-owned resource lifecycle inspection. The
+/// sensor deliberately performs no token resolution, boundary attribution, or actionability
+/// classification; those are product capabilities shared with the user-facing Resource Triage
+/// section.
 /// </summary>
 public static class LeakActionabilitySensor
 {
@@ -99,30 +73,49 @@ public static class LeakActionabilitySensor
         string name = Path.GetFileName(path);
         try
         {
-            var result = LeakTriageAnalyzer.AnalyzeAssemblyDetailed(path);
-            var exceptionPath = result.Candidates.Where(c => c.Shape == "exception-path-leak-candidate").ToList();
-            if (exceptionPath.Count == 0)
-                return new LeakActionabilityAssembly(name, Opened: true, TimedOut: false, 0, new Dictionary<string, int>(), []);
+            var inspection = ResourceLifecycleAnalysis.InspectAssembly(
+                path,
+                new FindingSubject(Path.GetFullPath(path), name));
+            if (inspection.Value
+                is not FindingInspection<ResourceLifecycleOccurrence>.Complete complete)
+            {
+                return inspection.Value
+                    is FindingInspection<ResourceLifecycleOccurrence>.Failed
+                        ? new LeakActionabilityAssembly(
+                            name,
+                            Opened: false,
+                            TimedOut: false,
+                            0,
+                            new Dictionary<string, int>(),
+                            [])
+                        : new LeakActionabilityAssembly(
+                            name,
+                            Opened: true,
+                            TimedOut: false,
+                            0,
+                            new Dictionary<string, int>(),
+                            []);
+            }
 
-            // Read into memory so no file handle is held during token resolution
-            // (resolution runs under the outer per-assembly timeout).
-            using var pe = new PEReader(ImmutableCollectionsMarshal.AsImmutableArray(File.ReadAllBytes(path)));
-            var reader = pe.GetMetadataReader();
+            var candidates = ResourceLifecycleAnalysis.SelectCandidates(complete);
+            if (candidates.Length == 0)
+                return new LeakActionabilityAssembly(name, Opened: true, TimedOut: false, 0, new Dictionary<string, int>(), []);
 
             var classCounts = new SortedDictionary<string, int>(StringComparer.Ordinal);
             var examples = new List<LeakActionabilityExample>();
-            foreach (var candidate in exceptionPath)
+            foreach (var candidate in candidates)
             {
-                var (cls, boundarySet) = Classify(pe, reader, candidate.Method.MetadataToken, candidate.RentOffset ?? candidate.ILOffset);
+                string cls = FormatActionability(
+                    candidate.Source.Payload.Actionability);
                 classCounts[cls] = classCounts.GetValueOrDefault(cls) + 1;
                 if (examples.Count < examplesPerAssembly)
                     examples.Add(new LeakActionabilityExample(
                         cls,
-                        $"{candidate.Method.DeclaringType.Name}::{candidate.Method.Name}",
-                        boundarySet));
+                        $"{candidate.Source.Payload.Method.DeclaringType.Name}::{candidate.Source.Payload.Method.Name}",
+                        FormatBoundarySet(candidate.Source.Payload.Boundaries)));
             }
 
-            return new LeakActionabilityAssembly(name, Opened: true, TimedOut: false, exceptionPath.Count, classCounts, examples);
+            return new LeakActionabilityAssembly(name, Opened: true, TimedOut: false, candidates.Length, classCounts, examples);
         }
         // Per-assembly boundary on a background thread: convert any input failure (a directory, a
         // truncated PE, ...) into a failed row and keep sweeping the corpus.
@@ -132,104 +125,25 @@ public static class LeakActionabilitySensor
         }
     }
 
-    // Resolve the boundary set for one candidate and aggregate its actionability class.
-    static (string Class, string BoundarySet) Classify(PEReader pe, MetadataReader reader, int methodToken, int? offset)
-    {
-        if (offset is not { } startOffset)
-            return (Unknown, "(no-offset)");
-        try
+    static string FormatActionability(ResourceActionability actionability)
+        => actionability switch
         {
-            var md = reader.GetMethodDefinition((MethodDefinitionHandle)MetadataTokens.EntityHandle(methodToken));
-            if (md.RelativeVirtualAddress == 0)
-                return (Unknown, "(no-body)");
-            var il = pe.GetMethodBody(md.RelativeVirtualAddress).GetILBytes() ?? [];
-            var instructions = InstructionDecoder.Decode(il);
-            int start = -1;
-            for (int i = 0; i < instructions.Length; i++)
-                if (instructions[i].Offset == startOffset) { start = i; break; }
-            if (start < 0)
-                return (Unknown, "(offset-miss)");
+            ResourceActionability.UntrustedActionable => Untrusted,
+            ResourceActionability.TrustedLowActionability => Trusted,
+            _ => Unknown,
+        };
 
-            // The array typically flows through non-throwing Span/Memory wrappers before its real
-            // boundary, and a rent can have several boundary uses (write-into then consume). Collect
-            // every substantive (non-wrapper) call from the rented-array use to the method's end.
-            var members = new List<(string Type, string Name)>();
-            for (int i = start; i < instructions.Length; i++)
-            {
-                var opcode = instructions[i].OpCode;
-                if (opcode is not (ILOpCode.Call or ILOpCode.Callvirt or ILOpCode.Newobj))
-                    continue;
-                var member = HarnessMemberResolution.ResolveToken(reader, checked((int)instructions[i].OperandValue));
-                if (IsInertWrapper(member.Type, member.Name))
-                    continue;
-                members.Add(member);
-            }
-            if (members.Count == 0)
-                return (Unknown, "(only-wrappers)");
+    static string FormatBoundarySet(
+        IReadOnlyList<ResourceBoundaryEvidence> boundaries)
+        => boundaries.Count == 0
+            ? "(no-boundary)"
+            : string.Join(
+                " + ",
+                boundaries
+                    .Select(boundary =>
+                        $"{Short(boundary.Operation.DeclaringType.ToQualifiedDisplayString())}::{boundary.Operation.Name}")
+                    .Distinct(StringComparer.Ordinal));
 
-            return (Aggregate(members), string.Join(" + ", members.Select(m => $"{Short(m.Type)}::{m.Name}").Distinct()));
-        }
-        catch (Exception ex)
-        {
-            return (Unknown, $"(err:{ex.GetType().Name})");
-        }
-    }
-
-    // A leak is actionable if ANY reachable boundary can throw on external input, so Untrusted
-    // dominates; else Trusted if any boundary is a known in-memory transform; else Unknown.
-    static string Aggregate(List<(string Type, string Name)> members)
-    {
-        var classes = members.Select(m => ClassifyMember(m.Type, m.Name)).ToList();
-        if (classes.Contains(Untrusted)) return Untrusted;
-        if (classes.Contains(Trusted)) return Trusted;
-        return Unknown;
-    }
-
-    // Non-throwing Span/Memory adapters the rented array flows through before its real boundary.
-    static bool IsInertWrapper(string declaringType, string member)
-    {
-        string type = Short(declaringType);
-        if (member is "op_Implicit" or "op_Explicit")
-            return true;
-        if (member is ".ctor" && type is "Span" or "ReadOnlySpan" or "Memory" or "ReadOnlyMemory")
-            return true;
-        return member is "AsSpan" or "AsMemory" or "Slice" or "GetPinnableReference" or "GetArrayDataReference";
-    }
-
-    // Consume-external => Untrusted; produce-from-memory => Trusted; otherwise Unknown.
-    static string ClassifyMember(string declaringType, string member)
-    {
-        string type = Short(declaringType);
-        string m = member;
-
-        // Untrusted: read / decode / parse external input.
-        if (IsStreamLike(type) && m.StartsWith("Read")) return Untrusted; // Read/ReadByte/ReadAsync/ReadExactly[Async]/ReadAtLeast[Async]
-        if ((type is "Decoder" || type.EndsWith("Decoder")) && m is "GetChars" or "GetString" or "Convert") return Untrusted;
-        if ((type is "Encoding" || type.EndsWith("Encoding")) && m is "GetChars" or "GetString") return Untrusted;
-        if (type is "Socket" && m.StartsWith("Receive")) return Untrusted;
-        if (type is "TextReader" or "StreamReader" or "BinaryReader" && m.StartsWith("Read")) return Untrusted;
-        if (m.StartsWith("Deserialize") || m.StartsWith("Tokenize") || m is "Decode") return Untrusted;
-        if ((m is "Parse" or "TryParse" || m.StartsWith("Parse")) && (type.Contains("Document") || type.Contains("Reader") || type.Contains("Parser"))) return Untrusted;
-
-        // Trusted: produce / transform validated in-memory data.
-        if (m.StartsWith("Escape")) return Trusted; // EscapeString/... - NOT Unescape (which decodes external input)
-        if ((type is "Encoding" || type.EndsWith("Encoding")) && m is "GetBytes" or "GetByteCount") return Trusted;
-        if (m.StartsWith("Encode") || m.StartsWith("Transcode") || m is "ToUtf8" or "EncodeHelper") return Trusted;
-        if (type is "Array" && m is "Copy" or "Clear" or "Resize" or "Fill") return Trusted;
-        if (type is "Buffer" && m.StartsWith("Block")) return Trusted;
-        if (type is "Unsafe" or "MemoryMarshal") return Trusted;
-        if (type is "String" && m is ".ctor") return Trusted;
-        if (m is "CopyTo" && !IsStreamLike(type)) return Trusted;
-        if (m.StartsWith("TryFormat") || m.StartsWith("Format")) return Trusted;
-        if (m.StartsWith("WriteString") || m.StartsWith("WriteValue") || m is "WriteStringByOptions" or "WriteStringByOptionsPropertyName") return Trusted;
-
-        return Unknown;
-    }
-
-    static bool IsStreamLike(string type) => type is "Stream" || type.EndsWith("Stream");
-
-    // Strip the namespace and any generic-arity backtick suffix so classifier checks (which use bare
-    // names like "Stream"/"Encoding"/"Span") match generic instances too (System.Span`1 -> Span).
     static string Short(string type)
     {
         if (type.Contains('.'))

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -59,15 +59,14 @@ const string Usage =
           per line in <file>) and report where it fires: total findings, the shape histogram, and
           example methods per assembly, as a Markout card. Default is Markdown; --tsv and --jsonl
           select the tabular formats (--json is an alias for --jsonl). This is the evidence engine
-          for #1992 - the analyzer is precision-first, so an empty card means recall (not a
-          user-facing section) is the next lever. --top bounds examples per assembly.
+          for correctness-oriented #1992 work - the analyzer is precision-first, so an empty
+          findings card means recall is the next lever. --top bounds examples per assembly.
 
       --leak-actionability <file> [--top N] [--tsv | --jsonl]
-          Classify the leak-triage `exception-path-leak-candidate` bucket by actionability
-          (#2439), measurement-only: for each candidate, resolve the boundary members the rented
-          array flows into and bucket the candidate as untrusted-actionable (a boundary reads/
-          decodes/parses external input), trusted-low-actionability (only in-memory transforms -
-          the deliberate no-finally BCL idiom), or unknown. Changes no analyzer behavior. Formats
+          Report Analysis-owned `analysis.resource-lifecycle` findings by actionability (#2439):
+          untrusted-actionable (an exact boundary reads/decodes/parses external input),
+          trusted-low-actionability (only in-memory transforms), or unknown. The harness owns
+          corpus orchestration and reporting, not boundary attribution or classification. Formats
           match --leak-triage; --top bounds examples per class.
 
       --memorypool-lifecycle <file> [--top N] [--tsv | --jsonl]

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -266,19 +266,22 @@ natural home for those (`Change`/`[MarkoutDelta]`). Each assembly is bounded by 
 timeout, and any per-assembly input failure (a directory path, a truncated PE) becomes an
 `Opened=false` row rather than crashing the sweep.
 
-This is the evidence engine that must earn any user-facing `Leak Triage` section: the analyzer
+This remains the evidence engine for any correctness-oriented `Leak Triage` section: the analyzer
 fails closed on incomplete CFG/RD, non-`Shared` pools, aliases, field stores, cross-method
-ownership, and ambiguous uses, so an **empty findings card on real code means recall — not a
-product section — is the next lever**. Use the candidate buckets to decide which recall gate to
+ownership, and ambiguous uses, so an **empty findings card on real code means recall is the next
+lever**. Use the candidate buckets to decide which correctness gate to
 model next. A 2026-07-05 run over CoreLib, `Microsoft.CodeAnalysis`, and
 `Microsoft.CodeAnalysis.CSharp` produced **0 findings** (all gates suppressed), while the fixture
-assembly's three known-misuse methods surfaced exactly once each. Wire the section only once this
-card shows non-zero, high-precision rows on real assemblies.
+assembly's three known-misuse methods surfaced exactly once each. The separate `Resource Triage`
+section uses the actionability contract below and does not reinterpret these rows as correctness
+findings.
 
 ## Leak actionability corpus sensor (#2439)
 
-`--leak-actionability` classifies the leak-triage `exception-path-leak-candidate` bucket by
-**actionability**, as a [Markout](https://github.com/richlander/markout) card:
+`--leak-actionability` reports the leak-triage `exception-path-leak-candidate` bucket by
+**actionability**, as a [Markout](https://github.com/richlander/markout) card. The harness consumes
+the same Analysis-owned `analysis.resource-lifecycle` findings as the product's explicit
+`Resource Triage` section:
 
 ```bash
 dotnet "$DLL" --leak-actionability assemblies.txt --top 5      # Markdown card (default)
@@ -286,10 +289,9 @@ dotnet "$DLL" --leak-actionability assemblies.txt --tsv        # section-tagged 
 dotnet "$DLL" --leak-actionability assemblies.txt --jsonl      # one JSON record per row
 ```
 
-Like `--leak-triage`, this is **measurement-only** — it changes no analyzer behavior and wires no
-product surface. For each `exception-path-leak-candidate`, it re-resolves via SRM every call the
-rented array flows into between `Rent` and the method's end, then classifies the boundary set by
-what it touches:
+The harness owns corpus orchestration and reporting only. Analysis attributes exact unprotected
+boundaries from the rented local's def-use evidence and classifies the boundary set by what it
+touches:
 
 - `untrusted-actionable` — a boundary **reads/decodes/parses external input**
   (`Stream.Read`, `Decoder.GetChars`, `Encoding.GetString`, `Parse`/`Tokenize`/`Deserialize`):
@@ -302,16 +304,18 @@ what it touches:
 
 A candidate is `untrusted-actionable` if **any** boundary is untrusted, else
 `trusted-low-actionability` if any is a known in-memory transform, else `unknown`. This is the
-evidence engine for the #2439 Slice-4 decision about which exception-path candidates could graduate
-toward findings; keeping the split out of the analyzer means it never affects a user-facing
-accusation. A 2026-07-07 run over the .NET 9.0.14 shared framework (305 assemblies) classified the
-34 exception-path candidates as 6 `untrusted-actionable` (e.g. `MessagePackReader::ReadStringSlow`,
-`HashAlgorithm::ComputeHash`), 19 `trusted-low-actionability` (e.g. `Utf8JsonWriter` escape
-writers, `BinaryWriter::Write`), and 9 `unknown`.
+measurement view for the same product-owned contract. `Resource Triage` exposes only
+`untrusted-actionable` rows and describes them as pool-churn-on-exception candidates, not permanent
+memory leaks or memory-corruption findings:
 
-Boundary attribution is a `Rent`-to-end window scan, coarser than the analyzer's def-use set (it
-can include an unrelated call in the window); it is exact for the small single-rent methods this
-bucket is dominated by. A def-use-precise attribution is the natural follow-up.
+```bash
+dotnet-inspect library MyLib.dll -S "Resource Triage" --jsonl
+```
+
+A 2026-07-16 run over the .NET 11 daily shared framework (314 assemblies) classified
+49 lifecycle candidates as 2 `untrusted-actionable`
+(`MessagePackReader::ReadStringSlow`, `BinaryReader::FillBuffer`),
+1 `trusted-low-actionability`, and 46 `unknown`.
 
 ## MemoryPool lifecycle corpus sensor (#2439, Slice 3)
 


### PR DESCRIPTION
## Summary

Graduates exception-path pool actionability from a harness-only experiment into
product-owned `analysis.resource-lifecycle` findings and an explicit
`Resource Triage` section.

- Analysis now owns exact ArrayPool acquisition and unprotected-boundary
  evidence, structured actionability, inspection outcomes, Finding identity,
  and stable candidate IDs
- boundary attribution follows inline and local-stored Span/Memory setup chains
  while failing closed on ambiguous uses
- `Resource Triage` exposes only untrusted-input candidates with Finding
  provenance, exact IL coordinates, impact, and cleanup direction
- the AnalysisHarness sensor is now a pure corpus/reporting consumer of the
  product inspection; its token resolution, window scanning, and independent
  classifier are deleted
- complete emptiness and inspection failure remain distinct and visible

This reports **pool churn if an external-input boundary throws**, not a permanent
memory leak, memory corruption, runtime frequency, or measured severity.

## Evidence

Current .NET 11 framework census:

| Metric | Result |
| --- | ---: |
| Assemblies opened | 314 / 314 |
| Lifecycle candidates | 49 |
| Untrusted-actionable | 2 |
| Trusted-low-actionability | 1 |
| Unknown | 46 |

The two curated rows are `MessagePackReader.ReadStringSlow` and
`BinaryReader.FillBuffer`. A baseline/head Leak Triage census preserves the
legacy population: 539 total candidates and 48 exception-path candidates on
both sides.

The new section is explicit-only; default `library -v:m` output is unchanged.
Markdown, TSV, and JSONL retain the same typed row contract.

## Validation

- Release solution build
- `ILInspector.Analysis.Tests`: 474 passed
- `dotnet-inspect.Tests`: 1,905 passed, 10 expected tool-dependent skips
- linux-x64 NativeAOT publish and live `BinaryReader.FillBuffer` Resource Triage
  query
- markdownlint

Closes #2439.
Advances #1992.
