### PR TITLE
Make package acquisition transactional

### DIFF
--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -153,7 +153,7 @@ each endpoint.
 | --- | --- | --- | --- |
 | NuGet global cache | `~/.nuget/packages/{name}/{version}/` | Permanent | `dotnet restore`, NuGet client |
 | App package cache | `$LOCAL_APP_DATA/dotnet-inspect/package-content-v2/{name}/{version}/` | Permanent | dotnet-inspect |
-| Platform packs | `$LOCAL_APP_DATA/dotnet-inspect/packs/{pack}/{version}/` | Permanent | dotnet-inspect |
+| Platform packs | `$LOCAL_APP_DATA/dotnet-inspect/packs-v2/{pack}/{version}/` | Permanent | dotnet-inspect |
 | Version resolution | `$LOCAL_APP_DATA/dotnet-inspect/versions/` | 1 hour | dotnet-inspect |
 | Package metadata | `$LOCAL_APP_DATA/dotnet-inspect/metadata/` | 1 hour | dotnet-inspect |
 | Symbol miss markers | `$LOCAL_APP_DATA/dotnet-inspect/symbol-misses/` | 1 day | dotnet-inspect |
@@ -195,6 +195,10 @@ directories. Failed acquisition leaves no final entry and can be retried.
 The flight and durable cache identity follow NuGet's coordinate cache model:
 cache root plus normalized package id and version. Source order selects the
 producer on a miss but is not a separate durable identity.
+
+Platform-pack projection never mutates the committed package. It copies the
+selected pack contents into a unique `packs-v2` staging directory and
+atomically publishes the complete derived pack with its own completion marker.
 
 ## Design rationale
 

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -152,7 +152,7 @@ each endpoint.
 | Cache | Location | TTL | Written by |
 | --- | --- | --- | --- |
 | NuGet global cache | `~/.nuget/packages/{name}/{version}/` | Permanent | `dotnet restore`, NuGet client |
-| App package cache | `$LOCAL_APP_DATA/dotnet-inspect/packages/{name}/{version}/` | Permanent | dotnet-inspect |
+| App package cache | `$LOCAL_APP_DATA/dotnet-inspect/package-content-v2/{name}/{version}/` | Permanent | dotnet-inspect |
 | Platform packs | `$LOCAL_APP_DATA/dotnet-inspect/packs/{pack}/{version}/` | Permanent | dotnet-inspect |
 | Version resolution | `$LOCAL_APP_DATA/dotnet-inspect/versions/` | 1 hour | dotnet-inspect |
 | Package metadata | `$LOCAL_APP_DATA/dotnet-inspect/metadata/` | 1 hour | dotnet-inspect |
@@ -185,6 +185,16 @@ offline mode, and unsupported local feed URLs are not cached as misses.
 | `SourceLink Availability` URL checks | Not cached by this command path. |
 | Service-index discovery for custom NuGet feeds | Not cached. nuget.org flat-container paths avoid this lookup. |
 | GitHub advisory enrichment | Not separately cached; it is covered when the package metadata cache is hit. |
+
+Exact package acquisition is single-flight within a process. A cache miss is
+downloaded and extracted into temporary storage, copied to a unique sibling
+staging directory, validated, and atomically renamed to its final
+`package-content-v2` path. Concurrent publishers in other processes either win
+that rename or validate and use the committed winner; readers never use staging
+directories. Failed acquisition leaves no final entry and can be retried.
+The flight and durable cache identity follow NuGet's coordinate cache model:
+cache root plus normalized package id and version. Source order selects the
+producer on a miss but is not a separate durable identity.
 
 ## Design rationale
 

--- a/src/DotnetInspector.Packages/NuGetCache.cs
+++ b/src/DotnetInspector.Packages/NuGetCache.cs
@@ -20,7 +20,7 @@ public static class NuGetCache
 {
     private const string PackageContentCategory = "package-content-v2";
     private const string PackageContentCategoryPrefix = "package-content-v";
-    private const string CommitMarkerName = ".dotnet-inspect.complete";
+    public const string CommitMarkerFileName = ".dotnet-inspect.complete";
     private static string? _appName;
     private static bool _skipNuGetCache;
 
@@ -249,7 +249,7 @@ public static class NuGetCache
             }
 
             using (var marker = new FileStream(
-                Path.Combine(stagingPath, CommitMarkerName),
+                Path.Combine(stagingPath, CommitMarkerFileName),
                 FileMode.CreateNew,
                 FileAccess.Write,
                 FileShare.None))
@@ -397,7 +397,8 @@ public static class NuGetCache
             if (!IsCachedPackageValid(cachedPath))
                 return false;
 
-            return File.ReadAllText(Path.Combine(cachedPath, CommitMarkerName))
+            return File.ReadAllText(
+                Path.Combine(cachedPath, CommitMarkerFileName))
                 .Equals(
                     GetCommitMarkerContent(packageName, version),
                     StringComparison.Ordinal);

--- a/src/DotnetInspector.Packages/NuGetCache.cs
+++ b/src/DotnetInspector.Packages/NuGetCache.cs
@@ -4,6 +4,12 @@ using NuGet.Versioning;
 namespace DotnetInspector.Packages;
 
 /// <summary>
+/// A package directory that became visible only after its complete contents
+/// were validated and atomically published.
+/// </summary>
+public sealed record CommittedPackage(string ExtractPath, string? NupkgPath);
+
+/// <summary>
 /// Utilities for working with NuGet package caches.
 /// Uses platform-appropriate cache directories (XDG on Linux, ~/Library/Caches on macOS).
 /// Never writes to ~/.nuget/packages (read-only).
@@ -12,6 +18,9 @@ namespace DotnetInspector.Packages;
 /// </summary>
 public static class NuGetCache
 {
+    private const string PackageContentCategory = "package-content-v2";
+    private const string PackageContentCategoryPrefix = "package-content-v";
+    private const string CommitMarkerName = ".dotnet-inspect.complete";
     private static string? _appName;
     private static bool _skipNuGetCache;
 
@@ -29,6 +38,9 @@ public static class NuGetCache
         _appName = appName;
         _skipNuGetCache = skipNuGetCache;
         CoreCache.Initialize(appName, basePath);
+        CoreCache.RegisterVersionedCategory(
+            PackageContentCategoryPrefix,
+            PackageContentCategory);
     }
 
     private static string AppName => _appName
@@ -75,11 +87,21 @@ public static class NuGetCache
     public static string GetDefaultAppCacheBasePath() => CoreCache.GetDefaultBasePath();
 
     /// <summary>
-    /// Gets the path to the application package cache (read-write).
+    /// Gets the legacy package-artifact root used by symbol caches.
+    /// Extracted package contents use <see cref="GetPackageContentCachePath"/>.
     /// </summary>
     public static string GetAppCachePath()
     {
         return Path.Combine(GetAppCacheBasePath(), "packages");
+    }
+
+    /// <summary>
+    /// Gets the versioned application cache for transactionally published
+    /// package contents.
+    /// </summary>
+    public static string GetPackageContentCachePath()
+    {
+        return CoreCache.GetCategoryPath(PackageContentCategory);
     }
 
     /// <summary>
