### PR TITLE
Enforce network policy for package metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ scope.
 | `library X -S "SourceLink Integrity"` | Content verification (slow, opt-in) | Downloads every tracked source file and compares its hash to the PDB checksum; a mismatch exits non-zero. Never runs in a default flow. |
 | `package X -S Signals` | Full package signals | Package and dependency signals, including known vulnerabilities, package age, dependency vulnerability/deprecation counts, and dependency age. |
 
+Vulnerability-service traffic is capability-gated. It runs only for detailed
+package inspection or an explicitly selected network-using package section;
+requests outside that scope are blocked at the shared HTTP handler.
+
 ## Integrations
 
 `Integrations` is a library section for ecosystem support such as AI, ASP.NET

--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ scope.
 Vulnerability-service traffic is capability-gated. It runs only for detailed
 package inspection or an explicitly selected network-using package section;
 requests outside that scope are blocked at the shared HTTP handler.
+NuGet.org-wide statistics, verification, deprecation, and vulnerability
+metadata are queried only when `api.nuget.org` is among the configured package
+sources. RID companion-package verification follows the configured source list.
 
 ## Integrations
 

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -163,6 +163,12 @@ exceeding any one produces a visible rejection rather than a partial identity.
 
 ### Network and caches
 
+Network capability policy is enforced in the shared HTTP handler after the
+attempt is recorded for diagnostics and before it reaches the transport.
+Traffic families that require explicit authorization, currently vulnerability
+data, must run inside their matching `NetworkTelemetry.Allow` scope. Offline
+mode remains the broader prohibition over every traffic family.
+
 Network access derived from inspected content must be explicit in the command
 surface, use the untrusted-fetch client, have a timeout, and retain provenance.
 Cache paths must be hashed or use validated single components. Downloads should

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -41,6 +41,12 @@ applies: if a pack directory exists on disk, use it without querying NuGet.
 Package metadata (publish date, downloads, deprecation, vulnerabilities) is
 also cached with a 1-hour TTL.
 
+Those aggregate metadata services are NuGet.org-specific. They are queried only
+when `api.nuget.org` is present in the resolved source list; a custom-only feed
+does not leak its package identity to NuGet.org or reuse a NuGet.org metadata
+cache entry for a same-named private package. Package acquisition and RID
+companion-package verification continue to follow the configured sources.
+
 ### Always check (`Name@latest`)
 
 Forces a full network refresh. Bypasses the disk scan, version cache, and

--- a/src/DotnetInspector.Core/HttpClientFactory.cs
+++ b/src/DotnetInspector.Core/HttpClientFactory.cs
@@ -216,9 +216,14 @@ internal sealed class NetworkTelemetryHandler(HttpMessageHandler inner, string c
     protected override Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        NetworkTelemetry.RecordRequestStarting(
+        bool allowed = NetworkTelemetry.RecordRequestStarting(
             request,
             _clientKind);
+        if (!allowed)
+        {
+            throw new NetworkPolicyException(
+                $"Network traffic '{NetworkTelemetry.CurrentTrafficKind.ToTelemetryName()}' requires explicit capability authorization. Attempted: {request.Method} {request.RequestUri}");
+        }
 
         return base.SendAsync(request, cancellationToken);
     }
@@ -241,3 +246,9 @@ internal sealed class CountingHandler(HttpMessageHandler inner) : DelegatingHand
 /// Thrown when a network request is attempted in offline mode.
 /// </summary>
 public sealed class OfflineException(string message) : InvalidOperationException(message);
+
+/// <summary>
+/// Thrown when a request reaches the HTTP seam without the capability required
+/// by its current <see cref="NetworkTrafficKind"/>.
+/// </summary>
+public sealed class NetworkPolicyException(string message) : InvalidOperationException(message);

--- a/src/DotnetInspector.Core/NetworkTelemetry.cs
+++ b/src/DotnetInspector.Core/NetworkTelemetry.cs
@@ -144,7 +144,7 @@ public static class NetworkTelemetry
         return new Subscription(observer);
     }
 
