### PR TITLE
Fix catch-entry local scope collisions

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CatchEntryFoldingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CatchEntryFoldingTests.cs
@@ -101,8 +101,18 @@ public class CatchEntryFoldingTests
     [Fact]
     public void SiblingCatchesSharingFoldedLocal_KeepTheirBindings()
     {
-        var specific = Catch(TypeRef.CoreLib("System", "InvalidOperationException"), 0);
-        var general = Catch(Exception, 0);
+        var specific = new CatchClause(
+            TypeRef.CoreLib("System", "InvalidOperationException"),
+            Body(new ExpressionStatement(new LoadLocal(0, Exception))))
+        {
+            VariableIndex = 0
+        };
+        var general = new CatchClause(
+            Exception,
+            Body(new ExpressionStatement(new LoadLocal(0, Exception))))
+        {
+            VariableIndex = 0
+        };
         var function = Function(new TryCatch(Body(), [specific, general]), Exception);
 
         new CatchVariableScopePass().Run(function, PassContext.None);

--- a/src/ILInspector.Decompiler.Tests/CatchEntryFoldingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CatchEntryFoldingTests.cs
@@ -1,0 +1,101 @@
+using ILInspector.Decompiler.Pipeline;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.Decompiler.Tests;
+
+// EhStructuringPass.FoldEntryConsumption folds a catch-entry `stloc` of the
+// caught exception into the clause variable — but only when that local is
+// confined to the handler. Issue #2828: when the destination local is declared
+// before the try and read after the catch, folding it emits a duplicate catch
+// variable (CS0136) and drops the `local = ex` assignment. Because the folded
+// shape is load-bearing for the using/foreach/async scaffold passes, the fix is
+// a late pass (CatchVariableScopePass) that runs after those consumers and
+// un-folds only surviving plain clauses whose folded local escapes the clause:
+// it rebinds a fresh catch variable and restores the `local = ex` entry store.
+// Ordinary handler-local folding is preserved.
+public class CatchEntryFoldingTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return function;
+    }
+
+    [Fact]
+    public void HandlerLocalCatchVariable_FoldsIntoClause()
+    {
+        var function = Raised(nameof(CfgSampleClass.CatchFoldsHandlerLocal));
+
+        var clause = Assert.Single(function.Descendants.OfType<TryCatch>()).Clauses.Single();
+        Assert.NotNull(clause.VariableIndex);
+        // The fold consumed the entry store: no bare caught exception, and no
+        // re-introduced `local = caught` assignment inside the handler body.
+        Assert.Empty(clause.Body.Descendants.OfType<CaughtException>());
+
+        string? output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.Contains("catch (Exception", output);
+        AssertCompiles("int", "CatchFoldsHandlerLocal", output);
+    }
+
+    [Fact]
+    public void PredeclaredLocalAssignedInCatch_DeclinesFoldAndBindsFreshVariable()
+    {
+        var function = Raised(nameof(CfgSampleClass.CatchAssignsPredeclaredLocal));
+
+        var clause = Assert.Single(function.Descendants.OfType<TryCatch>()).Clauses.Single();
+        Assert.NotNull(clause.VariableIndex);
+
+        // The predeclared local (slot 0, `captured`) is initialized before the
+        // try, so the clause variable must be a distinct fresh slot, not slot 0.
+        Assert.NotEqual(0, clause.VariableIndex);
+
+        // The `captured = ex` assignment survives: a store into slot 0 inside the
+        // handler, reading the freshly bound catch variable.
+        var assignment = Assert.Single(
+            clause.Body.Descendants.OfType<StoreLocal>(), s => s.Index == 0);
+        var read = Assert.IsType<LoadLocal>(assignment.Value);
+        Assert.Equal(clause.VariableIndex, read.Index);
+
+        // No bare caught exception leaks, and the catch variable name differs
+        // from the predeclared local's name — so the emitted C# binds (no CS0136).
+        Assert.Empty(clause.Body.Descendants.OfType<CaughtException>());
+
+        string? output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.Contains("captured = ", output);
+        AssertCompiles("string", "CatchAssignsPredeclaredLocal", output);
+    }
+
+    static void AssertCompiles(string returnType, string name, string body)
+    {
+        string source = $$"""
+            using System;
+            static class __Gate
+            {
+                static {{returnType}} M(string s)
+                {
+            {{body}}
+                }
+            }
+            """;
+        var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview));
+        var compilation = CSharpCompilation.Create(
+            "__gate",
+            [tree],
+            RoslynTestReferences.TrustedPlatform,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+        var errors = compilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => $"{d.Id}: {d.GetMessage()}")
+            .ToArray();
+        Assert.True(
+            errors.Length == 0,
+            $"Rendered {name} must compile, got:\n  " + string.Join("\n  ", errors) + "\n--- body ---\n" + body);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/CatchEntryFoldingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CatchEntryFoldingTests.cs
@@ -16,6 +16,10 @@ namespace ILInspector.Decompiler.Tests;
 // Ordinary handler-local folding is preserved.
 public class CatchEntryFoldingTests
 {
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef Exception = TypeRef.CoreLib("System", "Exception");
+    static readonly TypeRef Holder = TypeRef.Definition("Synthetic", "Tests", "Holder");
+
     static IrFunction Raised(string methodName)
     {
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
@@ -70,6 +74,69 @@ public class CatchEntryFoldingTests
         Assert.NotNull(output);
         Assert.Contains("captured = ", output);
         AssertCompiles("string", "CatchAssignsPredeclaredLocal", output);
+    }
+
+    [Fact]
+    public void NestedCatchSharingFoldedLocal_RebindsInnerClause()
+    {
+        var inner = Catch(Exception, 0);
+        var outerBody = Body(new TryCatch(Body(), [inner]));
+        var outer = new CatchClause(Exception, outerBody) { VariableIndex = 0 };
+        var function = Function(new TryCatch(Body(), [outer]), Exception);
+
+        new CatchVariableScopePass().Run(function, PassContext.None);
+
+        Assert.Equal(0, outer.VariableIndex);
+        Assert.NotEqual(0, inner.VariableIndex);
+        var restore = Assert.Single(inner.Body.Descendants.OfType<StoreLocal>());
+        Assert.Equal(0, restore.Index);
+        Assert.Equal(inner.VariableIndex, Assert.IsType<LoadLocal>(restore.Value).Index);
+        function.CheckInvariant();
+
+        string? output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        AssertCompiles("void", "NestedCatchSharingFoldedLocal", output);
+    }
+
+    [Fact]
+    public void SiblingCatchesSharingFoldedLocal_KeepTheirBindings()
+    {
+        var specific = Catch(TypeRef.CoreLib("System", "InvalidOperationException"), 0);
+        var general = Catch(Exception, 0);
+        var function = Function(new TryCatch(Body(), [specific, general]), Exception);
+
+        new CatchVariableScopePass().Run(function, PassContext.None);
+
+        Assert.Equal(0, specific.VariableIndex);
+        Assert.Equal(0, general.VariableIndex);
+        Assert.Single(function.Locals);
+        Assert.Empty(function.Descendants.OfType<StoreLocal>());
+        function.CheckInvariant();
+
+        string? output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        AssertCompiles("void", "SiblingCatchesSharingFoldedLocal", output);
+    }
+
+    static CatchClause Catch(TypeRef type, int variable)
+        => new(type, Body()) { VariableIndex = variable };
+
+    static IrFunction Function(IrNode statement, params TypeRef[] locals)
+        => new(
+            "M",
+            Holder,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [.. locals],
+            Body(statement));
+
+    static BlockContainer Body(params IrNode[] statements)
+    {
+        var body = new BlockContainer();
+        var block = new Block(0);
+        foreach (var statement in statements)
+            block.Add(statement);
+        body.Add(block);
+        return body;
     }
 
     static void AssertCompiles(string returnType, string name, string body)

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -907,6 +907,46 @@ public class CfgSampleClass
         catch (OverflowException) { return -2; }
     }
 
