### PR TITLE
Document cache concurrency and publication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ READMEs, and focused skills.
 | Area | Read first |
 | --- | --- |
 | Commands, sections, and output | `docs/design/progressive-disclosure.md`, `docs/design/output-shapes.md`, `docs/design/style-guide.md`, `docs/design/section-model.md` |
-| Metadata, source, and acquisition | `docs/design/assembly-inspection-query.md`, `docs/design/source-finding-producers.md`, `docs/pdb-acquisition.md`, `docs/design/version-resolution.md` |
+| Metadata, source, and acquisition | `docs/design/assembly-inspection-query.md`, `docs/design/source-finding-producers.md`, `docs/pdb-acquisition.md`, `docs/design/version-resolution.md`, `docs/design/cache-concurrency.md` |
 | Security and untrusted input | `docs/design/untrusted-data-threat-model.md` |
 | Analysis, Findings, and Research | `docs/design/finding-nomenclature.md`, `docs/design/finding-producers.md`, `docs/design/finding-adoption.md`, `docs/design/finding-coordinates.md`, `docs/design/analysis-ux-scopes.md` |
 | Shared IL/control-flow substrate | `docs/design/instruction-substrate.md`, plus the consuming subsystem's docs |

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,6 +71,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Member Body Substrate](design/member-body-substrate.md) | One base for skeleton/full/merged/diff body rendering: `ApiType` shape, `MemberAnchor` address, one scope, and `MemberBody`'s scalar (whole-body) and vector (offset-keyed) shapes. |
 | [NuGet API](design/nuget.md) | NuGet API endpoints used by the tool. |
 | [Version Resolution](design/version-resolution.md) | Package/platform version and cache behavior. |
+| [Cache concurrency and publication](design/cache-concurrency.md) | Process-local single-flight, cross-process atomic publication, dependency overlap, and filesystem guarantees. |
 | [Assembly Inspection Query Model](design/assembly-inspection-query.md) | Target boundary where the CLI forms a query and the metadata/service layer resolves, opens, and returns the final shape (why the CLI should not hold a `PEReader`). |
 | [Skill Guidance Taste](../taste/skill-guidance.md) | Good and bad examples for maintaining the embedded skill. |
 

