### PR TITLE
Make custom attributes opt-in and emit one attribute per line

### DIFF
--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -309,7 +309,7 @@ public sealed class CSharpTypePrinterTests
             new CSharpTypePrintOptions { IncludeCustomAttributes = true });
 
         Assert.Contains(
-            $"[{attribute}] public record Point(int value)",
+            $"[{attribute}]\npublic record Point(int value)",
             Assert.Single(result.Units).Source,
             StringComparison.Ordinal);
     }
@@ -1358,11 +1358,11 @@ public sealed class CSharpTypePrinterTests
             });
 
         Assert.Contains(
-            "[TypeMarker] public class Container<T> : Samples.BaseType, Samples.IContract where T : System.IDisposable",
+            "[TypeMarker]\npublic class Container<T> : Samples.BaseType, Samples.IContract where T : System.IDisposable",
             rendered.Source,
             StringComparison.Ordinal);
         Assert.Contains(
-            "[MemberMarker] [return: ReturnMarker] public T Transform([ParamMarker] T value);",
+            "[MemberMarker]\n    [return: ReturnMarker]\n    public T Transform([ParamMarker] T value);",
             rendered.Source,
             StringComparison.Ordinal);
         Assert.Contains(

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -26,7 +26,7 @@ internal sealed record CSharpDeclarationOptions
     public bool TerminateMemberDeclaration { get; init; }
     public bool ForceAsync { get; init; }
     public bool ForceUnsafe { get; init; }
-    public bool IncludeCustomAttributes { get; init; } = true;
+    public bool IncludeCustomAttributes { get; init; } = false;
     public bool IncludeObsoleteAttribute { get; init; } = true;
     public bool OmitInterfaceMemberModifiers { get; init; }
     public bool OmitPropertyAccessors { get; init; }
@@ -100,13 +100,18 @@ internal static class CSharpDeclarationWriter
             if (declaration.Length > 0 && NeedsTerminator(declaration))
                 declaration += ";";
             if (declaration.Length > 0)
-                lines.Add("    " + plan.Apply(declaration));
+                lines.Add(IndentEveryLine(plan.Apply(declaration), "    "));
         }
         lines.Add("}");
 
         var source = ComposeUnit(lines, plan.GeneratedUsings, options);
         return new CSharpRenderedDeclaration(source, plan.GeneratedUsings, plan.Diagnostics);
     }
+
+    static string IndentEveryLine(string text, string pad)
+        => text.Contains('\n', StringComparison.Ordinal)
+            ? string.Join('\n', text.Split('\n').Select(line => line.Length == 0 ? line : pad + line))
+            : pad + text;
 
     public static string RenderTypeDeclaration(ApiType type, CSharpDeclarationOptions? options = null)
     {
@@ -275,9 +280,10 @@ internal static class CSharpDeclarationWriter
             declaration += " : " + string.Join(", ", bases);
 
         declaration = AppendTypeParameterConstraints(declaration, type.TypeParameters);
-        return !options.IncludeCustomAttributes || type.Attributes.Count == 0
-            ? declaration
-            : $"[{string.Join(", ", type.Attributes)}] {declaration}";
+        if (!options.IncludeCustomAttributes || type.Attributes.Count == 0)
+            return declaration;
+        return string.Join("\n", type.Attributes.Select(attribute => $"[{attribute}]"))
+            + "\n" + declaration;
     }
 
     static bool NeedsTerminator(string declaration)
@@ -348,17 +354,18 @@ internal static class CSharpDeclarationWriter
         if (!options.AbbreviateSignature)
             signature = EscapeParameterLists(signature);
 
-        List<string> parts = [];
+        List<string> attributeLines = [];
         if (options.IncludeCustomAttributes)
         {
             foreach (var attribute in member.Attributes)
-                parts.Add($"[{attribute}]");
+                attributeLines.Add($"[{attribute}]");
         }
         if (options.IncludeObsoleteAttribute && member.IsObsolete)
-            parts.Add(FormatObsoleteAttribute(member.ObsoleteMessage));
+            attributeLines.Add(FormatObsoleteAttribute(member.ObsoleteMessage));
         if (member.SignatureModel?.ReturnAttributes is { Count: > 0 } returnAttributes)
-            parts.Add($"[return: {string.Join(", ", returnAttributes)}]");
+            attributeLines.Add($"[return: {string.Join(", ", returnAttributes)}]");
 
