### PR TITLE
Bind multi-use generic declaration pattern to cache local (#2872)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GenericDeclarationPatternExtractionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GenericDeclarationPatternExtractionTests.cs
@@ -605,6 +605,40 @@ public class GenericDeclarationPatternExtractionTests
         Assert.Matches(@"\bV_\d+ = V_\d+;", output);
     }
 
+    // Synthetic (#2872 gate, Issue 1): the cache local's managed address is
+    // captured into a ref local (`ref T p = ref c;`) that outlives the guarded
+    // arm. The address load sits inside the arm, so confinement alone is
+    // satisfied, but re-pointing the binding narrows `c` to the pattern's scope
+    // and leaves the escaped reference dangling. The copy must survive.
+    [Fact]
+    public void CacheAddressCapturedToRefLocal_DoesNotBindToCacheLocal()
+    {
+        var generic = TypeRef.GenericParameter(0, "T");
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var byRef = TypeRef.ByRef(generic);
+        IrExpression Subject() => new LoadArgument(0, "subject", generic);
+
+        var then = new Block();
+        then.Add(new StoreLocal(0, generic, new LoadLocal(1, generic)));
+        then.Add(new StoreLocal(2, byRef, new LoadLocalAddress(0, generic)));
+        var block = new Block();
+        block.Add(new IfStatement(new IsPattern(Subject(), generic, 1), then, null));
+        block.Add(new Return(new Constant(null, objectType)));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(objectType, [new Parameter("subject", generic)], HasThis: false, GenericParameterCount: 1),
+            [generic, generic, byRef],
+            body);
+
+        var output = RunPipelineAndPrint(function);
+
+        Assert.Matches(@"is T V_\d+", output);
+        Assert.Matches(@"\bV_\d+ = V_\d+;", output);
+    }
+
     static string RunPipelineAndPrint(IrFunction function)
     {
         IrPasses.Run(function);

--- a/src/ILInspector.Decompiler.Tests/GenericDeclarationPatternExtractionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GenericDeclarationPatternExtractionTests.cs
@@ -605,7 +605,48 @@ public class GenericDeclarationPatternExtractionTests
         Assert.Matches(@"\bV_\d+ = V_\d+;", output);
     }
 
-    // Synthetic (#2872 gate, Issue 1): the cache local's managed address is
+    // Synthetic (#2872 gate, Issue 1 re-review): the cache local's address is
+    // forwarded through a by-ref-returning receiver call — `p = ref c.Ref()` —
+    // and stored into a ref local that outlives the arm. The `LoadLocalAddress`
+    // sits directly under the `Call`, so a gate that only inspects the address's
+    // direct parent (Store/Return) would miss the escape and fold. The pointer
+    // still escapes once the binding narrows to the pattern's scope, so the fold
+    // must be rejected and the copy must survive. This exercises the
+    // in-place-receiver allow-list's non-by-ref-result clause: a by-ref-returning
+    // receiver call is not an in-place consumer.
+    [Fact]
+    public void CacheAddressForwardedThroughByRefReturningCall_DoesNotBindToCacheLocal()
+    {
+        var generic = TypeRef.GenericParameter(0, "T");
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var byRef = TypeRef.ByRef(generic);
+        IrExpression Subject() => new LoadArgument(0, "subject", generic);
+
+        // A by-ref-returning instance method on the cache local; the returned
+        // reference forwards the receiver's address to the caller.
+        var refReturn = new MethodRef(generic, "Ref", byRef, [], HasThis: true);
+
+        var then = new Block();
+        then.Add(new StoreLocal(0, generic, new LoadLocal(1, generic)));
+        then.Add(new StoreLocal(2, byRef,
+            new Call(refReturn, isVirtual: false, [new LoadLocalAddress(0, generic)])));
+        var block = new Block();
+        block.Add(new IfStatement(new IsPattern(Subject(), generic, 1), then, null));
+        block.Add(new Return(new Constant(null, objectType)));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(objectType, [new Parameter("subject", generic)], HasThis: false, GenericParameterCount: 1),
+            [generic, generic, byRef],
+            body);
+
+        var output = RunPipelineAndPrint(function);
+
+        Assert.Matches(@"is T V_\d+", output);
+        Assert.Matches(@"\bV_\d+ = V_\d+;", output);
+    }
     // captured into a ref local (`ref T p = ref c;`) that outlives the guarded
     // arm. The address load sits inside the arm, so confinement alone is
     // satisfied, but re-pointing the binding narrows `c` to the pattern's scope

