### PR TITLE
Key ReturnToSender's closure index on the seam identifier producer

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CompileBackTypeIdentityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompileBackTypeIdentityTests.cs
@@ -1,0 +1,147 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+using ILInspector.CSharp;
+using ILInspector.DecompilerHarness;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.Decompiler.Tests;
+
+// The closure index (CompileBackTypeIdentity.FromDefinition) keys the FullTypes map on
+// the identifier the product seam actually emits, so a missing type Roslyn reports —
+// which reflects the seam's emitted spelling — matches the index key by construction
+// (issue #2778). Each case pins index-key == CSharpIdentifier.Sanitize(<arity-stripped
+// metadata name>) against a real compiled assembly.
+public class CompileBackTypeIdentityTests
+{
+    [Fact]
+    public void FromDefinition_KeywordType_KeysOnKeywordEscapedSpelling()
+    {
+        using var compiled = Compile("namespace Sample { public class @class {} }");
+        var identity = IdentityOf(compiled.Reader, "class");
+
+        Assert.Equal("@class", identity.DisplayName);
+        Assert.Equal("Sample.@class", identity.FullName);
+        Assert.Equal(Expected("class"), identity.DisplayName);
+    }
+
+    [Fact]
+    public void FromDefinition_GenericType_KeysOnArityStrippedSpelling()
+    {
+        using var compiled = Compile("namespace Sample { public class Container<T> {} }");
+        var identity = IdentityOf(compiled.Reader, "Container`1");
+
+        Assert.Equal("Container", identity.DisplayName);
+        Assert.Equal("Sample.Container", identity.FullName);
+        Assert.Equal(Expected("Container`1"), identity.DisplayName);
+    }
+
+    [Fact]
+    public void FromDefinition_NestedType_QualifiesWithDotSeparators()
+    {
+        using var compiled = Compile(
+            "namespace Sample { public class Outer { public class Inner {} } }");
+        var inner = IdentityOf(compiled.Reader, "Inner");
+
+        Assert.Equal("Inner", inner.DisplayName);
+        Assert.Equal("Sample.Outer.Inner", inner.FullName);
+        Assert.DoesNotContain('+', inner.FullName);
+    }
+
+    [Fact]
+    public void FromDefinition_KeywordNamespace_EscapesEachSegment()
+    {
+        using var compiled = Compile("namespace @for.@class { public class Widget {} }");
+        var identity = IdentityOf(compiled.Reader, "Widget");
+
+        Assert.Equal("@for.@class.Widget", identity.FullName);
+    }
+
+    [Fact]
+    public void FromDefinition_FileLocalType_KeysOnSanitizedSpellableIdentifier()
+    {
+        using var compiled = Compile("namespace Sample { file class Widget {} }");
+        var metadataName = FindMetadataName(compiled.Reader, name => name.StartsWith('<'));
+        var identity = IdentityOf(compiled.Reader, metadataName);
+
+        Assert.Equal(Expected(metadataName), identity.DisplayName);
+        Assert.DoesNotContain('<', identity.DisplayName);
+        Assert.DoesNotContain('>', identity.DisplayName);
+        Assert.True(
+            CSharpIdentifier.IsIdentifierLike(identity.DisplayName),
+            $"Expected a spellable identifier, got '{identity.DisplayName}'.");
+    }
+
+    static string Expected(string metadataName)
+        => CSharpIdentifier.Sanitize(StripArity(metadataName));
+
+    static string StripArity(string name)
+    {
+        int tick = name.IndexOf('`');
+        return tick >= 0 ? name[..tick] : name;
+    }
+
+    static CompileBackTypeIdentity IdentityOf(MetadataReader reader, string metadataName)
+    {
+        foreach (var handle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(handle);
+            if (reader.GetString(typeDef.Name) == metadataName)
+                return CompileBackTypeIdentity.FromDefinition(reader, typeDef);
+        }
+
+        throw new Xunit.Sdk.XunitException($"No type definition named '{metadataName}'.");
+    }
+
+    static string FindMetadataName(MetadataReader reader, Func<string, bool> predicate)
+    {
+        foreach (var handle in reader.TypeDefinitions)
+        {
+            string name = reader.GetString(reader.GetTypeDefinition(handle).Name);
+            if (predicate(name))
+                return name;
+        }
+
+        throw new Xunit.Sdk.XunitException("No matching type definition.");
+    }
+
+    static Compiled Compile(string source)
+    {
+        var compilation = CSharpCompilation.Create(
+            "CompileBackTypeIdentityTests",
+            [CSharpSyntaxTree.ParseText(
+                source,
+                new CSharpParseOptions(LanguageVersion.Latest),
+                cancellationToken: TestContext.Current.CancellationToken)],
+            RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var stream = new MemoryStream();
+        var emit = compilation.Emit(stream, cancellationToken: TestContext.Current.CancellationToken);
+        var errors = emit.Diagnostics
+            .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToImmutableArray();
+        Assert.True(emit.Success, string.Join(Environment.NewLine, errors));
+        stream.Position = 0;
+        return new Compiled(stream, new PEReader(stream, PEStreamOptions.LeaveOpen));
+    }
+
+    static ImmutableArray<MetadataReference> RuntimeReferences()
+        => ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+            .ToImmutableArray();
+
+    sealed class Compiled(MemoryStream stream, PEReader pe) : IDisposable
+    {
+        public MetadataReader Reader { get; } = pe.GetMetadataReader();
+
+        public void Dispose()
+        {
+            pe.Dispose();
+            stream.Dispose();
+        }
+    }
+}

--- a/tools/DecompilerHarness/ClosureDiagnosticEvidence.cs
+++ b/tools/DecompilerHarness/ClosureDiagnosticEvidence.cs
@@ -1,3 +1,5 @@
+using ILInspector.CSharp;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -334,7 +336,7 @@ internal static class ClosureDiagnosticEvidence
         var names = new Stack<string>();
         for (INamedTypeSymbol? current = named.OriginalDefinition; current is not null; current = current.ContainingType)
         {
-            string name = CompileBackCSharpNames.Identifier(current.Name);
+            string name = CSharpIdentifier.Sanitize(current.Name);
             names.Push(includeGenericArity && current.Arity > 0
                 ? $"{name}`{current.Arity}"
                 : name);
@@ -342,7 +344,7 @@ internal static class ClosureDiagnosticEvidence
 
         string typeName = string.Join(".", names);
         string ns = named.ContainingNamespace is { IsGlobalNamespace: false } containingNamespace
-            ? CompileBackCSharpNames.EscapeNamespace(NamespaceName(containingNamespace))
+            ? CSharpFormatter.EscapeNamespace(NamespaceName(containingNamespace))
             : "";
         return ns.Length == 0 ? typeName : $"{ns}.{typeName}";
     }

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1659,8 +1659,8 @@ static class ReturnToSender
                     && reference.ContainingNamespace is { Length: > 0 } containingNamespace)
                 {
                     string metadataFullName = $"{containingNamespace}.{reference.Name}";
-                    string displayNamespace = CompileBackCSharpNames.EscapeNamespace(containingNamespace);
-                    string displayName = CompileBackCSharpNames.Identifier(reference.Name);
+                    string displayNamespace = CSharpFormatter.EscapeNamespace(containingNamespace);
+                    string displayName = CSharpIdentifier.Sanitize(reference.Name);
                     string displayFullName = $"{displayNamespace}.{displayName}";
                     grew |= AddRoots(indexes, indexes.FullTypes, displayFullName, diagnostic, metadataFullName, targetNamespace, preferredRoot, addMemberSurfaceFact: false, closureRoots, closureFacts);
                     grew |= AddRoots(indexes, indexes.Namespaces, metadataFullName, diagnostic, metadataFullName, targetNamespace, preferredRoot, addMemberSurfaceFact: false, closureRoots, closureFacts);

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -298,7 +298,7 @@ public sealed record CompileBackTypeIdentity(string Namespace, string MetadataNa
     public static CompileBackTypeIdentity FromDefinition(MetadataReader reader, TypeDefinition typeDef)
     {
         string metadataName = reader.GetString(typeDef.Name);
-        string displayName = CompileBackCSharpNames.Identifier(CompileBackCSharpNames.StripArity(metadataName));
+        string displayName = CSharpIdentifier.Sanitize(CompileBackCSharpNames.StripArity(metadataName));
         if (!typeDef.GetDeclaringType().IsNil)
         {
             var declaring = FromDefinition(reader, reader.GetTypeDefinition(typeDef.GetDeclaringType()));
@@ -311,7 +311,7 @@ public sealed record CompileBackTypeIdentity(string Namespace, string MetadataNa
         }
 
         string ns = reader.GetString(typeDef.Namespace);
-        string displayNamespace = CompileBackCSharpNames.EscapeNamespace(ns);
+        string displayNamespace = CSharpFormatter.EscapeNamespace(ns);
         string fullName = displayNamespace.Length == 0 ? displayName : $"{displayNamespace}.{displayName}";
         string metadataFullName = ns.Length == 0 ? metadataName : $"{ns}.{metadataName}";
         return new CompileBackTypeIdentity(ns, metadataName, displayName, fullName, metadataFullName);


### PR DESCRIPTION
Closes #2778.

## What

The RTS closure index and its missing-type lookups escaped/sanitized C# identifiers through the harness-local `CompileBackCSharpNames` wrapper. Deleting that wrapper (the #2777 endgame) would break Roslyn's missing-type closure expansion: Roslyn reports the *sanitized* name the product seam actually emits (e.g. `__file___Foo` for a `<file>__Foo` type), which never matches a raw metadata index key.

This points the three closure sites at the seam producer directly, so the index key equals the emitted name by construction and no C# escaping remains in the closure path:

- `CompileBackTypeIdentity.FromDefinition` (the `FullTypes` key builder) keys on `CSharpIdentifier.Sanitize` + `CSharpFormatter.EscapeNamespace`. Arity stripping — a metadata-name concern, not C# spelling — is unchanged.
- The CS0234 lookup in `ReturnToSender.cs` and the receiver spelling in `ClosureDiagnosticEvidence.TypeName` use the same seam APIs; both files now carry zero `CompileBackCSharpNames` references.

## Why it's low risk

Behavior-preserving: `CompileBackCSharpNames.Identifier` already delegated to `CSharpIdentifier.Sanitize` and `EscapeNamespace` to `CSharpFormatter.EscapeNamespace` (post-#2797), so the emitted spellings are identical. This removes the indirection so #2777 step 3 can delete `CompileBackCSharpNames` without silently breaking closure expansion.

## Evidence

- New real-metadata tests (`CompileBackTypeIdentityTests`) pin the `FullTypes` key to the seam spelling for keyword (`@class`), generic-arity (`Container` backtick 1 stripped to `Container`), nested-type (`.`-qualified, no `+`), keyword-namespace (`@for.@class`), and generated/file-local (`<...>__Widget` sanitized to a spellable identifier with no `<`/`>`) cases.
- Targeted suites green: `CompileBackTypeIdentityTests` + `ClosureDiagnosticEvidenceTests` + `ReturnToSenderPrototypeTests` + `FidelityCheckGeneratedFilterTests` → 181/0.
- The #2776 parity gate stays green on the pinned 14-assembly corpus (`--compile-cap 0 --corpus-fidelity-cap 3 --corpus-fidelity-oracle rts-parity`): 7 known burn-down rows, 0 new regressions, exit 0.

## Acceptance (#2778)

- [x] Closure expansion works with no harness-side C# escaping.
- [x] `CompileBackCSharpNames` callers in `ReturnToSender.cs` and `ClosureDiagnosticEvidence.cs` are gone.
- [x] Tests cover keyword, generic-arity, nested-type, and generated/file-local (sanitized) cases.
- [x] The parity gate (#2776) stays green.

Adversarial review to follow.
