### PR TITLE
Fix extensions and cache usability findings

### DIFF
--- a/src/dotnet-inspect.Tests/CacheCommandTests.cs
+++ b/src/dotnet-inspect.Tests/CacheCommandTests.cs
@@ -5,6 +5,7 @@ using DotnetInspector.Options;
 using DotnetInspector.Packages;
 using DotnetInspector.Views;
 using Markout;
+using System.Text.Json;
 
 namespace DotnetInspector.Tests;
 
@@ -48,6 +49,39 @@ public class CacheCommandTests : IDisposable
         Assert.Contains("## Categories", output);
         Assert.Contains("| Packages | 1.0 MB | 3 packages |", output);
         Assert.DoesNotContain("----------", output);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyCache_JsonFormat_EmitsValidJson()
+    {
+        // Finding 9 follow-up: machine formats must emit structured output even for
+        // an empty cache, not the "Cache is empty." plaintext fallback.
+        var options = new CacheOptions(Clean: false, Verbose: false, Format: OutputFormat.Json);
+
+        var (result, output, _) = await ConsoleCapture.RunAsync(
+            () => CacheCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, result);
+        Assert.DoesNotContain("Cache is empty", output);
+        using var doc = JsonDocument.Parse(output.Trim());
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.GetProperty("categories").ValueKind);
+        Assert.Empty(doc.RootElement.GetProperty("categories").EnumerateArray());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyCache_JsonlFormat_EmitsSingleValidLine()
+    {
+        // JSONL must be a single valid JSON record per line, with no blank separator.
+        var options = new CacheOptions(Clean: false, Verbose: false, Format: OutputFormat.Jsonl);
+
+        var (result, output, _) = await ConsoleCapture.RunAsync(
+            () => CacheCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, result);
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        Assert.Single(lines);
+        using var doc = JsonDocument.Parse(lines[0]);
+        Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/CacheCommandTests.cs
+++ b/src/dotnet-inspect.Tests/CacheCommandTests.cs
@@ -3,6 +3,8 @@ using DotnetInspector.Core;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Options;
 using DotnetInspector.Packages;
+using DotnetInspector.Views;
+using Markout;
 
 namespace DotnetInspector.Tests;
 
@@ -26,6 +28,26 @@ public class CacheCommandTests : IDisposable
     {
         if (Directory.Exists(_cacheBasePath))
             Directory.Delete(_cacheBasePath, recursive: true);
+    }
+
+    [Fact]
+    public void CacheInfoView_DefaultFormat_RendersMarkdownTable()
+    {
+        var view = new CacheInfoView
+        {
+            Location = "/tmp/cache",
+            Total = "1.0 MB",
+            Categories = [new CacheCategoryRow("Packages", "1.0 MB", "3 packages")]
+        };
+
+        var output = MarkoutSerializer.Serialize(view, CacheInfoContext.Default);
+
+        // Finding 9: cache should render markdown tables, not dashed plaintext.
+        Assert.Contains("| Field | Value |", output);
+        Assert.Contains("| Location |", output);
+        Assert.Contains("## Categories", output);
+        Assert.Contains("| Packages | 1.0 MB | 3 packages |", output);
+        Assert.DoesNotContain("----------", output);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
+++ b/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
@@ -312,6 +312,25 @@ public class ExtensionsCommandTests
     }
 
     [Fact]
+    public void FormatResults_ReachableUniformType_KeepsTypeColumn()
+    {
+        // All rows are reachable via the same intermediate type. Type is uniform but
+        // differs from the queried type, so the column must stay visible.
+        var results = new List<ExtensionMethodResult>
+        {
+            new() { MethodName = "ReadFromJsonAsync", Kind = "method", ExtensionClass = "HttpContentJsonExtensions", Assembly = "System.Net.Http.Json", ReachablePath = ".Content", ReachableFromType = "System.Net.Http.HttpContent" },
+            new() { MethodName = "ReadFromJsonAsAsyncEnumerable", Kind = "method", ExtensionClass = "HttpContentJsonExtensions", Assembly = "System.Net.Http.Json", ReachablePath = ".Content", ReachableFromType = "System.Net.Http.HttpContent" },
+        };
+
+        var view = ExtensionsOutputFormatter.BuildView("HttpResponseMessage", results);
+        var output = MarkoutSerializer.Serialize(view, SearchViewContext.Default);
+
+        Assert.Contains("| Type ", output);
+        Assert.Contains("System.Net.Http.HttpContent", output);
+        Assert.Contains("| Via ", output);
+    }
+
+    [Fact]
     public void CollapseOverloads_PreservesAllSignatures()
     {
         var results = CreateOverloadResults();

--- a/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
+++ b/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
@@ -262,7 +262,53 @@ public class ExtensionsCommandTests
 
         // Should produce a single row, not 3 duplicate rows
         Assert.Single(tableRows);
-        Assert.Contains("3 overloads", tableRows[0]);
+        Assert.Contains("ToDictionary", tableRows[0]);
+        // Overload count now lives in a dedicated numeric column, not baked into the name.
+        Assert.DoesNotContain("3 overloads", tableRows[0]);
+        Assert.Contains("Overloads", output);
+        var cells = tableRows[0].Split('|').Select(c => c.Trim()).ToList();
+        Assert.Contains("3", cells);
+    }
+
+    [Fact]
+    public void FormatResults_DirectOnly_HidesRedundantColumns()
+    {
+        // All direct, single-overload extensions: Overloads, Type, and Via columns
+        // carry no distinguishing information and should be dropped.
+        var results = new List<ExtensionMethodResult>
+        {
+            new() { MethodName = "Where", Kind = "method", ExtensionClass = "System.Linq.Enumerable", Assembly = "System.Linq" },
+            new() { MethodName = "Select", Kind = "method", ExtensionClass = "System.Linq.Enumerable", Assembly = "System.Linq" },
+        };
+
+        var view = ExtensionsOutputFormatter.BuildView("IEnumerable<T>", results);
+        var output = MarkoutSerializer.Serialize(view, SearchViewContext.Default);
+
+        Assert.Contains("| Name ", output);
+        Assert.Contains("| Class ", output);
+        Assert.DoesNotContain("| Overloads ", output);
+        Assert.DoesNotContain("| Type ", output);
+        Assert.DoesNotContain("| Via ", output);
+    }
+
+    [Fact]
+    public void FormatResults_ReachableExtensions_ShowTypeAndViaColumns()
+    {
+        // A reachable (indirect) extension gives a distinct Type and a Via path,
+        // so those columns must remain visible.
+        var results = new List<ExtensionMethodResult>
+        {
+            new() { MethodName = "Where", Kind = "method", ExtensionClass = "System.Linq.Enumerable", Assembly = "System.Linq" },
+            new() { MethodName = "CopyToAsync", Kind = "method", ExtensionClass = "StreamExt", Assembly = "System.IO", ReachablePath = ".GetStreamAsync()", ReachableFromType = "Stream" },
+        };
+
+        var view = ExtensionsOutputFormatter.BuildView("HttpClient", results);
+        var output = MarkoutSerializer.Serialize(view, SearchViewContext.Default);
+
+        Assert.Contains("| Type ", output);
+        Assert.Contains("| Via ", output);
+        Assert.Contains(".GetStreamAsync()", output);
+        Assert.Contains("Stream", output);
     }
 
     [Fact]

--- a/src/dotnet-inspect/CommandLine/Commands/UtilityCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/UtilityCommandDefinitions.cs
@@ -18,6 +18,10 @@ public static class UtilityCommandDefinitions
         var cleanOption = new Option<bool>("--clean", "--clear") { Hidden = true };
 
         cacheCommand.Options.Add(cleanOption);
+        cacheCommand.Options.Add(opts.Json);
+        cacheCommand.Options.Add(opts.Markdown);
+        cacheCommand.Options.Add(opts.PlainText);
+        opts.AddTableOptionsTo(cacheCommand);
         opts.AddOutputOptionsTo(cacheCommand, supportsRowWindows: false);
 
         // Subcommand: clear
@@ -43,7 +47,9 @@ public static class UtilityCommandDefinitions
             var verbosity = OptionParsers.ParseVerbosity(parseResult.GetValue(opts.Verbosity));
             var options = new CacheOptions(
                 Clean: clean,
-                Verbose: parseResult.GetValue(opts.Verbose) || verbosity >= Verbosity.Detailed);
+                Verbose: parseResult.GetValue(opts.Verbose) || verbosity >= Verbosity.Detailed,
+                Format: opts.ResolveFormat(parseResult),
+                NoHeader: parseResult.GetValue(opts.NoHeaders));
 
             return await CacheCommand.ExecuteAsync(options);
         });

