### PR TITLE
Render typed explicit-interface events in C# and RTS

### DIFF
--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -578,6 +578,56 @@ public sealed class CSharpDeclarationWriterTests
     }
 
     [Fact]
+    public void ExplicitEventDeclaration_RendersFromStructuredAccessorShape()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Some.@event.IEvents.Changed",
+            Kind = "explicit-interface-implementation",
+            IsStatic = true,
+            IsUnsafe = true,
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "System.EventHandler",
+                MemberName = "Some.event.IEvents.Changed",
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "add" },
+                    new ApiAccessor { Kind = "remove" }
+                ]
+            }
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal(
+            "static unsafe event System.EventHandler Some.@event.IEvents.Changed",
+            declaration);
+    }
+
+    [Fact]
+    public void ExplicitEventDeclaration_RequiresTypedAccessorShape()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Some.IEvents.Changed",
+            Kind = "explicit-interface-implementation",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "System.EventHandler",
+                MemberName = "Some.IEvents.Changed"
+            }
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.DoesNotContain("Some.IEvents.Changed", declaration, StringComparison.Ordinal);
+        Assert.DoesNotContain("event ", declaration, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ShortWithUsings_KeepsCollidingSimpleNamesQualified()
     {
         var type = new ApiType

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -240,6 +240,84 @@ public sealed class CSharpTypePrinterTests
     }
 
     [Fact]
+    public void FullExplicitInterfaceEventRendersTypedAccessorBodies()
+    {
+        var explicitEvent = new ApiMember
+        {
+            Name = "Samples.IEvents.Changed",
+            Kind = "explicit-interface-implementation",
+            IsStatic = true,
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "System.EventHandler",
+                MemberName = "Samples.IEvents.Changed",
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "add" },
+                    new ApiAccessor { Kind = "remove" }
+                ]
+            }
+        };
+        var type = CreateEmptyType("Samples", "Widget");
+        type.Members.Add(explicitEvent);
+
+        var result = _printer.Print(new CSharpTypePrintRequest(
+            type,
+            memberPolicyOverrides:
+            [
+                new CSharpMemberPolicy(
+                    explicitEvent,
+                    CSharpBodyPolicy.Full,
+                    new CSharpEventBody(
+                        CSharpAccessorBody.Block("_changed += value;"),
+                        CSharpAccessorBody.Block("_changed -= value;")))
+            ]));
+
+        Assert.Contains(
+            """
+                static event EventHandler Samples.IEvents.Changed
+                {
+                    add
+                    {
+                        _changed += value;
+                    }
+                    remove
+                    {
+                        _changed -= value;
+                    }
+                }
+            """,
+            result.Units[0].Source,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExplicitInterfaceEventSkeletonFailsClosed()
+    {
+        var type = CreateEmptyType("Samples", "Widget");
+        type.Members.Add(new ApiMember
+        {
+            Name = "Samples.IEvents.Changed",
+            Kind = "explicit-interface-implementation",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "System.EventHandler",
+                MemberName = "Samples.IEvents.Changed",
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "add" },
+                    new ApiAccessor { Kind = "remove" }
+                ]
+            }
+        });
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => _printer.Print(new CSharpTypePrintRequest(type)));
+
+        Assert.Contains("requires add/remove bodies", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void StubFieldFailsClosed()
     {
         var type = CreateEmptyType("Samples", "Widget");

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -333,7 +333,8 @@ internal static class CSharpDeclarationWriter
         {
             signature = FormatOperatorSignature(signature, member.Name);
         }
-        else if (member.Kind is "method" or "extension-method" or "explicit-interface-implementation")
+        else if (member.Kind is "method" or "extension-method" or "explicit-interface-implementation"
+            && !IsExplicitInterfaceEvent(member))
         {
             if (methodParameters is { Count: > 0 })
                 signature = AddMethodGenericParameters(signature, member.Name, methodParameters);
@@ -341,11 +342,11 @@ internal static class CSharpDeclarationWriter
                 signature = AddExtensionThisModifier(signature);
             signature = EscapeMemberNameInSignature(signature, member.Name);
         }
-        else if (member.Kind == "event" && !signature.StartsWith("event ", StringComparison.Ordinal))
+        else if (IsEvent(member) && !signature.StartsWith("event ", StringComparison.Ordinal))
         {
             signature = $"event {signature}";
         }
-        if (member.Kind is "property" or "field" or "event")
+        if (member.Kind is "property" or "field" or "event" || IsExplicitInterfaceEvent(member))
         {
             signature = EscapeMemberNameInSignature(signature, member.Name);
         }
@@ -860,10 +861,11 @@ internal static class CSharpDeclarationWriter
                 : $"{head} {propertyMemberName} {{ {string.Join(" ", model.Accessors.Select(AccessorDeclaration))} }}";
             return true;
         }
-        if (member.Kind == "event"
+        if ((member.Kind == "event" || IsExplicitInterfaceEvent(member))
             && model.ReturnType is { Length: > 0 } eventType
-            && IsOrdinaryPropertyName(member.Name)
-            && IsOrdinaryPropertyName(model.MemberName))
+            && (IsExplicitInterfaceEvent(member)
+                || IsOrdinaryPropertyName(member.Name)
+                    && IsOrdinaryPropertyName(model.MemberName)))
         {
             var eventMemberName = string.IsNullOrWhiteSpace(model.MemberName)
                 ? member.Name
@@ -904,7 +906,19 @@ internal static class CSharpDeclarationWriter
     static bool IsExplicitInterfaceProperty(ApiMember member)
         => member.Kind == "explicit-interface-implementation"
             && member.Name.Contains('.', StringComparison.Ordinal)
-            && member.SignatureModel?.Accessors.Count > 0;
+            && HasOnlyAccessors(member, "get", "set");
+
+    static bool IsExplicitInterfaceEvent(ApiMember member)
+        => member.Kind == "explicit-interface-implementation"
+            && member.Name.Contains('.', StringComparison.Ordinal)
+            && HasOnlyAccessors(member, "add", "remove");
+
+    static bool IsEvent(ApiMember member)
+        => member.Kind == "event" || IsExplicitInterfaceEvent(member);
+
+    static bool HasOnlyAccessors(ApiMember member, string first, string second)
+        => member.SignatureModel?.Accessors is { Count: > 0 } accessors
+            && accessors.All(accessor => accessor.Kind == first || accessor.Kind == second);
 
     internal static string FormatParameter(ApiParameter parameter)
     {

--- a/src/ILInspector.CSharp/CSharpTypePrintContracts.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrintContracts.cs
@@ -78,6 +78,10 @@ public sealed record CSharpPropertyBody(
     CSharpAccessorBody? Getter,
     CSharpAccessorBody? Setter) : CSharpMemberBody;
 
+public sealed record CSharpEventBody(
+    CSharpAccessorBody Adder,
+    CSharpAccessorBody Remover) : CSharpMemberBody;
+
 public sealed record CSharpMemberPolicy(
     ApiMember Member,
     CSharpBodyPolicy BodyPolicy,
@@ -182,6 +186,12 @@ public sealed class CSharpTypePrintRequest
             case CSharpPropertyBody property:
                 ValidateAccessor(property.Getter, parameterName);
                 ValidateAccessor(property.Setter, parameterName);
+                return;
+            case CSharpEventBody { Adder: null } or CSharpEventBody { Remover: null }:
+                throw new ArgumentException("Event bodies require add and remove accessors.", parameterName);
+            case CSharpEventBody eventBody:
+                ValidateAccessor(eventBody.Adder, parameterName);
+                ValidateAccessor(eventBody.Remover, parameterName);
                 return;
             case CSharpBlockBody:
             case CSharpFieldInitializer:

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -317,6 +317,9 @@ public sealed class CSharpTypePrinter
         if (IsProperty(member.Member))
             return RenderProperty(type, member, formatter, propertyFormatter, indent);
 
+        if (IsEvent(member.Member))
+            return RenderEvent(type, member, formatter, indent);
+
         string memberDeclaration = member.Body is null
             ? formatter.FormatMember(type.Type, member.Member)
             : formatter.FormatMemberWithBody(type.Type, member.Member, member.Body);
@@ -379,6 +382,35 @@ public sealed class CSharpTypePrinter
         };
         AddAccessor(lines, member.Member, "get", body.Getter, indent + 1);
         AddAccessor(lines, member.Member, "set", body.Setter, indent + 1);
+        lines.Add($"{pad}}}");
+        return lines;
+    }
+
+    static IEnumerable<string> RenderEvent(
+        PreparedType type,
+        PreparedMember member,
+        CSharpFormatter formatter,
+        int indent)
+    {
+        string pad = new(' ', indent * 4);
+        if (member.Policy == CSharpBodyPolicy.Skeleton)
+        {
+            string skeleton = formatter.FormatMember(type.Type, member.Member);
+            return [PadDeclaration(EnsureTerminated(skeleton), pad)];
+        }
+
+        var body = (CSharpEventBody)member.Body!;
+        string declaration = formatter.FormatMemberWithBody(
+            type.Type,
+            member.Member,
+            body);
+        var lines = new List<string>
+        {
+            PadDeclaration(declaration, pad),
+            $"{pad}{{"
+        };
+        AddAccessor(lines, member.Member, "add", body.Adder, indent + 1);
+        AddAccessor(lines, member.Member, "remove", body.Remover, indent + 1);
         lines.Add($"{pad}}}");
         return lines;
     }
@@ -680,10 +712,31 @@ public sealed class CSharpTypePrinter
                 $"Abstract member '{member.Name}' must use skeleton body policy.",
                 parameterName);
         }
