### PR TITLE
Measure the decompiler fidelity residual portfolio

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Text.Json;
 
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
@@ -49,6 +50,146 @@ public class CorpusSensorComparisonTests
                 CorpusProfile.RealWorld,
                 qualityDiffCard: true,
                 qualityCardRisky: false));
+    }
+
+    [Fact]
+    public void FidelityResidualPolicy_UsesExactProducerFacets()
+    {
+        Assert.Equal(
+            FidelityResidualDisposition.RecoverableRoadmap,
+            FidelityResidualPolicy.Classify(new CorpusFidelityCauseSnapshot(
+                DiagnosticIds.UnrepresentableMetadataName,
+                DecompilerFidelityDiscriminators.DisplayClassTypeName)).Disposition);
+        Assert.Equal(
+            FidelityResidualDisposition.PolicyFloor,
+            FidelityResidualPolicy.Classify(new CorpusFidelityCauseSnapshot(
+                DiagnosticIds.UnrepresentableMetadataName,
+                DecompilerFidelityDiscriminators.UnspellableTypeName)).Disposition);
+        Assert.Equal(
+            FidelityResidualDisposition.Unclassified,
+            FidelityResidualPolicy.Classify(new CorpusFidelityCauseSnapshot(
+                DiagnosticIds.UnrepresentableMetadataName,
+                "new-name-shape")).Disposition);
+        Assert.Equal(
+            FidelityResidualDisposition.RecoverableRoadmap,
+            FidelityResidualPolicy.Classify(new CorpusFidelityCauseSnapshot(
+                DiagnosticIds.UnsupportedConstruct,
+                "iterator")).Disposition);
+        Assert.Equal(
+            FidelityResidualDisposition.Unclassified,
+            FidelityResidualPolicy.Classify(new CorpusFidelityCauseSnapshot(
+                DiagnosticIds.UnsupportedConstruct,
+                "calli")).Disposition);
+        Assert.Equal(
+            FidelityResidualDisposition.Unclassified,
+            FidelityResidualPolicy.Classify(new CorpusFidelityCauseSnapshot(
+                DiagnosticIds.UnsupportedExceptionFilter,
+                null)).Disposition);
+    }
+
+    [Fact]
+    public void FidelityResidualPortfolio_SeparatesSitesMethodsAndStructuralPrimary()
+    {
+        var displayClass = new CorpusFidelityCauseSnapshot(
+            DiagnosticIds.UnrepresentableMetadataName,
+            DecompilerFidelityDiscriminators.DisplayClassTypeName,
+            Sites: 2);
+        var unspellable = new CorpusFidelityCauseSnapshot(
+            DiagnosticIds.UnrepresentableMetadataName,
+            DecompilerFidelityDiscriminators.UnspellableTypeName);
+        var unknownType = new CorpusFidelityCauseSnapshot(
+            DiagnosticIds.UnknownResultType,
+            null);
+        var unsupportedFunctionPointer = new CorpusFidelityCauseSnapshot(
+            DiagnosticIds.UnsupportedFunctionPointer,
+            null);
+
+        CorpusMethodSnapshot[] methods =
+        [
+            SnapshotMethod("Full"),
+            ResidualMethod(
+                "Recoverable",
+                "fidelity: DEC0009",
+                displayClass,
+                unknownType),
+            ResidualMethod("Floor", "fidelity: DEC0009", displayClass, unspellable),
+            ResidualMethod("Unknown", "fidelity: DEC0006", unsupportedFunctionPointer),
+            ResidualMethod("Missing", "fidelity: DEC0009"),
+            ResidualMethod("Structural", "structuring: conditional-branch", displayClass),
+            ResidualMethod("EhStructural", "eh: leave/endfinally", displayClass),
+        ];
+
+        var portfolio = FidelityResidualPortfolioBuilder.Build(
+            methods,
+            totalMethods: methods.Length,
+            fullyRaisedMethods: 1);
+
+        Assert.Equal(4, portfolio.FidelityPrimaryMethods);
+        Assert.Equal(7, portfolio.FidelityCauseSites);
+        Assert.Equal(1, portfolio.RecoverableMethods);
+        Assert.Equal(1, portfolio.PolicyFloorMethods);
+        Assert.Equal(2, portfolio.UnclassifiedMethods);
+        Assert.Equal(1, portfolio.MissingCauseMethods);
+        Assert.Equal(2, portfolio.StructuralPrimaryMethodsWithFidelityCauses);
+        Assert.Equal(4, portfolio.StructuralPrimaryFidelityCauseSites);
+        Assert.Equal(2, portfolio.RoadmapTargetLowerMethods);
+        Assert.Equal(4, portfolio.RoadmapTargetUpperMethods);
+
+        var facet = Assert.Single(
+            portfolio.Facets,
+            summary => summary.Discriminator
+                == DecompilerFidelityDiscriminators.DisplayClassTypeName);
+        Assert.Equal(4, facet.CauseSites);
+        Assert.Equal(2, facet.Methods);
+        Assert.Equal(
+            ["nuget:pinned/lib.dll!T::Floor()", "nuget:pinned/lib.dll!T::Recoverable()"],
+            facet.Examples);
+    }
+
+    [Fact]
+    public void CorpusMethodSnapshot_PreV4JsonLeavesFidelityCausesAbsent()
+    {
+        const string json =
+            """
+            {
+              "assembly": "Pinned",
+              "assemblyPath": "pinned.dll",
+              "type": "T",
+              "method": "M",
+              "overload": 0,
+              "signature": "()",
+              "fidelity": "Partial",
+              "fullyRaised": false,
+              "residual": "fidelity: DEC0009",
+              "passBug": null,
+              "validity": "not-sampled",
+              "fidelityCheck": "not-sampled"
+            }
+            """;
+
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+        var method = JsonSerializer.Deserialize<CorpusMethodSnapshot>(json, options);
+
+        Assert.NotNull(method);
+        Assert.Null(method.FidelityCauses);
+        Assert.DoesNotContain(
+            "stableKey",
+            JsonSerializer.Serialize(method, options),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CorpusFidelityCauseSnapshot_RejectsInvalidSiteMultiplicity()
+    {
+        var cause = new CorpusFidelityCauseSnapshot(
+            DiagnosticIds.UnrepresentableMetadataName,
+            DecompilerFidelityDiscriminators.DisplayClassTypeName,
+            Sites: 0);
+
+        Assert.Throws<InvalidDataException>(() => cause.SiteCount);
     }
 
     [Fact]
@@ -1108,6 +1249,25 @@ public class CorpusSensorComparisonTests
             Validity: validity,
             FidelityCheck: fidelityCheck,
             FidelityReference: fidelityReference);
+
+    static CorpusMethodSnapshot ResidualMethod(
+        string method,
+        string residual,
+        params CorpusFidelityCauseSnapshot[] causes)
+        => new(
+            Assembly: "Pinned",
+            AssemblyPath: "nuget:pinned/lib.dll",
+            Type: "T",
+            Method: method,
+            Overload: 0,
+            Signature: "()",
+            Fidelity: "Partial",
+            FullyRaised: false,
+            Residual: residual,
+            PassBug: null,
+            Validity: "not-sampled",
+            FidelityCheck: "not-sampled",
+            FidelityCauses: causes.Length == 0 ? null : causes);
 
     static CorpusMethodSnapshot RtsMethod(
         string method,

--- a/src/ILInspector.Decompiler.Tests/DecompilerFindingsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DecompilerFindingsTests.cs
@@ -11,6 +11,24 @@ public class DecompilerFindingsTests
     static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
 
     [Fact]
+    public void CauseConstructors_PreserveSixParameterBinarySignature()
+    {
+        Type[] legacyParameterTypes =
+        [
+            typeof(string),
+            typeof(DecompilerFidelityLocation),
+            typeof(string),
+            typeof(string),
+            typeof(string),
+            typeof(string),
+        ];
+        Type[] inventoryParameterTypes = [.. legacyParameterTypes, typeof(string)];
+
+        Assert.NotNull(typeof(DecompilerFidelityCause).GetConstructor(legacyParameterTypes));
+        Assert.NotNull(typeof(DecompilerFidelityCause).GetConstructor(inventoryParameterTypes));
+    }
+
+    [Fact]
     public void Inspect_FullFunction_IsCompleteEmptyCensus()
     {
         var inspection = CompleteInspection(

--- a/src/ILInspector.Decompiler.Tests/DecompilerFindingsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DecompilerFindingsTests.cs
@@ -119,6 +119,7 @@ public class DecompilerFindingsTests
         Assert.Equal(
             DecompilerFidelityDiscriminators.UnsupportedTypeShape,
             cause.Discriminator);
+        Assert.Equal("custom modifier; function pointer", cause.InventoryBucket);
         Assert.Contains("function pointer", cause.Reason);
         Assert.Contains("custom modifier", cause.Reason);
         Assert.Equal(DecompilerFidelityLocationKind.Signature, cause.Location.Kind);
@@ -294,6 +295,33 @@ public class DecompilerFindingsTests
 
         var comparison = CompleteComparison(
             DecompilerFindings.CompareFidelityCauses(oldFunction, newFunction, Subject));
+
+        Assert.True(comparison.IsExact);
+        Assert.All(comparison.Pairs, pair => Assert.Equal(PairKind.Present, pair.Kind));
+    }
+
+    [Fact]
+    public void Compare_InventoryBucketOnlyChange_IsExact()
+    {
+        static IrFunction FunctionWithUnsupportedParameter(string reason)
+        {
+            var container = new BlockContainer();
+            var block = new Block(0);
+            container.Add(block);
+            block.Add(new Return(new Constant(0, Int32)));
+            var signature = new MethodSignature(
+                Int32,
+                [new Parameter("value", TypeRef.Unsupported(reason))],
+                HasThis: false,
+                GenericParameterCount: 0);
+            return new IrFunction("M", Object, signature, [], container);
+        }
+
+        var comparison = CompleteComparison(
+            DecompilerFindings.CompareFidelityCauses(
+                FunctionWithUnsupportedParameter("function pointer"),
+                FunctionWithUnsupportedParameter("custom modifier"),
+                Subject));
 
         Assert.True(comparison.IsExact);
         Assert.All(comparison.Pairs, pair => Assert.Equal(PairKind.Present, pair.Kind));

--- a/src/ILInspector.Decompiler.Tests/DecompilerFindingsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DecompilerFindingsTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Findings;
 
@@ -115,9 +116,138 @@ public class DecompilerFindingsTests
                 .Findings).Payload;
 
         Assert.Equal(DiagnosticIds.UnsupportedType, cause.Code);
-        Assert.Contains("function pointer", cause.Discriminator);
-        Assert.Contains("custom modifier", cause.Discriminator);
+        Assert.Equal(
+            DecompilerFidelityDiscriminators.UnsupportedTypeShape,
+            cause.Discriminator);
+        Assert.Contains("function pointer", cause.Reason);
+        Assert.Contains("custom modifier", cause.Reason);
         Assert.Equal(DecompilerFidelityLocationKind.Signature, cause.Location.Kind);
+    }
+
+    [Fact]
+    public void Inspect_GeneratedTypeName_HasStructuredDiscriminator()
+    {
+        var closure = TypeRef.Definition(
+            "Synthetic",
+            "Samples",
+            "<>c__DisplayClass0_0");
+        var function = Function(
+            new StoreLocal(0, closure, new Constant(null, closure)),
+            locals: [closure]);
+
+        var causes =
+            CompleteInspection(DecompilerFindings.InspectFidelityCauses(function, Subject))
+                .Findings
+                .Select(finding => finding.Payload)
+                .ToArray();
+
+        Assert.NotEmpty(causes);
+        Assert.All(causes, cause =>
+        {
+            Assert.Equal(DiagnosticIds.UnrepresentableMetadataName, cause.Code);
+            Assert.Equal(
+                DecompilerFidelityDiscriminators.DisplayClassTypeName,
+                cause.Discriminator);
+        });
+    }
+
+    [Fact]
+    public void Inspect_UnspellableTypeName_IsNotClassifiedAsGenerated()
+    {
+        var invalid = TypeRef.Definition("Synthetic", "Samples", "bad-name");
+        var function = Function(
+            new StoreLocal(0, invalid, new Constant(null, invalid)),
+            locals: [invalid]);
+
+        var causes =
+            CompleteInspection(DecompilerFindings.InspectFidelityCauses(function, Subject))
+                .Findings
+                .Select(finding => finding.Payload)
+                .ToArray();
+
+        Assert.NotEmpty(causes);
+        Assert.All(causes, cause =>
+        {
+            Assert.Equal(DiagnosticIds.UnrepresentableMetadataName, cause.Code);
+            Assert.Equal(
+                DecompilerFidelityDiscriminators.UnspellableTypeName,
+                cause.Discriminator);
+        });
+    }
+
+    [Fact]
+    public void Inspect_GenericParameterName_DistinguishesGeneratedShape()
+    {
+        var generated = TypeRef.GenericParameter(0, "<Value>j__TPar");
+        var invalid = TypeRef.GenericParameter(1, "bad-name");
+        var generatedCause = Assert.Single(CompleteInspection(
+                DecompilerFindings.InspectFidelityCauses(
+                    Function(new Return(new Constant(null, generated))),
+                    Subject))
+            .Findings).Payload;
+        var invalidCause = Assert.Single(CompleteInspection(
+                DecompilerFindings.InspectFidelityCauses(
+                    Function(new Return(new Constant(null, invalid))),
+                    Subject))
+            .Findings).Payload;
+
+        Assert.Equal(
+            DecompilerFidelityDiscriminators.GeneratedGenericParameterName,
+            generatedCause.Discriminator);
+        Assert.Equal(
+            DecompilerFidelityDiscriminators.UnspellableGenericParameterName,
+            invalidCause.Discriminator);
+    }
+
+    [Fact]
+    public void Inspect_FieldName_DistinguishesEscapableKeyword()
+    {
+        var holder = TypeRef.Definition("Synthetic", "Samples", "Holder");
+        var keyword = new FieldRef(holder, "else", Int32);
+        var invalid = new FieldRef(holder, "bad-name", Int32);
+
+        var keywordCause = Assert.Single(CompleteInspection(
+                DecompilerFindings.InspectFidelityCauses(
+                    Function(new Return(new LoadField(keyword, instance: null))),
+                    Subject))
+            .Findings).Payload;
+        var invalidCause = Assert.Single(CompleteInspection(
+                DecompilerFindings.InspectFidelityCauses(
+                    Function(new Return(new LoadField(invalid, instance: null))),
+                    Subject))
+            .Findings).Payload;
+
+        Assert.Equal(
+            DecompilerFidelityDiscriminators.EscapableFieldName,
+            keywordCause.Discriminator);
+        Assert.Equal(
+            DecompilerFidelityDiscriminators.UnspellableFieldName,
+            invalidCause.Discriminator);
+    }
+
+    [Fact]
+    public void Inspect_UnverifiedAccessor_HasStructuredDiscriminator()
+    {
+        var holder = TypeRef.Definition("Synthetic", "Samples", "Holder");
+        var accessor = new MethodRef(holder, "get_Value", Int32, [], HasThis: true)
+        {
+            IsSpecialName = true,
+            AccessorKind = AccessorKind.Unknown,
+        };
+        var function = Function(
+            new Return(new Call(
+                accessor,
+                isVirtual: true,
+                [new LoadArgument(0, "self", holder)])));
+
+        var cause = Assert.Single(
+            CompleteInspection(DecompilerFindings.InspectFidelityCauses(function, Subject))
+                .Findings).Payload;
+
+        Assert.Equal(DiagnosticIds.UnrepresentableMetadataName, cause.Code);
+        Assert.Equal(
+            DecompilerFidelityDiscriminators.AccessorMetadataUnavailable,
+            cause.Discriminator);
     }
 
     [Fact]
@@ -231,10 +361,16 @@ public class DecompilerFindingsTests
         Assert.Contains(DiagnosticIds.InternalError, comparison.Failure);
     }
 
-    static IrFunction Function(IrNode statement, int blockOffset = 0)
-        => Function([statement], blockOffset);
+    static IrFunction Function(
+        IrNode statement,
+        int blockOffset = 0,
+        ImmutableArray<TypeRef> locals = default)
+        => Function([statement], blockOffset, locals);
 
-    static IrFunction Function(IReadOnlyList<IrNode> statements, int blockOffset = 0)
+    static IrFunction Function(
+        IReadOnlyList<IrNode> statements,
+        int blockOffset = 0,
+        ImmutableArray<TypeRef> locals = default)
     {
         var container = new BlockContainer();
         var block = new Block(blockOffset);
@@ -247,7 +383,12 @@ public class DecompilerFindingsTests
             [],
             HasThis: false,
             GenericParameterCount: 0);
-        return new IrFunction("M", Object, signature, [], container);
+        return new IrFunction(
+            "M",
+            Object,
+            signature,
+            locals.IsDefault ? [] : locals,
+            container);
     }
 
     static FindingInspection<DecompilerFidelityCause>.Complete CompleteInspection(

--- a/src/ILInspector.Decompiler.Tests/FidelityCauseBucketsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCauseBucketsTests.cs
@@ -30,7 +30,7 @@ public class FidelityCauseBucketsTests
     }
 
     [Fact]
