### PR TITLE
Explain safe dnx skill invocation

### DIFF
--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -10,9 +10,9 @@ Use dotnet-inspect for evidence instead of guesses about .NET packages, platform
 libraries, assemblies, APIs, dependencies, or API version diffs. Focused skills
 are listed at the end.
 
-```bash
-dnx dotnet-inspect -y -- <command>
-```
+Run through `dnx` as `dnx dotnet-inspect -y -- <command>`: `-y` skips
+interactive confirmation, including after package updates; `--` sends the
+remaining options to dotnet-inspect, so `--help` does not show `dnx` help.
 
 ## Common starts
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -6,13 +6,14 @@ description: Find evidence instead of guessing for .NET packages, platform libra
 
 # dotnet-inspect
 
-Use dotnet-inspect for evidence instead of guesses about .NET packages, platform
-libraries, assemblies, APIs, dependencies, or API version diffs. Focused skills
-are listed at the end.
+Use dotnet-inspect for evidence instead of guesses about .NET packages,
+platform libraries, assemblies, APIs, dependencies, or API version diffs.
 
-Run through `dnx` as `dnx dotnet-inspect -y -- <command>`: `-y` skips
-interactive confirmation, including after package updates; `--` sends the
-remaining options to dotnet-inspect, so `--help` does not show `dnx` help.
+```bash
+dnx dotnet-inspect -y -- <command>
+```
+
+`-y` skips interactive confirmation, including after package updates; `--` sends remaining options to dotnet-inspect, so `--help` does not show `dnx` help.
 
 ## Common starts
 
@@ -30,10 +31,9 @@ remaining options to dotnet-inspect, so `--help` does not show `dnx` help.
 
 ## Member lookup
 
-Run `find Name` when scope is unknown, inspect the type, then `-S "Member Index"`
-to list overloads. Select with `Name:N` (1-based) or `Name~digest` (stable). A
-selected overload defaults to `Signature`. You can also pass a fully-qualified
-`Namespace.Type.Member` and the tool finds the type/member split — no scope.
+Run `find Name` when scope is unknown, inspect the type, then `-S "Member Index"` to list
+overloads. Select with `Name:N` (1-based) or `Name~digest` (stable). A selected overload
+defaults to `Signature`. A fully-qualified `Namespace.Type.Member` needs no scope.
 
 ```bash
 dnx dotnet-inspect -y -- find JsonSerializer


### PR DESCRIPTION
## Summary

- explain why agents should pass `-y` to avoid interactive confirmation, including after package updates
- explain why `--` must separate `dnx` options from `dotnet-inspect` options
- keep the rationale in the authoritative base skill without exceeding its 50-line cap or duplicating it across focused skills

Advances #1567.

## Evidence

- `npx markdownlint-cli skills/dotnet-inspect/SKILL.md`
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-restore -- -class DotnetInspector.Tests.SkillCommandTests` — 20 passed
- base skill remains exactly 50 lines

## Risk

Documentation-only; no command behavior or generated output structure changes. Adversarial review is not required for this mechanical guidance update.