### PR TITLE
Fix multi-member record with-expression folding

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LadderRung5/LadderRung5.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung5/LadderRung5.cs
@@ -106,6 +106,13 @@ public class Program
     {
         return point with { X = point.X + dx };
     }
+
+    // Multi-member nondestructive mutation over a positional record. Roslyn emits
+    // a dup between init-only setters for this shape.
+    public WithProbe MultiMemberWith(WithProbe r)
+    {
+        return r with { A = 1, B = 2 };
+    }
 }
 
 // Positional record with an extra init-only property: rung 5 "records/init where
@@ -116,6 +123,8 @@ public record Point(int X, int Y)
 {
     public int Magnitude { get; init; }
 }
+
+public record WithProbe(int A, int B);
 
 // C# 11 checked user-defined operators (#1706): a modern-syntax construct whose
 // USE must render with a checked(...) context, not an explicit op_Checked* method

--- a/src/ILInspector.Decompiler.Tests/LadderRung5GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung5GateTests.cs
@@ -45,8 +45,8 @@ public class LadderRung5GateTests
     static readonly string[] ExpectedProgramMembers =
     [
         ".ctor", "Describe", "FromEnd", "IsOrigin", "IsRealString", "LastElement",
-        "MakeScaled", "MiddleSlice", "Prefix", "Quadrant", "Shift", "Size",
-        "UsingDeclaration",
+        "MakeScaled", "MiddleSlice", "MultiMemberWith", "Prefix", "Quadrant",
+        "Shift", "Size", "UsingDeclaration",
     ];
 
     // The record's compiler-synthesized member set (primary + copy ctor, Clone,
@@ -184,6 +184,33 @@ public class LadderRung5GateTests
 
         // nondestructive mutation (with-expression) on a record.
         Assert.Contains("return point with { X = point.X + dx };", Body("Shift"));
+
+        var multiMemberWith = Body("MultiMemberWith");
+        Assert.Equal("return r with { A = 1, B = 2 };", multiMemberWith);
+        Assert.DoesNotContain(".B = 2", multiMemberWith);
+    }
+
+    [Fact]
+    public void Rung5Fixture_RendersCompilerProducedMultiMemberWith()
+    {
+        var function = LoadImportedMember(ProgramType, "MultiMemberWith");
+        foreach (var pass in IrPasses.Default)
+        {
+            if (pass is WithExpressionPass)
+                break;
+            pass.Run(function, PassContext.None);
+            function.CheckInvariant();
+        }
+
+        Assert.Contains(function.Descendants.OfType<StoreStackSlot>(), store => store.Value is LoadStackSlot);
+        Assert.Equal(["A", "B"], function.Descendants.OfType<StoreProperty>().Select(store => store.PropertyName).ToArray());
+
+        new WithExpressionPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        var output = CSharpPrinter.PrintRaised(function).Output?.Trim() ?? "";
+        Assert.Equal("return r with { A = 1, B = 2 };", output);
+        Assert.DoesNotContain(".B = 2", output);
     }
 
     // The compiler-synthesized record members render at the rung 5 bar. These pin
@@ -347,12 +374,25 @@ public class LadderRung5GateTests
     static List<(string Type, string Name, IrFunction Function)> LoadRaisedMembers()
     {
         var members = new List<(string Type, string Name, IrFunction Function)>();
+        foreach (var member in LoadImportedMembers())
+        {
+            IrPasses.Run(member.Function);
+            members.Add(member);
+        }
+        return members;
+    }
+
+    static IrFunction LoadImportedMember(string typeName, string methodName)
+        => LoadImportedMembers().Single(member => member.Type == typeName && member.Name == methodName).Function;
+
+    static List<(string Type, string Name, IrFunction Function)> LoadImportedMembers()
+    {
+        var members = new List<(string Type, string Name, IrFunction Function)>();
         using var source = MetadataSource.Open(FixturePath);
         foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
         {
             if (!typeName.StartsWith("LadderRung5.", StringComparison.Ordinal))
                 continue;
-            IrPasses.Run(function);
             members.Add((typeName, methodName, function));
         }
         return members;

--- a/src/ILInspector.Decompiler.Tests/WithExpressionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/WithExpressionPassTests.cs
@@ -45,6 +45,25 @@ public class WithExpressionPassTests
     }
 
     [Fact]
