### PR TITLE
Separate resource observations from triage assessments

### DIFF
--- a/docs/analysis-baselines.md
+++ b/docs/analysis-baselines.md
@@ -70,9 +70,10 @@ where each `CalculateDepth` step re-scans all spans) — the O(N·D·N) waterfal
 
 ### 2. Leak-after-exception — highest-precision lane
 
-Pooled-buffer churn on the exception path (see catalog issue #2572 and #2439). Analysis classifies
-exact def-use-attributed `ArrayPool` boundaries by whether they consume external input;
-`Resource Triage` exposes the untrusted-actionable candidates.
+Pooled-buffer churn on the exception path (see catalog issue #2572 and #2439).
+`ResourceLifecycleAnalysis` records exact def-use-attributed `ArrayPool` boundaries, and
+`ResourceTriageAnalysis` assesses whether they consume external input; `Resource Triage` exposes
+the untrusted-actionable candidates.
 
 - Historical broadened-package sensor (44 asm): 12 exception-path candidates →
   **5 untrusted-actionable, all confirmed**

--- a/docs/design/finding-adoption.md
+++ b/docs/design/finding-adoption.md
@@ -216,13 +216,15 @@ therefore useful for a runtime/static join within one build, while
 correspondence paths. Aggregate judgments such as `allocation-hotspot`
 deliberately have no exact source Finding.
 
-`Resource Triage` follows the same rule. Its pool-churn impact and cleanup
-direction are downstream judgments over exact
-`analysis.resource-lifecycle` observations; rows retain the native descriptor,
-candidate identity, resolved boundary, and acquisition/boundary IL offsets.
+`Resource Triage` follows the same rule. Exact
+`analysis.resource-lifecycle` observations remain policy-free; the
+Analysis-owned `ResourceTriageAnalysis` contract adds typed actionability,
+reason, impact, remediation, and confidence. CLI projection owns only their
+human wording. Rows retain the native descriptor, version-local candidate
+identity, resolved boundary, and acquisition/boundary IL offsets.
 Multi-boundary candidates expand into one row per typed operation/offset pair.
-The harness measures all actionability classes from that same inspection,
-while the product section selects the untrusted-actionable subset.
+The harness measures every assessment class from the same inspection, while the
+product section selects the untrusted-actionable subset.
 
 ## Adoption review
 

--- a/docs/design/finding-producers.md
+++ b/docs/design/finding-producers.md
@@ -214,12 +214,14 @@ constructors, or merge branches.
 
 Resource lifecycle observations are a single-version Analysis producer under
 `analysis.resource-lifecycle`. Each occurrence retains one acquisition and its
-exact unprotected boundary set; boundary kinds and aggregate actionability are
-producer-owned API-shape facets. The explicit `Resource Triage` section keeps
-the complete `FindingInspection<ResourceLifecycleOccurrence>`, exposes only
-untrusted-actionable candidates, and adds impact/fix language downstream.
+exact unprotected boundary set without scenario policy.
+`ResourceTriageAnalysis` assesses those observations into typed boundary kinds,
+aggregate actionability, reason, impact, remediation, confidence, and
+version-local candidate identity. The explicit `Resource Triage` section keeps
+the complete `FindingInspection<ResourceLifecycleOccurrence>`, selects
+untrusted-actionable assessments, and maps their typed judgments to prose.
 `Complete([])` and `Failed` remain distinct, and the corpus harness consumes the
-same inspection rather than resolving tokens or classifying boundaries itself.
+same assessments rather than resolving tokens or classifying boundaries itself.
 
 The same three Analysis censuses now compose with the N-address correlation
 tier. `timeline --member M --finding analysis.*` uses Metadata only to resolve

--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -77,7 +77,7 @@ public sealed class LeakTriageAnalyzerTests
     }
 
     [Fact]
-    public void ResourceLifecycleAnalysis_ClassifiesExactBoundaryEvidence()
+    public void ResourceLifecycleAnalysis_ReportsExactBoundaryEvidence()
     {
         var inspection = ResourceLifecycleAnalysis.InspectAssembly(
             typeof(ArrayPoolLeakFixtures).Assembly.Location,
@@ -85,129 +85,175 @@ public sealed class LeakTriageAnalyzerTests
         var complete =
             Assert.IsType<FindingInspection<ResourceLifecycleOccurrence>.Complete>(
                 inspection.Value);
-        var candidates = ResourceLifecycleAnalysis.SelectCandidates(complete);
 
-        var external = Assert.Single(candidates.Where(candidate =>
-            candidate.Source.Payload.Method.Name
+        var external = Assert.Single(complete.Findings.Where(finding =>
+            finding.Payload.Method.Name
                 == nameof(ArrayPoolLeakFixtures.ExternalReadBeforeReturn)));
-        Assert.Equal("analysis.resource-lifecycle", external.Source.Descriptor.Id);
+        Assert.Equal("analysis.resource-lifecycle", external.Descriptor.Id);
+        var externalBoundary = Assert.Single(external.Payload.Boundaries);
+        Assert.Equal("Read", externalBoundary.Operation.Name);
+        Assert.True(
+            externalBoundary.ILOffset > external.Payload.AcquireOffset);
+
+        Assert.DoesNotContain(
+            typeof(ResourceLifecycleOccurrence).GetProperties(),
+            property => property.Name == "Actionability");
+        Assert.DoesNotContain(
+            typeof(ResourceBoundaryEvidence).GetProperties(),
+            property => property.Name == "Kind");
+
+        var clone = external.Payload with
+        {
+            Boundaries = [.. external.Payload.Boundaries],
+        };
+        Assert.Equal(external.Payload, clone);
+        Assert.Equal(external.Payload.GetHashCode(), clone.GetHashCode());
+    }
+
+    [Fact]
+    public void ResourceTriageAnalysis_AssessesExactBoundaryEvidence()
+    {
+        var inspection = ResourceLifecycleAnalysis.InspectAssembly(
+            typeof(ArrayPoolLeakFixtures).Assembly.Location,
+            new FindingSubject("fixtures", "fixtures"));
+        var complete =
+            Assert.IsType<FindingInspection<ResourceLifecycleOccurrence>.Complete>(
+                inspection.Value);
+        var assessments = ResourceTriageAnalysis.Assess(complete);
+
+        var external = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.ExternalReadBeforeReturn)));
         Assert.StartsWith("rt~", external.CandidateId);
         Assert.Equal(
-            ResourceActionability.UntrustedActionable,
-            external.Source.Payload.Actionability);
-        var externalBoundary = Assert.Single(external.Source.Payload.Boundaries);
-        Assert.Equal("Read", externalBoundary.Operation.Name);
-        Assert.Equal(ResourceBoundaryKind.ExternalInput, externalBoundary.Kind);
-        Assert.True(
-            externalBoundary.ILOffset > external.Source.Payload.AcquireOffset);
+            ResourceTriageActionability.UntrustedActionable,
+            external.Actionability);
+        Assert.Equal(
+            ResourceTriageReason.ExternalInputBoundaryBeforeCleanup,
+            external.Reason);
+        Assert.Equal(
+            ResourceTriageImpact.PoolChurnOnException,
+            external.Impact);
+        Assert.Equal(
+            ResourceTriageRemediation.EnsureExceptionalCleanup,
+            external.Remediation);
+        Assert.Equal(ResourceTriageConfidence.Medium, external.Confidence);
+        var externalBoundary = Assert.Single(external.Boundaries);
+        Assert.Equal("Read", externalBoundary.Evidence.Operation.Name);
+        Assert.Equal(
+            ResourceTriageBoundaryKind.ExternalInput,
+            externalBoundary.Kind);
 
-        var throughSetup = Assert.Single(candidates.Where(candidate =>
-            candidate.Source.Payload.Method.Name
+        var throughSetup = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
                 == nameof(ArrayPoolLeakFixtures.ExternalDecodeThroughSpan)));
         Assert.Equal(
-            ResourceActionability.UntrustedActionable,
-            throughSetup.Source.Payload.Actionability);
-        Assert.Contains(throughSetup.Source.Payload.Boundaries, boundary =>
-            boundary.Operation.Name == "GetChars"
-            && boundary.Kind == ResourceBoundaryKind.ExternalInput);
-        Assert.DoesNotContain(throughSetup.Source.Payload.Boundaries, boundary =>
-            boundary.Operation.Name == "AsSpan");
+            ResourceTriageActionability.UntrustedActionable,
+            throughSetup.Actionability);
+        Assert.Contains(throughSetup.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "GetChars"
+            && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
+        Assert.DoesNotContain(throughSetup.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "AsSpan");
 
-        var throughLocal = Assert.Single(candidates.Where(candidate =>
-            candidate.Source.Payload.Method.Name
+        var throughLocal = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
                 == nameof(ArrayPoolLeakFixtures.ExternalDecodeThroughSpanLocal)));
         Assert.Equal(
-            ResourceActionability.UntrustedActionable,
-            throughLocal.Source.Payload.Actionability);
-        Assert.Contains(throughLocal.Source.Payload.Boundaries, boundary =>
-            boundary.Operation.Name == "GetChars"
-            && boundary.Kind == ResourceBoundaryKind.ExternalInput);
+            ResourceTriageActionability.UntrustedActionable,
+            throughLocal.Actionability);
+        Assert.Contains(throughLocal.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "GetChars"
+            && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
 
-        var throughStringArgument = Assert.Single(candidates.Where(candidate =>
-            candidate.Source.Payload.Method.Name
+        var throughStringArgument = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
                 == nameof(ArrayPoolLeakFixtures.ExternalParseThroughSpanWithTag)));
         Assert.Equal(
-            ResourceActionability.UntrustedActionable,
-            throughStringArgument.Source.Payload.Actionability);
+            ResourceTriageActionability.UntrustedActionable,
+            throughStringArgument.Actionability);
         Assert.Contains(
-            throughStringArgument.Source.Payload.Boundaries,
+            throughStringArgument.Boundaries,
             boundary =>
-                boundary.Operation.Name == "Parse"
-                && boundary.Kind == ResourceBoundaryKind.ExternalInput);
+                boundary.Evidence.Operation.Name == "Parse"
+                && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
 