-    internal static void RecordRequestStarting(
+    internal static bool RecordRequestStarting(
         HttpRequestMessage request,
         string clientKind)
     {
@@ -167,6 +167,8 @@ public static class NetworkTelemetry
 
         foreach (var subscriber in subscribers)
             subscriber.OnNext(observation);
+
+        return observation.IsAllowedByPolicy;
     }
 
     private sealed class Subscription(IObserver<NetworkRequestObservation> observer) : IDisposable

--- a/src/DotnetInspector.Core/NetworkTelemetry.cs
+++ b/src/DotnetInspector.Core/NetworkTelemetry.cs
@@ -195,8 +195,10 @@ public static class NetworkTelemetry
     private static bool IsAllowedByPolicy(NetworkTrafficKind kind) =>
         kind switch
         {
-            // Package load/search traffic is always allowed; vulnerability traffic is view-gated.
-            NetworkTrafficKind.VulnerabilityData => AllowedKinds.Value?.Contains(kind) == true,
+            // Package load/search traffic is always allowed. NuGet and GitHub
+            // vulnerability enrichment share one view-gated capability.
+            NetworkTrafficKind.VulnerabilityData or NetworkTrafficKind.AdvisoryData =>
+                AllowedKinds.Value?.Contains(NetworkTrafficKind.VulnerabilityData) == true,
             _ => true
         };
 }

--- a/src/DotnetInspector.Services.Tests/LocalFolderSourceTests.cs
+++ b/src/DotnetInspector.Services.Tests/LocalFolderSourceTests.cs
@@ -118,6 +118,31 @@ public class LocalFolderSourceTests : IDisposable
             && l.Contains("non-HTTP", StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public async Task TryGetNuspec_UsesConfiguredServiceIndex()
+    {
+        var handler = new StubHandler();
+        handler.Add(
+            "feed.example.test/v3/index.json",
+            """{"resources":[{"@type":"PackageBaseAddress/3.0.0","@id":"https://content.example.test/flat/"}]}""");
+        handler.Add(
+            "content.example.test/flat/testpackage/1.0.0/testpackage.nuspec",
+            """<?xml version="1.0"?><package><metadata><id>TestPackage</id><version>1.0.0</version></metadata></package>""");
+        using var client = new HttpClient(handler);
+        var sourceOptions = new NuGetSourceOptions
+        {
+            Sources = ["https://feed.example.test/v3/index.json"]
+        };
+
+        string? nuspec = await PackageExtractor.TryGetNuspecXmlAsync(
+            client,
+            "TestPackage",
+            "1.0.0",
+            sourceOptions: sourceOptions);
+
+        Assert.Contains("<id>TestPackage</id>", nuspec);
+    }
+
     /// <summary>
     /// HTTP handler that throws on any request — proves no network call was attempted.
     /// </summary>

--- a/src/DotnetInspector.Services.Tests/PackageMetadataServiceTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackageMetadataServiceTests.cs
@@ -173,6 +173,26 @@ public class PackageMetadataServiceTests : IDisposable
             StringComparison.Ordinal));
     }
 
+    [Fact]
+    public async Task FetchAllMetadataAsync_FileSourceNamedApiNuGetOrgDoesNotQueryNuGetOrg()
+    {
+        var handler = new CountingHandler();
+        var sourceOptions = new NuGetSourceOptions
+        {
+            Sources = ["file://api.nuget.org/private-feed"]
+        };
+
+        var result = await PackageMetadataService.FetchAllMetadataAsync(
+            new HttpClient(handler),
+            "Private.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: sourceOptions);
+
+        Assert.Equal(0, handler.RequestCount);
+        Assert.Null(result.Published);
+    }
+
     private sealed class FailingHandler : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(

--- a/src/DotnetInspector.Services.Tests/PackageMetadataServiceTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackageMetadataServiceTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using DotnetInspector.Core;
+using DotnetInspector.Packages;
 
 namespace DotnetInspector.Services.Tests;
 
@@ -145,12 +146,51 @@ public class PackageMetadataServiceTests : IDisposable
         Assert.Equal(published, result);
     }
 
+    [Fact]
+    public async Task FetchAllMetadataAsync_CustomSourceDoesNotQueryNuGetOrg()
+    {
+        var handler = new CountingHandler();
+        var messages = new List<string>();
+        MetadataFieldCache.Set(
+            "private.package@1.0.0",
+            new PackageMetadata { Published = DateTimeOffset.UnixEpoch });
+        var sourceOptions = new NuGetSourceOptions
+        {
+            Sources = [Path.Combine(Path.GetTempPath(), $"feed-{Guid.NewGuid():N}")]
+        };
+
+        var result = await PackageMetadataService.FetchAllMetadataAsync(
+            new HttpClient(handler),
+            "Private.Package",
+            "1.0.0",
+            messages.Add,
+            sourceOptions: sourceOptions);
+
+        Assert.Equal(0, handler.RequestCount);
+        Assert.Null(result.Published);
+        Assert.Contains(messages, message => message.Contains(
+            "configured package sources do not include api.nuget.org",
+            StringComparison.Ordinal));
+    }
+
     private sealed class FailingHandler : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
             throw new HttpRequestException($"Network access not allowed in test: {request.RequestUri}");
+        }
+    }
+
+    private sealed class CountingHandler : HttpMessageHandler
+    {
+        public int RequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
         }
     }
 }

