### PR TITLE
Add IL difficulty scoring to rank hard-IL corpus candidates

### DIFF
--- a/tools/DecompilerHarness/IlDifficultyScorer.cs
+++ b/tools/DecompilerHarness/IlDifficultyScorer.cs
@@ -1,0 +1,159 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+using ILInspector.Instructions;
+
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// A per-method IL difficulty profile plus a single composite <see cref="Score"/>
+/// used to rank the "diabolical" methods for the hard-IL corpus. Every component
+/// is a structural fact read off the shared <see cref="MethodInstructions"/>
+/// substrate (decode + EH-aware block graph) — no inspected-assembly loading, no
+/// abstract interpretation. Ranking, not the absolute scale, is what matters; the
+/// components are retained so a selection pass can re-weight or filter on any
+/// single axis.
+/// </summary>
+internal sealed record IlDifficulty(
+    int IlSize,
+    int BlockCount,
+    int BranchCount,
+    int SwitchCount,
+    int ExceptionRegionCount,
+    int ExceptionNestingDepth,
+    int RareOpcodeCount,
+    int LocalCount,
+    int MaxStack,
+    double Score)
+{
+    public static readonly IlDifficulty Empty = new(0, 0, 0, 0, 0, 0, 0, 0, 0, 0.0);
+}
+
+/// <summary>
+/// Scores a method body's IL difficulty from the shared instruction substrate.
+/// The composite weighting deliberately biases toward the shapes that stress the
+/// decompiler's raise the most — exception-handler nesting, jump tables, and rare
+/// unsafe/typed-reference lowerings — rather than raw size, so the hard-IL corpus
+/// fills with genuinely hard puzzles instead of merely long trivial methods.
+/// </summary>
+static class IlDifficultyScorer
+{
+    // Genuinely rare / hard-to-raise opcodes: unsafe block memory, stack
+    // allocation, function pointers, typed references, varargs, and other
+    // low-frequency shapes that carry unusual lowerings. Common opcodes with
+    // well-understood raises (calls, field access, arithmetic, ordinary
+    // branches, box/unbox, generic constrained calls) are intentionally absent.
+    static readonly ImmutableHashSet<ILOpCode> RareOpcodes = ImmutableHashSet.Create(
+        ILOpCode.Calli,
+        ILOpCode.Cpblk,
+        ILOpCode.Initblk,
+        ILOpCode.Localloc,
+        ILOpCode.Sizeof,
+        ILOpCode.Mkrefany,
+        ILOpCode.Refanyval,
+        ILOpCode.Refanytype,
+        ILOpCode.Arglist,
+        ILOpCode.Ckfinite,
+        ILOpCode.Jmp,
+        ILOpCode.Cpobj,
+        ILOpCode.Endfilter,
+        ILOpCode.Unaligned,
+        ILOpCode.Tail);
+
+    /// <summary>
+    /// Computes the difficulty profile for a decoded method body. When the body
+    /// could not be decoded, the size/local/stack scalars are still recorded and
+    /// the control-flow components stay zero, so a decode failure never inflates
+    /// a method's rank.
+    /// </summary>
+    public static IlDifficulty Score(MethodInstructions decoded, int ilSize, int localCount, int maxStack)
+    {
+        int branchCount = 0;
+        int switchCount = 0;
+        int rareOpcodeCount = 0;
+        foreach (var instruction in decoded.Instructions)
+        {
+            if (instruction.Branches)
+                branchCount++;
+            if (instruction.OpCode == ILOpCode.Switch)
+                switchCount++;
+            if (RareOpcodes.Contains(instruction.OpCode))
+                rareOpcodeCount++;
+        }
+
+        int blockCount = decoded.Blocks.Blocks.Length;
+        int ehRegionCount = decoded.Blocks.Regions.Length;
+        int ehNestingDepth = ExceptionNestingDepth(decoded.Blocks.Regions);
+
+        // Weighting rationale (ranking-only; absolute magnitude is irrelevant).
+        // The size-like axes (IL bytes, block count, branch count, locals) grow
+        // without bound on large methods, so they are damped with a square root:
+        // a 6 KB dispatcher should rank high, but its size must not swamp a small,
+        // genuinely diabolical body. The per-feature structural signals the raise
+        // most often fails on stay linear so they can dominate:
+        //   - EH nesting depth (nested try/catch/finally/filter) — highest weight.
+        //   - Rare unsafe / typed-reference / function-pointer opcodes.
+        //   - Switch tables and the raw count of EH regions.
+        double score =
+              Math.Sqrt(ilSize) * 0.6
+            + Math.Sqrt(blockCount) * 2.0
+            + Math.Sqrt(branchCount) * 2.0
+            + switchCount * 5.0
+            + ehRegionCount * 4.0
+            + ehNestingDepth * 10.0
+            + rareOpcodeCount * 6.0
+            + Math.Sqrt(localCount) * 0.5
+            + maxStack * 0.3;
+
+        return new IlDifficulty(
+            ilSize,
+            blockCount,
+            branchCount,
+            switchCount,
+            ehRegionCount,
+            ehNestingDepth,
+            rareOpcodeCount,
+            localCount,
+            maxStack,
+            Math.Round(score, 1));
+    }
+
+    /// <summary>
+    /// Maximum exception-handler nesting depth: the longest chain of regions
+    /// where each region's protected try lies wholly inside another region's try
+    /// or handler span. A flat method with no EH scores 0; a single try/catch
+    /// scores 1; a try nested inside a catch (or a try) scores 2, and so on.
+    /// </summary>
+    static int ExceptionNestingDepth(ImmutableArray<ExceptionRegionModel> regions)
+    {
+        if (regions.Length == 0)
+            return 0;
+
+        int maxDepth = 0;
+        foreach (var region in regions)
+        {
+            int depth = 1;
+            foreach (var other in regions)
+            {
+                if (ReferenceEquals(other, region))
+                    continue;
+
+                // Strict containment only: sibling handlers on the same try share
+                // identical try spans and must not count as nesting each other.
+                bool nestedInTry =
+                    other.TryStart <= region.TryStart && region.TryEnd <= other.TryEnd
+                    && (other.TryStart < region.TryStart || region.TryEnd < other.TryEnd);
+                bool nestedInHandler =
+                    other.HandlerStart <= region.TryStart && region.TryEnd <= other.HandlerEnd
+                    && (other.HandlerStart < region.TryStart || region.TryEnd < other.HandlerEnd);
+                if (nestedInTry || nestedInHandler)
+                    depth++;
+            }
+
+            if (depth > maxDepth)
+                maxDepth = depth;
+        }
+
+        return maxDepth;
+    }
+}

