### PR TITLE
Widen Annotation to IAnnotation/Annotation<T>; migrate AllocationOccurrenceFactProducer

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AllocationOccurrenceFactTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AllocationOccurrenceFactTests.cs
@@ -7,10 +7,10 @@ namespace ILInspector.Decompiler.Tests;
 
 public class AllocationOccurrenceFactTests
 {
-    static IReadOnlyList<Annotation> Classify(string methodName)
+    static IReadOnlyList<IAnnotation> Classify(string methodName)
         => Classify(methodName, resolver: null);
 
-    static IReadOnlyList<Annotation> Classify(string methodName, ILInspector.Metadata.IAssemblyReferenceResolver? resolver)
+    static IReadOnlyList<IAnnotation> Classify(string methodName, ILInspector.Metadata.IAssemblyReferenceResolver? resolver)
     {
         var source = resolver is null
             ? MetadataSource.Open(typeof(AllocSampleClass).Assembly.Location)
@@ -25,7 +25,7 @@ public class AllocationOccurrenceFactTests
     // default sibling resolver cannot find corelib beside the test assembly.
     static readonly ILInspector.Metadata.IAssemblyReferenceResolver RuntimeResolver = TestAssemblyReferenceResolvers.RuntimeAssemblies();
 
-    static IReadOnlyList<string> Ids(IReadOnlyList<Annotation> annotations)
+    static IReadOnlyList<string> Ids(IReadOnlyList<IAnnotation> annotations)
         => annotations.Select(a => a.Descriptor.Id).ToList();
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/AllocationOccurrenceFactTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AllocationOccurrenceFactTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using ILInspector.Analysis;
 using ILInspector.Decompiler.Annotations;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Research;
@@ -39,6 +40,24 @@ public class AllocationOccurrenceFactTests
         Assert.Equal("int; alloc=boxed System.Int32; path=straight-line; path-confidence=dominates-return; post-dominance=return-post-dominates; escape=escapes; escape-kind=escapes-return; multiplicity=once", box.Detail);
         Assert.True(box.SourceOffset >= 0, "the annotation should carry IL provenance");
         Assert.Equal(AnnotationCategory.Allocation, box.Descriptor.Category);
+    }
+
+    [Fact]
+    public void Box_CarriesItsTypedPayload_NotJustAFlattenedDetailString()
+    {
+        // The producer must hand back the Annotation<T> atom -- not the legacy
+        // string-only Annotation -- so a typed consumer (e.g. future identity
+        // diffing) can read the AllocationOccurrence directly instead of
+        // re-parsing Detail.
+        var annotations = Classify(nameof(AllocSampleClass.BoxInt));
+        var box = Assert.Single(annotations, a => a.Descriptor.Id == "alloc.box");
+
+        var typed = Assert.IsType<Annotation<AllocationOccurrence>>(box);
+        Assert.Equal(AllocationKind.Box, typed.Payload.Kind);
+        Assert.Equal(typed.SourceOffset, typed.Payload.ILOffset);
+        // Detail is a computed projection of Payload through Formatter, not a
+        // stored field independently settable from it.
+        Assert.Equal(typed.Formatter!(typed.Payload), typed.Detail);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationAnchorTests.cs
@@ -9,7 +9,7 @@ public class AnnotationAnchorTests
 {
     // Classify the imported tree, then raise it in place and anchor the
     // annotations onto the raised statements — the real pipeline order.
-    static (IrFunction Raised, IReadOnlyDictionary<IrNode, IReadOnlyList<Annotation>> Map) AnchorFor(string methodName)
+    static (IrFunction Raised, IReadOnlyDictionary<IrNode, IReadOnlyList<IAnnotation>> Map) AnchorFor(string methodName)
     {
         var source = MetadataSource.Open(typeof(AllocSampleClass).Assembly.Location);
         var function = IrImporter.Import(source, typeof(AllocSampleClass).FullName!, methodName);

--- a/src/ILInspector.Decompiler.Tests/AnnotationStructuredViewTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationStructuredViewTests.cs
@@ -13,7 +13,7 @@ public class AnnotationStructuredViewTests
         return IrImporter.Import(source, typeof(AllocSampleClass).FullName!, methodName)!;
     }
 
-    static IReadOnlyList<Annotation> Collect(string methodName)
+    static IReadOnlyList<IAnnotation> Collect(string methodName)
     {
         var source = MetadataSource.Open(typeof(AllocSampleClass).Assembly.Location);
         return ResearchViews.CollectFacts(source, typeof(AllocSampleClass).FullName!, methodName);

--- a/src/ILInspector.Decompiler.Tests/LifetimeClassifierTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LifetimeClassifierTests.cs
@@ -6,7 +6,7 @@ namespace ILInspector.Decompiler.Tests;
 
 public class LifetimeClassifierTests
 {
-    static IReadOnlyList<Annotation> Classify(string methodName)
+    static IReadOnlyList<IAnnotation> Classify(string methodName)
     {
         var source = MetadataSource.Open(typeof(LifetimeSampleClass).Assembly.Location);
         return ResearchViews.CollectFacts(source, typeof(LifetimeSampleClass).FullName!, methodName)

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -71,7 +71,7 @@ public class UnsafeEmitterTests
     static string DecompileLegacySimulate(string method) =>
         DecompileSimulate(typeof(LegacyFixtures).Assembly.Location, typeof(LegacyFixtures).FullName!, method);
 
-    static (IrFunction Function, IReadOnlyList<Annotation> Annotations) ClassifyNew(string method)
+    static (IrFunction Function, IReadOnlyList<IAnnotation> Annotations) ClassifyNew(string method)
     {
         var source = MetadataSource.Open(typeof(NewFixtures).Assembly.Location);
         var function = IrImporter.Import(source, typeof(NewFixtures).FullName!, method);

--- a/src/ILInspector.Decompiler.Tests/UnsafetyMixedTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafetyMixedTests.cs
@@ -6,7 +6,7 @@ namespace ILInspector.Decompiler.Tests;
 
 public class UnsafetyMixedTests
 {
-    static IReadOnlyList<Annotation> Classify(string methodName)
+    static IReadOnlyList<IAnnotation> Classify(string methodName)
     {
         var source = MetadataSource.Open(typeof(MixedSampleClass).Assembly.Location);
         return ResearchViews.CollectFacts(source, typeof(MixedSampleClass).FullName!, methodName)

--- a/src/ILInspector.Decompiler.Tests/UnsafetyOccurrenceFactTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafetyOccurrenceFactTests.cs
@@ -1,3 +1,4 @@
+using ILInspector.Analysis;
 using ILInspector.Decompiler.Annotations;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Research;
@@ -19,6 +20,23 @@ public class UnsafetyOccurrenceFactTests
     {
         var facts = Classify(nameof(UnsafeSampleClass.ReadPtr));
         Assert.Contains(facts, f => f.Descriptor.Id == "unsafe.deref" && f.Detail == "int");
+    }
+
+    [Fact]
+    public void PointerRead_CarriesItsTypedPayload_NotJustAFlattenedDetailString()
+    {
+        // Same contract as Annotation<AllocationOccurrence>: the producer must
+        // hand back the typed atom -- Method identity in particular, which the
+        // legacy Annotation(Descriptor, ILOffset, Detail) shape discarded
+        // entirely -- not just the pre-flattened string.
+        var facts = Classify(nameof(UnsafeSampleClass.ReadPtr));
+        var deref = Assert.Single(facts, f => f.Descriptor.Id == "unsafe.deref");
+
+        var typed = Assert.IsType<Annotation<UnsafetyOccurrence>>(deref);
+        Assert.Equal(UnsafetyKind.Deref, typed.Payload.Kind);
+        Assert.Equal(typed.SourceOffset, typed.Payload.ILOffset);
+        Assert.Equal(nameof(UnsafeSampleClass.ReadPtr), typed.Payload.Method.Name);
+        Assert.Equal(typed.Formatter!(typed.Payload), typed.Detail);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/UnsafetyOccurrenceFactTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafetyOccurrenceFactTests.cs
@@ -6,7 +6,7 @@ namespace ILInspector.Decompiler.Tests;
 
 public class UnsafetyOccurrenceFactTests
 {
-    static IReadOnlyList<Annotation> Classify(string methodName)
+    static IReadOnlyList<IAnnotation> Classify(string methodName)
     {
         var source = MetadataSource.Open(typeof(UnsafeSampleClass).Assembly.Location);
         return ResearchViews.CollectFacts(source, typeof(UnsafeSampleClass).FullName!, methodName)

--- a/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationAnchor.cs
@@ -20,12 +20,12 @@ public static class AnnotationAnchor
     /// statement range covers binds to the nearest preceding statement, so it is
     /// never dropped (positive-only: a fact is always shown somewhere).
     /// </summary>
-    public static IReadOnlyDictionary<IrNode, IReadOnlyList<Annotation>> Anchor(
-        IrFunction raised, IReadOnlyList<Annotation> annotations)
+    public static IReadOnlyDictionary<IrNode, IReadOnlyList<IAnnotation>> Anchor(
+        IrFunction raised, IReadOnlyList<IAnnotation> annotations)
     {
         var statements = ComputeSpans(raised);
 
-        var map = new Dictionary<IrNode, List<Annotation>>();
+        var map = new Dictionary<IrNode, List<IAnnotation>>();
         foreach (var annotation in annotations)
         {
             var owner = Best(statements, annotation.SourceOffset);
@@ -38,7 +38,7 @@ public static class AnnotationAnchor
 
         return map.ToDictionary(
             entry => entry.Key,
-            entry => (IReadOnlyList<Annotation>)[.. entry.Value.OrderBy(a => a.SourceOffset)]);
+            entry => (IReadOnlyList<IAnnotation>)[.. entry.Value.OrderBy(a => a.SourceOffset)]);
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Annotations/AnnotationStructuredView.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationStructuredView.cs
@@ -17,7 +17,7 @@ namespace ILInspector.Decompiler.Annotations;
 /// </summary>
 public static class AnnotationStructuredView
 {
-    public static string Json(IReadOnlyList<Annotation> annotations)
+    public static string Json(IReadOnlyList<IAnnotation> annotations)
     {
         using var stream = new MemoryStream();
         using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
@@ -49,7 +49,7 @@ public static class AnnotationStructuredView
         return Encoding.UTF8.GetString(stream.ToArray());
     }
 
-    public static string Tsv(IReadOnlyList<Annotation> annotations)
+    public static string Tsv(IReadOnlyList<IAnnotation> annotations)
     {
         var sb = new StringBuilder();
         sb.Append("id\tcategory\tconditionality\toffset\tdetail\n");

--- a/src/ILInspector.Decompiler/Annotations/AnnotationText.cs
+++ b/src/ILInspector.Decompiler/Annotations/AnnotationText.cs
@@ -12,7 +12,7 @@ namespace ILInspector.Decompiler.Annotations;
 /// </summary>
 public static class AnnotationText
 {
-    public static string Format(Annotation fact)
+    public static string Format(IAnnotation fact)
     {
         var sb = new StringBuilder(fact.Descriptor.Id);
         if (!string.IsNullOrEmpty(fact.Detail))
@@ -22,7 +22,7 @@ public static class AnnotationText
         return sb.ToString();
     }
 
-    public static string Format(IReadOnlyList<Annotation> facts)
+    public static string Format(IReadOnlyList<IAnnotation> facts)
         => string.Join("; ", facts.Select(Format));
 
     static string Kebab(AnnotationConditionality conditionality) => conditionality switch

--- a/src/ILInspector.Decompiler/Annotations/Annotations.cs
+++ b/src/ILInspector.Decompiler/Annotations/Annotations.cs
@@ -93,6 +93,29 @@ public enum AnnotationStage
 public sealed record AnnotationDescriptor(string Id, AnnotationCategory Category, string Title);
 
 /// <summary>
+/// The non-generic observation contract, mirroring <c>IFinding</c>
+/// (<see cref="ILInspector.Findings"/>). A heterogeneous fact stream can carry
+/// <see cref="Annotation{T}"/> values with different payload types — and the
+/// legacy string-<see cref="Detail"/>-only <see cref="Annotation"/> atom —
+/// while every consumer (renderer, JSON/TSV projection, anchor) reads the same
+/// four members.
+/// </summary>
+public interface IAnnotation
+{
+    /// <summary>The fact family this occurrence belongs to.</summary>
+    AnnotationDescriptor Descriptor { get; }
+
+    /// <summary>IL offset of the originating instruction, or -1 when unknown (a synthetic node with no provenance).</summary>
+    int SourceOffset { get; }
+
+    /// <summary>How often the fact materialises at run time.</summary>
+    AnnotationConditionality Conditionality { get; }
+
+    /// <summary>Rendered specifics for this occurrence. Computed, never producer-flattened, for <see cref="Annotation{T}"/>.</summary>
+    string? Detail { get; }
+}
+
+/// <summary>
 /// One occurrence of a hidden fact. Positive-only and descriptive: it marks the
 /// presence of a fact, never the absence of others. Keyed to
 /// <see cref="SourceOffset"/> (an IL offset) so it projects onto both the IL
@@ -110,7 +133,34 @@ public sealed record Annotation(
     int SourceOffset,
     string? Detail = null,
     AnnotationConditionality Conditionality = AnnotationConditionality.Always,
-    IrNode? Node = null);
+    IrNode? Node = null) : IAnnotation;
+
+/// <summary>
+/// The typed atom: an occurrence that carries its producer's domain payload
+/// (e.g. <c>AllocationOccurrence</c>) instead of a pre-flattened
+/// <see cref="Detail"/> string, mirroring <c>Finding&lt;T&gt;</c>
+/// (<see cref="ILInspector.Findings"/>). <see cref="Detail"/> is a render-time
+/// projection of <see cref="Payload"/> through <see cref="Formatter"/>, so the
+/// structure survives for typed consumers (e.g. identity-diffing) and the
+/// rendered text is computed exactly once, in one place, rather than
+/// hand-joined by every producer. <see cref="Formatter"/> keeps this type
+/// domain-agnostic: the Decompiler layer never needs to know what a <c>T</c> is.
+/// </summary>
+/// <param name="Descriptor">The fact family this occurrence belongs to.</param>
+/// <param name="SourceOffset">IL offset of the originating instruction, or -1 when unknown.</param>
+/// <param name="Payload">The producer's typed domain evidence for this occurrence.</param>
+/// <param name="Conditionality">How often the fact materialises at run time. Defaults to <see cref="AnnotationConditionality.Always"/>.</param>
+/// <param name="Formatter">Renders <see cref="Payload"/> into the same detail text a hand-formatted <see cref="Annotation"/> would carry. Null yields no detail.</param>
+public sealed record Annotation<T>(
+    AnnotationDescriptor Descriptor,
+    int SourceOffset,
+    T Payload,
+    AnnotationConditionality Conditionality = AnnotationConditionality.Always,
+    Func<T, string?>? Formatter = null) : IAnnotation
+    where T : notnull
+{
+    public string? Detail => Formatter?.Invoke(Payload);
+}
 
 /// <summary>
 /// Produces hidden-fact annotations from the IR. The read-only dual of an

--- a/src/ILInspector.Decompiler/SourceLine.cs
+++ b/src/ILInspector.Decompiler/SourceLine.cs
@@ -50,7 +50,7 @@ public sealed record AnnotatedSourceLine(
     string Text,
     int Offset,
     SourceLineKind Kind,
-    IReadOnlyList<Annotation> Annotations)
+    IReadOnlyList<IAnnotation> Annotations)
 {
     /// <summary>A line with no annotations attached.</summary>
     public AnnotatedSourceLine(string Text, int Offset, SourceLineKind Kind)

--- a/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
@@ -373,12 +373,12 @@ public class ResearchFactRegistryTests
         string name,
         IReadOnlyList<string>? dependsOn = null,
         IReadOnlyList<string>? produces = null,
-        IReadOnlyList<Annotation>? facts = null) : IResearchFactProducer
+        IReadOnlyList<IAnnotation>? facts = null) : IResearchFactProducer
     {
         public string Name => name;
         public IReadOnlyList<string> Produces { get; } = produces ?? [];
         public IReadOnlyList<string> DependsOn { get; } = dependsOn ?? [];
-        public IReadOnlyList<Annotation> Produce(ResearchFactContext context) => facts ?? [];
+        public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context) => facts ?? [];
     }
 
     sealed class CountingProducer : IResearchFactProducer
@@ -391,7 +391,7 @@ public class ResearchFactRegistryTests
         public IReadOnlyList<string> Produces { get; } = ["cost.test", "semantics.test", "cost.header.test"];
         public IReadOnlyList<string> DependsOn => [];
 
-        public IReadOnlyList<Annotation> Produce(ResearchFactContext context)
+        public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context)
         {
             FactCollectCount++;
             AssemblyContext = context.Assembly;

--- a/src/ILInspector.Research/AllocationOccurrenceFactProducer.cs
+++ b/src/ILInspector.Research/AllocationOccurrenceFactProducer.cs
@@ -18,7 +18,7 @@ sealed class AllocationOccurrenceFactProducer : IResearchFactProducer
     public IReadOnlyList<string> Produces { get; } = ["alloc.*"];
     public IReadOnlyList<string> DependsOn => [];
 
-    public IReadOnlyList<Annotation> Produce(ResearchFactContext context)
+    public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context)
     {
         var function = context.Imported;
         if (function.AssemblyPath is not { Length: > 0 } path || function.MetadataToken == 0)
@@ -43,7 +43,7 @@ sealed class AllocationOccurrenceFactProducer : IResearchFactProducer
         return new FindingSubject(subject.Id, subject.Display);
     }
 
-    static Annotation ToAnnotation(AllocationOccurrence occurrence)
+    static Annotation<AllocationOccurrence> ToAnnotation(AllocationOccurrence occurrence)
     {
         var descriptor = occurrence.Kind switch
         {
@@ -61,7 +61,12 @@ sealed class AllocationOccurrenceFactProducer : IResearchFactProducer
             AllocationFrequency.PerIteration => AnnotationConditionality.PerIteration,
             _ => AnnotationConditionality.Always,
         };
-        return new Annotation(descriptor, occurrence.ILOffset, Detail(occurrence), conditionality, Node: null);
+        return new Annotation<AllocationOccurrence>(
+            descriptor,
+            occurrence.ILOffset,
+            occurrence,
+            conditionality,
+            Detail);
     }
 
     static string? Detail(AllocationOccurrence occurrence)

--- a/src/ILInspector.Research/CallSiteCostFactProducer.cs
+++ b/src/ILInspector.Research/CallSiteCostFactProducer.cs
@@ -16,7 +16,7 @@ sealed class CallSiteCostFactProducer : IResearchFactProducer
     public IReadOnlyList<string> Produces { get; } = ["cost.callee"];
     public IReadOnlyList<string> DependsOn { get; } = [];
 
-    public IReadOnlyList<Annotation> Produce(ResearchFactContext context)
+    public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context)
     {
         if (context.Assembly is not { } assembly || context.Imported.MetadataToken == 0)
             return [];

--- a/src/ILInspector.Research/CallSiteSemanticsFactProducer.cs
+++ b/src/ILInspector.Research/CallSiteSemanticsFactProducer.cs
@@ -14,7 +14,7 @@ sealed class CallSiteSemanticsFactProducer : IResearchFactProducer
     public IReadOnlyList<string> Produces { get; } = ["semantics.callee", "safety.callee"];
     public IReadOnlyList<string> DependsOn { get; } = [];
 
-    public IReadOnlyList<Annotation> Produce(ResearchFactContext context)
+    public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context)
     {
         if (context.Assembly is not { } assembly || context.Imported.MetadataToken == 0)
             return [];

--- a/src/ILInspector.Research/MethodHeaderLeverageFactProducer.cs
+++ b/src/ILInspector.Research/MethodHeaderLeverageFactProducer.cs
@@ -15,7 +15,7 @@ sealed class MethodHeaderLeverageFactProducer : IResearchFactProducer
     public IReadOnlyList<string> Produces { get; } = ["cost.method"];
     public IReadOnlyList<string> DependsOn { get; } = [];
 
-    public IReadOnlyList<Annotation> Produce(ResearchFactContext context) => [];
+    public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context) => [];
 
     public IReadOnlyList<ResearchHeaderFact> ProduceHeaderFacts(ResearchFactContext context)
     {

--- a/src/ILInspector.Research/ResearchFactRegistry.cs
+++ b/src/ILInspector.Research/ResearchFactRegistry.cs
@@ -62,7 +62,7 @@ public interface IResearchFactProducer
     string Name { get; }
     IReadOnlyList<string> Produces { get; }
     IReadOnlyList<string> DependsOn { get; }
-    IReadOnlyList<Annotation> Produce(ResearchFactContext context);
+    IReadOnlyList<IAnnotation> Produce(ResearchFactContext context);
     IReadOnlyList<ResearchHeaderFact> ProduceHeaderFacts(ResearchFactContext context) => [];
 }
 
@@ -87,7 +87,7 @@ public sealed class ResearchFactRegistry
         new MethodHeaderLeverageFactProducer(),
         new DecompilerLifetimeFactProducer());
 
-    public IReadOnlyList<Annotation> Collect(ResearchFactContext context)
+    public IReadOnlyList<IAnnotation> Collect(ResearchFactContext context)
         => [.. _producers.SelectMany(producer => producer.Produce(context)).OrderBy(fact => fact.SourceOffset).ThenBy(fact => fact.Descriptor.Id, StringComparer.Ordinal)];
 
     public IReadOnlyList<ResearchHeaderFact> CollectHeaderFacts(ResearchFactContext context)
@@ -126,6 +126,6 @@ sealed class DecompilerLifetimeFactProducer : IResearchFactProducer
     public IReadOnlyList<string> Produces { get; } = ["lifetime.*"];
     public IReadOnlyList<string> DependsOn => [];
 
-    public IReadOnlyList<Annotation> Produce(ResearchFactContext context)
+    public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context)
         => new Decompiler.Annotations.LifetimeClassifier().Classify(context.Imported);
 }

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -141,7 +141,7 @@ public static partial class ResearchViews
         }
     }
 
-    public static IReadOnlyList<Annotation> CollectFacts(
+    public static IReadOnlyList<IAnnotation> CollectFacts(
         MetadataSource source, string type, string method, int overloadIndex = 0, bool publicOnly = false,
         ResearchFactRegistry? registry = null)
     {
@@ -156,11 +156,11 @@ public static partial class ResearchViews
             registry);
     }
 
-    public static IReadOnlyList<Annotation> CollectFacts(
+    public static IReadOnlyList<IAnnotation> CollectFacts(
         MetadataSource source, IrFunction imported, ResearchFactRegistry? registry = null)
         => (registry ?? ResearchFactRegistry.Default).Collect(new ResearchFactContext(source, imported));
 
-    public static IReadOnlyList<Annotation> CollectFacts(
+    public static IReadOnlyList<IAnnotation> CollectFacts(
         MetadataSource source, IrFunction imported, ResearchAssemblyContext? assembly, ResearchFactRegistry? registry = null)
         => (registry ?? ResearchFactRegistry.Default).Collect(new ResearchFactContext(source, imported, assembly));
 
@@ -195,7 +195,7 @@ public static partial class ResearchViews
         string type,
         string method,
         IrFunction imported,
-        IReadOnlyList<Annotation> annotations,
+        IReadOnlyList<IAnnotation> annotations,
         AnnotationStage stage,
         int overloadIndex,
         bool publicOnly,
@@ -228,12 +228,12 @@ public static partial class ResearchViews
         IrFunction imported,
         string csText,
         IReadOnlyDictionary<IrNode, int> statementLines,
-        IReadOnlyList<Annotation> annotations,
+        IReadOnlyList<IAnnotation> annotations,
         IReadOnlyList<SourceLine> annotatedInstrLines)
     {
         var spans = AnnotationAnchor.ComputeSpans(imported);
 
-        var annotationsByLine = new Dictionary<int, List<Annotation>>();
+        var annotationsByLine = new Dictionary<int, List<IAnnotation>>();
         foreach (var annotation in annotations)
         {
             if (AnnotationAnchor.Best(spans, annotation.SourceOffset) is not { } owner)
@@ -264,7 +264,7 @@ public static partial class ResearchViews
         {
             var csLine = csLines[i];
             var lineAnnotations = annotationsByLine.TryGetValue(i, out var annos)
-                ? (IReadOnlyList<Annotation>)annos
+                ? (IReadOnlyList<IAnnotation>)annos
                 : [];
             stream.Add(new AnnotatedSourceLine(
                 csLine.Text,
@@ -331,7 +331,7 @@ public static partial class ResearchViews
         return sb.ToString().TrimEnd();
     }
 
-    static DecompilerResult RenderRaisedOverlay(IrFunction imported, IReadOnlyList<Annotation> annotations)
+    static DecompilerResult RenderRaisedOverlay(IrFunction imported, IReadOnlyList<IAnnotation> annotations)
     {
         var result = CSharpPrinter.PrintRaised(imported, out var statementLines);
         if (result.Output is not { } output)
@@ -346,7 +346,7 @@ public static partial class ResearchViews
         string type,
         string method,
         IrFunction imported,
-        IReadOnlyList<Annotation> facts,
+        IReadOnlyList<IAnnotation> facts,
         IReadOnlyList<ResearchHeaderFact> headerFacts)
     {
         var linesByFact = CSharpLinesByFact(imported, facts);
@@ -382,7 +382,7 @@ public static partial class ResearchViews
         IrFunction raised,
         string output,
         IReadOnlyDictionary<IrNode, int> statementLines,
-        IReadOnlyList<Annotation> annotations)
+        IReadOnlyList<IAnnotation> annotations)
     {
         var stream = CorrelateOverlay(raised, output, statementLines, annotations);
         return RenderOverlayStream(output, stream);
@@ -398,9 +398,9 @@ public static partial class ResearchViews
         IrFunction raised,
         string output,
         IReadOnlyDictionary<IrNode, int> statementLines,
-        IReadOnlyList<Annotation> annotations)
+        IReadOnlyList<IAnnotation> annotations)
     {
-        var annotationsByLine = new Dictionary<int, IReadOnlyList<Annotation>>();
+        var annotationsByLine = new Dictionary<int, IReadOnlyList<IAnnotation>>();
         foreach (var (statement, facts) in AnnotationAnchor.Anchor(raised, annotations))
             if (AnnotationAnchor.TryGetPrintedLine(statement, statementLines, out int line))
                 annotationsByLine[line] = facts;
@@ -453,13 +453,13 @@ public static partial class ResearchViews
         return string.Join(Environment.NewLine, lines);
     }
 
-    static Dictionary<Annotation, int> CSharpLinesByFact(IrFunction imported, IReadOnlyList<Annotation> facts)
+    static Dictionary<IAnnotation, int> CSharpLinesByFact(IrFunction imported, IReadOnlyList<IAnnotation> facts)
     {
         var result = CSharpPrinter.PrintRaised(imported, out var statementLines);
         if (result.Output is null || facts.Count == 0)
             return [];
         var spans = AnnotationAnchor.ComputeSpans(imported);
-        var lines = new Dictionary<Annotation, int>();
+        var lines = new Dictionary<IAnnotation, int>();
         foreach (var fact in facts)
         {
             if (AnnotationAnchor.Best(spans, fact.SourceOffset) is { } owner
@@ -471,15 +471,15 @@ public static partial class ResearchViews
         return lines;
     }
 
-    static Dictionary<int, IReadOnlyList<Annotation>> FactsByOffset(IReadOnlyList<Annotation> annotations)
+    static Dictionary<int, IReadOnlyList<IAnnotation>> FactsByOffset(IReadOnlyList<IAnnotation> annotations)
         => annotations
             .Where(annotation => annotation.SourceOffset >= 0)
             .GroupBy(annotation => annotation.SourceOffset)
             .ToDictionary(
                 group => group.Key,
-                group => (IReadOnlyList<Annotation>)[.. group.OrderBy(annotation => annotation.Descriptor.Id, StringComparer.Ordinal)]);
+                group => (IReadOnlyList<IAnnotation>)[.. group.OrderBy(annotation => annotation.Descriptor.Id, StringComparer.Ordinal)]);
 
-    static string AddFactsToAnnotatedLine(string line, IReadOnlyList<Annotation>? facts)
+    static string AddFactsToAnnotatedLine(string line, IReadOnlyList<IAnnotation>? facts)
     {
         if (facts is not { Count: > 0 })
             return line;

--- a/src/ILInspector.Research/UnsafetyOccurrenceFactProducer.cs
+++ b/src/ILInspector.Research/UnsafetyOccurrenceFactProducer.cs
@@ -33,7 +33,7 @@ sealed class UnsafetyOccurrenceFactProducer : IResearchFactProducer
         ];
     }
 
-    static Annotation ToAnnotation(UnsafetyOccurrence occurrence)
+    static Annotation<UnsafetyOccurrence> ToAnnotation(UnsafetyOccurrence occurrence)
     {
         var descriptor = occurrence.Kind switch
         {
@@ -41,6 +41,6 @@ sealed class UnsafetyOccurrenceFactProducer : IResearchFactProducer
             UnsafetyKind.CallIndirect => Calli,
             _ => Deref,
         };
-        return new Annotation(descriptor, occurrence.ILOffset, occurrence.Detail);
+        return new Annotation<UnsafetyOccurrence>(descriptor, occurrence.ILOffset, occurrence, Formatter: static o => o.Detail);
     }
 }

--- a/src/ILInspector.Research/UnsafetyOccurrenceFactProducer.cs
+++ b/src/ILInspector.Research/UnsafetyOccurrenceFactProducer.cs
@@ -14,7 +14,7 @@ sealed class UnsafetyOccurrenceFactProducer : IResearchFactProducer
     public IReadOnlyList<string> Produces { get; } = ["unsafe.*"];
     public IReadOnlyList<string> DependsOn => [];
 
-    public IReadOnlyList<Annotation> Produce(ResearchFactContext context)
+    public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context)
     {
         var function = context.Imported;
         if (function.AssemblyPath is not { Length: > 0 } path || function.MetadataToken == 0)


### PR DESCRIPTION
## Summary

Introduces IAnnotation (the non-generic observation contract, mirroring
IFinding in ILInspector.Findings) and Annotation<T> (the typed atom,
mirroring Finding<T>), and migrates AllocationOccurrenceFactProducer to
use it for real.

This grew out of issue #2564's evidence-spine discussion: AnnotatedSourceLine
already validated the "one discriminator bit + typed per-mechanism payload"
shape (ResearchChange/Mechanism does the same), and Annotation was the
one place in that family still hand-flattening a fully-typed payload
(AllocationOccurrence) into a Detail string at construction time.

## What changed

- **Annotations.cs**: added IAnnotation (Descriptor, SourceOffset,
  Conditionality, Detail) and Annotation<T> : IAnnotation (Payload +
  Formatter, with Detail computed lazily via Formatter?.Invoke(Payload)).
  Existing Annotation now implements IAnnotation unchanged.
- **AllocationOccurrenceFactProducer**: ToAnnotation now returns
  Annotation<AllocationOccurrence> carrying the occurrence as Payload,
  with the existing Detail(AllocationOccurrence) static method passed
  unchanged as Formatter -- rendered text is byte-identical to before.
- Widened the shared surface from Annotation to IAnnotation via
  IReadOnlyList<T> covariance: SourceLine.AnnotatedSourceLine,
  AnnotationText, AnnotationStructuredView, AnnotationAnchor,
  IResearchFactProducer, ResearchFactRegistry, ResearchViews, and the
  four other fact producers (Unsafety, MethodHeaderLeverage,
  CallSiteSemantics, CallSiteCost). Most of these needed a one-line signature
  edit only, no body changes.
- AnnotationEngine/IHiddenFactClassifier.Classify (LifetimeClassifier)
  are left untouched -- no production consumer outside AnnotationEngine
  calls them, so this stays out of the migration's blast radius.

## Why

Annotation<T> lets a producer carry its domain payload (not just a
flattened string), which unblocks future identity-diffing over structured
fields (workstream 2 of #2564) without changing today's rendered output.
Detail staying computed (not stored) keeps the Decompiler layer
domain-agnostic: it never references AllocationOccurrence or any Analysis
type.

## Validation

- dotnet build dotnet-inspect.slnx -c Release -- 0 errors.
- \dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ...\ for all 7 Annotation-touching test classes: 77/77 pass, including exact \Detail\ string assertions.
- \dotnet run --project src/ILInspector.Research.Tests -c Release --no-build\: 113/113 pass.
- \dotnet run --project src/dotnet-inspect.Tests -c Release --no-build\: 1938 total, 4 failures -- confirmed pre-existing and unrelated (CRLF line-ending and network-dependent URL assertions) by reproducing on a clean \main\ checkout.

## Review

This is a shape change to the shared fact substrate (new interface + generic
type, widened signatures across two projects), so it needs adversarial
review per AGENTS.md before merge.