### PR TITLE
Add real-corpus authored-source census (--authored-source-census)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AuthoredSourceCensusTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredSourceCensusTests.cs
@@ -137,3 +137,48 @@ public sealed class ReturnToSenderSourceProbeQualityCardTests
         Assert.Contains("no checkable rows", card);
     }
 }
+
+public sealed class AuthoredSourceCensusDiversificationTests
+{
+    [Fact]
+    public void DiversifyByKey_RoundRobinsAcrossKeys_WhenPoolExceedsCap()
+    {
+        string[] candidates = ["A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9", "A10", "B1", "C1"];
+
+        var selected = AuthoredSourceCensus.DiversifyByKey(candidates, 4, item => item[..1]);
+
+        Assert.Equal(["A1", "B1", "C1", "A2"], selected);
+    }
+
+    [Fact]
+    public void DiversifyByKey_ReturnsAllCandidates_WhenPoolFitsWithinCap()
+    {
+        string[] candidates = ["A1", "B1", "C1"];
+
+        var selected = AuthoredSourceCensus.DiversifyByKey(candidates, 10, item => item[..1]);
+
+        Assert.Same(candidates, selected);
+    }
+
+    [Fact]
+    public void DiversifyByKey_ReturnsEmpty_WhenCapIsNotPositive()
+    {
+        string[] candidates = ["A1", "B1"];
+
+        var selected = AuthoredSourceCensus.DiversifyByKey(candidates, 0, item => item[..1]);
+
+        Assert.Empty(selected);
+    }
+
+    [Fact]
+    public void DiversifyByKey_StopsAtCap_WhenOneKeyDominatesThePool()
+    {
+        // Mirrors a real-world corpus where a generated resource-string type
+        // (e.g. SR) contributes far more property getters than any other type.
+        string[] candidates = Enumerable.Range(0, 50).Select(i => $"SR{i}").Append("Other1").ToArray();
+
+        var selected = AuthoredSourceCensus.DiversifyByKey(candidates, 3, item => item.StartsWith("SR", StringComparison.Ordinal) ? "SR" : "Other");
+
+        Assert.Equal(["SR0", "Other1", "SR1"], selected);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/AuthoredSourceCensusTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredSourceCensusTests.cs
@@ -87,3 +87,53 @@ public sealed class AuthoredSourceCensusTests
         Assert.True(result.Failed);
     }
 }
