### PR TITLE
Finish repository guidance cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ documentation.
 | Security and untrusted input | `docs/design/untrusted-data-threat-model.md` |
 | Analysis, Findings, and Research | `docs/design/finding-adoption.md` |
 | Shared IL/control-flow substrate | `docs/design/instruction-substrate.md`, plus the consuming subsystem's docs |
+| IL round-trip tests | `tests/DotnetInspector.ILRoundtrip.Tests/README.md` |
 | Decompiler behavior or harnesses | `docs/decompiler-correctness-pipeline.md` |
 | Skills | `taste/skill-guidance.md` |
 | Release and publishing | `docs/release-workflow.md` |
@@ -189,14 +190,8 @@ Tests use xUnit executable projects. **Use `dotnet run`, not `dotnet test`**;
 | Metadata | `dotnet run --project tests/ILInspector.Metadata.Tests -c Release` |
 
 Some CLI tests require `ilasm`/`ildasm` and skip when those tools are absent.
-`DotnetInspector.ILRoundtrip.Tests` is outside the default solution and requires
-the vendored managed ILAssembler. Run `eng/restore-ilassembler.sh` before:
-
-```bash
-dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release -- \
-  -trait- "Speed=Slow"
-dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release
-```
+The IL round-trip project has separate dependency restore and fast/full test
+commands; follow `tests/DotnetInspector.ILRoundtrip.Tests/README.md`.
 
 Pack and publish flows remain separate and build `src/dotnet-inspect`
 directly.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 This document describes the design and implementation of dotnet-inspect.
 
-## Design Philosophy
+## Design philosophy
 
 dotnet-inspect is designed for **LLM-driven .NET development**. The tool prioritizes:
 
@@ -11,7 +11,7 @@ dotnet-inspect is designed for **LLM-driven .NET development**. The tool priorit
 3. **Minimal tokens** - `--table`, `--tsv`, `--jsonl`, and `--compact` options reduce output size
 4. **Self-documenting** - `skill` command prints the SKILL.md; `--help` and `-v` show CLI structure
 
-## Command Structure
+## Command structure
 
 The tool is organized around source inspection, API lookup, relationship, and utility commands:
 
@@ -150,7 +150,7 @@ Searches for types across packages, platform libraries, projects, and local asse
 
 Resolves SourceLink URLs, source text, and MethodDef token + IL offset pairs to source locations.
 
-## LLM Integration
+## LLM integration
 
 ### SKILL.md
 
