### PR TITLE
Recover protected-region leave as structured continue

### DIFF
--- a/docs/design/decompiler-substrate.md
+++ b/docs/design/decompiler-substrate.md
@@ -36,11 +36,16 @@ call. The live substrate layers are:
 | `GeneratedCodeIdentity` | Compiler-generated shape (attribute-gated) | Is this a non-capturing lambda holder? |
 | `PlaceIdentity` | Intra-method re-evaluable place identity | Are these two reads the same local? |
 | `ReferenceOwnership` | Reference-scope ownership for consumed scaffolds | Is every use of this synthetic local inside the nodes this rewrite consumes? |
+| `ProtectedRegionControlFlow` | EH transfer legality | Can this protected-region leave become structured control flow? |
 
 They are siblings by construction — thin, allocation-light, no pass state, named
 for the evidence category not the caller — but each owns a different category:
 metadata identity, compiler-shape evidence, intra-method place identity, and
-reference-scope ownership.
+reference-scope ownership. `ProtectedRegionControlFlow` adds the narrow EH
+category shared by `StructuringPass` and `ForLoopPass`: it proves that a
+`Leave` exits a `try`/`catch` region and never originates in a `finally` body.
+Its boundary-aware atom also proves that the protected region is below the
+candidate construct; the consuming pass still owns target and loop identity.
 
 ## Boundaries and roadmap
 

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1903,6 +1903,61 @@ public class CfgSampleClass
             }
         }
     }
+
+    public static void Issue2861_ForLoopTryAndCatchContinues()
+    {
+        for (int i = 0; i < 10; i++)
+        {
+            try
+            {
+                if (i == 2)
+                    continue;
+                if (i == 5)
+                    throw new System.InvalidOperationException();
+                System.Console.WriteLine();
+            }
+            catch (System.InvalidOperationException)
+            {
+                if (i == 5)
+                    continue;
+                System.Console.WriteLine();
+            }
+            System.Console.WriteLine();
+        }
+    }
+
+    public static void Issue2861_NestedProtectedLeaveToOuterIncrement()
+    {
+        int i = 0;
+        while (i < 10)
+        {
+            try
+            {
+                if (i == 2)
+                    goto Increment;
+                System.Console.WriteLine();
+            }
+            catch (System.Exception)
+            {
+            }
+            for (int j = 0; j < 3; j++)
+            {
+                try
+                {
+                    if (i == j)
+                        goto Increment;
+                    System.Console.WriteLine();
+                }
+                catch (System.Exception)
+                {
+                }
+            }
+            System.Console.WriteLine();
+        Increment:
+            i++;
+        }
+    }
+
     public static int LoopWithBreak(int[] values, int limit)
     {
         int sum = 0;

--- a/src/ILInspector.Decompiler.Tests/DecompilerFindingsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DecompilerFindingsTests.cs
@@ -98,6 +98,20 @@ public class DecompilerFindingsTests
     }
 
     [Fact]