--- a/src/DotnetInspector.Services/PackageMetadataService.cs
+++ b/src/DotnetInspector.Services/PackageMetadataService.cs
@@ -57,7 +57,7 @@ public static class PackageMetadataService
                 }
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not NetworkPolicyException)
         {
             log?.Invoke($"Error fetching publish date: {ex.Message}");
         }
@@ -114,6 +114,8 @@ public static class PackageMetadataService
     {
         bool supported = NuGetSourceResolver.ResolveSources(sourceOptions).Any(source =>
             Uri.TryCreate(source.Url, UriKind.Absolute, out var uri)
+            && (uri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+                || uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
             && uri.Host.Equals("api.nuget.org", StringComparison.OrdinalIgnoreCase));
         if (!supported)
         {
@@ -158,7 +160,7 @@ public static class PackageMetadataService
                 }
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not NetworkPolicyException)
         {
             log?.Invoke($"Error fetching registration metadata: {ex.Message}");
         }
@@ -185,7 +187,7 @@ public static class PackageMetadataService
                     }
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not NetworkPolicyException)
             {
                 log?.Invoke($"Error fetching catalog entry: {ex.Message}");
             }
@@ -254,7 +256,7 @@ public static class PackageMetadataService
                 }
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not NetworkPolicyException)
         {
             log?.Invoke($"Error fetching search metadata: {ex.Message}");
         }
@@ -268,7 +270,7 @@ public static class PackageMetadataService
                 metadata.Vulnerabilities = vulnerabilities;
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not NetworkPolicyException)
         {
             log?.Invoke($"Error fetching vulnerability data: {ex.Message}");
         }
@@ -287,7 +289,7 @@ public static class PackageMetadataService
                 metadata.PackageSize = contentLength;
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not NetworkPolicyException)
         {
             log?.Invoke($"Error fetching package size: {ex.Message}");
         }
@@ -433,7 +435,7 @@ public static class PackageMetadataService
                     vuln.Severity = char.ToUpper(sev[0]) + sev[1..].ToLower();
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not NetworkPolicyException)
         {
             log?.Invoke($"Error fetching GitHub advisory: {ex.Message}");
         }

--- a/src/DotnetInspector.Services/PackageMetadataService.cs
+++ b/src/DotnetInspector.Services/PackageMetadataService.cs
@@ -13,10 +13,17 @@ public static class PackageMetadataService
     /// <summary>
     /// Gets the published date for a specific package version.
     /// </summary>
