### PR TITLE
Add offline authored-source correspondence benchmark + vendored corpus

### DIFF
--- a/eng/restore-authored-source-corpus.sh
+++ b/eng/restore-authored-source-corpus.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Materializes the vendor/authored-source-corpus orphan branch at
+# external/authored-source-corpus.
+#
+# The branch carries the vendored authored-source correspondence corpus: JSONL
+# where each row is a real method identity plus a checksum-verified authored
+# member body captured through SourceLink at harvest time (see the branch
+# README.md for provenance and licensing policy). The offline benchmark run-mode
+# (`decompiler-harness --benchmark-authored-corpus`) consumes it, so no network
+# access is required at benchmark time. It lives on an orphan branch so the
+# harvested third-party source snapshots never enter main's history.
+#
+# Because it is a git worktree, edits made under external/authored-source-corpus
+# commit directly to the vendor branch.
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+dest="$root/external/authored-source-corpus"
+branch="vendor/authored-source-corpus"
+
+if [ -d "$dest" ]; then
+    echo "Already restored: $dest"
+    exit 0
+fi
+
+if ! git -C "$root" rev-parse --verify --quiet "$branch" > /dev/null; then
+    echo "Local branch '$branch' not found; fetching from origin..."
+    git -C "$root" fetch origin "$branch:$branch"
+fi
+
+git -C "$root" worktree add "$dest" "$branch"
+echo "Restored $branch at $dest"

--- a/tools/DecompilerHarness/AuthoredCorpusBenchmark.cs
+++ b/tools/DecompilerHarness/AuthoredCorpusBenchmark.cs
@@ -119,8 +119,10 @@ static class AuthoredCorpusBenchmark
         Console.WriteLine($"  corpus rows        : {corpusRows}");
         Console.WriteLine($"  assemblies matched : {matchedAssemblies} / {corpusAssemblies}");
         if (unmatchedRows > 0)
-            Console.WriteLine($"  rows without asm   : {unmatchedRows} (no local assembly supplied)");
+            Console.WriteLine($"  rows without asm   : {unmatchedRows} (BLOCKER: no local assembly supplied)");
         Console.WriteLine($"  targets evaluated  : {evaluated}");
+        if (evaluated == 0)
+            Console.WriteLine($"  (BLOCKER: no targets evaluated — nothing was checked)");
         int lowering = results.Count(result => ClassifyTaste(result) == TasteBucket.Lowering);
         int knownTaste = results.Count(result => ClassifyTaste(result) == TasteBucket.KnownTaste);
         int frontierExact = results.Count(result => ClassifyTaste(result) == TasteBucket.FrontierIlExact);
@@ -164,8 +166,11 @@ static class AuthoredCorpusBenchmark
         // Nonzero exit if any target failed to round-trip (Invalid) or the corpus
         // no longer corresponds to the pinned assembly (Drift/Unsupported). Not-Full
         // is a surfaced decompiler limitation, not a corpus problem, so it does not
-        // fail the run on its own.
-        return invalid == 0 && drift == 0 && unsupported == 0 ? 0 : 1;
+        // fail the run on its own. Honest-exit contract: an empty or partially
+        // unmatched run is never a success — every corpus row must be checked, so
+        // unmatched rows (assembly not supplied) and a zero-target run also fail.
+        bool honest = unmatchedRows == 0 && evaluated > 0;
+        return honest && invalid == 0 && drift == 0 && unsupported == 0 ? 0 : 1;
     }
 
     enum TasteBucket
@@ -253,6 +258,10 @@ static class AuthoredCorpusBenchmark
         int notFull = results.Count(result => ClassifyTaste(result) == TasteBucket.NotFull);
         int drift = results.Count(result => ClassifyTaste(result) == TasteBucket.Drift);
         int unsupported = results.Count(result => ClassifyTaste(result) == TasteBucket.Unsupported);
+        int evaluated = results.Count;
+        // Honest-exit contract: an empty or partially unmatched run is never a
+        // success — unmatched rows (assembly not supplied) and a zero-target run fail.
+        bool honest = unmatchedRows == 0 && evaluated > 0;
 
         var payload = new
         {
@@ -260,7 +269,8 @@ static class AuthoredCorpusBenchmark
             matchedAssemblies,
             corpusAssemblies,
             unmatchedRows,
-            targetsEvaluated = results.Count,
+            targetsEvaluated = evaluated,
+            honest,
             correct = match,
             validDifferent = different,
             validBreakdown = new
@@ -290,6 +300,6 @@ static class AuthoredCorpusBenchmark
         };
 
         Console.WriteLine(JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
-        return invalid == 0 && drift == 0 && unsupported == 0 ? 0 : 1;
+        return honest && invalid == 0 && drift == 0 && unsupported == 0 ? 0 : 1;
     }
 }

