### PR TITLE
Fix unconstrained generic pattern extraction

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GenericDeclarationPatternExtractionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GenericDeclarationPatternExtractionTests.cs
@@ -449,6 +449,162 @@ public class GenericDeclarationPatternExtractionTests
         Assert.DoesNotContain("(object)", output);
     }
 
+    [Fact]
+    public void UnboxOfIsInstance_WithAddressTakenInlineLocalFunctionArgument_DoesNotBridge()
+    {
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var generic = TypeRef.GenericParameter(0, "T");
+        IrExpression ReadArgument() => new LoadArgument(0, "value", objectType);
+
+        var thenBlock = new Block();
+        thenBlock.Add(new InitObject(
+            objectType,
+            new LoadArgumentAddress(0, "value", objectType)));
+        thenBlock.Add(new Return(new Box(
+            generic,
+            new UnboxAny(generic, new IsInstance(generic, ReadArgument())))));
+
+        var localFunctionBlock = new Block();
+        localFunctionBlock.Add(new IfStatement(
+            new IsInstance(generic, ReadArgument()),
+            thenBlock,
+            null));
+        var localFunctionBody = new BlockContainer();
+        localFunctionBody.Add(localFunctionBlock);
+        var localFunction = new LocalFunctionStatement(
+            "Local",
+            objectType,
+            [new Parameter("value", objectType)],
+            isStatic: true,
+            [],
+            [],
+            usesUpdatedMemorySafetyRules: false,
+            skipLocalsInit: false,
+            localFunctionBody);
+
+        var outer = new Block();
+        outer.Add(localFunction);
+        var body = new BlockContainer();
+        body.Add(outer);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(
+                TypeRef.CoreLib("System", "Void"),
+                [],
+                HasThis: false,
+                GenericParameterCount: 1),
+            [],
+            body);
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.DoesNotContain("(object)", output);
+    }
+
+    [Fact]
+    public void UnboxOfIsInstance_OuterAddressDoesNotBlockInlineLocalFunction()
+    {
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var generic = TypeRef.GenericParameter(0, "T");
+        IrExpression ReadArgument() => new LoadArgument(0, "value", objectType);
+
+        var thenBlock = new Block();
+        thenBlock.Add(new Return(new Box(
+            generic,
+            new UnboxAny(generic, new IsInstance(generic, ReadArgument())))));
+
+        var localFunctionBlock = new Block();
+        localFunctionBlock.Add(new IfStatement(
+            new IsInstance(generic, ReadArgument()),
+            thenBlock,
+            null));
+        var localFunctionBody = new BlockContainer();
+        localFunctionBody.Add(localFunctionBlock);
+        var localFunction = new LocalFunctionStatement(
+            "Local",
+            objectType,
+            [new Parameter("value", objectType)],
+            isStatic: true,
+            [],
+            [],
+            usesUpdatedMemorySafetyRules: false,
+            skipLocalsInit: false,
+            localFunctionBody);
+
+        var outer = new Block();
+        outer.Add(new ExpressionStatement(
+            new LoadArgumentAddress(0, "outer", objectType)));
+        outer.Add(localFunction);
+        var body = new BlockContainer();
+        body.Add(outer);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(
+                TypeRef.CoreLib("System", "Void"),
+                [new Parameter("outer", objectType)],
+                HasThis: false,
+                GenericParameterCount: 1),
+            [],
+            body);
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("(T)(object)value", output);
+    }
+
+    [Fact]
+    public void UnboxOfIsInstance_FlatGuardInsideLoopRegion_Bridges()
+    {
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var generic = TypeRef.GenericParameter(0, "T");
+        IrExpression ReadLocal() => new LoadLocal(0, objectType);
+
+        var guardBlock = new Block(0);
+        guardBlock.Add(new ConditionalBranch(
+            new LogicalNot(new IsInstance(generic, ReadLocal())),
+            targetOffset: 100));
+        var siteBlock = new Block(10);
+        siteBlock.Add(new StoreLocal(
+            1,
+            generic,
+            new UnboxAny(generic, new IsInstance(generic, ReadLocal()))));
+        var failBlock = new Block(100);
+        var guardedRegion = new BlockContainer();
+        guardedRegion.Add(guardBlock);
+        guardedRegion.Add(siteBlock);
+        guardedRegion.Add(failBlock);
+
+        var catchBody = new BlockContainer();
+        catchBody.Add(new Block(200));
+        var loopBody = new Block();
+        loopBody.Add(new TryCatch(
+            guardedRegion,
+            [new CatchClause(TypeRef.CoreLib("System", "Exception"), catchBody)]));
+        var outer = new Block();
+        outer.Add(new WhileLoop(
+            new Constant(true, TypeRef.CoreLib("System", "Boolean")),
+            loopBody));
+        var body = new BlockContainer();
+        body.Add(outer);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(
+                TypeRef.CoreLib("System", "Void"),
+                [],
+                HasThis: false,
+                GenericParameterCount: 1),
+            [objectType, generic],
+            body);
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("(T)(object)V_0", output);
+        Assert.DoesNotContain("as T", output);
+    }
+
     static void AssertBridgedLocal(string output, bool negatedGuard)
     {
         string condition = negatedGuard ? "is not T" : "is T";

--- a/src/ILInspector.Decompiler.Tests/GenericDeclarationPatternExtractionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GenericDeclarationPatternExtractionTests.cs
@@ -1,0 +1,439 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Coverage for #2831: csc's unconstrained/struct-constrained generic
+/// declaration-pattern extraction (<c>if (Subject is T t)</c>) cannot store the
+/// <c>isinst</c> result through an <c>as T</c> local, so it re-tests the value
+/// inline — <c>UnboxAny T(IsInstance T(...))</c> — instead of the usual
+/// <c>StoreLocal(IsInstance) + null-test</c> shape <c>IsPatternPass</c>
+/// already recovers. <c>CSharpPrinter.UnboxAnyOperand</c> must recognize
+/// the exact same-target test/extract relationship and bridge it through the
+/// same <c>(object)</c> intermediary the box+unbox.any generic-math idiom uses,
+/// rather than routing the nested test through the general <c>is</c>/<c>as</c>
+/// expression rule (invalid for a non-class-constrained <c>T</c> either way —
+/// CS0030 for <c>is</c>, CS0413 for <c>as</c>).
+/// </summary>
+public class GenericDeclarationPatternExtractionTests
+{
+    static string Print(Type declaringType, string methodName)
+    {
+        using var source = MetadataSource.Open(declaringType.Assembly.Location);
+        var function = IrImporter.Import(source, declaringType.FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return CSharpPrinter.Print(function!).Output!;
+    }
+
+    [Fact]
+    public void UnconstrainedDeclarationPattern_BridgesExtractionThroughObject()
+    {
+        var output = Print(
+            typeof(GenericDeclarationPatternSpecimens<,>),
+            nameof(GenericDeclarationPatternSpecimens<object, object>.Unconstrained));
+
+        Assert.Contains("if ((V_1) is T)", output);
+        Assert.Contains("(T)(object)(V_1)", output);
+        Assert.DoesNotContain("as T", output);
+    }
+
+    [Fact]
+    public void StructConstrainedDeclarationPattern_BridgesExtractionThroughObject()
+    {
+        var output = Print(
+            typeof(GenericDeclarationPatternSpecimensStruct<,>),
+            nameof(GenericDeclarationPatternSpecimensStruct<int, object>.StructConstrained));
+
+        Assert.Contains("if ((V_1) is T)", output);
+        Assert.Contains("(T)(object)(V_1)", output);
+        Assert.DoesNotContain("as T", output);
+    }
+
+    // Positive, flat-CFG variant (#2831 real-world shape): when the pattern's
+    // result feeds a later use rather than an immediate return, StructuringPass
+    // leaves the region as raw blocks and a `ConditionalBranch` — the exact
+    // shape FluentAssertions' `Be`/`BeOfType`/etc. compile to (a value merged
+    // from a ternary-like `cond ? isinst-extract : default`, not an early
+    // return) — instead of an `IfStatement`. `IsProvenByFlatGuard` must still
+    // recognize the single-predecessor, opposite-polarity guard and bridge it.
+    [Fact]
+    public void UnconstrainedDeclarationPattern_FlatGuard_BridgesExtractionThroughObject()
+    {
+        var output = Print(
+            typeof(FlatGuardDeclarationPatternSpecimens<,>),
+            nameof(FlatGuardDeclarationPatternSpecimens<object, object>.ExtractThenUse));
+
+        Assert.Contains("if ((V_1) is not T) goto", output);
+        Assert.Contains("(T)(object)(V_1)", output);
+        Assert.DoesNotContain("as T", output);
+    }
+
+    // Negative: class-constrained T never reaches UnboxAny at all (a class-
+    // constrained `as T` result is already the pattern's type — no unboxing
+    // round-trip). #1752's flat `T t = (T)((Subject) as T); if (t is not null)`
+    // form must stay exactly as-is.
+    [Fact]
+    public void ClassConstrainedDeclarationPattern_StaysUnaffected()
+    {
+        var output = Print(
+            typeof(GenericDeclarationPatternSpecimensClass<,>),
+            nameof(GenericDeclarationPatternSpecimensClass<object, object>.ClassConstrained));
+
+        Assert.Contains("as T", output);
+        Assert.DoesNotContain("(object)", output);
+    }
+
+    // Negative: a concrete reference type resolves through IsValueTypeTarget and
+    // never nests IsInstance inside UnboxAny (there is no UnboxAny at all) — the
+    // pre-existing `as string` + null-test form must stay exactly as-is.
+    [Fact]
+    public void ConcreteReferenceTypeDeclarationPattern_StaysUnaffected()
+    {
+        var output = Print(
+            typeof(ConcreteDeclarationPatternSpecimens),
+            nameof(ConcreteDeclarationPatternSpecimens.ConcreteReference));
+
+        Assert.Contains("as string", output);
+        Assert.DoesNotContain("(object)", output);
+    }
+
+    // Negative: a concrete value type's UnboxAny operand is the stored object
+    // local directly (no nested IsInstance duplicate — csc reuses the temp), so
+    // the new same-target bridge must not fire; the existing bare `(int)V_1`
+    // form must stay exactly as-is.
+    [Fact]
+    public void ConcreteValueTypeDeclarationPattern_StaysUnaffected()
+    {
+        var output = Print(
+            typeof(ConcreteDeclarationPatternSpecimens),
+            nameof(ConcreteDeclarationPatternSpecimens.ConcreteValue));
+
+        Assert.Contains("(int)V_1", output);
+        Assert.DoesNotContain("(object)", output);
+    }
+
+    // Negative: an else arm alongside the proven branch — the same-target test
+    // still gates only its own Then, so the fallthrough extraction after the
+    // early return (which happens to be the same object local, not the
+    // duplicated IsInstance shape) renders as it always did.
+    [Fact]
+    public void MismatchTargetWithElseArm_StaysUnaffected()
+    {
+        var output = Print(
+            typeof(MismatchDeclarationPatternSpecimens<>),
+            nameof(MismatchDeclarationPatternSpecimens<object>.MismatchWithElse));
+
+        Assert.Contains("if (V_1 is T)", output);
+        Assert.Contains("(T)V_1", output);
+        Assert.DoesNotContain("as T", output);
+    }
+
+    // Synthetic (#2831 proof-boundary): the same UnboxAny(IsInstance(x, T)) shape
+    // with no enclosing guard at all. Nothing proves the isinst already
+    // succeeded, so the bridge must not fire — bridging unconditionally would
+    // hide a real failure (NullReferenceException on unbox vs. a silently
+    // different outcome) behind an always-succeeds cast. The prior fallback
+    // (`as T`, already an existing, separately-tracked limitation for this
+    // ungated shape) is left untouched rather than papered over.
+    [Fact]
+    public void UnboxOfIsInstance_WithoutGuardingIf_DoesNotBridge()
+    {
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var generic = TypeRef.GenericParameter(0, "T");
+        var test = new IsInstance(generic, new LoadArgument(0, "value", objectType));
+        var extraction = new Box(generic, new UnboxAny(generic, test));
+
+        var block = new Block();
+        block.Add(new Return(extraction));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(objectType, [new Parameter("value", objectType)], HasThis: false, GenericParameterCount: 1),
+            [],
+            body);
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.DoesNotContain("(object)", output);
+    }
+
+    // Synthetic (#2831 proof-boundary): the extraction sits in the guard's Else
+    // arm — the known-failed branch — rather than its Then. Bridging there would
+    // claim a test that is known NOT to have succeeded; must not bridge.
+    [Fact]
+    public void UnboxOfIsInstance_InElseArm_DoesNotBridge()
+    {
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var generic = TypeRef.GenericParameter(0, "T");
+        IrExpression Test() => new IsInstance(generic, new LoadArgument(0, "value", objectType));
+        var extraction = new Box(generic, new UnboxAny(generic, Test()));
+
+        var thenBlock = new Block();
+        thenBlock.Add(new Return(new Constant(null, objectType)));
+        var elseBlock = new Block();
+        elseBlock.Add(new Return(extraction));
+        var ifStatement = new IfStatement(Test(), thenBlock, elseBlock);
+
+        var outer = new Block();
+        outer.Add(ifStatement);
+        var body = new BlockContainer();
+        body.Add(outer);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(objectType, [new Parameter("value", objectType)], HasThis: false, GenericParameterCount: 1),
+            [],
+            body);
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.DoesNotContain("(object)", output);
+    }
+
+    // Synthetic (#2831 proof-boundary): the guard tests argument 0 but the
+    // extraction reads argument 1 — a structurally different value, so the
+    // duplicate-read proof cannot hold even though both use the same type. Must
+    // not bridge.
+    [Fact]
+    public void UnboxOfIsInstance_MismatchedGuardOperand_DoesNotBridge()
+    {
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var generic = TypeRef.GenericParameter(0, "T");
+        var guardTest = new IsInstance(generic, new LoadArgument(0, "a", objectType));
+        var extractionTest = new IsInstance(generic, new LoadArgument(1, "b", objectType));
+        var extraction = new Box(generic, new UnboxAny(generic, extractionTest));
+
+        var thenBlock = new Block();
+        thenBlock.Add(new Return(extraction));
+        var ifStatement = new IfStatement(guardTest, thenBlock, null);
+
+        var outer = new Block();
+        outer.Add(ifStatement);
+        var body = new BlockContainer();
+        body.Add(outer);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(objectType, [new Parameter("a", objectType), new Parameter("b", objectType)], HasThis: false, GenericParameterCount: 1),
+            [],
+            body);
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.DoesNotContain("(object)", output);
+    }
+
+    // Synthetic (#2831 proof-boundary): a store to the tested local between the
+    // guard and the extraction invalidates the "same unmutated read" proof even
+    // though the two IsInstance operands are structurally identical locals —
+    // the local could hold a different value by the time of extraction. Must
+    // not bridge.
+    [Fact]
+    public void UnboxOfIsInstance_WithInterveningWrite_DoesNotBridge()
+    {
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var generic = TypeRef.GenericParameter(0, "T");
+        IrExpression ReadLocal() => new LoadLocal(0, objectType);
+        var guardTest = new IsInstance(generic, ReadLocal());
+        var extraction = new Box(generic, new UnboxAny(generic, new IsInstance(generic, ReadLocal())));
+
+        var thenBlock = new Block();
+        thenBlock.Add(new StoreLocal(0, objectType, new Constant(null, objectType)));
+        thenBlock.Add(new Return(extraction));
+        var ifStatement = new IfStatement(guardTest, thenBlock, null);
+
+        var outer = new Block();
+        outer.Add(ifStatement);
+        var body = new BlockContainer();
+        body.Add(outer);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(objectType, [], HasThis: false, GenericParameterCount: 1),
+            [objectType],
+            body);
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.DoesNotContain("(object)", output);
+    }
+
+    // Synthetic (#2831 proof-boundary, flat-guard positive): the
+    // "jump-target-is-the-success-path" polarity — `if (x is T) goto Success;`
+    // — that IsProvenByFlatGuard's non-negated case handles, exercised directly
+    // since it does not arise in any compiled fixture in this file. A single
+    // predecessor reaches the extraction block only via that jump, so the
+    // bridge must fire.
+    [Fact]
+    public void UnboxOfIsInstance_FlatGuard_JumpTargetPolarity_Bridges()
+    {
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var generic = TypeRef.GenericParameter(0, "T");
+        IrExpression ReadLocal() => new LoadLocal(0, objectType);
+
+        var guardBlock = new Block(0);
+        guardBlock.Add(new StoreLocal(0, objectType, new LoadArgument(0, "value", objectType)));
+        guardBlock.Add(new ConditionalBranch(new IsInstance(generic, ReadLocal()), targetOffset: 50));
+
+        var falseBlock = new Block(10);
+        falseBlock.Add(new Return(new Constant(null, objectType)));
+
+        var successBlock = new Block(50);
+        successBlock.Add(new Return(new Box(generic, new UnboxAny(generic, new IsInstance(generic, ReadLocal())))));
+
+        var body = new BlockContainer();
+        body.Add(guardBlock);
+        body.Add(falseBlock);
+        body.Add(successBlock);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(objectType, [new Parameter("value", objectType)], HasThis: false, GenericParameterCount: 1),
+            [objectType],
+            body);
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("(object)", output);
+        Assert.DoesNotContain("as T", output);
+    }
+
+    // Synthetic (#2831 proof-boundary, flat-guard negative): a second block
+    // branches directly into the extraction block, bypassing the guard
+    // entirely — the single-predecessor requirement must reject this even
+    // though the guard's own edge still has the right polarity, because some
+    // runtime path reaches the extraction without ever evaluating the test.
+    [Fact]
+    public void UnboxOfIsInstance_FlatGuard_WithAlternatePredecessor_DoesNotBridge()
+    {
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var generic = TypeRef.GenericParameter(0, "T");
+        IrExpression ReadLocal() => new LoadLocal(0, objectType);
+
+        var guardBlock = new Block(0);
+        guardBlock.Add(new StoreLocal(0, objectType, new LoadArgument(0, "value", objectType)));
+        guardBlock.Add(new ConditionalBranch(new LogicalNot(new IsInstance(generic, ReadLocal())), targetOffset: 100));
+
+        var siteBlock = new Block(10);
+        siteBlock.Add(new Return(new Box(generic, new UnboxAny(generic, new IsInstance(generic, ReadLocal())))));
+
+        var bypassBlock = new Block(20);
+        bypassBlock.Add(new Branch(targetOffset: 10));
+
+        var failBlock = new Block(100);
+        failBlock.Add(new Return(new Constant(null, objectType)));
+
+        var body = new BlockContainer();
+        body.Add(guardBlock);
+        body.Add(siteBlock);
+        body.Add(bypassBlock);
+        body.Add(failBlock);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(objectType, [new Parameter("value", objectType)], HasThis: false, GenericParameterCount: 1),
+            [objectType],
+            body);
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.DoesNotContain("(object)", output);
+    }
+}
+
+public class GenericDeclarationPatternSpecimens<T, TSubject>
+{
+    public TSubject Subject { get; set; } = default!;
+
+    // #2831 minimal repro: unconstrained T cannot store `Subject as T` (CS0413),
+    // so csc re-tests+unboxes at the use site instead.
+    public void Unconstrained()
+    {
+        if (Subject is T t)
+        {
+            System.Console.WriteLine(t);
+        }
+    }
+}
+
+public class GenericDeclarationPatternSpecimensStruct<T, TSubject> where T : struct
+{
+    public TSubject Subject { get; set; } = default!;
+
+    public void StructConstrained()
+    {
+        if (Subject is T t)
+        {
+            System.Console.WriteLine(t);
+        }
+    }
+}
+
+// #2831 flat-CFG real-world shape: the pattern's result feeds a later
+// statement (not an immediate return), so StructuringPass leaves the region
+// as raw blocks/ConditionalBranch instead of nesting an IfStatement — mirrors
+// FluentAssertions' `Be`/`BeOfType`/etc.
+public class FlatGuardDeclarationPatternSpecimens<T, TSubject>
+{
+    public TSubject Subject { get; set; } = default!;
+
+    public T ExtractThenUse()
+    {
+        T typed = Subject is T t ? t : default!;
+        System.Console.WriteLine("after");
+        return typed;
+    }
+}
+
+public class GenericDeclarationPatternSpecimensClass<T, TSubject> where T : class
+{
+    public TSubject Subject { get; set; } = default!;
+
+    public void ClassConstrained()
+    {
+        if (Subject is T t)
+        {
+            System.Console.WriteLine(t);
+        }
+    }
+}
+
+public class ConcreteDeclarationPatternSpecimens
+{
+    public object Subject { get; set; } = default!;
+
+    public void ConcreteReference()
+    {
+        if (Subject is string t)
+        {
+            System.Console.WriteLine(t);
+        }
+    }
+
+    public void ConcreteValue()
+    {
+        if (Subject is int t)
+        {
+            System.Console.WriteLine(t);
+        }
+    }
+}
+
+public class MismatchDeclarationPatternSpecimens<T>
+{
+    public object Subject { get; set; } = default!;
+
+    public void MismatchWithElse()
+    {
+        if (Subject is T t)
+        {
+            System.Console.WriteLine(t);
+            return;
+        }
+        System.Console.WriteLine("no");
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/GenericDeclarationPatternExtractionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GenericDeclarationPatternExtractionTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
@@ -34,8 +35,7 @@ public class GenericDeclarationPatternExtractionTests
             typeof(GenericDeclarationPatternSpecimens<,>),
             nameof(GenericDeclarationPatternSpecimens<object, object>.Unconstrained));
 
-        Assert.Contains("if ((V_1) is T)", output);
-        Assert.Contains("(T)(object)(V_1)", output);
+        AssertBridgedLocal(output, negatedGuard: false);
         Assert.DoesNotContain("as T", output);
     }
 
