### PR TITLE
Raise nested fixed-buffer indices inside out

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
@@ -26,6 +26,8 @@ public unsafe struct FixedBufferResiduals
 
     public void WriteAtNestedIndex() => Data[Data[1]] = 1;
 
+    public void WriteAtNestedZeroIndex() => Data[Data[0]] = 1;
+
     public int ReadAtThroughFixedAddress(int index)
     {
         fixed (int* p = &Data[index])

--- a/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
@@ -24,6 +24,8 @@ public unsafe struct FixedBufferResiduals
 
     public void WriteFirst(int value) => Data[0] = value;
 
+    public void WriteAtNestedIndex() => Data[Data[1]] = 1;
+
     public int ReadAtThroughFixedAddress(int index)
     {
         fixed (int* p = &Data[index])

--- a/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
@@ -53,6 +53,14 @@ public struct FixedBufferResiduals
         }
     }
 
+    public void WriteAtNestedIndex()
+    {
+        unsafe
+        {
+            Data[Data[1]] = 1;
+        }
+    }
+
     public int ReadAtThroughFixedAddress(int index)
     {
         unsafe

--- a/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
@@ -61,6 +61,14 @@ public struct FixedBufferResiduals
         }
     }
 
+    public void WriteAtNestedZeroIndex()
+    {
+        unsafe
+        {
+            Data[Data[0]] = 1;
+        }
+    }
+
     public int ReadAtThroughFixedAddress(int index)
     {
         unsafe

--- a/src/ILInspector.Decompiler.Tests/FixedBufferElementAccessPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FixedBufferElementAccessPassTests.cs
@@ -155,6 +155,20 @@ public class FixedBufferElementAccessPassTests
 
     [Theory]
     [MemberData(nameof(FixedBufferFixtures))]
+    public void CompilerNestedZeroFixedBufferIndex_RaisesInsideOutAndReachesFull(string assemblyPath, string typeName)
+    {
+        var function = Raised(assemblyPath, typeName, "WriteAtNestedZeroIndex");
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Equal(2, function.Descendants.OfType<FixedBufferElementAddress>().Count());
+        Assert.Contains("Data[Data[0]] = 1;", output);
+        Assert.DoesNotContain("FixedElementField", output);
+        Assert.DoesNotContain("Unsafe.Add", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(FixedBufferFixtures))]
     public void CompilerFixedBufferAddressInFixedInitializer_RendersSourceAddress(string assemblyPath, string typeName)
     {
         var function = Raised(assemblyPath, typeName, "ReadAtThroughFixedAddress");

--- a/src/ILInspector.Decompiler.Tests/FixedBufferElementAccessPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FixedBufferElementAccessPassTests.cs
@@ -141,6 +141,20 @@ public class FixedBufferElementAccessPassTests
 
     [Theory]
     [MemberData(nameof(FixedBufferFixtures))]
+    public void CompilerNestedFixedBufferIndex_RaisesInsideOutAndReachesFull(string assemblyPath, string typeName)
+    {
+        var function = Raised(assemblyPath, typeName, "WriteAtNestedIndex");
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Equal(2, function.Descendants.OfType<FixedBufferElementAddress>().Count());
+        Assert.Contains("Data[Data[1]] = 1;", output);
+        Assert.DoesNotContain("FixedElementField", output);
+        Assert.DoesNotContain("Unsafe.Add", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(FixedBufferFixtures))]
     public void CompilerFixedBufferAddressInFixedInitializer_RendersSourceAddress(string assemblyPath, string typeName)
     {
         var function = Raised(assemblyPath, typeName, "ReadAtThroughFixedAddress");

--- a/src/ILInspector.Decompiler/Pipeline/Passes/FixedBufferElementAccessPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/FixedBufferElementAccessPass.cs
@@ -19,7 +19,10 @@ public sealed class FixedBufferElementAccessPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
-        foreach (var node in function.Descendants.ToList())
+        // Raise inner accesses before their parents. Creating an outer access
+        // clones its index expression, so a top-down snapshot would leave any
+        // nested fixed-buffer access only partially raised in the live clone.
+        foreach (var node in function.Descendants.Reverse().ToList())
         {
             switch (node)
             {


### PR DESCRIPTION
- Follow-up to #2902
- Raises nested fixed-buffer indices inside out instead of leaving cloned inner
  pointer arithmetic behind
- Card revision: `c1114e761ec0c0e42776d62197cbdc6db40e1cff`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — bottom-up traversal ensures an inner fixed-buffer
access is already raised before an outer access clones its index expression.

### Original source

```csharp
public void WriteAtNestedIndex()
{
    Data[Data[1]] = 1;
}
```

### Before

```csharp
public unsafe void WriteAtNestedIndex()
{
    Data[(ref Data.FixedElementField + 4)] = 1;
}
```

- Valid: False
- Correct: False

`(ref Data.FixedElementField + 4)` is not a legal expression or index — a `ref`
expression cannot be an operand of `+` or an array index. The inner `Data[1]` is
left as lowered fixed-buffer pointer-arithmetic residue, so it does not compile
and is not fully raised.

### After

```csharp
public void WriteAtNestedIndex()
{
    Data[Data[1]] = 1;
}
```

- Valid: True
- Correct: True

Binds as written and is identical to the original source.

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

Reported Before → After so the card shows the change, not just the current pass
state. The two nested-index rows differ across the columns and are the proof
this change is exercised; the regression guards read the same in both columns by
design.

| Check | Before | After |
| --- | --- | --- |
| Nested-index focused tests (`CompilerNestedFixedBufferIndex...`, `...NestedZero...`) | fail against pre-fix raiser — outer clone keeps lowered `Data[(ref Data.FixedElementField + 4)]`, fidelity not Full | pass — inner access raised first, `Data[Data[1]] = 1;`, Full |
| Real witness (current + legacy compiler fixtures) | inner index left as pointer-arithmetic residue, not Full | both reach Full |
| Fixed-buffer pass tests | 130 passed (nested tests absent) | 134 passed |
| Decompiler fast suite | 2,782 passed | 2,782 passed |
| Close boundary (130 positive / decline cases) | green | green |
| Product build | Pass | Pass |

The original pass walked a top-down snapshot. Raising the outer access cloned
its still-lowered index into the live tree, while the snapshot later rewrote
only the detached original. Reversing that existing snapshot is sufficient:
children raise first, and the outer clone therefore contains the raised inner
access.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — this is a localized traversal-order correction with
compiler-produced current and legacy witnesses; no recognition predicate or
accepted shape is broadened.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- \
  -class "ILInspector.Decompiler.Tests.FixedBufferElementAccessPassTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- \
  -trait- "Speed=Slow"
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config
```



