### PR TITLE
Strengthen classic state-machine corpus evidence

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.ClassicStateMachines/ClassicStateMachineFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.ClassicStateMachines/ClassicStateMachineFixtures.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace ILInspector.Decompiler.Fixtures.ClassicStateMachines;
@@ -22,11 +25,10 @@ namespace ILInspector.Decompiler.Fixtures.ClassicStateMachines;
 /// <c>Iterator_</c> (classic <c>yield</c> iterator), <c>AsyncIterator_</c>
 /// (classic async iterator — <c>IAsyncEnumerable&lt;T&gt;</c> combining both
 /// state-machine shapes), and <c>Switch_</c> (a plain, non-pattern switch
-/// statement — the old jump-table lowering, TFM/LangVersion-agnostic like the
-/// rest of this fixture, so it is measured here rather than requiring a
-/// downlevel TFM/LangVersion axis).
+/// statement used as a control). This is a representative current-compiler
+/// matrix, not an exhaustive cross-compiler or downlevel-TFM corpus.
 /// </summary>
-public static class ClassicStateMachineFixtures
+public class ClassicStateMachineFixtures
 {
     public static async Task<int> Async_AwaitValue(Task<int> a, int b) => await a + b;
 
@@ -57,6 +59,37 @@ public static class ClassicStateMachineFixtures
             sum += await task;
         }
         return sum;
+    }
+
+    public static async void Async_VoidBuilder(Action completed)
+    {
+        await Task.Yield();
+        completed();
+    }
+
+    public static async ValueTask<int> Async_ValueTaskBuilder(ValueTask<int> value)
+        => await value;
+
+    public async Task<T> Async_InstanceGeneric<T>(Task<T> value)
+    {
+        await Task.Yield();
+        return await value;
+    }
+
+    public static async Task<int> Async_AwaitInCatchAndFinally(Task<int> value)
+    {
+        try
+        {
+            throw new InvalidOperationException();
+        }
+        catch (InvalidOperationException)
+        {
+            return await value;
+        }
+        finally
+        {
+            await Task.Yield();
+        }
     }
 
     public static IEnumerable<int> Iterator_YieldSequence(int count)
@@ -96,6 +129,24 @@ public static class ClassicStateMachineFixtures
         }
     }
 
+    public static IEnumerable Iterator_NonGeneric()
+    {
+        yield return "classic";
+        yield return 42;
+    }
+
+    public static IEnumerable<T> Iterator_Generic<T>(T first, T second)
+    {
+        yield return first;
+        yield return second;
+    }
+
+    public IEnumerable<int> Iterator_Instance(int value)
+    {
+        yield return value;
+        yield return value + 1;
+    }
+
     public static async IAsyncEnumerable<int> AsyncIterator_AwaitThenYield(Task<int>[] tasks)
     {
         foreach (var task in tasks)
@@ -116,6 +167,33 @@ public static class ClassicStateMachineFixtures
             }
             yield return await task;
             i++;
+        }
+    }
+
+    public static async IAsyncEnumerable<int> AsyncIterator_WithCancellation(
+        int count,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Yield();
+            yield return i;
+        }
+    }
+
+    public static async IAsyncEnumerable<int> AsyncIterator_TryFinallyAndDisposal(
+        IAsyncEnumerable<int> source)
+    {
+        await using var resource = new AsyncResource();
+        try
+        {
+            await foreach (int item in source)
+                yield return item;
+        }
+        finally
+        {
+            await resource.TouchAsync();
         }
     }
 
@@ -153,5 +231,12 @@ public static class ClassicStateMachineFixtures
             default:
                 return "many";
         }
+    }
+
+    sealed class AsyncResource : IAsyncDisposable
+    {
+        public ValueTask TouchAsync() => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }

--- a/src/ILInspector.Decompiler.Fixtures.ClassicStateMachines/ILInspector.Decompiler.Fixtures.ClassicStateMachines.csproj
+++ b/src/ILInspector.Decompiler.Fixtures.ClassicStateMachines/ILInspector.Decompiler.Fixtures.ClassicStateMachines.csproj
@@ -3,15 +3,12 @@
   <!--
     Issue #2818 (classic async/iterator state-machine corpus lane, child of #2814).
     Extends the classic-async axis (RuntimeAsync=off, see
-    ILInspector.Decompiler.Fixtures.ClassicAsync) to also pin classic iterators and
-    classic async iterators in the same lowering mode. No CI corpus contained a
-    single classic async state machine before #2818; iterators and async iterators
-    were entirely absent. A plain switch statement is included so the old
-    jump-table switch lowering — cascading alongside classic async/iterator state
-    dispatch — is measured in the same pinned lane (the harness README's
-    "downlevel TFM/LangVersion" candidate axis; this reaches the same classic
-    lowering set without a downlevel runtime pack by reusing the proven
-    RuntimeAsync=off axis).
+    ILInspector.Decompiler.Fixtures.ClassicAsync) to pin a representative matrix
+    of classic async builders, iterators, and async iterators in the same lowering
+    mode. No CI corpus contained a single classic async state machine before
+    #2818; iterators and async iterators were entirely absent. A plain switch
+    statement is included as a control. This current-compiler lane does not claim
+    exhaustive compiler-version or downlevel-TFM coverage.
 
     Built by the normal solution graph and addressable through FixtureCatalog.
     Point the harness at the built DLL with the classic-state-machines corpus

--- a/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
@@ -412,6 +412,52 @@ public class CorpusSensorComparisonTests
     }
 
     [Fact]