--- a/src/ILInspector.Decompiler.Tests/GenericDeclarationPatternExtractionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GenericDeclarationPatternExtractionTests.cs
@@ -57,9 +57,10 @@ public class GenericDeclarationPatternExtractionTests
         AssertRaisedBinding(output);
     }
 
-    // #2862 robustness: when the binding is read more than once csc caches the
-    // single extraction in a real local; the guard still raises to a pattern
-    // binding that feeds the cache, with no `(object)` bridge left behind.
+    // #2872: when the binding is read more than once csc caches the single
+    // extraction in a real, source-named local; the pattern binds that local
+    // directly (recovering its name) with no redundant copy and no `(object)`
+    // bridge left behind.
     [Fact]
     public void MultipleUsesDeclarationPattern_RaisesBinding()
     {
@@ -67,8 +68,12 @@ public class GenericDeclarationPatternExtractionTests
             typeof(GenericDeclarationPatternSpecimens<,>),
             nameof(GenericDeclarationPatternSpecimens<object, object>.MultipleUses));
 
-        Assert.Matches(@"if \(Subject is T V_\d+\)", output);
-        Assert.Equal(2, Regex.Matches(output, @"Console\.WriteLine\(").Count);
+        Assert.Matches(@"if \(Subject is T t\)", output);
+        Assert.Equal(2, Regex.Matches(output, @"Console\.WriteLine\(t\)").Count);
+        // No redundant `t = V_N;` copy and no stray up-front declaration of the
+        // cache local — the pattern binding owns it.
+        Assert.DoesNotMatch(@"t = V_\d+", output);
+        Assert.DoesNotMatch(@"(?m)^\s*T t;\s*$", output);
         Assert.DoesNotContain("(object)", output);
         Assert.DoesNotContain("as T", output);
     }
@@ -533,6 +538,71 @@ public class GenericDeclarationPatternExtractionTests
         var output = RunPipelineAndPrint(function);
 
         Assert.DoesNotMatch(@"is T V_\d+", output);
+    }
+
+    // Synthetic (#2872 gate): the cache local is read AFTER the guard, so binding
+    // it in the pattern (which scopes it to the guarded arm) would leave the
+    // trailing read referencing an out-of-scope variable. The copy must survive.
+    [Fact]
+    public void CacheReadAfterGuard_DoesNotBindToCacheLocal()
+    {
+        var generic = TypeRef.GenericParameter(0, "T");
+        var objectType = TypeRef.CoreLib("System", "Object");
+        IrExpression Subject() => new LoadArgument(0, "subject", generic);
+
+        var then = new Block();
+        then.Add(new StoreLocal(0, generic, new LoadLocal(1, generic)));
+        then.Add(new Return(new Box(generic, new LoadLocal(0, generic))));
+        var block = new Block();
+        block.Add(new IfStatement(new IsPattern(Subject(), generic, 1), then, null));
+        block.Add(new Return(new Box(generic, new LoadLocal(0, generic))));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(objectType, [new Parameter("subject", generic)], HasThis: false, GenericParameterCount: 1),
+            [generic, generic],
+            body);
+
+        var output = RunPipelineAndPrint(function);
+
+        // The pattern keeps its synthesized binding and the local-to-local copy
+        // survives, because the cache local escapes the guarded arm.
+        Assert.Matches(@"is T V_\d+", output);
+        Assert.Matches(@"\bV_\d+ = V_\d+;", output);
+    }
+
+    // Synthetic (#2872 gate): the cache local is assigned twice inside the guarded
+    // arm, so it is not a single-assignment temp; re-pointing the pattern to it
+    // would drop the second assignment's value. The copy must survive.
+    [Fact]
+    public void CacheAssignedTwice_DoesNotBindToCacheLocal()
+    {
+        var generic = TypeRef.GenericParameter(0, "T");
+        var objectType = TypeRef.CoreLib("System", "Object");
+
+        var then = new Block();
+        then.Add(new StoreLocal(0, generic, new LoadLocal(1, generic)));
+        then.Add(new StoreLocal(0, generic, new LoadArgument(0, "other", generic)));
+        then.Add(new Return(new Box(generic, new LoadLocal(0, generic))));
+        var block = new Block();
+        block.Add(new IfStatement(
+            new IsPattern(new LoadArgument(0, "other", generic), generic, 1), then, null));
+        block.Add(new Return(new Constant(null, objectType)));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(objectType, [new Parameter("other", generic)], HasThis: false, GenericParameterCount: 1),
+            [generic, generic],
+            body);
+
+        var output = RunPipelineAndPrint(function);
+
+        Assert.Matches(@"is T V_\d+", output);
+        Assert.Matches(@"\bV_\d+ = V_\d+;", output);
     }
 
     static string RunPipelineAndPrint(IrFunction function)