+    public void Inspect_ProvenProtectedForContinue_HasNoResidualCause()
+    {
+        var function = Function(
+            new Continue(ContinueOrigin.ProtectedRegionLeaveToForIncrement),
+            blockOffset: 0x20);
+
+        var inspection = CompleteInspection(
+            DecompilerFindings.InspectFidelityCauses(function, Subject));
+
+        Assert.Empty(inspection.Findings);
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
+
+    [Fact]
     public void Inspect_CauseInSyntheticBlock_HasUnknownLocation()
     {
         var function = Function(new Continue(), blockOffset: -10);

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -102,14 +102,11 @@ public class FidelityGateTests
         // is compile-back-checked on every fidelity-gate run rather than left to
         // the sampled corpus.
         "SwitchStoreThenUse",
-        // Issue2830_* are the protected-continue fallback fixtures. ForLoopPass
-        // deliberately leaves these as while loops because their increment
-        // blocks remain live leave targets; the printer's explicit default
-        // declaration before the initializer adds an opcode pair on
-        // compile-back. Valid fallback C#, but not opcode-exact.
-        "Issue2830_ForLoopEhCleanupContinue",
-        "Issue2830_ForLoopLeave",
-        "Issue2830_ForLoopNestedContinue",
+        // The #2861 nested-loop fixture deliberately retains #2857's valid
+        // outer while-loop fallback because one protected leave targeting its
+        // increment belongs to the nested loop. Its explicit default declaration
+        // adds an opcode pair on compile-back, so the fallback is not opcode-exact.
+        "Issue2861_NestedProtectedLeaveToOuterIncrement",
         // CharConditionalElementStore (#1784): the char ternary element store
         // spills to temps and recompiles to a different (valid) stream. Honest
         // over-render. Pre-existing slow-docket gap surfaced by running the gate
@@ -282,6 +279,10 @@ public class FidelityGateTests
         "NullCoalescingAssignInstanceField",
         "LazyFieldGetter",
         "SubIntPromotionToUInt",
+        "Issue2830_ForLoopEhCleanupContinue",
+        "Issue2830_ForLoopLeave",
+        "Issue2830_ForLoopNestedContinue",
+        "Issue2861_ForLoopTryAndCatchContinues",
         "WhileTrueWithReturns",
         "WhileTrueWithBreak",
         "KeywordParam",

--- a/src/ILInspector.Decompiler.Tests/ForLoopPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForLoopPassTests.cs
@@ -34,6 +34,96 @@ public class ForLoopPassTests
     }
 
     [Fact]
+    public void ProtectedLeaveToTrailingIncrement_RaisesAtomically()
+    {
+        var function = FunctionWithProtectedIncrementTargets(protectedLeaveCount: 1);
+
+        new ForLoopPass().Run(function, PassContext.None);
+
+        var loop = Assert.Single(function.Descendants.OfType<ForLoop>());
+        var next = Assert.Single(loop.Body.Descendants.OfType<Continue>());
+        Assert.Equal(ContinueOrigin.ProtectedRegionLeaveToForIncrement, next.Origin);
+        Assert.Equal(0x20, next.SourceOffset);
+        Assert.Empty(function.Descendants.OfType<Leave>());
+        Assert.Empty(function.Descendants.OfType<WhileLoop>());
+    }
+
+    [Fact]
+    public void MultipleProtectedLeavesToTrailingIncrement_RaiseTogether()
+    {
+        var function = FunctionWithProtectedIncrementTargets(protectedLeaveCount: 2);
+
+        new ForLoopPass().Run(function, PassContext.None);
+
+        var loop = Assert.Single(function.Descendants.OfType<ForLoop>());
+        var continues = loop.Body.Descendants.OfType<Continue>().ToList();
+        Assert.Equal(2, continues.Count);
+        Assert.All(continues, next =>
+            Assert.Equal(ContinueOrigin.ProtectedRegionLeaveToForIncrement, next.Origin));
+        Assert.Empty(function.Descendants.OfType<Leave>());
+        Assert.Empty(function.Descendants.OfType<WhileLoop>());
+    }
+
+    [Fact]
+    public void ProtectedLeaveAndBranchToTrailingIncrement_StayWhileLoop()
+    {
+        var function = FunctionWithProtectedIncrementTargets(
+            protectedLeaveCount: 1,
+            includeBranchTarget: true);
+
+        new ForLoopPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<WhileLoop>());
+        Assert.Single(function.Descendants.OfType<Leave>());
+        Assert.Single(function.Descendants.OfType<Branch>());
+        Assert.Empty(function.Descendants.OfType<Continue>());
+        Assert.Empty(function.Descendants.OfType<ForLoop>());
+    }
+
+    [Fact]
+    public void LeaveInsideFinallyBody_StaysWhileLoop()
+    {
+        var function = FunctionWithProtectedIncrementTargets(
+            protectedLeaveCount: 1,
+            leaveInsideFinally: true);
+
+        new ForLoopPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<WhileLoop>());
+        Assert.Single(function.Descendants.OfType<Leave>());
+        Assert.Empty(function.Descendants.OfType<Continue>());
+        Assert.Empty(function.Descendants.OfType<ForLoop>());
+    }
+
+    [Fact]
+    public void LeaveWithOnlyOuterProtectedRegion_StaysWhileLoop()
+    {
+        var function = FunctionWithOuterProtectedIncrementTarget();
+
+        new ForLoopPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<WhileLoop>());
+        Assert.Single(function.Descendants.OfType<Leave>());
+        Assert.Empty(function.Descendants.OfType<Continue>());
+        Assert.Empty(function.Descendants.OfType<ForLoop>());
+    }
+
+    [Fact]
+    public void ProtectedLeaveOwnedByNestedLoop_DoesNotRaiseOuterLoop()
+    {
+        var function = FunctionWithProtectedIncrementTargets(
+            protectedLeaveCount: 1,
+            leaveInsideNestedLoop: true);
+
+        new ForLoopPass().Run(function, PassContext.None);
+
+        Assert.Equal(2, function.Descendants.OfType<WhileLoop>().Count());
+        Assert.Single(function.Descendants.OfType<Leave>());
+        Assert.Empty(function.Descendants.OfType<Continue>());
+        Assert.Empty(function.Descendants.OfType<ForLoop>());
+    }
+
+    [Fact]
     public void ContinueInNestedLoop_DoesNotBlockOuterForLoop()
     {
         var function = FunctionWithNestedContinueLoop();
@@ -177,6 +267,101 @@ public class ForLoopPassTests
             GenericParameterCount: 0);
 
         return new IrFunction("M", Owner, signature, [Int32], container);