--- a/tools/DecompilerHarness/AuthoredCorpusBenchmark.cs
+++ b/tools/DecompilerHarness/AuthoredCorpusBenchmark.cs
@@ -1,0 +1,209 @@
+using System.Text.Json;
+
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// Offline benchmark run-mode over the vendored authored-source correspondence
+/// corpus. Each corpus row carries a real method identity plus a checksum-verified
+/// authored member body captured at harvest time. The benchmark rebuilds the RTS
+/// <see cref="ReturnToSender.RequestedTarget"/> for every row and feeds the
+/// snapshotted authored bodies into the existing source-correspondence oracle
+/// (<see cref="ReturnToSenderSourceProbe"/>) via an in-memory
+/// <see cref="ReturnToSenderSourceIndex"/>. The decompiler output is therefore
+/// compared against the authored source in the same RTS shell the on-demand probe
+/// uses, but with no network access: the corpus is the source of truth.
+///
+/// Because every row has a body by construction, <c>SourceUnavailable</c> is a
+/// drift signal (corpus row whose identity no longer resolves against the pinned
+/// assembly) rather than an expected outcome.
+/// </summary>
+static class AuthoredCorpusBenchmark
+{
+    public static int Run(IReadOnlyList<string> assemblies, string corpusPath, bool json)
+    {
+        if (!File.Exists(corpusPath))
+        {
+            Console.Error.WriteLine($"Corpus file not found: {corpusPath}");
+            return 1;
+        }
+
+        var records = ReadCorpus(corpusPath);
+        if (records.Count == 0)
+        {
+            Console.Error.WriteLine($"Corpus is empty or unparseable: {corpusPath}");
+            return 1;
+        }
+
+        var byAssembly = records
+            .GroupBy(record => record.Assembly, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => (IReadOnlyList<AuthoredSourceHarvest.CorpusRecord>)group.ToArray(), StringComparer.Ordinal);
+
+        var results = new List<ReturnToSenderSourceProbeResult>();
+        var matchedGroups = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var assemblyPath in assemblies)
+        {
+            if (!File.Exists(assemblyPath))
+                continue;
+
+            string name = AuthoredSourceHarvest.ReadAssemblyIdentity(assemblyPath).Name;
+            if (!byAssembly.TryGetValue(name, out var group) || !matchedGroups.Add(name))
+                continue;
+
+            var index = ReturnToSenderSourceIndex.FromMembers(group.Select(ToSourceMember));
+            var targets = group.Select(ToTarget).ToArray();
+            results.AddRange(ReturnToSenderSourceProbe.EvaluateWithIndex(assemblyPath, targets, index));
+        }
+
+        int unmatchedRows = byAssembly
+            .Where(entry => !matchedGroups.Contains(entry.Key))
+            .Sum(entry => entry.Value.Count);
+
+        if (json)
+            return WriteJson(results, records.Count, matchedGroups.Count, byAssembly.Count, unmatchedRows);
+
+        return WriteCard(results, records.Count, matchedGroups.Count, byAssembly.Count, unmatchedRows);
+    }
+
+    static ReturnToSenderSourceMember ToSourceMember(AuthoredSourceHarvest.CorpusRecord record)
+        => new(
+            record.Type,
+            record.Method,
+            record.Overload,
+            record.Signature ?? "",
+            record.SourceUrl ?? "",
+            record.AuthoredBody);
+
+    static ReturnToSender.RequestedTarget ToTarget(AuthoredSourceHarvest.CorpusRecord record)
+        => new(record.Type, record.Method, record.Overload, record.Signature);
+
+    static List<AuthoredSourceHarvest.CorpusRecord> ReadCorpus(string corpusPath)
+    {
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+        var records = new List<AuthoredSourceHarvest.CorpusRecord>();
+        foreach (var line in File.ReadLines(corpusPath))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+            try
+            {
+                if (JsonSerializer.Deserialize<AuthoredSourceHarvest.CorpusRecord>(line, options) is { } record)
+                    records.Add(record);
+            }
+            catch (JsonException ex)
+            {
+                Console.Error.WriteLine($"Skipping malformed corpus row: {ex.Message}");
+            }
+        }
+
+        return records;
+    }
+
+    static int WriteCard(
+        IReadOnlyList<ReturnToSenderSourceProbeResult> results,
+        int corpusRows,
+        int matchedAssemblies,
+        int corpusAssemblies,
+        int unmatchedRows)
+    {
+        int match = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.ValidMatch);
+        int different = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.ValidDifferent);
+        int invalid = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.Invalid);
+        int unavailable = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.SourceUnavailable);
+        int unsupported = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.UnsupportedTarget);
+        int evaluated = results.Count;
+        int valid = match + different;
+
+        Console.WriteLine($"AUTHORED-SOURCE CORPUS BENCHMARK");
+        Console.WriteLine();
+        Console.WriteLine($"  corpus rows        : {corpusRows}");
+        Console.WriteLine($"  assemblies matched : {matchedAssemblies} / {corpusAssemblies}");
+        if (unmatchedRows > 0)
+            Console.WriteLine($"  rows without asm   : {unmatchedRows} (no local assembly supplied)");
+        Console.WriteLine($"  targets evaluated  : {evaluated}");
+        Console.WriteLine();
+        Console.WriteLine($"  Correct  (valid, matches authored)  : {match}");
+        Console.WriteLine($"  Valid    (valid, differs)           : {different}");
+        Console.WriteLine($"  Invalid  (does not round-trip)      : {invalid}");
+        if (unavailable > 0)
+            Console.WriteLine($"  Drift    (source-unavailable)       : {unavailable}");
+        if (unsupported > 0)
+            Console.WriteLine($"  Unsupported (rts-target)            : {unsupported}");
+        Console.WriteLine();
+        if (valid + invalid > 0)
+        {
+            double correctPct = valid == 0 ? 0 : 100.0 * match / valid;
+            double validPct = evaluated == 0 ? 0 : 100.0 * valid / evaluated;
+            Console.WriteLine($"  Valid rate         : {valid}/{evaluated} ({validPct:F1}%)");
+            Console.WriteLine($"  Correct rate       : {match}/{valid} of valid ({correctPct:F1}%)");
+        }
+
+        WriteReasonBuckets("Valid-but-different reasons", results, ReturnToSenderSourceOutcome.ValidDifferent);
+        WriteReasonBuckets("Invalid reasons", results, ReturnToSenderSourceOutcome.Invalid);
+        WriteReasonBuckets("Drift reasons", results, ReturnToSenderSourceOutcome.SourceUnavailable);
+
+        // Nonzero exit if any target failed to round-trip or drifted from the corpus.
+        return invalid == 0 && unavailable == 0 ? 0 : 1;
+    }
+
+    static void WriteReasonBuckets(
+        string title,
+        IReadOnlyList<ReturnToSenderSourceProbeResult> results,
+        ReturnToSenderSourceOutcome outcome)
+    {
+        var buckets = results
+            .Where(result => result.Outcome == outcome)
+            .GroupBy(result => result.Reason, StringComparer.Ordinal)
+            .OrderByDescending(group => group.Count())
+            .ThenBy(group => group.Key, StringComparer.Ordinal)
+            .ToArray();
+        if (buckets.Length == 0)
+            return;
+
+        Console.WriteLine();
+        Console.WriteLine($"  {title}:");
+        foreach (var bucket in buckets)
+            Console.WriteLine($"    {bucket.Count(),5}  {bucket.Key}");
+    }
+
+    static int WriteJson(
+        IReadOnlyList<ReturnToSenderSourceProbeResult> results,
+        int corpusRows,
+        int matchedAssemblies,
+        int corpusAssemblies,
+        int unmatchedRows)
+    {
+        int match = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.ValidMatch);
+        int different = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.ValidDifferent);
+        int invalid = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.Invalid);
+        int unavailable = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.SourceUnavailable);
+        int unsupported = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.UnsupportedTarget);
+
+        var payload = new
+        {
+            corpusRows,
+            matchedAssemblies,
+            corpusAssemblies,
+            unmatchedRows,
+            targetsEvaluated = results.Count,
+            correct = match,
+            validDifferent = different,
+            invalid,
+            drift = unavailable,
+            unsupported,
+            rows = results.Select(result => new
+            {
+                type = result.Target.Type,
+                method = result.Target.Method,
+                overload = result.Target.Overload,
+                outcome = result.Outcome.ToString(),
+                compileBackStatus = result.CompileBackStatus?.ToString(),
+                reason = result.Reason,
+                detail = result.Detail,
+                sourceFile = result.SourcePath,
+            }),
+        };
+
+        Console.WriteLine(JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
+        return invalid == 0 && unavailable == 0 ? 0 : 1;
+    }
+}

--- a/tools/DecompilerHarness/AuthoredCorpusBenchmark.cs
+++ b/tools/DecompilerHarness/AuthoredCorpusBenchmark.cs
@@ -120,9 +120,21 @@ static class AuthoredCorpusBenchmark
         if (unmatchedRows > 0)
             Console.WriteLine($"  rows without asm   : {unmatchedRows} (no local assembly supplied)");
         Console.WriteLine($"  targets evaluated  : {evaluated}");
+        int lowering = results.Count(result => ClassifyTaste(result) == TasteBucket.Lowering);
+        int knownTaste = results.Count(result => ClassifyTaste(result) == TasteBucket.KnownTaste);
+        int frontierExact = results.Count(result => ClassifyTaste(result) == TasteBucket.FrontierIlExact);
+        int frontierDiff = results.Count(result => ClassifyTaste(result) == TasteBucket.FrontierIlDiff);
+        int frontierUnknown = results.Count(result => ClassifyTaste(result) == TasteBucket.FrontierIlUnknown);
+
         Console.WriteLine();
         Console.WriteLine($"  Correct  (valid, matches authored)  : {match}");
         Console.WriteLine($"  Valid    (valid, differs)           : {different}");
+        Console.WriteLine($"    lowering (inherent, unrecoverable): {lowering}");
+        Console.WriteLine($"    known taste (documented decision) : {knownTaste}");
+        Console.WriteLine($"    frontier, IL-exact (cosmetic)     : {frontierExact}");
+        Console.WriteLine($"    frontier, IL-diff (semantic)      : {frontierDiff}");
+        if (frontierUnknown > 0)
+            Console.WriteLine($"    frontier, IL-unknown              : {frontierUnknown}");
         Console.WriteLine($"  Invalid  (does not round-trip)      : {invalid}");
         if (unavailable > 0)
             Console.WriteLine($"  Drift    (source-unavailable)       : {unavailable}");
@@ -137,21 +149,63 @@ static class AuthoredCorpusBenchmark
             Console.WriteLine($"  Correct rate       : {match}/{valid} of valid ({correctPct:F1}%)");
         }
 
-        WriteReasonBuckets("Valid-but-different reasons", results, ReturnToSenderSourceOutcome.ValidDifferent);
-        WriteReasonBuckets("Invalid reasons", results, ReturnToSenderSourceOutcome.Invalid);
-        WriteReasonBuckets("Drift reasons", results, ReturnToSenderSourceOutcome.SourceUnavailable);
+        WriteReasonBuckets("Frontier, IL-diff (semantic) reasons", results, result => ClassifyTaste(result) == TasteBucket.FrontierIlDiff);
+        WriteReasonBuckets("Frontier, IL-exact (cosmetic) reasons", results, result => ClassifyTaste(result) == TasteBucket.FrontierIlExact);
+        WriteReasonBuckets("Lowering (inherent) reasons", results, result => ClassifyTaste(result) == TasteBucket.Lowering);
+        WriteReasonBuckets("Known-taste reasons", results, result => ClassifyTaste(result) == TasteBucket.KnownTaste);
+        WriteReasonBuckets("Invalid reasons", results, result => result.Outcome == ReturnToSenderSourceOutcome.Invalid);
+        WriteReasonBuckets("Drift reasons", results, result => result.Outcome == ReturnToSenderSourceOutcome.SourceUnavailable);
 
         // Nonzero exit if any target failed to round-trip or drifted from the corpus.
         return invalid == 0 && unavailable == 0 ? 0 : 1;
     }
 
