### PR TITLE
Move base-type spelling into the seam; retire redundant harness usings (#2777)

### DIFF
--- a/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
+++ b/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
@@ -86,22 +86,23 @@ public sealed class TypeShellProducerTests
         var member = new CSharpMemberPolicy(
             new ApiMember { Name = "Value", Kind = "field", ReturnType = "System.Int32" },
             CSharpBodyPolicy.Skeleton);
+        // Nested spec deliberately claims Kind=Struct for a type whose metadata is a
+        // static class, proving modifiers are read from metadata rather than the spec
+        // kind, and that an object-family base is left implicit (null).
         var nested = new CSharpTypeShellSpec(
-            Handle(nameof(InstanceFixture)),
+            Handle(nameof(StaticFixture)),
             Namespace: "Samples",
-            MetadataName: "InstanceFixture",
-            Kind: CSharpTypeShellKind.Class,
-            BaseTypeDisplayName: null,
+            MetadataName: "StaticFixture",
+            Kind: CSharpTypeShellKind.Struct,
             InterfaceDisplayNames: [],
             MemberPolicies: [],
             PrimaryConstructorParameters: [],
             NestedTypes: []);
         var spec = new CSharpTypeShellSpec(
-            Handle(nameof(StaticFixture)),
+            Handle(nameof(DerivedFixture)),
             Namespace: "Samples",
-            MetadataName: "StaticFixture",
-            Kind: CSharpTypeShellKind.Struct,
-            BaseTypeDisplayName: "Samples.Widget",
+            MetadataName: "DerivedFixture",
+            Kind: CSharpTypeShellKind.Class,
             InterfaceDisplayNames: ["System.IDisposable"],
             MemberPolicies: [member],
             PrimaryConstructorParameters: [],
@@ -111,26 +112,28 @@ public sealed class TypeShellProducerTests
 
         // Spec-supplied facts flow straight through.
         Assert.Equal("Samples", request.Type.Namespace);
-        Assert.Equal("StaticFixture", request.Type.Name);
-        Assert.Equal("StaticFixture", request.Type.MetadataName);
-        Assert.Equal("struct", request.Type.Kind);
-        Assert.Equal("Samples.Widget", request.Type.BaseType);
+        Assert.Equal("DerivedFixture", request.Type.Name);
+        Assert.Equal("DerivedFixture", request.Type.MetadataName);
+        Assert.Equal("class", request.Type.Kind);
         Assert.Equal(["System.IDisposable"], request.Type.Interfaces);
         Assert.Same(member, Assert.Single(request.MemberPolicyOverrides));
         Assert.Equal("Value", Assert.Single(request.Type.Members).Name);
         Assert.Same(member.Member, request.Type.Members[0]);
 
-        // Modifiers are read from the type's own metadata, not the spec kind.
-        Assert.True(request.Type.IsStatic);
-        Assert.True(request.Type.IsAbstract);
-        Assert.True(request.Type.IsSealed);
+        // The base type is reconstructed by the seam from the type's own metadata
+        // (same-assembly non-generic class base), not carried on the spec.
+        Assert.NotNull(request.Type.BaseType);
+        Assert.EndsWith("BaseFixture", request.Type.BaseType);
 
-        // Nested shells recurse through the same builder.
+        // Modifiers are read from the type's own metadata, not the spec kind.
         var nestedRequest = Assert.Single(request.NestedTypes);
-        Assert.Equal("InstanceFixture", nestedRequest.Type.Name);
-        Assert.Equal("class", nestedRequest.Type.Kind);
+        Assert.Equal("StaticFixture", nestedRequest.Type.Name);
+        Assert.Equal("struct", nestedRequest.Type.Kind);
+        Assert.True(nestedRequest.Type.IsStatic);
+        Assert.True(nestedRequest.Type.IsAbstract);
         Assert.True(nestedRequest.Type.IsSealed);
-        Assert.False(nestedRequest.Type.IsStatic);
+        // A static class's object-family base is left implicit.
+        Assert.Null(nestedRequest.Type.BaseType);
     }
 
     static async Task RuntimeAsyncFixture()
@@ -148,6 +151,14 @@ public sealed class TypeShellProducerTests
     }
 
     static class StaticFixture
