### PR TITLE
Bound metadata relationship traversal

### DIFF
--- a/docs/design/bounded-metadata-traversal.md
+++ b/docs/design/bounded-metadata-traversal.md
@@ -309,23 +309,31 @@ separate work; adopting either is not a prerequisite for this safety substrate.
 ## Budget policy
 
 All limits live in one metadata-safety policy rather than in individual
-formatters. The implementation PR must pin a real-artifact census and record the
-observed maxima before activating new limits.
+formatters. An implementation PR must pin a real-artifact census and record the
+observed maxima before activating a new limit.
 
-Candidate starting ceilings are:
+Current and candidate ceilings are:
 
-| Dimension | Candidate ceiling | Rationale |
+| Dimension | Ceiling | Status and rationale |
 | --- | ---: | --- |
-| Relationship nodes | 256 | Matches existing guarded recursion ceilings while remaining far above normal nesting |
-| Projected characters | 8,192 | Bounds repeated long names and argument expansion without constraining ordinary identities |
-| Generic arity expansion | 1,024 | Prevents metadata names such as ``Type`2000000000`` from driving unbounded loops |
-| TypeSpec active bytes | 4,096 | Existing `TypeSpecGuard` policy |
-| Signature structural depth | 512 | Existing `SignatureBlobGuard` policy |
+| Relationship nodes | 256 | Active; matches existing guarded recursion ceilings and is far above the measured maximum |
+| Projected characters | 8,192 | Candidate; bounds repeated long names and argument expansion without constraining ordinary identities |
+| Generic arity expansion | 1,024 | Candidate; prevents metadata names such as ``Type`2000000000`` from driving unbounded loops |
+| TypeSpec active bytes | 4,096 | Active existing `TypeSpecGuard` policy |
+| Signature structural depth | 512 | Active existing `SignatureBlobGuard` policy |
 
-The relationship-node value aligns with existing guarded recursion. The text
-and arity values come from prior hardening experiments but are not active
-policy until the implementation PR records a pinned corpus's maximum observed
-identity length and generic arity, then demonstrates adequate margin.
+The relationship-node ceiling was activated after scanning the .NET 11
+preview 6 runtime and reference packs
+(`11.0.0-preview.6.26359.118`): 623 assemblies, no malformed images or cycles,
+and maximum chain lengths of 5 TypeDefs, 3 TypeRefs, and 3 ExportedTypes. The
+ordered input DLL digest was
+`d6d2fef7d7ccdf240f308cbfddd90fa21fdeb82b55d89d0028ef37ffd87e04af`.
+The 256-node ceiling leaves more than 50 times the observed TypeDef depth while
+aligning with the existing TypeSpec re-entry ceiling.
+
+The text and arity values come from prior hardening experiments but are not
+active policy until an implementation PR records a pinned corpus's maximum
+observed identity length and generic arity, then demonstrates adequate margin.
 
 Once activated, these are security ceilings, not user-tunable output limits. A
 future change must update the policy, census evidence, and adversarial fixtures

--- a/src/ILInspector.Metadata/MetadataReaderExtensions.cs
+++ b/src/ILInspector.Metadata/MetadataReaderExtensions.cs
@@ -18,7 +18,15 @@ public static class MetadataReaderExtensions
         /// Gets the fully qualified name (Namespace.Name) of a <see cref="TypeDefinition"/>.
         /// </summary>
         public string GetFullTypeName(TypeDefinition typeDef)
-            => TypeResolver.GetFullName(reader, typeDef);
+            => TypeResolver.ResolveFullName(reader, typeDef).GetValueOrThrow();
+
+        /// <summary>
+        /// Resolves the fully qualified name of a TypeDefinition through a
+        /// bounded declaring-type walk.
+        /// </summary>
+        public RelationshipTraversalResult<string> ResolveFullTypeName(
+            TypeDefinitionHandle handle)
+            => TypeResolver.ResolveTypeNameFromDefinition(reader, handle);
 
         /// <summary>
         /// Gets the fully qualified name of a <see cref="TypeReference"/>,
@@ -26,19 +34,29 @@ public static class MetadataReaderExtensions
         /// match <see cref="GetFullTypeName(TypeDefinition)"/>.
         /// </summary>
         public string GetFullTypeName(TypeReference typeRef)
-            => typeRef.ResolutionScope.Kind == HandleKind.TypeReference
-                ? $"{reader.GetFullTypeName(reader.GetTypeReference((TypeReferenceHandle)typeRef.ResolutionScope))}.{reader.GetString(typeRef.Name)}"
-                : TypeResolver.GetFullName(reader.GetString(typeRef.Namespace), reader.GetString(typeRef.Name));
+            => TypeResolver.ResolveFullName(reader, typeRef).GetValueOrThrow();
+
+        /// <summary>
+        /// Resolves the fully qualified name of a TypeReference through a
+        /// bounded resolution-scope walk.
+        /// </summary>
+        public RelationshipTraversalResult<string> ResolveFullTypeName(
+            TypeReferenceHandle handle)
+            => TypeResolver.ResolveTypeNameFromReference(reader, handle);
 
         /// <summary>
         /// Gets the fully qualified name (Namespace.Name) of an <see cref="ExportedType"/>.
         /// </summary>
         public string GetFullTypeName(ExportedType exportedType)
-        {
-            string ns = reader.GetString(exportedType.Namespace);
-            string name = reader.GetString(exportedType.Name);
-            return TypeResolver.GetFullName(ns, name);
-        }
+            => TypeResolver.ResolveFullName(reader, exportedType).GetValueOrThrow();
+
+        /// <summary>
+        /// Resolves the fully qualified name of an ExportedType through a
+        /// bounded implementation walk.
+        /// </summary>
+        public RelationshipTraversalResult<string> ResolveFullTypeName(
+            ExportedTypeHandle handle)
+            => TypeResolver.ResolveTypeNameFromExportedType(reader, handle);
 
         /// <summary>
         /// Gets the name of a generic parameter from its handle.

--- a/src/ILInspector.Metadata/MetadataReaderExtensions.cs
+++ b/src/ILInspector.Metadata/MetadataReaderExtensions.cs
@@ -18,7 +18,7 @@ public static class MetadataReaderExtensions
         /// Gets the fully qualified name (Namespace.Name) of a <see cref="TypeDefinition"/>.
         /// </summary>
         public string GetFullTypeName(TypeDefinition typeDef)
-            => TypeResolver.ResolveFullName(reader, typeDef).GetValueOrThrow();
+            => TypeResolver.GetFullName(reader, typeDef);
 
         /// <summary>
         /// Resolves the fully qualified name of a TypeDefinition through a
@@ -34,7 +34,7 @@ public static class MetadataReaderExtensions
         /// match <see cref="GetFullTypeName(TypeDefinition)"/>.
         /// </summary>
         public string GetFullTypeName(TypeReference typeRef)
-            => TypeResolver.ResolveFullName(reader, typeRef).GetValueOrThrow();
+            => TypeResolver.GetFullName(reader, typeRef);
 
         /// <summary>
         /// Resolves the fully qualified name of a TypeReference through a
@@ -48,7 +48,7 @@ public static class MetadataReaderExtensions
         /// Gets the fully qualified name (Namespace.Name) of an <see cref="ExportedType"/>.
         /// </summary>
         public string GetFullTypeName(ExportedType exportedType)
-            => TypeResolver.ResolveFullName(reader, exportedType).GetValueOrThrow();
+            => TypeResolver.GetFullName(reader, exportedType);
 
         /// <summary>
         /// Resolves the fully qualified name of an ExportedType through a

--- a/src/ILInspector.MetadataPrimitives/AttributeDecoder.cs
+++ b/src/ILInspector.MetadataPrimitives/AttributeDecoder.cs
@@ -25,8 +25,7 @@ public static class AttributeDecoder
         if (constructorHandle.Kind == HandleKind.MethodDefinition)
         {
             var methodDef = reader.GetMethodDefinition((MethodDefinitionHandle)constructorHandle);
-            var typeDef = reader.GetTypeDefinition(methodDef.GetDeclaringType());
-            return TypeResolver.GetFullName(reader, typeDef);
+            return TypeResolver.GetTypeNameFromDefinition(reader, methodDef.GetDeclaringType());
         }
         return null;
     }
@@ -74,7 +73,7 @@ public static class AttributeDecoder
         public bool IsSystemType(string type) => type == "System.Type";
         public string GetSZArrayType(string elementType) => elementType + "[]";
         public string GetTypeFromDefinition(MetadataReader r, TypeDefinitionHandle handle, byte rawTypeKind)
-            => TypeResolver.GetFullName(r, r.GetTypeDefinition(handle));
+            => TypeResolver.GetTypeNameFromDefinition(r, handle);
         public string GetTypeFromReference(MetadataReader r, TypeReferenceHandle handle, byte rawTypeKind)
             => TypeResolver.GetTypeName(r, handle) ?? "object";
         public string GetTypeFromSerializedName(string name)
