### PR TITLE
Reconstruct same-assembly generic base shells

### DIFF
--- a/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
+++ b/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
@@ -133,6 +133,36 @@ public sealed class TypeShellProducerTests
         Assert.False(nestedRequest.Type.IsStatic);
     }
 
+    [Fact]
+    public void GetReconstructedBaseType_ResolvesSameAssemblyGenericBases()
+    {
+        using var pe = new PEReader(File.OpenRead(typeof(TypeShellProducerTests).Assembly.Location));
+        var reader = pe.GetMetadataReader();
+
+        TypeDefinitionHandle Handle(string name) => reader.TypeDefinitions
+            .Single(handle => reader.GetString(reader.GetTypeDefinition(handle).Name) == name);
+        TypeDefinition Type(string name) => reader.GetTypeDefinition(Handle(name));
+
+        var open = Assert.NotNull(TypeShellProducer.GetReconstructedBaseType(
+            reader,
+            Type("ShellOpenGenericDerived`1"),
+            isClass: true));
+        Assert.Equal("ILInspector.CSharp.Tests.ShellGenericBase<T>", open.DisplayName);
+        Assert.Equal(Handle("ShellGenericBase`1"), open.Definition);
+
+        var closed = Assert.NotNull(TypeShellProducer.GetReconstructedBaseType(
+            reader,
+            Type(nameof(ShellClosedGenericDerived)),
+            isClass: true));
+        Assert.Equal("ILInspector.CSharp.Tests.ShellGenericBase<int>", closed.DisplayName);
+        Assert.Equal(Handle("ShellGenericBase`1"), closed.Definition);
+
+        Assert.Null(TypeShellProducer.GetReconstructedBaseType(
+            reader,
+            Type(nameof(ShellExternalGenericDerived)),
+            isClass: true));
+    }
+
     static async Task RuntimeAsyncFixture()
         => await Task.Yield();
 
@@ -158,4 +188,29 @@ public sealed class TypeShellProducerTests
     interface IInterfaceFixture
     {
     }
+}
+
+class ShellGenericBase<T>
+{
+    public ShellGenericBase(int seed)
+    {
+    }
+}
+
+class ShellOpenGenericDerived<T> : ShellGenericBase<T>
+{
+    public ShellOpenGenericDerived() : base(1)
+    {
+    }
+}
+
+class ShellClosedGenericDerived : ShellGenericBase<int>
+{
+    public ShellClosedGenericDerived() : base(1)
+    {
+    }
+}
+
+class ShellExternalGenericDerived : List<int>
+{
 }

--- a/src/ILInspector.CSharp/TypeShellProducer.cs
+++ b/src/ILInspector.CSharp/TypeShellProducer.cs
@@ -6,6 +6,14 @@ using ILInspector.Metadata;
 namespace ILInspector.CSharp;
 
 /// <summary>
+/// A product-owned C# base clause and, when same-assembly, the metadata
+/// definition from which the shell can reconstruct supporting members.
+/// </summary>
+public readonly record struct ReconstructedBaseType(
+    string DisplayName,
+    TypeDefinitionHandle Definition);
+
+/// <summary>
 /// Produces C#-flavored type <em>shapes</em> — the skeletal facts a consumer needs
 /// to render a type declaration and its members without decompiling method bodies,
 /// loading the inspected assembly, or using Roslyn. It is the C#-spelling companion
@@ -95,15 +103,28 @@ public static class TypeShellProducer
     /// <paramref name="typeDef"/>, or <see langword="null"/> when the base should
     /// be dropped (left to its compiler-implied default).
     ///
-    /// Attributes always keep their <c>System.Attribute</c> base. Otherwise only a
-    /// same-assembly (<see cref="HandleKind.TypeDefinition"/>) non-generic plain
-    /// class base is reconstructed: external (TypeReference) and generic
-    /// instantiation (TypeSpecification) bases are dropped because the shell cannot
-    /// own their construction, and object-family / value-type / delegate bases are
-    /// left implicit to avoid conflicts. <paramref name="isClass"/> is the caller's
-    /// resolved kind (records/structs/enums/delegates pass <see langword="false"/>).
+    /// This name-only compatibility form delegates to
+    /// <see cref="GetReconstructedBaseType"/>.
     /// </summary>
     public static string? ReconstructedBaseTypeName(MetadataReader reader, TypeDefinition typeDef, bool isClass)
