### PR TITLE
Add hard-IL corpus harvest tooling (--harvest-hard-il-corpus)

### DIFF
--- a/eng/prepare-hard-il-corpus.sh
+++ b/eng/prepare-hard-il-corpus.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 # Prepares the broad-source assembly pool for the hard-IL decompiler corpus.
-# Without an argument it emits one managed assembly path per line on stdout; with
-# an output directory it writes <outdir>/assemblies.txt (+ sweep-manifest.json).
+# Requires an output directory and writes:
+#   <outdir>/assemblies.txt      the deduped managed assembly path list
+#   <outdir>/sweep/              the extracted sweep packages (durable)
+#   <outdir>/sweep-manifest.json the sweep manifest (resolved versions/TFMs)
+#
+# The sweep tool copies each selected assembly into <outdir>/sweep/packages/... and
+# records those paths, so the sweep output MUST live in the durable output
+# directory (not a temp dir) or the emitted paths would dangle after cleanup.
 #
 # The hard-IL corpus is an adversarial stress set: the most diabolical real
 # methods, ranked by IL difficulty, drawn from a much broader pool than the fixed
@@ -23,36 +29,41 @@ set -euo pipefail
 # Number of top NuGet ranks to sweep (the package list currently holds 100).
 PACKAGE_COUNT="${HARD_IL_PACKAGE_COUNT:-100}"
 
-root="$(git rev-parse --show-toplevel)"
 outdir="${1:-}"
+if [ -z "$outdir" ]; then
+  echo "usage: $0 <output-directory>" >&2
+  echo "  writes <output-directory>/assemblies.txt and keeps the extracted sweep" >&2
+  echo "  packages under <output-directory>/sweep so the listed paths stay valid." >&2
+  exit 2
+fi
+
+root="$(git rev-parse --show-toplevel)"
+mkdir -p "$outdir"
+outdir="$(cd "$outdir" && pwd)"
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
 
-# 1. Broad-source NuGet sweep -> $work/sweep/assemblies.txt.
-dotnet run "$root/eng/prepare-decompiler-package-sweep.cs" -- "$work/sweep" 1 "$PACKAGE_COUNT" >&2
+# 1. Broad-source NuGet sweep. The sweep extracts assemblies into
+#    <outdir>/sweep/packages/... and lists those durable paths, so it must write
+#    into the persisted output directory, never the temp dir.
+dotnet run "$root/eng/prepare-decompiler-package-sweep.cs" -- "$outdir/sweep" 1 "$PACKAGE_COUNT" >&2
 
-# 2. Fixed real-world corpus assemblies -> $work/real-world.txt.
+# 2. Fixed real-world corpus assemblies -> $work/real-world.txt (durable repo/nuget
+#    cache paths, so the intermediate list itself may be ephemeral).
 bash "$root/eng/prepare-decompiler-corpus.sh" "$work/real-world.txt"
 
 # 3. Union, de-duplicated, deterministic order.
 #    Real-world assemblies lead so shared affinity is stable regardless of which
 #    packages the sweep resolves.
-combined="$work/assemblies.txt"
-cat "$work/real-world.txt" "$work/sweep/assemblies.txt" \
-    | awk 'NF && !seen[$0]++' > "$combined"
+cat "$work/real-world.txt" "$outdir/sweep/assemblies.txt" \
+    | awk 'NF && !seen[$0]++' > "$outdir/assemblies.txt"
 
-count="$(wc -l < "$combined" | tr -d ' ')"
-echo "Hard-IL pool: $count assemblies ($PACKAGE_COUNT-rank sweep + real-world)." >&2
-
-if [ -n "$outdir" ]; then
-  mkdir -p "$outdir"
-  cp "$combined" "$outdir/assemblies.txt"
-  # Preserve the sweep manifest next to the list, so the resolved package
-  # versions/TFMs are recoverable.
-  if [ -f "$work/sweep/manifest.json" ]; then
-    cp "$work/sweep/manifest.json" "$outdir/sweep-manifest.json"
-  fi
-  echo "Wrote $outdir/assemblies.txt (+ sweep-manifest.json)." >&2
-else
-  cat "$combined"
+# Surface the sweep manifest at the top level so resolved versions/TFMs are easy
+# to find (it also remains at <outdir>/sweep/manifest.json).
+if [ -f "$outdir/sweep/manifest.json" ]; then
+  cp "$outdir/sweep/manifest.json" "$outdir/sweep-manifest.json"
 fi