-        var throughConstructedArgument = Assert.Single(candidates.Where(candidate =>
-            candidate.Source.Payload.Method.Name
+        var throughConstructedArgument = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
                 == nameof(ArrayPoolLeakFixtures.ExternalParseThroughSpanWithConstructedTag)));
         Assert.Equal(
-            ResourceActionability.UntrustedActionable,
-            throughConstructedArgument.Source.Payload.Actionability);
+            ResourceTriageActionability.UntrustedActionable,
+            throughConstructedArgument.Actionability);
         Assert.Contains(
-            throughConstructedArgument.Source.Payload.Boundaries,
+            throughConstructedArgument.Boundaries,
             boundary =>
-                boundary.Operation.Name == "Parse"
-                && boundary.Kind == ResourceBoundaryKind.ExternalInput);
+                boundary.Evidence.Operation.Name == "Parse"
+                && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
         Assert.DoesNotContain(
-            throughConstructedArgument.Source.Payload.Boundaries,
-            boundary => boundary.Operation.Name == ".ctor");
+            throughConstructedArgument.Boundaries,
+            boundary => boundary.Evidence.Operation.Name == ".ctor");
 
-        var throughStaticArgument = Assert.Single(candidates.Where(candidate =>
-            candidate.Source.Payload.Method.Name
+        var throughStaticArgument = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
                 == nameof(ArrayPoolLeakFixtures.ExternalParseThroughSpanWithStaticTag)));
         Assert.Equal(
-            ResourceActionability.UntrustedActionable,
-            throughStaticArgument.Source.Payload.Actionability);
+            ResourceTriageActionability.UntrustedActionable,
+            throughStaticArgument.Actionability);
         Assert.Contains(
-            throughStaticArgument.Source.Payload.Boundaries,
+            throughStaticArgument.Boundaries,
             boundary =>
-                boundary.Operation.Name == "Parse"
-                && boundary.Kind == ResourceBoundaryKind.ExternalInput);
+                boundary.Evidence.Operation.Name == "Parse"
+                && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
 
-        var constructorBoundary = Assert.Single(candidates.Where(candidate =>
-            candidate.Source.Payload.Method.Name
+        var constructorBoundary = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
                 == nameof(ArrayPoolLeakFixtures.SpanConsumedByConstructor)));
         Assert.Equal(
-            ResourceActionability.Unknown,
-            constructorBoundary.Source.Payload.Actionability);
+            ResourceTriageActionability.Unknown,
+            constructorBoundary.Actionability);
         Assert.Equal(
             ".ctor",
-            Assert.Single(constructorBoundary.Source.Payload.Boundaries)
-                .Operation.Name);
+            Assert.Single(constructorBoundary.Boundaries)
+                .Evidence.Operation.Name);
 