+    public void MultipleMutationsThroughCompilerCopy_RaiseInSourceOrder()
+    {
+        var function = FunctionWithClone(compilerGenerated: true, secondMember: true, copyBeforeSecondMember: true);
+
+        new WithExpressionPass().Run(function, PassContext.None);
+
+        var withExpression = Assert.Single(function.Descendants.OfType<WithExpression>());
+        Assert.Equal(["X", "Y"], withExpression.Members);
+        Assert.Equal(["set_X", "set_Y"], withExpression.Entries.Select(entry => entry.ConsumedMethod?.Name));
+        Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
+        Assert.Empty(function.Descendants.OfType<StoreProperty>());
+        function.CheckInvariant();
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("return point with { X = dx, Y = dy };", output);
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
+
+    [Fact]
     public void SameNamedNonGeneratedClone_DoesNotRaise()
     {
         var function = FunctionWithClone(compilerGenerated: false);
@@ -72,6 +91,24 @@ public class WithExpressionPassTests
     }
 
     [Fact]
+    public void DuplicateMemberMutationThroughCopy_DoesNotFoldIntoInvalidWithExpression()
+    {
+        var function = FunctionWithClone(
+            compilerGenerated: true,
+            secondMember: true,
+            copyBeforeSecondMember: true,
+            duplicateMember: true);
+
+        new WithExpressionPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<WithExpression>());
+        Assert.Equal(2, function.Descendants.OfType<StoreProperty>().Count());
+        Assert.Equal(2, function.Descendants.OfType<StoreStackSlot>().Count());
+        Assert.Single(function.Descendants.OfType<Call>(), call => call.Callee.Name == "<Clone>$");
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void CloneWithExtraUse_DoesNotFoldIntoSingleExpression()
     {
         var function = FunctionWithClone(compilerGenerated: true, keepAliveUse: true);
@@ -80,6 +117,41 @@ public class WithExpressionPassTests
 
         Assert.Empty(function.Descendants.OfType<WithExpression>());
         Assert.Single(function.Descendants.OfType<StoreProperty>());
+        Assert.Single(function.Descendants.OfType<Call>(), call => call.Callee.Name == "<Clone>$");
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void CloneCopyWithExtraUse_DoesNotFoldIntoSingleExpression()
+    {
+        var function = FunctionWithClone(
+            compilerGenerated: true,
+            secondMember: true,
+            copyBeforeSecondMember: true,
+            extraUseAfterCopy: true);
+
+        new WithExpressionPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<WithExpression>());
+        Assert.Equal(2, function.Descendants.OfType<StoreProperty>().Count());
+        Assert.Equal(2, function.Descendants.OfType<StoreStackSlot>().Count());
+        Assert.Single(function.Descendants.OfType<Call>(), call => call.Callee.Name == "<Clone>$");
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void UnrelatedStackSlotCopy_DoesNotJoinWithExpressionRun()
+    {
+        var function = FunctionWithClone(
+            compilerGenerated: true,
+            secondMember: true,
+            unrelatedCopyBeforeSecondMember: true);
+
+        new WithExpressionPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<WithExpression>());
+        Assert.Equal(2, function.Descendants.OfType<StoreProperty>().Count());
+        Assert.Equal(3, function.Descendants.OfType<StoreStackSlot>().Count());
         Assert.Single(function.Descendants.OfType<Call>(), call => call.Callee.Name == "<Clone>$");
         function.CheckInvariant();
     }
@@ -102,7 +174,10 @@ public class WithExpressionPassTests
         bool keepAliveUse = false,
         bool receiverUsesTargetSlot = false,
         bool secondMember = false,
-        bool duplicateMember = false)
+        bool duplicateMember = false,
+        bool copyBeforeSecondMember = false,
+        bool extraUseAfterCopy = false,
+        bool unrelatedCopyBeforeSecondMember = false)
     {
         var clone = new MethodRef(Point, "<Clone>$", Point, [], HasThis: true)
         {
@@ -115,7 +190,12 @@ public class WithExpressionPassTests
         var keepAlive = new MethodRef(TypeRef.CoreLib("System", "GC"), "KeepAlive", Void, [TypeRef.CoreLib("System", "Object")], HasThis: false);
 
         const int slot = 256;
+        const int copySlot = 257;
+        const int unrelatedSlot = 258;
+        int activeSlot = slot;
         var block = new Block();
+        if (unrelatedCopyBeforeSecondMember)
+            block.Add(new StoreStackSlot(unrelatedSlot, new LoadArgument(0, "point", Point)));
         if (receiverUsesTargetSlot)
             block.Add(new StoreStackSlot(slot, new LoadArgument(0, "point", Point)));
         block.Add(new StoreStackSlot(
@@ -125,14 +205,28 @@ public class WithExpressionPassTests
                 : new LoadArgument(0, "point", Point)])));
         block.Add(new StoreProperty(Setter("X"), new LoadStackSlot(slot, Point), [], new LoadArgument(1, "dx", Int32)));
         if (secondMember)