--- a/docs/design/cache-concurrency.md
+++ b/docs/design/cache-concurrency.md
@@ -1,0 +1,150 @@
+# Cache concurrency and publication
+
+This document owns the coordination model for immutable package contents and
+derived platform packs. [Version resolution](version-resolution.md) owns which
+package coordinate is selected and when network lookup occurs; this document
+owns how content for an exact coordinate becomes visible safely.
+
+## Guarantees
+
+The cache model provides:
+
+- one shared acquisition task per exact coordinate within a process;
+- complete-tree visibility through marked, atomic directory publication;
+- convergence on one valid winner when processes publish concurrently; and
+- no lock ordering between package coordinates.
+
+It does not guarantee globally unique work. Separate processes may download and
+extract the same immutable coordinate concurrently. It also does not provide a
+power-loss-durable filesystem transaction.
+
+## Precedents
+
+The design follows familiar NuGet, Docker, and Git patterns without claiming to
+implement any of those architectures exactly.
+
+| Precedent | Pattern adopted by dotnet-inspect | Important difference |
+| --- | --- | --- |
+| NuGet global packages | Package id/version coordinates identify immutable entries, and readers require a completion marker. | NuGet.Client serializes installation with a cross-process file lock; dotnet-inspect allows independent staging and converges through atomic rename. |
+| Docker daemon | Concurrent requests for one exact package coordinate share one in-process task. | dotnet-inspect has no daemon, so separate CLI processes can still duplicate download and extraction work. |
+| Git immutable objects | Writers build and validate complete content in a temporary sibling directory, then atomically rename it into place. | Entries are identified by the cache root, normalized package id, and version rather than by a content hash. |
+| Git competing writers | One atomic rename wins; a losing publisher validates and uses the committed winner. | The loser may have performed duplicate work before converging. |
+| Git mutable-state locks | Immutable entries do not require a long-lived cross-process lock when publishers can converge on one valid result. | Explicit locking remains appropriate for future mutable state that cannot use winner convergence. |
+
+NuGet.Client is the closest domain comparison. Its global-packages installer
+acquires a file lock for the target package, checks `.nupkg.metadata` to
+recognize a completed installation, repairs an incomplete target while holding
+the lock, and writes the metadata marker last. Processes waiting on that lock
+then observe the marker and skip duplicate installation.
+
+dotnet-inspect keeps NuGet's coordinate identity and marked-completion model but
+chooses a different cross-process tradeoff. Each process may build a complete
+candidate independently; whole-directory atomic rename selects one winner, and
+losers validate and use it. This avoids holding a shared lock across package
+work, but it permits duplicate download and extraction.
+
+## Process-local single-flight
+
+The process-wide in-flight registry is keyed by the final cache path for one
+exact package coordinate. Concurrent callers receive the same task. The
+registry entry is removed after completion, whether acquisition succeeds or
+fails, because the committed filesystem entry remains authoritative and is
+revalidated by later requests.
+
+The acquisition factory only downloads, extracts, validates, and commits its
+own coordinate. It does not resolve dependencies or wait on another registry
+key. Follow-on work such as dependency traversal, tool-package redirection, and
+platform-pack projection starts only after that exact-coordinate task has
+completed.
+
+## Transactional publication
+
+Package content publication follows this sequence:
+
+1. Download and extract into temporary storage.
+2. Copy the complete result into a unique sibling staging directory under the
+   final directory's parent.
+3. Validate the extracted package structure.
+4. Write `.dotnet-inspect.complete` inside the staging directory.
+5. Close all files opened by dotnet-inspect.
+6. Move the staging directory atomically to its final
+   `package-content-v2/{id}/{version}` path.
+7. If another publisher won, validate and use its committed directory.
+
+Readers accept only final directories with the expected structure and marker;
+they never inspect staging paths. Platform-pack projection applies the same
+transaction separately under `packs-v2` with its own completion marker. It
+copies from committed package content and never mutates that package directory.
+
+The versioned `package-content-v2` and `packs-v2` namespaces fence these
+transactions from older direct-copy writers.
+
+## Filesystem coordination
+
+`Directory.Move(stagingPath, targetPath)` delegates coordination to the
+filesystem. Renaming a directory changes a parent directory's name-to-object
+mapping; it does not copy the directory tree. The filesystem serializes that
+metadata operation across processes, so callers observe one order of competing
+moves without an application lock file.
+
+The staging directory is a sibling of the final directory so both paths are on
+the same filesystem or volume. This is required for atomic directory rename.
+The relevant .NET behavior is consistent across supported desktop platforms:
+
+| Platform | Primitive and losing-writer behavior |
+| --- | --- |
+| Windows | `Directory.Move` uses a non-overwriting `MoveFile` operation. One move succeeds; later moves fail because the destination exists. |
+| Linux | `Directory.Move` uses Unix `rename` semantics. A committed target is non-empty, so a competing directory rename cannot replace it and fails. |
+| macOS | Uses the same Unix directory-rename model as Linux; the committed non-empty destination prevents replacement. |
+
+Before the winning rename, the final path is absent. After it, that path names
+the complete tree that already contained its marker. A competing
+`Directory.Move` reports an `IOException`; dotnet-inspect treats it as a lost
+race only when the final directory validates, otherwise it surfaces the error.
+Closing dotnet-inspect's own file handles before the move is especially
+important on Windows, where incompatible open handles can prevent a rename.
+
+These guarantees assume a local filesystem with normal rename semantics, such
+as NTFS, APFS, ext4, or similar filesystems. A cache redirected to a network,
+FUSE, or other unusual filesystem is limited by that filesystem's rename and
+cache-coherency guarantees.
+
+## Overlapping dependency work
+
+Two in-process dependency graphs that overlap on a package either await the
+same task for that exact coordinate or perform independent manifest reads.
+Tasks for different coordinates do not wait on one another, so they cannot form
+a wait cycle. Dependency traversal fetches only dependency nuspecs and uses a
+traversal-local seen set to terminate dependency cycles.
+
+Across processes there is no coordination wait. Publishers use unique staging
+directories, and the final rename succeeds or reports a conflict without
+acquiring a cross-process lock. The losing process validates the winner rather
+than waiting for it while holding another resource.
+
+This is safe because exact package coordinates are immutable, different
+coordinates have disjoint final paths, and readers accept only complete,
+committed directories. Duplicate cross-process work can cost network and disk
+I/O, but it cannot expose partial content or create a cache-coordination
+deadlock.
+
+The single-coordinate factory is a required invariant. Future acquisition code
+must not recursively await another package while its own in-flight entry is
+active. A future mutable operation spanning multiple entries would instead
+need an explicit ordering and cycle policy.
+
+## Crash and failure boundaries
+
+Atomic rename provides atomic visibility, not full transaction durability:
+
+- A process crash before rename leaves the final path absent and may leave an
+  unreferenced staging directory.
+- A process crash after rename leaves a final directory that later readers
+  validate before use.
+- dotnet-inspect closes its files but does not `fsync` every file and parent
+  directory as a power-loss transaction. Storage failure or power loss can
+  therefore leave an invalid final entry.
+
+An invalid final entry is preserved and acquisition fails visibly. Deleting it
+without a lock could race and remove a newly committed winner. A later retry can
+proceed after the cache is explicitly cleared.

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -186,81 +186,19 @@ offline mode, and unsupported local feed URLs are not cached as misses.
 | Service-index discovery for custom NuGet feeds | Not cached. nuget.org flat-container paths avoid this lookup. |
 | GitHub advisory enrichment | Not separately cached; it is covered when the package metadata cache is hit. |
 