+    public void ClassicStateMachineCoverage_CountsKickoffResultsByFamily()
+    {
+        var coverage = CorpusSensor.BuildClassicStateMachineCoverage(
+        [
+            ClassicKickoff("Async_Value", fullyRaised: true),
+            ClassicKickoff("Iterator_Sequence", fullyRaised: false),
+            ClassicKickoff("AsyncIterator_Sequence", fullyRaised: false),
+            ClassicKickoff("MoveNext", fullyRaised: true, type: "T.<Async_Value>d__1"),
+            ClassicKickoff("Switch_Control", fullyRaised: true),
+        ]);
+
+        Assert.Equal(new ClassicStateMachineFeatureMetrics(1, 1, 0), coverage["classic-async"]);
+        Assert.Equal(new ClassicStateMachineFeatureMetrics(1, 0, 1), coverage["classic-iterator"]);
+        Assert.Equal(new ClassicStateMachineFeatureMetrics(1, 0, 1), coverage["classic-async-iterator"]);
+        Assert.Equal(3, coverage.Count);
+    }
+
+    [Fact]
+    public void Compare_RejectsClassicStateMachineRaisedRegression()
+    {
+        var baselineCoverage = CompleteClassicStateMachineCoverage()
+            .SetItem("classic-async", new ClassicStateMachineFeatureMetrics(4, 4, 0));
+        var currentCoverage = CompleteClassicStateMachineCoverage()
+            .SetItem("classic-async", new ClassicStateMachineFeatureMetrics(4, 3, 1));
+        var baseline = Snapshot(
+            4, 4, 10_000, null,
+            profile: CorpusProfile.ClassicStateMachines,
+            featureCoverage: CompleteClassicFeatureCoverage(),
+            classicStateMachineCoverage: baselineCoverage);
+        var current = Snapshot(
+            4, 3, 7_500, null,
+            profile: CorpusProfile.ClassicStateMachines,
+            featureCoverage: CompleteClassicFeatureCoverage(),
+            classicStateMachineCoverage: currentCoverage);
+
+        var regressions = CorpusSensor.Compare(baseline, current, []);
+
+        Assert.Contains(
+            "classic state-machine fully raised 'classic-async' dropped (baseline 4, current 3)",
+            regressions);
+        Assert.Contains(
+            "classic state-machine residual 'classic-async' increased (baseline 0, current 1)",
+            regressions);
+    }
+
+    [Fact]
     public void CompilerFeatureOptions_ReplaysMemorySafetyModeFromModuleMetadata()
     {
         string updatedAssembly =
@@ -1114,7 +1160,8 @@ public class CorpusSensorComparisonTests
         CorpusFidelityOracle fidelityOracle = CorpusFidelityOracle.CompileBack,
         ReturnToSenderParityMetrics? returnToSenderParity = null,
         CorpusProfile profile = CorpusProfile.RealWorld,
-        IReadOnlyDictionary<string, int>? featureCoverage = null)
+        IReadOnlyDictionary<string, int>? featureCoverage = null,
+        IReadOnlyDictionary<string, ClassicStateMachineFeatureMetrics>? classicStateMachineCoverage = null)
     {
         return new CorpusSensorSnapshot(
             SchemaVersion: 1,
@@ -1150,8 +1197,26 @@ public class CorpusSensorComparisonTests
                     ReturnToSenderParity: returnToSenderParity)),
             FidelityOracle: fidelityOracle,
             Profile: profile,
-            FeatureCoverage: featureCoverage);
+            FeatureCoverage: featureCoverage,
+            ClassicStateMachineCoverage: classicStateMachineCoverage);
     }
+
+    static ImmutableDictionary<string, int> CompleteClassicFeatureCoverage()
+        => new Dictionary<string, int>(StringComparer.Ordinal)
+        {
+            ["classic-async-methods"] = 1,
+            ["classic-iterator-methods"] = 1,
+            ["classic-async-iterator-methods"] = 1,
+            ["switch-methods"] = 1,
+        }.ToImmutableDictionary(StringComparer.Ordinal);
+
+    static ImmutableDictionary<string, ClassicStateMachineFeatureMetrics> CompleteClassicStateMachineCoverage()
+        => new Dictionary<string, ClassicStateMachineFeatureMetrics>(StringComparer.Ordinal)
+        {
+            ["classic-async"] = new(1, 1, 0),
+            ["classic-iterator"] = new(1, 1, 0),
+            ["classic-async-iterator"] = new(1, 1, 0),
+        }.ToImmutableDictionary(StringComparer.Ordinal);
 
     static ImmutableDictionary<string, int> CompleteFeatureCoverage()
         => new Dictionary<string, int>(StringComparer.Ordinal)
@@ -1249,6 +1314,24 @@ public class CorpusSensorComparisonTests
             Validity: validity,
             FidelityCheck: fidelityCheck,
             FidelityReference: fidelityReference);
+
+    static CorpusMethodSnapshot ClassicKickoff(
+        string method,
+        bool fullyRaised,
+        string type = "ClassicStateMachineFixtures")
+        => new(
+            Assembly: "Fixture",
+            AssemblyPath: "fixture.dll",
+            Type: type,
+            Method: method,
+            Overload: 0,
+            Signature: "()",
+            Fidelity: fullyRaised ? "Full" : "Partial",
+            FullyRaised: fullyRaised,
+            Residual: fullyRaised ? null : "fidelity: unsupported-node",
+            PassBug: null,
+            Validity: "not-sampled",
+            FidelityCheck: "not-sampled");
 
     static CorpusMethodSnapshot ResidualMethod(
         string method,

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -157,7 +157,12 @@ internal static class CorpusSensor
         }
 
         if (diffBaseline is null)
-            return current.Metrics.PassBugs > 0 || FeatureCoverageFailures(current).Length > 0 || rtsParityRegressed ? 1 : 0;
+            return current.Metrics.PassBugs > 0
+                || FeatureCoverageFailures(current).Length > 0
+                || ClassicStateMachineCoverageFailures(current, current).Length > 0
+                || rtsParityRegressed
+                ? 1
+                : 0;
 
         var baseline = JsonSerializer.Deserialize<CorpusSensorSnapshot>(
             ReadBaselineText(diffBaseline, diffBaselineRef),
@@ -327,7 +332,8 @@ internal static class CorpusSensor
             Metrics: metrics,
             FidelityOracle: fidelityOracle,
             Profile: profile,
-            FeatureCoverage: completeness.FeatureCoverage);
+            FeatureCoverage: completeness.FeatureCoverage,
+            ClassicStateMachineCoverage: completeness.ClassicStateMachineCoverage);
 
         return (snapshot, fidelityReports);
     }
@@ -489,7 +495,48 @@ internal static class CorpusSensor
             residualBuckets.OrderBy(kvp => kvp.Key, StringComparer.Ordinal).ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.Ordinal),
             methodReports.OrderBy(m => MethodKey(m), StringComparer.Ordinal).ToImmutableArray(),
             featureCoverage.OrderBy(pair => pair.Key, StringComparer.Ordinal)
-                .ToImmutableSortedDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal));
+                .ToImmutableSortedDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal),
+            profile == CorpusProfile.ClassicStateMachines
+                ? BuildClassicStateMachineCoverage(methodReports)
+                : null);
+    }
+
+    internal static ImmutableSortedDictionary<string, ClassicStateMachineFeatureMetrics>
+        BuildClassicStateMachineCoverage(IEnumerable<CorpusMethodSnapshot> methods)
+    {
+        var coverage = new Dictionary<string, ClassicStateMachineFeatureMetrics>(StringComparer.Ordinal);
+        foreach (var method in methods)
+        {
+            // Count source kickoffs, not every generated interface/support member.
+            // The kickoff's post-pass fidelity is the product-visible result of
+            // reconstructing its sibling MoveNext through the import seam.
+            if (method.Type.Contains('<', StringComparison.Ordinal))
+                continue;
+
+            string? feature = method.Method switch
+            {
+                var name when name.StartsWith("AsyncIterator_", StringComparison.Ordinal)
+                    => "classic-async-iterator",
+                var name when name.StartsWith("Iterator_", StringComparison.Ordinal)
+                    => "classic-iterator",
+                var name when name.StartsWith("Async_", StringComparison.Ordinal)
+                    => "classic-async",
+                _ => null,
+            };
+            if (feature is null)
+                continue;
+
+            coverage.TryGetValue(feature, out var current);
+            current ??= new ClassicStateMachineFeatureMetrics();
+            coverage[feature] = current with
+            {
+                Population = current.Population + 1,
+                FullyRaised = current.FullyRaised + (method.FullyRaised ? 1 : 0),
+                Residual = current.Residual + (method.FullyRaised ? 0 : 1),
+            };
+        }
+
+        return coverage.ToImmutableSortedDictionary(StringComparer.Ordinal);
     }
 
     static void RecordUnionCoverage(
@@ -1291,6 +1338,7 @@ internal static class CorpusSensor
                 + $"current {CorpusProfileName(current.Profile)})");
         }
         failures.AddRange(FeatureCoverageFailures(current));
