### PR TITLE
Preserve authored enclosing context for nested dynamic raises (#2906)

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LadderRung9/LadderRung9MemberContexts.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung9/LadderRung9MemberContexts.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace LadderRung9;
 
@@ -47,7 +48,17 @@ public class DynamicMemberContexts
         return Get();
     }
 
+    // Iterator state-machine body: csc lowers this to a MoveNext method whose
+    // declaring type is the generated iterator state machine, while the
+    // GetMember context remains the authored enclosing type (same bridge as
+    // InLambda, but through the iterator predicate).
+    public IEnumerable<object> InIterator(dynamic value)
+    {
+        yield return value.Length;
+    }
+
     static object Identity(object value) => value;
 
     public object Last => _last;
 }
+

--- a/src/ILInspector.Decompiler.Tests/DynamicCallSitePassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DynamicCallSitePassTests.cs
@@ -1452,15 +1452,13 @@ public class DynamicCallSitePassTests
     }
 
     [Fact]
-    public void NestedContext_LambdaDisplayClass_RemainsPartial()
+    public void NestedContext_LambdaDisplayClass_Raises()
     {
-        // Boundary (tracked): csc lowers the lambda body into a display-class
-        // method whose declaring type is the generated environment, while the
-        // GetMember context typeof is the authored enclosing type. No typed
-        // enclosing-authored-type fact exists to bridge them without parsing the
-        // display-class name (prohibited), so the exact context check declines
-        // and the site honestly stays explicit rather than raising via a fuzzy
-        // heuristic.
+        // csc lowers the lambda body into a display-class method whose
+        // declaring type is the generated environment, while the GetMember
+        // context typeof is the authored enclosing type. The declaring type's
+        // metadata-decoded EnclosingType chain (TypeRef.EnclosingType) bridges
+        // the two without parsing the display-class name, so the site raises.
         var path = typeof(LadderRung9.DynamicMemberContexts).Assembly.Location;
         using var source = MetadataSource.Open(path);
         string? displayClassOutput = null;
@@ -1473,8 +1471,90 @@ public class DynamicCallSitePassTests
             }
         }
         Assert.NotNull(displayClassOutput);
-        Assert.Contains("Binder.GetMember", displayClassOutput);
-        Assert.DoesNotContain("(dynamic)", displayClassOutput);
+        Assert.Contains("((dynamic)value).Length", displayClassOutput);
+        Assert.DoesNotContain("Binder.GetMember", displayClassOutput);
+    }
+
+    [Fact]
+    public void NestedContext_IteratorStateMachine_Raises()
+    {
+        // csc lowers the iterator body into a MoveNext method whose declaring
+        // type is the generated state machine (matched by
+        // GeneratedCodeIdentity.IsIteratorStateMachineTypeName), while the
+        // GetMember context typeof is the authored enclosing type — the same
+        // EnclosingType bridge as the lambda display-class case, but through
+        // the state-machine predicate instead of the display-class predicate.
+        var path = typeof(LadderRung9.DynamicMemberContexts).Assembly.Location;
+        using var source = MetadataSource.Open(path);
+        string? moveNextOutput = null;
+        foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+        {
+            if (methodName == "MoveNext" && typeName.Contains("InIterator"))
+            {
+                moveNextOutput = CSharpPrinter.PrintRaised(function, mr => IrImporter.Import(source, mr)).Output;
+                break;
+            }
+        }
+        Assert.NotNull(moveNextOutput);
+        Assert.Contains("((dynamic)value).Length", moveNextOutput);
+        Assert.DoesNotContain("Binder.GetMember", moveNextOutput);
+    }
+
+    /// <summary>Imports the InLambda display-class method, running every pass up to (not including) dynamic-callsite, so tests can mutate the tree before proving the pass's own decision.</summary>
+    static IrFunction LoadLambdaDisplayClassFunction()
+    {
+        var path = typeof(LadderRung9.DynamicMemberContexts).Assembly.Location;
+        using var source = MetadataSource.Open(path);
+        IrFunction? found = null;
+        foreach (var (_, methodName, function) in IrImporter.ImportAssembly(source))
+        {
+            if (methodName.Contains("InLambda") && methodName.Contains("b__"))
+            {
+                found = function;
+                break;
+            }
+        }
+        Assert.NotNull(found);
+
+        var context = new PassContext(new Stepper(enabled: false));
+        foreach (var pass in IrPasses.Default)
+        {
+            if (pass.Name == "dynamic-callsite")
+                break;
+            pass.Run(found!, context);
+        }
+        return found!;
+    }
+
+    [Fact]
+    public void NestedContext_MismatchedEnclosingType_Declines()
+    {
+        // The display-class method's own metadata evidence is real (name,
+        // attribute, EnclosingType), but the binder context typeof is neither
+        // the declaring type nor its true enclosing type — a spoofed/foreign
+        // context must decline rather than raise.
+        var f = LoadLambdaDisplayClassFunction();
+        var context = ContextDefStore(f);
+        context.Value.ReplaceWith(new TypeOf(ObjectType));
+        Assert.False(RunPass(f));
+    }
+
+    [Fact]
+    public void NestedContext_MissingCompilerGeneratedEvidence_Declines()
+    {
+        // A hand-authored (or otherwise unverified) nested type that merely
+        // matches the "<>c__DisplayClass" name pattern must not benefit from
+        // the enclosing-type bridge without the declaring type's own
+        // [CompilerGenerated] attribute evidence — attribute evidence is
+        // required before generated-name patterns are trusted.
+        var f = LoadLambdaDisplayClassFunction();
+        var body = (BlockContainer)Detach(f.Children.Single());
+        var mutated = new IrFunction(f.Name, f.DeclaringType, f.Signature, f.Locals, body)
+        {
+            DeclaringTypeCompilerGenerated = MetadataFactState.No,
+            CompilerGenerated = f.CompilerGenerated,
+        };
+        Assert.False(RunPass(mutated));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/TypeRefDecoderRecursionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeRefDecoderRecursionTests.cs
@@ -61,6 +61,55 @@ public class TypeRefDecoderRecursionTests
     }
 
     [Fact]