+    enum TasteBucket
+    {
+        Correct,
+        Lowering,
+        KnownTaste,
+        FrontierIlExact,
+        FrontierIlDiff,
+        FrontierIlUnknown,
+        Invalid,
+        Drift,
+        Unsupported,
+    }
+
+    /// <summary>
+    /// Buckets a probe result along two taste axes. Family comes first: authored
+    /// sugar the compiler erases (<c>compiler_lowering</c>) is an inherent,
+    /// unrecoverable limit, and a documented product decision (<c>known_taste</c>)
+    /// is already accounted for. Everything else is the raise frontier, split by
+    /// whether the shape difference is free at the IL level (Exact) or carries an
+    /// opcode/operand diff (semantic).
+    /// </summary>
+    static TasteBucket ClassifyTaste(ReturnToSenderSourceProbeResult result)
+        => result.Outcome switch
+        {
+            ReturnToSenderSourceOutcome.ValidMatch => TasteBucket.Correct,
+            ReturnToSenderSourceOutcome.Invalid => TasteBucket.Invalid,
+            ReturnToSenderSourceOutcome.SourceUnavailable => TasteBucket.Drift,
+            ReturnToSenderSourceOutcome.UnsupportedTarget => TasteBucket.Unsupported,
+            ReturnToSenderSourceOutcome.ValidDifferent when result.Reason.Contains("compiler_lowering", StringComparison.Ordinal) => TasteBucket.Lowering,
+            ReturnToSenderSourceOutcome.ValidDifferent when result.Reason.Contains("known_taste", StringComparison.Ordinal) => TasteBucket.KnownTaste,
+            ReturnToSenderSourceOutcome.ValidDifferent => result.CompileBackStatus switch
+            {
+                FidelityCheck.CompileBackStatus.Exact => TasteBucket.FrontierIlExact,
+                FidelityCheck.CompileBackStatus.OpcodeDiff or FidelityCheck.CompileBackStatus.OperandDiff => TasteBucket.FrontierIlDiff,
+                _ => TasteBucket.FrontierIlUnknown,
+            },
+            _ => TasteBucket.FrontierIlUnknown,
+        };
+
     static void WriteReasonBuckets(
         string title,
         IReadOnlyList<ReturnToSenderSourceProbeResult> results,
-        ReturnToSenderSourceOutcome outcome)
+        Func<ReturnToSenderSourceProbeResult, bool> predicate)
     {
         var buckets = results
-            .Where(result => result.Outcome == outcome)
+            .Where(predicate)
             .GroupBy(result => result.Reason, StringComparer.Ordinal)
             .OrderByDescending(group => group.Count())
             .ThenBy(group => group.Key, StringComparer.Ordinal)
@@ -187,6 +241,14 @@ static class AuthoredCorpusBenchmark
             targetsEvaluated = results.Count,
             correct = match,
             validDifferent = different,
+            validBreakdown = new
+            {
+                lowering = results.Count(result => ClassifyTaste(result) == TasteBucket.Lowering),
+                knownTaste = results.Count(result => ClassifyTaste(result) == TasteBucket.KnownTaste),
+                frontierIlExact = results.Count(result => ClassifyTaste(result) == TasteBucket.FrontierIlExact),
+                frontierIlDiff = results.Count(result => ClassifyTaste(result) == TasteBucket.FrontierIlDiff),
+                frontierIlUnknown = results.Count(result => ClassifyTaste(result) == TasteBucket.FrontierIlUnknown),
+            },
             invalid,
             drift = unavailable,
             unsupported,
@@ -196,6 +258,7 @@ static class AuthoredCorpusBenchmark
                 method = result.Target.Method,
                 overload = result.Target.Overload,
                 outcome = result.Outcome.ToString(),
+                tasteBucket = ClassifyTaste(result).ToString(),
                 compileBackStatus = result.CompileBackStatus?.ToString(),
                 reason = result.Reason,
                 detail = result.Detail,

--- a/tools/DecompilerHarness/AuthoredCorpusBenchmark.cs
+++ b/tools/DecompilerHarness/AuthoredCorpusBenchmark.cs
@@ -107,9 +107,10 @@ static class AuthoredCorpusBenchmark
     {
         int match = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.ValidMatch);
         int different = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.ValidDifferent);
-        int invalid = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.Invalid);
-        int unavailable = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.SourceUnavailable);
-        int unsupported = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.UnsupportedTarget);
+        int invalid = results.Count(result => ClassifyTaste(result) == TasteBucket.Invalid);
+        int notFull = results.Count(result => ClassifyTaste(result) == TasteBucket.NotFull);
+        int drift = results.Count(result => ClassifyTaste(result) == TasteBucket.Drift);
+        int unsupported = results.Count(result => ClassifyTaste(result) == TasteBucket.Unsupported);
         int evaluated = results.Count;
         int valid = match + different;
 
@@ -136,8 +137,10 @@ static class AuthoredCorpusBenchmark
         if (frontierUnknown > 0)
             Console.WriteLine($"    frontier, IL-unknown              : {frontierUnknown}");
         Console.WriteLine($"  Invalid  (does not round-trip)      : {invalid}");
-        if (unavailable > 0)
-            Console.WriteLine($"  Drift    (source-unavailable)       : {unavailable}");
+        if (notFull > 0)
+            Console.WriteLine($"  Not-Full (uncheckable at Full)      : {notFull}");
+        if (drift > 0)
+            Console.WriteLine($"  Drift    (corpus source unresolved) : {drift}");
         if (unsupported > 0)
             Console.WriteLine($"  Unsupported (rts-target)            : {unsupported}");
         Console.WriteLine();
@@ -153,11 +156,16 @@ static class AuthoredCorpusBenchmark
         WriteReasonBuckets("Frontier, IL-exact (cosmetic) reasons", results, result => ClassifyTaste(result) == TasteBucket.FrontierIlExact);
         WriteReasonBuckets("Lowering (inherent) reasons", results, result => ClassifyTaste(result) == TasteBucket.Lowering);
         WriteReasonBuckets("Known-taste reasons", results, result => ClassifyTaste(result) == TasteBucket.KnownTaste);
-        WriteReasonBuckets("Invalid reasons", results, result => result.Outcome == ReturnToSenderSourceOutcome.Invalid);
-        WriteReasonBuckets("Drift reasons", results, result => result.Outcome == ReturnToSenderSourceOutcome.SourceUnavailable);
+        WriteReasonBuckets("Invalid reasons", results, result => ClassifyTaste(result) == TasteBucket.Invalid);
+        WriteReasonBuckets("Not-Full reasons", results, result => ClassifyTaste(result) == TasteBucket.NotFull);
+        WriteReasonBuckets("Drift reasons", results, result => ClassifyTaste(result) == TasteBucket.Drift);
+        WriteReasonBuckets("Unsupported reasons", results, result => ClassifyTaste(result) == TasteBucket.Unsupported);
 
-        // Nonzero exit if any target failed to round-trip or drifted from the corpus.
-        return invalid == 0 && unavailable == 0 ? 0 : 1;
+        // Nonzero exit if any target failed to round-trip (Invalid) or the corpus
+        // no longer corresponds to the pinned assembly (Drift/Unsupported). Not-Full
+        // is a surfaced decompiler limitation, not a corpus problem, so it does not
+        // fail the run on its own.
+        return invalid == 0 && drift == 0 && unsupported == 0 ? 0 : 1;
     }
 
     enum TasteBucket
@@ -169,6 +177,7 @@ static class AuthoredCorpusBenchmark
         FrontierIlDiff,
         FrontierIlUnknown,
         Invalid,
+        NotFull,
         Drift,
         Unsupported,
     }
@@ -176,20 +185,26 @@ static class AuthoredCorpusBenchmark
     /// <summary>
     /// Buckets a probe result along two taste axes. Family comes first: authored
     /// sugar the compiler erases (<c>compiler_lowering</c>) is an inherent,
-    /// unrecoverable limit, and a documented product decision (<c>known_taste</c>)
-    /// is already accounted for. Everything else is the raise frontier, split by
-    /// whether the shape difference is free at the IL level (Exact) or carries an
-    /// opcode/operand diff (semantic).
+    /// unrecoverable limit, and a documented product decision (<c>known_taste</c>
+    /// or <c>known_compiler_option</c>) is already accounted for. Everything else
+    /// is the raise frontier, split by whether the shape difference is free at the
+    /// IL level (Exact) or carries an opcode/operand diff (semantic).
+    ///
+    /// The probe collapses several statuses into <c>SourceUnavailable</c>: a
+    /// decompiler body that could not be graded at Full fidelity
+    /// (<c>fidelity-unavailable</c>/<c>NotFull</c>) is a decompiler limitation, not
+    /// corpus drift, so it gets its own <c>NotFull</c> bucket; only a genuinely
+    /// unresolved corpus identity counts as <c>Drift</c>.
     /// </summary>
     static TasteBucket ClassifyTaste(ReturnToSenderSourceProbeResult result)
         => result.Outcome switch
         {
             ReturnToSenderSourceOutcome.ValidMatch => TasteBucket.Correct,
             ReturnToSenderSourceOutcome.Invalid => TasteBucket.Invalid,
-            ReturnToSenderSourceOutcome.SourceUnavailable => TasteBucket.Drift,
+            ReturnToSenderSourceOutcome.SourceUnavailable => IsNotFullReason(result.Reason) ? TasteBucket.NotFull : TasteBucket.Drift,
             ReturnToSenderSourceOutcome.UnsupportedTarget => TasteBucket.Unsupported,
             ReturnToSenderSourceOutcome.ValidDifferent when result.Reason.Contains("compiler_lowering", StringComparison.Ordinal) => TasteBucket.Lowering,
-            ReturnToSenderSourceOutcome.ValidDifferent when result.Reason.Contains("known_taste", StringComparison.Ordinal) => TasteBucket.KnownTaste,
+            ReturnToSenderSourceOutcome.ValidDifferent when result.Reason.Contains("known_taste", StringComparison.Ordinal) || result.Reason.Contains("known_compiler_option", StringComparison.Ordinal) => TasteBucket.KnownTaste,
             ReturnToSenderSourceOutcome.ValidDifferent => result.CompileBackStatus switch
             {
                 FidelityCheck.CompileBackStatus.Exact => TasteBucket.FrontierIlExact,
@@ -198,6 +213,12 @@ static class AuthoredCorpusBenchmark
             },
             _ => TasteBucket.FrontierIlUnknown,
         };