--- a/src/dotnet-inspect/Commands/CacheCommand.cs
+++ b/src/dotnet-inspect/Commands/CacheCommand.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Services;
@@ -20,10 +21,10 @@ public class CacheCommand
             return Task.FromResult(CleanCache());
         }
 
-        return Task.FromResult(ShowCacheInfo());
+        return Task.FromResult(ShowCacheInfo(options));
     }
 
-    private static int ShowCacheInfo()
+    private static int ShowCacheInfo(CacheOptions options)
     {
         var info = PackageCacheService.GetCacheInfo();
 
@@ -33,19 +34,51 @@ public class CacheCommand
             return 0;
         }
 
+        var categories = info.Categories.Select(c =>
+        {
+            var label = c.Name == "Packages" ? "packages" : "files";
+            return new CacheCategoryRow(c.Name, CacheOutputFormatter.FormatSize(c.Size), $"{c.Count} {label}");
+        }).ToList();
+        var total = CacheOutputFormatter.FormatSize(info.TotalSize);
+
+        if (options.Format == OutputFormat.Json)
+        {
+            var json = new CacheInfoJson(
+                info.Location,
+                total,
+                categories.Select(c => new CacheCategoryJson(c.Name, c.Size, c.Items)).ToList());
+            Console.WriteLine(JsonSerializer.Serialize(json, CacheInfoJsonContext.Default.CacheInfoJson));
+            return 0;
+        }
+
         var view = new CacheInfoView
         {
             Location = info.Location,
-            Categories = info.Categories.Select(c =>
-            {
-                var label = c.Name == "Packages" ? "packages" : "files";
-                return new CacheCategoryRow(c.Name, CacheOutputFormatter.FormatSize(c.Size), $"{c.Count} {label}");
-            }).ToList(),
-            Total = CacheOutputFormatter.FormatSize(info.TotalSize)
+            Categories = categories,
+            Total = total
         };
 
