### PR TITLE
Printer-derived usings + short type names; #2811 follow-ups

### DIFF
--- a/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpFormatterTests.cs
@@ -384,6 +384,18 @@ public sealed class CSharpFormatterTests
     public void CleanTypeDisplay_NormalizesToCSharpSpelling(string type, string expected)
         => Assert.Equal(expected, CSharpFormatter.CleanTypeDisplay(type));
 
+    [Theory]
+    [InlineData("int modreq(System.Runtime.CompilerServices.IsVolatile)", "int System.Runtime.CompilerServices.IsVolatile")]
+    [InlineData("System.Int32 modopt(Mod)", "int Mod")]
+    public void CleanTypeDisplay_StripsCustomModifierWrappers(string type, string expected)
+        => Assert.Equal(expected, CSharpFormatter.CleanTypeDisplay(type));
+
+    [Theory]
+    [InlineData("(int, string)", "(int, string)")]
+    [InlineData("System.ValueTuple<(int, string), object>", "System.ValueTuple<(int, string), object>")]
+    public void CleanTypeDisplay_PreservesUnrelatedParentheses(string type, string expected)
+        => Assert.Equal(expected, CSharpFormatter.CleanTypeDisplay(type));
+
     [Fact]
     public void CleanTypeDisplay_CollapsesUnspeakableGenericParameterToObject()
         => Assert.Equal("object", CSharpFormatter.CleanTypeDisplay("!0"));

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -887,6 +887,32 @@ public sealed class CSharpTypePrinterTests
     }
 
     [Fact]