+
+count="$(wc -l < "$outdir/assemblies.txt" | tr -d ' ')"
+echo "Hard-IL pool: $count assemblies ($PACKAGE_COUNT-rank sweep + real-world)." >&2
+echo "Wrote $outdir/assemblies.txt (sweep packages under $outdir/sweep)." >&2

--- a/eng/prepare-hard-il-corpus.sh
+++ b/eng/prepare-hard-il-corpus.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Prepares the broad-source assembly pool for the hard-IL decompiler corpus.
+# Without an argument it emits one managed assembly path per line on stdout; with
+# an output directory it writes <outdir>/assemblies.txt (+ sweep-manifest.json).
+#
+# The hard-IL corpus is an adversarial stress set: the most diabolical real
+# methods, ranked by IL difficulty, drawn from a much broader pool than the fixed
+# real-world corpus. The pool is the union of:
+#
+#   1. The top-ranked NuGet packages (docs/data/nuget-top-packages.json), acquired
+#      by eng/prepare-decompiler-package-sweep.cs.
+#   2. The 14 pinned real-world corpus assemblies (eng/prepare-decompiler-corpus.sh),
+#      so the two corpora share affinity and can grow in lock step.
+#
+# Feed the emitted list to the harvester's difficulty-ranked mode:
+#
+#   bash eng/prepare-hard-il-corpus.sh /tmp/hard-il-pool
+#   dotnet run --project tools/DecompilerHarness -c Release -- \
+#     --harvest-hard-il-corpus /tmp/hard-il-corpus.jsonl --harvest-target 12000 \
+#     $(cat /tmp/hard-il-pool/assemblies.txt)
+set -euo pipefail
+
+# Number of top NuGet ranks to sweep (the package list currently holds 100).
+PACKAGE_COUNT="${HARD_IL_PACKAGE_COUNT:-100}"
+
+root="$(git rev-parse --show-toplevel)"
+outdir="${1:-}"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# 1. Broad-source NuGet sweep -> $work/sweep/assemblies.txt.
+dotnet run "$root/eng/prepare-decompiler-package-sweep.cs" -- "$work/sweep" 1 "$PACKAGE_COUNT" >&2
+
+# 2. Fixed real-world corpus assemblies -> $work/real-world.txt.
+bash "$root/eng/prepare-decompiler-corpus.sh" "$work/real-world.txt"
+
+# 3. Union, de-duplicated, deterministic order.
+#    Real-world assemblies lead so shared affinity is stable regardless of which
+#    packages the sweep resolves.
+combined="$work/assemblies.txt"
+cat "$work/real-world.txt" "$work/sweep/assemblies.txt" \
+    | awk 'NF && !seen[$0]++' > "$combined"
+
+count="$(wc -l < "$combined" | tr -d ' ')"
+echo "Hard-IL pool: $count assemblies ($PACKAGE_COUNT-rank sweep + real-world)." >&2
+
+if [ -n "$outdir" ]; then
+  mkdir -p "$outdir"
+  cp "$combined" "$outdir/assemblies.txt"
+  # Preserve the sweep manifest next to the list, so the resolved package
+  # versions/TFMs are recoverable.
+  if [ -f "$work/sweep/manifest.json" ]; then
+    cp "$work/sweep/manifest.json" "$outdir/sweep-manifest.json"
+  fi
+  echo "Wrote $outdir/assemblies.txt (+ sweep-manifest.json)." >&2
+else
+  cat "$combined"
+fi

--- a/eng/prepare-hard-il-corpus.sh
+++ b/eng/prepare-hard-il-corpus.sh
@@ -54,9 +54,15 @@ bash "$root/eng/prepare-decompiler-corpus.sh" "$work/real-world.txt"
 
 # 3. Union, de-duplicated, deterministic order.
 #    Real-world assemblies lead so shared affinity is stable regardless of which