--- a/tools/DecompilerHarness/IlDifficultyScorer.cs
+++ b/tools/DecompilerHarness/IlDifficultyScorer.cs
@@ -68,6 +68,14 @@ static class IlDifficultyScorer
     /// </summary>
     public static IlDifficulty Score(MethodInstructions decoded, int ilSize, int localCount, int maxStack)
     {
+        // A body that did not fully decode yields unreliable control-flow facts
+        // (empty or partial blocks and instructions). Scoring it on raw size
+        // alone would float undecodable junk to the top of the hard-IL ranking,
+        // so it is recorded with its true size/local/stack scalars but a zero
+        // score to sink it — a decode failure must never inflate a rank.
+        if (!decoded.IsComplete)
+            return new IlDifficulty(ilSize, 0, 0, 0, 0, 0, 0, localCount, maxStack, 0.0);
+
         int branchCount = 0;
         int switchCount = 0;
         int rareOpcodeCount = 0;
@@ -119,34 +127,59 @@ static class IlDifficultyScorer
     }
 
     /// <summary>
-    /// Maximum exception-handler nesting depth: the longest chain of regions
-    /// where each region's protected try lies wholly inside another region's try
-    /// or handler span. A flat method with no EH scores 0; a single try/catch
-    /// scores 1; a try nested inside a catch (or a try) scores 2, and so on.
+    /// Maximum exception-handler nesting depth: the longest chain of protected
+    /// <c>try</c> blocks where each is wholly contained inside another region's
+    /// try, handler, or filter span. Nesting is measured over <em>distinct</em>
+    /// try spans, so the multiple sibling handlers a single <c>try</c> emits
+    /// (each a region sharing the same try span) collapse to one level. A flat
+    /// method with no EH scores 0; a single try/catch scores 1; a try nested
+    /// inside another try/handler/filter scores 2, and so on. A
+    /// <c>try/catch/finally</c> nested inside a <c>try/catch/finally</c> scores 4
+    /// because the compiler emits the <c>finally</c> as an outer region whose try
+    /// span also protects its sibling <c>catch</c>.
     /// </summary>
     static int ExceptionNestingDepth(ImmutableArray<ExceptionRegionModel> regions)
     {
         if (regions.Length == 0)
             return 0;
 
-        int maxDepth = 0;
+        // Collapse sibling handlers: multiple catch/filter clauses on one try
+        // each emit a region with an identical try span, but together they are a
+        // single level of protection, so nesting is counted over distinct try
+        // spans only.
+        var tryScopes = new HashSet<(int Start, int End)>();
+        foreach (var region in regions)
+            tryScopes.Add((region.TryStart, region.TryEnd));
+
+        // A try can also be nested inside a handler body or a filter block. These
+        // spans are distinct per region, so no deduplication is needed; the
+        // filter span exists only for filter-kind regions.
+        var enclosingScopes = new HashSet<(int Start, int End)>();
         foreach (var region in regions)
         {
+            enclosingScopes.Add((region.HandlerStart, region.HandlerEnd));
+            if (region.Kind == HandlerKind.Filter)
+                enclosingScopes.Add((region.FilterStart, region.FilterEnd));
+        }
+
+        int maxDepth = 0;
+        foreach (var inner in tryScopes)
+        {
             int depth = 1;
-            foreach (var other in regions)
+            foreach (var outer in tryScopes)
             {
-                if (ReferenceEquals(other, region))
+                if (outer.Start == inner.Start && outer.End == inner.End)
                     continue;
 
-                // Strict containment only: sibling handlers on the same try share
-                // identical try spans and must not count as nesting each other.
-                bool nestedInTry =
-                    other.TryStart <= region.TryStart && region.TryEnd <= other.TryEnd
-                    && (other.TryStart < region.TryStart || region.TryEnd < other.TryEnd);
-                bool nestedInHandler =
-                    other.HandlerStart <= region.TryStart && region.TryEnd <= other.HandlerEnd
-                    && (other.HandlerStart < region.TryStart || region.TryEnd < other.HandlerEnd);
-                if (nestedInTry || nestedInHandler)
+                // Distinct spans: containment here is necessarily strict.
+                if (outer.Start <= inner.Start && inner.End <= outer.End)
+                    depth++;
+            }
+
+            foreach (var scope in enclosingScopes)
+            {
+                if (scope.Start <= inner.Start && inner.End <= scope.End
+                    && (scope.Start < inner.Start || inner.End < scope.End))
                     depth++;
             }
 

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -669,13 +669,23 @@ static class Program
 
             grandTotal += targets.Count;
             Console.WriteLine($"{Path.GetFileName(assemblyPath)}: {targets.Count} real-method targets");
-            foreach (var target in targets.Take(maxExamples))
+            // Surface the hardest methods first: the difficulty ranking is the
+            // whole point of the enumeration for the hard-IL corpus.
+            foreach (var target in targets
+                .OrderByDescending(target => target.Difficulty.Score)
+                .Take(maxExamples))
             {
                 string overload = target.Overload == 0 ? "" : $"#{target.Overload}";
                 string sig = target.Signature is null ? " (ordinal)" : $" [{target.Signature}]";
+                var difficulty = target.Difficulty;
                 Console.WriteLine(
-                    $"  {target.Type}::{target.Method}{overload}"
-                    + $" params={target.ParameterCount} il={target.IlSize}{sig}");
+                    $"  score={difficulty.Score,7:F1}  {target.Type}::{target.Method}{overload}");
+                Console.WriteLine(
+                    $"    params={target.ParameterCount} il={difficulty.IlSize} blocks={difficulty.BlockCount}"
+                    + $" branches={difficulty.BranchCount} switch={difficulty.SwitchCount}"
+                    + $" eh={difficulty.ExceptionRegionCount} ehDepth={difficulty.ExceptionNestingDepth}"
+                    + $" rare={difficulty.RareOpcodeCount} locals={difficulty.LocalCount}"
+                    + $" maxStack={difficulty.MaxStack}{sig}");
             }
         }
 

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -307,6 +307,56 @@ the harvested third-party source snapshots never enter main's history. Restore i
 with `bash eng/restore-authored-source-corpus.sh`, which adds a git worktree at
 `external/authored-source-corpus`.
 
