### PR TITLE
Move type-shell print-request composition into the ILInspector.CSharp seam

### DIFF
--- a/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
+++ b/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
+using ILInspector.Metadata;
 
 namespace ILInspector.CSharp.Tests;
 
@@ -71,6 +72,65 @@ public sealed class TypeShellProducerTests
         Assert.True(TypeShellProducer.IsStaticType(Type(nameof(StaticFixture))));
         Assert.False(TypeShellProducer.IsStaticType(Type(nameof(InstanceFixture))));
         Assert.False(TypeShellProducer.IsStaticType(Type(nameof(IInterfaceFixture))));
+    }
+
+    [Fact]
+    public void BuildPrintRequest_ComposesApiTypeFromSpecAndMetadata()
+    {
+        using var pe = new PEReader(File.OpenRead(typeof(TypeShellProducerTests).Assembly.Location));
+        var reader = pe.GetMetadataReader();
+
+        TypeDefinitionHandle Handle(string name) => reader.TypeDefinitions
+            .Single(handle => reader.GetString(reader.GetTypeDefinition(handle).Name) == name);
+
+        var member = new CSharpMemberPolicy(
+            new ApiMember { Name = "Value", Kind = "field", ReturnType = "System.Int32" },
+            CSharpBodyPolicy.Skeleton);
+        var nested = new CSharpTypeShellSpec(
+            Handle(nameof(InstanceFixture)),
+            Namespace: "Samples",
+            MetadataName: "InstanceFixture",
+            Kind: CSharpTypeShellKind.Class,
+            BaseTypeDisplayName: null,
+            InterfaceDisplayNames: [],
+            MemberPolicies: [],
+            PrimaryConstructorParameters: [],
+            NestedTypes: []);
+        var spec = new CSharpTypeShellSpec(
+            Handle(nameof(StaticFixture)),
+            Namespace: "Samples",
+            MetadataName: "StaticFixture",
+            Kind: CSharpTypeShellKind.Struct,
+            BaseTypeDisplayName: "Samples.Widget",
+            InterfaceDisplayNames: ["System.IDisposable"],
+            MemberPolicies: [member],
+            PrimaryConstructorParameters: [],
+            NestedTypes: [nested]);
+
+        var request = TypeShellProducer.BuildPrintRequest(reader, spec);
+
+        // Spec-supplied facts flow straight through.
+        Assert.Equal("Samples", request.Type.Namespace);
+        Assert.Equal("StaticFixture", request.Type.Name);
+        Assert.Equal("StaticFixture", request.Type.MetadataName);
+        Assert.Equal("struct", request.Type.Kind);
+        Assert.Equal("Samples.Widget", request.Type.BaseType);
+        Assert.Equal(["System.IDisposable"], request.Type.Interfaces);
+        Assert.Same(member, Assert.Single(request.MemberPolicyOverrides));
+        Assert.Equal("Value", Assert.Single(request.Type.Members).Name);
+        Assert.Same(member.Member, request.Type.Members[0]);
+
+        // Modifiers are read from the type's own metadata, not the spec kind.
+        Assert.True(request.Type.IsStatic);
+        Assert.True(request.Type.IsAbstract);
+        Assert.True(request.Type.IsSealed);
+
+        // Nested shells recurse through the same builder.
+        var nestedRequest = Assert.Single(request.NestedTypes);
+        Assert.Equal("InstanceFixture", nestedRequest.Type.Name);
+        Assert.Equal("class", nestedRequest.Type.Kind);
+        Assert.True(nestedRequest.Type.IsSealed);
+        Assert.False(nestedRequest.Type.IsStatic);
     }
 
     static async Task RuntimeAsyncFixture()