-    public void BucketFor_PrivateImplementationFacet_PreservesLegacyInventoryLabel()
+    public void BucketFor_UsesProducerOwnedInventoryLabel()
     {
         var cause = new DecompilerFidelityCause(
             DiagnosticIds.UnsupportedType,
@@ -38,10 +38,12 @@ public class FidelityCauseBucketsTests
             "IrFunction",
             "Function M",
             "references an unrepresentable type",
-            DecompilerFidelityDiscriminators.PrivateImplementationDetailsType);
+            $"{DecompilerFidelityDiscriminators.PrivateImplementationDetailsType}; "
+                + DecompilerFidelityDiscriminators.UnsupportedTypeShape,
+            "custom modifier; unspellable C# type name '__PrivateImplementationDetails_'");
 
         Assert.Equal(
-            "unspellable C# type name '__PrivateImplementationDetails_'",
+            "custom modifier; unspellable C# type name '__PrivateImplementationDetails_'",
             FidelityCauseBuckets.BucketFor(cause));
     }
 

--- a/src/ILInspector.Decompiler.Tests/FidelityCauseBucketsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCauseBucketsTests.cs
@@ -68,6 +68,15 @@ public class FidelityCauseBucketsTests
         Assert.Throws<InvalidOperationException>(() => FidelityCauseBuckets.PrimaryBucket(census));
     }
 