-    public static async Task<DateTimeOffset?> GetPublishedDateAsync(HttpClient client, string packageName, string version, Action<string>? log)
+    public static async Task<DateTimeOffset?> GetPublishedDateAsync(
+        HttpClient client,
+        string packageName,
+        string version,
+        Action<string>? log,
+        NuGetSourceOptions? sourceOptions = null)
     {
         var normalizedName = packageName.ToLowerInvariant();
         var cacheKey = $"{normalizedName}@{version}";
+        if (!SupportsNuGetOrgMetadata(sourceOptions, log))
+            return null;
         PackageMetadata? cached;
         using (NetworkTelemetry.Scope(NetworkTrafficKind.PackageMetadata))
         {
@@ -63,10 +70,17 @@ public static class PackageMetadataService
     /// Results are cached on disk; use <paramref name="forceLatest"/> to bypass the cache.
     /// </summary>
     public static async Task<PackageMetadata> FetchAllMetadataAsync(
-        HttpClient client, string packageName, string version, Action<string>? log, bool forceLatest = false)
+        HttpClient client,
+        string packageName,
+        string version,
+        Action<string>? log,
+        bool forceLatest = false,
+        NuGetSourceOptions? sourceOptions = null)
     {
         var normalizedName = packageName.ToLowerInvariant();
         string cacheKey = $"{normalizedName}@{version}";
+        if (!SupportsNuGetOrgMetadata(sourceOptions, log))
+            return new PackageMetadata();
 
         // Try cache first (unless @latest forces refresh)
         if (!forceLatest)
@@ -92,6 +106,21 @@ public static class PackageMetadataService
         }
 
         return metadata;
+    }
+
+    internal static bool SupportsNuGetOrgMetadata(
+        NuGetSourceOptions? sourceOptions,
+        Action<string>? log = null)
+    {
+        bool supported = NuGetSourceResolver.ResolveSources(sourceOptions).Any(source =>
+            Uri.TryCreate(source.Url, UriKind.Absolute, out var uri)
+            && uri.Host.Equals("api.nuget.org", StringComparison.OrdinalIgnoreCase));
+        if (!supported)
+        {
+            log?.Invoke(
+                "NuGet.org aggregate metadata is unavailable because the configured package sources do not include api.nuget.org.");
+        }
+        return supported;
     }
 
     private static async Task<PackageMetadata> FetchAllMetadataFromNetworkAsync(

--- a/src/dotnet-inspect.Tests/HttpClientFactoryTests.cs
+++ b/src/dotnet-inspect.Tests/HttpClientFactoryTests.cs
@@ -135,18 +135,30 @@ public class HttpClientFactoryTests : IDisposable
     }
 
     [Fact]
-    public async Task EnableNetworkTrafficLogging_PrintsPolicyErrorForUnallowedVulnerabilityTraffic()
+    public async Task NetworkPolicy_BlocksUnallowedVulnerabilityTrafficAfterRecordingIt()
     {
-        var stderr = await CaptureTrafficLogAsync(
-            NetworkTrafficKind.VulnerabilityData,
-            allowTrafficKind: false);
+        using var error = new StringWriter();
+        var transport = new StubHttpMessageHandler();
+        using (DotnetInspector.Core.HttpClientFactory.EnableNetworkTrafficLogging(error))
+        using (var client = new HttpClient(new NetworkTelemetryHandler(
+            transport,
+            NetworkClientKinds.Shared)))
+        using (NetworkTelemetry.Scope(NetworkTrafficKind.VulnerabilityData))
+        {
+            var exception = await Assert.ThrowsAsync<NetworkPolicyException>(() => client.GetAsync(
+                "https://api.nuget.org/v3/vulnerabilities/index.json",
+                TestContext.Current.CancellationToken));
+            Assert.Contains("requires explicit capability authorization", exception.Message);
+        }
 
+        var stderr = error.ToString();
         Assert.Contains(
             "Network traffic [vulnerability-data]: GET https://api.nuget.org/v3/vulnerabilities/index.json",
             stderr);
         Assert.Contains(
             "Network policy error [vulnerability-data]: NuGet vulnerability service was accessed outside detailed view or an explicit network-using section",
             stderr);
+        Assert.Equal(0, transport.RequestCount);
     }
 
     [Fact]
@@ -308,9 +320,14 @@ public class HttpClientFactoryTests : IDisposable
 
     private sealed class StubHttpMessageHandler : HttpMessageHandler
     {
+        public int RequestCount { get; private set; }
+
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
-            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        {
+            RequestCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
     }
 }

--- a/src/dotnet-inspect.Tests/HttpClientFactoryTests.cs
+++ b/src/dotnet-inspect.Tests/HttpClientFactoryTests.cs
@@ -175,6 +175,43 @@ public class HttpClientFactoryTests : IDisposable
     }
 
     [Fact]
