### PR TITLE
Clean up repository agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Agent Instructions
+# Agent instructions
 
 ## Start here
 
@@ -6,28 +6,66 @@
 projects, platform libraries, metadata, APIs, dependencies, source provenance,
 analysis, Findings, implementation diffs, and decompilation.
 
-Read:
+Read this file before doing work. Then read only the task-specific entry
+documents relevant to the change:
 
-1. `README.md` for current capabilities, commands, and examples.
-2. `docs/overview.md` for the minimum system and ownership model.
-3. `docs/architecture.md` for command, source, and evidence architecture.
-4. The task-specific docs below before changing that area.
+- Read `README.md` when changing user-visible capabilities, commands, or
+  examples.
+- Read `docs/overview.md` when a change crosses subsystem ownership boundaries.
+- Read the relevant section of `docs/architecture.md` only when implementation
+  structure matters to the task.
+- Follow the task-specific entry points below and then only the links relevant
+  to the change.
 
-Keep this file to repository-wide engineering and workflow rules. Detailed
-design, subsystem mechanics, and historical context belong in `docs/`, tool
-READMEs, and focused skills.
+This file is the source of truth for repository-wide engineering and workflow
+rules. Detailed design, subsystem mechanics, version requirements, and
+historical context belong with their owning code, workflow, or focused
+documentation.
+
+## Before changing files
+
+- `main` is protected. Keep the primary repository checkout attached to
+  `main`; never detach its HEAD or develop in it.
+- Before starting a change, run `git fetch origin main` from the primary
+  checkout, then create a descriptive branch and linked worktree with
+  `git worktree add -b <branch> <path> origin/main`. Make all edits, builds,
+  tests, and commits in the worktree, not the primary checkout.
+- Use one development worktree per PR, plus temporary worktrees for independent
+  reviews. Do not reuse a worktree across unrelated changes.
+- Never amend commits; create follow-up commits.
+- Before requesting review, fetch `origin/main` and incorporate it into the
+  feature branch. Rebase only before the branch's first push. Once a branch is
+  public or under review, merge `origin/main`; never amend, rebase, or
+  force-push reviewed history.
+- After updating from main or resolving conflicts, re-read `AGENTS.md` and
+  task-relevant docs before continuing.
+- Do not mix unrelated changes into one commit or sweep another contributor's
+  working-tree changes into your work.
+- Treat worktrees as temporary. For a PR requiring adversarial review, confirm
+  the exact reviewed head is pushed, then remove the development and review
+  worktrees with `git worktree remove <path>` as soon as both fixed-head
+  reviews are clean. For a change that does not require adversarial review,
+  remove its development worktree after merge. Do not retain inactive
+  worktrees in case more work appears; recreate one for the branch if follow-up
+  work is needed.
 
 ## Task-specific guidance
 
 | Area | Read first |
 | --- | --- |
-| Commands, sections, and output | `docs/design/progressive-disclosure.md`, `docs/design/output-shapes.md`, `docs/design/style-guide.md`, `docs/design/section-model.md` |
-| Metadata, source, and acquisition | `docs/design/assembly-inspection-query.md`, `docs/design/source-finding-producers.md`, `docs/pdb-acquisition.md`, `docs/design/version-resolution.md`, `docs/design/cache-concurrency.md` |
+| Command defaults and disclosure | `docs/design/progressive-disclosure.md` |
+| Output data shapes | `docs/design/output-shapes.md` |
+| Output style | `docs/design/style-guide.md` |
+| Sections and selection | `docs/design/section-model.md` |
+| Metadata and API inspection | `docs/design/assembly-inspection-query.md` |
+| PDB and source acquisition | `docs/pdb-acquisition.md` |
+| Source Finding producers | `docs/design/source-finding-producers.md` |
+| Package resolution and caches | `docs/design/version-resolution.md` |
 | Security and untrusted input | `docs/design/untrusted-data-threat-model.md` |