+    }
+
+    static IrFunction FunctionWithProtectedIncrementTargets(
+        int protectedLeaveCount,
+        bool includeBranchTarget = false,
+        bool leaveInsideFinally = false,
+        bool leaveInsideNestedLoop = false)
+    {
+        const int incrementOffset = 0x42;
+        var protectedBlock = new Block();
+        for (int i = 0; i < protectedLeaveCount; i++)
+        {
+            var then = new Block();
+            var leave = new Leave(incrementOffset);
+            leave.SetSourceOffset(0x20 + i);
+            then.Add(leave);
+            protectedBlock.Add(new IfStatement(new LoadArgument(0, "skip", Bool), then, elseArm: null));
+        }
+
+        var protectedBody = new BlockContainer();
+        protectedBody.Add(protectedBlock);
+        var emptyBody = new BlockContainer();
+        emptyBody.Add(new Block());
+
+        IrNode protectedRegion = leaveInsideFinally
+            ? new TryFinally(emptyBody, protectedBody)
+            : new TryCatch(protectedBody, [new CatchClause(TypeRef.CoreLib("System", "Exception"), emptyBody)]);
+
+        var loopBody = new Block();
+        if (leaveInsideNestedLoop)
+        {
+            var nestedBody = new Block();
+            nestedBody.Add(protectedRegion);
+            loopBody.Add(new WhileLoop(new LoadArgument(0, "skip", Bool), nestedBody));
+        }
+        else
+        {
+            loopBody.Add(protectedRegion);
+        }
+
+        if (includeBranchTarget)
+            loopBody.Add(new Branch(incrementOffset));
+
+        var increment = Increment();
+        increment.SetSourceOffset(incrementOffset);
+        loopBody.Add(increment);
+
+        var container = new BlockContainer();
+        var block = new Block();
+        block.Add(new StoreLocal(0, Int32, new Constant(0, Int32)));
+        block.Add(new WhileLoop(
+            new Comparison(ComparisonKind.LessThan, isUnsigned: false, new LoadLocal(0, Int32), new Constant(10, Int32)),
+            loopBody));
+        block.Add(new Return(new LoadLocal(0, Int32)));
+        container.Add(block);
+
+        var signature = new MethodSignature(
+            Int32,
+            [new Parameter("skip", Bool)],
+            HasThis: false,
+            GenericParameterCount: 0);
+        return new IrFunction("M", Owner, signature, [Int32], container);
+    }
+
+    static IrFunction FunctionWithOuterProtectedIncrementTarget()
+    {
+        const int incrementOffset = 0x42;
+        var loopBody = new Block();
+        loopBody.Add(new Leave(incrementOffset));
+        var increment = Increment();
+        increment.SetSourceOffset(incrementOffset);
+        loopBody.Add(increment);
+
+        var tryBlock = new Block();
+        tryBlock.Add(new StoreLocal(0, Int32, new Constant(0, Int32)));
+        tryBlock.Add(new WhileLoop(
+            new Comparison(ComparisonKind.LessThan, isUnsigned: false, new LoadLocal(0, Int32), new Constant(10, Int32)),
+            loopBody));
+        var tryBody = new BlockContainer();
+        tryBody.Add(tryBlock);
+        var catchBody = new BlockContainer();
+        catchBody.Add(new Block());
+
+        var rootBlock = new Block();
+        rootBlock.Add(new TryCatch(
+            tryBody,
+            [new CatchClause(TypeRef.CoreLib("System", "Exception"), catchBody)]));
+        var container = new BlockContainer();
+        container.Add(rootBlock);
+        return new IrFunction(
+            "M",
+            Owner,
+            new MethodSignature(Int32, [], HasThis: false, GenericParameterCount: 0),
+            [Int32],
+            container);
     }
 
     static StoreLocal Increment()

--- a/src/ILInspector.Decompiler.Tests/IdiomShapeScorecard.ControlFlowCases.cs
+++ b/src/ILInspector.Decompiler.Tests/IdiomShapeScorecard.ControlFlowCases.cs
@@ -23,11 +23,13 @@ internal sealed class ControlFlowScorecardCases : IdiomShapeScorecardTests.ICase
         new("ForeachStatementPass", nameof(CfgSampleClass.ForeachString), SyntaxKind.ForEachStatement, [SyntaxKind.ForStatement]),
         new("ForeachStatementPass", nameof(CfgSampleClass.ForeachRectangularArray), SyntaxKind.ForEachStatement, [SyntaxKind.ForStatement]),
         new("ForeachStatementPass", nameof(CfgSampleClass.ForeachPatternEnumerable), SyntaxKind.ForEachStatement, [SyntaxKind.WhileStatement]),
