### PR TITLE
Propagate ArrayPool evidence through typed wrappers

### DIFF
--- a/docs/analysis-baselines.md
+++ b/docs/analysis-baselines.md
@@ -45,7 +45,7 @@ are the cheapest "found something interesting" wins.
 | # | Analysis type | Command | Volume (44 asm) | Precision | Actionability | Verdict |
 | - | ------------- | ------- | --------------- | --------- | ------------- | ------- |
 | 1 | Algorithmic scan-in-loop | `Performance Triage` (`scan-method-in-loop-call`, `linq-scan-in-loop`, `string-build-in-loop`, `allocation-hotspot`) | 155 | High | **Very high** (quadratic) | **Headline** |
-| 2 | Leak-after-exception | `Resource Triage` (harness `--leak-actionability` for the full census) | 4 current framework / 9 historical confirmed | **Very high** | High (`try/finally`) | **Headline** |
+| 2 | Leak-after-exception | `Resource Triage` (harness `--leak-actionability` for the full census) | 5 current framework / 9 historical confirmed | **Very high** | High (`try/finally`) | **Headline** |
 | 3 | Delegate allocation | `Performance Triage` (`instance-method-group-delegate`, `capturing-delegate`) | 3,327 raw / 128 hot | High (real) / High in loops | High in loops | **Worthy w/ ranking** |
 | 4 | Enumerator allocation | `Performance Triage` (`enumerator-allocation`) | 121 / 117 hot | High | Med–High | **Worthy** |
 | 5 | Reach / leverage | `Top Leverage` | ranking | — | Impact multiplier for 1,3,4 | **Worthy as a lens** |
@@ -86,9 +86,10 @@ the untrusted-actionable candidates.
 - **9/9 confirmed exception-path pool-retention defects**, IL-verified. Lowest volume,
   highest precision, clean `try/finally` fix.
 - Current exact product contract (.NET 11 daily, 314 assemblies): 57 lifecycle
-  observations → 4 untrusted-actionable (`MessagePackReader.ReadStringSlow`,
+  observations → 5 untrusted-actionable (`MessagePackReader.ReadStringSlow`,
   `EncodingExtensions.GetString`, `TypeMapLazyDictionary.ConvertUtf8ToUtf16`,
-  and `BinaryReader.FillBuffer`), 31 trusted, and 22 unknown.
+  `BinaryReader.FillBuffer`, and `HashAlgorithm.ComputeHashAsyncCore`), 31
+  trusted, and 21 unknown.
 - Current pinned community contract (9 assemblies): 19 lifecycle observations →
   3 untrusted-actionable (`MessagePackReader.ReadStringSlow`, Npgsql
   `TextConverter.GetChars`, and Pipelines.Sockets `AsyncPipeStream.ReadByte`)

--- a/docs/analysis-baselines.md
+++ b/docs/analysis-baselines.md
@@ -85,15 +85,17 @@ the untrusted-actionable candidates.
 - Historical framework sensor (308 asm): 4 untrusted-actionable, all confirmed.
 - **9/9 confirmed exception-path pool-retention defects**, IL-verified. Lowest volume,
   highest precision, clean `try/finally` fix.
-- Current exact product contract (.NET 11 daily, 314 assemblies): 34 lifecycle
+- Current exact product contract (.NET 11 daily, 314 assemblies): 57 lifecycle
   observations → 4 untrusted-actionable (`MessagePackReader.ReadStringSlow`,
   `EncodingExtensions.GetString`, `TypeMapLazyDictionary.ConvertUtf8ToUtf16`,
-  and `BinaryReader.FillBuffer`), 4 trusted, and 26 unknown.
-- Current pinned community contract (9 assemblies): 8 lifecycle observations →
+  and `BinaryReader.FillBuffer`), 31 trusted, and 22 unknown.
+- Current pinned community contract (9 assemblies): 19 lifecycle observations →
   3 untrusted-actionable (`MessagePackReader.ReadStringSlow`, Npgsql
   `TextConverter.GetChars`, and Pipelines.Sockets `AsyncPipeStream.ReadByte`)
-  and 5 unknown. The Npgsql and Pipelines consumers are now reached through
-  typed `Span<T>`/`Memory<T>` wrapper propagation. MimeKit's two
+  plus 11 trusted and 5 unknown. The Npgsql and Pipelines consumers are now
+  reached through typed `Span<T>`/`Memory<T>` wrapper propagation. Eleven
+  System.Text.Json rows identify trusted `Span<T>.Slice` work rather than the
+  implicit conversion. MimeKit's two
   `TokenDecoder` constructor boundaries remain unknown because the later
   tokenizer calls are protected by cleanup.
 

--- a/docs/analysis-baselines.md
+++ b/docs/analysis-baselines.md
@@ -45,7 +45,7 @@ are the cheapest "found something interesting" wins.
 | # | Analysis type | Command | Volume (44 asm) | Precision | Actionability | Verdict |
 | - | ------------- | ------- | --------------- | --------- | ------------- | ------- |
 | 1 | Algorithmic scan-in-loop | `Performance Triage` (`scan-method-in-loop-call`, `linq-scan-in-loop`, `string-build-in-loop`, `allocation-hotspot`) | 155 | High | **Very high** (quadratic) | **Headline** |
-| 2 | Leak-after-exception | `Resource Triage` (harness `--leak-actionability` for the full census) | 2 current framework / 9 historical confirmed | **Very high** | High (`try/finally`) | **Headline** |
+| 2 | Leak-after-exception | `Resource Triage` (harness `--leak-actionability` for the full census) | 4 current framework / 9 historical confirmed | **Very high** | High (`try/finally`) | **Headline** |
 | 3 | Delegate allocation | `Performance Triage` (`instance-method-group-delegate`, `capturing-delegate`) | 3,327 raw / 128 hot | High (real) / High in loops | High in loops | **Worthy w/ ranking** |
 | 4 | Enumerator allocation | `Performance Triage` (`enumerator-allocation`) | 121 / 117 hot | High | Med–High | **Worthy** |
 | 5 | Reach / leverage | `Top Leverage` | ranking | — | Impact multiplier for 1,3,4 | **Worthy as a lens** |
@@ -85,15 +85,17 @@ the untrusted-actionable candidates.
 - Historical framework sensor (308 asm): 4 untrusted-actionable, all confirmed.
 - **9/9 confirmed exception-path pool-retention defects**, IL-verified. Lowest volume,
   highest precision, clean `try/finally` fix.
-- Current exact product contract (.NET 11 daily, 314 assemblies): 50 lifecycle
-  observations → 2 untrusted-actionable
-  (`MessagePackReader.ReadStringSlow`, `BinaryReader.FillBuffer`), 1 trusted,
-  and 47 unknown.
-- Current pinned community contract (9 assemblies): 19 lifecycle observations →
-  1 untrusted-actionable (`MessagePackReader.ReadStringSlow`) and 18 unknown.
-  Four unknowns are previously confirmed defects in MimeKit, Npgsql, and
-  Pipelines.Sockets; 13 are System.Text.Json's historically low-actionability
-  in-memory-transform idiom. This is a product recall gap rather than a non-action.
+- Current exact product contract (.NET 11 daily, 314 assemblies): 34 lifecycle
+  observations → 4 untrusted-actionable (`MessagePackReader.ReadStringSlow`,
+  `EncodingExtensions.GetString`, `TypeMapLazyDictionary.ConvertUtf8ToUtf16`,
+  and `BinaryReader.FillBuffer`), 4 trusted, and 26 unknown.
+- Current pinned community contract (9 assemblies): 8 lifecycle observations →
+  3 untrusted-actionable (`MessagePackReader.ReadStringSlow`, Npgsql
+  `TextConverter.GetChars`, and Pipelines.Sockets `AsyncPipeStream.ReadByte`)
+  and 5 unknown. The Npgsql and Pipelines consumers are now reached through
+  typed `Span<T>`/`Memory<T>` wrapper propagation. MimeKit's two
+  `TokenDecoder` constructor boundaries remain unknown because the later
+  tokenizer calls are protected by cleanup.
 
 ### 3–4. Delegate & enumerator allocation
 

--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -254,6 +254,19 @@ public sealed class LeakTriageAnalyzerTests
             boundary.Evidence.Operation.Name == ".ctor"
             && boundary.Kind == ResourceTriageBoundaryKind.Unknown);
 
+        var delayedMemory = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.ExternalReadThroughDelayedMemory)));
+        Assert.Equal(
+            ResourceTriageActionability.UntrustedActionable,
+            delayedMemory.Actionability);
+        Assert.Contains(delayedMemory.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "Read"
+            && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
+        Assert.Contains(delayedMemory.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == ".ctor"
+            && boundary.Kind == ResourceTriageBoundaryKind.Unknown);
+
         var throughReadOnlySpan = Assert.Single(assessments.Where(assessment =>
             assessment.Source.Payload.Method.Name
                 == nameof(ArrayPoolLeakFixtures.ExternalParseThroughReadOnlySpan)));
@@ -1166,6 +1179,7 @@ internal sealed class ArrayPoolLeakFixtures
 {
     static byte[]? s_field;
     static Memory<byte> s_memory;
+    static int s_counter;
     static readonly string s_tag = "wire";
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -1421,6 +1435,23 @@ internal sealed class ArrayPoolLeakFixtures
         var memory = new Memory<byte>(buffer, 0, 16);
         Memory<byte> alias = memory;
         int read = stream.Read(alias);
+        ArrayPool<byte>.Shared.Return(buffer);
+        return read;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int ExternalReadThroughDelayedMemory(
+        ExternalMemoryStream stream)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        var memory = new Memory<byte>(buffer, 0, 16);
+        s_counter++;
+        s_counter++;
+        s_counter++;
+        s_counter++;
+        s_counter++;
+        s_counter++;
+        int read = stream.Read(memory);
         ArrayPool<byte>.Shared.Return(buffer);
         return read;
     }

--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -229,6 +229,44 @@ public sealed class LeakTriageAnalyzerTests
         Assert.DoesNotContain(throughReadOnlySpan.Boundaries, boundary =>
             boundary.Evidence.Operation.Name == "op_Implicit");
 
+        var throughSpanByRef = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.ExternalParseThroughSpanByRef)));
+        Assert.Equal(
+            ResourceTriageActionability.UntrustedActionable,
+            throughSpanByRef.Actionability);
+        Assert.Contains(throughSpanByRef.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "Parse"
+            && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
+        Assert.DoesNotContain(throughSpanByRef.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "op_Implicit");
+
+        var nestedArgument = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.SpanLocalWithNestedExternalRead)));
+        Assert.Equal(
+            ResourceTriageActionability.Unknown,
+            nestedArgument.Actionability);
+        Assert.Contains(nestedArgument.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "Blend"
+            && boundary.Kind == ResourceTriageBoundaryKind.Unknown);
+        Assert.DoesNotContain(nestedArgument.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "Read");
+
+        var spanSlice = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.SpanSliceBeforeReturn)));
+        Assert.Equal(
+            ResourceTriageActionability.TrustedLowActionability,
+            spanSlice.Actionability);
+        Assert.Contains(spanSlice.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "Slice"
+            && boundary.Kind == ResourceTriageBoundaryKind.InMemoryTransform);
+
+        Assert.DoesNotContain(assessments, assessment =>
+            assessment.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.SpanFillBeforeReturn));
+
         var throughStringArgument = Assert.Single(assessments.Where(assessment =>
             assessment.Source.Payload.Method.Name
                 == nameof(ArrayPoolLeakFixtures.ExternalParseThroughSpanWithTag)));