--- a/src/ILInspector.Decompiler.Tests/ReferenceOwnershipTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReferenceOwnershipTests.cs
@@ -81,6 +81,50 @@ public class ReferenceOwnershipTests
         Assert.False(ReferenceOwnership.SubtreeStoresLocal(returnLoad, 0));
     }
 
+    // A local can be bound or written through a designation that carries the
+    // index directly (a null-coalescing target, a pattern binding, a foreach
+    // header) rather than an explicit Load/Store. ReferencesLocal only knows the
+    // Load/Store atoms, so a confinement proof built on it alone is blind to
+    // these; BindsLocal / ReferencesOrBindsLocal close that gap.
+    [Fact]
+    public void BindsLocal_CountsIndexBearingDesignationsMissedByReferencesLocal()
+    {
+        var generic = TypeRef.GenericParameter(0, "T");
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var nullCoalescing = new NullCoalescingAssignment(0, Int, new Constant(1, Int));
+        var pattern = new IsPattern(new LoadArgument(0, "x", objectType), generic, 0);
+
+        Assert.False(ReferenceOwnership.ReferencesLocal(nullCoalescing, 0));
+        Assert.False(ReferenceOwnership.ReferencesLocal(pattern, 0));
+
+        Assert.True(ReferenceOwnership.BindsLocal(nullCoalescing, 0));
+        Assert.True(ReferenceOwnership.BindsLocal(pattern, 0));
+        Assert.True(ReferenceOwnership.ReferencesOrBindsLocal(nullCoalescing, 0));
+        Assert.True(ReferenceOwnership.ReferencesOrBindsLocal(pattern, 0));
+
+        Assert.False(ReferenceOwnership.BindsLocal(nullCoalescing, 1));
+        Assert.False(ReferenceOwnership.BindsLocal(pattern, 1));
+    }
+
+    // The legacy Load/Store-only confinement check passes even when an external
+    // binding writes the local through an index-bearing designation, because it
+    // never sees that node kind. The completeness-aware variant rejects it, so a
+    // rewrite that narrows the local's scope cannot leave the external binding
+    // referencing an out-of-scope local.
+    [Fact]
+    public void LocalReferencedOrBoundOnlyWithin_RejectsExternalBindingLoadStoreMisses()
+    {
+        var allowed = new Block();
+        allowed.Add(new StoreLocal(0, Int, new Constant(1, Int)));
+        var external = new Block();
+        external.Add(new NullCoalescingAssignment(0, Int, new Constant(2, Int)));
+
+        var function = Function(allowed, external);
+
+        Assert.True(ReferenceOwnership.LocalReferencesOnlyWithin(function, 0, [allowed]));
+        Assert.False(ReferenceOwnership.LocalReferencedOrBoundOnlyWithin(function, 0, [allowed]));
+    }
+
     static IrFunction Function(params Block[] blocks)
     {
         var container = new BlockContainer();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
@@ -242,14 +242,21 @@ public sealed class IsPatternPass : IIrPass
             }
 
             // The cache local's managed address must not escape the guarded
