### PR TITLE
Raise real-world fidelity sampling

### DIFF
--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -123,7 +123,7 @@ jobs:
             --emit-corpus-snapshot artifacts/deep-inspect/corpus-snapshot.json \
             --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json \
             --compile-cap 4000 \
-            --corpus-fidelity-cap 3 \
+            --corpus-fidelity-cap 50 \
             --max-examples 3
 
       - name: Run return-address equivalence census

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -278,7 +278,7 @@ mechanically (never hand-edit it) after a deliberate population change:
 ```bash
 dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
   --compile-cap 0 \
-  --corpus-fidelity-cap 3 \
+  --corpus-fidelity-cap 50 \
   --corpus-fidelity-oracle rts-parity \
   --emit-rts-parity-burndown tools/DecompilerHarness/corpus/rts-parity-burndown.json
 ```


### PR DESCRIPTION
- Advances #2815
- Changes the harness-only real-world compile-back sample; product output is unchanged
- Evidence revision: `8f32b4b6`

## Change

> Should we accept this corpus-gate change?

**Conclusion:** **PASS** — raise the deterministic per-assembly fidelity cap
from 3 to 50, increasing useful compile-back coverage from 36 to 600 methods
while keeping the full sensor near 15–17 minutes locally.

The change updates the committed baseline, Deep Inspect flag, and documented
reproduction command atomically.

## Scope and safety

- **Root cause:** the standing sample checked 36 of 89,065 methods (0.04%),
  leaving the deepest semantic oracle too sparse for broad discovery.
- **Fix shape:** raise only the existing deterministic sample cap; no sampler,
  product, decompiler, or changed-method logic changes.
- **Product impact:** none.
- **Scope boundary:** the global sample is discovery breadth, not fidelity
  proof for a behavior PR. Risky changes still use
  `--fidelity-check --fidelity-method-delta`.
- **RTS boundary:** not changed.

## Measured staircase

All runs used the fixed 14-assembly corpus, `--compile-cap 4000`, and one
fidelity cap per full sensor invocation.

| Cap | Checked | Exact | OpcodeDiff | RecompileFail | ContextFail | Wall time |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 3 | 36 | 32 | 4 | 0 | 0 | 382s |
| 10 | 120 | 106 | 14 | 0 | 0 | 381s |
| 25 | 300 | 261 | 39 | 0 | 0 | 584s |
| **50** | **600** | **510** | **90** | **0** | **0** | **909s** |
| 100 | 1,151 | 964 | 187 | 0 | 0 | 1,683s |

Useful coverage does not plateau, so cost selects the standing cap. Cap 50
raises coverage 16.7x at 15m09s. Cap 100 adds 551 checks but nearly doubles the
sensor to 28m03s. A clean post-merge cap-50 repeat completed in 995s.

Twelve assemblies contribute exactly 50 checked methods each. The two Roslyn
compiler assemblies remain outside the safely checkable population; this PR
does not adapt the harness around them.

## Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Baseline ref: `origin/main`
Correctness coverage: validity compiled 25,183 methods (compile-cap 4,000; per-sample, not corpus-wide); fidelity (compile-back) sampled 600 / 89,065 (0.67%)

| Metric | Change | Count delta |
| ------ | ------ | ----------- |
| Detected lowering residue (-) | 10,659 (11.97%) → 10,659 (11.97%) (neutral) | 0 |
| Conditional-branch residue (-) | 2,401 (2.70%) → 2,401 (2.70%) (neutral) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) → 2,286 (2.57%) (neutral) | 0 |
| Full malformed (-) | 0 → 0 (neutral) | 0 |
| Semantic defects (sampling differs) | 54 (0.21%) → 96 (0.38%) | n/a |
| Fidelity opcode diffs (sampling differs) | 4 (11.11%) → 90 (15.00%) | n/a |
| Fidelity recompile failures (sampling differs) | 0 (0.00%) → 0 (0.00%) | n/a |
| Fidelity context failures (sampling differs) | 0 (0.00%) → 0 (0.00%) | n/a |
| Pass bugs (-) | 0 → 0 (neutral) | 0 |
| Fidelity check coverage (+) | 36 (0.04%) → 600 (0.67%) (good) | +564 |
| Fidelity exact (sampling differs) | 32 (88.89%) → 510 (85.00%) | n/a |
| Fully raised (sampling differs) | 24,520 (90.01%) → 24,444 (89.73%) | n/a |

Pinned-subset gate (PR quick rate/count regressions evaluated here): detected lowering residue 11.97% -> 11.97% (0 pp); conditional-branch residue 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); semantic defects ungated (sampling differs); fidelity ungated (sampling differs; rely on changed-method fidelity).

Current measured debt: 10,659 methods with detected lowering residue; 96 semantic defects among 25,183 checked; 90 fidelity opcode diffs among 600 checked.
Regression verdict: PASS — corpus sensor matched baseline tolerances.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Cap 100 | Not selected | 1.92x cap-50 checks at 1.85x wall time; preserve as future headroom |
| 90 OpcodeDiff rows | Visible measured debt | Newly sampled population, not regressions in changed methods |
| Changed-method fidelity | Unchanged | Remains the merge-blocking instrument for risky behavior PRs |
| PR CI | Unchanged | The expensive sample remains in opt-in Deep Inspect only |

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --no-restore
npx markdownlint-cli tools/DecompilerHarness/README.md
jq empty tools/DecompilerHarness/corpus/real-world-baseline.json

dotnet run --project tools/DecompilerHarness -c Release --no-build --no-restore -- \
  "${assemblies[@]}" \
  --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json \
  --diff-corpus-baseline-ref origin/main \
  --quality-diff-card \
  --compile-cap 4000 \
  --corpus-fidelity-cap 50 \
  --max-examples 3
```

Closes #2815