-#    packages the sweep resolves.
-cat "$work/real-world.txt" "$outdir/sweep/assemblies.txt" \
-    | awk 'NF && !seen[$0]++' > "$outdir/assemblies.txt"
+#    packages the sweep resolves. Dedup on the assembly file name (not the full
+#    path): the harvester and benchmark key libraries by assembly name, so an
+#    assembly reachable via two pool sources (e.g. a package that is both a
+#    real-world pin and a top-N sweep hit) must contribute one library, not two.
+#    Real-world leading means its pinned version wins the overlap.
+sweep_list="$outdir/sweep/assemblies.txt"
+[ -f "$sweep_list" ] || sweep_list=/dev/null
+cat "$work/real-world.txt" "$sweep_list" \
+    | awk -F/ '$0 != "" && !seen[$NF]++' > "$outdir/assemblies.txt"
 
 # Surface the sweep manifest at the top level so resolved versions/TFMs are easy
 # to find (it also remains at <outdir>/sweep/manifest.json).

--- a/tools/DecompilerHarness/AuthoredSourceHarvest.cs
+++ b/tools/DecompilerHarness/AuthoredSourceHarvest.cs
@@ -10,19 +10,27 @@ using ILInspector.Metadata;
 namespace ILInspector.DecompilerHarness;
 
 /// <summary>
-/// Harvests the authored-source correspondence corpus: for a fixed set of input
-/// assemblies (the real-world corpus libraries), enumerate real-method targets,
-/// resolve each target's authoritative authored source through SourceLink, and
-/// snapshot the checksum-verified member body to a vendored JSONL corpus. Because
-/// the authored body is captured at generation time, benchmark runs that consume
-/// the corpus are fully offline.
+/// Harvests authored-source correspondence corpora: for a set of input
+/// assemblies, enumerate real-method targets, resolve each target's
+/// authoritative authored source through SourceLink, and snapshot the
+/// checksum-verified member body to a vendored JSONL corpus. Because the
+/// authored body is captured at generation time, benchmark runs that consume the
+/// corpus are fully offline.
 ///