@@ -122,11 +144,14 @@ public static class NuGetCache
         }
 
         // Check app cache
-        var appCachePath = GetAppCachePath();
+        var appCachePath = GetPackageContentCachePath();
         if (Directory.Exists(appCachePath))
         {
             var appPackageDir = Path.Combine(appCachePath, normalizedName, normalizedVersion);
-            if (Directory.Exists(appPackageDir) && IsCachedPackageValid(appPackageDir, normalizedName))
+            if (IsCommittedPackageValid(
+                appPackageDir,
+                normalizedName,
+                normalizedVersion))
             {
                 InfoTracker.RecordCacheHit();
                 CacheTelemetry.Record("packages", cacheKey, CacheAccessResult.Hit);
@@ -140,65 +165,147 @@ public static class NuGetCache
     }
 
     /// <summary>
-    /// Gets the path where a package should be cached in the app cache.
-    /// Creates the directory structure if it doesn't exist.
+    /// Gets the final path for a package in the transactional content cache.
     /// </summary>
     public static string GetPackageCachePath(string packageName, string version)
     {
         ValidatePathComponent(packageName, "package name");
         ValidatePathComponent(version, "version");
 
-        var appCachePath = GetAppCachePath();
+        var appCachePath = GetPackageContentCachePath();
         var packageDir = Path.Combine(appCachePath, packageName.ToLowerInvariant(), version.ToLowerInvariant());
         return packageDir;
     }
 
     /// <summary>
-    /// Caches an extracted package to the app cache.
+    /// Validates and atomically publishes an extracted package to the app cache.
+    /// Concurrent publishers either win the final rename or converge on the
+    /// already committed winner.
     /// </summary>
     /// <param name="extractedPath">Path to the extracted package contents</param>
+    /// <param name="nupkgPath">Optional source archive to retain with the committed contents</param>
     /// <param name="packageName">The package name</param>
     /// <param name="version">The package version</param>
-    /// <returns>The path to the cached package, or null if caching failed</returns>
-    public static string? CachePackage(string extractedPath, string packageName, string version)
+    public static CommittedPackage CommitPackage(
+        string extractedPath,
+        string? nupkgPath,
+        string packageName,
+        string version)
     {
         ValidatePathComponent(packageName, "package name");
         ValidatePathComponent(version, "version");
 
+        string normalizedName = packageName.ToLowerInvariant();
+        string normalizedVersion = version.ToLowerInvariant();
+        string targetPath = GetPackageCachePath(
+            normalizedName,
+            normalizedVersion);
+        string? parentDir = Path.GetDirectoryName(targetPath)
+            ?? throw new InvalidOperationException(
+                $"Package cache path has no parent: {targetPath}");
+
+        CoreCache.EnsurePathInCacheContext(targetPath);
+        Directory.CreateDirectory(parentDir);
+
+        if (IsCommittedPackageValid(
+            targetPath,
+            normalizedName,
+            normalizedVersion))
+        {
+            return OpenCommittedPackage(
+                targetPath,
+                normalizedName,
+                normalizedVersion);
+        }
+
+        if (Directory.Exists(targetPath))
+        {
+            throw new InvalidDataException(
+                $"Package cache entry '{targetPath}' is incomplete or corrupt. Clear the cache before retrying.");
+        }
+
+        string stagingPath = Path.Combine(
+            parentDir,
+            $".{normalizedVersion}.tmp-{Guid.NewGuid():N}");
+        CoreCache.EnsurePathInCacheContext(stagingPath);
+
         try
         {
-            var targetPath = GetPackageCachePath(packageName, version);
+            CopyDirectory(extractedPath, stagingPath);
 
-            // If already exists and valid, return it
-            if (Directory.Exists(targetPath) && IsCachedPackageValid(targetPath))
+            string? committedNupkgPath = null;
+            if (nupkgPath is not null)
             {
-                return targetPath;
+                committedNupkgPath = Path.Combine(
+                    stagingPath,
+                    $"{normalizedName}.{normalizedVersion}.nupkg");
+                File.Copy(nupkgPath, committedNupkgPath, overwrite: false);
             }
 
-            // Create parent directories
-            var parentDir = Path.GetDirectoryName(targetPath);
-            if (parentDir != null && !Directory.Exists(parentDir))
+            if (!IsCachedPackageValid(stagingPath))
             {
-                Directory.CreateDirectory(parentDir);
+                throw new InvalidDataException(
+                    $"Package '{packageName}@{version}' has no valid extracted package structure.");
             }
 
-            // Remove incomplete cache if exists
-            if (Directory.Exists(targetPath))
+            using (var marker = new FileStream(
+                Path.Combine(stagingPath, CommitMarkerName),
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None))
+            using (var writer = new StreamWriter(marker))
             {
-                CoreCache.EnsurePathInCacheContext(targetPath);
-                Directory.Delete(targetPath, recursive: true);
+                writer.Write(
+                    GetCommitMarkerContent(
+                        normalizedName,
+                        normalizedVersion));
             }
 
-            // Copy to cache
-            CopyDirectory(extractedPath, targetPath);
-            CacheTelemetry.Record("packages", $"{packageName.ToLowerInvariant()}@{version.ToLowerInvariant()}", CacheAccessResult.Store);
+            try
+            {
+                Directory.Move(stagingPath, targetPath);
+            }
+            catch (IOException) when (IsCommittedPackageValid(
+                targetPath,
+                normalizedName,
+                normalizedVersion))
+            {
+                return OpenCommittedPackage(
+                    targetPath,
+                    normalizedName,
+                    normalizedVersion);
+            }
 
-            return targetPath;
+            CacheTelemetry.Record(
+                "packages",
+                $"{normalizedName}@{normalizedVersion}",
+                CacheAccessResult.Store);
+
+            return new CommittedPackage(
+                targetPath,
+                committedNupkgPath is null
+                    ? null
+                    : Path.Combine(targetPath, Path.GetFileName(committedNupkgPath)));
         }
-        catch
+        finally
         {
-            // Caching is best-effort, don't fail the operation
-            return null;
+            if (Directory.Exists(stagingPath))
+            {
+                try
+                {
+                    Directory.Delete(stagingPath, recursive: true);
+                }
+                catch (IOException)
+                {
+                    // The committed destination is authoritative; abandoned
+                    // staging cleanup remains best-effort.
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    // The committed destination is authoritative; abandoned
+                    // staging cleanup remains best-effort.
+                }
+            }
         }
     }
 
@@ -211,21 +318,31 @@ public static class NuGetCache
         var normalizedName = packageName.ToLowerInvariant();
 
         // Newest non-prerelease, structurally-valid version across both caches.
-        bool IsValid(string dir) => IsCachedPackageValid(dir, normalizedName);
+        bool IsNuGetCacheValid(string dir) =>
+            IsCachedPackageValid(dir, normalizedName);
+        bool IsAppCacheValid(string dir)
+        {
+            string version = Path.GetFileName(dir);
+            return IsCommittedPackageValid(dir, normalizedName, version);
+        }
         VersionDir? best = null;
 
         // Check NuGet global cache — skip in isolated mode
         if (!_skipNuGetCache)
         {
             best = VersionDirectory.Higher(best, VersionDirectory.SelectBest(
-                Path.Combine(GetNuGetCachePath(), normalizedName), includePrerelease: false, IsValid));
+                Path.Combine(GetNuGetCachePath(), normalizedName),
+                includePrerelease: false,
+                IsNuGetCacheValid));
         }
 
         // Check app cache
         try
         {
             best = VersionDirectory.Higher(best, VersionDirectory.SelectBest(
-                Path.Combine(GetAppCachePath(), normalizedName), includePrerelease: false, IsValid));
+                Path.Combine(GetPackageContentCachePath(), normalizedName),
+                includePrerelease: false,
+                IsAppCacheValid));
         }
         catch (InvalidOperationException)
         {
@@ -258,14 +375,60 @@ public static class NuGetCache
         }
         else
         {
-            // Fallback: scan for any nuspec file
-            hasNuspec = Directory.GetFiles(cachedPath, "*.nuspec").Length > 0;
+            // Extracted archives preserve authored casing for the nuspec name.
+            hasNuspec = Directory.EnumerateFiles(cachedPath)
+                .Any(path => path.EndsWith(
+                    ".nuspec",
+                    StringComparison.OrdinalIgnoreCase));
         }
         var hasLib = Directory.Exists(Path.Combine(cachedPath, "lib"));
         var hasTools = Directory.Exists(Path.Combine(cachedPath, "tools"));
 
         return hasNuspec || hasLib || hasTools;
     }
