### PR TITLE
Add classic state-machine corpus profile (#2818)

### DIFF
--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -126,6 +126,20 @@ jobs:
             --corpus-fidelity-cap 50 \
             --max-examples 3
 
+      - name: Build classic state-machine corpus fixture
+        run: dotnet build src/ILInspector.Decompiler.Fixtures.ClassicStateMachines -c Release
+
+      - name: Run classic state-machine corpus sensor
+        shell: bash
+        run: |
+          mkdir -p artifacts/deep-inspect
+          dotnet run --project tools/DecompilerHarness -c Release -- \
+            artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll \
+            --corpus-profile classic-state-machines \
+            --emit-corpus-snapshot artifacts/deep-inspect/classic-state-machines-snapshot.json \
+            --diff-corpus-baseline tools/DecompilerHarness/corpus/classic-state-machines-baseline.json \
+            --max-examples 10
+
       - name: Run return-address equivalence census
         shell: bash
         run: |

--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -33,6 +33,7 @@
     <Project Path="src/ILInspector.Findings/ILInspector.Findings.csproj" />
     <Project Path="src/ILInspector.Decompiler.Fixtures.CheckedArithmetic/ILInspector.Decompiler.Fixtures.CheckedArithmetic.csproj" />
     <Project Path="src/ILInspector.Decompiler.Fixtures.ClassicAsync/ILInspector.Decompiler.Fixtures.ClassicAsync.csproj" />
+    <Project Path="src/ILInspector.Decompiler.Fixtures.ClassicStateMachines/ILInspector.Decompiler.Fixtures.ClassicStateMachines.csproj" />
     <Project Path="src/ILInspector.Decompiler.Fixtures.Ladder/ILInspector.Decompiler.Fixtures.Ladder.csproj" />
     <Project Path="src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/ILInspector.Decompiler.Fixtures.LegacyUnsafe.csproj" />
     <Project Path="src/ILInspector.Decompiler.Fixtures.NewUnsafe/ILInspector.Decompiler.Fixtures.NewUnsafe.csproj" />

--- a/src/ILInspector.Decompiler.Fixtures.ClassicStateMachines/ClassicStateMachineFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.ClassicStateMachines/ClassicStateMachineFixtures.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ILInspector.Decompiler.Fixtures.ClassicStateMachines;
+
+/// <summary>
+/// Classic-lowering state-machine fixtures for issue #2818 (child of the #2814
+/// decompiler-quality direction, successor to #622's broader-coverage
+/// recommendations). Compiled with <c>runtime-async=off</c> (see the .csproj),
+/// so every await here lowers to a classic <c>AsyncTaskMethodBuilder</c> state
+/// machine rather than the runtime-async <c>AsyncHelpers.Await</c> form the rest
+/// of the repo's corpora use. Iterators and async iterators always lower to a
+/// compiler-generated <c>MoveNext</c> state machine regardless of the
+/// runtime-async switch, so they are measured here too — together with classic
+/// async, this is the full "classic era" state-machine set the real-world and
+/// opt-in-net11 corpora do not exercise.
+///
+/// Method-name prefixes are the feature-coverage contract read by
+/// <c>CorpusSensor.RecordClassicStateMachineFeatureCoverage</c>: <c>Async_</c>
+/// (classic async kickoff + its compiler-generated <c>MoveNext</c>),
+/// <c>Iterator_</c> (classic <c>yield</c> iterator), <c>AsyncIterator_</c>
+/// (classic async iterator — <c>IAsyncEnumerable&lt;T&gt;</c> combining both
+/// state-machine shapes), and <c>Switch_</c> (a plain, non-pattern switch
+/// statement — the old jump-table lowering, TFM/LangVersion-agnostic like the
+/// rest of this fixture, so it is measured here rather than requiring a
+/// downlevel TFM/LangVersion axis).
+/// </summary>
+public static class ClassicStateMachineFixtures
+{
+    public static async Task<int> Async_AwaitValue(Task<int> a, int b) => await a + b;
+
+    public static async Task Async_TwoSequentialAwaits(Task<int> a, Task<int> b)
+    {
+        int x = await a;
+        int y = await b;
+        GC.KeepAlive((x, y));
+    }
+
+    public static async Task<int> Async_AwaitInTryFinally(Task<int> a)
+    {
+        try
+        {
+            return await a;
+        }
+        finally
+        {
+            GC.KeepAlive(a);
+        }
+    }
+
+    public static async Task<int> Async_AwaitInLoop(Task<int>[] tasks)
+    {
+        int sum = 0;
+        foreach (var task in tasks)
+        {
+            sum += await task;
+        }
+        return sum;
+    }
+
+    public static IEnumerable<int> Iterator_YieldSequence(int count)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            yield return i;
+        }
+    }
+
+    public static IEnumerable<int> Iterator_YieldBreakEarly(int limit)
+    {
+        int i = 0;
+        while (true)
+        {
+            if (i >= limit)
+            {
+                yield break;
+            }
+            yield return i;
+            i++;
+        }
+    }
+
+    public static IEnumerable<int> Iterator_YieldInTryFinally(IEnumerable<int> source)
+    {
+        try
+        {
+            foreach (var item in source)
+            {
+                yield return item;
+            }
+        }
+        finally
+        {
+            GC.KeepAlive(source);
+        }
+    }
+
+    public static async IAsyncEnumerable<int> AsyncIterator_AwaitThenYield(Task<int>[] tasks)
+    {
+        foreach (var task in tasks)
+        {
+            int value = await task;
+            yield return value;
+        }
+    }
+
+    public static async IAsyncEnumerable<int> AsyncIterator_YieldBreakEarly(Task<int>[] tasks, int limit)
+    {
+        int i = 0;
+        foreach (var task in tasks)
+        {
+            if (i >= limit)
+            {
+                yield break;
+            }
+            yield return await task;
+            i++;
+        }
+    }
+
+    // Plain (non-pattern) integer switch: the old jump-table lowering, exercised
+    // alongside the classic async/iterator state-machine's own internal state
+    // dispatch (also a switch, over the compiler-generated `<>1__state` field).
+    // This lowering is TFM/LangVersion-agnostic, so it belongs in this lane
+    // rather than a separate downlevel-TFM axis.
+    public static string Switch_ClassifyState(int state)
+    {
+        switch (state)
+        {
+            case -1:
+                return "not-started";
+            case 0:
+                return "running";
+            case 1:
+                return "suspended";
+            case 2:
+                return "finished";
+            default:
+                return "unknown";
+        }
+    }
+
+    public static async Task<string> Switch_InsideAsync(Task<int> a)
+    {
+        int value = await a;
+        switch (value)
+        {
+            case 0:
+                return "zero";
+            case 1:
+                return "one";
+            default:
+                return "many";
+        }
+    }
+}

--- a/src/ILInspector.Decompiler.Fixtures.ClassicStateMachines/ClassicStateMachineFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.ClassicStateMachines/ClassicStateMachineFixtures.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace ILInspector.Decompiler.Fixtures.ClassicStateMachines;
@@ -22,11 +25,10 @@ namespace ILInspector.Decompiler.Fixtures.ClassicStateMachines;
 /// <c>Iterator_</c> (classic <c>yield</c> iterator), <c>AsyncIterator_</c>
 /// (classic async iterator — <c>IAsyncEnumerable&lt;T&gt;</c> combining both
 /// state-machine shapes), and <c>Switch_</c> (a plain, non-pattern switch
-/// statement — the old jump-table lowering, TFM/LangVersion-agnostic like the
-/// rest of this fixture, so it is measured here rather than requiring a
-/// downlevel TFM/LangVersion axis).
+/// statement used as a control). This is a representative current-compiler
+/// matrix, not an exhaustive cross-compiler or downlevel-TFM corpus.
 /// </summary>
-public static class ClassicStateMachineFixtures
+public class ClassicStateMachineFixtures
 {
     public static async Task<int> Async_AwaitValue(Task<int> a, int b) => await a + b;
 
@@ -57,6 +59,37 @@ public static class ClassicStateMachineFixtures
             sum += await task;
         }
         return sum;
+    }
+
+    public static async void Async_VoidBuilder(Action completed)
+    {
+        await Task.Yield();
+        completed();
+    }
+
+    public static async ValueTask<int> Async_ValueTaskBuilder(ValueTask<int> value)
+        => await value;
+
+    public async Task<T> Async_InstanceGeneric<T>(Task<T> value)
+    {
+        await Task.Yield();
+        return await value;
+    }
+
+    public static async Task<int> Async_AwaitInCatchAndFinally(Task<int> value)
+    {
+        try
+        {
+            throw new InvalidOperationException();
+        }
+        catch (InvalidOperationException)
+        {
+            return await value;
+        }
+        finally
+        {
+            await Task.Yield();
+        }
     }
 
     public static IEnumerable<int> Iterator_YieldSequence(int count)
@@ -96,6 +129,24 @@ public static class ClassicStateMachineFixtures
         }
     }
 
+    public static IEnumerable Iterator_NonGeneric()
+    {
+        yield return "classic";
+        yield return 42;
+    }
+
+    public static IEnumerable<T> Iterator_Generic<T>(T first, T second)
+    {
+        yield return first;
+        yield return second;
+    }
+
+    public IEnumerable<int> Iterator_Instance(int value)
+    {
+        yield return value;
+        yield return value + 1;
+    }
+
     public static async IAsyncEnumerable<int> AsyncIterator_AwaitThenYield(Task<int>[] tasks)
     {
         foreach (var task in tasks)
@@ -116,6 +167,33 @@ public static class ClassicStateMachineFixtures
             }
             yield return await task;
             i++;
+        }
+    }
+
+    public static async IAsyncEnumerable<int> AsyncIterator_WithCancellation(
+        int count,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Yield();
+            yield return i;
+        }
+    }
+
+    public static async IAsyncEnumerable<int> AsyncIterator_TryFinallyAndDisposal(
+        IAsyncEnumerable<int> source)
+    {
+        await using var resource = new AsyncResource();
+        try
+        {
+            await foreach (int item in source)
+                yield return item;
+        }
+        finally
+        {
+            await resource.TouchAsync();
         }
     }
 
@@ -153,5 +231,12 @@ public static class ClassicStateMachineFixtures
             default:
                 return "many";
         }
+    }
+
+    sealed class AsyncResource : IAsyncDisposable
+    {
+        public ValueTask TouchAsync() => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }

--- a/src/ILInspector.Decompiler.Fixtures.ClassicStateMachines/ILInspector.Decompiler.Fixtures.ClassicStateMachines.csproj
+++ b/src/ILInspector.Decompiler.Fixtures.ClassicStateMachines/ILInspector.Decompiler.Fixtures.ClassicStateMachines.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Issue #2818 (classic async/iterator state-machine corpus lane, child of #2814).
+    Extends the classic-async axis (RuntimeAsync=off, see
+    ILInspector.Decompiler.Fixtures.ClassicAsync) to also pin classic iterators and
+    classic async iterators in the same lowering mode. No CI corpus contained a
+    single classic async state machine before #2818; iterators and async iterators
+    were entirely absent. A plain switch statement is included so the old
+    jump-table switch lowering — cascading alongside classic async/iterator state
+    dispatch — is measured in the same pinned lane (the harness README's
+    "downlevel TFM/LangVersion" candidate axis; this reaches the same classic
+    lowering set without a downlevel runtime pack by reusing the proven
+    RuntimeAsync=off axis).
+
+    Built by the normal solution graph and addressable through FixtureCatalog.
+    Point the harness at the built DLL with the classic-state-machines corpus
+    profile (see tools/DecompilerHarness/README.md).
+  -->
+  <PropertyGroup>
+    <TargetFramework>net11.0</TargetFramework>
+    <RuntimeAsync>off</RuntimeAsync>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Decompiler.Fixtures.ClassicStateMachines/ILInspector.Decompiler.Fixtures.ClassicStateMachines.csproj
+++ b/src/ILInspector.Decompiler.Fixtures.ClassicStateMachines/ILInspector.Decompiler.Fixtures.ClassicStateMachines.csproj
@@ -3,15 +3,12 @@
   <!--
     Issue #2818 (classic async/iterator state-machine corpus lane, child of #2814).
     Extends the classic-async axis (RuntimeAsync=off, see
-    ILInspector.Decompiler.Fixtures.ClassicAsync) to also pin classic iterators and
-    classic async iterators in the same lowering mode. No CI corpus contained a
-    single classic async state machine before #2818; iterators and async iterators
-    were entirely absent. A plain switch statement is included so the old
-    jump-table switch lowering — cascading alongside classic async/iterator state
-    dispatch — is measured in the same pinned lane (the harness README's
-    "downlevel TFM/LangVersion" candidate axis; this reaches the same classic
-    lowering set without a downlevel runtime pack by reusing the proven
-    RuntimeAsync=off axis).
+    ILInspector.Decompiler.Fixtures.ClassicAsync) to pin a representative matrix
+    of classic async builders, iterators, and async iterators in the same lowering
+    mode. No CI corpus contained a single classic async state machine before
+    #2818; iterators and async iterators were entirely absent. A plain switch
+    statement is included as a control. This current-compiler lane does not claim
+    exhaustive compiler-version or downlevel-TFM coverage.
 
     Built by the normal solution graph and addressable through FixtureCatalog.
     Point the harness at the built DLL with the classic-state-machines corpus

--- a/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
@@ -412,6 +412,52 @@ public class CorpusSensorComparisonTests
     }
 
     [Fact]
+    public void ClassicStateMachineCoverage_CountsKickoffResultsByFamily()
+    {
+        var coverage = CorpusSensor.BuildClassicStateMachineCoverage(
+        [
+            ClassicKickoff("Async_Value", fullyRaised: true),
+            ClassicKickoff("Iterator_Sequence", fullyRaised: false),
+            ClassicKickoff("AsyncIterator_Sequence", fullyRaised: false),
+            ClassicKickoff("MoveNext", fullyRaised: true, type: "T.<Async_Value>d__1"),
+            ClassicKickoff("Switch_Control", fullyRaised: true),
+        ]);
+
+        Assert.Equal(new ClassicStateMachineFeatureMetrics(1, 1, 0), coverage["classic-async"]);
+        Assert.Equal(new ClassicStateMachineFeatureMetrics(1, 0, 1), coverage["classic-iterator"]);
+        Assert.Equal(new ClassicStateMachineFeatureMetrics(1, 0, 1), coverage["classic-async-iterator"]);
+        Assert.Equal(3, coverage.Count);
+    }
+
+    [Fact]
+    public void Compare_RejectsClassicStateMachineRaisedRegression()
+    {
+        var baselineCoverage = CompleteClassicStateMachineCoverage()
+            .SetItem("classic-async", new ClassicStateMachineFeatureMetrics(4, 4, 0));
+        var currentCoverage = CompleteClassicStateMachineCoverage()
+            .SetItem("classic-async", new ClassicStateMachineFeatureMetrics(4, 3, 1));
+        var baseline = Snapshot(
+            4, 4, 10_000, null,
+            profile: CorpusProfile.ClassicStateMachines,
+            featureCoverage: CompleteClassicFeatureCoverage(),
+            classicStateMachineCoverage: baselineCoverage);
+        var current = Snapshot(
+            4, 3, 7_500, null,
+            profile: CorpusProfile.ClassicStateMachines,
+            featureCoverage: CompleteClassicFeatureCoverage(),
+            classicStateMachineCoverage: currentCoverage);
+
+        var regressions = CorpusSensor.Compare(baseline, current, []);
+
+        Assert.Contains(
+            "classic state-machine fully raised 'classic-async' dropped (baseline 4, current 3)",
+            regressions);
+        Assert.Contains(
+            "classic state-machine residual 'classic-async' increased (baseline 0, current 1)",
+            regressions);
+    }
+
+    [Fact]
     public void CompilerFeatureOptions_ReplaysMemorySafetyModeFromModuleMetadata()
     {
         string updatedAssembly =
@@ -1114,7 +1160,8 @@ public class CorpusSensorComparisonTests
         CorpusFidelityOracle fidelityOracle = CorpusFidelityOracle.CompileBack,
         ReturnToSenderParityMetrics? returnToSenderParity = null,
         CorpusProfile profile = CorpusProfile.RealWorld,
-        IReadOnlyDictionary<string, int>? featureCoverage = null)
+        IReadOnlyDictionary<string, int>? featureCoverage = null,
+        IReadOnlyDictionary<string, ClassicStateMachineFeatureMetrics>? classicStateMachineCoverage = null)
     {
         return new CorpusSensorSnapshot(
             SchemaVersion: 1,
@@ -1150,8 +1197,26 @@ public class CorpusSensorComparisonTests
                     ReturnToSenderParity: returnToSenderParity)),
             FidelityOracle: fidelityOracle,
             Profile: profile,
-            FeatureCoverage: featureCoverage);
+            FeatureCoverage: featureCoverage,
+            ClassicStateMachineCoverage: classicStateMachineCoverage);
     }
+
+    static ImmutableDictionary<string, int> CompleteClassicFeatureCoverage()
+        => new Dictionary<string, int>(StringComparer.Ordinal)
+        {
+            ["classic-async-methods"] = 1,
+            ["classic-iterator-methods"] = 1,
+            ["classic-async-iterator-methods"] = 1,
+            ["switch-methods"] = 1,
+        }.ToImmutableDictionary(StringComparer.Ordinal);
+
+    static ImmutableDictionary<string, ClassicStateMachineFeatureMetrics> CompleteClassicStateMachineCoverage()
+        => new Dictionary<string, ClassicStateMachineFeatureMetrics>(StringComparer.Ordinal)
+        {
+            ["classic-async"] = new(1, 1, 0),
+            ["classic-iterator"] = new(1, 1, 0),
+            ["classic-async-iterator"] = new(1, 1, 0),
+        }.ToImmutableDictionary(StringComparer.Ordinal);
 
     static ImmutableDictionary<string, int> CompleteFeatureCoverage()
         => new Dictionary<string, int>(StringComparer.Ordinal)
@@ -1249,6 +1314,24 @@ public class CorpusSensorComparisonTests
             Validity: validity,
             FidelityCheck: fidelityCheck,
             FidelityReference: fidelityReference);
+
+    static CorpusMethodSnapshot ClassicKickoff(
+        string method,
+        bool fullyRaised,
+        string type = "ClassicStateMachineFixtures")
+        => new(
+            Assembly: "Fixture",
+            AssemblyPath: "fixture.dll",
+            Type: type,
+            Method: method,
+            Overload: 0,
+            Signature: "()",
+            Fidelity: fullyRaised ? "Full" : "Partial",
+            FullyRaised: fullyRaised,
+            Residual: fullyRaised ? null : "fidelity: unsupported-node",
+            PassBug: null,
+            Validity: "not-sampled",
+            FidelityCheck: "not-sampled");
 
     static CorpusMethodSnapshot ResidualMethod(
         string method,

--- a/tests/DotnetInspector.Fixtures/FixtureCatalog.cs
+++ b/tests/DotnetInspector.Fixtures/FixtureCatalog.cs
@@ -72,6 +72,7 @@ public static class FixtureIds
 
     public const string DecompilerCheckedArithmetic = "decompiler.checked-arithmetic";
     public const string DecompilerClassicAsync = "decompiler.classic-async";
+    public const string DecompilerClassicStateMachines = "decompiler.classic-state-machines";
     public const string DecompilerLadderIterator = "decompiler.ladder.iterator";
     public const string DecompilerLadderRung1 = "decompiler.ladder.rung1";
     public const string DecompilerLadderRung2 = "decompiler.ladder.rung2";
@@ -241,6 +242,13 @@ public static class FixtureCatalog
         Boundaries(FixtureBoundary.CompilerLowering),
         "decompiler", "async", "classic-async", "compiler-axis", "rts-candidate");
 
+    public static readonly FixtureDefinition DecompilerClassicStateMachines = Fixture(
+        FixtureIds.DecompilerClassicStateMachines,
+        "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+        "ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+        Boundaries(FixtureBoundary.CompilerLowering),
+        "decompiler", "async", "iterator", "classic-state-machines", "compiler-axis");
+
     public static readonly FixtureDefinition DecompilerLadderIterator = Fixture(
         FixtureIds.DecompilerLadderIterator,
         "ILInspector.Decompiler.Fixtures.Ladder",
@@ -350,6 +358,7 @@ public static class FixtureCatalog
         AnalysisSpoofSystemRuntime,
         DecompilerCheckedArithmetic,
         DecompilerClassicAsync,
+        DecompilerClassicStateMachines,
         DecompilerLadderIterator,
         DecompilerLadderRung1,
         DecompilerLadderRung2,
@@ -395,6 +404,7 @@ public static class FixtureCatalog
         [
             DecompilerCheckedArithmetic,
             DecompilerClassicAsync,
+            DecompilerClassicStateMachines,
             DecompilerLadderIterator,
             DecompilerLadderRung1,
             DecompilerLadderRung2,

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -157,7 +157,12 @@ internal static class CorpusSensor
         }
 
         if (diffBaseline is null)
-            return current.Metrics.PassBugs > 0 || FeatureCoverageFailures(current).Length > 0 || rtsParityRegressed ? 1 : 0;
+            return current.Metrics.PassBugs > 0
+                || FeatureCoverageFailures(current).Length > 0
+                || ClassicStateMachineCoverageFailures(current, current).Length > 0
+                || rtsParityRegressed
+                ? 1
+                : 0;
 
         var baseline = JsonSerializer.Deserialize<CorpusSensorSnapshot>(
             ReadBaselineText(diffBaseline, diffBaselineRef),
@@ -327,7 +332,8 @@ internal static class CorpusSensor
             Metrics: metrics,
             FidelityOracle: fidelityOracle,
             Profile: profile,
-            FeatureCoverage: completeness.FeatureCoverage);
+            FeatureCoverage: completeness.FeatureCoverage,
+            ClassicStateMachineCoverage: completeness.ClassicStateMachineCoverage);
 
         return (snapshot, fidelityReports);
     }
