### PR TITLE
Render generic types in async/P/Invoke tables as code spans

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -9584,6 +9584,40 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task AsyncMethods_DeclaringTypeAndSignature_RenderAsCodeSpansWithExpandedArity()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--platform", "System.Text.Json",
+            "--section", "Async Methods", "-v:d", "--tips", "q");
+
+        Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
+        // Generic declaring types expand arity to a C#-friendly code span (no raw `2, no escaped angle brackets).
+        Assert.Contains(
+            "`System.Text.Json.Serialization.Converters.IAsyncEnumerableOfTConverter<T1, T2>.BufferedAsyncEnumerable`",
+            output);
+        // Generic signatures render as code spans with literal angle brackets.
+        Assert.Contains("`System.Collections.Generic.IAsyncEnumerator<TElement> GetAsyncEnumerator", output);
+        Assert.DoesNotContain("&#96;", output);
+        Assert.DoesNotContain("&lt;", output);
+        Assert.DoesNotContain("&gt;", output);
+    }
+
+    [Fact]
+    public async Task AsyncMethods_MachineOutput_KeepsRawValuesWithoutCodeMarkup()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--platform", "System.Text.Json",
+            "--section", "Async Methods", "--jsonl");
+
+        Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
+        Assert.Contains(
+            "\"declaring_type\":\"System.Text.Json.Serialization.Converters.IAsyncEnumerableOfTConverter<T1, T2>.BufferedAsyncEnumerable\"",
+            output);
+        Assert.DoesNotContain("<code>", output);
+        Assert.DoesNotContain("`", output);
+    }
+
+    [Fact]
     public async Task Project_SkillsPrint_JsonlIsSingleCompactRecord()
     {
         var (projectPath, tempDir) = CreateProjectWithPackageDocs(

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -94,7 +94,11 @@ public class LibraryInspectionView
             .OrderBy(m => m.DeclaringType, StringComparer.OrdinalIgnoreCase)
             .ThenBy(m => m.MethodName, StringComparer.OrdinalIgnoreCase)
             .ThenBy(m => m.Signature, StringComparer.OrdinalIgnoreCase)
-            .Select(m => new AsyncMethodRow(m.MethodName, m.DeclaringType, m.Kind, m.Signature))
+            .Select(m => new AsyncMethodRow(
+                m.MethodName,
+                MarkoutInline.Code(MetadataTypeNameFormatter.FormatGenericTypeName(m.DeclaringType)),
+                m.Kind,
+                MarkoutInline.Code(m.Signature)))
             .ToList();
 
     [MarkoutIgnore]
@@ -200,7 +204,11 @@ public class LibraryInspectionView
             .ThenBy(m => m.MethodName, StringComparer.OrdinalIgnoreCase)
             .ThenBy(m => m.ModuleName, StringComparer.OrdinalIgnoreCase)
             .ThenBy(m => m.Signature, StringComparer.OrdinalIgnoreCase)
-            .Select(m => new PInvokeMethodRow(m.MethodName, m.DeclaringType, m.ModuleName ?? "", m.Signature))
+            .Select(m => new PInvokeMethodRow(
+                m.MethodName,
+                MarkoutInline.Code(MetadataTypeNameFormatter.FormatGenericTypeName(m.DeclaringType)),
+                m.ModuleName ?? "",
+                MarkoutInline.Code(m.Signature)))
             .ToList();
 
     [MarkoutIgnore]


### PR DESCRIPTION
## Summary

The library command's **Async Methods** and **P/Invoke Methods** sections rendered the `Declaring Type` and `Signature` columns as plain strings. Markout escapes plain table-cell content in Markdown, so generic types leaked HTML entities and declaring types showed raw metadata arity with an escaped backtick:

```
| ParseAsync | System.Text.Json.Nodes.JsonNode | State machine | System.Threading.Tasks.Task&lt;System.Text.Json.Nodes.JsonNode&gt; ParseAsync(...) |
| GetAsyncEnumerator | ...IAsyncEnumerableOfTConverter&#96;2.BufferedAsyncEnumerable | State machine | ... |
```

## Fix

Wrap both columns in `MarkoutInline.Code(...)` and expand generic arity via `MetadataTypeNameFormatter.FormatGenericTypeName(...)`, mirroring the type-name rendering convention established in #2836 (the `implements` Type column and `diff` headings).

`MarkoutInline.Code` is format-aware:

- **Markdown** → clean backtick code span with literal angle brackets.
- **`--table` / `--tsv` / `--jsonl`** → raw inner text, no `<code>`/backticks.

Arity is expanded in the underlying value (as `implements` already does), so machine output shows `IAsyncEnumerableOfTConverter<T1, T2>` rather than the backtick form.

After:

```
| GetAsyncEnumerator | `System.Text.Json.Serialization.Converters.IAsyncEnumerableOfTConverter<T1, T2>.BufferedAsyncEnumerable` | State machine | `System.Collections.Generic.IAsyncEnumerator<TElement> GetAsyncEnumerator(...)` |
```

## Evidence

- New CLI tests: `AsyncMethods_DeclaringTypeAndSignature_RenderAsCodeSpansWithExpandedArity` (Markdown code span, expanded arity, no escaped entities) and `AsyncMethods_MachineOutput_KeepsRawValuesWithoutCodeMarkup` (jsonl rawness).
- Full `dotnet-inspect.Tests` suite: **1934 passed, 0 failed** (10 skipped for absent ildasm).
- Verified real CLI output across `-v:d` Markdown, `--jsonl`, and `--tsv` for `library --platform System.Text.Json --section "Async Methods"`.

## Compatibility

Low-risk, mechanical rendering change consistent with the merged #2836 convention. Markdown-only escaping is fixed; machine formats gain C#-friendly arity in `declaring_type` (matching `implements`), with no `<code>` leakage.

## Review

One adversarial review (GPT-5.5, isolated checkout) — **no blocking findings**. It independently confirmed Markout 0.22 defends against backticks in code spans (longer fences) and escapes pipes in cells, so any residual arity backtick and table-breaking characters stay safe.