@@ -88,7 +87,7 @@ public static class AttributeDecoder
             foreach (var handle in reader.TypeDefinitions)
             {
                 var def = reader.GetTypeDefinition(handle);
-                if (TypeResolver.GetFullName(reader, def) != type)
+                if (TypeResolver.GetTypeNameFromDefinition(reader, handle) != type)
                     continue;
                 foreach (var fieldHandle in def.GetFields())
                 {

--- a/src/ILInspector.MetadataPrimitives/MetadataRelationshipTraversal.cs
+++ b/src/ILInspector.MetadataPrimitives/MetadataRelationshipTraversal.cs
@@ -1,0 +1,145 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata;
+
+/// <summary>Fixed safety ceilings for artifact-derived metadata operations.</summary>
+public static class MetadataSafetyPolicy
+{
+    /// <summary>
+    /// Maximum unique handles in one TypeDef, TypeRef, or ExportedType
+    /// relationship chain.
+    /// </summary>
+    public const int MaxRelationshipNodes = 256;
+}
+
+/// <summary>Bounded iterative walks over SRM metadata relationships.</summary>
+public static class MetadataRelationshipTraversal
+{
+    /// <summary>Walks a TypeDef declaring-type chain from its outermost type to the requested leaf.</summary>
+    public static RelationshipTraversalResult<RelationshipChain<TypeDefinitionHandle>>
+        WalkTypeDefinitionDeclaringChain(
+            MetadataReader reader,
+            TypeDefinitionHandle handle)
+        => Walk(
+            handle,
+            HandleKind.TypeDefinition,
+            static entity => (TypeDefinitionHandle)entity,
+            current => reader.GetTypeDefinition(current).GetDeclaringType());
+
+    /// <summary>Walks a TypeRef resolution-scope chain from its outermost type to the requested leaf.</summary>
+    public static RelationshipTraversalResult<RelationshipChain<TypeReferenceHandle>>
+        WalkTypeReferenceResolutionScope(
+            MetadataReader reader,
+            TypeReferenceHandle handle)
+        => Walk(
+            handle,
+            HandleKind.TypeReference,
+            static entity => (TypeReferenceHandle)entity,
+            current => reader.GetTypeReference(current).ResolutionScope);
+
+    /// <summary>Walks an ExportedType implementation chain from its outermost type to the requested leaf.</summary>
+    public static RelationshipTraversalResult<RelationshipChain<ExportedTypeHandle>>
+        WalkExportedTypeImplementationChain(
+            MetadataReader reader,
+            ExportedTypeHandle handle)
+        => Walk(
+            handle,
+            HandleKind.ExportedType,
+            static entity => (ExportedTypeHandle)entity,
+            current => reader.GetExportedType(current).Implementation);
+
+    static RelationshipTraversalResult<RelationshipChain<THandle>> Walk<THandle>(
+        EntityHandle start,
+        HandleKind relationshipKind,
+        Func<EntityHandle, THandle> convert,
+        Func<THandle, EntityHandle> next)
+        where THandle : struct
+    {
+        if (start.IsNil)
+        {
+            return Reject<THandle>(
+                RelationshipTraversalRejectionKind.MalformedMetadata,
+                "The relationship starts with a nil handle.",
+                start,
+                consumedNodes: 0);
+        }
+
+        var visited = new HashSet<EntityHandle>();
+        var leafToRoot = ImmutableArray.CreateBuilder<THandle>();
+        var current = start;
+
+        while (!current.IsNil && current.Kind == relationshipKind)
+        {
+            if (!visited.Add(current))
+            {
+                return Reject<THandle>(
+                    RelationshipTraversalRejectionKind.Cycle,
+                    $"The {relationshipKind} relationship repeats handle {FormatHandle(current)}.",
+                    current,
+                    leafToRoot.Count);
+            }
+
+            if (leafToRoot.Count >= MetadataSafetyPolicy.MaxRelationshipNodes)
+            {
+                return Reject<THandle>(
+                    RelationshipTraversalRejectionKind.NodeBudget,
+                    $"The {relationshipKind} relationship exceeds "
+                    + $"{MetadataSafetyPolicy.MaxRelationshipNodes} nodes.",
+                    current,
+                    leafToRoot.Count);
+            }
+
+            THandle typedHandle;
+            try
+            {
+                typedHandle = convert(current);
+                leafToRoot.Add(typedHandle);
+                current = next(typedHandle);
+            }
+            catch (BadImageFormatException ex)
+            {
+                return Malformed<THandle>(ex, current, leafToRoot.Count);
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                return Malformed<THandle>(ex, current, leafToRoot.Count);
+            }
+        }
+
+        var rootToLeaf = ImmutableArray.CreateBuilder<THandle>(leafToRoot.Count);
+        for (int i = leafToRoot.Count - 1; i >= 0; i--)
+            rootToLeaf.Add(leafToRoot[i]);
+
+        return new RelationshipTraversalResult<RelationshipChain<THandle>>.Completed(
+            new RelationshipChain<THandle>(rootToLeaf.MoveToImmutable(), current),
+            leafToRoot.Count);
+    }
+
+    static RelationshipTraversalResult<RelationshipChain<THandle>> Malformed<THandle>(
+        Exception exception,
+        EntityHandle subject,
+        int consumedNodes)
+        where THandle : struct
+        => Reject<THandle>(
+            RelationshipTraversalRejectionKind.MalformedMetadata,
+            exception.Message,
+            subject,
+            consumedNodes);
+
+    static RelationshipTraversalResult<RelationshipChain<THandle>> Reject<THandle>(
+        RelationshipTraversalRejectionKind kind,
+        string detail,
+        EntityHandle subject,
+        int consumedNodes)
+        where THandle : struct
+        => new RelationshipTraversalResult<RelationshipChain<THandle>>.Rejected(
+            new RelationshipTraversalRejection(
+                kind,
+                detail,
+                subject,
+                consumedNodes));
+
+    static string FormatHandle(EntityHandle handle)
+        => $"0x{System.Reflection.Metadata.Ecma335.MetadataTokens.GetToken(handle):X8}";
+}

--- a/src/ILInspector.MetadataPrimitives/MetadataRelationshipTraversal.cs
+++ b/src/ILInspector.MetadataPrimitives/MetadataRelationshipTraversal.cs
@@ -65,9 +65,32 @@ public static class MetadataRelationshipTraversal
                 consumedNodes: 0);
         }
 
-        var visited = new HashSet<EntityHandle>();
+        THandle firstHandle;
+        EntityHandle current;
+        try
+        {
+            firstHandle = convert(start);
+            current = next(firstHandle);
+        }
+        catch (BadImageFormatException ex)
+        {
+            return Malformed<THandle>(ex, start, consumedNodes: 1);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            return Malformed<THandle>(ex, start, consumedNodes: 1);
+        }
+
+        if (current.IsNil || current.Kind != relationshipKind)
+        {
+            return new RelationshipTraversalResult<RelationshipChain<THandle>>.Completed(
+                new RelationshipChain<THandle>([firstHandle], current),
+                consumedNodes: 1);
+        }
+
+        var visited = new HashSet<EntityHandle> { start };
         var leafToRoot = ImmutableArray.CreateBuilder<THandle>();
-        var current = start;
+        leafToRoot.Add(firstHandle);
 
         while (!current.IsNil && current.Kind == relationshipKind)
         {
@@ -90,10 +113,9 @@ public static class MetadataRelationshipTraversal
                     leafToRoot.Count);
             }
 
-            THandle typedHandle;
             try
             {
-                typedHandle = convert(current);
+                var typedHandle = convert(current);
                 leafToRoot.Add(typedHandle);
                 current = next(typedHandle);
             }