-| Analysis, Findings, and Research | `docs/design/finding-nomenclature.md`, `docs/design/finding-producers.md`, `docs/design/finding-adoption.md`, `docs/design/finding-coordinates.md`, `docs/design/analysis-ux-scopes.md` |
+| Analysis, Findings, and Research | `docs/design/finding-adoption.md` |
 | Shared IL/control-flow substrate | `docs/design/instruction-substrate.md`, plus the consuming subsystem's docs |
-| Decompiler behavior or harnesses | `docs/decompiler-quality.md`, `docs/decompiler-correctness-pipeline.md`, `docs/decompiler-raise-discipline.md`, `docs/design/decompiler-substrate.md`, `tools/DecompilerHarness/README.md` |
-| Skills | `taste/skill-guidance.md`, `skills/dotnet-inspect/SKILL.md`, and the relevant `skills/<scenario>/SKILL.md` |
+| Decompiler behavior or harnesses | `docs/decompiler-correctness-pipeline.md` |
+| Skills | `taste/skill-guidance.md` |
 | Release and publishing | `docs/release-workflow.md` |
 
 PR templates:
@@ -39,8 +77,9 @@ PR templates:
 | Compile-back harness, fidelity skeleton, or ReturnToSender coverage | `docs/templates/decompiler-compile-back-harness-pr.md` |
 
 Some files under `docs/design/` record proposals or design history. Prefer
-current behavior in `README.md`, `docs/overview.md`, `docs/architecture.md`,
-focused current docs, and tests when sources disagree.
+current product behavior and tests over design history. When current sources
+disagree, stop and resolve which owner is authoritative rather than silently
+choosing one.
 
 When adding a focused skill, register it in `SkillCommand.Skills`. Its YAML
 frontmatter `description:` is the single source of truth for the generated
@@ -115,43 +154,22 @@ library is needed. Write probes under `/tmp/` and run them with:
 dotnet run /tmp/check.cs
 ```
 
-A file-based app can reference a project directly:
-
-```csharp
-#:project ../src/MyLib/MyLib.csproj
-
-using MyLib.Domain;
-
-var items = await MyService.LoadAsync();
-Console.WriteLine($"Found {items.Count} items");
-```
-
 ## Building and testing
 
-Repository development uses a .NET 11 daily SDK. Before installing an SDK or
-changing `PATH`, inspect the current selection:
+Use the SDK and toolchain selected by current repository configuration and CI.
+Version requirements belong with those owners, not in this file. Before
+installing an SDK or changing `PATH`, inspect the current selection:
 
 ```bash
 command -v dotnet
 dotnet --version
 ```
 
-If `dotnet` already resolves to a dotnetup-managed .NET 11 daily SDK, use normal
-`dotnet` commands. If it is centrally installed (for example under `/usr/bin`,
+If `dotnet` is centrally installed (for example under `/usr/bin`,
 `/usr/local/share/dotnet`, `/snap`, or `C:\Program Files\dotnet`), stop and ask
-before installing, replacing, or shadowing it.
-
-Use dotnetup for non-invasive user-level acquisition when approved:
-
-```bash
-curl -fsSL --retry 3 https://aka.ms/dotnetup/get-dotnetup.sh -o /tmp/get-dotnetup.sh
-bash /tmp/get-dotnetup.sh --install-dir "$HOME/.local/bin"
-dotnetup sdk install 11.0-daily --interactive false
-```
-
-Use `dotnetup dotnet ...` for command isolation, or evaluate its environment
-script for one shell. Do not modify shell startup files unless explicitly
-requested.
+before installing, replacing, or shadowing it. Follow
+`README.md#repository-development-sdk` for the current SDK acquisition
+workflow. Do not modify shell startup files unless explicitly requested.
 
 Build the normal product, test, and fixture graph with:
 
