### PR TITLE
Replace fixture-boundary literal wall with axis-coverage invariant

### DIFF
--- a/tests/DotnetInspector.Fixtures.Tests/FixtureCatalogTests.cs
+++ b/tests/DotnetInspector.Fixtures.Tests/FixtureCatalogTests.cs
@@ -140,29 +140,26 @@ public class FixtureCatalogTests
             Assert.NotEmpty(fixture.Boundaries));
     }
 
-    [Theory]
-    [InlineData(FixtureIds.DiffV1, FixtureBoundary.VersionPair)]
-    [InlineData(FixtureIds.DiffV2, FixtureBoundary.VersionPair)]
-    [InlineData(FixtureIds.DiffAsmCaller, FixtureBoundary.AssemblyIdentity)]
-    [InlineData(FixtureIds.AnalysisCallerGraphCaller, FixtureBoundary.CrossAssemblyBoundary)]
-    [InlineData(FixtureIds.AnalysisCallerGraphCallerTwin, FixtureBoundary.CrossAssemblyBoundary)]
-    [InlineData(FixtureIds.AnalysisCallerGraphLookalikeCaller, FixtureBoundary.CrossAssemblyBoundary)]
-    [InlineData(FixtureIds.AnalysisCallerGraphTarget, FixtureBoundary.CrossAssemblyBoundary)]
-    [InlineData(FixtureIds.AnalysisCrossAsmCollision, FixtureBoundary.ExternAlias)]
-    [InlineData(FixtureIds.AnalysisFacade, FixtureBoundary.TargetFramework)]
-    [InlineData(FixtureIds.AnalysisLookalike, FixtureBoundary.AssemblyIdentity)]
-    [InlineData(FixtureIds.AnalysisRender, FixtureBoundary.FrameworkReference)]
-    [InlineData(FixtureIds.DecompilerCheckedArithmetic, FixtureBoundary.CompilerLowering)]
-    [InlineData(FixtureIds.DecompilerClassicAsync, FixtureBoundary.CompilerLowering)]
-    [InlineData(FixtureIds.DecompilerUnsafeLegacy, FixtureBoundary.ModuleAttribute)]
-    [InlineData(FixtureIds.DecompilerUnsafeNew, FixtureBoundary.ModuleAttribute)]
-    [InlineData(FixtureIds.DecompilerUnsafeChainA, FixtureBoundary.CrossAssemblyBoundary)]
-    [InlineData(FixtureIds.DecompilerUnsafeChainB, FixtureBoundary.CrossAssemblyBoundary)]
-    [InlineData(FixtureIds.DecompilerUnsafeChainC, FixtureBoundary.OutputKind)]
-    [InlineData(FixtureIds.RunFasterAllocation, FixtureBoundary.SidecarAsset)]
-    public void BoundaryMetadata_DocumentsSemanticAxes(string fixtureId, FixtureBoundary boundary)
+    [Fact]
+    public void BoundaryMetadata_EverySemanticAxisHasFixtureCoverage()
     {
-        AssertBoundary(FixtureCatalog.Get(fixtureId), boundary);
+        // Corpus-design invariant: every FixtureBoundary axis is exercised by at
+        // least one registered fixture. This iterates the advertised inventory and
+        // each fixture's own declared boundaries (docs/fixture-governance.md,
+        // "Expectation ownership") rather than pinning per-fixture id -> boundary
+        // literals, so adding a fixture never forces a matching test edit; only
+        // introducing a brand-new axis with no covering fixture fails here.
+        var covered = FixtureCatalog.All
+            .SelectMany(fixture => fixture.Boundaries)
+            .ToHashSet();
+
+        var uncovered = Enum.GetValues<FixtureBoundary>()
+            .Where(boundary => !covered.Contains(boundary))
+            .ToArray();
+
+        Assert.True(
+            uncovered.Length == 0,
+            $"No fixture declares these boundary axes: {string.Join(", ", uncovered)}");
     }
 
     [Fact]


### PR DESCRIPTION
## What

Applies the merged **"Expectation ownership"** governance
(`docs/fixture-governance.md`, PR #2783) to the built-assembly
`FixtureCatalogTests`.

Replaces `BoundaryMetadata_DocumentsSemanticAxes` — a 19-row `[Theory]` that
re-encoded each fixture's own declared `Boundaries` as a co-located
`id -> boundary` literal table — with
`BoundaryMetadata_EverySemanticAxisHasFixtureCoverage`, which iterates the
advertised inventory (`FixtureCatalog.All`) and the `FixtureBoundary` enum to
assert every semantic axis is exercised by at least one registered fixture.

## Why

The old test pinned one test asset (the `InlineData` table) against another
(the fixture's `Boundaries(...)` declaration). Both are co-located, edited in
the same change, and reviewed together, so the copy bought maintenance cost
without adversarial safety. Its failure mode was exactly the one the doc calls
out: *"someone added a valid fixture, now update my literal list."*

The wall had **already drifted**: `DecompilerUnsafeChainA` declares
`CrossAssemblyBoundary, ModuleAttribute` (FixtureCatalog.cs:304) but the table
only checked `CrossAssemblyBoundary`; `ChainC` declares three boundaries but the
table omitted `ModuleAttribute` — proof it was mirroring, not verifying.

The new invariant flips the drift surface: adding a fixture never forces a test
edit; only introducing a brand-new `FixtureBoundary` axis with no covering
fixture fails.

## Scope / non-actions

- The structural "every separate-project fixture declares >=1 boundary" invariant
  (`BoundaryMetadata_CoversIntentionalSeparateFixtureProjects`) is unchanged and
  complements the new coverage check.
- The remaining `AssertBoundary`/tag reads in `UnsafeFixtures_*`,
  `UnsafeChainFixtures_*`, and `AssemblyNameAxisFixtures_*` are **kept on
  purpose**: they sit next to genuine built-artifact assertions (PE custom
  attributes, assembly references, spoofed file names) and correlate a fixture's
  declared claim against the real compiled artifact — the test-asset-vs-product
  boundary the doc *wants* rigor on, not a test-asset-vs-test-asset copy.

## Evidence

Test-only change; no product or harness behavior touched.

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config` — succeeded.
- `dotnet run --project tests/DotnetInspector.Fixtures.Tests -c Release --no-build -- -class DotnetInspector.Fixtures.Tests.FixtureCatalogTests` — **Total: 17, Failed: 0**.

## Risk

Low: no product/harness code changed; a pure test-hygiene refactor implementing
already-merged governance. New coverage test verified passing against the live
corpus (all 11 axes covered).