+        failures.AddRange(ClassicStateMachineCoverageFailures(baseline, current));
         if (baseline.FeatureCoverage is not null && current.FeatureCoverage is not null)
         {
             foreach (var (feature, baselineCount) in baseline.FeatureCoverage)
@@ -1427,6 +1475,49 @@ internal static class CorpusSensor
 
         AddCountRegression(failures, "pass bugs", baseline.Metrics.PassBugs, current.Metrics.PassBugs, tolerance.PassBugIncrease);
 
+        return failures.ToImmutable();
+    }
+
+    internal static ImmutableArray<string> ClassicStateMachineCoverageFailures(
+        CorpusSensorSnapshot baseline,
+        CorpusSensorSnapshot current)
+    {
+        if (current.Profile != CorpusProfile.ClassicStateMachines)
+            return [];
+
+        var failures = ImmutableArray.CreateBuilder<string>();
+        foreach (string feature in new[] { "classic-async", "classic-iterator", "classic-async-iterator" })
+        {
+            var currentMetrics = current.ClassicStateMachineCoverage?.GetValueOrDefault(feature);
+            if (currentMetrics is null || currentMetrics.Population == 0)
+            {
+                failures.Add($"classic state-machine evidence '{feature}' has no kickoff specimens");
+                continue;
+            }
+
+            var baselineMetrics = baseline.ClassicStateMachineCoverage?.GetValueOrDefault(feature);
+            if (baselineMetrics is null)
+                continue;
+            if (currentMetrics.Population < baselineMetrics.Population)
+            {
+                failures.Add(
+                    $"classic state-machine population '{feature}' dropped "
+                    + $"(baseline {baselineMetrics.Population}, current {currentMetrics.Population})");
+            }
+            if (currentMetrics.FullyRaised < baselineMetrics.FullyRaised)
+            {
+                failures.Add(
+                    $"classic state-machine fully raised '{feature}' dropped "
+                    + $"(baseline {baselineMetrics.FullyRaised}, current {currentMetrics.FullyRaised})");
+            }
+            if (currentMetrics.Population == baselineMetrics.Population
+                && currentMetrics.Residual > baselineMetrics.Residual)
+            {
+                failures.Add(
+                    $"classic state-machine residual '{feature}' increased "
+                    + $"(baseline {baselineMetrics.Residual}, current {currentMetrics.Residual})");
+            }
+        }
         return failures.ToImmutable();
     }
 
@@ -1897,13 +1988,25 @@ internal static class CorpusSensor
 
     static void PrintFeatureCoverage(CorpusSensorSnapshot snapshot)
     {
-        if (snapshot.FeatureCoverage is not { Count: > 0 } coverage)
-            return;
+        if (snapshot.FeatureCoverage is { Count: > 0 } coverage)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Feature evidence:");
+            foreach (var (feature, count) in coverage.OrderBy(pair => pair.Key, StringComparer.Ordinal))
+                Console.WriteLine($"- `{feature}`: {count}");
+        }
 
-        Console.WriteLine();
-        Console.WriteLine("Feature evidence:");
-        foreach (var (feature, count) in coverage.OrderBy(pair => pair.Key, StringComparer.Ordinal))
-            Console.WriteLine($"- `{feature}`: {count}");
+        if (snapshot.ClassicStateMachineCoverage is { Count: > 0 } stateMachines)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Classic state-machine kickoff evidence:");
+            foreach (var (feature, metrics) in stateMachines.OrderBy(pair => pair.Key, StringComparer.Ordinal))
+            {
+                Console.WriteLine(
+                    $"- `{feature}`: population {metrics.Population}, "
+                    + $"fully raised {metrics.FullyRaised}, residual {metrics.Residual}");
+            }
+        }
     }
 
     internal static string QualityCardHeadingForProfile(CorpusProfile profile)
@@ -2498,7 +2601,13 @@ internal sealed record CorpusSensorSnapshot(
     CorpusFidelityOracle FidelityOracle = CorpusFidelityOracle.CompileBack,
     [property: JsonConverter(typeof(JsonStringEnumConverter<CorpusProfile>))]
     CorpusProfile Profile = CorpusProfile.RealWorld,
-    IReadOnlyDictionary<string, int>? FeatureCoverage = null);
+    IReadOnlyDictionary<string, int>? FeatureCoverage = null,
+    IReadOnlyDictionary<string, ClassicStateMachineFeatureMetrics>? ClassicStateMachineCoverage = null);
+
+internal sealed record ClassicStateMachineFeatureMetrics(
+    int Population = 0,
+    int FullyRaised = 0,
+    int Residual = 0);
 
 internal sealed record CorpusAssemblySnapshot(string Assembly, string Path, int TotalMethods);
 
