### PR TITLE
Add inline Valid/Correct verdicts to raise PR template

### DIFF
--- a/docs/templates/decompiler-pr.md
+++ b/docs/templates/decompiler-pr.md
@@ -9,6 +9,17 @@ Every raise PR must keep Before, After, and Fully raised. Before and After must
 each show a concrete C# example. After records this PR's output; Fully raised
 records the intended endpoint.
 
+Under Before and After, record two independent verdicts on the shown C# so the
+assessment sits next to the code it judges:
+
+- Valid: does it compile and bind (True/False)?
+- Correct: does it preserve the original observable behavior (True/False)?
+
+Add optional prose only to explain a verdict. Keeping both Before and After
+makes this a before→after comparison, not a snapshot of only the raised output:
+a snapshot cannot reveal a regression that leaves the After invalid or
+behavior-changing.
+
 Look for the authoritative original source with `dotnet-inspect`, including
 through SourceLink:
 
@@ -53,11 +64,21 @@ only after checking with dotnet-inspect (relying on SourceLink).
 // short failing or lower-quality output
 ```
 
+- Valid: {True/False}
+- Correct: {True/False}
+
+{optional prose to elaborate on the verdict}
+
 ### After
 
 ```csharp
 // output produced by this PR, including an honest fallback when not fully raised
 ```
+
+- Valid: {True/False}
+- Correct: {True/False}
+
+{optional prose to elaborate on the verdict}
 
 ### Fully raised
 


### PR DESCRIPTION
## Change

Adds two inline verdicts under **Before** and **After** in the raise PR
template (`docs/templates/decompiler-pr.md`):

- **Valid**: does the shown C# compile and bind?
- **Correct**: does it preserve the original observable behavior?

with optional prose to explain a verdict. Co-locating the assessment with the
code it judges keeps the before→after comparison readable. Because both Before
and After now carry the verdicts, the section is a genuine before→after
comparison rather than a snapshot of only the raised output — a snapshot cannot
reveal a regression that leaves After invalid or behavior-changing.

The top HTML comment documents the two dimensions. This is purely additive on
top of the current template (Original source / Before / After / Fully raised /
Baseline|Head evidence remain unchanged).

## Evidence

- Docs-only change; no product build or tests required.
- `markdownlint` clean on `docs/templates/decompiler-pr.md`.

Low risk: documentation template only, no behavior change, no adversarial
review required.