-        new("ForLoopPass", nameof(CfgSampleClass.Issue2830_ForLoopLeave), SyntaxKind.WhileStatement, [SyntaxKind.ForStatement]),
+        new("ForLoopPass", nameof(CfgSampleClass.Issue2830_ForLoopLeave), SyntaxKind.ForStatement, [SyntaxKind.WhileStatement]),
         new("ForLoopPass", nameof(CfgSampleClass.Issue2830_ForLoopLeaveToAnotherTarget), SyntaxKind.ForStatement, [SyntaxKind.WhileStatement]),
-        new("ForLoopPass", nameof(CfgSampleClass.Issue2830_ForLoopEhCleanupContinue), SyntaxKind.WhileStatement, [SyntaxKind.ForStatement]),
+        new("ForLoopPass", nameof(CfgSampleClass.Issue2830_ForLoopEhCleanupContinue), SyntaxKind.ForStatement, [SyntaxKind.WhileStatement]),
         new("ForLoopPass", nameof(CfgSampleClass.Issue2830_ForLoopWithNestedLambdaTargetConflict), SyntaxKind.ForStatement, [SyntaxKind.WhileStatement]),
-        new("ForLoopPass", nameof(CfgSampleClass.Issue2830_ForLoopNestedContinue), SyntaxKind.ForStatement, []),
+        new("ForLoopPass", nameof(CfgSampleClass.Issue2830_ForLoopNestedContinue), SyntaxKind.ForStatement, [SyntaxKind.WhileStatement]),
+        new("ForLoopPass", nameof(CfgSampleClass.Issue2861_ForLoopTryAndCatchContinues), SyntaxKind.ForStatement, [SyntaxKind.WhileStatement]),
+        new("ForLoopPass", nameof(CfgSampleClass.Issue2861_NestedProtectedLeaveToOuterIncrement), SyntaxKind.WhileStatement, []),
         new("FixedStatementPass", nameof(CfgSampleClass.SumPinnedArray), SyntaxKind.FixedStatement, []),
     ];
 }

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -86,13 +86,14 @@ public class LoweredFidelityGateTests
         // lowered gate is Speed=Slow and only runs in Deep Inspect / publish, not PR CI. Verified
         // pre-existing (fails with MixedShortCircuitChainPass off as well).
         "SwitchStoreThenUse",
-        // Issue2830_* deliberately retain while-loop fallback output because
-        // their increment blocks remain protected leave targets. As in the
-        // sugared view, the explicit default declaration before initialization
-        // adds an opcode pair on compile-back: valid, but not opcode-exact.
+        // Lowered output omits ForLoopPass, so protected increment targets retain
+        // #2857's valid while-loop fallback. The explicit default declaration
+        // before initialization adds an opcode pair on compile-back.
         "Issue2830_ForLoopEhCleanupContinue",
         "Issue2830_ForLoopLeave",
         "Issue2830_ForLoopNestedContinue",
+        "Issue2861_ForLoopTryAndCatchContinues",
+        "Issue2861_NestedProtectedLeaveToOuterIncrement",
         // CharConditionalElementStore (#1784) and WhileNestedContinueKeepsArmExclusive:
         // pre-existing slow-docket gaps from recent main merges (a char ternary
         // element store that spills to temps; a nested-continue loop structuring),