-        if (member.Kind == "event" && policy.BodyPolicy != CSharpBodyPolicy.Skeleton)
+        if (IsExplicitInterfaceEvent(member) && policy.BodyPolicy == CSharpBodyPolicy.Skeleton)
+        {
+            throw new NotSupportedException(
+                $"Explicit interface event '{member.Name}' requires add/remove bodies.");
+        }
+        if (member.Kind == "event"
+            && policy.BodyPolicy != CSharpBodyPolicy.Skeleton
+            && policy.Body is null)
         {
             throw new NotSupportedException(
                 $"Event '{member.Name}' does not support body policy '{policy.BodyPolicy}'.");
+        }
+        if (IsEvent(member)
+            && policy.BodyPolicy != CSharpBodyPolicy.Skeleton
+            && policy.Body is not CSharpEventBody)
+        {
+            throw new NotSupportedException(
+                $"Event '{member.Name}' requires an explicit add/remove body shape.");
+        }
+        if (policy.Body is CSharpEventBody { Adder.Kind: CSharpAccessorBodyKind.Auto }
+            or CSharpEventBody { Remover.Kind: CSharpAccessorBodyKind.Auto })
+        {
+            throw new ArgumentException(
+                $"Event '{member.Name}' cannot use auto accessor bodies.",
+                parameterName);
         }
         if (member.Kind == "field" && policy.BodyPolicy == CSharpBodyPolicy.Stub)
         {
@@ -718,6 +771,7 @@ public sealed class CSharpTypePrinter
             (_, null) => policy.BodyPolicy != CSharpBodyPolicy.Full,
             ("field", CSharpFieldInitializer) => true,
             (_, CSharpPropertyBody) when IsProperty(member) => true,
+            (_, CSharpEventBody) when IsEvent(member) => true,
             ("method" or "extension-method" or "explicit-interface-implementation" or "constructor", CSharpBlockBody) => true,
             _ => false,
         };
