### PR TITLE
Move C# identifier producer into the ILInspector.CSharp seam (#2777 step 2 slice)

### DIFF
--- a/src/ILInspector.CSharp.Tests/CSharpIdentifierTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpIdentifierTests.cs
@@ -1,0 +1,69 @@
+namespace ILInspector.CSharp.Tests;
+
+public sealed class CSharpIdentifierTests
+{
+    [Theory]
+    [InlineData("return", "@return")]
+    [InlineData("class", "@class")]
+    [InlineData("await", "@await")] // contextual, but illegal bare inside async bodies
+    [InlineData("value", "value")]
+    [InlineData("Foo", "Foo")]
+    public void Escape_EscapesReservedKeywordsOnly(string input, string expected)
+        => Assert.Equal(expected, CSharpIdentifier.Escape(input));
+
+    [Theory]
+    // Declaration-only contextual keywords are legal bare identifiers in expression
+    // and body position, so the position-agnostic producer must NOT escape them.
+    // Declaration-position escaping (CSharpDeclarationWriter.EscapeIdentifier) does.
+    [InlineData("record")]
+    [InlineData("required")]
+    [InlineData("init")]
+    [InlineData("file")]
+    [InlineData("scoped")]
+    public void Escape_LeavesDeclarationOnlyContextualKeywordsBare(string input)
+        => Assert.Equal(input, CSharpIdentifier.Escape(input));
+
+    [Theory]
+    [InlineData("Foo", "Foo")]                       // already spellable -> unchanged
+    [InlineData("return", "@return")]                // identifier-like keyword -> escaped
+    [InlineData("<>c__DisplayClass0_0", "___c__DisplayClass0_0")] // unspellable -> sanitized (prefix + <,> -> _)
+    [InlineData("<Foo>k__BackingField", "__Foo_k__BackingField")]
+    [InlineData("a-b", "a_b")]                       // hyphen -> underscore
+    [InlineData("1Leading", "_1Leading")]            // leading digit -> underscore prefix
+    [InlineData("", "_")]                            // empty -> underscore
+    public void Sanitize_ProducesSpellableIdentifier(string input, string expected)
+        => Assert.Equal(expected, CSharpIdentifier.Sanitize(input));
+
+    [Theory]
+    [InlineData("<>c", "___c")]
+    [InlineData("has space", "has_space")]
+    [InlineData("_ok", "_ok")]
+    public void SanitizeUnspellable_ReplacesNonIdentifierCharacters(string input, string expected)
+        => Assert.Equal(expected, CSharpIdentifier.SanitizeUnspellable(input));
+
+    [Theory]
+    [InlineData("Foo", true)]
+    [InlineData("_x", true)]
+    [InlineData("return", false)]   // escapable keyword is not usable bare
+    [InlineData("1x", false)]       // leading digit
+    [InlineData("a-b", false)]      // non-identifier char
+    [InlineData("", false)]
+    public void IsUsable_RejectsKeywordsAndNonIdentifiers(string input, bool expected)
+        => Assert.Equal(expected, CSharpIdentifier.IsUsable(input));
+
+    [Theory]
+    [InlineData("return", true)]    // escapable keyword IS an escapable identifier
+    [InlineData("Foo", true)]
+    [InlineData("a-b", false)]
+    [InlineData("<>c", false)]
+    public void IsEscapable_RecognizesIdentifierShape(string input, bool expected)
+        => Assert.Equal(expected, CSharpIdentifier.IsEscapable(input));
+
+    [Theory]
+    [InlineData("Foo", true)]
+    [InlineData("café", true)]      // Unicode letter is identifier-like
+    [InlineData("<>c", false)]
+    [InlineData("", false)]
+    public void IsIdentifierLike_UsesUnicodeGrammar(string input, bool expected)
+        => Assert.Equal(expected, CSharpIdentifier.IsIdentifierLike(input));
+}

