### PR TITLE
Extract constructor body-facts into the product (#2777 step 1)

### DIFF
--- a/src/ILInspector.CSharp/ConstructorBodyFacts.cs
+++ b/src/ILInspector.CSharp/ConstructorBodyFacts.cs
@@ -1,0 +1,33 @@
+namespace ILInspector.CSharp;
+
+/// <summary>
+/// Neutral, IR-free constructor body facts extracted from a decompiled constructor.
+/// ReturnToSender and the C# seam use these to reconstruct constructor-chain
+/// initializers and primary-constructor shells without reading Decompiler IR, so the
+/// IR-to-fact extraction lives in the product (ILInspector.Decompiler, which owns the
+/// IR) rather than in the harness. All fields are plain strings and indices; no
+/// Decompiler type crosses this boundary.
+/// </summary>
+public sealed record ConstructorBodyFacts(
+    IReadOnlyList<string>? ChainParameterTypes,
+    IReadOnlyList<PrimaryConstructorFieldStore>? PrimaryConstructorPrologue)
+{
+    /// <summary>
+    /// No chain call and no primary-constructor prologue: the shape used for
+    /// non-constructor methods and bodies with neither fact.
+    /// </summary>
+    public static ConstructorBodyFacts None { get; } = new(null, null);
+}
+
+/// <summary>
+/// One <c>this.field = argN;</c> assignment in a primary-constructor prologue, in
+/// source order. <paramref name="SourceArgumentIndex"/> is the IL argument slot the
+/// stored value came from (0 is <c>this</c>, so a real parameter is &gt;= 1),
+/// <paramref name="FieldName"/> is the stored field's metadata name, and
+/// <paramref name="BackingPropertyName"/> is the property name when the field backs an
+/// auto-property, or null when there is no such proof.
+/// </summary>
+public sealed record PrimaryConstructorFieldStore(
+    int SourceArgumentIndex,
+    string FieldName,
+    string? BackingPropertyName);

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4611,3 +4611,31 @@ public class ForeachElementProbe
         return total;
     }
 }
+
+// Fixtures for ConstructorBodyFactExtractorTests. The neutral constructor
+// body-fact extractor pattern-matches decompiled IR, so these compiled
+// constructor shapes exercise the chain-call and primary-constructor-prologue
+// detections directly.
+public class ChainedCtorSample
+{
+    public int Value;
+    public string Label;
+
+    // Overload 0 (declared first): parameterless ctor chaining to the
+    // (int, string) overload -> chain parameter types [int, string].
+    public ChainedCtorSample() : this(0, "none")
+    {
+    }
+
+    public ChainedCtorSample(int value, string label)
+    {
+        Value = value;
+        Label = label;
+    }
+}
+
+public class PrimaryCtorSample(int alpha, string beta)
+{
+    public int Alpha => alpha;
+    public string Beta => beta;
+}

--- a/src/ILInspector.Decompiler.Tests/ConstructorBodyFactExtractorTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ConstructorBodyFactExtractorTests.cs
@@ -1,0 +1,56 @@
+using ILInspector.CSharp;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ConstructorBodyFactExtractorTests
+{
+    static ConstructorBodyFacts ExtractFor(string typeFullName, string methodName, int overloadIndex = 0)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeFullName, methodName, overloadIndex);
+        Assert.NotNull(function);
+        return ConstructorBodyFactExtractor.Extract(function);
+    }
+
+    [Fact]
+    public void ChainedConstructor_ReportsChainCalleeParameterTypes()
+    {
+        // The parameterless overload chains to `this(int, string)`, so the chain
+        // fact carries the chained-to constructor's parameter type displays and
+        // the body is NOT primary-constructor-prologue shaped.
+        var facts = ExtractFor(typeof(ChainedCtorSample).FullName!, ".ctor", overloadIndex: 0);
+
+        Assert.NotNull(facts.ChainParameterTypes);
+        Assert.Equal(["int", "string"], facts.ChainParameterTypes);
+        Assert.Null(facts.PrimaryConstructorPrologue);
+    }
+
+    [Fact]
+    public void PrimaryConstructor_ReportsOrderedFieldStores()
+    {
+        // A primary constructor lowers to `this.<field> = argN;` stores followed
+        // by a parameterless base call, so the prologue fact carries one store
+        // per captured parameter in source-argument order.
+        var facts = ExtractFor(typeof(PrimaryCtorSample).FullName!, ".ctor");
+
+        Assert.NotNull(facts.PrimaryConstructorPrologue);
+        var prologue = facts.PrimaryConstructorPrologue!;
+        Assert.Equal(2, prologue.Count);
+        Assert.Equal([1, 2], prologue.Select(store => store.SourceArgumentIndex).ToArray());
+        Assert.All(prologue, store => Assert.False(string.IsNullOrEmpty(store.FieldName)));
+        Assert.NotEqual(prologue[0].FieldName, prologue[1].FieldName);
+    }
+
+    [Fact]
+    public void NonConstructorMethod_ReportsNoFacts()
+    {
+        // A plain method has neither a chain call nor a primary-constructor
+        // prologue, so both facts are absent.
+        var facts = ExtractFor(typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.Add));
+
+        Assert.Null(facts.ChainParameterTypes);
+        Assert.Null(facts.PrimaryConstructorPrologue);
+    }
+}