-        MarkoutSerializer.Serialize(view, Console.Out, new PlainTextFormatter(), CacheInfoContext.Default);
-        Console.WriteLine("Run 'dotnet-inspect cache clear' to clear the cache.");
+        switch (options.Format)
+        {
+            case OutputFormat.Table:
+            case OutputFormat.Tsv:
+            case OutputFormat.Jsonl:
+                var writerOptions = OutputFormatter.CreateTableWriterOptions(
+                    tsv: options.Format == OutputFormat.Tsv,
+                    jsonl: options.Format == OutputFormat.Jsonl);
+                MarkoutSerializer.Serialize(
+                    view, Console.Out, new TableFormatter(!options.NoHeader), CacheInfoContext.Default, writerOptions);
+                break;
+            case OutputFormat.PlainText:
+                MarkoutSerializer.Serialize(view, Console.Out, new PlainTextFormatter(), CacheInfoContext.Default);
+                Console.WriteLine("Run 'dotnet-inspect cache clear' to clear the cache.");
+                break;
+            default:
+                MarkoutSerializer.Serialize(view, Console.Out, CacheInfoContext.Default);
+                Console.WriteLine("Run 'dotnet-inspect cache clear' to clear the cache.");
+                break;
+        }
+
         return 0;
     }
 

--- a/src/dotnet-inspect/Commands/CacheCommand.cs
+++ b/src/dotnet-inspect/Commands/CacheCommand.cs
@@ -27,12 +27,7 @@ public class CacheCommand
     private static int ShowCacheInfo(CacheOptions options)
     {
         var info = PackageCacheService.GetCacheInfo();
-
-        if (info.Categories.Count == 0)
-        {
-            Console.WriteLine("Cache is empty.");
-            return 0;
-        }
+        bool isEmpty = info.Categories.Count == 0;
 
         var categories = info.Categories.Select(c =>
         {
@@ -41,7 +36,9 @@ public class CacheCommand
         }).ToList();
         var total = CacheOutputFormatter.FormatSize(info.TotalSize);
 
-        if (options.Format == OutputFormat.Json)
+        // JSON and JSONL always emit a single structured record, even for an empty
+        // cache, so machine consumers never receive the plaintext fallback.
+        if (options.Format is OutputFormat.Json or OutputFormat.Jsonl)
         {
             var json = new CacheInfoJson(
                 info.Location,
@@ -54,7 +51,7 @@ public class CacheCommand
         var view = new CacheInfoView
         {
             Location = info.Location,
-            Categories = categories,
+            Categories = categories.Count > 0 ? categories : null,
             Total = total
         };
 
@@ -62,18 +59,27 @@ public class CacheCommand
         {
             case OutputFormat.Table:
             case OutputFormat.Tsv:
-            case OutputFormat.Jsonl:
                 var writerOptions = OutputFormatter.CreateTableWriterOptions(
                     tsv: options.Format == OutputFormat.Tsv,
-                    jsonl: options.Format == OutputFormat.Jsonl);
+                    jsonl: false);
                 MarkoutSerializer.Serialize(
                     view, Console.Out, new TableFormatter(!options.NoHeader), CacheInfoContext.Default, writerOptions);
                 break;
             case OutputFormat.PlainText:
+                if (isEmpty)
+                {
+                    Console.WriteLine("Cache is empty.");
+                    break;
+                }
                 MarkoutSerializer.Serialize(view, Console.Out, new PlainTextFormatter(), CacheInfoContext.Default);
                 Console.WriteLine("Run 'dotnet-inspect cache clear' to clear the cache.");
                 break;
             default:
+                if (isEmpty)
+                {
+                    Console.WriteLine("Cache is empty.");
+                    break;
+                }
                 MarkoutSerializer.Serialize(view, Console.Out, CacheInfoContext.Default);
                 Console.WriteLine("Run 'dotnet-inspect cache clear' to clear the cache.");
                 break;

--- a/src/dotnet-inspect/Options/CacheOptions.cs
+++ b/src/dotnet-inspect/Options/CacheOptions.cs
@@ -6,4 +6,6 @@ namespace DotnetInspector.Options;
 public record CacheOptions(
     bool Clean,
     bool Verbose,
-    string? Session = null);
+    string? Session = null,
+    OutputFormat Format = OutputFormat.Markdown,
+    bool NoHeader = false);

--- a/src/dotnet-inspect/Output/ExtensionsOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ExtensionsOutputFormatter.cs
@@ -64,12 +64,11 @@ public static class ExtensionsOutputFormatter
                 var sourceDisplay = r.SourceVersion != null
                     ? $"{r.Source}@{r.SourceVersion}"
                     : r.Source ?? "";
-                var name = r.Overloads > 1
-                    ? $"{r.MethodName} ({r.Overloads} overloads)"
-                    : r.MethodName;
+                var name = r.MethodName;
+                var overloads = r.Overloads ?? 1;
                 var type = r.ReachableFromType ?? targetType;
                 var via = r.ReachablePath ?? "";
-                return new ExtensionRow(name, r.Kind, r.ExtensionClass ?? "", r.Assembly ?? "", sourceDisplay, type, via);
+                return new ExtensionRow(name, overloads, r.Kind, r.ExtensionClass ?? "", r.Assembly ?? "", sourceDisplay, type, via);
             })
             .ToList();
 