+    public async Task NetworkPolicy_VulnerabilityCapabilityAllowsAdvisoryTraffic()
+    {
+        using var error = new StringWriter();
+        var transport = new StubHttpMessageHandler();
+        using (DotnetInspector.Core.HttpClientFactory.EnableNetworkTrafficLogging(error))
+        using (var client = new HttpClient(new NetworkTelemetryHandler(
+            transport,
+            NetworkClientKinds.Shared)))
+        using (NetworkTelemetry.Allow(NetworkTrafficKind.VulnerabilityData))
+        using (NetworkTelemetry.Scope(NetworkTrafficKind.AdvisoryData))
+        using (var response = await client.GetAsync(
+            "https://api.github.com/advisories/GHSA-test",
+            TestContext.Current.CancellationToken))
+        {
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        Assert.DoesNotContain("Network policy error", error.ToString());
+        Assert.Equal(1, transport.RequestCount);
+    }
+
+    [Fact]
+    public async Task NetworkPolicy_BlocksAdvisoryTrafficWithoutVulnerabilityCapability()
+    {
+        var transport = new StubHttpMessageHandler();
+        using var client = new HttpClient(new NetworkTelemetryHandler(
+            transport,
+            NetworkClientKinds.Shared));
+        using var trafficScope = NetworkTelemetry.Scope(NetworkTrafficKind.AdvisoryData);
+
+        await Assert.ThrowsAsync<NetworkPolicyException>(() => client.GetAsync(
+            "https://api.github.com/advisories/GHSA-test",
+            TestContext.Current.CancellationToken));
+        Assert.Equal(0, transport.RequestCount);
+    }
+
+    [Fact]
     public void RequestMermaidDiagram_RendersObservedTrafficSequence()
     {
         using var diagram = RequestMermaidDiagram.Start();

--- a/src/dotnet-inspect.Tests/RidPackageVerifierTests.cs
+++ b/src/dotnet-inspect.Tests/RidPackageVerifierTests.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using System.Text;
+using DotnetInspector.Core;
+using DotnetInspector.Inspectors;
+using DotnetInspector.Models;
+using DotnetInspector.Output;
+using DotnetInspector.Packages;
+
+namespace DotnetInspector.Tests;
+
+public class RidPackageVerifierTests
+{
+    [Fact]
+    public async Task VerifyAsync_UsesConfiguredV3Source()
+    {
+        CoreCache.Initialize("dotnet-inspect-test");
+        var handler = new StubHandler();
+        handler.Add(
+            "feed.example.test/v3/index.json",
+            """{"resources":[{"@type":"PackageBaseAddress/3.0.0","@id":"https://content.example.test/flat/"}]}""");
+        handler.Add(
+            "content.example.test/flat/testpackage.linux-x64/1.0.0/testpackage.linux-x64.nuspec",
+            """<?xml version="1.0"?><package><metadata><id>TestPackage.linux-x64</id><version>1.0.0</version></metadata></package>""");
+        using var client = new HttpClient(handler);
+        var result = new InspectionResult
+        {
+            RuntimeIdentifierPackages =
+            [
+                new RidPackageReference
+                {
+                    RuntimeIdentifier = "linux-x64",
+                    PackageId = "TestPackage.linux-x64"
+                }
+            ]
+        };
+
+        await RidPackageVerifier.VerifyAsync(
+            client,
+            result,
+            "1.0.0",
+            localDir: null,
+            logger: new VerboseLogger(enabled: false),
+            sourceOptions: new NuGetSourceOptions { Sources = ["https://feed.example.test/v3/index.json"] });
+
+        Assert.True(
+            Assert.Single(result.RuntimeIdentifierPackages).Exists,
+            string.Join(Environment.NewLine, handler.Requests));
+        Assert.DoesNotContain(handler.Requests, request =>
+            request.Host.Equals("api.nuget.org", StringComparison.OrdinalIgnoreCase));
+    }
+
+    sealed class StubHandler : HttpMessageHandler
+    {
+        readonly List<(string Match, string Body)> _routes = [];
+
+        public List<Uri> Requests { get; } = [];
+
+        public void Add(string match, string body) => _routes.Add((match, body));
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests.Add(request.RequestUri!);
+            var route = _routes.FirstOrDefault(candidate =>
+                request.RequestUri!.ToString().Contains(candidate.Match, StringComparison.Ordinal));
+            return Task.FromResult(route == default
+                ? new HttpResponseMessage(HttpStatusCode.NotFound)
+                : new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(route.Body, Encoding.UTF8, "application/xml")
+                });
+        }
+    }
+}

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -417,9 +417,7 @@ public class PackageCommand
 
             bool wantsSignals = options.IncludeSections?.Contains(PackageSections.Signals) == true
                 || DiscoverRequestsSection(options.Discover, PackageSections.Signals, pipeline);