@@ -939,7 +977,12 @@ public sealed class LeakTriageAnalyzerTests
             TokenShared => new MemberRef(arrayPoolOfByte, "get_Shared", [], arrayPoolOfByte, MemberKind.Method),
             TokenRent => new MemberRef(arrayPoolOfByte, "Rent", [TypeRef.CoreLib("System", "Int32")], byteArray, MemberKind.Method) { HasThis = true },
             TokenReturn => new MemberRef(arrayPoolOfByte, "Return", [byteArray], TypeRef.CoreLib("System", "Void"), MemberKind.Method) { HasThis = true },
-            TokenUnknown => new MemberRef(TypeRef.Definition("Fixture", "Fixtures", "Unknown"), "Use", [], TypeRef.CoreLib("System", "Void"), MemberKind.Method),
+            TokenUnknown => new MemberRef(
+                TypeRef.Definition("Fixture", "Fixtures", "Unknown"),
+                "Use",
+                [byteArray],
+                TypeRef.CoreLib("System", "Void"),
+                MemberKind.Method),
             TokenKeepAlive => new MemberRef(TypeRef.CoreLib("System", "GC"), "KeepAlive", [TypeRef.CoreLib("System", "Object")], TypeRef.CoreLib("System", "Void"), MemberKind.Method),
             TokenArrayCopy => new MemberRef(
                 TypeRef.CoreLib("System", "Array"),
@@ -1293,6 +1336,46 @@ internal sealed class ArrayPoolLeakFixtures
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int ExternalParseThroughSpanByRef()
+    {
+        var chars = ArrayPool<char>.Shared.Rent(16);
+        Span<char> value = chars;
+        int parsed = ExternalInputReader.Parse(ref value);
+        ArrayPool<char>.Shared.Return(chars);
+        return parsed;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int SpanLocalWithNestedExternalRead(
+        ExternalMemoryStream stream)
+    {
+        var chars = ArrayPool<char>.Shared.Rent(16);
+        Span<char> value = chars;
+        int result = SpanConsumer.Blend(value, stream.Read());
+        ArrayPool<char>.Shared.Return(chars);
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int SpanSliceBeforeReturn()
+    {
+        var chars = ArrayPool<char>.Shared.Rent(16);
+        Span<char> value = chars;
+        int length = value.Slice(0, 8).Length;
+        ArrayPool<char>.Shared.Return(chars);
+        return length;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void SpanFillBeforeReturn()
+    {
+        var chars = ArrayPool<char>.Shared.Rent(16);
+        Span<char> value = chars;
+        value.Fill('x');
+        ArrayPool<char>.Shared.Return(chars);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static int ExternalParseThroughSpanWithTag()
     {
         var chars = ArrayPool<char>.Shared.Rent(16);
@@ -1406,6 +1489,9 @@ internal sealed class ArrayPoolLeakFixtures
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         public int Read(ReadOnlyMemory<byte> buffer) => buffer.Length;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Read() => 1;
     }
 
     internal static class ExternalInputReader
@@ -1416,6 +1502,9 @@ internal sealed class ArrayPoolLeakFixtures
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static int Parse(ReadOnlySpan<char> value) => value.Length;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static int Parse(ref Span<char> value) => value.Length;
     }
 
     internal sealed class SpanConsumer
@@ -1426,6 +1515,10 @@ internal sealed class ArrayPoolLeakFixtures
         }
 
         public int Length { get; }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static int Blend(Span<char> value, int suffix)
+            => value.Length + suffix;
     }
 
     // Same shape with `catch (Exception)`, which also runs for every managed exception type.

--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -204,6 +204,31 @@ public sealed class LeakTriageAnalyzerTests
             boundary.Evidence.Operation.Name == ".ctor"
             && boundary.Kind == ResourceTriageBoundaryKind.Unknown);
 
+        var throughMemoryLocal = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.ExternalReadThroughMemoryLocal)));
+        Assert.Equal(
+            ResourceTriageActionability.UntrustedActionable,
+            throughMemoryLocal.Actionability);
+        Assert.Contains(throughMemoryLocal.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "Read"
+            && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
+        Assert.Contains(throughMemoryLocal.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == ".ctor"
+            && boundary.Kind == ResourceTriageBoundaryKind.Unknown);
+
+        var throughReadOnlySpan = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.ExternalParseThroughReadOnlySpan)));
+        Assert.Equal(
+            ResourceTriageActionability.UntrustedActionable,
+            throughReadOnlySpan.Actionability);
+        Assert.Contains(throughReadOnlySpan.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "Parse"
+            && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
+        Assert.DoesNotContain(throughReadOnlySpan.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "op_Implicit");
+
         var throughStringArgument = Assert.Single(assessments.Where(assessment =>
             assessment.Source.Payload.Method.Name
                 == nameof(ArrayPoolLeakFixtures.ExternalParseThroughSpanWithTag)));
@@ -697,6 +722,30 @@ public sealed class LeakTriageAnalyzerTests
     }
 
     [Fact]