@@ -46,8 +46,7 @@ public class GenericDeclarationPatternExtractionTests
             typeof(GenericDeclarationPatternSpecimensStruct<,>),
             nameof(GenericDeclarationPatternSpecimensStruct<int, object>.StructConstrained));
 
-        Assert.Contains("if ((V_1) is T)", output);
-        Assert.Contains("(T)(object)(V_1)", output);
+        AssertBridgedLocal(output, negatedGuard: false);
         Assert.DoesNotContain("as T", output);
     }
 
@@ -65,8 +64,7 @@ public class GenericDeclarationPatternExtractionTests
             typeof(FlatGuardDeclarationPatternSpecimens<,>),
             nameof(FlatGuardDeclarationPatternSpecimens<object, object>.ExtractThenUse));
 
-        Assert.Contains("if ((V_1) is not T) goto", output);
-        Assert.Contains("(T)(object)(V_1)", output);
+        AssertBridgedLocal(output, negatedGuard: true);
         Assert.DoesNotContain("as T", output);
     }
 
@@ -110,7 +108,7 @@ public class GenericDeclarationPatternExtractionTests
             typeof(ConcreteDeclarationPatternSpecimens),
             nameof(ConcreteDeclarationPatternSpecimens.ConcreteValue));
 
-        Assert.Contains("(int)V_1", output);
+        Assert.Matches(@"\(int\)V_\d+", output);
         Assert.DoesNotContain("(object)", output);
     }
 
