### PR TITLE
Bound .NET tool wrapper redirect cycles

### DIFF
--- a/docs/design/cache-concurrency.md
+++ b/docs/design/cache-concurrency.md
@@ -55,7 +55,8 @@ The acquisition factory only downloads, extracts, validates, and commits its
 own coordinate. It does not resolve dependencies or wait on another registry
 key. Follow-on work such as dependency traversal, tool-package redirection, and
 platform-pack projection starts only after that exact-coordinate task has
-completed.
+completed. Tool-package redirection is iterative and fails visibly when a
+package id repeats in one redirect chain.
 
 ## Transactional publication
 

--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -83,44 +83,69 @@ public static class PackageExtractor
             return ExtractLocalPackage(packageSource, log, tempDirPrefix);
         }
 
-        var outcome = await DownloadAndExtractPackageAsync(client, packageSource, log, tempDirPrefix, sourceOptions, version, forceLatest, includePrerelease).ConfigureAwait(false);
-        if (!outcome.IsSuccess)
-            return outcome;
+        // Keep redirect traversal outside exact-coordinate acquisition so one
+        // package flight never waits on another package key.
+        var visitedPackageIds = new HashSet<string>(
+            StringComparer.OrdinalIgnoreCase);
+        List<string> redirectChain = [];
+        string currentPackageSource = packageSource;
+        string? currentVersion = version;
+        bool currentForceLatest = forceLatest;
+        bool currentIncludePrerelease = includePrerelease;
 
-        return await MaybeRedirectToolWrapperAsync(outcome.Result!, client, log, tempDirPrefix, sourceOptions).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// .NET tool packages built as runtime-specific (NativeAOT) tools ship a thin wrapper
-    /// package whose payload is only a <c>DotnetToolSettings.xml</c> manifest pointing at
-    /// per-RID packages. The wrapper has no managed libraries to inspect, so redirect to the
-    /// portable <c>any</c> RID package (the framework-dependent build) which carries the
-    /// managed assemblies. Detection lives in NuGetFetch (<see cref="NuGetFetch.PackageExtractor.TryGetToolWrapperRedirect"/>).
-    /// </summary>
-    private static async Task<PackageExtractionOutcome> MaybeRedirectToolWrapperAsync(
-        PackageExtractionResult result,
-        HttpClient client,
-        Action<string>? log,
-        string tempDirPrefix,
-        NuGetSourceOptions? sourceOptions)
-    {
-        var anyId = NuGetFetch.PackageExtractor.TryGetToolWrapperRedirect(result.ExtractPath);
-        if (anyId == null || string.Equals(anyId, result.PackageName, StringComparison.OrdinalIgnoreCase))
-            return result;
-
-        log?.Invoke($"'{result.PackageName}' is a tool wrapper with no managed libraries; inspecting '{anyId}' instead.");
-
-        var redirected = await ExtractPackageAsync(
-            client, anyId, log, tempDirPrefix, sourceOptions, version: result.Version).ConfigureAwait(false);
-
-        // The wrapper download is no longer needed; the redirected package owns its own temp dir.
-        if (redirected.IsSuccess && result.TempDir != null)
+        while (true)
         {
-            try { Directory.Delete(result.TempDir, recursive: true); } catch { }
-        }
+            var outcome = await DownloadAndExtractPackageAsync(
+                client,
+                currentPackageSource,
+                log,
+                tempDirPrefix,
+                sourceOptions,
+                currentVersion,
+                currentForceLatest,
+                currentIncludePrerelease).ConfigureAwait(false);
+            if (!outcome.IsSuccess)
+                return outcome;
 
-        return redirected;
+            PackageExtractionResult result = outcome.Result!;
+            string? redirectId =
+                NuGetFetch.PackageExtractor.TryGetToolWrapperRedirect(
+                    result.ExtractPath);
+            if (redirectId is null)
+                return result;
+
+            if (string.IsNullOrWhiteSpace(result.PackageName))
+            {
+                return PackageExtractionOutcome.Error(
+                    $"Tool wrapper at '{result.ExtractPath}' has no package identity.");
+            }
+
+            if (!visitedPackageIds.Add(result.PackageName))
+            {
+                return ToolWrapperRedirectCycle(
+                    redirectChain,
+                    result.PackageName);
+            }
+
+            redirectChain.Add(result.PackageName);
+            if (visitedPackageIds.Contains(redirectId))
+                return ToolWrapperRedirectCycle(redirectChain, redirectId);
+
+            log?.Invoke(
+                $"'{result.PackageName}' is a tool wrapper with no managed libraries; inspecting '{redirectId}' instead.");
+
+            currentPackageSource = redirectId;
+            currentVersion = result.Version;
+            currentForceLatest = false;
+            currentIncludePrerelease = false;
+        }
     }
+
+    private static PackageExtractionOutcome ToolWrapperRedirectCycle(
+        IReadOnlyList<string> redirectChain,
+        string repeatedPackageId)
+        => PackageExtractionOutcome.Error(
+            $"Tool wrapper redirect cycle detected: {string.Join(" -> ", redirectChain)} -> {repeatedPackageId}.");
 
     private static PackageExtractionOutcome ExtractLocalPackage(
         string packageSource,

--- a/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
+++ b/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
@@ -107,6 +107,93 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
     }
 
     [Fact]