@@ -2521,7 +2630,8 @@ internal sealed record CompletenessSensorMetrics(
     int PassBugs,
     IReadOnlyDictionary<string, int> ResidualBuckets,
     IReadOnlyList<CorpusMethodSnapshot> Methods,
-    IReadOnlyDictionary<string, int> FeatureCoverage);
+    IReadOnlyDictionary<string, int> FeatureCoverage,
+    IReadOnlyDictionary<string, ClassicStateMachineFeatureMetrics>? ClassicStateMachineCoverage);
 
 internal sealed record ValiditySensorMetrics(
     int FullMalformedMethods,

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -484,16 +484,18 @@ bash eng/report-decompiler-opt-in-corpus-drift.sh
 ```
 
 **Classic state-machine corpus** (`--corpus-profile classic-state-machines`):
-a pinned lane for classic (non-`RuntimeAsync`) compiler-generated state
-machines — async kickoff/resume, iterators, async iterators, and a plain
-non-pattern `switch` — none of which had dedicated corpus coverage before
-(#2818, a child of #2814). Its one fixture assembly,
+a pinned, representative current-compiler lane for classic (non-`RuntimeAsync`)
+compiler-generated state machines — async kickoff/resume, iterators, async
+iterators, and a plain non-pattern `switch` control — none of which had
+dedicated corpus coverage before (#2818, a child of #2814). Its one fixture
+assembly,
 `ILInspector.Decompiler.Fixtures.ClassicStateMachines`, builds on the same
 `RuntimeAsync=off` axis as `ILInspector.Decompiler.Fixtures.ClassicAsync`
-rather than a downlevel TFM/LangVersion pack, since classic lowering for these
-four shapes does not depend on an older runtime or compiler; this reaches the
-same classic lowering set without the added complexity of installing a
-downlevel runtime pack.
+rather than a downlevel TFM/LangVersion pack. The fixture spans `Task`,
+`async void`, and `ValueTask` builders; static, instance, generic, and
+non-generic iterators; and cancellation, exception-region, `await foreach`, and
+async-disposal shapes. It is not exhaustive across compiler versions or older
+TFMs; those remain a separate candidate axis.
 
 Unlike the other corpus profiles, this lane wires the cross-method import seam
 (`PassContext.ForImport`, the same helper `--dump`/`--library-report` use) into
@@ -501,14 +503,18 @@ Unlike the other corpus profiles, this lane wires the cross-method import seam
 `ClassicAsyncReconstructionPass` — which pulls in the sibling `MoveNext` body —
 raise the same way they do outside the corpus sensor. No other corpus profile
 wires this seam; `real-world` and `opt-in-net11` still raise each method
-standalone. Snapshot schema v4 records feature-local evidence
+standalone. Snapshot schema v4 records feature-local population evidence
 (`classic-async-methods`, `classic-iterator-methods`,
 `classic-async-iterator-methods`, `switch-methods`), tagged by the method-name
 prefix contract documented on `ClassicStateMachineFixtures`
-(`Async_`/`Iterator_`/`AsyncIterator_`/`Switch_`). As with the opt-in-net11
-profile, its baseline is separate from `real-world-baseline.json` and never
-blended into real-world rates; this is a first published census (successor to
-the earlier "0/21" classic-async gap), not yet a quality target.
+(`Async_`/`Iterator_`/`AsyncIterator_`/`Switch_`). The separate
+`classicStateMachineCoverage` object reports source-kickoff population, fully
+raised, and residual counts for each state-machine family. Baseline comparison
+blocks a lost specimen, a lower fully-raised count, or increased residuals when
+the population is stable. As with the opt-in-net11 profile, its baseline is
+separate from `real-world-baseline.json` and never blended into real-world
+rates; this is a first published census (successor to the earlier "0/21"
+classic-async gap), not yet a broad real-world quality target.
 
 ```bash
 dotnet build src/ILInspector.Decompiler.Fixtures.ClassicStateMachines -c Release

--- a/tools/DecompilerHarness/corpus/classic-state-machines-baseline.json
+++ b/tools/DecompilerHarness/corpus/classic-state-machines-baseline.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 4,
   "description": "#2818 classic async/iterator state-machine corpus: pinned classic async, iterator, async-iterator, and switch fixtures, raised with the cross-method import seam wired.",
-  "generatedUtc": "2026-07-18T19:48:15.289718+00:00",
+  "generatedUtc": "2026-07-18T22:39:15.098946+00:00",
   "validityCompileCap": 4000,
   "fidelityCompileCap": 0,
   "methodCap": null,
@@ -20,14 +20,14 @@
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "path": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "totalMethods": 73
+      "totalMethods": 144
     }
   ],
   "methods": [
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": ".ctor",
       "overload": 0,
       "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
@@ -44,12 +44,12 @@
           "sites": 7
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::.ctor#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::.ctor#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "MoveNext",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Void",
@@ -59,12 +59,12 @@
       "passBug": null,
       "validity": "not-sampled",
       "fidelityCheck": "not-sampled",
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::MoveNext#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::MoveNext#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "SetStateMachine",
       "overload": 0,
       "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
@@ -74,12 +74,12 @@
       "passBug": null,
       "validity": "not-sampled",
       "fidelityCheck": "not-sampled",
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::SetStateMachine#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::SetStateMachine#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator",
       "overload": 0,
       "signature": "(corelib:System.Threading.CancellationToken) -\u003E corelib:System.Collections.Generic.IAsyncEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
@@ -96,12 +96,12 @@
           "sites": 20
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask\u00601\u003Ccorelib:System.Boolean\u003E",
@@ -118,12 +118,12 @@
           "sites": 18
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Int32",
@@ -140,12 +140,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "System.IAsyncDisposable.DisposeAsync",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask",
@@ -162,12 +162,12 @@
           "sites": 18
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.IAsyncDisposable.DisposeAsync#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::System.IAsyncDisposable.DisposeAsync#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource.GetResult",
       "overload": 0,
       "signature": "(corelib:System.Int16) -\u003E corelib:System.Void",
@@ -184,12 +184,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Threading.Tasks.Sources.IValueTaskSource.GetResult#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::System.Threading.Tasks.Sources.IValueTaskSource.GetResult#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource.GetStatus",
       "overload": 0,
       "signature": "(corelib:System.Int16) -\u003E corelib:System.Threading.Tasks.Sources.ValueTaskSourceStatus",
@@ -206,12 +206,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Threading.Tasks.Sources.IValueTaskSource.GetStatus#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::System.Threading.Tasks.Sources.IValueTaskSource.GetStatus#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted",
       "overload": 0,
       "signature": "(corelib:System.Action\u00601\u003Ccorelib:System.Object\u003E, corelib:System.Object, corelib:System.Int16, corelib:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags) -\u003E corelib:System.Void",
@@ -228,12 +228,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult",
       "overload": 0,
       "signature": "(corelib:System.Int16) -\u003E corelib:System.Boolean",
@@ -250,12 +250,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus",
       "overload": 0,
       "signature": "(corelib:System.Int16) -\u003E corelib:System.Threading.Tasks.Sources.ValueTaskSourceStatus",
@@ -272,12 +272,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted",
       "overload": 0,
       "signature": "(corelib:System.Action\u00601\u003Ccorelib:System.Object\u003E, corelib:System.Object, corelib:System.Int16, corelib:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags) -\u003E corelib:System.Void",
@@ -294,12 +294,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__7::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_AwaitThenYield\u003Ed__14::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": ".ctor",
       "overload": 0,
       "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
@@ -316,12 +316,12 @@
           "sites": 7
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::.ctor#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::.ctor#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "MoveNext",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Void",
@@ -331,12 +331,12 @@
       "passBug": null,
       "validity": "not-sampled",
       "fidelityCheck": "not-sampled",
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::MoveNext#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::MoveNext#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "SetStateMachine",
       "overload": 0,
       "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
@@ -346,12 +346,12 @@
       "passBug": null,
       "validity": "not-sampled",
       "fidelityCheck": "not-sampled",
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::SetStateMachine#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::SetStateMachine#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator",
       "overload": 0,
       "signature": "(corelib:System.Threading.CancellationToken) -\u003E corelib:System.Collections.Generic.IAsyncEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
@@ -365,15 +365,15 @@
         {
           "code": "DEC0009",
           "discriminator": "state-machine-type-name",
-          "sites": 24
+          "sites": 20
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask\u00601\u003Ccorelib:System.Boolean\u003E",
@@ -390,12 +390,12 @@
           "sites": 18
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Int32",
@@ -412,12 +412,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "System.IAsyncDisposable.DisposeAsync",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask",
@@ -434,12 +434,12 @@
           "sites": 18
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.IAsyncDisposable.DisposeAsync#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::System.IAsyncDisposable.DisposeAsync#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource.GetResult",
       "overload": 0,
       "signature": "(corelib:System.Int16) -\u003E corelib:System.Void",
@@ -456,12 +456,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Threading.Tasks.Sources.IValueTaskSource.GetResult#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::System.Threading.Tasks.Sources.IValueTaskSource.GetResult#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource.GetStatus",
       "overload": 0,
       "signature": "(corelib:System.Int16) -\u003E corelib:System.Threading.Tasks.Sources.ValueTaskSourceStatus",
@@ -478,12 +478,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Threading.Tasks.Sources.IValueTaskSource.GetStatus#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::System.Threading.Tasks.Sources.IValueTaskSource.GetStatus#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted",
       "overload": 0,
       "signature": "(corelib:System.Action\u00601\u003Ccorelib:System.Object\u003E, corelib:System.Object, corelib:System.Int16, corelib:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags) -\u003E corelib:System.Void",
@@ -500,12 +500,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult",
       "overload": 0,
       "signature": "(corelib:System.Int16) -\u003E corelib:System.Boolean",
@@ -522,12 +522,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus",
       "overload": 0,
       "signature": "(corelib:System.Int16) -\u003E corelib:System.Threading.Tasks.Sources.ValueTaskSourceStatus",
@@ -544,12 +544,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17",
       "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted",
       "overload": 0,
       "signature": "(corelib:System.Action\u00601\u003Ccorelib:System.Object\u003E, corelib:System.Object, corelib:System.Int16, corelib:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags) -\u003E corelib:System.Void",
@@ -566,7 +566,581 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__8::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_TryFinallyAndDisposal\u003Ed__17::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": ".ctor",
+      "overload": 0,
+      "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 7
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::.ctor#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "SetStateMachine",
+      "overload": 0,
+      "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::SetStateMachine#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator",
+      "overload": 0,
+      "signature": "(corelib:System.Threading.CancellationToken) -\u003E corelib:System.Collections.Generic.IAsyncEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 40
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask\u00601\u003Ccorelib:System.Boolean\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 18
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Int32",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "System.IAsyncDisposable.DisposeAsync",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 18
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::System.IAsyncDisposable.DisposeAsync#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource.GetResult",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::System.Threading.Tasks.Sources.IValueTaskSource.GetResult#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource.GetStatus",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Threading.Tasks.Sources.ValueTaskSourceStatus",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::System.Threading.Tasks.Sources.IValueTaskSource.GetStatus#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted",
+      "overload": 0,
+      "signature": "(corelib:System.Action\u00601\u003Ccorelib:System.Object\u003E, corelib:System.Object, corelib:System.Int16, corelib:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Boolean",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Threading.Tasks.Sources.ValueTaskSourceStatus",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted",
+      "overload": 0,
+      "signature": "(corelib:System.Action\u00601\u003Ccorelib:System.Object\u003E, corelib:System.Object, corelib:System.Int16, corelib:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_WithCancellation\u003Ed__16::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": ".ctor",
+      "overload": 0,
+      "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 7
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::.ctor#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "SetStateMachine",
+      "overload": 0,
+      "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::SetStateMachine#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator",
+      "overload": 0,
+      "signature": "(corelib:System.Threading.CancellationToken) -\u003E corelib:System.Collections.Generic.IAsyncEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 24
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::System.Collections.Generic.IAsyncEnumerable\u003CSystem.Int32\u003E.GetAsyncEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask\u00601\u003Ccorelib:System.Boolean\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 18
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.MoveNextAsync#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Int32",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::System.Collections.Generic.IAsyncEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "System.IAsyncDisposable.DisposeAsync",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 18
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::System.IAsyncDisposable.DisposeAsync#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource.GetResult",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::System.Threading.Tasks.Sources.IValueTaskSource.GetResult#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource.GetStatus",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Threading.Tasks.Sources.ValueTaskSourceStatus",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::System.Threading.Tasks.Sources.IValueTaskSource.GetStatus#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted",
+      "overload": 0,
+      "signature": "(corelib:System.Action\u00601\u003Ccorelib:System.Object\u003E, corelib:System.Object, corelib:System.Int16, corelib:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Boolean",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetResult#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus",
+      "overload": 0,
+      "signature": "(corelib:System.Int16) -\u003E corelib:System.Threading.Tasks.Sources.ValueTaskSourceStatus",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.GetStatus#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15",
+      "method": "System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted",
+      "overload": 0,
+      "signature": "(corelib:System.Action\u00601\u003Ccorelib:System.Object\u003E, corelib:System.Object, corelib:System.Int16, corelib:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsyncIterator_YieldBreakEarly\u003Ed__15::System.Threading.Tasks.Sources.IValueTaskSource\u003CSystem.Boolean\u003E.OnCompleted#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_AwaitInCatchAndFinally\u003Ed__7",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_AwaitInCatchAndFinally\u003Ed__7::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_AwaitInCatchAndFinally\u003Ed__7",
+      "method": "SetStateMachine",
+      "overload": 0,
+      "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_AwaitInCatchAndFinally\u003Ed__7::SetStateMachine#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
@@ -661,6 +1235,36 @@
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_InstanceGeneric\u003Ed__6\u00601",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_InstanceGeneric\u003Ed__6\u00601::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_InstanceGeneric\u003Ed__6\u00601",
+      "method": "SetStateMachine",
+      "overload": 0,
+      "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_InstanceGeneric\u003Ed__6\u00601::SetStateMachine#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
       "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_TwoSequentialAwaits\u003Ed__1",
       "method": "MoveNext",
       "overload": 0,
@@ -691,7 +1295,67 @@
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_ValueTaskBuilder\u003Ed__5",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_ValueTaskBuilder\u003Ed__5::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_ValueTaskBuilder\u003Ed__5",
+      "method": "SetStateMachine",
+      "overload": 0,
+      "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_ValueTaskBuilder\u003Ed__5::SetStateMachine#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_VoidBuilder\u003Ed__4",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_VoidBuilder\u003Ed__4::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_VoidBuilder\u003Ed__4",
+      "method": "SetStateMachine",
+      "overload": 0,
+      "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CAsync_VoidBuilder\u003Ed__4::SetStateMachine#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601",
       "method": ".ctor",
       "overload": 0,
       "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
@@ -708,37 +1372,15 @@
           "sites": 5
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::.ctor#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601::.ctor#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601",
       "method": "MoveNext",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Boolean",
-      "fidelity": "Partial",
-      "fullyRaised": false,
-      "residual": "structuring: conditional-branch",
-      "passBug": null,
-      "validity": "not-sampled",
-      "fidelityCheck": "not-sampled",
-      "fidelityCauses": [
-        {
-          "code": "DEC0009",
-          "discriminator": "state-machine-type-name",
-          "sites": 22
-        }
-      ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::MoveNext#0"
-    },
-    {
-      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
-      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
-      "method": "System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator",
-      "overload": 0,
-      "signature": "() -\u003E corelib:System.Collections.Generic.IEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
       "fidelity": "Partial",
       "fullyRaised": false,
       "residual": "fidelity: DEC0009",
@@ -749,18 +1391,40 @@
         {
           "code": "DEC0009",
           "discriminator": "state-machine-type-name",
-          "sites": 16
+          "sites": 20
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601::MoveNext#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
-      "method": "System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601",
+      "method": "System.Collections.Generic.IEnumerable\u003CT\u003E.GetEnumerator",
       "overload": 0,
-      "signature": "() -\u003E corelib:System.Int32",
+      "signature": "() -\u003E corelib:System.Collections.Generic.IEnumerator\u00601\u003C!0\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 20
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601::System.Collections.Generic.IEnumerable\u003CT\u003E.GetEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601",
+      "method": "System.Collections.Generic.IEnumerator\u003CT\u003E.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E !0",
       "fidelity": "Partial",
       "fullyRaised": false,
       "residual": "fidelity: DEC0009",
@@ -774,12 +1438,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601::System.Collections.Generic.IEnumerator\u003CT\u003E.get_Current#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601",
       "method": "System.Collections.IEnumerable.GetEnumerator",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Collections.IEnumerator",
@@ -796,12 +1460,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::System.Collections.IEnumerable.GetEnumerator#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601::System.Collections.IEnumerable.GetEnumerator#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601",
       "method": "System.Collections.IEnumerator.Reset",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Void",
@@ -811,12 +1475,12 @@
       "passBug": null,
       "validity": "not-sampled",
       "fidelityCheck": "not-sampled",
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::System.Collections.IEnumerator.Reset#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601::System.Collections.IEnumerator.Reset#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601",
       "method": "System.Collections.IEnumerator.get_Current",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Object",
@@ -833,12 +1497,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::System.Collections.IEnumerator.get_Current#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601::System.Collections.IEnumerator.get_Current#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601",
       "method": "System.IDisposable.Dispose",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Void",
@@ -855,12 +1519,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__5::System.IDisposable.Dispose#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Generic\u003Ed__12\u00601::System.IDisposable.Dispose#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13",
       "method": ".ctor",
       "overload": 0,
       "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
@@ -877,12 +1541,519 @@
           "sites": 5
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::.ctor#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13::.ctor#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Boolean",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 20
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13",
+      "method": "System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Collections.Generic.IEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 16
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13::System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13",
+      "method": "System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Int32",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13::System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13",
+      "method": "System.Collections.IEnumerable.GetEnumerator",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Collections.IEnumerator",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13::System.Collections.IEnumerable.GetEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13",
+      "method": "System.Collections.IEnumerator.Reset",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13::System.Collections.IEnumerator.Reset#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13",
+      "method": "System.Collections.IEnumerator.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Object",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13::System.Collections.IEnumerator.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13",
+      "method": "System.IDisposable.Dispose",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_Instance\u003Ed__13::System.IDisposable.Dispose#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11",
+      "method": ".ctor",
+      "overload": 0,
+      "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 5
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11::.ctor#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Boolean",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 16
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11",
+      "method": "System.Collections.Generic.IEnumerable\u003CSystem.Object\u003E.GetEnumerator",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Collections.Generic.IEnumerator\u00601\u003Ccorelib:System.Object\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 9
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11::System.Collections.Generic.IEnumerable\u003CSystem.Object\u003E.GetEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11",
+      "method": "System.Collections.Generic.IEnumerator\u003CSystem.Object\u003E.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Object",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11::System.Collections.Generic.IEnumerator\u003CSystem.Object\u003E.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11",
+      "method": "System.Collections.IEnumerable.GetEnumerator",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Collections.IEnumerator",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11::System.Collections.IEnumerable.GetEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11",
+      "method": "System.Collections.IEnumerator.Reset",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11::System.Collections.IEnumerator.Reset#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11",
+      "method": "System.Collections.IEnumerator.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Object",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11::System.Collections.IEnumerator.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11",
+      "method": "System.IDisposable.Dispose",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_NonGeneric\u003Ed__11::System.IDisposable.Dispose#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9",
+      "method": ".ctor",
+      "overload": 0,
+      "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 5
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9::.ctor#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9",
+      "method": "MoveNext",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Boolean",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "structuring: conditional-branch",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 22
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9::MoveNext#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9",
+      "method": "System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Collections.Generic.IEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 16
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9::System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9",
+      "method": "System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Int32",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9::System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9",
+      "method": "System.Collections.IEnumerable.GetEnumerator",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Collections.IEnumerator",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9::System.Collections.IEnumerable.GetEnumerator#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9",
+      "method": "System.Collections.IEnumerator.Reset",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9::System.Collections.IEnumerator.Reset#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9",
+      "method": "System.Collections.IEnumerator.get_Current",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Object",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9::System.Collections.IEnumerator.get_Current#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9",
+      "method": "System.IDisposable.Dispose",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldBreakEarly\u003Ed__9::System.IDisposable.Dispose#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10",
+      "method": ".ctor",
+      "overload": 0,
+      "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "not-sampled",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 5
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10::.ctor#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10",
       "method": "\u003C\u003Em__Finally1",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Void",
@@ -899,12 +2070,12 @@
           "sites": 4
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::\u003C\u003Em__Finally1#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10::\u003C\u003Em__Finally1#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10",
       "method": "\u003C\u003Em__Finally2",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Void",
@@ -921,12 +2092,12 @@
           "sites": 6
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::\u003C\u003Em__Finally2#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10::\u003C\u003Em__Finally2#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10",
       "method": "MoveNext",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Boolean",
@@ -943,12 +2114,12 @@
           "sites": 30
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::MoveNext#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10::MoveNext#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10",
       "method": "System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Collections.Generic.IEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
@@ -965,12 +2136,12 @@
           "sites": 16
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10::System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10",
       "method": "System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Int32",
@@ -987,12 +2158,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10::System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10",
       "method": "System.Collections.IEnumerable.GetEnumerator",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Collections.IEnumerator",
@@ -1009,12 +2180,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::System.Collections.IEnumerable.GetEnumerator#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10::System.Collections.IEnumerable.GetEnumerator#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10",
       "method": "System.Collections.IEnumerator.Reset",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Void",
@@ -1024,12 +2195,12 @@
       "passBug": null,
       "validity": "not-sampled",
       "fidelityCheck": "not-sampled",
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::System.Collections.IEnumerator.Reset#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10::System.Collections.IEnumerator.Reset#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10",
       "method": "System.Collections.IEnumerator.get_Current",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Object",
@@ -1046,12 +2217,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::System.Collections.IEnumerator.get_Current#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10::System.Collections.IEnumerator.get_Current#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10",
       "method": "System.IDisposable.Dispose",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Void",
@@ -1068,12 +2239,12 @@
           "sites": 10
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__6::System.IDisposable.Dispose#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldInTryFinally\u003Ed__10::System.IDisposable.Dispose#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8",
       "method": ".ctor",
       "overload": 0,
       "signature": "(corelib:System.Int32) -\u003E corelib:System.Void",
@@ -1090,12 +2261,12 @@
           "sites": 5
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::.ctor#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8::.ctor#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8",
       "method": "MoveNext",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Boolean",
@@ -1112,12 +2283,12 @@
           "sites": 22
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::MoveNext#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8::MoveNext#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8",
       "method": "System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Collections.Generic.IEnumerator\u00601\u003Ccorelib:System.Int32\u003E",
@@ -1134,12 +2305,12 @@
           "sites": 16
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8::System.Collections.Generic.IEnumerable\u003CSystem.Int32\u003E.GetEnumerator#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8",
       "method": "System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Int32",
@@ -1156,12 +2327,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8::System.Collections.Generic.IEnumerator\u003CSystem.Int32\u003E.get_Current#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8",
       "method": "System.Collections.IEnumerable.GetEnumerator",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Collections.IEnumerator",
@@ -1178,12 +2349,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::System.Collections.IEnumerable.GetEnumerator#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8::System.Collections.IEnumerable.GetEnumerator#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8",
       "method": "System.Collections.IEnumerator.Reset",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Void",
@@ -1193,12 +2364,12 @@
       "passBug": null,
       "validity": "not-sampled",
       "fidelityCheck": "not-sampled",
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::System.Collections.IEnumerator.Reset#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8::System.Collections.IEnumerator.Reset#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8",
       "method": "System.Collections.IEnumerator.get_Current",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Object",
@@ -1215,12 +2386,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::System.Collections.IEnumerator.get_Current#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8::System.Collections.IEnumerator.get_Current#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8",
       "method": "System.IDisposable.Dispose",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Void",
@@ -1237,12 +2408,12 @@
           "sites": 2
         }
       ],
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__4::System.IDisposable.Dispose#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CIterator_YieldSequence\u003Ed__8::System.IDisposable.Dispose#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CSwitch_InsideAsync\u003Ed__10",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CSwitch_InsideAsync\u003Ed__19",
       "method": "MoveNext",
       "overload": 0,
       "signature": "() -\u003E corelib:System.Void",
@@ -1252,12 +2423,12 @@
       "passBug": null,
       "validity": "not-sampled",
       "fidelityCheck": "not-sampled",
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CSwitch_InsideAsync\u003Ed__10::MoveNext#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CSwitch_InsideAsync\u003Ed__19::MoveNext#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
-      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CSwitch_InsideAsync\u003Ed__10",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CSwitch_InsideAsync\u003Ed__19",
       "method": "SetStateMachine",
       "overload": 0,
       "signature": "(corelib:System.Runtime.CompilerServices.IAsyncStateMachine) -\u003E corelib:System.Void",
@@ -1267,7 +2438,67 @@
       "passBug": null,
       "validity": "not-sampled",
       "fidelityCheck": "not-sampled",
-      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CSwitch_InsideAsync\u003Ed__10::SetStateMachine#0"
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.\u003CSwitch_InsideAsync\u003Ed__19::SetStateMachine#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.AsyncResource",
+      "method": ".ctor",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "valid",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.AsyncResource::.ctor#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.AsyncResource",
+      "method": "DisposeAsync",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "valid",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.AsyncResource::DisposeAsync#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.AsyncResource",
+      "method": "TouchAsync",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Threading.Tasks.ValueTask",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "valid",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures.AsyncResource::TouchAsync#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": ".ctor",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Void",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "valid",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::.ctor#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
@@ -1295,6 +2526,50 @@
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
       "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "AsyncIterator_TryFinallyAndDisposal",
+      "overload": 0,
+      "signature": "(corelib:System.Collections.Generic.IAsyncEnumerable\u00601\u003Ccorelib:System.Int32\u003E) -\u003E corelib:System.Collections.Generic.IAsyncEnumerable\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "partial-malformed:CS1003,CS1013,CS1525",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::AsyncIterator_TryFinallyAndDisposal#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "AsyncIterator_WithCancellation",
+      "overload": 0,
+      "signature": "(corelib:System.Int32, corelib:System.Threading.CancellationToken) -\u003E corelib:System.Collections.Generic.IAsyncEnumerable\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "partial-malformed:CS1003,CS1013,CS1525",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 2
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::AsyncIterator_WithCancellation#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
       "method": "AsyncIterator_YieldBreakEarly",
       "overload": 0,
       "signature": "(corelib:System.Threading.Tasks.Task\u00601\u003Ccorelib:System.Int32\u003E[], corelib:System.Int32) -\u003E corelib:System.Collections.Generic.IAsyncEnumerable\u00601\u003Ccorelib:System.Int32\u003E",
@@ -1312,6 +2587,28 @@
         }
       ],
       "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::AsyncIterator_YieldBreakEarly#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Async_AwaitInCatchAndFinally",