+        List<string> parts = [];
         List<string> modifiers = [];
         if (member.Name == ".cctor")
         {
@@ -405,7 +412,16 @@ internal static class CSharpDeclarationWriter
             parts.Add(string.Join(" ", modifiers));
         parts.Add(signature);
 
-        return string.Join(" ", parts);
+        string declarationLine = string.Join(" ", parts);
+        if (attributeLines.Count == 0)
+            return declarationLine;
+
+        // On the opt-in surfaces that emit custom attributes (annotated source and
+        // the full type printer) each leading attribute goes on its own line, as is
+        // idiomatic C#. Single-line/table contexts (which never emit custom
+        // attributes) keep obsolete/return attributes inline so the row stays intact.
+        string separator = options.IncludeCustomAttributes ? "\n" : " ";
+        return string.Join(separator, attributeLines) + separator + declarationLine;
     }
 
     static IEnumerable<string> CollectTypeReferences(ApiType type)

--- a/src/ILInspector.CSharp/CSharpFormatter.cs
+++ b/src/ILInspector.CSharp/CSharpFormatter.cs
@@ -26,7 +26,7 @@ public sealed record CSharpFormatOptions
     public bool TerminateMemberDeclaration { get; init; }
     public bool ForceAsync { get; init; }
     public bool ForceUnsafe { get; init; }
-    public bool IncludeCustomAttributes { get; init; } = true;
+    public bool IncludeCustomAttributes { get; init; } = false;
     public bool IncludeObsoleteAttribute { get; init; } = true;
     public bool OmitInterfaceMemberModifiers { get; init; }
     public bool OmitPropertyAccessors { get; init; }
@@ -142,7 +142,7 @@ public sealed class CSharpFormatter
         }
 
         string attributes = _declarationOptions.IncludeCustomAttributes && type.Attributes.Count > 0
-            ? $"[{string.Join(", ", type.Attributes)}] "
+            ? string.Join("\n", type.Attributes.Select(attribute => $"[{attribute}]")) + "\n"
             : "";
         string unsafeText = invoke.IsUnsafe ? " unsafe" : "";
         string parameters = FormatParameterList(signature.Parameters);

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -279,7 +279,7 @@ public sealed class CSharpTypePrinter
 
         var lines = new List<string>
         {
-            $"{pad}{declaration}",
+            PadDeclaration(declaration, pad),
             $"{pad}{{"
         };
         if (prepared.Type.Kind == "enum")
@@ -310,8 +310,8 @@ public sealed class CSharpTypePrinter
         {
             string declaration = formatter.FormatMember(type.Type, member.Member);
             if (member.Body is CSharpFieldInitializer fieldInitializer)
-                return [$"{pad}{declaration} = {fieldInitializer.Source};"];
-            return [$"{pad}{EnsureTerminated(declaration)}"];
+                return [$"{PadDeclaration(declaration, pad)} = {fieldInitializer.Source};"];
+            return [PadDeclaration(EnsureTerminated(declaration), pad)];
         }
 
         if (member.Member.Kind == "property")
@@ -324,13 +324,13 @@ public sealed class CSharpTypePrinter
             || member.Member.IsAbstract
             || member.Policy == CSharpBodyPolicy.Skeleton)
         {
-            return [$"{pad}{EnsureTerminated(memberDeclaration)}"];
+            return [PadDeclaration(EnsureTerminated(memberDeclaration), pad)];
         }
         string initializer = member.Body is CSharpBlockBody { ConstructorInitializer: { } constructorInitializer }
             ? " " + CSharpFormatter.FormatConstructorInitializer(constructorInitializer)
             : "";
         if (member.Body is null && member.Policy == CSharpBodyPolicy.Stub)
-            return [$"{pad}{memberDeclaration}{initializer} {{ throw null; }}"];
+            return [$"{PadDeclaration(memberDeclaration, pad)}{initializer} {{ throw null; }}"];
 
         var body = member.Body switch
         {
@@ -339,7 +339,7 @@ public sealed class CSharpTypePrinter
                 $"Member '{member.Member.Name}' has no renderable block body."),
         };
         if (member.Policy == CSharpBodyPolicy.Stub && body == "throw null;")
