### PR TITLE
Render explicit interface properties in RTS shells

### DIFF
--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -1052,6 +1052,55 @@ public sealed class CSharpTypePrinterTests
     }
 
     [Fact]
+    public void ExplicitInterfacePropertyPreservesQualifiedNameAndOmitsAccessibility()
+    {
+        var property = new ApiMember
+        {
+            Name = "Samples.IValue.Value",
+            Kind = "explicit-interface-implementation",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "int",
+                MemberName = "Samples.IValue.Value",
+                Accessors = [new ApiAccessor { Kind = "get" }]
+            }
+        };
+        var type = CreateEmptyType("Samples", "Widget");
+        type.Interfaces.Add("Samples.IValue");
+        type.Members.Add(property);
+        var request = new CSharpTypePrintRequest(
+            type,
+            memberPolicyOverrides:
+            [
+                new CSharpMemberPolicy(
+                    property,
+                    CSharpBodyPolicy.Full,
+                    new CSharpPropertyBody(
+                        CSharpAccessorBody.Block("return 42;"),
+                        null))
+            ]);
+
+        var result = _printer.Print(request);
+
+        Assert.Contains(
+            """
+                int Samples.IValue.Value
+                {
+                    get
+                    {
+                        return 42;
+                    }
+                }
+            """,
+            result.Units[0].Source,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "public int Samples.IValue.Value",
+            result.Units[0].Source,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void NestedTypesAndPrimaryConstructorsRenderInFileScopedNamespaceUnits()
     {
         var nested = CreateEmptyType("Samples", "Nested");

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -1101,6 +1101,56 @@ public sealed class CSharpTypePrinterTests
     }
 
     [Fact]
+    public void ExplicitInterfaceIndexerPreservesQualifierAndOmitsAccessibility()
+    {
+        var indexer = new ApiMember
+        {
+            Name = "Samples.IValues.Item",
+            Kind = "explicit-interface-implementation",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "int",
+                MemberName = "this[]",
+                Parameters = [new ApiParameter { Type = "int", Name = "index" }],
+                Accessors = [new ApiAccessor { Kind = "get" }]
+            }
+        };
+        var type = CreateEmptyType("Samples", "Widget");
+        type.Interfaces.Add("Samples.IValues");
+        type.Members.Add(indexer);
+        var request = new CSharpTypePrintRequest(
+            type,
+            memberPolicyOverrides:
+            [
+                new CSharpMemberPolicy(
+                    indexer,
+                    CSharpBodyPolicy.Full,
+                    new CSharpPropertyBody(
+                        CSharpAccessorBody.Block("return index;"),
+                        null))
+            ]);
+
+        var result = _printer.Print(request);
+
+        Assert.Contains(
+            """
+                int Samples.IValues.this[int index]
+                {
+                    get
+                    {
+                        return index;
+                    }
+                }
+            """,
+            result.Units[0].Source,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "public int Samples.IValues.this",
+            result.Units[0].Source,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void NestedTypesAndPrimaryConstructorsRenderInFileScopedNamespaceUnits()
     {
         var nested = CreateEmptyType("Samples", "Nested");

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -344,7 +344,10 @@ internal static class CSharpDeclarationWriter
             signature = EscapeMemberNameInSignature(signature, member.Name);
         }
 
-        signature = EscapeQualifiedKeywordSegments(signature);
+        signature = EscapeQualifiedKeywordSegments(
+            signature,
+            preserveQualifiedIndexerKeyword: IsExplicitInterfaceProperty(member)
+                && member.SignatureModel?.MemberName == "this[]");
         if (!options.AbbreviateSignature)
             signature = EscapeParameterLists(signature);
 
@@ -824,7 +827,9 @@ internal static class CSharpDeclarationWriter
         {
             var head = model.IsRequired ? $"required {propertyType}" : propertyType;
             var propertyMemberName = model.MemberName == "this[]"
-                ? $"this[{parameters}]"
+                ? IsExplicitInterfaceProperty(member)
+                    ? $"{member.Name[..(member.Name.LastIndexOf('.') + 1)]}this[{parameters}]"
+                    : $"this[{parameters}]"
                 : string.IsNullOrWhiteSpace(model.MemberName)
                     ? member.Name
                     : model.MemberName!;
@@ -1186,7 +1191,9 @@ internal static class CSharpDeclarationWriter
             : string.Concat(signature.AsSpan(0, nameIndex), escaped, signature.AsSpan(nameIndex + memberName.Length));
     }
 
-    internal static string EscapeQualifiedKeywordSegments(string signature)
+    internal static string EscapeQualifiedKeywordSegments(
+        string signature,
+        bool preserveQualifiedIndexerKeyword = false)
     {
         var sb = new StringBuilder(signature.Length);
         bool inString = false;
@@ -1233,6 +1240,13 @@ internal static class CSharpDeclarationWriter
                 end++;
 
             string segment = signature[start..end];
+            if (preserveQualifiedIndexerKeyword
+                && segment == "this"
+                && end < signature.Length
+                && signature[end] == '[')
+            {
+                continue;
+            }
             string escaped = EscapeIdentifier(segment);
             if (escaped != segment)
             {

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -815,11 +815,12 @@ internal static class CSharpDeclarationWriter
             signature = AppendTypeParameterConstraints($"{returnType} {memberName}({parameters})", model.TypeParameters);
             return true;
         }
-        if (member.Kind == "property"
+        if ((member.Kind == "property" || IsExplicitInterfaceProperty(member))
             && model.ReturnType is { Length: > 0 } propertyType
             && model.Accessors.Count > 0
-            && IsOrdinaryPropertyName(member.Name)
-            && IsOrdinaryPropertyName(model.MemberName))
+            && (member.Kind == "explicit-interface-implementation"
+                || IsOrdinaryPropertyName(member.Name)
+                    && IsOrdinaryPropertyName(model.MemberName)))
         {
             var head = model.IsRequired ? $"required {propertyType}" : propertyType;
             var propertyMemberName = model.MemberName == "this[]"
@@ -872,6 +873,11 @@ internal static class CSharpDeclarationWriter
                || name == "this[]"
                || !name.Contains('.', StringComparison.Ordinal);
     }
+
+    static bool IsExplicitInterfaceProperty(ApiMember member)
+        => member.Kind == "explicit-interface-implementation"
+            && member.Name.Contains('.', StringComparison.Ordinal)
+            && member.SignatureModel?.Accessors.Count > 0;
 
     internal static string FormatParameter(ApiParameter parameter)
     {

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -314,7 +314,7 @@ public sealed class CSharpTypePrinter
             return [$"{pad}{EnsureTerminated(declaration)}"];
         }
 
-        if (member.Member.Kind == "property")
+        if (IsProperty(member.Member))
             return RenderProperty(type, member, formatter, propertyFormatter, indent);
 
         string memberDeclaration = member.Body is null
@@ -683,7 +683,7 @@ public sealed class CSharpTypePrinter
             throw new NotSupportedException(
                 $"Field '{member.Name}' does not support body policy '{policy.BodyPolicy}'.");
         }
-        if (member.Kind == "property"
+        if (IsProperty(member)
             && policy.BodyPolicy != CSharpBodyPolicy.Skeleton
             && policy.Body is null)
         {
@@ -710,7 +710,7 @@ public sealed class CSharpTypePrinter
         {
             (_, null) => policy.BodyPolicy != CSharpBodyPolicy.Full,
             ("field", CSharpFieldInitializer) => true,
-            ("property", CSharpPropertyBody) => true,
+            (_, CSharpPropertyBody) when IsProperty(member) => true,
             ("method" or "extension-method" or "explicit-interface-implementation" or "constructor", CSharpBlockBody) => true,
             _ => false,
         };
@@ -728,6 +728,12 @@ public sealed class CSharpTypePrinter
                 parameterName);
         }
     }
+
+    static bool IsProperty(ApiMember member)
+        => member.Kind == "property"
+            || member.Kind == "explicit-interface-implementation"
+                && member.Name.Contains('.', StringComparison.Ordinal)
+                && member.SignatureModel?.Accessors.Count > 0;
 
     sealed record PreparedType(
         string Namespace,

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -157,6 +157,47 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackFirstPropertyGetter_RoundTripsInheritedExplicitInterfaceProperty()
+    {
+        var assemblyPath = CompileFixture("""
+            public sealed class ExplicitPropertyFixture : IDerived
+            {
+                int IBase.Value => 42;
+
+                void IBase.Touch()
+                {
+                }
+            }
+
+            public interface IDerived : IBase
+            {
+            }
+
+            public interface IBase
+            {
+                int Value { get; }
+
+                void Touch();
+            }
+            """);
+        try
+        {
+            var result = ReturnToSender.CompileBackFirstPropertyGetter(assemblyPath);
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains("int IBase.Value", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("IBase_Value", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_ExposesTypedModuleAndTypeShellPlan()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -198,6 +198,50 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackFirstPropertyGetter_PreservesRequiredImplicitInterfaceProperty()
+    {
+        var assemblyPath = CompileFixture("""
+            public sealed class Consumer
+            {
+                public int Read => ((IBase)new ImplicitPropertyFixture()).Value;
+            }
+
+            public sealed class ImplicitPropertyFixture : IDerived
+            {
+                public int Value => 42;
+
+                public void Touch()
+                {
+                }
+            }
+
+            public interface IDerived : IBase
+            {
+            }
+
+            public interface IBase
+            {
+                int Value { get; }
+
+                void Touch();
+            }
+            """);
+        try
+        {
+            var result = ReturnToSender.CompileBackFirstPropertyGetter(assemblyPath);
+
+            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains("public int Value", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("public void Touch", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_ExposesTypedModuleAndTypeShellPlan()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -242,6 +242,63 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackFirstPropertyGetter_ProjectsPropertiesFromRequiredInterfaceSurface()
+    {
+        var assemblyPath = CompileFixture("""
+            public sealed class InheritedTypeParameter : IGenericTypeParameter, IGenericParameter
+            {
+                private readonly IGenericTypeParameter _parentParameter;
+
+                public InheritedTypeParameter(IGenericTypeParameter parentParameter)
+                {
+                    _parentParameter = parentParameter;
+                }
+
+                public bool MustBeReferenceType => _parentParameter.MustBeReferenceType;
+
+                public ITypeDefinition DefiningType => _parentParameter.DefiningType;
+            }
+
+            public interface IGenericTypeParameter : IGenericParameter
+            {
+                ITypeDefinition DefiningType { get; }
+            }
+
+            public interface IGenericParameter
+            {
+                bool MustBeReferenceType { get; }
+            }
+
+            public interface ITypeDefinition
+            {
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "InheritedTypeParameter",
+                    "get_MustBeReferenceType",
+                    0)]));
+
+            Assert.DoesNotContain("CS0535", result.Detail ?? "", StringComparison.Ordinal);
+            var targetType = Assert.Single(
+                result.Plan.Types,
+                type => type.Name == "InheritedTypeParameter");
+            Assert.Contains(targetType.Members, member =>
+                member.Name == "DefiningType"
+                && member.SourceFacts.Any(fact =>
+                    fact.Id == "required-interface-property"));
+            Assert.Equal(1, targetType.Members.Count(member => member.Name == "MustBeReferenceType"));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_ExposesTypedModuleAndTypeShellPlan()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -198,6 +198,42 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackFirstPropertyGetter_RoundTripsExplicitInterfaceIndexer()
+    {
+        var assemblyPath = CompileFixture("""
+            public sealed class ExplicitIndexerFixture : IValues
+            {
+                int IValues.this[int index] => index;
+            }
+
+            public interface IValues
+            {
+                int this[int index] { get; }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "ExplicitIndexerFixture",
+                    "IValues.get_Item",
+                    0)]));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains("int IValues.this[int index]", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("public int IValues.this", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_PreservesRequiredImplicitInterfaceProperty()
     {
         var assemblyPath = CompileFixture("""

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -2843,112 +2843,14 @@ public static class CompileBackSourceComposer
             IReadOnlyDictionary<string, CompileBackTypeRequirement> requirementsByMetadataName,
             List<CompileBackMemberRequirement> members)
         {
-            var addedProperties = new HashSet<PropertyDefinitionHandle>();
-            foreach (var implementationHandle in typeDef.GetMethodImplementations())
-            {
-                var implementation = reader.GetMethodImplementation(implementationHandle);
-                if (implementation.MethodBody.Kind != HandleKind.MethodDefinition
-                    || implementation.MethodDeclaration.Kind != HandleKind.MethodDefinition)
-                {
-                    continue;
-                }
-
-                var bodyHandle = (MethodDefinitionHandle)implementation.MethodBody;
-                var declarationHandle = (MethodDefinitionHandle)implementation.MethodDeclaration;
-                var interfaceHandle = reader.GetMethodDefinition(declarationHandle).GetDeclaringType();
-                var interfaceDef = reader.GetTypeDefinition(interfaceHandle);
-                var interfaceIdentity = CompileBackTypeIdentity.FromDefinition(reader, interfaceDef);
-                if (!requirementsByMetadataName.TryGetValue(
-                        interfaceIdentity.MetadataFullName,
-                        out var interfaceRequirement))
-                {
-                    continue;
-                }
-
-                var interfaceProperty = PropertyForAccessor(reader, interfaceDef, declarationHandle);
-                if (interfaceProperty.IsNil)
-                    continue;
-                string interfacePropertyName = Identifier(reader.GetString(
-                    reader.GetPropertyDefinition(interfaceProperty).Name));
-                if (!interfaceRequirement.RequiredMembers.Any(member =>
-                        (member.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet)
-                        && member.Identity.Method == interfacePropertyName))
-                {
-                    continue;
-                }
-
-                var propertyHandle = PropertyForAccessor(reader, typeDef, bodyHandle);
-                if (propertyHandle.IsNil || !addedProperties.Add(propertyHandle))
-                    continue;
-
-                var body = reader.GetMethodDefinition(bodyHandle);
-                var property = PropertyRequirement(
-                    reader,
-                    typeDef,
-                    requirement.Type,
-                    propertyHandle,
-                    reader.GetString(body.Name),
-                    "required-explicit-interface-property");
-                if (property is not null
-                    && !members.Any(existing =>
-                        SameMemberDeclaration(existing, property)
-                        || existing.ExplicitInterfaceMemberName == property.ExplicitInterfaceMemberName))
-                {
-                    members.Add(property);
-                }
-            }
-
-            foreach (var propertyHandle in typeDef.GetProperties())
-            {
-                if (addedProperties.Contains(propertyHandle))
-                    continue;
-                var propertyDef = reader.GetPropertyDefinition(propertyHandle);
-                string metadataName = reader.GetString(propertyDef.Name);
-                int separator = metadataName.LastIndexOf('.');
-                if (separator <= 0
-                    || !requirementsByMetadataName.TryGetValue(
-                        metadataName[..separator],
-                        out var interfaceRequirement))
-                {
-                    continue;
-                }
-
-                string interfacePropertyName = Identifier(metadataName[(separator + 1)..]);
-                if (!interfaceRequirement.RequiredMembers.Any(member =>
-                        (member.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet)
-                        && member.Identity.Method == interfacePropertyName))
-                {
-                    continue;
-                }
-
-                var accessors = propertyDef.GetAccessors();
-                var accessor = !accessors.Getter.IsNil ? accessors.Getter : accessors.Setter;
-                if (accessor.IsNil)
-                    continue;
-
-                var property = PropertyRequirement(
-                    reader,
-                    typeDef,
-                    requirement.Type,
-                    propertyHandle,
-                    reader.GetString(reader.GetMethodDefinition(accessor).Name),
-                    "required-explicit-interface-property");
-                if (property is not null
-                    && !members.Any(existing =>
-                        SameMemberDeclaration(existing, property)
-                        || existing.ExplicitInterfaceMemberName == property.ExplicitInterfaceMemberName))
-                {
-                    members.Add(property);
-                }
-            }
-
             foreach (var implementationHandle in typeDef.GetInterfaceImplementations())
             {
                 var implementation = reader.GetInterfaceImplementation(implementationHandle);
                 if (implementation.Interface.Kind != HandleKind.TypeDefinition)
                     continue;
 
-                var interfaceDef = reader.GetTypeDefinition((TypeDefinitionHandle)implementation.Interface);
+                var interfaceDef = reader.GetTypeDefinition(
+                    (TypeDefinitionHandle)implementation.Interface);
                 var interfaceIdentity = CompileBackTypeIdentity.FromDefinition(reader, interfaceDef);
                 if (!requirementsByMetadataName.TryGetValue(
                         interfaceIdentity.MetadataFullName,
@@ -2957,16 +2859,18 @@ public static class CompileBackSourceComposer
                     continue;
                 }
 
-                foreach (var interfaceMember in interfaceRequirement.RequiredMembers.Where(member =>
-                    member.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet))
+                foreach (var interfaceMember in interfaceRequirement.RequiredMembers.Where(
+                    member => member.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet))
                 {
-                    var propertyHandle = typeDef.GetProperties().FirstOrDefault(handle =>
-                        Identifier(reader.GetString(reader.GetPropertyDefinition(handle).Name))
-                            == interfaceMember.Identity.Method);
-                    if (propertyHandle.IsNil || addedProperties.Contains(propertyHandle))
+                    var propertyHandle = ImplementingProperty(
+                        reader,
+                        typeDef,
+                        interfaceDef,
+                        interfaceMember);
+                    if (propertyHandle.IsNil)
                         continue;
-
-                    var accessors = reader.GetPropertyDefinition(propertyHandle).GetAccessors();
+                    var propertyDef = reader.GetPropertyDefinition(propertyHandle);
+                    var accessors = propertyDef.GetAccessors();
                     var accessor = interfaceMember.Kind == CompileBackMemberKind.PropertyGet
                         ? accessors.Getter
                         : accessors.Setter;
@@ -2981,13 +2885,58 @@ public static class CompileBackSourceComposer
                         reader.GetString(reader.GetMethodDefinition(accessor).Name),
                         "required-interface-property");
                     if (property is not null
-                        && !members.Any(existing => SameMemberDeclaration(existing, property)))
+                        && !members.Any(existing =>
+                            SameMemberDeclaration(existing, property)
+                            || property.ExplicitInterfaceMemberName is not null
+                                && existing.ExplicitInterfaceMemberName
+                                    == property.ExplicitInterfaceMemberName))
                     {
                         members.Add(property);
-                        addedProperties.Add(propertyHandle);
                     }
                 }
             }
+        }
+
+        static PropertyDefinitionHandle ImplementingProperty(
+            MetadataReader reader,
+            TypeDefinition typeDef,
+            TypeDefinition interfaceDef,
+            CompileBackMemberRequirement interfaceMember)
+        {
+            var interfaceProperty = interfaceDef.GetProperties().FirstOrDefault(handle =>
+                Identifier(reader.GetString(reader.GetPropertyDefinition(handle).Name))
+                    == interfaceMember.Identity.Method);
+            if (interfaceProperty.IsNil)
+                return default;
+
+            var interfaceAccessors = reader.GetPropertyDefinition(interfaceProperty).GetAccessors();
+            var declaration = interfaceMember.Kind == CompileBackMemberKind.PropertyGet
+                ? interfaceAccessors.Getter
+                : interfaceAccessors.Setter;
+            foreach (var implementationHandle in typeDef.GetMethodImplementations())
+            {
+                var implementation = reader.GetMethodImplementation(implementationHandle);
+                if (implementation.MethodDeclaration == declaration
+                    && implementation.MethodBody.Kind == HandleKind.MethodDefinition)
+                {
+                    return PropertyForAccessor(
+                        reader,
+                        typeDef,
+                        (MethodDefinitionHandle)implementation.MethodBody);
+                }
+            }
+
+            string interfaceName = CompileBackTypeIdentity.FromDefinition(
+                reader,
+                interfaceDef).MetadataFullName;
+            string propertyName = reader.GetString(
+                reader.GetPropertyDefinition(interfaceProperty).Name);
+            return typeDef.GetProperties().FirstOrDefault(handle =>
+            {
+                string candidateName = reader.GetString(reader.GetPropertyDefinition(handle).Name);
+                return candidateName == propertyName
+                    || candidateName == $"{interfaceName}.{propertyName}";
+            });
         }
 
         static PropertyDefinitionHandle PropertyForAccessor(

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -918,7 +918,7 @@ public static class CompileBackSourceComposer
                 continue;
 
             var requirement = requirements[requirementIndex];
-            if (!requirement.RequiredMembers.Any(existing => SameMemberDeclaration(existing, member)))
+            if (!requirement.RequiredMembers.Any(existing => TypeProducer.SameMemberShape(existing, member)))
             {
                 requirements[requirementIndex] = requirement with
                 {
@@ -2799,7 +2799,7 @@ public static class CompileBackSourceComposer
                 AddClosureMemberSurface(reader, typeDef, requirement, members, diagnostics);
             if (kind is CompileBackTypeKind.Class or CompileBackTypeKind.Record or CompileBackTypeKind.Struct)
             {
-                AddRequiredExplicitInterfaceProperties(
+                AddRequiredInterfaceProperties(
                     reader,
                     typeDef,
                     requirement,
@@ -2848,7 +2848,7 @@ public static class CompileBackSourceComposer
                     diagnostics));
         }
 
-        static void AddRequiredExplicitInterfaceProperties(
+        static void AddRequiredInterfaceProperties(
             MetadataReader reader,
             TypeDefinition typeDef,
             CompileBackTypeRequirement requirement,
@@ -2871,7 +2871,19 @@ public static class CompileBackSourceComposer
                     continue;
                 }
 
-                foreach (var interfaceMember in interfaceRequirement.RequiredMembers.Where(
+                var interfaceMembers = RequiredMemberRequirements(interfaceRequirement);
+                if (interfaceRequirement.IncludeMemberSurface)
+                {
+                    // The interface's own BuildSpec call reports surface diagnostics.
+                    AddClosureMemberSurface(
+                        reader,
+                        interfaceDef,
+                        interfaceRequirement,
+                        interfaceMembers,
+                        diagnostics: []);
+                }
+
+                foreach (var interfaceMember in interfaceMembers.Where(
                     member => member.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet))
                 {
                     var propertyHandle = ImplementingProperty(
@@ -2897,11 +2909,7 @@ public static class CompileBackSourceComposer
                         reader.GetString(reader.GetMethodDefinition(accessor).Name),
                         "required-interface-property");
                     if (property is not null
-                        && !members.Any(existing =>
-                            SameMemberDeclaration(existing, property)
-                            || property.ExplicitInterfaceMemberName is not null
-                                && existing.ExplicitInterfaceMemberName
-                                    == property.ExplicitInterfaceMemberName))
+                        && !members.Any(existing => SameMemberShape(existing, property)))
                     {
                         members.Add(property);
                     }
@@ -2963,6 +2971,24 @@ public static class CompileBackSourceComposer
                     return propertyHandle;
             }
             return default;
+        }
+
+        internal static bool SameMemberShape(
+            CompileBackMemberRequirement left,
+            CompileBackMemberRequirement right)
+        {
+            if (SameMemberDeclaration(left, right))
+                return true;
+            if (left.Kind is not (CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet)
+                || right.Kind is not (CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet))
+            {
+                return false;
+            }
+
+            string leftName = left.ExplicitInterfaceMemberName ?? left.Identity.Method;
+            string rightName = right.ExplicitInterfaceMemberName ?? right.Identity.Method;
+            return leftName == rightName
+                && SameParameters(left.Parameters, right.Parameters);
         }
 
         static CSharpTypeShellKind ToShellKind(CompileBackTypeKind kind)

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -319,7 +319,8 @@ public sealed record CompileBackMemberRequirement(
     bool IsAsync = false,
     bool IsExtension = false,
     CompileBackAccessibility Accessibility = CompileBackAccessibility.Public,
-    string? ConstructorInitializer = null)
+    string? ConstructorInitializer = null,
+    string? ExplicitInterfaceMemberName = null)
 {
     public string Name => Identity.Method;
     public string Type => ReturnType?.DisplayName ?? "";
@@ -713,7 +714,9 @@ public static class CompileBackSourceComposer
         var propertyDeclaration = MetadataDeclarationQuery.GetProperty(reader, targetTypeDef, property);
         var accessors = property.GetAccessors();
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
-        string propertyName = Identifier(reader.GetString(property.Name));
+        string metadataPropertyName = reader.GetString(property.Name);
+        string propertyName = Identifier(metadataPropertyName);
+        string? explicitInterfaceMemberName = ExplicitInterfaceMemberName(metadataPropertyName);
         var returnType = CompileBackTypeSignature.Display(signature.ReturnType);
         bool targetIsAutoProperty = IsAutoProperty(reader, targetTypeDef, property, targetGetter, returnType.DisplayName);
 
@@ -748,7 +751,8 @@ public static class CompileBackSourceComposer
                     ]
                     : [new CompileBackFact("metadata", "target-property-getter", reader.GetString(reader.GetMethodDefinition(targetGetter).Name))],
                 propertyDeclaration.Attributes,
-                MetadataDeclarationQuery.GetMethod(reader, targetTypeDef, getter, getterSignature).Signature.ReturnAttributes)
+                MetadataDeclarationQuery.GetMethod(reader, targetTypeDef, getter, getterSignature).Signature.ReturnAttributes,
+                ExplicitInterfaceMemberName: explicitInterfaceMemberName)
         };
         AddRequiredMembers(targetMembers, closureMemberRequirements, targetType);
 
@@ -774,6 +778,7 @@ public static class CompileBackSourceComposer
 
             AddClosureTypeRequirements(requirements, reader, dependency, closureFacts, closureMemberRequirements);
         }
+        AddExplicitInterfacePropertyDeclaration(requirements, reader, targetTypeDef, targetGetter);
 
         var production = TypeProducer.Produce(reader, requirements, diagnostics);
         var declarations = production.Requests;
@@ -869,6 +874,61 @@ public static class CompileBackSourceComposer
         }
     }
 
+    static void AddExplicitInterfacePropertyDeclaration(
+        List<CompileBackTypeRequirement> requirements,
+        MetadataReader reader,
+        TypeDefinition targetType,
+        MethodDefinitionHandle targetAccessor)
+    {
+        foreach (var implementationHandle in targetType.GetMethodImplementations())
+        {
+            var implementation = reader.GetMethodImplementation(implementationHandle);
+            if (implementation.MethodBody != targetAccessor
+                || implementation.MethodDeclaration.Kind != HandleKind.MethodDefinition)
+            {
+                continue;
+            }
+
+            var declarationHandle = (MethodDefinitionHandle)implementation.MethodDeclaration;
+            var declaration = reader.GetMethodDefinition(declarationHandle);
+            var interfaceHandle = declaration.GetDeclaringType();
+            var interfaceDef = reader.GetTypeDefinition(interfaceHandle);
+            var propertyHandle = interfaceDef.GetProperties().FirstOrDefault(handle =>
+            {
+                var accessors = reader.GetPropertyDefinition(handle).GetAccessors();
+                return accessors.Getter == declarationHandle || accessors.Setter == declarationHandle;
+            });
+            if (propertyHandle.IsNil)
+                continue;
+
+            var interfaceIdentity = CompileBackTypeIdentity.FromDefinition(reader, interfaceDef);
+            var member = TypeProducer.PropertyRequirement(
+                reader,
+                interfaceDef,
+                interfaceIdentity,
+                propertyHandle,
+                reader.GetString(declaration.Name),
+                "explicit-interface-target-property");
+            if (member is null)
+                continue;
+
+            int requirementIndex = requirements.FindIndex(
+                requirement => requirement.Type.MetadataFullName == interfaceIdentity.MetadataFullName);
+            if (requirementIndex < 0)
+                continue;
+
+            var requirement = requirements[requirementIndex];
+            if (!requirement.RequiredMembers.Any(existing => SameMemberDeclaration(existing, member)))
+            {
+                requirements[requirementIndex] = requirement with
+                {
+                    RequiredMembers = requirement.RequiredMembers.Append(member).ToArray()
+                };
+            }
+            return;
+        }
+    }
+
     public static CompileBackSourceResult ComposePropertySetter(
         string assemblyPath,
         MetadataReader reader,
@@ -891,7 +951,9 @@ public static class CompileBackSourceComposer
         var propertySignature = GuardedSignatureText.PropertyText(reader, property, GenericContext.ForType(reader, targetTypeDef));
         var propertyDeclaration = MetadataDeclarationQuery.GetProperty(reader, targetTypeDef, property);
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
-        string propertyName = Identifier(reader.GetString(property.Name));
+        string metadataPropertyName = reader.GetString(property.Name);
+        string propertyName = Identifier(metadataPropertyName);
+        string? explicitInterfaceMemberName = ExplicitInterfaceMemberName(metadataPropertyName);
         var returnType = CompileBackTypeSignature.Display(propertySignature.ReturnType);
         bool targetIsAutoProperty = IsAutoPropertySetter(reader, targetTypeDef, property, targetSetter, returnType.DisplayName);
 
@@ -925,7 +987,8 @@ public static class CompileBackSourceComposer
                         new CompileBackFact("metadata", "target-property-setter", reader.GetString(setter.Name)),
                         new CompileBackFact("metadata", "auto-property", propertyName)
                     ]
-                    : [new CompileBackFact("metadata", "target-property-setter", reader.GetString(setter.Name))])
+                    : [new CompileBackFact("metadata", "target-property-setter", reader.GetString(setter.Name))],
+                ExplicitInterfaceMemberName: explicitInterfaceMemberName)
         };
         AddRequiredMembers(targetMembers, closureMemberRequirements, targetType);
 
@@ -950,6 +1013,7 @@ public static class CompileBackSourceComposer
 
             AddClosureTypeRequirements(requirements, reader, dependency, closureFacts, closureMemberRequirements);
         }
+        AddExplicitInterfacePropertyDeclaration(requirements, reader, targetTypeDef, targetSetter);
 
         var production = TypeProducer.Produce(reader, requirements, diagnostics);
         var declarations = production.Requests;
@@ -1186,18 +1250,22 @@ public static class CompileBackSourceComposer
     static ApiMember ToApiMember(CompileBackMemberRequirement member)
     {
         string? returnType = member.ReturnType?.DisplayName;
+        bool isExplicitInterfaceProperty = member.ExplicitInterfaceMemberName is not null
+            && member.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet;
         var apiMember = new ApiMember
         {
-            Name = member.Identity.Method,
-            Kind = member.Kind switch
-            {
-                CompileBackMemberKind.PropertyGet => "property",
-                CompileBackMemberKind.PropertySet => "property",
-                CompileBackMemberKind.Constructor => "constructor",
-                CompileBackMemberKind.Method => "method",
-                CompileBackMemberKind.Field => "field",
-                _ => throw new NotSupportedException($"Unsupported member declaration kind '{member.Kind}'."),
-            },
+            Name = member.ExplicitInterfaceMemberName ?? member.Identity.Method,
+            Kind = isExplicitInterfaceProperty
+                ? "explicit-interface-implementation"
+                : member.Kind switch
+                {
+                    CompileBackMemberKind.PropertyGet => "property",
+                    CompileBackMemberKind.PropertySet => "property",
+                    CompileBackMemberKind.Constructor => "constructor",
+                    CompileBackMemberKind.Method => "method",
+                    CompileBackMemberKind.Field => "field",
+                    _ => throw new NotSupportedException($"Unsupported member declaration kind '{member.Kind}'."),
+                },
             ReturnType = returnType,
             IsStatic = member.IsStatic,
             IsAbstract = member.IsAbstract,
@@ -1251,7 +1319,7 @@ public static class CompileBackSourceComposer
             {
                 apiMember.SignatureModel.MemberName = member.Parameters.Count > 0
                     ? "this[]"
-                    : member.Identity.Method;
+                    : apiMember.Name;
                 apiMember.SignatureModel.Accessors = PropertyAccessors(member);
             }
         }
@@ -2321,6 +2389,17 @@ public static class CompileBackSourceComposer
 
     static string Identifier(string name) => CSharpIdentifier.Sanitize(name);
 
+    static string? ExplicitInterfaceMemberName(string metadataPropertyName)
+    {
+        int separator = metadataPropertyName.LastIndexOf('.');
+        if (separator <= 0 || separator == metadataPropertyName.Length - 1)
+            return null;
+
+        string interfaceName = Clean(metadataPropertyName[..separator]);
+        string memberName = CSharpIdentifier.Sanitize(metadataPropertyName[(separator + 1)..]);
+        return $"{interfaceName}.{memberName}";
+    }
+
     sealed class TypeProducer
     {
         public static CompileBackMemberRequirement? TryCreateClosureMemberRequirement(
@@ -2531,7 +2610,7 @@ public static class CompileBackSourceComposer
             }
         }
 
-        static CompileBackMemberRequirement? PropertyRequirement(
+        internal static CompileBackMemberRequirement? PropertyRequirement(
             MetadataReader reader,
             TypeDefinition typeDef,
             CompileBackTypeIdentity typeIdentity,
@@ -2542,9 +2621,9 @@ public static class CompileBackSourceComposer
             var property = reader.GetPropertyDefinition(propertyHandle);
             var accessors = property.GetAccessors();
             string propertyName = reader.GetString(property.Name);
-            if (propertyName.Contains('<', StringComparison.Ordinal)
-                || propertyName.Contains('.', StringComparison.Ordinal))
+            if (propertyName.Contains('<', StringComparison.Ordinal))
                 return null;
+            string? explicitInterfaceMemberName = ExplicitInterfaceMemberName(propertyName);
 
             MetadataPropertyDeclaration propertyDeclaration;
             try
@@ -2593,7 +2672,8 @@ public static class CompileBackSourceComposer
                 propertyDeclaration.Attributes,
                 propertyDeclaration.Signature.ReturnAttributes,
                 IsAbstract: isAbstractAccessor,
-                IsVirtual: !accessor.IsNil && propertyDeclaration.IsVirtual);
+                IsVirtual: !accessor.IsNil && propertyDeclaration.IsVirtual,
+                ExplicitInterfaceMemberName: explicitInterfaceMemberName);
         }
 
         static CompileBackMemberRequirement? MethodRequirement(
@@ -2705,6 +2785,15 @@ public static class CompileBackSourceComposer
             bool includeMemberSurface = requirement.IncludeMemberSurface;
             if (includeMemberSurface && kind != CompileBackTypeKind.Delegate)
                 AddClosureMemberSurface(reader, typeDef, requirement, members, diagnostics);
+            if (kind is CompileBackTypeKind.Class or CompileBackTypeKind.Record or CompileBackTypeKind.Struct)
+            {
+                AddRequiredExplicitInterfaceProperties(
+                    reader,
+                    typeDef,
+                    requirement,
+                    requirementsByMetadataName,
+                    members);
+            }
             // When this class is reconstructed as the base of another shell type, a
             // derived stub constructor emits an implicit `: base()`. If the class has
             // only parameterized constructors (no accessible parameterless one), that
@@ -2745,6 +2834,174 @@ public static class CompileBackSourceComposer
                     includeMemberSurface,
                     producedRequirements,
                     diagnostics));
+        }
+
+        static void AddRequiredExplicitInterfaceProperties(
+            MetadataReader reader,
+            TypeDefinition typeDef,
+            CompileBackTypeRequirement requirement,
+            IReadOnlyDictionary<string, CompileBackTypeRequirement> requirementsByMetadataName,
+            List<CompileBackMemberRequirement> members)
+        {
+            var addedProperties = new HashSet<PropertyDefinitionHandle>();
+            foreach (var implementationHandle in typeDef.GetMethodImplementations())
+            {
+                var implementation = reader.GetMethodImplementation(implementationHandle);
+                if (implementation.MethodBody.Kind != HandleKind.MethodDefinition
+                    || implementation.MethodDeclaration.Kind != HandleKind.MethodDefinition)
+                {
+                    continue;
+                }
+
+                var bodyHandle = (MethodDefinitionHandle)implementation.MethodBody;
+                var declarationHandle = (MethodDefinitionHandle)implementation.MethodDeclaration;
+                var interfaceHandle = reader.GetMethodDefinition(declarationHandle).GetDeclaringType();
+                var interfaceDef = reader.GetTypeDefinition(interfaceHandle);
+                var interfaceIdentity = CompileBackTypeIdentity.FromDefinition(reader, interfaceDef);
+                if (!requirementsByMetadataName.TryGetValue(
+                        interfaceIdentity.MetadataFullName,
+                        out var interfaceRequirement))
+                {
+                    continue;
+                }
+
+                var interfaceProperty = PropertyForAccessor(reader, interfaceDef, declarationHandle);
+                if (interfaceProperty.IsNil)
+                    continue;
+                string interfacePropertyName = Identifier(reader.GetString(
+                    reader.GetPropertyDefinition(interfaceProperty).Name));
+                if (!interfaceRequirement.RequiredMembers.Any(member =>
+                        (member.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet)
+                        && member.Identity.Method == interfacePropertyName))
+                {
+                    continue;
+                }
+
+                var propertyHandle = PropertyForAccessor(reader, typeDef, bodyHandle);
+                if (propertyHandle.IsNil || !addedProperties.Add(propertyHandle))
+                    continue;
+
+                var body = reader.GetMethodDefinition(bodyHandle);
+                var property = PropertyRequirement(
+                    reader,
+                    typeDef,
+                    requirement.Type,
+                    propertyHandle,
+                    reader.GetString(body.Name),
+                    "required-explicit-interface-property");
+                if (property is not null
+                    && !members.Any(existing =>
+                        SameMemberDeclaration(existing, property)
+                        || existing.ExplicitInterfaceMemberName == property.ExplicitInterfaceMemberName))
+                {
+                    members.Add(property);
+                }
+            }
+
+            foreach (var propertyHandle in typeDef.GetProperties())
+            {
+                if (addedProperties.Contains(propertyHandle))
+                    continue;
+                var propertyDef = reader.GetPropertyDefinition(propertyHandle);
+                string metadataName = reader.GetString(propertyDef.Name);
+                int separator = metadataName.LastIndexOf('.');
+                if (separator <= 0
+                    || !requirementsByMetadataName.TryGetValue(
+                        metadataName[..separator],
+                        out var interfaceRequirement))
+                {
+                    continue;
+                }
+
+                string interfacePropertyName = Identifier(metadataName[(separator + 1)..]);
+                if (!interfaceRequirement.RequiredMembers.Any(member =>
+                        (member.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet)
+                        && member.Identity.Method == interfacePropertyName))
+                {
+                    continue;
+                }
+
+                var accessors = propertyDef.GetAccessors();
+                var accessor = !accessors.Getter.IsNil ? accessors.Getter : accessors.Setter;
+                if (accessor.IsNil)
+                    continue;
+
+                var property = PropertyRequirement(
+                    reader,
+                    typeDef,
+                    requirement.Type,
+                    propertyHandle,
+                    reader.GetString(reader.GetMethodDefinition(accessor).Name),
+                    "required-explicit-interface-property");
+                if (property is not null
+                    && !members.Any(existing =>
+                        SameMemberDeclaration(existing, property)
+                        || existing.ExplicitInterfaceMemberName == property.ExplicitInterfaceMemberName))
+                {
+                    members.Add(property);
+                }
+            }
+
+            foreach (var implementationHandle in typeDef.GetInterfaceImplementations())
+            {
+                var implementation = reader.GetInterfaceImplementation(implementationHandle);
+                if (implementation.Interface.Kind != HandleKind.TypeDefinition)
+                    continue;
+
+                var interfaceDef = reader.GetTypeDefinition((TypeDefinitionHandle)implementation.Interface);
+                var interfaceIdentity = CompileBackTypeIdentity.FromDefinition(reader, interfaceDef);
+                if (!requirementsByMetadataName.TryGetValue(
+                        interfaceIdentity.MetadataFullName,
+                        out var interfaceRequirement))
+                {
+                    continue;
+                }
+
+                foreach (var interfaceMember in interfaceRequirement.RequiredMembers.Where(member =>
+                    member.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet))
+                {
+                    var propertyHandle = typeDef.GetProperties().FirstOrDefault(handle =>
+                        Identifier(reader.GetString(reader.GetPropertyDefinition(handle).Name))
+                            == interfaceMember.Identity.Method);
+                    if (propertyHandle.IsNil || addedProperties.Contains(propertyHandle))
+                        continue;
+
+                    var accessors = reader.GetPropertyDefinition(propertyHandle).GetAccessors();
+                    var accessor = interfaceMember.Kind == CompileBackMemberKind.PropertyGet
+                        ? accessors.Getter
+                        : accessors.Setter;
+                    if (accessor.IsNil)
+                        continue;
+
+                    var property = PropertyRequirement(
+                        reader,
+                        typeDef,
+                        requirement.Type,
+                        propertyHandle,
+                        reader.GetString(reader.GetMethodDefinition(accessor).Name),
+                        "required-interface-property");
+                    if (property is not null
+                        && !members.Any(existing => SameMemberDeclaration(existing, property)))
+                    {
+                        members.Add(property);
+                        addedProperties.Add(propertyHandle);
+                    }
+                }
+            }
+        }
+
+        static PropertyDefinitionHandle PropertyForAccessor(
+            MetadataReader reader,
+            TypeDefinition typeDef,
+            MethodDefinitionHandle accessor)
+        {
+            foreach (var propertyHandle in typeDef.GetProperties())
+            {
+                var accessors = reader.GetPropertyDefinition(propertyHandle).GetAccessors();
+                if (accessors.Getter == accessor || accessors.Setter == accessor)
+                    return propertyHandle;
+            }
+            return default;
         }
 
         static CSharpTypeShellKind ToShellKind(CompileBackTypeKind kind)

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -716,7 +716,7 @@ public static class CompileBackSourceComposer
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
         string metadataPropertyName = reader.GetString(property.Name);
         string propertyName = Identifier(metadataPropertyName);
-        string? explicitInterfaceMemberName = ExplicitInterfaceMemberName(metadataPropertyName);
+        string? explicitInterfaceMemberName = ExplicitInterfaceMemberName(reader, metadataPropertyName);
         var returnType = CompileBackTypeSignature.Display(signature.ReturnType);
         bool targetIsAutoProperty = IsAutoProperty(reader, targetTypeDef, property, targetGetter, returnType.DisplayName);
 
@@ -953,7 +953,7 @@ public static class CompileBackSourceComposer
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
         string metadataPropertyName = reader.GetString(property.Name);
         string propertyName = Identifier(metadataPropertyName);
-        string? explicitInterfaceMemberName = ExplicitInterfaceMemberName(metadataPropertyName);
+        string? explicitInterfaceMemberName = ExplicitInterfaceMemberName(reader, metadataPropertyName);
         var returnType = CompileBackTypeSignature.Display(propertySignature.ReturnType);
         bool targetIsAutoProperty = IsAutoPropertySetter(reader, targetTypeDef, property, targetSetter, returnType.DisplayName);
 
@@ -2389,13 +2389,25 @@ public static class CompileBackSourceComposer
 
     static string Identifier(string name) => CSharpIdentifier.Sanitize(name);
 
-    static string? ExplicitInterfaceMemberName(string metadataPropertyName)
+    static string? ExplicitInterfaceMemberName(
+        MetadataReader reader,
+        string metadataPropertyName)
     {
         int separator = metadataPropertyName.LastIndexOf('.');
         if (separator <= 0 || separator == metadataPropertyName.Length - 1)
             return null;
 
-        string interfaceName = Clean(metadataPropertyName[..separator]);
+        string interfaceMetadataName = metadataPropertyName[..separator];
+        if (TypeProducer.FindType(reader, interfaceMetadataName) is not { } interfaceHandle)
+            return null;
+        var interfaceDef = reader.GetTypeDefinition(interfaceHandle);
+        if (interfaceDef.GetGenericParameters().Count != 0
+            || !IsSupportedClosureRoot(reader, interfaceDef))
+        {
+            return null;
+        }
+
+        string interfaceName = Clean(interfaceMetadataName);
         string memberName = CSharpIdentifier.Sanitize(metadataPropertyName[(separator + 1)..]);
         return $"{interfaceName}.{memberName}";
     }
@@ -2623,7 +2635,7 @@ public static class CompileBackSourceComposer
             string propertyName = reader.GetString(property.Name);
             if (propertyName.Contains('<', StringComparison.Ordinal))
                 return null;
-            string? explicitInterfaceMemberName = ExplicitInterfaceMemberName(propertyName);
+            string? explicitInterfaceMemberName = ExplicitInterfaceMemberName(reader, propertyName);
 
             MetadataPropertyDeclaration propertyDeclaration;
             try
@@ -3537,7 +3549,7 @@ public static class CompileBackSourceComposer
         static string MethodSignatureText(string name, MethodSignature<string> signature)
             => $"{signature.ReturnType} {name}({string.Join(", ", signature.ParameterTypes)})";
 
-        static TypeDefinitionHandle? FindType(MetadataReader reader, string metadataFullName)
+        internal static TypeDefinitionHandle? FindType(MetadataReader reader, string metadataFullName)
         {
             foreach (var handle in reader.TypeDefinitions)
             {


### PR DESCRIPTION
## Summary

Render same-assembly explicit-interface properties as real C# explicit implementations in RTS shells, and project only the concrete properties required by minimized interface contracts.

- preserve qualified property names through the RTS data contract
- let `CSharpTypePrinter` own explicit-property declaration and body rendering
- render qualified explicit-interface indexers as `IInterface.this[...]`
- project matching explicit or implicit implementation properties without adding unrelated interface siblings
- keep external TypeRef interfaces outside this reconstruction path
- deduplicate projections by effective C# property shape

Closes #2827.

## Evidence

Pinned community and compiler assemblies improve without any reverse row transitions:

| Assembly | Exact | OpcodeDiff | RecompileFail | ContextFail | CS0535 |
| --- | ---: | ---: | ---: | ---: | ---: |
| Newtonsoft.Json 13.0.4 | 535 -> 544 | 16 -> 16 | 15 -> 8 | 15 -> 13 | 7 -> 0 |
| Microsoft.ApplicationInsights 2.23.0 | 522 -> 548 | 12 -> 12 | 17 -> 17 | 26 -> 0 | 4 -> 0 |
| Microsoft.CodeAnalysis 5.0.0 | 1084 -> 1188 | 13 -> 13 | 1431 -> 1431 | 104 -> 0 | 22 -> 0 |
| Microsoft.CodeAnalysis.CSharp 5.0.0 | 3600 -> 3601 | 3 -> 3 | 7384 -> 7384 | 37 -> 36 | 1 -> 0 |

Row-level comparison reports 9 improvements for Newtonsoft.Json, 26 for ApplicationInsights, and 104 for CodeAnalysis, with no successful row worsening.

The issue's historical 26-row estimate predates the current pinned corpus. The current assembly versions expose 34 `CS0535` rows across these four canaries; all 34 are removed. Six CodeAnalysis rows return to their pre-existing inherited-interface `CS1061` boundary rather than regressing to `CS0535`.

The cap-3 RTS parity result and lost-row set are identical on clean `origin/main` and this branch. Both currently report the same pre-existing `CSharpPrinter.CheckedSafeCast` manifest drift; this change adds no parity row.

## Validation

- Release solution build
- 2,666 decompiler tests
- 271 C# seam tests
- 118 focused RTS prototype tests
- cap-3 RTS parity comparison against clean `origin/main`