-            bool allowsVulnerabilityTraffic = options.Verbosity >= Verbosity.Detailed
-                || options.IncludeSections?.Any(IsNetworkUsingPackageSection) == true;
-            using var vulnerabilityTrafficScope = allowsVulnerabilityTraffic
+            using var vulnerabilityTrafficScope = AllowsVulnerabilityTraffic(options)
                 ? NetworkTelemetry.Allow(NetworkTrafficKind.VulnerabilityData)
                 : null;
 
@@ -1212,6 +1210,9 @@ public class PackageCommand
 
             bool wantsSignals = options.IncludeSections?.Contains(PackageSections.Signals) == true
                 || DiscoverRequestsSection(options.Discover, PackageSections.Signals, PackageSectionDescriptors.CreatePipeline());
+            using var vulnerabilityTrafficScope = AllowsVulnerabilityTraffic(options)
+                ? NetworkTelemetry.Allow(NetworkTrafficKind.VulnerabilityData)
+                : null;
             var result = await PackageInspector.InspectAsync(
                 extractPath,
                 target.PackageName,
@@ -1756,6 +1757,10 @@ public class PackageCommand
         section.Equals(PackageSections.Signals, StringComparison.OrdinalIgnoreCase)
         || section.Equals(PackageSections.Statistics, StringComparison.OrdinalIgnoreCase)
         || section.Equals(PackageSections.Vulnerabilities, StringComparison.OrdinalIgnoreCase);
+
+    private static bool AllowsVulnerabilityTraffic(InspectionOptions options) =>
+        options.Verbosity >= Verbosity.Detailed
+        || options.IncludeSections?.Any(IsNetworkUsingPackageSection) == true;
 
     private static bool ValidatePackageLibraryMode(InspectionOptions options)
     {

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -428,7 +428,8 @@ public class PackageCommand
                 target.IsLocalFile ? target.OriginalArgument : null,
                 nuspec, client, logger, options.ForceLatest, options.Verbosity,
                 resolution.NupkgPath,
-                fetchMetadata: wantsSignals);
+                fetchMetadata: wantsSignals,
+                sourceOptions: options.SourceOptions);
 
             // Apply package size (not cached in index — comes from nupkg file)
             if (packageSize.HasValue)
@@ -469,7 +470,8 @@ public class PackageCommand
             }
 
             if (wantsSignals)
-                await AuditSignalBuilder.PopulatePackageAuditAsync(result, client, logger);
+                await AuditSignalBuilder.PopulatePackageAuditAsync(
+                    result, client, logger, options.SourceOptions);
 
             // Output results
             if (effectiveDiscovery)
@@ -1222,7 +1224,8 @@ public class PackageCommand
                 options.ForceLatest,
                 options.Verbosity,
                 resolution.NupkgPath,
-                fetchMetadata: wantsSignals);
+                fetchMetadata: wantsSignals,
+                sourceOptions: options.SourceOptions);
 
             if (packageSize.HasValue)
                 result.PackageSize = packageSize;
@@ -1236,7 +1239,8 @@ public class PackageCommand
             {
                 result.BinarySignals = await PackageInspector.ScanBinarySignalsAsync(
                     extractPath, target.PackageName, version, context.HttpClient, logger, acquirePdb: true);
-                await AuditSignalBuilder.PopulatePackageAuditAsync(result, context.HttpClient, logger);
+                await AuditSignalBuilder.PopulatePackageAuditAsync(
+                    result, context.HttpClient, logger, options.SourceOptions);
             }
 
             return result;

