### PR TITLE
Add intra-process cache single-flight coordination

### DIFF
--- a/src/DotnetInspector.Core/AsyncCache.cs
+++ b/src/DotnetInspector.Core/AsyncCache.cs
@@ -1,0 +1,94 @@
+using System.Collections.Concurrent;
+
+namespace DotnetInspector.Core;
+
+/// <summary>
+/// Shares one asynchronous resolution per key and retains successful results.
+/// Faulted and cancelled resolutions are removed so a later request can retry.
+/// Cancellation captured by a value factory affects every waiter sharing that
+/// resolution; caller-only cancellation should cancel the wait, not the factory.
+/// </summary>
+public sealed class AsyncCache<TKey, TValue> where TKey : notnull
+{
+    private readonly ConcurrentDictionary<TKey, Lazy<Task<TValue>>> _entries;
+
+    public AsyncCache(IEqualityComparer<TKey>? comparer = null)
+    {
+        _entries = new ConcurrentDictionary<TKey, Lazy<Task<TValue>>>(
+            comparer ?? EqualityComparer<TKey>.Default);
+    }
+
+    /// <summary>
+    /// Returns the existing resolution task for <paramref name="key"/>, or
+    /// publishes one new resolution task. Concurrent callers receive the exact
+    /// same task.
+    /// </summary>
+    /// <param name="shouldCache">
+    /// Optional predicate that decides whether a successfully resolved value
+    /// remains cached. A rejected value is still returned to current waiters,
+    /// but a later request can retry. The factory and predicate from the entry
+    /// that wins publication define the shared resolution.
+    /// </param>
+    public Task<TValue> GetOrAddAsync(
+        TKey key,
+        Func<TKey, Task<TValue>> valueFactory,
+        Func<TValue, bool>? shouldCache = null)
+    {
+        ArgumentNullException.ThrowIfNull(valueFactory);
+
+        Lazy<Task<TValue>>? candidate = null;
+        candidate = new Lazy<Task<TValue>>(
+            () => ResolveAsync(
+                key,
+                valueFactory,
+                shouldCache,
+                candidate!),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+
+        return _entries.GetOrAdd(key, candidate).Value;
+    }
+
+    /// <summary>
+    /// Removes <paramref name="key"/> only when it still identifies
+    /// <paramref name="task"/>.
+    /// </summary>
+    public bool TryRemove(TKey key, Task<TValue> task)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+
+        if (!_entries.TryGetValue(key, out var entry)
+            || !entry.IsValueCreated
+            || !ReferenceEquals(entry.Value, task))
+        {
+            return false;
+        }
+
+        return Remove(key, entry);
+    }
+
+    public void Clear() => _entries.Clear();
+
+    private async Task<TValue> ResolveAsync(
+        TKey key,
+        Func<TKey, Task<TValue>> valueFactory,
+        Func<TValue, bool>? shouldCache,
+        Lazy<Task<TValue>> entry)
+    {
+        try
+        {
+            TValue value = await valueFactory(key).ConfigureAwait(false);
+            if (shouldCache is not null && !shouldCache(value))
+                Remove(key, entry);
+            return value;
+        }
+        catch
+        {
+            Remove(key, entry);
+            throw;
+        }
+    }
+
+    private bool Remove(TKey key, Lazy<Task<TValue>> entry)
+        => ((ICollection<KeyValuePair<TKey, Lazy<Task<TValue>>>>)_entries)
+            .Remove(new KeyValuePair<TKey, Lazy<Task<TValue>>>(key, entry));
+}

--- a/src/DotnetInspector.Core/CoreCache.cs
+++ b/src/DotnetInspector.Core/CoreCache.cs
@@ -15,10 +15,10 @@ public static class CoreCache
     private static readonly object s_maintenanceLock = new();
     private static readonly List<VersionedCacheCategory> s_versionedCategories = [];
     private static CancellationTokenSource? s_maintenanceCts;
-    private static Task? s_maintenanceTask;
-    private static int s_maintenanceScheduled;
-    private static long s_maintenanceBytesFreed;
-    private static int s_maintenanceDirectoriesDeleted;
+    private static Task<CacheMaintenanceResult>? s_maintenanceTask;
+    private static CacheMaintenanceProgress? s_maintenanceProgress;
+    private static AsyncCache<string, CacheMaintenanceResult> s_maintenanceRequests =
+        new(StringComparer.Ordinal);
 
     /// <summary>
     /// Initializes the cache with the application name used for the cache directory.
