### PR TITLE
Add top-package decompiler discovery sweep

### DIFF
--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -11,8 +11,11 @@ on:
         options:
           - test
           - census
+          - package-sweep
           - nightly
           - all
+  schedule:
+    - cron: '0 9 * * 1'
 
 env:
   DOTNET_NOLOGO: true
@@ -24,6 +27,59 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  package-sweep:
+    name: NuGet package discovery sweep
+    if: github.event_name == 'schedule' || inputs.lane == 'package-sweep'
+    runs-on: ubuntu-26.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-package-sweep-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', '**/*.slnx') }}
+          restore-keys: |
+            nuget-package-sweep-${{ runner.os }}-${{ runner.arch }}-
+            nuget-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Build managed tool
+        run: dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
+
+      - name: Prepare top-package slice
+        run: |
+          mkdir -p artifacts/package-sweep
+          dotnet run eng/prepare-decompiler-package-sweep.cs -- \
+            artifacts/package-sweep 1 10 \
+            | tee artifacts/package-sweep/acquisition.txt
+
+      - name: Run bounded library report
+        shell: bash
+        run: |
+          set -o pipefail
+          mapfile -t assemblies < artifacts/package-sweep/assemblies.txt
+          dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
+            --library-report \
+            --corpus-method-cap 250 \
+            --compile-cap 25 \
+            --top-patterns 25 \
+            --max-examples 3 \
+            | tee artifacts/package-sweep/report.md
+
+      - name: Upload package sweep artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: deep-inspect-package-sweep
+          path: artifacts/package-sweep/
+          if-no-files-found: warn
+
   test:
     name: Test lane
     if: inputs.lane == 'test' || inputs.lane == 'all'

--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -53,7 +53,9 @@ jobs:
         run: dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
 
       - name: Prepare top-package slice
+        shell: bash
         run: |
+          set -o pipefail
           mkdir -p artifacts/package-sweep
           dotnet run eng/prepare-decompiler-package-sweep.cs -- \
             artifacts/package-sweep 1 10 \

--- a/docs/data/README.md
+++ b/docs/data/README.md
@@ -7,6 +7,10 @@ Static data files used by dotnet-inspect for package and assembly classification
 ### nuget-top-packages.json
 
 Top NuGet packages by download count, sourced from <https://www.nuget.org/stats/packages>.
+The weekly/on-demand Deep Inspect `package-sweep` lane consumes a bounded rank
+window from this list, resolves current stable versions, and records the exact
+package/version/TFM provenance in its run artifact. The list selects packages;
+it is not a quality baseline.
 
 ### Platform assembly lists
 

--- a/eng/prepare-decompiler-package-sweep.cs
+++ b/eng/prepare-decompiler-package-sweep.cs
@@ -1,0 +1,265 @@
+#:project ../src/DotnetInspector.Core/DotnetInspector.Core.csproj
+#:project ../src/DotnetInspector.Packages/DotnetInspector.Packages.csproj
+#:project ../src/DotnetInspector.Services/DotnetInspector.Services.csproj
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DotnetInspector.Core;
+using DotnetInspector.Packages;
+using DotnetInspector.Services;
+
+if (args.Length is < 1 or > 3)
+{
+    throw new ArgumentException(
+        "Usage: dotnet run eng/prepare-decompiler-package-sweep.cs -- "
+        + "<output-directory> [start-rank] [package-count]");
+}
+
+string root = FindRepositoryRoot(Directory.GetCurrentDirectory());
+string outputDirectory = Path.GetFullPath(args[0]);
+int startRank = args.Length >= 2 ? int.Parse(args[1]) : 1;
+int packageCount = args.Length >= 3 ? int.Parse(args[2]) : 10;
+if (startRank <= 0)
+    throw new ArgumentOutOfRangeException(nameof(startRank), "Start rank must be positive.");
+if (packageCount is <= 0 or > 100)
+    throw new ArgumentOutOfRangeException(nameof(packageCount), "Package count must be between 1 and 100.");
+
+string sourcePath = Path.Combine(root, "docs", "data", "nuget-top-packages.json");
+var jsonOptions = new JsonSerializerOptions
+{
+    PropertyNameCaseInsensitive = true,
+    WriteIndented = true,
+};
+var jsonContext = new PackageSweepJsonContext(jsonOptions);
+var packageList = JsonSerializer.Deserialize<List<PackageListEntry>>(
+    await File.ReadAllTextAsync(sourcePath),
+    jsonContext.ListPackageListEntry)
+    ?? throw new InvalidDataException($"Could not read package list '{sourcePath}'.");
+if (packageList.Any(entry => entry.Rank <= 0 || string.IsNullOrWhiteSpace(entry.Package)))
+    throw new InvalidDataException($"Package list '{sourcePath}' contains an invalid entry.");
+if (packageList.Select(entry => entry.Rank).Distinct().Count() != packageList.Count)
+    throw new InvalidDataException($"Package list '{sourcePath}' contains duplicate ranks.");
+
+var selected = packageList
+    .Where(entry => entry.Rank >= startRank)
+    .OrderBy(entry => entry.Rank)
+    .Take(packageCount)
+    .ToArray();
+if (selected.Length == 0)
+    throw new InvalidOperationException($"No packages were selected at or after rank {startRank}.");
+
+Directory.CreateDirectory(outputDirectory);
+string packageDirectory = Path.Combine(outputDirectory, "packages");
+Directory.CreateDirectory(packageDirectory);
+
+HttpClientFactory.Initialize();
+NuGetCache.Initialize("dotnet-inspect");
+
+var results = new List<SweepPackageResult>(selected.Length);
+var assemblies = new List<string>(selected.Length);
+foreach (var entry in selected)
+{
+    PackageExtractionResult? package = null;
+    try
+    {
+        var outcome = await PackageExtractor.ExtractPackageAsync(
+            HttpClientFactory.Shared,
+            $"{entry.Package}@latest",
+            tempDirPrefix: "decompiler-package-sweep",
+            forceLatest: true);
+        if (!outcome.IsSuccess)
+        {
+            results.Add(Failed(entry, "acquisition-failed", outcome.ErrorMessage));
+            Console.Error.WriteLine(
+                $"rank {entry.Rank}: {entry.Package}: acquisition failed: {outcome.ErrorMessage}");
+            continue;
+        }
+
+        package = outcome.Result!;
+        string resolvedPackage = package.PackageName ?? entry.Package;
+        var selection = TfmSelector.SelectPackageLibrary(
+            package.ExtractPath,
+            resolvedPackage,
+            requestedLibrary: null);
+        if (!selection.IsSelected)
+        {
+            string detail = selection.CandidatePaths.Count > 0
+                ? $"{selection.Status}: {string.Join(", ", selection.CandidatePaths.Select(Path.GetFileName))}"
+                : selection.Status.ToString();
+            results.Add(Failed(
+                entry,
+                "library-unavailable",
+                detail,
+                resolvedPackage,
+                package.Version,
+                selection.Tfm,
+                package.FromCache));
+            Console.Error.WriteLine(
+                $"rank {entry.Rank}: {entry.Package}: primary library unavailable: {detail}");
+            continue;
+        }
+
+        string source = selection.Paths[0];
+        string destinationDirectory = Path.Combine(
+            packageDirectory,
+            $"{entry.Rank:D3}-{SafePathSegment(entry.Package)}",
+            SafePathSegment(package.Version ?? "unknown"));
+        Directory.CreateDirectory(destinationDirectory);
+        string destination = Path.Combine(
+            destinationDirectory,
+            Path.GetFileName(source));
+        File.Copy(source, destination, overwrite: true);
+        destination = Path.GetFullPath(destination);
+        assemblies.Add(destination);
+        results.Add(new SweepPackageResult(
+            entry.Rank,
+            entry.Package,
+            entry.Downloads,
+            "selected",
+            Detail: null,
+            resolvedPackage,
+            package.Version,
+            selection.Tfm,
+            Path.GetRelativePath(outputDirectory, destination),
+            package.FromCache));
+        Console.WriteLine(
+            $"rank {entry.Rank}: {entry.Package}@{package.Version}: "
+            + $"{selection.Tfm ?? "unknown TFM"} -> {Path.GetFileName(destination)}");
+    }
+    catch (HttpRequestException ex)
+    {
+        RecordProcessingFailure(entry, package, ex);
+    }
+    catch (InvalidDataException ex)
+    {
+        RecordProcessingFailure(entry, package, ex);
+    }
+    catch (IOException ex)
+    {
+        RecordProcessingFailure(entry, package, ex);
+    }
+    catch (UnauthorizedAccessException ex)
+    {
+        RecordProcessingFailure(entry, package, ex);
+    }
+    finally
+    {
+        if (package?.TempDir is not null)
+            Directory.Delete(package.TempDir, recursive: true);
+    }
+}
+
+assemblies.Sort(StringComparer.Ordinal);
+await File.WriteAllLinesAsync(
+    Path.Combine(outputDirectory, "assemblies.txt"),
+    assemblies);
+var manifest = new PackageSweepManifest(
+    SchemaVersion: 1,
+    GeneratedAtUtc: DateTimeOffset.UtcNow,
+    Source: Path.GetRelativePath(root, sourcePath),
+    StartRank: startRank,
+    RequestedPackageCount: packageCount,
+    SelectedPackageCount: assemblies.Count,
+    Packages: results);
+await File.WriteAllTextAsync(
+    Path.Combine(outputDirectory, "manifest.json"),
+    JsonSerializer.Serialize(manifest, jsonContext.PackageSweepManifest) + Environment.NewLine);
+
+Console.WriteLine(
+    $"Selected {assemblies.Count} of {selected.Length} requested packages; "
+    + $"manifest: {Path.Combine(outputDirectory, "manifest.json")}");
+if (assemblies.Count == 0)
+    Environment.ExitCode = 1;
+
+void RecordProcessingFailure(
+    PackageListEntry entry,
+    PackageExtractionResult? package,
+    Exception exception)
+{
+    results.Add(Failed(
+        entry,
+        "processing-failed",
+        $"{exception.GetType().Name}: {exception.Message}",
+        package?.PackageName,
+        package?.Version,
+        fromCache: package?.FromCache));
+    Console.Error.WriteLine(
+        $"rank {entry.Rank}: {entry.Package}: processing failed: "
+        + $"{exception.GetType().Name}: {exception.Message}");
+}
+
+static SweepPackageResult Failed(
+    PackageListEntry entry,
+    string status,
+    string? detail,
+    string? resolvedPackage = null,
+    string? resolvedVersion = null,
+    string? tfm = null,
+    bool? fromCache = null)
+    => new(
+        entry.Rank,
+        entry.Package,
+        entry.Downloads,
+        status,
+        detail,
+        resolvedPackage,
+        resolvedVersion,
+        tfm,
+        AssemblyPath: null,
+        fromCache);
+
+static string FindRepositoryRoot(string start)
+{
+    for (var directory = new DirectoryInfo(start);
+        directory is not null;
+        directory = directory.Parent)
+    {
+        if (File.Exists(Path.Combine(directory.FullName, "dotnet-inspect.slnx")))
+            return directory.FullName;
+    }
+
+    throw new InvalidOperationException(
+        $"Could not find the repository root from '{start}'.");
+}
+
+static string SafePathSegment(string value)
+{
+    var invalid = Path.GetInvalidFileNameChars().ToHashSet();
+    string sanitized = new(value
+        .Select(character => invalid.Contains(character)
+            || character is '/' or '\\'
+                ? '_'
+                : character)
+        .ToArray());
+    return sanitized is "" or "." or ".." ? "_" : sanitized;
+}
+
+sealed record PackageListEntry(
+    [property: JsonPropertyName("rank")] int Rank,
+    [property: JsonPropertyName("package")] string Package,
+    [property: JsonPropertyName("downloads")] long Downloads);
+
+sealed record PackageSweepManifest(
+    int SchemaVersion,
+    DateTimeOffset GeneratedAtUtc,
+    string Source,
+    int StartRank,
+    int RequestedPackageCount,
+    int SelectedPackageCount,
+    IReadOnlyList<SweepPackageResult> Packages);
+
+sealed record SweepPackageResult(
+    int Rank,
+    string RequestedPackage,
+    long Downloads,
+    string Status,
+    string? Detail,
+    string? ResolvedPackage,
+    string? ResolvedVersion,
+    string? Tfm,
+    string? AssemblyPath,
+    bool? FromCache);
+
+[JsonSerializable(typeof(List<PackageListEntry>))]
+[JsonSerializable(typeof(PackageSweepManifest))]
+sealed partial class PackageSweepJsonContext : JsonSerializerContext;

--- a/eng/prepare-decompiler-package-sweep.cs
+++ b/eng/prepare-decompiler-package-sweep.cs
@@ -60,6 +60,7 @@ var assemblies = new List<string>(selected.Length);
 foreach (var entry in selected)
 {
     PackageExtractionResult? package = null;
+    int resultIndex = results.Count;
     try
     {
         var outcome = await PackageExtractor.ExtractPackageAsync(
@@ -144,8 +145,46 @@ foreach (var entry in selected)
     }
     finally
     {
-        if (package?.TempDir is not null)
-            Directory.Delete(package.TempDir, recursive: true);
+        if (package?.TempDir is null)
+        {
+            RecordCleanup("not-required", detail: null);
+        }
+        else
+        {
+            try
+            {
+                Directory.Delete(package.TempDir, recursive: true);
+                RecordCleanup("deleted", detail: null);
+            }
+            catch (IOException ex)
+            {
+                RecordCleanupFailure(ex);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                RecordCleanupFailure(ex);
+            }
+        }
+    }
+
+    void RecordCleanupFailure(Exception exception)
+    {
+        string detail = $"{exception.GetType().Name}: {exception.Message}";
+        RecordCleanup("failed", detail);
+        Console.Error.WriteLine(
+            $"rank {entry.Rank}: {entry.Package}: temporary-directory cleanup failed: {detail}");
+    }
+
+    void RecordCleanup(string status, string? detail)
+    {
+        if (results.Count > resultIndex)
+        {
+            results[resultIndex] = results[resultIndex] with
+            {
+                CleanupStatus = status,
+                CleanupDetail = detail,
+            };
+        }
     }
 }
 
@@ -258,7 +297,9 @@ sealed record SweepPackageResult(
     string? ResolvedVersion,
     string? Tfm,
     string? AssemblyPath,
-    bool? FromCache);
+    bool? FromCache,
+    string? CleanupStatus = null,
+    string? CleanupDetail = null);
 
 [JsonSerializable(typeof(List<PackageListEntry>))]
 [JsonSerializable(typeof(PackageSweepManifest))]

--- a/skills/deep-inspect/SKILL.md
+++ b/skills/deep-inspect/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dotnet-inspect-deep-inspect
 version: 0.1.0
-description: Run and interpret opt-in expensive validation lanes: full slow tests, IL round-trip sweep, corpus sensors, validity scans, and analysis census.
+description: Run and interpret opt-in expensive validation lanes: full slow tests, IL round-trip sweep, corpus sensors, package discovery, validity scans, and analysis census.
 ---
 
 # dotnet-inspect: Deep Inspect
@@ -16,13 +16,15 @@ lane also runs during publish before packages are built.
 | ---- | ------- | ---- |
 | `test` | Blocking proof before publish or risky merges | Full decompiler tests, full analysis tests, vendored ILAssembler restore, full IL round-trip sweep. |
 | `census` | Observational broad signal and triage | Real-world corpus sensor, validity predicate scan, uncapped validity sweep, assertion scan, analysis corpus sensor, paydirt recall. |
-| `all` | Release-candidate deep read | Both lanes. |
+| `package-sweep` | Weekly/on-demand discovery over current top NuGet packages | Product-backed package acquisition plus bounded per-library fully-raised, validity, defect-class, and promotion-candidate reporting. |
+| `all` | Release-candidate deep read | The `test` and `census` lanes. |
 
 Run manually:
 
 ```bash
 gh workflow run deep-inspect.yml -f lane=test
 gh workflow run deep-inspect.yml -f lane=census
+gh workflow run deep-inspect.yml -f lane=package-sweep
 gh workflow run deep-inspect.yml -f lane=all
 ```
 
@@ -56,6 +58,14 @@ dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release -- -trai
 For the census lane, prefer the workflow so artifacts are retained. If running
 locally, use the same scripts/baselines as `deep-inspect.yml` and preserve the
 generated snapshots/cards under `/tmp` or `artifacts/` for review.
+
+The package sweep runs every Monday at 09:00 UTC and can also be dispatched
+manually. It is owned by `@richlander`, is discovery-only, and never gates a
+pull request. Each run resolves the latest stable versions for ranks 1-10,
+records exact package/version/TFM provenance, and samples at most 250 methods
+and 25 semantic-validity candidates per selected library. Promote a package to
+an existing pinned corpus only after a reported defect or unsupported shape is
+accepted for ongoing coverage.
 
 ## Reading results
 

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -101,6 +101,8 @@
              Link="ValidityCheck.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\ValidityPredicateScan.cs"
              Link="ValidityPredicateScan.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\LibraryReport.cs"
+             Link="LibraryReport.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\AssertionEvaluator.cs"
              Link="AssertionEvaluator.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\AssertionPrinter.cs"

--- a/src/ILInspector.Decompiler.Tests/LibraryReportTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LibraryReportTests.cs
@@ -41,6 +41,32 @@ public class LibraryReportTests
             candidate.Reasons);
     }
 
+    [Fact]
+    public void BuildPortfolio_KeepsGlobalEvidenceOutsideDisplayedLibraries()
+    {
+        var hiddenDefect = Report(
+            "HiddenDefect",
+            new PatternReport("pass-bug: InvalidOperationException", 1, ["HiddenDefect::M"]))
+            with
+            {
+                PassBugs = 1,
+            };
+        var displayed = Report(
+            "Displayed",
+            new PatternReport("fidelity: unsupported-node", 10, ["Displayed::M"]));
+
+        var portfolio = LibraryReport.BuildPortfolio(
+            [hiddenDefect, displayed],
+            topPatterns: 10,
+            maxExamples: 2,
+            displayedLibraries: [displayed]);
+
+        Assert.Equal(1, portfolio.TotalPassBugs);
+        Assert.Equal("pass-bug: InvalidOperationException", Assert.Single(portfolio.DefectClasses).Name);
+        Assert.Equal("HiddenDefect", Assert.Single(portfolio.PromotionCandidates).Assembly);
+        Assert.Equal("Displayed", Assert.Single(portfolio.Libraries).Assembly);
+    }
+
     static AssemblyReport Report(string assembly, params PatternReport[] patterns)
         => new(
             assembly,

--- a/src/ILInspector.Decompiler.Tests/LibraryReportTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LibraryReportTests.cs
@@ -1,0 +1,60 @@
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class LibraryReportTests
+{
+    [Fact]
+    public void BuildPortfolio_SeparatesCorrectnessDefectsAndPromotionCandidates()
+    {
+        var clean = Report(
+            "Clean",
+            new PatternReport("fidelity: unsupported-node", 3, ["Clean::M"]));
+        var defective = Report(
+            "Defective",
+            new PatternReport("validity: malformed:CS1002", 2, ["Defective::M"]),
+            new PatternReport("pass-bug: InvalidOperationException", 1, ["Defective::N"]))
+            with
+            {
+                FullMalformed = 2,
+                SemanticDefectMethods = 1,
+                PassBugs = 1,
+            };
+
+        var portfolio = LibraryReport.BuildPortfolio(
+            [clean, defective],
+            topPatterns: 10,
+            maxExamples: 2);
+
+        Assert.Equal(2, portfolio.DefectClasses.Count);
+        Assert.DoesNotContain(
+            portfolio.DefectClasses,
+            pattern => pattern.Name == "fidelity: unsupported-node");
+        var candidate = Assert.Single(portfolio.PromotionCandidates);
+        Assert.Equal("Defective", candidate.Assembly);
+        Assert.Equal(
+            [
+                "1 pass bug method(s)",
+                "2 malformed Full method(s)",
+                "1 bound Full defect method(s)",
+            ],
+            candidate.Reasons);
+    }
+
+    static AssemblyReport Report(string assembly, params PatternReport[] patterns)
+        => new(
+            assembly,
+            $"/tmp/{assembly}.dll",
+            AvailableMethods: 10,
+            TotalMethods: 10,
+            FullMethods: 8,
+            PartialMethods: 2,
+            FullyRaisedMethods: 7,
+            RenderedMethods: 10,
+            FullMalformed: 0,
+            PartialMalformed: 0,
+            SemanticChecked: 0,
+            SemanticDefectMethods: 0,
+            PassBugs: 0,
+            patterns);
+}

--- a/src/ILInspector.Decompiler.Tests/LibraryReportTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LibraryReportTests.cs
@@ -30,6 +30,7 @@ public class LibraryReportTests
         Assert.DoesNotContain(
             portfolio.DefectClasses,
             pattern => pattern.Name == "fidelity: unsupported-node");
+        Assert.Equal("fidelity: unsupported-node", Assert.Single(portfolio.TopPatterns).Name);
         var candidate = Assert.Single(portfolio.PromotionCandidates);
         Assert.Equal("Defective", candidate.Assembly);
         Assert.Equal(
@@ -37,6 +38,7 @@ public class LibraryReportTests
                 "1 pass bug method(s)",
                 "2 malformed Full method(s)",
                 "1 bound Full defect method(s)",
+                "defect classes: validity: malformed:CS1002, pass-bug: InvalidOperationException",
             ],
             candidate.Reasons);
     }

--- a/tools/DecompilerHarness/LibraryReport.cs
+++ b/tools/DecompilerHarness/LibraryReport.cs
@@ -308,7 +308,9 @@ internal static class LibraryReport
             reports.Sum(report => report.PassBugs),
             [.. allPatterns.Where(pattern => IsCorrectnessDefect(pattern.Name))],
             PromotionCandidates(reports),
-            [.. allPatterns.Take(Math.Max(1, topPatterns))],
+            [.. allPatterns
+                .Where(pattern => !IsCorrectnessDefect(pattern.Name))
+                .Take(Math.Max(1, topPatterns))],
             displayedLibraries ?? reports);
     }
 
@@ -332,8 +334,8 @@ internal static class LibraryReport
                 var defectPatterns = report.Patterns
                     .Where(pattern => IsCorrectnessDefect(pattern.Name))
                     .ToArray();
-                if (reasons.Count == 0 && defectPatterns.Length > 0)
-                    reasons.Add($"{defectPatterns.Sum(pattern => pattern.Count)} correctness defect(s)");
+                if (defectPatterns.Length > 0)
+                    reasons.Add($"defect classes: {string.Join(", ", defectPatterns.Select(pattern => pattern.Name))}");
                 return new PromotionCandidate(report.Assembly, reasons);
             })
             .Where(candidate => candidate.Reasons.Count > 0)

--- a/tools/DecompilerHarness/LibraryReport.cs
+++ b/tools/DecompilerHarness/LibraryReport.cs
@@ -14,7 +14,44 @@ namespace ILInspector.DecompilerHarness;
 /// </summary>
 internal static class LibraryReport
 {
-    public static int Run(IReadOnlyList<string> assemblies, int compileCap, int maxExamples, bool json, int topPatterns, int? topLibraries)
+    public static int Run(
+        IReadOnlyList<string> assemblies,
+        int compileCap,
+        int maxExamples,
+        bool json,
+        int topPatterns,
+        int? topLibraries,
+        int methodCap)
+    {
+        var report = Evaluate(
+            assemblies,
+            compileCap,
+            maxExamples,
+            topPatterns,
+            topLibraries,
+            methodCap);
+
+        if (json)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(
+                report,
+                new JsonSerializerOptions { WriteIndented = true }));
+        }
+        else
+        {
+            PrintMarkdown(report, Math.Max(1, topPatterns), topLibraries);
+        }
+
+        return report.TotalPassBugs > 0 ? 1 : 0;
+    }
+
+    internal static LibraryPortfolioReport Evaluate(
+        IReadOnlyList<string> assemblies,
+        int compileCap,
+        int maxExamples,
+        int topPatterns,
+        int? topLibraries,
+        int methodCap)
     {
         var reports = new List<AssemblyReport>();
         using var metadata = CorpusMetadata.Create(assemblies);
@@ -34,25 +71,26 @@ internal static class LibraryReport
 
         foreach (var assembly in assemblies)
         {
-            reports.Add(AnalyzeAssembly(assembly, metadata, references, parseOptions, compileOptions, compileCap, maxExamples));
+            reports.Add(AnalyzeAssembly(
+                assembly,
+                metadata,
+                references,
+                parseOptions,
+                compileOptions,
+                compileCap,
+                maxExamples,
+                methodCap));
         }
 
         int patternLimit = Math.Max(1, topPatterns);
         var selectedReports = SelectLibraries(reports, topLibraries);
-        var topPatternReports = TopPatterns(selectedReports, patternLimit, maxExamples);
-
-        if (json)
-        {
-            Console.WriteLine(JsonSerializer.Serialize(
-                new LibraryPortfolioReport(topPatternReports, selectedReports),
-                new JsonSerializerOptions { WriteIndented = true }));
-        }
-        else
-        {
-            PrintMarkdown(selectedReports, topPatternReports, patternLimit, topLibraries);
-        }
-
-        return reports.Any(r => r.PassBugs > 0) ? 1 : 0;
+        return BuildPortfolio(
+            selectedReports,
+            patternLimit,
+            maxExamples,
+            methodCap,
+            compileCap,
+            reports.Sum(report => report.PassBugs));
     }
 
     static IReadOnlyList<AssemblyReport> SelectLibraries(IReadOnlyList<AssemblyReport> reports, int? topLibraries)
@@ -75,7 +113,8 @@ internal static class LibraryReport
         CSharpParseOptions parseOptions,
         CSharpCompilationOptions compileOptions,
         int compileCap,
-        int maxExamples)
+        int maxExamples,
+        int methodCap)
     {
         var buckets = new Dictionary<string, Bucket>(StringComparer.Ordinal);
         var report = new MutableReport(Path.GetFileName(path), path);
@@ -84,8 +123,11 @@ internal static class LibraryReport
         {
             using var source = MetadataSource.Open(path, context: metadata);
             report.Assembly = source.AssemblyName;
+            report.AvailableMethods = source.Reader.MethodDefinitions
+                .Count(handle => source.Reader.GetMethodDefinition(handle).RelativeVirtualAddress != 0);
             var constraints = ShellConstraints.Build(source);
-            foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+            foreach (var (typeName, methodName, function) in
+                IrImporter.ImportAssemblyStableSample(source, methodCap))
             {
                 report.TotalMethods++;
                 var id = $"{typeName}::{methodName}";
@@ -251,9 +293,54 @@ internal static class LibraryReport
             .Take(topPatterns)];
     }
 
-    static void PrintMarkdown(
+    internal static LibraryPortfolioReport BuildPortfolio(
         IReadOnlyList<AssemblyReport> reports,
-        IReadOnlyList<PatternSummary> topPatterns,
+        int topPatterns,
+        int maxExamples,
+        int methodCap = int.MaxValue,
+        int semanticCompileCap = int.MaxValue,
+        int? totalPassBugs = null)
+    {
+        var allPatterns = TopPatterns(reports, int.MaxValue, maxExamples);
+        return new LibraryPortfolioReport(
+            methodCap,
+            semanticCompileCap,
+            totalPassBugs ?? reports.Sum(report => report.PassBugs),
+            [.. allPatterns.Where(pattern => IsCorrectnessDefect(pattern.Name))],
+            PromotionCandidates(reports),
+            [.. allPatterns.Take(Math.Max(1, topPatterns))],
+            reports);
+    }
+
+    static bool IsCorrectnessDefect(string pattern)
+        => pattern.StartsWith("assembly-open:", StringComparison.Ordinal)
+            || pattern.StartsWith("pass-bug:", StringComparison.Ordinal)
+            || pattern.StartsWith("validity:", StringComparison.Ordinal);
+
+    static IReadOnlyList<PromotionCandidate> PromotionCandidates(
+        IReadOnlyList<AssemblyReport> reports)
+        => [.. reports
+            .Select(report =>
+            {
+                var reasons = new List<string>();
+                if (report.PassBugs > 0)
+                    reasons.Add($"{report.PassBugs} pass bug method(s)");
+                if (report.FullMalformed > 0)
+                    reasons.Add($"{report.FullMalformed} malformed Full method(s)");
+                if (report.SemanticDefectMethods > 0)
+                    reasons.Add($"{report.SemanticDefectMethods} bound Full defect method(s)");
+                var defectPatterns = report.Patterns
+                    .Where(pattern => IsCorrectnessDefect(pattern.Name))
+                    .ToArray();
+                if (reasons.Count == 0 && defectPatterns.Length > 0)
+                    reasons.Add($"{defectPatterns.Sum(pattern => pattern.Count)} correctness defect(s)");
+                return new PromotionCandidate(report.Assembly, reasons);
+            })
+            .Where(candidate => candidate.Reasons.Count > 0)
+            .OrderBy(candidate => candidate.Assembly, StringComparer.Ordinal)];
+
+    static void PrintMarkdown(
+        LibraryPortfolioReport report,
         int patternLimit,
         int? topLibraries)
     {
@@ -262,18 +349,48 @@ internal static class LibraryReport
         if (topLibraries is { } limit)
             Console.WriteLine($"Showing top {Math.Max(1, limit)} libraries by unsupported-pattern load.");
         else
-            Console.WriteLine($"Showing all {reports.Count} libraries.");
+            Console.WriteLine($"Showing all {report.Libraries.Count} libraries.");
+        if (report.MethodCap != int.MaxValue)
+            Console.WriteLine($"Methods are a deterministic hash-ranked sample of at most {report.MethodCap} per library.");
+        if (report.SemanticCompileCap != int.MaxValue)
+            Console.WriteLine($"Semantic validity is checked for at most {report.SemanticCompileCap} Full methods per library.");
         Console.WriteLine();
 
-        Console.WriteLine($"## Top {patternLimit} unsupported patterns");
+        Console.WriteLine("## Correctness defect-class docket");
         Console.WriteLine();
-        if (topPatterns.Count == 0)
+        if (report.DefectClasses.Count == 0)
         {
             Console.WriteLine("- (none)");
         }
         else
         {
-            foreach (var pattern in topPatterns)
+            foreach (var defect in report.DefectClasses)
+                Console.WriteLine($"- **{defect.Name}**: {defect.Count} across {defect.LibraryCount} librar{(defect.LibraryCount == 1 ? "y" : "ies")} — {string.Join("; ", defect.Examples.Take(2).Select(example => $"`{example}`"))}");
+        }
+        Console.WriteLine();
+
+        Console.WriteLine("## Promotion candidates");
+        Console.WriteLine();
+        if (report.PromotionCandidates.Count == 0)
+        {
+            Console.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var candidate in report.PromotionCandidates)
+                Console.WriteLine($"- **{candidate.Assembly}**: {string.Join("; ", candidate.Reasons)}");
+        }
+        Console.WriteLine();
+
+        Console.WriteLine($"## Top {patternLimit} unsupported patterns");
+        Console.WriteLine();
+        if (report.TopPatterns.Count == 0)
+        {
+            Console.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var pattern in report.TopPatterns)
             {
                 Console.WriteLine($"- **{pattern.Name}**: {pattern.Count} across {pattern.LibraryCount} librar{(pattern.LibraryCount == 1 ? "y" : "ies")}");
                 foreach (var library in pattern.AffectedLibraries.Take(5))
@@ -285,28 +402,28 @@ internal static class LibraryReport
         Console.WriteLine();
         Console.WriteLine("| Assembly | Methods | Full | Fully raised | Full malformed | Bound Full defects | Pass bugs | Top patterns |");
         Console.WriteLine("| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |");
-        foreach (var report in reports)
+        foreach (var library in report.Libraries)
         {
-            var top = report.Patterns.Take(Math.Min(3, patternLimit))
+            var top = library.Patterns.Take(Math.Min(3, patternLimit))
                 .Select(p => $"{p.Count} {Escape(p.Name)}");
-            Console.WriteLine($"| {Escape(report.Assembly)} | {report.TotalMethods} | {CountPercent(report.FullMethods, report.TotalMethods)} | {CountPercent(report.FullyRaisedMethods, report.TotalMethods)} | {report.FullMalformed} | {report.SemanticDefectMethods}/{report.SemanticChecked} | {report.PassBugs} | {string.Join("<br>", top)} |");
+            Console.WriteLine($"| {Escape(library.Assembly)} | {MethodCount(library)} | {CountPercent(library.FullMethods, library.TotalMethods)} | {CountPercent(library.FullyRaisedMethods, library.TotalMethods)} | {library.FullMalformed} | {library.SemanticDefectMethods}/{library.SemanticChecked} | {library.PassBugs} | {string.Join("<br>", top)} |");
         }
 
-        foreach (var report in reports)
+        foreach (var library in report.Libraries)
         {
             Console.WriteLine();
-            Console.WriteLine($"## {report.Assembly}");
+            Console.WriteLine($"## {library.Assembly}");
             Console.WriteLine();
-            Console.WriteLine($"Path: `{report.Path}`");
+            Console.WriteLine($"Path: `{library.Path}`");
             Console.WriteLine();
             Console.WriteLine($"Top {patternLimit} unsupported patterns:");
-            if (report.Patterns.Count == 0)
+            if (library.Patterns.Count == 0)
             {
                 Console.WriteLine("- (none)");
                 continue;
             }
 
-            foreach (var pattern in report.Patterns.Take(patternLimit))
+            foreach (var pattern in library.Patterns.Take(patternLimit))
             {
                 Console.WriteLine($"- **{pattern.Name}**: {pattern.Count}");
                 foreach (var example in pattern.Examples.Take(3))
@@ -320,6 +437,11 @@ internal static class LibraryReport
     static string CountPercent(int part, int whole)
         => whole == 0 ? "0/0" : $"{part}/{whole} ({100.0 * part / whole:F2}%)";
 
+    static string MethodCount(AssemblyReport report)
+        => report.TotalMethods == report.AvailableMethods
+            ? report.TotalMethods.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            : $"{report.TotalMethods}/{report.AvailableMethods} sampled";
+
     static string Escape(string value)
         => value.Replace("|", "\\|").Replace("\n", " ");
 
@@ -327,6 +449,7 @@ internal static class LibraryReport
     {
         public string Assembly { get; set; } = assembly;
         public string Path { get; } = path;
+        public int AvailableMethods { get; set; }
         public int TotalMethods { get; set; }
         public int FullMethods { get; set; }
         public int PartialMethods { get; set; }
@@ -342,6 +465,7 @@ internal static class LibraryReport
             => new(
                 Assembly,
                 Path,
+                AvailableMethods,
                 TotalMethods,
                 FullMethods,
                 PartialMethods,
@@ -369,6 +493,7 @@ internal static class LibraryReport
 internal sealed record AssemblyReport(
     string Assembly,
     string Path,
+    int AvailableMethods,
     int TotalMethods,
     int FullMethods,
     int PartialMethods,
@@ -384,8 +509,17 @@ internal sealed record AssemblyReport(
 internal sealed record PatternReport(string Name, int Count, IReadOnlyList<string> Examples);
 
 internal sealed record LibraryPortfolioReport(
+    int MethodCap,
+    int SemanticCompileCap,
+    int TotalPassBugs,
+    IReadOnlyList<PatternSummary> DefectClasses,
+    IReadOnlyList<PromotionCandidate> PromotionCandidates,
     IReadOnlyList<PatternSummary> TopPatterns,
     IReadOnlyList<AssemblyReport> Libraries);
+
+internal sealed record PromotionCandidate(
+    string Assembly,
+    IReadOnlyList<string> Reasons);
 
 internal sealed record PatternSummary(
     string Name,

--- a/tools/DecompilerHarness/LibraryReport.cs
+++ b/tools/DecompilerHarness/LibraryReport.cs
@@ -85,12 +85,12 @@ internal static class LibraryReport
         int patternLimit = Math.Max(1, topPatterns);
         var selectedReports = SelectLibraries(reports, topLibraries);
         return BuildPortfolio(
-            selectedReports,
+            reports,
             patternLimit,
             maxExamples,
             methodCap,
             compileCap,
-            reports.Sum(report => report.PassBugs));
+            selectedReports);
     }
 
     static IReadOnlyList<AssemblyReport> SelectLibraries(IReadOnlyList<AssemblyReport> reports, int? topLibraries)
@@ -299,17 +299,17 @@ internal static class LibraryReport
         int maxExamples,
         int methodCap = int.MaxValue,
         int semanticCompileCap = int.MaxValue,
-        int? totalPassBugs = null)
+        IReadOnlyList<AssemblyReport>? displayedLibraries = null)
     {
         var allPatterns = TopPatterns(reports, int.MaxValue, maxExamples);
         return new LibraryPortfolioReport(
             methodCap,
             semanticCompileCap,
-            totalPassBugs ?? reports.Sum(report => report.PassBugs),
+            reports.Sum(report => report.PassBugs),
             [.. allPatterns.Where(pattern => IsCorrectnessDefect(pattern.Name))],
             PromotionCandidates(reports),
             [.. allPatterns.Take(Math.Max(1, topPatterns))],
-            reports);
+            displayedLibraries ?? reports);
     }
 
     static bool IsCorrectnessDefect(string pattern)

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -437,7 +437,14 @@ static class Program
             return SlotUnifierCensus.Run(assemblies, corpusMethodCap, maxExamples);
 
         if (libraryReport)
-            return LibraryReport.Run(assemblies, compileCap, maxExamples, json, topPatterns, topLibraries);
+            return LibraryReport.Run(
+                assemblies,
+                compileCap,
+                maxExamples,
+                json,
+                topPatterns,
+                topLibraries,
+                corpusMethodCap);
 
         if (unsupportedNodes)
             return UnsupportedNodeReport.Run(assemblies, maxExamples, json);
@@ -1825,7 +1832,9 @@ static class Program
                                 non-zero on any precision violation.
           --library-report       per-assembly summary: Full %, fully-raised %,
                                 validity defects, residual pattern buckets, and
-                                examples. Use --json for machine-readable output.
+                                examples. Use --json for machine-readable output
+                                and --corpus-method-cap for a deterministic,
+                                bounded per-assembly sample.
           --unsupported-nodes    report every unsupported IL marker left in the
                                 raised tree, grouped by opcode/reason. Use --json
                                 for machine-readable output.

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -229,6 +229,17 @@ library. Use this for the direct "which patterns are unsupported in which
 library?" loop. `--top-patterns N` limits the global/per-library pattern lists,
 `--top-libraries N` limits the detailed library sections to the noisiest
 libraries, and `--json` emits the same data as structured JSON.
+`--corpus-method-cap N` applies the existing deterministic hash-ranked sampler
+independently to each library. The report keeps ordinary fidelity residuals in
+the discovery pattern list while separately projecting correctness defect
+classes and package-promotion candidates.
+
+The weekly Deep Inspect `package-sweep` lane prepares ranks 1-10 from
+`docs/data/nuget-top-packages.json` with product-owned package acquisition and
+TFM selection, then runs this report with bounded method and semantic-validity
+caps. Its manifest records the resolved package version, TFM, selected assembly,
+cache status, and failures. This is current-package discovery evidence, not a
+checked-in baseline or PR gate.
 
 **Real-world corpus sensor** (`--diff-corpus-baseline`): the Deep Inspect
 baseline for #1166. It measures the fixed #1150 corpus — pinned NuGet assemblies


### PR DESCRIPTION
## Summary

- Add a weekly/manual, discovery-only Deep Inspect lane over current NuGet ranks 1-10.
- Reuse product package acquisition and TFM selection, emitting portable package/version/TFM/cache/cleanup provenance without executing package code.
- Bound the existing library quality oracle with deterministic per-library sampling and project correctness defect classes and promotion candidates separately from unsupported patterns.
- Preserve acquisition, cleanup, pass-bug, and filtered-presentation failures instead of creating a new baseline protocol or PR gate.

Closes #2819.

## First automated sweep

- Resolved 10/10 packages at their current stable versions.
- Sampled 2,327 methods (250 maximum per library) and up to 25 Full semantic checks per library.
- Acquisition: 3.03 seconds; report: 5.54 seconds.
- Correctness defect-class docket: empty.
- Promotion candidates: empty.
- The earlier discovery run produced #2828, #2830, and #2831; all three were fixed before this run, demonstrating the docket-to-fix loop.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "ILInspector.Decompiler.Tests.LibraryReportTests"` (2 passed)
- One-package source-generated-JSON canary and ranks 1-10 bounded sweep
- Zero-selection pipeline canary (nonzero exit preserved through `tee`)
- `npx markdownlint-cli tools/DecompilerHarness/README.md docs/data/README.md skills/deep-inspect/SKILL.md`
- Full decompiler run: 2,991/2,993 passed; both failures reproduce unchanged on exact base `516c379e` (`LadderIteratorGateTests.IteratorFixture_RecoveredRowsCompileBackOpcodeExact` and `ValidityCoverageReportingTests.DecompilerAssembly_MissingReturnPopulationIsPinned`).

## Adversarial review

- Claude Opus 4.8: clean on exact head `c76a9351`.
- Gemini 3.1 Pro: clean on exact head `c76a9351`.
- Earlier findings about pipeline failure masking, global evidence filtering, defect presentation, promotion reasons, and cleanup visibility were fixed in follow-up commits `eabd121a` and `c76a9351`.