+    public void NestedTypeDefinition_EnclosingTypeIsImmediateParentOnly()
+    {
+        // A three-level nesting Root -> Mid -> Leaf. The decoded leaf carries its
+        // immediately-enclosing type (Mid) as provenance, and that enclosing
+        // TypeRef must not itself chain further: only one level is materialized,
+        // so deep nesting on untrusted metadata cannot amplify allocation.
+        TypeDefinitionHandle leafHandle = default;
+        var reader = BuildMetadata(metadata =>
+        {
+            var root = metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                metadata.GetOrAddString("N"),
+                metadata.GetOrAddString("Root"),
+                baseType: default,
+                fieldList: MetadataTokens.FieldDefinitionHandle(1),
+                methodList: MetadataTokens.MethodDefinitionHandle(1));
+            var mid = metadata.AddTypeDefinition(
+                TypeAttributes.NestedPublic,
+                default,
+                metadata.GetOrAddString("Mid"),
+                baseType: default,
+                fieldList: MetadataTokens.FieldDefinitionHandle(1),
+                methodList: MetadataTokens.MethodDefinitionHandle(1));
+            leafHandle = metadata.AddTypeDefinition(
+                TypeAttributes.NestedPublic,
+                default,
+                metadata.GetOrAddString("Leaf"),
+                baseType: default,
+                fieldList: MetadataTokens.FieldDefinitionHandle(1),
+                methodList: MetadataTokens.MethodDefinitionHandle(1));
+            metadata.AddNestedType(mid, root);
+            metadata.AddNestedType(leafHandle, mid);
+            return default(EntityHandle);
+        });
+
+        var result = TypeRefDecoder.Instance.GetTypeFromDefinition(reader, leafHandle, 0);
+
+        Assert.Equal(TypeRefKind.Definition, result.Kind);
+        Assert.Equal("Root+Mid+Leaf", result.Name);
+
+        var enclosing = result.EnclosingType;
+        Assert.NotNull(enclosing);
+        Assert.Equal("Root+Mid", enclosing!.Name);
+        Assert.Equal("N", enclosing.Namespace);
+        // Immediate-only: the enclosing provenance does not recurse further.
+        Assert.Null(enclosing.EnclosingType);
+    }
+
+    [Fact]
     public void OverBudgetResolutionScope_PreservesNodeBudgetFailure()
     {
         var reader = BuildMetadata(metadata =>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/DynamicCallSitePass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/DynamicCallSitePass.cs
@@ -96,6 +96,36 @@ public sealed class DynamicCallSitePass : IIrPass
     }
 
     /// <summary>
+    /// Proves the <c>typeof(...)</c> binder-context argument against the body's
+    /// declaring type. The direct case (an ordinary method) requires exact
+    /// equality. When the body is instead a compiler-generated environment
+    /// method (a capturing lambda's display-class instance method, or an
+    /// iterator/async state-machine's <c>MoveNext</c>), the binder context is
+    /// authored against the enclosing type the compiler captured from — proven
+    /// here via the declaring type's own metadata-decoded
+    /// <see cref="TypeRef.EnclosingType"/> chain (never by parsing the
+    /// generated type's <c>+</c>-joined name), and only once the declaring
+    /// type's <c>[CompilerGenerated]</c> attribute evidence
+    /// (<see cref="IrFunction.DeclaringTypeCompilerGenerated"/>) and a
+    /// corroborating generated-name shape both hold.
+    /// </summary>
+    static bool IsProvenBinderContext(TypeRef context, IrFunction function)
+    {
+        if (context.Equals(function.DeclaringType))
+            return true;
+
+        if (function.DeclaringTypeCompilerGenerated != MetadataFactState.Yes)
+            return false;
+
+        var declaringType = function.DeclaringType;
+        if (!GeneratedCodeIdentity.IsDisplayClassName(declaringType)
+            && !GeneratedCodeIdentity.IsIteratorStateMachineTypeName(declaringType))
+            return false;
+
+        return declaringType.EnclosingType is { } enclosing && context.Equals(enclosing);
+    }
+
+    /// <summary>
     /// Identifies a cache lazy-init guard and proves its polarity: the setup arm
     /// must be the arm the runtime selects when the cache is still null.
     /// <c>if (!cache) { setup } else {}</c> puts setup in the then arm;
@@ -218,7 +248,7 @@ public sealed class DynamicCallSitePass : IIrPass
         // --- [1] Context definition: typeof(DeclaringType) ---
         if (!TryDefinitionKey(statements[1], out var contextKey, out var contextValue))
             return false;
-        if (contextValue is not TypeOf contextTypeOf || !contextTypeOf.Type.Equals(function.DeclaringType))
+        if (contextValue is not TypeOf contextTypeOf || !IsProvenBinderContext(contextTypeOf.Type, function))
             return false;
 
         // The two setup definitions occupy distinct storage (no duplicate

--- a/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
@@ -138,12 +138,25 @@ public sealed class TypeRef : IEquatable<TypeRef>
     public MetadataFactState DeclaredInlineArray =>
         Kind == TypeRefKind.GenericInstance ? ElementType?.InlineArray ?? MetadataFactState.Unknown : InlineArray;
 
+    /// <summary>
+    /// The immediately-enclosing type for a nested type definition, decoded from
+    /// the metadata nested-type relationship (<c>TypeDef.GetDeclaringType</c>)
+    /// — never parsed from <see cref="Name"/>'s <c>+</c>-joined spelling, which
+    /// cannot be trusted to identify a real type (docs/design/untrusted-data-threat-model.md).
+    /// Null for a non-nested definition and for every kind other than
+    /// <see cref="TypeRefKind.Definition"/>. Like <see cref="ValueTypeHint"/>,
+    /// this is provenance rather than identity and is intentionally excluded
+    /// from equality.
+    /// </summary>
+    public TypeRef? EnclosingType { get; private init; }
+
     public static TypeRef Definition(
         string assembly,
         string ns,
         string name,
         ValueTypeHint valueTypeHint = ValueTypeHint.Unknown,
-        MetadataFactState inlineArray = MetadataFactState.Unknown)
+        MetadataFactState inlineArray = MetadataFactState.Unknown,
+        TypeRef? enclosingType = null)
         => new(TypeRefKind.Definition)
         {
             Assembly = assembly,
@@ -151,6 +164,7 @@ public sealed class TypeRef : IEquatable<TypeRef>
             Name = name,
             ValueTypeHint = valueTypeHint,
             InlineArray = inlineArray,
+            EnclosingType = enclosingType,
         };
 
     /// <summary>
