### PR TITLE
Keep static on explicitly implemented interface properties

### DIFF
--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -907,6 +907,30 @@ public sealed class CSharpDeclarationWriterTests
     }
 
     [Fact]
+    public void ExplicitInterfaceProperty_Static_RetainsStaticModifier()
+    {
+        // #2875: static-abstract interface members implemented explicitly must keep `static`
+        // while still omitting the access modifier.
+        var type = new ApiType { Namespace = "Samples", Name = "Counter", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Samples.ICounter.Count",
+            Kind = "explicit-interface-implementation",
+            IsStatic = true,
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "int",
+                MemberName = "Samples.ICounter.Count",
+                Accessors = [new ApiAccessor { Kind = "get" }]
+            }
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal("static int Samples.ICounter.Count { get; }", declaration);
+    }
+
+    [Fact]
     public void ExplicitInterfaceImplementation_WithUnsafeSignature_RetainsUnsafeModifier()
     {
         var type = new ApiType { Namespace = "Samples", Name = "UnsafeImpl", Kind = "class" };

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -402,9 +402,15 @@ internal static class CSharpDeclarationWriter
             if (member.IsUnsafe || options.ForceUnsafe)
                 modifiers.Add("unsafe");
         }
-        else if (member.IsUnsafe || options.ForceUnsafe)
+        else
         {
-            modifiers.Add("unsafe");
+            // Explicit interface implementations omit the access modifier but must still
+            // carry `static` (C# 11 static-abstract interface members implemented explicitly)
+            // and `unsafe`. Order mirrors the .cctor branch: static then unsafe.
+            if (member.IsStatic)
+                modifiers.Add("static");
+            if (member.IsUnsafe || options.ForceUnsafe)
+                modifiers.Add("unsafe");
         }
 
         if ((options.ForceAsync || member.IsAsync)

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -234,6 +234,42 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackFirstPropertyGetter_KeepsStaticOnExplicitInterfaceProperty()
+    {
+        // #2875: a C# 11 static-abstract interface member implemented explicitly must keep
+        // `static` (while omitting the access modifier). Dropping `static` reconstructs an
+        // instance member and fails the interface contract (CS0106/CS0539).
+        var assemblyPath = CompileFixture("""
+            public sealed class ExplicitStaticFixture : ICounter
+            {
+                static int ICounter.Count => 7;
+            }
+
+            public interface ICounter
+            {
+                static abstract int Count { get; }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "ExplicitStaticFixture",
+                    "ICounter.get_Count",
+                    0)]));
+
+            Assert.Contains("static int ICounter.Count", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("public int ICounter.Count", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("public static int ICounter.Count", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_PreservesRequiredImplicitInterfaceProperty()
     {
         var assemblyPath = CompileFixture("""


### PR DESCRIPTION
## Summary

Follow-up to #2827 / #2858. The explicit-interface-implementation modifier branch in `CSharpDeclarationWriter` omitted the access modifier correctly but never added `static`. A C# 11 static-abstract interface member implemented explicitly (`static int I.Count => ...`) reconstructed as an instance member (`int I.Count { get; }`), failing the interface contract on recompile (CS0106/CS0539).

- Add `static` (then `unsafe`, mirroring the `.cctor` order) to the explicit-impl modifier branch when `member.IsStatic`.

## Reachability

Confirmed reachable through RTS: the getter/setter builders carry the accessor's `MethodAttributes.Static`, and `ToApiMember` maps a dotted explicit property to `Kind == "explicit-interface-implementation"` with `IsStatic` intact, so the seam saw a static member and dropped the modifier.

## Evidence

- Seam unit test `ExplicitInterfaceProperty_Static_RetainsStaticModifier`: `static int Samples.ICounter.Count { get; }`.
- Compiled-fixture RTS canary `CompileBackFirstPropertyGetter_KeepsStaticOnExplicitInterfaceProperty`: reconstructs `static int ICounter.Count` from a real static-abstract explicit implementation. Fails on unfixed `main` (asserted `static` absent), passes with the fix.
- Seam suite 272/0; RTS explicit-interface suite 9/0.
- Newtonsoft `--return-to-sender` unchanged vs base: 544 Exact / 16 OpcodeDiff / 8 RecompileFail / 13 ContextFail (Newtonsoft has no static explicit-impl properties, so the additive change is a no-op there).
- #2776 parity gate exit 0 (4 known burn-down rows, 0 new).

## Risk

Low and contained: the change is additive — it adds `static` only for `Kind == "explicit-interface-implementation"` members with `IsStatic == true`. All non-static explicit implementations (the common case) are unaffected. Requesting the two-model adversarial review per policy given it is a behavior change in the seam.

Closes #2875.