@@ -489,7 +495,48 @@ internal static class CorpusSensor
             residualBuckets.OrderBy(kvp => kvp.Key, StringComparer.Ordinal).ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.Ordinal),
             methodReports.OrderBy(m => MethodKey(m), StringComparer.Ordinal).ToImmutableArray(),
             featureCoverage.OrderBy(pair => pair.Key, StringComparer.Ordinal)
-                .ToImmutableSortedDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal));
+                .ToImmutableSortedDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal),
+            profile == CorpusProfile.ClassicStateMachines
+                ? BuildClassicStateMachineCoverage(methodReports)
+                : null);
+    }
+
+    internal static ImmutableSortedDictionary<string, ClassicStateMachineFeatureMetrics>
+        BuildClassicStateMachineCoverage(IEnumerable<CorpusMethodSnapshot> methods)
+    {
+        var coverage = new Dictionary<string, ClassicStateMachineFeatureMetrics>(StringComparer.Ordinal);
+        foreach (var method in methods)
+        {
+            // Count source kickoffs, not every generated interface/support member.
+            // The kickoff's post-pass fidelity is the product-visible result of
+            // reconstructing its sibling MoveNext through the import seam.
+            if (method.Type.Contains('<', StringComparison.Ordinal))
+                continue;
+
+            string? feature = method.Method switch
+            {
+                var name when name.StartsWith("AsyncIterator_", StringComparison.Ordinal)
+                    => "classic-async-iterator",
+                var name when name.StartsWith("Iterator_", StringComparison.Ordinal)
+                    => "classic-iterator",
+                var name when name.StartsWith("Async_", StringComparison.Ordinal)
+                    => "classic-async",
+                _ => null,
+            };
+            if (feature is null)
+                continue;
+
+            coverage.TryGetValue(feature, out var current);
+            current ??= new ClassicStateMachineFeatureMetrics();
+            coverage[feature] = current with
+            {
+                Population = current.Population + 1,
+                FullyRaised = current.FullyRaised + (method.FullyRaised ? 1 : 0),
+                Residual = current.Residual + (method.FullyRaised ? 0 : 1),
+            };
+        }
+
+        return coverage.ToImmutableSortedDictionary(StringComparer.Ordinal);
     }
 
     static void RecordUnionCoverage(
@@ -1291,6 +1338,7 @@ internal static class CorpusSensor
                 + $"current {CorpusProfileName(current.Profile)})");
         }
         failures.AddRange(FeatureCoverageFailures(current));
+        failures.AddRange(ClassicStateMachineCoverageFailures(baseline, current));
         if (baseline.FeatureCoverage is not null && current.FeatureCoverage is not null)
         {
             foreach (var (feature, baselineCount) in baseline.FeatureCoverage)
@@ -1427,6 +1475,49 @@ internal static class CorpusSensor
 
         AddCountRegression(failures, "pass bugs", baseline.Metrics.PassBugs, current.Metrics.PassBugs, tolerance.PassBugIncrease);
 
+        return failures.ToImmutable();
+    }
+
+    internal static ImmutableArray<string> ClassicStateMachineCoverageFailures(
+        CorpusSensorSnapshot baseline,
+        CorpusSensorSnapshot current)
+    {
+        if (current.Profile != CorpusProfile.ClassicStateMachines)
+            return [];
+
+        var failures = ImmutableArray.CreateBuilder<string>();
+        foreach (string feature in new[] { "classic-async", "classic-iterator", "classic-async-iterator" })
+        {
+            var currentMetrics = current.ClassicStateMachineCoverage?.GetValueOrDefault(feature);
+            if (currentMetrics is null || currentMetrics.Population == 0)
+            {
+                failures.Add($"classic state-machine evidence '{feature}' has no kickoff specimens");
+                continue;
+            }
+
+            var baselineMetrics = baseline.ClassicStateMachineCoverage?.GetValueOrDefault(feature);
+            if (baselineMetrics is null)
+                continue;
+            if (currentMetrics.Population < baselineMetrics.Population)
+            {
+                failures.Add(
+                    $"classic state-machine population '{feature}' dropped "
+                    + $"(baseline {baselineMetrics.Population}, current {currentMetrics.Population})");
+            }
+            if (currentMetrics.FullyRaised < baselineMetrics.FullyRaised)
+            {
+                failures.Add(
+                    $"classic state-machine fully raised '{feature}' dropped "
+                    + $"(baseline {baselineMetrics.FullyRaised}, current {currentMetrics.FullyRaised})");
+            }
+            if (currentMetrics.Population == baselineMetrics.Population
+                && currentMetrics.Residual > baselineMetrics.Residual)
+            {
+                failures.Add(
+                    $"classic state-machine residual '{feature}' increased "
+                    + $"(baseline {baselineMetrics.Residual}, current {currentMetrics.Residual})");
+            }
+        }
         return failures.ToImmutable();
     }
 
@@ -1897,13 +1988,25 @@ internal static class CorpusSensor
 
     static void PrintFeatureCoverage(CorpusSensorSnapshot snapshot)
     {
-        if (snapshot.FeatureCoverage is not { Count: > 0 } coverage)
-            return;
+        if (snapshot.FeatureCoverage is { Count: > 0 } coverage)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Feature evidence:");
+            foreach (var (feature, count) in coverage.OrderBy(pair => pair.Key, StringComparer.Ordinal))
+                Console.WriteLine($"- `{feature}`: {count}");
+        }
 
-        Console.WriteLine();
-        Console.WriteLine("Feature evidence:");
-        foreach (var (feature, count) in coverage.OrderBy(pair => pair.Key, StringComparer.Ordinal))
-            Console.WriteLine($"- `{feature}`: {count}");
+        if (snapshot.ClassicStateMachineCoverage is { Count: > 0 } stateMachines)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Classic state-machine kickoff evidence:");
+            foreach (var (feature, metrics) in stateMachines.OrderBy(pair => pair.Key, StringComparer.Ordinal))
+            {
+                Console.WriteLine(
+                    $"- `{feature}`: population {metrics.Population}, "
+                    + $"fully raised {metrics.FullyRaised}, residual {metrics.Residual}");
+            }
+        }
     }
 
     internal static string QualityCardHeadingForProfile(CorpusProfile profile)
@@ -2498,7 +2601,13 @@ internal sealed record CorpusSensorSnapshot(
     CorpusFidelityOracle FidelityOracle = CorpusFidelityOracle.CompileBack,
     [property: JsonConverter(typeof(JsonStringEnumConverter<CorpusProfile>))]
     CorpusProfile Profile = CorpusProfile.RealWorld,
-    IReadOnlyDictionary<string, int>? FeatureCoverage = null);
+    IReadOnlyDictionary<string, int>? FeatureCoverage = null,
+    IReadOnlyDictionary<string, ClassicStateMachineFeatureMetrics>? ClassicStateMachineCoverage = null);
+
+internal sealed record ClassicStateMachineFeatureMetrics(
+    int Population = 0,
+    int FullyRaised = 0,
+    int Residual = 0);
 
 internal sealed record CorpusAssemblySnapshot(string Assembly, string Path, int TotalMethods);
 
@@ -2521,7 +2630,8 @@ internal sealed record CompletenessSensorMetrics(
     int PassBugs,
     IReadOnlyDictionary<string, int> ResidualBuckets,
     IReadOnlyList<CorpusMethodSnapshot> Methods,
-    IReadOnlyDictionary<string, int> FeatureCoverage);
+    IReadOnlyDictionary<string, int> FeatureCoverage,
+    IReadOnlyDictionary<string, ClassicStateMachineFeatureMetrics>? ClassicStateMachineCoverage);
 
 internal sealed record ValiditySensorMetrics(
     int FullMalformedMethods,

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -29,6 +29,9 @@ internal enum CorpusProfile
 
     [JsonStringEnumMemberName("opt-in-net11")]
     OptInNet11,
+
+    [JsonStringEnumMemberName("classic-state-machines")]
+    ClassicStateMachines,
 }
 
 internal static class CorpusSensor
@@ -56,6 +59,15 @@ internal static class CorpusSensor
             ["union-switch-methods"] = 1,
             ["union-types"] = 1,
             ["updated-memory-safety-methods"] = 1,
+        }.ToImmutableSortedDictionary(StringComparer.Ordinal);
+
+    static readonly ImmutableSortedDictionary<string, int> RequiredClassicStateMachinesFeatures =
+        new Dictionary<string, int>(StringComparer.Ordinal)
+        {
+            ["classic-async-methods"] = 1,
+            ["classic-iterator-methods"] = 1,
+            ["classic-async-iterator-methods"] = 1,
+            ["switch-methods"] = 1,
         }.ToImmutableSortedDictionary(StringComparer.Ordinal);
 
     public static int Run(
@@ -327,6 +339,8 @@ internal static class CorpusSensor
                 => "#1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies.",
             CorpusProfile.OptInNet11
                 => "#2766 net11 opt-in compiler-feature corpus: pinned runtime-async, union, and memory-safety fixtures.",
+            CorpusProfile.ClassicStateMachines
+                => "#2818 classic async/iterator state-machine corpus: pinned classic async, iterator, async-iterator, and switch fixtures, raised with the cross-method import seam wired.",
             _ => throw new ArgumentOutOfRangeException(nameof(profile)),
         };
 
@@ -387,6 +401,16 @@ internal static class CorpusSensor
                             source.AssemblyName,
                             StageDump.PassesThatChanged(stages),
                             featureCoverage);
+                    }
+                    else if (profile == CorpusProfile.ClassicStateMachines)
+                    {
+                        // Wires the cross-method import seam (same helper the
+                        // product and --dump/--library-report paths use) so
+                        // cross-method passes like ClassicAsyncReconstructionPass
+                        // can pull in the sibling MoveNext body, exactly as they
+                        // do outside the corpus sensor (#2818).
+                        IrPasses.Run(function, IrPasses.Default, PassContext.ForImport(method => IrImporter.Import(source, method)));
+                        RecordClassicStateMachineFeatureCoverage(typeName, methodName, featureCoverage);
                     }
                     else
                     {
@@ -561,6 +585,33 @@ internal static class CorpusSensor
             StringComparer.Ordinal);
         RecordMethodFeatureCoverage(function, "", [], coverage);
         return coverage;
