### PR TITLE
Add P/Invoke rendering coverage for code-span table cells

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -9618,6 +9618,40 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task PInvokeMethods_DeclaringTypeAndSignature_RenderAsCodeSpansWithFunctionPointerPunctuation()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--platform", "System.Diagnostics.Process",
+            "--section", "P/Invoke Methods", "-v:d", "--tips", "q");
+
+        Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
+        Assert.Contains("`Interop.User32`", output);
+        // Function-pointer signature renders as a code span with literal punctuation (no escaped angle brackets).
+        Assert.Contains(
+            "`Interop.BOOL EnumWindows(delegate* unmanaged<nint, nint, Interop.BOOL> callback, nint extraData)`",
+            output);
+        Assert.DoesNotContain("&#96;", output);
+        Assert.DoesNotContain("&lt;", output);
+        Assert.DoesNotContain("&gt;", output);
+    }
+
+    [Fact]
+    public async Task PInvokeMethods_MachineOutput_KeepsRawValuesWithoutCodeMarkup()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--platform", "System.Diagnostics.Process",
+            "--section", "P/Invoke Methods", "--jsonl");
+
+        Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
+        Assert.Contains("\"declaring_type\":\"Interop.User32\"", output);
+        Assert.Contains(
+            "\"signature\":\"Interop.BOOL EnumWindows(delegate* unmanaged<nint, nint, Interop.BOOL> callback, nint extraData)\"",
+            output);
+        Assert.DoesNotContain("<code>", output);
+        Assert.DoesNotContain("`", output);
+    }
+
+    [Fact]
     public async Task Project_SkillsPrint_JsonlIsSingleCompactRecord()
     {
         var (projectPath, tempDir) = CreateProjectWithPackageDocs(


### PR DESCRIPTION
## Summary

PR #2842 changed both Async Methods and P/Invoke Methods to render declaring types and signatures through MarkoutInline.Code and to expand generic arity, but its new tests only covered Async Methods. This adds symmetric coverage for P/Invoke Methods.

## Changes

- \PInvokeMethods_DeclaringTypeAndSignature_RenderAsCodeSpansWithFunctionPointerPunctuation\: Markdown (\-v:d\) test asserting the declaring type and signature render as code spans, using \System.Diagnostics.Process\'s \Interop.User32.EnumWindows\, whose signature contains function-pointer punctuation (\delegate* unmanaged<...>\), with no HTML-escaped punctuation.
- \PInvokeMethods_MachineOutput_KeepsRawValuesWithoutCodeMarkup\: JSONL test asserting the same fields are emitted as raw values without any Markdown code-span markup.

## Validation

\\\
dotnet build src/dotnet-inspect.Tests -c Release --configfile nuget.config
dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- -method "*PInvokeMethods*"
=== TEST EXECUTION SUMMARY ===
   dotnet-inspect.Tests  Total: 5, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
\\\

Also ran the full \dotnet-inspect.Tests\ suite; the only failures are 11 pre-existing, unrelated cases (missing fixture binaries that require a full \dotnet-inspect.slnx\ build, plus a flaky network-dependent URL test) — none touch Async/P/Invoke rendering.

Test-only change (no product behavior change); low risk, no adversarial review required.

Fixes #2849