+    {
+    }
+
+    class BaseFixture
+    {
+    }
+
+    sealed class DerivedFixture : BaseFixture
     {
     }
 

--- a/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
+++ b/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
@@ -123,7 +123,9 @@ public sealed class TypeShellProducerTests
         // The base type is reconstructed by the seam from the type's own metadata
         // (same-assembly non-generic class base), not carried on the spec.
         Assert.NotNull(request.Type.BaseType);
-        Assert.EndsWith("BaseFixture", request.Type.BaseType);
+        Assert.Equal(
+            "ILInspector.CSharp.Tests.TypeShellProducerTests.BaseFixture",
+            request.Type.BaseType);
 
         // Modifiers are read from the type's own metadata, not the spec kind.
         var nestedRequest = Assert.Single(request.NestedTypes);

--- a/src/ILInspector.CSharp/CSharpTypeShellSpec.cs
+++ b/src/ILInspector.CSharp/CSharpTypeShellSpec.cs
@@ -21,8 +21,9 @@ public enum CSharpTypeShellKind
 /// A neutral, IR- and planner-free description of a type shell to compose into a
 /// <see cref="CSharpTypePrintRequest"/>. The consumer (for example the ReturnToSender
 /// harness) discovers the members and resolves the C# spelling of the type's own
-/// name, base type, and interfaces; the seam owns turning this description plus the
-/// type's metadata into the <see cref="ApiType"/> and print-request tree. Every field
+/// name and interfaces; the seam owns turning this description plus the
+/// type's metadata into the <see cref="ApiType"/> (including the base-type spelling)
+/// and print-request tree. Every field
 /// is a plain string, a metadata handle, or an already-seam/Metadata type — no
 /// consumer planning type crosses this boundary.
 /// </summary>
@@ -35,8 +36,6 @@ public enum CSharpTypeShellKind
 /// used verbatim for both <see cref="ApiType.Name"/> and
 /// <see cref="ApiType.MetadataName"/>.</param>
 /// <param name="Kind">The reconstructed C# kind.</param>
-/// <param name="BaseTypeDisplayName">The C# display spelling of the reconstructed
-/// base type, or null when no base is reconstructed.</param>
 /// <param name="InterfaceDisplayNames">The C# display spellings of the reconstructed
 /// implemented interfaces.</param>
 /// <param name="MemberPolicies">The members to emit with their per-member body
@@ -49,7 +48,6 @@ public sealed record CSharpTypeShellSpec(
     string Namespace,
     string MetadataName,
     CSharpTypeShellKind Kind,
-    string? BaseTypeDisplayName,
     IReadOnlyList<string> InterfaceDisplayNames,
     IReadOnlyList<CSharpMemberPolicy> MemberPolicies,
     IReadOnlyList<ApiParameter> PrimaryConstructorParameters,

--- a/src/ILInspector.CSharp/TypeShellProducer.cs
+++ b/src/ILInspector.CSharp/TypeShellProducer.cs
@@ -151,6 +151,26 @@ public static class TypeShellProducer
     }
 
     /// <summary>
+    /// The C# display spelling of the base type a skeletal type shape should
+    /// reconstruct for <paramref name="typeDef"/>, or <see langword="null"/> when no
+    /// base is reconstructed (left implicit) or the reconstructed base cannot be
+    /// represented on a C# surface.
+    ///
+    /// Combines the metadata-level base gate (<see cref="ReconstructedBaseTypeName"/>)
+    /// with C# normalization (<see cref="CSharpFormatter.CleanTypeDisplay"/>) and the
+    /// surface-representability gate (<see cref="IsUnsupportedSurfaceSignature"/>) so
+    /// the seam owns the full base-type spelling decision end to end.
+    /// </summary>
+    public static string? ReconstructedBaseTypeDisplay(MetadataReader reader, TypeDefinition typeDef, bool isClass)
+    {
+        var baseType = ReconstructedBaseTypeName(reader, typeDef, isClass);
+        if (baseType is null)
+            return null;
+        string display = CSharpFormatter.CleanTypeDisplay(baseType);
+        return IsUnsupportedSurfaceSignature(display) ? null : display;
+    }
+
+    /// <summary>
     /// True when <paramref name="typeDef"/> is a C# <c>static class</c> — a type that
     /// is both <c>abstract</c> and <c>sealed</c> and is not an interface. Interfaces
     /// are also abstract, so they are excluded explicitly to avoid misreading an