+
+    // A SourceUnavailable row whose reason names a decompiler fidelity drop
+    // (the body could not be graded at Full) rather than a missing corpus source.
+    static bool IsNotFullReason(string reason)
+        => reason.Contains("fidelity-unavailable", StringComparison.Ordinal)
+            || reason.Equals("NotFull", StringComparison.Ordinal);
 
     static void WriteReasonBuckets(
         string title,
@@ -228,9 +249,10 @@ static class AuthoredCorpusBenchmark
     {
         int match = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.ValidMatch);
         int different = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.ValidDifferent);
-        int invalid = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.Invalid);
-        int unavailable = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.SourceUnavailable);
-        int unsupported = results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.UnsupportedTarget);
+        int invalid = results.Count(result => ClassifyTaste(result) == TasteBucket.Invalid);
+        int notFull = results.Count(result => ClassifyTaste(result) == TasteBucket.NotFull);
+        int drift = results.Count(result => ClassifyTaste(result) == TasteBucket.Drift);
+        int unsupported = results.Count(result => ClassifyTaste(result) == TasteBucket.Unsupported);
 
         var payload = new
         {
@@ -250,7 +272,8 @@ static class AuthoredCorpusBenchmark
                 frontierIlUnknown = results.Count(result => ClassifyTaste(result) == TasteBucket.FrontierIlUnknown),
             },
             invalid,
-            drift = unavailable,
+            notFull,
+            drift,
             unsupported,
             rows = results.Select(result => new
             {
@@ -267,6 +290,6 @@ static class AuthoredCorpusBenchmark
         };
 
         Console.WriteLine(JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
-        return invalid == 0 && unavailable == 0 ? 0 : 1;
+        return invalid == 0 && drift == 0 && unsupported == 0 ? 0 : 1;
     }
 }

--- a/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
+++ b/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
@@ -780,7 +780,7 @@ static class AuthoredRebuildFidelity
             drift.Add($"{name}={actual} (RTS uses {expected})");
     }
 
-    static async Task AcquirePdbAsync(
+    internal static async Task AcquirePdbAsync(
         SourceLinkService source,
         HttpClient httpClient)
     {

--- a/tools/DecompilerHarness/AuthoredSourceHarvest.cs
+++ b/tools/DecompilerHarness/AuthoredSourceHarvest.cs
@@ -280,7 +280,7 @@ static class AuthoredSourceHarvest
         }
     }
 