-        var unrelatedReader = Assert.Single(candidates.Where(candidate =>
-            candidate.Source.Payload.Method.Name
+        var unrelatedReader = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
                 == nameof(ArrayPoolLeakFixtures.UnrelatedTextReaderReadBeforeReturn)));
         Assert.Equal(
-            ResourceActionability.Unknown,
-            unrelatedReader.Source.Payload.Actionability);
+            ResourceTriageActionability.Unknown,
+            unrelatedReader.Actionability);
         Assert.Equal(
-            ResourceBoundaryKind.Unknown,
-            Assert.Single(unrelatedReader.Source.Payload.Boundaries).Kind);
+            ResourceTriageBoundaryKind.Unknown,
+            Assert.Single(unrelatedReader.Boundaries).Kind);
 
-        var frameworkReader = Assert.Single(candidates.Where(candidate =>
-            candidate.Source.Payload.Method.Name
+        var frameworkReader = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
                 == nameof(ArrayPoolLeakFixtures.FrameworkTextReaderReadBeforeReturn)));
         Assert.Equal(
-            ResourceActionability.UntrustedActionable,
-            frameworkReader.Source.Payload.Actionability);
+            ResourceTriageActionability.UntrustedActionable,
+            frameworkReader.Actionability);
         Assert.Equal(
-            ResourceBoundaryKind.ExternalInput,
-            Assert.Single(frameworkReader.Source.Payload.Boundaries).Kind);
+            ResourceTriageBoundaryKind.ExternalInput,
+            Assert.Single(frameworkReader.Boundaries).Kind);
 
-        var trusted = Assert.Single(candidates.Where(candidate =>
-            candidate.Source.Payload.Method.Name
+        var trusted = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
                 == nameof(ArrayPoolLeakFixtures.TrustedTransformWithUnrelatedReadAfterReturn)));
         Assert.Equal(
-            ResourceActionability.TrustedLowActionability,
-            trusted.Source.Payload.Actionability);
-        var trustedBoundary = Assert.Single(trusted.Source.Payload.Boundaries);
-        Assert.Equal("GetBytes", trustedBoundary.Operation.Name);
+            ResourceTriageActionability.TrustedLowActionability,
+            trusted.Actionability);
         Assert.Equal(
-            ResourceBoundaryKind.InMemoryTransform,
+            ResourceTriageReason.InMemoryBoundaryBeforeCleanup,
+            trusted.Reason);
+        var trustedBoundary = Assert.Single(trusted.Boundaries);
+        Assert.Equal("GetBytes", trustedBoundary.Evidence.Operation.Name);
+        Assert.Equal(
+            ResourceTriageBoundaryKind.InMemoryTransform,
             trustedBoundary.Kind);
 
-        var actionable = ResourceLifecycleAnalysis.SelectCandidates(
-            complete,
-            ResourceActionability.UntrustedActionable);
+        var actionable = assessments.Where(assessment =>
+            assessment.Actionability
+                == ResourceTriageActionability.UntrustedActionable);
         Assert.Contains(actionable, candidate =>
             candidate.Source.Payload.Method.Name
                 == nameof(ArrayPoolLeakFixtures.ExternalReadBeforeReturn));
@@ -215,12 +261,12 @@ public sealed class LeakTriageAnalyzerTests
             candidate.Source.Payload.Method.Name
                 == nameof(ArrayPoolLeakFixtures.TrustedTransformWithUnrelatedReadAfterReturn));
 
-        var clone = external.Source.Payload with
+        var clone = external with
         {
-            Boundaries = [.. external.Source.Payload.Boundaries],
+            Boundaries = [.. external.Boundaries],
         };
-        Assert.Equal(external.Source.Payload, clone);
-        Assert.Equal(external.Source.Payload.GetHashCode(), clone.GetHashCode());
+        Assert.Equal(external, clone);
+        Assert.Equal(external.GetHashCode(), clone.GetHashCode());
     }
 
     [Fact]

--- a/src/ILInspector.Analysis/ResourceLifecycleAnalysis.cs
+++ b/src/ILInspector.Analysis/ResourceLifecycleAnalysis.cs
@@ -1,30 +1,12 @@
 using System.Collections.Immutable;
-using System.Globalization;
-using System.Security.Cryptography;
-using System.Text;
 
 using ILInspector.Findings;
 
 namespace ILInspector.Analysis;
 
-public enum ResourceBoundaryKind
-{
-    Unknown,
-    ExternalInput,
-    InMemoryTransform,
-}
-
-public enum ResourceActionability
-{
-    Unknown,
-    TrustedLowActionability,
-    UntrustedActionable,
-}
-
 public readonly record struct ResourceBoundaryEvidence(
     int ILOffset,
-    MemberRef Operation,
-    ResourceBoundaryKind Kind);
+    MemberRef Operation);
 
 public sealed record ResourceLifecycleOccurrence
 {
@@ -35,8 +17,7 @@ public sealed record ResourceLifecycleOccurrence
         string Resource,
         string Shape,
         int AcquireOffset,
-        ImmutableArray<ResourceBoundaryEvidence> Boundaries,
-        ResourceActionability Actionability)
+        ImmutableArray<ResourceBoundaryEvidence> Boundaries)
     {
         this.Method = Method ?? throw new ArgumentNullException(nameof(Method));
         ArgumentException.ThrowIfNullOrWhiteSpace(Resource);
@@ -50,7 +31,6 @@ public sealed record ResourceLifecycleOccurrence
         _boundaries = ImmutableArrayValueEquality.RequireInitialized(
             Boundaries,
             nameof(Boundaries));
-        this.Actionability = Actionability;
     }
 
     public MethodIdentity Method { get; }
@@ -64,16 +44,13 @@ public sealed record ResourceLifecycleOccurrence
             value,
             nameof(Boundaries));
     }
-    public ResourceActionability Actionability { get; }
-
     public bool Equals(ResourceLifecycleOccurrence? other)
         => other is not null
             && Method == other.Method
             && string.Equals(Resource, other.Resource, StringComparison.Ordinal)
             && string.Equals(Shape, other.Shape, StringComparison.Ordinal)
             && AcquireOffset == other.AcquireOffset
-            && ImmutableArrayValueEquality.SequenceEqual(Boundaries, other.Boundaries)
-            && Actionability == other.Actionability;
+            && ImmutableArrayValueEquality.SequenceEqual(Boundaries, other.Boundaries);
 
     public override int GetHashCode()
     {
@@ -83,14 +60,9 @@ public sealed record ResourceLifecycleOccurrence
         hash.Add(Shape, StringComparer.Ordinal);
         hash.Add(AcquireOffset);
         ImmutableArrayValueEquality.AddToHash(ref hash, Boundaries);
-        hash.Add(Actionability);
         return hash.ToHashCode();
     }
 }