--- a/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
+++ b/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
@@ -58,12 +58,14 @@ internal static class AuditSignalBuilder
     public static async Task PopulatePackageAuditAsync(
         InspectionResult result,
         HttpClient httpClient,
-        VerboseLogger logger)
+        VerboseLogger logger,
+        NuGetSourceOptions? sourceOptions = null)
     {
         List<AuditSignal> signals = [];
 
         var directDependencies = GetDirectDependenciesForLatestTfm(result);
-        var dependencySignals = await GetDependencySignalsAsync(directDependencies.Dependencies, httpClient, logger);
+        var dependencySignals = await GetDependencySignalsAsync(
+            directDependencies.Dependencies, httpClient, logger, sourceOptions);
         var context = new PackageSignalContext(result, directDependencies, dependencySignals);
         AddPackageSignals(signals, in context);
 
@@ -80,7 +82,8 @@ internal static class AuditSignalBuilder
     private static async Task<DependencySignalSummary> GetDependencySignalsAsync(
         List<PackageDependency> directDependencies,
         HttpClient httpClient,
-        VerboseLogger logger)
+        VerboseLogger logger,
+        NuGetSourceOptions? sourceOptions)
     {
         List<int> ages = [];
         int checkedDependencies = 0;
@@ -93,7 +96,7 @@ internal static class AuditSignalBuilder
                 continue;
 
             var metadata = await PackageMetadataService.FetchAllMetadataAsync(
-                httpClient, dep.Id, version, logger.Log).ConfigureAwait(false);
+                httpClient, dep.Id, version, logger.Log, sourceOptions: sourceOptions).ConfigureAwait(false);
             checkedDependencies++;
 
             if (metadata.Vulnerabilities is { Count: > 0 })

--- a/src/dotnet-inspect/Inspectors/PackageInspector.cs
+++ b/src/dotnet-inspect/Inspectors/PackageInspector.cs
@@ -4,6 +4,7 @@ using DotnetInspector.Core;
 using DotnetInspector.Models;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
+using DotnetInspector.Packages;
 using DotnetInspector.Services;
 
 namespace DotnetInspector.Inspectors;
@@ -26,7 +27,8 @@ internal static class PackageInspector
         bool forceLatest = false,
         Verbosity verbosity = Verbosity.Minimal,
         string? nupkgPath = null,