+        => GetReconstructedBaseType(reader, typeDef, isClass)?.DisplayName;
+
+    /// <summary>
+    /// The base type a skeletal type shape should reconstruct for
+    /// <paramref name="typeDef"/>, or <see langword="null"/> when the base should
+    /// be dropped.
+    ///
+    /// Attributes always keep their <c>System.Attribute</c> base. Otherwise the
+    /// base must resolve to a same-assembly type definition, either directly or as
+    /// the generic type in a <see cref="HandleKind.TypeSpecification"/>. External
+    /// bases and object-family / value-type / delegate bases remain implicit.
+    /// <paramref name="isClass"/> is the caller's resolved kind
+    /// (records/structs/enums/delegates pass <see langword="false"/>).
+    /// </summary>
+    public static ReconstructedBaseType? GetReconstructedBaseType(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        bool isClass)
     {
         if ((typeDef.Attributes & TypeAttributes.Interface) != 0)
             return null;
@@ -111,9 +132,22 @@ public static class TypeShellProducer
             return null;
 
         string? baseType;
+        TypeDefinitionHandle baseDefinition;
         try
         {
-            baseType = TypeResolver.GetTypeName(reader, typeDef.BaseType, GenericContext.ForType(reader, typeDef));
+            var context = GenericContext.ForType(reader, typeDef);
+            baseType = TypeResolver.GetTypeName(reader, typeDef.BaseType, context);
+            // Attributes are the one supported external base.
+            if (baseType is "System.Attribute")
+                return new ReconstructedBaseType(baseType, default);
+            if (!TypeResolver.TryGetSameAssemblyTypeDefinition(
+                    reader,
+                    typeDef.BaseType,
+                    context,
+                    out baseDefinition))
+            {
+                return null;
+            }
         }
         catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
         {
@@ -122,21 +156,15 @@ public static class TypeShellProducer
 
         if (baseType is null)
             return null;
-        // Attributes must derive from System.Attribute (existing behavior).
-        if (baseType is "System.Attribute")
-            return baseType;
-        // Only reconstruct same-assembly base classes. External (TypeReference) and
-        // generic-instantiation (TypeSpecification) bases are dropped: the shell
-        // cannot own their construction, so an external base whose only constructor
-        // is parameterized would make the derived stub's implicit `: base()` fail
-        // (CS7036) where the baseline compiled without a base.
-        if (typeDef.BaseType.Kind != HandleKind.TypeDefinition)
+        // An external base whose only constructor is parameterized would make the
+        // derived stub's implicit `: base()` fail (CS7036) where the baseline
+        // compiled without a base.
+        if (baseDefinition.IsNil)
             return null;
         // Only plain classes reconstruct a real base class; records/structs/enums/
         // delegates keep their compiler-implied base to avoid primary-constructor
-        // and value-type conflicts. A generic type's base can reference its own type
-        // parameters, which the flat shell does not carry, so skip it.
-        if (!isClass || typeDef.GetGenericParameters().Count != 0)
+        // and value-type conflicts.
+        if (!isClass)
             return null;
         if (baseType is "System.Object" or "System.ValueType" or "System.Enum"
             or "System.Delegate" or "System.MulticastDelegate")
@@ -147,7 +175,7 @@ public static class TypeShellProducer
         // Clean'd display name. Running the pure heuristic on the RAW metadata name
         // here would diverge from that normalized decision (e.g. wrongly dropping a
         // generated `<>`-named base). This method owns only the metadata-level gates.
-        return baseType;
+        return new ReconstructedBaseType(baseType, baseDefinition);
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -78,51 +78,42 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
-    public void CompileBackTargets_DoesNotReconstructGenericBaseClass()
+    public void CompileBackTargets_ReconstructsSameAssemblyGenericBaseClass()
     {
-        // Issue #2527 guard (Gemini review of #2732): a closed generic base
-        // instantiation (`Derived : Base<int>`) is a TypeSpecification, which the
-        // flat shell cannot carry and cannot own a synthetic constructor for. It must
-        // be dropped rather than emitted, so the derived stub does not fail on an
-        // implicit `: base()` with no parameterless target.
+        // Issue #2779: a constructed generic base is a TypeSpecification,
+        // but its generic type is a same-assembly TypeDefinition. The product seam
+        // reconstructs the base signature and definition identity. The inherited
+        // field access cannot compile without that relationship.
         var assemblyPath = CompileFixture("""
-            using System;
-
             public class Base<T>
             {
-                public Base(int seed)
+                protected Base(T value)
                 {
-                    Seed = seed;
+                    Value = value;
                 }
 
-                public int Seed { get; }
+                protected T Value;
             }
 
-            public class Derived : Base<int>
+            public class Derived<T> : Base<T>
             {
-                public Derived() : base(1)
+                public Derived(T value) : base(value)
                 {
                 }
-            }
 
-            public static class Use
-            {
-                public static void Run()
-                {
-                    Console.WriteLine(new Base<int>(1));
-                    Console.WriteLine(new Derived());
-                }
+                public T Read() => Value;
             }
             """);
         try
         {
             var result = Assert.Single(ReturnToSender.CompileBackTargets(
                 assemblyPath,
-                [new ReturnToSender.RequestedTarget("Use", "Run", 0)]));
+                [new ReturnToSender.RequestedTarget("Derived`1", "Read", 0)]));
 
-            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
             Assert.False(result.UsedCompileBackFloor, result.Detail);
-            Assert.DoesNotContain(": Base", result.Source);
+            Assert.Contains("public class Base<T>", result.Source);
+            Assert.Contains("public class Derived<T> : Base<T>", result.Source);
         }
         finally
         {

--- a/src/ILInspector.MetadataPrimitives/TypeResolver.cs
+++ b/src/ILInspector.MetadataPrimitives/TypeResolver.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reflection.Metadata;
 
 namespace ILInspector.Metadata;
@@ -69,6 +70,47 @@ public static class TypeResolver
         TypeSpecificationHandle handle,
         GenericContext? context = null)
         => GuardedSignatureDecoder.DecodeTypeSpecification(reader, handle, context);
+
+    /// <summary>
+    /// Resolves a direct type definition or the generic type underlying a guarded
+    /// <see cref="HandleKind.TypeSpecification"/> when that definition belongs to
+    /// the current assembly. Type references and non-type signatures return
+    /// <see langword="false"/>.
+    /// </summary>
+    public static bool TryGetSameAssemblyTypeDefinition(
+        MetadataReader reader,
+        EntityHandle handle,
+        GenericContext? context,
+        out TypeDefinitionHandle definition)
+    {
+        definition = default;
+        if (handle.Kind == HandleKind.TypeDefinition)
+        {
+            definition = (TypeDefinitionHandle)handle;
+            return true;
+        }
+        if (handle.Kind != HandleKind.TypeSpecification)
+            return false;
+
+        try
+        {
+            if (!TypeSpecGuard.TryEnter(reader, (TypeSpecificationHandle)handle, out var scope))
+                return false;
+            using (scope)
+            {
+                var origin = reader.GetTypeSpecification((TypeSpecificationHandle)handle)
+                    .DecodeSignature(TypeDefinitionOriginProvider.Instance, context);
+                if (origin.IsDegraded || origin.Handle.Kind != HandleKind.TypeDefinition)
+                    return false;
+                definition = (TypeDefinitionHandle)origin.Handle;
+                return true;
+            }
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            return false;
+        }
+    }
 
     /// <summary>
     /// Gets the full name of a type definition (Namespace.Name), qualifying a
@@ -189,5 +231,67 @@ public static class TypeResolver
         }
 
         return result.ToString();
