### PR TITLE
Document Fully Raised state in decompiler PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ READMEs, and focused skills.
 | Skills | `taste/skill-guidance.md`, `skills/dotnet-inspect/SKILL.md`, and the relevant `skills/<scenario>/SKILL.md` |
 | Release and publishing | `docs/release-workflow.md` |
 
-Decompiler PR templates:
+PR templates:
 
 | Change | Template |
 | --- | --- |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,14 @@ READMEs, and focused skills.
 | Skills | `taste/skill-guidance.md`, `skills/dotnet-inspect/SKILL.md`, and the relevant `skills/<scenario>/SKILL.md` |
 | Release and publishing | `docs/release-workflow.md` |
 
+Decompiler PR templates:
+
+| Change | Template |
+| --- | --- |
+| Raising, structuring, validity, fidelity, or corpus behavior | `docs/templates/decompiler-pr.md` |
+| Focused invalid-`Full` or burndown row fix | `docs/templates/decompiler-burndown-fix-pr.md` |
+| Compile-back harness, fidelity skeleton, or ReturnToSender coverage | `docs/templates/decompiler-compile-back-harness-pr.md` |
+
 Some files under `docs/design/` record proposals or design history. Prefer
 current behavior in `README.md`, `docs/overview.md`, `docs/architecture.md`,
 focused current docs, and tests when sources disagree.

--- a/docs/templates/decompiler-pr.md
+++ b/docs/templates/decompiler-pr.md
@@ -5,6 +5,9 @@ Use this for decompiler PRs that affect raising, structuring, validity,
 fidelity, or corpus behavior. Delete sections that do not apply. Keep generated
 tables generated; do not re-key metric rows by hand.
 
+For raise PRs, keep Before, After, and Fully Raised. After records this PR's
+output; Fully Raised records the intended endpoint.
+
 For focused invalid-Full / burndown row fixes, prefer
 `docs/templates/decompiler-burndown-fix-pr.md`.
 -->
@@ -19,17 +22,34 @@ For focused invalid-Full / burndown row fixes, prefer
 
 **Conclusion:** **PASS/REVIEW/BLOCKED** — {one sentence with the decisive reason}.
 
-Before:
+### Before
 
 ```csharp
 // short failing or lower-quality output
 ```
 
-After:
+### After
 
 ```csharp
-// short fixed or improved output
+// output produced by this PR, including an honest fallback when not fully raised
 ```
+
+### Fully Raised
+
+<!--
+If After is fully raised, write exactly:
+
+The After decompilation is in the fully raised state.
+
+Otherwise, show the intended fully raised C# below and link one or more
+tracking issues that name the slices required to reach it.
+-->
+
+```csharp
+// intended fully raised output; delete when After is fully raised
+```
+
+- #{issue}: {required slice; delete when After is fully raised}
 
 ## Evidence
 

--- a/docs/templates/decompiler-pr.md
+++ b/docs/templates/decompiler-pr.md
@@ -5,8 +5,9 @@ Use this for decompiler PRs that affect raising, structuring, validity,
 fidelity, or corpus behavior. Delete sections that do not apply. Keep generated
 tables generated; do not re-key metric rows by hand.
 
-For raise PRs, keep Before, After, and Fully Raised. After records this PR's
-output; Fully Raised records the intended endpoint.
+Every raise PR must keep Before, After, and Fully Raised. Before and After must
+each show a concrete C# example. After records this PR's output; Fully Raised
+records the intended endpoint.
 
 For focused invalid-Full / burndown row fixes, prefer
 `docs/templates/decompiler-burndown-fix-pr.md`.
@@ -37,19 +38,24 @@ For focused invalid-Full / burndown row fixes, prefer
 ### Fully Raised
 
 <!--
-If After is fully raised, write exactly:
+Required for every raise PR. Choose one:
 
-The After decompilation is in the fully raised state.
+1. If After is fully raised, write exactly:
 
-Otherwise, show the intended fully raised C# below and link one or more
-tracking issues that name the slices required to reach it.
+   The After decompilation is in the fully raised state.
+
+   Then delete the code block and tracking-issue item below.
+
+2. Otherwise, show the intended fully raised C# below. At least one tracking
+   issue is required, and each linked issue must name the remaining slice or
+   slices needed to reach that state.
 -->
 
 ```csharp
 // intended fully raised output; delete when After is fully raised
 ```
 
-- #{issue}: {required slice; delete when After is fully raised}
+- Required tracking issue: #{issue} — {remaining slice or slices}
 
 ## Evidence
 

--- a/docs/templates/decompiler-pr.md
+++ b/docs/templates/decompiler-pr.md
@@ -9,6 +9,11 @@ Every raise PR must keep Before, After, and Fully Raised. Before and After must
 each show a concrete C# example. After records this PR's output; Fully Raised
 records the intended endpoint.
 
+Adversarial review evidence belongs in a separate PR comment, not this
+description. Before marking the PR ready, post a comment that names each
+reviewer/model, the exact head reviewed, findings and their resolution commits
+or explicit non-actions, and each reviewer's final verdict.
+
 For focused invalid-Full / burndown row fixes, prefer
 `docs/templates/decompiler-burndown-fix-pr.md`.
 -->
@@ -114,15 +119,6 @@ For the full local delta, see
 
 </details>
 <!-- markdownlint-enable MD033 -->
-
-## Review
-
-| Reviewer | Result | Notes |
-| --- | --- | --- |
-| {model/reviewer} | No blocking findings / findings resolved | {short evidence} |
-| {model/reviewer} | No blocking findings / findings resolved | {short evidence} |
-
-**Review conclusion:** **PASS/REVIEW/BLOCKED** — {one-line reconciliation}.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

Update the decompiler PR template so raise changes distinguish:

- **Before:** the baseline decompilation;
- **After:** the output produced by the current PR, including an honest
  fallback;
- **Fully Raised:** the intended endpoint.

When **After** is already fully raised, the template provides the standard
sentence used by #2854 and #2855. Otherwise, it requires the intended C# plus
tracking issues that name the remaining implementation slices, following
#2856, #2857, #2861, and #2862.

The template also removes adversarial-review evidence from the PR description.
It requires a separate PR comment naming the reviewers/models, exact reviewed
head, finding resolutions or explicit non-actions, and final verdicts.

`AGENTS.md` now lists every repository PR template by purpose so agents can
discover the raise, burndown-fix, and compile-back-harness formats.

## Validation

`markdownlint` passes for `docs/templates/decompiler-pr.md`.

This is a documentation-only template change with no product behavior.