-## Concurrency and publication model
+## Package and pack publication
 
-The design follows familiar Git and Docker coordination patterns without
-claiming to implement either tool's architecture exactly.
+Version resolution ends with an exact package coordinate. Package extraction
+then shares one acquisition task per coordinate within a process and publishes
+complete app-cache entries transactionally. Separate processes may duplicate
+immutable work, but readers observe only a marked, atomically published winner.
+Platform-pack projection uses the same model in a separate cache namespace.
 
-| Precedent | Pattern adopted by dotnet-inspect | Important difference |
-| --- | --- | --- |
-| NuGet global packages | Package id/version coordinates identify immutable entries, and readers require a completion marker. | NuGet.Client serializes installation with a cross-process file lock; dotnet-inspect allows independent staging and converges through atomic rename. |
-| Docker daemon | Concurrent requests for one exact package coordinate share one in-process task. | dotnet-inspect has no daemon, so separate CLI processes can still duplicate download and extraction work. |
-| Git immutable objects | Writers build and validate complete content in a temporary sibling directory, then atomically rename it into place. | Entries are identified by the NuGet cache root, normalized package id, and version rather than by a content hash. |
-| Git competing writers | One atomic rename wins; a losing publisher validates and uses the committed winner. | The loser may have performed duplicate work before converging. |
-| Git mutable-state locks | Immutable entries do not require a long-lived cross-process lock when publishers can converge on one valid result. | Explicit locking remains appropriate for future mutable state that cannot use winner convergence. |
-
-NuGet.Client is the closest domain comparison. Its global-packages installer
-acquires a file lock for the target package, checks `.nupkg.metadata` to
-recognize a completed installation, repairs an incomplete target while holding
-the lock, and writes the metadata marker last. Processes waiting on that lock
-then observe the marker and skip duplicate installation.
-
-dotnet-inspect keeps NuGet's coordinate identity and marked-completion model but
-chooses a different cross-process tradeoff. Each process may build a complete
-candidate independently; whole-directory atomic rename selects one winner, and
-losers validate and use it. This avoids holding a shared lock across package
-work, but it permits duplicate download and extraction. Without a lock, an
-invalid final entry cannot be deleted safely, so dotnet-inspect preserves it and
-fails visibly instead.
-
-For an exact package cache miss, one process downloads and extracts the archive
-once for all of its waiters. It copies the result to a unique sibling staging
-directory, validates the package structure, writes a completion marker, closes
-all files, and atomically renames the directory to its final
-`package-content-v2` path. Readers accept only the final marked directory and
-never inspect staging paths. A competing process either publishes first or
-validates and uses that committed winner.
-
-Overlapping dependency work does not introduce a lock-ordering problem. The
-in-process registry is keyed to one exact package coordinate, and its factory
-only downloads, extracts, validates, and commits that coordinate. It does not
-acquire dependencies or wait on another registry key. The entry is removed
-before the caller performs follow-on work such as traversing package
-dependencies, following a tool-package redirect, or projecting a platform
-pack. Dependency traversal fetches only dependency nuspecs and uses a
-traversal-local seen set to terminate dependency cycles.
-
-Consequently, two in-process dependency graphs that overlap on a package either
-await the same task for that exact coordinate or perform independent manifest
-reads. Tasks for different coordinates do not wait on one another, so they
-cannot form a wait cycle. Across processes there is no coordination wait:
-publishers use unique staging directories, and the final atomic rename either
-succeeds or reports a conflict without acquiring a cross-process lock. The
-losing process validates the winner rather than waiting for it while holding
-another resource.
-
-This is safe because exact package coordinates are immutable, different
-coordinates have disjoint final paths, and readers accept only complete,
-committed directories. Duplicate cross-process work can cost network and disk
-I/O, but it cannot expose partial content or create a cache-coordination
-deadlock. The single-coordinate factory is a required invariant: future
-acquisition code must not recursively await another package while its own
-in-flight entry is active. A future mutable operation spanning multiple entries
-would instead need an explicit ordering and cycle policy.
-
-Platform-pack projection applies the same transaction separately. It never
-mutates the committed package; it copies selected contents into a unique
-`packs-v2` staging directory and atomically publishes a marked derived pack.
-
-The versioned `package-content-v2` and `packs-v2` namespaces fence these
-transactions from older direct-copy writers. An invalid final entry is not
-silently replaced because deleting it could race a valid publisher. Acquisition
-fails visibly and a later retry can proceed after the cache is cleared.
-
-This model guarantees complete publication, not globally unique work. Separate
-processes can download the same immutable coordinate concurrently, but readers
-observe only one validated final entry. Source order selects the producer on a
-miss and is not a separate durable cache identity.
+Cache identity is the cache root, normalized package id, and version.
+Source order selects the producer on a miss and is not a separate durable cache
+identity. See [cache concurrency and publication](cache-concurrency.md) for the
+single-flight boundary, dependency-overlap safety, filesystem rename semantics,
+failure model, and NuGet, Docker, and Git precedents.
 
 ## Design rationale
 

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -202,7 +202,9 @@ failure model, and NuGet, Docker, and Git precedents.
 
 ## Design rationale
 
