### PR TITLE
Add loud API diff divergence check between legacy and Finding lanes

### DIFF
--- a/src/ILInspector.Metadata/MetadataFindings.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.cs
@@ -351,6 +351,7 @@ public static partial class MetadataFindings
         ApiDiffScope scope)
     {
         var changesByKey = BuildTypeChangeMap(diff);
+        var consumedKeys = new HashSet<string>(StringComparer.Ordinal);
         var builder = ImmutableArray.CreateBuilder<PairFinding<ApiTypeHandle>>(pairs.Length);
         foreach (var pair in pairs)
         {
@@ -358,7 +359,10 @@ public static partial class MetadataFindings
             {
                 var details = new List<string>();
                 if (changesByKey.TryGetValue(present.New.Payload.TypeFullName, out var changes))
+                {
+                    consumedKeys.Add(present.New.Payload.TypeFullName);
                     details.AddRange(changes.Select(FormatApiChange));
+                }
                 AddTypeFacetDetails(present.Old.Payload.Type, present.New.Payload.Type, scope, details);
 
                 builder.Add(details.Count == 0
@@ -375,6 +379,7 @@ public static partial class MetadataFindings
             }
         }
 
+        ThrowIfLegacyChangesUnconsumed("type", changesByKey, consumedKeys);
         return builder.ToImmutable();
     }
 
@@ -384,6 +389,7 @@ public static partial class MetadataFindings
         ApiDiffScope scope)
     {
         var changesByKey = BuildMemberChangeMap(diff);
+        var consumedKeys = new HashSet<string>(StringComparer.Ordinal);
         var builder = ImmutableArray.CreateBuilder<PairFinding<ApiMemberHandle>>(pairs.Length);
         foreach (var pair in pairs)
         {
@@ -392,7 +398,10 @@ public static partial class MetadataFindings
                 string key = present.New.Key.IdentityKey;
                 var details = new List<string>();
                 if (changesByKey.TryGetValue(key, out var changes))
+                {
+                    consumedKeys.Add(key);
                     details.AddRange(changes.Select(FormatApiChange));
+                }
                 AddMemberFacetDetails(present.Old.Payload.Member, present.New.Payload.Member, scope, details);
 
                 builder.Add(details.Count == 0
@@ -433,8 +442,40 @@ public static partial class MetadataFindings
             }
         }
 
+        ThrowIfLegacyChangesUnconsumed("member", changesByKey, consumedKeys);
         return builder.ToImmutable();
     }
+
+    /// <summary>
+    /// Cross-validates the legacy <see cref="ApiDiffAnalyzer"/> lane against the Finding
+    /// lane (finding-adoption.md rule 1): every present-in-both facet change the legacy
+    /// analyzer reports must land on a matching identity-set <c>Present</c> pair here. A
+    /// legacy change with no matching pair means the two lanes disagree about which
+    /// types/members correspond across surfaces -- a producer or adapter bug that must
+    /// fail loudly rather than silently render only the legacy change.
+    /// </summary>
+    static void ThrowIfLegacyChangesUnconsumed(
+        string domain,
+        Dictionary<string, List<ApiChange>> changesByKey,
+        HashSet<string> consumedKeys)
+    {
+        var unconsumed = changesByKey.Keys
+            .Where(key => !consumedKeys.Contains(key))
+            .OrderBy(key => key, StringComparer.Ordinal)
+            .ToList();
+        if (unconsumed.Count == 0)
+            return;
+
+        throw new InvalidOperationException(
+            $"API {domain} diff divergence: the legacy ApiDiffAnalyzer reported "
+            + $"{unconsumed.Count} present-in-both {domain} change(s) that the Finding-lane "
+            + "identity-set comparison did not match to a Present pair: "
+            + string.Join(", ", unconsumed)
+            + ". This means the legacy and Finding lanes disagree about correspondence "
+            + "for these identities.");
+    }
+
+
 
     static ImmutableArray<PairFinding<ApiAttributeHandle>> ApplyAttributeValueChanges(
         ImmutableArray<PairFinding<ApiAttributeHandle>> pairs)


### PR DESCRIPTION
## Summary

Step 1 toward #2893 (schedule the legacy diff-lane deletions promised by finding-adoption).

Of the three dual-lane diff domains (API/IL/C#), API was the worst offender: it had **no divergence check at all** between the legacy `ApiDiffAnalyzer` lane (which drives default `DiffCommand` rendering) and the Finding-lane identity-set comparison. IL and C# at least record a soft `ResearchChange` on disagreement via `ImplementationDiff.FindingDivergenceChange`.

## Change

`ApplyTypeFacetChanges`/`ApplyMemberFacetChanges` in `MetadataFindings.cs` already fold every legacy present-in-both facet change onto its matching Finding-lane `Present` pair by identity key (type full name / member canonical signature). This adds `ThrowIfLegacyChangesUnconsumed`, which tracks which legacy change keys were actually consumed by a `Present` pair during that fold and throws loudly when a legacy change exists for a type/member the Finding lane's identity-set comparison never matched to a `Present` pair.

This mirrors the `docs/design/finding-adoption.md` rule 1 correspondence-check pattern already used by `ExtensionsCommand`/`TimelineCommand` (throw when scanner/legacy inventory has no matching Finding observation), rather than the softer IL/C# pattern of merely recording a `ResearchChange`.

## Scope and follow-up

This is **detection-only** — it does not delete either lane yet. Per #2893's suggested direction, the next steps are: define the "required scale" gate for API, then delete the legacy `ApiDiffAnalyzer` lane from `DiffCommand`'s default rendering once this check has run clean at that scale. IL and C# have their own softer divergence checks already; whether to strengthen those to throw (matching this one) is a separate follow-up.

## Validation

- `dotnet build src\ILInspector.Metadata -c Release --configfile ./nuget.config` — 0 errors.
- `dotnet run --project tests\ILInspector.Metadata.Tests -c Release --no-build`: 616 total, 1 failed — confirmed via `git stash` against unmodified `main` that this single failure (`MemberSourceProducer_UsesFirstVisibleDocumentWhenRootIsOmitted`, a source-document-mapping test) is pre-existing and unrelated to this change.
- `ILInspector.Metadata.Tests.MetadataFindingsTests`: 24/24 passing — these already exercise diverse `ApiDiff` scenarios (facet changes, member acceptance thresholds, attribute changes, exact matches), and none tripped the new throw, giving real regression coverage of the consumption-tracking logic.
- Real-world smoke test via the CLI `diff` command across three diverse corpora with genuine signature changes, additive members/types, and extension-heavy surfaces — zero divergence exceptions:
  - `Humanizer.Core@2.11.10..2.14.1` (1 breaking signature change, 28 additive, 9 potentially breaking)
  - `System.Text.Json@6.0.0..8.0.0` (major version jump)
  - `Newtonsoft.Json@12.0.3..13.0.4`