+        {
+            if (copyBeforeSecondMember)
+            {
+                block.Add(new StoreStackSlot(copySlot, new LoadStackSlot(activeSlot, Point)));
+                activeSlot = copySlot;
+            }
+            else if (unrelatedCopyBeforeSecondMember)
+            {
+                block.Add(new StoreStackSlot(copySlot, new LoadStackSlot(unrelatedSlot, Point)));
+                activeSlot = copySlot;
+            }
+            if (extraUseAfterCopy)
+                block.Add(new ExpressionStatement(new Call(keepAlive, isVirtual: false, [new LoadStackSlot(activeSlot, Point)])));
             block.Add(new StoreProperty(
                 Setter(duplicateMember ? "X" : "Y"),
-                new LoadStackSlot(slot, Point),
+                new LoadStackSlot(activeSlot, Point),
                 [],
                 new LoadArgument(2, "dy", Int32)));
+        }
         if (keepAliveUse)
             block.Add(new ExpressionStatement(new Call(keepAlive, isVirtual: false, [new LoadStackSlot(slot, Point)])));
-        block.Add(new Return(new LoadStackSlot(slot, Point)));
+        block.Add(new Return(new LoadStackSlot(activeSlot, Point)));
 
         var body = new BlockContainer();
         body.Add(block);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/WithExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/WithExpressionPass.cs
@@ -3,8 +3,8 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <summary>
 /// Raises the compiler's record <c>with</c> lowering back into
 /// <c>receiver with { X = value, ... }</c>. The supported shape is a synthesized