+
+    private static bool IsCommittedPackageValid(
+        string cachedPath,
+        string packageName,
+        string version)
+    {
+        try
+        {
+            if (!IsCachedPackageValid(cachedPath))
+                return false;
+
+            return File.ReadAllText(Path.Combine(cachedPath, CommitMarkerName))
+                .Equals(
+                    GetCommitMarkerContent(packageName, version),
+                    StringComparison.Ordinal);
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    private static CommittedPackage OpenCommittedPackage(
+        string targetPath,
+        string packageName,
+        string version)
+    {
+        string nupkgPath = Path.Combine(
+            targetPath,
+            $"{packageName}.{version}.nupkg");
+        return new CommittedPackage(
+            targetPath,
+            File.Exists(nupkgPath) ? nupkgPath : null);
+    }
+
+    private static string GetCommitMarkerContent(
+        string packageName,
+        string version)
+        => $"{PackageContentCategory}:{packageName}@{version}";
 
     private static void CopyDirectory(string sourceDir, string targetDir)
     {

--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -51,6 +51,9 @@ public sealed record PackageReferenceTarget(
 /// </summary>
 public static class PackageExtractor
 {
+    private static readonly AsyncCache<PackageAcquisitionRequest, PackageExtractionOutcome>
+        s_packageRequests = new();
+
     /// <summary>
     /// Extracts a package from a local .nupkg file or downloads from NuGet sources.
     /// </summary>
@@ -189,6 +192,39 @@ public static class PackageExtractor
         string normalizedName = packageName.ToLowerInvariant();
         string normalizedVersion = version.ToLowerInvariant();
 
+        var request = new PackageAcquisitionRequest(
+            Path.GetFullPath(
+                NuGetCache.GetPackageCachePath(
+                    normalizedName,
+                    normalizedVersion)));
+        return await s_packageRequests.GetOrAddAsync(
+            request,
+            _ => AcquireResolvedPackageAsync(
+                client,
+                packageName,
+                version,
+                normalizedName,
+                normalizedVersion,
+                sources,
+                sourceOptions,
+                log,
+                tempDirPrefix),
+            // This is an in-flight registry. The committed filesystem entry is
+            // authoritative and is revalidated by every later request.
+            static _ => false).ConfigureAwait(false);
+    }
+
+    private static async Task<PackageExtractionOutcome> AcquireResolvedPackageAsync(
+        HttpClient client,
+        string packageName,
+        string version,
+        string normalizedName,
+        string normalizedVersion,
+        IReadOnlyList<NuGetSource> sources,
+        NuGetSourceOptions? sourceOptions,
+        Action<string>? log,
+        string tempDirPrefix)
+    {
         // Check NuGet cache first
         string? cachedPath;
         using (NetworkTelemetry.Scope(NetworkTrafficKind.PackageLoad))
@@ -209,68 +245,121 @@ public static class PackageExtractor
         string tempDir = Directory.CreateTempSubdirectory(tempDirPrefix).FullName;
         string extractPath = Path.Combine(tempDir, "extracted");
 
-        // Try each source in order, streaming the package straight to disk (no in-memory buffer).
-        string nupkgPath = Path.Combine(tempDir, $"{packageName}.{version}.nupkg");
-        string? successfulSource = null;
-
-        foreach (var source in sources)
-        {
-            var nupkgUrl = await GetPackageDownloadUrlAsync(client, source, normalizedName, normalizedVersion, log).ConfigureAwait(false);
-            if (nupkgUrl == null)
-                continue;
-
-            log?.Invoke($"Downloading: {packageName} {version} from {source.Name}");
-
-            try
-            {
-                var ok = await HttpRetryHelper.DownloadToFileWithRetryAsync(
-                    client, nupkgUrl, nupkgPath, log: log, auth: source.GetAuthHeader(),
-                    trafficKind: NetworkTrafficKind.PackageDownload).ConfigureAwait(false);
-                if (ok)
-                {
-                    successfulSource = source.Name;
-                    break;
-                }
-            }
-            catch (HttpRequestException ex)
-            {
-                log?.Invoke($"Source {source.Name} failed: {ex.Message}");
-                continue;
-            }
-        }
-
-        if (successfulSource == null)
-        {
-            try { Directory.Delete(tempDir, recursive: true); } catch { }
-
-            // Differentiate "package doesn't exist" from "version doesn't exist"
-            var knownVersions = await GetVersionsAsync(client, packageName, includePrerelease: true, limit: null, log: null, sourceOptions: sourceOptions).ConfigureAwait(false);
-            if (knownVersions == null || knownVersions.Count == 0)
-                return PackageExtractionOutcome.Error($"Package '{packageName}' not found.");
-
-            return PackageExtractionOutcome.Error($"Version '{version}' of package '{packageName}' not found. Use --versions to see available versions.");
-        }
-
         try
         {
+            // Try each source in order, streaming the package straight to disk
+            // without an in-memory archive buffer.
+            string nupkgPath = Path.Combine(
+                tempDir,
+                $"{packageName}.{version}.nupkg");
+            string? successfulSource = null;
+
+            foreach (var source in sources)
+            {
+                var nupkgUrl = await GetPackageDownloadUrlAsync(
+                    client,
+                    source,
+                    normalizedName,
+                    normalizedVersion,
+                    log).ConfigureAwait(false);
+                if (nupkgUrl == null)
+                    continue;
+
+                log?.Invoke(
+                    $"Downloading: {packageName} {version} from {source.Name}");
+
+                try
+                {
+                    var ok = await HttpRetryHelper.DownloadToFileWithRetryAsync(
+                        client,
+                        nupkgUrl,
+                        nupkgPath,
+                        log: log,
+                        auth: source.GetAuthHeader(),
+                        trafficKind: NetworkTrafficKind.PackageDownload)
+                        .ConfigureAwait(false);
+                    if (ok)
+                    {
+                        successfulSource = source.Name;
+                        break;
+                    }
+                }
+                catch (HttpRequestException ex)
+                {
+                    log?.Invoke($"Source {source.Name} failed: {ex.Message}");
+                }
+            }
+
+            if (successfulSource == null)
+            {
+                // Differentiate "package doesn't exist" from "version doesn't exist"
+                var knownVersions = await GetVersionsAsync(
+                    client,
+                    packageName,
+                    includePrerelease: true,
+                    limit: null,
+                    log: null,
+                    sourceOptions: sourceOptions).ConfigureAwait(false);
+                if (knownVersions == null || knownVersions.Count == 0)
+                {
+                    return PackageExtractionOutcome.Error(
+                        $"Package '{packageName}' not found.");
+                }
+
+                return PackageExtractionOutcome.Error(
+                    $"Version '{version}' of package '{packageName}' not found. Use --versions to see available versions.");
+            }
+
             ZipFile.ExtractToDirectory(nupkgPath, extractPath);
             log?.Invoke($"Package downloaded successfully from {successfulSource}.");
 
-            // Cache the package for future use
-            var newCachePath = NuGetCache.CachePackage(extractPath, packageName, version);
-            if (newCachePath != null)
-            {
-                log?.Invoke($"Cached to: {newCachePath}");
-            }
+            CommittedPackage committed = NuGetCache.CommitPackage(
+                extractPath,
+                nupkgPath,
+                packageName,
+                version);
+            log?.Invoke($"Cached to: {committed.ExtractPath}");
+
+            return new PackageExtractionResult(
+                committed.ExtractPath,
+                TempDir: null,
+                packageName,
+                version,
+                committed.NupkgPath,
+                FromCache: true);
         }
-        catch (Exception ex)
+        catch (IOException ex)
         {
-            try { Directory.Delete(tempDir, recursive: true); } catch { }
             return PackageExtractionOutcome.Error($"Failed to extract package '{packageName}@{version}': {ex.Message}");
         }
-
-        return new PackageExtractionResult(extractPath, tempDir, packageName, version, nupkgPath);
+        catch (InvalidDataException ex)
+        {
+            return PackageExtractionOutcome.Error($"Failed to extract package '{packageName}@{version}': {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return PackageExtractionOutcome.Error($"Failed to extract package '{packageName}@{version}': {ex.Message}");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+                // The committed cache entry is independent of this temporary
+                // download workspace.
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // The committed cache entry is independent of this temporary
+                // download workspace.
+            }
+        }
     }
+
+    private readonly record struct PackageAcquisitionRequest(string CachePath);
 
     /// <summary>
     /// Gets the download URL for a package from a specific source.

--- a/src/DotnetInspector.Services/PlatformPackService.cs
+++ b/src/DotnetInspector.Services/PlatformPackService.cs
@@ -10,6 +10,17 @@ namespace DotnetInspector.Services;
 /// </summary>
 public static class PlatformPackService
 {
+    private const string PacksCategory = "packs-v2";
+    private const string PacksCategoryPrefix = "packs-v";
+    private const string CommitMarkerFileName = ".dotnet-inspect.pack.complete";
+
+    static PlatformPackService()
+    {
+        CoreCache.RegisterVersionedCategory(
+            PacksCategoryPrefix,
+            PacksCategory);
+    }
+
     /// <summary>
     /// Gets the app cache packs directory, or null if CoreCache is not initialized.
     /// </summary>
@@ -17,7 +28,7 @@ public static class PlatformPackService
     {
         try
         {
-            return Path.Combine(CoreCache.GetBasePath(), "packs");
+            return Path.Combine(CoreCache.GetBasePath(), PacksCategory);
         }
         catch (InvalidOperationException)
         {
@@ -267,23 +278,27 @@ public static class PlatformPackService
 
         try
         {
-            Directory.CreateDirectory(packDir);
-            CopyContents(result.ExtractPath, packDir);
-
-            log?.Invoke($"Cached pack: {packDir}");
-            return packDir;
+            string committedPath = CommitPack(
+                result.ExtractPath,
+                packDir,
+                packName,
+                version);
+            log?.Invoke($"Cached pack: {committedPath}");
+            return committedPath;
         }
-        catch (Exception)
+        catch (IOException ex)
         {
-            try
-            {
-                if (Directory.Exists(packDir))
-                {
-                    CoreCache.EnsurePathInCacheContext(packDir);
-                    Directory.Delete(packDir, recursive: true);
-                }
-            }
-            catch { }
+            log?.Invoke($"Failed to cache pack '{packName}@{version}': {ex.Message}");
+            return null;
+        }
+        catch (InvalidDataException ex)
+        {
+            log?.Invoke($"Failed to cache pack '{packName}@{version}': {ex.Message}");
+            return null;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            log?.Invoke($"Failed to cache pack '{packName}@{version}': {ex.Message}");
             return null;
         }
         finally
@@ -293,13 +308,105 @@ public static class PlatformPackService
     }
 
     /// <summary>
-    /// Returns true if a cached pack directory is valid (contains ref/ or data/ subdirectory).
+    /// Returns true if a cached pack directory is complete and contains a
+    /// ref/ or data/ subdirectory.
     /// </summary>
     internal static bool IsPackValid(string packDir)
     {
-        return Directory.Exists(packDir)
-            && (Directory.Exists(Path.Combine(packDir, "ref"))
-                || Directory.Exists(Path.Combine(packDir, "data")));
+        try
+        {
+            if (!Directory.Exists(packDir)
+                || (!Directory.Exists(Path.Combine(packDir, "ref"))
+                    && !Directory.Exists(Path.Combine(packDir, "data"))))
+            {
+                return false;
+            }
+
+            return File.Exists(Path.Combine(packDir, CommitMarkerFileName));
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    private static string CommitPack(
+        string source,
+        string targetPath,
+        string packName,
+        string version)
+    {
+        if (IsPackValid(targetPath))
+            return targetPath;
+        if (Directory.Exists(targetPath))
+        {
+            throw new InvalidDataException(
+                $"Pack cache entry '{targetPath}' is incomplete or corrupt. Clear the cache before retrying.");
+        }
+
+        string? parentDir = Path.GetDirectoryName(targetPath)
+            ?? throw new InvalidOperationException(
+                $"Pack cache path has no parent: {targetPath}");
+        CoreCache.EnsurePathInCacheContext(targetPath);
+        Directory.CreateDirectory(parentDir);
+        string stagingPath = Path.Combine(
+            parentDir,
+            $".{version}.tmp-{Guid.NewGuid():N}");
+        CoreCache.EnsurePathInCacheContext(stagingPath);
+
+        try
+        {
+            CopyContents(source, stagingPath);
+            if (!Directory.Exists(Path.Combine(stagingPath, "ref"))
+                && !Directory.Exists(Path.Combine(stagingPath, "data")))
+            {
+                throw new InvalidDataException(
+                    $"Pack '{packName}@{version}' has no ref or data directory.");
+            }
+
+            using (var marker = new FileStream(
+                Path.Combine(stagingPath, CommitMarkerFileName),
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None))
+            using (var writer = new StreamWriter(marker))
+            {
+                writer.Write($"{PacksCategory}:{packName}@{version}");
+            }
+
+            try
+            {
+                Directory.Move(stagingPath, targetPath);
+            }
+            catch (IOException) when (IsPackValid(targetPath))
+            {
+                return targetPath;
+            }
+
+            return targetPath;
+        }
+        finally
+        {
+            if (Directory.Exists(stagingPath))
+            {
+                try
+                {
+                    Directory.Delete(stagingPath, recursive: true);
+                }
+                catch (IOException)
+                {
+                    // The committed destination is authoritative.
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    // The committed destination is authoritative.
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -332,7 +439,9 @@ public static class PlatformPackService
 
             // Skip NuGet metadata files
             if (fileName.Equals("[Content_Types].xml", StringComparison.OrdinalIgnoreCase)
-                || fileName.Equals(".dotnet-inspect.complete", StringComparison.Ordinal)
+                || fileName.Equals(
+                    NuGetCache.CommitMarkerFileName,
+                    StringComparison.Ordinal)
                 || fileName.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase)
                 || fileName.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase))
                 continue;

--- a/src/DotnetInspector.Services/PlatformPackService.cs
+++ b/src/DotnetInspector.Services/PlatformPackService.cs
@@ -268,7 +268,7 @@ public static class PlatformPackService
         try
         {
             Directory.CreateDirectory(packDir);
-            MoveContents(result.ExtractPath, packDir);
+            CopyContents(result.ExtractPath, packDir);
 
             log?.Invoke($"Cached pack: {packDir}");
             return packDir;
@@ -303,10 +303,11 @@ public static class PlatformPackService
     }
 
     /// <summary>
-    /// Moves directory contents from source to destination, preserving structure.
+    /// Copies directory contents from source to destination, preserving structure.
+    /// Package extraction paths may be shared cache entries and must remain immutable.
     /// Skips NuGet metadata files (.nuspec, [Content_Types].xml, _rels/, package/).
     /// </summary>
-    private static void MoveContents(string source, string destination)
+    private static void CopyContents(string source, string destination)
     {
         foreach (var dir in Directory.GetDirectories(source))
         {
@@ -322,7 +323,7 @@ public static class PlatformPackService
                 CoreCache.EnsurePathInCacheContext(destDir);
                 Directory.Delete(destDir, recursive: true);
             }
-            Directory.Move(dir, destDir);
+            CopyDirectory(dir, destDir);
         }
 
         foreach (var file in Directory.GetFiles(source))
@@ -331,11 +332,32 @@ public static class PlatformPackService
 
             // Skip NuGet metadata files
             if (fileName.Equals("[Content_Types].xml", StringComparison.OrdinalIgnoreCase)
-                || fileName.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase))
+                || fileName.Equals(".dotnet-inspect.complete", StringComparison.Ordinal)
+                || fileName.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase)
+                || fileName.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase))
                 continue;
 
             var destFile = Path.Combine(destination, fileName);
-            File.Move(file, destFile, overwrite: true);
+            File.Copy(file, destFile, overwrite: true);
+        }
+    }
+
+    private static void CopyDirectory(string source, string destination)
+    {
+        Directory.CreateDirectory(destination);
+        foreach (var file in Directory.GetFiles(source))
+        {
+            File.Copy(
+                file,
+                Path.Combine(destination, Path.GetFileName(file)),
+                overwrite: true);
+        }
+
+        foreach (var directory in Directory.GetDirectories(source))
+        {
+            CopyDirectory(
+                directory,
+                Path.Combine(destination, Path.GetFileName(directory)));
         }
     }
 }

--- a/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
+++ b/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
@@ -240,7 +240,7 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
     }
 
     [Fact]
-    public async Task EnsurePackAsync_DoesNotMutateCommittedPackage()
+    public async Task EnsurePackAsync_ConcurrentRequestsPublishOneImmutablePack()
     {
         const string PackageName = "Microsoft.NETCore.App.Ref";
         const string Version = "10.0.1";
@@ -262,12 +262,17 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
             Version);
         using var client = new HttpClient(new FailingHandler());
 
-        string? packPath = await PlatformPackService.EnsurePackAsync(
-            PackageName,
-            Version,
-            client);
+        Task<string?>[] requests = Enumerable.Range(0, 16)
+            .Select(_ => PlatformPackService.EnsurePackAsync(
+                PackageName,
+                Version,
+                client))
+            .ToArray();
+        string?[] packPaths = await Task.WhenAll(requests);
+        string? packPath = packPaths[0];
 
         Assert.NotNull(packPath);
+        Assert.All(packPaths, path => Assert.Equal(packPath, path));
         Assert.True(
             File.Exists(
                 Path.Combine(
@@ -285,6 +290,41 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
         Assert.Equal(
             committed.ExtractPath,
             NuGetCache.TryGetCachedPackage(PackageName, Version));
+        AssertNoPackStagingDirectories(PackageName);
+    }
+
+    [Fact]
+    public async Task EnsurePackAsync_PreservesExistingInvalidPackEntry()
+    {
+        const string PackageName = "Microsoft.WindowsDesktop.App.Ref";
+        const string Version = "10.0.2";
+        string source = Path.Combine(_testRoot, "windowsdesktop-pack");
+        Directory.CreateDirectory(Path.Combine(source, "ref", "net10.0"));
+        File.WriteAllText(
+            Path.Combine(source, $"{PackageName}.nuspec"),
+            "<package />");
+        NuGetCache.CommitPackage(
+            source,
+            nupkgPath: null,
+            PackageName,
+            Version);
+        string packPath = Path.Combine(
+            PlatformPackService.GetPacksCachePath()!,
+            PackageName,
+            Version);
+        Directory.CreateDirectory(packPath);
+        string existingFile = Path.Combine(packPath, "existing.txt");
+        File.WriteAllText(existingFile, "preserve");
+        using var client = new HttpClient(new FailingHandler());
+
+        string? result = await PlatformPackService.EnsurePackAsync(
+            PackageName,
+            Version,
+            client);
+
+        Assert.Null(result);
+        Assert.Equal("preserve", File.ReadAllText(existingFile));
+        AssertNoPackStagingDirectories(PackageName);
     }
 
     [Fact]
@@ -413,6 +453,17 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
             packageName,
             "unused");
         string parent = Path.GetDirectoryName(packagePath)!;
+        if (!Directory.Exists(parent))
+            return;
+
+        Assert.Empty(Directory.GetDirectories(parent, ".*.tmp-*"));
+    }
+
+    private static void AssertNoPackStagingDirectories(string packageName)
+    {
+        string parent = Path.Combine(
+            PlatformPackService.GetPacksCachePath()!,
+            packageName);
         if (!Directory.Exists(parent))
             return;
 

--- a/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
+++ b/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
@@ -1,0 +1,480 @@
+using System.IO.Compression;
+using System.Net;
+
+using DotnetInspector.Packages;
+using DotnetInspector.Services;
+
+namespace DotnetInspector.Tests;
+
+[Collection("Console")]
+public sealed class PackageAcquisitionConcurrencyTests : IDisposable
+{
+    private static readonly NuGetSourceOptions s_nugetOrgSource = new()
+    {
+        Sources = ["https://api.nuget.org/v3/index.json"],
+    };
+
+    private readonly string _testRoot = Path.Combine(
+        Path.GetTempPath(),
+        $"dotnet-inspect-package-transaction-{Guid.NewGuid():N}");
+    private readonly string _cachePath;
+
+    public PackageAcquisitionConcurrencyTests()
+    {
+        _cachePath = Path.Combine(_testRoot, "cache");
+        Core.HttpClientFactory.Initialize(offline: false);
+        Core.HttpClientFactory.ResetSharedForTesting();
+        NuGetCache.Initialize(
+            "dotnet-inspect-test",
+            _cachePath,
+            skipNuGetCache: true);
+    }
+
+    public void Dispose()
+    {
+        Core.HttpClientFactory.Initialize(offline: false);
+        Core.HttpClientFactory.ResetSharedForTesting();
+        if (Directory.Exists(_testRoot))
+            Directory.Delete(_testRoot, recursive: true);
+    }
+
+    [Fact]
+    public async Task ExtractPackageAsync_ConcurrentRequestsShareOneDownload()
+    {
+        string packageName = $"singleflight.test.{Guid.NewGuid():N}";
+        const string Version = "1.0.0";
+        byte[] archive = CreatePackageArchive(packageName, Version);
+        var handler = new GatedPackageHandler(archive);
+        using var client = new HttpClient(handler);
+        string tempPrefix = $"package-flight-{Guid.NewGuid():N}-";
+
+        Task<PackageExtractionOutcome>[] requests = Enumerable.Range(0, 32)
+            .Select(_ => PackageExtractor.ExtractPackageAsync(
+                client,
+                packageName,
+                tempDirPrefix: tempPrefix,
+                sourceOptions: s_nugetOrgSource,
+                version: Version))
+            .ToArray();
+
+        try
+        {
+            await handler.RequestStarted.WaitAsync(
+                TestContext.Current.CancellationToken);
+            Assert.Equal(1, handler.RequestCount);
+            Assert.False(
+                Directory.Exists(
+                    NuGetCache.GetPackageCachePath(packageName, Version)));
+        }
+        finally
+        {
+            handler.Release();
+        }
+
+        PackageExtractionOutcome[] outcomes = await Task.WhenAll(requests);
+
+        Assert.All(outcomes, outcome => Assert.True(outcome.IsSuccess));
+        PackageExtractionResult first = outcomes[0].Result!;
+        Assert.All(
+            outcomes,
+            outcome =>
+            {
+                Assert.Equal(first.ExtractPath, outcome.Result!.ExtractPath);
+                Assert.Null(outcome.Result.TempDir);
+                Assert.True(outcome.Result.FromCache);
+            });
+        Assert.Equal(1, handler.RequestCount);
+        Assert.Equal(
+            NuGetCache.GetPackageCachePath(packageName, Version),
+            first.ExtractPath);
+        Assert.True(File.Exists(first.NupkgPath));
+        Assert.Equal(
+            first.ExtractPath,
+            NuGetCache.TryGetCachedPackage(packageName, Version));
+        AssertNoStagingDirectories(packageName);
+        AssertNoTemporaryDirectories(tempPrefix);
+
+        var cached = await PackageExtractor.ExtractPackageAsync(
+            client,
+            packageName,
+            tempDirPrefix: tempPrefix,
+            sourceOptions: s_nugetOrgSource,
+            version: Version);
+
+        Assert.True(cached.IsSuccess);
+        Assert.Equal(first.ExtractPath, cached.Result!.ExtractPath);
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task CommitPackage_ConcurrentPublishersConvergeOnOneCompleteTree()
+    {
+        string packageName = $"publisher.test.{Guid.NewGuid():N}";
+        const string Version = "2.0.0";
+        string sourceA = CreateExtractedPackage(
+            Path.Combine(_testRoot, "source-a"),
+            packageName,
+            "A",
+            payloadCount: 128);
+        string sourceB = CreateExtractedPackage(
+            Path.Combine(_testRoot, "source-b"),
+            packageName,
+            "B",
+            payloadCount: 128);
+        using var ready = new CountdownEvent(2);
+        using var start = new ManualResetEventSlim();
+
+        Task<CommittedPackage> publishA = Task.Run(() =>
+        {
+            ready.Signal();
+            start.Wait();
+            return NuGetCache.CommitPackage(
+                sourceA,
+                nupkgPath: null,
+                packageName,
+                Version);
+        });
+        Task<CommittedPackage> publishB = Task.Run(() =>
+        {
+            ready.Signal();
+            start.Wait();
+            return NuGetCache.CommitPackage(
+                sourceB,
+                nupkgPath: null,
+                packageName,
+                Version);
+        });
+
+        Assert.True(
+            ready.Wait(
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken));
+        start.Set();
+        CommittedPackage[] committed = await Task.WhenAll(publishA, publishB);
+
+        Assert.Equal(committed[0].ExtractPath, committed[1].ExtractPath);
+        string[] payloads = Directory.GetFiles(
+            Path.Combine(committed[0].ExtractPath, "payload"),
+            "*.txt");
+        Assert.Equal(128, payloads.Length);
+        string winner = File.ReadAllText(payloads[0]);
+        Assert.True(winner is "A" or "B");
+        Assert.All(
+            payloads,
+            payload => Assert.Equal(winner, File.ReadAllText(payload)));
+        AssertNoStagingDirectories(packageName);
+    }
+
+    [Fact]
+    public void CommitPackage_InvalidPackageLeavesNoVisibleEntry()
+    {
+        string packageName = $"invalid.test.{Guid.NewGuid():N}";
+        const string Version = "3.0.0";
+        string source = Path.Combine(_testRoot, "invalid-source");
+        Directory.CreateDirectory(source);
+        File.WriteAllText(Path.Combine(source, "readme.txt"), "not a package");
+
+        Assert.Throws<InvalidDataException>(
+            () => NuGetCache.CommitPackage(
+                source,
+                nupkgPath: null,
+                packageName,
+                Version));
+
+        Assert.False(
+            Directory.Exists(
+                NuGetCache.GetPackageCachePath(packageName, Version)));
+        AssertNoStagingDirectories(packageName);
+    }
+
+    [Fact]
+    public void CommitPackage_PreservesExistingInvalidEntry()
+    {
+        string packageName = $"corrupt.test.{Guid.NewGuid():N}";
+        const string Version = "3.1.0";
+        string target = NuGetCache.GetPackageCachePath(packageName, Version);
+        Directory.CreateDirectory(target);
+        string existingFile = Path.Combine(target, "existing.txt");
+        File.WriteAllText(existingFile, "preserve");
+        string source = CreateExtractedPackage(
+            Path.Combine(_testRoot, "valid-source"),
+            packageName,
+            "valid",
+            payloadCount: 1);
+
+        Assert.Throws<InvalidDataException>(
+            () => NuGetCache.CommitPackage(
+                source,
+                nupkgPath: null,
+                packageName,
+                Version));
+
+        Assert.Equal("preserve", File.ReadAllText(existingFile));
+        AssertNoStagingDirectories(packageName);
+    }
+
+    [Fact]
+    public void CommitPackage_AcceptsAuthoredCaseRefOnlyPackage()
+    {
+        const string PackageName = "Microsoft.AspNetCore.App.Ref";
+        const string Version = "10.0.0";
+        string source = Path.Combine(_testRoot, "authored-case-ref-pack");
+        Directory.CreateDirectory(
+            Path.Combine(source, "ref", "net10.0"));
+        File.WriteAllText(
+            Path.Combine(source, $"{PackageName}.nuspec"),
+            "<package />");
+        File.WriteAllText(
+            Path.Combine(source, "ref", "net10.0", "Test.dll"),
+            "fixture");
+
+        CommittedPackage committed = NuGetCache.CommitPackage(
+            source,
+            nupkgPath: null,
+            PackageName,
+            Version);
+
+        Assert.Equal(
+            committed.ExtractPath,
+            NuGetCache.TryGetCachedPackage(PackageName, Version));
+    }
+
+    [Fact]
+    public async Task EnsurePackAsync_DoesNotMutateCommittedPackage()
+    {
+        const string PackageName = "Microsoft.NETCore.App.Ref";
+        const string Version = "10.0.1";
+        string source = Path.Combine(_testRoot, "platform-pack");
+        string refFile = Path.Combine(
+            source,
+            "ref",
+            "net10.0",
+            "System.Runtime.dll");
+        Directory.CreateDirectory(Path.GetDirectoryName(refFile)!);
+        File.WriteAllText(
+            Path.Combine(source, $"{PackageName}.nuspec"),
+            "<package />");
+        File.WriteAllText(refFile, "fixture");
+        CommittedPackage committed = NuGetCache.CommitPackage(
+            source,
+            nupkgPath: null,
+            PackageName,
+            Version);
+        using var client = new HttpClient(new FailingHandler());
+
+        string? packPath = await PlatformPackService.EnsurePackAsync(
+            PackageName,
+            Version,
+            client);
+
+        Assert.NotNull(packPath);
+        Assert.True(
+            File.Exists(
+                Path.Combine(
+                    packPath,
+                    "ref",
+                    "net10.0",
+                    "System.Runtime.dll")));
+        Assert.True(
+            File.Exists(
+                Path.Combine(
+                    committed.ExtractPath,
+                    "ref",
+                    "net10.0",
+                    "System.Runtime.dll")));
+        Assert.Equal(
+            committed.ExtractPath,
+            NuGetCache.TryGetCachedPackage(PackageName, Version));
+    }
+
+    [Fact]
+    public async Task ExtractPackageAsync_FailedArchiveCanRetry()
+    {
+        string packageName = $"retry.test.{Guid.NewGuid():N}";
+        const string Version = "4.0.0";
+        var handler = new QueuePackageHandler(
+            "not a zip"u8.ToArray(),
+            CreatePackageArchive(packageName, Version));
+        using var client = new HttpClient(handler);
+        string tempPrefix = $"package-retry-{Guid.NewGuid():N}-";
+
+        var failed = await PackageExtractor.ExtractPackageAsync(
+            client,
+            packageName,
+            tempDirPrefix: tempPrefix,
+            sourceOptions: s_nugetOrgSource,
+            version: Version);
+
+        Assert.False(failed.IsSuccess);
+        Assert.False(
+            Directory.Exists(
+                NuGetCache.GetPackageCachePath(packageName, Version)));
+
+        var retried = await PackageExtractor.ExtractPackageAsync(
+            client,
+            packageName,
+            tempDirPrefix: tempPrefix,
+            sourceOptions: s_nugetOrgSource,
+            version: Version);
+
+        Assert.True(retried.IsSuccess);
+        Assert.Equal(2, handler.RequestCount);
+        AssertNoTemporaryDirectories(tempPrefix);
+    }
+
+    [Fact]
+    public void TryGetCachedPackage_DoesNotUseLegacyDirectCopyNamespace()
+    {
+        string packageName = $"legacy.test.{Guid.NewGuid():N}";
+        const string Version = "5.0.0";
+        CreateExtractedPackage(
+            Path.Combine(
+                NuGetCache.GetAppCachePath(),
+                packageName,
+                Version),
+            packageName,
+            "legacy",
+            payloadCount: 1);
+
+        Assert.Null(NuGetCache.TryGetCachedPackage(packageName, Version));
+    }
+
+    private static byte[] CreatePackageArchive(
+        string packageName,
+        string version)
+    {
+        using var buffer = new MemoryStream();
+        using (var archive = new ZipArchive(
+            buffer,
+            ZipArchiveMode.Create,
+            leaveOpen: true))
+        {
+            WriteEntry(
+                archive,
+                $"{packageName}.nuspec",
+                $"""
+                <?xml version="1.0"?>
+                <package>
+                  <metadata>
+                    <id>{packageName}</id>
+                    <version>{version}</version>
+                  </metadata>
+                </package>
+                """);
+            WriteEntry(archive, "lib/net10.0/Test.dll", "fixture");
+        }
+
+        return buffer.ToArray();
+    }
+
+    private static void WriteEntry(
+        ZipArchive archive,
+        string path,
+        string content)
+    {
+        using Stream stream = archive.CreateEntry(path).Open();
+        using var writer = new StreamWriter(stream);
+        writer.Write(content);
+    }
+
+    private static string CreateExtractedPackage(
+        string path,
+        string packageName,
+        string content,
+        int payloadCount)
+    {
+        Directory.CreateDirectory(path);
+        File.WriteAllText(
+            Path.Combine(path, $"{packageName.ToLowerInvariant()}.nuspec"),
+            "<package />");
+        string payloadPath = Path.Combine(path, "payload");
+        Directory.CreateDirectory(payloadPath);
+        for (int i = 0; i < payloadCount; i++)
+        {
+            File.WriteAllText(
+                Path.Combine(payloadPath, $"{i:D4}.txt"),
+                content);
+        }
+
+        return path;
+    }
+
+    private static void AssertNoTemporaryDirectories(string prefix)
+    {
+        Assert.Empty(
+            Directory.GetDirectories(
+                Path.GetTempPath(),
+                $"{prefix}*"));
+    }
+
+    private static void AssertNoStagingDirectories(string packageName)
+    {
+        string packagePath = NuGetCache.GetPackageCachePath(
+            packageName,
+            "unused");
+        string parent = Path.GetDirectoryName(packagePath)!;
+        if (!Directory.Exists(parent))
+            return;
+
+        Assert.Empty(Directory.GetDirectories(parent, ".*.tmp-*"));
+    }
+
+    private sealed class GatedPackageHandler(byte[] response)
+        : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource<bool> _requestStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> _release =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _requestCount;
+
+        public Task RequestStarted => _requestStarted.Task;
+
+        public int RequestCount => Volatile.Read(ref _requestCount);
+
+        public void Release() => _release.TrySetResult(true);
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _requestCount);
+            _requestStarted.TrySetResult(true);
+            await _release.Task.WaitAsync(cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(response),
+            };
+        }
+    }
+
+    private sealed class QueuePackageHandler(params byte[][] responses)
+        : HttpMessageHandler
+    {
+        private readonly Queue<byte[]> _responses = new(responses);
+        private int _requestCount;
+
+        public int RequestCount => Volatile.Read(ref _requestCount);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _requestCount);
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(_responses.Dequeue()),
+                });
+        }
+    }
+
+    private sealed class FailingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => throw new InvalidOperationException(
+                $"Unexpected network request: {request.RequestUri}");
+    }
+}