--- a/src/ILInspector.CSharp/CSharpTypeShellSpec.cs
+++ b/src/ILInspector.CSharp/CSharpTypeShellSpec.cs
@@ -1,0 +1,56 @@
+using System.Reflection.Metadata;
+using ILInspector.Metadata;
+
+namespace ILInspector.CSharp;
+
+/// <summary>
+/// The C# kind of a reconstructed type shell. Neutral spelling of the kinds the
+/// seam can compose, independent of any consumer's planning vocabulary.
+/// </summary>
+public enum CSharpTypeShellKind
+{
+    Class,
+    Record,
+    Struct,
+    Interface,
+    Enum,
+    Delegate,
+}
+
+/// <summary>
+/// A neutral, IR- and planner-free description of a type shell to compose into a
+/// <see cref="CSharpTypePrintRequest"/>. The consumer (for example the ReturnToSender
+/// harness) discovers the members and resolves the C# spelling of the type's own
+/// name, base type, and interfaces; the seam owns turning this description plus the
+/// type's metadata into the <see cref="ApiType"/> and print-request tree. Every field
+/// is a plain string, a metadata handle, or an already-seam/Metadata type — no
+/// consumer planning type crosses this boundary.
+/// </summary>
+/// <param name="Handle">The type definition whose metadata supplies the remaining
+/// shell facts (type parameters, custom attributes, and abstract/sealed/static
+/// modifiers).</param>
+/// <param name="Namespace">The type's C# namespace, or the empty string for the
+/// global namespace.</param>
+/// <param name="MetadataName">The type's metadata name (arity ticks preserved),
+/// used verbatim for both <see cref="ApiType.Name"/> and
+/// <see cref="ApiType.MetadataName"/>.</param>
+/// <param name="Kind">The reconstructed C# kind.</param>
+/// <param name="BaseTypeDisplayName">The C# display spelling of the reconstructed
+/// base type, or null when no base is reconstructed.</param>
+/// <param name="InterfaceDisplayNames">The C# display spellings of the reconstructed
+/// implemented interfaces.</param>
+/// <param name="MemberPolicies">The members to emit with their per-member body
+/// policies, in declaration order.</param>
+/// <param name="PrimaryConstructorParameters">The primary-constructor parameter list,
+/// or empty when the type has no primary constructor.</param>
+/// <param name="NestedTypes">The nested type shells, composed recursively.</param>
+public sealed record CSharpTypeShellSpec(
+    TypeDefinitionHandle Handle,
+    string Namespace,
+    string MetadataName,
+    CSharpTypeShellKind Kind,
+    string? BaseTypeDisplayName,
+    IReadOnlyList<string> InterfaceDisplayNames,
+    IReadOnlyList<CSharpMemberPolicy> MemberPolicies,
+    IReadOnlyList<ApiParameter> PrimaryConstructorParameters,
+    IReadOnlyList<CSharpTypeShellSpec> NestedTypes);

--- a/src/ILInspector.CSharp/TypeShellProducer.cs
+++ b/src/ILInspector.CSharp/TypeShellProducer.cs
@@ -160,4 +160,59 @@ public static class TypeShellProducer
         => (typeDef.Attributes & TypeAttributes.Abstract) != 0
             && (typeDef.Attributes & TypeAttributes.Sealed) != 0
             && (typeDef.Attributes & TypeAttributes.Interface) == 0;