+    [Fact]
+    public void PrimaryBucket_RejectsEmptyCompleteInspection()
+    {
+        var census = FidelityCauseBuckets.FromInspection(
+            new FindingInspection<DecompilerFidelityCause>.Complete([]));
+
+        Assert.Throws<InvalidOperationException>(() => FidelityCauseBuckets.PrimaryBucket(census));
+    }
+
     static IrFunction Function(IrNode statement)
     {
         var container = new BlockContainer();

--- a/src/ILInspector.Decompiler.Tests/FidelityCauseBucketsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCauseBucketsTests.cs
@@ -30,6 +30,22 @@ public class FidelityCauseBucketsTests
     }
 
     [Fact]
+    public void BucketFor_PrivateImplementationFacet_PreservesLegacyInventoryLabel()
+    {
+        var cause = new DecompilerFidelityCause(
+            DiagnosticIds.UnsupportedType,
+            DecompilerFidelityLocation.Signature,
+            "IrFunction",
+            "Function M",
+            "references an unrepresentable type",
+            DecompilerFidelityDiscriminators.PrivateImplementationDetailsType);
+
+        Assert.Equal(
+            "unspellable C# type name '__PrivateImplementationDetails_'",
+            FidelityCauseBuckets.BucketFor(cause));
+    }
+
+    [Fact]
     public void Inspect_OperationFailure_IsSurfaced()
     {
         var function = Function(new Return(new Constant(0, Int32)));

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -67,6 +67,8 @@
              Link="CompilerFeatureOptions.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\FidelityCauseBuckets.cs"
              Link="FidelityCauseBuckets.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\FidelityResidualPortfolio.cs"
+             Link="FidelityResidualPortfolio.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\FidelityCheck.cs"
              Link="FidelityCheck.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\MetadataInstructionProducer.cs"

--- a/src/ILInspector.Decompiler.Tests/PinnedLocalFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PinnedLocalFidelityTests.cs
@@ -57,6 +57,7 @@ public class PinnedLocalFidelityTests
                 _ => throw new InvalidOperationException("Expected a complete fidelity-cause inspection."),
             }).Payload;
         Assert.Equal(DiagnosticIds.UnraisedPinnedLocal, cause.Code);
+        Assert.Equal(DecompilerFidelityDiscriminators.PinnedLocal, cause.Discriminator);
         Assert.Equal(DecompilerFidelityLocationKind.Local, cause.Location.Kind);
         Assert.Equal(0, cause.Location.LocalIndex);
     }

--- a/src/ILInspector.Decompiler.Tests/SwitchBranchRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwitchBranchRenderingTests.cs
@@ -368,7 +368,7 @@ public class SwitchBranchRenderingTests
         var function = IrImporter.Import(
             source,
             typeof(CSharpSpellability).FullName!,
-            "TypeReason");
+            "TypeIssue");
         Assert.NotNull(function);
 
         var result = CSharpPrinter.PrintRaised(function);

--- a/src/ILInspector.Decompiler/DecompilerFidelityCause.cs
+++ b/src/ILInspector.Decompiler/DecompilerFidelityCause.cs
@@ -1,5 +1,38 @@
 namespace ILInspector.Decompiler;
 
+/// <summary>
+/// Stable semantic facets for <see cref="DecompilerFidelityCause.Discriminator"/>.
+/// Human-readable diagnostic reasons are deliberately not part of this contract.
+/// </summary>
+public static class DecompilerFidelityDiscriminators
+{
+    public const string AccessorMetadataUnavailable = "accessor-metadata-unavailable";
+    public const string DisplayClassTypeName = "display-class-type-name";
+    public const string EscapableFieldName = "escapable-field-name";
+    public const string EscapableInitializerMemberName = "escapable-initializer-member-name";
+    public const string EscapablePropertyName = "escapable-property-name";
+    public const string GeneratedFieldName = "generated-field-name";
+    public const string GeneratedGenericParameterName = "generated-generic-parameter-name";
+    public const string GeneratedInitializerMemberName = "generated-initializer-member-name";
+    public const string GeneratedMethodName = "generated-method-name";
+    public const string GeneratedPropertyName = "generated-property-name";
+    public const string GeneratedTypeName = "generated-type-name";
+    public const string LambdaHolderTypeName = "lambda-holder-type-name";
+    public const string LambdaMethodName = "lambda-method-name";
+    public const string LocalFunctionMethodName = "local-function-method-name";
+    public const string PinnedLocal = "pinned-local";
+    public const string PrivateImplementationDetailsType = "private-implementation-details-type";
+    public const string StateMachineTypeName = "state-machine-type-name";
+    public const string UnsupportedTypeShape = "unsupported-type-shape";
+    public const string UnspellableFieldName = "unspellable-field-name";
+    public const string UnspellableGenericParameterName = "unspellable-generic-parameter-name";
+    public const string UnspellableInitializerMemberName = "unspellable-initializer-member-name";
+    public const string UnspellableLocalFunctionName = "unspellable-local-function-name";
+    public const string UnspellableMethodName = "unspellable-method-name";
+    public const string UnspellablePropertyName = "unspellable-property-name";
+    public const string UnspellableTypeName = "unspellable-type-name";
+}
+
 public enum DecompilerFidelityLocationKind
 {
     Unknown,

--- a/src/ILInspector.Decompiler/DecompilerFidelityCause.cs
+++ b/src/ILInspector.Decompiler/DecompilerFidelityCause.cs
@@ -102,8 +102,19 @@ public sealed record DecompilerFidelityCause
         string nodeKind,
         string node,
         string reason,
-        string? discriminator = null,
-        string? inventoryBucket = null)
+        string? discriminator = null)
+        : this(code, location, nodeKind, node, reason, discriminator, null)
+    {
+    }
+
+    public DecompilerFidelityCause(
+        string code,
+        DecompilerFidelityLocation location,
+        string nodeKind,
+        string node,
+        string reason,
+        string? discriminator,
+        string? inventoryBucket)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(code);
         ArgumentException.ThrowIfNullOrWhiteSpace(nodeKind);

--- a/src/ILInspector.Decompiler/DecompilerFidelityCause.cs
+++ b/src/ILInspector.Decompiler/DecompilerFidelityCause.cs
@@ -102,7 +102,8 @@ public sealed record DecompilerFidelityCause
         string nodeKind,
         string node,
         string reason,
-        string? discriminator = null)
+        string? discriminator = null,
+        string? inventoryBucket = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(code);
         ArgumentException.ThrowIfNullOrWhiteSpace(nodeKind);
@@ -115,6 +116,7 @@ public sealed record DecompilerFidelityCause
         Node = node;
         Reason = reason;
         Discriminator = discriminator;
+        InventoryBucket = inventoryBucket;
     }
 
     public string Code { get; }
@@ -132,4 +134,11 @@ public sealed record DecompilerFidelityCause
     /// such as an unsupported opcode or type-shape reason.
     /// </summary>
     public string? Discriminator { get; }
+
+    /// <summary>
+    /// Producer-owned grouping label retained for inventory presentation
+    /// compatibility. This is display data, not a semantic classification facet;
+    /// policy consumers must use <see cref="Discriminator"/>.
+    /// </summary>
+    public string? InventoryBucket { get; }
 }