--- a/src/ILInspector.MetadataPrimitives/RelationshipTraversalResult.cs
+++ b/src/ILInspector.MetadataPrimitives/RelationshipTraversalResult.cs
@@ -1,0 +1,130 @@
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata;
+
+/// <summary>Why an artifact-derived metadata relationship walk did not complete.</summary>
+public enum RelationshipTraversalRejectionKind
+{
+    /// <summary>A metadata handle repeated in the active relationship chain.</summary>
+    Cycle,
+
+    /// <summary>The relationship chain exceeded the fixed node ceiling.</summary>
+    NodeBudget,
+
+    /// <summary>SRM rejected a row or relationship handle.</summary>
+    MalformedMetadata,
+}
+
+/// <summary>Inspectable evidence for a rejected metadata relationship walk.</summary>
+public sealed record RelationshipTraversalRejection
+{
+    public RelationshipTraversalRejection(
+        RelationshipTraversalRejectionKind kind,
+        string detail,
+        EntityHandle subject,
+        int consumedNodes)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(detail);
+        ArgumentOutOfRangeException.ThrowIfNegative(consumedNodes);
+        Kind = kind;
+        Detail = detail;
+        Subject = subject;
+        ConsumedNodes = consumedNodes;
+    }
+
+    public RelationshipTraversalRejectionKind Kind { get; }
+    public string Detail { get; }
+    public EntityHandle Subject { get; }
+    public int ConsumedNodes { get; }
+}
+
+/// <summary>
+/// A completed metadata relationship chain, ordered from the outermost handle
+/// to the requested leaf handle.
+/// </summary>
+public sealed record RelationshipChain<THandle>
+    where THandle : struct
+{
+    public RelationshipChain(
+        ImmutableArray<THandle> handles,
+        EntityHandle terminal)
+    {
+        if (handles.IsDefaultOrEmpty)
+            throw new ArgumentException("A relationship chain must contain at least one handle.", nameof(handles));
+
+        Handles = handles;
+        Terminal = terminal;
+    }
+
+    public ImmutableArray<THandle> Handles { get; }
+    public EntityHandle Terminal { get; }
+}
+
+/// <summary>
+/// The outcome of a bounded metadata relationship operation. A rejected
+/// operation never carries a partial success-shaped value.
+/// </summary>
+public abstract record RelationshipTraversalResult<T>
+    where T : notnull
+{
+    private protected RelationshipTraversalResult()
+    {
+    }
+
+    /// <summary>The relationship operation completed.</summary>
+    public sealed record Completed : RelationshipTraversalResult<T>
+    {
+        public Completed(T value, int consumedNodes)
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            ArgumentOutOfRangeException.ThrowIfNegative(consumedNodes);
+            Value = value;
+            ConsumedNodes = consumedNodes;
+        }
+
+        public T Value { get; }
+        public int ConsumedNodes { get; }
+    }
+
+    /// <summary>The relationship operation was rejected before producing a trustworthy value.</summary>
+    public sealed record Rejected : RelationshipTraversalResult<T>
+    {
+        public Rejected(RelationshipTraversalRejection rejection)
+        {
+            ArgumentNullException.ThrowIfNull(rejection);
+            Rejection = rejection;
+        }
+
+        public RelationshipTraversalRejection Rejection { get; }
+    }
+
+    /// <summary>Returns whether this outcome carries a completed value.</summary>
+    public bool TryGetValue([MaybeNullWhen(false)] out T value)
+    {
+        if (this is Completed completed)
+        {
+            value = completed.Value;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the completed value or throws <see cref="BadImageFormatException"/>
+    /// at a caller-owned whole-operation failure boundary.
+    /// </summary>
+    public T GetValueOrThrow()
+        => this switch
+        {
+            Completed completed => completed.Value,
+            Rejected rejected => throw new BadImageFormatException(
+                $"Metadata relationship traversal rejected ({rejected.Rejection.Kind}): "
+                + rejected.Rejection.Detail),
+            _ => throw new InvalidOperationException(
+                "Unknown metadata relationship traversal result."),
+        };
+}

--- a/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
+++ b/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
@@ -43,7 +43,7 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
     };
 
     public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
-        => TypeResolver.GetFullName(reader, reader.GetTypeDefinition(handle));
+        => TypeResolver.GetTypeNameFromDefinition(reader, handle);
 
     public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
         => TypeResolver.GetTypeNameFromReference(reader, handle);

--- a/src/ILInspector.MetadataPrimitives/TypeResolver.cs
+++ b/src/ILInspector.MetadataPrimitives/TypeResolver.cs
@@ -41,10 +41,18 @@ public static class TypeResolver
     /// </summary>
     public static string GetTypeNameFromReference(MetadataReader reader, TypeReferenceHandle handle)
     {
-        var typeRef = reader.GetTypeReference(handle);
-        return typeRef.ResolutionScope.Kind != HandleKind.TypeReference
-            ? GetFullName(reader.GetString(typeRef.Namespace), reader.GetString(typeRef.Name))
-            : ResolveTypeNameFromReference(reader, handle).GetValueOrThrow();
+        try
+        {
+            var typeRef = reader.GetTypeReference(handle);
+            if (typeRef.ResolutionScope.Kind != HandleKind.TypeReference)
+                return GetFullName(reader.GetString(typeRef.Namespace), reader.GetString(typeRef.Name));
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
+        {
+            return ThrowMalformed(ex, handle);
+        }
+
+        return ResolveTypeNameFromReference(reader, handle).GetValueOrThrow();
     }
 
     /// <summary>
@@ -93,10 +101,18 @@ public static class TypeResolver
     /// </summary>
     public static string GetTypeNameFromDefinition(MetadataReader reader, TypeDefinitionHandle handle)
     {
-        var typeDef = reader.GetTypeDefinition(handle);
-        return typeDef.GetDeclaringType().IsNil
-            ? GetFullName(reader.GetString(typeDef.Namespace), reader.GetString(typeDef.Name))
-            : ResolveTypeNameFromDefinition(reader, handle).GetValueOrThrow();
+        try
+        {
+            var typeDef = reader.GetTypeDefinition(handle);
+            if (typeDef.GetDeclaringType().IsNil)
+                return GetFullName(reader.GetString(typeDef.Namespace), reader.GetString(typeDef.Name));
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
+        {
+            return ThrowMalformed(ex, handle);
+        }
+
+        return ResolveTypeNameFromDefinition(reader, handle).GetValueOrThrow();
     }
 
     /// <summary>
@@ -188,10 +204,18 @@ public static class TypeResolver
         MetadataReader reader,
         ExportedTypeHandle handle)
     {
-        var exportedType = reader.GetExportedType(handle);
-        return exportedType.Implementation.Kind != HandleKind.ExportedType
-            ? GetFullName(reader.GetString(exportedType.Namespace), reader.GetString(exportedType.Name))
-            : ResolveTypeNameFromExportedType(reader, handle).GetValueOrThrow();
+        try
+        {
+            var exportedType = reader.GetExportedType(handle);
+            if (exportedType.Implementation.Kind != HandleKind.ExportedType)
+                return GetFullName(reader.GetString(exportedType.Namespace), reader.GetString(exportedType.Name));
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
+        {
+            return ThrowMalformed(ex, handle);
+        }
+
+        return ResolveTypeNameFromExportedType(reader, handle).GetValueOrThrow();
     }
 
     /// <summary>
@@ -564,4 +588,9 @@ public static class TypeResolver
         RelationshipTraversalRejection rejection)
         where T : notnull
         => new RelationshipTraversalResult<T>.Rejected(rejection);
+
+    static string ThrowMalformed(
+        Exception exception,
+        EntityHandle subject)
+        => Malformed<string>(exception, subject, consumedNodes: 1).GetValueOrThrow();
 }

--- a/src/ILInspector.MetadataPrimitives/TypeResolver.cs
+++ b/src/ILInspector.MetadataPrimitives/TypeResolver.cs
@@ -40,7 +40,12 @@ public static class TypeResolver
     /// <c>Builder</c>). Mirrors <see cref="GetFullName(MetadataReader, TypeDefinition)"/>.
     /// </summary>
     public static string GetTypeNameFromReference(MetadataReader reader, TypeReferenceHandle handle)
-        => ResolveTypeNameFromReference(reader, handle).GetValueOrThrow();
+    {
+        var typeRef = reader.GetTypeReference(handle);
+        return typeRef.ResolutionScope.Kind != HandleKind.TypeReference
+            ? GetFullName(reader.GetString(typeRef.Namespace), reader.GetString(typeRef.Name))
+            : ResolveTypeNameFromReference(reader, handle).GetValueOrThrow();
+    }
 
     /// <summary>
     /// Resolves a TypeReference name through a bounded, cycle-aware
@@ -49,7 +54,30 @@ public static class TypeResolver
     public static RelationshipTraversalResult<string> ResolveTypeNameFromReference(
         MetadataReader reader,
         TypeReferenceHandle handle)
-        => FormatChain(
+    {
+        try
+        {
+            var typeRef = reader.GetTypeReference(handle);
+            if (typeRef.ResolutionScope.Kind != HandleKind.TypeReference)
+            {
+                return CompleteLeafName(
+                    reader,
+                    typeRef.Namespace,
+                    typeRef.Name,
+                    handle,
+                    consumedNodes: 1);
+            }
+        }
+        catch (BadImageFormatException ex)
+        {
+            return Malformed<string>(ex, handle, consumedNodes: 1);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            return Malformed<string>(ex, handle, consumedNodes: 1);
+        }
+
+        return FormatChain(
             reader,
             MetadataRelationshipTraversal.WalkTypeReferenceResolutionScope(reader, handle),
             current =>
@@ -58,12 +86,18 @@ public static class TypeResolver
                 return (typeRef.Namespace, typeRef.Name);
             },
             static current => current);
+    }
 
     /// <summary>
     /// Gets the type name from a TypeDefinition handle.
     /// </summary>
     public static string GetTypeNameFromDefinition(MetadataReader reader, TypeDefinitionHandle handle)