--- a/src/dotnet-inspect.Tests/PackageFileListerTests.cs
+++ b/src/dotnet-inspect.Tests/PackageFileListerTests.cs
@@ -1,5 +1,6 @@
 using DotnetInspector.Inspectors;
 using DotnetInspector.Models;
+using DotnetInspector.Packages;
 
 namespace DotnetInspector.Tests;
 
@@ -31,6 +32,7 @@ public class PackageFileListerTests
             "package/services/metadata/core-properties/abc.psmdcp",
             ".signature.p7s",
             ".nupkg.metadata",
+            NuGetCache.CommitMarkerFileName,
             "foo.1.0.0.nupkg",
             "foo.1.0.0.nupkg.sha512");
         try

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -2586,10 +2586,8 @@ public class PackageCommand
 
         var relativePaths = files
             .Select(f => Path.GetRelativePath(relativeBase, f))
-            .Where(p => !p.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase))
-            .Where(p => !p.StartsWith("_rels", StringComparison.OrdinalIgnoreCase))
-            .Where(p => !p.StartsWith("[Content_Types]", StringComparison.OrdinalIgnoreCase))
-            .Where(p => !p.EndsWith(".psmdcp", StringComparison.OrdinalIgnoreCase))
+            .Where(p => !PackageFileLister.IsPlumbing(
+                p.Replace('\\', '/')))
             .OrderBy(p => p);
 
         var results = options.Limit.HasValue 

