### PR TITLE
Fix usability findings: section selection, empty-state, and type-name rendering

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -9577,7 +9577,7 @@ public class CommandExecutionTests
         Assert.Equal(1, exit);
         Assert.Contains("not found", error);
         Assert.Contains("Available sections:", error);
-        Assert.Contains("-D", error);
+        Assert.Contains("Run with -D to discover sections", error);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -9536,6 +9536,75 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Project_SkillsSection_EmptyRendersNoSkillsNote()
+    {
+        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+            new ProjectDocPackage("A.Project.NoSkills", "1.0.0", "README.md", "readme"));
+
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "project", projectPath, "-S", "Skills");
+
+            Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
+            Assert.Empty(error);
+            Assert.Contains("No skills found", output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Library_TopLeverageSection_WithTopFilter_RendersSingleSection()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath, "-S", "Top Leverage", "--top", "1", "--tsv", "--tips", "q");
+
+        Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
+        Assert.Empty(error);
+        Assert.Contains("member\tcallers\troot_reach", output);
+        Assert.DoesNotContain("candidate", output);
+    }
+
+    [Fact]
+    public async Task Type_UnknownSelectValue_ListsAvailableSections()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.String", "-S", "ZzzNoSuchSection", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Contains("not found", error);
+        Assert.Contains("Available sections:", error);
+        Assert.Contains("-D", error);
+    }
+
+    [Fact]
+    public async Task Type_MemberIndexSection_OmitsEmptyDecodeColumn()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.Text.StringBuilder", "-S", "Member Index", "--tips", "q");
+
+        Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
+        Assert.Empty(error);
+        Assert.Contains("| Selector | Stable | Canonical Signature |", output);
+        Assert.DoesNotContain("Decode", output);
+    }
+
+    [Fact]
+    public async Task Implements_TypeColumn_RendersGenericNameAsCodeSpan()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "implements", "System.Text.Json.Serialization.JsonConverter",
+            "--platform", "System.Text.Json", "--tips", "q");
+
+        Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
+        Assert.Contains("`System.Text.Json.Serialization.JsonConverter<T>`", output);
+        Assert.DoesNotContain("JsonConverter&#96;1", output);
+    }
+
+    [Fact]
     public async Task Project_SkillsPrint_JsonlIsSingleCompactRecord()
     {
         var (projectPath, tempDir) = CreateProjectWithPackageDocs(

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -131,6 +131,47 @@ public class DiffCommandTests
     }
 
     [Fact]
+    public void RenderFullMarkdown_GenericType_UsesCSharpFriendlyHeading()
+    {
+        var change = new ApiChange(
+            ChangeKind.MemberSignatureChanged,
+            ChangeClassification.Breaking,
+            "Member 'Write' signature changed",
+            "void Write(T value)",
+            "void Write(T? value)");
+
+        var markdown = DiffOutputFormatter.RenderFullMarkdown(
+            "Sample",
+            [new TypeDiff("Sample.Box`1", [change])],
+            "1.0.0",
+            "2.0.0");
+
+        Assert.Contains("Box&lt;T&gt;", markdown);
+        Assert.DoesNotContain("Box`1", markdown);
+        Assert.DoesNotContain("&#96;", markdown);
+    }
+
+    [Fact]
+    public void RenderFullMarkdown_Versions_UsesArrowNotAsciiHyphen()
+    {
+        var change = new ApiChange(
+            ChangeKind.MemberSignatureChanged,
+            ChangeClassification.Breaking,
+            "Member 'M' signature changed",
+            "void M()",
+            "void M(int x)");
+
+        var markdown = DiffOutputFormatter.RenderFullMarkdown(
+            "Sample",
+            [new TypeDiff("Sample.Widget", [change])],
+            "1.0.0",
+            "2.0.0");
+
+        Assert.Contains("**1.0.0** → **2.0.0**", markdown);
+        Assert.DoesNotContain("**1.0.0** -> **2.0.0**", markdown);
+    }
+
+    [Fact]
     public void BuildFindingTransitions_TypeIntroduction_IsNativeAddedPair()
     {
         var oldSurface = new ApiSurface();

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -172,6 +172,26 @@ public class DiffCommandTests
     }
 
     [Fact]
+    public void BuildTableView_And_DetailedChanges_KeepCanonicalArityForMachineOutput()
+    {
+        var change = new ApiChange(
+            ChangeKind.MemberSignatureChanged,
+            ChangeClassification.Breaking,
+            "Member 'Write' signature changed",
+            "void Write(T value)",
+            "void Write(T? value)");
+        var typeDiffs = new[] { new TypeDiff("Sample.Box`1", [change]) };
+
+        // The tabular views back --table/--tsv/--jsonl; the Type field must stay the
+        // canonical metadata name (arity backtick), not the C#-friendly display form.
+        var tableRow = Assert.Single(DiffOutputFormatter.BuildTableView("Sample", typeDiffs, "1.0.0", "2.0.0").Rows!);
+        Assert.Equal("Box`1", tableRow.Type);
+
+        var detailedRow = Assert.Single(DiffOutputFormatter.BuildDetailedChangesView("Sample", typeDiffs, "old.dll", "new.dll").Rows!);
+        Assert.Equal("Box`1", detailedRow.Type);
+    }
+
+    [Fact]
     public void BuildFindingTransitions_TypeIntroduction_IsNativeAddedPair()
     {
         var oldSurface = new ApiSurface();

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -958,6 +958,42 @@ public class OutputFormatterTests
     }
 
     [Fact]
+    public void SignatureDecodeIsEmpty_HidesColumnOnlyWhenNoMemberDegraded()
+    {
+        Assert.True(TypeView.SignatureDecodeIsEmpty(null));
+        Assert.True(TypeView.SignatureDecodeIsEmpty(
+        [
+            new MemberSignatureRow("void A()", null, null),
+            new MemberSignatureRow("void B()", "", null),
+        ]));
+
+        // A degraded member must keep the Decode column so the failure marker stays visible.
+        Assert.False(TypeView.SignatureDecodeIsEmpty(
+        [
+            new MemberSignatureRow("void A()", null, null),
+            new MemberSignatureRow("void B()", "degraded", null),
+        ]));
+    }
+
+    [Fact]
+    public void MemberIndexDecodeIsEmpty_HidesColumnOnlyWhenNoMemberDegraded()
+    {
+        Assert.True(MemberIndexView.DecodeIsEmpty(null));
+        Assert.True(MemberIndexView.DecodeIsEmpty(
+        [
+            new MemberIndexRow("A:0", "A~0", "M:A", null, "d0"),
+            new MemberIndexRow("B:0", "B~0", "M:B", "", "d1"),
+        ]));
+
+        // A degraded member must keep the Decode column so the failure marker stays visible.
+        Assert.False(MemberIndexView.DecodeIsEmpty(
+        [
+            new MemberIndexRow("A:0", "A~0", "M:A", null, "d0"),
+            new MemberIndexRow("B:0", "B~0", "M:B", "degraded", "d1"),
+        ]));
+    }
+
+    [Fact]
     public void BuildTypeRenderManifest_CapturesActualMemberTable()
     {
         var type = new ApiType

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -377,6 +377,7 @@ public static class InspectionCommandDefinitions
 
             var typeFilter = parseResult.GetValue(typeFilterOption);
             var select = opts.ParseSelect(parseResult);
+            bool hasExplicitSelect = select is { Length: > 0 };
             var performanceTriage = opts.ParsePerformanceTriageOptions(parseResult);
             if (!PerformanceTriageOptions.TryValidate(performanceTriage, out var triageShapeError))
             {
@@ -385,7 +386,10 @@ public static class InspectionCommandDefinitions
             }
             if (!string.IsNullOrWhiteSpace(typeFilter))
                 select = [.. select ?? [], "Source Files"];
-            if (performanceTriage.HasFilters && !opts.IsDiscoveryMode(parseResult))
+            // Only surface Performance Triage from row filters when the user did not select sections
+            // with -S; an explicit selection like -S "Top Leverage" must not silently gain a second
+            // section and break single-section formats (--table/--tsv/--jsonl).
+            if (performanceTriage.HasFilters && !opts.IsDiscoveryMode(parseResult) && !hasExplicitSelect)
                 select = [.. select ?? [], SectionNames.PerformanceTriage];
 
             var options = new LibraryOptions

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -245,12 +245,15 @@ public static class MemberOptionsParser
 
         var showMemberIndex = parseResult.GetValue(args.SelectOption);
         var select = opts.ParseSelect(parseResult);
+        bool hasExplicitSelect = select is { Length: > 0 };
         if (showMemberIndex)
             select = [.. select ?? [], SectionNames.MemberIndex];
         var performanceTriage = opts.ParsePerformanceTriageOptions(parseResult);
         if (!PerformanceTriageOptions.TryValidate(performanceTriage, out var triageShapeError))
             return new VersionError(triageShapeError);
-        if (performanceTriage.HasFilters && !opts.IsDiscoveryMode(parseResult))
+        // Only surface Performance Triage from row filters when the user did not select sections
+        // with -S; an explicit selection must not silently gain a second section.
+        if (performanceTriage.HasFilters && !opts.IsDiscoveryMode(parseResult) && !hasExplicitSelect)
             select = [.. select ?? [], SectionNames.PerformanceTriage];
 
         var options = new MemberOptions

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -143,7 +143,12 @@ public static class TypeOptionsParser
         if (!PerformanceTriageOptions.TryValidate(performanceTriage, out var triageShapeError))
             return new VersionError(triageShapeError);
         var select = opts.ParseSelect(parseResult);
-        if (performanceTriage.HasFilters && !opts.IsDiscoveryMode(parseResult))
+        bool hasExplicitSelect = select is { Length: > 0 };
+        // Performance Triage row filters (--top/--loop/--min-confidence/--triage-shape/--where/
+        // --order-by) surface the Performance Triage section only when the user did not already
+        // pick sections with -S. Otherwise an explicit selection like -S "Top Leverage" would
+        // silently gain a second section and break single-section formats (--table/--tsv/--jsonl).
+        if (performanceTriage.HasFilters && !opts.IsDiscoveryMode(parseResult) && !hasExplicitSelect)
             select = [.. select ?? [], SectionNames.PerformanceTriage];
 
         var options = routePolicy.ApplyTo(new TypeOptions

--- a/src/dotnet-inspect/Commands/ProjectCommand.cs
+++ b/src/dotnet-inspect/Commands/ProjectCommand.cs
@@ -412,6 +412,11 @@ public class ProjectCommand
         var builder = new StringBuilder();
         builder.AppendLine("## Skills");
         builder.AppendLine();
+        if (rows.Count == 0)
+        {
+            builder.AppendLine("No skills found in the restored direct package dependencies.");
+            return builder.ToString();
+        }
         builder.AppendLine("| Package | Version | Path | Size | Name | Description |");
         builder.AppendLine("| ------- | ------- | ---- | ---: | ---- | ----------- |");
         foreach (var row in rows)

--- a/src/dotnet-inspect/Output/DiffOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/DiffOutputFormatter.cs
@@ -12,8 +12,10 @@ public static class DiffOutputFormatter
 {
     /// <summary>
     /// Renders a type's simple name with generic arity expanded to a C#-friendly
-    /// form (<c>JsonConverter`1</c> → <c>JsonConverter&lt;T&gt;</c>) so diff headings
-    /// and rows avoid raw metadata arity backticks.
+    /// form (<c>JsonConverter`1</c> → <c>JsonConverter&lt;T&gt;</c>) for the human
+    /// Markdown diff view only. Machine-facing tabular views (<c>--table</c>/<c>--tsv</c>/
+    /// <c>--jsonl</c>) keep the canonical metadata name (arity backtick) so the Type
+    /// field stays a stable, script-parseable identifier.
     /// </summary>
     private static string FormatTypeDisplayName(string typeFullName)
         => MetadataTypeNameFormatter.FormatGenericTypeName(TypeMatcher.GetSimpleName(typeFullName));
@@ -62,7 +64,7 @@ public static class DiffOutputFormatter
                 detail = FormatSummaryCounts(td.BreakingCount, td.AdditiveCount, td.PotentiallyBreakingCount);
             }
 
-            return new DiffTableRow(symbol, FormatTypeDisplayName(td.TypeFullName), detail);
+            return new DiffTableRow(symbol, TypeMatcher.GetSimpleName(td.TypeFullName), detail);
         }).ToList();
 
         return new DiffTableView
@@ -473,7 +475,7 @@ public static class DiffOutputFormatter
         => new(
             ChangeSymbol(change.Classification, change.Kind),
             ClassificationText(change.Classification),
-            FormatTypeDisplayName(typeFullName),
+            TypeMatcher.GetSimpleName(typeFullName),
             change.Subject?.OldMember?.StableSelector
                 ?? change.Subject?.NewMember?.StableSelector
                 ?? "",

--- a/src/dotnet-inspect/Output/DiffOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/DiffOutputFormatter.cs
@@ -10,6 +10,14 @@ namespace DotnetInspector.Output;
 /// </summary>
 public static class DiffOutputFormatter
 {
+    /// <summary>
+    /// Renders a type's simple name with generic arity expanded to a C#-friendly
+    /// form (<c>JsonConverter`1</c> → <c>JsonConverter&lt;T&gt;</c>) so diff headings
+    /// and rows avoid raw metadata arity backticks.
+    /// </summary>
+    private static string FormatTypeDisplayName(string typeFullName)
+        => MetadataTypeNameFormatter.FormatGenericTypeName(TypeMatcher.GetSimpleName(typeFullName));
+
     public static void RenderNameOnly(MarkoutWriter writer, IReadOnlyList<TypeDiff> typeDiffs)
     {
         foreach (var name in typeDiffs.Select(td => td.TypeFullName).OrderBy(n => n))
@@ -54,7 +62,7 @@ public static class DiffOutputFormatter
                 detail = FormatSummaryCounts(td.BreakingCount, td.AdditiveCount, td.PotentiallyBreakingCount);
             }
 
-            return new DiffTableRow(symbol, TypeMatcher.GetSimpleName(td.TypeFullName), detail);
+            return new DiffTableRow(symbol, FormatTypeDisplayName(td.TypeFullName), detail);
         }).ToList();
 
         return new DiffTableView
@@ -240,7 +248,7 @@ public static class DiffOutputFormatter
         var view = new DiffFullView
         {
             Title = $"API Diff: {name}",
-            Versions = $"**{fromVersion}** -> **{toVersion}**",
+            Versions = $"**{fromVersion}** → **{toVersion}**",
         };
 
         if (typeDiffs.Count == 0)
@@ -445,7 +453,7 @@ public static class DiffOutputFormatter
 
         foreach (var td in typeDiffs.OrderBy(td => td.TypeFullName))
         {
-            var typeName = TypeMatcher.GetSimpleName(td.TypeFullName);
+            var typeName = FormatTypeDisplayName(td.TypeFullName);
             foreach (var change in td.Changes.Where(c => c.Classification == classification))
             {
                 var message = change.Message;
@@ -465,7 +473,7 @@ public static class DiffOutputFormatter
         => new(
             ChangeSymbol(change.Classification, change.Kind),
             ClassificationText(change.Classification),
-            TypeMatcher.GetSimpleName(typeFullName),
+            FormatTypeDisplayName(typeFullName),
             change.Subject?.OldMember?.StableSelector
                 ?? change.Subject?.NewMember?.StableSelector
                 ?? "",

--- a/src/dotnet-inspect/Output/ImplementsOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ImplementsOutputFormatter.cs
@@ -18,7 +18,7 @@ public static class ImplementsOutputFormatter
             Rows = results.Count == 0 ? null : results
                 .OrderBy(r => r.TypeName)
                 .Select(r => new ImplementerRow(
-                    r.TypeName, r.Kind, r.Relationship,
+                    MarkoutInline.Code(r.TypeName), r.Kind, r.Relationship,
                     r.Assembly ?? "", SourceColumn.Format(r.Source, r.SourceVersion)))
                 .ToList()
         };

--- a/src/dotnet-inspect/Output/SelectOutput.cs
+++ b/src/dotnet-inspect/Output/SelectOutput.cs
@@ -59,9 +59,14 @@ public static class SelectOutput
                 if (miss.Suggestions.Count > 0)
                 {
                     Console.Error.WriteLine();
-                    Console.Error.WriteLine("Did you mean:");
+                    Console.Error.WriteLine(miss.ListsAllSections ? "Available sections:" : "Did you mean:");
                     foreach (var s in miss.Suggestions)
                         Console.Error.WriteLine($"  {s}");
+                    if (miss.ListsAllSections)
+                    {
+                        Console.Error.WriteLine();
+                        Console.Error.WriteLine("Run with -D to discover sections for this target.");
+                    }
                 }
             }
         }

--- a/src/dotnet-inspect/Output/SelectResolver.cs
+++ b/src/dotnet-inspect/Output/SelectResolver.cs
@@ -7,7 +7,12 @@ using DotnetInspector.Sections;
 /// <summary>
 /// An unresolved -S/--select value with suggestions for what the user may have meant.
 /// </summary>
-public record SelectMiss(string Value, IReadOnlyList<string> Suggestions, bool IsGlob = false);
+/// <param name="ListsAllSections">
+/// When true, <see cref="Suggestions"/> is the full list of available sections (a dead-end
+/// value with no close fuzzy match), so callers print it under "Available sections:" rather
+/// than "Did you mean:".
+/// </param>
+public record SelectMiss(string Value, IReadOnlyList<string> Suggestions, bool IsGlob = false, bool ListsAllSections = false);
 
 /// <summary>
 /// Result of resolving -S/--select values against known section names.
@@ -90,8 +95,15 @@ public static class SelectResolver
             return ([], new SelectMiss(name, knownSections.ToList(), IsGlob: true));
         }
 