@@ -32,11 +32,12 @@ public static class CoreCache
         lock (s_maintenanceLock)
         {
             s_maintenanceCts?.Cancel();
+            s_maintenanceCts?.Dispose();
             s_maintenanceCts = null;
             s_maintenanceTask = null;
-            s_maintenanceScheduled = 0;
-            s_maintenanceBytesFreed = 0;
-            s_maintenanceDirectoriesDeleted = 0;
+            s_maintenanceProgress = null;
+            s_maintenanceRequests = new AsyncCache<string, CacheMaintenanceResult>(
+                StringComparer.Ordinal);
         }
     }
 
@@ -363,12 +364,14 @@ public static class CoreCache
     /// </summary>
     public static CacheMaintenanceResult CancelAndWaitForMaintenance(TimeSpan timeout)
     {
-        Task? task;
+        Task<CacheMaintenanceResult>? task;
         CancellationTokenSource? cts;
+        CacheMaintenanceProgress? progress;
         lock (s_maintenanceLock)
         {
             task = s_maintenanceTask;
             cts = s_maintenanceCts;
+            progress = s_maintenanceProgress;
         }
 
         if (task != null)
@@ -387,9 +390,10 @@ public static class CoreCache
             }
         }
 
-        return new CacheMaintenanceResult(
-            Interlocked.Read(ref s_maintenanceBytesFreed),
-            Volatile.Read(ref s_maintenanceDirectoriesDeleted));
+        if (task is { IsCompletedSuccessfully: true })
+            return task.Result;
+
+        return progress?.Snapshot() ?? default;
     }
 
     /// <summary>
@@ -415,51 +419,57 @@ public static class CoreCache
     private static void RecordCacheMiss()
     {
         InfoTracker.RecordCacheMiss();
-        ScheduleMaintenanceOnMiss();
+        _ = RequestVersionedCategoryCleanupAsync();
     }
 
-    private static void ScheduleMaintenanceOnMiss()
+    /// <summary>
+    /// Returns the single versioned-category cleanup task used by cache-miss
+    /// maintenance so callers can observe or drain the real operation.
+    /// </summary>
+    internal static Task<CacheMaintenanceResult> RequestVersionedCategoryCleanupAsync()
     {
-        if (Volatile.Read(ref s_maintenanceScheduled) != 0)
-            return;
-
-        VersionedCacheCategory[] categories;
-        string root;
         lock (s_maintenanceLock)
         {
-            if (s_maintenanceScheduled != 0)
-                return;
             if (s_versionedCategories.Count == 0)
-                return;
+                return Task.FromResult(default(CacheMaintenanceResult));
 
-            try
-            {
-                root = GetBasePath();
-            }
-            catch
-            {
-                return;
-            }
-            s_maintenanceScheduled = 1;
-            categories = [.. s_versionedCategories];
+            string root = GetBasePath();
+
+            if (s_maintenanceTask is { IsFaulted: false, IsCanceled: false })
+                return s_maintenanceTask;
+
+            VersionedCacheCategory[] categories = [.. s_versionedCategories];
+            s_maintenanceCts?.Dispose();
             s_maintenanceCts = new CancellationTokenSource();
+            s_maintenanceProgress = new CacheMaintenanceProgress();
             var token = s_maintenanceCts.Token;
-            s_maintenanceTask = Task.Run(() => CleanupVersionedCategories(root, categories, token), CancellationToken.None);
+            var progress = s_maintenanceProgress;
+            s_maintenanceTask = s_maintenanceRequests.GetOrAddAsync(
+                root,
+                _ => Task.Run(
+                    () => CleanupVersionedCategories(
+                        root,
+                        categories,
+                        token,
+                        progress),
+                    CancellationToken.None));
+            return s_maintenanceTask;
         }
     }
 