-            return [$"{pad}{memberDeclaration}{initializer} {{ throw null; }}"];
+            return [$"{PadDeclaration(memberDeclaration, pad)}{initializer} {{ throw null; }}"];
         return RenderBlock(memberDeclaration + initializer, body, indent);
     }
 
@@ -354,7 +354,7 @@ public sealed class CSharpTypePrinter
         if (member.Policy == CSharpBodyPolicy.Skeleton)
         {
             string skeleton = formatter.FormatMember(type.Type, member.Member);
-            return [$"{pad}{EnsureTerminated(skeleton)}"];
+            return [PadDeclaration(EnsureTerminated(skeleton), pad)];
         }
 
         var body = (CSharpPropertyBody)member.Body!;
@@ -369,12 +369,12 @@ public sealed class CSharpTypePrinter
                 accessors.Add(AccessorHead(member.Member, "get") + ";");
             if (body.Setter is not null)
                 accessors.Add(AccessorHead(member.Member, "set") + ";");
-            return [$"{pad}{declaration} {{ {string.Join(" ", accessors)} }}"];
+            return [$"{PadDeclaration(declaration, pad)} {{ {string.Join(" ", accessors)} }}"];
         }
 
         var lines = new List<string>
         {
-            $"{pad}{declaration}",
+            PadDeclaration(declaration, pad),
             $"{pad}{{"
         };
         AddAccessor(lines, member.Member, "get", body.Getter, indent + 1);
@@ -427,7 +427,7 @@ public sealed class CSharpTypePrinter
     {
         string pad = new(' ', indent * 4);
         var invoke = prepared.Members.Single(member => member.Member.Name == "Invoke").Member;
-        return $"{pad}{formatter.FormatDelegate(prepared.Type, invoke)}";
+        return PadDeclaration(formatter.FormatDelegate(prepared.Type, invoke), pad);
     }
 
     static string RenderEnumMember(PreparedMember member, int indent, bool trailingComma)
@@ -459,12 +459,19 @@ public sealed class CSharpTypePrinter
     static IEnumerable<string> RenderBlock(string declaration, string source, int indent)
     {
         string pad = new(' ', indent * 4);
-        yield return $"{pad}{declaration}";
+        yield return PadDeclaration(declaration, pad);
         yield return $"{pad}{{";
         foreach (var line in SourceLines(source))
             yield return $"{pad}    {line}";
         yield return $"{pad}}}";
     }
+
+    // A rendered declaration may span several lines when leading attributes are
+    // emitted one per line; indent every line so nested members stay aligned.
+    static string PadDeclaration(string declaration, string pad)
+        => declaration.Contains('\n', StringComparison.Ordinal)
+            ? string.Join('\n', declaration.Split('\n').Select(line => line.Length == 0 ? line : pad + line))
+            : pad + declaration;
 
     static IEnumerable<string> SourceLines(string source)
         => source.Split('\n')

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -3478,17 +3478,17 @@ public class ReturnToSenderPrototypeTests
                 result =>
                 {
                     Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
-                    Assert.Contains("[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage] public int Method1()", result.Source);
+                    Assert.Contains("[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]\n    public int Method1()", result.Source);
                 },
                 result =>
                 {
                     Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
-                    Assert.Contains("[System.Obsolete(\"use Method1\")] public int ObsoleteMethod()", result.Source);
+                    Assert.Contains("[System.Obsolete(\"use Method1\")]\n    public int ObsoleteMethod()", result.Source);
                 },
                 result =>
                 {
                     Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
-                    Assert.Contains("[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage] public string Text", result.Source);
+                    Assert.Contains("[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]\n    public string Text", result.Source);
                 },
                 result =>
                 {
@@ -3527,12 +3527,12 @@ public class ReturnToSenderPrototypeTests
                 result =>
                 {
                     Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
-                    Assert.Contains("[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage] public class Class1", result.Source);
+                    Assert.Contains("[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]\npublic class Class1", result.Source);
                 },
                 result =>
                 {
                     Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
-                    Assert.Contains("[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage] public class Class1", result.Source);
+                    Assert.Contains("[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]\npublic class Class1", result.Source);
                 });
         }
         finally

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -10,6 +10,8 @@ namespace DotnetInspector.Tests;
 public class ApiSurfaceExtractorTests
 {
     static readonly CSharpFormatter Formatter = new();
+    static readonly CSharpFormatter AttributeFormatter = new(
+        new CSharpFormatOptions { IncludeCustomAttributes = true });
 
     [Fact]
     public void Extract_IncludesParameterNamesInMethodSignatures()
@@ -369,23 +371,23 @@ public class ApiSurfaceExtractorTests
 
         var method = testType.Members.FirstOrDefault(m => m.Name == "MethodWithMemberAttribute");
         Assert.NotNull(method);
-        var methodDeclaration = Formatter.FormatMember(testType, method);
+        var methodDeclaration = AttributeFormatter.FormatMember(testType, method);
         Assert.StartsWith(
-            "[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage] public int MethodWithMemberAttribute()",
+            "[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]\npublic int MethodWithMemberAttribute()",
             methodDeclaration,
             StringComparison.Ordinal);
 
         var property = testType.Members.FirstOrDefault(m => m.Name == "PropertyWithMemberAttribute");
         Assert.NotNull(property);
-        var propertyDeclaration = Formatter.FormatMember(testType, property);
+        var propertyDeclaration = AttributeFormatter.FormatMember(testType, property);
         Assert.StartsWith(
-            "[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage] public string PropertyWithMemberAttribute",
+            "[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]\npublic string PropertyWithMemberAttribute",
             propertyDeclaration,
             StringComparison.Ordinal);
 
         var decimalField = testType.Members.FirstOrDefault(m => m.Name == "DecimalField");
         Assert.NotNull(decimalField);
-        var decimalFieldDeclaration = Formatter.FormatMember(testType, decimalField);
+        var decimalFieldDeclaration = AttributeFormatter.FormatMember(testType, decimalField);
         Assert.DoesNotContain("DecimalConstant", decimalFieldDeclaration);
         Assert.Contains("DecimalField", decimalFieldDeclaration);
     }