-        => ResolveTypeNameFromDefinition(reader, handle).GetValueOrThrow();
+    {
+        var typeDef = reader.GetTypeDefinition(handle);
+        return typeDef.GetDeclaringType().IsNil
+            ? GetFullName(reader.GetString(typeDef.Namespace), reader.GetString(typeDef.Name))
+            : ResolveTypeNameFromDefinition(reader, handle).GetValueOrThrow();
+    }
 
     /// <summary>
     /// Resolves a TypeDefinition name through a bounded, cycle-aware
@@ -72,7 +106,30 @@ public static class TypeResolver
     public static RelationshipTraversalResult<string> ResolveTypeNameFromDefinition(
         MetadataReader reader,
         TypeDefinitionHandle handle)
-        => FormatChain(
+    {
+        try
+        {
+            var typeDef = reader.GetTypeDefinition(handle);
+            if (typeDef.GetDeclaringType().IsNil)
+            {
+                return CompleteLeafName(
+                    reader,
+                    typeDef.Namespace,
+                    typeDef.Name,
+                    handle,
+                    consumedNodes: 1);
+            }
+        }
+        catch (BadImageFormatException ex)
+        {
+            return Malformed<string>(ex, handle, consumedNodes: 1);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            return Malformed<string>(ex, handle, consumedNodes: 1);
+        }
+
+        return FormatChain(
             reader,
             MetadataRelationshipTraversal.WalkTypeDefinitionDeclaringChain(reader, handle),
             current =>
@@ -81,6 +138,7 @@ public static class TypeResolver
                 return (typeDef.Namespace, typeDef.Name);
             },
             static current => current);
+    }
 
     /// <summary>
     /// Resolves an ExportedType name through a bounded, cycle-aware
@@ -89,7 +147,30 @@ public static class TypeResolver
     public static RelationshipTraversalResult<string> ResolveTypeNameFromExportedType(
         MetadataReader reader,
         ExportedTypeHandle handle)
-        => FormatChain(
+    {
+        try
+        {
+            var exportedType = reader.GetExportedType(handle);
+            if (exportedType.Implementation.Kind != HandleKind.ExportedType)
+            {
+                return CompleteLeafName(
+                    reader,
+                    exportedType.Namespace,
+                    exportedType.Name,
+                    handle,
+                    consumedNodes: 1);
+            }
+        }
+        catch (BadImageFormatException ex)
+        {
+            return Malformed<string>(ex, handle, consumedNodes: 1);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            return Malformed<string>(ex, handle, consumedNodes: 1);
+        }
+
+        return FormatChain(
             reader,
             MetadataRelationshipTraversal.WalkExportedTypeImplementationChain(reader, handle),
             current =>
@@ -98,6 +179,7 @@ public static class TypeResolver
                 return (exportedType.Namespace, exportedType.Name);
             },
             static current => current);
+    }
 
     /// <summary>
     /// Gets an ExportedType name or throws at a caller-owned failure boundary.
@@ -105,7 +187,12 @@ public static class TypeResolver
     public static string GetTypeNameFromExportedType(
         MetadataReader reader,
         ExportedTypeHandle handle)
-        => ResolveTypeNameFromExportedType(reader, handle).GetValueOrThrow();
+    {
+        var exportedType = reader.GetExportedType(handle);
+        return exportedType.Implementation.Kind != HandleKind.ExportedType
+            ? GetFullName(reader.GetString(exportedType.Namespace), reader.GetString(exportedType.Name))
+            : ResolveTypeNameFromExportedType(reader, handle).GetValueOrThrow();
+    }
 
     /// <summary>
     /// Gets the type name from a TypeSpecification handle (generic instantiations).

--- a/src/ILInspector.MetadataPrimitives/TypeResolver.cs
+++ b/src/ILInspector.MetadataPrimitives/TypeResolver.cs
@@ -241,7 +241,25 @@ public static class TypeResolver
     /// nested type through its declaring type (Outer.Inner).
     /// </summary>
     public static string GetFullName(MetadataReader reader, TypeDefinition typeDef)
-        => ResolveFullName(reader, typeDef).GetValueOrThrow();
+    {
+        TypeDefinitionHandle declaringType;
+        try
+        {
+            declaringType = typeDef.GetDeclaringType();
+            if (declaringType.IsNil)
+                return GetFullName(reader.GetString(typeDef.Namespace), reader.GetString(typeDef.Name));
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
+        {
+            return ThrowMalformed(ex, default, consumedNodes: 0);
+        }
+
+        return AppendLeaf(
+            reader,
+            ResolveTypeNameFromDefinition(reader, declaringType),
+            typeDef.Name,
+            declaringType).GetValueOrThrow();
+    }
 
     /// <summary>
     /// Resolves the full name of a TypeDefinition value whose handle is not
@@ -286,6 +304,31 @@ public static class TypeResolver
     public static string GetFullName(string? ns, string name)
     {
         return string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
+    }
+
+    /// <summary>
+    /// Gets the full name of a type reference, qualifying a nested type through
+    /// its resolution-scope chain.
+    /// </summary>
+    public static string GetFullName(MetadataReader reader, TypeReference typeRef)
+    {
+        EntityHandle resolutionScope;
+        try
+        {
+            resolutionScope = typeRef.ResolutionScope;
+            if (resolutionScope.Kind != HandleKind.TypeReference)
+                return GetFullName(reader.GetString(typeRef.Namespace), reader.GetString(typeRef.Name));
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
+        {
+            return ThrowMalformed(ex, default, consumedNodes: 0);
+        }
+
+        return AppendLeaf(
+            reader,
+            ResolveTypeNameFromReference(reader, (TypeReferenceHandle)resolutionScope),
+            typeRef.Name,
+            resolutionScope).GetValueOrThrow();
     }
 
     /// <summary>
@@ -360,6 +403,31 @@ public static class TypeResolver
         {
             return Malformed<string>(ex, default, consumedNodes: 0);
         }
+    }
+
+    /// <summary>
+    /// Gets the full name of an exported type, qualifying a nested type through
+    /// its implementation chain.
+    /// </summary>
+    public static string GetFullName(MetadataReader reader, ExportedType exportedType)
+    {
+        EntityHandle implementation;
+        try
+        {
+            implementation = exportedType.Implementation;
+            if (implementation.Kind != HandleKind.ExportedType)
+                return GetFullName(reader.GetString(exportedType.Namespace), reader.GetString(exportedType.Name));
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
+        {
+            return ThrowMalformed(ex, default, consumedNodes: 0);
+        }
+
+        return AppendLeaf(
+            reader,
+            ResolveTypeNameFromExportedType(reader, (ExportedTypeHandle)implementation),
+            exportedType.Name,
+            implementation).GetValueOrThrow();
     }
 
     /// <summary>
@@ -591,6 +659,7 @@ public static class TypeResolver
 
     static string ThrowMalformed(
         Exception exception,
-        EntityHandle subject)
-        => Malformed<string>(exception, subject, consumedNodes: 1).GetValueOrThrow();
+        EntityHandle subject,
+        int consumedNodes = 1)
+        => Malformed<string>(exception, subject, consumedNodes).GetValueOrThrow();
 }

--- a/src/ILInspector.MetadataPrimitives/TypeResolver.cs
+++ b/src/ILInspector.MetadataPrimitives/TypeResolver.cs
@@ -1,4 +1,5 @@
 using System.Reflection.Metadata;
+using System.Text;
 
 namespace ILInspector.Metadata;
 
@@ -39,18 +40,72 @@ public static class TypeResolver
     /// <c>Builder</c>). Mirrors <see cref="GetFullName(MetadataReader, TypeDefinition)"/>.
     /// </summary>
     public static string GetTypeNameFromReference(MetadataReader reader, TypeReferenceHandle handle)
-    {
-        var typeRef = reader.GetTypeReference(handle);
-        if (typeRef.ResolutionScope.Kind == HandleKind.TypeReference)
-            return $"{GetTypeNameFromReference(reader, (TypeReferenceHandle)typeRef.ResolutionScope)}.{reader.GetString(typeRef.Name)}";
-        return GetFullName(reader.GetString(typeRef.Namespace), reader.GetString(typeRef.Name));
-    }
+        => ResolveTypeNameFromReference(reader, handle).GetValueOrThrow();
+
+    /// <summary>
+    /// Resolves a TypeReference name through a bounded, cycle-aware
+    /// resolution-scope walk.
+    /// </summary>
+    public static RelationshipTraversalResult<string> ResolveTypeNameFromReference(
+        MetadataReader reader,
+        TypeReferenceHandle handle)
+        => FormatChain(
+            reader,
+            MetadataRelationshipTraversal.WalkTypeReferenceResolutionScope(reader, handle),
+            current =>
+            {
+                var typeRef = reader.GetTypeReference(current);
+                return (typeRef.Namespace, typeRef.Name);
+            },
+            static current => current);
 
     /// <summary>
     /// Gets the type name from a TypeDefinition handle.
     /// </summary>
     public static string GetTypeNameFromDefinition(MetadataReader reader, TypeDefinitionHandle handle)