@@ -161,10 +175,10 @@ public sealed class TypeRef : IEquatable<TypeRef>
     /// returned unchanged.
     /// </summary>
     public TypeRef WithValueTypeHint(ValueTypeHint hint)
-        => Kind == TypeRefKind.Definition ? Definition(Assembly, Namespace, Name, hint, InlineArray) : this;
+        => Kind == TypeRefKind.Definition ? Definition(Assembly, Namespace, Name, hint, InlineArray, EnclosingType) : this;
 
     public TypeRef WithInlineArrayFact(MetadataFactState fact)
-        => Kind == TypeRefKind.Definition ? Definition(Assembly, Namespace, Name, ValueTypeHint, fact) : this;
+        => Kind == TypeRefKind.Definition ? Definition(Assembly, Namespace, Name, ValueTypeHint, fact, EnclosingType) : this;
 
     public static TypeRef CoreLib(string ns, string name)
         => Definition(CoreLibrary, ns, name);
@@ -306,6 +320,7 @@ public sealed class TypeRef : IEquatable<TypeRef>
             FunctionPointerParameterRefKinds = functionPointerParameterRefKinds ?? FunctionPointerParameterRefKinds,
             ValueTypeHint = ValueTypeHint,
             InlineArray = InlineArray,
+            EnclosingType = EnclosingType,
             CustomModifiers = customModifiers ?? CustomModifiers,
         };
 

