### PR TITLE
Move backing-field-reference extraction into MemberBodyFacts (#2777)

### DIFF
--- a/src/ILInspector.CSharp/BackingFieldReference.cs
+++ b/src/ILInspector.CSharp/BackingFieldReference.cs
@@ -1,0 +1,46 @@
+namespace ILInspector.CSharp;
+
+/// <summary>
+/// How a decompiled member body touches a backing field, so ReturnToSender can decide
+/// which auto-property/field member requirements to synthesize without inspecting
+/// Decompiler IR itself.
+/// </summary>
+public enum BackingFieldAccess
+{
+    /// <summary>A field load (<c>ldfld</c>/<c>ldflda</c>) — the body reads the field.</summary>
+    Read,
+
+    /// <summary>An instance field store whose receiver is <c>this</c> (argument 0).</summary>
+    InstanceWrite,
+
+    /// <summary>A static field store.</summary>
+    StaticWrite,
+}
+
+/// <summary>
+/// A neutral, IR-free reference to a backing field a decompiled member body reads or
+/// writes. ReturnToSender uses these to reconstruct the auto-properties/fields the body
+/// depends on without reading Decompiler IR, so the IR-to-fact extraction lives in the
+/// product (ILInspector.Decompiler, which owns the IR) rather than in the harness. All
+/// fields are plain strings and an access enum; no Decompiler type crosses this boundary.
+/// </summary>
+/// <param name="DeclaringNamespace">
+/// Namespace of the field's declaring type (the definition, with any generic instance
+/// unwrapped), so the harness can match it against the target type's identity.
+/// </param>
+/// <param name="DeclaringName">
+/// Metadata name of the field's declaring type definition, matching the harness's
+/// self-type name form.
+/// </param>
+/// <param name="FieldName">The stored/loaded field's metadata name.</param>
+/// <param name="BackingPropertyName">
+/// The property name when the field backs an auto-property, or null when there is no
+/// such proof.
+/// </param>
+/// <param name="Access">Whether the reference is a read, an instance write, or a static write.</param>
+public sealed record BackingFieldReference(
+    string DeclaringNamespace,
+    string DeclaringName,
+    string FieldName,
+    string? BackingPropertyName,
+    BackingFieldAccess Access);

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4724,3 +4724,16 @@ public static class NamespaceRefSample
     // References only System (Int32).
     public static int ReferencesOnlySystem(int x) => x + 1;
 }
+
+// Fixtures for MemberBodyFactsTests backing-field cases. Auto-property accessors
+// touch the compiler-generated backing field directly, so importing get_/set_
+// exercises the LoadField/StoreField walk with a resolvable BackingPropertyName.
+public class BackingFieldSample
+{
+    public int Number { get; set; }
+
+    public static string Label { get; set; } = "";
+
+    // Reads no field, so the walk reports nothing.
+    public int NoFieldAccess(int x) => x + 1;
+}

--- a/src/ILInspector.Decompiler.Tests/MemberBodyFactsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberBodyFactsTests.cs
@@ -22,6 +22,14 @@ public class MemberBodyFactsTests
         return MemberBodyFacts.Constructor(function);
     }
 
