### PR TITLE
Drain rts-parity row: dedup self-recursive target method in RTS closure (#2777)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -4780,6 +4780,48 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
+    [Fact]
+    public void CompileBackTargets_DoesNotDuplicateSelfRecursiveTargetMethodDuringClosureSurface()
+    {
+        // Guard for the rts-parity burndown row TypeResolver::GetTypeNameFromReference:
+        // a target method that calls itself recursively must not also be reconstructed
+        // as a hollow `throw null` closure stub (the self-reference resolves to the
+        // target method's own handle). Emitting both the body-backed method and a
+        // same-signature stub produced CS0111 (duplicate member) and forced the
+        // compile-back floor. A referenced sibling (Combine) must still be stubbed.
+        var assemblyPath = CompileFixture("""
+            public static class Class1
+            {
+                public static string Describe(int depth, string name)
+                {
+                    if (depth > 0)
+                        return Describe(depth - 1, name);
+                    return Combine(name, name);
+                }
+
+                public static string Combine(string left, string right) => left + right;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", "Describe", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            // The recursive target keeps exactly one declaration (body-backed, not a
+            // hollow stub); the referenced sibling is the only `throw null` member.
+            Assert.Equal(1, result.Source.Split("string Describe(").Length - 1);
+            Assert.DoesNotContain("string Describe(int depth, string name) { throw null; }", result.Source);
+            Assert.Contains("public static string Combine(string left, string right) { throw null; }", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
     static string CompileFixture(
         string source,
         string? directory = null,

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -437,6 +437,7 @@ public static class CompileBackSourceComposer
             request.Reader,
             request.Function,
             request.TargetType,
+            request.TargetMethod,
             targetRoot,
             closure.Roots,
             closure.Facts,
@@ -456,6 +457,7 @@ public static class CompileBackSourceComposer
         MetadataReader reader,
         IrFunction function,
         TypeDefinitionHandle targetType,
+        MethodDefinitionHandle targetMethod,
         TypeDefinitionHandle targetRoot,
         HashSet<TypeDefinitionHandle> closureRoots,
         Dictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
@@ -577,10 +579,28 @@ public static class CompileBackSourceComposer
         void AddSingleMethodFact(MethodRef method, bool allowTargetRoot)
         {
             AddMemberFact(method.DeclaringType, "method", method.Name);
+            // A self-reference to the target method itself (e.g. a recursive call)
+            // must never spawn a closure member requirement: the target method is
+            // already emitted with its real body, and a second hollow `throw null`
+            // stub of the same signature produces a CS0111 duplicate-member break.
+            // Sibling members on the target type are still reconstructed (they are
+            // distinct handles); only the target method's own handle is excluded.
+            if (ResolvesToTargetMethod(method))
+                return;
             AddMemberRequirement(
                 method.DeclaringType,
                 root => TryCreateClosureMemberRequirement(reader, root, method),
                 allowTargetRoot);
+        }
+
+        bool ResolvesToTargetMethod(MethodRef method)
+        {
+            var definition = method.DeclaringType.Kind == TypeRefKind.GenericInstance
+                ? method.DeclaringType.ElementType ?? method.DeclaringType
+                : method.DeclaringType;
+            if (TryResolveHandle(definition) is not { } handle || handle != targetType)
+                return false;
+            return TypeProducer.TryFindMethod(reader, reader.GetTypeDefinition(targetType), method) == targetMethod;
         }
 
         void AddFieldFact(FieldRef field)
@@ -2544,7 +2564,7 @@ public static class CompileBackSourceComposer
             return null;
         }
 
-        static MethodDefinitionHandle? TryFindMethod(
+        public static MethodDefinitionHandle? TryFindMethod(
             MetadataReader reader,
             TypeDefinition typeDef,
             MethodRef methodRef)

--- a/tools/DecompilerHarness/corpus/rts-parity-burndown.json
+++ b/tools/DecompilerHarness/corpus/rts-parity-burndown.json
@@ -11,10 +11,6 @@
       "status": "RecompileFail"
     },
     {
-      "method": "ILInspector.MetadataPrimitives!ILInspector.Metadata.TypeResolver::GetTypeNameFromReference#0",
-      "status": "RecompileFail"
-    },
-    {
       "method": "Newtonsoft.Json!Newtonsoft.Json.Utilities.Base64Encoder::WriteCharsAsync#0",
       "status": "RecompileFail"
     },


### PR DESCRIPTION
- Part of #2777 (make ReturnToSender a thin orchestrator; drain the rts-parity burn-down)
- Row: `ILInspector.MetadataPrimitives!ILInspector.Metadata.TypeResolver::GetTypeNameFromReference#0`
- Evidence revision: `44f22373`

## Fix

> Should we accept this row fix?

**Conclusion:** **PASS** — a self-recursive target method was re-emitted as a hollow `throw null` stub next to its own body-backed declaration (CS0111 duplicate member), forcing the compile-back floor; excluding the target method's own handle from closure member requirements makes it recompile Exact under ReturnToSender with no floor.

False output (RTS reconstruction, before):

```csharp
public static class TypeResolver
{
    public static string GetTypeNameFromReference(MetadataReader reader, TypeReferenceHandle handle)
    { /* real body */ }
    public static string GetTypeNameFromReference(MetadataReader reader, TypeReferenceHandle handle) { throw null; } // CS0111
    public static string GetFullName(string ns, string name) { throw null; }
}
```

Fixed output:

```csharp
public static class TypeResolver
{
    public static string GetTypeNameFromReference(MetadataReader reader, TypeReferenceHandle handle)
    { /* real body; recursive self-call binds here */ }
    public static string GetFullName(string ns, string name) { throw null; } // referenced sibling, still stubbed
}
```

## Root cause and scope

- **Root cause:** The shared closure walk (`SeedTypedClosureRoots`) turns every consumed member reference into a closure member requirement. Because the target method references a *sibling* on its own type (`GetFullName`), `allowTargetRoot` is set for the target root — which also let the method's *self-recursive* call become a closure requirement. That produced a second hollow stub of the target method. `AddRequiredMembers` dedups by exact signature **text**, and the target-with-body path and the closure path format signature text differently, so the duplicate was not deduped → CS0111.
- **Fix shape:** Thread the target `MethodDefinitionHandle` into `SeedTypedClosureRoots`; `AddSingleMethodFact` skips a `MethodRef` that resolves to the target method's own handle. Keyed on the method handle, so real overloads and sibling members (distinct handles) are still reconstructed, and the self-recursive call binds to the emitted body.
- **Scope boundary:** Harness-only (`tools/DecompilerHarness`); no product paths touched. Does not address the other four burn-down rows (distinct causes: enum-member surface, cross-assembly enum→int typing, type-as-namespace using synthesis, un-reconstructed closure member).

## Witnesses

| Witness | Before | After |
| --- | --- | --- |
| `TypeResolver::GetTypeNameFromReference#0` (real corpus row) | `RecompileFail: CS0111 duplicate member`, floor used | `Exact`, floor not used |
| `Class1::Describe` (compiled fixture, self-recursive + sibling call) | duplicate stub | one body-backed method + one sibling stub, `Exact`, no floor |

## Evidence

| Check | Result |
| --- | --- |
| Full `dotnet-inspect.slnx` build (Release) | Pass, 0 warnings |
| Focused test | `ReturnToSenderPrototypeTests.CompileBackTargets_DoesNotDuplicateSelfRecursiveTargetMethodDuringClosureSurface` passes |
| RTS oracle suites | Evidence 3 / FixtureCatalog 82 / Prototype 119 / GeneratedFilter 25 / MemberBodyFacts 10 — all green |
| Real witness | `TypeResolver::GetTypeNameFromReference` recompiles Exact via RTS without the compile-back floor |

## Corpus validity

> Did this row fix introduce new rts-parity regressions?

**Conclusion:** **PASS** — enforcing gate exit 0, no new regressions; the fixed row is flagged resolved and dropped from the manifest (5 → 4).

Run: 14-assembly prepared corpus (`eng/prepare-decompiler-corpus.sh`), `--corpus-fidelity-oracle rts-parity --corpus-fidelity-cap 3 --compile-cap 0`, enforcing `--rts-parity-burndown`.

| Metric | Before | After |
| --- | ---: | ---: |
| rts-parity burn-down rows | 5 | 4 |
| New Exact→RecompileFail regressions | - | 0 |

Manifest change: removed `ILInspector.MetadataPrimitives!ILInspector.Metadata.TypeResolver::GetTypeNameFromReference#0`.

## Out of scope / sibling rows

- `SymbolPackageDownloader::CheckPdbHeader` — reconstructed enum missing member (CS0117).
- `LibraryBodyIndex::HollowUnsafeMethods` — cross-assembly enum→int typing (CS0266); product raise concern.
- `Base64Encoder::WriteCharsAsync` — using synthesis treats a type as a namespace (CS0138).
- `ParseResult::GetValue#2` — closure member not reconstructed (CS0234).

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| GPT-5.6 Sol | **CLEAN** | Built harness + tests; Prototype 119 / FixtureCatalog 82 / Evidence 3 / GeneratedFilter 25 green; corpus rts-parity gate exit 0 (4 rows); clean tree at head. |
| Gemini 3.1 Pro | **CLEAN** | Verified attack points with throwaway xUnit tests (recursive properties, accessor siblings, generics/instantiations, overloads); corpus gate exit 0 (4 rows). |

**Review conclusion:** CLEAN — two independent adversarial reviews (GPT-5.6 Sol, Gemini 3.1 Pro), neither my own model family, both CLEAN with no findings.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "ILInspector.Decompiler.Tests.ReturnToSenderPrototypeTests"
# corpus enforcing gate (14 asm, cap 3): exit 0, 4 rows
```