-    private static void CleanupVersionedCategories(
+    private static CacheMaintenanceResult CleanupVersionedCategories(
         string root,
         IReadOnlyList<VersionedCacheCategory> categories,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        CacheMaintenanceProgress progress)
     {
         if (!Directory.Exists(root))
-            return;
+            return progress.Snapshot();
 
         foreach (var category in categories)
         {
             if (cancellationToken.IsCancellationRequested)
-                return;
+                return progress.Snapshot();
 
             string[] directories;
             try
@@ -474,7 +484,7 @@ public static class CoreCache
             foreach (var directory in directories)
             {
                 if (cancellationToken.IsCancellationRequested)
-                    return;
+                    return progress.Snapshot();
 
                 var name = Path.GetFileName(directory);
                 if (name.Equals(category.Current, StringComparison.OrdinalIgnoreCase))
@@ -488,8 +498,7 @@ public static class CoreCache
                 try
                 {
                     Directory.Delete(directory, recursive: true);
-                    Interlocked.Add(ref s_maintenanceBytesFreed, size);
-                    Interlocked.Increment(ref s_maintenanceDirectoriesDeleted);
+                    progress.RecordDeletion(size);
                 }
                 catch
                 {
@@ -497,6 +506,8 @@ public static class CoreCache
                 }
             }
         }
+
+        return progress.Snapshot();
     }
 
     private static long GetDirectorySizeBestEffort(string path)
@@ -535,6 +546,23 @@ public static class CoreCache
 public readonly record struct CacheMaintenanceResult(long BytesFreed, int DirectoriesDeleted);
 
 internal readonly record struct VersionedCacheCategory(string Prefix, string Current);
+
+internal sealed class CacheMaintenanceProgress
+{
+    private long _bytesFreed;
+    private int _directoriesDeleted;
+
+    public void RecordDeletion(long bytesFreed)
+    {
+        Interlocked.Add(ref _bytesFreed, bytesFreed);
+        Interlocked.Increment(ref _directoriesDeleted);
+    }
+
+    public CacheMaintenanceResult Snapshot()
+        => new(
+            Interlocked.Read(ref _bytesFreed),
+            Volatile.Read(ref _directoriesDeleted));
+}
 
 /// <summary>
 /// Cache statistics for a category or the entire cache.

--- a/src/DotnetInspector.Services.Tests/AsyncCacheTests.cs
+++ b/src/DotnetInspector.Services.Tests/AsyncCacheTests.cs
@@ -1,0 +1,99 @@
+using DotnetInspector.Core;
+
+namespace DotnetInspector.Services.Tests;
+
+public class AsyncCacheTests
+{
+    [Fact]
+    public async Task GetOrAddAsync_ConcurrentRequestsShareOneTask()
+    {
+        var cache = new AsyncCache<string, object>();
+        var release = new TaskCompletionSource<object>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        int invocations = 0;
+
+        Task<object>[] requests = Enumerable.Range(0, 32)
+            .Select(_ => cache.GetOrAddAsync(
+                "key",
+                _ =>
+                {
+                    Interlocked.Increment(ref invocations);
+                    return release.Task;
+                }))
+            .ToArray();
+
+        Assert.All(requests, request => Assert.Same(requests[0], request));
+        Assert.Equal(1, Volatile.Read(ref invocations));
+
+        var value = new object();
+        release.SetResult(value);
+        object[] results = await Task.WhenAll(requests);
+
+        Assert.All(results, result => Assert.Same(value, result));
+        Assert.Same(
+            requests[0],
+            cache.GetOrAddAsync(
+                "key",
+                _ => Task.FromResult(new object())));
+    }
+
+    [Fact]
+    public async Task GetOrAddAsync_FaultedResolutionCanRetry()
+    {
+        var cache = new AsyncCache<string, int>();
+        var failure = new InvalidOperationException("failed");
+
+        var first = cache.GetOrAddAsync(
+            "key",
+            _ => Task.FromException<int>(failure));
+
+        Assert.Same(failure, await Assert.ThrowsAsync<InvalidOperationException>(() => first));
+
+        var second = cache.GetOrAddAsync(
+            "key",
+            _ => Task.FromResult(42));
+
+        Assert.NotSame(first, second);
+        Assert.Equal(42, await second);
+    }
+
+    [Fact]
+    public async Task GetOrAddAsync_CancelledResolutionCanRetry()
+    {
+        var cache = new AsyncCache<string, int>();
+
+        var first = cache.GetOrAddAsync(
+            "key",
+            _ => Task.FromCanceled<int>(new CancellationToken(canceled: true)));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => first);
+
+        var second = cache.GetOrAddAsync(
+            "key",
+            _ => Task.FromResult(42));
+
+        Assert.NotSame(first, second);
+        Assert.Equal(42, await second);
+    }
+
+    [Fact]
+    public async Task GetOrAddAsync_RejectedResultCanRetry()
+    {
+        var cache = new AsyncCache<string, string?>();
+
+        var first = cache.GetOrAddAsync(
+            "key",
+            _ => Task.FromResult<string?>(null),
+            static value => value is not null);
+
+        Assert.Null(await first);
+
+        var second = cache.GetOrAddAsync(
+            "key",
+            _ => Task.FromResult<string?>("value"),
+            static value => value is not null);
+
+        Assert.NotSame(first, second);
+        Assert.Equal("value", await second);
+    }
+}

