### PR TITLE
Harden manifest resource extraction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ READMEs, and focused skills.
 | --- | --- |
 | Commands, sections, and output | `docs/design/progressive-disclosure.md`, `docs/design/output-shapes.md`, `docs/design/style-guide.md`, `docs/design/section-model.md` |
 | Metadata, source, and acquisition | `docs/design/assembly-inspection-query.md`, `docs/design/source-finding-producers.md`, `docs/pdb-acquisition.md`, `docs/design/version-resolution.md` |
+| Security and untrusted input | `docs/design/untrusted-data-threat-model.md` |
 | Analysis, Findings, and Research | `docs/design/finding-nomenclature.md`, `docs/design/finding-producers.md`, `docs/design/finding-adoption.md`, `docs/design/finding-coordinates.md`, `docs/design/analysis-ux-scopes.md` |
 | Shared IL/control-flow substrate | `docs/design/instruction-substrate.md`, plus the consuming subsystem's docs |
 | Decompiler behavior or harnesses | `docs/decompiler-quality.md`, `docs/decompiler-correctness-pipeline.md`, `docs/decompiler-raise-discipline.md`, `docs/design/decompiler-substrate.md`, `tools/DecompilerHarness/README.md` |

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -1,0 +1,201 @@
+# Untrusted Data Threat Model
+
+`dotnet-inspect` reads artifacts that may be malformed or intentionally hostile.
+Inspection must not grant those artifacts authority to execute code, choose
+network destinations, escape storage boundaries, or turn malformed input into
+unbounded work.
+
+This document records the trust boundaries and security rules for product code.
+It is a living model: new acquisition paths, parsers, caches, or output features
+must update the relevant boundary and verification obligations.
+
+## Security objectives
+
+The product must:
+
+1. Inspect assemblies without loading or executing them.
+2. Keep artifact-derived paths inside an explicit caller- or product-owned root.
+3. Treat artifact-derived URLs as untrusted network destinations.
+4. Bound CPU, memory, network, archive, and recursion work where hostile input
+   can amplify it.
+5. Keep malformed-input failures visible rather than returning plausible,
+   success-shaped output.
+6. Treat rendered artifact text as data, not terminal commands, markup
+   authority, or agent instructions.
+
+The product path remains SRM-only, NativeAOT-friendly, Roslyn-free, and free of
+inspected-assembly loading. Those architectural constraints are security
+boundaries as well as deployment choices.
+
+## Trust boundaries
+
+| Boundary | Untrusted input | Trusted side | Primary risks |
+| --- | --- | --- | --- |
+| Assembly inspection | PE headers, metadata tables, signatures, IL, resources | Metadata, Instructions, Analysis, Decompiler | Parser crashes, recursion or allocation denial of service, path derivation, misleading identities |
+| Package acquisition | `.nupkg` / `.snupkg`, nuspec and package file names, feed responses | Package extraction and cache roots | Archive traversal, disk exhaustion, cache poisoning, dependency confusion |
+| Symbols and source | Portable/embedded PDBs, SourceLink maps, document names, checksums, source URLs and content | PDB sessions, source cache, source rendering | SSRF, local-file access, cache escape, oversized downloads, spoofed provenance |
+| Restored project inputs | `project.assets.json`, `.deps.json`, runtime/tool settings, paths within those files | Project and dependency resolvers | Path confusion, unintended file reads, excessive graph expansion |
+| Filesystem output | Resource names, generated file names, user-selected output paths | Explicit output or cache directory | Arbitrary write, overwrite, symlink/reparse escape, partial output |
+| Presentation | Names, documentation, source, paths, diagnostics, package metadata | Terminal, Markdown/JSON consumers, agents | Terminal control injection, broken structured output, prompt-like content treated as authority |
+
+User-supplied local paths are trusted as *locations the user chose*, but the
+contents found there are not trusted. Product cache directories and
+process-created temporary directories are trusted roots; names appended beneath
+them are not trusted unless derived from a cryptographic key or validated
+component.
+
+## Existing controls
+
+### Assemblies are parsed, never loaded
+
+Assembly, metadata, and method-body paths use
+`System.Reflection.PortableExecutable` and `System.Reflection.Metadata`. Product
+inspection must not introduce `Assembly.Load`, `AssemblyLoadContext`, reflection
+over inspected binaries, module initializers, or dependency resolution that
+executes target code.
+
+Reader-backed values remain inside their owning session. Values that cross a
+session boundary are copied or reduced to immutable tokens and shapes. This
+prevents use-after-dispose and avoids lending privileged readers to higher
+layers.
+
+### Package archives use traversal-aware extraction
+
+NuGet package and symbol-package extraction uses
+`ZipFile.ExtractToDirectory`, which rejects archive entries that escape the
+destination directory. Extraction occurs under process-created temporary
+directories before selected content is copied into product caches.
+
+Package identifiers and versions used as cache path components pass
+`NuGetCache.ValidatePathComponent`. General cache entries use SHA-256-derived
+keys through `CoreCache`.
+
+Archive containment does not itself bound expanded bytes, entry count, or disk
+consumption. Resource budgets remain an open requirement below.
+
+### Artifact-derived source URLs use an SSRF-hardened client
+
+SourceLink and other artifact-derived fetches must use
+`HttpClientFactory.SharedUntrustedFetch`. It allows only HTTP(S), resolves every
+connection including redirects, and rejects loopback, link-local, private,
+CGNAT, multicast, unspecified, and reserved destinations. Callers must not
+replace it with the general shared client.
+
+Checksums from portable PDB documents authenticate source content when the
+workflow claims authored-source integrity. A reachable URL without a matching
+checksum is not equivalent to verified source.
+
+## Resource extraction contract
+
+Manifest resource names are attacker-controlled metadata. They are not safe
+paths merely because a compiler normally emits dotted logical names.
+
+Resource extraction therefore follows this contract:
+
+- Preserve nested resource paths only after validating every component.
+- Treat both `/` and `\` as separators on every platform.
+- Reject rooted and drive-qualified names, empty components, `.` and `..`,
+  control characters, a fixed portable set of invalid filename characters,
+  alternate data stream syntax, trailing dot/space aliases, and Windows device
+  names.
+- Normalize and case-fold destination identities so extraction has one
+  deterministic collision policy across operating systems and filesystems.
+- Preflight all resource data ranges and destination paths before creating the
+  output directory or writing any resource.
+- Reject malformed resource payloads, duplicate destinations, and
+  file/directory prefix conflicts.
+- Reject existing destination files; extraction never overwrites.
+- Reject existing symbolic-link or reparse-point components beneath the output
+  root.
+- Open destination files with create-new semantics so a concurrent file
+  creation cannot become an overwrite.
+- Surface the failure to the caller. Do not silently skip an unsafe name.
+
+The caller-selected output directory is the trust anchor. Portable .NET APIs do
+not currently provide an atomic cross-platform "open beneath this directory,
+never follow links" primitive. Reparse checks and create-new writes narrow the
+race window, but a local adversary able to mutate the chosen directory
+concurrently remains a residual risk. Security-sensitive automation should use
+a fresh directory with permissions restricted to the invoking user.
+
+## Required rules for new code
+
+These are requirements for new or changed paths and audit targets for existing
+code. They do not claim that every legacy scanner already distinguishes
+malformed input from an ordinary empty or zero-valued result.
+
+### Derived paths
+
+Validate before side effects. Prefer rejection over sanitization: sanitization
+can create collisions and hides the artifact's original identity.
+
+For each artifact-derived path:
+
+1. Define the trusted root.
+2. Parse the untrusted value into components.
+3. Reject rooted, traversing, empty, control, device, and platform-alias forms.
+4. Resolve the full destination and prove it remains beneath the root.
+5. Preflight collisions across the full operation.
+6. Refuse unintended overwrite.
+7. Keep failures visible and attributable to the offending artifact.
+
+Do not use `Path.Combine(root, untrustedValue)` as a containment check.
+
+### Parsing and resource consumption
+
+Use existing guarded signature, metadata, IL, and recursion limits. A new
+decoder must identify:
+
+- maximum input size;
+- maximum nesting or graph depth;
+- maximum produced rows or objects;
+- cancellation and timeout behavior;
+- malformed-input failure shape.
+
+Do not catch `Exception` and return an ordinary empty result for malformed
+input. Empty means the producer completed and found no evidence; failure is a
+different state.
+
+### Network and caches
+
+Network access derived from inspected content must be explicit in the command
+surface, use the untrusted-fetch client, have a timeout, and retain provenance.
+Cache paths must be hashed or use validated single components. Downloads should
+land in temporary files and become visible atomically after validation.
+
+### Presentation
+
+Artifact text can contain Markdown delimiters, newlines, terminal control
+characters, URLs, or prompt-like instructions. Renderers must preserve output
+structure and must not interpret inspected text as authority. JSON serializers
+provide structural escaping; Markdown, table, plain-text, and stderr paths need
+equivalent control-character and delimiter discipline.
+
+## Verification obligations
+
+Security-sensitive parsers and writers require close negative fixtures, not
+only ordinary compiler output.
+
+| Surface | Required evidence |
+| --- | --- |
+| Resource extraction | Traversal and rooted names rejected before writes; valid nested and empty resources retained; malformed ranges rejected; separator/case aliases collide; existing file preserved; device/control names rejected |
+| Archive extraction | Zip-slip fixture; expanded-size and entry-count policy tests once budgets exist |
+| Metadata and signatures | Malformed table/blob fixtures, depth/size limits, no process crash |
+| SourceLink | Private/loopback/redirect targets rejected; allowed public target and checksum path retained |
+| Cache paths | Traversal/separator components rejected; content-addressed keys deterministic |
+| Structured output | Untrusted delimiters/control characters cannot escape the selected format |
+
+## Open work
+
+1. Define package, symbol, source-download, and decompressed-archive byte and
+   entry-count budgets.
+2. Audit every product write against the derived-path rules, including symbol
+   server cache path construction.
+3. Audit Markdown, plain-text, and stderr rendering for terminal control
+   characters and structure injection.
+4. Expand malformed PE/PDB fuzz and adversarial fixtures around parser depth,
+   row count, and allocation limits.
+5. Migrate legacy metadata scanners that collapse malformed reads into empty or
+   zero-valued results onto explicit failure-bearing outcomes.
+6. Revisit filesystem containment if .NET exposes a portable atomic
+   no-follow/open-beneath primitive.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -38,6 +38,7 @@ Agents working in this repo should preserve these principles:
 - [Architecture](architecture.md): command and metadata architecture.
 - [Signals](assembly-audit.md): package/library signal semantics and network scope.
 - [PDB acquisition](pdb-acquisition.md): symbols and SourceLink acquisition.
+- [Untrusted data threat model](design/untrusted-data-threat-model.md): trust boundaries and security rules for inspected artifacts, network input, caches, output paths, and rendering.
 - [Rendering model](design/rendering-model.md): output mode and verbosity design.
 - [Progressive disclosure](design/progressive-disclosure.md): verbosity, `-D`/`-S`, opt-in sections, `-S @All`, and limiter behavior.
 - [Command transitions](design/command-transition-model.md): when source, focus, operation arity, lens, traversal, or rendering changes should switch commands versus stay within one command.

--- a/src/ILInspector.Metadata/AssemblyInspectionSession.cs
+++ b/src/ILInspector.Metadata/AssemblyInspectionSession.cs
@@ -52,7 +52,10 @@ public sealed class AssemblyInspectionSession : IDisposable
     public List<ManifestResourceInfo> Resources()
         => ResourceScanner.Scan(_image.PEReader);
 
-    /// <summary>Extracts embedded manifest resources to a directory.</summary>
+    /// <summary>
+    /// Extracts embedded manifest resources beneath a directory without allowing
+    /// path escape or overwriting existing files.
+    /// </summary>
     public List<string> ExtractResources(string outputDirectory)
         => ResourceScanner.ExtractAll(_image.PEReader, outputDirectory);
 

--- a/src/ILInspector.Metadata/ResourceExtractor.cs
+++ b/src/ILInspector.Metadata/ResourceExtractor.cs
@@ -1,0 +1,347 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata;
+
+static class ResourceExtractor
+{
+    readonly record struct ExtractionPlan(
+        string Name,
+        int Rva,
+        int Size,
+        string DestinationPath,
+        string DestinationFullPath);
+
+    static readonly char[] s_portableInvalidFileNameCharacters = ['<', '>', '"', '|', '?', '*'];
+
+    public static List<string> ExtractAll(PEReader peReader, string outputDirectory)
+    {
+        if (!peReader.HasMetadata)
+            return [];
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputDirectory);
+
+        var reader = peReader.GetMetadataReader();
+        var resourcesDirectory = peReader.PEHeaders.CorHeader!.ResourcesDirectory;
+        if (resourcesDirectory.Size == 0)
+            return [];
+
+        var outputRoot = Path.GetFullPath(outputDirectory);
+        var plans = CreatePlans(
+            peReader,
+            reader,
+            resourcesDirectory.RelativeVirtualAddress,
+            resourcesDirectory.Size,
+            outputDirectory,
+            outputRoot);
+        if (plans.Count == 0)
+            return [];
+
+        EnsureDirectoryIsSafe(outputRoot, outputRoot);
+        List<string> extracted = [];
+        foreach (var plan in plans)
+        {
+            var bytes = peReader.GetSectionData(plan.Rva)
+                .GetReader(4, plan.Size)
+                .ReadBytes(plan.Size);
+            EnsureDirectoryIsSafe(outputRoot, Path.GetDirectoryName(plan.DestinationFullPath)!);
+            using (var destination = new FileStream(
+                plan.DestinationFullPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None))
+            {
+                destination.Write(bytes);
+            }
+            extracted.Add(plan.DestinationPath);
+        }
+        return extracted;
+    }
+
+    static int ReadResourceSize(
+        PEReader peReader,
+        int resourcesSize,
+        long offset,
+        int rva,
+        string name)
+    {
+        try
+        {
+            if (offset < 0
+                || resourcesSize < sizeof(int)
+                || offset > resourcesSize - sizeof(int))
+            {
+                throw new BadImageFormatException();
+            }
+
+            var sectionData = peReader.GetSectionData(rva);
+            if (sectionData.Length < 4)
+                throw new BadImageFormatException();
+
+            int size = sectionData.GetReader(0, 4).ReadInt32();
+            long endOffset = offset + sizeof(int) + (long)size;
+            if (size < 0
+                || endOffset > resourcesSize
+                || size + (long)sizeof(int) > sectionData.Length)
+            {
+                throw new BadImageFormatException();
+            }
+            return size;
+        }
+        catch (Exception ex) when (ex is BadImageFormatException
+            or InvalidOperationException
+            or ArgumentOutOfRangeException)
+        {
+            throw new InvalidDataException(
+                $"Manifest resource '{name}' has an invalid data range.",
+                ex);
+        }
+    }
+
+    static List<ExtractionPlan> CreatePlans(
+        PEReader peReader,
+        MetadataReader reader,
+        int resourcesRva,
+        int resourcesSize,
+        string outputDirectory,
+        string outputRoot)
+    {
+        HashSet<string> destinations = new(StringComparer.OrdinalIgnoreCase);
+        List<ExtractionPlan> plans = [];
+
+        foreach (var handle in reader.ManifestResources)
+        {
+            var resource = reader.GetManifestResource(handle);
+            if (!resource.Implementation.IsNil)
+                continue;
+
+            string name = reader.GetString(resource.Name);
+            var relativePath = Path.Combine(GetSafePathComponents(name));
+            var destinationPath = Path.Combine(outputDirectory, relativePath);
+            var destinationFullPath = Path.GetFullPath(Path.Combine(outputRoot, relativePath));
+            EnsureContained(outputRoot, destinationFullPath, name);
+
+            if (!destinations.Add(destinationFullPath.Normalize()))
+            {
+                throw new InvalidDataException(
+                    $"Manifest resource '{name}' resolves to a duplicate extraction path.");
+            }
+
+            int rva;
+            try
+            {
+                rva = checked(resourcesRva + (int)resource.Offset);
+            }
+            catch (OverflowException ex)
+            {
+                throw new InvalidDataException(
+                    $"Manifest resource '{name}' has an invalid data offset.",
+                    ex);
+            }
+            int size = ReadResourceSize(
+                peReader,
+                resourcesSize,
+                resource.Offset,
+                rva,
+                name);
+            plans.Add(new ExtractionPlan(
+                name,
+                rva,
+                size,
+                destinationPath,
+                destinationFullPath));
+        }
+
+        foreach (var plan in plans)
+        {
+            var parent = Path.GetDirectoryName(plan.DestinationFullPath);
+            while (parent is not null && !PathsEqual(parent, outputRoot))
+            {
+                if (destinations.Contains(parent.Normalize()))
+                {
+                    throw new InvalidDataException(
+                        $"Manifest resource '{plan.Name}' conflicts with another resource path.");
+                }
+                if (!TryGetAttributes(parent, out _)
+                    && FindExistingAlias(parent) is { } alias)
+                {
+                    throw new IOException(
+                        $"Resource extraction path conflicts with existing path: '{alias}'.");
+                }
+                EnsureExistingDirectoryIsSafe(parent);
+                parent = Path.GetDirectoryName(parent);
+            }
+
+            if (TryGetAttributes(plan.DestinationFullPath, out _)
+                || FindExistingAlias(plan.DestinationFullPath) is not null)
+            {
+                throw new IOException(
+                    $"Resource destination already exists: '{plan.DestinationFullPath}'.");
+            }
+        }
+
+        EnsureExistingDirectoryIsSafe(outputRoot);
+        return plans;
+    }
+
+    static string[] GetSafePathComponents(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name)
+            || name.Any(char.IsControl)
+            || name[0] is '/' or '\\'
+            || Path.IsPathRooted(name)
+            || IsDriveQualified(name))
+        {
+            throw UnsafeResourceName(name);
+        }
+
+        var components = name.Split(['/', '\\'], StringSplitOptions.None);
+        foreach (var component in components)
+        {
+            if (component.Length == 0
+                || component is "." or ".."
+                || component.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0
+                || component.IndexOfAny(s_portableInvalidFileNameCharacters) >= 0
+                || component.Contains(':')
+                || component.EndsWith(' ')
+                || component.EndsWith('.')
+                || IsWindowsDeviceName(component))
+            {
+                throw UnsafeResourceName(name);
+            }
+        }
+        return components;
+    }
+
+    static bool IsDriveQualified(string name)
+        => name.Length >= 2 && char.IsAsciiLetter(name[0]) && name[1] == ':';
+
+    static bool IsWindowsDeviceName(string component)
+    {
+        var separator = component.IndexOf('.');
+        var stem = (separator >= 0 ? component[..separator] : component).TrimEnd(' ', '.');
+        return stem.Equals("CON", StringComparison.OrdinalIgnoreCase)
+            || stem.Equals("PRN", StringComparison.OrdinalIgnoreCase)
+            || stem.Equals("AUX", StringComparison.OrdinalIgnoreCase)
+            || stem.Equals("NUL", StringComparison.OrdinalIgnoreCase)
+            || stem.Equals("CLOCK$", StringComparison.OrdinalIgnoreCase)
+            || IsNumberedDevice(stem, "COM")
+            || IsNumberedDevice(stem, "LPT");
+    }
+
+    static bool IsNumberedDevice(string stem, string prefix)
+        => stem.Length == prefix.Length + 1
+            && stem.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            && IsDeviceDigit(stem[^1]);
+
+    static bool IsDeviceDigit(char value)
+        => value is >= '1' and <= '9' or '\u00B9' or '\u00B2' or '\u00B3';
+
+    static InvalidDataException UnsafeResourceName(string name)
+        => new($"Manifest resource '{name}' is not a safe relative extraction path.");
+
+    static void EnsureContained(string outputRoot, string destination, string name)
+    {
+        var relative = Path.GetRelativePath(outputRoot, destination);
+        if (Path.IsPathRooted(relative)
+            || relative == ".."
+            || relative.StartsWith($"..{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+        {
+            throw UnsafeResourceName(name);
+        }
+    }
+
+    static void EnsureDirectoryIsSafe(string outputRoot, string directory)
+    {
+        Directory.CreateDirectory(outputRoot);
+        EnsureExistingDirectoryIsSafe(outputRoot);
+
+        var relative = Path.GetRelativePath(outputRoot, directory);
+        if (relative == ".")
+            return;
+        if (Path.IsPathRooted(relative)
+            || relative == ".."
+            || relative.StartsWith($"..{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+        {
+            throw new IOException($"Resource extraction directory escapes the output root: '{directory}'.");
+        }
+
+        var current = outputRoot;
+        foreach (var component in relative.Split(Path.DirectorySeparatorChar))
+        {
+            current = Path.Combine(current, component);
+            if (!TryGetAttributes(current, out _))
+            {
+                if (FindExistingAlias(current) is { } alias)
+                {
+                    throw new IOException(
+                        $"Resource extraction path conflicts with existing path: '{alias}'.");
+                }
+                Directory.CreateDirectory(current);
+            }
+            EnsureExistingDirectoryIsSafe(current);
+        }
+    }
+
+    static string? FindExistingAlias(string path)
+    {
+        var parent = Path.GetDirectoryName(path);
+        if (parent is null || !Directory.Exists(parent))
+            return null;
+
+        string expectedName = Path.GetFileName(path).Normalize();
+        foreach (var entry in Directory.EnumerateFileSystemEntries(parent))
+        {
+            if (string.Equals(
+                Path.GetFileName(entry).Normalize(),
+                expectedName,
+                StringComparison.OrdinalIgnoreCase))
+            {
+                return entry;
+            }
+        }
+        return null;
+    }
+
+    static void EnsureExistingDirectoryIsSafe(string path)
+    {
+        if (!TryGetAttributes(path, out var attributes))
+            return;
+        if ((attributes & FileAttributes.ReparsePoint) != 0)
+        {
+            throw new IOException(
+                $"Resource extraction path contains a symbolic link or reparse point: '{path}'.");
+        }
+        if ((attributes & FileAttributes.Directory) == 0)
+            throw new IOException($"Resource extraction path is not a directory: '{path}'.");
+    }
+
+    static bool TryGetAttributes(string path, out FileAttributes attributes)
+    {
+        try
+        {
+            attributes = File.GetAttributes(path);
+            return true;
+        }
+        catch (FileNotFoundException)
+        {
+            attributes = default;
+            return false;
+        }
+        catch (DirectoryNotFoundException)
+        {
+            attributes = default;
+            return false;
+        }
+    }
+
+    static bool PathsEqual(string left, string right)
+    {
+        var comparison = OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        return string.Equals(
+            Path.TrimEndingDirectorySeparator(left),
+            Path.TrimEndingDirectorySeparator(right),
+            comparison);
+    }
+}

--- a/src/ILInspector.Metadata/ResourceScanner.cs
+++ b/src/ILInspector.Metadata/ResourceScanner.cs
@@ -79,8 +79,9 @@ public static class ResourceScanner
     }
 
     /// <summary>
-    /// Extracts all embedded resources from an assembly to a directory.
-    /// Returns the list of extracted file paths.
+    /// Extracts embedded resources to validated relative paths beneath a directory.
+    /// The operation fails before writing when a resource path is unsafe, conflicts
+    /// with another resource, or would overwrite an existing file.
     /// </summary>
     public static List<string> ExtractAll(Stream peStream, string outputDir)
     {
@@ -89,57 +90,10 @@ public static class ResourceScanner
     }
 
     /// <summary>
-    /// Extracts all embedded resources from an assembly to a directory.
-    /// Returns the list of extracted file paths.
+    /// Extracts embedded resources to validated relative paths beneath a directory.
+    /// The operation fails before writing when a resource path is unsafe, conflicts
+    /// with another resource, or would overwrite an existing file.
     /// </summary>
     public static List<string> ExtractAll(PEReader peReader, string outputDir)
-    {
-        List<string> extracted = [];
-
-        if (!peReader.HasMetadata)
-            return extracted;
-
-        var reader = peReader.GetMetadataReader();
-        var resourcesDir = peReader.PEHeaders.CorHeader!.ResourcesDirectory;
-        if (resourcesDir.Size == 0)
-            return extracted;
-
-        Directory.CreateDirectory(outputDir);
-
-        foreach (var handle in reader.ManifestResources)
-        {
-            var resource = reader.GetManifestResource(handle);
-            if (!resource.Implementation.IsNil)
-                continue; // skip external resources
-
-            string name = reader.GetString(resource.Name);
-            int rva = resourcesDir.RelativeVirtualAddress + (int)resource.Offset;
-
-            try
-            {
-                var sectionData = peReader.GetSectionData(rva);
-                if (sectionData.Length < 4) continue;
-
-                var blobReader = sectionData.GetReader(0, 4);
-                int size = blobReader.ReadInt32();
-                if (size <= 0 || size + 4 > sectionData.Length) continue;
-
-                var data = sectionData.GetReader(4, size);
-                var filePath = Path.Combine(outputDir, name);
-
-                // Create subdirectories if resource name contains dots that look like paths
-                var dir = Path.GetDirectoryName(filePath);
-                if (dir != null) Directory.CreateDirectory(dir);
-
-                File.WriteAllBytes(filePath, data.ReadBytes(size));
-                extracted.Add(filePath);
-            }
-            catch
-            {
-                // Skip resources that can't be read
-            }
-        }
-
-        return extracted;
-    }
+        => ResourceExtractor.ExtractAll(peReader, outputDir);
 }

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -107,6 +107,56 @@ public class CommandExecutionTests
         File.WriteAllBytes(path, image.ToArray());
     }
 
+    private static void WriteResourceAssembly(
+        string path,
+        params (string Name, byte[] Content)[] resources)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString(Path.GetFileName(path)),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString(Path.GetFileNameWithoutExtension(path)),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        var resourceData = new BlobBuilder();
+        foreach (var (name, content) in resources)
+        {
+            int offset = resourceData.Count;
+            resourceData.WriteInt32(content.Length);
+            resourceData.WriteBytes(content);
+            metadata.AddManifestResource(
+                ManifestResourceAttributes.Public,
+                metadata.GetOrAddString(name),
+                default,
+                (uint)offset);
+        }
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata),
+            new BlobBuilder(),
+            managedResources: resourceData,
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        File.WriteAllBytes(path, image.ToArray());
+    }
+
     private sealed class NestedDrillTarget
     {
         public NestedDrillTarget(int value) => Value = value;
@@ -6463,6 +6513,36 @@ public class CommandExecutionTests
 
         Assert.Equal(1, exit);
         Assert.Contains("--il-offset requires an IL coordinate section", error);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_ExtractResources_RejectsTraversalWithFailureExit()
+    {
+        var tempDirectory = Directory.CreateTempSubdirectory("resource-extraction-command-");
+        try
+        {
+            var assemblyPath = Path.Combine(tempDirectory.FullName, "MaliciousResources.dll");
+            var outputPath = Path.Combine(tempDirectory.FullName, "output");
+            var escapedPath = Path.Combine(tempDirectory.FullName, "escaped.txt");
+            WriteResourceAssembly(
+                assemblyPath,
+                ("safe.txt", "safe"u8.ToArray()),
+                ("../escaped.txt", "escaped"u8.ToArray()));
+
+            var (exit, _, error) = await RunAppAsync(
+                "library", assemblyPath,
+                "--extract-resources", outputPath,
+                "--tips", "q");
+
+            Assert.Equal(1, exit);
+            Assert.Contains("safe relative extraction path", error);
+            Assert.False(Directory.Exists(outputPath));
+            Assert.False(File.Exists(escapedPath));
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -6529,12 +6529,14 @@ public class CommandExecutionTests
                 ("safe.txt", "safe"u8.ToArray()),
                 ("../escaped.txt", "escaped"u8.ToArray()));
 
-            var (exit, _, error) = await RunAppAsync(
+            var (exit, output, error) = await RunAppAsync(
                 "library", assemblyPath,
                 "--extract-resources", outputPath,
+                "--json",
                 "--tips", "q");
 
             Assert.Equal(1, exit);
+            Assert.Empty(output);
             Assert.Contains("safe relative extraction path", error);
             Assert.False(Directory.Exists(outputPath));
             Assert.False(File.Exists(escapedPath));

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -295,7 +295,10 @@ public static class InspectionCommandDefinitions
         typeFilterOption.Aliases.Add("--type");
         var ilOffsetOption = new Option<string?>("--il-offset") { Description = "MethodDef token + IL offset for coordinate-scoped sections (e.g., 0x06000001+0x5)" };
         var ilOffsetsOption = new Option<string?>("--il-offsets") { Description = "Text file of sparse MethodDef token + IL offset coordinates to explain" };
-        var extractResourcesOption = new Option<string?>("--extract-resources") { Description = "Extract embedded resources to a directory" };
+        var extractResourcesOption = new Option<string?>("--extract-resources")
+        {
+            Description = "Extract embedded resources beneath a directory without overwriting files"
+        };
         assemblyCommand.Arguments.Add(assemblyPathArg);
         assemblyCommand.Options.Add(referencesOption);
         assemblyCommand.Options.Add(dependenciesOption);

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -281,8 +281,8 @@ public class LibraryCommand
                 if (options.Value || options.Urls || options.Paths)
                     return WriteLibraryShapeProjection(inspection, options);
                 WarnEmptySections(inspection, options, pipeline);
-                OutputFormatter.WriteLibraryResult(inspection, options, pipeline);
                 ExtractResourcesIfRequested(resolvedPath!, options);
+                OutputFormatter.WriteLibraryResult(inspection, options, pipeline);
                 return IntegrityExitCode(inspection);
             }
             else if (!string.IsNullOrEmpty(options.PackagePath))
@@ -351,13 +351,13 @@ public class LibraryCommand
                 if (options.Value || options.Urls || options.Paths)
                     return WriteLibraryShapeProjection(inspections[0], options);
                 WarnEmptySections(inspections[0], options, pipeline);
+                if (assemblyPaths.Count > 0)
+                    ExtractResourcesIfRequested(assemblyPaths[0], options);
+
                 if (inspections.Count == 1)
                     OutputFormatter.WriteLibraryResult(inspections[0], options, pipeline);
                 else
                     OutputFormatter.WriteLibraryResults(inspections, options, pipeline);
-
-                if (assemblyPaths.Count > 0)
-                    ExtractResourcesIfRequested(assemblyPaths[0], options);
 
                 return IntegrityExitCode([.. inspections]);
             }
@@ -407,8 +407,8 @@ public class LibraryCommand
                 if (options.Value || options.Urls || options.Paths)
                     return WriteLibraryShapeProjection(inspection, options);
                 WarnEmptySections(inspection, options, pipeline);
-                OutputFormatter.WriteLibraryResult(inspection, options, pipeline);
                 ExtractResourcesIfRequested(assemblyPath!, options);
+                OutputFormatter.WriteLibraryResult(inspection, options, pipeline);
                 return IntegrityExitCode(inspection);
             }
         }

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -282,7 +282,7 @@ public class LibraryCommand
                     return WriteLibraryShapeProjection(inspection, options);
                 WarnEmptySections(inspection, options, pipeline);
                 OutputFormatter.WriteLibraryResult(inspection, options, pipeline);
-                ExtractResourcesIfRequested(resolvedPath!, options, logger);
+                ExtractResourcesIfRequested(resolvedPath!, options);
                 return IntegrityExitCode(inspection);
             }
             else if (!string.IsNullOrEmpty(options.PackagePath))
@@ -357,7 +357,7 @@ public class LibraryCommand
                     OutputFormatter.WriteLibraryResults(inspections, options, pipeline);
 
                 if (assemblyPaths.Count > 0)
-                    ExtractResourcesIfRequested(assemblyPaths[0], options, logger);
+                    ExtractResourcesIfRequested(assemblyPaths[0], options);
 
                 return IntegrityExitCode([.. inspections]);
             }
@@ -408,7 +408,7 @@ public class LibraryCommand
                     return WriteLibraryShapeProjection(inspection, options);
                 WarnEmptySections(inspection, options, pipeline);
                 OutputFormatter.WriteLibraryResult(inspection, options, pipeline);
-                ExtractResourcesIfRequested(assemblyPath!, options, logger);
+                ExtractResourcesIfRequested(assemblyPath!, options);
                 return IntegrityExitCode(inspection);
             }
         }
@@ -1454,31 +1454,24 @@ public class LibraryCommand
                    descriptor => descriptor.Name.Equals(section, StringComparison.OrdinalIgnoreCase));
     }
 
-    private static void ExtractResourcesIfRequested(string assemblyPath, LibraryOptions options, VerboseLogger logger)
+    private static void ExtractResourcesIfRequested(string assemblyPath, LibraryOptions options)
     {
         if (string.IsNullOrEmpty(options.ExtractResources))
             return;
 
-        try
+        using var session = AssemblyInspectionSession.Open(assemblyPath);
+        var extracted = session.ExtractResources(options.ExtractResources);
+        if (extracted.Count == 0)
         {
-            using var session = AssemblyInspectionSession.Open(assemblyPath);
-            var extracted = session.ExtractResources(options.ExtractResources);
-            if (extracted.Count == 0)
-            {
-                Console.Error.WriteLine("No embedded resources found.");
-            }
-            else
-            {
-                Console.Error.WriteLine($"Extracted {extracted.Count} resource(s) to {options.ExtractResources}");
-                foreach (var path in extracted)
-                {
-                    Console.Error.WriteLine($"  {Path.GetFileName(path)}");
-                }
-            }
+            Console.Error.WriteLine("No embedded resources found.");
         }
-        catch (Exception ex)
+        else
         {
-            Console.Error.WriteLine($"Error extracting resources: {ex.Message}");
+            Console.Error.WriteLine($"Extracted {extracted.Count} resource(s) to {options.ExtractResources}");
+            foreach (var path in extracted)
+            {
+                Console.Error.WriteLine($"  {Path.GetFileName(path)}");
+            }
         }
     }
 

--- a/tests/ILInspector.Metadata.Tests/ResourceScannerExtractionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ResourceScannerExtractionTests.cs
@@ -1,0 +1,298 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests;
+
+public class ResourceScannerExtractionTests
+{
+    [Fact]
+    public void ExtractAll_PreservesValidatedNestedPaths()
+    {
+        using var image = CreateAssembly(("nested/data.txt", "content"u8.ToArray()));
+        using var output = new TemporaryDirectory();
+
+        var extracted = ResourceScanner.ExtractAll(image, output.Path);
+
+        var expected = System.IO.Path.Combine(output.Path, "nested", "data.txt");
+        Assert.Equal([expected], extracted);
+        Assert.Equal("content", File.ReadAllText(expected));
+    }
+
+    [Fact]
+    public void ExtractAll_PreservesEmptyResource()
+    {
+        using var image = CreateAssembly(("empty.txt", []));
+        using var output = new TemporaryDirectory();
+
+        var extracted = ResourceScanner.ExtractAll(image, output.Path);
+
+        var expected = System.IO.Path.Combine(output.Path, "empty.txt");
+        Assert.Equal([expected], extracted);
+        Assert.Empty(File.ReadAllBytes(expected));
+    }
+
+    [Fact]
+    public void ExtractAll_RejectsTraversalBeforeWritingAnyResource()
+    {
+        using var image = CreateAssembly(
+            ("safe.txt", "safe"u8.ToArray()),
+            ("../escaped.txt", "escaped"u8.ToArray()));
+        using var parent = new TemporaryDirectory();
+        var output = System.IO.Path.Combine(parent.Path, "output");
+        var escaped = System.IO.Path.Combine(parent.Path, "escaped.txt");
+
+        var exception = Assert.Throws<InvalidDataException>(
+            () => ResourceScanner.ExtractAll(image, output));
+
+        Assert.Contains("safe relative extraction path", exception.Message);
+        Assert.False(Directory.Exists(output));
+        Assert.False(File.Exists(escaped));
+    }
+
+    [Fact]
+    public void ExtractAll_RejectsRootedResourceName()
+    {
+        using var parent = new TemporaryDirectory();
+        var escaped = System.IO.Path.Combine(parent.Path, "escaped.txt");
+        using var image = CreateAssembly((escaped, "escaped"u8.ToArray()));
+        var output = System.IO.Path.Combine(parent.Path, "output");
+
+        Assert.Throws<InvalidDataException>(() => ResourceScanner.ExtractAll(image, output));
+
+        Assert.False(Directory.Exists(output));
+        Assert.False(File.Exists(escaped));
+    }
+
+    [Fact]
+    public void ExtractAll_RejectsNormalizedDestinationCollisionBeforeWriting()
+    {
+        using var image = CreateAssembly(
+            ("nested/data.txt", "first"u8.ToArray()),
+            (@"nested\data.txt", "second"u8.ToArray()));
+        using var parent = new TemporaryDirectory();
+        var output = System.IO.Path.Combine(parent.Path, "output");
+
+        var exception = Assert.Throws<InvalidDataException>(
+            () => ResourceScanner.ExtractAll(image, output));
+
+        Assert.Contains("duplicate extraction path", exception.Message);
+        Assert.False(Directory.Exists(output));
+    }
+
+    [Fact]
+    public void ExtractAll_RejectsCaseFoldedDestinationCollisionBeforeWriting()
+    {
+        using var image = CreateAssembly(
+            ("Data.txt", "first"u8.ToArray()),
+            ("data.txt", "second"u8.ToArray()));
+        using var parent = new TemporaryDirectory();
+        var output = System.IO.Path.Combine(parent.Path, "output");
+
+        Assert.Throws<InvalidDataException>(() => ResourceScanner.ExtractAll(image, output));
+
+        Assert.False(Directory.Exists(output));
+    }
+
+    [Fact]
+    public void ExtractAll_RejectsFileDirectoryPrefixConflictBeforeWriting()
+    {
+        using var image = CreateAssembly(
+            ("nested", "file"u8.ToArray()),
+            ("nested/data.txt", "nested"u8.ToArray()));
+        using var parent = new TemporaryDirectory();
+        var output = System.IO.Path.Combine(parent.Path, "output");
+
+        var exception = Assert.Throws<InvalidDataException>(
+            () => ResourceScanner.ExtractAll(image, output));
+
+        Assert.Contains("conflicts with another resource path", exception.Message);
+        Assert.False(Directory.Exists(output));
+    }
+
+    [Fact]
+    public void ExtractAll_RefusesToOverwriteExistingFile()
+    {
+        using var image = CreateAssembly(("data.txt", "replacement"u8.ToArray()));
+        using var output = new TemporaryDirectory();
+        var destination = System.IO.Path.Combine(output.Path, "data.txt");
+        File.WriteAllText(destination, "original");
+
+        var exception = Assert.Throws<IOException>(
+            () => ResourceScanner.ExtractAll(image, output.Path));
+
+        Assert.Contains("already exists", exception.Message);
+        Assert.Equal("original", File.ReadAllText(destination));
+    }
+
+    [Fact]
+    public void ExtractAll_RejectsCaseFoldedExistingFileAlias()
+    {
+        if (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
+            return;
+
+        using var image = CreateAssembly(("data.txt", "replacement"u8.ToArray()));
+        using var output = new TemporaryDirectory();
+        var existing = System.IO.Path.Combine(output.Path, "Data.txt");
+        File.WriteAllText(existing, "original");
+
+        Assert.Throws<IOException>(() => ResourceScanner.ExtractAll(image, output.Path));
+
+        Assert.Equal("original", File.ReadAllText(existing));
+        Assert.False(File.Exists(System.IO.Path.Combine(output.Path, "data.txt")));
+    }
+
+    [Fact]
+    public void ExtractAll_RejectsCaseFoldedExistingDirectoryAlias()
+    {
+        if (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
+            return;
+
+        using var image = CreateAssembly(("nested/data.txt", "content"u8.ToArray()));
+        using var output = new TemporaryDirectory();
+        var existing = System.IO.Path.Combine(output.Path, "Nested");
+        Directory.CreateDirectory(existing);
+
+        Assert.Throws<IOException>(() => ResourceScanner.ExtractAll(image, output.Path));
+
+        Assert.Empty(Directory.EnumerateFiles(existing));
+        Assert.False(Directory.Exists(System.IO.Path.Combine(output.Path, "nested")));
+    }
+
+    [Fact]
+    public void ExtractAll_RejectsSymbolicLinkBelowOutputRoot()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        using var image = CreateAssembly(("nested/data.txt", "escaped"u8.ToArray()));
+        using var output = new TemporaryDirectory();
+        using var outside = new TemporaryDirectory();
+        Directory.CreateSymbolicLink(
+            System.IO.Path.Combine(output.Path, "nested"),
+            outside.Path);
+
+        var exception = Assert.Throws<IOException>(
+            () => ResourceScanner.ExtractAll(image, output.Path));
+
+        Assert.Contains("symbolic link or reparse point", exception.Message);
+        Assert.False(File.Exists(System.IO.Path.Combine(outside.Path, "data.txt")));
+    }
+
+    [Fact]
+    public void ExtractAll_RejectsMalformedResourceDataBeforeWriting()
+    {
+        using var image = CreateAssembly(
+            ("safe.txt", 4, "safe"u8.ToArray()),
+            ("malformed.txt", 1024, "short"u8.ToArray()));
+        using var parent = new TemporaryDirectory();
+        var output = System.IO.Path.Combine(parent.Path, "output");
+
+        var exception = Assert.Throws<InvalidDataException>(
+            () => ResourceScanner.ExtractAll(image, output));
+
+        Assert.Contains("malformed.txt", exception.Message);
+        Assert.Contains("invalid data range", exception.Message);
+        Assert.False(Directory.Exists(output));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(".")]
+    [InlineData("..")]
+    [InlineData("nested//data.txt")]
+    [InlineData("data.txt.")]
+    [InlineData("NUL")]
+    [InlineData("COM\u00B9.txt")]
+    [InlineData("value:stream")]
+    [InlineData("wild*.txt")]
+    [InlineData("question?.txt")]
+    [InlineData("pipe|.txt")]
+    [InlineData("line\nbreak.txt")]
+    public void ExtractAll_RejectsUnsafeResourceNames(string name)
+    {
+        using var image = CreateAssembly((name, "content"u8.ToArray()));
+        using var parent = new TemporaryDirectory();
+        var output = System.IO.Path.Combine(parent.Path, "output");
+
+        Assert.Throws<InvalidDataException>(() => ResourceScanner.ExtractAll(image, output));
+
+        Assert.False(Directory.Exists(output));
+    }
+
+    static MemoryStream CreateAssembly(params (string Name, byte[] Content)[] resources)
+        => CreateAssembly(
+            resources
+                .Select(resource => (resource.Name, resource.Content.Length, resource.Content))
+                .ToArray());
+
+    static MemoryStream CreateAssembly(
+        params (string Name, int DeclaredSize, byte[] Content)[] resources)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString("ResourceFixture.dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("ResourceFixture"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        var resourceData = new BlobBuilder();
+        foreach (var (name, declaredSize, content) in resources)
+        {
+            int offset = resourceData.Count;
+            resourceData.WriteInt32(declaredSize);
+            resourceData.WriteBytes(content);
+            metadata.AddManifestResource(
+                ManifestResourceAttributes.Public,
+                metadata.GetOrAddString(name),
+                default,
+                (uint)offset);
+        }
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata),
+            new BlobBuilder(),
+            managedResources: resourceData,
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return new MemoryStream(image.ToArray());
+    }
+
+    sealed class TemporaryDirectory : IDisposable
+    {
+        public TemporaryDirectory()
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"resource-extraction-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Closes #2798.

Manifest resource names and payload ranges are now fully preflighted before the output directory is created or any file is written. Extraction preserves validated nested paths, but rejects rooted/traversing/platform-alias names, malformed payloads, normalized or case-folded collisions, file/directory conflicts, existing destinations, and symlink/reparse components beneath the output root. Files are opened with create-new semantics, and extraction failures now produce a nonzero CLI exit instead of success-shaped output.

The PR also adds `docs/design/untrusted-data-threat-model.md`, covering assemblies, packages, symbols and SourceLink, restored project inputs, caches and output paths, network boundaries, rendering, required controls, verification obligations, and open resource-budget/audit work. The documented residual risk is a local adversary concurrently replacing filesystem components because .NET does not expose a portable atomic open-beneath/no-follow primitive.

Validation:
- `dotnet build dotnet-inspect.slnx -c Release --configfile ./nuget.config`
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release`
- NativeAOT publish plus resource-extraction smoke test
- markdownlint on all changed Markdown

An exact merge-base executable A/B for a normal embedded-resource assembly was identical: status 0, 11 files, identical SHA-256 manifests, stdout, and normalized stderr. Adversarial synthetic PE tests cover traversal, rooted paths, separator/case aliases, file-directory conflicts, existing files and directory aliases, symlinks, malformed ranges, empty resources, device names, control characters, and portable invalid characters.