--- a/src/ILInspector.Decompiler.Tests/ProtectedContinueRecoveryTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ProtectedContinueRecoveryTests.cs
@@ -1,0 +1,54 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ProtectedContinueRecoveryTests
+{
+    [Fact]
+    public void TryAndCatchContinues_RaiseWithOwningForLoop()
+    {
+        var function = Raised(nameof(CfgSampleClass.Issue2861_ForLoopTryAndCatchContinues));
+
+        var loop = Assert.Single(function.Descendants.OfType<ForLoop>());
+        var tryCatch = Assert.Single(loop.Body.Descendants.OfType<TryCatch>());
+        Assert.Contains(tryCatch.TryBody.Descendants, node => node is Continue);
+        Assert.Contains(tryCatch.Clauses, clause => clause.Body.Descendants.OfType<Continue>().Any());
+        Assert.Equal(2, loop.Body.Descendants.OfType<Continue>().Count());
+        Assert.Empty(function.Descendants.OfType<Leave>());
+        Assert.Empty(function.Descendants.OfType<WhileLoop>());
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+
+        var output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("for (int i = 0; i < 10; i++)", output);
+        Assert.Equal(2, output.Split("continue;", StringSplitOptions.None).Length - 1);
+        Assert.DoesNotContain("goto", output);
+        Assert.DoesNotContain("IL_", output);
+    }
+
+    [Fact]
+    public void NestedLoopLeaveToOuterIncrement_PreservesWhileFallback()
+    {
+        var function = Raised(nameof(CfgSampleClass.Issue2861_NestedProtectedLeaveToOuterIncrement));
+
+        Assert.Single(function.Descendants.OfType<WhileLoop>());
+        Assert.Single(function.Descendants.OfType<ForLoop>());
+        Assert.Equal(2, function.Descendants.OfType<Leave>().Count());
+        Assert.Empty(function.Descendants.OfType<Continue>());
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+
+        var output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("while (", output);
+        Assert.Contains("for (int j = 0; j < 3; j++)", output);
+        Assert.Contains("goto IL_", output);
+    }
+
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return function;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ProtectedRegionControlFlowTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ProtectedRegionControlFlowTests.cs
@@ -1,0 +1,100 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ProtectedRegionControlFlowTests
+{
+    [Fact]
+    public void LeaveInTryBelowBoundary_IsRaisable()
+    {
+        var (leave, boundary) = LeaveInProtectedRegion(ProtectedLocation.Try);
+
+        Assert.True(ProtectedRegionControlFlow.CanRaiseLeave(leave));
+        Assert.True(ProtectedRegionControlFlow.CanRaiseLeave(leave, boundary));
+    }
+
+    [Fact]
+    public void LeaveInCatchBelowBoundary_IsRaisable()
+    {
+        var (leave, boundary) = LeaveInProtectedRegion(ProtectedLocation.Catch);
+
+        Assert.True(ProtectedRegionControlFlow.CanRaiseLeave(leave));
+        Assert.True(ProtectedRegionControlFlow.CanRaiseLeave(leave, boundary));
+    }
+
+    [Fact]
+    public void LeaveInFinallyBody_IsNotRaisable()
+    {
+        var (leave, boundary) = LeaveInProtectedRegion(ProtectedLocation.Finally);
+
+        Assert.False(ProtectedRegionControlFlow.CanRaiseLeave(leave));
+        Assert.False(ProtectedRegionControlFlow.CanRaiseLeave(leave, boundary));
+    }
+
+    [Fact]
+    public void ProtectedRegionAboveBoundary_DoesNotLicenseBoundedRaise()
+    {
+        var leave = new Leave(0x42);
+        var loopBody = new Block();
+        loopBody.Add(leave);
+        var loop = new WhileLoop(new Constant(true, TypeRef.CoreLib("System", "Boolean")), loopBody);
+        var tryBlock = new Block();
+        tryBlock.Add(loop);
+        var tryBody = Container(tryBlock);
+        var catchBody = Container(new Block());
+        _ = Root(new TryCatch(
+            tryBody,
+            [new CatchClause(TypeRef.CoreLib("System", "Exception"), catchBody)]));
+
+        Assert.True(ProtectedRegionControlFlow.CanRaiseLeave(leave));
+        Assert.False(ProtectedRegionControlFlow.CanRaiseLeave(leave, loop));
+    }
+
+    static (Leave Leave, WhileLoop Boundary) LeaveInProtectedRegion(ProtectedLocation location)
+    {
+        var leave = new Leave(0x42);
+        var leaveBody = Container(Block(leave));
+        var emptyBody = Container(new Block());
+        IrNode region = location switch
+        {
+            ProtectedLocation.Try => new TryCatch(
+                leaveBody,
+                [new CatchClause(TypeRef.CoreLib("System", "Exception"), emptyBody)]),
+            ProtectedLocation.Catch => new TryCatch(
+                emptyBody,
+                [new CatchClause(TypeRef.CoreLib("System", "Exception"), leaveBody)]),
+            ProtectedLocation.Finally => new TryFinally(emptyBody, leaveBody),
+            _ => throw new ArgumentOutOfRangeException(nameof(location)),
+        };
+
+        var loopBody = new Block();
+        loopBody.Add(region);
+        var loop = new WhileLoop(new Constant(true, TypeRef.CoreLib("System", "Boolean")), loopBody);
+        _ = Root(loop);
+        return (leave, loop);
+    }
+
+    static Block Block(IrNode node)
+    {
+        var block = new Block();
+        block.Add(node);
+        return block;
+    }
+
+    static BlockContainer Container(Block block)
+    {
+        var container = new BlockContainer();
+        container.Add(block);
+        return container;
+    }
+
+    static BlockContainer Root(IrNode node)
+        => Container(Block(node));
+
+    enum ProtectedLocation
+    {
+        Try,
+        Catch,
+        Finally,
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/SubstratePredicateCensusTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SubstratePredicateCensusTests.cs
@@ -30,8 +30,6 @@ public class SubstratePredicateCensusTests
             "FieldRef equality paired with pass-owned receiver/index-shape checks for null-coalescing assignment.",
         [new("NullCoalescingAssignmentPass.cs", "SameReceiver")] =
             "Pass-local receiver admissibility: null static receiver or PlaceIdentity.SameVariable only.",
-        [new("StructuringPass.cs", "IsInsideFinallyBody")] =
-            "Structuring-specific leave-target guard for finally bodies, not a general ancestor/location helper.",
         [new("UnionSwitchExpressionPass.cs", "SameTailExpression")] =
             "Union switch store-tail folding compares a pass-owned duplicated tail shape; this is not a reusable re-evaluable-place atom and declines on unlisted expression kinds.",
         [new("UnionSwitchExpressionPass.cs", "SameTailExpressions")] =

--- a/src/ILInspector.Decompiler/Pipeline/FidelityRemarks.cs
+++ b/src/ILInspector.Decompiler/Pipeline/FidelityRemarks.cs
@@ -87,7 +87,7 @@ public static class FidelityRemarks
                         node,
                         "residual exception filter boundary (endfilter) with no standalone C# spelling");
                     break;
-                case Continue:
+                case Continue { Origin: ContinueOrigin.Unverified }:
                     yield return Cause(
                         DiagnosticIds.UnverifiedContinue,
                         LocationOf(node),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -919,13 +919,27 @@ public sealed class Break : IrNode
 }
 
 /// <summary>
-/// A C# <c>continue</c>: a loop back-edge raised from a branch or an EH
-/// <see cref="Leave"/> to the loop header. Childless terminator, like
-/// <see cref="Branch"/>.
+/// A C# <c>continue</c>: a loop-continuation transfer raised from a branch or
+/// an EH <see cref="Leave"/>. Childless terminator, like <see cref="Branch"/>.
 /// </summary>
 public sealed class Continue : IrNode
 {
+    public Continue(ContinueOrigin origin = ContinueOrigin.Unverified)
+        => Origin = origin;
+
+    public ContinueOrigin Origin { get; }
+
     public override string Describe() => "Continue";
+}
+
+/// <summary>The structural proof, if any, that licenses a raised <see cref="Continue"/>.</summary>
+public enum ContinueOrigin
+{
+    /// <summary>No proof currently licenses opcode-exact fidelity.</summary>
+    Unverified,
+
+    /// <summary>A protected-region leave bound to the owning for-loop increment.</summary>
+    ProtectedRegionLeaveToForIncrement,
 }
 
 public enum ComparisonKind { Equal, NotEqual, LessThan, LessThanOrEqual, GreaterThan, GreaterThanOrEqual }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForLoopPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForLoopPass.cs
@@ -13,17 +13,10 @@ public sealed class ForLoopPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
-        var liveTargetsByScope = new Dictionary<IrNode, HashSet<int>>();
+        var targetSourcesByScope = new Dictionary<IrNode, Dictionary<int, List<IrNode>>>();
 
         foreach (var loop in function.Descendants.OfType<WhileLoop>().ToList())
         {
-            var scope = EnclosingFunctionScope(loop, function);
-            if (!liveTargetsByScope.TryGetValue(scope, out var liveTargets))
-            {
-                liveTargets = CollectLiveTargets(scope);
-                liveTargetsByScope.Add(scope, liveTargets);
-            }
-
             if (loop.Parent is not Block container)
                 continue;
             int slot = loop.ChildIndex;
@@ -50,14 +43,47 @@ public sealed class ForLoopPass : IIrPass
             if (ContainsCurrentLoopContinue(loop.Body))
                 continue;
 
-            if (increment.SourceOffset >= 0 && liveTargets.Contains(increment.SourceOffset))
-                continue;
+            var scope = EnclosingFunctionScope(loop, function);
+            if (!targetSourcesByScope.TryGetValue(scope, out var targetSources))
+            {
+                targetSources = CollectTargetSources(scope);
+                targetSourcesByScope.Add(scope, targetSources);
+            }
+
+            IReadOnlyList<Leave> protectedContinues = [];
+            if (increment.SourceOffset >= 0
+                && targetSources.TryGetValue(increment.SourceOffset, out var targeters))
+            {
+                var candidates = new List<Leave>(targeters.Count);
+                bool allTargetsConsumed = true;
+                foreach (var targeter in targeters)
+                {
+                    if (targeter is not Leave leave
+                        || !ProtectedRegionControlFlow.CanRaiseLeave(leave, loop)
+                        || !BelongsToLoop(leave, loop))
+                    {
+                        allTargetsConsumed = false;
+                        break;
+                    }
+                    candidates.Add(leave);
+                }
+                if (!allTargetsConsumed)
+                    continue;
+                protectedContinues = candidates;
+            }
 
             increment.Detach();
             var parts = loop.DetachChildren();  // [condition, body]
             initializer.Detach();               // reindexes the loop's slot
             context.Stepper.StepOver("raise while loop to for loop", loop);
             loop.ReplaceWith(new ForLoop(initializer, (IrExpression)parts[0], increment, (Block)parts[1]));
+
+            foreach (var leave in protectedContinues)
+            {
+                var next = new Continue(ContinueOrigin.ProtectedRegionLeaveToForIncrement);
+                next.InheritSourceOffset(leave);
+                leave.ReplaceWith(next);
+            }
         }
     }
 
@@ -71,20 +97,39 @@ public sealed class ForLoopPass : IIrPass
         return function;
     }
 