-        => GetFullName(reader, reader.GetTypeDefinition(handle));
+        => ResolveTypeNameFromDefinition(reader, handle).GetValueOrThrow();
+
+    /// <summary>
+    /// Resolves a TypeDefinition name through a bounded, cycle-aware
+    /// declaring-type walk.
+    /// </summary>
+    public static RelationshipTraversalResult<string> ResolveTypeNameFromDefinition(
+        MetadataReader reader,
+        TypeDefinitionHandle handle)
+        => FormatChain(
+            reader,
+            MetadataRelationshipTraversal.WalkTypeDefinitionDeclaringChain(reader, handle),
+            current =>
+            {
+                var typeDef = reader.GetTypeDefinition(current);
+                return (typeDef.Namespace, typeDef.Name);
+            },
+            static current => current);
+
+    /// <summary>
+    /// Resolves an ExportedType name through a bounded, cycle-aware
+    /// implementation walk.
+    /// </summary>
+    public static RelationshipTraversalResult<string> ResolveTypeNameFromExportedType(
+        MetadataReader reader,
+        ExportedTypeHandle handle)
+        => FormatChain(
+            reader,
+            MetadataRelationshipTraversal.WalkExportedTypeImplementationChain(reader, handle),
+            current =>
+            {
+                var exportedType = reader.GetExportedType(current);
+                return (exportedType.Namespace, exportedType.Name);
+            },
+            static current => current);
+
+    /// <summary>
+    /// Gets an ExportedType name or throws at a caller-owned failure boundary.
+    /// </summary>
+    public static string GetTypeNameFromExportedType(
+        MetadataReader reader,
+        ExportedTypeHandle handle)
+        => ResolveTypeNameFromExportedType(reader, handle).GetValueOrThrow();
 
     /// <summary>
     /// Gets the type name from a TypeSpecification handle (generic instantiations).
@@ -75,11 +130,43 @@ public static class TypeResolver
     /// nested type through its declaring type (Outer.Inner).
     /// </summary>
     public static string GetFullName(MetadataReader reader, TypeDefinition typeDef)
+        => ResolveFullName(reader, typeDef).GetValueOrThrow();
+
+    /// <summary>
+    /// Resolves the full name of a TypeDefinition value whose handle is not
+    /// available to the caller.
+    /// </summary>
+    public static RelationshipTraversalResult<string> ResolveFullName(
+        MetadataReader reader,
+        TypeDefinition typeDef)
     {
-        var declaringType = typeDef.GetDeclaringType();
-        if (!declaringType.IsNil)
-            return $"{GetFullName(reader, reader.GetTypeDefinition(declaringType))}.{reader.GetString(typeDef.Name)}";
-        return GetFullName(reader.GetString(typeDef.Namespace), reader.GetString(typeDef.Name));
+        try
+        {
+            var declaringType = typeDef.GetDeclaringType();
+            if (declaringType.IsNil)
+            {
+                return CompleteLeafName(
+                    reader,
+                    typeDef.Namespace,
+                    typeDef.Name,
+                    default,
+                    consumedNodes: 1);
+            }
+
+            return AppendLeaf(
+                reader,
+                ResolveTypeNameFromDefinition(reader, declaringType),
+                typeDef.Name,
+                declaringType);
+        }
+        catch (BadImageFormatException ex)
+        {
+            return Malformed<string>(ex, default, consumedNodes: 0);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            return Malformed<string>(ex, default, consumedNodes: 0);
+        }
     }
 
     /// <summary>
@@ -88,6 +175,80 @@ public static class TypeResolver
     public static string GetFullName(string? ns, string name)
     {
         return string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
+    }
+
+    /// <summary>
+    /// Resolves the full name of a TypeReference value whose handle is not
+    /// available to the caller.
+    /// </summary>
+    public static RelationshipTraversalResult<string> ResolveFullName(
+        MetadataReader reader,
+        TypeReference typeRef)
+    {
+        try
+        {
+            var resolutionScope = typeRef.ResolutionScope;
+            if (resolutionScope.Kind != HandleKind.TypeReference)
+            {
+                return CompleteLeafName(
+                    reader,
+                    typeRef.Namespace,
+                    typeRef.Name,
+                    resolutionScope,
+                    consumedNodes: 1);
+            }
+
+            return AppendLeaf(
+                reader,
+                ResolveTypeNameFromReference(reader, (TypeReferenceHandle)resolutionScope),
+                typeRef.Name,
+                resolutionScope);
+        }
+        catch (BadImageFormatException ex)
+        {
+            return Malformed<string>(ex, default, consumedNodes: 0);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            return Malformed<string>(ex, default, consumedNodes: 0);
+        }
+    }
+
+    /// <summary>
+    /// Resolves the full name of an ExportedType value whose handle is not
+    /// available to the caller.
+    /// </summary>
+    public static RelationshipTraversalResult<string> ResolveFullName(
+        MetadataReader reader,
+        ExportedType exportedType)
+    {
+        try
+        {
+            var implementation = exportedType.Implementation;
+            if (implementation.Kind != HandleKind.ExportedType)
+            {
+                return CompleteLeafName(
+                    reader,
+                    exportedType.Namespace,
+                    exportedType.Name,
+                    implementation,
+                    consumedNodes: 1);
+            }
+
+            return AppendLeaf(
+                reader,
+                ResolveTypeNameFromExportedType(reader, (ExportedTypeHandle)implementation),
+                exportedType.Name,
+                implementation);
+        }
+        catch (BadImageFormatException ex)
+        {
+            return Malformed<string>(ex, default, consumedNodes: 0);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            return Malformed<string>(ex, default, consumedNodes: 0);
+        }
     }
 
     /// <summary>
@@ -190,4 +351,130 @@ public static class TypeResolver
 
         return result.ToString();
     }
+
+    static RelationshipTraversalResult<string> FormatChain<THandle>(
+        MetadataReader reader,
+        RelationshipTraversalResult<RelationshipChain<THandle>> traversal,
+        Func<THandle, (StringHandle Namespace, StringHandle Name)> getName,
+        Func<THandle, EntityHandle> getSubject)
+        where THandle : struct
+    {
+        if (traversal is RelationshipTraversalResult<RelationshipChain<THandle>>.Rejected rejected)
+            return Reject<string>(rejected.Rejection);
+
+        var chain = ((RelationshipTraversalResult<RelationshipChain<THandle>>.Completed)traversal).Value;
+        var builder = new StringBuilder();
+        for (int i = 0; i < chain.Handles.Length; i++)
+        {
+            var handle = chain.Handles[i];
+            try
+            {
+                var (namespaceHandle, nameHandle) = getName(handle);
+                if (i == 0)
+                {
+                    string ns = reader.GetString(namespaceHandle);
+                    if (ns.Length > 0)
+                    {
+                        builder.Append(ns);
+                        builder.Append('.');
+                    }
+                }
+                else
+                {
+                    builder.Append('.');
+                }
+
+                builder.Append(reader.GetString(nameHandle));
+            }
+            catch (BadImageFormatException ex)
+            {
+                return Malformed<string>(ex, getSubject(handle), consumedNodes: i + 1);
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                return Malformed<string>(ex, getSubject(handle), consumedNodes: i + 1);
+            }
+        }
+
+        return new RelationshipTraversalResult<string>.Completed(
+            builder.ToString(),
+            chain.Handles.Length);
+    }
+
+    static RelationshipTraversalResult<string> AppendLeaf(
+        MetadataReader reader,
+        RelationshipTraversalResult<string> declaringName,
+        StringHandle leafName,
+        EntityHandle subject)
+    {
+        if (declaringName is RelationshipTraversalResult<string>.Rejected rejected)
+            return Reject<string>(rejected.Rejection);
+
+        var completed = (RelationshipTraversalResult<string>.Completed)declaringName;
+        if (completed.ConsumedNodes >= MetadataSafetyPolicy.MaxRelationshipNodes)
+        {
+            return new RelationshipTraversalResult<string>.Rejected(
+                new RelationshipTraversalRejection(
+                    RelationshipTraversalRejectionKind.NodeBudget,
+                    $"The metadata relationship exceeds "
+                    + $"{MetadataSafetyPolicy.MaxRelationshipNodes} nodes.",
+                    subject,
+                    completed.ConsumedNodes));
+        }
+
+        try
+        {
+            return new RelationshipTraversalResult<string>.Completed(
+                $"{completed.Value}.{reader.GetString(leafName)}",
+                completed.ConsumedNodes + 1);
+        }
+        catch (BadImageFormatException ex)
+        {
+            return Malformed<string>(ex, subject, completed.ConsumedNodes + 1);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            return Malformed<string>(ex, subject, completed.ConsumedNodes + 1);
+        }
+    }
+
+    static RelationshipTraversalResult<string> CompleteLeafName(
+        MetadataReader reader,
+        StringHandle namespaceHandle,
+        StringHandle nameHandle,
+        EntityHandle subject,
+        int consumedNodes)
+    {
+        try
+        {
+            return new RelationshipTraversalResult<string>.Completed(
+                GetFullName(reader.GetString(namespaceHandle), reader.GetString(nameHandle)),
+                consumedNodes);
+        }
+        catch (BadImageFormatException ex)
+        {
+            return Malformed<string>(ex, subject, consumedNodes);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            return Malformed<string>(ex, subject, consumedNodes);
+        }
+    }
+
+    static RelationshipTraversalResult<T> Malformed<T>(
+        Exception exception,
+        EntityHandle subject,
+        int consumedNodes)
+        where T : notnull
+        => new RelationshipTraversalResult<T>.Rejected(
+            new RelationshipTraversalRejection(
+                RelationshipTraversalRejectionKind.MalformedMetadata,
+                exception.Message,
+                subject,
+                consumedNodes));
+
+    static RelationshipTraversalResult<T> Reject<T>(
+        RelationshipTraversalRejection rejection)
+        where T : notnull
+        => new RelationshipTraversalResult<T>.Rejected(rejection);
 }