-    static (string Name, string Version) ReadAssemblyIdentity(string assemblyPath)
+    internal static (string Name, string Version) ReadAssemblyIdentity(string assemblyPath)
     {
         try
         {

--- a/tools/DecompilerHarness/AuthoredSourceHarvest.cs
+++ b/tools/DecompilerHarness/AuthoredSourceHarvest.cs
@@ -171,10 +171,24 @@ static class AuthoredSourceHarvest
 
         (string name, string version) = ReadAssemblyIdentity(assemblyPath);
         SourceLinkService? source = null;
+        bool ownershipTransferred = false;
         try
         {
             source = SourceLinkService.Open(assemblyPath);
             await AuthoredRebuildFidelity.AcquirePdbAsync(source, httpClient);
+
+            var state = new LibraryState
+            {
+                AssemblyPath = assemblyPath,
+                AssemblyName = name,
+                AssemblyVersion = version,
+                Tfm = InferTfm(assemblyPath),
+                Source = source,
+                Candidates = new Queue<RealMethodTargetEnumerator.RealMethodTarget>(
+                    DiversifyByDeclaringType(targets)),
+            };
+            ownershipTransferred = true;
+            return state;
         }
         catch (Exception ex) when (ex is HttpRequestException
             or IOException
@@ -184,20 +198,16 @@ static class AuthoredSourceHarvest
         {
             Console.Error.WriteLine(
                 $"Warning: harvest skipped '{assemblyPath}' opening SourceLink ({ex.GetType().Name}: {ex.Message}).");
-            source?.Dispose();
             return null;
         }
-
-        return new LibraryState
+        finally
         {
-            AssemblyPath = assemblyPath,
-            AssemblyName = name,
-            AssemblyVersion = version,
-            Tfm = InferTfm(assemblyPath),
-            Source = source,
-            Candidates = new Queue<RealMethodTargetEnumerator.RealMethodTarget>(
-                DiversifyByDeclaringType(targets)),
-        };
+            // Own the SourceLinkService until it is handed to a returned LibraryState.
+            // Any failure path (caught transient error, an unlisted exception, or the
+            // Queue/DiversifyByDeclaringType materialization throwing) disposes it here.
+            if (!ownershipTransferred)
+                source?.Dispose();
+        }
     }
 
     static async Task<CorpusRecord?> TryHarvestAsync(

--- a/tools/DecompilerHarness/AuthoredSourceHarvest.cs
+++ b/tools/DecompilerHarness/AuthoredSourceHarvest.cs
@@ -1,0 +1,305 @@
+using System.Reflection.PortableExecutable;
+using System.Reflection.Metadata;
+using System.Text.Json;
+
+using DotnetInspector.Core;
+using DotnetInspector.Services;
+using ILInspector.Findings;
+using ILInspector.Metadata;
+
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// Harvests the authored-source correspondence corpus: for a fixed set of input
+/// assemblies (the real-world corpus libraries), enumerate real-method targets,
+/// resolve each target's authoritative authored source through SourceLink, and
+/// snapshot the checksum-verified member body to a vendored JSONL corpus. Because
+/// the authored body is captured at generation time, benchmark runs that consume
+/// the corpus are fully offline.
+///
+/// Selection is identity-only and biased toward small libraries: candidates are
+/// ordered by round-robin across declaring types within each library, then pulled
+/// round-robin across libraries in ascending candidate-count order so a few large
+/// libraries do not drown out the small ones. Source content is fetched last, only
+/// to snapshot and verify; a failed or unavailable fetch simply advances to the
+/// next candidate, so every emitted row has real, checksum-verified source.
+/// </summary>
+static class AuthoredSourceHarvest
+{
+    internal sealed record CorpusRecord(
+        string Assembly,
+        string AssemblyVersion,
+        string Tfm,
+        string Type,
+        string Method,
+        int Overload,
+        string? Signature,
+        int MetadataToken,
+        int ParameterCount,
+        int IlSize,
+        string? SourceUrl,
+        string? ChecksumAlgorithm,
+        string? Checksum,
+        string AuthoredBody);
+
+    sealed class LibraryState
+    {
+        public required string AssemblyPath { get; init; }
+        public required string AssemblyName { get; init; }
+        public required string AssemblyVersion { get; init; }
+        public required string Tfm { get; init; }
+        public required SourceLinkService Source { get; init; }
+        public required Queue<RealMethodTargetEnumerator.RealMethodTarget> Candidates { get; init; }
+    }
+
+    public static int Run(IReadOnlyList<string> assemblies, string outputPath, int target)
+        => RunAsync(assemblies, outputPath, target).GetAwaiter().GetResult();
+
+    static async Task<int> RunAsync(IReadOnlyList<string> assemblies, string outputPath, int target)
+    {
+        if (assemblies.Count == 0)
+        {
+            Console.Error.WriteLine("Harvest requires at least one input assembly.");
+            return 1;
+        }
+
+        HttpClientFactory.Initialize();
+        using var httpClient = HttpClientFactory.CreateNew();
+        var fetcher = new SourceFetcher(HttpClientFactory.SharedUntrustedFetch);
+
+        var libraries = new List<LibraryState>();
+        try
+        {
+            foreach (string assemblyPath in assemblies)
+            {
+                var library = TryOpenLibrary(assemblyPath, httpClient).GetAwaiter().GetResult();
+                if (library is not null)
+                    libraries.Add(library);
+            }
+
+            if (libraries.Count == 0)
+            {
+                Console.Error.WriteLine("No input assembly produced real-method candidates.");
+                return 1;
+            }
+
+            // Smallest candidate pool first so small libraries are guaranteed a
+            // fair share before large libraries exhaust the target budget.
+            libraries.Sort((left, right) => left.Candidates.Count.CompareTo(right.Candidates.Count));
+
+            long attempts = 0;
+            long resolved = 0;
+            long skipped = 0;
+            var perLibraryKept = new Dictionary<string, int>(StringComparer.Ordinal);
+
+            await using var writer = new StreamWriter(outputPath, append: false);
+            var jsonOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = false,
+            };
+
+            bool progressed = true;
+            while (resolved < target && progressed)
+            {
+                progressed = false;
+                foreach (var library in libraries)
+                {
+                    if (resolved >= target)
+                        break;
+                    if (library.Candidates.Count == 0)
+                        continue;
+
+                    progressed = true;
+                    var candidate = library.Candidates.Dequeue();
+                    attempts++;
+
+                    var record = await TryHarvestAsync(library, candidate, fetcher);
+                    if (record is null)
+                    {
+                        skipped++;
+                        continue;
+                    }
+
+                    await writer.WriteLineAsync(JsonSerializer.Serialize(record, jsonOptions));
+                    resolved++;
+                    perLibraryKept.TryGetValue(library.AssemblyName, out int kept);
+                    perLibraryKept[library.AssemblyName] = kept + 1;
+                }
+            }
+
+            await writer.FlushAsync();
+
+            Console.WriteLine($"AUTHORED-SOURCE HARVEST -> {outputPath}");
+            Console.WriteLine($"  target        : {target}");
+            Console.WriteLine($"  resolved      : {resolved}");
+            Console.WriteLine($"  attempts      : {attempts}");
+            Console.WriteLine($"  skipped       : {skipped}");
+            Console.WriteLine($"  libraries     : {libraries.Count}");
+            Console.WriteLine("  per library   :");
+            foreach (var entry in perLibraryKept.OrderByDescending(pair => pair.Value))
+                Console.WriteLine($"    {entry.Key,-40} {entry.Value}");
+
+            return resolved == 0 ? 1 : 0;
+        }
+        finally
+        {
+            foreach (var library in libraries)
+                library.Source.Dispose();
+        }
+    }
+
+    static async Task<LibraryState?> TryOpenLibrary(string assemblyPath, HttpClient httpClient)
+    {
+        IReadOnlyList<RealMethodTargetEnumerator.RealMethodTarget> targets;
+        try
+        {
+            targets = RealMethodTargetEnumerator.Enumerate(assemblyPath);
+        }
+        catch (Exception ex) when (ex is IOException
+            or UnauthorizedAccessException
+            or BadImageFormatException
+            or InvalidOperationException)
+        {
+            Console.Error.WriteLine(
+                $"Warning: harvest skipped '{assemblyPath}' ({ex.GetType().Name}: {ex.Message}).");
+            return null;
+        }
+
+        if (targets.Count == 0)
+            return null;
+
+        (string name, string version) = ReadAssemblyIdentity(assemblyPath);
+        var source = SourceLinkService.Open(assemblyPath);
+        await AuthoredRebuildFidelity.AcquirePdbAsync(source, httpClient);
+
+        return new LibraryState
+        {
+            AssemblyPath = assemblyPath,
+            AssemblyName = name,
+            AssemblyVersion = version,
+            Tfm = InferTfm(assemblyPath),
+            Source = source,
+            Candidates = new Queue<RealMethodTargetEnumerator.RealMethodTarget>(
+                DiversifyByDeclaringType(targets)),
+        };
+    }
+
+    static async Task<CorpusRecord?> TryHarvestAsync(
+        LibraryState library,
+        RealMethodTargetEnumerator.RealMethodTarget candidate,
+        SourceFetcher fetcher)
+    {
+        var subject = new FindingSubject(
+            $"{candidate.Type}::{candidate.Method}#{candidate.Overload}",
+            $"{candidate.Type}.{candidate.Method}");
+
+        AuthoredMemberSourceInspection authored;
+        try
+        {
+            authored = await AuthoredSourceAcquisition.AcquireMemberAsync(
+                library.Source,
+                candidate.MetadataToken,
+                candidate.Method,
+                subject,
+                fetcher);
+        }
+        catch (Exception ex) when (ex is IOException
+            or InvalidOperationException
+            or HttpRequestException
+            or TaskCanceledException)
+        {
+            return null;
+        }
+
+        if (authored.Text is not { } memberSource || memberSource.Length == 0)
+            return null;
+
+        // Reduce the PDB line-span slice to the clean, disambiguated member body
+        // the benchmark will compare the decompiler output against.
+        if (!AuthoredRebuildFidelity.TryExtractTargetBody(
+                memberSource,
+                candidate.Method,
+                candidate.ParameterCount,
+                out string body)
+            || body.Length == 0)
+        {
+            return null;
+        }
+
+        return new CorpusRecord(
+            Assembly: library.AssemblyName,
+            AssemblyVersion: library.AssemblyVersion,
+            Tfm: library.Tfm,
+            Type: candidate.Type,
+            Method: candidate.Method,
+            Overload: candidate.Overload,
+            Signature: candidate.Signature,
+            MetadataToken: candidate.MetadataToken,
+            ParameterCount: candidate.ParameterCount,
+            IlSize: candidate.IlSize,
+            SourceUrl: authored.Document?.ResolvedUrl,
+            ChecksumAlgorithm: authored.Document?.ChecksumAlgorithm,
+            Checksum: authored.Document?.Checksum,
+            AuthoredBody: body);
+    }
+
+    // Round-robin across declaring types so no single type dominates a library's
+    // contribution to the corpus.
+    static IEnumerable<RealMethodTargetEnumerator.RealMethodTarget> DiversifyByDeclaringType(
+        IReadOnlyList<RealMethodTargetEnumerator.RealMethodTarget> targets)
+    {
+        var byType = new Dictionary<string, Queue<RealMethodTargetEnumerator.RealMethodTarget>>(
+            StringComparer.Ordinal);
+        var order = new List<string>();
+        foreach (var target in targets)
+        {
+            if (!byType.TryGetValue(target.Type, out var queue))
+            {
+                queue = new Queue<RealMethodTargetEnumerator.RealMethodTarget>();
+                byType[target.Type] = queue;
+                order.Add(target.Type);
+            }
+
+            queue.Enqueue(target);
+        }
+
+        bool progressed = true;
+        while (progressed)
+        {
+            progressed = false;
+            foreach (string type in order)
+            {
+                var queue = byType[type];
+                if (queue.Count == 0)
+                    continue;
+
+                progressed = true;
+                yield return queue.Dequeue();
+            }
+        }
+    }
+
+    static (string Name, string Version) ReadAssemblyIdentity(string assemblyPath)
+    {
+        try
+        {
+            using var pe = new PEReader(File.OpenRead(assemblyPath));
+            var reader = pe.GetMetadataReader();
+            var assembly = reader.GetAssemblyDefinition();
+            return (reader.GetString(assembly.Name), assembly.Version.ToString());
+        }
+        catch (Exception ex) when (ex is IOException or BadImageFormatException or InvalidOperationException)
+        {
+            return (Path.GetFileNameWithoutExtension(assemblyPath), "0.0.0.0");
+        }
+    }
+
+    // The published corpus assemblies live under lib/<tfm>/Name.dll; the parent
+    // directory name is the target framework moniker.
+    static string InferTfm(string assemblyPath)
+    {
+        string? directory = Path.GetDirectoryName(assemblyPath);
+        return directory is null ? "" : Path.GetFileName(directory);
+    }
+}

--- a/tools/DecompilerHarness/AuthoredSourceHarvest.cs
+++ b/tools/DecompilerHarness/AuthoredSourceHarvest.cs
@@ -170,8 +170,23 @@ static class AuthoredSourceHarvest
             return null;
 
         (string name, string version) = ReadAssemblyIdentity(assemblyPath);
-        var source = SourceLinkService.Open(assemblyPath);
-        await AuthoredRebuildFidelity.AcquirePdbAsync(source, httpClient);
+        SourceLinkService? source = null;
+        try
+        {
+            source = SourceLinkService.Open(assemblyPath);
+            await AuthoredRebuildFidelity.AcquirePdbAsync(source, httpClient);
+        }
+        catch (Exception ex) when (ex is HttpRequestException
+            or IOException
+            or TaskCanceledException
+            or InvalidOperationException
+            or BadImageFormatException)
+        {
+            Console.Error.WriteLine(
+                $"Warning: harvest skipped '{assemblyPath}' opening SourceLink ({ex.GetType().Name}: {ex.Message}).");
+            source?.Dispose();
+            return null;
+        }
 
         return new LibraryState
         {

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -71,6 +71,8 @@ static class Program
         bool enumerateRealMethods = false;
         bool harvestAuthoredCorpus = false;
         string? harvestOutputPath = null;
+        bool benchmarkAuthoredCorpus = false;
+        string? benchmarkCorpusPath = null;
         int harvestTarget = 12000;
         bool censusTsv = false;
         bool censusJsonl = false;
@@ -193,6 +195,10 @@ static class Program
                         harvestOutputPath = NextArg(args, ref i, flag);
                         break;
                     case "--harvest-target": harvestTarget = int.Parse(NextArg(args, ref i, flag)); break;
+                    case "--benchmark-authored-corpus":
+                        benchmarkAuthoredCorpus = true;
+                        benchmarkCorpusPath = NextArg(args, ref i, flag);
+                        break;
                     case "--emit-not-my-type-snapshot":
                         emitNotMyTypeSnapshot = NextArg(args, ref i, flag); notMyType = true; break;
                     case "--diff-not-my-type-baseline":
@@ -432,6 +438,9 @@ static class Program
 
         if (harvestAuthoredCorpus)
             return AuthoredSourceHarvest.Run(assemblies, harvestOutputPath!, harvestTarget);
+
+        if (benchmarkAuthoredCorpus)
+            return AuthoredCorpusBenchmark.Run(assemblies, benchmarkCorpusPath!, json);
 
         if (returnToSenderAb)
             return ReturnToSender.RunComparison(assemblies, cap, maxExamples);

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -69,6 +69,9 @@ static class Program
         string? diffNotMyTypeBaseline = null;
         string? emitHarnessReport = null;
         bool enumerateRealMethods = false;
+        bool harvestAuthoredCorpus = false;
+        string? harvestOutputPath = null;
+        int harvestTarget = 12000;
         bool censusTsv = false;
         bool censusJsonl = false;
         bool returnToSenderAb = false;
@@ -185,6 +188,11 @@ static class Program
                         diffReturnAddressBaseline = NextArg(args, ref i, flag); returnAddress = true; break;
                     case "--not-my-type": notMyType = true; break;
                     case "--enumerate-real-methods": enumerateRealMethods = true; break;
+                    case "--harvest-authored-corpus":
+                        harvestAuthoredCorpus = true;
+                        harvestOutputPath = NextArg(args, ref i, flag);
+                        break;
+                    case "--harvest-target": harvestTarget = int.Parse(NextArg(args, ref i, flag)); break;
                     case "--emit-not-my-type-snapshot":
                         emitNotMyTypeSnapshot = NextArg(args, ref i, flag); notMyType = true; break;
                     case "--diff-not-my-type-baseline":
@@ -421,6 +429,9 @@ static class Program
 
         if (enumerateRealMethods)
             return RunEnumerateRealMethods(assemblies, maxExamples);
+
+        if (harvestAuthoredCorpus)
+            return AuthoredSourceHarvest.Run(assemblies, harvestOutputPath!, harvestTarget);
 
         if (returnToSenderAb)
             return ReturnToSender.RunComparison(assemblies, cap, maxExamples);

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -68,6 +68,7 @@ static class Program
         string? emitNotMyTypeSnapshot = null;
         string? diffNotMyTypeBaseline = null;
         string? emitHarnessReport = null;
+        bool enumerateRealMethods = false;
         bool censusTsv = false;
         bool censusJsonl = false;
         bool returnToSenderAb = false;
@@ -183,6 +184,7 @@ static class Program
                     case "--diff-return-address-baseline":
                         diffReturnAddressBaseline = NextArg(args, ref i, flag); returnAddress = true; break;
                     case "--not-my-type": notMyType = true; break;
+                    case "--enumerate-real-methods": enumerateRealMethods = true; break;
                     case "--emit-not-my-type-snapshot":
                         emitNotMyTypeSnapshot = NextArg(args, ref i, flag); notMyType = true; break;
                     case "--diff-not-my-type-baseline":
@@ -417,6 +419,9 @@ static class Program
                 diffNotMyTypeBaseline,
                 emitHarnessReport);
 
+        if (enumerateRealMethods)
+            return RunEnumerateRealMethods(assemblies, maxExamples);
+
         if (returnToSenderAb)
             return ReturnToSender.RunComparison(assemblies, cap, maxExamples);
 
@@ -619,6 +624,45 @@ static class Program
     /// up; the residual-kind docket is the prioritized work. It measures
     /// completeness, not correctness — pair it with <c>--fidelity-check</c> for fidelity.
     /// </summary>
+    // Diagnostic: enumerate real-method targets per assembly and print counts
+    // plus a small sample. Proves RealMethodTargetEnumerator against real
+    // assemblies without invoking source acquisition or the decompiler.
+    static int RunEnumerateRealMethods(List<string> assemblies, int maxExamples)
+    {
+        long grandTotal = 0;
+        foreach (string assemblyPath in assemblies)
+        {
+            IReadOnlyList<RealMethodTargetEnumerator.RealMethodTarget> targets;
+            try
+            {
+                targets = RealMethodTargetEnumerator.Enumerate(assemblyPath);
+            }
+            catch (Exception ex) when (ex is IOException
+                or UnauthorizedAccessException
+                or BadImageFormatException
+                or InvalidOperationException)
+            {
+                Console.Error.WriteLine(
+                    $"Warning: skipped '{assemblyPath}' ({ex.GetType().Name}: {ex.Message}).");
+                continue;
+            }
+
+            grandTotal += targets.Count;
+            Console.WriteLine($"{Path.GetFileName(assemblyPath)}: {targets.Count} real-method targets");
+            foreach (var target in targets.Take(maxExamples))
+            {
+                string overload = target.Overload == 0 ? "" : $"#{target.Overload}";
+                string sig = target.Signature is null ? " (ordinal)" : $" [{target.Signature}]";
+                Console.WriteLine(
+                    $"  {target.Type}::{target.Method}{overload}"
+                    + $" params={target.ParameterCount} il={target.IlSize}{sig}");
+            }
+        }
+
+        Console.WriteLine($"Total real-method targets: {grandTotal}");
+        return 0;
+    }
+
     static int CompletenessScan(List<string> assemblies, int maxExamples, bool byShape = false)
     {
         long total = 0, clean = 0, crashes = 0;

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -275,15 +275,28 @@ assembly name, feeds the vendored authored bodies into the same
 source-correspondence oracle the on-demand census uses (through an in-memory
 `ReturnToSenderSourceIndex`), and emits a taste card (`--json` for structured
 output). Each target is `Correct` (valid, matches authored), one of four
-valid-but-different taste buckets, or `Invalid` (does not round-trip):
+valid-but-different taste buckets, `Invalid` (does not round-trip), or one of the
+diagnostic buckets below:
 
 - **lowering (inherent)** — authored used sugar the compiler erases (iterator,
   async, dynamic call site); unrecoverable from IL.
-- **known taste** — a documented product decision already explains the delta.
+- **known taste** — a documented product decision already explains the delta
+  (`known_taste` or a `known_compiler_option` such as a checked context).
 - **frontier, IL-exact (cosmetic)** — same semantics and identical IL; a pure
   surface-shape difference at the raise frontier.
 - **frontier, IL-diff (semantic)** — differs with an opcode/operand diff; worth
   scrutiny.
+- **Not-Full (uncheckable at Full)** — the decompiler body could not be graded at
+  Full fidelity (`fidelity-unavailable`/`NotFull`), so correspondence is not
+  decidable. This is a decompiler limitation, not corpus drift, so it does not
+  fail the run on its own.
+- **Drift (corpus source unresolved)** — the corpus identity no longer resolves to
+  a source slice in the pinned assembly (`source-slice-unavailable`/
+  `fixture-source-unavailable`); the corpus has drifted from the assembly.
+- **Unsupported (rts-target)** — the target is not an RTS-compilable member.
+
+The run exits nonzero when any target is `Invalid`, `Drift`, or `Unsupported`
+(round-trip failure or corpus/assembly drift). `Not-Full` alone does not fail.
 
 The corpus is vendored on the `vendor/authored-source-corpus` orphan branch so
 the harvested third-party source snapshots never enter main's history. Restore it

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -240,6 +240,56 @@ reports deterministic-build and portable-PDB option/reference context
 separately. `SourceAbsent` is missing evidence; `SourceFailed` is an acquisition
 or integrity failure.
 
+### Authored-source correspondence corpus (offline benchmark)
+
+`--authored-rebuild-fidelity` and `--source-correspondence-census` resolve
+authored source live through SourceLink, so they need network access and report
+`SourceUnavailable` whenever a library has no SourceLink. The authored-source
+correspondence corpus removes that variability: a vendored JSONL where each row
+is a real method identity plus a checksum-verified authored member body captured
+at harvest time. Benchmark runs over it are fully offline and, because every row
+carries a body, `SourceUnavailable` becomes a drift signal rather than an
+expected outcome.
+
+`--harvest-authored-corpus <out.jsonl> [--harvest-target N]` (default 12000)
+builds the corpus. It enumerates real-method targets across the input
+assemblies, orders candidates smallest-library-first with per-type
+diversification so a few large libraries do not drown out the small ones, then
+resolves each target's authoritative authored source through SourceLink and
+snapshots the member-only body with its `sourceUrl`, checksum algorithm, and
+checksum. A target whose source does not resolve is skipped, so every emitted
+row has real, verified source. The real-world corpus is harvested from the same
+14 pinned assemblies as the fixed real-world corpus
+(`eng/prepare-decompiler-corpus.sh`), keeping the two in lock step:
+
+```bash
+bash eng/prepare-decompiler-corpus.sh /tmp/corpus-assemblies.txt
+dotnet run --project tools/DecompilerHarness -c Release -- \
+  --harvest-authored-corpus /tmp/authored-corpus.jsonl --harvest-target 12000 \
+  $(cat /tmp/corpus-assemblies.txt)
+```
+
+`--benchmark-authored-corpus <corpus.jsonl> <assembly...>` runs the benchmark. It
+groups corpus rows by assembly, matches them to the supplied pinned assemblies by
+assembly name, feeds the vendored authored bodies into the same
+source-correspondence oracle the on-demand census uses (through an in-memory
+`ReturnToSenderSourceIndex`), and emits a taste card (`--json` for structured
+output). Each target is `Correct` (valid, matches authored), one of four
+valid-but-different taste buckets, or `Invalid` (does not round-trip):
+
+- **lowering (inherent)** — authored used sugar the compiler erases (iterator,
+  async, dynamic call site); unrecoverable from IL.
+- **known taste** — a documented product decision already explains the delta.
+- **frontier, IL-exact (cosmetic)** — same semantics and identical IL; a pure
+  surface-shape difference at the raise frontier.
+- **frontier, IL-diff (semantic)** — differs with an opcode/operand diff; worth
+  scrutiny.
+
+The corpus is vendored on the `vendor/authored-source-corpus` orphan branch so
+the harvested third-party source snapshots never enter main's history. Restore it
+with `bash eng/restore-authored-source-corpus.sh`, which adds a git worktree at
+`external/authored-source-corpus`.
+
 The generated fixture ladder is intentionally staged:
 
 | Stage | Harness responsibility |

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -296,7 +296,11 @@ diagnostic buckets below:
 - **Unsupported (rts-target)** — the target is not an RTS-compilable member.
 
 The run exits nonzero when any target is `Invalid`, `Drift`, or `Unsupported`
-(round-trip failure or corpus/assembly drift). `Not-Full` alone does not fail.
+(round-trip failure or corpus/assembly drift). It also exits nonzero — with a
+named blocker — when the run is not *honest*: any corpus row whose assembly was
+not supplied (`unmatchedRows > 0`) or a run that evaluated no targets at all.
+Every corpus row must be checked, so an empty or partially-unmatched run is never
+a success. `Not-Full` alone does not fail.
 
 The corpus is vendored on the `vendor/authored-source-corpus` orphan branch so
 the harvested third-party source snapshots never enter main's history. Restore it

--- a/tools/DecompilerHarness/RealMethodTargetEnumerator.cs
+++ b/tools/DecompilerHarness/RealMethodTargetEnumerator.cs
@@ -1,0 +1,205 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
+
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// Enumerates the "real" method targets of an assembly: body-bearing, named
+/// methods that are neither compiler-generated nor <c>SpecialName</c>
+/// accessors/operators/constructors. Property and event accessors, static and
+/// instance constructors, and compiler-synthesized members are intentionally
+/// excluded so the authored-source corpus is biased toward hand-written method
+/// bodies rather than trivial generated shapes.
+///
+/// Each target carries the same identity coordinates that
+/// <see cref="ReturnToSender.RequestedTarget"/> is matched against — the full
+/// type name, method name, and 0-based overload ordinal computed exactly as
+/// <c>ReturnToSender.TryFindMethod</c> computes it (counting every same-named
+/// method in <see cref="TypeDefinition.GetMethods"/> order, regardless of RVA)
+/// — plus a uniquely round-tripping signature when one exists and the raw
+/// metadata token for direct SourceLink acquisition.
+/// </summary>
+static class RealMethodTargetEnumerator
+{
+    /// <summary>
+    /// A single enumerated real-method target.
+    /// </summary>
+    /// <param name="Type">Full type name as produced by <c>GetFullTypeName</c>;
+    /// the key <see cref="ReturnToSender.RequestedTarget.Type"/> is matched on.</param>
+    /// <param name="Method">Method name.</param>
+    /// <param name="Overload">0-based ordinal among same-named methods in
+    /// <see cref="TypeDefinition.GetMethods"/> order.</param>
+    /// <param name="Signature">Normalized signature that resolves uniquely among
+    /// body-bearing same-named methods, or <c>null</c> when no such signature
+    /// exists (fall back to the ordinal).</param>
+    /// <param name="MetadataToken">Method-definition metadata token for direct
+    /// SourceLink acquisition.</param>
+    /// <param name="ParameterCount">Parameter count, used when extracting the
+    /// authored member body.</param>
+    /// <param name="IlSize">Method body IL byte length, used by difficulty
+    /// scoring for the hard-IL corpus.</param>
+    internal sealed record RealMethodTarget(
+        string Type,
+        string Method,
+        int Overload,
+        string? Signature,
+        int MetadataToken,
+        int ParameterCount,
+        int IlSize)
+    {
+        public ReturnToSender.RequestedTarget ToRequestedTarget()
+            => new(Type, Method, Overload, Signature);
+    }
+
+    /// <summary>
+    /// Enumerates every real-method target in <paramref name="assemblyPath"/>.
+    /// Types that are not classes or structs, the <c>&lt;Module&gt;</c> type, and
+    /// compiler-generated types (names containing <c>'&lt;'</c>) are skipped so the
+    /// results match what <c>ReturnToSender.CompileBackTargets</c> can resolve.
+    /// </summary>
+    public static IReadOnlyList<RealMethodTarget> Enumerate(string assemblyPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(assemblyPath);
+
+        var targets = new List<RealMethodTarget>();
+        using var pe = new PEReader(File.OpenRead(assemblyPath));
+        if (!pe.HasMetadata)
+            throw new InvalidOperationException("Assembly has no metadata.");
+
+        var reader = pe.GetMetadataReader();
+        using var metadata = CorpusMetadata.Create([assemblyPath]);
+        using var source = MetadataSource.Open(assemblyPath, context: metadata);
+
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            string typeName = reader.GetString(typeDef.Name);
+            if (typeName == "<Module>"
+                || typeName.Contains('<', StringComparison.Ordinal)
+                || source.ClassifyType((EntityHandle)typeHandle)
+                    is not (TypeShapeKind.Class or TypeShapeKind.Struct))
+            {
+                continue;
+            }
+
+            string fullType = reader.GetFullTypeName(typeDef);
+            if (fullType.Length == 0)
+                continue;
+
+            var overloadCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+            foreach (var methodHandle in typeDef.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                string methodName = reader.GetString(method.Name);
+
+                // Overload ordinal counts every same-named method in metadata
+                // order, exactly as ReturnToSender.TryFindMethod does, so a
+                // skipped accessor still advances the ordinal for later real
+                // overloads.
+                int overload = overloadCounts.TryGetValue(methodName, out int seen) ? seen : 0;
+                overloadCounts[methodName] = overload + 1;
+
+                if (!IsRealMethod(method, methodName))
+                    continue;
+
+                int parameterCount = ParameterCount(reader, typeDef, method);
+                string? signature = ResolveUniqueSignature(reader, typeDef, methodName, methodHandle);
+                int ilSize = BodyIlSize(pe, method);
+
+                targets.Add(new RealMethodTarget(
+                    fullType,
+                    methodName,
+                    overload,
+                    signature,
+                    MetadataTokens.GetToken(methodHandle),
+                    parameterCount,
+                    ilSize));
+            }
+        }
+
+        return targets;
+    }
+
+    static bool IsRealMethod(MethodDefinition method, string methodName)
+    {
+        if (method.RelativeVirtualAddress == 0)
+            return false;
+
+        // Exclude accessors, operators, constructors, and other special-name
+        // members: the authored-source corpus targets hand-written method
+        // bodies, not generated or ceremonial shapes.
+        if ((method.Attributes & (MethodAttributes.SpecialName | MethodAttributes.RTSpecialName)) != 0)
+            return false;
+
+        // Exclude compiler-generated methods (e.g. <Foo>b__0, lambda/local
+        // function bodies, iterator/async MoveNext) whose names carry '<'.
+        if (methodName.Contains('<', StringComparison.Ordinal))
+            return false;
+
+        // Exclude P/Invoke and other bodyless declarations defensively; these
+        // already fail the RVA check above but the intent is explicit.
+        if ((method.Attributes & MethodAttributes.PinvokeImpl) != 0)
+            return false;
+
+        return true;
+    }
+
+    static int ParameterCount(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)
+    {
+        try
+        {
+            return method.DecodeSignature(
+                    SignatureDecoder.Instance,
+                    GenericContext.ForMethod(reader, typeDef, method))
+                .ParameterTypes.Length;
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            return method.GetParameters().Count;
+        }
+    }
+
+    static string? ResolveUniqueSignature(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        string methodName,
+        MethodDefinitionHandle methodHandle)
+    {
+        string? signature;
+        try
+        {
+            signature = SignatureIdentity.ForMetadataMethod(reader, typeDef, methodHandle);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            return null;
+        }
+
+        if (signature is null)
+            return null;
+
+        return ReturnToSender.ResolvesUniquelyBySignature(reader, typeDef, methodName, signature, methodHandle)
+            ? signature
+            : null;
+    }
+
+    static int BodyIlSize(PEReader pe, MethodDefinition method)
+    {
+        if (method.RelativeVirtualAddress == 0)
+            return 0;
+
+        try
+        {
+            return pe.GetMethodBody(method.RelativeVirtualAddress).GetILBytes()?.Length ?? 0;
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            return 0;
+        }
+    }
+}

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -225,6 +225,16 @@ static partial class ReturnToSenderSourceProbe
             ReturnToSenderSourceIndex.TryCreate(sourcePaths),
             "source index could not be built from the supplied source paths");
 