--- a/src/ILInspector.CSharp/CSharpIdentifier.cs
+++ b/src/ILInspector.CSharp/CSharpIdentifier.cs
@@ -1,0 +1,134 @@
+using System.Globalization;
+using System.Text;
+
+namespace ILInspector.CSharp;
+
+/// <summary>
+/// The authoritative producer of spellable C# identifiers: reserved-keyword
+/// <c>@</c>-escaping and the sanitization of unspellable metadata names (names with
+/// non-identifier characters such as compiler-generated <c>&lt;&gt;c__DisplayClass</c>
+/// spellings) back into legal identifiers. These are stateless functions of their
+/// string inputs.
+/// </summary>
+/// <remarks>
+/// This is the <em>position-agnostic</em> escaper: it escapes only names that are
+/// unsafe as a bare identifier in <em>any</em> position — the always-reserved
+/// keywords plus the contextual <c>await</c> keyword (illegal bare inside async
+/// bodies). It deliberately does <em>not</em> escape declaration-only contextual
+/// keywords (<c>record</c>, <c>required</c>, <c>init</c>, <c>file</c>, <c>scoped</c>),
+/// which are legal bare identifiers in expression and body position where raised and
+/// compile-back identifiers live. Declaration-position escaping, which additionally
+/// covers those contextual keywords, is
+/// <see cref="CSharpDeclarationWriter.EscapeIdentifier"/>.
+/// </remarks>
+public static class CSharpIdentifier
+{
+    /// <summary>A name safe to emit bare as a C# identifier: valid identifier
+    /// characters and start, and not a keyword that requires an <c>@</c> escape.</summary>
+    public static bool IsUsable(string name)
+        => IsEscapable(name) && !RequiresEscape(name);
+
+    /// <summary>
+    /// A name C# can emit as an identifier, possibly via an <c>@</c> escape: valid
+    /// ASCII identifier characters and start, regardless of whether it is a reserved
+    /// keyword. This distinguishes an escapable keyword like <c>return</c> (which
+    /// <see cref="Escape"/> renders as the legal <c>@return</c>) from a fundamentally
+    /// unspellable metadata name like <c>bad-name</c>.
+    /// </summary>
+    public static bool IsEscapable(string name)
+    {
+        if (string.IsNullOrEmpty(name) || !(char.IsLetter(name[0]) || name[0] == '_'))
+            return false;
+        foreach (char c in name)
+        {
+            if (!(char.IsLetterOrDigit(c) || c == '_'))
+                return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Whether a name spells as a C# identifier under the full Unicode identifier
+    /// grammar (letters, connector/combining marks, and letter-number categories),
+    /// so that an escapable keyword or a Unicode identifier is recognized rather than
+    /// leaking a raw unspeakable name into <see cref="Sanitize"/>'s sanitizing branch.
+    /// </summary>
+    public static bool IsIdentifierLike(string name)
+    {
+        if (name.Length == 0)
+            return false;
+        bool first = true;
+        foreach (var rune in name.EnumerateRunes())
+        {
+            if (first)
+            {
+                if (!IsIdentifierStartRune(rune))
+                    return false;
+                first = false;
+            }
+            else if (!IsIdentifierPartRune(rune))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// <summary>An identifier safe to emit in C# source: a reserved keyword is
+    /// <c>@</c>-escaped (a parameter named <c>delegate</c> becomes <c>@delegate</c>).
+    /// The contextual <c>await</c> keyword is escaped too: it is illegal as a bare
+    /// identifier inside async methods, which is where recovered local functions and
+    /// parameter references can appear.</summary>
+    public static string Escape(string name)
+        => RequiresEscape(name) ? "@" + name : name;
+
+    /// <summary>The safest emittable spelling of a metadata name: an identifier-like
+    /// name is keyword-escaped, and any other name is sanitized into a legal
+    /// identifier by <see cref="SanitizeUnspellable"/>.</summary>
+    public static string Sanitize(string name)
+        => IsIdentifierLike(name) ? Escape(name) : SanitizeUnspellable(name);
+
+    /// <summary>Rewrites an unspellable metadata name into a legal C# identifier:
+    /// a non-identifier start gets a leading underscore, and every non-identifier
+    /// character becomes <c>_</c>. The result is keyword-escaped for completeness.</summary>
+    public static string SanitizeUnspellable(string name)
+    {
+        var sb = new StringBuilder(name.Length + 1);
+        if (name.Length == 0 || !(char.IsLetter(name[0]) || name[0] == '_'))
+            sb.Append('_');
+        foreach (char c in name)
+            sb.Append(char.IsLetterOrDigit(c) || c == '_' ? c : '_');
+        return RequiresEscape(sb.ToString()) ? "@" + sb : sb.ToString();
+    }
+
+    static bool RequiresEscape(string name)
+        => ReservedKeywords.Contains(name) || name == "await";
+
+    static bool IsIdentifierStartRune(Rune rune)
+        => rune.Value == '_'
+            || Rune.IsLetter(rune)
+            || Rune.GetUnicodeCategory(rune) == UnicodeCategory.LetterNumber;
+
+    static bool IsIdentifierPartRune(Rune rune)
+        => rune.Value == '_'
+            || Rune.IsLetterOrDigit(rune)
+            || Rune.GetUnicodeCategory(rune) is
+                UnicodeCategory.LetterNumber
+                or UnicodeCategory.NonSpacingMark
+                or UnicodeCategory.SpacingCombiningMark
+                or UnicodeCategory.ConnectorPunctuation
+                or UnicodeCategory.Format;
+
+    static readonly HashSet<string> ReservedKeywords = new(StringComparer.Ordinal)
+    {
+        "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked",
+        "class", "const", "continue", "decimal", "default", "delegate", "do", "double", "else",
+        "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for",
+        "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock",
+        "long", "namespace", "new", "null", "object", "operator", "out", "override", "params",
+        "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short",
+        "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true",
+        "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual",
+        "void", "volatile", "while",
+    };
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
@@ -1,17 +1,21 @@
+using ILInspector.CSharp;
+
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
-/// Pure C# identifier and name spelling utilities used by <see cref="CSharpPrinter"/>:
-/// reserved-keyword recognition, usable-identifier validation, and the decoding of
+/// C# name spelling utilities used by <see cref="CSharpPrinter"/>: the decoding of
 /// compiler-generated metadata names (auto-property backing fields, local-function
-/// mangled names) back to their source spelling. These are stateless functions of
-/// their string inputs — they hold no per-function printer state.
+/// mangled names) back to their source spelling, and thin re-exports of the seam's
+/// identifier producer (<see cref="CSharpIdentifier"/>) so printer call sites keep a
+/// single spelling entry point. The identifier escaping/sanitization policy itself
+/// lives in <c>ILInspector.CSharp</c>; these are stateless functions of their string
+/// inputs.
 /// </summary>
 internal static class CSharpNaming
 {
     /// <summary>A name safe to emit bare as a C# identifier: letters/digits/underscore, no leading digit, and not a reserved keyword (which would need an <c>@</c> escape).</summary>
     public static bool IsUsableIdentifier(string name)
-        => IsEscapableIdentifier(name) && !RequiresEscape(name);
+        => CSharpIdentifier.IsUsable(name);
 
     /// <summary>
     /// A name C# can emit as an identifier, possibly via an <c>@</c> escape: valid
@@ -21,16 +25,7 @@ internal static class CSharpNaming
     /// fundamentally unspellable metadata name like <c>bad-name</c>.
     /// </summary>
     public static bool IsEscapableIdentifier(string name)
-    {
-        if (string.IsNullOrEmpty(name) || !(char.IsLetter(name[0]) || name[0] == '_'))
-            return false;
-        foreach (char c in name)
-        {
-            if (!(char.IsLetterOrDigit(c) || c == '_'))
-                return false;
-        }
-        return true;
-    }
+        => CSharpIdentifier.IsEscapable(name);
 
     /// <summary>An identifier safe to emit in C# source: a reserved keyword is
     /// <c>@</c>-escaped (a parameter named <c>delegate</c> becomes
@@ -38,10 +33,10 @@ internal static class CSharpNaming
     /// is illegal as a bare identifier inside async methods, which is where
     /// recovered local functions and parameter references can appear.</summary>
     public static string EscapeIdentifier(string name)
-        => RequiresEscape(name) ? "@" + name : name;
+        => CSharpIdentifier.Escape(name);
 
     public static string SafeIdentifier(string name)
-        => IsIdentifierLike(name) ? EscapeIdentifier(name) : SanitizeUnspellableIdentifier(name);
+        => CSharpIdentifier.Sanitize(name);
 
     public static string SourceMethodName(string metadataName)
     {
@@ -51,22 +46,6 @@ internal static class CSharpNaming
 
     public static string TypeNameSegment(string metadataName)
         => SafeIdentifier(StripArity(metadataName));
-
-    static bool RequiresEscape(string name)
-        => ReservedKeywords.Contains(name) || name == "await";
-
-    static readonly HashSet<string> ReservedKeywords = new(StringComparer.Ordinal)
-    {
-        "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked",
-        "class", "const", "continue", "decimal", "default", "delegate", "do", "double", "else",
-        "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for",
-        "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock",
-        "long", "namespace", "new", "null", "object", "operator", "out", "override", "params",
-        "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short",
-        "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true",
-        "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual",
-        "void", "volatile", "while",
-    };
 
     /// <summary>The property name an auto-property backing field <c>&lt;Prop&gt;k__BackingField</c> backs, or null for an ordinary field.</summary>
     public static string? BackingFieldProperty(string fieldName)
@@ -90,55 +69,10 @@ internal static class CSharpNaming
         return fieldName.Length > suffix.Length + 1
             && fieldName[0] == '<'
             && fieldName.EndsWith(suffix, StringComparison.Ordinal)
-            && IsIdentifierLike(fieldName[1..^suffix.Length])
+            && CSharpIdentifier.IsIdentifierLike(fieldName[1..^suffix.Length])
             ? fieldName[1..^suffix.Length]
             : null;
     }
-
-    /// <summary>
-    /// A Unicode-aware C# identifier shape, evaluated per Rune so astral-plane
-    /// (surrogate-pair) characters classify correctly. Looser than
-    /// <see cref="IsEscapableIdentifier"/> (which is ASCII-ish): the start is a
-    /// letter, letter-number, or <c>_</c>, and each part adds digits, combining
-    /// marks, connectors, and format characters — the C# identifier rule. So a
-    /// recovered metadata name whose source identifier uses a valid Unicode
-    /// character is recognized rather than leaking the raw unspeakable name.
-    /// </summary>
-    static bool IsIdentifierLike(string name)
-    {
-        if (name.Length == 0)
-            return false;
-        bool first = true;
-        foreach (var rune in name.EnumerateRunes())
-        {
-            if (first)
-            {
-                if (!IsIdentifierStartRune(rune))
-                    return false;
-                first = false;
-            }
-            else if (!IsIdentifierPartRune(rune))
-            {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    static bool IsIdentifierStartRune(System.Text.Rune rune)
-        => rune.Value == '_'
-            || System.Text.Rune.IsLetter(rune)
-            || System.Text.Rune.GetUnicodeCategory(rune) == System.Globalization.UnicodeCategory.LetterNumber;
-
-    static bool IsIdentifierPartRune(System.Text.Rune rune)
-        => rune.Value == '_'
-            || System.Text.Rune.IsLetterOrDigit(rune)
-            || System.Text.Rune.GetUnicodeCategory(rune) is
-                System.Globalization.UnicodeCategory.LetterNumber
-                or System.Globalization.UnicodeCategory.NonSpacingMark
-                or System.Globalization.UnicodeCategory.SpacingCombiningMark
-                or System.Globalization.UnicodeCategory.ConnectorPunctuation
-                or System.Globalization.UnicodeCategory.Format;
 
     /// <summary>
     /// The source name of a call target. A compiler-generated local function
@@ -162,15 +96,5 @@ internal static class CSharpNaming
     {
         int tick = name.IndexOf('`');
         return tick < 0 ? name : name[..tick];
-    }
-
-    static string SanitizeUnspellableIdentifier(string name)
-    {
-        var sb = new System.Text.StringBuilder(name.Length + 1);
-        if (name.Length == 0 || !(char.IsLetter(name[0]) || name[0] == '_'))
-            sb.Append('_');
-        foreach (char c in name)
-            sb.Append(char.IsLetterOrDigit(c) || c == '_' ? c : '_');
-        return RequiresEscape(sb.ToString()) ? "@" + sb : sb.ToString();
     }
 }

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -45,7 +45,7 @@ static class CompileBackCSharpNames
                     int end = close + 1;
                     while (end < type.Length && IsGeneratedTypeSuffixChar(type[end]))
                         end++;
-                    sb.Append(CSharpNaming.SafeIdentifier(type[i..end]));
+                    sb.Append(CSharpIdentifier.Sanitize(type[i..end]));
                     i = end;
                     continue;
                 }
@@ -79,7 +79,7 @@ static class CompileBackCSharpNames
         return tick >= 0 ? name[..tick] : name;
     }
 
-    public static string Identifier(string name) => CSharpNaming.SafeIdentifier(name);
+    public static string Identifier(string name) => CSharpIdentifier.Sanitize(name);
 
     public static string EscapeNamespace(string ns)
         => CSharpFormatter.EscapeNamespace(ns);

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Reflection.PortableExecutable;
+using ILInspector.CSharp;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Metadata;
@@ -713,8 +714,8 @@ static class ValidityCheck
 
     static string ParameterText(Parameter parameter)
         => parameter.Type.Kind == TypeRefKind.ByRef
-            ? $"ref {TypeText(parameter.Type.ElementType!)} {CSharpNaming.EscapeIdentifier(parameter.Name)}"
-            : $"{TypeText(parameter.Type)} {CSharpNaming.EscapeIdentifier(parameter.Name)}";
+            ? $"ref {TypeText(parameter.Type.ElementType!)} {CSharpIdentifier.Escape(parameter.Name)}"
+            : $"{TypeText(parameter.Type)} {CSharpIdentifier.Escape(parameter.Name)}";
 
     static string TypeText(TypeRef type)
     {


### PR DESCRIPTION
## Why

Part of #2777 (make ReturnToSender a thin orchestrator; epic #2782). RTS's
compile-back path and other harness call sites reached into the **Decompiler's
internal** `CSharpNaming` for C# identifier spelling (keyword `@`-escaping +
unspellable-metadata-name sanitization). That put a piece of the C# spelling
policy inside the Decompiler and forced the harness to depend on Decompiler
internals for it.

This PR relocates the identifier **producer** into the `ILInspector.CSharp`
seam so the seam owns identifier spelling and consumers delegate.

## What

- **NEW** `src/ILInspector.CSharp/CSharpIdentifier.cs` — the authoritative,
  position-agnostic identifier producer: `IsUsable`, `IsEscapable`,
  `IsIdentifierLike`, `Escape`, `Sanitize`, `SanitizeUnspellable`. It carries the
  **exact** base-keyword + `await` policy the Decompiler enforced.
- `CSharpNaming` (Decompiler) producer members become **thin forwarders**; the
  private policy internals (`RequiresEscape`, `ReservedKeywords`,
  `IsIdentifierLike`, `SanitizeUnspellableIdentifier`) are deleted.
- Harness repoints its three producer reach-ins
  (`CompileBackCSharpNames.SanitizeGeneratedTypeSegments`/`.Identifier`,
  `ValidityCheck.ParameterText`) at `CSharpIdentifier`.

## Behavior-preserving — three deliberate notes

1. **Two escapers coexist by design.** `CSharpIdentifier.Escape` is
   *position-agnostic*: it escapes only names unsafe as a bare identifier in
   **any** position (reserved keywords + `await`). It deliberately leaves the
   *declaration-only* contextual keywords (`record`/`required`/`init`/`file`/`scoped`)
   bare — they are legal identifiers in the expression/body positions where raised
   and compile-back identifiers live. Declaration-position escaping (which also
   covers those) stays in `CSharpDeclarationWriter.EscapeIdentifier`. Preserving
   the base+`await` set (not the extended set) is what keeps Decompiler printer
   output byte-identical. Locked by negative tests.
2. **Name *decoding* stays in the Decompiler.** `MethodName`/`SourceMethodName`
   (un-mangling `<Enclosing>g__Local|N_M`), backing-field decoding, etc. are a
   generated-name-decoding concern, not identifier spelling. Out of scope.
3. **tokenize-before-sanitize / `SanitizeQualified` is deferred** to the later
   composition slice. It has no consumer yet, so adding it now would be dead code
   with no nested-type canary. It lands with the slice that routes qualified names
   through the seam.

## Evidence

- Full `dotnet-inspect.slnx` Release build clean.
- **NEW** `CSharpIdentifierTests` (34) lock the base+`await` policy, including
  negative cases that assert the declaration-only contextual keywords are NOT
  escaped.
- `ILInspector.Decompiler.Tests` fast subset **2476** pass — printer byte-identity
  preserved.
- RTS oracle: Evidence/FixtureCatalog/Generated **103** + Prototype **114**.
- RTS parity corpus gate (14 assemblies, `rts-parity` oracle + committed burn-down
  manifest): **exit 0**, the **7** committed burn-down rows unchanged, **0 new**
  Exact→recompile-fail regressions.

## Review

Behavior-changing surface is subtle (identifier escaping), so this needs two
non-Opus adversarial reviews per AGENTS.md. Attack points: keyword-policy
divergence (did any Decompiler printer / harness output change?), forwarder
faithfulness, deleted-internal completeness.

Do **not** merge without @richlander approval.