-            // arm. An in-place consumer (a constrained call receiver such as
-            // `c.CompareTo(x)`) is safe, but capturing the address into storage
-            // that outlives the arm — a ref local `p = ref c`, a ref return, or
-            // a ref field / indirect store — would dangle once the binding
-            // narrows to the pattern's scope, so reject those.
+            // arm. The only escape-free consumer we admit is an in-place
+            // instance-call receiver whose result is not itself a managed
+            // reference (such as `c.CompareTo(x)` returning an int). Any other
+            // address use — storing the pointer into a wider-scoped
+            // local/slot/field, a ref return, an indirect store, passing the
+            // address as a by-ref argument, or a by-ref-returning receiver
+            // call that forwards the pointer onward — could outlive the arm
+            // once the binding narrows to the pattern's scope, so reject the
+            // fold. Checking only the direct parent is not enough: a
+            // by-ref-returning call forwards the pointer through a `Call` node,
+            // so the admitted shape is matched positively rather than
+            // denied by an incomplete escape-node list.
             if (function.Descendants.OfType<LoadLocalAddress>()
                 .Where(address => address.Index == cacheIndex)
-                .Any(address => address.Parent is StoreLocal or StoreStackSlot or StoreField or StoreIndirect or Return))
+                .Any(address => !IsInPlaceReceiver(address)))
             {
                 continue;
             }
@@ -262,6 +269,19 @@ public sealed class IsPatternPass : IIrPass
         }
         return false;
     }
+
+    // An address use is escape-free only when it is the receiver of an
+    // instance call whose result is not a managed reference. Such a call
+    // consumes the pointer in place (the struct receiver), so the pointer does
+    // not outlive the guarded arm. A by-ref-returning receiver call, a static
+    // call taking the address as a by-ref argument, or any non-call parent
+    // (store, indirect store, ref return) may forward the pointer onward and
+    // is therefore not admitted.
+    static bool IsInPlaceReceiver(LoadLocalAddress address)
+        => address.Parent is Call { Callee.HasThis: true } call
+            && call.Children.Count > 0
+            && ReferenceEquals(call.Children[0], address)
+            && call.ResultType is not { Kind: TypeRefKind.ByRef };
 
     static bool TransformOne(IrFunction function, Stepper stepper)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
@@ -66,7 +66,8 @@ public sealed class IsPatternPass : IIrPass
             || FoldPositionalPatternReturnOne(function, context.Stepper)
             || FoldUnionValueReceiverCopy(function, context.Stepper)
             || RaiseGenericDeclarationPattern(function, context.Stepper)
-            || InlineGenericPatternSubject(function, context.Stepper))
+            || InlineGenericPatternSubject(function, context.Stepper)
+            || BindGenericPatternToCacheLocal(function, context.Stepper))
         {
         }
     }
@@ -183,6 +184,66 @@ public sealed class IsPatternPass : IIrPass
                 store.Detach();
                 return true;
             }
