### PR TITLE
Strengthen BodyNamespaceExtractor ordinal-order test

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4816,6 +4816,17 @@ public static class NamespaceRefSample
 
     // References only System (Int32).
     public static int ReferencesOnlySystem(int x) => x + 1;
+
+    // References NamespaceOrderFixtures.HPack and NamespaceOrderFixtures.Headers,
+    // whose ordinal order (HPack, then Headers) differs from their culture-aware
+    // and case-insensitive order (Headers, then HPack). See NamespaceOrderFixtures.cs.
+    public static void ReferencesCaseOrderFlippedNamespaces(
+        NamespaceOrderFixtures.HPack.Marker hpack,
+        NamespaceOrderFixtures.Headers.Marker headers)
+    {
+        _ = hpack.ToString();
+        _ = headers.ToString();
+    }
 }
 
 // Fixtures for MemberBodyFactsTests backing-field cases. Auto-property accessors

--- a/src/ILInspector.Decompiler.Tests/MemberBodyFactsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberBodyFactsTests.cs
@@ -61,13 +61,22 @@ public class MemberBodyFactsTests
     public void ReferencedNamespaces_ResultIsOrdinalSorted()
     {
         // The usings the harness builds from this set depend on a stable ordinal
-        // ordering, so the query must return its namespaces sorted.
+        // ordering, so the query must return its namespaces sorted. HPack and
+        // Headers are chosen because their ordinal order (HPack, then Headers)
+        // differs from their culture-aware and case-insensitive order (Headers,
+        // then HPack): a regression to a culture-aware or case-insensitive
+        // comparer would fail this assertion even though it would pass for
+        // System/System.Text/System.Collections.Generic, whose relative order is
+        // the same under every comparer.
         var namespaces = NamespacesFor(
             typeof(NamespaceRefSample).FullName!,
-            nameof(NamespaceRefSample.ReferencesTextAndGenerics));
+            nameof(NamespaceRefSample.ReferencesCaseOrderFlippedNamespaces));
 
         Assert.Equal(
             namespaces.OrderBy(ns => ns, StringComparer.Ordinal).ToArray(),
+            namespaces.ToArray());
+        Assert.NotEqual(
+            namespaces.OrderBy(ns => ns, StringComparer.OrdinalIgnoreCase).ToArray(),
             namespaces.ToArray());
     }
 

--- a/src/ILInspector.Decompiler.Tests/NamespaceOrderFixtures.cs
+++ b/src/ILInspector.Decompiler.Tests/NamespaceOrderFixtures.cs
@@ -1,0 +1,24 @@
+// Fixture namespaces for MemberBodyFactsTests.ReferencedNamespaces_ResultIsOrdinalSorted.
+//
+// "NamespaceOrderFixtures.HPack" and "NamespaceOrderFixtures.Headers" share the
+// prefix "NamespaceOrderFixtures.H" and then diverge on 'P' (0x50) vs 'e' (0x65):
+// StringComparer.Ordinal ranks HPack before Headers (uppercase 'P' < lowercase
+// 'e'), while StringComparer.CurrentCulture/InvariantCulture and
+// StringComparer.OrdinalIgnoreCase rank Headers before HPack (letter 'e' < 'p').
+// Referencing both from one method pins ReferencedNamespaces to ordinal ordering
+// specifically, rather than to an ordering shared by ordinal and culture-aware
+// comparers alike.
+
+namespace NamespaceOrderFixtures.HPack
+{
+    public sealed class Marker
+    {
+    }
+}
+
+namespace NamespaceOrderFixtures.Headers
+{
+    public sealed class Marker
+    {
+    }
+}


### PR DESCRIPTION
Fixes #2846.

`ReferencedNamespaces_ResultIsOrdinalSorted` used `System`, `System.Collections.Generic`, and `System.Text`, whose relative order is identical under ordinal, culture-aware, and case-insensitive comparers, so the assertion (re-sorting an already-ordinal-sorted result by `StringComparer.Ordinal`) could never fail even if the implementation regressed to a different comparer.

## Change

Added `NamespaceOrderFixtures.HPack` and `NamespaceOrderFixtures.Headers` (`src/ILInspector.Decompiler.Tests/NamespaceOrderFixtures.cs`) whose ordinal order (HPack, then Headers) differs from their culture-aware/case-insensitive order (Headers, then HPack): shared prefix `NamespaceOrderFixtures.H`, then `'P'` (0x50) vs `'e'` (0x65) diverges under `StringComparer.Ordinal` vs letter-wise comparison under culture-aware/`OrdinalIgnoreCase` comparers.

Added `NamespaceRefSample.ReferencesCaseOrderFlippedNamespaces` referencing both marker types, and updated the test to assert both the ordinal order and that it differs from the `OrdinalIgnoreCase` order.

## Evidence

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.MemberBodyFactsTests`: 10/10 pass.
- Verified the strengthened assertion actually catches a regression: temporarily changed `MemberBodyFacts.ReferencedNamespaces`'s `SortedSet<string>` comparer from `StringComparer.Ordinal` to `StringComparer.OrdinalIgnoreCase` and confirmed the test fails with a mismatch at the expected namespace pair; reverted afterward (verified via `git status`/`git diff`).

This is a non-blocking test-strength change with no production behavior change (test fixtures only), so no adversarial review is required.