-
-public sealed record ResourceTriageCandidate(
-    string CandidateId,
-    Finding<ResourceLifecycleOccurrence> Source);
 
 public static class ResourceLifecycleAnalysis
 {
@@ -106,7 +78,7 @@ public static class ResourceLifecycleAnalysis
             var occurrences = LeakTriageAnalyzer
                 .AnalyzeAssemblyDetailed(path)
                 .ExceptionPathCandidates
-                .Select(Classify);
+                .Select(CreateOccurrence);
             return new FindingInspection<ResourceLifecycleOccurrence>.Complete(
                 AnalysisFindings.InspectResourceLifecycles(occurrences, subject));
         }
@@ -127,207 +99,16 @@ public static class ResourceLifecycleAnalysis
         }
     }
 
-    public static ImmutableArray<ResourceTriageCandidate> SelectCandidates(
-        FindingInspection<ResourceLifecycleOccurrence>.Complete inspection,
-        ResourceActionability? actionability = null)
-    {
-        ArgumentNullException.ThrowIfNull(inspection);
-
-        var candidateIds = new HashSet<string>(StringComparer.Ordinal);
-        var candidates =
-            ImmutableArray.CreateBuilder<ResourceTriageCandidate>(
-                inspection.Findings.Length);
-        foreach (var finding in inspection.Findings)
-        {
-            int fingerprintLength = InitialFingerprintLength;
-            string candidateId;
-            while (true)
-            {
-                candidateId = CreateCandidateId(
-                    finding,
-                    fingerprintLength);
-                if (candidateIds.Add(candidateId))
-                    break;
-                if (fingerprintLength == MaximumFingerprintLength)
-                {
-                    throw new InvalidOperationException(
-                        $"Duplicate Resource Triage candidate identity '{candidateId}'.");
-                }
-
-                fingerprintLength = Math.Min(
-                    fingerprintLength + 8,
-                    MaximumFingerprintLength);
-            }
-
-            candidates.Add(
-                new ResourceTriageCandidate(candidateId, finding));
-        }
-
-        return actionability is null
-            ? candidates.MoveToImmutable()
-            : candidates
-                .Where(candidate =>
-                    candidate.Source.Payload.Actionability
-                        == actionability)
-                .ToImmutableArray();
-    }
-
-    static ResourceLifecycleOccurrence Classify(ArrayPoolExceptionPathCandidate candidate)
-    {
-        var boundaries = candidate.Boundaries
-            .Select(boundary => new ResourceBoundaryEvidence(
-                boundary.ILOffset,
-                boundary.Operation,
-                ClassifyBoundary(boundary.Operation)))
-            .ToImmutableArray();
-
-        ResourceActionability actionability = boundaries.Any(
-            static boundary => boundary.Kind == ResourceBoundaryKind.ExternalInput)
-                ? ResourceActionability.UntrustedActionable
-                : boundaries.Any(
-                    static boundary => boundary.Kind == ResourceBoundaryKind.Unknown)
-                    || boundaries.Length == 0
-                    ? ResourceActionability.Unknown
-                    : ResourceActionability.TrustedLowActionability;
-
-        return new ResourceLifecycleOccurrence(
+    static ResourceLifecycleOccurrence CreateOccurrence(
+        ArrayPoolExceptionPathCandidate candidate)
+        => new(
             candidate.Method,
             "ArrayPool<T>",
             "pool-churn-on-exception",
             candidate.RentOffset,
-            boundaries,
-            actionability);
-    }
-
-    static ResourceBoundaryKind ClassifyBoundary(MemberRef member)
-    {
-        TypeRef declaringType = member.DeclaringType;
-        string type = SimpleTypeName(declaringType);
-        string method = member.Name;
-
-        if ((IsStreamLike(declaringType)
-                && method.StartsWith("Read", StringComparison.Ordinal))
-            || ((IsType(declaringType, "System.Text", "Decoder")
-                    || HasTypeNameSuffix(declaringType, "Decoder"))
-                && method is "GetChars" or "GetString" or "Convert")
-            || ((IsType(declaringType, "System.Text", "Encoding")
-                    || HasTypeNameSuffix(declaringType, "Encoding"))
-                && method is "GetChars" or "GetString")
-            || (IsType(declaringType, "System.Net.Sockets", "Socket")
-                && method.StartsWith("Receive", StringComparison.Ordinal))
-            || ((IsType(declaringType, "System.IO", "TextReader")
-                    || IsType(declaringType, "System.IO", "StreamReader")
-                    || IsType(declaringType, "System.IO", "BinaryReader"))
-                && method.StartsWith("Read", StringComparison.Ordinal))
-            || method.StartsWith("Deserialize", StringComparison.Ordinal)
-            || method.StartsWith("Tokenize", StringComparison.Ordinal)
-            || method == "Decode"
-            || ((method is "Parse" or "TryParse"
-                    || method.StartsWith("Parse", StringComparison.Ordinal))
-                && (type.Contains("Document", StringComparison.Ordinal)
-                    || type.Contains("Reader", StringComparison.Ordinal)
-                    || type.Contains("Parser", StringComparison.Ordinal))))
-        {
-            return ResourceBoundaryKind.ExternalInput;
-        }
-
-        if (method.StartsWith("Escape", StringComparison.Ordinal)
-            || ((IsType(declaringType, "System.Text", "Encoding")
-                    || HasTypeNameSuffix(declaringType, "Encoding"))
-                && method is "GetBytes" or "GetByteCount")
-            || method.StartsWith("Encode", StringComparison.Ordinal)
-            || method.StartsWith("Transcode", StringComparison.Ordinal)
-            || method is "ToUtf8" or "EncodeHelper"
-            || (IsType(declaringType, "System", "Array")
-                && method is "Copy" or "Clear" or "Resize" or "Fill")
-            || (IsType(declaringType, "System", "Buffer")
-                && method.StartsWith("Block", StringComparison.Ordinal))
-            || IsType(
-                declaringType,
-                "System.Runtime.CompilerServices",
-                "Unsafe")
-            || IsType(
-                declaringType,
-                "System.Runtime.InteropServices",
-                "MemoryMarshal")
-            || (IsType(declaringType, "System", "String")
-                && method == ".ctor")
-            || (!IsStreamLike(declaringType)
-                && method == "CopyTo")
-            || method.StartsWith("TryFormat", StringComparison.Ordinal)
-            || method.StartsWith("Format", StringComparison.Ordinal)
-            || method.StartsWith("WriteString", StringComparison.Ordinal)
-            || method.StartsWith("WriteValue", StringComparison.Ordinal)
-            || method is "WriteStringByOptions" or "WriteStringByOptionsPropertyName")
-        {
-            return ResourceBoundaryKind.InMemoryTransform;
-        }
-
-        return ResourceBoundaryKind.Unknown;
-    }
-
-    static bool IsStreamLike(TypeRef type)
-        => IsType(type, "System.IO", "Stream")
-            || HasTypeNameSuffix(type, "Stream");
-
-    static bool IsType(TypeRef type, string @namespace, string name)
-    {
-        TypeRef definition = TypeDefinition(type);
-        return string.Equals(
-                definition.Namespace,
-                @namespace,
-                StringComparison.Ordinal)
-            && string.Equals(definition.Name, name, StringComparison.Ordinal);
-    }
-
-    static bool HasTypeNameSuffix(TypeRef type, string suffix)
-    {
-        string name = SimpleTypeName(type);
-        return name.Length > suffix.Length
-            && name.EndsWith(suffix, StringComparison.Ordinal);
-    }
-
-    static string SimpleTypeName(TypeRef type)
-    {
-        TypeRef definition = TypeDefinition(type);
-        int tick = definition.Name.IndexOf('`');
-        return tick >= 0
-            ? definition.Name[..tick]
-            : definition.Name;
-    }
-
-    static TypeRef TypeDefinition(TypeRef type)
-        => type.Kind == TypeRefKind.GenericInstance
-            ? type.ElementType ?? type
-            : type;
-
-    const int InitialFingerprintLength = 16;
-    const int MaximumFingerprintLength = 64;
-
-    static string CreateCandidateId(
-        Finding<ResourceLifecycleOccurrence> finding,
-        int fingerprintLength)
-    {
-        ArgumentOutOfRangeException.ThrowIfLessThan(
-            fingerprintLength,
-            InitialFingerprintLength);
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(
-            fingerprintLength,
-            MaximumFingerprintLength);
-
-        const string fingerprintNamespace = "dotnet-inspect.resource-triage.v1\n";
-        ResourceLifecycleOccurrence occurrence = finding.Payload;
-        string coordinate =
-            $"0x{occurrence.Method.MetadataToken:X8}+0x{occurrence.AcquireOffset:X4}";
-        byte[] input = Encoding.UTF8.GetBytes(
-            $"{fingerprintNamespace}{Part(finding.Descriptor.Id)}\n"
-            + $"{Part(finding.Key.IdentityKey)}\n"
-            + $"{Part(coordinate)}");
-        string fingerprint = Convert.ToHexString(SHA256.HashData(input))
-            .ToLowerInvariant();
-        return $"rt~{fingerprint[..fingerprintLength]}";
-    }
-
-    static string Part(string value)
-        => $"{value.Length.ToString(CultureInfo.InvariantCulture)}:{value}";
+            candidate.Boundaries
+                .Select(boundary => new ResourceBoundaryEvidence(
+                    boundary.ILOffset,
+                    boundary.Operation))
+                .ToImmutableArray());
 }