+      "overload": 0,
+      "signature": "(corelib:System.Threading.Tasks.Task\u00601\u003Ccorelib:System.Int32\u003E) -\u003E corelib:System.Threading.Tasks.Task\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "syntax-valid",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 13
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Async_AwaitInCatchAndFinally#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
@@ -1362,6 +2659,28 @@
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
       "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
       "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Async_InstanceGeneric",
+      "overload": 0,
+      "signature": "\u00601(corelib:System.Threading.Tasks.Task\u00601\u003C!!0\u003E) -\u003E corelib:System.Threading.Tasks.Task\u00601\u003C!!0\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "syntax-valid",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 13
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Async_InstanceGeneric#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
       "method": "Async_TwoSequentialAwaits",
       "overload": 0,
       "signature": "(corelib:System.Threading.Tasks.Task\u00601\u003Ccorelib:System.Int32\u003E, corelib:System.Threading.Tasks.Task\u00601\u003Ccorelib:System.Int32\u003E) -\u003E corelib:System.Threading.Tasks.Task",
@@ -1372,6 +2691,100 @@
       "validity": "syntax-valid",
       "fidelityCheck": "not-sampled",
       "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Async_TwoSequentialAwaits#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Async_ValueTaskBuilder",
+      "overload": 0,
+      "signature": "(corelib:System.Threading.Tasks.ValueTask\u00601\u003Ccorelib:System.Int32\u003E) -\u003E corelib:System.Threading.Tasks.ValueTask\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "syntax-valid",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Async_ValueTaskBuilder#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Async_VoidBuilder",
+      "overload": 0,
+      "signature": "(corelib:System.Action) -\u003E corelib:System.Void",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: DEC0009",
+      "passBug": null,
+      "validity": "syntax-valid",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0009",
+          "discriminator": "state-machine-type-name",
+          "sites": 11
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Async_VoidBuilder#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Iterator_Generic",
+      "overload": 0,
+      "signature": "\u00601(!!0, !!0) -\u003E corelib:System.Collections.Generic.IEnumerable\u00601\u003C!!0\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: unsupported-node",
+      "passBug": null,
+      "validity": "syntax-valid",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0004",
+          "discriminator": "iterator"
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Iterator_Generic#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Iterator_Instance",
+      "overload": 0,
+      "signature": "(corelib:System.Int32) -\u003E corelib:System.Collections.Generic.IEnumerable\u00601\u003Ccorelib:System.Int32\u003E",
+      "fidelity": "Partial",
+      "fullyRaised": false,
+      "residual": "fidelity: unsupported-node",
+      "passBug": null,
+      "validity": "syntax-valid",
+      "fidelityCheck": "not-sampled",
+      "fidelityCauses": [
+        {
+          "code": "DEC0004",
+          "discriminator": "iterator"
+        }
+      ],
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Iterator_Instance#0"
+    },
+    {
+      "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
+      "assemblyPath": "artifacts/bin/ILInspector.Decompiler.Fixtures.ClassicStateMachines/release/ILInspector.Decompiler.Fixtures.ClassicStateMachines.dll",
+      "type": "ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures",
+      "method": "Iterator_NonGeneric",
+      "overload": 0,
+      "signature": "() -\u003E corelib:System.Collections.IEnumerable",
+      "fidelity": "Full",
+      "fullyRaised": true,
+      "residual": null,
+      "passBug": null,
+      "validity": "syntax-valid",
+      "fidelityCheck": "not-sampled",
+      "displayMethod": "ILInspector.Decompiler.Fixtures.ClassicStateMachines!ILInspector.Decompiler.Fixtures.ClassicStateMachines.ClassicStateMachineFixtures::Iterator_NonGeneric#0"
     },
     {
       "assembly": "ILInspector.Decompiler.Fixtures.ClassicStateMachines",
@@ -1469,31 +2882,31 @@
     }
   ],
   "metrics": {
-    "totalMethods": 73,
-    "fullyRaisedMethods": 23,
-    "fullyRaisedBasisPoints": 3151,
+    "totalMethods": 144,
+    "fullyRaisedMethods": 44,
+    "fullyRaisedBasisPoints": 3056,
     "conditionalBranchMethods": 3,
-    "conditionalBranchBasisPoints": 411,
-    "forwardMergeStoppedContainers": 7,
-    "forwardMergeBasisPoints": 959,
+    "conditionalBranchBasisPoints": 208,
+    "forwardMergeStoppedContainers": 14,
+    "forwardMergeBasisPoints": 972,
     "fullMalformedMethods": 0,
-    "semanticCheckedMethods": 1,
+    "semanticCheckedMethods": 5,
     "semanticDefectMethods": 0,
     "passBugs": 0,
     "residualBuckets": {
-      "fidelity: DEC0009": 45,
-      "fidelity: unsupported-node": 2,
+      "fidelity: DEC0009": 93,
+      "fidelity: unsupported-node": 4,
       "structuring: conditional-branch": 3
     },
     "structuring": {
-      "totalMethods": 73,
-      "structuredContainers": 21,
-      "stoppedContainers": 10,
-      "methodsWithStops": 10,
+      "totalMethods": 144,
+      "structuredContainers": 37,
+      "stoppedContainers": 20,
+      "methodsWithStops": 16,
       "passBugs": 0,
       "stopReasons": {
-        "arm-externally-entered": 2,
-        "cond-target-past-region": 6,
+        "arm-externally-entered": 5,
+        "cond-target-past-region": 13,
         "forward-branch-not-region-exit": 1,
         "unconsumed-regions": 1
       }
@@ -1510,9 +2923,26 @@
   "fidelityOracle": "compile-back",
   "profile": "classic-state-machines",
   "featureCoverage": {
-    "classic-async-iterator-methods": 28,
-    "classic-async-methods": 12,
-    "classic-iterator-methods": 29,
+    "classic-async-iterator-methods": 56,
+    "classic-async-methods": 24,
+    "classic-iterator-methods": 56,
     "switch-methods": 4
+  },
+  "classicStateMachineCoverage": {
+    "classic-async": {
+      "population": 8,
+      "fullyRaised": 5,
+      "residual": 3
+    },
+    "classic-async-iterator": {
+      "population": 4,
+      "fullyRaised": 0,
+      "residual": 4
+    },
+    "classic-iterator": {
+      "population": 6,
+      "fullyRaised": 2,
+      "residual": 4
+    }
   }
 }


### PR DESCRIPTION
## Summary

Strengthens the classic state-machine corpus evidence in the decompiler harness. Stacked on #2885 (base `feature/issue-2818-classic-state-machine-corpus`); this PR's diff is the single commit `b2a1ab6f`.

- Adds classic state-machine fixtures: async void, `ValueTask`, instance generic, await-in-catch/finally, iterators, cancellation, try-finally with disposal.
- Adds per-family coverage metrics to the corpus snapshot: `ClassicStateMachineFeatureMetrics(Population, FullyRaised, Residual)` and a `ClassicStateMachineCoverage` map, built by `BuildClassicStateMachineCoverage`.
- Adds a `ClassicStateMachineCoverageFailures` gate: fails on zero specimens, population drop, fully-raised drop, or residual increase at stable population.

The coverage metric buckets source kickoffs into families by fixture-name prefix (`Async_`/`Iterator_`/`AsyncIterator_`) and skips compiler-generated support types (`Type.Contains('<')`). The **fidelity judgment itself** (`FullyRaised`/`Residual`) is driven entirely by the product's `DecompilationFidelity.Full` result — the harness reads the product's raising decision, it does not reconstruct it.

## Evidence

- Snapshot schema is already `v4` (matches README); the new nullable `ClassicStateMachineCoverage` field deserializes older baselines to `null` and the gate handles that gracefully.
- Harness build + comparison tests: `ILInspector.Decompiler.Tests` — 50 total, 0 failed.
- Baseline JSON round-trips with the new field (verified per-family populations: 8 classic-async, 6 classic-iterator, 4 classic-async-iterator).

## Adversarial review

Two-model review (Gemini 3.1 Pro + MAI-Code-1-Flash) at commit `b2a1ab6f`, each isolated in a separate worktree.

- **Gemini 3.1 Pro:** no blocking issues. Verified name-prefix classifier, `Type.Contains('<')` skip robustness (source kickoffs use backticks, generated types use `<>`), schema/baseline back-compat, and the harness-boundary rule (metric purely aggregates the product's `FullyRaised` output).
- **MAI-Code-1-Flash:** raised a harness-boundary "blocking" concern that the name-prefix classifies raising success. **Dismissed after code adjudication:** the name prefix only assigns a family bucket; `FullyRaised`/`Residual` come from the product's `DecompilationFidelity.Full` (`CorpusSensor.cs:1225`), not from the name. Gemini independently verified this.

**Non-blocking (both reviewers):** a residual regression can be masked if population grows while the fully-raised count stays flat, because the residual check requires exactly stable population. Accepted as by-design for this coarse feature-bucket sub-metric — the exact per-method `Compare()` gate independently tracks individual fidelity regressions. Recorded as a possible follow-up (gate on fully-raised ratio).