+    static IReadOnlyList<BackingFieldReference> BackingFieldsFor(string typeFullName, string methodName, int overloadIndex = 0)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeFullName, methodName, overloadIndex);
+        Assert.NotNull(function);
+        return MemberBodyFacts.BackingFieldReferences(function);
+    }
+
     [Fact]
     public void ReferencedNamespaces_ReportsEveryDistinctReferencedNamespace()
     {
@@ -101,5 +109,53 @@ public class MemberBodyFactsTests
 
         Assert.Null(facts.ChainParameterTypes);
         Assert.Null(facts.PrimaryConstructorPrologue);
+    }
+
+    [Fact]
+    public void BackingFields_InstanceGetter_ReportsBackingFieldRead()
+    {
+        // An instance auto-property getter loads its backing field, so the walk
+        // reports one Read carrying the field's declaring type and property name.
+        var references = BackingFieldsFor(typeof(BackingFieldSample).FullName!, "get_Number");
+
+        var reference = Assert.Single(references);
+        Assert.Equal(BackingFieldAccess.Read, reference.Access);
+        Assert.Equal("ILInspector.Decompiler.Tests", reference.DeclaringNamespace);
+        Assert.Equal(nameof(BackingFieldSample), reference.DeclaringName);
+        Assert.Equal("Number", reference.BackingPropertyName);
+        Assert.Contains("Number", reference.FieldName);
+    }
+
+    [Fact]
+    public void BackingFields_InstanceSetter_ReportsInstanceWrite()
+    {
+        // An instance auto-property setter stores through `this`, so the walk
+        // reports one InstanceWrite.
+        var references = BackingFieldsFor(typeof(BackingFieldSample).FullName!, "set_Number");
+
+        var reference = Assert.Single(references);
+        Assert.Equal(BackingFieldAccess.InstanceWrite, reference.Access);
+        Assert.Equal("Number", reference.BackingPropertyName);
+    }
+
+    [Fact]
+    public void BackingFields_StaticSetter_ReportsStaticWrite()
+    {
+        // A static auto-property setter stores a static field, so the walk reports
+        // one StaticWrite.
+        var references = BackingFieldsFor(typeof(BackingFieldSample).FullName!, "set_Label");
+
+        var reference = Assert.Single(references);
+        Assert.Equal(BackingFieldAccess.StaticWrite, reference.Access);
+        Assert.Equal("Label", reference.BackingPropertyName);
+    }
+
+    [Fact]
+    public void BackingFields_NoFieldAccess_ReportsNothing()
+    {
+        // A method that touches no field yields no backing-field references.
+        var references = BackingFieldsFor(typeof(BackingFieldSample).FullName!, nameof(BackingFieldSample.NoFieldAccess));
+
+        Assert.Empty(references);
     }
 }