-        bool fetchMetadata = false)
+        bool fetchMetadata = false,
+        NuGetSourceOptions? sourceOptions = null)
     {
         fetchMetadata = !isLocalFile && (fetchMetadata || verbosity >= Verbosity.Detailed);
 
@@ -42,7 +44,8 @@ internal static class PackageInspector
             {
                 if (fetchMetadata)
                 {
-                    var metadata = await PackageMetadataService.FetchAllMetadataAsync(httpClient, packageName, version, logger.Log, forceLatest);
+                    var metadata = await PackageMetadataService.FetchAllMetadataAsync(
+                        httpClient, packageName, version, logger.Log, forceLatest, sourceOptions);
                     ApplyMetadata(cached, metadata);
                 }
                 return cached;
@@ -129,7 +132,8 @@ internal static class PackageInspector
         if (result.IsRidSpecificPointerPackage && result.RuntimeIdentifierPackages is { Count: > 0 })
         {
             string? localDir = isLocalFile ? Path.GetDirectoryName(Path.GetFullPath(localFilePath!)) : null;
-            await RidPackageVerifier.VerifyAsync(httpClient, result, result.Version, localDir, logger);
+            await RidPackageVerifier.VerifyAsync(
+                httpClient, result, result.Version, localDir, logger, sourceOptions);
         }
 
         // Extract build date from nupkg (only on cache miss)
@@ -148,7 +152,8 @@ internal static class PackageInspector
         // Fetch package metadata from NuGet (only at detailed verbosity)
         if (fetchMetadata)
         {
-            var metadata = await PackageMetadataService.FetchAllMetadataAsync(httpClient, packageName, version, logger.Log, forceLatest);
+            var metadata = await PackageMetadataService.FetchAllMetadataAsync(
+                httpClient, packageName, version, logger.Log, forceLatest, sourceOptions);
             ApplyMetadata(result, metadata);
         }
 

--- a/src/dotnet-inspect/Inspectors/RidPackageVerifier.cs
+++ b/src/dotnet-inspect/Inspectors/RidPackageVerifier.cs
@@ -1,4 +1,3 @@
-using DotnetInspector.Core;
 using DotnetInspector.Models;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
@@ -15,7 +14,8 @@ public static class RidPackageVerifier
         InspectionResult result,
         string version,
         string? localDir,
-        VerboseLogger logger)
+        VerboseLogger logger,
+        NuGetSourceOptions? sourceOptions = null)
     {
         if (result.RuntimeIdentifierPackages == null)
             return;
@@ -34,25 +34,24 @@ public static class RidPackageVerifier
             }
             else
             {
-                // Remote verification: check NuGet API with retry
-                string packageId = ridPkg.PackageId.ToLowerInvariant();
-                string checkVersion = version.ToLowerInvariant();
-                string url = $"https://api.nuget.org/v3-flatcontainer/{packageId}/{checkVersion}/{packageId}.nuspec";
-
                 try
                 {
-                    using var response = await HttpRetryHelper.HeadWithRetryAsync(
-                        client, url,
-                        trafficKind: NetworkTrafficKind.RidPackageProbe);
-                    ridPkg.Exists = response != null && response.IsSuccessStatusCode;
+                    string? nuspec = await PackageExtractor.TryGetNuspecXmlAsync(
+                        client,
+                        ridPkg.PackageId,
+                        version,
+                        logger.Log,
+                        sourceOptions);
+                    ridPkg.Exists = nuspec is not null;
 
                     string status = ridPkg.Exists == true ? "available" : "NOT FOUND";
                     logger.Log($"  {ridPkg.RuntimeIdentifier}: {status} ({ridPkg.PackageId} {version})");
                 }
-                catch
+                catch (Exception ex)
                 {
                     ridPkg.Exists = false;
-                    logger.Log($"  {ridPkg.RuntimeIdentifier}: ERROR checking ({ridPkg.PackageId} {version})");
+                    logger.Log(
+                        $"  {ridPkg.RuntimeIdentifier}: ERROR checking ({ridPkg.PackageId} {version}): {ex.Message}");
                 }
             }
         }


### PR DESCRIPTION
## Summary

Enforce package network capability policy at the shared HTTP seam and keep configured package sources authoritative.

- blocks vulnerability and GitHub advisory traffic unless the selected view explicitly authorizes the shared vulnerability capability
- applies the same authorization to single- and multi-package inspection
- prevents custom/file sources named `api.nuget.org` from enabling NuGet.org aggregate metadata
- keeps `NetworkPolicyException` visible instead of converting policy violations into empty metadata
- routes package metadata and RID companion verification through the configured source set

Fixes #2897.

## Duplicate check

No open or recently merged PR implements this issue. The recent Softserve redirect, classic-corpus, and tuple-switch branches were excluded because their work already merged as #2904, #2888, and #2901.

## Validation

- solution build
- Services tests: 266 passed
- focused changed tests: 54 passed
- markdownlint on README and changed design docs
- full CLI tests reached two unrelated P/Invoke rendering failures; both reproduce unchanged on `origin/main`

## Adversarial review

Round one used isolated worktrees and the same threat-focused prompt:

- Claude Opus found that multi-package detailed inspection lacked the vulnerability authorization scope and silently dropped known CVEs.
- Gemini Pro independently found the same multi-package false-negative, plus a `file://api.nuget.org` source spoof and GitHub advisory traffic outside the vulnerability capability.

Resolved in `a21a96cd` by sharing the authorization predicate across command paths, binding advisory traffic to the vulnerability capability, requiring HTTP(S) NuGet.org sources, propagating policy exceptions, and adding focused regressions.

Fixed-head review:

- Gemini Pro: clean on `a21a96cd`, including a real multi-package CVE run.
- MAI-Code: clean on `a21a96cd`. It reproduced a partial/full metadata-cache collision, then confirmed that behavior is unchanged on `origin/main` and is pre-existing rather than introduced here.