+    public void DetailedAnalysis_CovariantArrayToSpan_RemainsThrowingBoundary()
+    {
+        var result = AnalyzeSyntheticDetailed([
+            .. Call(TokenStringShared),
+            0x1F, 0x10,
+            .. Callvirt(TokenStringRent),
+            0x0A,
+            0x06,
+            .. Call(TokenObjectSpanImplicit),
+            0x26,
+            .. Call(TokenStringShared),
+            0x06,
+            0x16,
+            .. Callvirt(TokenStringReturn),
+            0x2A,
+        ], []);
+
+        AssertCandidate(
+            result,
+            nameof(Synthetic),
+            "exception-path-leak-candidate");
+    }
+
+    [Fact]
     public void DetailedAnalysis_ThrowingBoundaryAfterSetup_IsExceptionPathCandidate()
     {
         var result = AnalyzeSyntheticDetailed([
@@ -842,6 +891,10 @@ public sealed class LeakTriageAnalyzerTests
     const int TokenArrayClear = 0x0A00000A;
     const int TokenSpanCopyTo = 0x0A00000B;
     const int TokenSpanImplicit = 0x0A00000C;
+    const int TokenStringShared = 0x0A00000D;
+    const int TokenStringRent = 0x0A00000E;
+    const int TokenStringReturn = 0x0A00000F;
+    const int TokenObjectSpanImplicit = 0x0A000010;
 
     static ImmutableArray<LeakTriageFinding> AnalyzeSynthetic(byte[] il, IReadOnlyCollection<ExceptionRegion> exceptionRegions)
         => AnalyzeSyntheticDetailed(il, exceptionRegions).Findings;
@@ -872,6 +925,14 @@ public sealed class LeakTriageAnalyzerTests
         var coreLibSpanOfByte = TypeRef.GenericInstance(
             TypeRef.CoreLib("System", "Span`1"),
             [TypeRef.CoreLib("System", "Byte")]);
+        var arrayPoolOfString = TypeRef.GenericInstance(
+            TypeRef.Definition("System.Buffers", "System.Buffers", "ArrayPool`1"),
+            [TypeRef.CoreLib("System", "String")]);
+        var stringArray = TypeRef.SzArray(TypeRef.CoreLib("System", "String"));
+        var objectArray = TypeRef.SzArray(TypeRef.CoreLib("System", "Object"));
+        var coreLibSpanOfObject = TypeRef.GenericInstance(
+            TypeRef.CoreLib("System", "Span`1"),
+            [TypeRef.CoreLib("System", "Object")]);
 
         return token switch
         {
@@ -917,6 +978,32 @@ public sealed class LeakTriageAnalyzerTests
                 "op_Implicit",
                 [byteArray],
                 coreLibSpanOfByte,
+                MemberKind.Method),
+            TokenStringShared => new MemberRef(
+                arrayPoolOfString,
+                "get_Shared",
+                [],
+                arrayPoolOfString,
+                MemberKind.Method),
+            TokenStringRent => new MemberRef(
+                arrayPoolOfString,
+                "Rent",
+                [TypeRef.CoreLib("System", "Int32")],
+                stringArray,
+                MemberKind.Method)
+            { HasThis = true },
+            TokenStringReturn => new MemberRef(
+                arrayPoolOfString,
+                "Return",
+                [stringArray],
+                TypeRef.CoreLib("System", "Void"),
+                MemberKind.Method)
+            { HasThis = true },
+            TokenObjectSpanImplicit => new MemberRef(
+                coreLibSpanOfObject,
+                "op_Implicit",
+                [objectArray],
+                coreLibSpanOfObject,
                 MemberKind.Method),
             _ => MemberRef.Unsupported($"unknown token 0x{token:X8}"),
         };
@@ -1186,6 +1273,26 @@ internal sealed class ArrayPoolLeakFixtures
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int ExternalReadThroughMemoryLocal(ExternalMemoryStream stream)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        var memory = new Memory<byte>(buffer, 0, 16);
+        int read = stream.Read(memory);
+        ArrayPool<byte>.Shared.Return(buffer);
+        return read;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int ExternalParseThroughReadOnlySpan()
+    {
+        var chars = ArrayPool<char>.Shared.Rent(16);
+        ReadOnlySpan<char> value = chars;
+        int parsed = ExternalInputReader.Parse(value);
+        ArrayPool<char>.Shared.Return(chars);
+        return parsed;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static int ExternalParseThroughSpanWithTag()
     {
         var chars = ArrayPool<char>.Shared.Rent(16);
@@ -1306,6 +1413,9 @@ internal sealed class ArrayPoolLeakFixtures
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static int Parse(Span<char> destination, string tag)
             => destination.Length + tag.Length;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static int Parse(ReadOnlySpan<char> value) => value.Length;
     }
 
     internal sealed class SpanConsumer

--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -267,6 +267,16 @@ public sealed class LeakTriageAnalyzerTests
             boundary.Evidence.Operation.Name == ".ctor"
             && boundary.Kind == ResourceTriageBoundaryKind.Unknown);
 
+        var reinitializedMemory = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.ExternalReadThroughReinitializedMemory)));
+        Assert.Equal(
+            ResourceTriageActionability.UntrustedActionable,
+            reinitializedMemory.Actionability);
+        Assert.Contains(reinitializedMemory.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "Read"
+            && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
+
         var throughReadOnlySpan = Assert.Single(assessments.Where(assessment =>
             assessment.Source.Payload.Method.Name
                 == nameof(ArrayPoolLeakFixtures.ExternalParseThroughReadOnlySpan)));
@@ -1451,6 +1461,19 @@ internal sealed class ArrayPoolLeakFixtures
         s_counter++;
         s_counter++;
         s_counter++;
+        int read = stream.Read(memory);
+        ArrayPool<byte>.Shared.Return(buffer);
+        return read;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int ExternalReadThroughReinitializedMemory(
+        ExternalMemoryStream stream)
+    {
+        Memory<byte> memory = Memory<byte>.Empty;
+        _ = stream.Read(memory);
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        memory = new Memory<byte>(buffer, 0, 16);
         int read = stream.Read(memory);
         ArrayPool<byte>.Shared.Return(buffer);
         return read;

--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -166,6 +166,44 @@ public sealed class LeakTriageAnalyzerTests
             boundary.Evidence.Operation.Name == "GetChars"
             && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
 
+        var throughImplicitSpan = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.ExternalDecodeThroughImplicitSpan)));
+        Assert.Equal(
+            ResourceTriageActionability.UntrustedActionable,
+            throughImplicitSpan.Actionability);
+        Assert.Contains(throughImplicitSpan.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "GetChars"
+            && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
+        Assert.DoesNotContain(throughImplicitSpan.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "op_Implicit");
+
+        var throughMemory = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.ExternalReadThroughMemory)));
+        Assert.Equal(
+            ResourceTriageActionability.UntrustedActionable,
+            throughMemory.Actionability);
+        Assert.Contains(throughMemory.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "Read"
+            && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
+        Assert.Contains(throughMemory.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == ".ctor"
+            && boundary.Kind == ResourceTriageBoundaryKind.Unknown);
+
+        var throughReadOnlyMemory = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.ExternalReadThroughReadOnlyMemory)));
+        Assert.Equal(
+            ResourceTriageActionability.UntrustedActionable,
+            throughReadOnlyMemory.Actionability);
+        Assert.Contains(throughReadOnlyMemory.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "Read"
+            && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
+        Assert.Contains(throughReadOnlyMemory.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == ".ctor"
+            && boundary.Kind == ResourceTriageBoundaryKind.Unknown);
+
         var throughStringArgument = Assert.Single(assessments.Where(assessment =>
             assessment.Source.Payload.Method.Name
                 == nameof(ArrayPoolLeakFixtures.ExternalParseThroughSpanWithTag)));
@@ -214,6 +252,18 @@ public sealed class LeakTriageAnalyzerTests
         Assert.Equal(
             ".ctor",
             Assert.Single(constructorBoundary.Boundaries)
+                .Evidence.Operation.Name);
+
+        var implicitConstructorBoundary = Assert.Single(
+            assessments.Where(assessment =>
+                assessment.Source.Payload.Method.Name
+                    == nameof(ArrayPoolLeakFixtures.ImplicitSpanConsumedByConstructor)));
+        Assert.Equal(
+            ResourceTriageActionability.Unknown,
+            implicitConstructorBoundary.Actionability);
+        Assert.Equal(
+            ".ctor",
+            Assert.Single(implicitConstructorBoundary.Boundaries)
                 .Evidence.Operation.Name);
 
         var unrelatedReader = Assert.Single(assessments.Where(assessment =>
@@ -1103,6 +1153,39 @@ internal sealed class ArrayPoolLeakFixtures
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int ExternalDecodeThroughImplicitSpan(byte[] source)
+    {
+        var chars = ArrayPool<char>.Shared.Rent(16);
+        Span<char> destination = chars;
+        int written = System.Text.Encoding.UTF8
+            .GetDecoder()
+            .GetChars(
+                source.AsSpan(),
+                destination,
+                flush: true);
+        ArrayPool<char>.Shared.Return(chars);
+        return written;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int ExternalReadThroughMemory(ExternalMemoryStream stream)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        int read = stream.Read(new Memory<byte>(buffer, 0, 16));
+        ArrayPool<byte>.Shared.Return(buffer);
+        return read;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int ExternalReadThroughReadOnlyMemory(ExternalMemoryStream stream)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        int read = stream.Read(new ReadOnlyMemory<byte>(buffer, 0, 16));
+        ArrayPool<byte>.Shared.Return(buffer);
+        return read;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static int ExternalParseThroughSpanWithTag()
     {
         var chars = ArrayPool<char>.Shared.Rent(16);
@@ -1136,6 +1219,16 @@ internal sealed class ArrayPoolLeakFixtures
     {
         var chars = ArrayPool<char>.Shared.Rent(16);
         var consumer = new SpanConsumer(chars.AsSpan());
+        ArrayPool<char>.Shared.Return(chars);
+        return consumer.Length;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int ImplicitSpanConsumedByConstructor()
+    {
+        var chars = ArrayPool<char>.Shared.Rent(16);
+        Span<char> value = chars;
+        var consumer = new SpanConsumer(value);
         ArrayPool<char>.Shared.Return(chars);
         return consumer.Length;
     }
@@ -1197,6 +1290,15 @@ internal sealed class ArrayPoolLeakFixtures
     {
         [MethodImpl(MethodImplOptions.NoInlining)]
         public int Read(byte[] buffer) => buffer.Length;
+    }
+
+    internal sealed class ExternalMemoryStream
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Read(Memory<byte> buffer) => buffer.Length;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Read(ReadOnlyMemory<byte> buffer) => buffer.Length;
     }
 
     internal static class ExternalInputReader

--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -7,11 +7,27 @@ using System.Runtime.CompilerServices;
 using ILInspector.Analysis;
 using ILInspector.AnalysisHarness;
 using ILInspector.Findings;
+using ILInspector.Instructions;
 
 namespace ILInspector.Analysis.Tests;
 
 public sealed class LeakTriageAnalyzerTests
 {
+    [Fact]
+    public void WrapperControlFlowFixtures_UseInPlaceConstructors()
+    {
+        AssertInPlaceConstructor(
+            nameof(ArrayPoolLeakFixtures.ExternalReadThroughReinitializedMemory));
+        AssertInPlaceConstructor(
+            nameof(ArrayPoolLeakFixtures.ExternalReadThroughLoopReinitializedMemory),
+            minimumInitobjCount: 2);
+        AssertInPlaceConstructor(
+            nameof(ArrayPoolLeakFixtures.ExternalReadThroughConditionallyResetMemory),
+            minimumInitobjCount: 1);
+        AssertInPlaceConstructor(
+            nameof(ArrayPoolLeakFixtures.DisjointMemoryUseDoesNotConsumeRent));
+    }
+
     [Fact]
     public void CleanArrayPoolFixtures_ProduceZeroRows()
     {
@@ -276,6 +292,39 @@ public sealed class LeakTriageAnalyzerTests
         Assert.Contains(reinitializedMemory.Boundaries, boundary =>
             boundary.Evidence.Operation.Name == "Read"
             && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
+
+        var loopReinitializedMemory = Assert.Single(
+            assessments.Where(assessment =>
+                assessment.Source.Payload.Method.Name
+                    == nameof(ArrayPoolLeakFixtures.ExternalReadThroughLoopReinitializedMemory)));
+        Assert.Equal(
+            ResourceTriageActionability.UntrustedActionable,
+            loopReinitializedMemory.Actionability);
+        Assert.Contains(loopReinitializedMemory.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "Read"
+            && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
+        Assert.DoesNotContain(loopReinitializedMemory.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "Observe");
+
+        var conditionallyResetMemory = Assert.Single(
+            assessments.Where(assessment =>
+                assessment.Source.Payload.Method.Name
+                    == nameof(ArrayPoolLeakFixtures.ExternalReadThroughConditionallyResetMemory)));
+        Assert.Equal(
+            ResourceTriageActionability.UntrustedActionable,
+            conditionallyResetMemory.Actionability);
+        Assert.Contains(conditionallyResetMemory.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "Read"
+            && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
+
+        var disjointMemoryUse = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.DisjointMemoryUseDoesNotConsumeRent)));
+        Assert.Equal(
+            ResourceTriageActionability.Unknown,
+            disjointMemoryUse.Actionability);
+        Assert.DoesNotContain(disjointMemoryUse.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "Read");
 
         var throughReadOnlySpan = Assert.Single(assessments.Where(assessment =>
             assessment.Source.Payload.Method.Name
@@ -1174,6 +1223,30 @@ public sealed class LeakTriageAnalyzerTests
     static void AssertNoCandidate(LeakTriageResult result, string methodName, string shape)
         => Assert.DoesNotContain(result.Candidates, candidate => candidate.Method.Name == methodName && candidate.Shape == shape);
 
+    static void AssertInPlaceConstructor(
+        string methodName,
+        int minimumInitobjCount = 0)
+    {
+        var method = typeof(ArrayPoolLeakFixtures).GetMethod(methodName)
+            ?? throw new InvalidOperationException(
+                $"Fixture method {methodName} was not found.");
+        var instructions = InstructionDecoder.Decode(
+            method.GetMethodBody()?.GetILAsByteArray() ?? []);
+
+        Assert.Contains(
+            Enumerable.Range(0, instructions.Length),
+            index => instructions[index].OpCode
+                    is ILOpCode.Ldloca or ILOpCode.Ldloca_s
+                && instructions
+                    .Skip(index + 1)
+                    .Take(5)
+                    .Any(instruction => instruction.OpCode == ILOpCode.Call));
+        Assert.True(
+            instructions.Count(instruction =>
+                instruction.OpCode == ILOpCode.Initobj)
+            >= minimumInitobjCount);
+    }
+
     static void AssertSingleShape(ImmutableArray<LeakTriageFinding> findings, string methodName, string shape)
     {
         var finding = Assert.Single(ForMethod(findings, methodName));
@@ -1480,6 +1553,62 @@ internal sealed class ArrayPoolLeakFixtures
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int ExternalReadThroughLoopReinitializedMemory(
+        ExternalMemoryStream stream,
+        bool repeat)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        Memory<byte> memory = default;
+        int read;
+        do
+        {
+            memory = new Memory<byte>(buffer, 0, 16);
+            read = stream.Read(memory);
+            memory = default;
+            stream.Observe(memory);
+        }
+        while (repeat);
+        ArrayPool<byte>.Shared.Return(buffer);
+        return read;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int DisjointMemoryUseDoesNotConsumeRent(
+        ExternalMemoryStream stream,
+        Memory<byte> caller,
+        bool useRented)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        Memory<byte> memory = caller;
+        int result;
+        if (useRented)
+        {
+            memory = new Memory<byte>(buffer, 0, 16);
+            result = 0;
+        }
+        else
+        {
+            result = stream.Read(memory);
+        }
+        ArrayPool<byte>.Shared.Return(buffer);
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int ExternalReadThroughConditionallyResetMemory(
+        ExternalMemoryStream stream,
+        bool reset)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        var memory = new Memory<byte>(buffer, 0, 16);
+        if (reset)
+            memory = default;
+        int read = stream.Read(memory);
+        ArrayPool<byte>.Shared.Return(buffer);
+        return read;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static int ExternalParseThroughReadOnlySpan()
     {
         var chars = ArrayPool<char>.Shared.Rent(16);
@@ -1675,6 +1804,9 @@ internal sealed class ArrayPoolLeakFixtures
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         public int Read() => 1;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Observe(Memory<byte> buffer) => s_counter += buffer.Length;
     }
 
     internal sealed class ExternalMemoryOnlyStream

--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -217,6 +217,30 @@ public sealed class LeakTriageAnalyzerTests
             boundary.Evidence.Operation.Name == ".ctor"
             && boundary.Kind == ResourceTriageBoundaryKind.Unknown);
 
+        var throughImplicitMemory = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.ExternalReadThroughImplicitMemory)));
+        Assert.Equal(
+            ResourceTriageActionability.UntrustedActionable,
+            throughImplicitMemory.Actionability);
+        Assert.Contains(throughImplicitMemory.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "Read"
+            && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
+        Assert.DoesNotContain(throughImplicitMemory.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "op_Implicit");
+
+        var throughMemoryChain = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.ExternalReadThroughMemoryChain)));
+        Assert.Equal(
+            ResourceTriageActionability.UntrustedActionable,
+            throughMemoryChain.Actionability);
+        Assert.Contains(throughMemoryChain.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "Read"
+            && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
+        Assert.DoesNotContain(throughMemoryChain.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name is ".ctor" or "op_Implicit");
+
         var throughReadOnlySpan = Assert.Single(assessments.Where(assessment =>
             assessment.Source.Payload.Method.Name
                 == nameof(ArrayPoolLeakFixtures.ExternalParseThroughReadOnlySpan)));
@@ -228,6 +252,18 @@ public sealed class LeakTriageAnalyzerTests
             && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
         Assert.DoesNotContain(throughReadOnlySpan.Boundaries, boundary =>
             boundary.Evidence.Operation.Name == "op_Implicit");
+
+        var throughExplicitSpan = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.ExternalParseThroughExplicitSpan)));
+        Assert.Equal(
+            ResourceTriageActionability.UntrustedActionable,
+            throughExplicitSpan.Actionability);
+        Assert.Contains(throughExplicitSpan.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "Parse"
+            && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
+        Assert.DoesNotContain(throughExplicitSpan.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == ".ctor");
 
         var throughSpanByRef = Assert.Single(assessments.Where(assessment =>
             assessment.Source.Payload.Method.Name
@@ -266,6 +302,9 @@ public sealed class LeakTriageAnalyzerTests
         Assert.DoesNotContain(assessments, assessment =>
             assessment.Source.Payload.Method.Name
                 == nameof(ArrayPoolLeakFixtures.SpanFillBeforeReturn));
+        Assert.DoesNotContain(assessments, assessment =>
+            assessment.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.ExactMemoryConstructorEscape));
 
         var throughStringArgument = Assert.Single(assessments.Where(assessment =>
             assessment.Source.Payload.Method.Name
@@ -1100,6 +1139,7 @@ internal static class Synthetic
 internal sealed class ArrayPoolLeakFixtures
 {
     static byte[]? s_field;
+    static Memory<byte> s_memory;
     static readonly string s_tag = "wire";
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -1326,11 +1366,43 @@ internal sealed class ArrayPoolLeakFixtures
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int ExternalReadThroughImplicitMemory(
+        ExternalMemoryOnlyStream stream)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        int read = stream.Read(buffer);
+        ArrayPool<byte>.Shared.Return(buffer);
+        return read;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int ExternalReadThroughMemoryChain(
+        ExternalMemoryStream stream)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        var memory = new Memory<byte>(buffer);
+        ReadOnlyMemory<byte> readOnlyMemory = memory;
+        int read = stream.Read(readOnlyMemory);
+        ArrayPool<byte>.Shared.Return(buffer);
+        return read;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static int ExternalParseThroughReadOnlySpan()
     {
         var chars = ArrayPool<char>.Shared.Rent(16);
         ReadOnlySpan<char> value = chars;
         int parsed = ExternalInputReader.Parse(value);
+        ArrayPool<char>.Shared.Return(chars);
+        return parsed;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int ExternalParseThroughExplicitSpan()
+    {
+        var chars = ArrayPool<char>.Shared.Rent(16);
+        var value = new Span<char>(chars);
+        int parsed = ExternalInputReader.Parse(value, "wire");
         ArrayPool<char>.Shared.Return(chars);
         return parsed;
     }
@@ -1373,6 +1445,14 @@ internal sealed class ArrayPoolLeakFixtures
         Span<char> value = chars;
         value.Fill('x');
         ArrayPool<char>.Shared.Return(chars);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ExactMemoryConstructorEscape()
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        s_memory = new Memory<byte>(buffer);
+        ArrayPool<byte>.Shared.Return(buffer);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -1492,6 +1572,12 @@ internal sealed class ArrayPoolLeakFixtures
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         public int Read() => 1;
+    }
+
+    internal sealed class ExternalMemoryOnlyStream
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Read(Memory<byte> buffer) => buffer.Length;
     }
 
     internal static class ExternalInputReader

--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -241,6 +241,19 @@ public sealed class LeakTriageAnalyzerTests
         Assert.DoesNotContain(throughMemoryChain.Boundaries, boundary =>
             boundary.Evidence.Operation.Name is ".ctor" or "op_Implicit");
 
+        var throughMemoryAlias = Assert.Single(assessments.Where(assessment =>
+            assessment.Source.Payload.Method.Name
+                == nameof(ArrayPoolLeakFixtures.ExternalReadThroughMemoryAlias)));
+        Assert.Equal(
+            ResourceTriageActionability.UntrustedActionable,
+            throughMemoryAlias.Actionability);
+        Assert.Contains(throughMemoryAlias.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "Read"
+            && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
+        Assert.Contains(throughMemoryAlias.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == ".ctor"
+            && boundary.Kind == ResourceTriageBoundaryKind.Unknown);
+
         var throughReadOnlySpan = Assert.Single(assessments.Where(assessment =>
             assessment.Source.Payload.Method.Name
                 == nameof(ArrayPoolLeakFixtures.ExternalParseThroughReadOnlySpan)));
@@ -264,6 +277,19 @@ public sealed class LeakTriageAnalyzerTests
             && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
         Assert.DoesNotContain(throughExplicitSpan.Boundaries, boundary =>
             boundary.Evidence.Operation.Name == ".ctor");
+
+        var throughReadOnlySpanChain = Assert.Single(
+            assessments.Where(assessment =>
+                assessment.Source.Payload.Method.Name
+                    == nameof(ArrayPoolLeakFixtures.ExternalParseThroughReadOnlySpanChain)));
+        Assert.Equal(
+            ResourceTriageActionability.UntrustedActionable,
+            throughReadOnlySpanChain.Actionability);
+        Assert.Contains(throughReadOnlySpanChain.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "Parse"
+            && boundary.Kind == ResourceTriageBoundaryKind.ExternalInput);
+        Assert.DoesNotContain(throughReadOnlySpanChain.Boundaries, boundary =>
+            boundary.Evidence.Operation.Name == "op_Implicit");
 
         var throughSpanByRef = Assert.Single(assessments.Where(assessment =>
             assessment.Source.Payload.Method.Name
@@ -1388,6 +1414,18 @@ internal sealed class ArrayPoolLeakFixtures
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int ExternalReadThroughMemoryAlias(
+        ExternalMemoryStream stream)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        var memory = new Memory<byte>(buffer, 0, 16);
+        Memory<byte> alias = memory;
+        int read = stream.Read(alias);
+        ArrayPool<byte>.Shared.Return(buffer);
+        return read;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static int ExternalParseThroughReadOnlySpan()
     {
         var chars = ArrayPool<char>.Shared.Rent(16);
@@ -1403,6 +1441,17 @@ internal sealed class ArrayPoolLeakFixtures
         var chars = ArrayPool<char>.Shared.Rent(16);
         var value = new Span<char>(chars);
         int parsed = ExternalInputReader.Parse(value, "wire");
+        ArrayPool<char>.Shared.Return(chars);
+        return parsed;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int ExternalParseThroughReadOnlySpanChain()
+    {
+        var chars = ArrayPool<char>.Shared.Rent(16);
+        Span<char> value = chars;
+        ReadOnlySpan<char> readOnlyValue = value;
+        int parsed = ExternalInputReader.Parse(readOnlyValue);
         ArrayPool<char>.Shared.Return(chars);
         return parsed;
     }

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -694,7 +694,7 @@ public static class LeakTriageAnalyzer
         TypeRef? valueType = null)
     {
         if (!TryFindInstruction(instructions, loadOffset, out int index, out var load)
-            || !IsLoadLocal(load, slot))
+            || !IsLoadLocalOrAddress(load, slot))
             return UseClassification.OwnershipTransfer("Rented array use could not be classified.");
 
         int extra = 0;
@@ -721,6 +721,24 @@ public static class LeakTriageAnalyzer
             {
                 if (IsArrayPoolReturn(callee) && extra < callee.ParameterTypes.Length)
                     return UseClassification.Release;
+                int consumedArguments =
+                    callee.ParameterTypes.Length
+                    + (instruction.OpCode != ILOpCode.Newobj && callee.HasThis
+                        ? 1
+                        : 0);
+                if (consumedArguments <= extra)
+                {
+                    extra -= consumedArguments;
+                    if (instruction.OpCode == ILOpCode.Newobj
+                        || !FrameworkIdentity.IsCoreLibraryType(
+                            callee.ReturnType,
+                            "System",
+                            "Void"))
+                    {
+                        extra++;
+                    }
+                    continue;
+                }
                 return UseClassification.CrossMethod(
                     $"Rented array is passed to {callee.DeclaringType.Name}::{callee.Name}.",
                     IsNonThrowingSetupBoundary(callee, valueType),
@@ -817,9 +835,6 @@ public static class LeakTriageAnalyzer
                 foreach (var use in reaching.UsesOf(definition)
                     .OrderBy(static use => use.Offset))
                 {
-                    if (use.Address)
-                        return null;
-
                     var classification = ClassifyUse(
                         instructions,
                         calls,
@@ -911,7 +926,7 @@ public static class LeakTriageAnalyzer
             {
                 return null;
             }
-            if (!IsLoadLocal(instruction, slot))
+            if (!IsLoadLocalOrAddress(instruction, slot))
                 continue;
 
             var classification = ClassifyUse(
@@ -1014,6 +1029,13 @@ public static class LeakTriageAnalyzer
             ILOpCode.Ldloc_s or ILOpCode.Ldloc => instruction.OperandValue == slot,
             _ => false,
         };
+
+    static bool IsLoadLocalOrAddress(
+        DecodedInstruction instruction,
+        int slot)
+        => IsLoadLocal(instruction, slot)
+            || (TryReadLoadLocalAddress(instruction, out int addressSlot)
+                && addressSlot == slot);
 
     static bool TryReadLoadLocalAddress(
         DecodedInstruction instruction,
@@ -1127,7 +1149,8 @@ public static class LeakTriageAnalyzer
             return true;
         }
 
-        return member.Name == "Clear" && IsSpanType(member.DeclaringType);
+        return member.Name is "Clear" or "Fill"
+            && IsSpanType(member.DeclaringType);
     }
 
     static bool IsTransparentWrapperBoundary(MemberRef member)

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -999,27 +999,172 @@ public static class LeakTriageAnalyzer
             instructions,
             reaching,
             calls,
-            reaching.Uses.Where(use =>
-                !use.IsArgument
-                && use.Slot == slot
-                && use.Offset > instructions[setupIndex].Offset
-                // The constructor overwrites the value-type local through its
-                // address, so explicit definitions before it no longer apply.
-                && use.ReachingDefinitions.All(definition =>
-                    definition.Offset < instructions[setupIndex].Offset)),
+            FindNormalFlowLocalUses(
+                instructions,
+                calls,
+                setupIndex,
+                slot),
             slot,
             depth);
+
+    static ImmutableArray<LocalUse> FindNormalFlowLocalUses(
+        ImmutableArray<DecodedInstruction> instructions,
+        IReadOnlyDictionary<int, MemberRef> calls,
+        int setupIndex,
+        int slot)
+    {
+        if (setupIndex + 1 >= instructions.Length)
+            return [];
+
+        var definitionReceivers = new HashSet<int>();
+        for (int i = 0; i < instructions.Length; i++)
+        {
+            if (TryFindAddressWriteLocal(
+                    instructions,
+                    i,
+                    out int writeSlot,
+                    out int receiverIndex)
+                && writeSlot == slot)
+            {
+                definitionReceivers.Add(receiverIndex);
+                continue;
+            }
+
+            if (calls.TryGetValue(instructions[i].Offset, out var member)
+                && TryFindInPlaceWrapperLocal(
+                    instructions,
+                    i,
+                    member,
+                    out int constructorSlot,
+                    out receiverIndex)
+                && constructorSlot == slot)
+            {
+                definitionReceivers.Add(receiverIndex);
+            }
+        }
+
+        var indexByOffset = instructions
+            .Select((instruction, index) =>
+                (instruction.Offset, Index: index))
+            .ToDictionary(static pair => pair.Offset, static pair => pair.Index);
+        var pending = new Stack<int>();
+        var visited = new HashSet<int>();
+        var uses = new Dictionary<int, LocalUse>();
+
+        // The local is defined only when the constructor returns, so follow
+        // normal IL edges and stop before any later write to the same slot.
+        pending.Push(setupIndex + 1);
+        while (pending.TryPop(out int index))
+        {
+            if (!visited.Add(index))
+                continue;
+
+            var instruction = instructions[index];
+            if (definitionReceivers.Contains(index)
+                || (TryReadStoreLocal(instruction, out int storedSlot)
+                    && storedSlot == slot))
+            {
+                continue;
+            }
+
+            if (IsLoadLocalOrAddress(instruction, slot))
+            {
+                bool address = TryReadLoadLocalAddress(
+                    instruction,
+                    out _);
+                uses.TryAdd(
+                    instruction.Offset,
+                    new LocalUse(
+                        slot,
+                        IsArgument: false,
+                        instruction.Offset,
+                        address,
+                        []));
+            }
+
+            if (instruction.LeavesRegion)
+                continue;
+
+            foreach (int target in instruction.BranchTargets)
+                if (indexByOffset.TryGetValue(target, out int targetIndex))
+                    pending.Push(targetIndex);
+
+            if (instruction.FallsThrough && index + 1 < instructions.Length)
+                pending.Push(index + 1);
+        }
+
+        return uses.Values
+            .OrderBy(static use => use.Offset)
+            .ToImmutableArray();
+    }
+
+    static bool TryFindAddressWriteLocal(
+        ImmutableArray<DecodedInstruction> instructions,
+        int writeIndex,
+        out int slot,
+        out int receiverIndex)
+    {
+        slot = -1;
+        receiverIndex = -1;
+        int pushedValues = instructions[writeIndex].OpCode switch
+        {
+            ILOpCode.Initobj => 0,
+            ILOpCode.Stobj or ILOpCode.Cpobj => 1,
+            _ => -1,
+        };
+        if (pushedValues < 0)
+            return false;
+
+        int index = writeIndex - 1;
+        for (int remaining = pushedValues; remaining > 0; remaining--)
+        {
+            while (index >= 0 && instructions[index].OpCode == ILOpCode.Nop)
+                index--;
+            if (index < 0
+                || !IsSetupArgumentPush(instructions[index].OpCode))
+            {
+                return false;
+            }
+            index--;
+        }
+
+        while (index >= 0 && instructions[index].OpCode == ILOpCode.Nop)
+            index--;
+        if (index < 0
+            || !TryReadLoadLocalAddress(instructions[index], out slot))
+        {
+            return false;
+        }
+
+        receiverIndex = index;
+        return true;
+    }
 
     static bool TryFindInPlaceWrapperLocal(
         ImmutableArray<DecodedInstruction> instructions,
         int setupIndex,
         MemberRef member,
         out int slot)
+        => TryFindInPlaceWrapperLocal(
+            instructions,
+            setupIndex,
+            member,
+            out slot,
+            out _);
+
+    static bool TryFindInPlaceWrapperLocal(
+        ImmutableArray<DecodedInstruction> instructions,
+        int setupIndex,
+        MemberRef member,
+        out int slot,
+        out int receiverIndex)
     {
         slot = -1;
+        receiverIndex = -1;
         if (instructions[setupIndex].OpCode != ILOpCode.Call
             || !member.HasThis
-            || !IsTransparentWrapperBoundary(member))
+            || member.Name != ".ctor"
+            || !IsTypedWrapperType(member.DeclaringType))
         {
             return false;
         }
@@ -1041,8 +1186,14 @@ public static class LeakTriageAnalyzer
 
         while (index >= 0 && instructions[index].OpCode == ILOpCode.Nop)
             index--;
-        return index >= 0
-            && TryReadLoadLocalAddress(instructions[index], out slot);
+        if (index < 0
+            || !TryReadLoadLocalAddress(instructions[index], out slot))
+        {
+            return false;
+        }
+
+        receiverIndex = index;
+        return true;
     }
 
     static bool TryFindNextNonNop(ImmutableArray<DecodedInstruction> instructions, int offset, out DecodedInstruction instruction)

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -834,36 +834,12 @@ public static class LeakTriageAnalyzer
                 if (definition is null)
                     return null;
 
-                foreach (var use in reaching.UsesOf(definition)
-                    .OrderBy(static use => use.Offset))
-                {
-                    var classification = ClassifyUse(
-                        instructions,
-                        calls,
-                        use.Offset,
-                        slot);
-                    if (classification.CandidateShape
-                            != "cross-method-suppressed"
-                        || classification.Boundary is not { } localBoundary)
-                    {
-                        continue;
-                    }
-
-                    if (!classification.NonThrowingSetupBoundary)
-                        return localBoundary;
-
-                    if (FindBoundaryAfterSetup(
-                            instructions,
-                            reaching,
-                            calls,
-                            localBoundary,
-                            depth + 1) is { } downstream)
-                    {
-                        return downstream;
-                    }
-                }
-
-                return null;
+                return FindBoundaryFromLocalDefinition(
+                    instructions,
+                    reaching,
+                    calls,
+                    definition,
+                    depth);
             }
 
             if (!calls.TryGetValue(instruction.Offset, out var callee))
@@ -910,6 +886,94 @@ public static class LeakTriageAnalyzer
         return null;
     }
 
+    static ArrayPoolExceptionBoundary? FindBoundaryFromLocalDefinition(
+        ImmutableArray<DecodedInstruction> instructions,
+        ReachingDefinitionsResult reaching,
+        IReadOnlyDictionary<int, MemberRef> calls,
+        LocalDefinition definition,
+        int depth)
+    {
+        if (depth >= 4)
+            return null;
+
+        foreach (var use in reaching.UsesOf(definition)
+            .OrderBy(static use => use.Offset))
+        {
+            var classification = ClassifyUse(
+                instructions,
+                calls,
+                use.Offset,
+                definition.Slot);
+            if (classification.CandidateShape
+                    != "cross-method-suppressed"
+                || classification.Boundary is not { } boundary)
+            {
+                if (classification.CandidateShape
+                        == "alias-or-field-suppressed"
+                    && FindBoundaryAfterLocalAlias(
+                        instructions,
+                        reaching,
+                        calls,
+                        use.Offset,
+                        depth + 1) is { } aliasBoundary)
+                {
+                    return aliasBoundary;
+                }
+                continue;
+            }
+            if (!classification.NonThrowingSetupBoundary)
+                return boundary;
+
+            if (FindBoundaryAfterSetup(
+                    instructions,
+                    reaching,
+                    calls,
+                    boundary,
+                    depth + 1) is { } downstream)
+            {
+                return downstream;
+            }
+        }
+
+        return null;
+    }
+
+    static ArrayPoolExceptionBoundary? FindBoundaryAfterLocalAlias(
+        ImmutableArray<DecodedInstruction> instructions,
+        ReachingDefinitionsResult reaching,
+        IReadOnlyDictionary<int, MemberRef> calls,
+        int loadOffset,
+        int depth)
+    {
+        if (depth >= 4
+            || !TryFindInstruction(
+                instructions,
+                loadOffset,
+                out _,
+                out var load)
+            || !TryFindNextNonNop(
+                instructions,
+                load.NextOffset,
+                out var store)
+            || !TryReadStoreLocal(store, out int aliasSlot))
+        {
+            return null;
+        }
+
+        var definition = reaching.Definitions.FirstOrDefault(candidate =>
+            !candidate.IsArgument
+            && candidate.Slot == aliasSlot
+            && candidate.Offset == store.Offset);
+        return definition is null
+            ? null
+            : FindBoundaryFromLocalDefinition(
+                instructions,
+                reaching,
+                calls,
+                definition,
+                depth);
+    }
+
     static ArrayPoolExceptionBoundary? FindBoundaryAfterInPlaceSetup(
         ImmutableArray<DecodedInstruction> instructions,
         ReachingDefinitionsResult reaching,
@@ -941,7 +1005,18 @@ public static class LeakTriageAnalyzer
             if (classification.CandidateShape != "cross-method-suppressed"
                 || classification.Boundary is not { } boundary)
             {
-                return null;
+                if (classification.CandidateShape
+                        == "alias-or-field-suppressed"
+                    && FindBoundaryAfterLocalAlias(
+                        instructions,
+                        reaching,
+                        calls,
+                        instruction.Offset,
+                        depth + 1) is { } aliasBoundary)
+                {
+                    return aliasBoundary;
+                }
+                continue;
             }
             if (!classification.NonThrowingSetupBoundary)
                 return boundary;
@@ -1165,7 +1240,7 @@ public static class LeakTriageAnalyzer
         }
 
         if (IsExactArrayWrapperConstructor(member, valueType)
-            || IsMemoryToReadOnlyMemoryConversion(member))
+            || IsMutableToReadOnlyWrapperConversion(member))
         {
             return true;
         }
@@ -1192,13 +1267,15 @@ public static class LeakTriageAnalyzer
             && valueType?.Equals(array) == true
             && IsTypedWrapperType(member.DeclaringType);
 
-    static bool IsMemoryToReadOnlyMemoryConversion(MemberRef member)
+    static bool IsMutableToReadOnlyWrapperConversion(MemberRef member)
         => member.Name == "op_Implicit"
             && member.ParameterTypes is [var source]
-            && IsFrameworkGenericType(source, "Memory`1")
-            && IsFrameworkGenericType(
-                member.ReturnType,
-                "ReadOnlyMemory`1")
+            && ((IsFrameworkGenericType(source, "Memory`1")
+                    && IsFrameworkGenericType(
+                        member.ReturnType,
+                        "ReadOnlyMemory`1"))
+                || (IsSpanType(source)
+                    && IsReadOnlySpanType(member.ReturnType)))
             && source.TypeArguments.SequenceEqual(
                 member.ReturnType.TypeArguments);
 

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -247,7 +247,10 @@ public static class LeakTriageAnalyzer
                             directThrowingBoundaries.Add(boundary);
                             directUseOffsets.TryAdd(boundary.ILOffset, use.Offset);
                         }
-                        else if (FindBoundaryAfterSetup(
+                        if ((classification.NonThrowingSetupBoundary
+                                || IsTransparentWrapperBoundary(
+                                    boundary.Operation))
+                            && FindBoundaryAfterSetup(
                             instructions,
                             reaching,
                             calls,
@@ -709,7 +712,7 @@ public static class LeakTriageAnalyzer
                     return UseClassification.Release;
                 return UseClassification.CrossMethod(
                     $"Rented array is passed to {callee.DeclaringType.Name}::{callee.Name}.",
-                    IsNonThrowingSetupBoundary(instructions, calls, i, callee),
+                    IsNonThrowingSetupBoundary(callee),
                     new ArrayPoolExceptionBoundary(instruction.Offset, callee));
             }
             return UseClassification.OwnershipTransfer($"Rented array reaches unsupported opcode {opcode}.");
@@ -742,19 +745,21 @@ public static class LeakTriageAnalyzer
         if (depth >= 4)
             return null;
 
-        if (FrameworkIdentity.IsCoreLibraryType(
-            setup.Operation.ReturnType,
-            "System",
-            "Void"))
-        {
-            return null;
-        }
-
         if (!TryFindInstruction(
             instructions,
             setup.ILOffset,
             out int setupIndex,
-            out _))
+            out var setupInstruction))
+        {
+            return null;
+        }
+
+        // Constructor signatures return void, but newobj pushes the constructed value.
+        if (setupInstruction.OpCode != ILOpCode.Newobj
+            && FrameworkIdentity.IsCoreLibraryType(
+                setup.Operation.ReturnType,
+                "System",
+                "Void"))
         {
             return null;
         }
@@ -843,11 +848,7 @@ public static class LeakTriageAnalyzer
 
             var boundary =
                 new ArrayPoolExceptionBoundary(instruction.Offset, callee);
-            if (!IsNonThrowingSetupBoundary(
-                instructions,
-                calls,
-                i,
-                callee))
+            if (!IsNonThrowingSetupBoundary(callee))
             {
                 return boundary;
             }
@@ -986,11 +987,7 @@ public static class LeakTriageAnalyzer
         => FrameworkIdentity.IsKnownFrameworkType(type, "System.Buffers", "System.Buffers", "ArrayPool`1")
            || FrameworkIdentity.IsCoreLibraryType(type, "System.Buffers", "ArrayPool`1");
 
-    static bool IsNonThrowingSetupBoundary(
-        ImmutableArray<DecodedInstruction> instructions,
-        IReadOnlyDictionary<int, MemberRef> calls,
-        int callIndex,
-        MemberRef member)
+    static bool IsNonThrowingSetupBoundary(MemberRef member)
     {
         if (member.Kind == MemberKind.Unsupported)
             return false;
@@ -1014,56 +1011,43 @@ public static class LeakTriageAnalyzer
             return true;
         }
 
-        if (member.Name == "op_Implicit"
-            && member.ParameterTypes.Length == 1
-            && member.ParameterTypes[0].Kind == TypeRefKind.SzArray
-            && IsSpanType(member.ReturnType)
-            && NextCallIsSpanCopyTo(instructions, calls, callIndex))
+        if (IsArrayToSpanConversion(member))
         {
+            // Shared ArrayPool<T> returns an exact T[], so the Span<T> conversion
+            // cannot encounter a covariant-array type mismatch.
             return true;
         }
 
         return member.Name == "Clear" && IsSpanType(member.DeclaringType);
     }
 
-    static bool NextCallIsSpanCopyTo(
-        ImmutableArray<DecodedInstruction> instructions,
-        IReadOnlyDictionary<int, MemberRef> calls,
-        int callIndex)
-    {
-        for (int i = callIndex + 1, skipped = 0; i < instructions.Length; i++)
-        {
-            var instruction = instructions[i];
-            if (instruction.OpCode == ILOpCode.Nop)
-                continue;
+    static bool IsTransparentWrapperBoundary(MemberRef member)
+        => member.Name == ".ctor"
+            && member.ParameterTypes is [{ Kind: TypeRefKind.SzArray }, ..]
+            && (IsFrameworkGenericType(member.DeclaringType, "Memory`1")
+                || IsFrameworkGenericType(
+                    member.DeclaringType,
+                    "ReadOnlyMemory`1"));
 
-            if (calls.TryGetValue(instruction.Offset, out var next))
-                return next.Name == "CopyTo" && IsSpanType(next.DeclaringType);
-
-            if (IsCopyToArgumentSetup(instruction.OpCode) && skipped++ < 6)
-                continue;
-
-            return false;
-        }
-
-        return false;
-    }
-
-    static bool IsCopyToArgumentSetup(ILOpCode opcode)
-        => opcode is ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or ILOpCode.Stloc_2 or ILOpCode.Stloc_3
-            or ILOpCode.Stloc_s or ILOpCode.Stloc
-            or ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2 or ILOpCode.Ldloc_3
-            or ILOpCode.Ldloc_s or ILOpCode.Ldloc or ILOpCode.Ldloca_s or ILOpCode.Ldloca
-            or ILOpCode.Ldarg_0 or ILOpCode.Ldarg_1 or ILOpCode.Ldarg_2 or ILOpCode.Ldarg_3
-            or ILOpCode.Ldarg_s or ILOpCode.Ldarg or ILOpCode.Ldarga_s or ILOpCode.Ldarga;
+    static bool IsArrayToSpanConversion(MemberRef member)
+        => member.Name == "op_Implicit"
+            && member.ParameterTypes is [{ Kind: TypeRefKind.SzArray }]
+            && IsSpanType(member.ReturnType);
 
     static bool IsSpanType(TypeRef type)
+        => IsFrameworkGenericType(type, "Span`1");
+
+    static bool IsFrameworkGenericType(TypeRef type, string name)
     {
         if (type.Kind != TypeRefKind.GenericInstance || type.ElementType is not { } definition)
             return false;
 
-        return FrameworkIdentity.IsCoreLibraryType(definition, "System", "Span`1")
-            || FrameworkIdentity.IsKnownFrameworkType(definition, "System.Memory", "System", "Span`1");
+        return FrameworkIdentity.IsCoreLibraryType(definition, "System", name)
+            || FrameworkIdentity.IsKnownFrameworkType(
+                definition,
+                "System.Memory",
+                "System",
+                name);
     }
 
     static int ArgumentSlotCount(MethodIdentity method)

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -1003,7 +1003,10 @@ public static class LeakTriageAnalyzer
                 !use.IsArgument
                 && use.Slot == slot
                 && use.Offset > instructions[setupIndex].Offset
-                && use.ReachingDefinitions.IsEmpty),
+                // The constructor overwrites the value-type local through its
+                // address, so explicit definitions before it no longer apply.
+                && use.ReachingDefinitions.All(definition =>
+                    definition.Offset < instructions[setupIndex].Offset)),
             slot,
             depth);
 

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -800,9 +800,11 @@ public static class LeakTriageAnalyzer
             {
                 return FindBoundaryAfterInPlaceSetup(
                     instructions,
+                    reaching,
                     calls,
                     setupIndex,
-                    slot);
+                    slot,
+                    depth);
             }
 
             return null;
@@ -910,9 +912,11 @@ public static class LeakTriageAnalyzer
 
     static ArrayPoolExceptionBoundary? FindBoundaryAfterInPlaceSetup(
         ImmutableArray<DecodedInstruction> instructions,
+        ReachingDefinitionsResult reaching,
         IReadOnlyDictionary<int, MemberRef> calls,
         int setupIndex,
-        int slot)
+        int slot,
+        int depth)
     {
         for (int i = setupIndex + 1;
             i < instructions.Length && i <= setupIndex + 16;
@@ -934,9 +938,20 @@ public static class LeakTriageAnalyzer
                 calls,
                 instruction.Offset,
                 slot);
-            return classification.CandidateShape == "cross-method-suppressed"
-                ? classification.Boundary
-                : null;
+            if (classification.CandidateShape != "cross-method-suppressed"
+                || classification.Boundary is not { } boundary)
+            {
+                return null;
+            }
+            if (!classification.NonThrowingSetupBoundary)
+                return boundary;
+
+            return FindBoundaryAfterSetup(
+                instructions,
+                reaching,
+                calls,
+                boundary,
+                depth + 1);
         }
 
         return null;
@@ -1143,8 +1158,14 @@ public static class LeakTriageAnalyzer
             return true;
         }
 