--- a/tests/ILInspector.Metadata.Tests/MetadataRelationshipTraversalTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataRelationshipTraversalTests.cs
@@ -1,0 +1,448 @@
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+namespace ILInspector.Metadata.Tests;
+
+public class MetadataRelationshipTraversalTests
+{
+    const string WorkerVariable = "DOTNET_INSPECT_RELATIONSHIP_TRAVERSAL_WORKER";
+
+    [Fact]
+    public void TypeDefinitionChain_CompletesOutermostToLeaf()
+    {
+        TypeDefinitionHandle outer = default;
+        TypeDefinitionHandle middle = default;
+        TypeDefinitionHandle leaf = default;
+        using var image = BuildMetadata(metadata =>
+        {
+            outer = AddTypeDefinition(metadata, TypeAttributes.Public, "N", "Outer");
+            middle = AddTypeDefinition(metadata, TypeAttributes.NestedPublic, "", "Middle");
+            leaf = AddTypeDefinition(metadata, TypeAttributes.NestedPublic, "", "Leaf");
+            metadata.AddNestedType(middle, outer);
+            metadata.AddNestedType(leaf, middle);
+        });
+
+        var completed = Assert.IsType<
+            RelationshipTraversalResult<RelationshipChain<TypeDefinitionHandle>>.Completed>(
+                MetadataRelationshipTraversal.WalkTypeDefinitionDeclaringChain(
+                    image.Reader,
+                    leaf));
+
+        Assert.Equal([outer, middle, leaf], completed.Value.Handles);
+        Assert.True(completed.Value.Terminal.IsNil);
+        Assert.Equal(3, completed.ConsumedNodes);
+        Assert.Equal(
+            "N.Outer.Middle.Leaf",
+            TypeResolver.ResolveTypeNameFromDefinition(image.Reader, leaf).GetValueOrThrow());
+    }
+
+    [Fact]
+    public void TypeReferenceChain_CompletesOutermostToLeaf()
+    {
+        TypeReferenceHandle outer = default;
+        TypeReferenceHandle middle = default;
+        TypeReferenceHandle leaf = default;
+        AssemblyReferenceHandle assembly = default;
+        using var image = BuildMetadata(metadata =>
+        {
+            assembly = AddAssemblyReference(metadata);
+            outer = metadata.AddTypeReference(
+                assembly,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("Outer"));
+            middle = metadata.AddTypeReference(
+                outer,
+                default,
+                metadata.GetOrAddString("Middle"));
+            leaf = metadata.AddTypeReference(
+                middle,
+                default,
+                metadata.GetOrAddString("Leaf"));
+        });
+
+        var completed = Assert.IsType<
+            RelationshipTraversalResult<RelationshipChain<TypeReferenceHandle>>.Completed>(
+                MetadataRelationshipTraversal.WalkTypeReferenceResolutionScope(
+                    image.Reader,
+                    leaf));
+
+        Assert.Equal([outer, middle, leaf], completed.Value.Handles);
+        Assert.Equal((EntityHandle)assembly, completed.Value.Terminal);
+        Assert.Equal(
+            "N.Outer.Middle.Leaf",
+            image.Reader.ResolveFullTypeName(leaf).GetValueOrThrow());
+    }
+
+    [Fact]
+    public void ExportedTypeChain_CompletesOutermostToLeaf()
+    {
+        ExportedTypeHandle outer = default;
+        ExportedTypeHandle middle = default;
+        ExportedTypeHandle leaf = default;
+        AssemblyReferenceHandle assembly = default;
+        using var image = BuildMetadata(metadata =>
+        {
+            assembly = AddAssemblyReference(metadata);
+            outer = metadata.AddExportedType(
+                TypeAttributes.Public,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("Outer"),
+                assembly,
+                typeDefinitionId: 0);
+            middle = metadata.AddExportedType(
+                TypeAttributes.NestedPublic,
+                default,
+                metadata.GetOrAddString("Middle"),
+                outer,
+                typeDefinitionId: 0);
+            leaf = metadata.AddExportedType(
+                TypeAttributes.NestedPublic,
+                default,
+                metadata.GetOrAddString("Leaf"),
+                middle,
+                typeDefinitionId: 0);
+        });
+
+        var completed = Assert.IsType<
+            RelationshipTraversalResult<RelationshipChain<ExportedTypeHandle>>.Completed>(
+                MetadataRelationshipTraversal.WalkExportedTypeImplementationChain(
+                    image.Reader,
+                    leaf));
+
+        Assert.Equal([outer, middle, leaf], completed.Value.Handles);
+        Assert.Equal((EntityHandle)assembly, completed.Value.Terminal);
+        Assert.Equal(
+            "N.Outer.Middle.Leaf",
+            image.Reader.ResolveFullTypeName(leaf).GetValueOrThrow());
+    }
+
+    [Fact]
+    public void DeepAcyclicTypeReferenceChain_EnforcesExactNodeCeiling()
+    {
+        TypeReferenceHandle atCeiling = default;
+        TypeReferenceHandle overCeiling = default;
+        using var image = BuildMetadata(metadata =>
+        {
+            EntityHandle scope = AddAssemblyReference(metadata);
+            for (int i = 1; i <= MetadataSafetyPolicy.MaxRelationshipNodes + 1; i++)
+            {
+                var handle = metadata.AddTypeReference(
+                    scope,
+                    i == 1 ? metadata.GetOrAddString("N") : default,
+                    metadata.GetOrAddString($"T{i}"));
+                scope = handle;
+                if (i == MetadataSafetyPolicy.MaxRelationshipNodes)
+                    atCeiling = handle;
+                else if (i == MetadataSafetyPolicy.MaxRelationshipNodes + 1)
+                    overCeiling = handle;
+            }
+        });
+
+        var completed = Assert.IsType<
+            RelationshipTraversalResult<RelationshipChain<TypeReferenceHandle>>.Completed>(
+                MetadataRelationshipTraversal.WalkTypeReferenceResolutionScope(
+                    image.Reader,
+                    atCeiling));
+        Assert.Equal(MetadataSafetyPolicy.MaxRelationshipNodes, completed.ConsumedNodes);
+        var completedValue = Assert.IsType<RelationshipTraversalResult<string>.Completed>(
+            TypeResolver.ResolveFullName(
+                image.Reader,
+                image.Reader.GetTypeReference(atCeiling)));
+        Assert.Equal(MetadataSafetyPolicy.MaxRelationshipNodes, completedValue.ConsumedNodes);
+
+        AssertRejected(
+            MetadataRelationshipTraversal.WalkTypeReferenceResolutionScope(
+                image.Reader,
+                overCeiling),
+            RelationshipTraversalRejectionKind.NodeBudget,
+            MetadataSafetyPolicy.MaxRelationshipNodes);
+        AssertRejected(
+            TypeResolver.ResolveFullName(
+                image.Reader,
+                image.Reader.GetTypeReference(overCeiling)),
+            RelationshipTraversalRejectionKind.NodeBudget,
+            MetadataSafetyPolicy.MaxRelationshipNodes);
+        Assert.Throws<BadImageFormatException>(
+            () => image.Reader.GetFullTypeName(
+                image.Reader.GetTypeReference(overCeiling)));
+    }
+
+    [Fact]
+    public void MalformedTypeReferenceHandle_IsRejected()
+    {
+        TypeReferenceHandle handle = default;
+        using var image = BuildMetadata(metadata =>
+        {
+            handle = metadata.AddTypeReference(
+                MetadataTokens.TypeReferenceHandle(2),
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("Broken"));
+        });
+
+        AssertRejected(
+            MetadataRelationshipTraversal.WalkTypeReferenceResolutionScope(
+                image.Reader,
+                handle),
+            RelationshipTraversalRejectionKind.MalformedMetadata,
+            consumedNodes: 2);
+    }
+
+    [Fact]
+    public void CyclicRelationshipFunnels_AreContainedInChildProcess()
+        => RunWorker(nameof(CyclicRelationshipFunnelsWorker));
+
+    [Fact]
+    public void MultiRowCyclicRelationshipFunnels_AreContainedInChildProcess()
+        => RunWorker(nameof(MultiRowCyclicRelationshipFunnelsWorker));
+
+    [Fact]
+    public void CyclicRelationshipFunnelsWorker()
+    {
+        if (!IsSelectedWorker(nameof(CyclicRelationshipFunnelsWorker)))
+            return;
+
+        TypeDefinitionHandle typeDefinition = default;
+        using (var image = BuildMetadata(metadata =>
+        {
+            typeDefinition = AddTypeDefinition(
+                metadata,
+                TypeAttributes.NestedPublic,
+                "N",
+                "TypeDefLoop");
+            metadata.AddNestedType(typeDefinition, typeDefinition);
+        }))
+        {
+            AssertRejected(
+                image.Reader.ResolveFullTypeName(typeDefinition),
+                RelationshipTraversalRejectionKind.Cycle,
+                consumedNodes: 1);
+            Assert.Throws<BadImageFormatException>(
+                () => image.Reader.GetFullTypeName(
+                    image.Reader.GetTypeDefinition(typeDefinition)));
+        }
+
+        TypeReferenceHandle typeReference = default;
+        using (var image = BuildMetadata(metadata =>
+        {
+            typeReference = metadata.AddTypeReference(
+                MetadataTokens.TypeReferenceHandle(1),
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("TypeRefLoop"));
+        }))
+        {
+            AssertRejected(
+                image.Reader.ResolveFullTypeName(typeReference),
+                RelationshipTraversalRejectionKind.Cycle,
+                consumedNodes: 1);
+            Assert.Throws<BadImageFormatException>(
+                () => image.Reader.GetFullTypeName(
+                    image.Reader.GetTypeReference(typeReference)));
+        }
+
+        ExportedTypeHandle exportedType = default;
+        using (var image = BuildMetadata(metadata =>
+        {
+            exportedType = metadata.AddExportedType(
+                TypeAttributes.NestedPublic,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("ExportedTypeLoop"),
+                MetadataTokens.ExportedTypeHandle(1),
+                typeDefinitionId: 0);
+        }))
+        {
+            AssertRejected(
+                image.Reader.ResolveFullTypeName(exportedType),
+                RelationshipTraversalRejectionKind.Cycle,
+                consumedNodes: 1);
+            Assert.Throws<BadImageFormatException>(
+                () => image.Reader.GetFullTypeName(
+                    image.Reader.GetExportedType(exportedType)));
+        }
+    }
+
+    [Fact]
+    public void MultiRowCyclicRelationshipFunnelsWorker()
+    {
+        if (!IsSelectedWorker(nameof(MultiRowCyclicRelationshipFunnelsWorker)))
+            return;
+
+        TypeDefinitionHandle firstTypeDefinition = default;
+        using (var image = BuildMetadata(metadata =>
+        {
+            firstTypeDefinition = AddTypeDefinition(
+                metadata,
+                TypeAttributes.NestedPublic,
+                "N",
+                "FirstTypeDef");
+            var second = AddTypeDefinition(
+                metadata,
+                TypeAttributes.NestedPublic,
+                "",
+                "SecondTypeDef");
+            metadata.AddNestedType(firstTypeDefinition, second);
+            metadata.AddNestedType(second, firstTypeDefinition);
+        }))
+        {
+            AssertRejected(
+                image.Reader.ResolveFullTypeName(firstTypeDefinition),
+                RelationshipTraversalRejectionKind.Cycle,
+                consumedNodes: 2);
+            Assert.Throws<BadImageFormatException>(
+                () => TypeResolver.GetTypeNameFromDefinition(
+                    image.Reader,
+                    firstTypeDefinition));
+        }
+
+        TypeReferenceHandle firstTypeReference = default;
+        using (var image = BuildMetadata(metadata =>
+        {
+            firstTypeReference = metadata.AddTypeReference(
+                MetadataTokens.TypeReferenceHandle(2),
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("FirstTypeRef"));
+            metadata.AddTypeReference(
+                firstTypeReference,
+                default,
+                metadata.GetOrAddString("SecondTypeRef"));
+        }))
+        {
+            AssertRejected(
+                image.Reader.ResolveFullTypeName(firstTypeReference),
+                RelationshipTraversalRejectionKind.Cycle,
+                consumedNodes: 2);
+            Assert.Throws<BadImageFormatException>(
+                () => TypeResolver.GetTypeNameFromReference(
+                    image.Reader,
+                    firstTypeReference));
+        }
+
+        ExportedTypeHandle firstExportedType = default;
+        using (var image = BuildMetadata(metadata =>
+        {
+            firstExportedType = metadata.AddExportedType(
+                TypeAttributes.NestedPublic,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("FirstExportedType"),
+                MetadataTokens.ExportedTypeHandle(2),
+                typeDefinitionId: 0);
+            metadata.AddExportedType(
+                TypeAttributes.NestedPublic,
+                default,
+                metadata.GetOrAddString("SecondExportedType"),
+                firstExportedType,
+                typeDefinitionId: 0);
+        }))
+        {
+            AssertRejected(
+                image.Reader.ResolveFullTypeName(firstExportedType),
+                RelationshipTraversalRejectionKind.Cycle,
+                consumedNodes: 2);
+            Assert.Throws<BadImageFormatException>(
+                () => TypeResolver.GetTypeNameFromExportedType(
+                    image.Reader,
+                    firstExportedType));
+        }
+    }
+
+    static void AssertRejected<T>(
+        RelationshipTraversalResult<T> result,
+        RelationshipTraversalRejectionKind kind,
+        int consumedNodes)
+        where T : notnull
+    {
+        var rejected = Assert.IsType<RelationshipTraversalResult<T>.Rejected>(result);
+        Assert.Equal(kind, rejected.Rejection.Kind);
+        Assert.Equal(consumedNodes, rejected.Rejection.ConsumedNodes);
+    }
+
+    static bool IsSelectedWorker(string methodName)
+        => Environment.GetEnvironmentVariable(WorkerVariable) == methodName;
+
+    static void RunWorker(string workerMethod)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add(typeof(MetadataRelationshipTraversalTests).Assembly.Location);
+        startInfo.ArgumentList.Add("-method");
+        startInfo.ArgumentList.Add($"*{workerMethod}*");
+        startInfo.Environment[WorkerVariable] = workerMethod;
+
+        using var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+        bool exited = process.WaitForExit(30_000);
+        if (!exited)
+            process.Kill(entireProcessTree: true);
+        string standardOutput = process.StandardOutput.ReadToEnd();
+        string standardError = process.StandardError.ReadToEnd();
+
+        Assert.True(exited, $"Child worker {workerMethod} timed out.");
+        Assert.True(
+            process.ExitCode == 0,
+            $"Child worker {workerMethod} exited {process.ExitCode}.\n"
+            + $"stdout:\n{standardOutput}\nstderr:\n{standardError}");
+    }
+
+    static TypeDefinitionHandle AddTypeDefinition(
+        MetadataBuilder metadata,
+        TypeAttributes attributes,
+        string ns,
+        string name)
+        => metadata.AddTypeDefinition(
+            attributes,
+            ns.Length == 0 ? default : metadata.GetOrAddString(ns),
+            metadata.GetOrAddString(name),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+    static AssemblyReferenceHandle AddAssemblyReference(MetadataBuilder metadata)
+        => metadata.AddAssemblyReference(
+            metadata.GetOrAddString("Reference"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKeyOrToken: default,
+            flags: default,
+            hashValue: default);
+
+    static MetadataImage BuildMetadata(Action<MetadataBuilder> addRows)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("Synthetic.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Synthetic"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        AddTypeDefinition(metadata, default, "", "<Module>");
+        addRows(metadata);
+
+        var rootBuilder = new MetadataRootBuilder(metadata, suppressValidation: true);
+        var image = new BlobBuilder();
+        rootBuilder.Serialize(image, methodBodyStreamRva: 0, mappedFieldDataStreamRva: 0);
+        return new MetadataImage(image.ToImmutableArray());
+    }
+
+    sealed class MetadataImage(ImmutableArray<byte> image) : IDisposable
+    {
+        readonly MetadataReaderProvider provider =
+            MetadataReaderProvider.FromMetadataImage(image);
+
+        public MetadataReader Reader => provider.GetMetadataReader();
+
+        public void Dispose() => provider.Dispose();
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/MetadataRelationshipTraversalTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataRelationshipTraversalTests.cs
@@ -115,6 +115,9 @@ public class MetadataRelationshipTraversalTests
         Assert.Equal([outer, middle, leaf], completed.Value.Handles);
         Assert.Equal((EntityHandle)assembly, completed.Value.Terminal);
         Assert.Equal(
+            "N.Outer",
+            image.Reader.GetFullTypeName(image.Reader.GetExportedType(outer)));
+        Assert.Equal(
             "N.Outer.Middle.Leaf",
             image.Reader.ResolveFullTypeName(leaf).GetValueOrThrow());
     }

--- a/tests/ILInspector.Metadata.Tests/MetadataRelationshipTraversalTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataRelationshipTraversalTests.cs
@@ -194,6 +194,25 @@ public class MetadataRelationshipTraversalTests
     }
 
     [Fact]
+    public void CompatibilityApis_NormalizeMalformedLeafHandles()
+    {
+        using var image = BuildMetadata(static _ => { });
+
+        AssertCompatibilityMalformed(
+            () => TypeResolver.GetTypeNameFromDefinition(
+                image.Reader,
+                MetadataTokens.TypeDefinitionHandle(99)));
+        AssertCompatibilityMalformed(
+            () => TypeResolver.GetTypeNameFromReference(
+                image.Reader,
+                MetadataTokens.TypeReferenceHandle(99)));
+        AssertCompatibilityMalformed(
+            () => TypeResolver.GetTypeNameFromExportedType(
+                image.Reader,
+                MetadataTokens.ExportedTypeHandle(99)));
+    }
+
+    [Fact]
     public void CyclicRelationshipFunnels_AreContainedInChildProcess()
         => RunWorker(nameof(CyclicRelationshipFunnelsWorker));
 
@@ -359,6 +378,15 @@ public class MetadataRelationshipTraversalTests
         var rejected = Assert.IsType<RelationshipTraversalResult<T>.Rejected>(result);
         Assert.Equal(kind, rejected.Rejection.Kind);
         Assert.Equal(consumedNodes, rejected.Rejection.ConsumedNodes);
+    }
+
+    static void AssertCompatibilityMalformed(Action action)
+    {
+        var exception = Assert.Throws<BadImageFormatException>(action);
+        Assert.StartsWith(
+            "Metadata relationship traversal rejected (MalformedMetadata):",
+            exception.Message,
+            StringComparison.Ordinal);
     }
 
     static bool IsSelectedWorker(string methodName)