-/// Selection is identity-only and biased toward small libraries: candidates are
-/// ordered by round-robin across declaring types within each library, then pulled
-/// round-robin across libraries in ascending candidate-count order so a few large
-/// libraries do not drown out the small ones. Source content is fetched last, only
-/// to snapshot and verify; a failed or unavailable fetch simply advances to the
-/// next candidate, so every emitted row has real, checksum-verified source.
+/// Two selection policies share this harvester. Both order libraries by ascending
+/// candidate count so a few large libraries do not drown out the small ones, and
+/// both round-robin across declaring types so no single type dominates a
+/// library's contribution. They differ only in what each type contributes next:
+/// <list type="bullet">
+/// <item>The <em>real-world</em> corpus (identity-only) keeps candidates in
+/// enumeration order.</item>
+/// <item>The <em>hard-IL</em> corpus orders each type's candidates by descending
+/// IL difficulty score, so each library contributes its most diabolical methods
+/// first, and attaches the difficulty profile to every emitted row.</item>
+/// </list>
+/// Source content is fetched last, only to snapshot and verify; a failed or
+/// unavailable fetch simply advances to the next candidate, so every emitted row
+/// has real, checksum-verified source.
 /// </summary>
 static class AuthoredSourceHarvest
 {
@@ -40,7 +48,12 @@ static class AuthoredSourceHarvest
         string? SourceUrl,
         string? ChecksumAlgorithm,
         string? Checksum,
-        string AuthoredBody);
+        string AuthoredBody,
+        // Omitted for the identity (real-world) corpus so its rows stay
+        // schema-identical to the vendored corpus; populated only for hard-IL.
+        [property: System.Text.Json.Serialization.JsonIgnore(
+            Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+        IlDifficulty? Difficulty = null);
 
     sealed class LibraryState
     {
@@ -52,10 +65,10 @@ static class AuthoredSourceHarvest
         public required Queue<RealMethodTargetEnumerator.RealMethodTarget> Candidates { get; init; }
     }
 
-    public static int Run(IReadOnlyList<string> assemblies, string outputPath, int target)
-        => RunAsync(assemblies, outputPath, target).GetAwaiter().GetResult();
+    public static int Run(IReadOnlyList<string> assemblies, string outputPath, int target, bool hardIl = false)
+        => RunAsync(assemblies, outputPath, target, hardIl).GetAwaiter().GetResult();
 
-    static async Task<int> RunAsync(IReadOnlyList<string> assemblies, string outputPath, int target)
+    static async Task<int> RunAsync(IReadOnlyList<string> assemblies, string outputPath, int target, bool hardIl)
     {
         if (assemblies.Count == 0)
         {
@@ -72,7 +85,7 @@ static class AuthoredSourceHarvest
         {
             foreach (string assemblyPath in assemblies)
             {
-                var library = TryOpenLibrary(assemblyPath, httpClient).GetAwaiter().GetResult();
+                var library = TryOpenLibrary(assemblyPath, httpClient, hardIl).GetAwaiter().GetResult();
                 if (library is not null)
                     libraries.Add(library);
             }
@@ -114,7 +127,7 @@ static class AuthoredSourceHarvest
                     var candidate = library.Candidates.Dequeue();
                     attempts++;
 
-                    var record = await TryHarvestAsync(library, candidate, fetcher);
+                    var record = await TryHarvestAsync(library, candidate, fetcher, hardIl);
                     if (record is null)
                     {
                         skipped++;
@@ -130,7 +143,7 @@ static class AuthoredSourceHarvest
 
             await writer.FlushAsync();
 
-            Console.WriteLine($"AUTHORED-SOURCE HARVEST -> {outputPath}");
+            Console.WriteLine($"{(hardIl ? "HARD-IL" : "AUTHORED-SOURCE")} HARVEST -> {outputPath}");
             Console.WriteLine($"  target        : {target}");
             Console.WriteLine($"  resolved      : {resolved}");
             Console.WriteLine($"  attempts      : {attempts}");
@@ -149,7 +162,7 @@ static class AuthoredSourceHarvest
         }
     }
 
-    static async Task<LibraryState?> TryOpenLibrary(string assemblyPath, HttpClient httpClient)
+    static async Task<LibraryState?> TryOpenLibrary(string assemblyPath, HttpClient httpClient, bool hardIl)
     {
         IReadOnlyList<RealMethodTargetEnumerator.RealMethodTarget> targets;
         try
@@ -185,7 +198,7 @@ static class AuthoredSourceHarvest
                 Tfm = InferTfm(assemblyPath),
                 Source = source,
                 Candidates = new Queue<RealMethodTargetEnumerator.RealMethodTarget>(
-                    DiversifyByDeclaringType(targets)),
+                    DiversifyByDeclaringType(targets, hardIl)),
             };
             ownershipTransferred = true;
             return state;
@@ -213,7 +226,8 @@ static class AuthoredSourceHarvest
     static async Task<CorpusRecord?> TryHarvestAsync(
         LibraryState library,
         RealMethodTargetEnumerator.RealMethodTarget candidate,
-        SourceFetcher fetcher)
+        SourceFetcher fetcher,
+        bool hardIl)
     {
         var subject = new FindingSubject(
             $"{candidate.Type}::{candidate.Method}#{candidate.Overload}",
@@ -266,18 +280,29 @@ static class AuthoredSourceHarvest
             SourceUrl: authored.Document?.ResolvedUrl,
             ChecksumAlgorithm: authored.Document?.ChecksumAlgorithm,
             Checksum: authored.Document?.Checksum,
-            AuthoredBody: body);
+            AuthoredBody: body,
+            Difficulty: hardIl ? candidate.Difficulty : null);
     }
 
     // Round-robin across declaring types so no single type dominates a library's