+    }
+
+    readonly record struct TypeDefinitionOrigin(EntityHandle Handle, bool IsDegraded);
+
+    sealed class TypeDefinitionOriginProvider : ISignatureTypeProvider<TypeDefinitionOrigin, GenericContext?>
+    {
+        public static TypeDefinitionOriginProvider Instance { get; } = new();
+
+        public TypeDefinitionOrigin GetTypeFromDefinition(
+            MetadataReader reader,
+            TypeDefinitionHandle handle,
+            byte rawTypeKind)
+            => new(handle, IsDegraded: false);
+
+        public TypeDefinitionOrigin GetTypeFromReference(
+            MetadataReader reader,
+            TypeReferenceHandle handle,
+            byte rawTypeKind)
+            => new(handle, IsDegraded: false);
+
+        public TypeDefinitionOrigin GetTypeFromSpecification(
+            MetadataReader reader,
+            GenericContext? context,
+            TypeSpecificationHandle handle,
+            byte rawTypeKind)
+        {
+            if (!TypeSpecGuard.TryEnter(reader, handle, out var scope))
+                return new(default, IsDegraded: true);
+            using (scope)
+            {
+                return reader.GetTypeSpecification(handle).DecodeSignature(this, context);
+            }
+        }
+
+        public TypeDefinitionOrigin GetGenericInstantiation(
+            TypeDefinitionOrigin genericType,
+            ImmutableArray<TypeDefinitionOrigin> typeArguments)
+            => new(
+                genericType.Handle,
+                genericType.IsDegraded || typeArguments.Any(argument => argument.IsDegraded));
+
+        public TypeDefinitionOrigin GetModifiedType(
+            TypeDefinitionOrigin modifier,
+            TypeDefinitionOrigin unmodifiedType,
+            bool isRequired)
+            => new(unmodifiedType.Handle, modifier.IsDegraded || unmodifiedType.IsDegraded);
+
+        public TypeDefinitionOrigin GetPinnedType(TypeDefinitionOrigin elementType)
+            => elementType;
+
+        public TypeDefinitionOrigin GetPrimitiveType(PrimitiveTypeCode typeCode) => default;
+        public TypeDefinitionOrigin GetSZArrayType(TypeDefinitionOrigin elementType) => new(default, elementType.IsDegraded);
+        public TypeDefinitionOrigin GetArrayType(TypeDefinitionOrigin elementType, ArrayShape shape) => new(default, elementType.IsDegraded);
+        public TypeDefinitionOrigin GetByReferenceType(TypeDefinitionOrigin elementType) => new(default, elementType.IsDegraded);
+        public TypeDefinitionOrigin GetPointerType(TypeDefinitionOrigin elementType) => new(default, elementType.IsDegraded);
+        public TypeDefinitionOrigin GetGenericMethodParameter(GenericContext? context, int index) => default;
+        public TypeDefinitionOrigin GetGenericTypeParameter(GenericContext? context, int index) => default;
+        public TypeDefinitionOrigin GetFunctionPointerType(MethodSignature<TypeDefinitionOrigin> signature)
+            => new(
+                default,
+                signature.ReturnType.IsDegraded
+                    || signature.ParameterTypes.Any(parameter => parameter.IsDegraded));
     }
 }