-        if (IsArrayToSpanConversion(member)
+        if (IsArrayToTypedWrapperConversion(member)
             && valueType?.Equals(member.ParameterTypes[0]) == true)
+        {
+            return true;
+        }
+
+        if (IsExactArrayWrapperConstructor(member, valueType)
+            || IsMemoryToReadOnlyMemoryConversion(member))
         {
             return true;
         }
@@ -1156,16 +1177,36 @@ public static class LeakTriageAnalyzer
     static bool IsTransparentWrapperBoundary(MemberRef member)
         => member.Name == ".ctor"
             && member.ParameterTypes is [{ Kind: TypeRefKind.SzArray }, ..]
-            && (IsFrameworkGenericType(member.DeclaringType, "Memory`1")
-                || IsFrameworkGenericType(
-                    member.DeclaringType,
-                    "ReadOnlyMemory`1"));
+            && IsTypedWrapperType(member.DeclaringType);
 
-    static bool IsArrayToSpanConversion(MemberRef member)
+    static bool IsArrayToTypedWrapperConversion(MemberRef member)
         => member.Name == "op_Implicit"
             && member.ParameterTypes is [{ Kind: TypeRefKind.SzArray }]
-            && (IsSpanType(member.ReturnType)
-                || IsReadOnlySpanType(member.ReturnType));
+            && IsTypedWrapperType(member.ReturnType);
+
+    static bool IsExactArrayWrapperConstructor(
+        MemberRef member,
+        TypeRef? valueType)
+        => member.Name == ".ctor"
+            && member.ParameterTypes is [{ Kind: TypeRefKind.SzArray } array]
+            && valueType?.Equals(array) == true
+            && IsTypedWrapperType(member.DeclaringType);
+
+    static bool IsMemoryToReadOnlyMemoryConversion(MemberRef member)
+        => member.Name == "op_Implicit"
+            && member.ParameterTypes is [var source]
+            && IsFrameworkGenericType(source, "Memory`1")
+            && IsFrameworkGenericType(
+                member.ReturnType,
+                "ReadOnlyMemory`1")
+            && source.TypeArguments.SequenceEqual(
+                member.ReturnType.TypeArguments);
+
+    static bool IsTypedWrapperType(TypeRef type)
+        => IsSpanType(type)
+            || IsReadOnlySpanType(type)
+            || IsFrameworkGenericType(type, "Memory`1")
+            || IsFrameworkGenericType(type, "ReadOnlyMemory`1");
 
     static bool IsSpanType(TypeRef type)
         => IsFrameworkGenericType(type, "Span`1");

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -892,18 +892,32 @@ public static class LeakTriageAnalyzer
         IReadOnlyDictionary<int, MemberRef> calls,
         LocalDefinition definition,
         int depth)