+    public void NestedTypeReferencedAsNamespaceIsNotImportedWhenEnclosingTypeIsReferenced()
+    {
+        // `System.Environment.SpecialFolder` is a nested type but arrives as a flat
+        // dotted string, so the last-dot split derives namespace `System.Environment`
+        // — which is actually a type. Emitting `using System.Environment;` is illegal.
+        // When the enclosing type `System.Environment` is itself referenced in the
+        // unit, its full name shows up as a derived namespace and must be excluded, so
+        // the nested reference stays fully qualified.
+        var type = CreateEmptyType("App", "Consumer");
+        var enclosing = CreateMethod("GetEnv");
+        enclosing.SignatureModel!.ReturnType = "System.Environment";
+        var nested = CreateMethod("GetFolder");
+        nested.SignatureModel!.ReturnType = "System.Environment.SpecialFolder";
+        type.Members.Add(enclosing);
+        type.Members.Add(nested);
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.DoesNotContain("using System.Environment;", result.Source, StringComparison.Ordinal);
+        Assert.Contains(
+            "System.Environment.SpecialFolder GetFolder();",
+            result.Units[0].Source,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void UsingsSuppressedKeepsReferencesQualified()
     {
         // With IncludeUsings=false the composed Source omits using directives, so

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -758,6 +758,31 @@ public sealed class CSharpTypePrinterTests
     }
 
     [Fact]
+    public void RawSignatureTupleReturnMethodTypeParameterStaysQualified()
+    {
+        // A tuple return type puts a '(' before the parameter list, so the raw-signature
+        // parser must anchor on the method name + generic list, not the first '('. The
+        // method type parameter `Task` still shadows the same-named references.
+        var type = CreateEmptyType("Samples", "Worker");
+        type.IsAbstract = true;
+        type.Members.Add(new ApiMember
+        {
+            Name = "Run",
+            Kind = "method",
+            IsAbstract = true,
+            Signature = "(System.Threading.Tasks.Task, int) Run<Task>(System.Threading.Tasks.Task value)"
+        });
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.DoesNotContain("using System.Threading.Tasks;", result.Source, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "(Task, int)",
+            result.Units[0].Source,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ReferenceCollidingWithDeclaredTypeStaysQualified()
     {
         // A type declared as `Task` referencing `System.Threading.Tasks.Task` must not

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -388,7 +388,7 @@ public sealed class CSharpTypePrinterTests
         var result = _printer.Print(new CSharpTypePrintRequest(type));
 
         Assert.Contains(
-            "public long GetTicks([System.Runtime.InteropServices.Optional, System.Runtime.CompilerServices.DateTimeConstant(0)] System.DateTime when);",
+            "public long GetTicks([Optional, DateTimeConstant(0)] DateTime when);",
             result.Units[0].Source,
             StringComparison.Ordinal);
     }
@@ -621,15 +621,137 @@ public sealed class CSharpTypePrinterTests
         var skeleton = _printer.Print(new CSharpTypePrintRequest(type));
 
         Assert.Contains(
-            "public unsafe async System.Threading.Tasks.Task Run()",
+            "public unsafe async Task Run()",
             full.Units[0].Source,
             StringComparison.Ordinal);
         Assert.Contains(
-            "public System.Threading.Tasks.Task Run();",
+            "public Task Run();",
             skeleton.Units[0].Source,
             StringComparison.Ordinal);
         Assert.False(member.IsAsync);
         Assert.False(member.IsUnsafe);
+    }
+
+    [Fact]
+    public void DerivedUsingShortensCrossNamespaceReference()
+    {
+        var type = CreateEmptyType("Samples", "Worker");
+        var member = CreateMethod("Run");
+        member.SignatureModel!.ReturnType = "System.Threading.Tasks.Task";
+        type.Members.Add(member);
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.Contains("using System.Threading.Tasks;", result.Source, StringComparison.Ordinal);
+        Assert.Contains("public Task Run();", result.Units[0].Source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ShortenTypeNamesDisabledKeepsReferencesQualified()
+    {
+        var type = CreateEmptyType("Samples", "Worker");
+        var member = CreateMethod("Run");
+        member.SignatureModel!.ReturnType = "System.Threading.Tasks.Task";
+        type.Members.Add(member);
+
+        var result = _printer.Print(
+            new CSharpTypePrintRequest(type),
+            new CSharpTypePrintOptions { ShortenTypeNames = false });
+
+        Assert.DoesNotContain("using System.Threading.Tasks;", result.Source, StringComparison.Ordinal);
+        Assert.Contains(
+            "public System.Threading.Tasks.Task Run();",
+            result.Units[0].Source,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CollidingSimpleNamesAcrossNamespacesStayQualified()
+    {
+        var type = CreateEmptyType("Samples", "Consumer");
+        type.Members.Add(new ApiMember
+        {
+            Name = "Convert",
+            Kind = "method",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "Alpha.Widget",
+                MemberName = "Convert",
+                Parameters = [new ApiParameter { Type = "Beta.Widget", Name = "value" }]
+            }
+        });
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.DoesNotContain("using Alpha;", result.Source, StringComparison.Ordinal);
+        Assert.DoesNotContain("using Beta;", result.Source, StringComparison.Ordinal);
+        Assert.Contains(
+            "public Alpha.Widget Convert(Beta.Widget value);",
+            result.Units[0].Source,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReferenceCollidingWithDeclaredTypeStaysQualified()
+    {
+        // A type declared as `Task` referencing `System.Threading.Tasks.Task` must not
+        // import the namespace: shortening the reference to `Task` would bind to the
+        // declared type, not the referenced one.
+        var type = CreateEmptyType("Samples", "Task");
+        var member = CreateMethod("Run");
+        member.SignatureModel!.ReturnType = "System.Threading.Tasks.Task";
+        type.Members.Add(member);
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.DoesNotContain("using System.Threading.Tasks;", result.Source, StringComparison.Ordinal);
+        Assert.Contains(
+            "public System.Threading.Tasks.Task Run();",
+            result.Units[0].Source,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AttributeArgumentEnumAccessDoesNotDeriveTypeAsNamespace()
+    {
+        // The attribute argument `UnmanagedType.I4` is a value expression, not a type
+        // reference; deriving `using System.Runtime.InteropServices.UnmanagedType;` from
+        // it would emit an illegal type-as-namespace using and mis-shorten the argument.
+        var type = CreateEmptyType("Samples", "Widget");
+        type.Members.Add(new ApiMember
+        {
+            Name = "Encode",
+            Kind = "method",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "int",
+                MemberName = "Encode",
+                Parameters =
+                [
+                    new ApiParameter
+                    {
+                        Type = "int",
+                        Name = "value",
+                        Attributes =
+                        [
+                            "System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)"
+                        ]
+                    }
+                ]
+            }
+        });
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.Contains("using System.Runtime.InteropServices;", result.Source, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "using System.Runtime.InteropServices.UnmanagedType;",
+            result.Source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "[MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)]",
+            result.Units[0].Source,
+            StringComparison.Ordinal);
     }
 
     [Theory]

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -735,6 +735,29 @@ public sealed class CSharpTypePrinterTests
     }
 
     [Fact]
+    public void RawSignatureMethodTypeParameterShadowsReferenceAndStaysQualified()
+    {
+        // A generic method whose signature failed structured decoding falls back to the
+        // raw Signature string (no SignatureModel). Its type parameter `Task` still
+        // shadows the same-named return type reference, so the namespace must not be
+        // imported and the reference must stay qualified.
+        var type = CreateEmptyType("Samples", "Worker");
+        type.IsAbstract = true;
+        type.Members.Add(new ApiMember
+        {
+            Name = "Run",
+            Kind = "method",
+            IsAbstract = true,
+            Signature = "System.Threading.Tasks.Task Run<Task>()"
+        });
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.DoesNotContain("using System.Threading.Tasks;", result.Source, StringComparison.Ordinal);
+        Assert.Contains("System.Threading.Tasks.Task Run<Task>()", result.Units[0].Source, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ReferenceCollidingWithDeclaredTypeStaysQualified()
     {
         // A type declared as `Task` referencing `System.Threading.Tasks.Task` must not

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -692,6 +692,49 @@ public sealed class CSharpTypePrinterTests
     }
 
     [Fact]
+    public void CrossTypeAmbiguousSimpleNameStaysQualifiedAcrossUnit()
+    {
+        // "String" is ambiguous unit-wide (System.String in TypeA, MyNamespace.String
+        // in TypeB) even though each type alone sees only one full name. Importing
+        // System/MyNamespace (justified by the unambiguous Int32/Int64) would shorten
+        // both references to `String`, producing an ambiguous reference. Neither
+        // namespace may be imported; every reference they own stays qualified.
+        var a = CreateEmptyType("Ns1", "TypeA");
+        a.Members.Add(new ApiMember
+        {
+            Name = "M1",
+            Kind = "method",
+            SignatureModel = new ApiSignature { ReturnType = "System.String", MemberName = "M1" }
+        });
+        a.Members.Add(new ApiMember
+        {
+            Name = "M2",
+            Kind = "method",
+            SignatureModel = new ApiSignature { ReturnType = "System.Int32", MemberName = "M2" }
+        });
+        var b = CreateEmptyType("Ns1", "TypeB");
+        b.Members.Add(new ApiMember
+        {
+            Name = "N1",
+            Kind = "method",
+            SignatureModel = new ApiSignature { ReturnType = "MyNamespace.String", MemberName = "N1" }
+        });
+        b.Members.Add(new ApiMember
+        {
+            Name = "N2",
+            Kind = "method",
+            SignatureModel = new ApiSignature { ReturnType = "MyNamespace.Int64", MemberName = "N2" }
+        });
+
+        var result = _printer.PrintBatch([new CSharpTypePrintRequest(a), new CSharpTypePrintRequest(b)]);
+
+        Assert.DoesNotContain("using System;", result.Source, StringComparison.Ordinal);
+        Assert.DoesNotContain("using MyNamespace;", result.Source, StringComparison.Ordinal);
+        Assert.Contains("public System.String M1();", result.Source, StringComparison.Ordinal);
+        Assert.Contains("public MyNamespace.String N1();", result.Source, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ReferenceCollidingWithDeclaredTypeStaysQualified()
     {
         // A type declared as `Task` referencing `System.Threading.Tasks.Task` must not
@@ -750,6 +793,68 @@ public sealed class CSharpTypePrinterTests
             StringComparison.Ordinal);
         Assert.Contains(
             "[MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)]",
+            result.Units[0].Source,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GenericTypeParameterShadowsReferenceAndStaysQualified()
+    {
+        // The type parameter `Task` shadows any same-named type reference within the
+        // type body, so importing System.Threading.Tasks and shortening the return type
+        // to `Task` would rebind it to the parameter. It must stay fully qualified.
+        var type = CreateEmptyType("Samples", "Box`1");
+        type.TypeParameters = [new TypeParameter { Name = "Task" }];
+        var member = CreateMethod("Run");
+        member.SignatureModel!.ReturnType = "System.Threading.Tasks.Task";
+        type.Members.Add(member);
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.DoesNotContain("using System.Threading.Tasks;", result.Source, StringComparison.Ordinal);
+        Assert.Contains(
+            "public System.Threading.Tasks.Task Run();",
+            result.Units[0].Source,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MethodTypeParameterShadowsReferenceAndStaysQualified()
+    {
+        // A method type parameter named `Task` shadows the same-named type reference;
+        // the namespace must not be imported.
+        var type = CreateEmptyType("Samples", "Worker");
+        var member = CreateMethod("Run");
+        member.SignatureModel!.ReturnType = "System.Threading.Tasks.Task";
+        member.SignatureModel!.TypeParameters = [new TypeParameter { Name = "Task" }];
+        type.Members.Add(member);
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.DoesNotContain("using System.Threading.Tasks;", result.Source, StringComparison.Ordinal);
+        Assert.Contains(
+            "System.Threading.Tasks.Task Run",
+            result.Units[0].Source,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UsingsSuppressedKeepsReferencesQualified()
+    {
+        // With IncludeUsings=false the composed Source omits using directives, so
+        // shortening a cross-namespace reference would leave it unresolvable.
+        var type = CreateEmptyType("Samples", "Worker");
+        var member = CreateMethod("Run");
+        member.SignatureModel!.ReturnType = "System.Threading.Tasks.Task";
+        type.Members.Add(member);
+
+        var result = _printer.Print(
+            new CSharpTypePrintRequest(type),
+            new CSharpTypePrintOptions { IncludeUsings = false });
+
+        Assert.DoesNotContain("using System.Threading.Tasks;", result.Source, StringComparison.Ordinal);
+        Assert.Contains(
+            "public System.Threading.Tasks.Task Run();",
             result.Units[0].Source,
             StringComparison.Ordinal);
     }

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -143,14 +143,52 @@ internal static class CSharpDeclarationWriter
             .Select(type => CSharpFormatter.StripArity(type.Name))
             .ToHashSet(StringComparer.Ordinal);
 
+        // Generic type/method parameters shadow same-named type references within
+        // their scope: importing a namespace and shortening a reference to a simple
+        // name that matches an in-scope type parameter would rebind it to the
+        // parameter. Exclude those namespaces so such references stay qualified.
+        foreach (var type in types)
+        {
+            foreach (var typeParameter in type.TypeParameters)
+                declaredSimpleNames.Add(typeParameter.Name);
+            foreach (var member in type.Members)
+            {
+                if (member.SignatureModel is { } signature)
+                {
+                    foreach (var typeParameter in signature.TypeParameters)
+                        declaredSimpleNames.Add(typeParameter.Name);
+                }
+            }
+        }
+
         var usings = new SortedSet<string>(StringComparer.Ordinal);
+        var collidingSimpleNames = typeRefs
+            .GroupBy(r => r.SimpleName, StringComparer.Ordinal)
+            .Where(g => g.Select(r => r.FullName).Distinct(StringComparer.Ordinal).Count() > 1)
+            .Select(g => g.Key)
+            .ToHashSet(StringComparer.Ordinal);
+
+        // A namespace contributes a simple name for every reference it owns. Per-type
+        // shortening keys off namespace membership, so importing a namespace shortens
+        // every reference it owns. If any of those simple names is ambiguous unit-wide
+        // or shadowed by a declared type or type parameter, importing the namespace is
+        // unsafe: the shortened reference would become ambiguous or rebind. Exclude the
+        // whole namespace so every reference it owns stays fully qualified.
+        var unsafeNamespaces = typeRefs
+            .Where(r => collidingSimpleNames.Contains(r.SimpleName) || declaredSimpleNames.Contains(r.SimpleName))
+            .Select(r => r.Namespace)
+            .ToHashSet(StringComparer.Ordinal);
+
         foreach (var group in typeRefs.GroupBy(r => r.SimpleName, StringComparer.Ordinal))
         {
-            if (group.Select(r => r.FullName).Distinct(StringComparer.Ordinal).Count() > 1)
+            if (collidingSimpleNames.Contains(group.Key))
                 continue;
             if (declaredSimpleNames.Contains(group.Key))
                 continue;
-            usings.Add(group.First().Namespace);
+            var ns = group.First().Namespace;
+            if (unsafeNamespaces.Contains(ns))
+                continue;
+            usings.Add(ns);
         }
 
         return usings.ToList();

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -158,6 +158,12 @@ internal static class CSharpDeclarationWriter
                     foreach (var typeParameter in signature.TypeParameters)
                         declaredSimpleNames.Add(typeParameter.Name);
                 }
+
+                // Members whose signature failed structured decoding fall back to the
+                // raw signature string, whose generic method parameters are not in
+                // SignatureModel. Parse them so they still shadow same-named references.
+                foreach (var name in RawSignatureGenericParameterNames(member))
+                    declaredSimpleNames.Add(name);
             }
         }
 
@@ -466,6 +472,61 @@ internal static class CSharpDeclarationWriter
         {
             if (TryParameterType(parameter, out var parameterType))
                 yield return parameterType;
+        }
+    }
+
+    static IEnumerable<string> RawSignatureGenericParameterNames(ApiMember member)
+    {
+        var signature = member.Signature;
+        if (string.IsNullOrWhiteSpace(signature))
+            yield break;
+        if (member.Kind is "property" or "field" or "event" or "constructor")
+            yield break;
+
+        var parenStart = signature.IndexOf('(');
+        if (parenStart < 0)
+            yield break;
+
+        var prefix = signature[..parenStart].TrimEnd();
+        var nameIndex = prefix.LastIndexOf(member.Name, StringComparison.Ordinal);
+        if (nameIndex < 0)
+            yield break;
+
+        var afterName = prefix[(nameIndex + member.Name.Length)..];
+        var i = 0;
+        while (i < afterName.Length && char.IsWhiteSpace(afterName[i]))
+            i++;
+        if (i >= afterName.Length || afterName[i] != '<')
+            yield break;
+
+        var depth = 0;
+        var start = i + 1;
+        var end = -1;
+        for (; i < afterName.Length; i++)
+        {
+            if (afterName[i] == '<')
+                depth++;
+            else if (afterName[i] == '>')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    end = i;
+                    break;
+                }
+            }
+        }
+        if (end < 0)
+            yield break;
+
+        foreach (var part in SplitTopLevel(afterName[start..end]))
+        {
+            var name = part.Trim();
+            var space = name.IndexOf(' ');
+            if (space >= 0)
+                name = name[(space + 1)..].Trim();
+            if (name.Length > 0)
+                yield return name;
         }
     }
 

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -483,50 +483,69 @@ internal static class CSharpDeclarationWriter
         if (member.Kind is "property" or "field" or "event" or "constructor")
             yield break;
 
-        var parenStart = signature.IndexOf('(');
-        if (parenStart < 0)
+        // The generic method parameter list is `Name<...>(` — the method name (a whole
+        // token) immediately followed by an angle-bracket group and then the parameter
+        // list. Anchor on that shape rather than on the first '(' in the signature, so a
+        // tuple or generic return type (whose own '(' / '<' come first) does not fool the
+        // parser. Scan every occurrence of the name to skip matches inside the return
+        // type (e.g. `TaskRun Run<T>()` or `Run<U> Run<T>()`).
+        var name = member.Name;
+        if (name.Length == 0)
             yield break;
 
-        var prefix = signature[..parenStart].TrimEnd();
-        var nameIndex = prefix.LastIndexOf(member.Name, StringComparison.Ordinal);
-        if (nameIndex < 0)
-            yield break;
-
-        var afterName = prefix[(nameIndex + member.Name.Length)..];
-        var i = 0;
-        while (i < afterName.Length && char.IsWhiteSpace(afterName[i]))
-            i++;
-        if (i >= afterName.Length || afterName[i] != '<')
-            yield break;
-
-        var depth = 0;
-        var start = i + 1;
-        var end = -1;
-        for (; i < afterName.Length; i++)
+        var searchStart = 0;
+        while (searchStart <= signature.Length - name.Length)
         {
-            if (afterName[i] == '<')
-                depth++;
-            else if (afterName[i] == '>')
+            var nameIndex = signature.IndexOf(name, searchStart, StringComparison.Ordinal);
+            if (nameIndex < 0)
+                yield break;
+            searchStart = nameIndex + 1;
+
+            if (nameIndex > 0 && (char.IsLetterOrDigit(signature[nameIndex - 1]) || signature[nameIndex - 1] == '_'))
+                continue;
+
+            var j = nameIndex + name.Length;
+            while (j < signature.Length && char.IsWhiteSpace(signature[j]))
+                j++;
+            if (j >= signature.Length || signature[j] != '<')
+                continue;
+
+            var depth = 0;
+            var start = j + 1;
+            var end = -1;
+            for (var i = j; i < signature.Length; i++)
             {
-                depth--;
-                if (depth == 0)
+                if (signature[i] == '<')
+                    depth++;
+                else if (signature[i] == '>')
                 {
-                    end = i;
-                    break;
+                    depth--;
+                    if (depth == 0)
+                    {
+                        end = i;
+                        break;
+                    }
                 }
             }
-        }
-        if (end < 0)
-            yield break;
+            if (end < 0)
+                continue;
 
-        foreach (var part in SplitTopLevel(afterName[start..end]))
-        {
-            var name = part.Trim();
-            var space = name.IndexOf(' ');
-            if (space >= 0)
-                name = name[(space + 1)..].Trim();
-            if (name.Length > 0)
-                yield return name;
+            var afterBracket = end + 1;
+            while (afterBracket < signature.Length && char.IsWhiteSpace(signature[afterBracket]))
+                afterBracket++;
+            if (afterBracket >= signature.Length || signature[afterBracket] != '(')
+                continue;
+
+            foreach (var part in SplitTopLevel(signature[start..end]))
+            {
+                var parameterName = part.Trim();
+                var space = parameterName.IndexOf(' ');
+                if (space >= 0)
+                    parameterName = parameterName[(space + 1)..].Trim();
+                if (parameterName.Length > 0)
+                    yield return parameterName;
+            }
+            yield break;
         }
     }
 

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -115,6 +115,47 @@ internal static class CSharpDeclarationWriter
         return plan.Apply(RenderTypeDeclarationCore(type, options));
     }
 
+    /// <summary>
+    /// Computes a collision-safe set of namespaces that can be imported as
+    /// <c>using</c> directives for a compilation unit declaring
+    /// <paramref name="types"/> (including any nested types the caller flattens in).
+    /// A namespace is included only when every simple type name it contributes is
+    /// unambiguous across the whole unit: the simple name maps to a single full name
+    /// and does not clash with a type declared in the unit. Importing such a
+    /// namespace and shortening those references therefore cannot introduce an
+    /// ambiguous or shadowed reference. References whose simple name is ambiguous
+    /// stay fully qualified and their namespaces are excluded.
+    /// </summary>
+    public static IReadOnlyList<string> DeriveContextualUsings(IReadOnlyCollection<ApiType> types)
+    {
+        ArgumentNullException.ThrowIfNull(types);
+
+        var typeRefs = types
+            .SelectMany(type => CollectTypeReferences(type)
+                .Concat(type.Members.SelectMany(CollectMemberTypeReferences)))
+            .Select(TypeRef.TryCreate)
+            .Where(r => r is not null)
+            .Select(r => r!)
+            .DistinctBy(r => r.FullName, StringComparer.Ordinal)
+            .ToList();
+
+        var declaredSimpleNames = types
+            .Select(type => CSharpFormatter.StripArity(type.Name))
+            .ToHashSet(StringComparer.Ordinal);
+
+        var usings = new SortedSet<string>(StringComparer.Ordinal);
+        foreach (var group in typeRefs.GroupBy(r => r.SimpleName, StringComparer.Ordinal))
+        {
+            if (group.Select(r => r.FullName).Distinct(StringComparer.Ordinal).Count() > 1)
+                continue;
+            if (declaredSimpleNames.Contains(group.Key))
+                continue;
+            usings.Add(group.First().Namespace);
+        }
+
+        return usings.ToList();
+    }
+
     static string ComposeUnit(IReadOnlyList<string> bodyLines, IReadOnlyList<string> usings, CSharpDeclarationOptions options)
     {
         var sb = new StringBuilder();
@@ -343,7 +384,7 @@ internal static class CSharpDeclarationWriter
                 if (!string.IsNullOrWhiteSpace(parameter.Type))
                     yield return parameter.Type;
                 foreach (var attribute in parameter.Attributes)
-                    yield return attribute;
+                    yield return StripAttributeArguments(attribute);
             }
             foreach (var typeParameter in signatureModel.TypeParameters)
                 foreach (var constraint in typeParameter.Constraints)
@@ -484,6 +525,18 @@ internal static class CSharpDeclarationWriter
         }
 
         return parameter;
+    }
+
+    // Attribute usages carry a constructor argument list whose contents are value
+    // expressions (enum member accesses like UnmanagedType.I4, consts, typeof), not
+    // type references. Treating those dotted value expressions as type names would
+    // derive bogus namespaces (e.g. `using System.Runtime.InteropServices.UnmanagedType;`)
+    // and mis-shorten the argument, so only the attribute type name (before the
+    // constructor argument list) participates in reference extraction and using derivation.
+    static string StripAttributeArguments(string attribute)
+    {
+        int paren = attribute.IndexOf('(', StringComparison.Ordinal);
+        return paren < 0 ? attribute : attribute[..paren];
     }
 
     static IEnumerable<string> ExtractQualifiedTypeNames(string expression)

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -174,6 +174,22 @@ internal static class CSharpDeclarationWriter
             .Select(g => g.Key)
             .ToHashSet(StringComparer.Ordinal);
 
+        // A nested type referenced as a type (e.g. `System.Environment.SpecialFolder`)
+        // arrives here as a flat dotted string, indistinguishable from a
+        // namespace-qualified reference: TypeRef.TryCreate splits at the last dot and
+        // derives namespace `System.Environment`, which is actually a type. Emitting
+        // `using System.Environment;` is illegal (CS0138). When the enclosing type is
+        // itself referenced in the unit we can detect this — its full name appears as a
+        // derived namespace — and exclude that namespace. (The isolated case, where the
+        // enclosing type is never referenced on its own, is not detectable from the
+        // flattened string alone; a full fix needs nested-type identity from the
+        // metadata layer. The failure mode is safe-visible: the reference stays
+        // qualified and, for a spurious using, RTS records a RecompileFail rather than
+        // miscompiling.)
+        var referencedFullNames = typeRefs
+            .Select(r => r.FullName)
+            .ToHashSet(StringComparer.Ordinal);
+
         // A namespace contributes a simple name for every reference it owns. Per-type
         // shortening keys off namespace membership, so importing a namespace shortens
         // every reference it owns. If any of those simple names is ambiguous unit-wide
@@ -193,6 +209,8 @@ internal static class CSharpDeclarationWriter
                 continue;
             var ns = group.First().Namespace;
             if (unsafeNamespaces.Contains(ns))
+                continue;
+            if (referencedFullNames.Contains(ns))
                 continue;
             usings.Add(ns);
         }

--- a/src/ILInspector.CSharp/CSharpFormatter.cs
+++ b/src/ILInspector.CSharp/CSharpFormatter.cs
@@ -181,6 +181,16 @@ public sealed class CSharpFormatter
         => CSharpDeclarationWriter.EscapeNamespace(@namespace);
 
     /// <summary>
+    /// Computes a collision-safe set of namespaces importable as <c>using</c>
+    /// directives for a compilation unit declaring <paramref name="types"/>
+    /// (flatten nested types in). See
+    /// <see cref="CSharpDeclarationWriter.DeriveContextualUsings"/> for the
+    /// safety contract.
+    /// </summary>
+    public static IReadOnlyList<string> DeriveContextualUsings(IReadOnlyCollection<ApiType> types)
+        => CSharpDeclarationWriter.DeriveContextualUsings(types);
+
+    /// <summary>
     /// Escapes C# reserved keywords used as identifiers within a type string while
     /// leaving type-syntax keywords (primitive aliases, parameter/type modifiers,
     /// function-pointer syntax) bare. This is the authoritative type-keyword escaper;
@@ -226,15 +236,68 @@ public sealed class CSharpFormatter
 
         type = SanitizeGeneratedTypeSegments(type);
 
-        type = type.Replace("modreq(", "", StringComparison.Ordinal)
-            .Replace("modopt(", "", StringComparison.Ordinal)
-            .Replace(")", "", StringComparison.Ordinal)
-            .Trim();
+        type = StripCustomModifiers(type).Trim();
 
         type = AliasPrimitiveTypeNames(type);
 
         return EscapeTypeKeywords(type);
     }
+
+    /// <summary>
+    /// Removes <c>modreq(…)</c>/<c>modopt(…)</c> custom-modifier wrappers, keeping
+    /// their inner type text. Only the parentheses that belong to a wrapper are
+    /// dropped: paren depth is tracked so unrelated parentheses (for example
+    /// tuple syntax such as <c>(int, string)</c>) are preserved verbatim.
+    /// </summary>
+    static string StripCustomModifiers(string type)
+    {
+        if (type.IndexOf("modreq(", StringComparison.Ordinal) < 0
+            && type.IndexOf("modopt(", StringComparison.Ordinal) < 0)
+            return type;
+
+        const int tokenLength = 7; // "modreq(" and "modopt(" are both 7 chars.
+        var sb = new StringBuilder(type.Length);
+        var modifierCloseDepths = new Stack<int>();
+        int depth = 0;
+        int i = 0;
+        while (i < type.Length)
+        {
+            if (MatchesAt(type, i, "modreq(") || MatchesAt(type, i, "modopt("))
+            {
+                modifierCloseDepths.Push(depth);
+                depth++;
+                i += tokenLength;
+                continue;
+            }
+
+            char c = type[i];
+            if (c == '(')
+            {
+                depth++;
+                sb.Append(c);
+            }
+            else if (c == ')')
+            {
+                depth--;
+                if (modifierCloseDepths.Count > 0 && modifierCloseDepths.Peek() == depth)
+                    modifierCloseDepths.Pop();
+                else
+                    sb.Append(c);
+            }
+            else
+            {
+                sb.Append(c);
+            }
+
+            i++;
+        }
+
+        return sb.ToString();
+    }
+
+    static bool MatchesAt(string value, int index, string token)
+        => index + token.Length <= value.Length
+            && string.CompareOrdinal(value, index, token, 0, token.Length) == 0;
 
     static string SanitizeGeneratedTypeSegments(string type)
     {

--- a/src/ILInspector.CSharp/CSharpTypePrintContracts.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrintContracts.cs
@@ -238,6 +238,15 @@ public sealed record CSharpTypePrintOptions
     public IReadOnlyList<string> ModuleAttributes { get; init; } = [];
 
     /// <summary>
+    /// When true (the default), type references in rendered declarations are
+    /// shortened to their simple names wherever doing so is unambiguous across the
+    /// compilation unit, and the namespaces that makes that possible are emitted as
+    /// <c>using</c> directives in the composed <see cref="CSharpTypePrintResult.Source"/>.
+    /// Set false to keep every reference fully qualified.
+    /// </summary>
+    public bool ShortenTypeNames { get; init; } = true;
+
+    /// <summary>
     /// When true, the composed source begins with <c>#pragma warning disable</c>.
     /// Off by default; compile-back callers opt in.
     /// </summary>
@@ -248,7 +257,28 @@ public sealed record CSharpTypeSourceUnit(string? Namespace, string Source);
 
 public sealed record CSharpTypePrintDiagnostic(string TypeName, string Message);
 
-public sealed record CSharpTypePrintResult(
-    ImmutableArray<CSharpTypeSourceUnit> Units,
-    ImmutableArray<CSharpTypePrintDiagnostic> Diagnostics,
-    string Source);
+public sealed record CSharpTypePrintResult
+{
+    readonly Lazy<string> _source;
+
+    public CSharpTypePrintResult(
+        ImmutableArray<CSharpTypeSourceUnit> units,
+        ImmutableArray<CSharpTypePrintDiagnostic> diagnostics,
+        Func<string> sourceFactory)
+    {
+        ArgumentNullException.ThrowIfNull(sourceFactory);
+        Units = units;
+        Diagnostics = diagnostics;
+        _source = new Lazy<string>(sourceFactory);
+    }
+
+    public ImmutableArray<CSharpTypeSourceUnit> Units { get; }
+
+    public ImmutableArray<CSharpTypePrintDiagnostic> Diagnostics { get; }
+
+    /// <summary>
+    /// The composed compilation-unit source. Composed lazily on first access so
+    /// callers that only read <see cref="Units"/> do not pay for it.
+    /// </summary>
+    public string Source => _source.Value;
+}

--- a/src/ILInspector.CSharp/CSharpTypePrintContracts.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrintContracts.cs
@@ -215,7 +215,12 @@ public sealed record CSharpTypePrintOptions
     /// <see cref="CSharpTypePrintResult.Source"/>. Escaped, de-duplicated, and
     /// ordinal-ordered at composition time. Ignored when <see cref="IncludeUsings"/>
     /// is false. The per-type <see cref="CSharpTypePrintResult.Units"/> never carry
-    /// usings.
+    /// their own using directives; under <see cref="ShortenTypeNames"/> a unit's
+    /// <see cref="CSharpTypeSourceUnit.Source"/> is therefore file-context-relative —
+    /// its shortened names resolve only against this using block in the composed
+    /// <see cref="CSharpTypePrintResult.Source"/>. A per-unit consumer must compose
+    /// against <see cref="CSharpTypePrintResult.Source"/> or set
+    /// <see cref="ShortenTypeNames"/> to false to get self-contained unit source.
     /// </summary>
     public IReadOnlyList<string> Usings { get; init; } = [];
 
@@ -253,6 +258,12 @@ public sealed record CSharpTypePrintOptions
     public bool EmitPragmaWarningDisable { get; init; }
 }
 
+/// <summary>
+/// One rendered type declaration. Under
+/// <see cref="CSharpTypePrintOptions.ShortenTypeNames"/> the <paramref name="Source"/>
+/// is file-context-relative: its shortened type names resolve against the using block
+/// in the composed <see cref="CSharpTypePrintResult.Source"/>, not in isolation.
+/// </summary>
 public sealed record CSharpTypeSourceUnit(string? Namespace, string Source);
 
 public sealed record CSharpTypePrintDiagnostic(string TypeName, string Message);
@@ -281,4 +292,15 @@ public sealed record CSharpTypePrintResult
     /// callers that only read <see cref="Units"/> do not pay for it.
     /// </summary>
     public string Source => _source.Value;
+
+    // Value equality is defined over the eagerly-known content (Units, Diagnostics)
+    // only. The lazy source field is excluded so equality neither forces composition
+    // nor degrades to reference identity of the Lazy wrapper.
+    public bool Equals(CSharpTypePrintResult? other)
+        => other is not null
+            && Units.SequenceEqual(other.Units)
+            && Diagnostics.SequenceEqual(other.Diagnostics);
+
+    public override int GetHashCode()
+        => HashCode.Combine(Units.Length, Diagnostics.Length);
 }

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -82,7 +82,10 @@ public sealed class CSharpTypePrinter
         IReadOnlyList<PreparedType> preparedTypes,
         CSharpTypePrintOptions options)
     {
-        if (!options.ShortenTypeNames)
+        // Shortening is only sound when the enabling `using` directives are
+        // actually emitted. When usings are suppressed, keep references qualified
+        // so the composed source stays compilable.
+        if (!options.ShortenTypeNames || !options.IncludeUsings)
             return [];
 
         var allTypes = new List<ApiType>();

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -46,13 +46,15 @@ public sealed class CSharpTypePrinter
                 nameof(requests)));
         }
 
+        var derivedUsings = ComputeDerivedUsings(preparedTypes, options);
+
         var units = ImmutableArray.CreateBuilder<CSharpTypeSourceUnit>();
         foreach (var group in preparedTypes.GroupBy(type => type.Namespace, StringComparer.Ordinal))
         {
             var containingNamespace = group.Key.Length == 0 ? null : group.Key;
             var source = string.Join(
                 "\n\n",
-                group.Select(type => RenderType(type, indent: 0, options, diagnostics)));
+                group.Select(type => RenderType(type, indent: 0, options, derivedUsings, diagnostics)));
             if (containingNamespace is not null)
             {
                 string renderedNamespace = CSharpFormatter.EscapeNamespace(containingNamespace);
@@ -68,11 +70,41 @@ public sealed class CSharpTypePrinter
         return new CSharpTypePrintResult(
             unitList,
             diagnostics.ToImmutable(),
-            ComposeSource(unitList, options));
+            () => ComposeSource(unitList, derivedUsings, options));
+    }
+
+    /// <summary>
+    /// Derives the collision-safe namespaces to shorten against, excluding the
+    /// unit's own declaring namespaces (their references are already shortened by
+    /// the same-namespace rule, so importing them would be redundant).
+    /// </summary>
+    static IReadOnlyList<string> ComputeDerivedUsings(
+        IReadOnlyList<PreparedType> preparedTypes,
+        CSharpTypePrintOptions options)
+    {
+        if (!options.ShortenTypeNames)
+            return [];
+
+        var allTypes = new List<ApiType>();
+        var declaringNamespaces = new HashSet<string>(StringComparer.Ordinal);
+        void Flatten(PreparedType prepared)
+        {
+            allTypes.Add(prepared.Type);
+            declaringNamespaces.Add(prepared.Namespace);
+            foreach (var nested in prepared.NestedTypes)
+                Flatten(nested);
+        }
+        foreach (var prepared in preparedTypes)
+            Flatten(prepared);
+
+        return CSharpFormatter.DeriveContextualUsings(allTypes)
+            .Where(ns => !declaringNamespaces.Contains(ns))
+            .ToArray();
     }
 
     static string ComposeSource(
         ImmutableArray<CSharpTypeSourceUnit> units,
+        IReadOnlyList<string> derivedUsings,
         CSharpTypePrintOptions options)
     {
         var sb = new System.Text.StringBuilder();
@@ -84,7 +116,7 @@ public sealed class CSharpTypePrinter
             sb.AppendLine($"[module: {attribute}]");
         if (options.IncludeUsings)
         {
-            foreach (var ns in options.Usings.Select(CSharpFormatter.EscapeNamespace).Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal))
+            foreach (var ns in options.Usings.Concat(derivedUsings).Select(CSharpFormatter.EscapeNamespace).Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal))
                 sb.AppendLine($"using {ns};");
         }
         foreach (var unit in units)