--- a/tests/ILInspector.Metadata.Tests/SignatureBlobGuardTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SignatureBlobGuardTests.cs
@@ -142,6 +142,73 @@ public class SignatureBlobGuardTests
     }
 
     [Fact]
+    public void SameAssemblyGenericTypeSpecification_ResolvesDefinition()
+    {
+        var md = NewModule();
+        var definition = md.AddTypeDefinition(
+            default,
+            default,
+            md.GetOrAddString("Base`1"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var signature = new BlobBuilder();
+        signature.WriteBytes(new byte[]
+        {
+            GenericInst,
+            Class,
+            0x08, // TypeDef row 2: (2 << 2) | TypeDef tag 0
+            0x01, // one generic argument
+            I4,
+        });
+        var specification = md.AddTypeSpecification(md.GetOrAddBlob(signature));
+        var reader = Serialize(md);
+
+        Assert.True(TypeResolver.TryGetSameAssemblyTypeDefinition(
+            reader,
+            specification,
+            context: null,
+            out var actual));
+        Assert.Equal(definition, actual);
+    }
+
+    [Fact]
+    public void SameAssemblyGenericTypeSpecification_RejectsUnsafeNestedSpecification()
+    {
+        var md = NewModule();
+        md.AddTypeDefinition(
+            default,
+            default,
+            md.GetOrAddString("Base`1"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        var nestedSignature = new BlobBuilder();
+        nestedSignature.WriteBytes(Nested(SzArray, 512));
+        md.AddTypeSpecification(md.GetOrAddBlob(nestedSignature));
+
+        var signature = new BlobBuilder();
+        signature.WriteBytes(new byte[]
+        {
+            GenericInst,
+            Class,
+            0x08, // TypeDef row 2
+            0x01, // one generic argument
+            Class,
+            0x06, // TypeSpec row 1: (1 << 2) | TypeSpec tag 2
+        });
+        var specification = md.AddTypeSpecification(md.GetOrAddBlob(signature));
+        var reader = Serialize(md);
+
+        Assert.False(TypeResolver.TryGetSameAssemblyTypeDefinition(
+            reader,
+            specification,
+            context: null,
+            out _));
+    }
+
+    [Fact]
     public void DeepPrefixChains_AreUnsafe()
     {
         // SRM recurses natively through by-ref, pinned, and custom-modifier prefixes, so a long

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -3044,11 +3044,14 @@ public static class CompileBackSourceComposer
         {
             // The product skeleton (TypeShellProducer) owns the metadata-level
             // gates that decide which base is reconstructable (interface/nil/same-
-            // assembly/non-generic/object-family). The harness applies its own C#
+            // assembly/object-family). The harness applies its own C#
             // surface-representability gate on the display form here, where the Clean
             // normalization lives: Clean strips generated <> segments (so a <>-named
             // base is kept) but not { or delegate*, matching origin/main exactly.
-            var baseType = TypeShellProducer.ReconstructedBaseTypeName(reader, typeDef, kind == CompileBackTypeKind.Class);
+            var baseType = TypeShellProducer.GetReconstructedBaseType(
+                reader,
+                typeDef,
+                kind == CompileBackTypeKind.Class)?.DisplayName;
             if (baseType is null)
                 return null;
             if (IsUnsupportedSurfaceSignature(baseType))
@@ -3060,7 +3063,7 @@ public static class CompileBackSourceComposer
         // derives from this class via a reconstructed (same-assembly) base
         // declaration, so its implicit `: base()` depends on this class exposing an
         // accessible parameterless constructor. Nested types are emitted by
-        // NestedTypes() from their enclosing requirement and are not present in
+        // NestedSpecs() from their enclosing requirement and are not present in
         // requirementsByMetadataName, so each requirement's nested tree is walked.
         static bool IsReconstructedBaseOfAnotherType(
             MetadataReader reader,
@@ -3103,11 +3106,14 @@ public static class CompileBackSourceComposer
         static string? ReconstructedSameAssemblyBaseName(MetadataReader reader, TypeDefinitionHandle handle, CompileBackTypeKind kind)
         {
             var typeDef = reader.GetTypeDefinition(handle);
-            if (typeDef.BaseType.Kind != HandleKind.TypeDefinition)
+            var baseType = TypeShellProducer.GetReconstructedBaseType(
+                reader,
+                typeDef,
+                kind == CompileBackTypeKind.Class);
+            if (baseType is not { Definition.IsNil: false }
+                || IsUnsupportedSurfaceSignature(baseType.Value.DisplayName))
                 return null;
-            if (BaseTypeSignature(reader, typeDef, kind) is null)
-                return null;
-            var baseDef = reader.GetTypeDefinition((TypeDefinitionHandle)typeDef.BaseType);
+            var baseDef = reader.GetTypeDefinition(baseType.Value.Definition);
             return CompileBackTypeIdentity.FromDefinition(reader, baseDef).MetadataFullName;
         }
 


### PR DESCRIPTION
Closes #2779.

## Change

**Conclusion:** same-assembly constructed generic bases now survive the
product-owned C# type-shell seam. Metadata resolves the guarded
`TypeSpecification` to its underlying `TypeDefinition`; the C# seam carries
both the rendered base clause and typed definition identity; RTS remains a thin
consumer of that product result.

- Supports open and closed forms such as `Derived<T> : Base<T>` and
  `Derived : Base<int>`.
- Keeps external generic bases dropped.
- Fails closed for malformed or structurally unsafe nested type specifications.
- Lets RTS reconstruct inherited-member shells without re-decoding generic-base
  identity in the harness.

## Evidence

| Claim | Exact-base / prior evidence | Exact head |
| --- | --- | --- |
| Compiled product base shapes | Generic `TypeSpecification` bases were dropped | Open and closed same-assembly bases resolve with their definition identity; external `List<int>` remains dropped |
| RTS inherited generic member | The negative guard required generic bases to be absent | `Derived<T>.Read()` recompiles `Exact` through `Base<T>.Value`, without the compile-back floor |
| Malformed nested `TypeSpecification` | No public same-assembly resolver | Guarded nested decode returns `false` |
| NuGet.Versioning 7.3.0, cap 500 | 156 Exact, 14 OpcodeDiff, 41 RecompileFail, 0 ContextFail | Identical; zero changed methods |

### Corrected historical acceptance claim

The issue inherited a claim that the generic-base change moved seven
`NuGet.Versioning` rows to `Exact`. Exact replay disproves that attribution:

- `NuGet.Versioning.dll` contains **zero** `TypeSpecification` base rows.
- Replaying historical parent `841fb9d1` against generic-base commit
  `f5f5ee7a` changes **zero** package methods.
- Comparing current merge-base `a31c4c22` with this PR also changes zero package
  methods.

Those seven rows came from other changes bundled into the predecessor PR, not
generic-base reconstruction. The compiled inherited-field fixture is the
population-aligned opcode proof for this change.

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 1 assembly, 309 methods
Correctness coverage: validity not run; fidelity (rts-parity) sampled 211 / 309 (68.28%), RTS parity 44 worse / 211 compared

| Metric | Change | Count delta |
| ------ | ------ | ----------- |
| Detected lowering residue (-) | 30 (9.71%) → 30 (9.71%) (neutral) | 0 |
| Conditional-branch residue (-) | 8 (2.59%) → 8 (2.59%) (neutral) | 0 |
| Forward-merge stops (-) | 8 (2.59%) → 8 (2.59%) (neutral) | 0 |
| Fidelity opcode diffs (-) | 14 (6.64%) → 14 (6.64%) (neutral) | 0 |
| Fidelity recompile failures (-) | 41 (19.43%) → 41 (19.43%) (neutral) | 0 |
| Fidelity context failures (-) | 0 (0.00%) → 0 (0.00%) (neutral) | 0 |
| RTS parity worse (-) | 44 → 44 (neutral) | 0 |
| Pass bugs (-) | 0 → 0 (neutral) | 0 |
| Fidelity check coverage (+) | 211 (68.28%) → 211 (68.28%) (neutral) | 0 |
| Fidelity exact (+) | 156 (73.93%) → 156 (73.93%) (neutral) | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): detected lowering residue 9.71% -> 9.71% (0 pp); conditional-branch residue 2.59% -> 2.59% (0 pp); opcode diffs 14 -> 14 (0).

Current measured debt: 30 methods with detected lowering residue; 14 fidelity opcode diffs among 211 checked; 41 fidelity recompile failures among 211 checked.
Regression verdict: PASS — corpus sensor matched baseline tolerances.

## Validation

| Check | Result |
| --- | --- |
| Solution build | Pass |
| Product build (`PublishAot=false`) | Pass |
| Metadata tests | 591 passed |
| C# type-shell tests | 12 passed |
| RTS prototype tests | 114 passed |
| Full decompiler suite | 2,663 passed |
| NuGet.Versioning RTS parity | Neutral; empty per-method delta |

Render-text A/B is not applicable: this changes type-shell reconstruction, not
decompiler raising, typing, or printer output.

## Review

| Reviewer | Exact-head result | Evidence |
| --- | --- | --- |
| Claude Opus 4.8 | CLEAN | Reviewed metadata origin/degradation, generic contexts, #2802 seam ownership, RTS constructor synthesis, and fixture validity |
| Gemini 3.1 Pro | CLEAN | 591 metadata, 241 C# seam, and 114 RTS prototype tests; independently verified nested-TypeSpec encoding and closure dependence |

Both reviews used isolated clean checkouts at `deea3631`. No resolution commit
applies because neither reviewer reported an actionable finding.