--- a/src/ILInspector.Decompiler/MemberBodyFacts.cs
+++ b/src/ILInspector.Decompiler/MemberBodyFacts.cs
@@ -13,11 +13,14 @@ public static class MemberBodyFacts
 {
     /// <summary>
     /// The distinct namespaces of every type referenced by <paramref name="function"/>
-    /// and its descendant nodes, in ordinal-sorted order, so the harness can assemble
-    /// <c>using</c> directives. Element/argument types of generic instances, arrays,
-    /// by-refs, pointers, and pinned types are unwrapped so only their underlying
-    /// definition namespaces are reported; the global namespace (empty string) is
-    /// excluded.
+    /// and its descendant nodes, so the harness can assemble <c>using</c> directives.
+    /// Element/argument types of generic instances, arrays, by-refs, pointers, and
+    /// pinned types are unwrapped so only their underlying definition namespaces are
+    /// reported; the global namespace (empty string) is excluded.
+    /// <para>
+    /// Order: ordinal-sorted (case-sensitive), because the harness builds a stable,
+    /// deterministic <c>using</c> block from this set.
+    /// </para>
     /// </summary>
     public static IReadOnlySet<string> ReferencedNamespaces(IrFunction function)
     {
@@ -60,9 +63,65 @@ public static class MemberBodyFacts
     /// constructor-chain initializers and primary-constructor shells. Callers should
     /// only apply the constructor-shaped facts to actual constructors; the extraction
     /// itself is body-shape driven.
+    /// <para>
+    /// Order: <see cref="ConstructorBodyFacts.ChainParameterTypes"/> follows the chain
+    /// call's parameter order, and <see cref="ConstructorBodyFacts.PrimaryConstructorPrologue"/>
+    /// follows the entry block's field-store order (source-argument order).
+    /// </para>
     /// </summary>
     public static ConstructorBodyFacts Constructor(IrFunction function)
         => new(ChainParameterTypes(function), PrimaryConstructorPrologue(function));
+
+    /// <summary>
+    /// The backing fields <paramref name="function"/> reads or writes, so the harness
+    /// can synthesize the auto-property/field member requirements the body depends on.
+    /// Field loads (<c>ldfld</c>/<c>ldflda</c>) report <see cref="BackingFieldAccess.Read"/>;
+    /// instance stores whose receiver is <c>this</c> (argument 0) report
+    /// <see cref="BackingFieldAccess.InstanceWrite"/> and static stores report
+    /// <see cref="BackingFieldAccess.StaticWrite"/>; instance stores to any other
+    /// receiver are omitted. A reference whose declaring type does not resolve to a type
+    /// definition is omitted, since it can never be a self-type member.
+    /// <para>
+    /// Order: all reads first (every <c>ldfld</c> in IR descendant order, then every
+    /// <c>ldflda</c> in IR descendant order), then all writes in IR descendant order.
+    /// The order is preserved because downstream de-duplication keeps the first member
+    /// it sees for a given property name.
+    /// </para>
+    /// </summary>
+    public static IReadOnlyList<BackingFieldReference> BackingFieldReferences(IrFunction function)
+    {
+        var references = new List<BackingFieldReference>();
+
+        foreach (var load in function.Descendants.OfType<LoadField>())
+            Add(load.Field, BackingFieldAccess.Read);
+        foreach (var address in function.Descendants.OfType<LoadFieldAddress>())
+            Add(address.Field, BackingFieldAccess.Read);
+        foreach (var store in function.Descendants.OfType<StoreField>())
+        {
+            BackingFieldAccess? access = store switch
+            {
+                { HasInstance: true, Instance: LoadArgument { Index: 0 } } => BackingFieldAccess.InstanceWrite,
+                { HasInstance: false } => BackingFieldAccess.StaticWrite,
+                _ => null,
+            };
+            if (access is { } write)
+                Add(store.Field, write);
+        }
+
+        return references;
+
+        void Add(FieldRef field, BackingFieldAccess access)
+        {
+            var declaring = field.DeclaringType.Kind == TypeRefKind.GenericInstance
+                ? field.DeclaringType.ElementType ?? field.DeclaringType
+                : field.DeclaringType;
+            if (declaring.Kind != TypeRefKind.Definition)
+                return;
+
+            references.Add(new BackingFieldReference(
+                declaring.Namespace, declaring.Name, field.Name, field.BackingPropertyName, access));
+        }
+    }
 
     /// <summary>
     /// The parameter type display names of the <c>this</c>/<c>base</c> <c>.ctor</c>

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1729,6 +1729,13 @@ public static class CompileBackSourceComposer
         return definition.Name == IdentityTypeRefName(identity);
     }
 
+    // The product already unwrapped the declaring type to a definition and captured its
+    // namespace/name, so the self-type check is a plain identity string compare here.
+    // Named distinctly from IsSelfType(TypeRef, ...) so reflection-by-name stays unambiguous.
+    static bool DeclaredBySelfType(BackingFieldReference reference, CompileBackTypeIdentity identity)
+        => reference.DeclaringNamespace == identity.Namespace
+            && reference.DeclaringName == IdentityTypeRefName(identity);
+
     static string IdentityTypeRefName(CompileBackTypeIdentity identity)
     {
         string localPath = identity.Namespace.Length > 0
@@ -1990,13 +1997,14 @@ public static class CompileBackSourceComposer
         var members = new List<CompileBackMemberRequirement>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
 
-        foreach (var fieldRef in TargetBackingFieldRefs(function))
+        foreach (var reference in MemberBodyFacts.BackingFieldReferences(function)
+            .Where(reference => reference.Access == BackingFieldAccess.Read))
         {
-            if (fieldRef.BackingPropertyName is not { Length: > 0 } propertyName)
+            if (reference.BackingPropertyName is not { Length: > 0 } propertyName)
                 continue;
-            if (!IsSelfType(fieldRef.DeclaringType, targetIdentity))
+            if (!DeclaredBySelfType(reference, targetIdentity))
                 continue;
-            if (FindField(reader, typeDef, fieldRef.Name) is not { } fieldHandle)
+            if (FindField(reader, typeDef, reference.FieldName) is not { } fieldHandle)
                 continue;
 
             var field = reader.GetFieldDefinition(fieldHandle);
@@ -2026,18 +2034,10 @@ public static class CompileBackSourceComposer
                 TypeParameters: [],
                 CompileBackStubBodyKind.None,
                 TargetBody: null,
-                [new CompileBackFact("metadata", "target-backing-field-read", fieldRef.Name)]));
+                [new CompileBackFact("metadata", "target-backing-field-read", reference.FieldName)]));
         }
 
         return members;
