### PR TITLE
Remove @All selector discovery hint

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -8087,6 +8087,9 @@ public class CommandExecutionTests
             Assert.Contains("Source Files", output);
             Assert.Contains("Manifest", output);
             Assert.Contains("Vulnerabilities", output);
+            Assert.Contains("@All", output);
+            Assert.Contains("@Default", output);
+            Assert.Contains("section (opt-in)", output);
             Assert.DoesNotContain("Tip:", error);
         }
         finally

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3318,7 +3318,6 @@ public class CommandExecutionTests
         Assert.Contains("| Call Graph | section (opt-in) |", output);
         Assert.Contains("| Facts | section (opt-in) |", output);
         Assert.DoesNotContain("IR (Stages)", output);
-        Assert.Contains("Use -S @All to select all sections.", output);
         Assert.DoesNotContain("| Methods | section |", output);
     }
 
@@ -3355,7 +3354,6 @@ public class CommandExecutionTests
         Assert.Contains("| Call Graph | section (opt-in) |", output);
         Assert.Contains("| Facts | section (opt-in) |", output);
         Assert.Contains("| Unsafe Operations | section (opt-in) |", output);
-        Assert.Contains("Use -S @All to select all sections.", output);
     }
 
     [Fact]
@@ -8089,28 +8087,6 @@ public class CommandExecutionTests
             Assert.Contains("Source Files", output);
             Assert.Contains("Manifest", output);
             Assert.Contains("Vulnerabilities", output);
-            Assert.DoesNotContain("Tip:", error);
-        }
-        finally
-        {
-            Directory.Delete(tempDir, recursive: true);
-        }
-    }
-
-    [Fact]
-    public async Task Package_DiscoverSchema_WritesAllSelectorHint()
-    {
-        var (packagePath, tempDir) = CreateLocalRefPackage("System.Runtime");
-        try
-        {
-            var (exit, output, error) = await RunAppAsync("package", packagePath, "-D", "--schema");
-
-            Assert.Equal(0, exit);
-            Assert.Contains("Signals", output);
-            Assert.Contains("section (opt-in)", output);
-            Assert.Contains("@Default", output);
-            Assert.Contains("@All", output);
-            Assert.Contains("Use -S @All to select all sections.", output);
             Assert.DoesNotContain("Tip:", error);
         }
         finally

--- a/src/dotnet-inspect/Output/DiscoverOutput.cs
+++ b/src/dotnet-inspect/Output/DiscoverOutput.cs
@@ -64,22 +64,8 @@ public static class DiscoverOutput
                     OutputFormatter.CreateTableWriterOptions(tsv, jsonl)));
         }
 
-        if (ShouldWriteAllSelectorHint(discover, json, tsv, jsonl, rows))
-        {
-            Console.WriteLine();
-            Console.WriteLine($"Note: Use -S {SelectResolver.AllSelector} to select all sections.");
-        }
-
         return 0;
     }
-
-    private static bool ShouldWriteAllSelectorHint(string[]? discover, bool json, bool tsv, bool jsonl,
-        IReadOnlyList<DiscoveryRow> rows)
-        => !json
-           && !tsv
-           && !jsonl
-           && discover is null or { Length: 0 }
-           && rows.Any(row => row.Kind.Contains(SectionAnnotations.OptIn, StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
     /// Runs discovery with effective filtering (only sections with data).


### PR DESCRIPTION
## What

Removes the trailing discovery note `Note: Use -S @All to select all sections.` (and its `ShouldWriteAllSelectorHint` helper) from `-D` output. The `@All` selector itself is unchanged — only the appended hint is gone.

## Changes

- `src/dotnet-inspect/Output/DiscoverOutput.cs`: drop the hint block and the now-unused `ShouldWriteAllSelectorHint` helper; execution flows to the existing `return 0;`.
- `src/dotnet-inspect.Tests/CommandExecutionTests.cs`: remove the three hint-text assertions and the redundant `Package_DiscoverSchema_DoesNotWriteAllSelectorHint` test; fold `@All`/`@Default`/opt-in category assertions into the surviving `Package_DiscoverSchema_ListsStaticSchema` test to retain coverage.

## Evidence

- `dotnet build src/dotnet-inspect -c Release` and `dotnet build src/dotnet-inspect.Tests -c Release`: 0 warnings, 0 errors.
- `dotnet-inspect System.Text.Json -D` no longer prints the note.
- `Package_DiscoverSchema_ListsStaticSchema` passes with the added category assertions.
- `SelectResolver.AllSelector` remains used across the codebase; `@All` selection still works.

## Adversarial review

Base `2116f839` → head `151745ce`. Two fixed-head clean reviews:
- **GPT-5.5** — clean both rounds.
- **Gemini 3.1 Pro** — round 1 raised one non-blocking coverage gap (removed test also covered `@All`/`@Default` rows); addressed in the follow-up commit; fixed-head re-review clean.

No blocking or pre-existing findings.