-    static HashSet<int> CollectLiveTargets(IrNode scope)
+    static Dictionary<int, List<IrNode>> CollectTargetSources(IrNode scope)
     {
-        var targets = new HashSet<int>();
+        var targets = new Dictionary<int, List<IrNode>>();
         foreach (var node in DescendantsOutsideNestedFunctions(scope))
         {
             switch (node)
             {
-                case Branch b: targets.Add(b.TargetOffset); break;
-                case ConditionalBranch cb: targets.Add(cb.TargetOffset); break;
-                case SwitchBranch sb: foreach (int t in sb.TargetOffsets) targets.Add(t); break;
-                case Leave l: targets.Add(l.TargetOffset); break;
+                case Branch branch:
+                    AddTargetSource(targets, branch.TargetOffset, branch);
+                    break;
+                case ConditionalBranch branch:
+                    AddTargetSource(targets, branch.TargetOffset, branch);
+                    break;
+                case SwitchBranch branch:
+                    foreach (int target in branch.TargetOffsets)
+                        AddTargetSource(targets, target, branch);
+                    break;
+                case Leave leave:
+                    AddTargetSource(targets, leave.TargetOffset, leave);
+                    break;
             }
         }
         return targets;
+    }
+
+    static void AddTargetSource(Dictionary<int, List<IrNode>> targets, int offset, IrNode source)
+    {
+        if (!targets.TryGetValue(offset, out var sources))
+        {
+            sources = [];
+            targets.Add(offset, sources);
+        }
+        sources.Add(source);
     }
 
     static IEnumerable<IrNode> DescendantsOutsideNestedFunctions(IrNode node)