+        }
+        return false;
+    }
+
+    // #2862 slice (#2872): bind a multi-use generic declaration pattern directly
+    // to csc's cache local and drop the redundant copy. When the binding is read
+    // more than once, csc caches the single `isinst` extraction in a real,
+    // source-named local, so RaiseGenericDeclarationPattern binds a synthesized
+    // `V_N` and leaves `cacheLocal = V_N;` at the top of the guarded arm. When
+    // that minted local feeds only the copy, and the cache local is assigned only
+    // there and read only inside the guarded arm, re-point the pattern to the
+    // cache local (recovering its name) and elide the copy — turning
+    // `if (x is T V_N) { c = V_N; ... c ... }` into `if (x is T c) { ... c ... }`.
+    static bool BindGenericPatternToCacheLocal(IrFunction function, Stepper stepper)
+    {
+        // Only root-scope guards: re-pointing the binding rewrites references in
+        // the root local pool, so a nested-function guard (separate pool) is out.
+        foreach (var ifStatement in GenericDeclarationPatternProof
+            .DescendantsOutsideNestedFunctions(function).OfType<IfStatement>().ToList())
+        {
+            if (ifStatement.Condition is not IsPattern pattern)
+                continue;
+
+            // The copy must be the guarded arm's first statement, so the cache
+            // local is bound before any read — exactly the pattern's own scope.
+            if (ifStatement.Then.Children is not [StoreLocal copy, ..]
+                || copy.Value is not LoadLocal { Index: var boundIndex }
+                || boundIndex != pattern.LocalIndex
+                || copy.Index == pattern.LocalIndex)
+            {
+                continue;
+            }
+
+            int cacheIndex = copy.Index;
+
+            // The minted binding must feed only this copy: its single reference is
+            // the `LoadLocal` inside `copy` (the pattern's LocalIndex is a slot
+            // designation, not a Load/Store reference, so it is not counted here).
+            if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, pattern.LocalIndex, [copy]))
+                continue;
+
+            // The cache local must be a single-assignment temp whose every use is
+            // inside this guarded arm, so binding it in the pattern covers all
+            // reads with the exact value the copy provided. A managed-address use
+            // (e.g. a constrained `t.CompareTo(...)` call) is safe: the pattern
+            // binding is an ordinary addressable local, and single assignment
+            // means the bound value equals the copied value, so any ref-use is
+            // preserved identically. The pattern's tested value must not read it.
+            if (function.Descendants.OfType<StoreLocal>().Count(s => s.Index == cacheIndex) != 1
+                || ReferenceOwnership.SubtreeReferencesLocal(pattern.Value, cacheIndex)
+                || !ReferenceOwnership.LocalReferencesOnlyWithin(function, cacheIndex, [ifStatement.Then]))
+            {
+                continue;
+            }
+
+            stepper.StepOver("bind generic declaration pattern to cache local", ifStatement);
+            pattern.ReplaceWith(new IsPattern(
+                (IrExpression)pattern.Value.Clone(), pattern.Type, cacheIndex));
+            copy.Detach();
+            return true;
         }
         return false;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
@@ -225,16 +225,31 @@ public sealed class IsPatternPass : IIrPass
             if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, pattern.LocalIndex, [copy]))
                 continue;
 
-            // The cache local must be a single-assignment temp whose every use is
-            // inside this guarded arm, so binding it in the pattern covers all
-            // reads with the exact value the copy provided. A managed-address use
-            // (e.g. a constrained `t.CompareTo(...)` call) is safe: the pattern
-            // binding is an ordinary addressable local, and single assignment
-            // means the bound value equals the copied value, so any ref-use is
-            // preserved identically. The pattern's tested value must not read it.
+            // The cache local must be a single-assignment temp whose every use
+            // is inside this guarded arm, so binding it in the pattern covers
+            // all reads with the exact value the copy provided. The pattern's
+            // tested value must not read it. Reference/binding checks count
+            // every designation that carries a local index (pattern bindings,
+            // foreach/using/fixed headers, deconstruction targets, catch
+            // variables, null-coalescing targets), not just explicit
+            // Load/Store, so an out-of-arm use expressed through one of those
+            // node kinds cannot slip past and reference an undeclared local.
             if (function.Descendants.OfType<StoreLocal>().Count(s => s.Index == cacheIndex) != 1
-                || ReferenceOwnership.SubtreeReferencesLocal(pattern.Value, cacheIndex)
-                || !ReferenceOwnership.LocalReferencesOnlyWithin(function, cacheIndex, [ifStatement.Then]))
+                || ReferenceOwnership.SubtreeReferencesOrBindsLocal(pattern.Value, cacheIndex)
+                || !ReferenceOwnership.LocalReferencedOrBoundOnlyWithin(function, cacheIndex, [ifStatement.Then]))
+            {
+                continue;
+            }
+
+            // The cache local's managed address must not escape the guarded
+            // arm. An in-place consumer (a constrained call receiver such as
+            // `c.CompareTo(x)`) is safe, but capturing the address into storage
+            // that outlives the arm — a ref local `p = ref c`, a ref return, or
+            // a ref field / indirect store — would dangle once the binding
+            // narrows to the pattern's scope, so reject those.
+            if (function.Descendants.OfType<LoadLocalAddress>()
+                .Where(address => address.Index == cacheIndex)
+                .Any(address => address.Parent is StoreLocal or StoreStackSlot or StoreField or StoreIndirect or Return))
             {
                 continue;
             }