-The Docker analogy:
+The Docker tag analogy below concerns version selection. Docker daemon request
+deduplication is covered separately in
+[cache concurrency and publication](cache-concurrency.md).
 
 - `docker run nginx:1.25` → pinned, reproducible
 - `docker run nginx` → uses local image if present, pulls if not

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -202,13 +202,15 @@ failure model, and NuGet, Docker, and Git precedents.
 
 ## Design rationale
 
-The Docker tag analogy below concerns version selection. Docker daemon request
-deduplication is covered separately in
+The following Docker tag analogy concerns version selection. Docker daemon
+request deduplication is covered separately in
 [cache concurrency and publication](cache-concurrency.md).
 
-- `docker run nginx:1.25` → pinned, reproducible
-- `docker run nginx` → uses local image if present, pulls if not
-- `docker pull nginx` → always checks the registry
+| Docker command | dotnet-inspect command | Version behavior |
+| --- | --- | --- |
+| `docker run nginx:1.25` | `dotnet-inspect package System.Text.Json@10.0.0` | Uses a pinned, reproducible coordinate. |
+| `docker run nginx` | `dotnet-inspect package System.Text.Json` | Uses the newest locally cached stable version, or resolves from NuGet when absent. |
+| `docker pull nginx` | `dotnet-inspect package System.Text.Json@latest` | Always checks NuGet for the current version. |
 
 NuGet packages are immutable once published (a given version string always
 refers to the same content), so pinned versions never go stale. The bare-name

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -186,19 +186,39 @@ offline mode, and unsupported local feed URLs are not cached as misses.
 | Service-index discovery for custom NuGet feeds | Not cached. nuget.org flat-container paths avoid this lookup. |
 | GitHub advisory enrichment | Not separately cached; it is covered when the package metadata cache is hit. |
 