@@ -183,7 +203,7 @@ public static class TypeShellProducer
             Name = spec.MetadataName,
             MetadataName = spec.MetadataName,
             Kind = TypeKindText(spec.Kind),
-            BaseType = spec.BaseTypeDisplayName,
+            BaseType = ReconstructedBaseTypeDisplay(reader, typeDef, spec.Kind == CSharpTypeShellKind.Class),
             TypeParameters = MetadataDeclarationQuery.GetTypeParameters(reader, typeDef).ToList(),
             Interfaces = spec.InterfaceDisplayNames.ToList(),
             Members = members,

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -2796,7 +2796,6 @@ public static class CompileBackSourceComposer
                 Namespace: requirement.Type.Namespace,
                 MetadataName: requirement.Type.MetadataName,
                 Kind: ToShellKind(kind),
-                BaseTypeDisplayName: BaseTypeSignature(reader, typeDef, kind)?.DisplayName,
                 InterfaceDisplayNames: InterfaceSignatures(reader, typeDef)
                     .Select(signature => signature.DisplayName)
                     .ToList(),
@@ -2944,22 +2943,6 @@ public static class CompileBackSourceComposer
             }
         }
 
-        static CompileBackTypeSignature? BaseTypeSignature(MetadataReader reader, TypeDefinition typeDef, CompileBackTypeKind kind)
-        {
-            // The product skeleton (TypeShellProducer) owns the metadata-level
-            // gates that decide which base is reconstructable (interface/nil/same-
-            // assembly/non-generic/object-family). The harness applies its own C#
-            // surface-representability gate on the display form here, where the Clean
-            // normalization lives: Clean strips generated <> segments (so a <>-named
-            // base is kept) but not { or delegate*, matching origin/main exactly.
-            var baseType = TypeShellProducer.ReconstructedBaseTypeName(reader, typeDef, kind == CompileBackTypeKind.Class);
-            if (baseType is null)
-                return null;
-            if (IsUnsupportedSurfaceSignature(baseType))
-                return null;
-            return CompileBackTypeSignature.Display(baseType);
-        }
-
         // True when some other reconstructed shell type — top-level or nested —
         // derives from this class via a reconstructed (same-assembly) base
         // declaration, so its implicit `: base()` depends on this class exposing an
@@ -3009,7 +2992,7 @@ public static class CompileBackSourceComposer
             var typeDef = reader.GetTypeDefinition(handle);
             if (typeDef.BaseType.Kind != HandleKind.TypeDefinition)
                 return null;