--- a/src/ILInspector.Analysis/ResourceTriageAnalysis.cs
+++ b/src/ILInspector.Analysis/ResourceTriageAnalysis.cs
@@ -1,0 +1,337 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
+using ILInspector.Findings;
+
+namespace ILInspector.Analysis;
+
+public enum ResourceTriageBoundaryKind
+{
+    Unknown,
+    ExternalInput,
+    InMemoryTransform,
+}
+
+public enum ResourceTriageActionability
+{
+    Unknown,
+    TrustedLowActionability,
+    UntrustedActionable,
+}
+
+public enum ResourceTriageReason
+{
+    NoBoundaryBeforeCleanup,
+    UnclassifiedBoundaryBeforeCleanup,
+    InMemoryBoundaryBeforeCleanup,
+    ExternalInputBoundaryBeforeCleanup,
+}
+
+public enum ResourceTriageImpact
+{
+    PoolChurnOnException,
+}
+
+public enum ResourceTriageRemediation
+{
+    EnsureExceptionalCleanup,
+}
+
+public enum ResourceTriageConfidence
+{
+    Medium,
+}
+
+public readonly record struct ResourceTriageBoundaryAssessment(
+    ResourceBoundaryEvidence Evidence,
+    ResourceTriageBoundaryKind Kind);
+
+public sealed record ResourceTriageAssessment
+{
+    ImmutableArray<ResourceTriageBoundaryAssessment> _boundaries;
+
+    public ResourceTriageAssessment(
+        string CandidateId,
+        Finding<ResourceLifecycleOccurrence> Source,
+        ImmutableArray<ResourceTriageBoundaryAssessment> Boundaries,
+        ResourceTriageActionability Actionability,
+        ResourceTriageReason Reason,
+        ResourceTriageImpact Impact,
+        ResourceTriageRemediation Remediation,
+        ResourceTriageConfidence Confidence)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(CandidateId);
+        this.Source = Source ?? throw new ArgumentNullException(nameof(Source));
+        this.CandidateId = CandidateId;
+        _boundaries = ImmutableArrayValueEquality.RequireInitialized(
+            Boundaries,
+            nameof(Boundaries));
+        this.Actionability = Actionability;
+        this.Reason = Reason;
+        this.Impact = Impact;
+        this.Remediation = Remediation;
+        this.Confidence = Confidence;
+    }
+
+    public string CandidateId { get; }
+    public Finding<ResourceLifecycleOccurrence> Source { get; }
+    public ImmutableArray<ResourceTriageBoundaryAssessment> Boundaries
+    {
+        get => _boundaries;
+        init => _boundaries = ImmutableArrayValueEquality.RequireInitialized(
+            value,
+            nameof(Boundaries));
+    }
+    public ResourceTriageActionability Actionability { get; }
+    public ResourceTriageReason Reason { get; }
+    public ResourceTriageImpact Impact { get; }
+    public ResourceTriageRemediation Remediation { get; }
+    public ResourceTriageConfidence Confidence { get; }
+
+    public bool Equals(ResourceTriageAssessment? other)
+        => other is not null
+            && string.Equals(CandidateId, other.CandidateId, StringComparison.Ordinal)
+            && Source == other.Source
+            && ImmutableArrayValueEquality.SequenceEqual(Boundaries, other.Boundaries)
+            && Actionability == other.Actionability
+            && Reason == other.Reason
+            && Impact == other.Impact
+            && Remediation == other.Remediation
+            && Confidence == other.Confidence;
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(CandidateId, StringComparer.Ordinal);
+        hash.Add(Source);
+        ImmutableArrayValueEquality.AddToHash(ref hash, Boundaries);
+        hash.Add(Actionability);
+        hash.Add(Reason);
+        hash.Add(Impact);
+        hash.Add(Remediation);
+        hash.Add(Confidence);
+        return hash.ToHashCode();
+    }
+}
+
+public static class ResourceTriageAnalysis
+{
+    public static ImmutableArray<ResourceTriageAssessment> Assess(
+        FindingInspection<ResourceLifecycleOccurrence>.Complete inspection)
+    {
+        ArgumentNullException.ThrowIfNull(inspection);
+
+        var candidateIds = new HashSet<string>(StringComparer.Ordinal);
+        var assessments =
+            ImmutableArray.CreateBuilder<ResourceTriageAssessment>(
+                inspection.Findings.Length);
+        foreach (var finding in inspection.Findings)
+        {
+            int fingerprintLength = InitialFingerprintLength;
+            string candidateId;
+            while (true)
+            {
+                candidateId = CreateCandidateId(
+                    finding,
+                    fingerprintLength);
+                if (candidateIds.Add(candidateId))
+                    break;
+                if (fingerprintLength == MaximumFingerprintLength)
+                {
+                    throw new InvalidOperationException(
+                        $"Duplicate Resource Triage candidate identity '{candidateId}'.");
+                }
+
+                fingerprintLength = Math.Min(
+                    fingerprintLength + 8,
+                    MaximumFingerprintLength);
+            }
+
+            assessments.Add(Assess(finding, candidateId));
+        }
+
+        return assessments.MoveToImmutable();
+    }
+
+    static ResourceTriageAssessment Assess(
+        Finding<ResourceLifecycleOccurrence> finding,
+        string candidateId)
+    {
+        var boundaries = finding.Payload.Boundaries
+            .Select(boundary => new ResourceTriageBoundaryAssessment(
+                boundary,
+                ClassifyBoundary(boundary.Operation)))
+            .ToImmutableArray();
+
+        ResourceTriageActionability actionability;
+        ResourceTriageReason reason;
+        if (boundaries.Any(
+            static boundary =>
+                boundary.Kind == ResourceTriageBoundaryKind.ExternalInput))
+        {
+            actionability = ResourceTriageActionability.UntrustedActionable;
+            reason = ResourceTriageReason.ExternalInputBoundaryBeforeCleanup;
+        }
+        else if (boundaries.Length == 0)
+        {
+            actionability = ResourceTriageActionability.Unknown;
+            reason = ResourceTriageReason.NoBoundaryBeforeCleanup;
+        }
+        else if (boundaries.Any(
+            static boundary =>
+                boundary.Kind == ResourceTriageBoundaryKind.Unknown))
+        {
+            actionability = ResourceTriageActionability.Unknown;
+            reason = ResourceTriageReason.UnclassifiedBoundaryBeforeCleanup;
+        }
+        else
+        {
+            actionability = ResourceTriageActionability.TrustedLowActionability;
+            reason = ResourceTriageReason.InMemoryBoundaryBeforeCleanup;
+        }
+
+        return new ResourceTriageAssessment(
+            candidateId,
+            finding,
+            boundaries,
+            actionability,
+            reason,
+            ResourceTriageImpact.PoolChurnOnException,
+            ResourceTriageRemediation.EnsureExceptionalCleanup,
+            ResourceTriageConfidence.Medium);
+    }
+
+    static ResourceTriageBoundaryKind ClassifyBoundary(MemberRef member)
+    {
+        TypeRef declaringType = member.DeclaringType;
+        string type = SimpleTypeName(declaringType);
+        string method = member.Name;
+
+        if ((IsStreamLike(declaringType)
+                && method.StartsWith("Read", StringComparison.Ordinal))
+            || ((IsType(declaringType, "System.Text", "Decoder")
+                    || HasTypeNameSuffix(declaringType, "Decoder"))
+                && method is "GetChars" or "GetString" or "Convert")
+            || ((IsType(declaringType, "System.Text", "Encoding")
+                    || HasTypeNameSuffix(declaringType, "Encoding"))
+                && method is "GetChars" or "GetString")
+            || (IsType(declaringType, "System.Net.Sockets", "Socket")
+                && method.StartsWith("Receive", StringComparison.Ordinal))
+            || ((IsType(declaringType, "System.IO", "TextReader")
+                    || IsType(declaringType, "System.IO", "StreamReader")
+                    || IsType(declaringType, "System.IO", "BinaryReader"))
+                && method.StartsWith("Read", StringComparison.Ordinal))
+            || method.StartsWith("Deserialize", StringComparison.Ordinal)
+            || method.StartsWith("Tokenize", StringComparison.Ordinal)
+            || method == "Decode"
+            || ((method is "Parse" or "TryParse"
+                    || method.StartsWith("Parse", StringComparison.Ordinal))
+                && (type.Contains("Document", StringComparison.Ordinal)
+                    || type.Contains("Reader", StringComparison.Ordinal)
+                    || type.Contains("Parser", StringComparison.Ordinal))))
+        {
+            return ResourceTriageBoundaryKind.ExternalInput;
+        }
+
+        if (method.StartsWith("Escape", StringComparison.Ordinal)
+            || ((IsType(declaringType, "System.Text", "Encoding")
+                    || HasTypeNameSuffix(declaringType, "Encoding"))
+                && method is "GetBytes" or "GetByteCount")
+            || method.StartsWith("Encode", StringComparison.Ordinal)
+            || method.StartsWith("Transcode", StringComparison.Ordinal)
+            || method is "ToUtf8" or "EncodeHelper"
+            || (IsType(declaringType, "System", "Array")
+                && method is "Copy" or "Clear" or "Resize" or "Fill")
+            || (IsType(declaringType, "System", "Buffer")
+                && method.StartsWith("Block", StringComparison.Ordinal))
+            || IsType(
+                declaringType,
+                "System.Runtime.CompilerServices",
+                "Unsafe")
+            || IsType(
+                declaringType,
+                "System.Runtime.InteropServices",
+                "MemoryMarshal")
+            || (IsType(declaringType, "System", "String")
+                && method == ".ctor")
+            || (!IsStreamLike(declaringType)
+                && method == "CopyTo")
+            || method.StartsWith("TryFormat", StringComparison.Ordinal)
+            || method.StartsWith("Format", StringComparison.Ordinal)
+            || method.StartsWith("WriteString", StringComparison.Ordinal)
+            || method.StartsWith("WriteValue", StringComparison.Ordinal)
+            || method is "WriteStringByOptions" or "WriteStringByOptionsPropertyName")
+        {
+            return ResourceTriageBoundaryKind.InMemoryTransform;
+        }
+
+        return ResourceTriageBoundaryKind.Unknown;
+    }
+
+    static bool IsStreamLike(TypeRef type)
+        => IsType(type, "System.IO", "Stream")
+            || HasTypeNameSuffix(type, "Stream");
+
+    static bool IsType(TypeRef type, string @namespace, string name)
+    {
+        TypeRef definition = TypeDefinition(type);
+        return string.Equals(
+                definition.Namespace,
+                @namespace,
+                StringComparison.Ordinal)
+            && string.Equals(definition.Name, name, StringComparison.Ordinal);
+    }
+
+    static bool HasTypeNameSuffix(TypeRef type, string suffix)
+    {
+        string name = SimpleTypeName(type);
+        return name.Length > suffix.Length
+            && name.EndsWith(suffix, StringComparison.Ordinal);
+    }
+
+    static string SimpleTypeName(TypeRef type)
+    {
+        TypeRef definition = TypeDefinition(type);
+        int tick = definition.Name.IndexOf('`');
+        return tick >= 0
+            ? definition.Name[..tick]
+            : definition.Name;
+    }
+
+    static TypeRef TypeDefinition(TypeRef type)
+        => type.Kind == TypeRefKind.GenericInstance
+            ? type.ElementType ?? type
+            : type;
+
+    const int InitialFingerprintLength = 16;
+    const int MaximumFingerprintLength = 64;
+
+    static string CreateCandidateId(
+        Finding<ResourceLifecycleOccurrence> finding,
+        int fingerprintLength)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(
+            fingerprintLength,
+            InitialFingerprintLength);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(
+            fingerprintLength,
+            MaximumFingerprintLength);
+
+        const string fingerprintNamespace = "dotnet-inspect.resource-triage.v1\n";
+        ResourceLifecycleOccurrence occurrence = finding.Payload;
+        string coordinate =
+            $"0x{occurrence.Method.MetadataToken:X8}+0x{occurrence.AcquireOffset:X4}";
+        byte[] input = Encoding.UTF8.GetBytes(
+            $"{fingerprintNamespace}{Part(finding.Descriptor.Id)}\n"
+            + $"{Part(finding.Key.IdentityKey)}\n"
+            + $"{Part(coordinate)}");
+        string fingerprint = Convert.ToHexString(SHA256.HashData(input))
+            .ToLowerInvariant();
+        return $"rt~{fingerprint[..fingerprintLength]}";
+    }
+
+    static string Part(string value)
+        => $"{value.Length.ToString(CultureInfo.InvariantCulture)}:{value}";
+}

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -855,37 +855,40 @@ internal static class LibraryMetadataService
         VerboseLogger logger)
     {
         var drillByToken = BuildLibraryDrillMap(path, logger);
-        return Analysis.ResourceLifecycleAnalysis
-            .SelectCandidates(
-                inspection,
-                Analysis.ResourceActionability.UntrustedActionable)
-            .Select(candidate =>
+        return Analysis.ResourceTriageAnalysis
+            .Assess(inspection)
+            .Where(assessment =>
+                assessment.Actionability
+                    == Analysis.ResourceTriageActionability.UntrustedActionable)
+            .Select(assessment =>
             {
-                var occurrence = candidate.Source.Payload;
+                var occurrence = assessment.Source.Payload;
                 drillByToken.TryGetValue(
                     occurrence.Method.MetadataToken,
                     out var drill);
                 return new ResourceTriageSummary
                 {
                     Member = FormatMethod(occurrence.Method),
-                    Candidate = candidate.CandidateId,
-                    Finding = candidate.Source.Descriptor.Id,
+                    Candidate = assessment.CandidateId,
+                    Finding = assessment.Source.Descriptor.Id,
                     Provenance = "exact",
                     Resource = occurrence.Resource,
                     Shape = occurrence.Shape,
-                    Impact = "pool churn if boundary throws",
-                    Actionability = "untrusted-input boundary",
+                    Impact = FormatResourceTriageImpact(assessment.Impact),
+                    Actionability = FormatResourceTriageActionability(
+                        assessment.Actionability),
                     AcquireOffset = occurrence.AcquireOffset,
-                    Boundaries = occurrence.Boundaries
+                    Boundaries = assessment.Boundaries
                         .Select(boundary => new ResourceBoundarySummary(
-                            boundary.Operation.ToQualifiedDisplayString(),
-                            boundary.ILOffset))
+                            boundary.Evidence.Operation.ToQualifiedDisplayString(),
+                            boundary.Evidence.ILOffset))
                         .Distinct()
                         .ToList(),
-                    Evidence =
-                        "An exact external-input boundary is reached before modeled cleanup; an exception can bypass Return.",
-                    Direction = "Return the pooled array from finally or catch-all cleanup.",
-                    Confidence = "medium",
+                    Evidence = FormatResourceTriageReason(assessment.Reason),
+                    Direction = FormatResourceTriageRemediation(
+                        assessment.Remediation),
+                    Confidence = FormatResourceTriageConfidence(
+                        assessment.Confidence),
                     Visibility = drill.Visibility,
                     Stable = drill.Stable,
                     Selector = drill.Selector,
@@ -902,6 +905,50 @@ internal static class LibraryMetadataService
                     : -1)
             .ToList();
     }
+
+    static string FormatResourceTriageImpact(
+        Analysis.ResourceTriageImpact impact)
+        => impact switch
+        {
+            Analysis.ResourceTriageImpact.PoolChurnOnException =>
+                "pool churn if boundary throws",
+            _ => throw new ArgumentOutOfRangeException(nameof(impact)),
+        };
+
+    static string FormatResourceTriageActionability(
+        Analysis.ResourceTriageActionability actionability)
+        => actionability switch
+        {
+            Analysis.ResourceTriageActionability.UntrustedActionable =>
+                "untrusted-input boundary",
+            _ => throw new ArgumentOutOfRangeException(nameof(actionability)),
+        };
+
+    static string FormatResourceTriageReason(
+        Analysis.ResourceTriageReason reason)
+        => reason switch
+        {
+            Analysis.ResourceTriageReason.ExternalInputBoundaryBeforeCleanup =>
+                "An exact external-input boundary is reached before modeled cleanup; an exception can bypass Return.",
+            _ => throw new ArgumentOutOfRangeException(nameof(reason)),
+        };
+
+    static string FormatResourceTriageRemediation(
+        Analysis.ResourceTriageRemediation remediation)
+        => remediation switch
+        {
+            Analysis.ResourceTriageRemediation.EnsureExceptionalCleanup =>
+                "Return the pooled array from finally or catch-all cleanup.",
+            _ => throw new ArgumentOutOfRangeException(nameof(remediation)),
+        };
+
+    static string FormatResourceTriageConfidence(
+        Analysis.ResourceTriageConfidence confidence)
+        => confidence switch
+        {
+            Analysis.ResourceTriageConfidence.Medium => "medium",
+            _ => throw new ArgumentOutOfRangeException(nameof(confidence)),
+        };
 
     // Performance Triage ordering: surface pay-dirt first. In-loop (repeated, hot)
     // allocations lead, then by confidence, then by call-graph leverage (root reach),

--- a/tools/AnalysisHarness/LeakActionabilitySensor.cs
+++ b/tools/AnalysisHarness/LeakActionabilitySensor.cs
@@ -97,25 +97,25 @@ public static class LeakActionabilitySensor
                             []);
             }
 