--- a/src/ILInspector.Decompiler/Pipeline/CSharpSpellability.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CSharpSpellability.cs
@@ -8,46 +8,48 @@ namespace ILInspector.Decompiler.Pipeline;
 /// </summary>
 internal static class CSharpSpellability
 {
-    public static bool HasUnrepresentableMetadataName(IrNode node)
-        => UnrepresentableMetadataNameReason(node) is not null;
+    internal readonly record struct NameIssue(string Discriminator, string Reason);
 
-    public static string? UnrepresentableMetadataNameReason(IrNode node)
+    public static bool HasUnrepresentableMetadataName(IrNode node)
+        => InspectUnrepresentableMetadataName(node) is not null;
+
+    internal static NameIssue? InspectUnrepresentableMetadataName(IrNode node)
     {
         foreach (var type in RenderedTypes(node))
         {
-            if (TypeReason(type) is { } reason)
-                return reason;
+            if (TypeIssue(type) is { } issue)
+                return issue;
         }
 
         if (node is IrExpression { ResultType: { } resultType }
-            && TypeReason(resultType) is { } expressionTypeReason)
+            && TypeIssue(resultType) is { } expressionTypeIssue)
         {
-            return expressionTypeReason;
+            return expressionTypeIssue;
         }
 
         return node switch
         {
-            Call call => MethodReason(call.Callee),
-            NewObject newObject => ConstructorReason(newObject.Constructor),
-            AddressOfMethod address => MethodReason(address.Method),
-            DelegateCreation creation => MethodReason(creation.Method),
-            LoadField load => FieldReason(load.Field),
-            StoreField store => FieldReason(store.Field),
-            LoadFieldAddress address => FieldReason(address.Field),
-            LoadProperty load => PropertyReason(load.PropertyName),
-            StoreProperty store => PropertyReason(store.PropertyName),
-            NullCoalescingFieldAssignment assignment => FieldReason(assignment.Field),
-            NullCoalescingFieldAssignmentExpression assignment => FieldReason(assignment.Field),
-            NullCoalescingPropertyAssignment assignment => PropertyReason(assignment.PropertyName),
-            AnonymousObject anonymous => InitializerMembersReason(anonymous.PropertyNames),
-            ObjectInitializerExpression initializer => InitializerMembersReason(initializer.Members),
-            WithExpression withExpression => InitializerMembersReason(withExpression.Members),
-            InitializerBlock block => InitializerMembersReason(block.Members),
-            DeconstructionTarget target => DeconstructionTargetReason(target),
-            RecursivePropertyDeclarationPattern pattern => PropertyReason(pattern.PropertyName),
-            EventSubscription subscription => PropertyReason(subscription.EventName),
-            LocalFunctionStatement statement => LocalFunctionReason(statement.Name),
-            LocalFunctionInvocation invocation => LocalFunctionReason(invocation.Name),
+            Call call => MethodIssue(call.Callee),
+            NewObject newObject => ConstructorIssue(newObject.Constructor),
+            AddressOfMethod address => MethodIssue(address.Method),
+            DelegateCreation creation => MethodIssue(creation.Method),
+            LoadField load => FieldIssue(load.Field),
+            StoreField store => FieldIssue(store.Field),
+            LoadFieldAddress address => FieldIssue(address.Field),
+            LoadProperty load => PropertyIssue(load.PropertyName),
+            StoreProperty store => PropertyIssue(store.PropertyName),
+            NullCoalescingFieldAssignment assignment => FieldIssue(assignment.Field),
+            NullCoalescingFieldAssignmentExpression assignment => FieldIssue(assignment.Field),
+            NullCoalescingPropertyAssignment assignment => PropertyIssue(assignment.PropertyName),
+            AnonymousObject anonymous => InitializerMembersIssue(anonymous.PropertyNames),
+            ObjectInitializerExpression initializer => InitializerMembersIssue(initializer.Members),
+            WithExpression withExpression => InitializerMembersIssue(withExpression.Members),
+            InitializerBlock block => InitializerMembersIssue(block.Members),
+            DeconstructionTarget target => DeconstructionTargetIssue(target),
+            RecursivePropertyDeclarationPattern pattern => PropertyIssue(pattern.PropertyName),
+            EventSubscription subscription => PropertyIssue(subscription.EventName),
+            LocalFunctionStatement statement => LocalFunctionIssue(statement.Name),
+            LocalFunctionInvocation invocation => LocalFunctionIssue(invocation.Name),
             _ => null,
         };
     }
@@ -69,44 +71,72 @@ internal static class CSharpSpellability
                 yield return catchType;
     }
 
-    static string? ConstructorReason(MethodRef constructor)
+    static NameIssue? ConstructorIssue(MethodRef constructor)
     {
         foreach (var argument in constructor.TypeArguments)
-            if (TypeReason(argument) is { } reason)
-                return reason;
+            if (TypeIssue(argument) is { } issue)
+                return issue;
         return null;
     }
 
-    static string? MethodReason(MethodRef method)
+    static NameIssue? MethodIssue(MethodRef method)
     {
         foreach (var argument in method.TypeArguments)
-            if (TypeReason(argument) is { } reason)
-                return reason;
+            if (TypeIssue(argument) is { } issue)
+                return issue;
 
         if (method.Name is ".ctor")
             return null;
 
         if (IsUnverifiedAccessorLikeMethod(method))
-            return $"method '{method.Name}' looks like a property/event accessor but accessor metadata was unavailable; explicit accessor calls have no C# spelling";
+        {
+            return Issue(
+                DecompilerFidelityDiscriminators.AccessorMetadataUnavailable,
+                $"method '{method.Name}' looks like a property/event accessor but accessor metadata was unavailable; explicit accessor calls have no C# spelling");
+        }
 
         string name = CSharpNaming.MethodName(method.Name);
         return CSharpNaming.IsEscapableIdentifier(name)
             ? null
-            : $"method name '{method.Name}' has no C# spelling";
+            : Issue(
+                MethodNameDiscriminator(method.Name),
+                $"method name '{method.Name}' has no C# spelling");
     }
 
-    static string? FieldReason(FieldRef field)
+    static NameIssue? FieldIssue(FieldRef field)
     {
         string name = field.BackingPropertyName ?? field.Name;
-        return CSharpNaming.IsUsableIdentifier(name)
-            ? null
-            : $"field name '{field.Name}' has no C# spelling";
+        if (CSharpNaming.IsUsableIdentifier(name))
+            return null;
+        if (CSharpNaming.IsEscapableIdentifier(name))
+        {
+            return Issue(
+                DecompilerFidelityDiscriminators.EscapableFieldName,
+                $"field name '{field.Name}' requires C# @ escaping");
+        }
+        return Issue(
+            GeneratedCodeIdentity.IsGeneratedFieldName(name)
+                ? DecompilerFidelityDiscriminators.GeneratedFieldName
+                : DecompilerFidelityDiscriminators.UnspellableFieldName,
+            $"field name '{field.Name}' has no C# spelling");
     }
 
-    static string? PropertyReason(string name)
-        => CSharpNaming.IsUsableIdentifier(name)
-            ? null
-            : $"property name '{name}' has no C# spelling";
+    static NameIssue? PropertyIssue(string name)
+    {
+        if (CSharpNaming.IsUsableIdentifier(name))
+            return null;
+        if (CSharpNaming.IsEscapableIdentifier(name))
+        {
+            return Issue(
+                DecompilerFidelityDiscriminators.EscapablePropertyName,
+                $"property name '{name}' requires C# @ escaping");
+        }
+        return Issue(
+            IsGeneratedNameShape(name)
+                ? DecompilerFidelityDiscriminators.GeneratedPropertyName
+                : DecompilerFidelityDiscriminators.UnspellablePropertyName,
+            $"property name '{name}' has no C# spelling");
+    }
 
     static bool IsUnverifiedAccessorLikeMethod(MethodRef method)
         => method.AccessorKind == AccessorKind.Unknown
@@ -122,32 +152,46 @@ internal static class CSharpSpellability
     // invalid identifier characters (e.g. a hand-written `bad-name`) has no C#
     // spelling. Use the keyword-tolerant predicate to avoid degrading the
     // keyword-escaped local functions #1465 made Full.
-    static string? LocalFunctionReason(string name)
+    static NameIssue? LocalFunctionIssue(string name)
         => CSharpNaming.IsEscapableIdentifier(name)
             ? null
-            : $"local function name '{name}' has no C# spelling";
+            : Issue(
+                DecompilerFidelityDiscriminators.UnspellableLocalFunctionName,
+                $"local function name '{name}' has no C# spelling");
 
-    static string? InitializerMembersReason(IEnumerable<string?> members)
+    static NameIssue? InitializerMembersIssue(IEnumerable<string?> members)
     {
         foreach (var member in members)
         {
             if (member is null)
                 continue;
             if (!CSharpNaming.IsUsableIdentifier(member))
-                return $"initializer member name '{member}' has no C# spelling";
+            {
+                if (CSharpNaming.IsEscapableIdentifier(member))
+                {
+                    return Issue(
+                        DecompilerFidelityDiscriminators.EscapableInitializerMemberName,
+                        $"initializer member name '{member}' requires C# @ escaping");
+                }
+                return Issue(
+                    IsGeneratedNameShape(member)
+                        ? DecompilerFidelityDiscriminators.GeneratedInitializerMemberName
+                        : DecompilerFidelityDiscriminators.UnspellableInitializerMemberName,
+                    $"initializer member name '{member}' has no C# spelling");
+            }
         }
         return null;
     }
 
-    static string? DeconstructionTargetReason(DeconstructionTarget target)
+    static NameIssue? DeconstructionTargetIssue(DeconstructionTarget target)
         => target.Kind switch
         {
-            DeconstructionTargetKind.Field when target.Field is { } field => FieldReason(field),
-            DeconstructionTargetKind.Property => PropertyReason(target.PropertyName),
+            DeconstructionTargetKind.Field when target.Field is { } field => FieldIssue(field),
+            DeconstructionTargetKind.Property => PropertyIssue(target.PropertyName),
             _ => null,
         };
 