+        => FindBoundaryFromLocalUses(
+            instructions,
+            reaching,
+            calls,
+            reaching.UsesOf(definition),
+            definition.Slot,
+            depth);
+
+    static ArrayPoolExceptionBoundary? FindBoundaryFromLocalUses(
+        ImmutableArray<DecodedInstruction> instructions,
+        ReachingDefinitionsResult reaching,
+        IReadOnlyDictionary<int, MemberRef> calls,
+        IEnumerable<LocalUse> uses,
+        int slot,
+        int depth)
     {
         if (depth >= 4)
             return null;
 
-        foreach (var use in reaching.UsesOf(definition)
-            .OrderBy(static use => use.Offset))
+        foreach (var use in uses.OrderBy(static use => use.Offset))
         {
             var classification = ClassifyUse(
                 instructions,
                 calls,
                 use.Offset,
-                definition.Slot);
+                slot);
             if (classification.CandidateShape
                     != "cross-method-suppressed"
                 || classification.Boundary is not { } boundary)
@@ -981,56 +995,17 @@ public static class LeakTriageAnalyzer
         int setupIndex,
         int slot,
         int depth)
-    {
-        for (int i = setupIndex + 1;
-            i < instructions.Length && i <= setupIndex + 16;
-            i++)
-        {
-            var instruction = instructions[i];
-            if (instruction.OpCode == ILOpCode.Nop)
-                continue;
-            if (TryReadStoreLocal(instruction, out int storedSlot)
-                && storedSlot == slot)
-            {
-                return null;
-            }
-            if (!IsLoadLocalOrAddress(instruction, slot))
-                continue;
-
-            var classification = ClassifyUse(
-                instructions,
-                calls,
-                instruction.Offset,
-                slot);
-            if (classification.CandidateShape != "cross-method-suppressed"
-                || classification.Boundary is not { } boundary)
-            {
-                if (classification.CandidateShape
-                        == "alias-or-field-suppressed"
-                    && FindBoundaryAfterLocalAlias(
-                        instructions,
-                        reaching,
-                        calls,
-                        instruction.Offset,
-                        depth + 1) is { } aliasBoundary)
-                {
-                    return aliasBoundary;
-                }
-                continue;
-            }
-            if (!classification.NonThrowingSetupBoundary)
-                return boundary;
-
-            return FindBoundaryAfterSetup(
-                instructions,
-                reaching,
-                calls,
-                boundary,
-                depth + 1);
-        }
-
-        return null;
-    }
+        => FindBoundaryFromLocalUses(
+            instructions,
+            reaching,
+            calls,
+            reaching.Uses.Where(use =>
+                !use.IsArgument
+                && use.Slot == slot
+                && use.Offset > instructions[setupIndex].Offset
+                && use.ReachingDefinitions.IsEmpty),
+            slot,
+            depth);
 
     static bool TryFindInPlaceWrapperLocal(
         ImmutableArray<DecodedInstruction> instructions,

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -223,7 +223,12 @@ public static class LeakTriageAnalyzer
                 continue;
             }
 