-            var candidates = ResourceLifecycleAnalysis.SelectCandidates(complete);
-            if (candidates.Length == 0)
+            var assessments = ResourceTriageAnalysis.Assess(complete);
+            if (assessments.Length == 0)
                 return new LeakActionabilityAssembly(name, Opened: true, TimedOut: false, 0, new Dictionary<string, int>(), []);
 
             var classCounts = new SortedDictionary<string, int>(StringComparer.Ordinal);
             var examples = new List<LeakActionabilityExample>();
-            foreach (var candidate in candidates)
+            foreach (var assessment in assessments)
             {
                 string cls = FormatActionability(
-                    candidate.Source.Payload.Actionability);
+                    assessment.Actionability);
                 classCounts[cls] = classCounts.GetValueOrDefault(cls) + 1;
                 if (examples.Count < examplesPerAssembly)
                     examples.Add(new LeakActionabilityExample(
                         cls,
-                        $"{candidate.Source.Payload.Method.DeclaringType.Name}::{candidate.Source.Payload.Method.Name}",
-                        FormatBoundarySet(candidate.Source.Payload.Boundaries)));
+                        $"{assessment.Source.Payload.Method.DeclaringType.Name}::{assessment.Source.Payload.Method.Name}",
+                        FormatBoundarySet(assessment.Boundaries)));
             }
 