+
+public sealed class ReturnToSenderSourceProbeQualityCardTests
+{
+    static ReturnToSender.RequestedTarget SyntheticTarget(string method)
+        => new("Synthetic.Type", method, 0);
+
+    static ReturnToSenderSourceProbeResult Synthetic(ReturnToSenderSourceOutcome outcome, string reason, string method = "M")
+        => new(SyntheticTarget(method), outcome, null, reason, null, null, null, null);
+
+    [Fact]
+    public void RenderQualityCard_AccountsForEveryResult_AcrossAllBuckets()
+    {
+        var results = new[]
+        {
+            Synthetic(ReturnToSenderSourceOutcome.ValidMatch, "valid_match", "A"),
+            Synthetic(ReturnToSenderSourceOutcome.ValidDifferent, "valid_different.known_taste", "B"),
+            Synthetic(ReturnToSenderSourceOutcome.ValidDifferent, "valid_different.semantic_opcode_diff", "C"),
+            Synthetic(ReturnToSenderSourceOutcome.Invalid, "invalid.recompile_fail", "D"),
+            Synthetic(ReturnToSenderSourceOutcome.SourceUnavailable, "source_unavailable", "E"),
+            Synthetic(ReturnToSenderSourceOutcome.UnsupportedTarget, "unsupported-rts-target", "F"),
+        };
+
+        string card = ReturnToSenderSourceProbe.RenderQualityCard(results, "2 test assemblies");
+
+        Assert.Contains("Source-correspondence quality card", card);
+        Assert.Contains("2 test assemblies", card);
+        Assert.Contains("6 target(s) sampled", card);
+        Assert.Contains("Valid match (+) | 1 (16.67%)", card);
+        Assert.Contains("ignorable known difference (+) | 1 (16.67%)", card);
+        Assert.Contains("semantic opcode diff (-) | 1 (16.67%)", card);
+        Assert.Contains("Invalid / RTS compile-back failed (-) | 1 (16.67%)", card);
+        Assert.Contains("Source unavailable (uncheckable) | 1 (16.67%)", card);
+        Assert.Contains("Unsupported target (uncheckable) | 1 (16.67%)", card);
+        Assert.Contains("Verdict:", card);
+    }
+
+    [Fact]
+    public void RenderQualityCard_ReportsNoSignalVerdict_WhenNothingIsCheckable()
+    {
+        var results = new[]
+        {
+            Synthetic(ReturnToSenderSourceOutcome.SourceUnavailable, "source_unavailable", "A"),
+            Synthetic(ReturnToSenderSourceOutcome.UnsupportedTarget, "unsupported-rts-target", "B"),
+        };
+
+        string card = ReturnToSenderSourceProbe.RenderQualityCard(results, "no-signal corpus");
+
+        Assert.Contains("no checkable rows", card);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/AuthoredSourceCensusTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredSourceCensusTests.cs
@@ -1,0 +1,89 @@
+using DotnetInspector.Fixtures;
+using DotnetInspector.Services;
+
+namespace ILInspector.DecompilerHarness;
+
+public sealed class AuthoredSourceCensusTests
+{
+    static ReturnToSender.Result RealDecompilerResult()
+        => ReturnToSender.CompileBackFirstPropertyGetter(FixtureCatalog.DiffPair.OldAssemblyPath());
+
+    static ReturnToSender.RequestedTarget TargetFor(ReturnToSender.Result result)
+    {
+        var identity = result.Plan.TargetMethod;
+        return new ReturnToSender.RequestedTarget(
+            identity.Type,
+            identity.Method,
+            identity.Overload,
+            identity.Signature);
+    }
+
+    [Fact]
+    [Trait("Speed", "Slow")]
+    public void ClassifyExpectedBody_ReportsValidMatch_WhenAuthoredBodyIsWhitespaceEquivalent()
+    {
+        var decompiler = RealDecompilerResult();
+        var target = TargetFor(decompiler);
+        string expected = $"  {decompiler.TargetBody}  \n";
+
+        var result = AuthoredSourceCensus.ClassifyExpectedBody(target, decompiler, "https://example.test/Source.cs", expected);
+
+        Assert.Equal(ReturnToSenderSourceOutcome.ValidMatch, result.Outcome);
+        Assert.Equal("valid_match", result.Reason);
+        Assert.True(result.Passed);
+        Assert.Equal(decompiler.TargetBody, result.ActualBody);
+    }
+
+    [Fact]
+    [Trait("Speed", "Slow")]
+    public void ClassifyExpectedBody_ReportsValidDifferent_WhenAuthoredBodyDiffersInSubstance()
+    {
+        var decompiler = RealDecompilerResult();
+        var target = TargetFor(decompiler);
+        string expected = decompiler.TargetBody + " /* an authored-only comment marker that is not whitespace */ return 12345;";
+
+        var result = AuthoredSourceCensus.ClassifyExpectedBody(target, decompiler, "https://example.test/Source.cs", expected);
+
+        Assert.Equal(ReturnToSenderSourceOutcome.ValidDifferent, result.Outcome);
+        Assert.True(result.Different);
+        Assert.Equal(expected, result.ExpectedBody);
+        Assert.Equal(decompiler.TargetBody, result.ActualBody);
+        Assert.False(string.IsNullOrWhiteSpace(result.Reason));
+    }
+
+    [Fact]
+    [Trait("Speed", "Slow")]
+    public async Task ClassifyAsync_ReportsUnsupportedTarget_WhenRtsProducedNoFinalRequest()
+    {
+        var decompiler = RealDecompilerResult() with { FinalRequest = null };
+        using var httpClient = new HttpClient();
+        var fetcher = new SourceFetcher(httpClient);
+
+        var result = await AuthoredSourceCensus.ClassifyAsync(null!, fetcher, decompiler);
+
+        Assert.Equal(ReturnToSenderSourceOutcome.UnsupportedTarget, result.Outcome);
+        Assert.Equal("unsupported-rts-target", result.Reason);
+    }
+
+    [Fact]
+    [Trait("Speed", "Slow")]
+    public async Task ClassifyAsync_ReportsInvalid_WhenRtsRecompileFailed()
+        => await AssertClassifiesInvalid(FidelityCheck.CompileBackStatus.RecompileFail);
+
+    [Fact]
+    [Trait("Speed", "Slow")]
+    public async Task ClassifyAsync_ReportsInvalid_WhenRtsContextFailed()
+        => await AssertClassifiesInvalid(FidelityCheck.CompileBackStatus.ContextFail);
+
+    static async Task AssertClassifiesInvalid(FidelityCheck.CompileBackStatus status)
+    {
+        var decompiler = RealDecompilerResult() with { Status = status, Detail = "synthetic failure detail" };
+        using var httpClient = new HttpClient();
+        var fetcher = new SourceFetcher(httpClient);
+
+        var result = await AuthoredSourceCensus.ClassifyAsync(null!, fetcher, decompiler);
+
+        Assert.Equal(ReturnToSenderSourceOutcome.Invalid, result.Outcome);
+        Assert.True(result.Failed);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/AuthoredSourceCensusTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredSourceCensusTests.cs
@@ -181,4 +181,58 @@ public sealed class AuthoredSourceCensusDiversificationTests
 
         Assert.Equal(["SR0", "Other1", "SR1"], selected);
     }
+
+    [Fact]
+    public void RoundRobinByKey_ReordersEntirePool_WithoutTruncating()
+    {
+        string[] items = ["A1", "A2", "A3", "B1", "C1", "C2"];
+
+        var reordered = AuthoredSourceCensus.RoundRobinByKey(items, item => item[..1]);
+
+        Assert.Equal(["A1", "B1", "C1", "A2", "C2", "A3"], reordered);
+        Assert.Equal(items.Length, reordered.Count);
+    }
+}
+
+public sealed class AuthoredSourceCensusRosterTests
+{
+    [Fact]
+    public void Roster_RoundTripsThroughJson()
+    {
+        var roster = new AuthoredSourceCensusRoster(
+            SchemaVersion: 1,
+            GeneratedUtc: new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            Assemblies:
+            [
+                new AuthoredSourceCensusRosterAssembly(
+                    "System.Text.Json.dll",
+                    [
+                        new AuthoredSourceCensusRosterMember("System.Text.Json.JsonDocument", "get_RootElement", 0, null),
+                        new AuthoredSourceCensusRosterMember("System.HexConverter", "get_CharToHexLookup", 0, "System.Byte[]"),
+                    ]),
+            ]);
+
+        string json = System.Text.Json.JsonSerializer.Serialize(
+            roster,
+            new System.Text.Json.JsonSerializerOptions
+            {
+                WriteIndented = true,
+                PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase,
+            });
+        var roundTripped = System.Text.Json.JsonSerializer.Deserialize<AuthoredSourceCensusRoster>(
+            json,
+            new System.Text.Json.JsonSerializerOptions
+            {
+                PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase,
+            });
+
+        Assert.NotNull(roundTripped);
+        Assert.Equal(roster.SchemaVersion, roundTripped!.SchemaVersion);
+        Assert.Equal(roster.GeneratedUtc, roundTripped.GeneratedUtc);
+        Assert.Single(roundTripped.Assemblies);
+        Assert.Equal("System.Text.Json.dll", roundTripped.Assemblies[0].AssemblyFileName);
+        Assert.Equal(2, roundTripped.Assemblies[0].Members.Count);
+        Assert.Equal("System.HexConverter", roundTripped.Assemblies[0].Members[1].Type);
+        Assert.Equal("System.Byte[]", roundTripped.Assemblies[0].Members[1].Signature);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/AuthoredSourceCensusTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredSourceCensusTests.cs
@@ -194,6 +194,68 @@ public sealed class AuthoredSourceCensusDiversificationTests
     }
 }
 
+public sealed class AuthoredSourceCensusAllocationTests
+{
+    [Fact]
+    public void AllocateAcrossLibraries_ReturnsFullCounts_WhenCorpusFitsWithinCap()
+    {
+        int[] counts = [10, 20, 30];
+
+        var allocation = AuthoredSourceCensus.AllocateAcrossLibraries(counts, cap: 1000);
+
+        Assert.Equal(counts, allocation);
+    }
+
+    [Fact]
+    public void AllocateAcrossLibraries_GivesSmallLibrariesTheirFullCount_AndLargestAbsorbsShortfall()
+    {
+        // total=5250, cap=1000 -> fairShare=1750; libraries sorted ascending
+        // [50,200,5000] each get min(1750, count) except the largest, which
+        // absorbs the remainder to hit the cap exactly.
+        int[] counts = [50, 200, 5000];
+
+        var allocation = AuthoredSourceCensus.AllocateAcrossLibraries(counts, cap: 1000);
+
+        Assert.Equal([50, 200, 750], allocation);
+        Assert.Equal(1000, allocation.Sum());
+    }
+
+    [Fact]
+    public void AllocateAcrossLibraries_DoesNotCrowdOutSmallLibraries_WhenOneLibraryDominates()
+    {
+        // A single huge library (e.g. System.Private.CoreLib) must not take
+        // the entire cap and leave nothing for much smaller libraries.
+        int[] counts = [30, 40, 100_000];
+
+        var allocation = AuthoredSourceCensus.AllocateAcrossLibraries(counts, cap: 100);
+
+        Assert.Equal(30, allocation[0]);
+        Assert.Equal(40, allocation[1]);
+        Assert.Equal(30, allocation[2]);
+        Assert.Equal(100, allocation.Sum());
+    }
+
+    [Fact]
+    public void AllocateAcrossLibraries_ClampsToActualTotal_WhenCorpusIsSmallerThanCap()
+    {
+        int[] counts = [5, 5];
+
+        var allocation = AuthoredSourceCensus.AllocateAcrossLibraries(counts, cap: 10_000);
+
+        Assert.Equal([5, 5], allocation);
+    }
+
+    [Fact]
+    public void AllocateAcrossLibraries_ReducesToPlainCap_ForASingleLibrary()
+    {
+        int[] counts = [500];
+
+        var allocation = AuthoredSourceCensus.AllocateAcrossLibraries(counts, cap: 200);
+
+        Assert.Equal([200], allocation);
+    }
+}
+
 public sealed class AuthoredSourceCensusRosterTests
 {
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -89,6 +89,8 @@
              Link="ReturnToSenderSourceProbe.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\AuthoredRebuildFidelity.cs"
              Link="AuthoredRebuildFidelity.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\AuthoredSourceCensus.cs"
+             Link="AuthoredSourceCensus.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\CSharpSourceIdentity.cs"
              Link="CSharpSourceIdentity.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\SignatureIdentity.cs"

--- a/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
+++ b/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
@@ -780,7 +780,7 @@ static class AuthoredRebuildFidelity
             drift.Add($"{name}={actual} (RTS uses {expected})");
     }
 
-    static async Task AcquirePdbAsync(
+    internal static async Task AcquirePdbAsync(
         SourceLinkService source,
         HttpClient httpClient)
     {

--- a/tools/DecompilerHarness/AuthoredSourceCensus.cs
+++ b/tools/DecompilerHarness/AuthoredSourceCensus.cs
@@ -1,6 +1,7 @@
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
+using System.Text.Json;
 
 using DotnetInspector.Core;
 using DotnetInspector.Services;
@@ -8,6 +9,38 @@ using ILInspector.Findings;
 using ILInspector.Metadata;
 
 namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// One locked member in an <see cref="AuthoredSourceCensusRoster"/>: enough
+/// identity to re-target the same member with
+/// <see cref="ReturnToSender.CompileBackTargets(string, IReadOnlyList{ReturnToSender.RequestedTarget})"/>
+/// in a later, separate run.
+/// </summary>
+internal sealed record AuthoredSourceCensusRosterMember(string Type, string Method, int Overload, string? Signature);
+
+/// <summary>
+/// The locked members captured for one assembly during roster generation, in
+/// the diversified order they were confirmed to have available authored
+/// source. Correlated back to a run's resolved assembly path by file name.
+/// </summary>
+internal sealed record AuthoredSourceCensusRosterAssembly(
+    string AssemblyFileName,
+    IReadOnlyList<AuthoredSourceCensusRosterMember> Members);
+
+/// <summary>
+/// A locked, generation-time snapshot of members confirmed to have authored
+/// source available (<c>Outcome</c> not <c>SourceUnavailable</c>/
+/// <c>UnsupportedTarget</c> at generation time), diversified by declaring
+/// type. Replaying this roster at increasing <c>--cap</c> values samples
+/// nested prefixes of the same locked population, so cap=100 and cap=1000
+/// runs are directly comparable to each other and to earlier runs over the
+/// same roster -- unlike plain live discovery, which can select a different
+/// population every time <c>--cap</c> changes.
+/// </summary>
+internal sealed record AuthoredSourceCensusRoster(
+    int SchemaVersion,
+    DateTimeOffset GeneratedUtc,
+    IReadOnlyList<AuthoredSourceCensusRosterAssembly> Assemblies);
 
 /// <summary>
 /// Runs the Slice-2 source-correspondence bucket classifier
@@ -111,14 +144,26 @@ static class AuthoredSourceCensus
         if (candidates.Count <= cap)
             return candidates;
 
-        var groups = candidates
+        return RoundRobinByKey(candidates, keySelector).Take(cap).ToList();
+    }
+
+    /// <summary>
+    /// Reorders (without truncating) <paramref name="items"/> into round-robin
+    /// order across the distinct keys produced by <paramref name="keySelector"/>,
+    /// preserving within-key order. Used directly by roster generation, which
+    /// needs a diversified iteration order over an entire candidate pool
+    /// (filtering some out along the way) rather than a fixed-size selection.
+    /// </summary>
+    internal static IReadOnlyList<T> RoundRobinByKey<T>(IReadOnlyList<T> items, Func<T, string> keySelector)
+    {
+        var groups = items
             .GroupBy(keySelector, StringComparer.Ordinal)
             .Select(group => group.ToArray())
             .ToArray();
 
-        var selected = new List<T>(cap);
+        var ordered = new List<T>(items.Count);
         int index = 0;
-        while (selected.Count < cap)
+        while (ordered.Count < items.Count)
         {
             bool progressed = false;
             foreach (var group in groups)
@@ -126,10 +171,8 @@ static class AuthoredSourceCensus
                 if (index >= group.Length)
                     continue;
 
-                selected.Add(group[index]);
+                ordered.Add(group[index]);
                 progressed = true;
-                if (selected.Count >= cap)
-                    break;
             }
 
             if (!progressed)
@@ -138,7 +181,189 @@ static class AuthoredSourceCensus
             index++;
         }
 
-        return selected;
+        return ordered;
+    }
+
+    static JsonSerializerOptions RosterJsonOptions()
+        => new() { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    /// <summary>
+    /// One-time generation phase: samples a diversified candidate pool per
+    /// assembly, classifies each candidate (real RTS compile-back + real
+    /// SourceLink acquisition), and locks in up to <paramref name="cap"/>
+    /// members per assembly whose authored source was actually available
+    /// (<c>Outcome</c> not <c>SourceUnavailable</c>/<c>UnsupportedTarget</c>) —
+    /// independent of whether RTS's compile-back succeeded, since that verdict
+    /// is exactly what later replay runs want to re-measure fresh. Writes the
+    /// locked roster to <paramref name="rosterPath"/> for repeated,
+    /// apples-to-apples replay via <see cref="RunFromRoster"/>.
+    /// </summary>
+    public static int GenerateRoster(IReadOnlyList<string> assemblies, int cap, string rosterPath)
+        => GenerateRosterAsync(assemblies, cap, rosterPath).GetAwaiter().GetResult();
+
+    static async Task<int> GenerateRosterAsync(IReadOnlyList<string> assemblies, int cap, string rosterPath)
+    {
+        HttpClientFactory.Initialize();
+        using var httpClient = HttpClientFactory.CreateNew();
+        var fetcher = new SourceFetcher(HttpClientFactory.SharedUntrustedFetch);
+        var rosterAssemblies = new List<AuthoredSourceCensusRosterAssembly>();
+        int totalLocked = 0;
+
+        foreach (string assemblyPath in assemblies)
+        {
+            if (totalLocked >= cap)
+                break;
+
+            int remainingBudget = cap - totalLocked;
+            int candidatePoolCap = remainingBudget >= int.MaxValue / DiversityPoolMultiplier
+                ? int.MaxValue
+                : remainingBudget * DiversityPoolMultiplier;
+
+            IReadOnlyList<ReturnToSender.Result> orderedCandidates;
+            try
+            {
+                var pool = ReturnToSender.CompileBackPropertyGetters(assemblyPath, candidatePoolCap);
+                orderedCandidates = RoundRobinByKey(pool, result => result.Plan.TargetMethod.Type);
+            }
+            catch (Exception ex) when (ex is IOException
+                or UnauthorizedAccessException
+                or BadImageFormatException
+                or InvalidOperationException)
+            {
+                Console.Error.WriteLine(
+                    $"Warning: roster generation skipped '{assemblyPath}' "
+                    + $"({ex.GetType().Name}: {ex.Message}).");
+                continue;
+            }
+
+            using var source = SourceLinkService.Open(assemblyPath);
+            await AuthoredRebuildFidelity.AcquirePdbAsync(source, httpClient);
+
+            var lockedMembers = new List<AuthoredSourceCensusRosterMember>();
+            foreach (var candidate in orderedCandidates)
+            {
+                if (lockedMembers.Count >= remainingBudget)
+                    break;
+
+                var classified = await ClassifyAsync(source, fetcher, candidate);
+                if (classified.Outcome is ReturnToSenderSourceOutcome.SourceUnavailable
+                    or ReturnToSenderSourceOutcome.UnsupportedTarget)
+                {
+                    continue;
+                }
+
+                var identity = candidate.Plan.TargetMethod;
+                lockedMembers.Add(new AuthoredSourceCensusRosterMember(
+                    identity.Type, identity.Method, identity.Overload, identity.Signature));
+            }
+
+            totalLocked += lockedMembers.Count;
+            rosterAssemblies.Add(new AuthoredSourceCensusRosterAssembly(Path.GetFileName(assemblyPath), lockedMembers));
+        }
+
+        var roster = new AuthoredSourceCensusRoster(SchemaVersion: 1, DateTimeOffset.UtcNow, rosterAssemblies);
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(rosterPath)) ?? ".");
+        File.WriteAllText(rosterPath, JsonSerializer.Serialize(roster, RosterJsonOptions()));
+        Console.Error.WriteLine(
+            $"Wrote authored-source census roster with {totalLocked} locked member(s) "
+            + $"across {rosterAssemblies.Count(assembly => assembly.Members.Count > 0)} assembly/assemblies to {rosterPath}");
+        return 0;
+    }
+
+    /// <summary>
+    /// Replays a locked roster written by <see cref="GenerateRoster"/>: takes
+    /// the first <paramref name="cap"/> members (a nested prefix, in the same
+    /// locked/diversified order captured at generation time) per matched
+    /// assembly, re-targets them with <see cref="ReturnToSender.CompileBackTargets(string, IReadOnlyList{ReturnToSender.RequestedTarget})"/>,
+    /// and classifies each fresh (real RTS compile-back + real SourceLink
+    /// acquisition). Unlike live discovery, the sampled population only grows
+    /// as <paramref name="cap"/> grows -- it never changes -- so runs at
+    /// different caps, or runs repeated over time, are directly comparable.
+    /// </summary>
+    public static int RunFromRoster(
+        IReadOnlyList<string> assemblies,
+        string rosterPath,
+        int cap,
+        int maxExamples,
+        bool json,
+        bool qualityCard = false)
+        => RunFromRosterAsync(assemblies, rosterPath, cap, maxExamples, json, qualityCard).GetAwaiter().GetResult();
+
+    static async Task<int> RunFromRosterAsync(
+        IReadOnlyList<string> assemblies,
+        string rosterPath,
+        int cap,
+        int maxExamples,
+        bool json,
+        bool qualityCard)
+    {
+        var roster = JsonSerializer.Deserialize<AuthoredSourceCensusRoster>(File.ReadAllText(rosterPath), RosterJsonOptions())
+            ?? throw new InvalidOperationException($"Could not read authored-source census roster '{rosterPath}'.");
+        var rosterByFileName = roster.Assemblies.ToDictionary(
+            assembly => assembly.AssemblyFileName, StringComparer.OrdinalIgnoreCase);
+
+        HttpClientFactory.Initialize();
+        using var httpClient = HttpClientFactory.CreateNew();
+        var fetcher = new SourceFetcher(HttpClientFactory.SharedUntrustedFetch);
+        List<ReturnToSenderSourceProbeResult> results = [];
+        int assemblyCount = 0;
+        int rosterTotal = roster.Assemblies.Sum(assembly => assembly.Members.Count);
+
+        foreach (string assemblyPath in assemblies)
+        {
+            if (results.Count >= cap)
+                break;
+
+            string fileName = Path.GetFileName(assemblyPath);
+            if (!rosterByFileName.TryGetValue(fileName, out var rosterAssembly))
+            {
+                Console.Error.WriteLine(
+                    $"Warning: roster '{rosterPath}' has no locked members for '{fileName}'; skipping.");
+                continue;
+            }
+
+            int remainingBudget = cap - results.Count;
+            var replayMembers = rosterAssembly.Members.Take(remainingBudget).ToArray();
+            if (replayMembers.Length == 0)
+                continue;
+
+            var targets = replayMembers
+                .Select(member => new ReturnToSender.RequestedTarget(member.Type, member.Method, member.Overload, member.Signature))
+                .ToArray();
+
+            IReadOnlyList<ReturnToSender.Result> decompilerResults;
+            try
+            {
+                decompilerResults = ReturnToSender.CompileBackTargets(assemblyPath, targets);
+            }
+            catch (Exception ex) when (ex is IOException
+                or UnauthorizedAccessException
+                or BadImageFormatException
+                or InvalidOperationException)
+            {
+                Console.Error.WriteLine(
+                    $"Warning: authored source census roster replay skipped '{assemblyPath}' "
+                    + $"({ex.GetType().Name}: {ex.Message}).");
+                continue;
+            }
+
+            assemblyCount++;
+            using var source = SourceLinkService.Open(assemblyPath);
+            await AuthoredRebuildFidelity.AcquirePdbAsync(source, httpClient);
+
+            foreach (var decompilerResult in decompilerResults)
+            {
+                if (results.Count >= cap)
+                    break;
+
+                results.Add(await ClassifyAsync(source, fetcher, decompilerResult));
+            }
+        }
+
+        string corpusLabel =
+            $"{results.Count}/{rosterTotal} locked roster member(s) across {assemblyCount} assembly/assemblies "
+            + $"(roster: {rosterPath})";
+        return ReturnToSenderSourceProbe.Report(results, maxExamples, json, qualityCard, corpusLabel);
     }
 
     internal static async Task<ReturnToSenderSourceProbeResult> ClassifyAsync(

--- a/tools/DecompilerHarness/AuthoredSourceCensus.cs
+++ b/tools/DecompilerHarness/AuthoredSourceCensus.cs
@@ -1,0 +1,245 @@
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+using DotnetInspector.Core;
+using DotnetInspector.Services;
+using ILInspector.Findings;
+using ILInspector.Metadata;
+
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// Runs the Slice-2 source-correspondence bucket classifier
+/// (<see cref="ReturnToSenderSourceProbe"/>) over real, non-fixture corpus
+/// assemblies using real SourceLink acquisition (the same acquisition lane as
+/// <see cref="AuthoredRebuildFidelity"/>). This closes the "assembly-wide
+/// source-only census: not added" gap left open by the fixture-only
+/// <c>--source-correspondence-census</c> mode, which selects zero targets for
+/// any assembly that is not registered in <c>FixtureCatalog</c>.
+///
+/// This is a peer of the RTS compile-back oracle and the authored-rebuild
+/// fidelity oracle, not a replacement for either: it reports its own
+/// <c>Absent</c>/<c>Failed</c>/<c>SourceUnavailable</c> outcomes distinctly and
+/// never blends its verdict into theirs.
+/// </summary>
+static class AuthoredSourceCensus
+{
+    public static int Run(IReadOnlyList<string> assemblies, int cap, int maxExamples, bool json)
+        => RunAsync(assemblies, cap, maxExamples, json).GetAwaiter().GetResult();
+
+    static async Task<int> RunAsync(
+        IReadOnlyList<string> assemblies,
+        int cap,
+        int maxExamples,
+        bool json)
+    {
+        HttpClientFactory.Initialize();
+        using var httpClient = HttpClientFactory.CreateNew();
+        var fetcher = new SourceFetcher(HttpClientFactory.SharedUntrustedFetch);
+        List<ReturnToSenderSourceProbeResult> results = [];
+
+        foreach (string assemblyPath in assemblies)
+        {
+            if (results.Count >= cap)
+                break;
+
+            IReadOnlyList<ReturnToSender.Result> decompilerResults;
+            try
+            {
+                decompilerResults = ReturnToSender.CompileBackPropertyGetters(
+                    assemblyPath,
+                    cap - results.Count);
+            }
+            catch (Exception ex) when (ex is IOException
+                or UnauthorizedAccessException
+                or BadImageFormatException
+                or InvalidOperationException)
+            {
+                Console.Error.WriteLine(
+                    $"Warning: authored source census skipped '{assemblyPath}' "
+                    + $"({ex.GetType().Name}: {ex.Message}).");
+                continue;
+            }
+
+            using var source = SourceLinkService.Open(assemblyPath);
+            await AuthoredRebuildFidelity.AcquirePdbAsync(source, httpClient);
+
+            foreach (var decompilerResult in decompilerResults)
+            {
+                if (results.Count >= cap)
+                    break;
+
+                results.Add(await ClassifyAsync(source, fetcher, decompilerResult));
+            }
+        }
+
+        return ReturnToSenderSourceProbe.Report(results, maxExamples, json);
+    }
+
+    internal static async Task<ReturnToSenderSourceProbeResult> ClassifyAsync(
+        SourceLinkService source,
+        SourceFetcher fetcher,
+        ReturnToSender.Result decompilerResult)
+    {
+        var identity = decompilerResult.Plan.TargetMethod;
+        var target = new ReturnToSender.RequestedTarget(
+            identity.Type,
+            identity.Method,
+            identity.Overload,
+            identity.Signature);
+
+        if (decompilerResult.FinalRequest is not { } request)
+        {
+            return new ReturnToSenderSourceProbeResult(
+                target,
+                ReturnToSenderSourceOutcome.UnsupportedTarget,
+                CompileBackStatus: decompilerResult.Status,
+                "unsupported-rts-target",
+                Detail: "RTS did not produce a final artifact request.",
+                SourcePath: null,
+                ExpectedBody: null,
+                ActualBody: decompilerResult.TargetBody,
+                MemberAnchor: decompilerResult.MemberAnchor);
+        }
+
+        if (decompilerResult.Status is FidelityCheck.CompileBackStatus.RecompileFail
+            or FidelityCheck.CompileBackStatus.ContextFail)
+        {
+            return new ReturnToSenderSourceProbeResult(
+                target,
+                ReturnToSenderSourceOutcome.Invalid,
+                decompilerResult.Status,
+                ReturnToSenderSourceProbe.FailureReason(decompilerResult),
+                decompilerResult.Detail,
+                SourcePath: null,
+                ExpectedBody: null,
+                ActualBody: decompilerResult.TargetBody,
+                MemberAnchor: decompilerResult.MemberAnchor);
+        }
+
+        if (decompilerResult.Status is not (FidelityCheck.CompileBackStatus.Exact or FidelityCheck.CompileBackStatus.OpcodeDiff))
+        {
+            return new ReturnToSenderSourceProbeResult(
+                target,
+                ReturnToSenderSourceOutcome.SourceUnavailable,
+                decompilerResult.Status,
+                ReturnToSenderSourceProbe.FailureReason(decompilerResult),
+                decompilerResult.Detail,
+                SourcePath: null,
+                ExpectedBody: null,
+                ActualBody: decompilerResult.TargetBody,
+                MemberAnchor: decompilerResult.MemberAnchor);
+        }
+
+        var subject = new FindingSubject(
+            decompilerResult.MemberAnchor?.StableSelector
+                ?? $"{request.FullType}.{request.MethodName}",
+            $"{request.FullType}.{request.MethodName}");
+        var authored = await AuthoredSourceAcquisition.AcquireMemberAsync(
+            source,
+            MetadataTokens.GetToken(request.TargetMethod),
+            request.MethodName,
+            subject,
+            fetcher);
+
+        if (authored.Lines.Value is FindingInspection<string>.Absent absent)
+        {
+            return SourceUnavailable(target, decompilerResult, "source-absent", absent.Detail);
+        }
+        if (authored.Lines.Value is FindingInspection<string>.Failed failed)
+        {
+            return SourceUnavailable(target, decompilerResult, "source-fetch-failed", failed.Error.Reason);
+        }
+        if (authored.Text is not { } authoredBody)
+        {
+            return SourceUnavailable(
+                target,
+                decompilerResult,
+                "source-fetch-failed",
+                "Authored-source acquisition completed without body text.");
+        }
+
+        if (!AuthoredRebuildFidelity.TryExtractTargetBody(
+            authoredBody,
+            request.MethodName,
+            request.Function.Signature.Parameters.Length,
+            out string expected))
+        {
+            return SourceUnavailable(
+                target,
+                decompilerResult,
+                "source-slice-unavailable",
+                "Checksum-verified authored member source did not contain the target body.");
+        }
+
+        string? sourcePath = authored.Document?.ResolvedUrl ?? authored.Mapping?.CanonicalPath;
+        return ClassifyExpectedBody(target, decompilerResult, sourcePath, expected);
+    }
+
+    /// <summary>
+    /// Compares a checksum-verified authored body against the decompiled body for
+    /// the same target and classifies the outcome using the same
+    /// valid_match/valid_different bucket taxonomy as the fixture-based probe.
+    /// Kept separate from acquisition so it can be exercised with a synthetic
+    /// authored body against a real RTS result without any network access.
+    /// </summary>
+    internal static ReturnToSenderSourceProbeResult ClassifyExpectedBody(
+        ReturnToSender.RequestedTarget target,
+        ReturnToSender.Result decompilerResult,
+        string? sourcePath,
+        string expected)
+    {
+        string actual = decompilerResult.TargetBody;
+        if (ReturnToSenderSourceProbe.NormalizeBody(expected) == ReturnToSenderSourceProbe.NormalizeBody(actual))
+        {
+            return new ReturnToSenderSourceProbeResult(
+                target,
+                ReturnToSenderSourceOutcome.ValidMatch,
+                decompilerResult.Status,
+                "valid_match",
+                Detail: null,
+                sourcePath,
+                expected,
+                actual,
+                MemberAnchor: decompilerResult.MemberAnchor);
+        }
+
+        string reason = ReturnToSenderSourceProbe.ClassifyValidDifference(
+            expected,
+            actual,
+            decompilerResult.Status,
+            decompilerResult.Decisions ?? [],
+            out var classificationDetail);
+        var opcodeEvidence = ReturnToSenderSourceProbe.OpcodeEvidence(decompilerResult);
+        return new ReturnToSenderSourceProbeResult(
+            target,
+            ReturnToSenderSourceOutcome.ValidDifferent,
+            decompilerResult.Status,
+            reason,
+            Detail: classificationDetail,
+            sourcePath,
+            expected,
+            actual,
+            OriginalOpcodes: opcodeEvidence?.OriginalOpcodes,
+            RecompiledOpcodes: opcodeEvidence?.RecompiledOpcodes,
+            IlDiffLines: opcodeEvidence?.IlDiffLines,
+            MemberAnchor: decompilerResult.MemberAnchor);
+    }
+
+    static ReturnToSenderSourceProbeResult SourceUnavailable(
+        ReturnToSender.RequestedTarget target,
+        ReturnToSender.Result decompilerResult,
+        string reason,
+        string? detail)
+        => new(
+            target,
+            ReturnToSenderSourceOutcome.SourceUnavailable,
+            decompilerResult.Status,
+            reason,
+            detail,
+            SourcePath: null,
+            ExpectedBody: null,
+            ActualBody: decompilerResult.TargetBody,
+            MemberAnchor: decompilerResult.MemberAnchor);
+}

--- a/tools/DecompilerHarness/AuthoredSourceCensus.cs
+++ b/tools/DecompilerHarness/AuthoredSourceCensus.cs
@@ -19,19 +19,31 @@ namespace ILInspector.DecompilerHarness;
 internal sealed record AuthoredSourceCensusRosterMember(string Type, string Method, int Overload, string? Signature);
 
 /// <summary>
-/// The locked members captured for one assembly during roster generation, in
-/// the diversified order they were confirmed to have available authored
-/// source. Correlated back to a run's resolved assembly path by file name.
+/// The locked candidate member identities captured for one assembly during
+/// roster generation, in diversified selection order. Membership is
+/// unconditional on any classification outcome -- see
+/// <see cref="AuthoredSourceCensusRoster"/> for why. Correlated back to a
+/// run's resolved assembly path by file name.
 /// </summary>
 internal sealed record AuthoredSourceCensusRosterAssembly(
     string AssemblyFileName,
     IReadOnlyList<AuthoredSourceCensusRosterMember> Members);
 
 /// <summary>
-/// A locked, generation-time snapshot of members confirmed to have authored
-/// source available (<c>Outcome</c> not <c>SourceUnavailable</c>/
-/// <c>UnsupportedTarget</c> at generation time), diversified by declaring
-/// type. Replaying this roster at increasing <c>--cap</c> values samples
+/// A locked, generation-time snapshot of candidate member identities,
+/// diversified by declaring type and fairly allocated across libraries with
+/// <see cref="AuthoredSourceCensus.AllocateAcrossLibraries"/>. Membership is
+/// locked by identity alone -- generation does <em>not</em> fetch SourceLink
+/// or filter by whether authored source currently resolves, so the same
+/// fixed population can be used to track <em>both</em> axes independently
+/// over time: the SourceLink oracle's own resolution rate (does authored
+/// source exist and can we fetch it), and RTS's match rate against whatever
+/// currently resolves. Baking a generation-time SourceLink outcome into
+/// corpus membership would make the corpus itself a product of the very
+/// oracle it's meant to hold fixed -- partial (members SourceLink fails on
+/// today can never enter the corpus, even after a later SourceLink fix) and
+/// circular (you can no longer tell "oracle got better" apart from "corpus
+/// changed"). Replaying this roster at increasing <c>--cap</c> values samples
 /// nested prefixes of the same locked population, so cap=100 and cap=1000
 /// runs are directly comparable to each other and to earlier runs over the
 /// same roster -- unlike plain live discovery, which can select a different
@@ -236,25 +248,21 @@ static class AuthoredSourceCensus
     /// candidate per assembly (via the same real RTS compile-back pipeline as
     /// live discovery), allocates the shared <paramref name="cap"/> across
     /// assemblies with <see cref="AllocateAcrossLibraries"/> so one large
-    /// library can't crowd out the rest of the corpus, diversifies each
-    /// assembly's allocation by declaring type, and classifies the result
-    /// (real SourceLink acquisition) to lock in every member whose authored
-    /// source was actually available (<c>Outcome</c> not
-    /// <c>SourceUnavailable</c>/<c>UnsupportedTarget</c>) — independent of
-    /// whether RTS's compile-back succeeded, since that verdict is exactly
-    /// what later replay runs want to re-measure fresh. Writes the locked
-    /// roster to <paramref name="rosterPath"/> for repeated, apples-to-apples
-    /// replay via <see cref="RunFromRoster"/>.
+    /// library can't crowd out the rest of the corpus, and diversifies each
+    /// assembly's allocation by declaring type. Membership is locked by
+    /// identity alone -- generation does <b>not</b> fetch SourceLink or run
+    /// any classification, and does not filter by whether authored source
+    /// currently resolves. See <see cref="AuthoredSourceCensusRoster"/> for
+    /// why: a generation-time SourceLink/RTS outcome filter would make corpus
+    /// membership itself a product of the very oracle and decompiler this
+    /// roster exists to measure repeatably. Both axes (SourceLink resolution
+    /// rate, RTS match rate) are measured fresh, every time, by
+    /// <see cref="RunFromRoster"/> against this same fixed population. Writes
+    /// the locked roster to <paramref name="rosterPath"/> for repeated,
+    /// apples-to-apples replay.
     /// </summary>
     public static int GenerateRoster(IReadOnlyList<string> assemblies, int cap, string rosterPath)
-        => GenerateRosterAsync(assemblies, cap, rosterPath).GetAwaiter().GetResult();
-
-    static async Task<int> GenerateRosterAsync(IReadOnlyList<string> assemblies, int cap, string rosterPath)
     {
-        HttpClientFactory.Initialize();
-        using var httpClient = HttpClientFactory.CreateNew();
-        var fetcher = new SourceFetcher(HttpClientFactory.SharedUntrustedFetch);
-
         var perLibrary = new List<(string AssemblyPath, IReadOnlyList<ReturnToSender.Result> Candidates)>();
         foreach (string assemblyPath in assemblies)
         {
@@ -283,29 +291,12 @@ static class AuthoredSourceCensus
         {
             var (assemblyPath, candidates) = perLibrary[i];
             var selected = DiversifyByKey(candidates, allocations[i], result => result.Plan.TargetMethod.Type);
-            if (selected.Count == 0)
-            {
-                rosterAssemblies.Add(new AuthoredSourceCensusRosterAssembly(Path.GetFileName(assemblyPath), []));
-                continue;
-            }
 
-            using var source = SourceLinkService.Open(assemblyPath);
-            await AuthoredRebuildFidelity.AcquirePdbAsync(source, httpClient);
-
-            var lockedMembers = new List<AuthoredSourceCensusRosterMember>();
-            foreach (var candidate in selected)
-            {
-                var classified = await ClassifyAsync(source, fetcher, candidate);
-                if (classified.Outcome is ReturnToSenderSourceOutcome.SourceUnavailable
-                    or ReturnToSenderSourceOutcome.UnsupportedTarget)
-                {
-                    continue;
-                }
-
-                var identity = candidate.Plan.TargetMethod;
-                lockedMembers.Add(new AuthoredSourceCensusRosterMember(
-                    identity.Type, identity.Method, identity.Overload, identity.Signature));
-            }
+            var lockedMembers = selected
+                .Select(candidate => candidate.Plan.TargetMethod)
+                .Select(identity => new AuthoredSourceCensusRosterMember(
+                    identity.Type, identity.Method, identity.Overload, identity.Signature))
+                .ToList();
 
             totalLocked += lockedMembers.Count;
             rosterAssemblies.Add(new AuthoredSourceCensusRosterAssembly(Path.GetFileName(assemblyPath), lockedMembers));
@@ -317,7 +308,8 @@ static class AuthoredSourceCensus
         Console.Error.WriteLine(
             $"Wrote authored-source census roster with {totalLocked} locked member(s) "
             + $"across {rosterAssemblies.Count(assembly => assembly.Members.Count > 0)} assembly/assemblies to {rosterPath} "
-            + $"(candidate pool: {candidateCounts.Sum()} across {perLibrary.Count} librar{(perLibrary.Count == 1 ? "y" : "ies")}, cap={cap}).");
+            + $"(candidate pool: {candidateCounts.Sum()} across {perLibrary.Count} librar{(perLibrary.Count == 1 ? "y" : "ies")}, cap={cap}); "
+            + "membership is locked by identity only -- SourceLink resolution and RTS match rate are measured fresh at replay.");
         return 0;
     }
 

--- a/tools/DecompilerHarness/AuthoredSourceCensus.cs
+++ b/tools/DecompilerHarness/AuthoredSourceCensus.cs
@@ -25,6 +25,17 @@ namespace ILInspector.DecompilerHarness;
 /// </summary>
 static class AuthoredSourceCensus
 {
+    /// <summary>
+    /// How many candidate targets to sample per requested slot before
+    /// diversifying by declaring type. Real assemblies commonly contain one
+    /// dominant type (e.g. a generated resource-string holder such as
+    /// <c>SR</c>) with far more property getters than any other type; without
+    /// this pool, a plain first-N-in-token-order selection can degenerate into
+    /// a corpus that is almost entirely one uncheckable type, which makes the
+    /// resulting quality card unrepresentative rather than a real benchmark.
+    /// </summary>
+    const int DiversityPoolMultiplier = 5;
+
     public static int Run(IReadOnlyList<string> assemblies, int cap, int maxExamples, bool json, bool qualityCard = false)
         => RunAsync(assemblies, cap, maxExamples, json, qualityCard).GetAwaiter().GetResult();
 
@@ -46,12 +57,16 @@ static class AuthoredSourceCensus
             if (results.Count >= cap)
                 break;
 
+            int remainingBudget = cap - results.Count;
+            int candidatePoolCap = remainingBudget >= int.MaxValue / DiversityPoolMultiplier
+                ? int.MaxValue
+                : remainingBudget * DiversityPoolMultiplier;
+
             IReadOnlyList<ReturnToSender.Result> decompilerResults;
             try
             {
-                decompilerResults = ReturnToSender.CompileBackPropertyGetters(
-                    assemblyPath,
-                    cap - results.Count);
+                var candidates = ReturnToSender.CompileBackPropertyGetters(assemblyPath, candidatePoolCap);
+                decompilerResults = DiversifyByKey(candidates, remainingBudget, result => result.Plan.TargetMethod.Type);
             }
             catch (Exception ex) when (ex is IOException
                 or UnauthorizedAccessException
@@ -79,6 +94,51 @@ static class AuthoredSourceCensus
 
         string corpusLabel = $"{assemblyCount} real assembly/assemblies (SourceLink-acquired authored source)";
         return ReturnToSenderSourceProbe.Report(results, maxExamples, json, qualityCard, corpusLabel);
+    }
+
+    /// <summary>
+    /// Selects up to <paramref name="cap"/> items from <paramref name="candidates"/>,
+    /// round-robining across the distinct keys produced by
+    /// <paramref name="keySelector"/> so that no single key (e.g. a declaring
+    /// type dominated by generated resource-string properties) can crowd out
+    /// the rest of the sample. Within-key order is preserved. Pure and
+    /// network-free so it can be unit tested directly.
+    /// </summary>
+    internal static IReadOnlyList<T> DiversifyByKey<T>(IReadOnlyList<T> candidates, int cap, Func<T, string> keySelector)
+    {
+        if (cap <= 0)
+            return [];
+        if (candidates.Count <= cap)
+            return candidates;
+
+        var groups = candidates
+            .GroupBy(keySelector, StringComparer.Ordinal)
+            .Select(group => group.ToArray())
+            .ToArray();
+
+        var selected = new List<T>(cap);
+        int index = 0;
+        while (selected.Count < cap)
+        {
+            bool progressed = false;
+            foreach (var group in groups)
+            {
+                if (index >= group.Length)
+                    continue;
+
+                selected.Add(group[index]);
+                progressed = true;
+                if (selected.Count >= cap)
+                    break;
+            }
+
+            if (!progressed)
+                break;
+
+            index++;
+        }
+
+        return selected;
     }
 
     internal static async Task<ReturnToSenderSourceProbeResult> ClassifyAsync(

--- a/tools/DecompilerHarness/AuthoredSourceCensus.cs
+++ b/tools/DecompilerHarness/AuthoredSourceCensus.cs
@@ -25,19 +25,21 @@ namespace ILInspector.DecompilerHarness;
 /// </summary>
 static class AuthoredSourceCensus
 {
-    public static int Run(IReadOnlyList<string> assemblies, int cap, int maxExamples, bool json)
-        => RunAsync(assemblies, cap, maxExamples, json).GetAwaiter().GetResult();
+    public static int Run(IReadOnlyList<string> assemblies, int cap, int maxExamples, bool json, bool qualityCard = false)
+        => RunAsync(assemblies, cap, maxExamples, json, qualityCard).GetAwaiter().GetResult();
 
     static async Task<int> RunAsync(
         IReadOnlyList<string> assemblies,
         int cap,
         int maxExamples,
-        bool json)
+        bool json,
+        bool qualityCard)
     {
         HttpClientFactory.Initialize();
         using var httpClient = HttpClientFactory.CreateNew();
         var fetcher = new SourceFetcher(HttpClientFactory.SharedUntrustedFetch);
         List<ReturnToSenderSourceProbeResult> results = [];
+        int assemblyCount = 0;
 
         foreach (string assemblyPath in assemblies)
         {
@@ -62,6 +64,7 @@ static class AuthoredSourceCensus
                 continue;
             }
 
+            assemblyCount++;
             using var source = SourceLinkService.Open(assemblyPath);
             await AuthoredRebuildFidelity.AcquirePdbAsync(source, httpClient);
 
@@ -74,7 +77,8 @@ static class AuthoredSourceCensus
             }
         }
 
-        return ReturnToSenderSourceProbe.Report(results, maxExamples, json);
+        string corpusLabel = $"{assemblyCount} real assembly/assemblies (SourceLink-acquired authored source)";
+        return ReturnToSenderSourceProbe.Report(results, maxExamples, json, qualityCard, corpusLabel);
     }
 
     internal static async Task<ReturnToSenderSourceProbeResult> ClassifyAsync(

--- a/tools/DecompilerHarness/AuthoredSourceCensus.cs
+++ b/tools/DecompilerHarness/AuthoredSourceCensus.cs
@@ -188,15 +188,63 @@ static class AuthoredSourceCensus
         => new() { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
     /// <summary>
-    /// One-time generation phase: samples a diversified candidate pool per
-    /// assembly, classifies each candidate (real RTS compile-back + real
-    /// SourceLink acquisition), and locks in up to <paramref name="cap"/>
-    /// members per assembly whose authored source was actually available
-    /// (<c>Outcome</c> not <c>SourceUnavailable</c>/<c>UnsupportedTarget</c>) —
-    /// independent of whether RTS's compile-back succeeded, since that verdict
-    /// is exactly what later replay runs want to re-measure fresh. Writes the
-    /// locked roster to <paramref name="rosterPath"/> for repeated,
-    /// apples-to-apples replay via <see cref="RunFromRoster"/>.
+    /// Allocates a shared <paramref name="cap"/> across libraries proportional
+    /// to how many candidates each one actually has available, in one
+    /// deterministic pass (no iterative water-filling): sort libraries
+    /// ascending by candidate count, let <c>n</c> be the simple average
+    /// (<c>sum(candidateCounts) / library count</c>), give every library
+    /// except the largest <c>min(n, its own count)</c>, and let the single
+    /// largest library absorb whatever is left over (bounded by its own
+    /// count) so the total reaches <paramref name="cap"/> exactly whenever the
+    /// corpus has enough candidates overall. This keeps small libraries from
+    /// being crowded out by a single huge one while still hitting the
+    /// requested total. Pure and network-free so it can be unit tested
+    /// directly. Returns allocations in the same order as
+    /// <paramref name="candidateCounts"/>.
+    /// </summary>
+    internal static IReadOnlyList<int> AllocateAcrossLibraries(IReadOnlyList<int> candidateCounts, int cap)
+    {
+        if (candidateCounts.Count == 0 || cap <= 0)
+            return new int[candidateCounts.Count];
+
+        long total = candidateCounts.Sum(count => (long)count);
+        if (total <= cap)
+            return candidateCounts.ToArray();
+
+        int fairShare = (int)(total / candidateCounts.Count);
+        var ascendingOrder = Enumerable.Range(0, candidateCounts.Count)
+            .OrderBy(index => candidateCounts[index])
+            .ToArray();
+
+        var allocation = new int[candidateCounts.Count];
+        int allocatedSoFar = 0;
+        for (int rank = 0; rank < ascendingOrder.Length - 1; rank++)
+        {
+            int index = ascendingOrder[rank];
+            int share = Math.Min(fairShare, candidateCounts[index]);
+            allocation[index] = share;
+            allocatedSoFar += share;
+        }
+
+        int largestIndex = ascendingOrder[^1];
+        allocation[largestIndex] = Math.Clamp(cap - allocatedSoFar, 0, candidateCounts[largestIndex]);
+        return allocation;
+    }
+
+    /// <summary>
+    /// One-time generation phase: collects every eligible property-getter
+    /// candidate per assembly (via the same real RTS compile-back pipeline as
+    /// live discovery), allocates the shared <paramref name="cap"/> across
+    /// assemblies with <see cref="AllocateAcrossLibraries"/> so one large
+    /// library can't crowd out the rest of the corpus, diversifies each
+    /// assembly's allocation by declaring type, and classifies the result
+    /// (real SourceLink acquisition) to lock in every member whose authored
+    /// source was actually available (<c>Outcome</c> not
+    /// <c>SourceUnavailable</c>/<c>UnsupportedTarget</c>) — independent of
+    /// whether RTS's compile-back succeeded, since that verdict is exactly
+    /// what later replay runs want to re-measure fresh. Writes the locked
+    /// roster to <paramref name="rosterPath"/> for repeated, apples-to-apples
+    /// replay via <see cref="RunFromRoster"/>.
     /// </summary>
     public static int GenerateRoster(IReadOnlyList<string> assemblies, int cap, string rosterPath)
         => GenerateRosterAsync(assemblies, cap, rosterPath).GetAwaiter().GetResult();
@@ -206,24 +254,13 @@ static class AuthoredSourceCensus
         HttpClientFactory.Initialize();
         using var httpClient = HttpClientFactory.CreateNew();
         var fetcher = new SourceFetcher(HttpClientFactory.SharedUntrustedFetch);
-        var rosterAssemblies = new List<AuthoredSourceCensusRosterAssembly>();
-        int totalLocked = 0;
 
+        var perLibrary = new List<(string AssemblyPath, IReadOnlyList<ReturnToSender.Result> Candidates)>();
         foreach (string assemblyPath in assemblies)
         {
-            if (totalLocked >= cap)
-                break;
-
-            int remainingBudget = cap - totalLocked;
-            int candidatePoolCap = remainingBudget >= int.MaxValue / DiversityPoolMultiplier
-                ? int.MaxValue
-                : remainingBudget * DiversityPoolMultiplier;
-
-            IReadOnlyList<ReturnToSender.Result> orderedCandidates;
             try
             {
-                var pool = ReturnToSender.CompileBackPropertyGetters(assemblyPath, candidatePoolCap);
-                orderedCandidates = RoundRobinByKey(pool, result => result.Plan.TargetMethod.Type);
+                perLibrary.Add((assemblyPath, ReturnToSender.CompileBackPropertyGetters(assemblyPath, int.MaxValue)));
             }
             catch (Exception ex) when (ex is IOException
                 or UnauthorizedAccessException
@@ -233,6 +270,22 @@ static class AuthoredSourceCensus
                 Console.Error.WriteLine(
                     $"Warning: roster generation skipped '{assemblyPath}' "
                     + $"({ex.GetType().Name}: {ex.Message}).");
+            }
+        }
+
+        var candidateCounts = perLibrary.Select(library => library.Candidates.Count).ToArray();
+        var allocations = AllocateAcrossLibraries(candidateCounts, cap);
+
+        var rosterAssemblies = new List<AuthoredSourceCensusRosterAssembly>();
+        int totalLocked = 0;
+
+        for (int i = 0; i < perLibrary.Count; i++)
+        {
+            var (assemblyPath, candidates) = perLibrary[i];
+            var selected = DiversifyByKey(candidates, allocations[i], result => result.Plan.TargetMethod.Type);
+            if (selected.Count == 0)
+            {
+                rosterAssemblies.Add(new AuthoredSourceCensusRosterAssembly(Path.GetFileName(assemblyPath), []));
                 continue;
             }
 
@@ -240,11 +293,8 @@ static class AuthoredSourceCensus
             await AuthoredRebuildFidelity.AcquirePdbAsync(source, httpClient);
 
             var lockedMembers = new List<AuthoredSourceCensusRosterMember>();
-            foreach (var candidate in orderedCandidates)
+            foreach (var candidate in selected)
             {
-                if (lockedMembers.Count >= remainingBudget)
-                    break;
-
                 var classified = await ClassifyAsync(source, fetcher, candidate);
                 if (classified.Outcome is ReturnToSenderSourceOutcome.SourceUnavailable
                     or ReturnToSenderSourceOutcome.UnsupportedTarget)
@@ -266,7 +316,8 @@ static class AuthoredSourceCensus
         File.WriteAllText(rosterPath, JsonSerializer.Serialize(roster, RosterJsonOptions()));
         Console.Error.WriteLine(
             $"Wrote authored-source census roster with {totalLocked} locked member(s) "
-            + $"across {rosterAssemblies.Count(assembly => assembly.Members.Count > 0)} assembly/assemblies to {rosterPath}");
+            + $"across {rosterAssemblies.Count(assembly => assembly.Members.Count > 0)} assembly/assemblies to {rosterPath} "
+            + $"(candidate pool: {candidateCounts.Sum()} across {perLibrary.Count} librar{(perLibrary.Count == 1 ? "y" : "ies")}, cap={cap}).");
         return 0;
     }
 

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -73,6 +73,7 @@ static class Program
         bool returnToSenderMarkout = false;
         bool returnToSenderSourceProbe = false;
         bool authoredRebuildFidelity = false;
+        bool authoredSourceCensus = false;
         string? returnToSenderFixtureGroup = null;
         bool fidelityTimings = false;
         int fidelityZeroSignalGuard = 0;
@@ -192,6 +193,7 @@ static class Program
                     case "--return-to-sender-source-probe": returnToSenderSourceProbe = true; break;
                     case "--source-correspondence-census": returnToSenderSourceProbe = true; break;
                     case "--authored-rebuild-fidelity": authoredRebuildFidelity = true; break;
+                    case "--authored-source-census": authoredSourceCensus = true; break;
                     case "--return-to-sender-fixtures": returnToSenderFixtureGroup = NextArg(args, ref i, flag); break;
                     case "--return-to-sender-catalog":
                         returnToSenderCatalog = true;
@@ -314,7 +316,7 @@ static class Program
         }
 
         if (returnToSenderFixtureGroup is not null
-            && !(returnToSender || returnToSenderAb || returnToSenderSourceProbe || authoredRebuildFidelity))
+            && !(returnToSender || returnToSenderAb || returnToSenderSourceProbe || authoredRebuildFidelity || authoredSourceCensus))
         {
             return Fail("--return-to-sender-fixtures requires a ReturnToSender or authored rebuild operation.");
         }
@@ -405,6 +407,9 @@ static class Program
 
         if (authoredRebuildFidelity)
             return AuthoredRebuildFidelity.Run(assemblies, cap, maxExamples);
+
+        if (authoredSourceCensus)
+            return AuthoredSourceCensus.Run(assemblies, cap, maxExamples, json);
 
         if (typeCheck)
             return TypeSourceCheck.Run(assemblies, cap, maxExamples);
@@ -1763,6 +1768,14 @@ static class Program
                                 each in the same RTS shell, and compare authored
                                 A->IL beside the independent decompiled B->IL lane;
                                 reports determinism and build-context drift separately.
+          --authored-source-census
+                                run the same source-correspondence bucket classifier
+                                as --source-correspondence-census, but over real
+                                (non-fixture) corpus assemblies using real SourceLink
+                                acquisition instead of the fixture-only source index;
+                                reports the same valid_match, valid_different,
+                                invalid, source_unavailable, and unsupported_target
+                                buckets. Use --json for machine-readable row output.
           --return-to-sender-fixtures <group>
                                 add built fixture assemblies from a FixtureCatalog
                                 group (for example rts.candidates) as inputs for

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -75,6 +75,8 @@ static class Program
         bool authoredRebuildFidelity = false;
         bool authoredSourceCensus = false;
         bool sourceQualityCard = false;
+        string? authoredSourceCensusGenerateRoster = null;
+        string? authoredSourceCensusRoster = null;
         string? returnToSenderFixtureGroup = null;
         bool fidelityTimings = false;
         int fidelityZeroSignalGuard = 0;
@@ -196,6 +198,14 @@ static class Program
                     case "--authored-rebuild-fidelity": authoredRebuildFidelity = true; break;
                     case "--authored-source-census": authoredSourceCensus = true; break;
                     case "--source-quality-card": sourceQualityCard = true; break;
+                    case "--authored-source-census-generate-roster":
+                        authoredSourceCensus = true;
+                        authoredSourceCensusGenerateRoster = NextArg(args, ref i, flag);
+                        break;
+                    case "--authored-source-census-roster":
+                        authoredSourceCensus = true;
+                        authoredSourceCensusRoster = NextArg(args, ref i, flag);
+                        break;
                     case "--return-to-sender-fixtures": returnToSenderFixtureGroup = NextArg(args, ref i, flag); break;
                     case "--return-to-sender-catalog":
                         returnToSenderCatalog = true;
@@ -291,6 +301,8 @@ static class Program
 
         if (returnToSenderMarkout && !returnToSenderCatalog)
             return Fail("--return-to-sender-markout requires --return-to-sender-catalog.");
+        if (authoredSourceCensusGenerateRoster is not null && authoredSourceCensusRoster is not null)
+            return Fail("--authored-source-census-generate-roster and --authored-source-census-roster are mutually exclusive.");
         if (cfgStageSpecified && (!cfg || dumpMethod is null))
             return Fail("--cfg-stage requires --dump --cfg.");
 
@@ -411,7 +423,13 @@ static class Program
             return AuthoredRebuildFidelity.Run(assemblies, cap, maxExamples);
 
         if (authoredSourceCensus)
+        {
+            if (authoredSourceCensusGenerateRoster is not null)
+                return AuthoredSourceCensus.GenerateRoster(assemblies, cap, authoredSourceCensusGenerateRoster);
+            if (authoredSourceCensusRoster is not null)
+                return AuthoredSourceCensus.RunFromRoster(assemblies, authoredSourceCensusRoster, cap, maxExamples, json, sourceQualityCard);
             return AuthoredSourceCensus.Run(assemblies, cap, maxExamples, json, sourceQualityCard);
+        }
 
         if (typeCheck)
             return TypeSourceCheck.Run(assemblies, cap, maxExamples);
@@ -1783,6 +1801,24 @@ static class Program
                                 state, no baseline) to --source-correspondence-census
                                 or --authored-source-census text-mode output; no
                                 effect with --json.
+          --authored-source-census-generate-roster <path>
+                                one-time generation phase: sample a diversified
+                                candidate pool (per --cap), classify each with real
+                                RTS compile-back and real SourceLink acquisition,
+                                and lock in members whose authored source was
+                                available (regardless of RTS pass/fail) to a roster
+                                JSON file at <path>. Implies --authored-source-census.
+          --authored-source-census-roster <path>
+                                replay a roster written by
+                                --authored-source-census-generate-roster: take the
+                                first --cap locked members (a nested, comparable
+                                prefix of the same population every time) and
+                                classify them fresh. Increasing --cap across runs
+                                grows the sample without discarding or reshuffling
+                                earlier members, so cap=100 and cap=1000 runs (now or
+                                later) are directly comparable. Implies
+                                --authored-source-census; mutually exclusive with
+                                --authored-source-census-generate-roster.
           --return-to-sender-fixtures <group>
                                 add built fixture assemblies from a FixtureCatalog
                                 group (for example rts.candidates) as inputs for

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -74,6 +74,7 @@ static class Program
         bool returnToSenderSourceProbe = false;
         bool authoredRebuildFidelity = false;
         bool authoredSourceCensus = false;
+        bool sourceQualityCard = false;
         string? returnToSenderFixtureGroup = null;
         bool fidelityTimings = false;
         int fidelityZeroSignalGuard = 0;
@@ -194,6 +195,7 @@ static class Program
                     case "--source-correspondence-census": returnToSenderSourceProbe = true; break;
                     case "--authored-rebuild-fidelity": authoredRebuildFidelity = true; break;
                     case "--authored-source-census": authoredSourceCensus = true; break;
+                    case "--source-quality-card": sourceQualityCard = true; break;
                     case "--return-to-sender-fixtures": returnToSenderFixtureGroup = NextArg(args, ref i, flag); break;
                     case "--return-to-sender-catalog":
                         returnToSenderCatalog = true;
@@ -403,13 +405,13 @@ static class Program
             return ReturnToSender.RunComparison(assemblies, cap, maxExamples);
 
         if (returnToSenderSourceProbe)
-            return ReturnToSenderSourceProbe.Run(assemblies, cap, maxExamples, json);
+            return ReturnToSenderSourceProbe.Run(assemblies, cap, maxExamples, json, sourceQualityCard);
 
         if (authoredRebuildFidelity)
             return AuthoredRebuildFidelity.Run(assemblies, cap, maxExamples);
 
         if (authoredSourceCensus)
-            return AuthoredSourceCensus.Run(assemblies, cap, maxExamples, json);
+            return AuthoredSourceCensus.Run(assemblies, cap, maxExamples, json, sourceQualityCard);
 
         if (typeCheck)
             return TypeSourceCheck.Run(assemblies, cap, maxExamples);
@@ -1776,6 +1778,11 @@ static class Program
                                 reports the same valid_match, valid_different,
                                 invalid, source_unavailable, and unsupported_target
                                 buckets. Use --json for machine-readable row output.
+          --source-quality-card
+                                add a PR-pasteable Markdown bucket-rate card (current
+                                state, no baseline) to --source-correspondence-census
+                                or --authored-source-census text-mode output; no
+                                effect with --json.
           --return-to-sender-fixtures <group>
                                 add built fixture assemblies from a FixtureCatalog
                                 group (for example rts.candidates) as inputs for

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -210,6 +210,22 @@ reports deterministic-build and portable-PDB option/reference context
 separately. `SourceAbsent` is missing evidence; `SourceFailed` is an acquisition
 or integrity failure.
 
+`--authored-source-census` runs the same source-correspondence bucket
+classifier as `--source-correspondence-census`/`--return-to-sender-source-probe`
+(`valid_match`, `valid_different`, `invalid`, `source_unavailable`,
+`unsupported_target`), but over real, non-fixture corpus assemblies using real
+SourceLink acquisition instead of the fixture-only source index. The fixture
+probe selects zero targets for any assembly that is not registered in
+`FixtureCatalog`; this mode closes that gap by reusing
+`--authored-rebuild-fidelity`'s real acquisition and body-extraction lane and
+feeding the checksum-verified authored body straight into the probe's
+comparison and reporting logic instead of RTS-recompiling it. It is a peer of
+the RTS compile-back oracle and the authored-rebuild fidelity oracle, not a
+replacement for either: `Absent`/`Failed`/`SourceUnavailable` outcomes are
+reported distinctly and never blended into the other oracles' verdicts. Use
+`--json` for the same machine-readable rows and `source_correspondence_findings`
+projection as the fixture-based census.
+
 The generated fixture ladder is intentionally staged:
 
 | Stage | Harness responsibility |

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -242,12 +242,20 @@ comparable to each other — the sampled members can differ each time. To get a
 fixed, growable population instead:
 
 `--authored-source-census-generate-roster <path>` runs a one-time generation
-phase: sample a diversified candidate pool (sized off `--cap`), classify each
-candidate with real RTS compile-back and real SourceLink acquisition, and
-lock in every member whose authored source was actually available — regardless
-of whether RTS's compile-back succeeded, since that pass/fail verdict is
-exactly what later replay runs want to re-measure fresh — to a roster JSON
-file at `<path>`. Implies `--authored-source-census`.
+phase: collect every eligible candidate from each library in the corpus
+(the full compile-back candidate list, not a `--cap`-sized sample), allocate
+the shared `--cap` across libraries fairly so one huge library (for example
+`System.Private.CoreLib`) can't crowd out much smaller ones — sort libraries
+ascending by candidate count, give every library except the largest
+`min(candidateCount, total / libraryCount)`, and let the single largest
+library absorb whatever is left over (bounded by its own count) to reach
+`--cap` exactly — diversify each library's allocation by declaring type,
+classify each selected candidate with real RTS compile-back and real
+SourceLink acquisition, and lock in every member whose authored source was
+actually available — regardless of whether RTS's compile-back succeeded,
+since that pass/fail verdict is exactly what later replay runs want to
+re-measure fresh — to a roster JSON file at `<path>`. Implies
+`--authored-source-census`.
 
 `--authored-source-census-roster <path>` replays a roster written by
 `--authored-source-census-generate-roster`: it takes the first `--cap` locked

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -249,13 +249,22 @@ the shared `--cap` across libraries fairly so one huge library (for example
 ascending by candidate count, give every library except the largest
 `min(candidateCount, total / libraryCount)`, and let the single largest
 library absorb whatever is left over (bounded by its own count) to reach
-`--cap` exactly — diversify each library's allocation by declaring type,
-classify each selected candidate with real RTS compile-back and real
-SourceLink acquisition, and lock in every member whose authored source was
-actually available — regardless of whether RTS's compile-back succeeded,
-since that pass/fail verdict is exactly what later replay runs want to
-re-measure fresh — to a roster JSON file at `<path>`. Implies
-`--authored-source-census`.
+`--cap` exactly — diversify each library's allocation by declaring type, and
+lock in every selected candidate's identity to a roster JSON file at `<path>`.
+Implies `--authored-source-census`.
+
+Locking is by identity alone: generation does **not** fetch SourceLink or run
+any classification, and does not filter by whether authored source currently
+resolves. SourceLink is itself an oracle whose own resolution rate we want to
+track over time, alongside RTS's match rate against whatever source currently
+resolves — baking a generation-time SourceLink/RTS outcome into corpus
+membership would make the corpus itself a product of the very oracle and
+decompiler this roster exists to measure, which is both partial (a member
+SourceLink fails on today can never enter the corpus, even after a later
+SourceLink fix) and circular (you can no longer tell "the oracle got better"
+apart from "the corpus changed"). Both axes — SourceLink resolution rate and
+RTS match rate — are measured fresh, every time, by
+`--authored-source-census-roster` against the same fixed population.
 
 `--authored-source-census-roster <path>` replays a roster written by
 `--authored-source-census-generate-roster`: it takes the first `--cap` locked

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -236,6 +236,31 @@ entirely one type — often one whose source isn't SourceLink-mapped at all —
 which makes the resulting sample and quality card unrepresentative rather than
 a real benchmark.
 
+Live discovery samples a fresh population every run, so `--cap 100` and
+`--cap 1000` runs (or the same `--cap` run again later) are not directly
+comparable to each other — the sampled members can differ each time. To get a
+fixed, growable population instead:
+
+`--authored-source-census-generate-roster <path>` runs a one-time generation
+phase: sample a diversified candidate pool (sized off `--cap`), classify each
+candidate with real RTS compile-back and real SourceLink acquisition, and
+lock in every member whose authored source was actually available — regardless
+of whether RTS's compile-back succeeded, since that pass/fail verdict is
+exactly what later replay runs want to re-measure fresh — to a roster JSON
+file at `<path>`. Implies `--authored-source-census`.
+
+`--authored-source-census-roster <path>` replays a roster written by
+`--authored-source-census-generate-roster`: it takes the first `--cap` locked
+members (a nested prefix, in the same order captured at generation time) per
+matched assembly and classifies them fresh. Because the prefix only grows as
+`--cap` grows — earlier members are never reshuffled or dropped — a
+`--cap 100` run and a `--cap 1000` run against the same roster (now, or months
+later) sample a strict subset/superset of each other and are directly
+comparable. Generate once at a high cap (for example 10000) to build a large
+locked population, then run repeatedly at whatever smaller caps make sense for
+a given PR or CI budget. Implies `--authored-source-census`; mutually
+exclusive with `--authored-source-census-generate-roster`.
+
 `--source-quality-card` adds a PR-pasteable Markdown bucket-rate card to either
 census (`--source-correspondence-census` or `--authored-source-census`),
 printed after the normal text-mode report (it has no effect with `--json`,

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -226,6 +226,19 @@ reported distinctly and never blended into the other oracles' verdicts. Use
 `--json` for the same machine-readable rows and `source_correspondence_findings`
 projection as the fixture-based census.
 
+`--source-quality-card` adds a PR-pasteable Markdown bucket-rate card to either
+census (`--source-correspondence-census` or `--authored-source-census`),
+printed after the normal text-mode report (it has no effect with `--json`,
+since the card is prose, not a machine-readable row shape). Unlike
+`--quality-diff-card` (decompiler IR/opcode raising quality against a pinned
+baseline), this card is specific to the RTS-vs-authored-source correspondence
+taxonomy and has no baseline yet: it reports today's bucket distribution
+(valid match, valid different by category, invalid, source unavailable,
+unsupported target) as counts and rates over the sampled corpus, with a
+descriptive verdict line rather than a pass/fail gate. It exists so reviewers
+can see the current-state quality distribution over a real corpus, not just an
+aggregate pass/fail count.
+
 The generated fixture ladder is intentionally staged:
 
 | Stage | Harness responsibility |

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -226,6 +226,16 @@ reported distinctly and never blended into the other oracles' verdicts. Use
 `--json` for the same machine-readable rows and `source_correspondence_findings`
 projection as the fixture-based census.
 
+Target selection is diversified by declaring type: a candidate pool up to 5x
+the requested `--cap` is sampled first, then round-robined across distinct
+declaring types down to `--cap`. Real assemblies commonly contain one dominant
+type with far more property getters than any other (for example a generated
+resource-string holder such as `SR`), and without this diversification a plain
+first-N-in-token-order selection can degenerate into a corpus that is almost
+entirely one type — often one whose source isn't SourceLink-mapped at all —
+which makes the resulting sample and quality card unrepresentative rather than
+a real benchmark.
+
 `--source-quality-card` adds a PR-pasteable Markdown bucket-rate card to either
 census (`--source-correspondence-census` or `--authored-source-census`),
 printed after the normal text-mode report (it has no effect with `--json`,

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -63,8 +63,17 @@ static partial class ReturnToSenderSourceProbe
     internal sealed record ProbeTarget(ReturnToSender.RequestedTarget Target, IReadOnlyList<string> ExpectedFragments);
 
     public static int Run(IReadOnlyList<string> assemblies, int cap, int maxExamples, bool json)
+        => Report(Evaluate(assemblies, cap), maxExamples, json);
+
+    /// <summary>
+    /// Renders the same summary/bucket/finding report as <see cref="Run"/>, for
+    /// callers that produce <see cref="ReturnToSenderSourceProbeResult"/> rows from
+    /// a different acquisition lane (for example real, network-acquired SourceLink
+    /// source in <c>AuthoredSourceCensus</c> rather than the fixture-only source
+    /// index). The bucket taxonomy and finding shape stay identical across lanes.
+    /// </summary>
+    public static int Report(IReadOnlyList<ReturnToSenderSourceProbeResult> results, int maxExamples, bool json)
     {
-        var results = Evaluate(assemblies, cap);
         int passed = results.Count(result => result.Passed);
         int different = results.Count(result => result.Different);
         int failed = results.Count(result => result.Failed);
@@ -400,7 +409,7 @@ static partial class ReturnToSenderSourceProbe
     static string TargetDisplay(ReturnToSender.RequestedTarget target)
         => $"{target.Type}.{target.Method}#{target.Overload}";
 
-    static OpcodeDiffEvidence? OpcodeEvidence(ReturnToSender.Result result)
+    internal static OpcodeDiffEvidence? OpcodeEvidence(ReturnToSender.Result result)
     {
         if (result.Status != FidelityCheck.CompileBackStatus.OpcodeDiff)
             return null;
@@ -417,7 +426,7 @@ static partial class ReturnToSenderSourceProbe
     static string? NullIfWhiteSpace(string value)
         => string.IsNullOrWhiteSpace(value) ? null : value;
 
-    sealed record OpcodeDiffEvidence(
+    internal sealed record OpcodeDiffEvidence(
         string? OriginalOpcodes,
         string? RecompiledOpcodes,
         IReadOnlyList<string> IlDiffLines);
@@ -949,7 +958,7 @@ static partial class ReturnToSenderSourceProbe
     static string StatementsText(BlockSyntax body)
         => string.Join(Environment.NewLine, body.Statements.Select(statement => statement.ToString()));
 
-    static string NormalizeBody(string text)
+    internal static string NormalizeBody(string text)
         => Regex.Replace(text, @"\s+", "");
 
     static bool TryKnownTasteDifference(
@@ -1285,7 +1294,7 @@ static partial class ReturnToSenderSourceProbe
         return match.Success ? match.Value : "recompile-fail";
     }
 
-    static string FailureReason(ReturnToSender.Result result)
+    internal static string FailureReason(ReturnToSender.Result result)
         => result.Status switch
         {
             FidelityCheck.CompileBackStatus.RecompileFail => DiagnosticCode(result.Detail),

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 
@@ -62,8 +63,8 @@ static partial class ReturnToSenderSourceProbe
 {
     internal sealed record ProbeTarget(ReturnToSender.RequestedTarget Target, IReadOnlyList<string> ExpectedFragments);
 
-    public static int Run(IReadOnlyList<string> assemblies, int cap, int maxExamples, bool json)
-        => Report(Evaluate(assemblies, cap), maxExamples, json);
+    public static int Run(IReadOnlyList<string> assemblies, int cap, int maxExamples, bool json, bool qualityCard = false, string? corpusLabel = null)
+        => Report(Evaluate(assemblies, cap), maxExamples, json, qualityCard, corpusLabel ?? $"{assemblies.Count} assembly/assemblies (fixture-only source index)");
 
     /// <summary>
     /// Renders the same summary/bucket/finding report as <see cref="Run"/>, for
@@ -72,7 +73,12 @@ static partial class ReturnToSenderSourceProbe
     /// source in <c>AuthoredSourceCensus</c> rather than the fixture-only source
     /// index). The bucket taxonomy and finding shape stay identical across lanes.
     /// </summary>
-    public static int Report(IReadOnlyList<ReturnToSenderSourceProbeResult> results, int maxExamples, bool json)
+    public static int Report(
+        IReadOnlyList<ReturnToSenderSourceProbeResult> results,
+        int maxExamples,
+        bool json,
+        bool qualityCard = false,
+        string? corpusLabel = null)
     {
         int passed = results.Count(result => result.Passed);
         int different = results.Count(result => result.Different);
@@ -152,6 +158,12 @@ static partial class ReturnToSenderSourceProbe
                         Console.WriteLine($"      recompiled-opcodes: {example.RecompiledOpcodes}");
                 }
             }
+        }
+
+        if (qualityCard)
+        {
+            Console.WriteLine();
+            Console.WriteLine(RenderQualityCard(results, corpusLabel ?? "unspecified corpus"));
         }
 
         return failed == 0 ? 0 : 1;
@@ -381,7 +393,7 @@ static partial class ReturnToSenderSourceProbe
         return Path.GetFileName(sourcePath.Replace('\\', '/'));
     }
 
-    static string SourceCorrespondenceCategory(ReturnToSenderSourceProbeResult result)
+    internal static string SourceCorrespondenceCategory(ReturnToSenderSourceProbeResult result)
     {
         if (result.Outcome == ReturnToSenderSourceOutcome.Invalid)
             return "invalid";
@@ -401,6 +413,54 @@ static partial class ReturnToSenderSourceProbe
             return "not-yet-raised-sugar";
 
         return "unclassified";
+    }
+
+    /// <summary>
+    /// Renders a compact, PR-ready Markdown bucket-rate card for a source-
+    /// correspondence census run, in the spirit of the decompiler quality-diff
+    /// card (docs/decompiler-quality.md) but for the RTS-vs-authored-source
+    /// correspondence taxonomy rather than IR/opcode raising quality. This is a
+    /// current-state card (no baseline/PR columns) since the RTS-vs-authored-
+    /// source lane has no established baseline population yet; it exists so
+    /// reviewers can see today's bucket distribution over a real corpus rather
+    /// than only a pass/fail count.
+    /// </summary>
+    internal static string RenderQualityCard(IReadOnlyList<ReturnToSenderSourceProbeResult> results, string corpusLabel)
+    {
+        int total = results.Count;
+        int validMatch = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.ValidMatch);
+        int sourceUnavailable = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.SourceUnavailable);
+        int unsupportedTarget = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.UnsupportedTarget);
+        var categorized = results
+            .Where(result => result.Outcome is ReturnToSenderSourceOutcome.ValidDifferent or ReturnToSenderSourceOutcome.Invalid)
+            .GroupBy(SourceCorrespondenceCategory, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.Ordinal);
+
+        string Rate(int count) => total == 0 ? "n/a" : $"{count} ({100.0 * count / total:0.00}%)";
+        int CategoryCount(string category) => categorized.TryGetValue(category, out int count) ? count : 0;
+
+        var sb = new StringBuilder();
+        sb.AppendLine("### Source-correspondence quality card");
+        sb.AppendLine();
+        sb.AppendLine($"Corpus: {corpusLabel}. {total} target(s) sampled.");
+        sb.AppendLine();
+        sb.AppendLine("| Bucket (desired direction) | Count (rate) |");
+        sb.AppendLine("| --- | ---: |");
+        sb.AppendLine($"| Valid match (+) | {Rate(validMatch)} |");
+        sb.AppendLine($"| Valid different - ignorable known difference (+) | {Rate(CategoryCount("ignorable"))} |");
+        sb.AppendLine($"| Valid different - not-yet-raised sugar (~) | {Rate(CategoryCount("not-yet-raised-sugar"))} |");
+        sb.AppendLine($"| Valid different - structuring residue (~) | {Rate(CategoryCount("structuring-residue"))} |");
+        sb.AppendLine($"| Valid different - semantic opcode diff (-) | {Rate(CategoryCount("semantic-opcode-diff"))} |");
+        sb.AppendLine($"| Valid different - unclassified (-) | {Rate(CategoryCount("unclassified"))} |");
+        sb.AppendLine($"| Invalid / RTS compile-back failed (-) | {Rate(CategoryCount("invalid"))} |");
+        sb.AppendLine($"| Source unavailable (uncheckable) | {Rate(sourceUnavailable)} |");
+        sb.AppendLine($"| Unsupported target (uncheckable) | {Rate(unsupportedTarget)} |");
+        sb.AppendLine();
+        int checkable = total - sourceUnavailable - unsupportedTarget;
+        sb.Append(checkable == 0
+            ? "Verdict: no checkable rows (all source-unavailable/unsupported); not enough signal to assess quality."
+            : $"Verdict: {validMatch}/{checkable} checkable row(s) ({(checkable == 0 ? 0 : 100.0 * validMatch / checkable):0.00}%) matched authored source exactly; this is a current-state snapshot, not yet compared against a floor.");
+        return sb.ToString();
     }
 
     static string TargetId(ReturnToSender.RequestedTarget target)


### PR DESCRIPTION
## Summary

Closes the one remaining gap called out in #2673's "frontiers" table
(introduced by #2717): **"Assembly-wide source-only census: Not added."**

`--source-correspondence-census` (Slice 2's `valid_match`/`valid_different`/
`invalid`/`source_unavailable`/`unsupported_target` bucket classifier) selects
**zero** targets for any assembly that is not registered in `FixtureCatalog`
(`ReturnToSenderSourceProbe.cs`'s target discovery is hard-scoped to the
fixture catalog). There was no way to run that bucket taxonomy over real,
non-fixture corpus assemblies.

This PR adds `--authored-source-census`, which runs the same bucket taxonomy
over real corpus assemblies using real SourceLink acquisition, by wiring
together two already-shipped, independently tested pieces rather than adding a
new oracle:

- `AuthoredRebuildFidelity`'s real acquisition lane (`SourceLinkService`,
  checksum-verified `SourceFetcher`, `AuthoredSourceAcquisition`,
  `TryExtractTargetBody`) to get the exact checksum-verified authored body for
  a real RTS target.
- `ReturnToSenderSourceProbe`'s existing comparison/classification/report logic
  (`NormalizeBody`, `ClassifyValidDifference`, and a newly extracted
  `Report(results, maxExamples, json)`) to bucket the authored body against
  the decompiled body using the identical taxonomy as the fixture-based probe.

This keeps the RTS compile-back oracle, the authored-rebuild-fidelity oracle,
and this new source-correspondence lane strictly peer, per the #2673 reviewer
guidance to never blend oracle verdicts: each reports its own
`Absent`/`Failed`/`SourceUnavailable` outcomes independently.

## Changes

- `tools/DecompilerHarness/AuthoredSourceCensus.cs` (new): the census runner.
  `ClassifyExpectedBody` is a pure, synchronous classification step kept
  separate from acquisition so it can be tested against a real RTS result
  without any network access.
- `tools/DecompilerHarness/ReturnToSenderSourceProbe.cs`: widened
  `NormalizeBody`, `FailureReason`, `OpcodeEvidence`/`OpcodeDiffEvidence` from
  private/file-scoped to `internal` for cross-file reuse; extracted
  `Report(results, maxExamples, json)` out of `Run` so both the fixture lane
  and the new real-corpus lane share one report/JSON shape.
- `tools/DecompilerHarness/AuthoredRebuildFidelity.cs`: widened
  `AcquirePdbAsync` to `internal` for reuse.
- `tools/DecompilerHarness/Program.cs`: new `--authored-source-census` CLI
  flag and help text.
- `tools/DecompilerHarness/README.md`: documents the new flag alongside
  `--source-correspondence-census` and `--authored-rebuild-fidelity`.
- `src/ILInspector.Decompiler.Tests/AuthoredSourceCensusTests.cs` (new): 5
  focused tests.

## Evidence

- `dotnet build tools\DecompilerHarness -c Release`: succeeded.
- `dotnet build src\ILInspector.Decompiler.Tests -c Release`: succeeded.
- `dotnet run --project src\ILInspector.Decompiler.Tests -c Release --no-build -- -class "ILInspector.DecompilerHarness.AuthoredSourceCensusTests"`:
  **5/5 passed.** Covers `ClassifyExpectedBody`'s `valid_match`/
  `valid_different` branches against a real RTS result, plus `ClassifyAsync`'s
  `UnsupportedTarget`/`Invalid` early-exit branches — all without network
  access.
- Live CLI smoke test:
  `decompiler-harness --authored-source-census --package System.Text.Json --cap 15 --max-examples 5`
  resolves the real package, discovers real RTS targets, and reaches
  classification end-to-end.

  **Caveat:** on this Windows dev machine, every row bucketed as
  `invalid`/`CS0009` because of a pre-existing, unrelated environment issue
  (RTS's reference-assembly scan picks up
  `aspnetcorev2_inprocess.dll`, a native non-managed DLL, from the shared
  framework directory — the same issue documented in #2876). This blocks
  observing `ValidMatch`/`ValidDifferent` rows in a live local run on this
  machine, but does not affect the new wiring itself, which is exercised by
  the unit tests above and reuses acquisition/classification code paths that
  are already covered by existing `AuthoredRebuildFidelityTests` and
  `ReturnToSenderSourceProbe`-based tests. This is expected to run cleanly on
  Linux/macOS CI.

## Review

This is a new, non-trivial feature (new corpus-wide acquisition + reporting
mode), so it requires two-model adversarial review per `AGENTS.md` before
merge. Requesting review.