--- a/src/dotnet-inspect/Views/CacheViews.cs
+++ b/src/dotnet-inspect/Views/CacheViews.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Markout;
 
 namespace DotnetInspector.Views;
@@ -5,7 +6,7 @@ namespace DotnetInspector.Views;
 /// <summary>
 /// View model for cache info output.
 /// </summary>
-[MarkoutSerializable(FieldLayout = FieldLayout.Plain)]
+[MarkoutSerializable(FieldLayout = FieldLayout.Table)]
 public class CacheInfoView
 {
     public string Location { get; set; } = "";
@@ -21,5 +22,23 @@ public record CacheCategoryRow(string Name, string Size, string Items);
 
 [MarkoutContext(typeof(CacheInfoView))]
 public partial class CacheInfoContext : MarkoutSerializerContext
+{
+}
+
+/// <summary>
+/// JSON projection for cache info output (used by <c>cache --json</c>).
+/// </summary>
+public record CacheInfoJson(
+    [property: JsonPropertyName("location")] string Location,
+    [property: JsonPropertyName("total")] string Total,
+    [property: JsonPropertyName("categories")] List<CacheCategoryJson> Categories);
+
+public record CacheCategoryJson(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("size")] string Size,
+    [property: JsonPropertyName("items")] string Items);
+
+[JsonSerializable(typeof(CacheInfoJson))]
+internal partial class CacheInfoJsonContext : JsonSerializerContext
 {
 }

--- a/src/dotnet-inspect/Views/ExtensionsViews.cs
+++ b/src/dotnet-inspect/Views/ExtensionsViews.cs
@@ -15,11 +15,26 @@ public class ExtensionsResultView
     public List<ExtensionCountRow>? Counts { get; set; }
 
     [MarkoutSection(Name = "Extensions")]
+    [MarkoutIgnoreColumnWhen(nameof(OverloadsUniform), nameof(ExtensionRow.Overloads))]
+    [MarkoutIgnoreColumnWhen(nameof(TypeUniform), nameof(ExtensionRow.Type))]
+    [MarkoutIgnoreColumnWhen(nameof(ViaEmpty), nameof(ExtensionRow.Via))]
     public List<ExtensionRow>? Extensions { get; set; }