-            return new LeakActionabilityAssembly(name, Opened: true, TimedOut: false, candidates.Length, classCounts, examples);
+            return new LeakActionabilityAssembly(name, Opened: true, TimedOut: false, assessments.Length, classCounts, examples);
         }
         // Per-assembly boundary on a background thread: convert any input failure (a directory, a
         // truncated PE, ...) into a failed row and keep sweeping the corpus.
@@ -125,23 +125,23 @@ public static class LeakActionabilitySensor
         }
     }
 
-    static string FormatActionability(ResourceActionability actionability)
+    static string FormatActionability(ResourceTriageActionability actionability)
         => actionability switch
         {
-            ResourceActionability.UntrustedActionable => Untrusted,
-            ResourceActionability.TrustedLowActionability => Trusted,
+            ResourceTriageActionability.UntrustedActionable => Untrusted,
+            ResourceTriageActionability.TrustedLowActionability => Trusted,
             _ => Unknown,
         };
 
     static string FormatBoundarySet(
-        IReadOnlyList<ResourceBoundaryEvidence> boundaries)
+        IReadOnlyList<ResourceTriageBoundaryAssessment> boundaries)
         => boundaries.Count == 0
             ? "(no-boundary)"
             : string.Join(
                 " + ",
                 boundaries
                     .Select(boundary =>
-                        $"{Short(boundary.Operation.DeclaringType.ToQualifiedDisplayString())}::{boundary.Operation.Name}")
+                        $"{Short(boundary.Evidence.Operation.DeclaringType.ToQualifiedDisplayString())}::{boundary.Evidence.Operation.Name}")
                     .Distinct(StringComparer.Ordinal));
 
     static string Short(string type)

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -289,9 +289,9 @@ dotnet "$DLL" --leak-actionability assemblies.txt --tsv        # section-tagged 
 dotnet "$DLL" --leak-actionability assemblies.txt --jsonl      # one JSON record per row
 ```
 
-The harness owns corpus orchestration and reporting only. Analysis attributes exact unprotected
-boundaries from the rented local's def-use evidence and classifies the boundary set by what it
-touches:
+The harness owns corpus orchestration and reporting only. `ResourceLifecycleAnalysis` attributes
+exact unprotected boundaries from the rented local's def-use evidence;
+`ResourceTriageAnalysis` assesses that evidence by what each boundary touches:
 
 - `untrusted-actionable` — a boundary **reads/decodes/parses external input**
   (`Stream.Read`, `Decoder.GetChars`, `Encoding.GetString`, `Parse`/`Tokenize`/`Deserialize`):
@@ -303,10 +303,10 @@ touches:
 - `unknown` — unclassified boundary; stays measurement-only.
 
 A candidate is `untrusted-actionable` if **any** boundary is untrusted, else
-`trusted-low-actionability` if any is a known in-memory transform, else `unknown`. This is the
-measurement view for the same product-owned contract. `Resource Triage` exposes only
-`untrusted-actionable` rows and describes them as pool-churn-on-exception candidates, not permanent
-memory leaks or memory-corruption findings:
+`trusted-low-actionability` if every boundary is a known in-memory transform, else `unknown`. This
+is the measurement view for the same product-owned assessment contract. `Resource Triage` exposes
+only `untrusted-actionable` rows and describes them as pool-churn-on-exception candidates, not
+permanent memory leaks or memory-corruption findings:
 
 ```bash
 dotnet-inspect library MyLib.dll -S "Resource Triage" --jsonl