@@ -402,9 +404,9 @@ public class ApiSurfaceExtractorTests
         var testType = surface.Types.FirstOrDefault(t => t.Name == nameof(SampleTypeAttributeHost));
         Assert.NotNull(testType);
 
-        var declaration = Formatter.FormatTypeDeclaration(testType);
+        var declaration = AttributeFormatter.FormatTypeDeclaration(testType);
         Assert.StartsWith(
-            "[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage] public class SampleTypeAttributeHost",
+            "[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]\npublic class SampleTypeAttributeHost",
             declaration,
             StringComparison.Ordinal);
     }

--- a/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
@@ -958,31 +958,15 @@ public class MemberOptionsParserTests
         Assert.Contains("List", options.TypeName);
     }
 
-    // Debug test
     [Fact]
     public async Task Debug_ListIndexOfParsing()
     {
         ArgumentPreprocessor.Reset();
         var (root, opts, cmdArgs) = CreateTestCommand();
         var parseResult = root.Parse(["member", "List<T>.IndexOf:3"]);
-        
+
         var result = await MemberOptionsParser.ParseAsync(parseResult, opts, cmdArgs);
-        
-        // Log what we got
-        Console.WriteLine($"Result type: {result.GetType().Name}");
-        if (result is MemberOptionsParser.VersionError ve)
-        {
-            Console.WriteLine($"Error: {ve.Message}");
-        }
-        else if (result is MemberOptionsParser.Success success)
-        {
-            Console.WriteLine($"TypeName: {success.Options.TypeName}");
-            Console.WriteLine($"PackagePath: {success.Options.PackagePath}");
-            Console.WriteLine($"PlatformAssembly: {success.Options.PlatformAssembly}");
-            Console.WriteLine($"MemberFilter: {string.Join(", ", success.Options.MemberFilter)}");
-        }
-        
-        // Assert for now
+
         Assert.IsType<MemberOptionsParser.Success>(result);
     }
 }

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -24,6 +24,8 @@ namespace DotnetInspector.Output;
 public static class ApiOutputFormatter
 {
     static readonly CSharpFormatter DefaultCSharpFormatter = new();
+    static readonly CSharpFormatter AnnotatedCSharpFormatter = new(
+        new CSharpFormatOptions { IncludeCustomAttributes = true });
     static readonly CSharpFormatter AbbreviatedCSharpFormatter = new(
         new CSharpFormatOptions { AbbreviateSignature = true });
     static readonly CSharpFormatter CSharpFormatterWithoutObsolete = new(
@@ -1570,7 +1572,8 @@ public static class ApiOutputFormatter
                 member,
                 code.MethodGenericParameters,
                 annotatedResult,
-                requiresAsyncBodyModifier: code.RequiresAsyncBodyModifier);
+                requiresAsyncBodyModifier: code.RequiresAsyncBodyModifier,
+                includeCustomAttributes: true);
             hasCode = true;
         }
 