@@ -125,8 +123,9 @@ public class GenericDeclarationPatternExtractionTests
             typeof(MismatchDeclarationPatternSpecimens<>),
             nameof(MismatchDeclarationPatternSpecimens<object>.MismatchWithElse));
 
-        Assert.Contains("if (V_1 is T)", output);
-        Assert.Contains("(T)V_1", output);
+        var guardedLocal = Regex.Match(output, @"if \((V_\d+) is T\)");
+        Assert.True(guardedLocal.Success, output);
+        Assert.Contains($"(T){guardedLocal.Groups[1].Value}", output);
         Assert.DoesNotContain("as T", output);
     }
 
@@ -342,6 +341,122 @@ public class GenericDeclarationPatternExtractionTests
         var output = CSharpPrinter.Print(function).Output!;
 
         Assert.DoesNotContain("(object)", output);
+    }
+
+    [Fact]
+    public void UnboxOfIsInstance_FlatGuard_AtEntryWithBackedge_DoesNotBridge()
+    {
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var generic = TypeRef.GenericParameter(0, "T");
+        IrExpression ReadLocal() => new LoadLocal(0, objectType);
+
+        var siteBlock = new Block(0);
+        siteBlock.Add(new StoreLocal(
+            1,
+            generic,
+            new UnboxAny(generic, new IsInstance(generic, ReadLocal()))));
+        siteBlock.Add(new Branch(targetOffset: 10));
+
+        var guardBlock = new Block(10);
+        guardBlock.Add(new ConditionalBranch(
+            new IsInstance(generic, ReadLocal()),
+            targetOffset: 0));
+
+        var exitBlock = new Block(20);
+        exitBlock.Add(new Return(null));
+
+        var body = new BlockContainer();
+        body.Add(siteBlock);
+        body.Add(guardBlock);
+        body.Add(exitBlock);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(voidType, [], HasThis: false, GenericParameterCount: 1),
+            [objectType, generic],
+            body);
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.DoesNotContain("(object)", output);
+    }
+
+    [Fact]
+    public void UnboxOfIsInstance_WithAddressTakenLocal_DoesNotBridge()
+    {
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var generic = TypeRef.GenericParameter(0, "T");
+        IrExpression ReadLocal() => new LoadLocal(0, objectType);
+
+        var thenBlock = new Block();
+        thenBlock.Add(new InitObject(objectType, new LoadLocalAddress(0, objectType)));
+        thenBlock.Add(new Return(new Box(
+            generic,
+            new UnboxAny(generic, new IsInstance(generic, ReadLocal())))));
+
+        var outer = new Block();
+        outer.Add(new IfStatement(new IsInstance(generic, ReadLocal()), thenBlock, null));
+        var body = new BlockContainer();
+        body.Add(outer);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(objectType, [], HasThis: false, GenericParameterCount: 1),
+            [objectType],
+            body);
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.DoesNotContain("(object)", output);
+    }
+
+    [Fact]
+    public void UnboxOfIsInstance_WithAddressTakenArgument_DoesNotBridge()
+    {
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var generic = TypeRef.GenericParameter(0, "T");
+        IrExpression ReadArgument() => new LoadArgument(0, "value", objectType);
+
+        var thenBlock = new Block();
+        thenBlock.Add(new InitObject(
+            objectType,
+            new LoadArgumentAddress(0, "value", objectType)));
+        thenBlock.Add(new Return(new Box(
+            generic,
+            new UnboxAny(generic, new IsInstance(generic, ReadArgument())))));
+
+        var outer = new Block();
+        outer.Add(new IfStatement(
+            new IsInstance(generic, ReadArgument()),
+            thenBlock,
+            null));
+        var body = new BlockContainer();
+        body.Add(outer);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(
+                objectType,
+                [new Parameter("value", objectType)],
+                HasThis: false,
+                GenericParameterCount: 1),
+            [],
+            body);
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.DoesNotContain("(object)", output);
+    }
+
+    static void AssertBridgedLocal(string output, bool negatedGuard)
+    {
+        string condition = negatedGuard ? "is not T" : "is T";
+        var guardedLocal = Regex.Match(
+            output,
+            $@"if \(\((V_\d+)\) {condition}\){(negatedGuard ? " goto" : "")}");
+        Assert.True(guardedLocal.Success, output);
+        Assert.Contains($"(T)(object)({guardedLocal.Groups[1].Value})", output);
     }
 }
 