@@ -158,14 +158,14 @@ The tool includes an embedded SKILL.md that is distributed via the [dotnet/skill
 
 Run `dotnet-inspect skill` to print the embedded SKILL.md.
 
-### Output Designed for LLMs
+### Output designed for LLMs
 
 - **Markdown tables** - Structured, parseable format
 - **Consistent formatting** - Same structure across invocations
 - **Full signatures** - Parameter names included, not just types
 - **Minimal noise** - Hidden/obsolete members excluded by default
 
-## Analysis, Research, and Decompiler Evidence
+## Analysis, Research, and Decompiler evidence
 
 Method-body evidence is split by representation altitude, then joined by a
 single overlay layer:
@@ -231,7 +231,7 @@ Roslyn-free, and free of `IrNode`/decompiler dependencies. New whole-assembly or
 R1 facts should be new Analysis-backed producers registered through Research,
 not direct `Decompiler -> Analysis` calls and not parallel presentation paths.
 
-## Library Inspection
+## Library inspection
 
 The tool uses `System.Reflection.Metadata` and `System.Reflection.PortableExecutable` for low-level assembly inspection without loading assemblies into the runtime.
 
@@ -256,7 +256,7 @@ each assembly is scanned once into Metadata's extension-member Finding census,
 then CLI target, reachability, overload, and display projections consume that
 shared inventory.
 
-### Metadata Extraction
+### Metadata extraction
 
 ```text
 ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
@@ -287,7 +287,7 @@ redirects to that portable `any` package (the framework-dependent build) at the 
 and inspects its managed assemblies. The redirect benefits every package-consuming command
 (`type`, `member`, `package`, `depends`).
 
-### Signature Decoding
+### Signature decoding
 
 Method and property signatures are decoded using `SignatureTypeProvider`, which implements `ISignatureTypeProvider<string, object?>`:
 
@@ -305,11 +305,11 @@ public string GetByReferenceType(string elementType) => $"ref {elementType}";
 
 Parameter names are extracted from the `Parameter` table in metadata, matching by sequence number.
 
-### Unsafe Code Detection
+### Unsafe code detection
 
 Unsafe code detection operates at two levels:
 
-#### Assembly-Level Detection
+#### Assembly-level detection
 
 Checks for `System.Security.UnverifiableCodeAttribute` on the assembly. This attribute is emitted by the C# compiler when `AllowUnsafeBlocks` is enabled, indicating the assembly contains unverifiable code.
 
@@ -327,7 +327,7 @@ private static bool CheckForUnsafeCode(MetadataReader reader)
 }
 ```
 
-#### Method-Level Detection (`--unsafe` filter)
+#### Method-level detection (`--unsafe` filter)
 
 The `--unsafe` filter identifies methods that require the caller to enter an
 unsafe context, from two metadata signals:
@@ -351,7 +351,7 @@ rules, so the check is self-gating and legacy assemblies are unaffected.
 
 This approach is intentionally **API-focused** - it surfaces methods that require the caller to use an unsafe context. Methods that use unsafe internally but expose a safe API are not included.
 
-#### What's Not Detected
+#### What's not detected
 
 For a **legacy** assembly (no `RequiresUnsafeAttribute`), a method declared with
 the `unsafe` keyword but without a pointer in its signature is not detected,
@@ -369,7 +369,7 @@ This method is `unsafe` but has a safe signature (`int StackAlloc()`), so for a
 legacy assembly `--unsafe` won't include it. Under the updated memory-safety
 rules the same member carries `RequiresUnsafeAttribute` and **is** detected.
 
-#### Fully Accurate Implementation
+#### Fully accurate implementation
 
 A complete implementation would require IL analysis to detect all unsafe constructs:
 
@@ -399,7 +399,7 @@ for (int i = 0; i < ilBytes.Length - 1; i++)
 
 This approach is significantly more expensive (requires reading IL for every method) and would slow down API extraction. The current signature-based approach is a pragmatic choice that covers the most common use case: finding methods that expose pointers in their public API.
 
-### Async Method Detection
+### Async method detection
 
 The **Async Methods** section lists public async methods and classifies each as one of two kinds:
 
@@ -435,7 +435,7 @@ extra scanning cost.
 > emits the `0x2000` flag regardless of body shape (loops, `try`/`catch`/`finally`,
 > `await using`, `await foreach`, `ConfigureAwait(false)` all classify as Runtime).
 
-### SourceLink Resolution
+### SourceLink resolution
 
 SourceLink information is embedded in PDBs (portable or embedded) as custom debug information with GUID `CC110556-A091-4D38-9FEC-25AB9A351A6A`.
 
@@ -457,7 +457,7 @@ The resolver:
 4. Applies URL pattern to generate raw source URL
 5. Converts to GitHub browse URL with line number
 
-### Determinism Audit
+### Determinism audit
 
 Determinism is detected via the `DebuggableAttribute` blob. Specifically, checking bit 0x100 in the debugging modes flags:
 
@@ -466,9 +466,9 @@ Determinism is detected via the `DebuggableAttribute` blob. Specifically, checki
 isDeterministic = (debuggingModes & 0x100) != 0;
 ```
 
-## Output Formatting
+## Output formatting
 
-### Serialization Architecture
+### Serialization architecture
 
 The tool supports two output formats — Markdown (via [Markout](https://github.com/richlander/markout)) and JSON — with a clean separation between data and presentation.
 
@@ -520,7 +520,7 @@ context.Serialize(view);
 
 This ensures data models never reference Markout, and presentation logic is fully contained in `Views/` and `Output/`.
 
-### Value Formatting
+### Value formatting
 
 Numeric and date formatting is handled declaratively through Markout attributes on view model properties:
 
@@ -533,7 +533,7 @@ Numeric and date formatting is handled declaratively through Markout attributes 
 
 Formatter implementations live in `Output/ValueFormatters.cs` (`ByteSizeFormatter`, `CompactNumberFormatter`).
 
-### Output Modes
+### Output modes
 
 | Mode | Flag | Description |
 | ---- | ---- | ----------- |
@@ -543,7 +543,7 @@ Formatter implementations live in `Output/ValueFormatters.cs` (`ByteSizeFormatte
 | JSON | `--json` | Full structured output |
 | Compact JSON | `--json --compact` | Minified, omits false/null values |
 
-### Verbosity Control
+### Verbosity control
 
 Output follows a **height × width** model:
 
@@ -561,7 +561,7 @@ Packages are resolved in order:
 
 `PackageCacheService` enforces this invariant: the app reads from both caches but only writes to the app cache. This prevents corrupting the shared NuGet cache.
 
-## Project Structure
+## Project structure
 
 The codebase is organized into domain providers, shared method-body engines, the
 Research overlay bridge, and the application layer:
@@ -622,7 +622,7 @@ Research overlay bridge, and the application layer:
 └─────────────────────────────────────────────────────────────┘
 ```
 
-### Layer Rules
+### Layer rules
 
 - **Domain providers** are application-agnostic. They know about NuGet packages and PE files, not about dotnet-inspect.
 - **Services** return DTOs (`NuspecData`, `DepsJsonData`, `PackageMetadata`), never mutate app types. They use `Action<string>?` for logging instead of app-specific logger types.
@@ -635,7 +635,7 @@ Research overlay bridge, and the application layer:
 - **Views** wrap models and own all Markout attributes, sections, field builders, and computed display properties. They are the only types registered in `MarkoutContext`.
 - **Commands** orchestrate: they call services, populate models, and hand off to `OutputFormatter`. Most commands should not import Markout directly.
 
-### Key Files
+### Key files
 
 ```text
 src/dotnet-inspect/
@@ -670,7 +670,7 @@ src/ILInspector.Decompiler/     # R2 per-method IR and source/IL projection
 src/ILInspector.Research/       # Registered fact overlay and annotated views
 ```
 
-## Key Design Decisions
+## Key design decisions
 
 1. **No assembly loading** — Uses `MetadataReader` to avoid loading assemblies into the runtime, enabling inspection of any .NET library regardless of target framework.
 
@@ -688,7 +688,7 @@ src/ILInspector.Research/       # Registered fact overlay and annotated views
 
 8. **Signature-first output** — Full method signatures with parameter names are the primary output, not just type names, because LLMs need complete information to generate correct code.
 
-9. **Deliberate metadata duplication — `ILInspector.Analysis` is a standalone product** — The whole-assembly memory-safety analyzer (`ILInspector.Analysis`: `LibraryBodyIndex`, `CallTree`, the `Hollow`/`Opaque`/`UnsafeLeverage` classifications) keeps **zero project references** and re-derives its own `TypeRef` / `TypeRefDecoder` / `MemberResolver` rather than sharing the codebase's other type-identity layers (`ILInspector.Metadata`, `ILInspector.MetadataPrimitives`, and the decompiler's `Pipeline/TypeRef`). This is a committed product boundary, not drift: the three `TypeRef` models answer different questions (display string, evidence matching, codegen IR), and `Analysis`'s SRM-direct independence is load-bearing — it ships and evolves as an independent memory-safety deliverable. The full rationale, the rejected consolidation path, and the single trip-wire that would reopen it are in [docs/metadata-primitives.md](metadata-primitives.md) ("Decision (2026-06): stop after step 3").
+9. **Deliberate metadata duplication — `ILInspector.Analysis` is a standalone product** — The whole-assembly memory-safety analyzer (`ILInspector.Analysis`: `LibraryBodyIndex`, `CallTree`, the `Hollow`/`Opaque`/`UnsafeLeverage` classifications) keeps **zero project references** and re-derives its own `TypeRef` / `TypeRefDecoder` / `MemberResolver` rather than sharing the codebase's other type-identity layers (`ILInspector.Metadata`, `ILInspector.MetadataPrimitives`, and the decompiler's `Pipeline/TypeRef`). This is a committed product boundary, not drift: the three `TypeRef` models answer different questions (display string, evidence matching, codegen IR), and `Analysis`'s SRM-direct independence lets it ship and evolve as an independent memory-safety deliverable. The full rationale, the rejected consolidation path, and the single trip-wire that would reopen it are in [docs/metadata-primitives.md](metadata-primitives.md) ("Decision (2026-06): stop after step 3").
 
 10. **Research seam for R1/R2 overlays** — `ILInspector.Research` is the accepted bridge above Analysis (R1 lower representation) and Decompiler (R2 projection/recovery representation). Research owns the `ResearchFactRegistry`, annotation producers, and fact-overlay presenters, so new facts flow through one offset-keyed overlay instead of direct `Analysis <-> Decompiler` edges or bypass renderers.
 

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -1,4 +1,4 @@
-# Decompiler Correctness Pipeline
+# Decompiler correctness pipeline
 
 This document designs the decompiler test and harness stack as an intentionally
 staged correctness gauntlet. It is **not** just a catalog of today's harness
@@ -61,7 +61,7 @@ highest relevant boss explicit. A docs-only PR may stop at markdown lint. A
 small pass refactor may need the entry gate plus a no-movement quality card. A
 new raise or structuring change must go much higher.
 
-## Entry gate checklist (Stage 0)
+## Entry gate checklist (stage 0)
 
 The entry gate is the one stage that must be green for **every** decompiler PR
 before any higher boss is claimed. It proves only that the code builds and the

--- a/docs/decompiler-ir.md
+++ b/docs/decompiler-ir.md
@@ -1,4 +1,4 @@
-# IR and Importer Design
+# IR and importer design
 
 The foundational design for the pipeline from [decompiler.md](decompiler.md). Everything else — passes, statement tree, printers — builds on the two contracts defined here: the importer's input model and the typed IR. Both are designed for the dotnet-org audience: a Roslyn or RyuJIT engineer should recognize every choice.
 
@@ -17,7 +17,7 @@ Strings end at the printers. Inside the pipeline, a type is a `TypeRef`: a struc
 - **Equality is semantic**, not textual: `List<int>` from two different facades that forward to the same definition compare equal; `int*` and `int[]` never collide because one renderer happened to print them alike.
 - **Rendering is a printer concern**: short names, using-directive elision, language keywords (`int` vs `Int32`) are decided where text is produced, with full information still in hand.
 
-Structured type identity is load-bearing: the moment a type degrades to a string, every downstream consumer inherits the loss, so `TypeRef` flows intact from importer to printer.
+Structured type identity must survive the pipeline: the moment a type degrades to a string, every downstream consumer inherits the loss, so `TypeRef` flows intact from importer to printer.
 
 ## The IR
 

--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -1,4 +1,4 @@
-# Decompiler Quality
+# Decompiler quality
 
 How `ILInspector.Decompiler` stays correct, and how it stays correct as the
 raising passes evolve. The companion docs split the concern: [decompiler.md](decompiler.md)
@@ -890,9 +890,8 @@ the product emits:
   drills into the per-pass IR of a single method to find which pass introduced
   the divergence; `--steps` / `--step-limit` narrows to a single rewrite.
 
-The connection is load-bearing: the final stage `--dump` shows is byte-identical
-to what `--fidelity-check` grades, so there is no drift between what you inspect
-and what is measured.
+The final stage `--dump` shows is byte-identical to what `--fidelity-check`
+grades, so what you inspect and what is measured cannot drift.
 
 Two gotchas that save head-scratching when diagnosing:
 

--- a/docs/decompiler.md
+++ b/docs/decompiler.md
@@ -1,4 +1,4 @@
-# Decompiler Design
+# Decompiler design
 
 This document describes the architecture of `ILInspector.Decompiler` — *how the
 pipeline decides* its output. Companion docs cover the rest:
@@ -20,7 +20,7 @@ That shape is the standard compiler pipeline, which Roslyn, RyuJIT, and ILSpy ar
 3. **Invariant validation after every pass** (debug builds).
 4. **All decisions made in the tree before output** — printing is a dumb final stage.
 
-Decompilation is this pipeline run in reverse. Where Roslyn *lowers* C# constructs to IL through named rewriters, we *raise* IL back through the inverse transforms. This duality is load-bearing: Roslyn's `Lowering/` directory is our completeness checklist, and each of our raising passes should be named and documented as the inverse of the Roslyn rewriter whose output it recognizes.
+Decompilation is this pipeline run in reverse. Where Roslyn *lowers* C# constructs to IL through named rewriters, we *raise* IL back through the inverse transforms. This duality defines our completeness model: Roslyn's `Lowering/` directory is our checklist, and each raising pass should be named and documented as the inverse of the Roslyn rewriter whose output it recognizes.
 
 ## Rosetta stone
 
@@ -125,7 +125,7 @@ replaying only what the binary records — and what the opt-in "simulate" mode
 
 The architecture earns its observability from one property: **every stage boundary is a projectable IR.** A single `IrPasses.RunWithStages` runner captures the typed tree at import and after every pass, and one `StageDump` formatter frames them — exactly JitDump's relationship to GenTree. Every harness mode reads that one capture rather than rebuilding it: `--dump` (the per-pass tree), `--diff` (each pass as a `+`/`-` hunk), `--facts` (the definite-assignment dataflow that decides `= default` elision), `--cfg` (block edges; `--mermaid` renders them), `--remarks` (the IR sites that cap fidelity, each with its `DEC####` code), and `--pass-impact` (the corpus-wide inverse — a pass's blast radius).
 
-The dump terminates on `CSharpPrinter.Print` of the fully-raised function, **byte-identical to the product's `PrintRaised`**. That is load-bearing: the final stage you inspect is exactly the artifact the verification checks grade, so there is no drift between observation and measurement. `--lowered` selects a lower render altitude — the `IrPasses.Lowered` list, the pipeline minus the cosmetic statement-sugar passes (`ForLoopPass`, `IncrementDecrementPass`, `LockSugarPass`) — still valid, recompilable C#, and earns the same checks.
+The dump terminates on `CSharpPrinter.Print` of the fully-raised function, **byte-identical to the product's `PrintRaised`**. The final stage you inspect is therefore exactly the artifact the verification checks grade, so observation and measurement cannot drift. `--lowered` selects a lower render altitude — the `IrPasses.Lowered` list, the pipeline minus the cosmetic statement-sugar passes (`ForLoopPass`, `IncrementDecrementPass`, `LockSugarPass`) — still valid, recompilable C#, and earns the same checks.
 
 How the checks (`--fidelity-check`, `--validity-check`, `--annotation-check`), the `--gaps` completeness view, and the corpus floors prove correctness, what gates CI, and the detect-then-diagnose loop they form are the subject of [decompiler-quality.md](decompiler-quality.md). The harness reference ([tools/DecompilerHarness/README.md](../tools/DecompilerHarness/README.md)) is the invocation guide for every mode named here, and [decompiler-ir-dumps.md](decompiler-ir-dumps.md) is the reading guide for the harness per-pass dump itself.
 

--- a/docs/design/assembly-inspection-query.md
+++ b/docs/design/assembly-inspection-query.md
@@ -1,4 +1,4 @@
-# Assembly Inspection Query Model
+# Assembly inspection query model
 
 > Design north-star for the CLI-thinning work tracked in
 > [#2122](https://github.com/richlander/dotnet-inspect/issues/2122). Describes the target

--- a/docs/design/decompiler-substrate.md
+++ b/docs/design/decompiler-substrate.md
@@ -80,8 +80,8 @@ ledger/scorecard movement, or a corpus/fidelity signal.
 ## Atoms, not one maximal predicate
 
 A substrate layer exposes **atoms the caller composes**, never a single "does
-everything" predicate. The equality
-logic is shared; *which node kinds a pass admits* is not — that admissibility is
+everything" predicate. Equality is shared; *which node kinds a pass admits* is
+not — that admissibility is
 a deliberate soundness discriminator the pass still owns.
 
 `PlaceIdentity` is the clearest illustration. Several passes — `??=`, `?.`, switch

--- a/docs/design/decompiler-substrate.md
+++ b/docs/design/decompiler-substrate.md
@@ -1,4 +1,4 @@
-# Decompiler Substrate Layers
+# Decompiler substrate layers
 
 How shared rewrite-gate predicates are factored out from the raising passes, and
 how we notice when several passes have independently grown the same need. This
@@ -79,8 +79,8 @@ ledger/scorecard movement, or a corpus/fidelity signal.
 
 ## Atoms, not one maximal predicate
 
-The load-bearing design choice is that a substrate layer exposes **atoms the
-caller composes**, never a single "does everything" predicate. The equality
+A substrate layer exposes **atoms the caller composes**, never a single "does
+everything" predicate. The equality
 logic is shared; *which node kinds a pass admits* is not — that admissibility is
 a deliberate soundness discriminator the pass still owns.
 

--- a/docs/design/finding-adoption.md
+++ b/docs/design/finding-adoption.md
@@ -1,4 +1,4 @@
-# Finding Adoption
+# Finding adoption
 
 A Finding producer is not adopted when a consumer merely calls it. Adoption is
 complete when the consumer retains the producer's outcome semantics, replaces
@@ -191,7 +191,7 @@ equality explicitly, or supply an explicit comparer.
 
 **Model.** [PR #2701](https://github.com/richlander/dotnet-inspect/pull/2701)
 gives Finding collection records sequence- and set-aware value equality while
-keeping matching key-driven. The load-bearing pin is
+keeping matching key-driven. The test that pins this behavior is
 `FindingPayloadEquality_IsProducerOwnedButMatchingRemainsKeyDriven`: equal keys
 still match while unequal payload content reports unequal, and that is correct.
 See [Finding Value Equality](finding-value-equality.md) and

--- a/docs/design/hidden-fact-annotations.md
+++ b/docs/design/hidden-fact-annotations.md
@@ -1,4 +1,4 @@
-# Hidden-Fact Annotations
+# Hidden-fact annotations
 
 This document describes the **hidden-fact annotation** layer: a read-only,
 descriptive system over the decompiler's IR that surfaces facts the C# source
@@ -40,9 +40,9 @@ is plainest at `Imported`; a cached-delegate shape only after `Raised`).
 
 An annotation marks the **presence** of a fact, never the absence of others.
 There is no "all clear" — any tally is a roll-up of what was found, never an
-oracle that asserts nothing else exists. This is load-bearing: it is what lets
-the layer stay honest under incomplete analysis. A missed fact is a recall gap,
-never a false "this method is allocation-free" claim.
+oracle that asserts nothing else exists. That rule keeps the layer honest under
+incomplete analysis. A missed fact is a recall gap, never a false "this method
+is allocation-free" claim.
 
 ### Categories and classifiers
 

--- a/docs/design/instruction-substrate.md
+++ b/docs/design/instruction-substrate.md
@@ -1,4 +1,4 @@
-# Instruction Substrate (`ILInspector.Instructions`)
+# Instruction substrate (`ILInspector.Instructions`)
 
 How one shared IL decode + EH-aware basic-block builder is factored out from the
 analyzer and the decompiler, why it is shaped the way it is, and how it is proven
@@ -90,9 +90,9 @@ Both carry the MIT "Ported from dotnet/runtime `<path>`" header.
 | `Internal.TypeSystem` `TypeDesc`/`MethodDesc` | SRM `MetadataReader` handles | **Not used** | stay SRM-only; never vendor the runtime type system |
 | RyuJIT `GenTree`/`typeInfo`, `ILStackHelper` heights | (none) | **Not used** | unlike consumers do not share an abstract interpretation |
 
-The last "not used" row is load-bearing: prior art runs three *separate* typed
-stacks over one shared reader, so we share decode + identity (Layer 0) and let
-each consumer build its own Layer 1.
+The last "not used" row keeps abstract interpretation consumer-owned: prior art
+runs three *separate* typed stacks over one shared reader, so we share decode +
+identity (Layer 0) and let each consumer build its own Layer 1.
 
 ### Port boundary: what the substrate does and doesn't validate
 

--- a/docs/design/inverse-architecture.md
+++ b/docs/design/inverse-architecture.md
@@ -74,7 +74,7 @@ metadata, not from the erased stack.
 
 This is what "confident" in *confident inverse* means: the decompiler's body-derived
 facts are a subset of what RyuJIT soundly recovers. RyuJIT's rules are therefore
-load-bearing spec, not analogy. The clearest example: RyuJIT normalizes
+the governing specification, not an analogy. The clearest example: RyuJIT normalizes
 `bool`/`byte`/`short` to `int32` on the evaluation stack and re-narrows on store (the
 ECMA-335 stack model). Any decompiler stage that forgets this — that treats a stack
 `bool` as distinguishable from a stack `int32` at a sink — is unsound against the
@@ -222,7 +222,7 @@ Two design rules keep this sound and cheap:
   *assumption checks* are debug-only: a `Debug.Assert(InverseAssumptions.…(…))` in the
   hot path (compiled out of release), backed by a release-capable `Check()` for the
   corpus gate — the same return-not-throw shape the coercion invariant already uses.
-- **The annotation is load-bearing, not decorative.** A coverage test requires every
+- **The annotation is enforced, not decorative.** A coverage test requires every
   in-domain node to carry `[InverseOf(...)]` or an explicit `[NotInverted(reason)]`,
   and CI diffs the generated ledger against the committed copy. If nothing goes red
   when an annotation is wrong or missing, it is just a fancy comment.
@@ -281,7 +281,7 @@ typed → structured → IR after each pass → C#).
 
 An opt-in assertion lane annotates each IR node in that staged view with its
 `[InverseOf]` forward construct and `assumes:` predicate, evaluates the predicate in
-place (the release-capable `Check()` the load-bearing rule requires), and marks each
+place (the release-capable `Check()` required by that contract), and marks each
 undischarged assertion by *where* it is observed — an informational `OBLIGATION` at
 any non-final stage (a downstream pass is contracted to discharge it), and an error
 `UNSOUND` only for a survivor at the final stage. Three properties make this more than

--- a/docs/design/member-body-substrate.md
+++ b/docs/design/member-body-substrate.md
@@ -1,4 +1,4 @@
-# Member Body Substrate
+# Member body substrate
 
 How the product renders a type and its member bodies through **one producer
 contract** repeated at each layer, so that skeleton source, full source, the
@@ -78,8 +78,8 @@ absent from the surface: `Metadata` and `CSharp` reach neither `ControlFlow` nor
 `Instructions`, which is exactly what lets the surface scenarios (signatures,
 shells) avoid the decode graph — the property this note's payoff rests on.
 
-`ControlFlow` is the one leaf drawn above, because *where* it is consumed is
-load-bearing for that payoff (decode/body side only). The other two leaves are
+`ControlFlow` is the one leaf drawn above because consuming it only on the
+decode/body side is what delivers that payoff. The other two leaves are
 pervasive and carry no layering argument, so their edges are omitted:
 `MetadataPrimitives` (low SRM helpers) is consumed by `Metadata`, `Instructions`,
 and `CSharp.Decompiler`; `Findings` (the shared finding/diagnostic type) is

--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -1,4 +1,4 @@
-# Output Shapes
+# Output shapes
 
 dotnet-inspect output narrows through a small ladder of **shapes**. Markout
 defines the shapes and produces them; dotnet-inspect flags choose which rung you

--- a/docs/design/readable-local-names.md
+++ b/docs/design/readable-local-names.md
@@ -1,4 +1,4 @@
-# Readable Local Names (opt-in)
+# Readable local names (opt-in)
 
 Design note for the #998 "Local naming and declaration placement" row. Scope is
 deliberately narrow: an **opt-in** mode that gives synthesized, readable names to
@@ -13,7 +13,7 @@ back to `V_index`. With no PDB — the common case for shipped/stripped assembli
 and the deterministic `--skip-pdb` reading path — every local is `V_0`, `V_1`, …,
 which is the single largest readability gap in otherwise-structured output.
 
-## Constraint: default output is load-bearing
+## Constraint: default output must remain stable
 
 `V_n` is not just cosmetic to leave alone — three things depend on it:
 

--- a/docs/design/section-model.md
+++ b/docs/design/section-model.md
@@ -1,4 +1,4 @@
-# Section selection, Column filtering and rendering flow
+# Section selection, column filtering, and rendering flow
 
 One of the strongest features of dotnet-inspect and Markout is section filtering and view models. Every operation is a query that can be evaluated and executed. This clarity enables a variety of decisions and optimizations to be made.
 

--- a/docs/design/source-finding-producers.md
+++ b/docs/design/source-finding-producers.md
@@ -1,4 +1,4 @@
-# Source Finding Producers
+# Source Finding producers
 
 Metadata owns the local, SRM-only observations available from PE and portable
 PDB data. Network source acquisition, checksum verdicts, decompiler source

--- a/docs/design/style-guide.md
+++ b/docs/design/style-guide.md
@@ -1,8 +1,8 @@
-# dotnet-inspect Output Style Guide
+# dotnet-inspect output style guide
 
 This document defines the output format conventions for `dotnet-inspect`. The primary goal is to produce output that is easily consumable by both humans and LLMs.
 
-## Document Structure
+## Document structure
 
 All markdown output follows a consistent four-part structure:
 
@@ -21,7 +21,7 @@ Optional description paragraph.
 | data   | data   |
 ```
 
-### 1. H1 Title
+### 1. H1 title
 
 Every output starts with a single H1 heading that names the **subject — and only the subject**:
 
@@ -40,7 +40,7 @@ that produced the metadata), and a field list scales to that and stays machine-e
 where a parenthetical can legibly hold only one item and is awkward to parse. The package view
 already follows this: `# System.Text.Json` with the rest in fields.
 
-### 2. Description Paragraph
+### 2. Description paragraph
 
 An optional plain-text paragraph immediately after the H1. This is where documentation summaries appear. No special formatting (not a blockquote, not italicized).
 
@@ -50,7 +50,7 @@ An optional plain-text paragraph immediately after the H1. This is where documen
 Provides functionality to serialize objects or value types to JSON and deserialize JSON into objects or value types.
 ```
 
-### 3. Key-Value Fields
+### 3. Key-value fields
 
 Structured metadata as `**Label:** value` pairs, one per line. These fields form the stable "header" that `--fields-only` preserves.
 
@@ -95,7 +95,7 @@ The `**Samples:**` field is a count indicator. Sample URL tables belong in a
 dedicated `Samples` section when package/docs metadata can provide trustworthy
 links.
 
-### 4. H2 Sections
+### 4. H2 sections
 
 Tables and structured content appear under H2 headings. Section visibility is controlled by verbosity level.
 
@@ -109,7 +109,7 @@ Tables and structured content appear under H2 headings. Section visibility is co
 
 When there is only a single table, the H2 heading may be omitted for brevity.
 
-## Verbosity Levels
+## Verbosity levels
 
 Verbosity controls which H2 sections appear, not which fields appear:
 
@@ -128,7 +128,7 @@ The H1, description, and fields are always present regardless of verbosity.
 
 Some views use the same layout at all verbosity levels because differentiation would not be meaningful. The **types listing** (full-library view) is verbosity-independent: it always shows per-kind sections (`## Classes`, `## Structs`, etc.) with `Type | Members` columns. The only variation is `--docs` adding a Description column. Verbosity differentiation is reserved for the **member view** (per-type), where quiet groups by name, minimal abbreviates signatures, and normal/detailed show full signatures.
 
-## Table Formatting
+## Table formatting
 
 Tables use pipe-delimited markdown:
 
@@ -151,7 +151,7 @@ Tables use pipe-delimited markdown:
 - Metadata tables: `| Property | Value |`
 - Audit tables: `| File | Deterministic | SourceLink |`
 
-## Code Formatting
+## Code formatting
 
 Signatures use inline backticks within tables:
 
@@ -171,7 +171,7 @@ All links in output should be **raw URLs**, not markdown-formatted links. This e
 - Users can copy/paste URLs without extraction
 - No ambiguity about what the link points to
 
-### GitHub Link Formats
+### GitHub link formats
 
 | Format | Example | Commit-Specific | Content | Redirect |
 | ------ | ------- | --------------- | ------- | -------- |
@@ -208,7 +208,7 @@ All links in output should be **raw URLs**, not markdown-formatted links. This e
 - ⚠️ 302 (temporary) redirect - not 301 (permanent), so caching behavior is appropriate
 - ✅ Trivial to convert to browsable URL: `raw` → `blob`
 
-### Preferred Format
+### Preferred format
 
 Use `github.com/.../raw/{sha}/path` format for all source links.
 
@@ -228,7 +228,7 @@ https://github.com/richlander/markout/raw/4bfea7c.../TreeNode.cs
 https://github.com/richlander/markout/blob/4bfea7c.../TreeNode.cs
 ```
 
-### Output Format
+### Output format
 
 Links should appear as raw URLs, not markdown links. Line numbers are omitted for type-level source URLs since they point to arbitrary members rather than the type declaration:
 
@@ -248,7 +248,7 @@ Not:
 - [Tree rendering](https://github.com/...)
 ```
 
-### Opting into Blob URLs
+### Opting into blob URLs
 
 Use `--blob` to switch from raw URLs to `/blob/` URLs for browser viewing:
 

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -1,4 +1,4 @@
-# Untrusted Data Threat Model
+# Untrusted data threat model
 
 `dotnet-inspect` reads artifacts that may be malformed or intentionally hostile.
 Inspection must not grant those artifacts authority to execute code, choose

--- a/docs/design/value-typed-emission.md
+++ b/docs/design/value-typed-emission.md
@@ -234,10 +234,11 @@ per print.
 ### 2. `Coerce(value, targetType)` — the node
 
 A single C#-surface coercion node, distinct from the existing `Convert` node.
-The two nodes represent different facts: `Convert` models the value's **IL history**
-(`conv.i8`); `Coerce` models the **C# rendering conversion** needed at a target. The
-new node is inserted during raising (or synthesised at the emission boundary) and
-owns, in one place, the rules the printer currently spreads around:
+The two nodes represent different facts: `Convert` models the value's **IL
+history** (`conv.i8`); `Coerce` models the **C# rendering conversion** needed at
+a target. The new node is inserted during raising (or synthesised at the
+emission boundary) and owns, in one place, the rules the printer currently
+spreads around:
 
 - implicit vs. explicit conversion (only literal `0` converts to an enum bare);
 - `unchecked(...)` for a constant that overflows the *backing* width, whether the

--- a/docs/design/value-typed-emission.md
+++ b/docs/design/value-typed-emission.md
@@ -234,7 +234,7 @@ per print.
 ### 2. `Coerce(value, targetType)` — the node
 
 A single C#-surface coercion node, distinct from the existing `Convert` node.
-This distinction is load-bearing: `Convert` models the value's **IL history**
+The two nodes represent different facts: `Convert` models the value's **IL history**
 (`conv.i8`); `Coerce` models the **C# rendering conversion** needed at a target. The
 new node is inserted during raising (or synthesised at the emission boundary) and
 owns, in one place, the rules the printer currently spreads around:

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -1,4 +1,4 @@
-# Version Resolution
+# Version resolution
 
 dotnet-inspect uses Docker-style version tags to balance freshness against
 latency. Version discovery is cached briefly; package contents are cached

--- a/docs/metadata-primitives.md
+++ b/docs/metadata-primitives.md
@@ -186,8 +186,9 @@ note is about. It turns the hypothesis into evidence:
   produces display **strings** and cannot answer "is there a pointer in this
   signature." `Analysis`'s own `TypeRefDecoder → TypeRef` is what makes the check
   possible. A shared model would have forced `Analysis` to keep its own anyway.
-- **`Analysis`'s independence is load-bearing.** The whole detector shipped
-  SRM-direct with no dependency negotiation. That is the property step 4 spends.
+- **`Analysis`'s independence is a product boundary.** The whole detector
+  shipped SRM-direct with no dependency negotiation. That is the property step
+  4 spends.
 - **The real duplication is tiny and stable.** `Analysis` hand-rolled
   `AttributeTypeName` (ctor → declaring-type namespace+name, `MemberReference`
   vs `MethodDefinition`) — the same SRM walk as

--- a/docs/pdb-acquisition.md
+++ b/docs/pdb-acquisition.md
@@ -1,4 +1,4 @@
-# PDB Acquisition
+# PDB acquisition
 
 This document describes how dotnet-inspect locates and downloads PDB (Program Database) files to enable SourceLink resolution and source code navigation.
 
@@ -6,7 +6,7 @@ This document describes how dotnet-inspect locates and downloads PDB (Program Da
 
 PDBs contain debug information that maps compiled code back to source. For SourceLink to work, we need access to a **Portable PDB** that contains the SourceLink JSON document.
 
-## PDB Formats
+## PDB formats
 
 ### Portable PDB
 
@@ -24,7 +24,7 @@ PDBs contain debug information that maps compiled code back to source. For Sourc
 - Cannot be read by System.Reflection.Metadata
 - Still used for native image PDBs (`.ni.pdb`) in Windows R2R builds
 
-## PDB Location Strategy
+## PDB location strategy
 
 The tool searches for PDBs in this order:
 
@@ -36,14 +36,14 @@ Check if the library has an embedded PDB (stored inside the PE file itself). Thi
 
 Look for a `.pdb` file next to the library with the same base name. Common when debugging locally.
 
-### 3. Symbol Package (.snupkg)
+### 3. Symbol package (.snupkg)
 
 For NuGet packages, download the corresponding `.snupkg` from:
 
 - `https://globalcdn.nuget.org/symbol-packages/{id}.{version}.snupkg`
 - `https://api.nuget.org/v3-flatcontainer/{id}/{version}/{id}.{version}.snupkg`
 
-### 4. Symbol Servers
+### 4. Symbol servers
 
 Query symbol servers using the CodeView GUID and age:
 
@@ -55,7 +55,7 @@ The symbol key format differs by PDB type:
 - Portable PDB: `{GUID}FFFFFFFF`
 - Windows PDB: `{GUID}{age:x}`
 
-## CodeView Debug Directory
+## CodeView debug directory
 
 The PE file's debug directory contains CodeView entries that provide:
 
@@ -64,7 +64,7 @@ The PE file's debug directory contains CodeView entries that provide:
 - **Age**: Build counter (always 1 for Portable PDBs)
 - **MinorVersion**: `0x504d` indicates Portable PDB format
 
-### Multiple CodeView Entries
+### Multiple CodeView entries
 
 **Important**: Some libraries have multiple CodeView entries. Windows ReadyToRun (R2R) assemblies typically have two:
 
@@ -80,22 +80,22 @@ CodeView Entry 1: System.Text.Json.ni.pdb (MinorVersion: 0x0000, Windows PDB)
 CodeView Entry 2: System.Text.Json.pdb    (MinorVersion: 0x504d, Portable PDB) ← use this
 ```
 
-## Microsoft vs Third-Party Libraries
+## Microsoft vs third-party libraries
 
-### Microsoft Platform Libraries
+### Microsoft platform libraries
 
 - Built by Microsoft from dotnet/runtime
 - Published to MSDL symbol server
 - SourceLink URLs point to `raw.githubusercontent.com/dotnet/runtime/...`
 
-### Distro Builds (Canonical, Red Hat, etc.)
+### Distro builds (Canonical, Red Hat, etc.)
 
 - Rebuilt from source by Linux distributions
 - SourceLink typically disabled during rebuild
 - Same metadata (Company: "Microsoft Corporation") but no symbols on MSDL
 - Detected by: symbols not found on any server
 
-### Third-Party NuGet Packages
+### Third-party NuGet packages
 
 - May publish `.snupkg` to NuGet.org
 - May publish to NuGet symbol server
@@ -108,7 +108,7 @@ Downloaded PDBs are cached locally to avoid repeated downloads:
 - **Symbol packages**: `~/.dotnet-inspect/symbols/{package}/{version}/{filename}.pdb`
 - **Symbol server**: `~/.dotnet-inspect/symbols/{pdbname}/{key}/{pdbname}`
 
-## Error Handling
+## Error handling
 
 When PDB acquisition fails, we report the reason:
 
@@ -117,7 +117,7 @@ When PDB acquisition fails, we report the reason:
 - **"embedded"**: PDB is embedded in the library (success case)
 - **"msdl.microsoft.com"**: Downloaded from Microsoft symbol server (success case)
 
-## Related Resources
+## Related resources
 
 - [SourceLink Exposure](sourcelink-exposure.md)
 - [Portable PDB Specification](https://github.com/dotnet/runtime/blob/main/docs/design/specs/PortablePdb-Metadata.md)

--- a/tests/DotnetInspector.ILRoundtrip.Tests/README.md
+++ b/tests/DotnetInspector.ILRoundtrip.Tests/README.md
@@ -1,0 +1,29 @@
+# IL round-trip tests
+
+This executable test project exercises canonical IL assembly round trips. It is
+outside the default solution and depends on the vendored managed ILAssembler.
+
+Run commands from the repository root. Use `dotnet run`, not `dotnet test`.
+
+## Restore the ILAssembler dependency
+
+Materialize the vendored project before building or running the tests:
+
+```bash
+eng/restore-ilassembler.sh
+```
+
+## Run the tests
+
+Run the fast subset used for pull-request validation:
+
+```bash
+dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release -- \
+  -trait- "Speed=Slow"
+```
+
+Run the full suite, including the assembly-wide sweep:
+
+```bash
+dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release
+```

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -1,4 +1,4 @@
-# Decompiler Harness
+# Decompiler harness
 
 The diagnostic harness from [docs/decompiler.md](../../docs/decompiler.md) — the asmdiffs analog for the decompiler. It inventories the pipeline's health, scores the real-gap completeness, validates output two ways, and dumps a single method through every pipeline stage. This is the invocation reference for the modes; the strategy they serve — which check proves what, what gates CI, the corpus-sweep plan — is [docs/decompiler-quality.md](../../docs/decompiler-quality.md).
 
@@ -33,7 +33,7 @@ corpus-scale analog of `--dump --assertions`' `UNSOUND` marker (see below and
 The `final-stage survivors (UNSOUND)` line is the real soundness number:
 `first violation sites` counts everything (mostly discharged obligations, which
 are the pipeline working as designed), while a non-zero survivor count is the
-load-bearing signal. "Final stage is zero survivors" for the wrappable population
+blocking signal. "Final stage is zero survivors" for the wrappable population
 is now measured corpus-wide rather than eyeballed from `--dump --assertions`
 exemplars (known `PrinterOwned` residuals excluded). `--emit-assertion-violations`
 persists the survivor flag (snapshot schema v2), and `--diff-assertion-violations`


### PR DESCRIPTION
## Summary

- Move IL round-trip restore and execution recipes from `AGENTS.md` to a focused test-project README, with a task-map route back to that owner.
- Normalize sentence-case headings across the central guidance documents while preserving proper nouns, named output sections, and code examples.
- Replace vague "load-bearing" phrasing with the specific invariant, boundary, test, or consequence each passage means.

## Compatibility

Documentation only; this does not change product, test, CI, or publishing behavior.

This is a low-risk editorial and guidance-ownership cleanup, so adversarial review is not required.

## Validation

- `npx markdownlint-cli` over every changed Markdown file
- `git diff --check origin/main...HEAD`