+    public async Task ExtractPackageAsync_DirectToolWrapperCycleReturnsError()
+    {
+        const string PackageName = "Wrapper.Direct";
+        const string RedirectPackageName = "wrapper.direct";
+        const string Version = "1.0.0";
+        var handler = new QueuePackageHandler(
+            CreateToolWrapperArchive(
+                PackageName,
+                Version,
+                redirectPackageName: RedirectPackageName));
+        using var client = new HttpClient(handler);
+
+        PackageExtractionOutcome outcome =
+            await PackageExtractor.ExtractPackageAsync(
+                client,
+                PackageName,
+                sourceOptions: s_nugetOrgSource,
+                version: Version);
+
+        Assert.False(outcome.IsSuccess);
+        Assert.Equal(
+            $"Tool wrapper redirect cycle detected: {PackageName} -> {RedirectPackageName}.",
+            outcome.ErrorMessage);
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task ExtractPackageAsync_MultiPackageToolWrapperCycleReturnsError()
+    {
+        const string FirstPackage = "Wrapper.First";
+        const string SecondPackage = "Wrapper.Second";
+        const string Version = "1.0.0";
+        var handler = new QueuePackageHandler(
+            CreateToolWrapperArchive(
+                FirstPackage,
+                Version,
+                redirectPackageName: SecondPackage),
+            CreateToolWrapperArchive(
+                SecondPackage,
+                Version,
+                redirectPackageName: FirstPackage));
+        using var client = new HttpClient(handler);
+
+        PackageExtractionOutcome outcome =
+            await PackageExtractor.ExtractPackageAsync(
+                client,
+                FirstPackage,
+                sourceOptions: s_nugetOrgSource,
+                version: Version);
+
+        Assert.False(outcome.IsSuccess);
+        Assert.Equal(
+            $"Tool wrapper redirect cycle detected: {FirstPackage} -> {SecondPackage} -> {FirstPackage}.",
+            outcome.ErrorMessage);
+        Assert.Equal(2, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task ExtractPackageAsync_ToolWrapperRedirectReturnsPayload()
+    {
+        const string WrapperPackage = "Wrapper.Valid";
+        const string PayloadPackage = "Wrapper.Valid.Any";
+        const string Version = "1.0.0";
+        var handler = new QueuePackageHandler(
+            CreateToolWrapperArchive(
+                WrapperPackage,
+                Version,
+                redirectPackageName: PayloadPackage),
+            CreatePackageArchive(PayloadPackage, Version));
+        using var client = new HttpClient(handler);
+
+        PackageExtractionOutcome outcome =
+            await PackageExtractor.ExtractPackageAsync(
+                client,
+                WrapperPackage,
+                sourceOptions: s_nugetOrgSource,
+                version: Version);
+
+        Assert.True(outcome.IsSuccess);
+        Assert.Equal(PayloadPackage, outcome.Result!.PackageName);
+        Assert.Equal(
+            NuGetCache.GetPackageCachePath(PayloadPackage, Version),
+            outcome.Result.ExtractPath);
+        Assert.Equal(2, handler.RequestCount);
+    }
+
+    [Fact]
     public async Task CommitPackage_ConcurrentPublishersConvergeOnOneCompleteTree()
     {
         string packageName = $"publisher.test.{Guid.NewGuid():N}";
@@ -402,6 +489,47 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
                 </package>
                 """);
             WriteEntry(archive, "lib/net10.0/Test.dll", "fixture");
+        }
+
+        return buffer.ToArray();
+    }
+
+    private static byte[] CreateToolWrapperArchive(
+        string packageName,
+        string version,
+        string redirectPackageName)
+    {
+        using var buffer = new MemoryStream();
+        using (var archive = new ZipArchive(
+            buffer,
+            ZipArchiveMode.Create,
+            leaveOpen: true))
+        {
+            WriteEntry(
+                archive,
+                $"{packageName}.nuspec",
+                $"""
+                <?xml version="1.0"?>
+                <package>
+                  <metadata>
+                    <id>{packageName}</id>
+                    <version>{version}</version>
+                  </metadata>
+                </package>
+                """);
+            WriteEntry(
+                archive,
+                "tools/net10.0/any/DotnetToolSettings.xml",
+                $"""
+                <DotNetCliTool Version="2">
+                  <Commands>
+                    <Command Name="{packageName}" />
+                  </Commands>
+                  <RuntimeIdentifierPackages>
+                    <RuntimeIdentifierPackage RuntimeIdentifier="any" Id="{redirectPackageName}" />
+                  </RuntimeIdentifierPackages>
+                </DotNetCliTool>
+                """);
         }
 
         return buffer.ToArray();


### PR DESCRIPTION
## Summary

- replace recursive .NET tool-wrapper redirects with iterative traversal
- detect repeated package IDs case-insensitively and return the complete redirect chain as a visible error
- preserve ordinary wrapper-to-payload behavior and keep redirects outside exact-coordinate single-flight

Closes #2807

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build --no-restore` — 1,925 total, 0 failed, 10 skipped
- `dotnet run --project src/DotnetInspector.Services.Tests -c Release --no-restore` — 264 total, 0 failed
- `npx markdownlint-cli docs/design/cache-concurrency.md`

## Compatibility

Initial version resolution retains the caller’s latest/prerelease policy. Redirected packages continue to use the resolved wrapper version, matching the previous recursive behavior. Local `.nupkg` extraction remains unchanged. Self-redirecting wrappers now return a visible cycle error instead of succeeding with an unusable wrapper that contains no managed libraries.