-    static string? TypeReason(TypeRef type)
+    static NameIssue? TypeIssue(TypeRef type)
     {
         switch (type.Kind)
         {
@@ -164,16 +208,20 @@ internal static class CSharpSpellability
                 {
                     string simpleSegment = StripArity(segment);
                     if (!CSharpNaming.IsEscapableIdentifier(simpleSegment))
-                        return $"type name '{simpleSegment}' has no C# spelling";
+                    {
+                        return Issue(
+                            TypeNameDiscriminator(simpleSegment),
+                            $"type name '{simpleSegment}' has no C# spelling");
+                    }
                 }
                 return null;
 
             case TypeRefKind.GenericInstance:
-                if (type.ElementType is { } definition && TypeReason(definition) is { } definitionReason)
-                    return definitionReason;
+                if (type.ElementType is { } definition && TypeIssue(definition) is { } definitionIssue)
+                    return definitionIssue;
                 foreach (var argument in type.TypeArguments)
-                    if (TypeReason(argument) is { } argumentReason)
-                        return argumentReason;
+                    if (TypeIssue(argument) is { } argumentIssue)
+                        return argumentIssue;
                 return null;
 
             case TypeRefKind.SzArray:
@@ -181,26 +229,63 @@ internal static class CSharpSpellability
             case TypeRefKind.ByRef:
             case TypeRefKind.Pointer:
             case TypeRefKind.Pinned:
-                return type.ElementType is { } element ? TypeReason(element) : null;
+                return type.ElementType is { } element ? TypeIssue(element) : null;
 
             case TypeRefKind.GenericParameter:
             case TypeRefKind.MethodGenericParameter:
                 return type.GenericParameterName.Length == 0 || CSharpNaming.IsEscapableIdentifier(type.GenericParameterName)
                     ? null
-                    : $"generic parameter name '{type.GenericParameterName}' has no C# spelling";
+                    : Issue(
+                        IsGeneratedNameShape(type.GenericParameterName)
+                            ? DecompilerFidelityDiscriminators.GeneratedGenericParameterName
+                            : DecompilerFidelityDiscriminators.UnspellableGenericParameterName,
+                        $"generic parameter name '{type.GenericParameterName}' has no C# spelling");
 
             case TypeRefKind.FunctionPointer:
-                if (type.ElementType is { } returnType && TypeReason(returnType) is { } returnReason)
-                    return returnReason;
+                if (type.ElementType is { } returnType && TypeIssue(returnType) is { } returnIssue)
+                    return returnIssue;
                 foreach (var parameter in type.TypeArguments)
-                    if (TypeReason(parameter) is { } parameterReason)
-                        return parameterReason;
+                    if (TypeIssue(parameter) is { } parameterIssue)
+                        return parameterIssue;
                 return null;
 
             default:
                 return null;
         }
     }
+
+    static string MethodNameDiscriminator(string name)
+    {
+        if (GeneratedCodeIdentity.IsSynthesizedLambdaMethodName(name))
+            return DecompilerFidelityDiscriminators.LambdaMethodName;
+        if (GeneratedCodeIdentity.IsSynthesizedLocalFunctionName(name))
+            return DecompilerFidelityDiscriminators.LocalFunctionMethodName;
+        return IsGeneratedNameShape(name)
+            ? DecompilerFidelityDiscriminators.GeneratedMethodName
+            : DecompilerFidelityDiscriminators.UnspellableMethodName;
+    }
+
+    static string TypeNameDiscriminator(string name)
+    {
+        if (name.StartsWith("<>c__DisplayClass", StringComparison.Ordinal))
+            return DecompilerFidelityDiscriminators.DisplayClassTypeName;
+        if (name == "<>c")
+            return DecompilerFidelityDiscriminators.LambdaHolderTypeName;
+        if (name.StartsWith("<", StringComparison.Ordinal)
+            && name.Contains(">d__", StringComparison.Ordinal))
+        {
+            return DecompilerFidelityDiscriminators.StateMachineTypeName;
+        }
+        return IsGeneratedNameShape(name)
+            ? DecompilerFidelityDiscriminators.GeneratedTypeName
+            : DecompilerFidelityDiscriminators.UnspellableTypeName;
+    }
+
+    static bool IsGeneratedNameShape(string name)
+        => name.StartsWith("<", StringComparison.Ordinal);
+
+    static NameIssue Issue(string discriminator, string reason)
+        => new(discriminator, reason);
 
     static bool IsCoreLibPrimitive(TypeRef type)
         => type.Assembly == TypeRef.CoreLibrary

--- a/src/ILInspector.Decompiler/Pipeline/FidelityRemarks.cs
+++ b/src/ILInspector.Decompiler/Pipeline/FidelityRemarks.cs
@@ -121,6 +121,12 @@ public static class FidelityRemarks
             if (unsupportedTypes is not null)
             {
                 string types = string.Join("; ", unsupportedTypes.Select(UnrepresentableTypeText));
+                string inventoryBucket = string.Join(
+                    "; ",
+                    unsupportedTypes
+                        .SelectMany(static type => type.UnsupportedReasons())
+                        .Distinct(StringComparer.Ordinal)
+                        .Order(StringComparer.Ordinal));
                 string discriminator = string.Join(
                     "; ",
                     unsupportedTypes
@@ -132,7 +138,8 @@ public static class FidelityRemarks
                     LocationOf(node),
                     node,
                     $"references an unrepresentable type ({types})",
-                    discriminator);
+                    discriminator,
+                    inventoryBucket);
             }
 
             if (CSharpSpellability.InspectUnrepresentableMetadataName(node) is { } nameIssue)
@@ -175,14 +182,16 @@ public static class FidelityRemarks
         DecompilerFidelityLocation location,
         IrNode node,
         string reason,
-        string? discriminator = null)
+        string? discriminator = null,
+        string? inventoryBucket = null)
         => new(
             code,
             location,
             node.GetType().Name,
             node.Describe(),
             reason,
-            discriminator);
+            discriminator,
+            inventoryBucket);
 
     static IEnumerable<int>? UnraisedPinnedLocals(IrFunction function)
     {

--- a/src/ILInspector.Decompiler/Pipeline/FidelityRemarks.cs
+++ b/src/ILInspector.Decompiler/Pipeline/FidelityRemarks.cs
@@ -124,7 +124,7 @@ public static class FidelityRemarks
                 string discriminator = string.Join(
                     "; ",
                     unsupportedTypes
-                        .SelectMany(static type => type.UnsupportedReasons())
+                        .SelectMany(static type => type.UnsupportedDiscriminators())
                         .Distinct(StringComparer.Ordinal)
                         .Order(StringComparer.Ordinal));
                 yield return Cause(
@@ -135,13 +135,14 @@ public static class FidelityRemarks
                     discriminator);
             }
 
-            if (CSharpSpellability.UnrepresentableMetadataNameReason(node) is { } nameReason)
+            if (CSharpSpellability.InspectUnrepresentableMetadataName(node) is { } nameIssue)
             {
                 yield return Cause(
                     DiagnosticIds.UnrepresentableMetadataName,
                     LocationOf(node),
                     node,
-                    nameReason);
+                    nameIssue.Reason,
+                    nameIssue.Discriminator);
             }
 
             if (node is IrExpression { ResultType: null })
@@ -164,8 +165,8 @@ public static class FidelityRemarks
                 DecompilerFidelityLocation.AtLocal(localIndex),
                 "PinnedLocal",
                 $"Pinned local V_{localIndex}",
-                "referenced pinned local has no owning fixed statement and no faithful C# declaration",
-                function.Locals[localIndex].ToDisplayString());
+                $"referenced pinned local has no owning fixed statement and no faithful C# declaration ({function.Locals[localIndex].ToDisplayString()})",
+                DecompilerFidelityDiscriminators.PinnedLocal);
         }
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
@@ -377,6 +377,20 @@ public sealed class TypeRef : IEquatable<TypeRef>
                 yield return reason;
     }
 