-    }
-
-    static IEnumerable<FieldRef> TargetBackingFieldRefs(IrFunction function)
-    {
-        foreach (var load in function.Descendants.OfType<LoadField>())
-            yield return load.Field;
-        foreach (var address in function.Descendants.OfType<LoadFieldAddress>())
-            yield return address.Field;
     }
 
     static IReadOnlyList<CompileBackMemberRequirement> TargetBackingFieldWriteMembers(
@@ -2050,19 +2050,15 @@ public static class CompileBackSourceComposer
         var members = new List<CompileBackMemberRequirement>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
 
-        foreach (var store in function.Descendants.OfType<StoreField>())
+        foreach (var reference in MemberBodyFacts.BackingFieldReferences(function)
+            .Where(reference => reference.Access == BackingFieldAccess.InstanceWrite
+                || (allowStaticStores && reference.Access == BackingFieldAccess.StaticWrite)))
         {
-            if (store is not { HasInstance: true, Instance: LoadArgument { Index: 0 } }
-                && !(allowStaticStores && store is { HasInstance: false }))
-            {
+            if (reference.BackingPropertyName is not { Length: > 0 } propertyName)
                 continue;
-            }
-            var fieldRef = store.Field;
-            if (fieldRef.BackingPropertyName is not { Length: > 0 } propertyName)
+            if (!DeclaredBySelfType(reference, targetIdentity))
                 continue;
-            if (!IsSelfType(fieldRef.DeclaringType, targetIdentity))
-                continue;
-            if (FindField(reader, typeDef, fieldRef.Name) is not { } fieldHandle)
+            if (FindField(reader, typeDef, reference.FieldName) is not { } fieldHandle)
                 continue;
 
             var field = reader.GetFieldDefinition(fieldHandle);
@@ -2092,7 +2088,7 @@ public static class CompileBackSourceComposer
                 TypeParameters: [],
                 CompileBackStubBodyKind.AutoProperty,
                 TargetBody: null,
-                [new CompileBackFact("metadata", "target-backing-field-write", fieldRef.Name)]));
+                [new CompileBackFact("metadata", "target-backing-field-write", reference.FieldName)]));
         }
 
         return members;


### PR DESCRIPTION
## Summary

Lifts the last IR-walk reconstruction leak in the RTS planner into the product, extending the `MemberBodyFacts` consolidation. The harness's `TargetBackingFieldReadMembers`/`WriteMembers` previously walked Decompiler `LoadField`/`LoadFieldAddress`/`StoreField` IR and read the Decompiler `FieldRef` directly to synthesize auto-property/field member requirements.

## Change

- New neutral DTO `BackingFieldReference` (`DeclaringNamespace`, `DeclaringName`, `FieldName`, `BackingPropertyName`, `BackingFieldAccess`) in `ILInspector.CSharp` — no Decompiler type crosses the harness boundary.
- New producer `MemberBodyFacts.BackingFieldReferences(IrFunction)`:
  - Field loads (`ldfld`/`ldflda`) → `Read`; this-receiver instance stores → `InstanceWrite`; static stores → `StaticWrite`; other stores and non-definition declaring types are omitted (they could never match either consumer).
  - Declaring type is unwrapped to its definition and captured as namespace/name, so the harness self-type check becomes a plain string compare (`DeclaredBySelfType`, named distinctly from `IsSelfType(TypeRef, …)` so the reflection-by-name RTS prototype test stays unambiguous).
- Per request, each `MemberBodyFacts` member's XML doc now states its sort order (namespaces ordinal-sorted; constructor facts in chain/entry order; backing fields = all reads `ldfld`-then-`ldflda` in IR order, then writes in IR order — the order downstream first-wins de-dup relies on).

## Risk / neutrality

Pure boundary move — the IR walks are relocated verbatim behind the neutral DTO, so behavior is byte-neutral. The only remaining `IrFunction` use in the RTS path is the legitimate `CSharpPrinter.PrintRaised` render (product code).

## Evidence

- Full `dotnet-inspect.slnx` build clean.
- `MemberBodyFactsTests` 10 (4 new backing-field cases: instance read, instance write, static write, no-field).
- RTS oracle suite 224 green (Evidence/FixtureCatalog/Prototype/GeneratedFilter).
- Corpus rts-parity enforcing gate (14 assemblies, `--corpus-fidelity-cap 3 --compile-cap 0`) **exit 0**, 5 burndown rows unchanged (no resolved rows, no new failures).

## Review

Touches member-requirement synthesis, so not purely mechanical — requesting adversarial review (two models from a different family than my own).