@@ -216,19 +248,22 @@ public sealed class CSharpTypePrinter
         PreparedType prepared,
         int indent,
         CSharpTypePrintOptions options,
+        IReadOnlyList<string> contextualUsings,
         ImmutableArray<CSharpTypePrintDiagnostic>.Builder diagnostics)
     {
-        var formatter = DeclarationFormatter(prepared.Namespace, options);
+        var formatter = DeclarationFormatter(prepared.Namespace, options, contextualUsings);
         if (prepared.Type.Kind == "delegate")
             return RenderDelegate(prepared, formatter, indent);
 
         var propertyFormatter = DeclarationFormatter(
             prepared.Namespace,
             options,
+            contextualUsings,
             omitPropertyAccessors: true);
         var diagnosticPass = DeclarationFormatter(
             prepared.Namespace,
             options,
+            contextualUsings,
             terminateMemberDeclaration: true)
             .FormatTypeUnit(prepared.Type, prepared.Type.Members);
         diagnostics.AddRange(diagnosticPass.Diagnostics.Select(
@@ -254,7 +289,7 @@ public sealed class CSharpTypePrinter
             foreach (var member in prepared.Members)
                 lines.AddRange(RenderMember(prepared, member, formatter, propertyFormatter, indent + 1));
             foreach (var nested in prepared.NestedTypes)
-                lines.Add(RenderType(nested, indent + 1, options, diagnostics));
+                lines.Add(RenderType(nested, indent + 1, options, contextualUsings, diagnostics));
         }
         lines.Add($"{pad}}}");
         return string.Join('\n', lines);
@@ -404,12 +439,14 @@ public sealed class CSharpTypePrinter
     static CSharpFormatter DeclarationFormatter(
         string containingNamespace,
         CSharpTypePrintOptions options,
+        IReadOnlyList<string> contextualUsings,
         bool omitPropertyAccessors = false,
         bool terminateMemberDeclaration = false)
         => new(new CSharpFormatOptions
         {
             TypeNamePolicy = CSharpTypeNamePolicy.ContextualShort,
             ContainingNamespace = containingNamespace.Length == 0 ? null : containingNamespace,
+            Usings = contextualUsings,
             NamespacePolicy = CSharpNamespacePolicy.Omit,
             IncludeCustomAttributes = options.IncludeCustomAttributes,
             OmitPropertyAccessors = omitPropertyAccessors,

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -3783,7 +3783,7 @@ public class ReturnToSenderPrototypeTests
         {
             var result = Assert.Single(ReturnToSender.CompileBackTargets(
                 assemblyPath,
-                [                new ReturnToSender.RequestedTarget("Row", "ToString", 0)]));
+                [new ReturnToSender.RequestedTarget("Row", "ToString", 0)]));
 
             Assert.True(
                 result.Status == FidelityCheck.CompileBackStatus.Exact,

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -313,7 +313,7 @@ public class ReturnToSenderPrototypeTests
                 result.Status == FidelityCheck.CompileBackStatus.Exact,
                 $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
             Assert.Contains("External", result.Plan.Module.Usings);
-            Assert.Contains("public External.Greeting Method1", result.Source);
+            Assert.Contains("public Greeting Method1", result.Source);
         }
         finally
         {
@@ -2978,7 +2978,7 @@ public class ReturnToSenderPrototypeTests
                 result =>
                 {
                     Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
-                    Assert.Contains("public T Comparable<T>(T value) where T : System.IComparable<T>", result.Source);
+                    Assert.Contains("public T Comparable<T>(T value) where T : IComparable<T>", result.Source);
                 });
         }
         finally
@@ -3120,9 +3120,9 @@ public class ReturnToSenderPrototypeTests
                 result =>
                 {
                     Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
-                    Assert.Contains("System.Runtime.CompilerServices.DateTimeConstant(637000000000000000L)", result.Source);
-                    Assert.Contains("System.DateTime when", result.Source);
-                    Assert.DoesNotContain("System.DateTime when =", result.Source);
+                    Assert.Contains("DateTimeConstant(637000000000000000L)", result.Source);
+                    Assert.Contains("DateTime when", result.Source);
+                    Assert.DoesNotContain("DateTime when =", result.Source);
                 });
         }
         finally