-Exact package acquisition is single-flight within a process. A cache miss is
-downloaded and extracted into temporary storage, copied to a unique sibling
-staging directory, validated, and atomically renamed to its final
-`package-content-v2` path. Concurrent publishers in other processes either win
-that rename or validate and use the committed winner; readers never use staging
-directories. Failed acquisition leaves no final entry and can be retried.
-The flight and durable cache identity follow NuGet's coordinate cache model:
-cache root plus normalized package id and version. Source order selects the
-producer on a miss but is not a separate durable identity.
+## Concurrency and publication model
 
-Platform-pack projection never mutates the committed package. It copies the
-selected pack contents into a unique `packs-v2` staging directory and
-atomically publishes the complete derived pack with its own completion marker.
+The design follows familiar Git and Docker coordination patterns without
+claiming to implement either tool's architecture exactly.
+
+| Precedent | Pattern adopted by dotnet-inspect | Important difference |
+| --- | --- | --- |
+| Docker daemon | Concurrent requests for one exact package coordinate share one in-process task. | dotnet-inspect has no daemon, so separate CLI processes can still duplicate download and extraction work. |
+| Git immutable objects | Writers build and validate complete content in a temporary sibling directory, then atomically rename it into place. | Entries are identified by the NuGet cache root, normalized package id, and version rather than by a content hash. |
+| Git competing writers | One atomic rename wins; a losing publisher validates and uses the committed winner. | The loser may have performed duplicate work before converging. |
+| Git mutable-state locks | Immutable entries do not require a long-lived cross-process lock when publishers can converge on one valid result. | Explicit locking remains appropriate for future mutable state that cannot use winner convergence. |
+
+For an exact package cache miss, one process downloads and extracts the archive
+once for all of its waiters. It copies the result to a unique sibling staging
+directory, validates the package structure, writes a completion marker, closes
+all files, and atomically renames the directory to its final
+`package-content-v2` path. Readers accept only the final marked directory and
+never inspect staging paths. A competing process either publishes first or
+validates and uses that committed winner.
+
+Platform-pack projection applies the same transaction separately. It never
+mutates the committed package; it copies selected contents into a unique
+`packs-v2` staging directory and atomically publishes a marked derived pack.
+
+The versioned `package-content-v2` and `packs-v2` namespaces fence these
+transactions from older direct-copy writers. An invalid final entry is not
+silently replaced because deleting it could race a valid publisher. Acquisition
+fails visibly and a later retry can proceed after the cache is cleared.
+
+This model guarantees complete publication, not globally unique work. Separate
+processes can download the same immutable coordinate concurrently, but readers
+observe only one validated final entry. Source order selects the producer on a
+miss and is not a separate durable cache identity.
 
 ## Design rationale
 

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -193,10 +193,25 @@ claiming to implement either tool's architecture exactly.
 
 | Precedent | Pattern adopted by dotnet-inspect | Important difference |
 | --- | --- | --- |
+| NuGet global packages | Package id/version coordinates identify immutable entries, and readers require a completion marker. | NuGet.Client serializes installation with a cross-process file lock; dotnet-inspect allows independent staging and converges through atomic rename. |
 | Docker daemon | Concurrent requests for one exact package coordinate share one in-process task. | dotnet-inspect has no daemon, so separate CLI processes can still duplicate download and extraction work. |
 | Git immutable objects | Writers build and validate complete content in a temporary sibling directory, then atomically rename it into place. | Entries are identified by the NuGet cache root, normalized package id, and version rather than by a content hash. |
 | Git competing writers | One atomic rename wins; a losing publisher validates and uses the committed winner. | The loser may have performed duplicate work before converging. |
 | Git mutable-state locks | Immutable entries do not require a long-lived cross-process lock when publishers can converge on one valid result. | Explicit locking remains appropriate for future mutable state that cannot use winner convergence. |