-            var classification = ClassifyUse(instructions, calls, use.Offset, rent.Slot);
+            var classification = ClassifyUse(
+                instructions,
+                calls,
+                use.Offset,
+                rent.Slot,
+                rent.Type);
             switch (classification.Kind)
             {
                 case UseKind.Release:
@@ -645,7 +650,12 @@ public static class LeakTriageAnalyzer
                 continue;
             }
 
-            yield return new RentedLocal(instruction.Offset, store.Offset, slot, definition);
+            yield return new RentedLocal(
+                instruction.Offset,
+                store.Offset,
+                slot,
+                definition,
+                callee.ReturnType);
         }
     }
 
@@ -680,7 +690,8 @@ public static class LeakTriageAnalyzer
         ImmutableArray<DecodedInstruction> instructions,
         IReadOnlyDictionary<int, MemberRef> calls,
         int loadOffset,
-        int slot)
+        int slot,
+        TypeRef? valueType = null)
     {
         if (!TryFindInstruction(instructions, loadOffset, out int index, out var load)
             || !IsLoadLocal(load, slot))
@@ -712,7 +723,7 @@ public static class LeakTriageAnalyzer
                     return UseClassification.Release;
                 return UseClassification.CrossMethod(
                     $"Rented array is passed to {callee.DeclaringType.Name}::{callee.Name}.",
-                    IsNonThrowingSetupBoundary(callee),
+                    IsNonThrowingSetupBoundary(callee, valueType),
                     new ArrayPoolExceptionBoundary(instruction.Offset, callee));
             }
             return UseClassification.OwnershipTransfer($"Rented array reaches unsupported opcode {opcode}.");