+    public static IReadOnlyList<ReturnToSenderSourceProbeResult> EvaluateWithIndex(
+        string assemblyPath,
+        IReadOnlyList<ReturnToSender.RequestedTarget> targets,
+        ReturnToSenderSourceIndex sourceIndex)
+        => EvaluateTargets(
+            assemblyPath,
+            targets,
+            sourceIndex,
+            "authored-source corpus row missing for target");
+
     static IReadOnlyList<ReturnToSenderSourceProbeResult> EvaluateTargets(
         string assemblyPath,
         IReadOnlyList<ReturnToSender.RequestedTarget> targets,
@@ -638,6 +648,42 @@ internal sealed class ReturnToSenderSourceIndex
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Builds an index directly from pre-snapshotted authored members (the vendored
+    /// authored-source corpus). Keys are derived exactly as <see cref="AddSourceFile"/>
+    /// does, so lookups from a <see cref="ReturnToSender.RequestedTarget"/> resolve
+    /// by signature when unambiguous and otherwise by (type, method, overload).
+    /// Members with no signature are indexed by overload key only.
+    /// </summary>
+    public static ReturnToSenderSourceIndex FromMembers(IEnumerable<ReturnToSenderSourceMember> sourceMembers)
+    {
+        var members = new Dictionary<string, ReturnToSenderSourceMember>(StringComparer.Ordinal);
+        var membersBySignature = new Dictionary<string, ReturnToSenderSourceMember>(StringComparer.Ordinal);
+        var ambiguousSignatures = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var member in sourceMembers)
+        {
+            members.TryAdd(Key(member.Type, member.Method, member.Overload), member);
+
+            if (string.IsNullOrEmpty(member.Signature))
+                continue;
+
+            var signatureKey = SigKey(member.Type, member.Method, member.Signature);
+            if (ambiguousSignatures.Contains(signatureKey))
+                continue;
+            if (!membersBySignature.TryAdd(signatureKey, member))
+            {
+                membersBySignature.Remove(signatureKey);
+                ambiguousSignatures.Add(signatureKey);
+            }
+        }
+
+        return new ReturnToSenderSourceIndex(
+            members,
+            membersBySignature,
+            ambiguousSignatures,
+            new Dictionary<string, RecordSourceInfo>(StringComparer.Ordinal));
     }
 
     static bool TryGetFixtureAssemblyPath(FixtureDefinition fixture, out string path)


### PR DESCRIPTION
## Summary

Adds an **offline authored-source correspondence benchmark** for the decompiler,
plus the vendored corpus it runs against. For each corpus row — a real method
identity paired with a checksum-verified authored member body — the benchmark
compiles the decompiler output against the authored source **in the same RTS
shell** and grades correspondence, with no network access at benchmark time.

This replaces the abandoned #2905 approach. The key realization is that
`ReturnToSenderSourceProbe` is *already* the on-demand "original source" oracle
(ValidMatch / ValidDifferent / Invalid / SourceUnavailable). The fixed benchmark
is that same classifier fed **corpus-vendored** bodies instead of live SourceLink
resolution, so `SourceUnavailable` drops to zero by construction and becomes a
drift signal rather than an expected outcome. Net new logic is small; the proven
classifier is reused wholesale.

## What's here

- **Harvester** (`--harvest-authored-corpus <out> [--harvest-target N]`, default
  12000): enumerates real-method targets across the pinned corpus assemblies,
  orders candidates smallest-library-first with per-type diversification, resolves
  each target's authoritative authored source through SourceLink, and snapshots
  the checksum-verified member-only body to JSONL. Unresolved targets are skipped,
  so every emitted row has real, verified source.
- **Benchmark** (`--benchmark-authored-corpus <corpus.jsonl> <asm...>`): builds an
  in-memory `ReturnToSenderSourceIndex.FromMembers` from corpus rows and runs the
  existing correspondence oracle via `EvaluateWithIndex`. Emits a taste card
  (text or `--json`).
- **Taste buckets**: valid-but-different is split along two axes the oracle
  already computes — family (`compiler_lowering` = inherent/unrecoverable,
  `known_taste` = documented, else raise frontier) and, for the frontier, IL cost
  (`Exact` = cosmetic vs `Opcode`/`OperandDiff` = semantic). Derived at card time;
  corpus rows are unchanged.
- **Vendored corpus**: harvested on the `vendor/authored-source-corpus` orphan
  branch (already pushed) as `real-world/corpus.jsonl` — 12,000 rows from the same
  14 pinned assemblies as the fixed real-world corpus (11 contributed; 3 lacked
  SourceLink → 0 rows). 0 malformed / 0 empty-body / 0 missing sourceUrl. Orphan
  branch keeps the source snapshots out of main's history.
- **`eng/restore-authored-source-corpus.sh`** mirrors `restore-ilassembler.sh`
  (worktree at the gitignored `external/authored-source-corpus`).
- **Docs**: DecompilerHarness README documents harvest, benchmark, taste buckets,
  and restore.

## Enumerator/harvester internals

The enumerator replicates RTS overload numbering (`OverloadIndex`/`TryFindMethod`)
exactly, so a corpus row's `(type, method, overload)` resolves against
`CompileBackTargets` for the pinned assembly. Because the benchmark builds both
the targets and the source index from the *same* corpus rows, `TryFind` always
resolves — `SourceUnavailable` only appears on genuine corpus/assembly drift.

## Evidence (offline: restore → benchmark, on the pinned DLLs)

Full offline path proven end-to-end. 4 small self-assemblies (268 rows) against
the vendored corpus:

```
Correct  (valid, matches authored)  : 37
Valid    (valid, differs)           : 195
  frontier, IL-exact (cosmetic)     : 132
  frontier, IL-diff (semantic)      : 63
Invalid  (does not round-trip)      : 36   (CS1001 x14, CS0029 x8, CS1503 x5, ...)
Valid rate   : 232/268 (86.6%)
```

The 36 Invalid rows are genuine decompiler round-trip defects surfaced by the
benchmark; the 63 semantic-frontier rows are the actionable divergences.

Harvest summary: target 12000, resolved 12000, attempts 18315, skipped 6315,
11/14 libraries contributing.

## Testing

- `dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release`
  clean (0 warnings), post-rebase on `origin/main`.
- Benchmark run (text + `--json`) proven on the 30-row Humanizer test corpus and
  on the vendored 12k corpus via the restore worktree.
- `markdownlint` clean on the changed Markdown.

This is a harness/tooling change — no product decompiler behavior changes. Not a
raise/printer change, so no render-text A/B applies.

## Review

Non-trivial harness behavior change; requesting **adversarial review from two of
{GPT-5.5, Gemini 3.1 Pro, MAI-Code-1-Flash}** per the AGENTS.md policy (author
model is Claude Opus 4.8). Attack points: overload-ordinal correspondence between
enumerator and RTS; the `FromMembers` signature/overload keying vs `TryFind`; the
taste-bucket family/IL-axis classification; and whether any `SourceUnavailable`
can arise from something other than true drift.

## Follow-up (not in this PR)

Hard-IL slice: IL difficulty scoring (branch/nesting/EH metrics; `ilSize` already
captured) + a broad-source harvest into `hard-il/corpus.jsonl` on the same vendor
branch.