--- a/src/ILInspector.Decompiler/Pipeline/ReferenceOwnership.cs
+++ b/src/ILInspector.Decompiler/Pipeline/ReferenceOwnership.cs
@@ -53,14 +53,47 @@ public static class ReferenceOwnership
         _ => false,
     };
 
+    /// <summary>
+    /// Whether the node binds the local <paramref name="index"/> through a
+    /// designation that carries the index directly — a pattern binding, a
+    /// foreach / using / fixed header, a deconstruction target, a catch
+    /// variable, or a null-coalescing-assignment target — rather than an
+    /// explicit <see cref="LoadLocal"/>/<see cref="StoreLocal"/>/<see
+    /// cref="LoadLocalAddress"/>. Mirrors the designation set the C# printer
+    /// treats as owning or declaring a local, so a confinement proof cannot be
+    /// blinded by a reference expressed through one of these node kinds.
+    /// </summary>
+    public static bool BindsLocal(IrNode node, int index) => node switch
+    {
+        NullCoalescingAssignment n => n.LocalIndex == index,
+        ForeachStatement f => f.LocalIndex == index,
+        UsingStatement u => u.LocalIndex == index,
+        Fixed fx => fx.LocalIndex == index,
+        IsPattern p => p.LocalIndex == index,
+        RecursivePropertyDeclarationPattern r => r.LocalIndex == index,
+        UnionSwitchExpressionArm a => a.LocalIndex == index,
+        CatchClause c => c.VariableIndex == index,
+        DeconstructionAssignment d => d.LocalIndices.Contains(index),
+        _ => false,
+    };
+
+    public static bool ReferencesOrBindsLocal(IrNode node, int index)
+        => ReferencesLocal(node, index) || BindsLocal(node, index);
+
     public static bool SubtreeReferencesLocal(IrNode root, int index)
         => root.Descendants.Prepend(root).Any(node => ReferencesLocal(node, index));
+
+    public static bool SubtreeReferencesOrBindsLocal(IrNode root, int index)
+        => root.Descendants.Prepend(root).Any(node => ReferencesOrBindsLocal(node, index));
 
     public static bool SubtreeStoresLocal(IrNode root, int index)
         => root.Descendants.Prepend(root).Any(node => node is StoreLocal store && store.Index == index);
 
     public static bool LocalReferencesOnlyWithin(IrFunction function, int index, IReadOnlyCollection<IrNode> allowed)
         => ReferencesOnlyWithin(function, node => ReferencesLocal(node, index), allowed);
+
+    public static bool LocalReferencedOrBoundOnlyWithin(IrFunction function, int index, IReadOnlyCollection<IrNode> allowed)
+        => ReferencesOnlyWithin(function, node => ReferencesOrBindsLocal(node, index), allowed);
 
     public static bool StackSlotReferencesOnlyWithin(IrFunction function, int slot, IReadOnlyCollection<IrNode> allowed)
         => ReferencesOnlyWithin(function, node => ReferencesStackSlot(node, slot), allowed);


### PR DESCRIPTION
- Fixes/advances #2872
- Changes multi-use generic declaration-pattern raise to bind csc's source-named cache local and drop the redundant copy
- Card revision: `29c196b4`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — re-pointing the pattern to the single-assignment cache local recovers the source name and removes the copy with no validity or fidelity change (FluentAssertions valid→valid 8, valid→invalid 0; defect diff 0 regressed).

### Original source

SourceLink-backed authored source for the witness member, retrieved via `dotnet-inspect member NumericAssertionsBase BePositive --package FluentAssertions -S "Original Source"` (FluentAssertions 8.10.0, net6.0):

```csharp
public AndConstraint<TAssertions> BePositive([StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
{
    CurrentAssertionChain
        .ForCondition(Subject is T subject && subject.CompareTo(default) > 0)
        .BecauseOf(because, becauseArgs)
        .FailWith("Expected {context:value} to be positive{reason}, but found {0}.", Subject);

    return new AndConstraint<TAssertions>((TAssertions)this);
}
```

The author wrote `Subject is T subject && subject.CompareTo(default) > 0` — a single declaration pattern named `subject`, read twice in the guard. csc caches the `isinst` in the source-named local; this PR re-points the raised pattern to that local so the decompiled shape matches the authored `is T subject`.