-/// record clone stored to one stack slot, followed by member stores on that slot
-/// and exactly one downstream load of the mutated clone.
+/// record clone threaded through a stack-slot dup chain, followed by member
+/// stores on those slots and exactly one downstream load of the mutated clone.
 /// </summary>
 public sealed class WithExpressionPass : IIrPass
 {
@@ -37,13 +37,22 @@ public sealed class WithExpressionPass : IIrPass
             return null;
 
         var statements = seed.Parent!.Children;
+        var aliasSlots = new HashSet<int> { seed.Slot };
         var entries = new List<InitializerEntry>();
         var consumed = new List<IrNode> { seed };
 
         for (int i = seed.ChildIndex + 1; i < statements.Count; i++)
         {
             var statement = statements[i];
-            if (TryMemberStore(statement, seed.Slot) is { } member)
+
+            if (statement is StoreStackSlot { Value: LoadStackSlot source } copy && aliasSlots.Contains(source.Slot))
+            {
+                aliasSlots.Add(copy.Slot);
+                consumed.Add(copy);
+                continue;
+            }
+
+            if (TryMemberStore(statement, aliasSlots) is { } member)
             {
                 entries.Add(member);
                 consumed.Add(statement);
@@ -53,23 +62,23 @@ public sealed class WithExpressionPass : IIrPass
             break;
         }
 
-        if (ReferencesSlot(clone.Arguments[0], seed.Slot))
+        if (ReferencesAnySlot(clone.Arguments[0], aliasSlots))
             return null;
 
         if (entries.Count == 0 || HasDuplicateMembers(entries))
             return null;
 
         foreach (var entry in entries)
-            if (ReferencesSlot(entry.Arguments[0], seed.Slot))
+            if (ReferencesAnySlot(entry.Arguments[0], aliasSlots))
                 return null;
 
         var consumedSet = consumed.ToHashSet();
         foreach (var store in function.Descendants.OfType<StoreStackSlot>())
-            if (store.Slot == seed.Slot && !consumedSet.Contains(store) && !HasAncestorIn(store, consumedSet))
+            if (aliasSlots.Contains(store.Slot) && !ReferenceOwnership.IsInsideAny(store, consumed))
                 return null;
 
         var outsideUses = function.Descendants.OfType<LoadStackSlot>()
-            .Where(load => load.Slot == seed.Slot && !HasAncestorIn(load, consumedSet))
+            .Where(load => aliasSlots.Contains(load.Slot) && !ReferenceOwnership.IsInsideAny(load, consumed))
             .ToList();
         if (outsideUses.Count != 1)
             return null;
@@ -98,16 +107,16 @@ public sealed class WithExpressionPass : IIrPass
             && receiverType.Equals(clone.Callee.ReturnType);
     }
 
-    static InitializerEntry? TryMemberStore(IrNode statement, int slot) => statement switch
+    static InitializerEntry? TryMemberStore(IrNode statement, HashSet<int> aliasSlots) => statement switch
     {
         StoreProperty { HasInstance: true, Instance: LoadStackSlot receiver } property
-            when receiver.Slot == slot
+            when aliasSlots.Contains(receiver.Slot)
                 && property.IndexArguments.Count == 0
                 && ObjectInitializerPass.IsInitializerSpellable(property)
             => new InitializerEntry(property.PropertyName, [property.Value], ConsumedMethod: property.Accessor),
 
         StoreField { Instance: LoadStackSlot receiver } field
-            when receiver.Slot == slot && CSharpNaming.IsUsableIdentifier(field.Field.Name)
+            when aliasSlots.Contains(receiver.Slot) && CSharpNaming.IsUsableIdentifier(field.Field.Name)
             => new InitializerEntry(field.Field.Name, [field.Value], ConsumedField: field.Field),
 
         _ => null,
@@ -122,17 +131,9 @@ public sealed class WithExpressionPass : IIrPass
         return false;
     }
 
-    static bool ReferencesSlot(IrNode node, int slot)
-        => (node is LoadStackSlot load && load.Slot == slot)
-            || node.Descendants.OfType<LoadStackSlot>().Any(descendant => descendant.Slot == slot);
-
-    static bool HasAncestorIn(IrNode node, HashSet<IrNode> set)
-    {
-        for (var parent = node.Parent; parent is not null; parent = parent.Parent)
-            if (set.Contains(parent))
-                return true;
-        return false;
-    }
+    static bool ReferencesAnySlot(IrNode node, HashSet<int> slots)
+        => (node is LoadStackSlot load && slots.Contains(load.Slot))
+            || node.Descendants.OfType<LoadStackSlot>().Any(descendant => slots.Contains(descendant.Slot));
 
     static void Apply(Plan plan)
     {


### PR DESCRIPTION
## Summary

Fixes #2829 by folding Roslyn's stack-slot copy chain into one complete
multi-member record `with` expression. The pass now proves ownership across
aliases before consuming member stores, so it no longer emits a partial
initializer followed by an invalid init-only assignment.

The widening remains conservative: duplicate members, external stores or
uses, malformed chains, multiple or missing escapes, and non-clone paths all
decline the raise. Record structs remain outside this clone-based path.

## Evidence

### Before

```csharp
RA S_257 = r with { A = 1 };
S_257.B = 2;
return S_257;
```

The trailing assignment fails with `CS8852` because `B` is init-only.

### After

```csharp
return r with { A = 1, B = 2 };
```

The compiler-produced fixture now folds every member into one valid `with`
expression.

### Fully Raised

The After decompilation is in the fully raised state.

## Validation

- `WithExpressionPassTests`: 10 passed
- `LadderRung5GateTests`: 9 passed
- Fast decompiler suite passed
- Full decompiler suite passed

## Adversarial review

- Gemini 3.1 Pro: clean on exact head `4e388454`
- Claude Opus 4.8: clean on exact head `4e388454`

Both reviewers attacked alias ownership, escape accounting, malformed and
duplicate-member near misses, record class/struct boundaries, and unrelated
IR consumption. Neither found a blocking issue.

The branch was rebased conflict-free onto `0599bfe7`; its stable patch ID is
unchanged from the reviewed pre-rebase patch.