### PR DESCRIPTION
## Conclusion

Resource lifecycle Findings are now objective observations, and Resource
Triage policy is an explicit typed assessment over those observations.
The CLI and corpus harness consume the same assessment contract without
reconstructing classification or remediation policy.

## Changes

- Remove boundary kind and actionability from `ResourceLifecycleOccurrence`.
- Add `ResourceTriageAnalysis` with typed boundary classification,
  actionability, reason, impact, remediation, confidence, and candidate IDs.
- Keep Finding identity and inspection outcomes on the observation contract.
- Migrate the CLI and `LeakActionabilitySensor` to consume assessments.
- Keep human wording in CLI projection and document the three contract levels.

## Evidence

- Exact merge-base/head JSONL parity for the 314-assembly .NET 11 framework
  census: 50 candidates, 2 untrusted-actionable, 1 trusted-low-actionability,
  and 47 unknown on both sides.
- Exact merge-base/head JSONL parity for the real
  `System.Private.CoreLib` `BinaryReader.FillBuffer` Resource Triage row,
  including `rt~b5dd937380c6a7f5`.
- 475 Analysis tests passed.
- 1,906 CLI tests passed with the same 10 expected tool-dependent skips.
- Release solution build passed with `PublishAot=false`; changed Markdown
  passes `markdownlint`.

Part of #2775.