### Before

```csharp
// FluentAssertions NumericAssertionsBase`3::BePositive (this PR's parent, #2871)
T subject;
T V_2;
bool S_1;
...
if (Subject is T V_3)
{
    subject = V_3;
    V_2 = default;
    S_1 = subject.CompareTo(V_2) > 0;
}
```

### After

```csharp
// output produced by this PR
T V_2;
bool S_1;
...
if (Subject is T subject)
{
    V_2 = default;
    S_1 = subject.CompareTo(V_2) > 0;
}
```

The pattern binds the cache local `subject` directly; the `subject = V_3;` copy and the up-front `T subject;` declaration are both gone. The minted `V_3` slot becomes unreferenced and produces no declaration.

### Fully Raised

This PR's slice — binding the pattern to csc's source-named cache local — is complete. The method as a whole is **not** yet fully raised: comparison against the authored source above shows three remaining, orthogonal residues (all pre-existing, none owned by this PR). The intended fully raised endpoint is the authored shape:

```csharp
CurrentAssertionChain
    .ForCondition(Subject is T subject && subject.CompareTo(default) > 0)
    .BecauseOf(because, becauseArgs)
    .FailWith("Expected {context:value} to be positive{reason}, but found {0}.", Subject);
```

Remaining slices to reach that state:
- Short-circuit `&&` reconstruction — the `if (Subject is T subject) { S_1 = …; } else { S_1 = false; }` boolean diamond should fold to `Subject is T subject && subject.CompareTo(default) > 0`.
- `default` literal inlining — `V_2 = default; … CompareTo(V_2)` should inline to `CompareTo(default)`.
- Fluent chain / temp re-composition — `S_256`/`S_257`/`S_258` should collapse to the `.ForCondition(…).BecauseOf(…).FailWith(…, Subject)` chain.

- Required tracking issue: #2877 — pattern-guarded short-circuit `&&` diamond, `default` temp inlining, and fluent-chain re-composition.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `GenericDeclarationPatternExtractionTests` passed (29/29) |
| Decompiler fast suite | Pass (2560/0, minus `Speed=Slow`) |
| Reduced fixture validity | Pass — FluentAssertions defect diff vs base `acde101a`: 0 regressed, 0 improved |
| Reduced fixture fidelity | Not currently checkable (render A/B structural, valid→valid 8) |
| Real witness | `NumericAssertionsBase\`3::BePositive` folded (copy + up-front decl eliminated) |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — pinned-subset lowering residue improves 17.83% → 17.67% (-0.16 pp) with 0 pass bugs; aggregate advisory movement is corpus drift (MetadataPrimitives 61→100 methods), not this change.

### PR quick gate

Run: PR quick corpus, hash-stable 100 methods per assembly; validity/fidelity ungated in the quick card (measured separately above).

| Metric (goal) | Baseline | PR | Rate delta |
| --- | ---: | ---: | ---: |
| Detected lowering residue (-) | 17.83% | 17.67% | -0.16 pp |
| Conditional-branch residue (-) | 3.00% | 3.00% | 0 pp |
| Pass bugs (-) | 0 | 0 | 0 |

> **Conclusion:** **PASS** — pinned-subset gate improves lowering residue with no new pass bugs.

### Aggregate context

Corpus: 15 assemblies, 1,500 methods. Baseline drift: corpus drifted from the pinned baseline (2026-06-26); `ILInspector.MetadataPrimitives` 61→100 methods (+39), so aggregate count deltas are not a clean PR signal.

| Metric (goal) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Detected lowering residue (-) | 248 (16.97%) | 252 (16.80%) | n/a (population differs) |
| Conditional-branch residue (-) | 35 (2.40%) | 47 (3.13%) | n/a (population differs) |
| Forward-merge stops (-) | 27 (1.85%) | 33 (2.20%) | n/a (population differs) |

> **Conclusion:** **ADVISORY** — aggregate movement is attributable to corpus drift; rebaseline before trusting count-based regressions. Regression verdict from the sensor: PASS.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.GenericDeclarationPatternExtractionTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
```