@@ -761,6 +772,21 @@ public static class LeakTriageAnalyzer
                 "System",
                 "Void"))
         {
+            // Roslyn can initialize a value-type wrapper local through
+            // ldloca + call .ctor instead of newobj + stloc.
+            if (TryFindInPlaceWrapperLocal(
+                    instructions,
+                    setupIndex,
+                    setup.Operation,
+                    out int slot))
+            {
+                return FindBoundaryAfterInPlaceSetup(
+                    instructions,
+                    calls,
+                    setupIndex,
+                    slot);
+            }
+
             return null;
         }
 
@@ -867,6 +893,75 @@ public static class LeakTriageAnalyzer
         return null;
     }
 
+    static ArrayPoolExceptionBoundary? FindBoundaryAfterInPlaceSetup(
+        ImmutableArray<DecodedInstruction> instructions,
+        IReadOnlyDictionary<int, MemberRef> calls,
+        int setupIndex,
+        int slot)
+    {
+        for (int i = setupIndex + 1;
+            i < instructions.Length && i <= setupIndex + 16;
+            i++)
+        {
+            var instruction = instructions[i];
+            if (instruction.OpCode == ILOpCode.Nop)
+                continue;
+            if (TryReadStoreLocal(instruction, out int storedSlot)
+                && storedSlot == slot)
+            {
+                return null;
+            }
+            if (!IsLoadLocal(instruction, slot))
+                continue;
+
+            var classification = ClassifyUse(
+                instructions,
+                calls,
+                instruction.Offset,
+                slot);
+            return classification.CandidateShape == "cross-method-suppressed"
+                ? classification.Boundary
+                : null;
+        }
+
+        return null;
+    }
+
+    static bool TryFindInPlaceWrapperLocal(
+        ImmutableArray<DecodedInstruction> instructions,
+        int setupIndex,
+        MemberRef member,
+        out int slot)
+    {
+        slot = -1;
+        if (instructions[setupIndex].OpCode != ILOpCode.Call
+            || !member.HasThis
+            || !IsTransparentWrapperBoundary(member))
+        {
+            return false;
+        }
+
+        int index = setupIndex - 1;
+        for (int remaining = member.ParameterTypes.Length;
+            remaining > 0;
+            remaining--)
+        {
+            while (index >= 0 && instructions[index].OpCode == ILOpCode.Nop)
+                index--;
+            if (index < 0
+                || !IsSetupArgumentPush(instructions[index].OpCode))
+            {
+                return false;
+            }
+            index--;
+        }
+
+        while (index >= 0 && instructions[index].OpCode == ILOpCode.Nop)
+            index--;
+        return index >= 0
+            && TryReadLoadLocalAddress(instructions[index], out slot);
+    }
+
     static bool TryFindNextNonNop(ImmutableArray<DecodedInstruction> instructions, int offset, out DecodedInstruction instruction)
     {
         foreach (var candidate in instructions)
@@ -919,6 +1014,19 @@ public static class LeakTriageAnalyzer
             ILOpCode.Ldloc_s or ILOpCode.Ldloc => instruction.OperandValue == slot,
             _ => false,
         };
+
+    static bool TryReadLoadLocalAddress(
+        DecodedInstruction instruction,
+        out int slot)
+    {
+        slot = instruction.OpCode switch
+        {
+            ILOpCode.Ldloca_s or ILOpCode.Ldloca =>
+                checked((int)instruction.OperandValue),
+            _ => -1,
+        };
+        return slot >= 0;
+    }
 
     static bool IsSimpleArgumentPush(ILOpCode opcode)
         => opcode is ILOpCode.Ldc_i4_m1 or ILOpCode.Ldc_i4_0 or ILOpCode.Ldc_i4_1 or ILOpCode.Ldc_i4_2
@@ -987,7 +1095,9 @@ public static class LeakTriageAnalyzer
         => FrameworkIdentity.IsKnownFrameworkType(type, "System.Buffers", "System.Buffers", "ArrayPool`1")
            || FrameworkIdentity.IsCoreLibraryType(type, "System.Buffers", "ArrayPool`1");
 
-    static bool IsNonThrowingSetupBoundary(MemberRef member)
+    static bool IsNonThrowingSetupBoundary(
+        MemberRef member,
+        TypeRef? valueType = null)
     {
         if (member.Kind == MemberKind.Unsupported)
             return false;
@@ -1011,10 +1121,9 @@ public static class LeakTriageAnalyzer
             return true;
         }
 
-        if (IsArrayToSpanConversion(member))
+        if (IsArrayToSpanConversion(member)
+            && valueType?.Equals(member.ParameterTypes[0]) == true)
         {
-            // Shared ArrayPool<T> returns an exact T[], so the Span<T> conversion
-            // cannot encounter a covariant-array type mismatch.
             return true;
         }
 
@@ -1032,10 +1141,14 @@ public static class LeakTriageAnalyzer
     static bool IsArrayToSpanConversion(MemberRef member)
         => member.Name == "op_Implicit"
             && member.ParameterTypes is [{ Kind: TypeRefKind.SzArray }]
-            && IsSpanType(member.ReturnType);
+            && (IsSpanType(member.ReturnType)
+                || IsReadOnlySpanType(member.ReturnType));
 
     static bool IsSpanType(TypeRef type)
         => IsFrameworkGenericType(type, "Span`1");