+    internal IEnumerable<string> UnsupportedDiscriminators()
+    {
+        if (Kind == TypeRefKind.Unsupported)
+            yield return DecompilerFidelityDiscriminators.UnsupportedTypeShape;
+        if (IsPrivateImplementationDetails)
+            yield return DecompilerFidelityDiscriminators.PrivateImplementationDetailsType;
+        if (ElementType is { } element)
+            foreach (var discriminator in element.UnsupportedDiscriminators())
+                yield return discriminator;
+        foreach (var argument in TypeArguments)
+            foreach (var discriminator in argument.UnsupportedDiscriminators())
+                yield return discriminator;
+    }
+
     public bool Equals(TypeRef? other)
     {
         if (other is null)

--- a/tools/DecompilerHarness/CorpusMethodDelta.cs
+++ b/tools/DecompilerHarness/CorpusMethodDelta.cs
@@ -23,9 +23,30 @@ internal sealed record CorpusMethodSnapshot(
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     string? FidelityCapture = null,
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    string? FidelityReference = null)
+    string? FidelityReference = null,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    IReadOnlyList<CorpusFidelityCauseSnapshot>? FidelityCauses = null)
 {
     public string DisplayMethod => $"{Assembly}!{Type}::{Method}#{Overload}";
+
+    [JsonIgnore]
+    public string StableKey => $"{AssemblyPath}!{Type}::{Method}{Signature}";
+}
+
+internal sealed record CorpusFidelityCauseSnapshot(
+    string Code,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? Discriminator,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    int? Sites = null)
+{
+    [JsonIgnore]
+    public int SiteCount => Sites switch
+    {
+        null => 1,
+        > 0 => Sites.Value,
+        _ => throw new InvalidDataException("A fidelity-cause facet must represent at least one site."),
+    };
 }
 
 internal sealed record CorpusMethodDeltaArtifact(

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -303,7 +303,7 @@ internal static class CorpusSensor
             selectedFidelity);
 
         var snapshot = new CorpusSensorSnapshot(
-            SchemaVersion: 3,
+            SchemaVersion: 4,
             Description: DescriptionForProfile(profile),
             GeneratedUtc: DateTimeOffset.UtcNow,
             ValidityCompileCap: validityCompileCap,
@@ -438,7 +438,22 @@ internal static class CorpusSensor
                     residual,
                     passBug,
                     Validity: "not-sampled",
-                    FidelityCheck: "not-sampled"));
+                    FidelityCheck: "not-sampled",
+                    FidelityCauses: fidelityCensus is { Succeeded: true, Causes.IsEmpty: false }
+                        ? fidelityCensus.Value.Causes
+                            .GroupBy(static cause => (cause.Code, cause.Discriminator))
+                            .Select(static group =>
+                            {
+                                int sites = group.Count();
+                                return new CorpusFidelityCauseSnapshot(
+                                    group.Key.Code,
+                                    group.Key.Discriminator,
+                                    sites > 1 ? sites : null);
+                            })
+                            .OrderBy(static cause => cause.Code, StringComparer.Ordinal)
+                            .ThenBy(static cause => cause.Discriminator, StringComparer.Ordinal)
+                            .ToImmutableArray()
+                        : null));
             });
             assemblyReports.Add(new CorpusAssemblySnapshot(source.AssemblyName, PortablePath(assemblyPath), methods));
         }
@@ -1168,7 +1183,7 @@ internal static class CorpusSensor
     }
 
     static string MethodKey(CorpusMethodSnapshot method)
-        => MethodKey(method.AssemblyPath, method.Type, method.Method, method.Signature);
+        => method.StableKey;
 
     static string MethodKey(string assemblyPath, string type, string method, string signature)
         => $"{assemblyPath}!{type}::{method}{signature}";
@@ -1577,6 +1592,95 @@ internal static class CorpusSensor
                 $"Fully raised: {fullyRaised.RaisedMethods}/{fullyRaised.CheckedMethods} "
                 + $"({FormatBps(RateBasisPoints(fullyRaised.RaisedMethods, fullyRaised.CheckedMethods))} "
                 + "of completed validity outcomes)");
+        }
+        PrintFidelityResidualPortfolio(snapshot);
+    }
+
+    static void PrintFidelityResidualPortfolio(CorpusSensorSnapshot snapshot)
+    {
+        if (snapshot.Methods is not { } methods
+            || !methods.Any(static method => method.FidelityCauses is not null))
+        {
+            return;
+        }
+
+        var portfolio = FidelityResidualPortfolioBuilder.Build(
+            methods,
+            snapshot.Metrics.TotalMethods,
+            snapshot.Metrics.FullyRaisedMethods);
+
+        Console.WriteLine();
+        Console.WriteLine($"## Fidelity residual portfolio (policy v{portfolio.PolicyVersion})");
+        Console.WriteLine();
+        Console.WriteLine(
+            $"Population: {Number(portfolio.FidelityPrimaryMethods)} fidelity-primary methods, "
+            + $"{Number(portfolio.FidelityCauseSites)} cause sites.");
+        Console.WriteLine(
+            "Method rollup: "
+            + $"{Number(portfolio.RecoverableMethods)} all causes recoverable; "
+            + $"{Number(portfolio.PolicyFloorMethods)} any cause at the policy floor; "
+            + $"{Number(portfolio.UnclassifiedMethods)} otherwise unclassified.");
+        if (portfolio.MissingCauseMethods > 0)
+        {
+            Console.WriteLine(
+                $"Missing cause snapshots: {Number(portfolio.MissingCauseMethods)} "
+                + "(counted as unclassified).");
+        }
+        Console.WriteLine(
+            "Current roadmap target range: "
+            + $"{Number(portfolio.RoadmapTargetLowerMethods)}–{Number(portfolio.RoadmapTargetUpperMethods)}"
+            + $"/{Number(portfolio.TotalMethods)} projected fully raised "
+            + $"({FormatBps(RateBasisPoints(portfolio.RoadmapTargetLowerMethods, portfolio.TotalMethods))}"
+            + $"–{FormatBps(RateBasisPoints(portfolio.RoadmapTargetUpperMethods, portfolio.TotalMethods))}).");
+        Console.WriteLine(
+            "The range excludes the current policy floor; its upper endpoint includes "
+            + "unclassified work, so it is a policy target, not a mathematical ceiling.");
+        Console.WriteLine(
+            $"Earlier structural-primary co-occurrence (excluded): "
+            + $"{Number(portfolio.StructuralPrimaryMethodsWithFidelityCauses)} methods, "
+            + $"{Number(portfolio.StructuralPrimaryFidelityCauseSites)} fidelity cause sites.");
+
+        PrintFidelityFacetSection(
+            "Recoverable roadmap",
+            portfolio.Facets,
+            FidelityResidualDisposition.RecoverableRoadmap);
+        PrintFidelityFacetSection(
+            "Policy floor",
+            portfolio.Facets,
+            FidelityResidualDisposition.PolicyFloor);
+        PrintFidelityFacetSection(
+            "Unclassified",
+            portfolio.Facets,
+            FidelityResidualDisposition.Unclassified);
+    }
+
+    static void PrintFidelityFacetSection(
+        string heading,
+        ImmutableArray<FidelityResidualFacetSummary> facets,
+        FidelityResidualDisposition disposition)
+    {
+        var selected = facets
+            .Where(facet => facet.Disposition == disposition)
+            .ToArray();
+        Console.WriteLine();
+        Console.WriteLine($"{heading} facets:");
+        if (selected.Length == 0)
+        {
+            Console.WriteLine("  none");
+            return;
+        }
+
+        foreach (var facet in selected)
+        {
+            string label = facet.Discriminator is null
+                ? facet.Code
+                : $"{facet.Code}/{facet.Discriminator}";
+            string example = facet.Examples.Length == 0
+                ? ""
+                : $"; e.g. {facet.Examples[0]}";
+            Console.WriteLine(
+                $"  {label}: {Number(facet.Methods)} methods, "
+                + $"{Number(facet.CauseSites)} sites{example}");
         }
     }
 