--- a/src/ILInspector.Decompiler.Tests/GenericDeclarationPatternExtractionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GenericDeclarationPatternExtractionTests.cs
@@ -261,6 +261,83 @@ public class GenericDeclarationPatternExtractionTests
         Assert.DoesNotContain("(object)", output);
     }
 
+    [Fact]
+    public void UnboxOfIsInstance_WithNestedInterveningWrite_DoesNotBridge()
+    {
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var generic = TypeRef.GenericParameter(0, "T");
+        IrExpression ReadLocal() => new LoadLocal(0, objectType);
+
+        var innerThen = new Block();
+        innerThen.Add(new StoreLocal(
+            0,
+            objectType,
+            new Constant(null, objectType)));
+        innerThen.Add(new Return(new Box(
+            generic,
+            new UnboxAny(generic, new IsInstance(generic, ReadLocal())))));
+        var outerThen = new Block();
+        outerThen.Add(new IfStatement(
+            new Constant(true, boolType),
+            innerThen,
+            null));
+        var outer = new Block();
+        outer.Add(new IfStatement(
+            new IsInstance(generic, ReadLocal()),
+            outerThen,
+            null));
+        var body = new BlockContainer();
+        body.Add(outer);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(objectType, [], HasThis: false, GenericParameterCount: 1),
+            [objectType],
+            body);
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.DoesNotContain("(object)", output);
+    }
+
+    [Fact]
+    public void UnboxOfIsInstance_WithinNestedStructuredBlock_Bridges()
+    {
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var generic = TypeRef.GenericParameter(0, "T");
+        IrExpression ReadLocal() => new LoadLocal(0, objectType);
+
+        var innerThen = new Block();
+        innerThen.Add(new Return(new Box(
+            generic,
+            new UnboxAny(generic, new IsInstance(generic, ReadLocal())))));
+        var outerThen = new Block();
+        outerThen.Add(new IfStatement(
+            new Constant(true, boolType),
+            innerThen,
+            null));
+        var outer = new Block();
+        outer.Add(new IfStatement(
+            new IsInstance(generic, ReadLocal()),
+            outerThen,
+            null));
+        var body = new BlockContainer();
+        body.Add(outer);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(objectType, [], HasThis: false, GenericParameterCount: 1),
+            [objectType],
+            body);
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("(T)(object)V_0", output);
+        Assert.DoesNotContain("as T", output);
+    }
+
     // Synthetic (#2831 proof-boundary, flat-guard positive): the
     // "jump-target-is-the-success-path" polarity — `if (x is T) goto Success;`
     // — that IsProvenByFlatGuard's non-negated case handles, exercised directly

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2577,9 +2577,7 @@ public sealed partial class CSharpPrinter
             if (!ReferenceOwnership.IsInside(site, ifStatement.Then))
                 return false;
 