--- a/src/ILInspector.Decompiler/ConstructorBodyFactExtractor.cs
+++ b/src/ILInspector.Decompiler/ConstructorBodyFactExtractor.cs
@@ -1,0 +1,97 @@
+using ILInspector.CSharp;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Extracts neutral <see cref="ConstructorBodyFacts"/> from a decompiled constructor's
+/// IR so ReturnToSender and the C# seam can reconstruct constructor-chain initializers
+/// and primary-constructor shells without reading Decompiler IR themselves. This is the
+/// single owner of the IR pattern-matches those consumers previously duplicated in the
+/// harness; the facts it returns carry only strings and indices.
+/// </summary>
+public static class ConstructorBodyFactExtractor
+{
+    /// <summary>
+    /// Produces the chain-call and primary-constructor-prologue facts for
+    /// <paramref name="function"/>. Callers should only apply the constructor-shaped
+    /// facts to actual constructors; the extraction itself is body-shape driven.
+    /// </summary>
+    public static ConstructorBodyFacts Extract(IrFunction function)
+        => new(ChainParameterTypes(function), PrimaryConstructorPrologue(function));
+
+    /// <summary>
+    /// The parameter type display names of the <c>this</c>/<c>base</c> <c>.ctor</c>
+    /// chain call in the entry block, or null when the body has no chain call. Mirrors
+    /// the chain-call detection so the shell can verify the chained-to constructor was
+    /// reconstructed before emitting the initializer.
+    /// </summary>
+    static IReadOnlyList<string>? ChainParameterTypes(IrFunction function)
+    {
+        if (function.Body.Blocks is not [{ } entry, ..])
+            return null;
+
+        foreach (var child in entry.Children)
+        {
+            if (child is ExpressionStatement
+                {
+                    Expression: Call { Callee: { Name: ".ctor", HasThis: true } } call
+                }
+                && call.Arguments is [_, ..])
+            {
+                return [.. call.Callee.ParameterTypes.Select(type => type.ToDisplayString())];
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The ordered <c>this.field = argN;</c> assignments in a primary-constructor
+    /// prologue: an entry block whose leading statements are field stores from method
+    /// arguments, followed by a parameterless <c>this</c>/<c>base</c> chain call and
+    /// nothing but returns. Null when the body is not primary-constructor-prologue
+    /// shaped. Metadata correspondence (which parameter, which field, field types) is
+    /// resolved by the caller, not here.
+    /// </summary>
+    static IReadOnlyList<PrimaryConstructorFieldStore>? PrimaryConstructorPrologue(IrFunction function)
+    {
+        if (function.Body.Blocks is not [{ } entry, ..])
+            return null;
+
+        int? chainIndex = null;
+        for (int i = 0; i < entry.Children.Count; i++)
+        {
+            if (entry.Children[i] is ExpressionStatement
+                {
+                    Expression: Call { Callee: { Name: ".ctor", HasThis: true }, Arguments: [LoadArgument { Index: 0 }] }
+                })
+            {
+                chainIndex = i;
+                break;
+            }
+        }
+
+        if (chainIndex is not > 0)
+            return null;
+        if (entry.Children.Skip(chainIndex.Value + 1).Any(node => node is not Return))
+            return null;
+
+        var stores = new List<PrimaryConstructorFieldStore>();
+        foreach (var node in entry.Children.Take(chainIndex.Value))
+        {
+            if (node is not StoreField
+                {
+                    HasInstance: true,
+                    Instance: LoadArgument { Index: 0 },
+                    Value: LoadArgument { Index: > 0 } value
+                } store)
+            {
+                return null;
+            }
+
+            stores.Add(new PrimaryConstructorFieldStore(value.Index, store.Field.Name, store.Field.BackingPropertyName));
+        }
+
+        return stores.Count == 0 ? null : stores;
+    }
+}

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Json;
 
 using DotnetInspector.Services;
+using ILInspector.CSharp;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Instructions;
@@ -936,7 +937,8 @@ static class FidelityCheck
             if (body is null)
                 continue;
             var requiredNamespaces = RequiredNamespaces(function);
-            PrimaryConstructorShape? primaryConstructor = PrimaryConstructorFromPrologue(reader, method, function, body);
+            PrimaryConstructorShape? primaryConstructor = PrimaryConstructorFromPrologue(
+                reader, method, ConstructorBodyFactExtractor.Extract(function).PrimaryConstructorPrologue, body);
             var original = MetadataInstructionProducer.Disassemble(pe, reader, method);
             if (original is null)
                 continue;
@@ -1014,7 +1016,7 @@ static class FidelityCheck
     static PrimaryConstructorShape? PrimaryConstructorFromPrologue(
         MetadataReader reader,
         MethodDefinition method,
-        IrFunction function,
+        IReadOnlyList<PrimaryConstructorFieldStore>? prologue,
         string renderedBody)
     {
         if (reader.GetString(method.Name) != ".ctor"
@@ -1025,25 +1027,9 @@ static class FidelityCheck
         if (CountInstanceConstructors(reader, declaringType) != 1
             || HasInAssemblyDerivedType(reader, declaringHandle))
             return null;
-        if (function.Body.Blocks is not [{ } entry, ..])
-            return null;
-
-        int? chainIndex = null;
-        for (int i = 0; i < entry.Children.Count; i++)
-        {
-            if (entry.Children[i] is ExpressionStatement
-                {
-                    Expression: Call { Callee: { Name: ".ctor", HasThis: true }, Arguments: [LoadArgument { Index: 0 }] }
-                })
-            {
-                chainIndex = i;
-                break;
-            }
-        }
-
-        if (chainIndex is not > 0)
-            return null;
-        if (entry.Children.Skip(chainIndex.Value + 1).Any(node => node is not Return))
+        // The IR-shape detection lives in the product extractor; a null prologue
+        // means the body is not primary-constructor shaped.
+        if (prologue is null)
             return null;
 
         var parameterNames = ParameterNames(reader, method);
@@ -1051,20 +1037,13 @@ static class FidelityCheck
             return null;
 
         var initializers = new List<(string Field, string Value)>();
-        foreach (var node in entry.Children.Take(chainIndex.Value))
+        foreach (var fieldStore in prologue)
         {
-            if (node is not StoreField
-                {
-                    HasInstance: true,
-                    Instance: LoadArgument { Index: 0 },
-                    Value: LoadArgument { Index: > 0 } value
-                } store)
-                return null;
-            if (!parameterNames.TryGetValue(value.Index - 1, out string? parameterName))
+            if (!parameterNames.TryGetValue(fieldStore.SourceArgumentIndex - 1, out string? parameterName))
                 return null;
 
-            string name = AutoPropertyNameForBackingField(reader, declaringType, store.Field.Name)
-                ?? store.Field.Name;
+            string name = AutoPropertyNameForBackingField(reader, declaringType, fieldStore.FieldName)
+                ?? fieldStore.FieldName;
             initializers.Add((name, parameterName));
         }
 

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1074,8 +1074,9 @@ public static class CompileBackSourceComposer
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
         string targetMethodName = Identifier(methodName);
         bool isConstructor = function.MethodKind is IrMethodKind.Constructor or IrMethodKind.StaticConstructor;
+        var bodyFacts = isConstructor ? ConstructorBodyFactExtractor.Extract(function) : ConstructorBodyFacts.None;
         var primaryConstructor = isConstructor
-            ? PrimaryConstructorFromPrologue(reader, method, function, targetBody)
+            ? PrimaryConstructorFromPrologue(reader, method, bodyFacts.PrimaryConstructorPrologue, targetBody)
             : PrimaryConstructorFromCapturedFields(reader, targetTypeDef, targetBody);
 
         var diagnostics = new List<CompileBackPlanningDiagnostic>();
@@ -1087,8 +1088,7 @@ public static class CompileBackSourceComposer
         if (closureFacts.TryGetValue(targetType, out var targetClosureFacts))
             targetFacts.AddRange(targetClosureFacts);
 
-        var chainCall = isConstructor ? ConstructorChainCall(function) : null;
-        var chainCallee = chainCall?.Callee;
+        var chainParameterTypes = bodyFacts.ChainParameterTypes;
         // Only this(...) self-chains are re-emitted as constructor initializers.
         // RTS shells are flat (object-based, no reconstructed base class), so a
         // base(args) initializer has no base constructor to bind to and would
@@ -1172,16 +1172,16 @@ public static class CompileBackSourceComposer
         // the chained-to constructor must be reconstructable in the shell, and a
         // same-arity sibling must be present to serve as its binding target.
         bool chainedConstructorReconstructed =
-            chainCallee is { } chainCtor
+            chainParameterTypes is { } chainParams
             // The chained-to constructor is reconstructed only when its signature
             // is fully supported (an unsupported parameter such as a function
             // pointer makes the planner drop it, mirroring MethodRequirement).
-            && chainCtor.ParameterTypes.All(type => !IsUnsupportedChainParameterType(type))
+            && chainParams.All(type => !TypeShellProducer.IsUnsupportedSurfaceSignature(type))
             // A same-arity non-target constructor must actually be present in the
             // shell for `: this(args)` to have a binding target.
             && targetMembers.Any(member => member.Kind == CompileBackMemberKind.Constructor
                 && member.StubBody != CompileBackStubBodyKind.TargetBody
-                && member.Parameters.Count == chainCtor.ParameterTypes.Length);
+                && member.Parameters.Count == chainParams.Count);
         if (targetConstructorInitializer is not null && !chainedConstructorReconstructed)
         {
             // The chained-to constructor was not reconstructed in the shell: either
@@ -1525,45 +1525,6 @@ public static class CompileBackSourceComposer
         => requirement.Kind == CompileBackMemberKind.PropertyGet
             ? new CSharpPropertyBody(body, null)
             : new CSharpPropertyBody(null, body);
-
-    /// <summary>
-    /// The base/this <c>.ctor</c> chain call in the entry block, or null when the
-    /// constructor body has no chain call (a struct ctor, or a body that never
-    /// chains). Mirrors the printer's chain-call detection so the shell can verify
-    /// the chained-to constructor was reconstructed before emitting the initializer
-    /// and letting the Roslyn oracle judge binding.
-    /// </summary>
-    static Call? ConstructorChainCall(IrFunction function)
-    {
-        if (function.Body.Blocks is not [{ } entry, ..])
-            return null;
-        foreach (var child in entry.Children)
-        {
-            if (child is ExpressionStatement
-                {
-                    Expression: Call { Callee: { Name: ".ctor", HasThis: true } } call
-                }
-                && call.Arguments is [_, ..])
-            {
-                return call;
-            }
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    /// Whether a constructor-chain parameter type would be dropped from the
-    /// reconstructed shell (mirrors <c>IsUnsupportedSurfaceSignature</c>): a
-    /// function pointer or a compiler-generated/anonymous type has no faithful
-    /// C# surface, so the chained-to constructor is not reconstructed and a
-    /// <c>: this(args)</c> initializer targeting it cannot bind.
-    /// </summary>
-    static bool IsUnsupportedChainParameterType(TypeRef type)
-        // Route surface-representability through the product seam (TypeShellProducer)
-        // so every RTS consumer judges droppable surfaces identically, instead of
-        // re-inlining the delegate*/<>/{ heuristic here.
-        => TypeShellProducer.IsUnsupportedSurfaceSignature(type.ToDisplayString());
 
     static CompileBackParameter ToCompileBackParameter(ApiParameter parameter)
         => new(
@@ -1968,7 +1929,7 @@ public static class CompileBackSourceComposer
     static CompileBackPrimaryConstructor? PrimaryConstructorFromPrologue(
         MetadataReader reader,
         MethodDefinition method,
-        IrFunction function,
+        IReadOnlyList<PrimaryConstructorFieldStore>? prologue,
         string renderedBody)
     {
         if (reader.GetString(method.Name) != ".ctor"
@@ -1979,25 +1940,10 @@ public static class CompileBackSourceComposer
         if (CountInstanceConstructors(reader, declaringType) != 1
             || HasInAssemblyDerivedType(reader, declaringHandle))
             return null;
-        if (function.Body.Blocks is not [{ } entry, ..])
-            return null;
-
-        int? chainIndex = null;
-        for (int i = 0; i < entry.Children.Count; i++)
-        {
-            if (entry.Children[i] is ExpressionStatement
-                {
-                    Expression: Call { Callee: { Name: ".ctor", HasThis: true }, Arguments: [LoadArgument { Index: 0 }] }
-                })
-            {
-                chainIndex = i;
-                break;
-            }
-        }
-
-        if (chainIndex is not > 0)
-            return null;
-        if (entry.Children.Skip(chainIndex.Value + 1).Any(node => node is not Return))
+        // The IR-shape detection (leading arg->field stores before a parameterless
+        // chain call, then only returns) lives in the product extractor; a null
+        // prologue means the body is not primary-constructor shaped.
+        if (prologue is null)
             return null;
 
         var parameterNames = ParameterNames(reader, method);
@@ -2006,18 +1952,11 @@ public static class CompileBackSourceComposer
 
         var fieldInitializers = new List<CompileBackMemberRequirement>();
         var initializerTexts = new List<(string Field, string Value)>();
-        foreach (var node in entry.Children.Take(chainIndex.Value))
+        foreach (var fieldStore in prologue)
         {
-            if (node is not StoreField
-                {
-                    HasInstance: true,
-                    Instance: LoadArgument { Index: 0 },
-                    Value: LoadArgument { Index: > 0 } value
-                } store)
+            if (!parameterNames.TryGetValue(fieldStore.SourceArgumentIndex - 1, out string? parameterName))
                 return null;
-            if (!parameterNames.TryGetValue(value.Index - 1, out string? parameterName))
-                return null;
-            if (FindField(reader, declaringType, store.Field.Name) is not { } fieldHandle)
+            if (FindField(reader, declaringType, fieldStore.FieldName) is not { } fieldHandle)
                 return null;
 
             var field = reader.GetFieldDefinition(fieldHandle);
@@ -2031,8 +1970,8 @@ public static class CompileBackSourceComposer
                 return null;
             }
 
-            string fieldName = store.Field.BackingPropertyName
-                ?? store.Field.Name;
+            string fieldName = fieldStore.BackingPropertyName
+                ?? fieldStore.FieldName;
             initializerTexts.Add((fieldName, parameterName));
             fieldInitializers.Add(new CompileBackMemberRequirement(
                 new CompileBackMethodIdentity(


### PR DESCRIPTION
## Why

ReturnToSender (the compile-back oracle in `tools/DecompilerHarness`) declares
the product decompiler's C# valid, but to reconstruct constructor-chain
initializers and primary-constructor shells it re-implemented its **own** walks
over Decompiler IR (`IrFunction` and its node types). Two harness consumers —
the RTS type planner and `FidelityCheck` — carried the **same** IR walk
verbatim. That is exactly the layering leak #2782 wants gone: the harness reads
product IR to make C#-shape decisions the product should own.

## What

Move the IR-to-fact extraction into the product (which owns the IR) and emit a
neutral, IR-free DTO the harness consumes:

- **`src/ILInspector.CSharp/ConstructorBodyFacts.cs`** (new) — neutral DTO:
  `ChainParameterTypes` (chained-to ctor's parameter type displays) and
  `PrimaryConstructorPrologue` (ordered `PrimaryConstructorFieldStore`s). Pure
  strings/indices; no Decompiler type crosses the seam.
- **`src/ILInspector.Decompiler/ConstructorBodyFactExtractor.cs`** (new) — the
  single owner of the chain-call and primary-constructor-prologue pattern
  matches, previously duplicated in the harness.
- **`ReturnToSenderTypePlanner.cs`** and **`FidelityCheck.cs`** now consume the
  neutral facts. Their duplicated IR walks and the `ConstructorChainCall` /
  `IsUnsupportedChainParameterType` helpers are deleted. Metadata resolution
  (parameter/field lookup, auto-property naming, surface-representability via
  `TypeShellProducer.IsUnsupportedSurfaceSignature`) stays harness-side — only
  the IR reads moved.

This is **step 1 of #2777** (dependency root of the #2782 "RTS thin
orchestrator" epic): the harness no longer reads IR to reconstruct constructor
initializers. Steps 2–3 (seam owns composition, delete `CompileBackCSharpNames`)
build on this DTO.

## Behavior

Pure refactor — the extractor replicates the moved pattern matches verbatim, so
RTS verdicts are unchanged.

## Evidence

- Full `dotnet-inspect.slnx` build clean.
- RTS oracle suites unchanged at baseline: **Evidence 3 / FixtureCatalog 82 /
  Prototype 114**; `FidelityCheckGeneratedFilter 25`; `GeneratedFixtureCatalog 18`.
- New `ConstructorBodyFactExtractorTests` (3): chained ctor → chain parameter
  types; primary-constructor prologue → ordered field stores; non-constructor →
  no facts.
- **RTS parity corpus gate** (`--corpus-fidelity-oracle rts-parity
  --rts-parity-burndown …`, 14-assembly corpus): **0 new** Exact→recompile-fail
  rows; the 7 committed burn-down rows are unchanged (gate exit 0).

## Review

RTS behavior-touching → requesting two adversarial reviews (GPT-5.5 + Gemini 3.1
Pro) in isolated worktrees. Do **not** merge without @richlander approval.