--- a/tools/DecompilerHarness/FidelityCauseBuckets.cs
+++ b/tools/DecompilerHarness/FidelityCauseBuckets.cs
@@ -12,9 +12,6 @@ namespace ILInspector.DecompilerHarness;
 /// </summary>
 internal static class FidelityCauseBuckets
 {
-    const string PrivateImplementationDetailsBucket =
-        "unspellable C# type name '__PrivateImplementationDetails_'";
-
     internal enum CensusState
     {
         Complete,
@@ -84,14 +81,8 @@ internal static class FidelityCauseBuckets
     internal static string BucketFor(DecompilerFidelityCause cause)
     {
         ArgumentNullException.ThrowIfNull(cause);
-        if (cause is
-            {
-                Code: DiagnosticIds.UnsupportedType,
-                Discriminator: DecompilerFidelityDiscriminators.PrivateImplementationDetailsType,
-            })
-        {
-            return PrivateImplementationDetailsBucket;
-        }
+        if (cause.InventoryBucket is { } inventoryBucket)
+            return inventoryBucket;
 
         return cause.Code switch
         {

--- a/tools/DecompilerHarness/FidelityCauseBuckets.cs
+++ b/tools/DecompilerHarness/FidelityCauseBuckets.cs
@@ -72,10 +72,10 @@ internal static class FidelityCauseBuckets
     {
         if (!census.Succeeded)
             throw new InvalidOperationException("A failed or absent inspection has no fidelity-cause bucket.");
+        if (census.Causes.IsEmpty)
+            throw new InvalidOperationException("A complete inspection with no causes has no fidelity-cause bucket.");
 
-        return census.Causes.Length > 0
-            ? BucketFor(census.Causes[0])
-            : "(typed)";
+        return BucketFor(census.Causes[0]);
     }
 
     internal static string BucketFor(DecompilerFidelityCause cause)

--- a/tools/DecompilerHarness/FidelityCauseBuckets.cs
+++ b/tools/DecompilerHarness/FidelityCauseBuckets.cs
@@ -12,6 +12,9 @@ namespace ILInspector.DecompilerHarness;
 /// </summary>
 internal static class FidelityCauseBuckets
 {
+    const string PrivateImplementationDetailsBucket =
+        "unspellable C# type name '__PrivateImplementationDetails_'";
+
     internal enum CensusState
     {
         Complete,
@@ -81,6 +84,15 @@ internal static class FidelityCauseBuckets
     internal static string BucketFor(DecompilerFidelityCause cause)
     {
         ArgumentNullException.ThrowIfNull(cause);
+        if (cause is
+            {
+                Code: DiagnosticIds.UnsupportedType,
+                Discriminator: DecompilerFidelityDiscriminators.PrivateImplementationDetailsType,
+            })
+        {
+            return PrivateImplementationDetailsBucket;
+        }
+
         return cause.Code switch
         {
             DiagnosticIds.UnsupportedConstruct or DiagnosticIds.UnsupportedType =>

--- a/tools/DecompilerHarness/FidelityResidualPortfolio.cs
+++ b/tools/DecompilerHarness/FidelityResidualPortfolio.cs
@@ -1,0 +1,252 @@
+using System.Collections.Immutable;
+
+using ILInspector.Decompiler;
+
+namespace ILInspector.DecompilerHarness;
+
+internal enum FidelityResidualDisposition
+{
+    RecoverableRoadmap,
+    PolicyFloor,
+    Unclassified,
+}
+
+internal readonly record struct FidelityResidualClassification(
+    FidelityResidualDisposition Disposition,
+    string RuleId);
+
+internal static class FidelityResidualPolicy
+{
+    public const int Version = 1;
+
+    static readonly ImmutableHashSet<string> RecoverableNameDiscriminators =
+        ImmutableHashSet.Create(
+            StringComparer.Ordinal,
+            DecompilerFidelityDiscriminators.AccessorMetadataUnavailable,
+            DecompilerFidelityDiscriminators.DisplayClassTypeName,
+            DecompilerFidelityDiscriminators.EscapableFieldName,
+            DecompilerFidelityDiscriminators.EscapableInitializerMemberName,
+            DecompilerFidelityDiscriminators.EscapablePropertyName,
+            DecompilerFidelityDiscriminators.GeneratedFieldName,
+            DecompilerFidelityDiscriminators.GeneratedGenericParameterName,
+            DecompilerFidelityDiscriminators.GeneratedInitializerMemberName,
+            DecompilerFidelityDiscriminators.GeneratedMethodName,
+            DecompilerFidelityDiscriminators.GeneratedPropertyName,
+            DecompilerFidelityDiscriminators.GeneratedTypeName,
+            DecompilerFidelityDiscriminators.LambdaHolderTypeName,
+            DecompilerFidelityDiscriminators.LambdaMethodName,
+            DecompilerFidelityDiscriminators.LocalFunctionMethodName,
+            DecompilerFidelityDiscriminators.StateMachineTypeName);
+
+    static readonly ImmutableHashSet<string> PolicyFloorNameDiscriminators =
+        ImmutableHashSet.Create(
+            StringComparer.Ordinal,
+            DecompilerFidelityDiscriminators.UnspellableFieldName,
+            DecompilerFidelityDiscriminators.UnspellableGenericParameterName,
+            DecompilerFidelityDiscriminators.UnspellableInitializerMemberName,
+            DecompilerFidelityDiscriminators.UnspellableLocalFunctionName,
+            DecompilerFidelityDiscriminators.UnspellableMethodName,
+            DecompilerFidelityDiscriminators.UnspellablePropertyName,
+            DecompilerFidelityDiscriminators.UnspellableTypeName);
+
+    public static FidelityResidualClassification Classify(
+        CorpusFidelityCauseSnapshot cause)
+    {
+        if (cause.Code == DiagnosticIds.UnrepresentableMetadataName)
+        {
+            if (cause.Discriminator is { } discriminator
+                && RecoverableNameDiscriminators.Contains(discriminator))
+            {
+                return Recoverable("name-shape-raising");
+            }
+            if (cause.Discriminator is { } floorDiscriminator
+                && PolicyFloorNameDiscriminators.Contains(floorDiscriminator))
+            {
+                return PolicyFloor("metadata-name-policy-floor");
+            }
+        }
+
+        return (cause.Code, cause.Discriminator) switch
+        {
+            (DiagnosticIds.UnsupportedConstruct, "iterator") =>
+                Recoverable("iterator-raising"),
+            (DiagnosticIds.UnsupportedConstruct, "call .ctor") =>
+                Recoverable("constructor-call-raising"),
+            (DiagnosticIds.UnsupportedType, DecompilerFidelityDiscriminators.PrivateImplementationDetailsType) =>
+                Recoverable("private-implementation-details-raising"),
+            (DiagnosticIds.UnknownResultType, _) =>
+                Recoverable("result-type-recovery"),
+            (DiagnosticIds.UnverifiedContinue, _) =>
+                Recoverable("continue-verification"),
+            (DiagnosticIds.UnraisedPinnedLocal, _) =>
+                Recoverable("fixed-statement-raising"),
+            _ => new FidelityResidualClassification(
+                FidelityResidualDisposition.Unclassified,
+                "unclassified"),
+        };
+    }
+
+    static FidelityResidualClassification Recoverable(string ruleId)
+        => new(FidelityResidualDisposition.RecoverableRoadmap, ruleId);
+
+    static FidelityResidualClassification PolicyFloor(string ruleId)
+        => new(FidelityResidualDisposition.PolicyFloor, ruleId);
+}
+
+internal sealed record FidelityResidualFacetSummary(
+    string Code,
+    string? Discriminator,
+    FidelityResidualDisposition Disposition,
+    string RuleId,
+    int CauseSites,
+    int Methods,
+    ImmutableArray<string> Examples);
+
+internal sealed record FidelityResidualPortfolio(
+    int PolicyVersion,
+    int TotalMethods,
+    int FullyRaisedMethods,
+    int FidelityPrimaryMethods,
+    int FidelityCauseSites,
+    int RecoverableMethods,
+    int PolicyFloorMethods,
+    int UnclassifiedMethods,
+    int MissingCauseMethods,
+    int StructuralPrimaryMethodsWithFidelityCauses,
+    int StructuralPrimaryFidelityCauseSites,
+    int RoadmapTargetLowerMethods,
+    int RoadmapTargetUpperMethods,
+    ImmutableArray<FidelityResidualFacetSummary> Facets);
+
+internal static class FidelityResidualPortfolioBuilder
+{
+    const int MaxExamples = 3;
+
+    readonly record struct Facet(string Code, string? Discriminator);
+
+    sealed class FacetAccumulator
+    {
+        public int CauseSites;
+        public HashSet<string> Methods { get; } = new(StringComparer.Ordinal);
+    }
+
+    public static FidelityResidualPortfolio Build(
+        IReadOnlyList<CorpusMethodSnapshot> methods,
+        int totalMethods,
+        int fullyRaisedMethods)
+    {
+        var facets = new Dictionary<Facet, FacetAccumulator>();
+        int fidelityPrimaryMethods = 0;
+        int fidelityCauseSites = 0;
+        int recoverableMethods = 0;
+        int policyFloorMethods = 0;
+        int unclassifiedMethods = 0;
+        int missingCauseMethods = 0;
+        int structuralPrimaryMethods = 0;
+        int structuralPrimarySites = 0;
+
+        foreach (var method in methods)
+        {
+            var causes = method.FidelityCauses;
+            bool fidelityPrimary = method.Residual?.StartsWith(
+                "fidelity:",
+                StringComparison.Ordinal) == true;
+
+            if (!fidelityPrimary)
+            {
+                if (IsEarlierStructuralResidual(method.Residual)
+                    && causes is { Count: > 0 })
+                {
+                    structuralPrimaryMethods++;
+                    structuralPrimarySites += causes.Sum(static cause => cause.SiteCount);
+                }
+                continue;
+            }
+
+            fidelityPrimaryMethods++;
+            if (causes is not { Count: > 0 })
+            {
+                missingCauseMethods++;
+                unclassifiedMethods++;
+                continue;
+            }
+
+            fidelityCauseSites += causes.Sum(static cause => cause.SiteCount);
+            string methodKey = method.StableKey;
+            var classifications = new FidelityResidualClassification[causes.Count];
+            for (int i = 0; i < causes.Count; i++)
+            {
+                var cause = causes[i];
+                var classification = FidelityResidualPolicy.Classify(cause);
+                classifications[i] = classification;
+                var facet = new Facet(cause.Code, cause.Discriminator);
+                if (!facets.TryGetValue(facet, out var accumulator))
+                {
+                    accumulator = new FacetAccumulator();
+                    facets.Add(facet, accumulator);
+                }
+                accumulator.CauseSites += cause.SiteCount;
+                accumulator.Methods.Add(methodKey);
+            }
+
+            if (classifications.All(static classification =>
+                    classification.Disposition == FidelityResidualDisposition.RecoverableRoadmap))
+            {
+                recoverableMethods++;
+            }
+            else if (classifications.Any(static classification =>
+                         classification.Disposition == FidelityResidualDisposition.PolicyFloor))
+            {
+                policyFloorMethods++;
+            }
+            else
+            {
+                unclassifiedMethods++;
+            }
+        }
+
+        var summaries = facets
+            .Select(pair =>
+            {
+                var cause = new CorpusFidelityCauseSnapshot(
+                    pair.Key.Code,
+                    pair.Key.Discriminator);
+                var classification = FidelityResidualPolicy.Classify(cause);
+                return new FidelityResidualFacetSummary(
+                    pair.Key.Code,
+                    pair.Key.Discriminator,
+                    classification.Disposition,
+                    classification.RuleId,
+                    pair.Value.CauseSites,
+                    pair.Value.Methods.Count,
+                    [.. pair.Value.Methods
+                        .Order(StringComparer.Ordinal)
+                        .Take(MaxExamples)]);
+            })
+            .OrderByDescending(static summary => summary.Methods)
+            .ThenByDescending(static summary => summary.CauseSites)
+            .ThenBy(static summary => summary.Code, StringComparer.Ordinal)
+            .ThenBy(static summary => summary.Discriminator, StringComparer.Ordinal)
+            .ToImmutableArray();
+
+        return new FidelityResidualPortfolio(
+            FidelityResidualPolicy.Version,
+            totalMethods,
+            fullyRaisedMethods,
+            fidelityPrimaryMethods,
+            fidelityCauseSites,
+            recoverableMethods,
+            policyFloorMethods,
+            unclassifiedMethods,
+            missingCauseMethods,
+            structuralPrimaryMethods,
+            structuralPrimarySites,
+            fullyRaisedMethods + recoverableMethods,
+            fullyRaisedMethods + recoverableMethods + unclassifiedMethods,
+            summaries);
+    }
+
+    static bool IsEarlierStructuralResidual(string? residual)
+        => residual?.StartsWith("structuring:", StringComparison.Ordinal) == true
+            || residual?.StartsWith("eh:", StringComparison.Ordinal) == true;
+}

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -314,6 +314,85 @@ old message-substring shell filter; they are genuine missing-return defects and
 remain visible measured debt. The fidelity-cap increase did not create that
 semantic-validity population.
 
+Run the uncapped completeness census without the quality-card lens to print the
+fidelity residual portfolio:
+
+```bash
+dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
+  --emit-corpus-snapshot /tmp/corpus-snapshot.json \
+  --compile-cap 0 \
+  --corpus-fidelity-cap 0 \
+  --max-examples 3
+```
+
+```text
+## Fidelity residual portfolio (policy v1)
+
+Population: ... fidelity-primary methods, ... cause sites.
+Method rollup: ... all causes recoverable; ... any cause at the policy floor;
+... otherwise unclassified.
+Current roadmap target range: ... projected fully raised (...).
+Earlier structural-primary co-occurrence (excluded): ... methods, ... sites.
+
+Recoverable roadmap facets:
+  DEC0009/display-class-type-name: ... methods, ... sites; e.g. <stable method>
+
+Policy floor facets:
+  DEC0009/unspellable-field-name: ... methods, ... sites; e.g. <stable method>
+
+Unclassified facets:
+  DEC0006: ... methods, ... sites; e.g. <stable method>
+```
+
+This is a measurement and prioritization report, not a regression gate. It
+starts with **fidelity-primary methods**: methods whose raised tree has no
+earlier branch or EH residual. Branch/EH-primary methods that also have fidelity
+causes remain visible as excluded co-occurrence, so resolving a fidelity cause
+does not get credit for a method that is still structurally blocked.
+
+Snapshot schema v4 records producer-owned fidelity observations as `code`, an
+optional `discriminator`, and the exact site multiplicity. Identical facets
+within one method share a row; their `sites` count preserves duplicate cause
+sites without bloating the tracked baseline. The snapshot does not persist
+harness-owned policy dispositions or rule IDs. Older snapshots remain readable;
+a method without v4 cause observations is counted as unclassified if a
+portfolio is built from it. Existing corpus regression gates continue to use
+the same primary residual and aggregate metrics.
+An empty complete cause census has no primary bucket; the old synthetic
+`(typed)` fallback is no longer emitted.
+
+Policy v1 rolls multiple causes up per method in this order:
+
+1. **Recoverable roadmap:** every cause is mapped to recoverable work.
+2. **Policy floor:** at least one cause is mapped to the current policy floor.
+3. **Unclassified:** every other combination, including any new producer facet
+   for which the harness has no rule.
+
+The current recoverable rules cover generated-name, escapable-keyword, and
+accessor-metadata DEC0009 facets; iterator and constructor-call DEC0004 facets;
+private-implementation DEC0005 residue; DEC0008 result-type recovery; DEC0013
+continue verification; and DEC0014 fixed-statement raising. The current floor
+covers only DEC0009 metadata names that are neither legal C# identifiers nor
+recognized generated name shapes. Other causes remain visible as unclassified;
+causes absent from the measured corpus are not speculatively assigned.
+
+The lower target endpoint adds only all-recoverable methods to the current
+fully-raised count. The upper endpoint also includes unclassified methods.
+Current policy-floor methods are excluded from both endpoints. This makes the
+range a versioned policy target, not a mathematical upper bound on what a
+future decompiler could represent.
+
+Facet rows report both cause-site and distinct-method counts and include the
+stable method identity
+`assemblyPath!type::method(signature)`. Ranking by method count identifies the
+largest recoverable backlog without letting a method with many repeated cause
+sites dominate the ordering.
+
+SourceLink/source-correspondence evidence remains a peer, explicitly acquired
+lane. Join it to this census by stable method identity when available; do not
+merge its covered subset, acquisition outcomes, or provenance into these local
+corpus totals.
+
 To capture an RTS snapshot without comparing it to the compile-back baseline:
 
 ```bash

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -358,6 +358,8 @@ harness-owned policy dispositions or rule IDs. Older snapshots remain readable;
 a method without v4 cause observations is counted as unclassified if a
 portfolio is built from it. Existing corpus regression gates continue to use
 the same primary residual and aggregate metrics.
+The producer's separate inventory-bucket label preserves those legacy residual
+strings; it is display-only and is neither persisted nor classified.
 An empty complete cause census has no primary bucket; the old synthetic
 `(typed)` fallback is no longer emitted.
 


### PR DESCRIPTION
## Summary

- turns the real-world decompiler fidelity residual into an evidence-backed portfolio of recoverable roadmap work, policy floor, and visible unclassified work
- adds product-owned stable cause facets, compact schema-v4 corpus observations, explicit method/site aggregation, and a versioned harness policy without parsing human reason text
- preserves existing primary residual labels and gates by separating semantic discriminators from producer-owned inventory presentation

Closes #2817.

## Measured result

The pinned 14-assembly corpus contains 89,065 methods: 78,406 fully raised and 10,659 with lowering residue. The 8,165 fidelity-primary methods contain 49,559 fidelity cause sites.

| Rollup | Methods |
| --- | ---: |
| All causes recoverable | 8,093 |
| Any cause at policy floor | 0 |
| Otherwise unclassified | 72 |

The resulting policy target is **86,499-86,571 / 89,065 methods (97.12%-97.20%)**. The upper endpoint includes unclassified work, so this is a policy target rather than a mathematical impossibility bound. The remaining unclassified facets are DEC0006 (59 methods / 84 sites) and DEC0010 (13 methods / 47 sites).

Earlier structural/EH-primary residuals contain another 18,955 fidelity cause sites across 627 methods; the report exposes that co-occurrence without crediting those methods to fidelity recovery.

The integrated cap-50 baseline records 510 exact and 90 opcode-different checks over 600 methods, with zero compile/context failures.

## Compatibility boundary

Primary residual maps match `origin/main` value-for-value, including the 27 private-implementation rows. Schema v4 persists only cause code, discriminator, and positive site multiplicity; inventory labels and policy decisions remain outside the snapshot. Pre-v4 snapshots remain readable and classify missing cause observations as unclassified.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- 78 focused decompiler/harness tests via the xUnit v3 executable
- pinned completeness-only 14-assembly corpus: 89,065 methods and all portfolio counts reproduced
- tracked baseline SHA-256: `3cb8269a01079245b9d02656f075495b4dc8c7d9f6de91035219e50963061892`
- corpus list SHA-256: `f507e5bf7417508503cd684df5f59f65f95b418f6e17dbb56f25db6569ca1e26`
- Markdown lint and diff checks

## Adversarial review

- Claude Opus 4.8 found that the first DEC0005 compatibility mapping changed mixed-facet inventory labels. Commit `b199c769` moved the exact legacy label to producer-owned `InventoryBucket` while leaving the stable discriminator semantic.
- Gemini 3.1 Pro found that adding the inventory parameter had replaced the public six-parameter cause constructor. Commit `5278b2b8` restored that exact binary signature and added a distinct seven-parameter overload plus a canary.
- Claude Opus 4.8 and Gemini 3.1 Pro both reviewed exact final head `5278b2b8174bf262389ff09cade5e2b974bc543a` and returned CLEAN.