### PR TITLE
Handle function-pointer component types in body namespace extraction

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4827,6 +4827,16 @@ public static class NamespaceRefSample
         _ = hpack.ToString();
         _ = headers.ToString();
     }
+
+    // References FunctionPointerNamespaceFixtures only through a function pointer
+    // parameter's return type and argument type (delegate*<...>'s element/type
+    // arguments), never as an ordinary local, field, or parameter/return type. See
+    // FunctionPointerNamespaceFixtures.cs.
+    public static unsafe void ReferencesNamespacesOnlyThroughFunctionPointer(
+        delegate*<FunctionPointerNamespaceFixtures.ParameterMarker, FunctionPointerNamespaceFixtures.ReturnMarker> callback)
+    {
+        _ = callback;
+    }
 }
 
 // Fixtures for MemberBodyFactsTests backing-field cases. Auto-property accessors

--- a/src/ILInspector.Decompiler.Tests/FunctionPointerNamespaceFixtures.cs
+++ b/src/ILInspector.Decompiler.Tests/FunctionPointerNamespaceFixtures.cs
@@ -1,0 +1,22 @@
+// Fixture namespace for MemberBodyFactsTests.ReferencedNamespaces_ReportsFunctionPointerComponentNamespaces.
+//
+// FunctionPointerNamespaceFixtures.ParameterMarker and .ReturnMarker are only
+// referenced through a function-pointer parameter/return type
+// (CfgSampleClass.TakesFunctionPointerWithCustomNamespaceTypes), never directly
+// as a local, field, or ordinary parameter/return type. That isolates
+// TypeRefKind.FunctionPointer as the only path MemberBodyFacts.ReferencedNamespaces
+// can discover this namespace through, so the fixture is a close negative for
+// issue #2847: before the fix, the extractor's Add() switch had no
+// TypeRefKind.FunctionPointer case, so a namespace reachable only via a function
+// pointer's return/parameter types was silently missed.
+
+namespace FunctionPointerNamespaceFixtures
+{
+    public struct ParameterMarker
+    {
+    }
+
+    public struct ReturnMarker
+    {
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/MemberBodyFactsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberBodyFactsTests.cs
@@ -81,6 +81,22 @@ public class MemberBodyFactsTests
     }
 
     [Fact]
+    public void ReferencedNamespaces_ReportsFunctionPointerComponentNamespaces()
+    {
+        // FunctionPointerNamespaceFixtures is referenced only through the
+        // function pointer parameter's return type and argument type
+        // (delegate*<ParameterMarker, ReturnMarker>), never as an ordinary
+        // local, field, or parameter/return type. Close-negative coverage for
+        // issue #2847: before TypeRefKind.FunctionPointer was added to the
+        // Add() switch, this namespace was silently omitted.
+        var namespaces = NamespacesFor(
+            typeof(NamespaceRefSample).FullName!,
+            nameof(NamespaceRefSample.ReferencesNamespacesOnlyThroughFunctionPointer));
+
+        Assert.Contains("FunctionPointerNamespaceFixtures", namespaces);
+    }
+
+    [Fact]
     public void Constructor_ChainedConstructor_ReportsChainCalleeParameterTypes()
     {
         // The parameterless overload chains to `this(int, string)`, so the chain

--- a/src/ILInspector.Decompiler/MemberBodyFacts.cs
+++ b/src/ILInspector.Decompiler/MemberBodyFacts.cs
@@ -16,7 +16,8 @@ public static class MemberBodyFacts
     /// and its descendant nodes, so the harness can assemble <c>using</c> directives.
     /// Element/argument types of generic instances, arrays, by-refs, pointers, and
     /// pinned types are unwrapped so only their underlying definition namespaces are
-    /// reported; the global namespace (empty string) is excluded.
+    /// reported; a function pointer's return type and parameter types are unwrapped
+    /// the same way; the global namespace (empty string) is excluded.
     /// <para>
     /// Order: ordinal-sorted (case-sensitive), because the harness builds a stable,
     /// deterministic <c>using</c> block from this set.
@@ -42,6 +43,11 @@ public static class MemberBodyFacts
                 case TypeRefKind.SzArray or TypeRefKind.Array
                     or TypeRefKind.ByRef or TypeRefKind.Pointer or TypeRefKind.Pinned:
                     Add(type.ElementType);
+                    break;
+                case TypeRefKind.FunctionPointer:
+                    Add(type.ElementType);
+                    foreach (var parameter in type.TypeArguments)
+                        Add(parameter);
                     break;
             }
         }


### PR DESCRIPTION
Fixes #2847.

`BodyNamespaceExtractor.ReferencedNamespaces` (now `MemberBodyFacts.ReferencedNamespaces`) preserves the former harness walk, which had no `TypeRefKind.FunctionPointer` case in its recursive `Add()` switch. Function-pointer return and parameter types could therefore contribute namespaces that were missed when they appeared only inside a function-pointer type. Per the issue, this is pre-existing behavior moved by #2841, not a regression introduced there.

## Change

- `src/ILInspector.Decompiler/MemberBodyFacts.cs`: added a `TypeRefKind.FunctionPointer` case to `Add()` that recurses into the return type (`TypeRef.ElementType`) and each parameter type (`TypeRef.TypeArguments`), matching the existing recursive handling already in place for generic instances, arrays, by-refs, pointers, and pinned types.
- `src/ILInspector.Decompiler.Tests/FunctionPointerNamespaceFixtures.cs` (new): `ParameterMarker`/`ReturnMarker` types in a dedicated namespace.
- `src/ILInspector.Decompiler.Tests/CfgSampleClass.cs`: added `NamespaceRefSample.ReferencesNamespacesOnlyThroughFunctionPointer(delegate*<ParameterMarker, ReturnMarker> callback)` — the fixture namespace is reachable *only* through the function pointer's return/argument types, never as an ordinary local, field, or parameter/return type, isolating the new code path as the sole discovery route.
- `src/ILInspector.Decompiler.Tests/MemberBodyFactsTests.cs`: added `ReferencedNamespaces_ReportsFunctionPointerComponentNamespaces`, asserting the namespace is now reported.

## Evidence

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.MemberBodyFactsTests`: 11/11 pass.
- Confirmed this is a genuine close-negative: temporarily reverted just the `MemberBodyFacts.cs` fix (via `git stash`) and reran the new test — it fails with `Assert.Contains() Failure: Item not found in set ... Not found: "FunctionPointerNamespaceFixtures"`. Restored the fix; full class passes again (11/11).

Test-only + small, mechanical product fix (one new switch case) with no behavior change outside the fixed gap, so no adversarial review is required.