--- a/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
+using System.Text;
 using ILInspector.Metadata;
 
 namespace ILInspector.Decompiler.Pipeline;
@@ -156,16 +157,17 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
         MetadataReader reader,
         ReadOnlySpan<TypeDefinitionHandle> handles)
     {
-        string name = reader.GetString(
-            reader.GetTypeDefinition(handles[0]).Name);
+        // Accumulate into a StringBuilder so a deep nested chain costs a single
+        // linear pass; the earlier Concat-per-level reallocated the growing
+        // prefix and grew quadratically in nesting depth on untrusted metadata.
+        var name = new StringBuilder(
+            reader.GetString(reader.GetTypeDefinition(handles[0]).Name));
         for (int i = 1; i < handles.Length; i++)
         {
-            name = string.Concat(
-                name,
-                "+",
-                reader.GetString(reader.GetTypeDefinition(handles[i]).Name));
+            name.Append('+');
+            name.Append(reader.GetString(reader.GetTypeDefinition(handles[i]).Name));
         }
-        return name;
+        return name.ToString();
     }
 
     /// <summary>
@@ -176,6 +178,14 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
     /// never by parsing the leaf's <c>+</c>-joined <see cref="TypeRef.Name"/>.
     /// Null when the leaf is not nested (a chain of length 1).
     /// </summary>
+    /// <remarks>
+    /// Only this single level is materialized. It is the sole level any consumer
+    /// reads (<c>DynamicCallSitePass.IsProvenBinderContext</c>), and
+    /// <see cref="TypeRef"/> equality excludes <see cref="TypeRef.EnclosingType"/>,
+    /// so no deeper ancestor is ever observed. Recursively rebuilding every
+    /// ancestor's joined name grew allocation cubically in nesting depth on
+    /// untrusted metadata.
+    /// </remarks>
     static TypeRef? EnclosingTypeFrom(
         MetadataReader reader,
         ReadOnlySpan<TypeDefinitionHandle> chain,
@@ -185,10 +195,8 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
         if (chain.Length <= 1)
             return null;
 
-        var ancestors = chain[..^1];
-        string name = TypeDefinitionName(reader, ancestors);
-        var enclosing = EnclosingTypeFrom(reader, ancestors, assembly, ns);
-        return TypeRef.Definition(assembly, ns, name, enclosingType: enclosing);
+        string name = TypeDefinitionName(reader, chain[..^1]);
+        return TypeRef.Definition(assembly, ns, name);
     }
 
     static string TypeReferenceName(

--- a/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
@@ -104,7 +104,8 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
                 ns,
                 name,
                 HintFrom(rawTypeKind),
-                InlineArrayFact(reader, leaf));
+                InlineArrayFact(reader, leaf),
+                EnclosingTypeFrom(reader, chain, assembly, ns));
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
         {
@@ -165,6 +166,29 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
                 reader.GetString(reader.GetTypeDefinition(handles[i]).Name));
         }
         return name;