@@ -3165,7 +3165,7 @@ public class ReturnToSenderPrototypeTests
                 result =>
                 {
                     Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
-                    Assert.Contains("System.Diagnostics.CodeAnalysis.NotNull", result.Source);
+                    Assert.Contains("[NotNull] string value", result.Source);
                     Assert.Contains("int Length(", result.Source);
                 },
                 result =>
@@ -3250,42 +3250,45 @@ public class ReturnToSenderPrototypeTests
                 result =>
                 {
                     Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
-                    Assert.Contains("System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)", result.Source);
+                    Assert.Contains("MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)", result.Source);
+                    Assert.DoesNotContain("System.Runtime.InteropServices.MarshalAs(", result.Source);
+                    Assert.Contains("using System.Runtime.InteropServices;", result.Source);
+                    Assert.DoesNotContain("using System.Runtime.InteropServices.UnmanagedType;", result.Source);
                 },
                 result =>
                 {
                     Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
-                    Assert.Contains("System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPStr)", result.Source);
+                    Assert.Contains("MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPStr)", result.Source);
                 },
                 result =>
                 {
                     Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
-                    Assert.Contains("System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.Bool)", result.Source);
+                    Assert.Contains("MarshalAs(System.Runtime.InteropServices.UnmanagedType.Bool)", result.Source);
                 },
                 result =>
                 {
                     Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
-                    Assert.Contains("System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeParamIndex = 1)", result.Source);
+                    Assert.Contains("MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeParamIndex = 1)", result.Source);
                 },
                 result =>
                 {
                     Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
-                    Assert.Contains("System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeConst = 4)", result.Source);
+                    Assert.Contains("MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeConst = 4)", result.Source);
                 },
                 result =>
                 {
                     Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
-                    Assert.Contains("System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray)", result.Source);
+                    Assert.Contains("MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray)", result.Source);
                 },
                 result =>
                 {
                     Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
-                    Assert.Contains("System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, SizeConst = 4)", result.Source);
+                    Assert.Contains("MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, SizeConst = 4)", result.Source);
                 },
                 result =>
                 {
                     Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
-                    Assert.Contains("System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, SizeConst = 0)", result.Source);
+                    Assert.Contains("MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, SizeConst = 0)", result.Source);
                 });
         }
         finally