+
+NuGet.Client is the closest domain comparison. Its global-packages installer
+acquires a file lock for the target package, checks `.nupkg.metadata` to
+recognize a completed installation, repairs an incomplete target while holding
+the lock, and writes the metadata marker last. Processes waiting on that lock
+then observe the marker and skip duplicate installation.
+
+dotnet-inspect keeps NuGet's coordinate identity and marked-completion model but
+chooses a different cross-process tradeoff. Each process may build a complete
+candidate independently; whole-directory atomic rename selects one winner, and
+losers validate and use it. This avoids holding a shared lock across package
+work, but it permits duplicate download and extraction. Without a lock, an
+invalid final entry cannot be deleted safely, so dotnet-inspect preserves it and
+fails visibly instead.
 
 For an exact package cache miss, one process downloads and extracts the archive
 once for all of its waiters. It copies the result to a unique sibling staging

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -221,6 +221,33 @@ all files, and atomically renames the directory to its final
 never inspect staging paths. A competing process either publishes first or
 validates and uses that committed winner.
 
+Overlapping dependency work does not introduce a lock-ordering problem. The
+in-process registry is keyed to one exact package coordinate, and its factory
+only downloads, extracts, validates, and commits that coordinate. It does not
+acquire dependencies or wait on another registry key. The entry is removed
+before the caller performs follow-on work such as traversing package
+dependencies, following a tool-package redirect, or projecting a platform
+pack. Dependency traversal fetches only dependency nuspecs and uses a
+traversal-local seen set to terminate dependency cycles.
+
+Consequently, two in-process dependency graphs that overlap on a package either
+await the same task for that exact coordinate or perform independent manifest
+reads. Tasks for different coordinates do not wait on one another, so they
+cannot form a wait cycle. Across processes there is no coordination wait:
+publishers use unique staging directories, and the final atomic rename either
+succeeds or reports a conflict without acquiring a cross-process lock. The
+losing process validates the winner rather than waiting for it while holding
+another resource.
+
+This is safe because exact package coordinates are immutable, different
+coordinates have disjoint final paths, and readers accept only complete,
+committed directories. Duplicate cross-process work can cost network and disk
+I/O, but it cannot expose partial content or create a cache-coordination
+deadlock. The single-coordinate factory is a required invariant: future
+acquisition code must not recursively await another package while its own
+in-flight entry is active. A future mutable operation spanning multiple entries
+would instead need an explicit ordering and cycle policy.
+
 Platform-pack projection applies the same transaction separately. It never
 mutates the committed package; it copies selected contents into a unique
 `packs-v2` staging directory and atomically publishes a marked derived pack.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -61,4 +61,5 @@ Agents working in this repo should preserve these principles:
 - [Member target resolution](design/member-target-resolution.md): typed member selector, anchor, and body-target resolution.
 - [Member ordering](design/member-order.md): canonical type/member section order and member-kind mapping.
 - [Version resolution](design/version-resolution.md): package/platform version and cache behavior.
+- [Cache concurrency and publication](design/cache-concurrency.md): process-local single-flight, atomic publication, dependency overlap, and filesystem guarantees.
 - [Skill guidance taste](../taste/skill-guidance.md): how to maintain the embedded agent skill.


### PR DESCRIPTION
## Summary

- add a focused cache concurrency and publication design
- document process-local single-flight, cross-process winner convergence, and overlapping dependency safety
- explain Windows, macOS, and Linux atomic directory-rename semantics and their same-filesystem boundary
- distinguish atomic visibility from power-loss durability and unusual-filesystem guarantees
- keep version resolution focused on coordinate selection and cache/network behavior
- relate the model to NuGet, Docker, and Git precedents

## Evidence

- `npx markdownlint-cli AGENTS.md docs/README.md docs/overview.md docs/design/version-resolution.md docs/design/cache-concurrency.md`

## Compatibility boundary

- documentation only; no product behavior or output changed
- the comparison describes adopted concurrency patterns, not architectural equivalence with Git, Docker, or NuGet