+
+    /// <summary>
+    /// Composes a <see cref="CSharpTypePrintRequest"/> for a reconstructed type shell
+    /// from a neutral <see cref="CSharpTypeShellSpec"/> and the type's own metadata.
+    /// The consumer supplies member discovery, body policies, and the C# spelling of
+    /// the type's name/base/interfaces; this seam owns assembling the
+    /// <see cref="ApiType"/> — kind text, generic parameters, custom attributes, and
+    /// abstract/sealed/static modifiers read straight from metadata — and recursing
+    /// into nested shells. SRM-only, Roslyn-free, and NativeAOT-friendly.
+    /// </summary>
+    public static CSharpTypePrintRequest BuildPrintRequest(MetadataReader reader, CSharpTypeShellSpec spec)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        ArgumentNullException.ThrowIfNull(spec);
+
+        var typeDef = reader.GetTypeDefinition(spec.Handle);
+        var members = spec.MemberPolicies.Select(policy => policy.Member).ToList();
+        var type = new ApiType
+        {
+            Namespace = spec.Namespace,
+            Name = spec.MetadataName,
+            MetadataName = spec.MetadataName,
+            Kind = TypeKindText(spec.Kind),
+            BaseType = spec.BaseTypeDisplayName,
+            TypeParameters = MetadataDeclarationQuery.GetTypeParameters(reader, typeDef).ToList(),
+            Interfaces = spec.InterfaceDisplayNames.ToList(),
+            Members = members,
+            Attributes = AttributeReader.RenderAttributes(reader, typeDef.GetCustomAttributes(), qualifyNames: true),
+            IsAbstract = (typeDef.Attributes & TypeAttributes.Abstract) != 0
+                && (typeDef.Attributes & TypeAttributes.Interface) == 0,
+            IsSealed = (typeDef.Attributes & TypeAttributes.Sealed) != 0,
+            IsStatic = IsStaticType(typeDef),
+        };
+
+        return new CSharpTypePrintRequest(
+            type,
+            members: members,
+            memberPolicyOverrides: spec.MemberPolicies,
+            primaryConstructorParameters: spec.PrimaryConstructorParameters,
+            nestedTypes: spec.NestedTypes
+                .Select(nested => BuildPrintRequest(reader, nested))
+                .ToList());
+    }
+
+    static string TypeKindText(CSharpTypeShellKind kind)
+        => kind switch
+        {
+            CSharpTypeShellKind.Class => "class",
+            CSharpTypeShellKind.Record => "record",
+            CSharpTypeShellKind.Struct => "struct",
+            CSharpTypeShellKind.Interface => "interface",
+            CSharpTypeShellKind.Enum => "enum",
+            CSharpTypeShellKind.Delegate => "delegate",
+            _ => throw new NotSupportedException($"Unsupported C# type-shell kind '{kind}'."),
+        };
 }

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -2607,13 +2607,14 @@ public static class CompileBackSourceComposer
                         SourceFacts: [new CompileBackFact("metadata", "declaring-closure-type", rootIdentity.FullName)]);
                 }
 
-                requests.Add(TypeRequest(
+                var rootSpec = BuildSpec(
                     reader,
                     rootHandle,
                     rootRequirement,
                     requirementsByMetadataName,
                     producedRequirements,
-                    diagnostics));
+                    diagnostics);
+                requests.Add(TypeShellProducer.BuildPrintRequest(reader, rootSpec));
             }
 
             return new TypeProduction(requests, producedRequirements);
@@ -2847,7 +2848,7 @@ public static class CompileBackSourceComposer
             return index;
         }
 