@@ -3350,7 +3353,7 @@ public class ReturnToSenderPrototypeTests
                 {
                     Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
                     Assert.Contains("[return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)]", result.Source);
-                    Assert.Contains("[System.Runtime.InteropServices.Optional, System.Runtime.CompilerServices.DateTimeConstant(637000000000000000L)] System.DateTime when", result.Source);
+                    Assert.Contains("[Optional, DateTimeConstant(637000000000000000L)] DateTime when", result.Source);
                     Assert.DoesNotContain("public [return:", result.Source);
                 });
         }
@@ -3708,7 +3711,7 @@ public class ReturnToSenderPrototypeTests
                 {
                     Assert.Equal(FidelityCheck.CompileBackStatus.Exact, toString.Status);
                     Assert.Contains("protected virtual bool PrintMembers", toString.Source);
-                    Assert.Contains("protected virtual System.Type EqualityContract", toString.Source);
+                    Assert.Contains("protected virtual Type EqualityContract", toString.Source);
                 },
                 equalsObject =>
                 {
@@ -3780,13 +3783,13 @@ public class ReturnToSenderPrototypeTests
         {
             var result = Assert.Single(ReturnToSender.CompileBackTargets(
                 assemblyPath,
-                [new ReturnToSender.RequestedTarget("Row", "ToString", 0)]));
+                [                new ReturnToSender.RequestedTarget("Row", "ToString", 0)]));
 
             Assert.True(
                 result.Status == FidelityCheck.CompileBackStatus.Exact,
                 $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
             Assert.Contains("PrintMembers<T>", result.Source);
-            Assert.Contains("PrintMembers(System.Text.StringBuilder", result.Source);
+            Assert.Contains("PrintMembers(StringBuilder", result.Source);
         }
         finally
         {

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -781,9 +781,6 @@ public static class CompileBackSourceComposer
             Usings: RequiredNamespaces(function)
                 .Concat(DeclarationNamespaces(declarations))
                 .Prepend("System")
-                .Select(CSharpFormatter.EscapeNamespace)
-                .Distinct(StringComparer.Ordinal)
-                .Order(StringComparer.Ordinal)
                 .ToArray(),
             AssemblyAttributes: [],
             ModuleAttributes: []);
