### PR TITLE
Bound distinct .NET tool wrapper redirect chains (#2813)

### DIFF
--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -51,6 +51,8 @@ public sealed record PackageReferenceTarget(
 /// </summary>
 public static class PackageExtractor
 {
+    private const int MaxToolWrapperRedirectHops = 8;
+
     private static readonly AsyncCache<PackageAcquisitionRequest, PackageExtractionOutcome>
         s_packageRequests = new();
 
@@ -130,6 +132,13 @@ public static class PackageExtractor
             redirectChain.Add(result.PackageName);
             if (visitedPackageIds.Contains(redirectId))
                 return ToolWrapperRedirectCycle(redirectChain, redirectId);
+
+            if (redirectChain.Count > MaxToolWrapperRedirectHops)
+            {
+                return PackageExtractionOutcome.Error(
+                    $"Tool wrapper redirect limit of {MaxToolWrapperRedirectHops} exceeded: " +
+                    $"{string.Join(" -> ", redirectChain)} -> {redirectId}.");
+            }
 
             log?.Invoke(
                 $"'{result.PackageName}' is a tool wrapper with no managed libraries; inspecting '{redirectId}' instead.");

--- a/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
+++ b/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
@@ -194,6 +194,98 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
     }
 
     [Fact]
+    public async Task ExtractPackageAsync_ToolWrapperRedirectAtHopLimitReturnsPayload()
+    {
+        const int MaxRedirectHops = 8;
+        const string PackagePrefix = "Wrapper.Bounded";
+        const string Version = "1.0.0";
+        byte[][] responses = Enumerable.Range(0, MaxRedirectHops)
+            .Select(index => CreateToolWrapperArchive(
+                $"{PackagePrefix}.{index}",
+                Version,
+                redirectPackageName: $"{PackagePrefix}.{index + 1}"))
+            .Append(CreatePackageArchive($"{PackagePrefix}.{MaxRedirectHops}", Version))
+            .ToArray();
+        var handler = new QueuePackageHandler(responses);
+        using var client = new HttpClient(handler);
+
+        PackageExtractionOutcome outcome =
+            await PackageExtractor.ExtractPackageAsync(
+                client,
+                $"{PackagePrefix}.0",
+                sourceOptions: s_nugetOrgSource,
+                version: Version);
+
+        Assert.True(outcome.IsSuccess);
+        Assert.Equal($"{PackagePrefix}.{MaxRedirectHops}", outcome.Result!.PackageName);
+        Assert.Equal(MaxRedirectHops + 1, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task ExtractPackageAsync_ToolWrapperRedirectBeyondHopLimitReturnsErrorBeforeNextDownload()
+    {
+        const int MaxRedirectHops = 8;
+        const string PackagePrefix = "Wrapper.Unbounded";
+        const string Version = "1.0.0";
+        byte[][] responses = Enumerable.Range(0, MaxRedirectHops + 1)
+            .Select(index => CreateToolWrapperArchive(
+                $"{PackagePrefix}.{index}",
+                Version,
+                redirectPackageName: $"{PackagePrefix}.{index + 1}"))
+            .ToArray();
+        var handler = new QueuePackageHandler(responses);
+        using var client = new HttpClient(handler);
+
+        PackageExtractionOutcome outcome =
+            await PackageExtractor.ExtractPackageAsync(
+                client,
+                $"{PackagePrefix}.0",
+                sourceOptions: s_nugetOrgSource,
+                version: Version);
+
+        Assert.False(outcome.IsSuccess);
+        Assert.Equal(
+            $"Tool wrapper redirect limit of {MaxRedirectHops} exceeded: " +
+            $"{string.Join(" -> ", Enumerable.Range(0, MaxRedirectHops + 1).Select(index => $"{PackagePrefix}.{index}"))}" +
+            $" -> {PackagePrefix}.{MaxRedirectHops + 1}.",
+            outcome.ErrorMessage);
+        Assert.Equal(MaxRedirectHops + 1, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task ExtractPackageAsync_CycleAtHopLimitReturnsSpecificCycleError()
+    {
+        const int MaxRedirectHops = 8;
+        const string PackagePrefix = "Wrapper.CycleAtLimit";
+        const string Version = "1.0.0";
+        byte[][] responses = Enumerable.Range(0, MaxRedirectHops + 1)
+            .Select(index => CreateToolWrapperArchive(
+                $"{PackagePrefix}.{index}",
+                Version,
+                redirectPackageName: index == MaxRedirectHops
+                    ? $"{PackagePrefix}.0"
+                    : $"{PackagePrefix}.{index + 1}"))
+            .ToArray();
+        var handler = new QueuePackageHandler(responses);
+        using var client = new HttpClient(handler);
+
+        PackageExtractionOutcome outcome =
+            await PackageExtractor.ExtractPackageAsync(
+                client,
+                $"{PackagePrefix}.0",
+                sourceOptions: s_nugetOrgSource,
+                version: Version);
+
+        Assert.False(outcome.IsSuccess);
+        Assert.Equal(
+            $"Tool wrapper redirect cycle detected: " +
+            $"{string.Join(" -> ", Enumerable.Range(0, MaxRedirectHops + 1).Select(index => $"{PackagePrefix}.{index}"))}" +
+            $" -> {PackagePrefix}.0.",
+            outcome.ErrorMessage);
+        Assert.Equal(MaxRedirectHops + 1, handler.RequestCount);
+    }
+
+    [Fact]
     public async Task CommitPackage_ConcurrentPublishersConvergeOnOneCompleteTree()
     {
         string packageName = $"publisher.test.{Guid.NewGuid():N}";


### PR DESCRIPTION
Fixes #2813.

## What

Adds an explicit redirect-hop budget (`MaxToolWrapperRedirectHops = 8`) to `PackageExtractor` for .NET tool-wrapper chains. When a wrapper graph redirects through more than 8 **distinct** package IDs, extraction returns a visible `PackageExtractionOutcome.Error` naming the chain, instead of continuing to download and transactionally commit an arbitrarily long sequence of packages.

## Why

PR #2810 already stops **repeated** package IDs from causing recursive stack overflow (cycle detection via `visitedPackageIds`). But a malformed wrapper graph can still redirect through an unbounded chain of *distinct* IDs, each hop costing a network download + transactional cache commit — a resource-exhaustion vector on untrusted input. This adds the missing distinct-hop bound as non-blocking follow-up from the #2810 review.

## Behavior

- Ordinary one-hop wrapper→payload behavior is preserved.
- The existing cycle check runs **before** the new budget check, so a cycle still yields the specific cycle error rather than the generic hop-limit error.
- At exactly 8 redirects the payload still resolves; the 9th redirect errors **before** the next download.

## Tests

Three new boundary tests in `PackageAcquisitionConcurrencyTests`:
- `ExtractPackageAsync_ToolWrapperRedirectAtHopLimitReturnsPayload` — 8 hops resolve the payload.
- `ExtractPackageAsync_ToolWrapperRedirectBeyondHopLimitReturnsErrorBeforeNextDownload` — 9th hop errors with no extra download (`RequestCount` asserted).
- `ExtractPackageAsync_CycleAtHopLimitReturnsSpecificCycleError` — cycle precedence preserved at the boundary.

`dotnet run --project src/dotnet-inspect.Tests -c Release -- -class DotnetInspector.Tests.PackageAcquisitionConcurrencyTests` → 15 passed, 0 failed.