--- a/src/DotnetInspector.Services.Tests/AuthoredSourceAcquisitionTests.cs
+++ b/src/DotnetInspector.Services.Tests/AuthoredSourceAcquisitionTests.cs
@@ -153,6 +153,43 @@ public class AuthoredSourceAcquisitionTests
         }
     }
 
+    [Fact]
+    public async Task FetchSource_ConcurrentRequestsShareNetworkOperation()
+    {
+        string cachePath = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-source-cache-{Guid.NewGuid():N}");
+        CoreCache.Initialize("dotnet-inspect-test", cachePath);
+        var handler = new GatedStringHandler(Source);
+        using var client = new HttpClient(handler);
+        var fetcher = new SourceFetcher(client);
+        const string Url = "https://example.test/Shared.cs";
+
+        try
+        {
+            Task<string?>[] requests = Enumerable.Range(0, 32)
+                .Select(_ => fetcher.FetchSourceAsync(Url))
+                .ToArray();
+
+            Assert.All(requests, request => Assert.Same(requests[0], request));
+            await handler.RequestStarted;
+            Assert.Equal(1, handler.RequestCount);
+
+            handler.Release();
+            string?[] results = await Task.WhenAll(requests);
+
+            Assert.All(results, result => Assert.Equal(Source, result));
+            Assert.Same(requests[0], fetcher.FetchSourceAsync(Url));
+            Assert.Equal(1, handler.RequestCount);
+        }
+        finally
+        {
+            handler.Release();
+            if (Directory.Exists(cachePath))
+                Directory.Delete(cachePath, recursive: true);
+        }
+    }
+
     static MemberSourceObservation Mapping()
         => new(
             new MemberAnchor(
@@ -195,6 +232,34 @@ public class AuthoredSourceAcquisitionTests
             {
                 Content = new ByteArrayContent(_responses.Dequeue()),
             });
+        }
+    }
+
+    sealed class GatedStringHandler(string response) : HttpMessageHandler
+    {
+        readonly TaskCompletionSource<bool> _requestStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        readonly TaskCompletionSource<bool> _release =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        int _requestCount;
+
+        public Task RequestStarted => _requestStarted.Task;
+
+        public int RequestCount => Volatile.Read(ref _requestCount);
+
+        public void Release() => _release.TrySetResult(true);
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _requestCount);
+            _requestStarted.TrySetResult(true);
+            await _release.Task.WaitAsync(cancellationToken);
+            return new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent(response),
+            };
         }
     }
 }

--- a/src/DotnetInspector.Services/SourceFetcher.cs
+++ b/src/DotnetInspector.Services/SourceFetcher.cs
@@ -10,7 +10,7 @@ namespace DotnetInspector.Services;
 /// </summary>
 public class SourceFetcher(HttpClient httpClient)
 {
-    private readonly ConcurrentDictionary<string, string> _memoryCache = new();
+    private readonly AsyncCache<string, string?> _sourceCache = new();
     private readonly ConcurrentDictionary<string, byte[]> _byteMemoryCache = new();
     private readonly HttpClient _httpClient = httpClient;
     private const string ByteCacheCategory = "source-bytes-v1";
@@ -20,32 +20,31 @@ public class SourceFetcher(HttpClient httpClient)
     /// Checks in-memory cache first, then disk cache, then fetches from network.
     /// Returns null if the fetch fails.
     /// </summary>
-    public async Task<string?> FetchSourceAsync(string url)
+    public Task<string?> FetchSourceAsync(string url)
     {
-        using var trafficScope = NetworkTelemetry.Scope(NetworkTrafficKind.SourceFetch);
-
         // URLs originate in untrusted artifacts (SourceLink data in a PDB). Restrict to absolute
         // http/https so attacker-supplied mappings cannot reach file:// or other schemes. The
         // injected HttpClient is additionally SSRF-hardened against private/internal IPs.
         if (!Uri.TryCreate(url, UriKind.Absolute, out var parsed)
             || (parsed.Scheme != Uri.UriSchemeHttps && parsed.Scheme != Uri.UriSchemeHttp))
         {
-            return null;
+            return Task.FromResult<string?>(null);
         }
 
-        // Check in-memory cache first
-        if (_memoryCache.TryGetValue(url, out string? cached))
-        {
-            return cached;
-        }
+        return _sourceCache.GetOrAddAsync(
+            url,
+            FetchSourceCoreAsync,
+            static content => content is not null);
+    }
+
+    private async Task<string?> FetchSourceCoreAsync(string url)
+    {
+        using var trafficScope = NetworkTelemetry.Scope(NetworkTrafficKind.SourceFetch);
 
         // Check persistent disk cache
         var diskCached = PackageCacheService.TryGetCachedSource(url);
         if (diskCached != null)
-        {
-            _memoryCache[url] = diskCached;
             return diskCached;
-        }
 
         // Fetch from network with retry
         try
@@ -55,7 +54,6 @@ public class SourceFetcher(HttpClient httpClient)
                 trafficKind: NetworkTrafficKind.SourceFetch).ConfigureAwait(false);
             if (content == null)
                 return null;
-            _memoryCache[url] = content;
             PackageCacheService.CacheSource(url, content);
             return content;
         }