--- a/tests/ILInspector.Metadata.Tests/MetadataRelationshipTraversalTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataRelationshipTraversalTests.cs
@@ -37,6 +37,9 @@ public class MetadataRelationshipTraversalTests
         Assert.Equal(
             "N.Outer.Middle.Leaf",
             TypeResolver.ResolveTypeNameFromDefinition(image.Reader, leaf).GetValueOrThrow());
+        Assert.Equal(
+            "N.Outer.Middle.Leaf",
+            image.Reader.GetFullTypeName(image.Reader.GetTypeDefinition(leaf)));
     }
 
     [Fact]
@@ -74,6 +77,9 @@ public class MetadataRelationshipTraversalTests
         Assert.Equal(
             "N.Outer.Middle.Leaf",
             image.Reader.ResolveFullTypeName(leaf).GetValueOrThrow());
+        Assert.Equal(
+            "N.Outer.Middle.Leaf",
+            image.Reader.GetFullTypeName(image.Reader.GetTypeReference(leaf)));
     }
 
     [Fact]
@@ -120,6 +126,9 @@ public class MetadataRelationshipTraversalTests
         Assert.Equal(
             "N.Outer.Middle.Leaf",
             image.Reader.ResolveFullTypeName(leaf).GetValueOrThrow());
+        Assert.Equal(
+            "N.Outer.Middle.Leaf",
+            image.Reader.GetFullTypeName(image.Reader.GetExportedType(leaf)));
     }
 
     [Fact]