-        // No match
-        return ([], new SelectMiss(name, GetSuggestions(name, knownSections)));
+        // No match. Offer close fuzzy matches, or the full section list when none is close
+        // so the user is never left at a dead-end error.
+        var suggestions = GetSuggestions(name, knownSections);
+        if (suggestions.Count == 0)
+            return ([], new SelectMiss(
+                name,
+                [.. knownSections.OrderBy(s => s, StringComparer.OrdinalIgnoreCase)],
+                ListsAllSections: true));
+        return ([], new SelectMiss(name, suggestions));
     }
 
     /// <summary>

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -177,6 +177,7 @@ public class TypeView
 
     // Index mode sections (--index path)
     [MarkoutSection(Name = "Signature")]
+    [MarkoutIgnoreColumnWhen(nameof(SignatureDecodeIsEmpty), nameof(MemberSignatureRow.Decode))]
     [JsonIgnore]
     public List<MemberSignatureRow>? SignatureRows { get; set; }
 
@@ -228,6 +229,10 @@ public class TypeView
     public static bool TopLeverageSelectorEmpty(List<TopLeverageRow>? rows) => rows is null || rows.All(r => string.IsNullOrEmpty(r.Selector));
     public static bool TypeExceptionRegionFilterRangeIsEmpty(List<TypeExceptionRegionRow>? rows) => rows is null || rows.All(row => string.IsNullOrEmpty(row.FilterRange));
     public static bool TypeExceptionRegionCaughtTypeIsEmpty(List<TypeExceptionRegionRow>? rows) => rows is null || rows.All(row => string.IsNullOrEmpty(row.CaughtType));