+    }
+
+    /// <summary>
+    /// Tags classic-state-machine fixture methods by the name-prefix contract
+    /// documented on <c>ClassicStateMachineFixtures</c> (#2818): a top-level
+    /// kickoff method and its compiler-generated state machine type both embed
+    /// the original method name, so either <paramref name="typeName"/> (e.g.
+    /// <c>&lt;Async_AwaitValue&gt;d__2</c>) or <paramref name="methodName"/>
+    /// carries the prefix. Check the more specific "AsyncIterator_"/"Iterator_"
+    /// prefixes before the plain "Async_" prefix, since "AsyncIterator_"
+    /// textually contains "Iterator_".
+    /// </summary>
+    static void RecordClassicStateMachineFeatureCoverage(
+        string typeName,
+        string methodName,
+        ConcurrentDictionary<string, int> featureCoverage)
+    {
+        string haystack = typeName + "::" + methodName;
+        if (haystack.Contains("AsyncIterator_", StringComparison.Ordinal))
+            AddFeature(featureCoverage, "classic-async-iterator-methods");
+        else if (haystack.Contains("Iterator_", StringComparison.Ordinal))
+            AddFeature(featureCoverage, "classic-iterator-methods");
+        else if (haystack.Contains("Async_", StringComparison.Ordinal))
+            AddFeature(featureCoverage, "classic-async-methods");
+
+        if (haystack.Contains("Switch_", StringComparison.Ordinal))
+            AddFeature(featureCoverage, "switch-methods");
     }
 
     static void AddFeature(
@@ -1381,11 +1432,17 @@ internal static class CorpusSensor
 
     internal static ImmutableArray<string> FeatureCoverageFailures(CorpusSensorSnapshot snapshot)
     {
-        if (snapshot.Profile != CorpusProfile.OptInNet11)
+        var required = snapshot.Profile switch
+        {
+            CorpusProfile.OptInNet11 => RequiredOptInNet11Features,
+            CorpusProfile.ClassicStateMachines => RequiredClassicStateMachinesFeatures,
+            _ => (ImmutableSortedDictionary<string, int>?)null,
+        };
+        if (required is null)
             return [];
 
         var failures = ImmutableArray.CreateBuilder<string>();
-        foreach (var (feature, minimum) in RequiredOptInNet11Features)
+        foreach (var (feature, minimum) in required)
         {
             int actual = snapshot.FeatureCoverage?.GetValueOrDefault(feature) ?? 0;
             if (actual < minimum)

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -1594,8 +1594,9 @@ static class Program
         {
             "real-world" => CorpusProfile.RealWorld,
             "opt-in-net11" => CorpusProfile.OptInNet11,
+            "classic-state-machines" => CorpusProfile.ClassicStateMachines,
             _ => throw new ArgumentException(
-                $"Unknown corpus profile '{value}'. Expected real-world or opt-in-net11."),
+                $"Unknown corpus profile '{value}'. Expected real-world, opt-in-net11, or classic-state-machines."),
         };
 
     static void PrintUsage() => Console.WriteLine("""
@@ -1885,9 +1886,10 @@ static class Program
                                 rts). RTS evaluates the same compile-back-selected
                                 target population without applying the compile-back floor.
           --corpus-profile <name>        label corpus snapshots and cards as
-                                real-world (default) or opt-in-net11. Profiles
-                                keep curated feature metrics distinct from
-                                real-world quality rates.
+                                real-world (default), opt-in-net11, or
+                                classic-state-machines. Profiles keep curated
+                                feature metrics distinct from real-world quality
+                                rates.
           --corpus-method-cap <n>        with corpus baseline modes: cap the
                                 completeness/structuring scan to a deterministic
                                 hash-ranked sample of n methods per assembly.

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -483,6 +483,42 @@ dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
 bash eng/report-decompiler-opt-in-corpus-drift.sh
 ```
 
+**Classic state-machine corpus** (`--corpus-profile classic-state-machines`):
+a pinned lane for classic (non-`RuntimeAsync`) compiler-generated state
+machines — async kickoff/resume, iterators, async iterators, and a plain
+non-pattern `switch` — none of which had dedicated corpus coverage before
+(#2818, a child of #2814). Its one fixture assembly,
+`ILInspector.Decompiler.Fixtures.ClassicStateMachines`, builds on the same
+`RuntimeAsync=off` axis as `ILInspector.Decompiler.Fixtures.ClassicAsync`
+rather than a downlevel TFM/LangVersion pack, since classic lowering for these
+four shapes does not depend on an older runtime or compiler; this reaches the
+same classic lowering set without the added complexity of installing a
+downlevel runtime pack.
+
+Unlike the other corpus profiles, this lane wires the cross-method import seam
+(`PassContext.ForImport`, the same helper `--dump`/`--library-report` use) into
+`CorpusSensor.AnalyzeCompleteness`, so cross-method passes such as
+`ClassicAsyncReconstructionPass` — which pulls in the sibling `MoveNext` body —
+raise the same way they do outside the corpus sensor. No other corpus profile
+wires this seam; `real-world` and `opt-in-net11` still raise each method
+standalone. Snapshot schema v4 records feature-local evidence
+(`classic-async-methods`, `classic-iterator-methods`,
+`classic-async-iterator-methods`, `switch-methods`), tagged by the method-name
+prefix contract documented on `ClassicStateMachineFixtures`
+(`Async_`/`Iterator_`/`AsyncIterator_`/`Switch_`). As with the opt-in-net11
+profile, its baseline is separate from `real-world-baseline.json` and never
+blended into real-world rates; this is a first published census (successor to
+the earlier "0/21" classic-async gap), not yet a quality target.
+
+```bash
+dotnet build src/ILInspector.Decompiler.Fixtures.ClassicStateMachines -c Release
+dotnet run --project tools/DecompilerHarness -c Release -- \
+  artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll \
+  --corpus-profile classic-state-machines \
+  --diff-corpus-baseline tools/DecompilerHarness/corpus/classic-state-machines-baseline.json \
+  --max-examples 10
+```
+
 **Render A/B** (`--emit-render-ab` / `--render-ab`): the before/after text
 oracle for raise and printer changes. The first run writes a method-keyed JSON
 baseline of rendered bodies; the second run compares the current render against
@@ -736,10 +772,13 @@ corpus omits: (1) put the mode-sensitive source in its own file (or reuse shared
 fixtures when one source is legal in both modes); (2) add a thin overlay csproj
 that sets the flag — preferably through a property in `Directory.Build.targets`
 for a reusable axis; (3) build it and baseline with `--library-report`. Keep it
-out of CI references so it stays a discovery tool. Candidate next axes:
-**checked arithmetic** (`CheckForOverflowUnderflow`) and **downlevel framework /
-LangVersion** (an older TFM, which cascades classic async + old switch/iterator
-lowerings at once).
+out of CI references so it stays a discovery tool. Candidate next axis:
+**checked arithmetic** (`CheckForOverflowUnderflow`). Classic iterators, async
+iterators, and classic async kickoff/resume are now pinned by the
+`classic-state-machines` corpus profile above, on the `RuntimeAsync=off` axis
+rather than a downlevel TFM; a genuinely older TFM/LangVersion pack (which
+would also change the classic switch/iterator lowering shapes themselves)
+remains a candidate next axis.
 
 **Validity check** (`--validity-check`): the *validity* check — `--gaps` is *completeness*, `--fidelity-check` is *fidelity*, this is *does it even compile*. The pipeline guarantees by construction only that it never crashes and never silently fabricates (unrepresentable IL becomes a visible `/* … */` comment and drops fidelity to `Partial`) — **not** that the rendered text is valid C#. This mode measures the gap: each body is wrapped in a method shell carrying its real signature (return type, generic parameters with their `where` constraints reconstructed from metadata, parameters, so locals/params/type-params and `this` all bind — without the constraints a constrained generic-math call like `byte.TryConvertFromTruncating<TOther>` spuriously fails CS0314), then (1) parsed — a parse error is unambiguously a decompiler defect; (2) checked for statement legality (the CS0201 rule — a bare cast/expression statement parses but isn't valid); (3) bound against the runtime references. Diagnostics are bucketed by code with the member/type-**visibility** codes (the shell can't see the real declaring type's fields/methods) filtered as noise, so genuine defects stand out — `CS0193` (`*`-deref of a managed ref), `CS0175` (`base(...)` rendered as a statement), `CS1620` (an `out` argument not marked `out`), `CS0165` (a local used before the decompiler assigned it). Reported split by fidelity: a `Partial` method is *expected* to carry invalid fragments; a **`Full` method that fails to compile is the real "claimed good but isn't" signal** and the prioritized fix docket. Compiler-generated members are excluded (their metadata names aren't valid identifiers). `--compile-cap N` bounds the (slow) semantic-binding pass; `--compile-cap all` runs an exhaustive binding sweep. Capped reports print how many eligible `Full` methods were actually compiled and label semantic findings as per-sample, not corpus-wide.
 

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -484,16 +484,18 @@ bash eng/report-decompiler-opt-in-corpus-drift.sh
 ```
 
 **Classic state-machine corpus** (`--corpus-profile classic-state-machines`):
-a pinned lane for classic (non-`RuntimeAsync`) compiler-generated state
-machines — async kickoff/resume, iterators, async iterators, and a plain
-non-pattern `switch` — none of which had dedicated corpus coverage before
-(#2818, a child of #2814). Its one fixture assembly,
+a pinned, representative current-compiler lane for classic (non-`RuntimeAsync`)
+compiler-generated state machines — async kickoff/resume, iterators, async
+iterators, and a plain non-pattern `switch` control — none of which had
+dedicated corpus coverage before (#2818, a child of #2814). Its one fixture
+assembly,
 `ILInspector.Decompiler.Fixtures.ClassicStateMachines`, builds on the same
 `RuntimeAsync=off` axis as `ILInspector.Decompiler.Fixtures.ClassicAsync`
-rather than a downlevel TFM/LangVersion pack, since classic lowering for these
-four shapes does not depend on an older runtime or compiler; this reaches the
-same classic lowering set without the added complexity of installing a
-downlevel runtime pack.
+rather than a downlevel TFM/LangVersion pack. The fixture spans `Task`,
+`async void`, and `ValueTask` builders; static, instance, generic, and
+non-generic iterators; and cancellation, exception-region, `await foreach`, and
+async-disposal shapes. It is not exhaustive across compiler versions or older
+TFMs; those remain a separate candidate axis.
 
 Unlike the other corpus profiles, this lane wires the cross-method import seam
 (`PassContext.ForImport`, the same helper `--dump`/`--library-report` use) into
@@ -501,14 +503,18 @@ Unlike the other corpus profiles, this lane wires the cross-method import seam
 `ClassicAsyncReconstructionPass` — which pulls in the sibling `MoveNext` body —
 raise the same way they do outside the corpus sensor. No other corpus profile
 wires this seam; `real-world` and `opt-in-net11` still raise each method
-standalone. Snapshot schema v4 records feature-local evidence
+standalone. Snapshot schema v4 records feature-local population evidence
 (`classic-async-methods`, `classic-iterator-methods`,
 `classic-async-iterator-methods`, `switch-methods`), tagged by the method-name
 prefix contract documented on `ClassicStateMachineFixtures`
-(`Async_`/`Iterator_`/`AsyncIterator_`/`Switch_`). As with the opt-in-net11
-profile, its baseline is separate from `real-world-baseline.json` and never
-blended into real-world rates; this is a first published census (successor to
-the earlier "0/21" classic-async gap), not yet a quality target.
+(`Async_`/`Iterator_`/`AsyncIterator_`/`Switch_`). The separate
+`classicStateMachineCoverage` object reports source-kickoff population, fully
+raised, and residual counts for each state-machine family. Baseline comparison
+blocks a lost specimen, a lower fully-raised count, or increased residuals when
+the population is stable. As with the opt-in-net11 profile, its baseline is
+separate from `real-world-baseline.json` and never blended into real-world
+rates; this is a first published census (successor to the earlier "0/21"
+classic-async gap), not yet a broad real-world quality target.
 
 ```bash
 dotnet build src/ILInspector.Decompiler.Fixtures.ClassicStateMachines -c Release

--- a/tools/DecompilerHarness/corpus/classic-state-machines-baseline.json
+++ b/tools/DecompilerHarness/corpus/classic-state-machines-baseline.json
@@ -1,0 +1,1518 @@
+{
+  "schemaVersion": 4,
+  "description": "#2818 classic async/iterator state-machine corpus: pinned classic async, iterator, async-iterator, and switch fixtures, raised with the cross-method import seam wired.",
+  "generatedUtc": "2026-07-18T19:48:15.289718+00:00",
+  "validityCompileCap": 4000,
+  "fidelityCompileCap": 0,
+  "methodCap": null,
+  "tolerances": {
+    "fullyRaisedDropBasisPoints": 10,
+    "conditionalBranchIncreaseBasisPoints": 10,
+    "forwardMergeIncreaseBasisPoints": 10,
+    "fullMalformedIncrease": 0,
+    "semanticDefectIncrease": 0,
+    "passBugIncrease": 0,
+    "fidelityOpcodeDiffIncrease": 0,
+    "fidelityRecompileFailIncrease": 0,
+    "fidelityContextFailIncrease": 0
+  },
+  "assemblies": [
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "path": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "totalMethods": 73
+    }
+  ],
+  "methods": [
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "method": ".ctor",
+      "overload": 0,
+      "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 7
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::.ctor#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "method": "SetStateMachine",
+      "overload": 0,
+      "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::SetStateMachine#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "method": "System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator",
+      "overload": 0,
+      "signature": "(corelib:System.Threading.CancellationToken) -\u003E corelib:System.Collections.Generic.IAsyncEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 20
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "method": "System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask\u00601\u003Ccorelib:System.Boolean\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 18
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "method": "System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Int32",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "method": "System.IAsyncDisposable.DisposeAsync",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 18
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.IAsyncDisposable.DisposeAsync#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource.GetResult",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Threading.Tasks.Sources.IValueTaskSource.GetResult#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource.GetStatus",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Threading.Tasks.Sources.ValueTaskSourceStatus",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Threading.Tasks.Sources.IValueTaskSource.GetStatus#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted",
+      "overload": 0,
+      "signature": "(corelib:System.Action\u00601\u003Ccorelib:System.Object\u003E, corelib:System.Object, corelib:System.Int16, corelib:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Boolean",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Threading.Tasks.Sources.ValueTaskSourceStatus",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted",
+      "overload": 0,
+      "signature": "(corelib:System.Action\u00601\u003Ccorelib:System.Object\u003E, corelib:System.Object, corelib:System.Int16, corelib:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "method": ".ctor",
+      "overload": 0,
+      "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 7
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::.ctor#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "method": "SetStateMachine",
+      "overload": 0,
+      "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::SetStateMachine#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "method": "System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator",
+      "overload": 0,
+      "signature": "(corelib:System.Threading.CancellationToken) -\u003E corelib:System.Collections.Generic.IAsyncEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 24
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "method": "System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask\u00601\u003Ccorelib:System.Boolean\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 18
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "method": "System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Int32",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "method": "System.IAsyncDisposable.DisposeAsync",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 18
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.IAsyncDisposable.DisposeAsync#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource.GetResult",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Threading.Tasks.Sources.IValueTaskSource.GetResult#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource.GetStatus",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Threading.Tasks.Sources.ValueTaskSourceStatus",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Threading.Tasks.Sources.IValueTaskSource.GetStatus#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted",
+      "overload": 0,
+      "signature": "(corelib:System.Action\u00601\u003Ccorelib:System.Object\u003E, corelib:System.Object, corelib:System.Int16, corelib:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Boolean",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Threading.Tasks.Sources.ValueTaskSourceStatus",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted",
+      "overload": 0,
+      "signature": "(corelib:System.Action\u00601\u003Ccorelib:System.Object\u003E, corelib:System.Object, corelib:System.Int16, corelib:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_AwaitInLoop\u003Ed__3",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_AwaitInLoop\u003Ed__3::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_AwaitInLoop\u003Ed__3",
+      "method": "SetStateMachine",
+      "overload": 0,
+      "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_AwaitInLoop\u003Ed__3::SetStateMachine#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_AwaitInTryFinally\u003Ed__2",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_AwaitInTryFinally\u003Ed__2::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_AwaitInTryFinally\u003Ed__2",
+      "method": "SetStateMachine",
+      "overload": 0,
+      "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_AwaitInTryFinally\u003Ed__2::SetStateMachine#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_AwaitValue\u003Ed__0",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_AwaitValue\u003Ed__0::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_AwaitValue\u003Ed__0",
+      "method": "SetStateMachine",
+      "overload": 0,
+      "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_AwaitValue\u003Ed__0::SetStateMachine#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_TwoSequentialAwaits\u003Ed__1",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_TwoSequentialAwaits\u003Ed__1::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_TwoSequentialAwaits\u003Ed__1",
+      "method": "SetStateMachine",
+      "overload": 0,
+      "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_TwoSequentialAwaits\u003Ed__1::SetStateMachine#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
+      "method": ".ctor",
+      "overload": 0,
+      "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 5
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::.ctor#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Boolean",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "structuring: conditional-branch",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 22
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
+      "method": "System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Collections.Generic.IEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 16
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
+      "method": "System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Int32",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
+      "method": "System.Collections.IEnumerable.GetEnumerator",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Collections.IEnumerator",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::System.Collections.IEnumerable.GetEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
+      "method": "System.Collections.IEnumerator.Reset",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::System.Collections.IEnumerator.Reset#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
+      "method": "System.Collections.IEnumerator.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Object",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::System.Collections.IEnumerator.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
+      "method": "System.IDisposable.Dispose",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::System.IDisposable.Dispose#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "method": ".ctor",
+      "overload": 0,
+      "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 5
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::.ctor#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "method": "\u003C\u003Em__Finally1",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 4
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::\u003C\u003Em__Finally1#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "method": "\u003C\u003Em__Finally2",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 6
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::\u003C\u003Em__Finally2#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Boolean",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "structuring: conditional-branch",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 30
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "method": "System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Collections.Generic.IEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 16
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "method": "System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Int32",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "method": "System.Collections.IEnumerable.GetEnumerator",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Collections.IEnumerator",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::System.Collections.IEnumerable.GetEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "method": "System.Collections.IEnumerator.Reset",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::System.Collections.IEnumerator.Reset#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "method": "System.Collections.IEnumerator.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Object",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::System.Collections.IEnumerator.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "method": "System.IDisposable.Dispose",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 10
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::System.IDisposable.Dispose#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "method": ".ctor",
+      "overload": 0,
+      "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 5
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::.ctor#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Boolean",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "structuring: conditional-branch",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 22
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "method": "System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Collections.Generic.IEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 16
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "method": "System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Int32",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "method": "System.Collections.IEnumerable.GetEnumerator",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Collections.IEnumerator",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::System.Collections.IEnumerable.GetEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "method": "System.Collections.IEnumerator.Reset",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::System.Collections.IEnumerator.Reset#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "method": "System.Collections.IEnumerator.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Object",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::System.Collections.IEnumerator.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "method": "System.IDisposable.Dispose",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::System.IDisposable.Dispose#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CSwitch_InsideAsync\u003Ed__10",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CSwitch_InsideAsync\u003Ed__10::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CSwitch_InsideAsync\u003Ed__10",
+      "method": "SetStateMachine",
+      "overload": 0,
+      "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CSwitch_InsideAsync\u003Ed__10::SetStateMachine#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "AsyncIterator_AwaitThenYield",
+      "overload": 0,
+      "signature": "(corelib:System.Threading.Tasks.Task\u00601\u003Ccorelib:System.Int32\u003E[]) -\u003E corelib:System.Collections.Generic.IAsyncEnumerable\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "partial-malformed:CS1003,CS1013,CS1525",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::AsyncIterator_AwaitThenYield#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "AsyncIterator_YieldBreakEarly",
+      "overload": 0,
+      "signature": "(corelib:System.Threading.Tasks.Task\u00601\u003Ccorelib:System.Int32\u003E[], corelib:System.Int32) -\u003E corelib:System.Collections.Generic.IAsyncEnumerable\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "partial-malformed:CS1003,CS1013,CS1525",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::AsyncIterator_YieldBreakEarly#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Async_AwaitInLoop",
+      "overload": 0,
+      "signature": "(corelib:System.Threading.Tasks.Task\u00601\u003Ccorelib:System.Int32\u003E[]) -\u003E corelib:System.Threading.Tasks.Task\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "syntax-valid",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Async_AwaitInLoop#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Async_AwaitInTryFinally",
+      "overload": 0,
+      "signature": "(corelib:System.Threading.Tasks.Task\u00601\u003Ccorelib:System.Int32\u003E) -\u003E corelib:System.Threading.Tasks.Task\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "syntax-valid",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Async_AwaitInTryFinally#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Async_AwaitValue",
+      "overload": 0,
+      "signature": "(corelib:System.Threading.Tasks.Task\u00601\u003Ccorelib:System.Int32\u003E, corelib:System.Int32) -\u003E corelib:System.Threading.Tasks.Task\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "syntax-valid",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Async_AwaitValue#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Async_TwoSequentialAwaits",
+      "overload": 0,
+      "signature": "(corelib:System.Threading.Tasks.Task\u00601\u003Ccorelib:System.Int32\u003E, corelib:System.Threading.Tasks.Task\u00601\u003Ccorelib:System.Int32\u003E) -\u003E corelib:System.Threading.Tasks.Task",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "syntax-valid",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Async_TwoSequentialAwaits#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Iterator_YieldBreakEarly",
+      "overload": 0,
+      "signature": "(corelib:System.Int32) -\u003E corelib:System.Collections.Generic.IEnumerable\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: unsupported-node",
+      "passBug": null,
+      "validity": "syntax-valid",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0004",
+          "discriminator": "iterator"
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Iterator_YieldBreakEarly#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Iterator_YieldInTryFinally",
+      "overload": 0,
+      "signature": "(corelib:System.Collections.Generic.IEnumerable\u00601\u003Ccorelib:System.Int32\u003E) -\u003E corelib:System.Collections.Generic.IEnumerable\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: unsupported-node",
+      "passBug": null,
+      "validity": "syntax-valid",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0004",
+          "discriminator": "iterator"
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Iterator_YieldInTryFinally#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Iterator_YieldSequence",
+      "overload": 0,
+      "signature": "(corelib:System.Int32) -\u003E corelib:System.Collections.Generic.IEnumerable\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "syntax-valid",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Iterator_YieldSequence#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Switch_ClassifyState",
+      "overload": 0,
+      "signature": "(corelib:System.Int32) -\u003E corelib:System.String",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "valid",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Switch_ClassifyState#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Switch_InsideAsync",
+      "overload": 0,
+      "signature": "(corelib:System.Threading.Tasks.Task\u00601\u003Ccorelib:System.Int32\u003E) -\u003E corelib:System.Threading.Tasks.Task\u00601\u003Ccorelib:System.String\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "syntax-valid",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 13
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Switch_InsideAsync#0"
+    }
+  ],
+  "metrics": {
+    "totalMethods": 73,
+    "fullyRaisedMethods": 23,
+    "fullyRaisedBasisPoints": 3151,
+    "conditionalBranchMethods": 3,
+    "conditionalBranchBasisPoints": 411,
+    "forwardMergeStoppedContainers": 7,
+    "forwardMergeBasisPoints": 959,
+    "fullMalformedMethods": 0,
+    "semanticCheckedMethods": 1,
+    "semanticDefectMethods": 0,
+    "passBugs": 0,
+    "residualBuckets": {
+      "fidelity: DEC0009": 45,
+      "fidelity: unsupported-node": 2,
+      "structuring: conditional-branch": 3
+    },
+    "structuring": {
+      "totalMethods": 73,
+      "structuredContainers": 21,
+      "stoppedContainers": 10,
+      "methodsWithStops": 10,
+      "passBugs": 0,
+      "stopReasons": {
+        "arm-externally-entered": 2,
+        "cond-target-past-region": 6,
+        "forward-branch-not-region-exit": 1,
+        "unconsumed-regions": 1
+      }
+    },
+    "fidelity": {
+      "checkedMethods": 0,
+      "exactMethods": 0,
+      "opcodeDiffMethods": 0,
+      "recompileFailMethods": 0,
+      "contextFailMethods": 0,
+      "notFullMethods": 0
+    }
+  },
+  "fidelityOracle": "compile-back",
+  "profile": "classic-state-machines",
+  "featureCoverage": {
+    "classic-async-iterator-methods": 28,
+    "classic-async-methods": 12,
+    "classic-iterator-methods": 29,
+    "switch-methods": 4
+  }
+}

--- a/tools/DecompilerHarness/corpus/classic-state-machines-baseline.json
+++ b/tools/DecompilerHarness/corpus/classic-state-machines-baseline.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 4,
   "description": "#2818 classic async/iterator state-machine corpus: pinned classic async, iterator, async-iterator, and switch fixtures, raised with the cross-method import seam wired.",
-  "generatedUtc": "2026-07-18T19:48:15.289718+00:00",
+  "generatedUtc": "2026-07-18T22:39:15.098946+00:00",
   "validityCompileCap": 4000,
   "fidelityCompileCap": 0,
   "methodCap": null,
@@ -20,14 +20,14 @@
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "path": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "totalMethods": 73
+      "totalMethods": 144
     }
   ],
   "methods": [
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": ".ctor",
       "overload": 0,
       "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
@@ -44,12 +44,12 @@
           "sites": 7
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::.ctor#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::.ctor#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "MoveNext",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Void",
@@ -59,12 +59,12 @@
       "passBug": null,
       "validity": "not-sampled",
       "fidelityCheck": "not-sampled",
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::MoveNext#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::MoveNext#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "SetStateMachine",
       "overload": 0,
       "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
@@ -74,12 +74,12 @@
       "passBug": null,
       "validity": "not-sampled",
       "fidelityCheck": "not-sampled",
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::SetStateMachine#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::SetStateMachine#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator",
       "overload": 0,
       "signature": "(corelib:System.Threading.CancellationToken) -\u003E corelib:System.Collections.Generic.IAsyncEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
@@ -96,12 +96,12 @@
           "sites": 20
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask\u00601\u003Ccorelib:System.Boolean\u003E",
@@ -118,12 +118,12 @@
           "sites": 18
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Int32",
@@ -140,12 +140,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "System.IAsyncDisposable.DisposeAsync",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask",
@@ -162,12 +162,12 @@
           "sites": 18
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.IAsyncDisposable.DisposeAsync#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::System.IAsyncDisposable.DisposeAsync#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource.GetResult",
       "overload": 0,
       "signature": "(corelib:System.Int16) -\u003E corelib:System.Void",
@@ -184,12 +184,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Threading.Tasks.Sources.IValueTaskSource.GetResult#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::System.Threading.Tasks.Sources.IValueTaskSource.GetResult#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource.GetStatus",
       "overload": 0,
       "signature": "(corelib:System.Int16) -\u003E corelib:System.Threading.Tasks.Sources.ValueTaskSourceStatus",
@@ -206,12 +206,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Threading.Tasks.Sources.IValueTaskSource.GetStatus#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::System.Threading.Tasks.Sources.IValueTaskSource.GetStatus#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted",
       "overload": 0,
       "signature": "(corelib:System.Action\u00601\u003Ccorelib:System.Object\u003E, corelib:System.Object, corelib:System.Int16, corelib:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags) -\u003E corelib:System.Void",
@@ -228,12 +228,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult",
       "overload": 0,
       "signature": "(corelib:System.Int16) -\u003E corelib:System.Boolean",
@@ -250,12 +250,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus",
       "overload": 0,
       "signature": "(corelib:System.Int16) -\u003E corelib:System.Threading.Tasks.Sources.ValueTaskSourceStatus",
@@ -272,12 +272,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted",
       "overload": 0,
       "signature": "(corelib:System.Action\u00601\u003Ccorelib:System.Object\u003E, corelib:System.Object, corelib:System.Int16, corelib:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags) -\u003E corelib:System.Void",
@@ -294,12 +294,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": ".ctor",
       "overload": 0,
       "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
@@ -316,12 +316,12 @@
           "sites": 7
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::.ctor#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::.ctor#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "MoveNext",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Void",
@@ -331,12 +331,12 @@
       "passBug": null,
       "validity": "not-sampled",
       "fidelityCheck": "not-sampled",
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::MoveNext#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::MoveNext#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "SetStateMachine",
       "overload": 0,
       "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
@@ -346,12 +346,12 @@
       "passBug": null,
       "validity": "not-sampled",
       "fidelityCheck": "not-sampled",
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::SetStateMachine#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::SetStateMachine#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator",
       "overload": 0,
       "signature": "(corelib:System.Threading.CancellationToken) -\u003E corelib:System.Collections.Generic.IAsyncEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
@@ -365,15 +365,15 @@
         {
           "code": "DEC0009",
           "discriminator": "state-machine-type-name",
-          "sites": 24
+          "sites": 20
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask\u00601\u003Ccorelib:System.Boolean\u003E",
@@ -390,12 +390,12 @@
           "sites": 18
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Int32",
@@ -412,12 +412,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "System.IAsyncDisposable.DisposeAsync",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask",
@@ -434,12 +434,12 @@
           "sites": 18
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.IAsyncDisposable.DisposeAsync#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::System.IAsyncDisposable.DisposeAsync#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource.GetResult",
       "overload": 0,
       "signature": "(corelib:System.Int16) -\u003E corelib:System.Void",
@@ -456,12 +456,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Threading.Tasks.Sources.IValueTaskSource.GetResult#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::System.Threading.Tasks.Sources.IValueTaskSource.GetResult#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource.GetStatus",
       "overload": 0,
       "signature": "(corelib:System.Int16) -\u003E corelib:System.Threading.Tasks.Sources.ValueTaskSourceStatus",
@@ -478,12 +478,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Threading.Tasks.Sources.IValueTaskSource.GetStatus#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::System.Threading.Tasks.Sources.IValueTaskSource.GetStatus#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted",
       "overload": 0,
       "signature": "(corelib:System.Action\u00601\u003Ccorelib:System.Object\u003E, corelib:System.Object, corelib:System.Int16, corelib:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags) -\u003E corelib:System.Void",
@@ -500,12 +500,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult",
       "overload": 0,
       "signature": "(corelib:System.Int16) -\u003E corelib:System.Boolean",
@@ -522,12 +522,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus",
       "overload": 0,
       "signature": "(corelib:System.Int16) -\u003E corelib:System.Threading.Tasks.Sources.ValueTaskSourceStatus",
@@ -544,12 +544,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted",
       "overload": 0,
       "signature": "(corelib:System.Action\u00601\u003Ccorelib:System.Object\u003E, corelib:System.Object, corelib:System.Int16, corelib:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags) -\u003E corelib:System.Void",
@@ -566,7 +566,581 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": ".ctor",
+      "overload": 0,
+      "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 7
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::.ctor#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "SetStateMachine",
+      "overload": 0,
+      "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::SetStateMachine#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator",
+      "overload": 0,
+      "signature": "(corelib:System.Threading.CancellationToken) -\u003E corelib:System.Collections.Generic.IAsyncEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 40
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask\u00601\u003Ccorelib:System.Boolean\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 18
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Int32",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "System.IAsyncDisposable.DisposeAsync",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 18
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::System.IAsyncDisposable.DisposeAsync#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource.GetResult",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::System.Threading.Tasks.Sources.IValueTaskSource.GetResult#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource.GetStatus",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Threading.Tasks.Sources.ValueTaskSourceStatus",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::System.Threading.Tasks.Sources.IValueTaskSource.GetStatus#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted",
+      "overload": 0,
+      "signature": "(corelib:System.Action\u00601\u003Ccorelib:System.Object\u003E, corelib:System.Object, corelib:System.Int16, corelib:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Boolean",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Threading.Tasks.Sources.ValueTaskSourceStatus",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted",
+      "overload": 0,
+      "signature": "(corelib:System.Action\u00601\u003Ccorelib:System.Object\u003E, corelib:System.Object, corelib:System.Int16, corelib:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": ".ctor",
+      "overload": 0,
+      "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 7
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::.ctor#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "SetStateMachine",
+      "overload": 0,
+      "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::SetStateMachine#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator",
+      "overload": 0,
+      "signature": "(corelib:System.Threading.CancellationToken) -\u003E corelib:System.Collections.Generic.IAsyncEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 24
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask\u00601\u003Ccorelib:System.Boolean\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 18
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Int32",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "System.IAsyncDisposable.DisposeAsync",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 18
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::System.IAsyncDisposable.DisposeAsync#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource.GetResult",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::System.Threading.Tasks.Sources.IValueTaskSource.GetResult#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource.GetStatus",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Threading.Tasks.Sources.ValueTaskSourceStatus",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::System.Threading.Tasks.Sources.IValueTaskSource.GetStatus#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted",
+      "overload": 0,
+      "signature": "(corelib:System.Action\u00601\u003Ccorelib:System.Object\u003E, corelib:System.Object, corelib:System.Int16, corelib:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Boolean",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Threading.Tasks.Sources.ValueTaskSourceStatus",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted",
+      "overload": 0,
+      "signature": "(corelib:System.Action\u00601\u003Ccorelib:System.Object\u003E, corelib:System.Object, corelib:System.Int16, corelib:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_AwaitInCatchAndFinally\u003Ed__7",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_AwaitInCatchAndFinally\u003Ed__7::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_AwaitInCatchAndFinally\u003Ed__7",
+      "method": "SetStateMachine",
+      "overload": 0,
+      "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_AwaitInCatchAndFinally\u003Ed__7::SetStateMachine#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
@@ -661,6 +1235,36 @@
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_InstanceGeneric\u003Ed__6\u00601",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_InstanceGeneric\u003Ed__6\u00601::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_InstanceGeneric\u003Ed__6\u00601",
+      "method": "SetStateMachine",
+      "overload": 0,
+      "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_InstanceGeneric\u003Ed__6\u00601::SetStateMachine#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
       "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_TwoSequentialAwaits\u003Ed__1",
       "method": "MoveNext",
       "overload": 0,
@@ -691,7 +1295,67 @@
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_ValueTaskBuilder\u003Ed__5",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_ValueTaskBuilder\u003Ed__5::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_ValueTaskBuilder\u003Ed__5",
+      "method": "SetStateMachine",
+      "overload": 0,
+      "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_ValueTaskBuilder\u003Ed__5::SetStateMachine#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_VoidBuilder\u003Ed__4",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_VoidBuilder\u003Ed__4::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_VoidBuilder\u003Ed__4",
+      "method": "SetStateMachine",
+      "overload": 0,
+      "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_VoidBuilder\u003Ed__4::SetStateMachine#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601",
       "method": ".ctor",
       "overload": 0,
       "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
@@ -708,37 +1372,15 @@
           "sites": 5
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::.ctor#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601::.ctor#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601",
       "method": "MoveNext",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Boolean",
-      "fidelity": "Partial",
-      "fullyRaised": false,
-      "residual": "structuring: conditional-branch",
-      "passBug": null,
-      "validity": "not-sampled",
-      "fidelityCheck": "not-sampled",
-      "fidelityCauses": [
-        {
-          "code": "DEC0009",
-          "discriminator": "state-machine-type-name",
-          "sites": 22
-        }
-      ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::MoveNext#0"
-    },
-    {
-      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
-      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
-      "method": "System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator",
-      "overload": 0,
-      "signature": "() -\u003E corelib:System.Collections.Generic.IEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
       "fidelity": "Partial",
       "fullyRaised": false,
       "residual": "fidelity: DEC0009",
@@ -749,18 +1391,40 @@
         {
           "code": "DEC0009",
           "discriminator": "state-machine-type-name",
-          "sites": 16
+          "sites": 20
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601::MoveNext#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
-      "method": "System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601",
+      "method": "System.Collections.Generic.IEnumerable\u003CT\u003E.GetEnumerator",
       "overload": 0,
-      "signature": "() -\u003E corelib:System.Int32",
+      "signature": "() -\u003E corelib:System.Collections.Generic.IEnumerator\u00601\u003C!0\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 20
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601::System.Collections.Generic.IEnumerable\u003CT\u003E.GetEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601",
+      "method": "System.Collections.Generic.IEnumerator\u003CT\u003E.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E !0",
       "fidelity": "Partial",
       "fullyRaised": false,
       "residual": "fidelity: DEC0009",
@@ -774,12 +1438,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601::System.Collections.Generic.IEnumerator\u003CT\u003E.get_Current#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601",
       "method": "System.Collections.IEnumerable.GetEnumerator",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Collections.IEnumerator",
@@ -796,12 +1460,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::System.Collections.IEnumerable.GetEnumerator#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601::System.Collections.IEnumerable.GetEnumerator#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601",
       "method": "System.Collections.IEnumerator.Reset",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Void",
@@ -811,12 +1475,12 @@
       "passBug": null,
       "validity": "not-sampled",
       "fidelityCheck": "not-sampled",
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::System.Collections.IEnumerator.Reset#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601::System.Collections.IEnumerator.Reset#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601",
       "method": "System.Collections.IEnumerator.get_Current",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Object",
@@ -833,12 +1497,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::System.Collections.IEnumerator.get_Current#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601::System.Collections.IEnumerator.get_Current#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601",
       "method": "System.IDisposable.Dispose",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Void",
@@ -855,12 +1519,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::System.IDisposable.Dispose#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601::System.IDisposable.Dispose#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13",
       "method": ".ctor",
       "overload": 0,
       "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
@@ -877,12 +1541,519 @@
           "sites": 5
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::.ctor#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13::.ctor#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Boolean",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 20
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13",
+      "method": "System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Collections.Generic.IEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 16
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13::System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13",
+      "method": "System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Int32",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13::System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13",
+      "method": "System.Collections.IEnumerable.GetEnumerator",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Collections.IEnumerator",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13::System.Collections.IEnumerable.GetEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13",
+      "method": "System.Collections.IEnumerator.Reset",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13::System.Collections.IEnumerator.Reset#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13",
+      "method": "System.Collections.IEnumerator.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Object",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13::System.Collections.IEnumerator.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13",
+      "method": "System.IDisposable.Dispose",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13::System.IDisposable.Dispose#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11",
+      "method": ".ctor",
+      "overload": 0,
+      "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 5
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11::.ctor#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Boolean",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 16
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11",
+      "method": "System.Collections.Generic.IEnumerable\u003CSystem.Object\u003E.GetEnumerator",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Collections.Generic.IEnumerator\u00601\u003Ccorelib:System.Object\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 9
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11::System.Collections.Generic.IEnumerable\u003CSystem.Object\u003E.GetEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11",
+      "method": "System.Collections.Generic.IEnumerator\u003CSystem.Object\u003E.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Object",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11::System.Collections.Generic.IEnumerator\u003CSystem.Object\u003E.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11",
+      "method": "System.Collections.IEnumerable.GetEnumerator",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Collections.IEnumerator",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11::System.Collections.IEnumerable.GetEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11",
+      "method": "System.Collections.IEnumerator.Reset",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11::System.Collections.IEnumerator.Reset#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11",
+      "method": "System.Collections.IEnumerator.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Object",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11::System.Collections.IEnumerator.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11",
+      "method": "System.IDisposable.Dispose",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11::System.IDisposable.Dispose#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9",
+      "method": ".ctor",
+      "overload": 0,
+      "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 5
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9::.ctor#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Boolean",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "structuring: conditional-branch",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 22
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9",
+      "method": "System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Collections.Generic.IEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 16
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9::System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9",
+      "method": "System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Int32",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9::System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9",
+      "method": "System.Collections.IEnumerable.GetEnumerator",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Collections.IEnumerator",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9::System.Collections.IEnumerable.GetEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9",
+      "method": "System.Collections.IEnumerator.Reset",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9::System.Collections.IEnumerator.Reset#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9",
+      "method": "System.Collections.IEnumerator.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Object",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9::System.Collections.IEnumerator.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9",
+      "method": "System.IDisposable.Dispose",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9::System.IDisposable.Dispose#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10",
+      "method": ".ctor",
+      "overload": 0,
+      "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 5
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10::.ctor#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10",
       "method": "\u003C\u003Em__Finally1",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Void",
@@ -899,12 +2070,12 @@
           "sites": 4
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::\u003C\u003Em__Finally1#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10::\u003C\u003Em__Finally1#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10",
       "method": "\u003C\u003Em__Finally2",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Void",
@@ -921,12 +2092,12 @@
           "sites": 6
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::\u003C\u003Em__Finally2#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10::\u003C\u003Em__Finally2#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10",
       "method": "MoveNext",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Boolean",
@@ -943,12 +2114,12 @@
           "sites": 30
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::MoveNext#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10::MoveNext#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10",
       "method": "System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Collections.Generic.IEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
@@ -965,12 +2136,12 @@
           "sites": 16
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10::System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10",
       "method": "System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Int32",
@@ -987,12 +2158,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10::System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10",
       "method": "System.Collections.IEnumerable.GetEnumerator",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Collections.IEnumerator",
@@ -1009,12 +2180,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::System.Collections.IEnumerable.GetEnumerator#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10::System.Collections.IEnumerable.GetEnumerator#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10",
       "method": "System.Collections.IEnumerator.Reset",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Void",
@@ -1024,12 +2195,12 @@
       "passBug": null,
       "validity": "not-sampled",
       "fidelityCheck": "not-sampled",
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::System.Collections.IEnumerator.Reset#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10::System.Collections.IEnumerator.Reset#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10",
       "method": "System.Collections.IEnumerator.get_Current",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Object",
@@ -1046,12 +2217,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::System.Collections.IEnumerator.get_Current#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10::System.Collections.IEnumerator.get_Current#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10",
       "method": "System.IDisposable.Dispose",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Void",
@@ -1068,12 +2239,12 @@
           "sites": 10
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::System.IDisposable.Dispose#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10::System.IDisposable.Dispose#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8",
       "method": ".ctor",
       "overload": 0,
       "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
@@ -1090,12 +2261,12 @@
           "sites": 5
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::.ctor#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8::.ctor#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8",
       "method": "MoveNext",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Boolean",
@@ -1112,12 +2283,12 @@
           "sites": 22
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::MoveNext#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8::MoveNext#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8",
       "method": "System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Collections.Generic.IEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
@@ -1134,12 +2305,12 @@
           "sites": 16
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8::System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8",
       "method": "System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Int32",
@@ -1156,12 +2327,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8::System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8",
       "method": "System.Collections.IEnumerable.GetEnumerator",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Collections.IEnumerator",
@@ -1178,12 +2349,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::System.Collections.IEnumerable.GetEnumerator#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8::System.Collections.IEnumerable.GetEnumerator#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8",
       "method": "System.Collections.IEnumerator.Reset",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Void",
@@ -1193,12 +2364,12 @@
       "passBug": null,
       "validity": "not-sampled",
       "fidelityCheck": "not-sampled",
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::System.Collections.IEnumerator.Reset#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8::System.Collections.IEnumerator.Reset#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8",
       "method": "System.Collections.IEnumerator.get_Current",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Object",
@@ -1215,12 +2386,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::System.Collections.IEnumerator.get_Current#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8::System.Collections.IEnumerator.get_Current#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8",
       "method": "System.IDisposable.Dispose",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Void",
@@ -1237,12 +2408,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::System.IDisposable.Dispose#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8::System.IDisposable.Dispose#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CSwitch_InsideAsync\u003Ed__10",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CSwitch_InsideAsync\u003Ed__19",
       "method": "MoveNext",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Void",
@@ -1252,12 +2423,12 @@
       "passBug": null,
       "validity": "not-sampled",
       "fidelityCheck": "not-sampled",
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CSwitch_InsideAsync\u003Ed__10::MoveNext#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CSwitch_InsideAsync\u003Ed__19::MoveNext#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CSwitch_InsideAsync\u003Ed__10",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CSwitch_InsideAsync\u003Ed__19",
       "method": "SetStateMachine",
       "overload": 0,
       "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
@@ -1267,7 +2438,67 @@
       "passBug": null,
       "validity": "not-sampled",
       "fidelityCheck": "not-sampled",
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CSwitch_InsideAsync\u003Ed__10::SetStateMachine#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CSwitch_InsideAsync\u003Ed__19::SetStateMachine#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.AsyncResource",
+      "method": ".ctor",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "valid",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.AsyncResource::.ctor#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.AsyncResource",
+      "method": "DisposeAsync",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "valid",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.AsyncResource::DisposeAsync#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.AsyncResource",
+      "method": "TouchAsync",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "valid",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.AsyncResource::TouchAsync#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": ".ctor",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "valid",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::.ctor#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
@@ -1295,6 +2526,50 @@
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
       "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "AsyncIterator_TryFinallyAndDisposal",
+      "overload": 0,
+      "signature": "(corelib:System.Collections.Generic.IAsyncEnumerable\u00601\u003Ccorelib:System.Int32\u003E) -\u003E corelib:System.Collections.Generic.IAsyncEnumerable\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "partial-malformed:CS1003,CS1013,CS1525",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::AsyncIterator_TryFinallyAndDisposal#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "AsyncIterator_WithCancellation",
+      "overload": 0,
+      "signature": "(corelib:System.Int32, corelib:System.Threading.CancellationToken) -\u003E corelib:System.Collections.Generic.IAsyncEnumerable\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "partial-malformed:CS1003,CS1013,CS1525",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::AsyncIterator_WithCancellation#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
       "method": "AsyncIterator_YieldBreakEarly",
       "overload": 0,
       "signature": "(corelib:System.Threading.Tasks.Task\u00601\u003Ccorelib:System.Int32\u003E[], corelib:System.Int32) -\u003E corelib:System.Collections.Generic.IAsyncEnumerable\u00601\u003Ccorelib:System.Int32\u003E",
@@ -1312,6 +2587,28 @@
         }
       ],
       "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::AsyncIterator_YieldBreakEarly#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Async_AwaitInCatchAndFinally",
+      "overload": 0,
+      "signature": "(corelib:System.Threading.Tasks.Task\u00601\u003Ccorelib:System.Int32\u003E) -\u003E corelib:System.Threading.Tasks.Task\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "syntax-valid",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 13
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Async_AwaitInCatchAndFinally#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
@@ -1362,6 +2659,28 @@
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
       "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Async_InstanceGeneric",
+      "overload": 0,
+      "signature": "\u00601(corelib:System.Threading.Tasks.Task\u00601\u003C!!0\u003E) -\u003E corelib:System.Threading.Tasks.Task\u00601\u003C!!0\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "syntax-valid",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 13
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Async_InstanceGeneric#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
       "method": "Async_TwoSequentialAwaits",
       "overload": 0,
       "signature": "(corelib:System.Threading.Tasks.Task\u00601\u003Ccorelib:System.Int32\u003E, corelib:System.Threading.Tasks.Task\u00601\u003Ccorelib:System.Int32\u003E) -\u003E corelib:System.Threading.Tasks.Task",
@@ -1372,6 +2691,100 @@
       "validity": "syntax-valid",
       "fidelityCheck": "not-sampled",
       "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Async_TwoSequentialAwaits#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Async_ValueTaskBuilder",
+      "overload": 0,
+      "signature": "(corelib:System.Threading.Tasks.ValueTask\u00601\u003Ccorelib:System.Int32\u003E) -\u003E corelib:System.Threading.Tasks.ValueTask\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "syntax-valid",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Async_ValueTaskBuilder#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Async_VoidBuilder",
+      "overload": 0,
+      "signature": "(corelib:System.Action) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "syntax-valid",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 11
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Async_VoidBuilder#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Iterator_Generic",
+      "overload": 0,
+      "signature": "\u00601(!!0, !!0) -\u003E corelib:System.Collections.Generic.IEnumerable\u00601\u003C!!0\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: unsupported-node",
+      "passBug": null,
+      "validity": "syntax-valid",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0004",
+          "discriminator": "iterator"
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Iterator_Generic#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Iterator_Instance",
+      "overload": 0,
+      "signature": "(corelib:System.Int32) -\u003E corelib:System.Collections.Generic.IEnumerable\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: unsupported-node",
+      "passBug": null,
+      "validity": "syntax-valid",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0004",
+          "discriminator": "iterator"
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Iterator_Instance#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Iterator_NonGeneric",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Collections.IEnumerable",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "syntax-valid",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Iterator_NonGeneric#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
@@ -1469,31 +2882,31 @@
     }
   ],
   "metrics": {
-    "totalMethods": 73,
-    "fullyRaisedMethods": 23,
-    "fullyRaisedBasisPoints": 3151,
+    "totalMethods": 144,
+    "fullyRaisedMethods": 44,
+    "fullyRaisedBasisPoints": 3056,
     "conditionalBranchMethods": 3,
-    "conditionalBranchBasisPoints": 411,
-    "forwardMergeStoppedContainers": 7,
-    "forwardMergeBasisPoints": 959,
+    "conditionalBranchBasisPoints": 208,
+    "forwardMergeStoppedContainers": 14,
+    "forwardMergeBasisPoints": 972,
     "fullMalformedMethods": 0,
-    "semanticCheckedMethods": 1,
+    "semanticCheckedMethods": 5,
     "semanticDefectMethods": 0,
     "passBugs": 0,
     "residualBuckets": {
-      "fidelity: DEC0009": 45,
-      "fidelity: unsupported-node": 2,
+      "fidelity: DEC0009": 93,
+      "fidelity: unsupported-node": 4,
       "structuring: conditional-branch": 3
     },
     "structuring": {
-      "totalMethods": 73,
-      "structuredContainers": 21,
-      "stoppedContainers": 10,
-      "methodsWithStops": 10,
+      "totalMethods": 144,
+      "structuredContainers": 37,
+      "stoppedContainers": 20,
+      "methodsWithStops": 16,
       "passBugs": 0,
       "stopReasons": {
-        "arm-externally-entered": 2,
-        "cond-target-past-region": 6,
+        "arm-externally-entered": 5,
+        "cond-target-past-region": 13,
         "forward-branch-not-region-exit": 1,
         "unconsumed-regions": 1
       }
@@ -1510,9 +2923,26 @@
   "fidelityOracle": "compile-back",
   "profile": "classic-state-machines",
   "featureCoverage": {
-    "classic-async-iterator-methods": 28,
-    "classic-async-methods": 12,
-    "classic-iterator-methods": 29,
+    "classic-async-iterator-methods": 56,
+    "classic-async-methods": 24,
+    "classic-iterator-methods": 56,
     "switch-methods": 4
+  },
+  "classicStateMachineCoverage": {
+    "classic-async": {
+      "population": 8,
+      "fullyRaised": 5,
+      "residual": 3
+    },
+    "classic-async-iterator": {
+      "population": 4,
+      "fullyRaised": 0,
+      "residual": 4
+    },
+    "classic-iterator": {
+      "population": 6,
+      "fullyRaised": 2,
+      "residual": 4
+    }
   }
 }


### PR DESCRIPTION
Closes #2818. Child of #2814 (decompiler quality direction) — the next
unstarted Tier 2 item, started ahead of #2819 (Tier 3, blocked by #2814's
sequencing rule) per the docket's "sequence, don't parallelize" rule for
Tier 2 and its "at most two children in flight at once" concurrency cap
(only PR #2852, for #2816, was in flight at the time).

## What

Adds a new pinned corpus lane, `classic-state-machines`, for classic
(`RuntimeAsync=off`) compiler-generated state machines — async
kickoff/resume, iterators, async iterators, and a plain non-pattern
`switch` — none of which had dedicated corpus coverage before. This is
the first published census for these shapes (successor to the earlier
known "0/21" classic-async gap).

- New fixture project `ILInspector.Decompiler.Fixtures.ClassicStateMachines`
  (net11.0, `RuntimeAsync=off`), reusing the same axis as the existing
  `ClassicAsync` fixture rather than an actual downlevel TFM/LangVersion
  pack. This is a deliberate scope decision: classic lowering for these
  four shapes does not depend on an older runtime or compiler, so it
  reaches the same "classic era" lowering set without the added
  complexity/risk of installing a downlevel runtime pack in CI. The
  README's "downlevel TFM/LangVersion" candidate-axis note is updated to
  reflect this and narrowed to the axis that remains open (checked
  arithmetic, plus a genuinely older TFM/LangVersion pack that would
  change the lowering shapes themselves).
- `CorpusSensor` gains `CorpusProfile.ClassicStateMachines`. Unlike the
  other two profiles, this lane wires the cross-method import seam
  (`PassContext.ForImport`, the same helper `--dump`/`--library-report`
  use) into `AnalyzeCompleteness`, so cross-method passes such as
  `ClassicAsyncReconstructionPass` (which pulls in the sibling
  `MoveNext` body) raise the same way they do outside the corpus
  sensor — addressing the issue's specific concern that a standalone
  `--validity-check` understates classic-async reconstruction.
  `real-world` and `opt-in-net11` are untouched and still raise each
  method standalone.
- Feature coverage (`classic-async-methods`, `classic-iterator-methods`,
  `classic-async-iterator-methods`, `switch-methods`) is tagged by the
  method-name prefix contract documented on `ClassicStateMachineFixtures`
  (`Async_`/`Iterator_`/`AsyncIterator_`/`Switch_`), following the same
  `RequiredXFeatures` + `FeatureCoverageFailures` gating pattern already
  used by `opt-in-net11`.
- Commits the first published census as
  `tools/DecompilerHarness/corpus/classic-state-machines-baseline.json`
  and wires a `--diff-corpus-baseline` step into the `census` CI lane
  (not `nightly`, since this fixture needs no special SDK).
- Registers the fixture in `dotnet-inspect.slnx` and `FixtureCatalog.cs`.
- Documents the new profile in `tools/DecompilerHarness/README.md`.

## Evidence

- `dotnet build src/ILInspector.Decompiler.Fixtures.ClassicStateMachines -c Release`
  and `dotnet build tools/DecompilerHarness -c Release` both succeed.
- Ad hoc honest census via `--library-report` before wiring the seam:
  23/73 Full. After wiring the seam via the new corpus profile, the
  same population's feature-coverage evidence is captured cleanly (0
  pass bugs, 0 crashes); the committed baseline records the current
  raise/residual state as a first census, not a claimed fix — the
  dominant residual (`DEC0009/state-machine-type-name`, 45 methods) is
  out of scope for this PR.
- `--diff-corpus-baseline` against the committed baseline on an
  unmodified rebuild reports "Corpus sensor matched baseline" (exit 0).
- Targeted tests: `dotnet run --project src/ILInspector.Decompiler.Tests
  -c Release -- -class ILInspector.Decompiler.Tests.CorpusSensorComparisonTests`
  → 48/48 passed. The full `ILInspector.Decompiler.Tests` suite includes
  several pre-existing long-running tests unrelated to this change
  (`SkeletonEmitTests`, `ClusterCaptureTests`) that run well past 20
  minutes each in this environment; given this PR only touches
  `tools/DecompilerHarness` (not `src/ILInspector.Decompiler`), the
  targeted class plus clean builds is the proportionate check per
  AGENTS.md's evidence guidance. Happy to run the full suite if a
  reviewer wants it as additional evidence.

## Non-actions

- Does not change `real-world` or `opt-in-net11` corpus behavior;
  `AnalyzeCompleteness`'s existing branches are untouched.
- Does not attempt to fix the `DEC0009/state-machine-type-name`
  residual this census surfaces — that's tracked as follow-up decompiler
  work, not part of this harness-surface PR.