--- a/src/dotnet-inspect/Inspectors/PackageFileLister.cs
+++ b/src/dotnet-inspect/Inspectors/PackageFileLister.cs
@@ -1,5 +1,6 @@
 using System.IO.Enumeration;
 using DotnetInspector.Models;
+using DotnetInspector.Packages;
 
 namespace DotnetInspector.Inspectors;
 
@@ -121,7 +122,7 @@ public static class PackageFileLister
         return path.IndexOf('/', dir.Length + 1) < 0;
     }
 
-    private static bool IsPlumbing(string rel)
+    internal static bool IsPlumbing(string rel)
         // Zip plumbing (OPC packaging artifacts inside the .nupkg).
         => rel.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase)
             || rel.StartsWith("_rels/", StringComparison.OrdinalIgnoreCase)
@@ -130,6 +131,9 @@ public static class PackageFileLister
             || rel.Equals(".signature.p7s", StringComparison.OrdinalIgnoreCase)
             // Restore-folder artifacts added by the NuGet client (not zip content).
             || rel.Equals(".nupkg.metadata", StringComparison.OrdinalIgnoreCase)
+            || rel.Equals(
+                NuGetCache.CommitMarkerFileName,
+                StringComparison.Ordinal)
             || rel.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase)
             || rel.EndsWith(".nupkg.sha512", StringComparison.OrdinalIgnoreCase);
 