@@ -159,7 +177,7 @@ Build the normal product, test, and fixture graph with:
 dotnet build dotnet-inspect.slnx -c Release
 ```
 
-Tests use xUnit v3 executable projects. **Use `dotnet run`, not `dotnet test`**;
+Tests use xUnit executable projects. **Use `dotnet run`, not `dotnet test`**;
 `dotnet test` silently executes no tests here.
 
 | Area | Command |
@@ -200,20 +218,6 @@ section and promote verbosity as needed. Keep alternate lenses, section
 selection, row queries, and rendering formats orthogonal; follow the current
 progressive-disclosure and output-shape docs for detailed behavior.
 
-## Git and worktrees
-
-- `main` is protected. Work on a descriptive feature or fix branch.
-- Development must happen in a worktree. A fresh worktree per PR and a reused
-  development worktree are both valid.
-- Start each new change from the latest `origin/main`.
-- Never amend commits; create follow-up commits.
-- Before opening a PR, fetch `origin/main`, update the feature branch by merge
-  or rebase, resolve conflicts locally, and rerun relevant checks.
-- After updating from main or resolving conflicts, re-read `AGENTS.md` and
-  task-relevant docs before continuing.
-- Do not mix unrelated changes into one commit or sweep another contributor's
-  working-tree changes into your work.
-
 When all merge-blocking validation, CI, and required review are complete, post
 a PR comment that says `Ready to merge`. Label later work as non-blocking
 follow-up so readiness remains unambiguous.
@@ -224,10 +228,10 @@ Any PR with non-trivial behavior changes, new heuristics or shapes, or subtle
 correctness, security, or compatibility risk requires adversarial review from
 two different models chosen from:
 
-- Claude Opus (for example Claude Opus 4.8)
-- Gemini Pro (for example Gemini 3.1 Pro)
-- GPT (for example GPT 5.6 Sol)
-- MAI-Code (for example MAI-Code-1-Flash)
+- Claude Opus
+- Gemini Pro
+- GPT
+- MAI-Code
 
 This list is the single source of truth for the reviewer roster; scenario docs
 should reference it rather than restating it.
@@ -238,10 +242,10 @@ model.
 
 Give both reviewers the same self-contained prompt: exact base and head, design
 intent, relevant diff, concrete attack points, and required real-run evidence.
-Isolate every reviewer in a separate checkout or worktree. Require scratch work
-under `/tmp/` and prohibit `git reset`, `git add`, and commits in review trees.
-Before acting on a blocking finding, reproduce it on a clean exact-head
-checkout.
+Isolate every reviewer in a separate linked review worktree; never detach the
+primary checkout for review. Require scratch work under `/tmp/` and prohibit
+`git reset`, `git add`, and commits in review trees. Before acting on a blocking
+finding, reproduce it on a clean exact-head review worktree.
 
 After addressing findings, re-review the fixed exact head. Reconcile both
 reviews publicly on the PR: attribute findings, state what was verified or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,7 +226,7 @@ follow-up so readiness remains unambiguous.
 
 Any PR with non-trivial behavior changes, new heuristics or shapes, or subtle
 correctness, security, or compatibility risk requires adversarial review from
-two different models chosen from:
+two different models (latest versions) chosen from:
 
 - Claude Opus
 - Gemini Pro

--- a/README.md
+++ b/README.md
@@ -363,7 +363,11 @@ dotnet-inspect is [designed for LLM-driven development](docs/llm-design.md). The
 
 ## Contributor and agent docs
 
-Start with [docs/overview.md](docs/overview.md) for system context. `AGENTS.md` is the agent resolver for this repo, and [taste/skill-guidance.md](taste/skill-guidance.md) captures good and bad examples for maintaining the embedded skill.
+Start with [AGENTS.md](AGENTS.md) for repository-wide engineering and workflow
+rules. It routes each change to the focused documentation that must be read.
+Use [docs/overview.md](docs/overview.md) when a change crosses subsystem
+ownership boundaries, and [taste/skill-guidance.md](taste/skill-guidance.md)
+when maintaining the embedded skill.
 
 ## License
 

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -10,6 +10,11 @@ output. [decompiler-quality.md](decompiler-quality.md) explains the quality
 strategy and target selection. This page answers a more operational design
 question: **which boss did this change beat, and which boss is still ahead?**
 
+For raising, typing, structuring, fidelity, or printer changes, continue to
+[raise-work discipline](decompiler-raise-discipline.md) and use the
+[decompiler PR template](templates/decompiler-pr.md). The harness command
+reference lives in [tools/DecompilerHarness/README.md](../tools/DecompilerHarness/README.md).
+
 The core idea is to stop treating the harness modes as a bag of independent
 tools. They should behave like a staged pipeline. Early stages are cheap, local,
 and should be green all the time. Later stages are broader, slower, and answer

--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -421,7 +421,9 @@ touches the same hotspots as raise work (`LoweringCoverage`, `IrPasses`,
 `CfgSampleClass`, the sidecar fact providers, and the scorecard), so two rows
 sharing a tree will collide. A per-row worktree keeps each review isolated,
 lets reviews proceed in parallel, and makes the upstream sync in the pass loop
-below clean. Tear the worktree down once the row's PR merges.
+below clean. Tear the development and review worktrees down as soon as both
+fixed-head reviews are clean. If later work is needed, recreate a worktree for
+the branch.
 
 #### Useful tool patterns
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -21,17 +21,11 @@ It is built for both humans and agents. Markdown is the default output because h
 - `src/ILInspector.Research/` owns the offset-keyed fact overlay above Analysis and Decompiler: its registry orders fact producers, joins R1 analysis occurrences with R2 decompiler projections, and projects facts into the Annotated Source, annotated IL, and Facts views used by `member`.
 - `tools/DecompilerHarness/` owns ReturnToSender closure discovery and type-cluster planning. RTS specifies the required Metadata/CSharp request shape; `ILInspector.CSharp` owns rendering it.
 
-## Agent contract
+## Engineering guidance
 
-Agents working in this repo should preserve these principles:
-
-1. Prefer factual inspection over guesses; keep `dotnet-inspect skill` guidance current with CLI behavior.
-2. Keep output section ownership clear: sectioned output should avoid duplicated rows across sections.
-3. Preserve behavior-safe defaults. Expensive network/source checks should stay explicit or capability-gated.
-4. Preserve the progressive-disclosure model: verbosity for curated defaults, `-D`/`-S` for query and backpressure, opt-in sections for expensive work, and `-S @All` only for intentional exhaustive output.
-5. Use built-in query/limiter concepts (`-D`, `-S`, `--columns`, `--fields`, `--count`, `--rows`) instead of shell-pipe workarounds when possible.
-6. Treat cache schema changes as versioned categories and invalidate/clean stale metadata caches deliberately.
-7. Preserve the R1/R2 boundary for method-body evidence: Analysis and ControlFlow stay SRM-only and decompiler-IR-free, while Research is the bridge that projects registered producers into user-visible annotation views.
+[AGENTS.md](../AGENTS.md) is the source of truth for repository-wide
+engineering and workflow rules. This document describes subsystem ownership;
+use the task map in `AGENTS.md` to find the focused guidance for a change.
 
 ## Important systems
 

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -47,12 +47,6 @@ Before dispatching a release:
 2. Confirm that the commit contains the intended `VersionPrefix` and release
    notes.
 3. Confirm that the version has not already been published.
-4. Confirm that the `nuget` GitHub environment and NuGet Trusted Publishing
-   policy are configured, and that the `NUGET_USER` identity input expected by
-   the workflow is available.
-
-NuGet Trusted Publishing uses GitHub OIDC through `NuGet/login`; it does not
-use a long-lived NuGet API key stored in repository secrets.
 
 ## Dispatching
 
@@ -70,9 +64,8 @@ The workflow then:
 3. Builds the pointer and managed fallback packages.
 4. Validates that the managed fallback retains its supported runtime reach and
    that the pointer remains TFM-agnostic.
-5. Authenticates to NuGet with OIDC.
-6. Publishes Native AOT packages, then the managed fallback, then the pointer.
-7. Creates a GitHub release from the package version and attaches all packages.
+5. Publishes Native AOT packages, then the managed fallback, then the pointer.
+6. Creates a GitHub release from the package version and attaches all packages.
 
 The pointer is deliberately published last because it references the
 runtime-specific packages.
@@ -86,8 +79,6 @@ runtime-specific packages.
   successful CI run, and dispatch again with that run ID.
 - **Reach validation fails:** fix the package shape rather than bypassing the
   guard.
-- **NuGet authentication fails:** check the `nuget` environment,
-  `NUGET_USER` identity input, and Trusted Publishing configuration.
 - **A package version already exists:** advance `VersionPrefix`; published
   package versions are immutable.
 - **A partially published release is retried:** the workflow uses

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -1,221 +1,95 @@
-# Release Workflow
-
-This document describes the build, test, and release workflow for dotnet-inspect.
-
-## Overview
-
-dotnet-inspect is distributed as a .NET tool with RID-specific Native AOT packages for optimal performance on common platforms, plus a CoreCLR fallback for all other platforms.
-
-### Package Structure
-
-| Package | Platform | Type |
-| ------- | -------- | ---- |
-| `dotnet-inspect` | - | Pointer package (references all variants) |
-| `dotnet-inspect.win-x64` | Windows x64 | Native AOT, self-contained |
-| `dotnet-inspect.win-arm64` | Windows ARM64 | Native AOT, self-contained |
-| `dotnet-inspect.linux-x64` | Linux x64 | Native AOT, self-contained |
-| `dotnet-inspect.linux-arm64` | Linux ARM64 | Native AOT, self-contained |
-| `dotnet-inspect.osx-arm64` | macOS ARM64 | Native AOT, self-contained |
-| `dotnet-inspect.any` | Any | CoreCLR, framework-dependent |
-
-When users install the tool, the .NET CLI automatically selects the best package for their platform.
-
-## Workflow Structure
-
-Two separate workflows handle CI and publishing:
-
-| Workflow | Trigger | Purpose |
-| -------- | ------- | ------- |
-| `ci.yml` | Push to main, PRs | Build, test, upload artifacts |
-| `release.yml` | Manual dispatch | Publish to NuGet from a CI run |
-
-### Artifacts vs Releases
-
-| Source | Workflow Artifacts | NuGet Packages | GitHub Release |
-| ------ | ------------------ | -------------- | -------------- |
-| Pull Request | ✓ Downloadable | ✗ | ✗ |
-| Push to `main` | ✓ Downloadable | ✗ | ✗ |
-| Manual publish | - | ✓ Published | ✓ Created |
-
-**Workflow Artifacts**: Every successful CI build uploads packages as artifacts. Download from the Actions run to test pre-release builds.
-
-**GitHub Releases**: Created when you manually trigger the publish workflow.
-
-## Development Workflow
-
-### Making Changes
-
-1. Create a feature branch from `main`:
-
-   ```bash
-   git checkout main
-   git pull origin main
-   git checkout -b feature/my-change
-   ```
-
-2. Make your changes and commit:
-
-   ```bash
-   git add .
-   git commit -m "Description of changes"
-   ```
-
-3. Push and create a Pull Request to `main`:
-
-   ```bash
-   git push -u origin feature/my-change
-   ```
-
-4. Wait for CI to pass all checks, then merge the PR.
-
-### CI Checks on Pull Requests
-
-When a PR is opened against `main`, GitHub Actions runs:
-
-1. **Markdownlint**: Lint markdown files (if docs changed)
-2. **Build**: Compile the pointer package and all RID-specific variants
-3. **Unit Tests**: Run xUnit tests
-4. **Smoke Tests**: Install the tool from built packages on each platform and verify core commands work
-
-All checks must pass before the PR can be merged.
-
-## Release Process
-
-### Publishing a Release
-
-1. Find the CI workflow run you want to publish (from Actions tab)
-2. Copy the run ID from the URL (e.g., `21724718480`)
-3. Go to Actions → Publish → Run workflow
-4. Enter the run ID and type "publish" to confirm
-5. The workflow publishes to NuGet and creates a GitHub Release
-
-### What Happens on Publish
-
-1. **Download packages** from the specified CI run
-2. **Publish to NuGet**:
-   - RID-specific packages first (win-x64, win-arm64, linux-x64, linux-arm64, osx-arm64, any)
-   - Pointer package last (must be published after RID packages are available)
-3. **Create GitHub Release** with version tag and attached packages
-
-### Publishing Order
-
-The pointer package references RID-specific packages, so the order matters:
-
-```text
-1. dotnet-inspect.win-x64.0.3.0.nupkg
-2. dotnet-inspect.win-arm64.0.3.0.nupkg
-3. dotnet-inspect.linux-x64.0.3.0.nupkg
-4. dotnet-inspect.linux-arm64.0.3.0.nupkg
-5. dotnet-inspect.osx-arm64.0.3.0.nupkg
-6. dotnet-inspect.any.0.3.0.nupkg
-7. dotnet-inspect.0.3.0.nupkg  ← pointer package, published last
-```
-
-## Build Matrix
-
-| Runner | RID | Build Type |
-| ------ | --- | ---------- |
-| `windows-latest` | win-x64 | Native AOT |
-| `windows-latest` | win-arm64 | Native AOT (cross-compile) |
-| `ubuntu-latest` | linux-x64 | Native AOT |
-| `ubuntu-24.04-arm` | linux-arm64 | Native AOT |
-| `macos-latest` | osx-arm64 | Native AOT |
-| `ubuntu-latest` | any | CoreCLR |
-
-## Version Management
-
-The version is defined in `src/dotnet-inspect/dotnet-inspect.csproj`:
-
-```xml
-<VersionPrefix>0.3.0</VersionPrefix>
-```
-
-Update this before publishing a new release.
-
-## Local Development
-
-### Building Locally
-
-```bash
-# Build all projects
-dotnet build src/dotnet-inspect
-
-# Build with Native AOT for your platform
-dotnet publish src/dotnet-inspect -c Release -r linux-x64 --self-contained -p:PublishAot=true
-```
-
-### Running Tests Locally
-
-```bash
-# Unit tests
-dotnet test src/dotnet-inspect.Tests
-
-# Baseline regression tests
-./scripts/baseline-test.sh
-
-# Update baseline after intentional changes
-./scripts/baseline-test.sh --update
-
-# Smoke tests (requires tool to be installed)
-./scripts/smoke-test.sh
-```
-
-### Creating Local Packages
-
-```bash
-# Create pointer package
-dotnet pack src/dotnet-inspect -c Release
-
-# Create RID-specific AOT package (on matching OS)
-dotnet pack src/dotnet-inspect -c Release -r linux-x64
-
-# Create CoreCLR fallback package
-dotnet pack src/dotnet-inspect -c Release -r any -p:PublishAot=false
-```
-
-### Testing a Local Package
-
-```bash
-# Install from local artifacts
-dotnet tool install --global dotnet-inspect --add-source ./artifacts/package/release --no-cache
-
-# Test it
-dotnet-inspect --version
-
-# Uninstall when done
-dotnet tool uninstall --global dotnet-inspect
-```
-
-## Repository Setup
-
-### Required Secrets
-
-In GitHub repository settings, configure:
-
-- **`NUGET_API_KEY`**: API key for publishing to nuget.org
-
-### Environment Protection (Optional)
-
-You can add protection rules to the `nuget-publish` environment:
-
-1. Go to Settings → Environments → nuget-publish
-2. Add required reviewers for manual approval before publishing
-3. Limit to specific users who can trigger the publish workflow
-
-## Troubleshooting
-
-### Build Failures
-
-- **Native AOT errors**: Ensure you're building on a platform that matches the target OS
-- **Missing dependencies**: Run `dotnet restore` first
-
-### Test Failures
-
-- **Baseline mismatch**: Review the diff; if changes are intentional, run `./scripts/baseline-test.sh --update`
-- **Smoke test failures**: Check that the package was built and the tool installed correctly
-
-### Publishing Failures
-
-- **NuGet API key issues**: Ensure `NUGET_API_KEY` secret is set in GitHub repository settings
-- **Package already exists**: Version numbers cannot be reused; bump the version
-- **Pointer package fails**: RID-specific packages may not be indexed yet; the workflow publishes them first to avoid this
+# Release workflow
+
+This document explains how a tested commit becomes published packages.
+Repository development, worktree, build, and test rules live in
+[AGENTS.md](../AGENTS.md). The executable source of truth for publishing is
+[release.yml](../.github/workflows/release.yml); update this document when that
+workflow changes.
+
+## Release boundary
+
+CI and publishing have separate responsibilities:
+
+| Workflow | Trigger | Responsibility |
+| --- | --- | --- |
+| `ci.yml` | Pull requests and pushes to `main` | Validate the changed commit |
+| `release.yml` | Manual dispatch | Rebuild, verify, and publish one selected commit |
+
+The publish workflow accepts a CI run ID only to resolve the exact commit SHA.
+It does not publish or otherwise trust packages produced by that CI run. Every
+release package is built fresh from the resolved commit in `release.yml`.
+
+## Packages
+
+The tool is published as a pointer package, Native AOT packages for supported
+runtime identifiers, and a managed fallback:
+
+| Package | Role |
+| --- | --- |
+| `dotnet-inspect` | TFM-agnostic pointer to the runtime-specific packages |
+| `dotnet-inspect.win-x64` | Windows Native AOT |
+| `dotnet-inspect.win-arm64` | Windows Native AOT |
+| `dotnet-inspect.linux-x64` | Linux Native AOT |
+| `dotnet-inspect.linux-arm64` | Linux Native AOT |
+| `dotnet-inspect.osx-arm64` | macOS Native AOT |
+| `dotnet-inspect.any` | Managed fallback at the supported runtime floor |
+
+The package version is owned by `VersionPrefix` in
+`src/dotnet-inspect/dotnet-inspect.csproj`. Do not copy the current value into
+guidance. The publish workflow reads it from the selected commit when creating
+the GitHub release tag.
+
+## Prerequisites
+
+Before dispatching a release:
+
+1. Select a successful CI run for the exact commit to publish.
+2. Confirm that the commit contains the intended `VersionPrefix` and release
+   notes.
+3. Confirm that the version has not already been published.
+4. Confirm that the `nuget` GitHub environment and NuGet Trusted Publishing
+   policy are configured, and that the `NUGET_USER` identity input expected by
+   the workflow is available.
+
+NuGet Trusted Publishing uses GitHub OIDC through `NuGet/login`; it does not
+use a long-lived NuGet API key stored in repository secrets.
+
+## Dispatching
+
+1. Open the selected run in GitHub Actions and copy its run ID.
+2. Open the **Publish** workflow and choose **Run workflow**.
+3. Enter the run ID and type `publish` in the confirmation field.
+4. Confirm that the resolve job reports the expected commit SHA before the
+   package jobs proceed.
+
+The workflow then:
+
+1. Runs the full publish-time product, CLI, decompiler, Analysis, and IL
+   round-trip checks against the resolved commit.
+2. Builds each Native AOT package on its supported host.
+3. Builds the pointer and managed fallback packages.
+4. Validates that the managed fallback retains its supported runtime reach and
+   that the pointer remains TFM-agnostic.
+5. Authenticates to NuGet with OIDC.
+6. Publishes Native AOT packages, then the managed fallback, then the pointer.
+7. Creates a GitHub release from the package version and attaches all packages.
+
+The pointer is deliberately published last because it references the
+runtime-specific packages.
+
+## Failure handling
+
+- **Run resolution fails:** verify the run ID belongs to this repository and
+  still exists.
+- **Resolved SHA is wrong:** cancel the workflow; do not publish a nearby run.
+- **Publish-time tests fail:** fix the product on a new commit, obtain a new
+  successful CI run, and dispatch again with that run ID.
+- **Reach validation fails:** fix the package shape rather than bypassing the
+  guard.
+- **NuGet authentication fails:** check the `nuget` environment,
+  `NUGET_USER` identity input, and Trusted Publishing configuration.
+- **A package version already exists:** advance `VersionPrefix`; published
+  package versions are immutable.
+- **A partially published release is retried:** the workflow uses
+  `--skip-duplicate`, but verify the complete package set and GitHub release
+  before treating the release as complete.

--- a/docs/templates/decompiler-pr.md
+++ b/docs/templates/decompiler-pr.md
@@ -40,7 +40,7 @@ For focused invalid-Full / burndown row fixes, prefer
 
 <!--
 Required when authoritative original source is available. Delete this section
-only after checking with dotnet-inspect, including SourceLink.
+only after checking with dotnet-inspect (relying on SourceLink).
 -->
 
 ```csharp