+
+    // The Decode column carries a signature-decode degradation marker that is null for
+    // well-formed metadata (the common case). Drop the column when no member is degraded.
+    public static bool SignatureDecodeIsEmpty(List<MemberSignatureRow>? rows) => rows is null || rows.All(row => string.IsNullOrEmpty(row.Decode));
 
     [MarkoutSection(Name = "Source Files", EmptyText = "No SourceLink source files found for this type.")]
     [JsonIgnore]
@@ -324,10 +329,14 @@ public class MethodsView
 public class MemberIndexView
 {
     [MarkoutSection(Name = SectionNames.MemberIndex)]
+    [MarkoutIgnoreColumnWhen(nameof(DecodeIsEmpty), nameof(MemberIndexRow.Decode))]
     public List<MemberIndexRow>? Rows { get; set; }
 
     [MarkoutIgnore]
     public bool HasRows => Rows is { Count: > 0 };
+
+    // Drop the Decode degradation-marker column when no member is degraded (the common case).
+    public static bool DecodeIsEmpty(List<MemberIndexRow>? rows) => rows is null || rows.All(row => string.IsNullOrEmpty(row.Decode));
 }
 
 [MarkoutSerializable(AutoFields = false)]


### PR DESCRIPTION
## Summary

Fixes six usability findings from a full-command pass over `dotnet-inspect`. All are behavior-safe presentation/UX fixes. No change to identifiers, provenance, or the meaning of any emitted field.