--- a/src/dotnet-inspect/Inspectors/SourceEnricher.cs
+++ b/src/dotnet-inspect/Inspectors/SourceEnricher.cs
@@ -450,20 +450,7 @@ internal static class SourceEnricher
     /// Finds the latest cached version for a package by checking the cache directory.
     /// </summary>
     private static string? FindCachedPackageVersion(string packageName)
-    {
-        var cachePath = NuGetCache.GetAppCachePath();
-        var packageDir = Path.Combine(cachePath, packageName.ToLowerInvariant());
-        if (!Directory.Exists(packageDir))
-            return null;
-
-        // Return the highest version directory (using numeric ordering for correct semver-like sort)
-        var comparer = StringComparer.Create(System.Globalization.CultureInfo.InvariantCulture, System.Globalization.CompareOptions.NumericOrdering);
-        return Directory.GetDirectories(packageDir)
-            .Select(d => Path.GetFileName(d))
-            .Where(name => name.Length > 0 && char.IsDigit(name[0]))
-            .OrderByDescending(v => v, comparer)
-            .FirstOrDefault();
-    }
+        => NuGetCache.TryGetLatestCachedVersion(packageName);
 
     /// <summary>
     /// Enriches multiple types from a single XML doc file (loaded once).


### PR DESCRIPTION
## Summary