@@ -111,6 +156,19 @@ public sealed class ForLoopPass : IIrPass
         {
             if (node is LoadLocal inner && inner.Index == localIndex)
                 return true;
+        }
+        return false;
+    }
+
+    static bool BelongsToLoop(IrNode node, WhileLoop loop)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+        {
+            if (ReferenceEquals(current, loop))
+                return true;
+            if (current is WhileLoop or DoWhileLoop or ForLoop or ForeachStatement
+                or Lambda or LocalFunctionStatement or IrFunction)
+                return false;
         }
         return false;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -742,26 +742,7 @@ public sealed class StructuringPass : IIrPass
         => container.Blocks.Count == 0 || MayFallThroughAfterRetryReplacement(container.Blocks[^1], retryTargetOffset);
 
     static bool CanRaiseRetryLeave(Leave leave)
-        => (HasAncestor<TryFinally>(leave) || HasAncestor<TryCatch>(leave))
-            && !IsInsideFinallyBody(leave);
-
-    static bool HasAncestor<T>(IrNode node) where T : IrNode
-    {
-        for (var current = node.Parent; current is not null; current = current.Parent)
-            if (current is T)
-                return true;
-        return false;
-    }
-
-    static bool IsInsideFinallyBody(Leave leave)
-    {
-        for (var current = leave.Parent; current is not null; current = current.Parent)
-        {
-            if (current.Parent is TryFinally tryFinally && ReferenceEquals(current, tryFinally.FinallyBody))
-                return true;
-        }
-        return false;
-    }
+        => ProtectedRegionControlFlow.CanRaiseLeave(leave);
 
     /// <summary>The <c>true</c> condition of a raised <c>while (true)</c> loop.</summary>
     static Constant TrueLiteral() => new(true, TypeRef.CoreLib("System", "Boolean"));

