### PR TITLE
Deduplicate System in RTS generated using directives

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -371,6 +371,38 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackFirstPropertyGetter_DeduplicatesSystemUsing_WhenBodyAlreadyReferencesSystem()
+    {
+        // Issue #2848: the module Usings list unconditionally prepended "System" to
+        // MemberBodyFacts.ReferencedNamespaces(function). A body that already
+        // references a System-namespace type (Guid, here) produced two "System"
+        // entries in the generated using list.
+        var assemblyPath = CompileFixture("""
+            namespace Fixtures;
+
+            public class Class1
+            {
+                public string Method1 => System.Guid.NewGuid().ToString();
+            }
+            """);
+        try
+        {
+            var result = ReturnToSender.CompileBackFirstPropertyGetter(assemblyPath);
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Equal(1, result.Plan.Module.Usings.Count(name => name == "System"));
+            Assert.DoesNotContain("using System;\r\nusing System;", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("using System;\nusing System;", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_FallsBackToCompileBackFloorForAttributeShellStall()
     {
         // Issue #2527: base-class reconstruction restores same-assembly base classes,

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -353,6 +353,19 @@ public static class CompileBackSourceComposer
         return new ProductTargetBody(printed.Output, printed.Decisions, printed.ConstructorChain);
     }
 
+    // ReferencedNamespaces already returns an ordinal-sorted set; route "System"
+    // through the same set instead of an unconditional Prepend so a body that
+    // already references a System namespace doesn't emit a duplicate using
+    // (issue #2848). Ordinal ordering is preserved for the merged result.
+    static string[] BuildUsings(IrFunction function)
+    {
+        var namespaces = new SortedSet<string>(MemberBodyFacts.ReferencedNamespaces(function), StringComparer.Ordinal)
+        {
+            "System",
+        };
+        return namespaces.ToArray();
+    }
+
     internal static ProductArtifact Compose(ArtifactRequest request)
     {
         var closure = CreateClosureInputs(request);
@@ -803,9 +816,7 @@ public static class CompileBackSourceComposer
         var production = TypeProducer.Produce(reader, requirements, diagnostics);
         var declarations = production.Requests;
         var module = new CompileBackModuleRequirement(
-            Usings: MemberBodyFacts.ReferencedNamespaces(function)
-                .Prepend("System")
-                .ToArray(),
+            Usings: BuildUsings(function),
             AssemblyAttributes: [],
             ModuleAttributes: []);
         var plan = new CompileBackReconstructionPlan(
@@ -1038,9 +1049,7 @@ public static class CompileBackSourceComposer
         var production = TypeProducer.Produce(reader, requirements, diagnostics);
         var declarations = production.Requests;
         var module = new CompileBackModuleRequirement(
-            Usings: MemberBodyFacts.ReferencedNamespaces(function)
-                .Prepend("System")
-                .ToArray(),
+            Usings: BuildUsings(function),
             AssemblyAttributes: [],
             ModuleAttributes: []);
         var plan = new CompileBackReconstructionPlan(
@@ -1240,9 +1249,7 @@ public static class CompileBackSourceComposer
         var production = TypeProducer.Produce(reader, requirements, diagnostics);
         var declarations = production.Requests;
         var module = new CompileBackModuleRequirement(
-            Usings: MemberBodyFacts.ReferencedNamespaces(function)
-                .Prepend("System")
-                .ToArray(),
+            Usings: BuildUsings(function),
             AssemblyAttributes: [],
             ModuleAttributes: []);
         var plan = new CompileBackReconstructionPlan(


### PR DESCRIPTION
Fixes #2848

## Change

`ReturnToSenderTypePlanner` (RTS compile-back harness) unconditionally
prepended `"System"` onto `MemberBodyFacts.ReferencedNamespaces(function)` at
three call sites (property getter, property setter, method reconstruction).
`ReferencedNamespaces` already returns an ordinal-sorted set, so when a
reconstructed body already referenced a `System`-namespace type, the
generated `using` list contained `System` twice — harmless but avoidable
generated-source noise, and a potential source of duplicate-using
diagnostics.

Added a single `BuildUsings(IrFunction)` helper that merges `"System"` into
the same `SortedSet<string>(..., StringComparer.Ordinal)` pattern already
used for skeleton usings (`FidelityCheck.cs`), then replaced all three
duplicated call sites with it. Ordinal ordering is preserved; the only
behavior change is removing the duplicate entry.

This is a mechanical, low-risk fix confined to the RTS test-harness
generated-source composer (`tools/DecompilerHarness`) — it does not touch
the product decompiler's raising, structuring, or fidelity behavior, and
does not affect corpus metrics. Per repo policy, adversarial review is not
required for this class of change.

## Evidence

- `dotnet build tools\DecompilerHarness -c Release` — 0 warnings, 0 errors.
- `dotnet build src\ILInspector.Decompiler.Tests -c Release` — 0 warnings, 0 errors.
- Added `CompileBackFirstPropertyGetter_DeduplicatesSystemUsing_WhenBodyAlreadyReferencesSystem`,
  whose fixture body references `System.Guid` so `ReferencedNamespaces`
  already contains `"System"`. The test's diagnostic output (which prints the
  actual generated source on failure) confirms a single `using System;` line
  is emitted instead of two.
- This dev machine has a pre-existing, unrelated environment issue (`CS0009`
  on `aspnetcorev2_inprocess.dll`, a non-managed native DLL picked up by the
  reference-assembly scan) that fails every RTS compile-back test, including
  untouched sibling tests — verified identical on unmodified `main`. Full
  `ReturnToSenderPrototypeTests` suite delta before/after this change is
  exactly +1 total/+1 failed (the new test, blocked by the same pre-existing
  environment issue), confirming no regressions. CI (Linux/macOS) is expected
  to run this test cleanly.