--- a/docs/templates/decompiler-pr.md
+++ b/docs/templates/decompiler-pr.md
@@ -5,9 +5,17 @@ Use this for decompiler PRs that affect raising, structuring, validity,
 fidelity, or corpus behavior. Delete sections that do not apply. Keep generated
 tables generated; do not re-key metric rows by hand.
 
-Every raise PR must keep Before, After, and Fully Raised. Before and After must
-each show a concrete C# example. After records this PR's output; Fully Raised
+Every raise PR must keep Before, After, and Fully raised. Before and After must
+each show a concrete C# example. After records this PR's output; Fully raised
 records the intended endpoint.
+
+Look for the authoritative original source with `dotnet-inspect`, including
+through SourceLink:
+
+dnx dotnet-inspect -y -- member {Type} {MethodSelector} {scope} -S "Original Source"
+
+When original source is available, keep Original source immediately before
+Before and include the relevant C#.
 
 Adversarial review evidence belongs in a separate PR comment, not this
 description. Before marking the PR ready, post a comment that names each
@@ -28,6 +36,17 @@ For focused invalid-Full / burndown row fixes, prefer
 
 **Conclusion:** **PASS/REVIEW/BLOCKED** — {one sentence with the decisive reason}.
 
+### Original source
+
+<!--
+Required when authoritative original source is available. Delete this section
+only after checking with dotnet-inspect, including SourceLink.
+-->
+
+```csharp
+// authoritative original source
+```
+
 ### Before
 
 ```csharp
@@ -40,7 +59,7 @@ For focused invalid-Full / burndown row fixes, prefer
 // output produced by this PR, including an honest fallback when not fully raised
 ```
 
-### Fully Raised
+### Fully raised
 
 <!--
 Required for every raise PR. Choose one:


### PR DESCRIPTION
## Summary

- Require branch-backed development worktrees, preserve public branch history, and remove development/review worktrees after two clean fixed-head reviews.
- Make `AGENTS.md` the repository-wide policy owner while routing agents to focused task entry documents instead of mandatory broad reading.
- Rewrite release guidance around fresh publish-time builds, removing stale development commands, scripts, credentials, and copied version values.
- Require available original source in decompiler raise PRs and use sentence case for **Fully raised**.

## Compatibility

Documentation only; this does not change product, CI, or publishing behavior. Version requirements remain with their owning configuration and workflow documentation rather than `AGENTS.md`.

This is a low-risk guidance cleanup, so adversarial review is not required.

## Validation

- `npx markdownlint-cli AGENTS.md README.md docs/overview.md docs/release-workflow.md docs/decompiler-correctness-pipeline.md docs/decompiler-quality.md docs/templates/decompiler-pr.md`
- `git diff --check origin/main...HEAD`