### PR TITLE
Add an RTS parity regression gate with a committed burn-down manifest

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
@@ -32,6 +32,75 @@ public class CorpusSensorComparisonTests
     }
 
     [Fact]
+    public void ExactReferenceRecompileRegressions_FlagsExactToRecompileAndContextFail()
+    {
+        var snapshot = ReturnToSenderSnapshot(
+            RtsMethod("Recompile", fidelityReference: "Exact", fidelityCheck: "RecompileFail"),
+            RtsMethod("Context", fidelityReference: "Exact", fidelityCheck: "ContextFail"));
+
+        var offenders = CorpusSensor.ExactReferenceRecompileRegressions(snapshot);
+
+        Assert.Equal(2, offenders.Length);
+        Assert.Contains(offenders, m => m.Method == "Recompile");
+        Assert.Contains(offenders, m => m.Method == "Context");
+    }
+
+    [Fact]
+    public void ExactReferenceRecompileRegressions_IgnoresRescuedSameAndUnpaired()
+    {
+        var snapshot = ReturnToSenderSnapshot(
+            RtsMethod("Rescued", fidelityReference: "OpcodeDiff", fidelityCheck: "Exact"),
+            RtsMethod("Same", fidelityReference: "Exact", fidelityCheck: "Exact"),
+            RtsMethod("OpcodeDrift", fidelityReference: "Exact", fidelityCheck: "OpcodeDiff"),
+            RtsMethod("NoReference", fidelityReference: null, fidelityCheck: "RecompileFail"));
+
+        Assert.Empty(CorpusSensor.ExactReferenceRecompileRegressions(snapshot));
+    }
+
+    [Fact]
+    public void ExactReferenceRecompileRegressions_OnlyAppliesToReturnToSenderOracle()
+    {
+        var snapshot = Snapshot(
+            totalMethods: 1,
+            fullyRaisedMethods: 1,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: [RtsMethod("Recompile", fidelityReference: "Exact", fidelityCheck: "RecompileFail")],
+            fidelityOracle: CorpusFidelityOracle.CompileBack);
+
+        Assert.Empty(CorpusSensor.ExactReferenceRecompileRegressions(snapshot));
+    }
+
+    [Fact]
+    public void Compare_FailsAndNamesExactToRecompileFailRegression()
+    {
+        var baseline = ReturnToSenderSnapshot(
+            RtsMethod("Recompile", fidelityReference: "Exact", fidelityCheck: "Exact"));
+        var current = ReturnToSenderSnapshot(
+            RtsMethod("Recompile", fidelityReference: "Exact", fidelityCheck: "RecompileFail"));
+
+        var regressions = CorpusSensor.Compare(baseline, current, []);
+
+        Assert.Contains(
+            regressions,
+            r => r.Contains("RTS parity lost", StringComparison.Ordinal)
+                && r.Contains("Pinned!T::Recompile#0", StringComparison.Ordinal)
+                && r.Contains("RecompileFail", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Compare_PassesWhenReferenceExactStaysExactUnderReturnToSender()
+    {
+        var baseline = ReturnToSenderSnapshot(
+            RtsMethod("Recompile", fidelityReference: "Exact", fidelityCheck: "Exact"));
+        var current = ReturnToSenderSnapshot(
+            RtsMethod("Recompile", fidelityReference: "Exact", fidelityCheck: "Exact"));
+
+        var regressions = CorpusSensor.Compare(baseline, current, []);
+
+        Assert.DoesNotContain(regressions, r => r.Contains("RTS parity lost", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Compare_RejectsCorpusProfileMismatch()
     {
         var baseline = Snapshot(
@@ -690,7 +759,8 @@ public class CorpusSensorComparisonTests
         string method,
         string assemblyPath = "nuget:pinned/lib.dll",
         string validity = "not-sampled",
-        string fidelityCheck = "not-sampled")
+        string fidelityCheck = "not-sampled",
+        string? fidelityReference = null)
         => new(
             Assembly: "Pinned",
             AssemblyPath: assemblyPath,
@@ -703,7 +773,25 @@ public class CorpusSensorComparisonTests
             Residual: null,
             PassBug: null,
             Validity: validity,
-            FidelityCheck: fidelityCheck);
+            FidelityCheck: fidelityCheck,
+            FidelityReference: fidelityReference);
+
+    static CorpusMethodSnapshot RtsMethod(
+        string method,
+        string? fidelityReference,
+        string fidelityCheck)
+        => SnapshotMethod(
+            method,
+            fidelityCheck: fidelityCheck,
+            fidelityReference: fidelityReference);
+
+    static CorpusSensorSnapshot ReturnToSenderSnapshot(params CorpusMethodSnapshot[] methods)
+        => Snapshot(
+            totalMethods: methods.Length,
+            fullyRaisedMethods: methods.Length,
+            fullyRaisedBasisPoints: 10_000,
+            pinnedMethods: methods,
+            fidelityOracle: CorpusFidelityOracle.ReturnToSender);
 
     static IReadOnlyList<CorpusMethodSnapshot> ValidityMethods(
         params (string Method, string Validity)[] values)

--- a/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
@@ -71,33 +71,62 @@ public class CorpusSensorComparisonTests
     }
 
     [Fact]
-    public void Compare_FailsAndNamesExactToRecompileFailRegression()
+    public void EvaluateRtsParityBurndown_FlagsNewRegressionNotInManifest()
     {
-        var baseline = ReturnToSenderSnapshot(
-            RtsMethod("Recompile", fidelityReference: "Exact", fidelityCheck: "Exact"));
-        var current = ReturnToSenderSnapshot(
-            RtsMethod("Recompile", fidelityReference: "Exact", fidelityCheck: "RecompileFail"));
+        var snapshot = ReturnToSenderSnapshot(
+            RtsMethod("Known", fidelityReference: "Exact", fidelityCheck: "RecompileFail"),
+            RtsMethod("New", fidelityReference: "Exact", fidelityCheck: "RecompileFail"));
 
-        var regressions = CorpusSensor.Compare(baseline, current, []);
+        var evaluation = CorpusSensor.EvaluateRtsParityBurndown(
+            snapshot,
+            ["Pinned!T::Known#0"]);
 
-        Assert.Contains(
-            regressions,
-            r => r.Contains("RTS parity lost", StringComparison.Ordinal)
-                && r.Contains("Pinned!T::Recompile#0", StringComparison.Ordinal)
-                && r.Contains("RecompileFail", StringComparison.Ordinal));
+        Assert.Equal(2, evaluation.KnownGaps.Length);
+        var offender = Assert.Single(evaluation.NewRegressions);
+        Assert.Equal("New", offender.Method);
+        Assert.Empty(evaluation.ResolvedRows);
     }
 
     [Fact]
-    public void Compare_PassesWhenReferenceExactStaysExactUnderReturnToSender()
+    public void EvaluateRtsParityBurndown_PassesWhenAllGapsAreInManifest()
     {
-        var baseline = ReturnToSenderSnapshot(
-            RtsMethod("Recompile", fidelityReference: "Exact", fidelityCheck: "Exact"));
-        var current = ReturnToSenderSnapshot(
-            RtsMethod("Recompile", fidelityReference: "Exact", fidelityCheck: "Exact"));
+        var snapshot = ReturnToSenderSnapshot(
+            RtsMethod("Known", fidelityReference: "Exact", fidelityCheck: "ContextFail"));
 
-        var regressions = CorpusSensor.Compare(baseline, current, []);
+        var evaluation = CorpusSensor.EvaluateRtsParityBurndown(
+            snapshot,
+            ["Pinned!T::Known#0"]);
 
-        Assert.DoesNotContain(regressions, r => r.Contains("RTS parity lost", StringComparison.Ordinal));
+        Assert.Empty(evaluation.NewRegressions);
+        Assert.Single(evaluation.KnownGaps);
+        Assert.Empty(evaluation.ResolvedRows);
+    }
+
+    [Fact]
+    public void EvaluateRtsParityBurndown_ReportsResolvedRowsNoLongerFailing()
+    {
+        var snapshot = ReturnToSenderSnapshot(
+            RtsMethod("StillExact", fidelityReference: "Exact", fidelityCheck: "Exact"));
+
+        var evaluation = CorpusSensor.EvaluateRtsParityBurndown(
+            snapshot,
+            ["Pinned!T::Fixed#0"]);
+
+        Assert.Empty(evaluation.NewRegressions);
+        Assert.Empty(evaluation.KnownGaps);
+        Assert.Equal("Pinned!T::Fixed#0", Assert.Single(evaluation.ResolvedRows));
+    }
+
+    [Fact]
+    public void EvaluateRtsParityBurndown_WithEmptyManifestTreatsEveryGapAsNew()
+    {
+        var snapshot = ReturnToSenderSnapshot(
+            RtsMethod("A", fidelityReference: "Exact", fidelityCheck: "RecompileFail"),
+            RtsMethod("B", fidelityReference: "Exact", fidelityCheck: "ContextFail"));
+
+        var evaluation = CorpusSensor.EvaluateRtsParityBurndown(snapshot, []);
+
+        Assert.Equal(2, evaluation.NewRegressions.Length);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
@@ -130,6 +130,62 @@ public class CorpusSensorComparisonTests
     }
 
     [Fact]
+    public void ValidateRtsParityBurndownFlags_RejectsNonReturnToSenderOracle()
+    {
+        var error = CorpusSensor.ValidateRtsParityBurndownFlags(
+            CorpusFidelityOracle.CompileBack, [3], "burndown.json", null);
+
+        Assert.NotNull(error);
+        Assert.Contains("rts-parity", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateRtsParityBurndownFlags_RejectsMissingPositiveFidelityCap()
+    {
+        var error = CorpusSensor.ValidateRtsParityBurndownFlags(
+            CorpusFidelityOracle.ReturnToSender, [0], "burndown.json", null);
+
+        Assert.NotNull(error);
+        Assert.Contains("--corpus-fidelity-cap", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateRtsParityBurndownFlags_RejectsEmitAndEnforceSamePath()
+    {
+        var error = CorpusSensor.ValidateRtsParityBurndownFlags(
+            CorpusFidelityOracle.ReturnToSender, [3], "burndown.json", "burndown.json");
+
+        Assert.NotNull(error);
+        Assert.Contains("same file", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateRtsParityBurndownFlags_AllowsWellFormedGateRun()
+    {
+        Assert.Null(CorpusSensor.ValidateRtsParityBurndownFlags(
+            CorpusFidelityOracle.ReturnToSender, [3], "burndown.json", null));
+        Assert.Null(CorpusSensor.ValidateRtsParityBurndownFlags(
+            CorpusFidelityOracle.CompileBack, [0], null, null));
+    }
+
+    [Fact]
+    public void ReadRtsParityBurndown_ManifestWithoutRowsArray_ReadsAsEmptyWithoutThrowing()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"rts-burndown-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, "{}");
+        try
+        {
+            var manifest = CorpusSensor.ReadRtsParityBurndown(path);
+            Assert.False(manifest.Rows.IsDefault);
+            Assert.Empty(manifest.Rows);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public void Compare_RejectsCorpusProfileMismatch()
     {
         var baseline = Snapshot(

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -71,7 +71,9 @@ internal static class CorpusSensor
         int? workers = null,
         bool sequential = false,
         CorpusFidelityOracle fidelityOracle = CorpusFidelityOracle.CompileBack,
-        CorpusProfile profile = CorpusProfile.RealWorld)
+        CorpusProfile profile = CorpusProfile.RealWorld,
+        string? rtsParityBurndown = null,
+        string? emitRtsParityBurndown = null)
     {
         if (assemblies.Count == 0)
         {
@@ -109,6 +111,10 @@ internal static class CorpusSensor
         if (!qualityDiffCard)
             PrintSummary(current, fidelityReports);
 
+        bool rtsParityRegressed = false;
+        if (fidelityOracle == CorpusFidelityOracle.ReturnToSender)
+            rtsParityRegressed = EnforceRtsParityBurndown(current, rtsParityBurndown, emitRtsParityBurndown, qualityDiffCard);
+
         if (emitBaseline is not null)
         {
             Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(emitBaseline)) ?? ".");
@@ -121,14 +127,7 @@ internal static class CorpusSensor
         }
 
         if (diffBaseline is null)
-        {
-            var exactRegressions = ExactReferenceRecompileRegressions(current);
-            foreach (var offender in exactRegressions)
-                Console.WriteLine($"- RTS parity lost: {offender.DisplayMethod} recompiled Exact under the product oracle but {offender.FidelityCheck} under ReturnToSender");
-            return current.Metrics.PassBugs > 0
-                || FeatureCoverageFailures(current).Length > 0
-                || exactRegressions.Length > 0 ? 1 : 0;
-        }
+            return current.Metrics.PassBugs > 0 || FeatureCoverageFailures(current).Length > 0 || rtsParityRegressed ? 1 : 0;
 
         var baseline = JsonSerializer.Deserialize<CorpusSensorSnapshot>(File.ReadAllText(diffBaseline), JsonOptions())
             ?? throw new InvalidOperationException($"Could not read corpus baseline '{diffBaseline}'.");
@@ -154,10 +153,10 @@ internal static class CorpusSensor
                 Console.WriteLine();
                 Console.WriteLine($"Per-method delta artifact: `{emitDelta}`");
             }
-            return regressions.Length == 0 ? 0 : 1;
+            return regressions.Length == 0 && !rtsParityRegressed ? 0 : 1;
         }
 
-        if (regressions.Length == 0)
+        if (regressions.Length == 0 && !rtsParityRegressed)
         {
             Console.WriteLine();
             Console.WriteLine($"Corpus sensor matched baseline: {diffBaseline}");
@@ -800,10 +799,11 @@ internal static class CorpusSensor
     static string FidelityResultKey(FidelityCheck.CompileBackResult result)
         => $"{result.Type}::{result.Method}::{result.Overload}::{result.Signature}";
 
-    // Absolute RTS-parity invariant: a method the product oracle recompiled Exact
-    // must never recompile-fail under ReturnToSender. This is baseline-independent
-    // (it reads the current snapshot alone) and names every offending row so a
-    // regression can be traced back to the method that lost parity.
+    // The RTS-parity burn-down set: methods the product oracle recompiled Exact but
+    // ReturnToSender could not (RecompileFail/ContextFail). These are the parity gaps
+    // the RTS-orchestrator migration must close; the gate fails only when a NEW row
+    // appears versus the committed burn-down manifest, so the known set stays a visible,
+    // shrinking checklist rather than a silent tolerance.
     internal static ImmutableArray<CorpusMethodSnapshot> ExactReferenceRecompileRegressions(
         CorpusSensorSnapshot snapshot)
     {
@@ -826,6 +826,114 @@ internal static class CorpusSensor
 
         return builder.ToImmutable();
     }
+
+    internal sealed record RtsParityBurndownRow(string Method, string Status);
+
+    internal sealed record RtsParityBurndownManifest(
+        string Description,
+        string Command,
+        ImmutableArray<RtsParityBurndownRow> Rows);
+
+    internal sealed record RtsParityBurndownEvaluation(
+        ImmutableArray<CorpusMethodSnapshot> NewRegressions,
+        ImmutableArray<CorpusMethodSnapshot> KnownGaps,
+        ImmutableArray<string> ResolvedRows);
+
+    // Pure gate: compare the current Exact->recompile-failure set against the committed
+    // burn-down. A NEW row (not in the manifest) is a hard regression; a row present in
+    // the manifest but no longer failing is "resolved" and should be dropped when the
+    // manifest is regenerated. Manifest rows are keyed by DisplayMethod so a change to a
+    // method's parity is traceable to a named target.
+    internal static RtsParityBurndownEvaluation EvaluateRtsParityBurndown(
+        CorpusSensorSnapshot current,
+        IReadOnlyCollection<string> knownRows)
+    {
+        var currentGaps = ExactReferenceRecompileRegressions(current);
+        var known = new HashSet<string>(knownRows, StringComparer.Ordinal);
+        var currentKeys = new HashSet<string>(currentGaps.Select(m => m.DisplayMethod), StringComparer.Ordinal);
+
+        var newRegressions = currentGaps
+            .Where(m => !known.Contains(m.DisplayMethod))
+            .ToImmutableArray();
+        var resolved = knownRows
+            .Where(row => !currentKeys.Contains(row))
+            .OrderBy(row => row, StringComparer.Ordinal)
+            .ToImmutableArray();
+
+        return new RtsParityBurndownEvaluation(newRegressions, currentGaps, resolved);
+    }
+
+    static RtsParityBurndownManifest BuildRtsParityBurndown(CorpusSensorSnapshot current)
+    {
+        var rows = ExactReferenceRecompileRegressions(current)
+            .OrderBy(m => m.DisplayMethod, StringComparer.Ordinal)
+            .Select(m => new RtsParityBurndownRow(m.DisplayMethod, m.FidelityCheck))
+            .ToImmutableArray();
+        return new RtsParityBurndownManifest(
+            Description: "RTS-parity burn-down: methods the product compile-back oracle recompiled Exact "
+                + "but ReturnToSender did not. Regenerate mechanically with --emit-rts-parity-burndown; "
+                + "the RTS-orchestrator work drains this list.",
+            Command: "decompiler-harness [corpus] --compile-cap 0 --corpus-fidelity-cap 3 "
+                + "--corpus-fidelity-oracle rts-parity --emit-rts-parity-burndown "
+                + "tools/DecompilerHarness/corpus/rts-parity-burndown.json",
+            Rows: rows);
+    }
+
+    // Enforces the RTS-parity burn-down gate and optionally regenerates the manifest.
+    // Returns true when a NEW Exact->recompile-failure regression is present.
+    static bool EnforceRtsParityBurndown(
+        CorpusSensorSnapshot current,
+        string? burndownPath,
+        string? emitBurndownPath,
+        bool quiet)
+    {
+        if (emitBurndownPath is not null)
+        {
+            var manifest = BuildRtsParityBurndown(current);
+            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(emitBurndownPath)) ?? ".");
+            File.WriteAllText(emitBurndownPath, JsonSerializer.Serialize(manifest, JsonOptions()));
+            if (!quiet)
+            {
+                Console.WriteLine();
+                HarnessLog.Status($"Wrote RTS-parity burn-down ({manifest.Rows.Length} row(s)): {emitBurndownPath}");
+            }
+        }
+
+        IReadOnlyCollection<string> knownRows = burndownPath is not null
+            ? ReadRtsParityBurndown(burndownPath).Rows.Select(r => r.Method).ToImmutableArray()
+            : [];
+        var evaluation = EvaluateRtsParityBurndown(current, knownRows);
+
+        if (!quiet)
+        {
+            Console.WriteLine();
+            Console.WriteLine(
+                $"RTS parity burn-down: {evaluation.KnownGaps.Length} method(s) recompiled Exact under the "
+                + "product oracle but not under ReturnToSender.");
+            foreach (var gap in evaluation.KnownGaps.OrderBy(m => m.DisplayMethod, StringComparer.Ordinal))
+            {
+                bool isNew = evaluation.NewRegressions.Any(m => m.DisplayMethod == gap.DisplayMethod);
+                Console.WriteLine($"- {(isNew ? "NEW " : "")}{gap.DisplayMethod} [{gap.FidelityCheck}]");
+            }
+            foreach (var resolved in evaluation.ResolvedRows)
+                Console.WriteLine($"- resolved (regenerate manifest to drop): {resolved}");
+        }
+
+        if (!evaluation.NewRegressions.IsEmpty)
+        {
+            Console.WriteLine();
+            Console.WriteLine(
+                $"RTS parity lost on {evaluation.NewRegressions.Length} new method(s) not in the burn-down manifest:");
+            foreach (var offender in evaluation.NewRegressions.OrderBy(m => m.DisplayMethod, StringComparer.Ordinal))
+                Console.WriteLine($"- {offender.DisplayMethod} recompiled Exact under the product oracle but {offender.FidelityCheck} under ReturnToSender");
+        }
+
+        return !evaluation.NewRegressions.IsEmpty;
+    }
+
+    static RtsParityBurndownManifest ReadRtsParityBurndown(string path)
+        => JsonSerializer.Deserialize<RtsParityBurndownManifest>(File.ReadAllText(path), JsonOptions())
+           ?? throw new InvalidOperationException($"Could not read RTS-parity burn-down '{path}'.");
 
     static string CompileBackTargetKey(FidelityCheck.CompileBackTarget target)
         => $"{target.Type}::{target.Method}::{target.Overload}::{target.Signature}";
@@ -1099,22 +1207,6 @@ internal static class CorpusSensor
                 baselineParity.WorseMethods,
                 currentParity.WorseMethods,
                 tolerance: 0);
-        }
-
-        // Baseline-independent hard gate: any method the product oracle recompiled Exact
-        // must not recompile-fail under ReturnToSender. Reads the current snapshot alone
-        // so it fires even when no comparable baseline sample exists.
-        var exactRegressions = ExactReferenceRecompileRegressions(current);
-        if (!exactRegressions.IsEmpty)
-        {
-            const int shown = 5;
-            var names = string.Join(
-                ", ",
-                exactRegressions.Take(shown).Select(m => $"{m.DisplayMethod} [{m.FidelityCheck}]"));
-            if (exactRegressions.Length > shown)
-                names += $", +{exactRegressions.Length - shown} more";
-            failures.Add(
-                $"RTS parity lost on {exactRegressions.Length} method(s): recompiled Exact under the product oracle but RecompileFail/ContextFail under ReturnToSender ({names})");
         }
 
         AddCountRegression(failures, "pass bugs", baseline.Metrics.PassBugs, current.Metrics.PassBugs, tolerance.PassBugIncrease);

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -121,7 +121,14 @@ internal static class CorpusSensor
         }
 
         if (diffBaseline is null)
-            return current.Metrics.PassBugs > 0 || FeatureCoverageFailures(current).Length > 0 ? 1 : 0;
+        {
+            var exactRegressions = ExactReferenceRecompileRegressions(current);
+            foreach (var offender in exactRegressions)
+                Console.WriteLine($"- RTS parity lost: {offender.DisplayMethod} recompiled Exact under the product oracle but {offender.FidelityCheck} under ReturnToSender");
+            return current.Metrics.PassBugs > 0
+                || FeatureCoverageFailures(current).Length > 0
+                || exactRegressions.Length > 0 ? 1 : 0;
+        }
 
         var baseline = JsonSerializer.Deserialize<CorpusSensorSnapshot>(File.ReadAllText(diffBaseline), JsonOptions())
             ?? throw new InvalidOperationException($"Could not read corpus baseline '{diffBaseline}'.");
@@ -793,6 +800,33 @@ internal static class CorpusSensor
     static string FidelityResultKey(FidelityCheck.CompileBackResult result)
         => $"{result.Type}::{result.Method}::{result.Overload}::{result.Signature}";
 
+    // Absolute RTS-parity invariant: a method the product oracle recompiled Exact
+    // must never recompile-fail under ReturnToSender. This is baseline-independent
+    // (it reads the current snapshot alone) and names every offending row so a
+    // regression can be traced back to the method that lost parity.
+    internal static ImmutableArray<CorpusMethodSnapshot> ExactReferenceRecompileRegressions(
+        CorpusSensorSnapshot snapshot)
+    {
+        if (snapshot.FidelityOracle != CorpusFidelityOracle.ReturnToSender
+            || snapshot.Methods is not { } methods)
+        {
+            return [];
+        }
+
+        var builder = ImmutableArray.CreateBuilder<CorpusMethodSnapshot>();
+        foreach (var method in methods)
+        {
+            if (string.Equals(method.FidelityReference, "Exact", StringComparison.Ordinal)
+                && (string.Equals(method.FidelityCheck, "RecompileFail", StringComparison.Ordinal)
+                    || string.Equals(method.FidelityCheck, "ContextFail", StringComparison.Ordinal)))
+            {
+                builder.Add(method);
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
     static string CompileBackTargetKey(FidelityCheck.CompileBackTarget target)
         => $"{target.Type}::{target.Method}::{target.Overload}::{target.Signature}";
 
@@ -1065,6 +1099,22 @@ internal static class CorpusSensor
                 baselineParity.WorseMethods,
                 currentParity.WorseMethods,
                 tolerance: 0);
+        }
+
+        // Baseline-independent hard gate: any method the product oracle recompiled Exact
+        // must not recompile-fail under ReturnToSender. Reads the current snapshot alone
+        // so it fires even when no comparable baseline sample exists.
+        var exactRegressions = ExactReferenceRecompileRegressions(current);
+        if (!exactRegressions.IsEmpty)
+        {
+            const int shown = 5;
+            var names = string.Join(
+                ", ",
+                exactRegressions.Take(shown).Select(m => $"{m.DisplayMethod} [{m.FidelityCheck}]"));
+            if (exactRegressions.Length > shown)
+                names += $", +{exactRegressions.Length - shown} more";
+            failures.Add(
+                $"RTS parity lost on {exactRegressions.Length} method(s): recompiled Exact under the product oracle but RecompileFail/ContextFail under ReturnToSender ({names})");
         }
 
         AddCountRegression(failures, "pass bugs", baseline.Metrics.PassBugs, current.Metrics.PassBugs, tolerance.PassBugIncrease);

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -98,6 +98,17 @@ internal static class CorpusSensor
             return 1;
         }
 
+        if (rtsParityBurndown is not null || emitRtsParityBurndown is not null)
+        {
+            var burndownError = ValidateRtsParityBurndownFlags(
+                fidelityOracle, fidelityCompileCaps, rtsParityBurndown, emitRtsParityBurndown);
+            if (burndownError is not null)
+            {
+                Console.Error.WriteLine(burndownError);
+                return 1;
+            }
+        }
+
         var (current, fidelityReports) = Capture(
             assemblies,
             validityCompileCap,
@@ -827,6 +838,36 @@ internal static class CorpusSensor
         return builder.ToImmutable();
     }
 
+    // Guards that make the RTS-parity burn-down flags refuse to run toothless: they
+    // require the rts-parity oracle (else EnforceRtsParityBurndown never fires) AND a
+    // positive fidelity cap (else the parity population is empty and every manifest row
+    // is spuriously "resolved" while the run exits 0). Enforcing against a just-emitted
+    // manifest (same path) would self-certify new regressions, so that is rejected too.
+    // Returns an error message, or null when the flags are usable.
+    internal static string? ValidateRtsParityBurndownFlags(
+        CorpusFidelityOracle fidelityOracle,
+        IReadOnlyList<int> fidelityCompileCaps,
+        string? rtsParityBurndown,
+        string? emitRtsParityBurndown)
+    {
+        if (rtsParityBurndown is null && emitRtsParityBurndown is null)
+            return null;
+        if (fidelityOracle != CorpusFidelityOracle.ReturnToSender)
+            return "--rts-parity-burndown and --emit-rts-parity-burndown require --corpus-fidelity-oracle rts-parity.";
+        if (!fidelityCompileCaps.Any(cap => cap > 0))
+            return "--rts-parity-burndown and --emit-rts-parity-burndown require a positive --corpus-fidelity-cap so the parity population is actually evaluated.";
+        if (rtsParityBurndown is not null
+            && emitRtsParityBurndown is not null
+            && string.Equals(
+                Path.GetFullPath(rtsParityBurndown),
+                Path.GetFullPath(emitRtsParityBurndown),
+                StringComparison.Ordinal))
+        {
+            return "--rts-parity-burndown and --emit-rts-parity-burndown must not point at the same file; enforcing against a just-emitted manifest would self-certify new regressions.";
+        }
+        return null;
+    }
+
     internal sealed record RtsParityBurndownRow(string Method, string Status);
 
     internal sealed record RtsParityBurndownManifest(
@@ -931,9 +972,12 @@ internal static class CorpusSensor
         return !evaluation.NewRegressions.IsEmpty;
     }
 
-    static RtsParityBurndownManifest ReadRtsParityBurndown(string path)
-        => JsonSerializer.Deserialize<RtsParityBurndownManifest>(File.ReadAllText(path), JsonOptions())
-           ?? throw new InvalidOperationException($"Could not read RTS-parity burn-down '{path}'.");
+    internal static RtsParityBurndownManifest ReadRtsParityBurndown(string path)
+    {
+        var manifest = JsonSerializer.Deserialize<RtsParityBurndownManifest>(File.ReadAllText(path), JsonOptions())
+            ?? throw new InvalidOperationException($"Could not read RTS-parity burn-down '{path}'.");
+        return manifest.Rows.IsDefault ? manifest with { Rows = [] } : manifest;
+    }
 
     static string CompileBackTargetKey(FidelityCheck.CompileBackTarget target)
         => $"{target.Type}::{target.Method}::{target.Overload}::{target.Signature}";

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -107,6 +107,8 @@ static class Program
         string? emitCorpusSnapshot = null;
         string? diffCorpusBaseline = null;
         string? emitCorpusDelta = null;
+        string? rtsParityBurndown = null;
+        string? emitRtsParityBurndown = null;
         string? fidelityMethodDelta = null;
         bool qualityDiffCard = false;
         bool qualityCardRisky = false;
@@ -224,6 +226,8 @@ static class Program
                     case "--emit-corpus-baseline": emitCorpusSnapshot = NextArg(args, ref i, flag); break;
                     case "--emit-corpus-snapshot": emitCorpusSnapshot = NextArg(args, ref i, flag); break;
                     case "--diff-corpus-baseline": diffCorpusBaseline = NextArg(args, ref i, flag); break;
+                    case "--rts-parity-burndown": rtsParityBurndown = NextArg(args, ref i, flag); break;
+                    case "--emit-rts-parity-burndown": emitRtsParityBurndown = NextArg(args, ref i, flag); break;
                     case "--emit-corpus-delta": emitCorpusDelta = NextArg(args, ref i, flag); break;
                     case "--fidelity-method-delta": fidelityMethodDelta = NextArg(args, ref i, flag); break;
                     case "--quality-diff-card": qualityDiffCard = true; break;
@@ -406,8 +410,8 @@ static class Program
         if (classifyDec0009)
             return Dec0009Classifier.Run(assemblies, maxExamples, json);
 
-        if (emitCorpusSnapshot is not null || diffCorpusBaseline is not null || emitCorpusDelta is not null || qualityDiffCard)
-            return CorpusSensor.Run(assemblies, compileCap, corpusFidelityCaps, maxExamples, emitCorpusSnapshot, diffCorpusBaseline, emitCorpusDelta, qualityDiffCard, qualityCardRisky, corpusMethodCap, workers, sequential, corpusFidelityOracle, corpusProfile);
+        if (emitCorpusSnapshot is not null || diffCorpusBaseline is not null || emitCorpusDelta is not null || qualityDiffCard || emitRtsParityBurndown is not null || rtsParityBurndown is not null)
+            return CorpusSensor.Run(assemblies, compileCap, corpusFidelityCaps, maxExamples, emitCorpusSnapshot, diffCorpusBaseline, emitCorpusDelta, qualityDiffCard, qualityCardRisky, corpusMethodCap, workers, sequential, corpusFidelityOracle, corpusProfile, rtsParityBurndown, emitRtsParityBurndown);
 
         if (renderAb is not null || emitRenderAb is not null)
             return RenderAbSensor.Run(assemblies, renderAb, emitRenderAb, maxExamples, corpusMethodCap, workers, sequential);
@@ -1809,6 +1813,14 @@ static class Program
           --emit-corpus-delta <f>        with --diff-corpus-baseline: write
                                 changed per-method corpus rows as JSON for
                                 reviewer drill-down and targeted fidelity runs.
+          --rts-parity-burndown <f>      with --corpus-fidelity-oracle rts-parity:
+                                fail if any method recompiles Exact under the
+                                product oracle but RecompileFail/ContextFail under
+                                ReturnToSender and is NOT already listed in the
+                                committed burn-down manifest <f> (a new regression).
+          --emit-rts-parity-burndown <f> with --corpus-fidelity-oracle rts-parity:
+                                mechanically (re)write the burn-down manifest <f>
+                                from the current Exact-to-recompile-failure set.
           --fidelity-method-delta <f>    with --fidelity-check: compile back the
                                 current changed methods from a corpus delta JSON.
           --quality-diff-card  with --diff-corpus-baseline: emit a Markdown

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -263,6 +263,17 @@ Because compile-back selects this population before RTS runs, `NotFullMethods`
 is structurally zero and failure buckets describe only the selected parity
 population; this mode measures parity, not independent RTS coverage.
 
+Regardless of any committed baseline, `rts-parity` snapshots are subject to a
+hard, per-row invariant: a method the compile-back oracle recompiled `Exact`
+must never recompile-fail (`RecompileFail` or `ContextFail`) under RTS. That
+transition means the ReturnToSender orchestrator dropped fidelity the product
+already proved, so the sensor fails and names every offending
+`Assembly!Type::Method#Overload`. The check reads the current snapshot alone, so
+it fires both when diffing against a baseline (`--diff-corpus-baseline`) and on a
+standalone `rts-parity` run with no baseline. It is the backbone gate for the
+RTS-orchestrator work: parity may improve (`OpcodeDiff` → `Exact` rescues) but
+must never regress an already-`Exact` method.
+
 Standalone `--fidelity-check` reports also print bounded examples for every
 non-success bucket: opcode diffs include canonical opcode streams, while
 recompile and context failures include the method and diagnostic detail. Use

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -263,16 +263,30 @@ Because compile-back selects this population before RTS runs, `NotFullMethods`
 is structurally zero and failure buckets describe only the selected parity
 population; this mode measures parity, not independent RTS coverage.
 
-Regardless of any committed baseline, `rts-parity` snapshots are subject to a
-hard, per-row invariant: a method the compile-back oracle recompiled `Exact`
-must never recompile-fail (`RecompileFail` or `ContextFail`) under RTS. That
+Regardless of the aggregate baseline, `rts-parity` snapshots carry a hard,
+per-row regression gate. A method the compile-back oracle recompiled `Exact`
+must not recompile-fail (`RecompileFail` or `ContextFail`) under RTS — that
 transition means the ReturnToSender orchestrator dropped fidelity the product
-already proved, so the sensor fails and names every offending
-`Assembly!Type::Method#Overload`. The check reads the current snapshot alone, so
-it fires both when diffing against a baseline (`--diff-corpus-baseline`) and on a
-standalone `rts-parity` run with no baseline. It is the backbone gate for the
-RTS-orchestrator work: parity may improve (`OpcodeDiff` → `Exact` rescues) but
-must never regress an already-`Exact` method.
+already proved. The current gaps are committed as a small, tool-emitted burn-down
+manifest (`tools/DecompilerHarness/corpus/rts-parity-burndown.json`); the gate
+fails only when a *new* `Exact`-to-recompile-failure row appears that is not
+already in the manifest, naming every offending `Assembly!Type::Method#Overload`.
+The known rows stay a visible, shrinking checklist that the RTS-orchestrator
+issues drain, rather than a silent tolerance. Regenerate the manifest
+mechanically (never hand-edit it) after a deliberate population change:
+
+```bash
+dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
+  --compile-cap 0 \
+  --corpus-fidelity-cap 3 \
+  --corpus-fidelity-oracle rts-parity \
+  --emit-rts-parity-burndown tools/DecompilerHarness/corpus/rts-parity-burndown.json
+```
+
+Pass `--rts-parity-burndown tools/DecompilerHarness/corpus/rts-parity-burndown.json`
+on any `rts-parity` run to enforce the gate; a row present in the manifest but no
+longer failing is reported as `resolved` so the manifest can be trimmed on the
+next regeneration.
 
 Standalone `--fidelity-check` reports also print bounded examples for every
 non-success bucket: opcode diffs include canonical opcode streams, while

--- a/tools/DecompilerHarness/corpus/rts-parity-burndown.json
+++ b/tools/DecompilerHarness/corpus/rts-parity-burndown.json
@@ -1,0 +1,34 @@
+{
+  "description": "RTS-parity burn-down: methods the product compile-back oracle recompiled Exact but ReturnToSender did not. Regenerate mechanically with --emit-rts-parity-burndown; the RTS-orchestrator work drains this list.",
+  "command": "decompiler-harness [corpus] --compile-cap 0 --corpus-fidelity-cap 3 --corpus-fidelity-oracle rts-parity --emit-rts-parity-burndown tools/DecompilerHarness/corpus/rts-parity-burndown.json",
+  "rows": [
+    {
+      "method": "DotnetInspector.Packages!DotnetInspector.Packages.SymbolPackageDownloader::CheckPdbHeader#0",
+      "status": "RecompileFail"
+    },
+    {
+      "method": "ILInspector.Analysis!ILInspector.Analysis.LibraryBodyIndex::HollowUnsafeMethods#0",
+      "status": "RecompileFail"
+    },
+    {
+      "method": "ILInspector.MetadataPrimitives!ILInspector.Metadata.TypeResolver::GetTypeNameFromReference#0",
+      "status": "RecompileFail"
+    },
+    {
+      "method": "Newtonsoft.Json!Newtonsoft.Json.JsonTextReader::get_PropertyNameTable#0",
+      "status": "RecompileFail"
+    },
+    {
+      "method": "Newtonsoft.Json!Newtonsoft.Json.Utilities.Base64Encoder::WriteCharsAsync#0",
+      "status": "RecompileFail"
+    },
+    {
+      "method": "System.CommandLine!System.CommandLine.EnvironmentVariablesDirective.EnvironmentVariablesDirectiveAction::SetEnvVars#0",
+      "status": "RecompileFail"
+    },
+    {
+      "method": "System.CommandLine!System.CommandLine.ParseResult::GetValue#2",
+      "status": "RecompileFail"
+    }
+  ]
+}


### PR DESCRIPTION
- Closes #2776
- Harness-only: adds an RTS-parity regression gate and its committed burn-down manifest; no product output changes.
- Evidence revision: `f869b295`

## Change

> Should we accept this harness change?

**Conclusion:** **PASS** — the RTS compile-back path had no mechanical guard against losing parity the product already proved; this adds a baseline-relative gate over a small committed burn-down that fails on any *new* Exact-to-recompile-failure and names the offender.

The gate is the measurement backbone the rest of the RTS-reversal work (#2777–#2781) cites: as those issues drain RTS's C# knowledge into the product seam, this proves no method that recompiled `Exact` under the product oracle silently starts failing to recompile under ReturnToSender.

### Design note (why not an absolute gate or a full snapshot baseline)

Running the gate over the real 14-assembly corpus revealed **7 methods that already recompile `Exact` under the product oracle but `RecompileFail` under RTS on `main`**. Two consequences:

- An *absolute* "any Exact→recompile-failure is a hard failure" gate would fail every `rts-parity` run today — useless as a regression signal.
- A full committed snapshot baseline would add a second ~68MB opaque JSON (matching `real-world-baseline.json`) that carries 7 rows of signal and that no reviewer can read.

So the gate is **baseline-relative against a small, tool-emitted burn-down manifest** (`tools/DecompilerHarness/corpus/rts-parity-burndown.json`, 1.5KB, 7 named rows). It fails only when a **new** row appears that is not already in the manifest, and reports rows that stopped failing as `resolved` so the manifest is trimmed on regeneration. The known rows are the "living burn-down checklist" the issue asked for — a visible list the follow-up issues shrink.

## Scope and safety

- **Root cause:** no mechanical assertion existed that RTS keeps parity with the product compile-back oracle across the reversal migration.
- **Fix shape:** harness orchestration/oracle/reporting — a pure gate (`EvaluateRtsParityBurndown`) plus wiring (`EnforceRtsParityBurndown`) and two CLI flags.
- **Product impact:** none. No product/decompiler code changed; the gate only reads product-produced fidelity data.
- **RTS boundary:** the gate does not add C# knowledge to RTS. It reads `FidelityCheck`/`FidelityReference` the harness already records and compares method identities. Consistent with the RTS-orchestrator direction.
- **Scope boundary:** the 7 pre-existing gaps are recorded as the burn-down, not fixed here; #2777–#2781 drain them.

## Evidence

| Check | Result |
| --- | --- |
| Harness build | Pass (`0 Warning(s), 0 Error(s)`) |
| Focused tests | `CorpusSensorComparisonTests` 30/0 |
| Decompiler targeted suite | `CorpusSensorComparisonTests` + `ReturnToSenderPrototypeTests` 144/0 |
| Real corpus emit | 14 assemblies, 89,065 methods; `rts-parity` cap 3 → wrote 7-row burn-down |
| Real corpus gate round-trip | re-run with `--rts-parity-burndown` → 7 known / 0 new / **exit 0** |
| Seeded regression | unit test: a gap not in the manifest → `NewRegressions` fails and is named |
| Markdownlint | Pass (`README.md`) |

Named burn-down (the failure taxonomy the issue requires — every decline maps to a named `Assembly!Type::Method#Overload` and a typed status):

```text
DotnetInspector.Packages!DotnetInspector.Packages.SymbolPackageDownloader::CheckPdbHeader#0 [RecompileFail]
ILInspector.Analysis!ILInspector.Analysis.LibraryBodyIndex::HollowUnsafeMethods#0 [RecompileFail]
ILInspector.MetadataPrimitives!ILInspector.Metadata.TypeResolver::GetTypeNameFromReference#0 [RecompileFail]
Newtonsoft.Json!Newtonsoft.Json.JsonTextReader::get_PropertyNameTable#0 [RecompileFail]
Newtonsoft.Json!Newtonsoft.Json.Utilities.Base64Encoder::WriteCharsAsync#0 [RecompileFail]
System.CommandLine!System.CommandLine.EnvironmentVariablesDirective.EnvironmentVariablesDirectiveAction::SetEnvVars#0 [RecompileFail]
System.CommandLine!System.CommandLine.ParseResult::GetValue#2 [RecompileFail]
```

## Reproduce

```bash
bash eng/prepare-decompiler-corpus.sh /tmp/corpus-assemblies.txt
assemblies=$(tr '\n' ' ' < /tmp/corpus-assemblies.txt)
dotnet run --project tools/DecompilerHarness -c Release -- $assemblies \
  --compile-cap 0 --corpus-fidelity-cap 3 --corpus-fidelity-oracle rts-parity \
  --rts-parity-burndown tools/DecompilerHarness/corpus/rts-parity-burndown.json
```

## Review

Requesting the mandated two-model adversarial review (GPT-5.5 + Gemini 3.1 Pro) in isolated worktrees. Key attack points: is the DisplayMethod key stable/unique enough to key the burn-down; does the gate correctly distinguish new vs known vs resolved; can a real regression hide as "same" or "resolved"; is cap 3 a meaningful denominator.