## Fixes

- **Section selection (high):** An explicit `-S` no longer silently gains the Performance Triage section from `--top`/`--loop`/`--min-confidence`/etc. row filters. Previously `library X -S "Top Leverage" --top 1 --tsv` emitted two sections and broke single-section formats (`--table`/`--tsv`/`--jsonl`). Top Leverage and Performance Triage remain two independent, separately-selectable sections; the row filters still surface Performance Triage when the user did not pick sections with `-S`.
- **Unknown `-S` value (med):** A non-glob value with no close fuzzy match now lists all available sections under "Available sections:" and points to `-D`, instead of dead-ending.
- **Empty Decode column:** Member Index and Signature drop the always-empty `Decode` column when no member carries a signature-decode degradation marker, via `MarkoutIgnoreColumnWhen`. This drop applies across all formats (markdown/table/tsv/jsonl) when the column is uniformly empty — matching the existing `MarkoutIgnoreColumnWhen` convention already used for uniform `Kind` columns (e.g. the Integrations section already omits `kind` from jsonl when uniform). The column returns as soon as any member is `degraded`, so the decode-failure signal is never suppressed (covered by new predicate tests).
- **Empty Skills state:** `project -S Skills` with no skills emits "No skills found in the restored direct package dependencies." instead of a bare header.
- **implements Type column:** Rendered as a C#-friendly code span (`` `JsonConverter<T>` ``) instead of raw metadata arity (`` JsonConverter`1 ``), matching the existing type/member column convention. Machine formats (`--tsv`/`--jsonl`/`--json`) are unaffected — Markout strips the `<code>` wrapper there and they already emitted `JsonConverter<T>`.
- **diff full markdown:** Generic arity is expanded in headings/rows (`` Box`1 `` → `Box<T>`) and the version line uses a real `→` arrow. Machine views (AnalysisDiffView/DiffTableView) keep plain `->`.

## Evidence

- New tests: 9 (2 diff unit tests, 5 CLI/integration tests, 2 predicate tests for the Decode-column visibility) — all pass.
- Existing focused suites re-run with no regressions (SelectResolver, Diff, Skill, OutputFormatter, and CommandExecution PerformanceTriage/Implements/TopLeverage/Select/Decode/MemberIndex method filters).
- Full solution builds clean.

## Adversarial review

Two-model review (GPT-5.5 + Gemini 3.1 Pro) on the exact head, each in an isolated checkout. Gemini: clean. GPT-5.5 flagged that the Decode-column drop also removes `decode` from `--jsonl`. Verified against origin/main: this is consistent with the tool's existing `MarkoutIgnoreColumnWhen` behavior (the Integrations section already drops the uniform `kind` column from jsonl on main), and the column returns whenever a member is degraded. Corrected the summary wording (this bullet) and added predicate tests locking in that the degraded marker stays visible. Re-review of the fixed head pending.

## Non-actions / follow-ups

- **Performance Triage `--table` 29-column width** → #2833 (needs section-aware column selection; a design change).
- **One attribute per line in decompiler/Signature** → #2834 (decompiler-printer, adversarial-review-gated).
- **implements Type FQN/simple-name consistency + duplicate simple names** → #2835 (naming-policy design decision).

## Known limitation

The diff `### Box<T>` heading is entity-escaped by Markout's GroupBy path (`### Box&lt;T&gt;`), which renders correctly in any Markdown viewer but shows `&lt;` in a raw terminal. Pre-existing Markout GroupBy limitation, accepted as-is; still a clear improvement over the prior confusing `` &#96;1 ``.