--- a/src/ILInspector.Decompiler/Pipeline/ProtectedRegionControlFlow.cs
+++ b/src/ILInspector.Decompiler/Pipeline/ProtectedRegionControlFlow.cs
@@ -1,0 +1,44 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>Shared structural proof for raising a protected-region <see cref="Leave"/>.</summary>
+public static class ProtectedRegionControlFlow
+{
+    public static bool CanRaiseLeave(Leave leave)
+        => (HasAncestor<TryFinally>(leave) || HasAncestor<TryCatch>(leave))
+            && !IsInsideFinallyBody(leave);
+
+    public static bool CanRaiseLeave(Leave leave, IrNode exclusiveBoundary)
+        => !IsInsideFinallyBody(leave)
+            && HasProtectedAncestorBelow(leave, exclusiveBoundary);
+
+    static bool HasAncestor<T>(IrNode node) where T : IrNode
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+            if (current is T)
+                return true;
+        return false;
+    }
+
+    static bool IsInsideFinallyBody(Leave leave)
+    {
+        for (var current = leave.Parent; current is not null; current = current.Parent)
+        {
+            if (current.Parent is TryFinally tryFinally && ReferenceEquals(current, tryFinally.FinallyBody))
+                return true;
+        }
+        return false;
+    }
+
+    static bool HasProtectedAncestorBelow(Leave leave, IrNode exclusiveBoundary)
+    {
+        bool foundProtectedRegion = false;
+        for (var current = leave.Parent; current is not null; current = current.Parent)
+        {
+            if (ReferenceEquals(current, exclusiveBoundary))
+                return foundProtectedRegion;
+            if (current is TryFinally or TryCatch)
+                foundProtectedRegion = true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Fixes #2861

- Recovers protected-region `leave` instructions as structured `continue` only
  when their owning `while` loop atomically raises to `for`.
- Preserves #2857's labeled `while` fallback for mixed, nested, unproven, and
  lowered shapes.
- Card revision: `364104e42bc3d720651f941ef722ecbe42165238`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the transform consumes every live increment target
or declines, and the recovered try/catch/finally fixtures recompile to the
original opcode stream.

### Original source

```csharp
public static void Issue2830_ForLoopLeave()
{
    for (int i = 0; i < 10; i++)
    {
        try
        {
            if (i == 5)
                continue;
            Console.WriteLine();
        }
        catch (Exception)
        {
        }
        Console.WriteLine();
    }
}
```

### Before

```csharp
public static void Issue2830_ForLoopLeave()
{
    int i = default;
    i = 0;
    while (i < 10)
    {
        try
        {
            if (i == 5)
            {
                goto IL_0010;
            }
            Console.WriteLine();
        }
        catch (Exception)
        {
        }
        Console.WriteLine();

    IL_0010:
        i++;
    }
}
```

### After

```csharp
public static void Issue2830_ForLoopLeave()
{
    for (int i = 0; i < 10; i++)
    {
        try
        {
            if (i == 5)
            {
                continue;
            }
            Console.WriteLine();
        }
        catch (Exception)
        {
        }
        Console.WriteLine();
    }
}
```

### Fully Raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Release solution passed |
| Focused tests | 19 substrate/pass/compiler-fixture tests passed |
| Compiler configurations | Release and Debug protected-shape fixtures passed |
| Decompiler fast suite | 2,561 tests passed |
| Sugared fidelity gate | All 4 gate tests passed; affected positives are pinned Exact |
| Changed-method fidelity | 4 Exact positives; 1 intentional fallback OpcodeDiff |
| Lowered fidelity | All 5 affected rows remain valid OpcodeDiff fallbacks |

The positive matrix covers try-body and catch-body continues, multiple leaves
to one increment, and intervening `finally` cleanup. Close negatives cover
nested loop ownership, nested-function offset collisions, finally bodies,
outer-only protected regions, ordinary current-loop `continue`, and mixed live
targets. `ContinueOrigin.ProtectedRegionLeaveToForIncrement` clears `DEC0013`
only for the proven atomic transform; all existing continues remain unverified.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — the pinned quick gate passes, and a clean
merge-base/head A/B over the exact same population is neutral with zero
per-method deltas.

### PR quick gate

Run: PR quick corpus, hash-stable 100 methods per assembly; 15 assemblies and
1,500 methods.

| Metric (goal) | Merge base | PR | Delta |
| --- | ---: | ---: | ---: |
| Detected lowering residue (-) | 251 (16.73%) | 251 (16.73%) | 0 |
| Conditional-branch residue (-) | 46 (3.07%) | 46 (3.07%) | 0 |
| Forward-merge stops (-) | 32 (2.13%) | 32 (2.13%) | 0 |
| Pass bugs (-) | 0 | 0 | 0 |

> **Conclusion:** **PASS** — pinned-subset residue and branch rates are
> unchanged, and the clean A/B produced zero changed methods.

### Aggregate context

The committed PR-quick baseline is stale because
`ILInspector.MetadataPrimitives` now contributes 100 rather than 61 sampled
methods. Its hard pinned-subset gate still passes, but aggregate baseline
movement is not attributed to this PR. The clean merge-base/head A/B above uses
the same current assemblies and population on both sides.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- \
  -class "ILInspector.Decompiler.Tests.ProtectedRegionControlFlowTests" \
  -class "ILInspector.Decompiler.Tests.ForLoopPassTests" \
  -class "ILInspector.Decompiler.Tests.ProtectedContinueRecoveryTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- \
  -trait- "Speed=Slow"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- \
  -class "ILInspector.Decompiler.Tests.FidelityGateTests"
npx markdownlint-cli docs/design/decompiler-substrate.md
```