@@ -740,7 +794,20 @@ public sealed class CSharpTypePrinter
         => member.Kind == "property"
             || member.Kind == "explicit-interface-implementation"
                 && member.Name.Contains('.', StringComparison.Ordinal)
-                && member.SignatureModel?.Accessors.Count > 0;
+                && HasOnlyAccessors(member, "get", "set");
+
+    static bool IsEvent(ApiMember member)
+        => member.Kind == "event"
+            || IsExplicitInterfaceEvent(member);
+
+    static bool IsExplicitInterfaceEvent(ApiMember member)
+        => member.Kind == "explicit-interface-implementation"
+            && member.Name.Contains('.', StringComparison.Ordinal)
+            && HasOnlyAccessors(member, "add", "remove");
+
+    static bool HasOnlyAccessors(ApiMember member, string first, string second)
+        => member.SignatureModel?.Accessors is { Count: > 0 } accessors
+            && accessors.All(accessor => accessor.Kind == first || accessor.Kind == second);
 
     sealed record PreparedType(
         string Namespace,

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -269,6 +269,111 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
+    [Theory]
+    [InlineData("IBaseEvents.add_Changed")]
+    [InlineData("IBaseEvents.remove_Changed")]
+    public void CompileBackEventAccessor_RoundTripsExplicitInterfaceEvent(string accessorName)
+    {
+        var assemblyPath = CompileFixture("""
+            using System;
+
+            public sealed class ExplicitEventFixture : IDerivedEvents
+            {
+                event Action IBaseEvents.Changed
+                {
+                    add
+                    {
+                        Console.WriteLine(value);
+                    }
+                    remove
+                    {
+                        Console.WriteLine(value);
+                    }
+                }
+            }
+
+            public interface IDerivedEvents : IBaseEvents
+            {
+            }
+
+            public interface IBaseEvents
+            {
+                event Action Changed;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "ExplicitEventFixture",
+                    accessorName,
+                    0)]));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains("event Action IBaseEvents.Changed", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("public event Action IBaseEvents.Changed", result.Source, StringComparison.Ordinal);
+            Assert.Contains("add", result.Source, StringComparison.Ordinal);
+            Assert.Contains("remove", result.Source, StringComparison.Ordinal);
+            Assert.Contains("Console.WriteLine(value);", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackEventAccessor_KeepsStaticOnExplicitInterfaceEvent()
+    {
+        var assemblyPath = CompileFixture("""
+            using System;
+
+            public sealed class ExplicitStaticEventFixture : IStaticEvents
+            {
+                static event Action IStaticEvents.Changed
+                {
+                    add
+                    {
+                        Console.WriteLine(value);
+                    }
+                    remove
+                    {
+                        Console.WriteLine(value);
+                    }
+                }
+            }
+
+            public interface IStaticEvents
+            {
+                static abstract event Action Changed;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "ExplicitStaticEventFixture",
+                    "IStaticEvents.add_Changed",
+                    0)]));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains("static event Action IStaticEvents.Changed", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("public static event Action IStaticEvents.Changed", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
     [Fact]
     public void CompileBackFirstPropertyGetter_PreservesRequiredImplicitInterfaceProperty()
     {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -375,6 +375,40 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackEventAccessor_PreservesOrdinaryFieldLikeEventHandling()
+    {
+        var assemblyPath = CompileFixture("""
+            using System;
+
+            public sealed class OrdinaryEventFixture
+            {
+                public event Action Changed;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "OrdinaryEventFixture",
+                    "add_Changed",
+                    0)]));
+
+            Assert.True(
+                result.Status is FidelityCheck.CompileBackStatus.Exact
+                    or FidelityCheck.CompileBackStatus.OpcodeDiff,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains("public void add_Changed(Action value)", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("event Action Changed", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_PreservesRequiredImplicitInterfaceProperty()
     {
         var assemblyPath = CompileFixture("""

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -696,12 +696,43 @@ static class ReturnToSender
         }
 
         if (TryFindMethod(reader, typeDef, target) is { } accessorHandle
-            && accessorToEvent.TryGetValue(accessorHandle, out var foundEventHandle))
+            && accessorToEvent.TryGetValue(accessorHandle, out var foundEventHandle)
+            && IsExplicitInterfaceEventAccessor(reader, typeDef, accessorHandle))
         {
             return (foundEventHandle, accessorHandle);
         }
 
         return null;
+    }
+
+    static bool IsExplicitInterfaceEventAccessor(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        MethodDefinitionHandle accessorHandle)
+    {
+        foreach (var implementationHandle in typeDef.GetMethodImplementations())
+        {
+            var implementation = reader.GetMethodImplementation(implementationHandle);
+            if (implementation.MethodBody != accessorHandle
+                || implementation.MethodDeclaration.Kind != HandleKind.MethodDefinition)
+            {
+                continue;
+            }
+
+            var declarationHandle = (MethodDefinitionHandle)implementation.MethodDeclaration;
+            var declaration = reader.GetMethodDefinition(declarationHandle);
+            var interfaceDef = reader.GetTypeDefinition(declaration.GetDeclaringType());
+            if (!interfaceDef.Attributes.HasFlag(TypeAttributes.Interface))
+                continue;
+            foreach (var eventHandle in interfaceDef.GetEvents())
+            {
+                var accessors = reader.GetEventDefinition(eventHandle).GetAccessors();
+                if (accessors.Adder == declarationHandle || accessors.Remover == declarationHandle)
+                    return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -535,6 +535,21 @@ static class ReturnToSender
                 continue;
             }
 
+            if (TryFindEventAccessor(reader, typeDef, target) is { } eventTarget)
+            {
+                results.Add(CompileBackEventAccessorOrContextFail(
+                    assemblyPath,
+                    pe,
+                    reader,
+                    source,
+                    typeHandle,
+                    eventTarget.Event,
+                    eventTarget.Accessor,
+                    MemberAnchorFor(memberAnchors, eventTarget.Accessor),
+                    sourceIndex));
+                continue;
+            }
+
             if (TryFindMethod(reader, typeDef, target) is { } methodHandle)
             {
                 results.Add(CompileBackMethodOrContextFail(
@@ -665,6 +680,30 @@ static class ReturnToSender
         return null;
     }
 
+    static (EventDefinitionHandle Event, MethodDefinitionHandle Accessor)? TryFindEventAccessor(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        RequestedTarget target)
+    {
+        var accessorToEvent = new Dictionary<MethodDefinitionHandle, EventDefinitionHandle>();
+        foreach (var eventHandle in typeDef.GetEvents())
+        {
+            var accessors = reader.GetEventDefinition(eventHandle).GetAccessors();
+            if (!accessors.Adder.IsNil)
+                accessorToEvent[accessors.Adder] = eventHandle;
+            if (!accessors.Remover.IsNil)
+                accessorToEvent[accessors.Remover] = eventHandle;
+        }
+
+        if (TryFindMethod(reader, typeDef, target) is { } accessorHandle
+            && accessorToEvent.TryGetValue(accessorHandle, out var foundEventHandle))
+        {
+            return (foundEventHandle, accessorHandle);
+        }
+
+        return null;
+    }
+
     /// <summary>
     /// Resolves the target metadata method by normalized signature when the target
     /// carries one (ordinal-independent), falling back to the count-all overload
@@ -789,6 +828,42 @@ static class ReturnToSender
         }
     }
 
+    static Result CompileBackEventAccessorOrContextFail(
+        string assemblyPath,
+        PEReader pe,
+        MetadataReader reader,
+        MetadataSource source,
+        TypeDefinitionHandle typeHandle,
+        EventDefinitionHandle eventHandle,
+        MethodDefinitionHandle accessorHandle,
+        MemberAnchor? memberAnchor,
+        ReturnToSenderSourceIndex? sourceIndex)
+    {
+        try
+        {
+            return CompileBackEventAccessor(
+                assemblyPath,
+                pe,
+                reader,
+                source,
+                typeHandle,
+                eventHandle,
+                accessorHandle,
+                memberAnchor,
+                sourceIndex);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            return ContextFailResult(
+                assemblyPath,
+                reader,
+                typeHandle,
+                accessorHandle,
+                $"{ex.GetType().Name}: {ex.Message}",
+                memberAnchor);
+        }
+    }
+
     static Result CompileBackPropertySetterOrContextFail(
         string assemblyPath,
         PEReader pe,
@@ -907,6 +982,60 @@ static class ReturnToSender
                 Function: function,
                 TargetType: typeHandle,
                 TargetMethod: methodHandle,
+                TargetBody: targetBody,
+                FullType: fullType,
+                MethodName: methodName,
+                Overload: overload,
+                SignatureText: CorpusMethodIdentity.SignatureText(function.Signature),
+                ClosureRoots: closureRoots,
+                ClosureFacts: closureFacts));
+    }
+
+    static Result CompileBackEventAccessor(
+        string assemblyPath,
+        PEReader pe,
+        MetadataReader reader,
+        MetadataSource source,
+        TypeDefinitionHandle typeHandle,
+        EventDefinitionHandle eventHandle,
+        MethodDefinitionHandle accessorHandle,
+        MemberAnchor? memberAnchor,
+        ReturnToSenderSourceIndex? sourceIndex)
+    {
+        var typeDef = reader.GetTypeDefinition(typeHandle);
+        var accessor = reader.GetMethodDefinition(accessorHandle);
+        string fullType = reader.GetFullTypeName(typeDef);
+        string methodName = reader.GetString(accessor.Name);
+        int overload = OverloadIndex(reader, typeDef, accessorHandle, methodName);
+
+        var function = IrImporter.Import(source, fullType, methodName, overload)
+            ?? throw new InvalidOperationException($"Could not import {fullType}::{methodName}.");
+        var targetBody = CompileBackSourceComposer.CreateTargetBody(source, function, fullType, methodName);
+
+        var original = MetadataInstructionProducer.Disassemble(pe, reader, accessor)
+            ?? throw new InvalidOperationException($"Could not disassemble {fullType}::{methodName}.");
+        var originalOps = original.Select(instruction => CanonicalOpcode(instruction.OpCodeName)).ToArray();
+
+        return CompileBackTarget(
+            assemblyPath,
+            reader,
+            typeHandle,
+            accessorHandle,
+            function,
+            targetBody,
+            fullType,
+            methodName,
+            overload,
+            originalOps,
+            memberAnchor,
+            sourceIndex,
+            (closureRoots, closureFacts) => new EventAccessorArtifactRequest(
+                AssemblyPath: assemblyPath,
+                Reader: reader,
+                Function: function,
+                TargetType: typeHandle,
+                TargetMethod: accessorHandle,
+                TargetEvent: eventHandle,
                 TargetBody: targetBody,
                 FullType: fullType,
                 MethodName: methodName,
@@ -1523,6 +1652,7 @@ static class ReturnToSender
             MethodArtifactRequest method => method with { TargetBody = targetBody },
             PropertyGetterArtifactRequest getter => getter with { TargetBody = targetBody },
             PropertySetterArtifactRequest setter => setter with { TargetBody = targetBody },
+            EventAccessorArtifactRequest eventAccessor => eventAccessor with { TargetBody = targetBody },
             _ => throw new ArgumentException($"Unknown artifact request type '{request.GetType().FullName}'.", nameof(request)),
         };
 
@@ -1532,6 +1662,7 @@ static class ReturnToSender
             MethodArtifactRequest method => method with { Reader = reader },
             PropertyGetterArtifactRequest getter => getter with { Reader = reader },
             PropertySetterArtifactRequest setter => setter with { Reader = reader },
+            EventAccessorArtifactRequest eventAccessor => eventAccessor with { Reader = reader },
             _ => throw new ArgumentException($"Unknown artifact request type '{request.GetType().FullName}'.", nameof(request)),
         };
 

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -137,6 +137,34 @@ internal sealed record PropertySetterArtifactRequest(
         ClosureRoots,
         ClosureFacts);
 
+internal sealed record EventAccessorArtifactRequest(
+    string AssemblyPath,
+    MetadataReader Reader,
+    IrFunction Function,
+    TypeDefinitionHandle TargetType,
+    MethodDefinitionHandle TargetMethod,
+    EventDefinitionHandle TargetEvent,
+    ProductTargetBody TargetBody,
+    string FullType,
+    string MethodName,
+    int Overload,
+    string SignatureText,
+    IReadOnlySet<TypeDefinitionHandle> ClosureRoots,
+    IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> ClosureFacts)
+    : ArtifactRequest(
+        AssemblyPath,
+        Reader,
+        Function,
+        TargetType,
+        TargetMethod,
+        TargetBody,
+        FullType,
+        MethodName,
+        Overload,
+        SignatureText,
+        ClosureRoots,
+        ClosureFacts);
+
 internal sealed record ProductArtifact(
     ArtifactRequest Request,
     ProductTargetBody TargetBody,
@@ -201,6 +229,8 @@ public enum CompileBackMemberKind
 {
     PropertyGet,
     PropertySet,
+    EventAdd,
+    EventRemove,
     Constructor,
     Method,
     Field,
@@ -336,6 +366,12 @@ internal sealed record ProductTargetBody(
     IReadOnlyList<DecompilerDecision> Decisions,
     string? ConstructorChain = null);
 
+internal sealed record ExplicitInterfaceEventInfo(
+    TypeDefinitionHandle InterfaceType,
+    EventDefinitionHandle InterfaceEvent,
+    string QualifiedName,
+    string AccessorName);
+
 public static class CompileBackSourceComposer
 {
     internal static ProductTargetBody CreateTargetBody(
@@ -394,6 +430,21 @@ public static class CompileBackSourceComposer
                 request.Function,
                 request.TargetType,
                 setter.TargetProperty,
+                request.TargetMethod,
+                request.TargetBody.Source,
+                request.FullType,
+                request.MethodName,
+                request.Overload,
+                request.SignatureText,
+                closure.Roots,
+                closure.Facts,
+                closure.MemberRequirements),
+            EventAccessorArtifactRequest eventAccessor => ComposeEventAccessor(
+                request.AssemblyPath,
+                request.Reader,
+                request.Function,
+                request.TargetType,
+                eventAccessor.TargetEvent,
                 request.TargetMethod,
                 request.TargetBody.Source,
                 request.FullType,
@@ -962,6 +1013,79 @@ public static class CompileBackSourceComposer
         }
     }
 
+    static ExplicitInterfaceEventInfo? ExplicitInterfaceEvent(
+        MetadataReader reader,
+        TypeDefinition targetType,
+        MethodDefinitionHandle targetAccessor)
+    {
+        foreach (var implementationHandle in targetType.GetMethodImplementations())
+        {
+            var implementation = reader.GetMethodImplementation(implementationHandle);
+            if (implementation.MethodBody != targetAccessor
+                || implementation.MethodDeclaration.Kind != HandleKind.MethodDefinition)
+            {
+                continue;
+            }
+
+            var declarationHandle = (MethodDefinitionHandle)implementation.MethodDeclaration;
+            var declaration = reader.GetMethodDefinition(declarationHandle);
+            var interfaceHandle = declaration.GetDeclaringType();
+            var interfaceDef = reader.GetTypeDefinition(interfaceHandle);
+            foreach (var eventHandle in interfaceDef.GetEvents())
+            {
+                var eventDefinition = reader.GetEventDefinition(eventHandle);
+                var accessors = eventDefinition.GetAccessors();
+                if (accessors.Adder != declarationHandle && accessors.Remover != declarationHandle)
+                    continue;
+
+                var interfaceIdentity = CompileBackTypeIdentity.FromDefinition(reader, interfaceDef);
+                string eventName = Identifier(reader.GetString(eventDefinition.Name));
+                return new ExplicitInterfaceEventInfo(
+                    interfaceHandle,
+                    eventHandle,
+                    $"{interfaceIdentity.FullName}.{eventName}",
+                    reader.GetString(declaration.Name));
+            }
+        }
+
+        return null;
+    }
+
+    static void AddExplicitInterfaceEventDeclaration(
+        List<CompileBackTypeRequirement> requirements,
+        MetadataReader reader,
+        ExplicitInterfaceEventInfo? explicitEvent)
+    {
+        if (explicitEvent is null)
+            return;
+
+        var interfaceDef = reader.GetTypeDefinition(explicitEvent.InterfaceType);
+        var interfaceIdentity = CompileBackTypeIdentity.FromDefinition(reader, interfaceDef);
+        var member = TypeProducer.EventRequirement(
+            reader,
+            interfaceDef,
+            interfaceIdentity,
+            explicitEvent.InterfaceEvent,
+            explicitEvent.AccessorName,
+            "explicit-interface-target-event");
+        if (member is null)
+            return;
+
+        int requirementIndex = requirements.FindIndex(
+            requirement => requirement.Type.MetadataFullName == interfaceIdentity.MetadataFullName);
+        if (requirementIndex < 0)
+            return;
+
+        var requirement = requirements[requirementIndex];
+        if (requirement.RequiredMembers.Any(existing => TypeProducer.SameMemberShape(existing, member)))
+            return;
+
+        requirements[requirementIndex] = requirement with
+        {
+            RequiredMembers = requirement.RequiredMembers.Append(member).ToArray()
+        };
+    }
+
     public static CompileBackSourceResult ComposePropertySetter(
         string assemblyPath,
         MetadataReader reader,
@@ -1060,6 +1184,106 @@ public static class CompileBackSourceComposer
             module,
             production.Requirements,
             declarations,
+            diagnostics);
+        return new CompileBackSourceResult(plan, ComposeCompilationUnit(plan));
+    }
+
+    public static CompileBackSourceResult ComposeEventAccessor(
+        string assemblyPath,
+        MetadataReader reader,
+        IrFunction function,
+        TypeDefinitionHandle targetType,
+        EventDefinitionHandle targetEvent,
+        MethodDefinitionHandle targetAccessor,
+        string targetBody,
+        string fullType,
+        string methodName,
+        int overload,
+        string signatureText,
+        IReadOnlySet<TypeDefinitionHandle> closureRoots,
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements)
+    {
+        var targetTypeDef = reader.GetTypeDefinition(targetType);
+        var eventDefinition = reader.GetEventDefinition(targetEvent);
+        var accessors = eventDefinition.GetAccessors();
+        var accessor = reader.GetMethodDefinition(targetAccessor);
+        var signature = GuardedSignatureText.MethodText(
+            reader,
+            accessor,
+            GenericContext.ForMethod(reader, targetTypeDef, accessor));
+        var parameters = MethodParameters(reader, accessor, signature);
+        if (parameters.Count != 1)
+            throw new InvalidOperationException("Event accessors must have exactly one value parameter.");
+
+        var kind = targetAccessor == accessors.Adder
+            ? CompileBackMemberKind.EventAdd
+            : targetAccessor == accessors.Remover
+                ? CompileBackMemberKind.EventRemove
+                : throw new InvalidOperationException("Target method is not an accessor of the selected event.");
+        var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
+        string metadataEventName = reader.GetString(eventDefinition.Name);
+        string eventName = Identifier(metadataEventName[(metadataEventName.LastIndexOf('.') + 1)..]);
+        var explicitEvent = ExplicitInterfaceEvent(
+            reader,
+            targetTypeDef,
+            targetAccessor);
+
+        var diagnostics = new List<CompileBackPlanningDiagnostic>();
+        var targetRoot = TopLevelRootOf(reader, targetType);
+        var targetFacts = new List<CompileBackFact>
+        {
+            new("metadata", "target-type", targetIdentity.FullName),
+        };
+        if (closureFacts.TryGetValue(targetType, out var targetClosureFacts))
+            targetFacts.AddRange(targetClosureFacts);
+
+        var targetMembers = new List<CompileBackMemberRequirement>
+        {
+            new(
+                new CompileBackMethodIdentity(targetIdentity.FullName, eventName, overload, signatureText),
+                kind,
+                accessor.Attributes.HasFlag(MethodAttributes.Static),
+                [],
+                parameters[0].Type,
+                [],
+                CompileBackStubBodyKind.TargetBody,
+                targetBody,
+                [new CompileBackFact("metadata", "target-event-accessor", reader.GetString(accessor.Name))],
+                MemberAttributes(reader, eventDefinition.GetCustomAttributes()),
+                RequiresUnsafeModifier: ContainsFixedBufferElementAccess(function),
+                ExplicitInterfaceMemberName: explicitEvent?.QualifiedName)
+        };
+        AddRequiredMembers(targetMembers, closureMemberRequirements, targetType);
+
+        var requirements = new List<CompileBackTypeRequirement>
+        {
+            new(
+                targetIdentity,
+                ShellKind(reader, targetTypeDef, targetFacts),
+                targetMembers,
+                PrimaryConstructor: null,
+                targetFacts)
+        };
+        AddClosureTypeRequirements(requirements, reader, targetRoot, closureFacts, closureMemberRequirements);
+        foreach (var dependency in closureRoots.OrderBy(handle => MetadataTokens.GetToken(handle)))
+        {
+            if (dependency != targetRoot)
+                AddClosureTypeRequirements(requirements, reader, dependency, closureFacts, closureMemberRequirements);
+        }
+        AddExplicitInterfaceEventDeclaration(requirements, reader, explicitEvent);
+
+        var production = TypeProducer.Produce(reader, requirements, diagnostics);
+        var module = new CompileBackModuleRequirement(
+            Usings: BuildUsings(function),
+            AssemblyAttributes: [],
+            ModuleAttributes: []);
+        var plan = new CompileBackReconstructionPlan(
+            assemblyPath,
+            new CompileBackMethodIdentity(fullType, methodName, overload, signatureText),
+            module,
+            production.Requirements,
+            production.Requests,
             diagnostics);
         return new CompileBackSourceResult(plan, ComposeCompilationUnit(plan));
     }
@@ -1282,15 +1506,19 @@ public static class CompileBackSourceComposer
         string? returnType = member.ReturnType?.DisplayName;
         bool isExplicitInterfaceProperty = member.ExplicitInterfaceMemberName is not null
             && member.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet;
+        bool isEvent = member.Kind is CompileBackMemberKind.EventAdd or CompileBackMemberKind.EventRemove;
+        bool isExplicitInterfaceEvent = member.ExplicitInterfaceMemberName is not null && isEvent;
         var apiMember = new ApiMember
         {
             Name = member.ExplicitInterfaceMemberName ?? member.Identity.Method,
-            Kind = isExplicitInterfaceProperty
+            Kind = isExplicitInterfaceProperty || isExplicitInterfaceEvent
                 ? "explicit-interface-implementation"
                 : member.Kind switch
                 {
                     CompileBackMemberKind.PropertyGet => "property",
                     CompileBackMemberKind.PropertySet => "property",
+                    CompileBackMemberKind.EventAdd => "event",
+                    CompileBackMemberKind.EventRemove => "event",
                     CompileBackMemberKind.Constructor => "constructor",
                     CompileBackMemberKind.Method => "method",
                     CompileBackMemberKind.Field => "field",
@@ -1353,6 +1581,15 @@ public static class CompileBackSourceComposer
                     : apiMember.Name;
                 apiMember.SignatureModel.Accessors = PropertyAccessors(member);
             }
+            else if (isEvent)
+            {
+                apiMember.SignatureModel.MemberName = apiMember.Name;
+                apiMember.SignatureModel.Accessors =
+                [
+                    new ApiAccessor { Kind = "add" },
+                    new ApiAccessor { Kind = "remove" },
+                ];
+            }
         }
         return apiMember;
     }
@@ -1396,6 +1633,11 @@ public static class CompileBackSourceComposer
                 => new(member, CSharpBodyPolicy.Skeleton),
             CompileBackStubBodyKind.Throw when requirement.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet
                 => new(member, CSharpBodyPolicy.Stub, PropertyBody(requirement, CSharpAccessorBody.Throw)),
+            CompileBackStubBodyKind.Throw when requirement.Kind is CompileBackMemberKind.EventAdd or CompileBackMemberKind.EventRemove
+                => new(
+                    member,
+                    CSharpBodyPolicy.Stub,
+                    new CSharpEventBody(CSharpAccessorBody.Throw, CSharpAccessorBody.Throw)),
             CompileBackStubBodyKind.Throw when requirement.Kind == CompileBackMemberKind.Constructor
                 && primaryConstructorParameterCount > 0
                 => new(
@@ -1420,6 +1662,11 @@ public static class CompileBackSourceComposer
                     member,
                     CSharpBodyPolicy.Full,
                     PropertyBody(requirement, CSharpAccessorBody.Block(requirement.TargetBody!))),
+            CompileBackStubBodyKind.TargetBody when requirement.Kind is CompileBackMemberKind.EventAdd or CompileBackMemberKind.EventRemove
+                => new(
+                    member,
+                    CSharpBodyPolicy.Full,
+                    EventBody(requirement, CSharpAccessorBody.Block(requirement.TargetBody!))),
             CompileBackStubBodyKind.TargetBody when requirement.Kind == CompileBackMemberKind.Constructor
                 && primaryConstructorParameterCount > 0
                 => new(
@@ -1465,6 +1712,13 @@ public static class CompileBackSourceComposer
         => requirement.Kind == CompileBackMemberKind.PropertyGet
             ? new CSharpPropertyBody(body, null)
             : new CSharpPropertyBody(null, body);
+
+    static CSharpEventBody EventBody(
+        CompileBackMemberRequirement requirement,
+        CSharpAccessorBody body)
+        => requirement.Kind == CompileBackMemberKind.EventAdd
+            ? new CSharpEventBody(body, CSharpAccessorBody.Throw)
+            : new CSharpEventBody(CSharpAccessorBody.Throw, body);
 
     static CompileBackParameter ToCompileBackParameter(ApiParameter parameter)
         => new(
@@ -2691,6 +2945,74 @@ public static class CompileBackSourceComposer
                 ExplicitInterfaceMemberName: explicitInterfaceMemberName);
         }
 
+        internal static CompileBackMemberRequirement? EventRequirement(
+            MetadataReader reader,
+            TypeDefinition typeDef,
+            CompileBackTypeIdentity typeIdentity,
+            EventDefinitionHandle eventHandle,
+            string accessorName,
+            string factId = "typed-closure-event")
+        {
+            var eventDefinition = reader.GetEventDefinition(eventHandle);
+            var accessors = eventDefinition.GetAccessors();
+            MethodDefinitionHandle accessorHandle;
+            if (!accessors.Adder.IsNil
+                && reader.GetString(reader.GetMethodDefinition(accessors.Adder).Name) == accessorName)
+            {
+                accessorHandle = accessors.Adder;
+            }
+            else if (!accessors.Remover.IsNil
+                && reader.GetString(reader.GetMethodDefinition(accessors.Remover).Name) == accessorName)
+            {
+                accessorHandle = accessors.Remover;
+            }
+            else
+            {
+                return null;
+            }
+
+            var accessor = reader.GetMethodDefinition(accessorHandle);
+            MethodSignature<string> signature;
+            IReadOnlyList<CompileBackParameter> parameters;
+            try
+            {
+                signature = GuardedSignatureText.MethodText(
+                    reader,
+                    accessor,
+                    GenericContext.ForMethod(reader, typeDef, accessor));
+                parameters = MethodParameters(reader, accessor, signature);
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+            {
+                return null;
+            }
+            if (parameters.Count != 1)
+                return null;
+
+            string eventName = Identifier(reader.GetString(eventDefinition.Name));
+            bool isAbstract = IsAbstractMethod(accessor);
+            bool hasNoBody = (typeDef.Attributes & TypeAttributes.Interface) != 0 || isAbstract;
+            return new CompileBackMemberRequirement(
+                new CompileBackMethodIdentity(
+                    typeIdentity.FullName,
+                    eventName,
+                    0,
+                    $"event {parameters[0].Type.DisplayName}"),
+                accessorHandle == accessors.Adder
+                    ? CompileBackMemberKind.EventAdd
+                    : CompileBackMemberKind.EventRemove,
+                accessor.Attributes.HasFlag(MethodAttributes.Static),
+                [],
+                parameters[0].Type,
+                [],
+                hasNoBody ? CompileBackStubBodyKind.None : CompileBackStubBodyKind.Throw,
+                null,
+                [new CompileBackFact("metadata", factId, accessorName)],
+                MemberAttributes(reader, eventDefinition.GetCustomAttributes()),
+                IsAbstract: isAbstract,
+                IsVirtual: IsVirtualMethod(accessor));
+        }
+
         static CompileBackMemberRequirement? MethodRequirement(
             MetadataReader reader,
             TypeDefinition typeDef,
@@ -2982,8 +3304,11 @@ public static class CompileBackSourceComposer
         {
             if (SameMemberDeclaration(left, right))
                 return true;
-            if (left.Kind is not (CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet)
-                || right.Kind is not (CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet))
+            bool bothProperties = left.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet
+                && right.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet;
+            bool bothEvents = left.Kind is CompileBackMemberKind.EventAdd or CompileBackMemberKind.EventRemove
+                && right.Kind is CompileBackMemberKind.EventAdd or CompileBackMemberKind.EventRemove;
+            if (!bothProperties && !bothEvents)
             {
                 return false;
             }
@@ -2991,6 +3316,7 @@ public static class CompileBackSourceComposer
             string leftName = left.ExplicitInterfaceMemberName ?? left.Identity.Method;
             string rightName = right.ExplicitInterfaceMemberName ?? right.Identity.Method;
             return leftName == rightName
+                && left.ReturnType == right.ReturnType
                 && SameParameters(left.Parameters, right.Parameters);
         }
 


### PR DESCRIPTION
## Summary

Render explicit-interface events from a typed `add`/`remove` accessor contract,
with `CSharpTypePrinter` owning the final C# syntax and RTS owning only
event/accessor reconstruction shape.

- add `CSharpEventBody` and structured explicit-event declaration/body rendering
- classify explicit properties and events by their typed accessor sets rather
  than dotted display names
- make explicit-event skeletons fail closed because C# requires custom accessor
  bodies
- teach RTS to discover explicit event accessors, reconstruct the same-assembly
  interface event declaration, and provide the target accessor plus an honest
  sibling stub

## Original source

```csharp
event Action IBaseEvents.Changed
{
    add
    {
        Console.WriteLine(value);
    }
    remove
    {
        Console.WriteLine(value);
    }
}
```

## Before

RTS treated the selected explicit event accessor as an ordinary method. For the
`IBaseEvents.add_Changed` target, it produced:

```csharp
public void IBaseEvents_add_Changed(Action value)
{
    Console.WriteLine(value);
}
```

## After

RTS now reconstructs the typed explicit-interface event. For the same add
accessor target, it produces:

```csharp
event Action IBaseEvents.Changed
{
    add
    {
        Console.WriteLine(value);
    }
    remove
    {
        throw null;
    }
}
```

The remove-accessor target produces the symmetric shape, with the decompiled
body under `remove` and the honest sibling stub under `add`.

## Fully raised

```csharp
event Action IBaseEvents.Changed
{
    add
    {
        Console.WriteLine(value);
    }
    remove
    {
        Console.WriteLine(value);
    }
}
```

- Required tracking issue: #2913 — recover and render both accessor bodies in
  one RTS reconstruction.

## Compatibility

Ordinary field-like event skeletons keep their existing behavior. The RTS
projection follows the existing explicit-property boundary: the interface
declaration is reconstructed from same-assembly `MethodImpl` evidence;
generic/external interface expansion is not added here.

## Validation

- Release solution build
- ILInspector.CSharp.Tests: 276 passed
- ReturnToSenderPrototypeTests: 127 passed
- fast ILInspector.Decompiler.Tests: 2,778 passed
- fixed-head adversarial review: Claude Opus 4.8 and Gemini 3.1 Pro CLEAN

Closes #2850