-        static CSharpTypePrintRequest TypeRequest(
+        static CSharpTypeShellSpec BuildSpec(
             MetadataReader reader,
             TypeDefinitionHandle handle,
             CompileBackTypeRequirement requirement,
@@ -2885,30 +2886,19 @@ public static class CompileBackSourceComposer
             var policies = members
                 .Select(member => ToMemberPolicy(member, primaryConstructorParameters.Length))
                 .ToArray();
-            var type = new ApiType
-            {
-                Namespace = requirement.Type.Namespace,
-                Name = requirement.Type.MetadataName,
-                MetadataName = requirement.Type.MetadataName,
-                Kind = TypeKindText(kind),
-                BaseType = BaseTypeSignature(reader, typeDef, kind)?.DisplayName,
-                TypeParameters = MetadataDeclarationQuery.GetTypeParameters(reader, typeDef).ToList(),
-                Interfaces = InterfaceSignatures(reader, typeDef)
+
+            return new CSharpTypeShellSpec(
+                Handle: handle,
+                Namespace: requirement.Type.Namespace,
+                MetadataName: requirement.Type.MetadataName,
+                Kind: ToShellKind(kind),
+                BaseTypeDisplayName: BaseTypeSignature(reader, typeDef, kind)?.DisplayName,
+                InterfaceDisplayNames: InterfaceSignatures(reader, typeDef)
                     .Select(signature => signature.DisplayName)
                     .ToList(),
-                Members = policies.Select(policy => policy.Member).ToList(),
-                Attributes = TypeAttributeList(reader, typeDef).ToList(),
-                IsAbstract = (typeDef.Attributes & TypeAttributes.Abstract) != 0
-                    && (typeDef.Attributes & TypeAttributes.Interface) == 0,
-                IsSealed = (typeDef.Attributes & TypeAttributes.Sealed) != 0,
-                IsStatic = TypeShellProducer.IsStaticType(typeDef),
-            };
-            return new CSharpTypePrintRequest(
-                type,
-                members: type.Members,
-                memberPolicyOverrides: policies,
-                primaryConstructorParameters: primaryConstructorParameters,
-                nestedTypes: NestedTypes(
+                MemberPolicies: policies,
+                PrimaryConstructorParameters: primaryConstructorParameters,
+                NestedTypes: NestedSpecs(
                     reader,
                     typeDef,
                     requirementsByMetadataName,
@@ -2917,18 +2907,17 @@ public static class CompileBackSourceComposer
                     diagnostics));
         }
 
-        static string TypeKindText(CompileBackTypeKind kind)
+        static CSharpTypeShellKind ToShellKind(CompileBackTypeKind kind)
             => kind switch
             {
-                CompileBackTypeKind.Class => "class",
-                CompileBackTypeKind.Record => "record",
-                CompileBackTypeKind.Struct => "struct",
-                CompileBackTypeKind.Interface => "interface",
-                CompileBackTypeKind.Enum => "enum",
-                CompileBackTypeKind.Delegate => "delegate",
+                CompileBackTypeKind.Class => CSharpTypeShellKind.Class,
+                CompileBackTypeKind.Record => CSharpTypeShellKind.Record,
+                CompileBackTypeKind.Struct => CSharpTypeShellKind.Struct,
+                CompileBackTypeKind.Interface => CSharpTypeShellKind.Interface,
+                CompileBackTypeKind.Enum => CSharpTypeShellKind.Enum,
+                CompileBackTypeKind.Delegate => CSharpTypeShellKind.Delegate,
                 _ => throw new NotSupportedException($"Unsupported RTS type kind '{kind}'."),
             };
-
         static CompileBackMemberRequirement DelegateInvokeRequirement(
             MetadataReader reader,
             TypeDefinition typeDef,
@@ -2961,7 +2950,7 @@ public static class CompileBackSourceComposer
                 .Select(member => member with { Accessibility = CompileBackAccessibility.Public })
                 .ToList();
 
-        static IReadOnlyList<CSharpTypePrintRequest> NestedTypes(
+        static IReadOnlyList<CSharpTypeShellSpec> NestedSpecs(
             MetadataReader reader,
             TypeDefinition typeDef,
             IReadOnlyDictionary<string, CompileBackTypeRequirement> requirementsByMetadataName,
@@ -2969,7 +2958,7 @@ public static class CompileBackSourceComposer
             List<CompileBackTypeRequirement> producedRequirements,
             List<CompileBackPlanningDiagnostic> diagnostics)
         {
-            var nestedTypes = new List<CSharpTypePrintRequest>();
+            var nestedTypes = new List<CSharpTypeShellSpec>();
             foreach (var nestedHandle in typeDef.GetNestedTypes())
             {
                 var nestedDef = reader.GetTypeDefinition(nestedHandle);
@@ -2994,7 +2983,7 @@ public static class CompileBackSourceComposer
                 var nestedRequirement = includeNestedMemberSurface
                     ? requirement with { IncludeMemberSurface = true }
                     : requirement;
-                nestedTypes.Add(TypeRequest(
+                nestedTypes.Add(BuildSpec(
                     reader,
                     nestedHandle,
                     nestedRequirement,
@@ -3009,10 +2998,10 @@ public static class CompileBackSourceComposer
                 {
                     var delegateDef = reader.GetTypeDefinition(delegateHandle);
                     var identity = CompileBackTypeIdentity.FromDefinition(reader, delegateDef);
-                    if (nestedTypes.Any(type => type.Type.Name == identity.MetadataName))
+                    if (nestedTypes.Any(spec => spec.MetadataName == identity.MetadataName))
                         continue;
 
-                    nestedTypes.Add(TypeRequest(
+                    nestedTypes.Add(BuildSpec(
                         reader,
                         delegateHandle,
                         new CompileBackTypeRequirement(
@@ -3050,9 +3039,6 @@ public static class CompileBackSourceComposer
                     yield return handle;
             }
         }
-
-        static IReadOnlyList<string> TypeAttributeList(MetadataReader reader, TypeDefinition typeDef)
-            => AttributeReader.RenderAttributes(reader, typeDef.GetCustomAttributes(), qualifyNames: true);
 
         static CompileBackTypeSignature? BaseTypeSignature(MetadataReader reader, TypeDefinition typeDef, CompileBackTypeKind kind)
         {


### PR DESCRIPTION
## Why

Part of #2777 (make ReturnToSender a thin orchestrator; move C# source
composition out of the harness into the product seam). This slice retires the
harness-local `TypeProducer` `ApiType`/`CSharpTypePrintRequest` assembly so the
seam — not the harness — owns turning type-shell facts into a print request.

## What

The harness now builds a **neutral `CSharpTypeShellSpec` tree** and hands the
root specs to a new seam entry point:

- **New** `src/ILInspector.CSharp/CSharpTypeShellSpec.cs` — `CSharpTypeShellKind`
  + `CSharpTypeShellSpec` (a plain-string / metadata-handle / seam-type DTO; **no
  `CompileBack*` planning vocabulary crosses the boundary**).
- **New** `TypeShellProducer.BuildPrintRequest(reader, spec)` — assembles the
  `ApiType` (kind text, generic parameters, custom attributes,
  abstract/sealed/static modifiers read straight from metadata) and recurses into
  nested shells. SRM-only, Roslyn-free, NativeAOT-friendly.
- **Harness** `TypeRequest` -> `BuildSpec`, `NestedTypes` -> `NestedSpecs`. Member
  discovery, `CompileBack* -> CSharpMemberPolicy` mapping, base/interface C#
  naming, and `plan.Types` evidence bookkeeping are **unchanged**. The
  harness-local `TypeKindText`/`TypeAttributeList` are removed (moved/inlined into
  the seam), replaced by a trivial `CompileBackTypeKind -> CSharpTypeShellKind`
  mapper.

### Intentionally left in the harness (separate threads)

- **Base/interface display naming** still flows through
  `CompileBackTypeIdentity`/`Clean`; those strings are pre-computed harness-side
  and passed into the spec. Migrating that spelling is a separate ongoing thread.
- **Member discovery + `CompileBack*` planning + evidence** (`plan.Types`,
  `producedRequirements`) — the ReturnToSender oracle's irreducible job.

## Evidence (behavior-preserving carve)

- Full `dotnet-inspect.slnx` build clean.
- RTS oracle: Evidence/Catalog 103 + Prototype 114 (**217** tests).
- Decompiler fast subset **2476** (printer byte-identity).
- CSharp.Tests **240**, incl. a new `BuildPrintRequest` seam test (spec-driven
  facts vs metadata-driven modifiers vs nested recursion).
- RTS parity corpus gate (14 assemblies, `rts-parity` oracle + burndown
  manifest): **exit 0**, the 7 committed burn-down rows unchanged, **0 new
  regressions**.

Rebased on latest `origin/main` (0 behind). Adversarial review to follow
(two non-Opus reviewers). Do not merge without @richlander approval.