- collapse concurrent exact remote package requests onto one process-wide
  in-flight task keyed by the final cache coordinate
- publish downloaded package contents and archive through validated,
  same-parent staging followed by atomic rename into the fenced
  `package-content-v2` namespace
- return cache-owned committed paths to remote callers while preserving
  caller-owned temporary extraction for local `.nupkg` files
- make lock-free competing publishers validate and converge on the committed
  winner; invalid finals remain visible and are never deleted under a race
- project platform packs immutably through their own transactional `packs-v2`
  staging/marker/rename boundary
- keep cache-owned marker/archive artifacts out of package file and layout
  output

Fixes #2804.

## Compatibility and boundaries

The durable identity intentionally follows NuGet's coordinate cache semantics:
cache root plus normalized package id and version. Ordered sources choose the
producer on a miss but are not a separate cache identity.

This uses atomic publication and winner convergence without adding an explicit
cross-process lock. Legacy direct-copy package and pack namespaces remain
fenced and unread by the new transactional paths. Local package extraction is
unchanged.

The pre-existing multi-package tool-wrapper redirect cycle is unchanged from
the base and tracked separately by #2807.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`:
  0 errors; three pre-existing nullable warnings in metadata tests
- `dotnet-inspect.Tests`: 1,912 passed, 10 expected ilasm/ildasm skips
- `DotnetInspector.Services.Tests`: 264 passed
- fixed-head package transaction stress: 100/100 runs
- real isolated `Microsoft.AspNetCore.App.Ref@10.0.0` canary:
  committed to `package-content-v2`, atomically projected to `packs-v2`, then
  reopened without mutating the committed package
- `markdownlint` passed for the cache documentation

## Adversarial review

Reviewed at fixed head `fabec1a9` against `793c14c9`:

- Claude Opus 4.8: **CLEAN**
- Gemini 3.1 Pro: **CLEAN**

First-round findings were resolved as follows:

- Claude found direct platform-pack publication could expose or corrupt a
  partial derived pack. Commit `fabec1a9` added the fenced transactional
  `packs-v2` publication boundary and concurrent coverage.
- Gemini found the new marker/archive files leaked into package listings.
  Commit `fabec1a9` centralized plumbing filtering and applied it to both file
  rows and `--layout`.
- An earlier adversarial pass found authored-case ref-only packages were
  rejected and platform-pack projection moved files out of shared cache paths.
  Commit `2eecda4b` includes the case-insensitive structural validation and
  immutable copy behavior, with synthetic and real ref-pack evidence.
- Claude also identified the pre-existing wrapper redirect cycle. The relevant
  method is unchanged by this diff; #2807 records the follow-up.

Both reviewers re-reviewed the fixed exact head and reported no outstanding
blocking or non-blocking findings.