-            if (BaseTypeSignature(reader, typeDef, kind) is null)
+            if (TypeShellProducer.ReconstructedBaseTypeDisplay(reader, typeDef, kind == CompileBackTypeKind.Class) is null)
                 return null;
             var baseDef = reader.GetTypeDefinition((TypeDefinitionHandle)typeDef.BaseType);
             return CompileBackTypeIdentity.FromDefinition(reader, baseDef).MetadataFullName;

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -779,7 +779,6 @@ public static class CompileBackSourceComposer
         var declarations = production.Requests;
         var module = new CompileBackModuleRequirement(
             Usings: RequiredNamespaces(function)
-                .Concat(DeclarationNamespaces(declarations))
                 .Prepend("System")
                 .ToArray(),
             AssemblyAttributes: [],
@@ -956,7 +955,6 @@ public static class CompileBackSourceComposer
         var declarations = production.Requests;
         var module = new CompileBackModuleRequirement(
             Usings: RequiredNamespaces(function)
-                .Concat(DeclarationNamespaces(declarations))
                 .Prepend("System")
                 .ToArray(),
             AssemblyAttributes: [],
@@ -1159,7 +1157,6 @@ public static class CompileBackSourceComposer
         var declarations = production.Requests;
         var module = new CompileBackModuleRequirement(
             Usings: RequiredNamespaces(function)
-                .Concat(DeclarationNamespaces(declarations))
                 .Prepend("System")
                 .ToArray(),
             AssemblyAttributes: [],
@@ -1186,66 +1183,6 @@ public static class CompileBackSourceComposer
                 Usings = plan.Module.Usings,
             }).Source;
 
-    static IEnumerable<string> DeclarationNamespaces(IEnumerable<CSharpTypePrintRequest> requests)
-    {
-        var declaredTypes = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var request in requests)
-            AddDeclaredTypeNames(request, declaredTypes);
-
-        foreach (var request in requests)
-        {
-            foreach (var ns in DeclarationNamespaces(request, declaredTypes))
-                yield return ns;
-        }
-    }
-
-    static void AddDeclaredTypeNames(CSharpTypePrintRequest request, HashSet<string> declaredTypes)
-    {
-        string name = CSharpFormatter.StripArity(request.Type.Name);
-        string fullName = string.IsNullOrEmpty(request.Type.Namespace)
-            ? name
-            : $"{request.Type.Namespace}.{name}";
-        declaredTypes.Add(fullName);
-        foreach (var nested in request.NestedTypes)
-            AddDeclaredTypeNames(nested, declaredTypes);
-    }
-
-    static IEnumerable<string> DeclarationNamespaces(CSharpTypePrintRequest request, IReadOnlySet<string> declaredTypes)
-    {
-        if (!string.IsNullOrWhiteSpace(request.Type.Namespace))
-            yield return request.Type.Namespace;
-
-        foreach (var iface in request.Type.Interfaces)
-            foreach (var ns in TypeNamespaces(iface, declaredTypes))
-                yield return ns;
-        if (request.Type.BaseType is { } baseType)
-            foreach (var ns in TypeNamespaces(baseType, declaredTypes))
-                yield return ns;
-        foreach (var member in request.Members)
-        {
-            if (member.ReturnType is { } returnType)
-                foreach (var ns in TypeNamespaces(returnType, declaredTypes))
-                    yield return ns;
-            if (member.SignatureModel is not { } signature)
-                continue;
-            foreach (var parameter in signature.Parameters)
-                foreach (var ns in TypeNamespaces(parameter.Type, declaredTypes))
-                    yield return ns;
-        }
-        foreach (var nested in request.NestedTypes)
-            foreach (var ns in DeclarationNamespaces(nested, declaredTypes))
-                yield return ns;
-    }
-
-    static IEnumerable<string> TypeNamespaces(string type, IReadOnlySet<string> declaredTypes)
-    {
-        foreach (var token in type.Split([',', '<', '>', '[', ']', '*', '&', ' '], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-        {
-            int dot = token.LastIndexOf('.');
-            if (dot > 0 && !declaredTypes.Contains(token[..dot]))
-                yield return token[..dot];
-        }
-    }
     static ApiMember ToApiMember(CompileBackMemberRequirement member)
     {
         string? returnType = member.ReturnType?.DisplayName;

--- a/tools/DecompilerHarness/corpus/rts-parity-burndown.json
+++ b/tools/DecompilerHarness/corpus/rts-parity-burndown.json
@@ -15,15 +15,7 @@
       "status": "RecompileFail"
     },
     {
-      "method": "Newtonsoft.Json!Newtonsoft.Json.JsonTextReader::get_PropertyNameTable#0",
-      "status": "RecompileFail"
-    },
-    {
       "method": "Newtonsoft.Json!Newtonsoft.Json.Utilities.Base64Encoder::WriteCharsAsync#0",
-      "status": "RecompileFail"
-    },
-    {
-      "method": "System.CommandLine!System.CommandLine.EnvironmentVariablesDirective.EnvironmentVariablesDirectiveAction::SetEnvVars#0",
       "status": "RecompileFail"
     },
     {


### PR DESCRIPTION
- Advances #2777 (RTS orchestrator thin; product seam owns C# spelling/shape)
- Changes: base-type C# spelling now computed by the seam; harness stops deriving its own declaration usings (printer owns them since #2825)

Two focused, independent epic-#2777 seam-ownership cleanups, kept as separate commits.

## 1. Move base-type spelling into the seam (byte-neutral)

The reconstructed base-type C# display name was computed harness-side
(`CompileBackSourceComposer.BaseTypeSignature`: metadata gate → `Clean`
normalization → surface gate) and carried across the boundary on
`CSharpTypeShellSpec.BaseTypeDisplayName`. That left a C# spelling decision in the
ReturnToSender harness.

- Add `TypeShellProducer.ReconstructedBaseTypeDisplay`, folding the existing seam
  primitives (`ReconstructedBaseTypeName` + `CleanTypeDisplay` +
  `IsUnsupportedSurfaceSignature`) into the full base-spelling decision.
- Compute `BaseType` inside `BuildPrintRequest` from the type's own metadata; drop
  `BaseTypeDisplayName` from the spec. `ReconstructedSameAssemblyBaseName`
  (base-of-another-type planning, legitimately harness-side) calls the seam for its
  reconstructed/not decision, so `BaseTypeSignature` is deleted.
- **Interface selection stays harness-side**: it uses RTS planning vocabulary
  (`IsSupportedClosureRoot`), so moving it would drag planning into the seam.
  `InterfaceDisplayNames` remains on the spec deliberately.

Behavior-preserving: same metadata gate, same `Clean`, same surface gate, same order.

## 2. Retire redundant harness declaration using-derivation (resolves 2 rows)

Since #2825 the printer derives contextual usings itself and shortens a name only
when it has derived the matching using — so every printed name is either fully
qualified (no using needed) or shortened with its using present. That makes the
harness's own declaration using-derivation (`DeclarationNamespaces` /
`AddDeclaredTypeNames` / `TypeNamespaces`, unioned into `plan.Module.Usings`)
redundant for compilation — and, being **not collision-safe**, it could inject an
ambiguous `using` the printer would have withheld.

Dropped the union from the three module-usings sites and deleted the three helpers.
`RequiredNamespaces(function)` stays (body-referenced namespaces the printer cannot
derive from declaration signatures).

## Evidence

| Check | Result |
| --- | --- |
| Product build (`dotnet-inspect.slnx -c Release`) | Pass |
| `ILInspector.CSharp.Tests` | 269 pass (BuildPrintRequest test reworked to prove seam-computed base) |
| RTS oracle (`ReturnToSenderPrototypeTests`/`EvidenceTests`/`FixtureCatalogTests`) | 199 pass, **zero prototype-fixture churn** |
| Decompiler fast suite (`-notrait Speed=Slow`) | 2496 pass |

### rts-parity corpus A/B (merge-base, deterministic cap-3 gate)

Pinned 14-assembly corpus, `--corpus-fidelity-cap 3 --corpus-fidelity-oracle rts-parity`:

| | exact | opcode | recompile-fail | manifest rows failing |
| --- | ---: | ---: | ---: | ---: |
| origin/main (a7bb425b) | 25 | 2 | 9 | 7/7 |
| this branch | 27 | 2 | 7 | 5/7 |

**+2 resolved, 0 regressions** (opcode diffs unchanged; no previously-Exact target dropped). The non-collision-safe harness usings injected an ambiguous `using` the printer's collision-safe derivation withholds, so these now recompile Exact:

- `Newtonsoft.Json!Newtonsoft.Json.JsonTextReader::get_PropertyNameTable#0`
- `System.CommandLine!...EnvironmentVariablesDirectiveAction::SetEnvVars#0`

Burndown manifest mechanically regenerated (2 rows dropped, 5 remain); enforcing gate exit 0.

### Scope / cap notes

- The committed `rts-parity-burndown.json` stays **cap-3 basis**, matching origin/main's committed manifest. #2832 raised the *documented* regeneration cap to 50 but did not regenerate the manifest; migrating it to cap-50 (which adds ~50 pre-existing rows) is a separate #2832 follow-up, out of scope here.
- Neither PR CI (`--corpus-fidelity-cap 0`, no rts-parity oracle) nor Deep Inspect (diffs the real-world baseline) enforces this manifest; it is a local-agent artifact.
- A broad cap-50 sweep was attempted but this shared machine's variable external load made the (worker-influenced) checked population non-comparable across runs (250/100/50 checked). Broad no-regression confidence rests on the deterministic cap-3 gate plus the #2825 collision-safety invariant (the printer never shortens a name without emitting its using). Reviewers on a quiet machine can run the documented cap-50 command.

## Adversarial review

Requesting two reviews (GPT-5.5 + Gemini 3.1 Pro) per the two-different-model policy (I am Opus 4.8). Focus: (a) is the base-spelling migration truly behavior-preserving; (b) can retiring the harness usings ever drop a *needed* using (regression), given the #2825 shorten-iff-derived-using contract.