@@ -961,9 +958,6 @@ public static class CompileBackSourceComposer
             Usings: RequiredNamespaces(function)
                 .Concat(DeclarationNamespaces(declarations))
                 .Prepend("System")
-                .Select(CSharpFormatter.EscapeNamespace)
-                .Distinct(StringComparer.Ordinal)
-                .Order(StringComparer.Ordinal)
                 .ToArray(),
             AssemblyAttributes: [],
             ModuleAttributes: []);
@@ -1167,9 +1161,6 @@ public static class CompileBackSourceComposer
             Usings: RequiredNamespaces(function)
                 .Concat(DeclarationNamespaces(declarations))
                 .Prepend("System")
-                .Select(CSharpFormatter.EscapeNamespace)
-                .Distinct(StringComparer.Ordinal)
-                .Order(StringComparer.Ordinal)
                 .ToArray(),
             AssemblyAttributes: [],
             ModuleAttributes: []);


### PR DESCRIPTION
## Why

Follow-up to merged #2811. Bundles the merge reviewer's three non-blocking
follow-ups with a new short-type-names capability on the product seam
`CSharpTypePrinter` (epic #2777).

## What

**Review follow-ups (#2811)**

1. **Lazy `Source`** — `CSharpTypePrintResult.Source` is composed on first access
   (`Lazy<string>`), so callers that read only `Units` skip composition.
2. **Scoped custom-modifier strip** — `CleanTypeDisplay` replaced its
   `.Replace(")", "")` (which nuked every close paren, mangling tuple types)
   with `StripCustomModifiers`, a paren-depth-tracked removal of only
   `modreq(…)`/`modopt(…)` wrappers. Tuple syntax is preserved. +negative test.
3. **Drop planner using pre-pass** — `ReturnToSenderTypePlanner` no longer
   escapes/dedups/orders usings; the printer already normalizes them.

**Short type names (feature)** — default on via
`CSharpTypePrintOptions.ShortenTypeNames`.

- `CSharpDeclarationWriter.DeriveContextualUsings` computes a **collision-safe**
  namespace set: a namespace is imported only when every simple name it
  contributes is unambiguous across the unit **and** does not clash with a
  declared type. Ambiguous/self-shadowing names stay fully qualified.
- `CSharpTypePrinter` derives those usings (excluding the unit's own declaring
  namespaces), feeds them to the declaration formatter, and unions them into the
  composed source. References shorten to simple names; the enabling namespaces
  are emitted as `using` directives.

**Scope note:** `CSharpTypePrinter.PrintBatch` currently has **no CLI consumer** —
it is used only by the ReturnToSender compile-back oracle and tests. So today the
short names change RTS's composed compile-back source (corpus-proven IL-neutral),
not the CLI `Decompiled Source` view (which renders via
`Decompiler.Pipeline.CSharpPrinter.PrintRaised`). This lands the capability on the
product seam per #2777 as a step toward the CLI consuming the seam.

## Soundness bug found + fixed during validation

`DeriveContextualUsings` initially mis-parsed an attribute argument enum access
(`MarshalAs(UnmanagedType.I4)`) as a type reference, emitting an **illegal**
`using System.Runtime.InteropServices.UnmanagedType;` (a type, not a namespace)
and mis-shortening the argument to `I4`. Fix: `StripAttributeArguments` — attribute
constructor arguments are value expressions (enum/const/typeof), not type
references, so only the attribute type name participates in reference/using
derivation. Post-fix output: `using System.Runtime.InteropServices;` +
`MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)` (attribute type
shortened, argument left qualified, valid, recompiles Exact). Covered by a unit
regression test and RTS prototype assertions.

## Evidence

- Full `dotnet-inspect.slnx` build clean.
- `ILInspector.CSharp.Tests` **262** (+5 feature tests: cross-namespace shorten,
  `ShortenTypeNames=false`, collision-stays-qualified, self-shadow-stays-qualified,
  attribute-enum-arg regression; +2 tuple/modifier tests).
- RTS oracle **199** (8 prototype tests updated to the shortened forms, from
  captured ground-truth output).
- Decompiler fast subset **2496**.
- **RTS parity corpus gate: 25 exact / 2 opcode diffs / 9 recompile failures over
  36, 7 burn-down rows unchanged, exit 0** — identical to baseline. Short-name RTS
  source is IL-neutral, including through full method bodies (this is an
  opcode-level oracle, not a byte diff).

## Review

Behavior-changing (RTS composed source). Requesting two adversarial reviews
(GPT-5.5 + Gemini 3.1 Pro). Attack points: `DeriveContextualUsings`
collision/self-shadow/attribute-argument soundness; lazy `Source` correctness;
`StripCustomModifiers` equivalence + tuple preservation; corpus Exact unchanged.