+
+    // Hide the Overloads column when every method has a single overload.
+    public static bool OverloadsUniform(List<ExtensionRow>? rows)
+        => rows is null || rows.All(r => r.Overloads <= 1);
+
+    // Hide the Type column when uniform (direct extensions all share the queried type, echoed in the title).
+    public static bool TypeUniform(List<ExtensionRow>? rows)
+        => rows?.Select(r => r.Type).Distinct(StringComparer.Ordinal).Count() <= 1;
+
+    // Hide the Via column when no reachable-path (indirect) extensions are present.
+    public static bool ViaEmpty(List<ExtensionRow>? rows)
+        => rows is null || rows.All(r => string.IsNullOrEmpty(r.Via));
 }
 
 [MarkoutSerializable]
 public record ExtensionCountRow(string Type, string Extensions, string Via);
 
 [MarkoutSerializable]
-public record ExtensionRow(string Name, string Kind, string Class, string Library, string Source, string Type, string Via);
+public record ExtensionRow(string Name, int Overloads, string Kind, string Class, string Library, string Source, string Type, string Via);

--- a/src/dotnet-inspect/Views/ExtensionsViews.cs
+++ b/src/dotnet-inspect/Views/ExtensionsViews.cs
@@ -24,9 +24,13 @@ public class ExtensionsResultView
     public static bool OverloadsUniform(List<ExtensionRow>? rows)
         => rows is null || rows.All(r => r.Overloads <= 1);
 
-    // Hide the Type column when uniform (direct extensions all share the queried type, echoed in the title).
+    // Hide the Type column only for all-direct results, where every row echoes the
+    // queried type shown in the title. Reachable (indirect) rows carry a distinct
+    // resolved type, so keep the column whenever any row has a Via path.
     public static bool TypeUniform(List<ExtensionRow>? rows)
-        => rows?.Select(r => r.Type).Distinct(StringComparer.Ordinal).Count() <= 1;
+        => rows is null
+            || (rows.All(r => string.IsNullOrEmpty(r.Via))
+                && rows.Select(r => r.Type).Distinct(StringComparer.Ordinal).Count() <= 1);
 
     // Hide the Via column when no reachable-path (indirect) extensions are present.
     public static bool ViaEmpty(List<ExtensionRow>? rows)


### PR DESCRIPTION
## Summary

Addresses four findings from the AOT usability pass (pass2). All are output-shape / convention fixes to bring `extensions` and `cache` in line with the rest of the tool.

**extensions**
- **Finding 4 (med):** `--jsonl` (and the default table) baked the overload count into the name (`"Aggregate (3 overloads)"`). Now emits a clean method name plus a separate numeric **Overloads** column. The column is hidden when every row has a single overload, so it only appears when it carries information.
- **Finding 6 (low):** the always-empty **Via** column is dropped when empty.
- **Finding 7 (low):** the **Type** column that repeated the queried type on every row is dropped when uniform.
  - Both Via and Type are hidden *only when uniform/empty*. Reachable (indirect) extensions still surface their distinct Type and Via path.

**cache**
- **Finding 9 (low):** `cache` rendered dashed plaintext unlike every other command. It now renders **markdown tables by default** and honors `--json` / `--table` / `--tsv` / `--jsonl` / `--plaintext`. The legacy dashed layout is still available via `--plaintext`.

Column hiding reuses the existing `MarkoutIgnoreColumnWhen` convention (as in `LibraryInspectionView`).

## Evidence

Built the CLI and verified against the built DLL:
- `extensions` default: Via/Type columns gone, Overloads column present (`3`, `2`, …).
- `extensions --jsonl`: `{"name":"Aggregate","overloads":"3",...}` — clean name + separate field.
- `cache` default: markdown `| Field | Value |` + `## Categories` table.
- `cache --json` valid JSON; `--table`/`--tsv`/`--plaintext` work; `--json --table` correctly rejected by the shared validator.

Tests (xUnit v3): added focused cases and updated the existing overload test.
- `ExtensionsCommandTests` — 20 pass (incl. new hide-when-uniform and show-when-reachable cases).
- `CacheCommandTests` — 6 pass (incl. new markdown-default rendering case).

## Compatibility / non-actions

- Finding 4's numeric value renders as a quoted string in `--jsonl`/`--tsv` (`"overloads":"3"`), matching how Markout stringifies **all** numeric cells tool-wide (e.g. `"callers":"238"`). Making it a true JSON number is a Markout-level change affecting every command — out of scope. The substantive ask (separate field, not baked into the name) is met.
- `cache clear` / session-clear paths are unchanged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