-    // contribution to the corpus.
+    // contribution to the corpus. For the hard-IL corpus, each type's candidates
+    // are ordered by descending IL difficulty first, so a type contributes its
+    // most diabolical methods before its easy ones while the round-robin still
+    // spreads the budget across types.
     static IEnumerable<RealMethodTargetEnumerator.RealMethodTarget> DiversifyByDeclaringType(
-        IReadOnlyList<RealMethodTargetEnumerator.RealMethodTarget> targets)
+        IReadOnlyList<RealMethodTargetEnumerator.RealMethodTarget> targets,
+        bool rankByDifficulty)
     {
+        IEnumerable<RealMethodTargetEnumerator.RealMethodTarget> ordered = rankByDifficulty
+            ? targets
+                .OrderByDescending(target => target.Difficulty.Score)
+                .ThenByDescending(target => target.Difficulty.IlSize)
+            : targets;
+
         var byType = new Dictionary<string, Queue<RealMethodTargetEnumerator.RealMethodTarget>>(
             StringComparer.Ordinal);
         var order = new List<string>();
-        foreach (var target in targets)
+        foreach (var target in ordered)
         {
             if (!byType.TryGetValue(target.Type, out var queue))
             {

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -70,6 +70,7 @@ static class Program
         string? emitHarnessReport = null;
         bool enumerateRealMethods = false;
         bool harvestAuthoredCorpus = false;
+        bool harvestHardIlCorpus = false;
         string? harvestOutputPath = null;
         bool benchmarkAuthoredCorpus = false;
         string? benchmarkCorpusPath = null;
@@ -192,6 +193,10 @@ static class Program
                     case "--enumerate-real-methods": enumerateRealMethods = true; break;
                     case "--harvest-authored-corpus":
                         harvestAuthoredCorpus = true;
+                        harvestOutputPath = NextArg(args, ref i, flag);
+                        break;
+                    case "--harvest-hard-il-corpus":
+                        harvestHardIlCorpus = true;
                         harvestOutputPath = NextArg(args, ref i, flag);
                         break;
                     case "--harvest-target": harvestTarget = int.Parse(NextArg(args, ref i, flag)); break;
@@ -438,6 +443,9 @@ static class Program
 
         if (harvestAuthoredCorpus)
             return AuthoredSourceHarvest.Run(assemblies, harvestOutputPath!, harvestTarget);
+
+        if (harvestHardIlCorpus)
+            return AuthoredSourceHarvest.Run(assemblies, harvestOutputPath!, harvestTarget, hardIl: true);
 
         if (benchmarkAuthoredCorpus)
             return AuthoredCorpusBenchmark.Run(assemblies, benchmarkCorpusPath!, json);

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -357,6 +357,43 @@ nesting each other; a `finally` that protects its sibling `catch` does deepen th
 chain, so `try/catch/finally` nested inside another `try/catch/finally` reports
 `ehDepth=4`.
 
+#### Hard-IL corpus harvest (`--harvest-hard-il-corpus`)
+
+`--harvest-hard-il-corpus <out.jsonl> [--harvest-target N]` (default 12000) builds
+the hard-IL corpus. It shares the whole authored-source harvest pipeline with
+`--harvest-authored-corpus` — the same SourceLink resolution, member-only body
+snapshot, checksum, and smallest-library-first fairness — but changes the
+*selection order*: within each library, candidates are ranked hardest-first by the
+difficulty score above (score, then IL size, as a tiebreak) before the per-type
+round-robin, so each declaring type contributes its most diabolical methods first.
+Every emitted row also carries the full `difficulty` object (the same components
+`--enumerate-real-methods` prints), so a later selection pass can re-rank or filter
+on any single axis without re-scoring. The identity (real-world) corpus omits that
+field entirely, keeping its rows schema-identical to the vendored real-world
+corpus; only hard-IL rows populate it.
+
+The hard-IL corpus draws from a much broader assembly pool than the 14 pinned
+real-world libraries. `eng/prepare-hard-il-corpus.sh` composes that pool: it runs
+the package sweep (`eng/prepare-decompiler-package-sweep.cs`, ranks 1..N from
+`docs/data/nuget-top-packages.json`, `HARD_IL_PACKAGE_COUNT` default 100) and
+unions it with the 14 pinned real-world assemblies
+(`eng/prepare-decompiler-corpus.sh`) into a single deduped `assemblies.txt`,
+preserving the sweep `manifest.json` as `sweep-manifest.json`:
+
+```bash
+bash eng/prepare-hard-il-corpus.sh /tmp/hard-il-pool
+dotnet run --project tools/DecompilerHarness -c Release -- \
+  --harvest-hard-il-corpus /tmp/hard-il-corpus.jsonl --harvest-target 12000 \
+  $(cat /tmp/hard-il-pool/assemblies.txt)
+```
+
+The result is vendored as `hard-il/corpus.jsonl` on the same
+`vendor/authored-source-corpus` orphan branch, a sibling of the real-world
+`real-world/corpus.jsonl`, and `bash eng/restore-authored-source-corpus.sh`
+restores both. Because it reuses `CorpusRecord`, the hard-IL corpus is consumable
+by `--benchmark-authored-corpus` exactly like the real-world corpus; the
+difficulty profile is selection/analysis metadata the oracle ignores.
+
 The generated fixture ladder is intentionally staged:
 
 | Stage | Harness responsibility |


### PR DESCRIPTION
## What / why

Adds the **hard-IL corpus harvest tooling** — the companion to the real-world authored-source corpus (#2927) and the follow-up to IL difficulty scoring (#2930). The hard-IL corpus is an *adversarial stress set*: the most "diabolical" real methods, ranked by IL difficulty, drawn from a much broader assembly pool than the 14 pinned real-world libraries.

**Scope is tooling-only.** Actually generating the 12k hard-IL corpus and vendoring `hard-il/corpus.jsonl` to the `vendor/authored-source-corpus` orphan branch is a deliberate follow-up PR (needs the networked SourceLink harvest run).

## Changes

- **`AuthoredSourceHarvest.cs`** — a second selection policy shares the existing harvester. Both policies order libraries smallest-candidate-pool-first (fairness) and round-robin across declaring types; they differ only in what each type contributes next:
  - *real-world* (identity): enumeration order (unchanged).
  - *hard-IL*: each type's candidates ordered by descending difficulty **score** (IL size tiebreak), so each library contributes its hardest methods first. Every hard-IL row carries the full `IlDifficulty` profile.
  - The identity corpus **omits** the `difficulty` field entirely (`JsonIgnore` `WhenWritingNull`), keeping its rows **schema-identical** to the vendored real-world corpus. Reuses `CorpusRecord`, so `--benchmark-authored-corpus` consumes both corpora unchanged (difficulty is selection/analysis metadata the oracle ignores).
- **`Program.cs`** — wires `--harvest-hard-il-corpus <out.jsonl> [--harvest-target N]` (default 12000).
- **`eng/prepare-hard-il-corpus.sh`** (new) — composes the broad-source pool: the top-N NuGet package sweep (`prepare-decompiler-package-sweep.cs`, `HARD_IL_PACKAGE_COUNT` default 100) unioned with the 14 pinned real-world assemblies into a deduped `<outdir>/assemblies.txt`, preserving the sweep `manifest.json` as `sweep-manifest.json`.
- **README** — documents the harvest mode, the prepare script, and the `hard-il/corpus.jsonl` sibling path on the orphan branch.

## Vendor layout

Two vendor branches total: `vendor/ilassembler` (code fork) and `vendor/authored-source-corpus` (corpora). The hard-IL corpus lands as `hard-il/corpus.jsonl`, a sibling of the existing `real-world/corpus.jsonl`, on the same branch — the existing `eng/restore-authored-source-corpus.sh` already covers it.

## Evidence

- Harness build clean (0 warn / 0 err).
- **Backward-compat**: identity harvest omits `difficulty` while other nullable fields (`signature`, `sourceUrl`) stay present; verified schema against the vendored real-world corpus shape.
- **Hard-IL harvest end-to-end** (14 real-world assemblies, `--harvest-target 8`): 8 rows resolved across libraries, each carrying a full `difficulty` object; each library contributed its top-scoring method (e.g. `IrImporter::BuildBlock` 241.7, `ApiSurfaceExtractor::Extract` 229.3).
- **Benchmark** consumes the difficulty-bearing hard-IL corpus unchanged (8/8 evaluated).
- **Prepare script** smoke test (`HARD_IL_PACKAGE_COUNT=1`): sweep+real-world union deduped to `assemblies.txt`, `sweep-manifest.json` preserved, exit 0.
- markdownlint clean on the README.

Base `origin/main` (0 behind). SRM-only / Roslyn-free / NativeAOT-friendly product paths untouched (all changes are harness/eng).

Adversarial review to follow (two non-Opus reviewers). Do **not** self-merge — awaiting @richlander approval.