@@ -2284,7 +2287,8 @@ public static class ApiOutputFormatter
         Decompiler.DecompilerResult result,
         bool preferExpressionBodied = false,
         IReadOnlyList<string>? leadingBodyComments = null,
-        bool requiresAsyncBodyModifier = false)
+        bool requiresAsyncBodyModifier = false,
+        bool includeCustomAttributes = false)
     {
         if (!result.Succeeded)
             return new CodeSection("csharp", DiagnosticComment(result));
@@ -2300,7 +2304,8 @@ public static class ApiOutputFormatter
                     result,
                     preferExpressionBodied,
                     leadingBodyComments,
-                    requiresAsyncBodyModifier));
+                    requiresAsyncBodyModifier,
+                    includeCustomAttributes));
         }
         catch (Exception ex)
         {
@@ -2317,7 +2322,8 @@ public static class ApiOutputFormatter
         Decompiler.DecompilerResult result,
         bool preferExpressionBodied = false,
         IReadOnlyList<string>? leadingBodyComments = null,
-        bool requiresAsyncBodyModifier = false)
+        bool requiresAsyncBodyModifier = false,
+        bool includeCustomAttributes = false)
     {
         var lowered = result.Output
             ?? throw new ArgumentException("A successful decompiler result is required.", nameof(result));
@@ -2326,7 +2332,8 @@ public static class ApiOutputFormatter
             RequiresAsyncModifier = requiresAsyncBodyModifier,
             RequiresUnsafeModifier = result.RequiresUnsafeBodyModifier
         };
-        var declaration = DefaultCSharpFormatter.FormatMemberWithBody(
+        var formatter = includeCustomAttributes ? AnnotatedCSharpFormatter : DefaultCSharpFormatter;
+        var declaration = formatter.FormatMemberWithBody(
             type,
             member,
             bodyShape,


### PR DESCRIPTION
Fixes #2834.

## Problem

Custom attributes rendered on every C# declaration surface as a single inline `[...] [...]` leading prefix. In the Signature table cell this produced an unreadable wall of text, e.g. `JsonSerializer.Serialize`:

> \`[System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("…")] [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("…")] public static string Serialize<TValue>(…)\`

One-line attribute runs are also not idiomatic C#.

## Change

**Attributes are now opt-in.** The `IncludeCustomAttributes` defaults on `CSharpDeclarationOptions` and `CSharpFormatOptions` flip to `false`, so Signature, the Methods list, and Decompiled Source no longer emit custom attributes. Only two surfaces opt back in:

- **Annotated Source** member view (`ApiOutputFormatter` selects an attrs-on formatter for the annotated path only).
- **The full type printer** (`CSharpTypePrinter`, via the RTS harness, which already set `IncludeCustomAttributes = true`).

**One attribute per line.** When shown, leading member- and type-level custom attributes emit one per line. Line-breaking is gated on `IncludeCustomAttributes`, so single-line/table contexts keep obsolete and return attributes inline and intact. Multi-line consumers (`CSharpTypePrinter`, `RenderTypeUnit`) reindent every line so nested members stay aligned.

Obsolete and parameter/accessor-return attributes are unchanged (deliberate scope limit).

## Evidence

- `ILInspector.CSharp.Tests`: 269 pass, 0 fail.
- `dotnet-inspect.Tests`: 1934 total, 0 fail.
- `ILInspector.Decompiler.Tests` (minus `Speed=Slow`): 2496 total, 0 fail — including RTS compile-back oracle (`CompileBackTargets_RoundTripsMemberAttributes`/`…TypeAttributes`), which compiles the type-printer output, confirming one-per-line stays valid C#.
- Manual CLI: Signature clean (no attrs), Annotated Source shows attrs one-per-line, Decompiled Source clean.

## Notes for reviewers

- Cost/Semantics overlay views were left attrs-OFF (only `AnnotatedSourceCode` opts in) — literal reading of "annotated source view".
- `CSharpTypePrinter` has no product (CLI) caller today; it is exercised via the RTS harness. Both requested surfaces show attributes.