+    // Positive fold: the caught exception is spilled into a real IL local at
+    // handler entry (the branch inside the handler forces csc to allocate a
+    // local for `e`). That local is handler-local — never read in the try or
+    // after the catch — so EhStructuringPass folds the entry store into the
+    // clause variable and emits `catch (Exception e) { ... }`.
+    public static int CatchFoldsHandlerLocal(string s)
+    {
+        try
+        {
+            return int.Parse(s);
+        }
+        catch (Exception e)
+        {
+            if (e.InnerException != null)
+                Console.WriteLine(e.Message);
+            Console.WriteLine(e.StackTrace);
+            return -1;
+        }
+    }
+
+    // Near miss / issue #2828 shape: the caught exception is assigned into a
+    // local that is declared before the try and read after the catch. csc emits
+    // the assignment as `stloc captured` at handler entry, but that local is live
+    // outside the handler, so folding it into the clause variable would emit a
+    // duplicate declaration (CS0136) and drop the `captured = ex` assignment.
+    public static string CatchAssignsPredeclaredLocal(string s)
+    {
+        Exception? captured = null;
+        try
+        {
+            return int.Parse(s).ToString();
+        }
+        catch (Exception ex)
+        {
+            captured = ex;
+        }
+
+        return captured?.Message ?? "ok";
+    }
+
     public static int ParseWithCleanup(string s, Action done)
     {
         try { return int.Parse(s); }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CatchVariableScopePass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CatchVariableScopePass.cs
@@ -1,0 +1,103 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Un-folds a catch clause whose folded variable is a local that lives outside
+/// the clause. <see cref="EhStructuringPass"/> folds a catch-entry
+/// <c>stloc L</c> of the caught exception into the clause header — the clause
+/// variable becomes <c>L</c> and the store disappears. That is correct when
+/// <c>L</c> is confined to the handler, and it is the shape the using/foreach/
+/// async scaffold passes consume, so the fold must happen up front and this
+/// correction must run <em>after</em> those passes have taken their clauses.
+///
+/// <para>When a plain catch clause survives to here with its folded local still
+/// read, written, or addressed outside the clause (issue #2828 — a local
+/// declared before the <c>try</c> and read after the <c>catch</c>, e.g.
+/// <c>Exception inner = null; try {…} catch (Exception) {} … use(inner)</c>),
+/// naming that outer local as the clause variable shadows its own declaration
+/// (CS0136) and drops the <c>inner = ex</c> assignment the empty body lost.
+/// Rebind the clause to a fresh variable <c>F</c> and restore the entry store as
+/// <c>inner = F</c>: <c>catch (Exception F) { inner = F; … }</c>. <c>F</c> is
+/// used exactly once for the #2828 shape, so csc re-elides it on recompile and
+/// the restored store round-trips to the original <c>stloc L</c>.</para>
+///
+/// <para>Scope: only clauses in the top-level function body (whose locals index
+/// the function's own slot table) and only ordinary catch clauses — a filter
+/// clause shares its exception local across the <c>when</c> and the handler, so
+/// moving the store into the handler body would leave the filter reading an
+/// unassigned local.</para>
+/// </summary>
+public sealed class CatchVariableScopePass : IIrPass
+{
+    public string Name => "catch-variable-scope";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        // Traverse the function's own scope only: a nested lambda / local
+        // function numbers its locals independently, so a slot index there is a
+        // different variable and must not be conflated with this scope's locals.
+        var scope = DescendantsOutsideNestedFunctions(function.Body).ToList();
+        foreach (var clause in scope.OfType<CatchClause>())
+        {
+            if (clause.VariableIndex is not { } local)
+                continue;
+            if (clause.Filter is not null)
+                continue;
+            if (!LocalUsedOutsideClause(scope, clause, local))
+                continue;
+
+            int fresh = function.AddLocal(clause.ExceptionType);
+            clause.VariableIndex = fresh;
+
+            var restore = new StoreLocal(local, function.Locals[local], new LoadLocal(fresh, clause.ExceptionType));
+            context.Stepper.StepOver("restore folded catch-entry assignment for a local used outside the clause", restore);
+            PrependStatement(clause.Body, restore);
+        }
+    }
+
+    static bool LocalUsedOutsideClause(IReadOnlyList<IrNode> scope, CatchClause clause, int local)
+    {
+        var inside = new HashSet<IrNode>(DescendantsOutsideNestedFunctions(clause));
+        foreach (var node in scope)
+        {
+            if (inside.Contains(node))
+                continue;
+            switch (node)
+            {
+                case LoadLocal load when load.Index == local:
+                case StoreLocal store when store.Index == local:
+                case LoadLocalAddress address when address.Index == local:
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    static void PrependStatement(BlockContainer body, IrNode statement)
+    {
+        if (body.Blocks is [var first, ..])
+        {
+            var existing = first.DetachChildren();
+            first.Add(statement);
+            foreach (var child in existing)
+                first.Add(child);
+        }
+        else
+        {
+            var block = new Block(0);
+            block.Add(statement);
+            body.Add(block);
+        }
+    }
+
+    static IEnumerable<IrNode> DescendantsOutsideNestedFunctions(IrNode node)
+    {
+        foreach (var child in node.Children)
+        {
+            yield return child;
+            if (child is Lambda or LocalFunctionStatement)
+                continue;
+            foreach (var descendant in DescendantsOutsideNestedFunctions(child))
+                yield return descendant;
+        }
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CatchVariableScopePass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CatchVariableScopePass.cs
@@ -61,6 +61,8 @@ public sealed class CatchVariableScopePass : IIrPass
         {
             if (inside.Contains(node))
                 continue;
+            if (BoundByAnotherCatch(node, clause, local))
+                continue;
             switch (node)
             {
                 case LoadLocal load when load.Index == local:
@@ -68,6 +70,18 @@ public sealed class CatchVariableScopePass : IIrPass
                 case LoadLocalAddress address when address.Index == local:
                     return true;
             }
+        }
+        return false;
+    }
+
+    static bool BoundByAnotherCatch(IrNode node, CatchClause clause, int local)
+    {
+        for (IrNode? ancestor = node.Parent; ancestor is not null; ancestor = ancestor.Parent)
+        {
+            if (ReferenceEquals(ancestor, clause))
+                return false;
+            if (ancestor is CatchClause { VariableIndex: var binding } && binding == local)
+                return true;
         }
         return false;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CatchVariableScopePass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CatchVariableScopePass.cs
@@ -10,11 +10,10 @@ namespace ILInspector.Decompiler.Pipeline;
 /// correction must run <em>after</em> those passes have taken their clauses.
 ///
 /// <para>When a plain catch clause survives to here with its folded local still
-/// read, written, or addressed outside the clause (issue #2828 — a local
-/// declared before the <c>try</c> and read after the <c>catch</c>, e.g.
-/// <c>Exception inner = null; try {…} catch (Exception) {} … use(inner)</c>),
-/// naming that outer local as the clause variable shadows its own declaration
-/// (CS0136) and drops the <c>inner = ex</c> assignment the empty body lost.
+/// read, written, or addressed outside the clause, or an enclosing catch binds
+/// the same slot (issue #2828), naming that local as the clause variable
+/// shadows its own declaration (CS0136) and drops the assignment represented
+/// by the handler-entry store.
 /// Rebind the clause to a fresh variable <c>F</c> and restore the entry store as
 /// <c>inner = F</c>: <c>catch (Exception F) { inner = F; … }</c>. <c>F</c> is
 /// used exactly once for the #2828 shape, so csc re-elides it on recompile and
@@ -42,7 +41,8 @@ public sealed class CatchVariableScopePass : IIrPass
                 continue;
             if (clause.Filter is not null)
                 continue;
-            if (!LocalUsedOutsideClause(scope, clause, local))
+            if (!LocalUsedOutsideClause(scope, clause, local)
+                && !EnclosingCatchBindsLocal(clause, local))
                 continue;
 
             int fresh = function.AddLocal(clause.ExceptionType);
@@ -68,6 +68,16 @@ public sealed class CatchVariableScopePass : IIrPass
                 case LoadLocalAddress address when address.Index == local:
                     return true;
             }
+        }
+        return false;
+    }
+
+    static bool EnclosingCatchBindsLocal(CatchClause clause, int local)
+    {
+        for (IrNode? ancestor = clause.Parent; ancestor is not null; ancestor = ancestor.Parent)
+        {
+            if (ancestor is CatchClause { VariableIndex: var enclosing } && enclosing == local)
+                return true;
         }
         return false;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -259,6 +259,12 @@ public static class IrPasses
         // Raise compiler-hidden enumerator using/while/current loops and the
         // indexed array lowering to foreach.
         new ForeachStatementPass(),
+        // After the try/catch-based scaffolds (using, foreach) have consumed the
+        // clauses they need EhStructuringPass to have folded, un-fold any plain
+        // catch clause whose folded variable is a local that lives outside the
+        // clause — restoring a distinct catch variable plus the entry assignment
+        // so the survivor does not shadow the outer local (CS0136, issue #2828).
+        new CatchVariableScopePass(),
         // Raise the csc pin lowering (a pinned managed-ref local + derived
         // pointer + optional unpin store) into fixed (T* p = &place) { ... }.
         // Runs after structuring and the second inlining so the pinned region's

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -83,6 +83,8 @@ internal static class NativePasses
     public static RuntimeAsyncAwaiterPass RuntimeAsyncAwaiter => new();
     [Native(NativeCategory.EmitArtifact, "record with-expression clone/member-set scaffold reconstructed to receiver with { ... }")]
     public static WithExpressionPass WithExpression => new();
+    [Native(NativeCategory.EmitArtifact, "a folded catch-entry store whose local lives outside the surviving clause un-folded back to a distinct catch variable plus the entry assignment (issue #2828)")]
+    public static CatchVariableScopePass CatchVariableScope => new();
 
     // ───────── IlErasure — reconstruct information the IL type system dropped ─────────
     [Native(NativeCategory.IlErasure, "int constants re-typed to bool/char/enum at typed positions")]


### PR DESCRIPTION
## Summary

Fixes #2828 by preserving a distinct catch variable when folding would collide
with a live outer local or an enclosing catch binding. The late
`CatchVariableScopePass` restores the caught-exception assignment after the
earlier folded shape has served using, foreach, and async consumers.

Sibling and cousin catches that independently bind the same slot are excluded
from escape detection, while real reads, writes, and managed-address uses
outside the binding still force rebinding.

## Evidence

### Before

Representative output reused the live outer local as the catch declaration:

```csharp
Exception V_1 = null;
try
{
    // ...
}
catch (Exception V_1)
{
}
return Use(V_1);
```

This fails with `CS0136` and loses the assignment needed by the post-handler
read.

### After

```csharp
Exception V_1 = null;
try
{
    // ...
}
catch (Exception V_2)
{
    V_1 = V_2;
}
return Use(V_1);
```

The distinct catch variable avoids the scope collision while preserving
Npgsql's caught exception for its later use.

### Fully Raised

The After decompilation is in the fully raised state.

## Validation

- `CatchEntryFoldingTests`: 7 passed on the rebased head
- Fast decompiler suite passed
- Compiler-backed nested, sibling, cousin, and escaping-local cases passed

## Adversarial review

Earlier Gemini and Claude Opus review rounds exposed two additional scope
boundaries:

- nested catches sharing a slot, resolved by `8e5148de`
- sibling catches with real local uses, resolved by `4b349fe3`

Gemini 3.1 Pro and Claude Opus 4.8 then both reported clean on exact head
`4b349fe3`.

The branch was rebased conflict-free onto `0599bfe7`; its stable patch ID is
unchanged from the reviewed pre-rebase series.