--- a/src/dotnet-inspect.Tests/CacheCommandTests.cs
+++ b/src/dotnet-inspect.Tests/CacheCommandTests.cs
@@ -57,7 +57,7 @@ public class CacheCommandTests : IDisposable
     }
 
     [Fact]
-    public void CacheMiss_CleansObsoleteVersionedCategories()
+    public async Task CacheMiss_CleansObsoleteVersionedCategories()
     {
         var oldDir = Path.Combine(_cacheBasePath, "pkg-index-v9");
         var currentDir = Path.Combine(_cacheBasePath, PackageIndexCache.Category);
@@ -69,7 +69,9 @@ public class CacheCommandTests : IDisposable
         CoreCache.RegisterVersionedCategory("pkg-index-v", PackageIndexCache.Category);
 
         Assert.Null(CoreCache.TryGet("versions", $"missing-{Guid.NewGuid():N}", extension: "txt"));
-        var result = CoreCache.CancelAndWaitForMaintenance(TimeSpan.FromSeconds(5));
+        var cleanup = CoreCache.RequestVersionedCategoryCleanupAsync();
+        Assert.Same(cleanup, CoreCache.RequestVersionedCategoryCleanupAsync());
+        var result = await cleanup;
 
         Assert.False(Directory.Exists(oldDir));
         Assert.True(Directory.Exists(currentDir));


### PR DESCRIPTION
## Summary

- add `AsyncCache<TKey, TValue>` as the Core-owned intra-process
  single-flight primitive: concurrent callers receive the exact shared task,
  accepted results are retained, and faults, cancellation, and rejected
  results remain retryable
- adopt it for same-URL source acquisition so one `SourceFetcher` performs one
  disk/network operation per URL
- make cache-miss maintenance expose and retain its real production task with
  per-run progress, allowing the deterministic cleanup test to await production
  behavior rather than use a synchronous bypass or timeout

This supersedes #2790 and fixes #2744 with a general product capability rather
than a test-only cleanup seam.

## Boundaries

This PR addresses intra-process coordination. Atomic file publication,
transactional package-directory publication, and cross-process coordination
remain separate follow-ups because they have different commit and locking
models.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config` on
  .NET SDK `11.0.100-preview.6.26359.118`: 0 warnings, 0 errors
- `DotnetInspector.Services.Tests`: 264 passed
- `dotnet-inspect.Tests`: 1,902 passed, 10 expected missing-ilasm/ildasm skips
- focused concurrency coverage proves exact task identity, one producer,
  successful retention, and retry after fault, cancellation, or rejected value
- production `SourceFetcher` canary proves 32 requests share one network
  operation; maintenance coverage awaits the cache-miss operation itself

## Adversarial review

Reviewed at exact head `ee83cb71` against `b62fd502`:

- Claude Opus 4.8: **CLEAN**
- Gemini 3.1 Pro: **CLEAN**

Gemini additionally ran a 64-thread exact-task/ABA repro and the complete
Services test suite. Neither reviewer reported blocking, non-blocking, or
pre-existing findings. The explicit non-actions are the publication and
cross-process boundaries above.
