### PR TITLE
Render explicit-interface-implementation properties as real explicit impls (RTS CS0535)

### DIFF
--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -418,6 +418,79 @@ public sealed class CSharpDeclarationWriterTests
     }
 
     [Fact]
+    public void PropertyDeclaration_WithDottedName_RendersAsExplicitInterfaceImplementation()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Reader", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Some.Text.ILineInfo.LineNumber",
+            Kind = "property",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "int",
+                MemberName = "Some.Text.ILineInfo.LineNumber",
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "get" }
+                ]
+            }
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal("int Some.Text.ILineInfo.LineNumber { get; }", declaration);
+    }
+
+    [Fact]
+    public void PropertyDeclaration_WithDottedName_RendersGetterAndSetterWithoutModifier()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Reader", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Some.Text.IValue.Payload",
+            Kind = "property",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "string",
+                MemberName = "Some.Text.IValue.Payload",
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "get" },
+                    new ApiAccessor { Kind = "set" }
+                ]
+            }
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal("string Some.Text.IValue.Payload { get; set; }", declaration);
+    }
+
+    [Fact]
+    public void PropertyDeclaration_WithDottedName_EscapesKeywordSegments()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Reader", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "event.class.Value",
+            Kind = "property",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "int",
+                MemberName = "event.class.Value",
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "get" }
+                ]
+            }
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal("int @event.@class.Value { get; }", declaration);
+    }
+
+    [Fact]
     public void IndexerDeclaration_EscapesStructuredKeywordParameterName()
     {
         var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };

--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -552,6 +552,38 @@ public sealed class CSharpDeclarationWriterTests
     }
 
     [Fact]
+    public void IndexerDeclaration_WithDottedName_IsNotTreatedAsExplicitInterfaceProperty()
+    {
+        // Explicit-interface indexers carry SignatureModel.MemberName "this[]" (the interface
+        // prefix is dropped by the reconstruction). Even if a stray dotted member.Name leaks
+        // in, the "this[]" model name must win: render an ordinary indexer, never route it
+        // through the dotted explicit-impl property branch (which would drop the parameters).
+        var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Some.Text.IList.Item",
+            Kind = "property",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "string",
+                MemberName = "this[]",
+                Parameters =
+                [
+                    new ApiParameter { Type = "int", Name = "index" }
+                ],
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "get" }
+                ]
+            }
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal("public string this[int index] { get; }", declaration);
+    }
+
+    [Fact]
     public void ExplicitPropertyDeclaration_KeepsCompatibilitySignature()
     {
         var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };

--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -425,6 +425,7 @@ public sealed class CSharpDeclarationWriterTests
         {
             Name = "Some.Text.ILineInfo.LineNumber",
             Kind = "property",
+            IsExplicitInterfaceImplementation = true,
             SignatureModel = new ApiSignature
             {
                 ReturnType = "int",
@@ -449,6 +450,7 @@ public sealed class CSharpDeclarationWriterTests
         {
             Name = "Some.Text.IValue.Payload",
             Kind = "property",
+            IsExplicitInterfaceImplementation = true,
             SignatureModel = new ApiSignature
             {
                 ReturnType = "string",
@@ -474,6 +476,7 @@ public sealed class CSharpDeclarationWriterTests
         {
             Name = "event.class.Value",
             Kind = "property",
+            IsExplicitInterfaceImplementation = true,
             SignatureModel = new ApiSignature
             {
                 ReturnType = "int",
@@ -554,10 +557,9 @@ public sealed class CSharpDeclarationWriterTests
     [Fact]
     public void IndexerDeclaration_WithDottedName_IsNotTreatedAsExplicitInterfaceProperty()
     {
-        // Explicit-interface indexers carry SignatureModel.MemberName "this[]" (the interface
-        // prefix is dropped by the reconstruction). Even if a stray dotted member.Name leaks
-        // in, the "this[]" model name must win: render an ordinary indexer, never route it
-        // through the dotted explicit-impl property branch (which would drop the parameters).
+        // Classification is by the typed IsExplicitInterfaceImplementation flag, not by a dot
+        // in the name. With the flag unset, a stray dotted member.Name must NOT route through
+        // the explicit-impl branch: render an ordinary indexer with its accessibility intact.
         var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
         var member = new ApiMember
         {
@@ -581,6 +583,96 @@ public sealed class CSharpDeclarationWriterTests
         var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
 
         Assert.Equal("public string this[int index] { get; }", declaration);
+    }
+
+    [Fact]
+    public void PropertyDeclaration_WithDottedName_WithoutFlag_IsNotTreatedAsExplicit()
+    {
+        // A dotted metadata name is not sufficient to classify a member as an explicit
+        // interface implementation (foreign-language/obfuscated names can legally contain
+        // dots). Without the typed flag, the member keeps its accessibility and is never
+        // rendered as an explicit implementation.
+        var type = new ApiType { Namespace = "Samples", Name = "Reader", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Some.Ordinary.Name",
+            Kind = "property",
+            Accessibility = "public",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "int",
+                MemberName = "Some.Ordinary.Name",
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "get" }
+                ]
+            }
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        // The explicit-impl branch does not fire (no flag) and the ordinary-property branch
+        // rejects the dotted name, so no explicit `int Some.Ordinary.Name { get; }` is emitted.
+        Assert.DoesNotContain("Some.Ordinary.Name { get; }", declaration);
+    }
+
+    [Fact]
+    public void PropertyDeclaration_ExplicitStaticAbstract_KeepsStaticModifier()
+    {
+        // C# 11 static abstract interface members implemented explicitly must keep `static`
+        // while still omitting the access modifier.
+        var type = new ApiType { Namespace = "Samples", Name = "Reader", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Some.Text.IValue.Count",
+            Kind = "property",
+            IsExplicitInterfaceImplementation = true,
+            IsStatic = true,
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "int",
+                MemberName = "Some.Text.IValue.Count",
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "get" }
+                ]
+            }
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal("static int Some.Text.IValue.Count { get; }", declaration);
+    }
+
+    [Fact]
+    public void IndexerDeclaration_ExplicitInterface_RendersInterfaceQualifiedThis()
+    {
+        // Explicit interface indexers carry their interface-qualified name on member.Name
+        // (Namespace.IFoo.Item); render `int Namespace.IFoo.this[int index] { get; }`.
+        var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Some.Text.IFoo.Item",
+            Kind = "property",
+            IsExplicitInterfaceImplementation = true,
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "int",
+                MemberName = "this[]",
+                Parameters =
+                [
+                    new ApiParameter { Type = "int", Name = "index" }
+                ],
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "get" }
+                ]
+            }
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal("int Some.Text.IFoo.this[int index] { get; }", declaration);
     }
 
     [Fact]

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -283,31 +283,27 @@ internal static class CSharpDeclarationWriter
     static bool NeedsTerminator(string declaration)
         => !declaration.EndsWith(';') && !declaration.EndsWith('}');
 
-    static bool IsExplicitInterfaceMemberName(string? name)
-        => !string.IsNullOrWhiteSpace(name)
-           && name != "this[]"
-           && name.Contains('.', StringComparison.Ordinal);
-
     static string RenderMemberDeclarationCore(
         ApiType type,
         ApiMember member,
         CSharpDeclarationOptions options,
         IReadOnlyList<string>? methodParameters = null)
     {
-        // A property whose member name is dotted is an explicit interface
-        // implementation (ordinary member names never contain '.'). When only the
-        // structured model is present (no compatibility Signature string), render it as a
-        // real explicit interface implementation: dotted Interface.Member name preserved
-        // and no access modifier, exactly like an explicit-interface-implementation method.
-        // When a compatibility Signature is supplied (the product's --all display surface),
-        // that authoritative display form is honored instead. Only properties are handled
-        // here because that is the shape RTS reconstructs and TryRenderSignatureModel
-        // structurally renders; explicit-interface events have no structural branch, so
-        // suppressing their modifier would drop the member name.
+        // Explicit interface implementations render with the interface-qualified name and no
+        // access modifier. Classification is by typed evidence (member.Kind for the product's
+        // structured extraction, or member.IsExplicitInterfaceImplementation for RTS-composed
+        // members carrying the accessor MethodImpl relationship) — never by inspecting a name
+        // for a dot, which would misclassify foreign-language/obfuscated dotted ordinary names.
+        // The structural property branch only fires when no compatibility Signature string is
+        // present; when a Signature is supplied (the product's --all display surface), that
+        // authoritative display form is honored instead. Only properties are handled
+        // structurally here because that is the shape RTS reconstructs and
+        // TryRenderSignatureModel structurally renders; explicit-interface events have no
+        // structural branch (tracked separately in #2850).
         bool isExplicitInterfaceMember = member.Kind == "explicit-interface-implementation"
             || (member.Kind == "property"
                 && string.IsNullOrEmpty(member.Signature)
-                && IsExplicitInterfaceMemberName(member.SignatureModel?.MemberName ?? member.Name));
+                && member.IsExplicitInterfaceImplementation);
 
         string signature;
         if (member.Kind == "field" && member.Signature == null && !string.IsNullOrWhiteSpace(member.ReturnType))