+#### Hard-IL difficulty ranking (`--enumerate-real-methods`)
+
+The real-world corpus tracks the 14 pinned assemblies for affinity. The
+companion *hard-IL* corpus is instead an adversarial stress set — the
+"diabolical" real methods drawn from a much broader assembly pool and ranked by
+how hard their IL is to raise. `--enumerate-real-methods [--max-examples N]
+<assembly...>` is the inspection command behind that ranking: it enumerates the
+real-method targets in each assembly, scores every body, and prints the top
+`N` by difficulty (highest first) with the full component breakdown, e.g.:
+
+```text
+  score=   85.6  DiffFixture.Graded::NestedEh
+    params=1 il=36 blocks=27 branches=5 switch=0 eh=4 ehDepth=4 rare=0 locals=1 maxStack=2 [`0(int)]
+```
+
+Every component is a structural fact read off the shared
+`ILInspector.Instructions` substrate (IL decode + EH-aware block graph); there is
+no inspected-assembly loading and no abstract interpretation, so the scorer stays
+SRM-only and NativeAOT-friendly. A body that fails to decode records only its
+size/local/stack scalars and zero control-flow, so a decode failure never
+inflates a rank.
+
+| Component | Meaning |
+| --- | --- |
+| `il` | IL body size in bytes. |
+| `blocks` | Basic-block count from the substrate's block graph. |
+| `branches` | Instructions that branch (includes `switch`). |
+| `switch` | `switch` (jump-table) instruction count. |
+| `eh` | Exception-handling region count (catch/filter/finally/fault). |
+| `ehDepth` | Deepest exception-region nesting chain (see below). |
+| `rare` | Rare/hard-to-raise opcodes: `calli`, `cpblk`, `initblk`, `localloc`, `sizeof`, `mkrefany`, `refanyval`, `refanytype`, `arglist`, `ckfinite`, `jmp`, `cpobj`, `endfilter`, `unaligned`, `tail`. |
+| `locals` | Local-variable count. |
+| `maxStack` | Declared maximum evaluation-stack depth. |
+
+The composite `score` is ranking-only — its absolute magnitude is meaningless.
+The size-like axes (`il`, `blocks`, `branches`, `locals`) are square-root damped
+so a large dispatcher ranks high without its sheer size swamping a small but
+genuinely nasty body, while the per-feature signals the raise most often fails on
+stay linear and can dominate: exception-nesting depth carries the highest weight,
+followed by rare opcodes, switch tables, and the raw EH-region count. Because the
+components are all printed, a later selection pass can re-weight or filter on any
+single axis.
+
+`ehDepth` is the longest chain of exception regions where each region's protected
+`try` lies strictly inside another region's `try` or handler span. Sibling
+handlers on one `try` share an identical `try` span and are not counted as
+nesting each other; a `finally` that protects its sibling `catch` does deepen the
+chain, so `try/catch/finally` nested inside another `try/catch/finally` reports
+`ehDepth=4`.
+
 The generated fixture ladder is intentionally staged:
 
 | Stage | Harness responsibility |

--- a/tools/DecompilerHarness/RealMethodTargetEnumerator.cs
+++ b/tools/DecompilerHarness/RealMethodTargetEnumerator.cs
@@ -4,6 +4,7 @@ using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 
 using ILInspector.Decompiler.Pipeline;
+using ILInspector.Instructions;
 using ILInspector.Metadata;
 
 namespace ILInspector.DecompilerHarness;
@@ -43,6 +44,8 @@ static class RealMethodTargetEnumerator
     /// authored member body.</param>
     /// <param name="IlSize">Method body IL byte length, used by difficulty
     /// scoring for the hard-IL corpus.</param>
+    /// <param name="Difficulty">Structural IL difficulty profile plus composite
+    /// score used to rank the hard-IL corpus.</param>
     internal sealed record RealMethodTarget(
         string Type,
         string Method,
@@ -50,7 +53,8 @@ static class RealMethodTargetEnumerator
         string? Signature,
         int MetadataToken,
         int ParameterCount,
-        int IlSize)
+        int IlSize,
+        IlDifficulty Difficulty)
     {
         public ReturnToSender.RequestedTarget ToRequestedTarget()
             => new(Type, Method, Overload, Signature);
@@ -109,7 +113,7 @@ static class RealMethodTargetEnumerator
 
                 int parameterCount = ParameterCount(reader, typeDef, method);
                 string? signature = ResolveUniqueSignature(reader, typeDef, methodName, methodHandle);
-                int ilSize = BodyIlSize(pe, method);
+                IlDifficulty difficulty = ComputeDifficulty(pe, reader, typeDef, method);
 
                 targets.Add(new RealMethodTarget(
                     fullType,
@@ -118,7 +122,8 @@ static class RealMethodTargetEnumerator
                     signature,
                     MetadataTokens.GetToken(methodHandle),
                     parameterCount,
-                    ilSize));
+                    difficulty.IlSize,
+                    difficulty));
             }
         }
 
@@ -188,14 +193,43 @@ static class RealMethodTargetEnumerator
             : null;
     }
 
-    static int BodyIlSize(PEReader pe, MethodDefinition method)
+    static IlDifficulty ComputeDifficulty(
+        PEReader pe,
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        MethodDefinition method)
     {
         if (method.RelativeVirtualAddress == 0)
+            return IlDifficulty.Empty;
+
+        try
+        {
+            var body = pe.GetMethodBody(method.RelativeVirtualAddress);
+            int ilSize = body.GetILBytes()?.Length ?? 0;
+            int localCount = LocalCount(reader, typeDef, method, body);
+            var decoded = MethodInstructions.Decode(body);
+            return IlDifficultyScorer.Score(decoded, ilSize, localCount, body.MaxStack);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            return IlDifficulty.Empty;
+        }
+    }
+
+    static int LocalCount(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        MethodDefinition method,
+        MethodBodyBlock body)
+    {
+        if (body.LocalSignature.IsNil)
             return 0;
 
         try
         {
-            return pe.GetMethodBody(method.RelativeVirtualAddress).GetILBytes()?.Length ?? 0;
+            return reader.GetStandaloneSignature(body.LocalSignature)
+                .DecodeLocalSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method))
+                .Length;
         }
         catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
         {


### PR DESCRIPTION
## Why

The authored-source correspondence work has two corpus slices: a **real-world** corpus pinned to the 14 benchmark assemblies (affinity), and a **hard-IL** corpus — an adversarial stress set of the *diabolical* real methods drawn from a much broader assembly pool and ranked by how hard their IL is to raise. This PR adds the **difficulty-ranking substrate** the future hard-IL harvest will select on. Harvest itself is a follow-up PR.

## What

- **New `IlDifficultyScorer` + `IlDifficulty`** (`tools/DecompilerHarness/IlDifficultyScorer.cs`). Computes a per-method structural profile entirely off the shared `ILInspector.Instructions` substrate (IL decode + EH-aware block graph). No inspected-assembly loading, no abstract interpretation — SRM-only, NativeAOT-friendly. Components: IL size, block count, branch count, switch count, EH-region count, EH-nesting depth, rare-opcode count, local count, max stack.
- **Ranking-only composite score.** Size-like axes (`il`/`blocks`/`branches`/`locals`) are square-root damped so a large dispatcher ranks high without its sheer size swamping a small but genuinely nasty body; the per-feature signals the raise most often fails on stay linear and can dominate — EH-nesting depth highest, then rare opcodes, switch tables, EH-region count.
- **EH-nesting depth** = longest chain of strictly-contained regions. Sibling handlers on one `try` share a `try` span and are *not* counted as nesting each other; a `finally` protecting its sibling `catch` does deepen the chain.
- **Decode failure never inflates rank** — falls back to size/local/stack scalars with zero control-flow.
- `RealMethodTarget` carries the profile; `--enumerate-real-methods` now sorts by difficulty descending and prints the full component breakdown. `IlSize` is preserved so the authored-source harvester is unaffected.
- README documents the command, components, weighting rationale, and EH-nesting semantics (markdownlint clean).

## Evidence

**Graded compiled-fixture canary** (Trivial → Branchy → Switchy → UnsafeBlocks → NestedEh), built and enumerated:

\`\`\`text
score=   75.6  Graded::NestedEh      eh=4 ehDepth=4
score=   32.1  Graded::UnsafeBlocks  rare=2 (localloc x2)
score=   26.3  Graded::Switchy       switch=1
score=   16.6  Graded::Branchy       branches=6
score=    5.6  Graded::Trivial       il=4
\`\`\`

Monotonic with intended difficulty. `NestedEh` correctly scores `ehDepth=4` because a `finally` protects its sibling `catch`, so the real ECMA region chain is inner-catch ⊂ inner-finally ⊂ outer-catch ⊂ outer-finally.

**Real-assembly canary** (`ILInspector.Decompiler.dll`, 3362 targets): the hardest methods surface first (`IrImporter::BuildBlock` at 244.9 — 1915 blocks / 214 branches / 7 switches / 121 locals), and the sqrt damping compresses the range (245→134 over the top 6) so nested-EH / unsafe / switch-heavy methods compete with sheer size rather than being buried.

- Harness build: clean (0 warn / 0 err) with `--configfile nuget.config`.
- No product-path change; harness-only (`tools/DecompilerHarness`).

## Adversarial review

Two reviewers (non-Opus) will review isolated worktrees at the pushed head. Attack points: EH-nesting correctness for sibling/nested/filter handlers, rare-opcode set justification, decode-failure handling, score-formula ranking sanity, no product-path or substrate violation. Reconciliation will be posted here. Do not merge without @richlander approval.