### PR TITLE
Drain rts-parity row: populate reconstructed enum members in RTS closure (#2777)

### DIFF
--- a/src/ILInspector.CSharp/TypeShellProducer.cs
+++ b/src/ILInspector.CSharp/TypeShellProducer.cs
@@ -212,6 +212,9 @@ public static class TypeShellProducer
                 && (typeDef.Attributes & TypeAttributes.Interface) == 0,
             IsSealed = (typeDef.Attributes & TypeAttributes.Sealed) != 0,
             IsStatic = IsStaticType(typeDef),
+            EnumUnderlyingType = spec.Kind == CSharpTypeShellKind.Enum
+                ? EnumUnderlyingType(reader, typeDef)
+                : null,
         };
 
         return new CSharpTypePrintRequest(
@@ -235,4 +238,20 @@ public static class TypeShellProducer
             CSharpTypeShellKind.Delegate => "delegate",
             _ => throw new NotSupportedException($"Unsupported C# type-shell kind '{kind}'."),
         };
+
+    // An enum's underlying type is carried by its special `value__` instance field.
+    // A reconstructed enum that omits a non-int base (e.g. `: long`) defaults to int
+    // and fails to bind members whose constant values do not fit int (CS0266), so the
+    // shell must reproduce it. The declaration writer suppresses the redundant `: int`.
+    static string? EnumUnderlyingType(MetadataReader reader, TypeDefinition typeDef)
+    {
+        foreach (var fieldHandle in typeDef.GetFields())
+        {
+            var field = reader.GetFieldDefinition(fieldHandle);
+            if (reader.GetString(field.Name) == "value__")
+                return MetadataDeclarationQuery.GetField(reader, typeDef, field).ReturnType;
+        }
+
+        return null;
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -4854,6 +4854,49 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
+    [Fact]
+    public void CompileBackTargets_PopulatesEnumMembersWhenTargetReferencesThemByName()
+    {
+        // A target method that returns a nested enum and references several of its
+        // members by name forces the enum to be reconstructed as a closure supporting
+        // type. A member-less `enum { }` shell cannot bind those references (CS0117)
+        // and drops the row to the compile-back floor; the reconstructed enum surface
+        // must carry its named members with their constant values.
+        var assemblyPath = CompileFixture("""
+            public class Host
+            {
+                public enum Kind { Unknown, First, Second }
+
+                public static Kind Classify(int value)
+                {
+                    if (value == 1)
+                        return Kind.First;
+                    if (value == 2)
+                        return Kind.Second;
+                    return Kind.Unknown;
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Host", "Classify", 0)]));
+
+            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.NotNull(result.Source);
+            Assert.Contains("enum Kind", result.Source);
+            Assert.Contains("Unknown = 0", result.Source);
+            Assert.Contains("First = 1", result.Source);
+            Assert.Contains("Second = 2", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
     static string CompileFixture(
         string source,
         string? directory = null,

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -4897,6 +4897,45 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
+    [Fact]
+    public void CompileBackTargets_ReconstructsNonIntEnumUnderlyingTypeForMemberValues()
+    {
+        // A reconstructed enum that names members whose constant values do not fit
+        // `int` (long/ulong/uint, negative, or byte-backed) must reproduce the enum's
+        // underlying type. Otherwise the shell defaults to `int` and the emitted
+        // members fail to bind (CS0266), dropping the row to the compile-back floor.
+        var assemblyPath = CompileFixture("""
+            public class Host
+            {
+                public enum ELong : long { A = 0, B = 2147483648L, C = -1L }
+                public enum EULong : ulong { None = 0, All = 18446744073709551615UL }
+                public enum EUInt : uint { Z = 0, Top = 2147483648 }
+                public enum EByte : byte { Lo = 0, Hi = 255 }
+
+                public static ELong GetL(long v) => v == 0 ? ELong.A : (v == 1 ? ELong.B : ELong.C);
+                public static EULong GetUL(int v) => v == 0 ? EULong.None : EULong.All;
+                public static EUInt GetUI(int v) => v == 0 ? EUInt.Z : EUInt.Top;
+                public static EByte GetB(int v) => v == 0 ? EByte.Lo : EByte.Hi;
+            }
+            """);
+        try
+        {
+            foreach (var method in new[] { "GetL", "GetUL", "GetUI", "GetB" })
+            {
+                var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                    assemblyPath,
+                    [new ReturnToSender.RequestedTarget("Host", method, 0)]));
+
+                Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+                Assert.False(result.UsedCompileBackFloor, $"{method}: {result.Detail}");
+            }
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
     static string CompileFixture(
         string source,
         string? directory = null,

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -3210,7 +3210,39 @@ public static class CompileBackSourceComposer
             bool allowUnsafeSurface = false)
         {
             if (requirement.RequiredKind == CompileBackTypeKind.Enum)
+            {
+                // An enum reconstructed as a closure supporting type must carry its
+                // named members: the target body can reference any of them by name, and
+                // a member-less `enum { }` shell fails to bind those references (CS0117).
+                // Emit each literal member with its constant value so references resolve
+                // and keep their numeric identity. The special `value__` storage field
+                // (not a literal) and any name-mangled fields are not enum members.
+                foreach (var enumFieldHandle in typeDef.GetFields())
+                {
+                    var enumField = reader.GetFieldDefinition(enumFieldHandle);
+                    if (!enumField.Attributes.HasFlag(FieldAttributes.Literal))
+                        continue;
+                    string enumMemberName = reader.GetString(enumField.Name);
+                    if (enumMemberName.Contains('.', StringComparison.Ordinal))
+                        continue;
+                    if (!TryFormatConstantField(reader, enumField, out var enumConstant))
+                        continue;
+                    if (members.Any(member => member.Kind == CompileBackMemberKind.Field
+                            && member.Identity.Method == Identifier(enumMemberName)))
+                        continue;
+                    members.Add(new CompileBackMemberRequirement(
+                        new CompileBackMethodIdentity(requirement.Type.FullName, Identifier(enumMemberName), 0, "enum-member"),
+                        CompileBackMemberKind.Field,
+                        IsStatic: true,
+                        Parameters: [],
+                        ReturnType: CompileBackTypeSignature.Display(requirement.Type.FullName),
+                        TypeParameters: [],
+                        StubBody: CompileBackStubBodyKind.TargetBody,
+                        TargetBody: enumConstant,
+                        [new CompileBackFact("metadata", "enum-member", enumMemberName)]));
+                }
                 return;
+            }
 
             allowUnsafeSurface = allowUnsafeSurface
                 || requirement.RequiredMembers.Count != 0

--- a/tools/DecompilerHarness/corpus/rts-parity-burndown.json
+++ b/tools/DecompilerHarness/corpus/rts-parity-burndown.json
@@ -3,10 +3,6 @@
   "command": "decompiler-harness [corpus] --compile-cap 0 --corpus-fidelity-cap 3 --corpus-fidelity-oracle rts-parity --emit-rts-parity-burndown tools/DecompilerHarness/corpus/rts-parity-burndown.json",
   "rows": [
     {
-      "method": "DotnetInspector.Packages!DotnetInspector.Packages.SymbolPackageDownloader::CheckPdbHeader#0",
-      "status": "RecompileFail"
-    },
-    {
       "method": "ILInspector.Analysis!ILInspector.Analysis.LibraryBodyIndex::HollowUnsafeMethods#0",
       "status": "RecompileFail"
     },


### PR DESCRIPTION
- Part of #2777 (make ReturnToSender a thin orchestrator; drain the rts-parity burn-down)
- Row: `DotnetInspector.Packages!DotnetInspector.Packages.SymbolPackageDownloader::CheckPdbHeader#0`
- Evidence revision: `ad5acd35`

## Fix

> Should we accept this row fix?

**Conclusion:** **PASS** — the RTS closure surface emitted enum supporting types as member-less `enum { }` shells, so a target body that referenced an enum member by name failed to bind (CS0117), stalling closure reconstruction and forcing the compile-back floor. Populating the reconstructed enum with its named members makes the row recompile Exact under ReturnToSender with no floor.

False output (RTS reconstruction, before):

```csharp
public static PdbHeaderKind CheckPdbHeader(string pdbPath)
{
    ...
    return PdbHeaderKind.Unknown; // CS0117: 'PdbHeaderKind' has no 'Unknown'
    ...
}
public enum PdbHeaderKind
{
}
```

Fixed output:

```csharp
public static PdbHeaderKind CheckPdbHeader(string pdbPath)
{
    ...
    return PdbHeaderKind.Unknown; // binds
    ...
}
public enum PdbHeaderKind
{
    Unknown = 0,
    Portable = 1,
    Windows = 2,
}
```

## Root cause and scope

- **Root cause:** `AddClosureMemberSurface` (`tools/DecompilerHarness/ReturnToSenderTypePlanner.cs`) began with `if (requirement.RequiredKind == CompileBackTypeKind.Enum) return;`, so a reconstructed enum never received any members. Enum-kind types render every member via the printer's `RenderEnumMember` path, so a member-less shell binds only when the target never names a member. `CheckPdbHeader` returns `PdbHeaderKind.Unknown`/`.Portable`/`.Windows` by name → CS0117 → closure-stalled → compile-back floor (status `Exact` but `UsedCompileBackFloor=True`).
- **Fix shape:** Replace the early return with a walk over the enum's literal fields, emitting each as a `Field` member requirement whose `TargetBody` is the formatted constant value (via the existing `TryFormatConstantField`). This maps to a `CSharpFieldInitializer`, which the enum printer renders as `Name = value`. The special `value__` storage field (not a literal) and any name-mangled fields are skipped; members are keyed to avoid duplicating any already-present field.
- **Scope boundary:** Harness member-population change plus a follow-up CSharp-layer fix (`src/ILInspector.CSharp/TypeShellProducer.cs` reproduces the enum underlying type, added after adversarial review — see the Review section). Both stay SRM-only and Roslyn-free. Does not address the other three burn-down rows (distinct causes: cross-assembly enum→int typing, type-as-namespace using synthesis, un-reconstructed closure member).

## Witnesses

| Witness | Before | After |
| --- | --- | --- |
| `SymbolPackageDownloader::CheckPdbHeader#0` (real corpus row) | `RecompileFail: CS0117`, floor used | `Exact`, floor not used |
| `Host::Classify` (compiled fixture, returns nested enum, names 3 members) | member-less enum, CS0117 | `enum Kind { Unknown = 0, First = 1, Second = 2 }`, `Exact`, no floor |

## Evidence

| Check | Result |
| --- | --- |
| Full `dotnet-inspect.slnx` build (Release) | Pass, 0 errors |
| Focused test | `ReturnToSenderPrototypeTests.CompileBackTargets_PopulatesEnumMembersWhenTargetReferencesThemByName` passes |
| RTS oracle suites | Prototype 121 / FixtureCatalog 82 / Evidence 3 / GeneratedFilter 25 / MemberBodyFacts 10 — all green |
| Real witness | `CheckPdbHeader` recompiles Exact via RTS without the compile-back floor |

## Corpus validity

> Did this row fix introduce new rts-parity regressions?

**Conclusion:** **PASS** — enforcing gate exit 0, no new regressions; the fixed row is flagged resolved and dropped from the manifest (4 → 3).

Run: 14-assembly prepared corpus (`eng/prepare-decompiler-corpus.sh`), `--corpus-fidelity-oracle rts-parity --corpus-fidelity-cap 3 --compile-cap 0`, enforcing `--rts-parity-burndown`.

| Metric | Before | After |
| --- | ---: | ---: |
| rts-parity burn-down rows | 4 | 3 |
| New Exact→RecompileFail regressions | - | 0 |

Manifest change: removed `DotnetInspector.Packages!DotnetInspector.Packages.SymbolPackageDownloader::CheckPdbHeader#0`.

## Out of scope / sibling rows

- `LibraryBodyIndex::HollowUnsafeMethods` — cross-assembly enum→int typing (CS0266); product raise concern.
- `Base64Encoder::WriteCharsAsync` — using synthesis treats a type as a namespace (CS0138).
- `ParseResult::GetValue#2` — closure member not reconstructed (CS0234).

## Review

| Reviewer | Round 1 (`ad5acd35`) | Re-review (`be11af7b`) |
| --- | --- | --- |
| GPT-5.6 Sol | Found non-int enum CS0266 (verified) | CLEAN (raised a malformed-`value__` concern, then withdrew it — see below) |
| Gemini 3.1 Pro | Found non-int enum CS0266 (verified) | CLEAN |

**Review conclusion:** round 1 finding (both reviewers, same defect) fixed in `be11af7b`; both re-reviews of the fixed head are CLEAN. GPT's re-review malformed-`value__` concern was a false positive (guarded decode degrades to `"object"`, never throws) and was withdrawn. See the reconciliation comments.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "ILInspector.Decompiler.Tests.ReturnToSenderPrototypeTests"
# corpus enforcing gate (14 asm, cap 3): exit 0, 3 rows
```