+
+    static bool IsReadOnlySpanType(TypeRef type)
+        => IsFrameworkGenericType(type, "ReadOnlySpan`1");
 
     static bool IsFrameworkGenericType(TypeRef type, string name)
     {
@@ -1056,7 +1169,12 @@ public static class LeakTriageAnalyzer
     internal static bool IsRecoverable(Exception ex)
         => ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException or IndexOutOfRangeException;
 
-    sealed record RentedLocal(int RentOffset, int StoreOffset, int Slot, LocalDefinition Definition);
+    sealed record RentedLocal(
+        int RentOffset,
+        int StoreOffset,
+        int Slot,
+        LocalDefinition Definition,
+        TypeRef Type);
 
     sealed record AmbiguousUse(int Offset, string Shape);
 

--- a/src/ILInspector.Analysis/ResourceTriageAnalysis.cs
+++ b/src/ILInspector.Analysis/ResourceTriageAnalysis.cs
@@ -258,6 +258,11 @@ public static class ResourceTriageAnalysis
                 && method == ".ctor")
             || (!IsStreamLike(declaringType)
                 && method == "CopyTo")
+            || (method == "Slice"
+                && (IsCoreLibraryGenericType(declaringType, "Span`1")
+                    || IsCoreLibraryGenericType(
+                        declaringType,
+                        "ReadOnlySpan`1")))
             || method.StartsWith("TryFormat", StringComparison.Ordinal)
             || method.StartsWith("Format", StringComparison.Ordinal)
             || method.StartsWith("WriteString", StringComparison.Ordinal)
@@ -273,6 +278,14 @@ public static class ResourceTriageAnalysis
     static bool IsStreamLike(TypeRef type)
         => IsType(type, "System.IO", "Stream")
             || HasTypeNameSuffix(type, "Stream");
+
+    static bool IsCoreLibraryGenericType(TypeRef type, string name)
+        => type.Kind == TypeRefKind.GenericInstance
+            && type.ElementType is { } definition
+            && FrameworkIdentity.IsCoreLibraryType(
+                definition,
+                "System",
+                name);
 
     static bool IsType(TypeRef type, string @namespace, string name)
     {

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -275,8 +275,8 @@ lever**. Use the candidate buckets to decide which correctness gate to model nex
 A 2026-07-17 run over the .NET 11 daily shared framework
 (`Microsoft.NETCore.App` + `Microsoft.AspNetCore.App`, 314 assemblies) produced **0 findings**
 across `arraypool-rent-not-returned`, `arraypool-use-after-return`, and
-`arraypool-double-return`. Its 543 measurement rows comprised 364
-`ownership-transfer-suppressed`, 122 `cross-method-suppressed`, 49
+`arraypool-double-return`. Its 519 measurement rows comprised 364
+`ownership-transfer-suppressed`, 122 `cross-method-suppressed`, 25
 `exception-path-leak-candidate`, and 8 `alias-or-field-suppressed` rows. The fixture assembly's
 three known-misuse methods still surface exactly once each. The broad real-code result does not
 justify promoting any of these three strict shapes into product output; the separate
@@ -285,8 +285,8 @@ rows as correctness findings.
 
 The shared framework is the false-positive gate, not the profitability corpus. The pinned
 ArrayPool-heavy community corpus prepared above contains the primary library from each of nine
-package roots. It produced **0 strict findings**, from 201 measurement rows: 145
-`ownership-transfer-suppressed`, 36 `cross-method-suppressed`, 19
+package roots. It produced **0 strict findings**, from 189 measurement rows: 145
+`ownership-transfer-suppressed`, 36 `cross-method-suppressed`, 7
 `exception-path-leak-candidate`, and 1 `alias-or-field-suppressed`.
 
 The assembly API delegates to a leak-only `LibraryBodyIndex` feature rather than reopening and
@@ -333,18 +333,20 @@ dotnet-inspect library MyLib.dll -S "Resource Triage" --jsonl
 ```
 
 A 2026-07-17 run over the .NET 11 daily shared framework (314 assemblies) classified
-50 lifecycle observations as 2 `untrusted-actionable`
-(`MessagePackReader::ReadStringSlow`, `BinaryReader::FillBuffer`),
-1 `trusted-low-actionability`, and 47 `unknown`.
+34 lifecycle observations as 4 `untrusted-actionable`
+(`MessagePackReader::ReadStringSlow`, `EncodingExtensions::GetString`,
+`TypeMapLazyDictionary::ConvertUtf8ToUtf16`, and `BinaryReader::FillBuffer`),
+4 `trusted-low-actionability`, and 26 `unknown`.
 
-The same-day pinned community run classified 19 lifecycle observations as 1
-`untrusted-actionable` (`MessagePackReader::ReadStringSlow`) and 18 `unknown`. Four of the unknown
-observations are the previously source-verified MimeKit `Rfc2047.DecodePhrase`/`DecodeText`,
-Npgsql `TextConverter.GetChars`, and Pipelines.Sockets `AsyncPipeStream.ReadByte` defects. Thirteen
-more are System.Text.Json's deliberate no-`finally` in-memory-transform idiom, historically
-classified as low actionability. The community corpus therefore proves the analysis family is
-profitable while exposing a current producer/classification recall gap; these known cases should
-not be treated as evidence for non-action.
+The same-day pinned community run classified 8 lifecycle observations as 3
+`untrusted-actionable` (`MessagePackReader::ReadStringSlow`, Npgsql
+`TextConverter::GetChars`, and Pipelines.Sockets `AsyncPipeStream.ReadByte`) and 5 `unknown`.
+Typed propagation through array-to-`Span<T>` conversion and `Memory<T>` construction recovers the
+Npgsql and Pipelines consumers without package-specific policy. MimeKit
+`Rfc2047.DecodePhrase`/`DecodeText` remain unknown because their only unprotected boundary is the
+`TokenDecoder` constructor; the later tokenizer calls are protected by cleanup. Eleven former
+System.Text.Json observations no longer count because their implicit array-to-`Span<T>` conversion
+is nonthrowing and no downstream throwing consumer is attributable.
 
 ## MemoryPool lifecycle corpus sensor (#2439, Slice 3)
 

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -285,8 +285,8 @@ rows as correctness findings.
 
 The shared framework is the false-positive gate, not the profitability corpus. The pinned
 ArrayPool-heavy community corpus prepared above contains the primary library from each of nine
-package roots. It produced **0 strict findings**, from 189 measurement rows: 145
-`ownership-transfer-suppressed`, 36 `cross-method-suppressed`, 7
+package roots. It produced **0 strict findings**, from 188 measurement rows: 145
+`ownership-transfer-suppressed`, 35 `cross-method-suppressed`, 7
 `exception-path-leak-candidate`, and 1 `alias-or-field-suppressed`.
 
 The assembly API delegates to a leak-only `LibraryBodyIndex` feature rather than reopening and
@@ -333,20 +333,21 @@ dotnet-inspect library MyLib.dll -S "Resource Triage" --jsonl
 ```
 
 A 2026-07-17 run over the .NET 11 daily shared framework (314 assemblies) classified
-34 lifecycle observations as 4 `untrusted-actionable`
+57 lifecycle observations as 4 `untrusted-actionable`
 (`MessagePackReader::ReadStringSlow`, `EncodingExtensions::GetString`,
 `TypeMapLazyDictionary::ConvertUtf8ToUtf16`, and `BinaryReader::FillBuffer`),
-4 `trusted-low-actionability`, and 26 `unknown`.
+31 `trusted-low-actionability`, and 22 `unknown`.
 
-The same-day pinned community run classified 8 lifecycle observations as 3
+The same-day pinned community run classified 19 lifecycle observations as 3
 `untrusted-actionable` (`MessagePackReader::ReadStringSlow`, Npgsql
-`TextConverter::GetChars`, and Pipelines.Sockets `AsyncPipeStream.ReadByte`) and 5 `unknown`.
+`TextConverter::GetChars`, and Pipelines.Sockets `AsyncPipeStream.ReadByte`), 11
+`trusted-low-actionability`, and 5 `unknown`.
 Typed propagation through array-to-`Span<T>` conversion and `Memory<T>` construction recovers the
 Npgsql and Pipelines consumers without package-specific policy. MimeKit
 `Rfc2047.DecodePhrase`/`DecodeText` remain unknown because their only unprotected boundary is the
-`TokenDecoder` constructor; the later tokenizer calls are protected by cleanup. Eleven former
-System.Text.Json observations no longer count because their implicit array-to-`Span<T>` conversion
-is nonthrowing and no downstream throwing consumer is attributable.
+`TokenDecoder` constructor; the later tokenizer calls are protected by cleanup. Eleven
+System.Text.Json observations now identify `Span<T>.Slice` rather than the nonthrowing implicit
+conversion and classify as trusted in-memory work.
 
 ## MemoryPool lifecycle corpus sensor (#2439, Slice 3)
 

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -333,10 +333,10 @@ dotnet-inspect library MyLib.dll -S "Resource Triage" --jsonl
 ```
 
 A 2026-07-17 run over the .NET 11 daily shared framework (314 assemblies) classified
-57 lifecycle observations as 4 `untrusted-actionable`
+57 lifecycle observations as 5 `untrusted-actionable`
 (`MessagePackReader::ReadStringSlow`, `EncodingExtensions::GetString`,
-`TypeMapLazyDictionary::ConvertUtf8ToUtf16`, and `BinaryReader::FillBuffer`),
-31 `trusted-low-actionability`, and 22 `unknown`.
+`TypeMapLazyDictionary::ConvertUtf8ToUtf16`, `BinaryReader::FillBuffer`, and
+`HashAlgorithm::ComputeHashAsyncCore`), 31 `trusted-low-actionability`, and 21 `unknown`.
 
 The same-day pinned community run classified 19 lifecycle observations as 3
 `untrusted-actionable` (`MessagePackReader::ReadStringSlow`, Npgsql


### PR DESCRIPTION
## Summary

- follow ArrayPool-backed values through typed array-to-`Span<T>` conversion and
  `Memory<T>`/`ReadOnlyMemory<T>` construction
- retain potentially throwing memory constructors as boundaries while adding
  the exact downstream consumer
- skip unrelated nested argument calls and attribute the exact wrapper consumer

## Product demo

NativeAOT `dotnet-inspect` over the pinned community assemblies now reports:

| Assembly / member | Before | After |
| --- | --- | --- |
| Npgsql `TextConverter.GetChars` | unknown at `Span<char>::op_Implicit` | actionable at `Decoder::GetChars` (`IL_00A9`) |
| Pipelines `AsyncPipeStream.ReadByte` | unknown at `Memory<byte>::.ctor` | actionable at `AsyncPipeStream::Read` (`IL_00A5`), with the constructor retained |

The implementation uses framework type and signature identity only. MimeKit's
two `TokenDecoder` constructor rows remain unknown because their later tokenizer
calls are already inside cleanup.

## Corpus evidence

- pinned community corpus: 19 lifecycle observations, 3 actionable, 11 trusted,
  5 unknown (previously 19 / 1 / 0 / 18)
- .NET 11 shared framework: 57 lifecycle observations, 5 actionable, 31 trusted,
  21 unknown (previously 50 / 2 / 1 / 47)
- strict Leak Triage remains at 0 findings in both corpora

## Validation

- Release solution build
- 483 Analysis tests
- markdownlint
- linux-x64 NativeAOT publish and product queries over Npgsql 8.0.4 and
  Pipelines.Sockets.Unofficial 2.2.8

Advances #1992.