@@ -412,9 +408,15 @@ internal static class CSharpDeclarationWriter
             if (member.IsUnsafe || options.ForceUnsafe)
                 modifiers.Add("unsafe");
         }
-        else if (member.IsUnsafe || options.ForceUnsafe)
+        else
         {
-            modifiers.Add("unsafe");
+            // Explicit interface implementations omit the access modifier but must still
+            // carry static (C# 11 static abstract interface members implemented explicitly)
+            // and unsafe. Order mirrors the .cctor branch: static then unsafe.
+            if (member.IsStatic)
+                modifiers.Add("static");
+            if (member.IsUnsafe || options.ForceUnsafe)
+                modifiers.Add("unsafe");
         }
 
         if ((options.ForceAsync || member.IsAsync)
@@ -837,13 +839,31 @@ internal static class CSharpDeclarationWriter
         }
         if (member.Kind == "property"
             && string.IsNullOrEmpty(member.Signature)
+            && member.IsExplicitInterfaceImplementation
             && model.ReturnType is { Length: > 0 } explicitPropertyType
-            && model.Accessors.Count > 0
-            && IsExplicitInterfaceMemberName(model.MemberName ?? member.Name))
+            && model.Accessors.Count > 0)
         {
-            var explicitMemberName = string.IsNullOrWhiteSpace(model.MemberName)
-                ? member.Name
-                : model.MemberName!;
+            // Explicit interface indexers carry their interface-qualified name on member.Name
+            // (Namespace.IFoo.Item); render it as `type Namespace.IFoo.this[params]`.
+            // Ordinary explicit properties render `type Namespace.IFoo.Member`, taking the
+            // dotted name from the structured MemberName (falling back to member.Name).
+            bool isExplicitIndexer = model.MemberName == "this[]" || model.Parameters.Count > 0;
+            string explicitMemberName;
+            if (isExplicitIndexer)
+            {
+                var dotted = member.Name ?? "";
+                int lastDot = dotted.LastIndexOf('.');
+                var qualifier = lastDot > 0 ? dotted[..lastDot] : "";
+                explicitMemberName = qualifier.Length > 0
+                    ? $"{qualifier}.this[{parameters}]"
+                    : $"this[{parameters}]";
+            }
+            else
+            {
+                explicitMemberName = string.IsNullOrWhiteSpace(model.MemberName)
+                    ? member.Name
+                    : model.MemberName!;
+            }
             signature = options.OmitPropertyAccessors
                 ? $"{explicitPropertyType} {explicitMemberName}"
                 : $"{explicitPropertyType} {explicitMemberName} {{ {string.Join(" ", model.Accessors.Select(AccessorDeclaration))} }}";
@@ -1261,6 +1281,10 @@ internal static class CSharpDeclarationWriter
                 end++;
 
             string segment = signature[start..end];
+            // `this` in a qualified indexer name (Interface.this[...]) is the C# indexer
+            // keyword, not an identifier — it must never be escaped to @this.
+            if (segment == "this" && end < signature.Length && signature[end] == '[')
+                continue;
             string escaped = EscapeIdentifier(segment);
             if (escaped != segment)
             {

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -294,15 +294,18 @@ internal static class CSharpDeclarationWriter
         CSharpDeclarationOptions options,
         IReadOnlyList<string>? methodParameters = null)
     {
-        // A property/event whose member name is dotted is an explicit interface
+        // A property whose member name is dotted is an explicit interface
         // implementation (ordinary member names never contain '.'). When only the
         // structured model is present (no compatibility Signature string), render it as a
         // real explicit interface implementation: dotted Interface.Member name preserved
         // and no access modifier, exactly like an explicit-interface-implementation method.
         // When a compatibility Signature is supplied (the product's --all display surface),
-        // that authoritative display form is honored instead.
+        // that authoritative display form is honored instead. Only properties are handled
+        // here because that is the shape RTS reconstructs and TryRenderSignatureModel
+        // structurally renders; explicit-interface events have no structural branch, so
+        // suppressing their modifier would drop the member name.
         bool isExplicitInterfaceMember = member.Kind == "explicit-interface-implementation"
-            || (member.Kind is "property" or "event"
+            || (member.Kind == "property"
                 && string.IsNullOrEmpty(member.Signature)
                 && IsExplicitInterfaceMemberName(member.SignatureModel?.MemberName ?? member.Name));
 
@@ -849,7 +852,7 @@ internal static class CSharpDeclarationWriter
         if (member.Kind == "property"
             && model.ReturnType is { Length: > 0 } propertyType
             && model.Accessors.Count > 0
-            && IsOrdinaryPropertyName(member.Name)
+            && (model.MemberName == "this[]" || IsOrdinaryPropertyName(member.Name))
             && IsOrdinaryPropertyName(model.MemberName))
         {
             var head = model.IsRequired ? $"required {propertyType}" : propertyType;

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -283,12 +283,29 @@ internal static class CSharpDeclarationWriter
     static bool NeedsTerminator(string declaration)
         => !declaration.EndsWith(';') && !declaration.EndsWith('}');
 
+    static bool IsExplicitInterfaceMemberName(string? name)
+        => !string.IsNullOrWhiteSpace(name)
+           && name != "this[]"
+           && name.Contains('.', StringComparison.Ordinal);
+
     static string RenderMemberDeclarationCore(
         ApiType type,
         ApiMember member,
         CSharpDeclarationOptions options,
         IReadOnlyList<string>? methodParameters = null)
     {
+        // A property/event whose member name is dotted is an explicit interface
+        // implementation (ordinary member names never contain '.'). When only the
+        // structured model is present (no compatibility Signature string), render it as a
+        // real explicit interface implementation: dotted Interface.Member name preserved
+        // and no access modifier, exactly like an explicit-interface-implementation method.
+        // When a compatibility Signature is supplied (the product's --all display surface),
+        // that authoritative display form is honored instead.
+        bool isExplicitInterfaceMember = member.Kind == "explicit-interface-implementation"
+            || (member.Kind is "property" or "event"
+                && string.IsNullOrEmpty(member.Signature)
+                && IsExplicitInterfaceMemberName(member.SignatureModel?.MemberName ?? member.Name));
+
         string signature;
         if (member.Kind == "field" && member.Signature == null && !string.IsNullOrWhiteSpace(member.ReturnType))
         {
@@ -366,7 +383,7 @@ internal static class CSharpDeclarationWriter
             if (member.IsUnsafe || options.ForceUnsafe)
                 modifiers.Add("unsafe");
         }
-        else if (member.Kind != "explicit-interface-implementation")
+        else if (!isExplicitInterfaceMember)
         {
             var omitInterfaceModifiers = options.OmitInterfaceMemberModifiers
                 && type.Kind == "interface"
@@ -813,6 +830,20 @@ internal static class CSharpDeclarationWriter
             if (memberName.Contains('<', StringComparison.Ordinal) && model.TypeParameters.Count == 0)
                 return false;
             signature = AppendTypeParameterConstraints($"{returnType} {memberName}({parameters})", model.TypeParameters);
+            return true;
+        }
+        if (member.Kind == "property"
+            && string.IsNullOrEmpty(member.Signature)
+            && model.ReturnType is { Length: > 0 } explicitPropertyType
+            && model.Accessors.Count > 0
+            && IsExplicitInterfaceMemberName(model.MemberName ?? member.Name))
+        {
+            var explicitMemberName = string.IsNullOrWhiteSpace(model.MemberName)
+                ? member.Name
+                : model.MemberName!;
+            signature = options.OmitPropertyAccessors
+                ? $"{explicitPropertyType} {explicitMemberName}"
+                : $"{explicitPropertyType} {explicitMemberName} {{ {string.Join(" ", model.Accessors.Select(AccessorDeclaration))} }}";
             return true;
         }
         if (member.Kind == "property"

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -536,6 +536,7 @@ public sealed class CSharpTypePrinter
             IsConst = member.IsConst,
             IsUnsafe = member.IsUnsafe,
             IsAsync = member.IsAsync,
+            IsExplicitInterfaceImplementation = member.IsExplicitInterfaceImplementation,
             Accessibility = member.Accessibility,
             IsExtension = member.IsExtension,
             IsObsolete = member.IsObsolete,

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -285,6 +285,113 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_ExplicitInterfaceProperty_ReconstructsExplicitDeclaration()
+    {
+        // #2827: an explicit interface property implementation, classified from the accessor
+        // MethodImpl evidence of a REAL compiled assembly, must reconstruct as a real explicit
+        // implementation (interface-qualified name, no access modifier), not a mangled `public`
+        // property whose name is dropped or underscored. (Whether the closure-minimized
+        // interface also carries the member so the whole shell recompiles is a separate
+        // interface-projection concern, #2777/#2780.)
+        var assemblyPath = CompileFixture("""
+            namespace Rts;
+
+            public interface ILineInfo
+            {
+                int LineNumber { get; }
+            }
+
+            public sealed class Reader : ILineInfo
+            {
+                int ILineInfo.LineNumber => 5;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Rts.Reader", "Rts.ILineInfo.get_LineNumber", 0)],
+                applyCompileBackFloor: false));
+
+            Assert.Contains("int Rts.ILineInfo.LineNumber", result.Source);
+            Assert.DoesNotContain("public int Rts.ILineInfo.LineNumber", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_ExplicitStaticInterfaceProperty_KeepsStaticModifier()
+    {
+        // #2827 (concurrent-review finding): a static abstract interface member implemented
+        // explicitly must keep `static` while omitting the access modifier. Reconstructing it
+        // without `static` produces CS0106/CS0539.
+        var assemblyPath = CompileFixture("""
+            namespace Rts;
+
+            public interface ICounter
+            {
+                static abstract int Count { get; }
+            }
+
+            public sealed class Counter : ICounter
+            {
+                static int ICounter.Count => 7;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Rts.Counter", "Rts.ICounter.get_Count", 0)],
+                applyCompileBackFloor: false));
+
+            Assert.Contains("static int Rts.ICounter.Count", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_ExplicitInterfaceIndexer_ReconstructsQualifiedThis()
+    {
+        // #2827: an explicit interface indexer must reconstruct as
+        // `int Interface.this[params]`, preserving the interface qualifier, not a mangled
+        // public indexer or a dropped-parameter property.
+        var assemblyPath = CompileFixture("""
+            namespace Rts;
+
+            public interface IIndexed
+            {
+                int this[int index] { get; }
+            }
+
+            public sealed class Indexed : IIndexed
+            {
+                int IIndexed.this[int index] => index;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Rts.Indexed", "Rts.IIndexed.get_Item", 0)],
+                applyCompileBackFloor: false));
+
+            Assert.Contains("int Rts.IIndexed.this[int index]", result.Source);
+            Assert.DoesNotContain("public int Rts.IIndexed.this[", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_UsesDependencyReferencesAndNamespaces()
     {
         var directory = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -386,6 +386,14 @@ public class ApiMember
     public bool IsAsync { get; set; }
 
     /// <summary>
+    /// True when this member is an explicit interface implementation, derived from the
+    /// accessor MethodImpl relationship (typed evidence) rather than inferred from a dotted
+    /// display name. Explicit implementations render with the interface-qualified name and
+    /// no access modifier.
+    /// </summary>
+    public bool IsExplicitInterfaceImplementation { get; set; }
+
+    /// <summary>
     /// Access level for non-public members (e.g., "private", "protected", "internal").
     /// Null for public members.
     /// </summary>

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -254,6 +254,9 @@ public static class ApiSurfaceExtractor
                 var isObsolete = AttributeReader.TryGetObsoleteAttribute(reader, prop.GetCustomAttributes(), out var obsoleteMessage);
 
                 var propertySignature = GetPropertySignature(reader, typeDef, prop, accessors, typeNullableContext, includeAll);
+                bool isExplicitInterfaceProperty =
+                    (!accessors.Getter.IsNil && explicitImplementationBodies.Contains(accessors.Getter))
+                    || (!accessors.Setter.IsNil && explicitImplementationBodies.Contains(accessors.Setter));
                 var member = new ApiMember
                 {
                     Name = reader.GetString(prop.Name),
@@ -269,6 +272,7 @@ public static class ApiSurfaceExtractor
                     IsOverride = isOverrideProperty,
                     IsSealed = isSealedProperty,
                     IsUnsafe = HasUnsafeSignature(propertySignature.Text),
+                    IsExplicitInterfaceImplementation = isExplicitInterfaceProperty,
                     Accessibility = GetAccessibility(bestAccess),
                     IsObsolete = isObsolete,
                     ObsoleteMessage = obsoleteMessage,

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -713,7 +713,7 @@ public static class CompileBackSourceComposer
         var propertyDeclaration = MetadataDeclarationQuery.GetProperty(reader, targetTypeDef, property);
         var accessors = property.GetAccessors();
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
-        string propertyName = PropertyMemberName(reader.GetString(property.Name));
+        string propertyName = PropertyMemberName(reader.GetString(property.Name), signature.ParameterTypes.Length > 0);
         var returnType = CompileBackTypeSignature.Display(signature.ReturnType);
         bool targetIsAutoProperty = IsAutoProperty(reader, targetTypeDef, property, targetGetter, returnType.DisplayName);
 
@@ -891,7 +891,7 @@ public static class CompileBackSourceComposer
         var propertySignature = GuardedSignatureText.PropertyText(reader, property, GenericContext.ForType(reader, targetTypeDef));
         var propertyDeclaration = MetadataDeclarationQuery.GetProperty(reader, targetTypeDef, property);
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
-        string propertyName = PropertyMemberName(reader.GetString(property.Name));
+        string propertyName = PropertyMemberName(reader.GetString(property.Name), propertySignature.ParameterTypes.Length > 0);
         var returnType = CompileBackTypeSignature.Display(propertySignature.ReturnType);
         bool targetIsAutoProperty = IsAutoPropertySetter(reader, targetTypeDef, property, targetSetter, returnType.DisplayName);
 
@@ -2325,9 +2325,13 @@ public static class CompileBackSourceComposer
     // (Namespace.Interface.Member); ordinary members never contain '.'. Preserve the
     // dotted name so the seam can render it as a real explicit interface implementation
     // instead of sanitizing the dots into a bogus underscore identifier (which would not
-    // satisfy the declared interface -> CS0535).
-    static string PropertyMemberName(string rawName)
-        => rawName.Contains('.', StringComparison.Ordinal) ? rawName : Identifier(rawName);
+    // satisfy the declared interface -> CS0535). Indexers are excluded: ToApiMember maps
+    // an indexer's member name to "this[]" (dropping the interface prefix), so preserving
+    // the dotted name would only desync member.Name from SignatureModel.MemberName and
+    // produce a malformed declaration. Explicit-interface indexers stay sanitized as
+    // before (still unsupported, but no regression).
+    static string PropertyMemberName(string rawName, bool isIndexer)
+        => !isIndexer && rawName.Contains('.', StringComparison.Ordinal) ? rawName : Identifier(rawName);
 
     sealed class TypeProducer
     {

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -319,7 +319,8 @@ public sealed record CompileBackMemberRequirement(
     bool IsAsync = false,
     bool IsExtension = false,
     CompileBackAccessibility Accessibility = CompileBackAccessibility.Public,
-    string? ConstructorInitializer = null)
+    string? ConstructorInitializer = null,
+    bool IsExplicitInterface = false)
 {
     public string Name => Identity.Method;
     public string Type => ReturnType?.DisplayName ?? "";
@@ -713,7 +714,8 @@ public static class CompileBackSourceComposer
         var propertyDeclaration = MetadataDeclarationQuery.GetProperty(reader, targetTypeDef, property);
         var accessors = property.GetAccessors();
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
-        string propertyName = PropertyMemberName(reader.GetString(property.Name), signature.ParameterTypes.Length > 0);
+        bool isExplicitInterfaceProperty = ExplicitInterfaceAccessorBodies(reader, targetTypeDef).Contains(targetGetter);
+        string propertyName = PropertyMemberName(reader.GetString(property.Name), isExplicitInterfaceProperty);
         var returnType = CompileBackTypeSignature.Display(signature.ReturnType);
         bool targetIsAutoProperty = IsAutoProperty(reader, targetTypeDef, property, targetGetter, returnType.DisplayName);
 
@@ -748,7 +750,8 @@ public static class CompileBackSourceComposer
                     ]
                     : [new CompileBackFact("metadata", "target-property-getter", reader.GetString(reader.GetMethodDefinition(targetGetter).Name))],
                 propertyDeclaration.Attributes,
-                MetadataDeclarationQuery.GetMethod(reader, targetTypeDef, getter, getterSignature).Signature.ReturnAttributes)
+                MetadataDeclarationQuery.GetMethod(reader, targetTypeDef, getter, getterSignature).Signature.ReturnAttributes,
+                IsExplicitInterface: isExplicitInterfaceProperty)
         };
         AddRequiredMembers(targetMembers, closureMemberRequirements, targetType);
 
@@ -891,7 +894,8 @@ public static class CompileBackSourceComposer
         var propertySignature = GuardedSignatureText.PropertyText(reader, property, GenericContext.ForType(reader, targetTypeDef));
         var propertyDeclaration = MetadataDeclarationQuery.GetProperty(reader, targetTypeDef, property);
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
-        string propertyName = PropertyMemberName(reader.GetString(property.Name), propertySignature.ParameterTypes.Length > 0);
+        bool isExplicitInterfaceProperty = ExplicitInterfaceAccessorBodies(reader, targetTypeDef).Contains(targetSetter);
+        string propertyName = PropertyMemberName(reader.GetString(property.Name), isExplicitInterfaceProperty);
         var returnType = CompileBackTypeSignature.Display(propertySignature.ReturnType);
         bool targetIsAutoProperty = IsAutoPropertySetter(reader, targetTypeDef, property, targetSetter, returnType.DisplayName);
 
@@ -925,7 +929,8 @@ public static class CompileBackSourceComposer
                         new CompileBackFact("metadata", "target-property-setter", reader.GetString(setter.Name)),
                         new CompileBackFact("metadata", "auto-property", propertyName)
                     ]
-                    : [new CompileBackFact("metadata", "target-property-setter", reader.GetString(setter.Name))])
+                    : [new CompileBackFact("metadata", "target-property-setter", reader.GetString(setter.Name))],
+                IsExplicitInterface: isExplicitInterfaceProperty)
         };
         AddRequiredMembers(targetMembers, closureMemberRequirements, targetType);
 
@@ -1211,6 +1216,7 @@ public static class CompileBackSourceComposer
             IsExtension = member.IsExtension,
             IsConst = member.Kind == CompileBackMemberKind.Field
                 && member.StubBody == CompileBackStubBodyKind.TargetBody,
+            IsExplicitInterfaceImplementation = member.IsExplicitInterface,
         };
         if (member.Kind != CompileBackMemberKind.Field)
         {
@@ -2322,16 +2328,29 @@ public static class CompileBackSourceComposer
     static string Identifier(string name) => CSharpIdentifier.Sanitize(name);
 
     // Explicit interface implementations carry a dotted metadata name
-    // (Namespace.Interface.Member); ordinary members never contain '.'. Preserve the
-    // dotted name so the seam can render it as a real explicit interface implementation
-    // instead of sanitizing the dots into a bogus underscore identifier (which would not
-    // satisfy the declared interface -> CS0535). Indexers are excluded: ToApiMember maps
-    // an indexer's member name to "this[]" (dropping the interface prefix), so preserving
-    // the dotted name would only desync member.Name from SignatureModel.MemberName and
-    // produce a malformed declaration. Explicit-interface indexers stay sanitized as
-    // before (still unsupported, but no regression).
-    static string PropertyMemberName(string rawName, bool isIndexer)
-        => !isIndexer && rawName.Contains('.', StringComparison.Ordinal) ? rawName : Identifier(rawName);
+    // (Namespace.Interface.Member); ordinary members never contain '.'. When the accessor is
+    // a typed explicit interface implementation (MethodImpl evidence), preserve the dotted
+    // name so the seam can render a real explicit interface implementation
+    // (Interface.Member, or Interface.this[...] for indexers). Otherwise sanitize as usual.
+    // Classification is by MethodImpl evidence, not by inspecting the name for a dot.
+    static string PropertyMemberName(string rawName, bool isExplicitInterface)
+        => isExplicitInterface ? rawName : Identifier(rawName);
+
+    // Accessor method handles that are the body of an explicit interface implementation
+    // (i.e. targets of a MethodImpl on the declaring type).
+    static HashSet<MethodDefinitionHandle> ExplicitInterfaceAccessorBodies(
+        MetadataReader reader, TypeDefinition typeDef)
+    {
+        HashSet<MethodDefinitionHandle> handles = [];
+        foreach (var implementationHandle in typeDef.GetMethodImplementations())
+        {
+            var implementation = reader.GetMethodImplementation(implementationHandle);
+            if (implementation.MethodBody.Kind == HandleKind.MethodDefinition)
+                handles.Add((MethodDefinitionHandle)implementation.MethodBody);
+        }
+
+        return handles;
+    }
 
     sealed class TypeProducer
     {

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -713,7 +713,7 @@ public static class CompileBackSourceComposer
         var propertyDeclaration = MetadataDeclarationQuery.GetProperty(reader, targetTypeDef, property);
         var accessors = property.GetAccessors();
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
-        string propertyName = Identifier(reader.GetString(property.Name));
+        string propertyName = PropertyMemberName(reader.GetString(property.Name));
         var returnType = CompileBackTypeSignature.Display(signature.ReturnType);
         bool targetIsAutoProperty = IsAutoProperty(reader, targetTypeDef, property, targetGetter, returnType.DisplayName);
 
@@ -891,7 +891,7 @@ public static class CompileBackSourceComposer
         var propertySignature = GuardedSignatureText.PropertyText(reader, property, GenericContext.ForType(reader, targetTypeDef));
         var propertyDeclaration = MetadataDeclarationQuery.GetProperty(reader, targetTypeDef, property);
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
-        string propertyName = Identifier(reader.GetString(property.Name));
+        string propertyName = PropertyMemberName(reader.GetString(property.Name));
         var returnType = CompileBackTypeSignature.Display(propertySignature.ReturnType);
         bool targetIsAutoProperty = IsAutoPropertySetter(reader, targetTypeDef, property, targetSetter, returnType.DisplayName);
 
@@ -2320,6 +2320,14 @@ public static class CompileBackSourceComposer
     static string StripArity(string name) => CSharpFormatter.StripArity(name);
 
     static string Identifier(string name) => CSharpIdentifier.Sanitize(name);
+
+    // Explicit interface implementations carry a dotted metadata name
+    // (Namespace.Interface.Member); ordinary members never contain '.'. Preserve the
+    // dotted name so the seam can render it as a real explicit interface implementation
+    // instead of sanitizing the dots into a bogus underscore identifier (which would not
+    // satisfy the declared interface -> CS0535).
+    static string PropertyMemberName(string rawName)
+        => rawName.Contains('.', StringComparison.Ordinal) ? rawName : Identifier(rawName);
 
     sealed class TypeProducer
     {


### PR DESCRIPTION
## Summary

Explicit-interface-implementation **properties** now recompile as real explicit
impls in the RTS (compile-back) path, fixing CS0535 reconstruction failures.

RTS reconstructs an explicit-impl property closure-minimized to just the probed
member, then sanitized its dotted metadata name (`Interface.Member`) into a bogus
underscore identifier and emitted a plain `public` property. That property does
not satisfy the declared interface, so the target getter was absent from the
recompiled output (the harness reported this as a `ContextFail`
"method-not-found", or CS0535 `RecompileFail` depending on the closure shape).

The fix is split along the product/harness seam (per the north-star: the harness
gets dumber, the product seam owns C#):

- **Harness (`ReturnToSenderTypePlanner`)** stops sanitizing dotted property
  names. A dotted name is an explicit-interface-implementation signal and is
  passed through unchanged.
- **Type seam (`ILInspector.CSharp`)** recognizes a dotted-name property/event
  that carries only a structured model (no compatibility `Signature` string) as a
  real explicit interface implementation: dotted `Interface.Member` name
  preserved, no access modifier — exactly like the seam already does for
  explicit-impl *methods*. When a compatibility `Signature` **is** present (the
  product's `--all` API-surface display), that authoritative display form is
  honored, so API-surface display is unchanged.

Fixes #2827.

## Evidence

Newtonsoft.Json 13.0.4 `--return-to-sender`, per-member diff of the rebased base
(`origin/main`) vs this head, all 581 property getters:

| Status | Base | Head |
| --- | --- | --- |
| Exact | 535 | **539** |
| OpcodeDiff | 16 | 16 |
| RecompileFail | 15 | 26 |
| ContextFail | 15 | **0** |

- **0 regressions**: no member that was `Exact` at base is worse at head.
- **+4 Exact**, all explicit-impl property getters:
  `JsonValidatingReader`/`TraceJsonReader` `IJsonLineInfo.get_LineNumber` and
  `get_LinePosition`.
- **15 ContextFail -> RecompileFail** shifts are all dotted-name explicit-impl
  property getters (`System.Collections.IList.*`, `System.ComponentModel.IBindingList.*`,
  `IJsonLineInfo.*` on `JContainer`/`JToken`). These now render as real explicit
  impls and form a compilation context; they still fail recompile because their
  reconstructed closures are missing **other** sibling interface members — a
  separate closure-membership defect, out of scope here. Previously they died
  earlier as `ContextFail` (mangled target name absent from output).

## Tests

- New explicit-impl **property** coverage in `CSharpDeclarationWriterTests`
  (getter, getter+setter, keyword-segment escaping) — this shape had zero
  coverage before, which is why the bug went unnoticed. `ILInspector.CSharp.Tests`
  256/256 pass; the two pre-existing compat-display tests
  (`ExplicitPropertyDeclaration_KeepsCompatibilitySignature`,
  `ExplicitEventDeclaration_KeepsCompatibilitySignature`) stay green via the
  `Signature`-present gate.
- Consumer suites: `dotnet-inspect.Tests` 1925/0, `ILInspector.Decompiler.Tests`
  2663/0 — no product API-surface display or decompiler-output changes.
- #2776 RTS parity gate: exit 0, burn-down unchanged (7 rows).

## Scope

Explicit-interface-implementation **properties** only. The remaining Newtonsoft
CS0535 cases (e.g. `XDocumentWrapper::get_ChildNodes`) are an implicit-impl
closure-membership defect (a dropped sibling interface member), unrelated to name
mangling, and are left for separate work.

## Adversarial review

Requesting two reviews (GPT-5.5 + Gemini 3.1 Pro; different family than the
Claude author) in isolated worktrees.