### PR DESCRIPTION
## Conclusion

Bound TypeDef, TypeRef, and ExportedType relationship traversal before migrating the broader consumer graph. Cycles, malformed rows, and chains over 256 nodes now produce typed rejection; compatibility name APIs throw catchable `BadImageFormatException` instead of recursing or returning a plausible partial identity.

Advances #2806. Text/item amplification and row-level consumer degradation remain follow-up slices.

## Behavior

- adds iterative, identity-cycle-aware relationship walkers in `ILInspector.MetadataPrimitives`;
- returns outermost-to-leaf handle chains plus terminal scope/implementation;
- distinguishes `Cycle`, `NodeBudget`, and `MalformedMetadata`, with subject handle and consumed-node evidence;
- adds result-returning TypeResolver and MetadataReader extension funnels;
- retains string compatibility APIs as whole-operation throwing boundaries;
- routes string signature and attribute providers through the bounded TypeDef/TypeRef funnels;
- qualifies nested ExportedTypes through their implementation chain;
- preserves allocation-neutral terminal fast paths for both handle and value APIs.

No inspected assembly is loaded. The product path remains SRM-only, Roslyn-free, and NativeAOT-friendly.

## Relationship ceiling evidence

A file-based SRM census enumerated every TypeDef, TypeRef, and ExportedType handle, followed each relationship iteratively with an unbounded per-start visited set, and recorded the maximum completed chain.

Pinned inputs: .NET runtime and reference packs `11.0.0-preview.6.26359.118` for Microsoft.NETCore.App and Microsoft.AspNetCore.App.

| Input | Result |
| --- | ---: |
| Assemblies | 623 |
| Malformed images | 0 |
| Cycles | 0 |
| Maximum TypeDef chain | 5 |
| Maximum TypeRef chain | 3 |
| Maximum ExportedType chain | 3 |

Ordered DLL digest: `d6d2fef7d7ccdf240f308cbfddd90fa21fdeb82b55d89d0028ef37ffd87e04af`.

The fixed 256-node ceiling is more than 50 times the observed maximum and aligns with the existing TypeSpec re-entry ceiling.

## Performance and output compatibility

File-based probes measured 500,000 warmed calls resolving a top-level `System.String` TypeDef, with the handle/value fetched outside the measured loop.

| Compatibility path | `origin/main` | Regressed revision | Fixed head `4e4f727f` |
| --- | ---: | ---: | ---: |
| `TypeResolver.GetTypeNameFromDefinition(handle)` | 128 B/call | 824 B/call (`cf30947b`) | 128 B/call |
| `reader.GetFullTypeName(typeDef)` | 128 B/call | 160 B/call (`2e768abe`) | 128 B/call |

The first regression came from relationship-set/builder work on terminal handles. The second came from allocating a completed result wrapper in the widely used value/extension path. Terminal handle and value paths now bypass both costs; bounded machinery remains confined to nested relationships.

`library System.Runtime -S "Type Forwarders"` is byte-identical to `origin/main` in Markdown (63,138 bytes) and JSON (116,383 bytes).

## Adversarial fixtures

- self and two-row TypeDef, TypeRef, and ExportedType cycles run in child processes;
- exactly 256 nodes complete; node 257 rejects for both handle and value-without-handle APIs;
- malformed relationship handles reject without a partial chain;
- malformed terminal handles normalize to `BadImageFormatException`;
- valid nested handle and value paths preserve namespace and qualification behavior.

## Adversarial review

Both reviewers assessed exact head `4e4f727f` against `origin/main` in isolated worktrees after the two measured allocation fixes.

- **Claude Opus 4.8:** clean after independently measuring handle and value APIs against main, checking nested allocation scope, full-framework naming parity, malformed normalization, cycle/budget behavior, overload resolution, and SRM/NativeAOT constraints.
- **Gemini 3.1 Pro:** clean after finding the 32 B/call value-wrapper regression at `2e768abe`, verifying its fix at `4e4f727f`, and rechecking nested cycle/budget semantics, exception boundaries, and both compatibility API families.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release` - 599 passed
- `dotnet run --project src/dotnet-inspect.Tests -c Release` - 1,912 passed, 10 skipped because ilasm/ildasm are unavailable
- `npx markdownlint-cli docs/design/bounded-metadata-traversal.md`