-            var guardedStatement = TopLevelStatementWithin(site, ifStatement.Then);
-            return guardedStatement is not null
-                && !HasInterveningWrite(ifStatement.Then, guardedStatement.ChildIndex, test.Operand);
+            return !HasInterveningWriteAlongPath(ifStatement.Then, site, test.Operand);
         }
         return IsProvenByFlatGuard(site, test);
     }
@@ -2715,8 +2713,25 @@ public sealed partial class CSharpPrinter
         return null;
     }
 
-    /// <summary>Whether any statement in <paramref name="scope"/> before index <paramref name="beforeChildIndex"/> could have reassigned a local/argument the read-only <paramref name="value"/> depends on.</summary>
-    static bool HasInterveningWrite(Block scope, int beforeChildIndex, IrExpression value)
+    /// <summary>
+    /// Whether any preceding sibling subtree on the path from
+    /// <paramref name="guardedBlock"/> to <paramref name="site"/> could have
+    /// reassigned a local or argument the tested value reads.
+    /// </summary>
+    static bool HasInterveningWriteAlongPath(Block guardedBlock, IrNode site, IrExpression value)
+    {
+        for (IrNode current = site; current.Parent is { } parent; current = parent)
+        {
+            if (HasInterveningWrite(parent, current.ChildIndex, value))
+                return true;
+            if (ReferenceEquals(parent, guardedBlock))
+                return false;
+        }
+        return true;
+    }
+
+    /// <summary>Whether any child subtree in <paramref name="scope"/> before index <paramref name="beforeChildIndex"/> could have reassigned a local/argument the read-only <paramref name="value"/> depends on.</summary>
+    static bool HasInterveningWrite(IrNode scope, int beforeChildIndex, IrExpression value)
     {
         var locals = new List<int>();
         var arguments = new List<int>();

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2563,9 +2563,9 @@ public sealed partial class CSharpPrinter
         for (var current = site.Parent; current is not null; current = current.Parent)
         {
             if (current is Lambda or LocalFunctionStatement)
-                return false;
+                break;
             if (current is WhileLoop or DoWhileLoop or ForLoop or ForeachStatement)
-                return false;
+                break;
             if (current is not IfStatement ifStatement)
                 continue;
             if (ifStatement.Condition is not IsInstance guard
@@ -2751,11 +2751,7 @@ public sealed partial class CSharpPrinter
         if (locals.Count == 0 && arguments.Count == 0)
             return false;
 
-        IrNode root = site;
-        while (root.Parent is not null)
-            root = root.Parent;
-
-        foreach (var node in DescendantsAndSelfOutsideNestedFunctions(root))
+        foreach (var node in DescendantsAndSelfOutsideNestedFunctions(EnclosingFunctionBody(site)))
         {
             if (node is LoadLocalAddress address && locals.Contains(address.Index))
                 return true;
@@ -2763,6 +2759,23 @@ public sealed partial class CSharpPrinter
                 return true;
         }
         return false;
+    }
+
+    static IrNode EnclosingFunctionBody(IrNode site)
+    {
+        for (IrNode? current = site; current is not null; current = current.Parent)
+        {
+            switch (current)
+            {
+                case Lambda lambda:
+                    return lambda.Body;
+                case LocalFunctionStatement localFunction:
+                    return localFunction.Body;
+                case IrFunction function:
+                    return function.Body;
+            }
+        }
+        return site;
     }
 
     static void CollectReadOnlyReferences(IrExpression value, List<int> locals, List<int> arguments)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2557,6 +2557,8 @@ public sealed partial class CSharpPrinter
     {
         if (!IsReadOnlyOperand(test.Operand))
             return false;
+        if (HasAddressTaken(site, test.Operand))
+            return false;
 
         for (var current = site.Parent; current is not null; current = current.Parent)
         {
@@ -2623,7 +2625,11 @@ public sealed partial class CSharpPrinter
                 break;
             }
         }
-        if (siteIndex < 0)
+        // The container's entry block also has an implicit predecessor from
+        // outside the region. Cfg models only intra-container edges, so it
+        // cannot prove that a backedge into block zero dominates the first
+        // execution of that block.
+        if (siteIndex <= 0)
             return false;
 
         var edges = Cfg.Build(blocks);
@@ -2727,6 +2733,34 @@ public sealed partial class CSharpPrinter
                 if (node is StoreArgument storeArgument && arguments.Contains(storeArgument.Index))
                     return true;
             }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Whether the tested local or argument has any managed-address use in its
+    /// function scope. Once an address exists, a later indirect write can
+    /// mutate the value without a direct <see cref="StoreLocal"/> or
+    /// <see cref="StoreArgument"/> between the guard and extraction.
+    /// </summary>
+    static bool HasAddressTaken(IrNode site, IrExpression value)
+    {
+        var locals = new List<int>();
+        var arguments = new List<int>();
+        CollectReadOnlyReferences(value, locals, arguments);
+        if (locals.Count == 0 && arguments.Count == 0)
+            return false;
+
+        IrNode root = site;
+        while (root.Parent is not null)
+            root = root.Parent;
+
+        foreach (var node in DescendantsAndSelfOutsideNestedFunctions(root))
+        {
+            if (node is LoadLocalAddress address && locals.Contains(address.Index))
+                return true;
+            if (node is LoadArgumentAddress argumentAddress && arguments.Contains(argumentAddress.Index))
+                return true;
         }
         return false;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Text;
+using ILInspector.ControlFlow;
 using ILInspector.Metadata;
 
 namespace ILInspector.Decompiler.Pipeline;
@@ -2507,9 +2508,243 @@ public sealed partial class CSharpPrinter
     {
         if (unbox.Operand is Box box)
             return $"(object){Operand(box.Operand)}";
+        // `isinst T; unbox.any T` on the exact same target is csc's unconstrained/
+        // struct-constrained declaration-pattern extraction (#2831): `if (x is T t)`
+        // cannot store the isinst result through an `as T` local (illegal for a
+        // non-class-constrained T), so csc re-tests and unboxes the value inline
+        // instead. The general IsInstance expression printer would then spell this
+        // nested test through `is`/`as` — `is` renders a bool (can't cast to T,
+        // CS0030), and `as` is CS0413 for a non-class-constrained T — so neither
+        // choice is valid here regardless of `IsValueTypeTarget`. Only when the
+        // exact same test is proven to have already succeeded (an enclosing
+        // `IfStatement` whose condition is the identical, side-effect-free test,
+        // with this site inside its `Then` and no intervening write to the tested
+        // value) is `isinst` redundant: the extraction then behaves exactly like the
+        // box+unbox.any object-bridge idiom above, so it renders the same way. Off
+        // that proven path the shape is left to fall through unchanged rather than
+        // hide it behind an always-succeeds cast that could rewrite failure
+        // semantics (NullReferenceException/false vs. a silently different throw).
+        if (unbox.Operand is IsInstance sameTargetTest
+            && sameTargetTest.Type.Equals(unbox.Type)
+            && IsProvenSuccessfulTypeTest(unbox, sameTargetTest))
+        {
+            return $"(object){Operand(sameTargetTest.Operand)}";
+        }
         if (NeedsObjectBridgeForGenericUnbox(unbox.Type, unbox.Operand.ResultType))
             return $"(object){Operand(unbox.Operand)}";
         return Operand(unbox.Operand);
+    }
+
+    /// <summary>
+    /// True when <paramref name="site"/> (an <see cref="UnboxAny"/> whose operand is
+    /// <paramref name="test"/>) sits inside the guaranteed-true arm of an
+    /// <see cref="IfStatement"/> that already proved the identical test, or — when
+    /// <see cref="StructuringPass"/> left the region flat — behind an equivalent
+    /// <see cref="ConditionalBranch"/> guard reached only on the successful path (see
+    /// <see cref="IsProvenByFlatGuard"/>). Both proofs are narrow by design: the
+    /// guard's test must be the same type test (same target type, structurally
+    /// identical operand) via <see cref="SameTestedValue"/>, the site must be
+    /// reachable only through the guard's successful edge (never its failed arm —
+    /// the structured proof's <c>Else</c>, or the flat proof's untaken branch), no
+    /// loop lies between the guard and the site for the structured proof (a later
+    /// iteration could have reassigned the tested value since the guard last ran),
+    /// and no store between the guard and the site can have reassigned a local the
+    /// tested operand reads. A nested lambda/local-function boundary ends the
+    /// structured search: its captured value can diverge from the enclosing scope's
+    /// at invocation time.
+    /// </summary>
+    static bool IsProvenSuccessfulTypeTest(IrNode site, IsInstance test)
+    {
+        if (!IsReadOnlyOperand(test.Operand))
+            return false;
+
+        for (var current = site.Parent; current is not null; current = current.Parent)
+        {
+            if (current is Lambda or LocalFunctionStatement)
+                return false;
+            if (current is WhileLoop or DoWhileLoop or ForLoop or ForeachStatement)
+                return false;
+            if (current is not IfStatement ifStatement)
+                continue;
+            if (ifStatement.Condition is not IsInstance guard
+                || !guard.Type.Equals(test.Type)
+                || !SameTestedValue(guard.Operand, test.Operand))
+            {
+                continue;
+            }
+            if (!ReferenceOwnership.IsInside(site, ifStatement.Then))
+                return false;
+
+            var guardedStatement = TopLevelStatementWithin(site, ifStatement.Then);
+            return guardedStatement is not null
+                && !HasInterveningWrite(ifStatement.Then, guardedStatement.ChildIndex, test.Operand);
+        }
+        return IsProvenByFlatGuard(site, test);
+    }
+
+    /// <summary>
+    /// The flat-CFG counterpart of the structured proof above: real-world
+    /// declaration-pattern extractions frequently sit in a ternary-shaped merge
+    /// region <see cref="StructuringPass"/> left as raw blocks and a
+    /// <see cref="ConditionalBranch"/> rather than an <see cref="IfStatement"/>
+    /// (e.g. <c>T x = cond ? isinst-extract : default;</c>). The proof mirrors the
+    /// structured one over the block graph instead of the statement tree: the
+    /// site's enclosing <see cref="Block"/> must be reached, via <see cref="Cfg"/>
+    /// edges, from exactly one predecessor — a block whose terminating
+    /// <see cref="ConditionalBranch"/> tests the identical value and only reaches
+    /// the site's block on the branch's successful arm (fall-through past a
+    /// negated test, or the jump target of an unnegated one). An unmodeled edge
+    /// (an EH leave, or a branch target outside the container) fails the proof
+    /// rather than being reasoned about, matching <see cref="DefiniteAssignment"/>'s
+    /// conservative bail on the same shapes.
+    /// </summary>
+    static bool IsProvenByFlatGuard(IrNode site, IsInstance test)
+    {
+        IrNode? current = site.Parent;
+        while (current is not null && current is not Block)
+            current = current.Parent;
+        if (current is not Block siteBlock || siteBlock.Parent is not BlockContainer container)
+            return false;
+
+        var guardedStatement = TopLevelStatementWithin(site, siteBlock);
+        if (guardedStatement is null
+            || HasInterveningWrite(siteBlock, guardedStatement.ChildIndex, test.Operand))
+        {
+            return false;
+        }
+
+        var blocks = container.Blocks;
+        int siteIndex = -1;
+        for (int i = 0; i < blocks.Count; i++)
+        {
+            if (ReferenceEquals(blocks[i], siteBlock))
+            {
+                siteIndex = i;
+                break;
+            }
+        }
+        if (siteIndex < 0)
+            return false;
+
+        var edges = Cfg.Build(blocks);
+        if (edges.Any(e => e.LeavesRegion || e.ExternalTargets.Count > 0))
+            return false;
+
+        for (int i = 0; i < blocks.Count; i++)
+        {
+            if (i == siteIndex || blocks[i].Children.Count == 0)
+                continue;
+            if (blocks[i].Children[^1] is not ConditionalBranch branch)
+                continue;
+
+            bool reachesSiteOnSuccess = branch.Condition switch
+            {
+                // `if (x is not T) goto Fail;` — fall-through (i+1) is the true path.
+                // The failure jump must land somewhere else: a target that (degenerately)
+                // coincides with the fall-through would mean the guard reaches the site
+                // on failure too, so the test would not actually gate the extraction.
+                LogicalNot { Operand: IsInstance negatedGuard }
+                    when negatedGuard.Type.Equals(test.Type) && SameTestedValue(negatedGuard.Operand, test.Operand)
+                    => i + 1 == siteIndex && branch.TargetOffset != siteBlock.StartOffset,
+                // `if (x is T) goto Success;` — the jump target is the true path. The
+                // fall-through must land somewhere else for the same reason: a
+                // fall-through that (degenerately) coincides with the jump target
+                // would mean the guard reaches the site on failure too.
+                IsInstance guard
+                    when guard.Type.Equals(test.Type) && SameTestedValue(guard.Operand, test.Operand)
+                    => branch.TargetOffset == siteBlock.StartOffset && i + 1 != siteIndex,
+                _ => false,
+            };
+            if (!reachesSiteOnSuccess)
+                continue;
+
+            if (HasSinglePredecessor(edges, siteIndex, i))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>Whether <paramref name="targetIndex"/> is reached from exactly one block in the container, and that block is <paramref name="expectedSourceIndex"/> — the single-entry requirement for the flat-guard proof (no other path into the guarded block could skip the test).</summary>
+    static bool HasSinglePredecessor(IReadOnlyList<BlockEdges> edges, int targetIndex, int expectedSourceIndex)
+    {
+        int count = 0;
+        bool matchesExpected = false;
+        for (int i = 0; i < edges.Count; i++)
+        {
+            if (!edges[i].Successors.Contains(targetIndex))
+                continue;
+            count++;
+            if (i == expectedSourceIndex)
+                matchesExpected = true;
+        }
+        return count == 1 && matchesExpected;
+    }
+
+    /// <summary>A read with no observable side effect: a local/argument load or a box over one. Matches the exact vocabulary csc emits for a cached declaration-pattern subject (never a call, allocation, or property getter).</summary>
+    static bool IsReadOnlyOperand(IrExpression value) => value switch
+    {
+        LoadLocal or LoadArgument or Constant => true,
+        Box box => IsReadOnlyOperand(box.Operand),
+        _ => false,
+    };
+
+    /// <summary>Structural equality over the narrow <see cref="IsReadOnlyOperand"/> vocabulary — enough to recognize csc's duplicated read of the one tested value, not a general expression comparer.</summary>
+    static bool SameTestedValue(IrExpression a, IrExpression b) => (a, b) switch
+    {
+        (LoadLocal x, LoadLocal y) => x.Index == y.Index && x.Type.Equals(y.Type),
+        (LoadArgument x, LoadArgument y) => x.Index == y.Index && x.Type.Equals(y.Type),
+        (Constant x, Constant y) => Equals(x.Value, y.Value) && x.Type.Equals(y.Type),
+        (Box x, Box y) => x.Type.Equals(y.Type) && SameTestedValue(x.Operand, y.Operand),
+        _ => false,
+    };
+
+    /// <summary>The direct child of <paramref name="scope"/> that contains <paramref name="node"/> — the statement whose position within the guarded block bounds the intervening-write scan.</summary>
+    static IrNode? TopLevelStatementWithin(IrNode node, Block scope)
+    {
+        for (var current = node; current is not null; current = current.Parent)
+        {
+            if (ReferenceEquals(current.Parent, scope))
+                return current;
+        }
+        return null;
+    }
+
+    /// <summary>Whether any statement in <paramref name="scope"/> before index <paramref name="beforeChildIndex"/> could have reassigned a local/argument the read-only <paramref name="value"/> depends on.</summary>
+    static bool HasInterveningWrite(Block scope, int beforeChildIndex, IrExpression value)
+    {
+        var locals = new List<int>();
+        var arguments = new List<int>();
+        CollectReadOnlyReferences(value, locals, arguments);
+        if (locals.Count == 0 && arguments.Count == 0)
+            return false;
+
+        for (int i = 0; i < beforeChildIndex && i < scope.Children.Count; i++)
+        {
+            foreach (var node in DescendantsAndSelfOutsideNestedFunctions(scope.Children[i]))
+            {
+                if (node is StoreLocal store && locals.Contains(store.Index))
+                    return true;
+                if (node is StoreArgument storeArgument && arguments.Contains(storeArgument.Index))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    static void CollectReadOnlyReferences(IrExpression value, List<int> locals, List<int> arguments)
+    {
+        switch (value)
+        {
+            case LoadLocal load:
+                locals.Add(load.Index);
+                break;
+            case LoadArgument argument:
+                arguments.Add(argument.Index);
+                break;
+            case Box box:
+                CollectReadOnlyReferences(box.Operand, locals, arguments);
+                break;
+        }
     }
 
     bool NeedsObjectBridgeForGenericUnbox(TypeRef target, TypeRef? source)


### PR DESCRIPTION
## Summary

Fixes #2831 by emitting the legal `(T)(object)value` bridge only when control
flow proves that an identical generic type test has succeeded. Unproven
`UnboxAny(IsInstance(...))` shapes remain unchanged rather than gaining an
unsafe cast.

The proof handles both structured and local flat-CFG guards. It rejects entry
block and alternate-predecessor cases, invalidates locals or arguments whose
managed address is taken, scopes scans to the immediate function body, and
checks intervening writes along the complete nested AST path.

## Evidence

### Before

```csharp
if (V_1 is T)
{
    Console.WriteLine((T)(V_1 as T));
}
```

The unconstrained `as T` fails with `CS0413`.

### After

```csharp
if (V_1 is T)
{
    Console.WriteLine((T)(object)V_1);
}
```

The compiler-produced declaration-pattern extraction now binds successfully.
Concrete reference-type `isinst` rendering and unproven generic shapes retain
their existing behavior.

### Fully Raised

The complete endpoint is to recover the declaration-pattern binding and use
that value directly:

```csharp
if (Subject is T t)
{
    Console.WriteLine(t);
}
```

The current object bridge is therefore a valid fallback, not the final raised
shape. #2862 tracks declaration-pattern recovery and safe removal of the
lowering-only subject temporary.

## Validation

- `GenericDeclarationPatternExtractionTests`: 21 passed in Release
- `GenericDeclarationPatternExtractionTests`: 21 passed in Debug
- Fast decompiler suite passed
- Adjacent generic `isinst` and `unbox.any` tests passed

## Adversarial review

Earlier Gemini and Claude Opus rounds drove conservative hardening:

- flat-CFG entry/backedge and managed-address rejection in `dfee57d5`
- nested function and loop proof scoping in `a85e0b4b`
- complete nested-path write detection in `446bbeba`

Gemini 3.1 Pro and Claude Opus 4.8 then both reported clean on exact head
`446bbeba`.

The branch was rebased conflict-free onto `0599bfe7`; its stable patch ID is
unchanged from the reviewed pre-rebase series.