+    }
+
+    /// <summary>
+    /// The immediately-enclosing type for a nested type-definition chain
+    /// (<paramref name="chain"/>, root-to-leaf per
+    /// <see cref="MetadataRelationshipTraversal.TryWalkTypeDefinitionDeclaringChain"/>),
+    /// built from the metadata nesting relationship the chain already proved —
+    /// never by parsing the leaf's <c>+</c>-joined <see cref="TypeRef.Name"/>.
+    /// Null when the leaf is not nested (a chain of length 1).
+    /// </summary>
+    static TypeRef? EnclosingTypeFrom(
+        MetadataReader reader,
+        ReadOnlySpan<TypeDefinitionHandle> chain,
+        string assembly,
+        string ns)
+    {
+        if (chain.Length <= 1)
+            return null;
+
+        var ancestors = chain[..^1];
+        string name = TypeDefinitionName(reader, ancestors);
+        var enclosing = EnclosingTypeFrom(reader, ancestors, assembly, ns);
+        return TypeRef.Definition(assembly, ns, name, enclosingType: enclosing);
     }
 
     static string TypeReferenceName(


### PR DESCRIPTION
- Advances #2906
- Preserves the authored enclosing-type context for a compiler-generated nested body (display-class lambda, iterator/state-machine `MoveNext`) so `DynamicCallSitePass` can raise `Binder.GetMember` scaffolding it previously had to leave explicit.
- Card revision: `76b2b6f6`

## Change

> Should we accept this change?

**Conclusion:** **REVIEW** — the core mechanism (metadata-decoded `TypeRef.EnclosingType`, gated on `[CompilerGenerated]` attribute evidence, never on name-parsing) is sound and covered by real compiled fixtures plus close-negative cases, but this branch is stacked on the still-unreviewed #2915 and the corpus/aggregate evidence sections below have not been run yet.

### Original source

Authored fixture `DynamicMemberContexts.InLambda` — a capturing lambda whose body performs a `dynamic` member access, which the compiler lowers to the display-class method `<>c__DisplayClass4_0.<InLambda>b__0`:

```csharp
public Func<object> InLambda(dynamic value)
{
    return () => value.Length;
}
```

### Before

Compiler-backed fixture (`LadderRung9.DynamicMemberContexts.InLambda`, capturing lambda lowered to `<>c__DisplayClass4_0.<InLambda>b__0`). The binder-context `typeof` in the display-class method is `typeof(DynamicMemberContexts)` — the *authored* enclosing type, not the display-class type itself — so the prior exact-equality check against `function.DeclaringType` declined and the scaffolding stayed explicit:

```csharp
CSharpArgumentInfo[] S_256;
Type S_257;

if (___o__4.___p__0 is null) goto IL_0009;
goto IL_0038;
IL_0009:
S_256 = new CSharpArgumentInfo[1];
S_257 = Type.GetTypeFromHandle(typeof(DynamicMemberContexts));
S_256[0] = CSharpArgumentInfo.Create((CSharpArgumentInfoFlags)0, null);
___o__4.___p__0 = CallSite<Func<CallSite, object, object>>.Create(Binder.GetMember((CSharpBinderFlags)0, "Length", S_257, S_256));
IL_0038:
return ___o__4.___p__0.Target.Invoke(___o__4.___p__0, value);
```

### After

```csharp
return ((dynamic)value).Length;
```

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass (`dotnet build src/ILInspector.Decompiler -c Release --configfile ./nuget.config`) |
| Focused tests | `ILInspector.Decompiler.Tests.DynamicCallSitePassTests` — 105/105 passed |
| Related regressions | `LadderRung9GateTests`, `TypeRefDecoderRecursionTests` (now 10, incl. immediate-parent guard), `GuardedDecodeTests`, `FunctionPointerDiagnosticsPassTests`, `PipelineImporterTests` — all passed |
| Decompiler quality corpus | Base/head structural inventory (SPC, 41,855 methods) **byte-identical** — 0 pp, 0 importer bugs |
| Reduced fixture validity | Not applicable (no shape/structuring change to a compile-back target) |
| Real witness | `LadderRung9.DynamicMemberContexts.InLambda` (display-class lambda) and `InIterator` (iterator state machine) — both now raise; verified via mutation testing (reverting the fix reproduces the prior `Binder.GetMember` output) |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **no regression.** Ran the harness structural inventory (Full% + stop-reason buckets + importer-bug detection) as a base/head A/B on the running-runtime System.Private.CoreLib sweep (41,855 methods). Base `2269483d` and head `76b2b6f6` are **byte-identical** (SHA-256 match): **0 pp movement, 0 importer bugs.** Expected — the change only *widens* an existing narrowly-gated raise into compiler-generated display-class/iterator bodies, a shape the corpus does not exercise; the feature itself is proven by the compiled `LadderRung9.DynamicMemberContexts` fixtures and the close-negative decline fixtures.

## Validation

```bash
dotnet build src/ILInspector.Decompiler.Tests -c Release --configfile ./nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class ILInspector.Decompiler.Tests.DynamicCallSitePassTests
```

## Notes

- Rebased onto `main` after #2915 landed (single feature commit replayed onto the collapsed `CSharpSpellability.IsDynamicCastableValue` gate; `IsProvenBinderContext` sits orthogonally on top).
- Adversarial two-family review complete (Gemini 3.1 Pro + GPT-5.6 Sol, isolated worktrees). Round 1 surfaced a High-severity allocation-amplification finding in `EnclosingTypeFrom` (recursive per-ancestor name rebuild → cubic on untrusted metadata), **fixed** in `76b2b6f6` (immediate-only `EnclosingType` + `StringBuilder`; guard test added). Both re-reviewed the fixed head **clean** (GPT re-probe: linear, 0.8 MiB @256 levels vs 1,431.7 MiB before). See the reconciliation comment.
- Follow-up: dynamic raises inside a **generic** enclosing type still decline (non-regression completeness gap) — tracked in #2968, intentionally out of scope here.


