### PR TITLE
Correct fidelity baseline guidance

### DIFF
--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -278,7 +278,7 @@ mechanically (never hand-edit it) after a deliberate population change:
 ```bash
 dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
   --compile-cap 0 \
-  --corpus-fidelity-cap 50 \
+  --corpus-fidelity-cap 3 \
   --corpus-fidelity-oracle rts-parity \
   --emit-rts-parity-burndown tools/DecompilerHarness/corpus/rts-parity-burndown.json
 ```
@@ -304,9 +304,15 @@ dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
   --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json \
   --quality-diff-card \
   --compile-cap 4000 \
-  --corpus-fidelity-cap 3 \
+  --corpus-fidelity-cap 50 \
   --max-examples 3
 ```
+
+The cap-50 baseline also incorporates the structured validity classification
+already shipped in #2684. Its 39 `CS0161` rows were previously hidden by the
+old message-substring shell filter; they are genuine missing-return defects and
+remain visible measured debt. The fidelity-cap increase did not create that
+semantic-validity population.
 
 To capture an RTS snapshot without comparing it to the compile-back baseline:
 


### PR DESCRIPTION
## Summary

Resolves the post-merge review findings from #2832.

- Restores the RTS-parity burn-down reproduction command to cap 3, matching
  its committed manifest.
- Raises the real-world baseline reproduction command to cap 50, matching the
  merged baseline and Deep Inspect floor.
- Classifies the 39 newly baselined `CS0161` rows: #2684 intentionally replaced
  the old message-substring shell filter and exposed genuine missing-return
  defects. The cap increase did not create that population.

## Evidence

| Contract | Documented | Committed artifact |
| --- | ---: | ---: |
| RTS parity burn-down | cap 3 | cap 3 |
| Real-world corpus baseline | cap 50 | cap 50 |
| Current real-world `CS0161` population | 39 | 39 |

The pre-#2832 baseline contained zero `CS0161` rows because it predated the
structured validity classifier. PR #2684 explicitly measured and reviewed that
sensor correction; this change documents the resulting measured debt rather
than treating it as a fidelity-cap regression.

## Scope and risk

Documentation-only correction. No product, harness, workflow, baseline, or
gate behavior changes; adversarial review is not required.

## Validation

- Markdown lint
- Command/artifact cap alignment checked against both JSON files
- Current baseline `CS0161` population counted mechanically
