### PR TITLE
Dedupe forward-dominance kernel onto ControlFlow substrate

### DIFF
--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -2137,7 +2137,8 @@ public sealed class LibraryBodyIndex
                 if (blockGraph.Blocks.Length == 0)
                     return new AllocationPathConfidenceIndex(confidenceByBlock);
 
-                var dominators = DominatorTree.Create(blockGraph);
+                var edges = blockGraph.Blocks.Select(static block => block.Edges).ToArray();
+                var dominators = Dominators.Of(edges);
                 var returnBlocks = ReturnBlocks(decodedBody);
                 for (int blockIndex = 0; blockIndex < blockGraph.Blocks.Length; blockIndex++)
                 {
@@ -2318,123 +2319,6 @@ public sealed class LibraryBodyIndex
                     activePath.Add(block);
                     frames.Push((block, 0));
                 }
-            }
-        }
-
-        sealed class DominatorTree
-        {
-            readonly int[] _idom;
-            readonly int _undefined;
-
-            DominatorTree(int[] idom, int undefined)
-            {
-                _idom = idom;
-                _undefined = undefined;
-            }
-
-            public static DominatorTree Create(BlockGraph blockGraph)
-            {
-                int n = blockGraph.Blocks.Length;
-                int undefined = n + 1;
-                var idom = new int[n];
-                Array.Fill(idom, undefined);
-                if (n == 0)
-                    return new DominatorTree(idom, undefined);
-
-                var predecessors = new List<int>[n];
-                for (int i = 0; i < n; i++)
-                    predecessors[i] = [];
-                for (int i = 0; i < n; i++)
-                {
-                    foreach (int successor in blockGraph.Blocks[i].Edges.Successors)
-                        if ((uint)successor < (uint)n)
-                            predecessors[successor].Add(i);
-                }
-
-                var postorder = new int[n];
-                Array.Fill(postorder, -1);
-                var order = new List<int>(n);
-                var visited = new bool[n];
-                var stack = new Stack<(int Block, int Next)>();
-                stack.Push((0, 0));
-                visited[0] = true;
-                while (stack.Count > 0)
-                {
-                    var (block, next) = stack.Pop();
-                    var successors = blockGraph.Blocks[block].Edges.Successors;
-                    if (next < successors.Count)
-                    {
-                        stack.Push((block, next + 1));
-                        int successor = successors[next];
-                        if ((uint)successor < (uint)n && !visited[successor])
-                        {
-                            visited[successor] = true;
-                            stack.Push((successor, 0));
-                        }
-                    }
-                    else
-                    {
-                        postorder[block] = order.Count;
-                        order.Add(block);
-                    }
-                }
-
-                idom[0] = 0;
-                var reversePostorder = new List<int>(order.Count);
-                for (int i = order.Count - 1; i >= 0; i--)
-                    if (order[i] != 0)
-                        reversePostorder.Add(order[i]);
-
-                bool changed = true;
-                while (changed)
-                {
-                    changed = false;
-                    foreach (int block in reversePostorder)
-                    {
-                        int newIdom = undefined;
-                        foreach (int predecessor in predecessors[block])
-                        {
-                            if (idom[predecessor] == undefined)
-                                continue;
-                            newIdom = newIdom == undefined
-                                ? predecessor
-                                : Intersect(predecessor, newIdom, idom, postorder);
-                        }
-                        if (newIdom != undefined && idom[block] != newIdom)
-                        {
-                            idom[block] = newIdom;
-                            changed = true;
-                        }
-                    }
-                }
-
-                return new DominatorTree(idom, undefined);
-            }
-
-            public bool Dominates(int dominator, int block)
-            {
-                if ((uint)dominator >= (uint)_idom.Length || (uint)block >= (uint)_idom.Length)
-                    return false;
-                for (int cursor = block; cursor != _undefined; cursor = _idom[cursor])
-                {
-                    if (cursor == dominator)
-                        return true;
-                    if (cursor == _idom[cursor])
-                        break;
-                }
-                return false;
-            }
-
-            static int Intersect(int a, int b, int[] idom, int[] postorder)
-            {
-                while (a != b)
-                {
-                    while (postorder[a] < postorder[b])
-                        a = idom[a];
-                    while (postorder[b] < postorder[a])
-                        b = idom[b];
-                }
-                return a;
             }
         }
 

--- a/src/ILInspector.Analysis/ReachingDefinitions.cs
+++ b/src/ILInspector.Analysis/ReachingDefinitions.cs
@@ -1,4 +1,3 @@
-using System.Buffers.Binary;
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
 
@@ -224,7 +223,7 @@ public static class ReachingDefinitions
 
         foreach (var instruction in instructions)
         {
-            if (TryReadLocalSlot(il, instruction.OpCode, instruction.OperandOffset, out var access)
+            if (TryReadLocalSlot(instruction.OpCode, instruction.OperandValue, out var access)
                 && access.Store)
             {
                 AddDefinition(new SlotKey(access.Slot, access.Argument), instruction.Offset);
@@ -252,7 +251,7 @@ public static class ReachingDefinitions
             {
                 if (instruction.Offset < blocks[i].Start || instruction.Offset >= blocks[i].End)
                     continue;
-                if (!TryReadLocalSlot(il, instruction.OpCode, instruction.OperandOffset, out var access))
+                if (!TryReadLocalSlot(instruction.OpCode, instruction.OperandValue, out var access))
                     continue;
 
                 var key = new SlotKey(access.Slot, access.Argument);
@@ -320,7 +319,10 @@ public static class ReachingDefinitions
             current.ExceptWith(ids);
     }
 
-    static bool TryReadLocalSlot(byte[] il, ILOpCode opcode, int operandOffset, out LocalAccess access)
+    // Slot/argument index operands are already decoded onto DecodedInstruction.OperandValue
+    // by the shared InstructionDecoder substrate; re-reading raw IL bytes here would duplicate
+    // that decode instead of reusing it.
+    static bool TryReadLocalSlot(ILOpCode opcode, long operandValue, out LocalAccess access)
     {
         access = default;
         switch (opcode)
@@ -329,43 +331,29 @@ public static class ReachingDefinitions
             case ILOpCode.Ldloc_1: access = new(1, Argument: false, Store: false, Address: false); return true;
             case ILOpCode.Ldloc_2: access = new(2, Argument: false, Store: false, Address: false); return true;
             case ILOpCode.Ldloc_3: access = new(3, Argument: false, Store: false, Address: false); return true;
-            case ILOpCode.Ldloc_s: access = new(ReadByteAt(il, operandOffset), Argument: false, Store: false, Address: false); return true;
-            case ILOpCode.Ldloc: access = new(ReadUInt16At(il, operandOffset), Argument: false, Store: false, Address: false); return true;
-            case ILOpCode.Ldloca_s: access = new(ReadByteAt(il, operandOffset), Argument: false, Store: false, Address: true); return true;
-            case ILOpCode.Ldloca: access = new(ReadUInt16At(il, operandOffset), Argument: false, Store: false, Address: true); return true;
+            case ILOpCode.Ldloc_s: access = new((int)operandValue, Argument: false, Store: false, Address: false); return true;
+            case ILOpCode.Ldloc: access = new((int)operandValue, Argument: false, Store: false, Address: false); return true;
+            case ILOpCode.Ldloca_s: access = new((int)operandValue, Argument: false, Store: false, Address: true); return true;
+            case ILOpCode.Ldloca: access = new((int)operandValue, Argument: false, Store: false, Address: true); return true;
             case ILOpCode.Stloc_0: access = new(0, Argument: false, Store: true, Address: false); return true;
             case ILOpCode.Stloc_1: access = new(1, Argument: false, Store: true, Address: false); return true;
             case ILOpCode.Stloc_2: access = new(2, Argument: false, Store: true, Address: false); return true;
             case ILOpCode.Stloc_3: access = new(3, Argument: false, Store: true, Address: false); return true;
-            case ILOpCode.Stloc_s: access = new(ReadByteAt(il, operandOffset), Argument: false, Store: true, Address: false); return true;
-            case ILOpCode.Stloc: access = new(ReadUInt16At(il, operandOffset), Argument: false, Store: true, Address: false); return true;
+            case ILOpCode.Stloc_s: access = new((int)operandValue, Argument: false, Store: true, Address: false); return true;
+            case ILOpCode.Stloc: access = new((int)operandValue, Argument: false, Store: true, Address: false); return true;
             case ILOpCode.Ldarg_0: access = new(0, Argument: true, Store: false, Address: false); return true;
             case ILOpCode.Ldarg_1: access = new(1, Argument: true, Store: false, Address: false); return true;
             case ILOpCode.Ldarg_2: access = new(2, Argument: true, Store: false, Address: false); return true;
             case ILOpCode.Ldarg_3: access = new(3, Argument: true, Store: false, Address: false); return true;
-            case ILOpCode.Ldarg_s: access = new(ReadByteAt(il, operandOffset), Argument: true, Store: false, Address: false); return true;
-            case ILOpCode.Ldarg: access = new(ReadUInt16At(il, operandOffset), Argument: true, Store: false, Address: false); return true;
-            case ILOpCode.Ldarga_s: access = new(ReadByteAt(il, operandOffset), Argument: true, Store: false, Address: true); return true;
-            case ILOpCode.Ldarga: access = new(ReadUInt16At(il, operandOffset), Argument: true, Store: false, Address: true); return true;
-            case ILOpCode.Starg_s: access = new(ReadByteAt(il, operandOffset), Argument: true, Store: true, Address: false); return true;
-            case ILOpCode.Starg: access = new(ReadUInt16At(il, operandOffset), Argument: true, Store: true, Address: false); return true;
+            case ILOpCode.Ldarg_s: access = new((int)operandValue, Argument: true, Store: false, Address: false); return true;
+            case ILOpCode.Ldarg: access = new((int)operandValue, Argument: true, Store: false, Address: false); return true;
+            case ILOpCode.Ldarga_s: access = new((int)operandValue, Argument: true, Store: false, Address: true); return true;
+            case ILOpCode.Ldarga: access = new((int)operandValue, Argument: true, Store: false, Address: true); return true;
+            case ILOpCode.Starg_s: access = new((int)operandValue, Argument: true, Store: true, Address: false); return true;
+            case ILOpCode.Starg: access = new((int)operandValue, Argument: true, Store: true, Address: false); return true;
             default:
                 return false;
         }
-    }
-
-    static byte ReadByteAt(byte[] il, int offset)
-    {
-        if ((uint)offset >= (uint)il.Length)
-            throw new BadImageFormatException($"Malformed IL at IL_{offset:X4}");
-        return il[offset];
-    }
-
-    static int ReadUInt16At(byte[] il, int offset)
-    {
-        if (offset < 0 || offset + 2 > il.Length)
-            throw new BadImageFormatException($"Malformed IL operand at IL_{offset:X4}");
-        return BinaryPrimitives.ReadUInt16LittleEndian(il.AsSpan(offset));
     }
 
     readonly record struct SlotKey(int Slot, bool IsArgument);

--- a/src/ILInspector.ControlFlow/Dominators.cs
+++ b/src/ILInspector.ControlFlow/Dominators.cs
@@ -1,0 +1,134 @@
+namespace ILInspector.ControlFlow;
+
+/// <summary>
+/// Immediate dominators over one container's block CFG, from the Cooper-Harvey-Kennedy
+/// iterative fixpoint on the forward CFG rooted at block 0 (the entry). Pure analysis
+/// over <see cref="BlockEdges"/>; shared kernel: no dependency on any IL representation.
+/// The dual of <see cref="PostDominators"/> (that class computes the same fixpoint over
+/// the reverse CFG rooted at a virtual exit).
+/// </summary>
+public sealed class Dominators
+{
+    readonly int[] _idom;
+    readonly int _undefined;
+
+    Dominators(int[] idom, int undefined)
+    {
+        _idom = idom;
+        _undefined = undefined;
+    }
+
+    /// <summary>The number of blocks the analysis covers.</summary>
+    public int Count => _idom.Length;
+
+    /// <summary>
+    /// True when <paramref name="dominator"/> dominates <paramref name="block"/> (walking the
+    /// immediate-dominator chain from <paramref name="block"/> reaches it before the entry).
+    /// A block dominates itself. Out-of-range indices return false rather than throwing.
+    /// </summary>
+    public bool Dominates(int dominator, int block)
+    {
+        if ((uint)dominator >= (uint)_idom.Length || (uint)block >= (uint)_idom.Length)
+            return false;
+        for (int cursor = block; cursor != _undefined; cursor = _idom[cursor])
+        {
+            if (cursor == dominator)
+                return true;
+            if (cursor == _idom[cursor])
+                break;
+        }
+        return false;
+    }
+
+    public static Dominators Of(IReadOnlyList<BlockEdges> edges)
+    {
+        int n = edges.Count;
+        int undefined = n + 1;
+        var idom = new int[n];
+        Array.Fill(idom, undefined);
+        if (n == 0)
+            return new Dominators(idom, undefined);
+
+        var predecessors = new List<int>[n];
+        for (int i = 0; i < n; i++)
+            predecessors[i] = [];
+        for (int i = 0; i < n; i++)
+            foreach (int successor in edges[i].Successors)
+                if ((uint)successor < (uint)n)
+                    predecessors[successor].Add(i);
+
+        // Postorder of the forward CFG rooted at the entry (block 0).
+        var postorder = new int[n];
+        Array.Fill(postorder, -1);
+        var order = new List<int>(n);
+        var visited = new bool[n];
+        var stack = new Stack<(int Block, int Next)>();
+        stack.Push((0, 0));
+        visited[0] = true;
+        while (stack.Count > 0)
+        {
+            var (block, next) = stack.Pop();
+            var successors = edges[block].Successors;
+            if (next < successors.Count)
+            {
+                stack.Push((block, next + 1));
+                int successor = successors[next];
+                if ((uint)successor < (uint)n && !visited[successor])
+                {
+                    visited[successor] = true;
+                    stack.Push((successor, 0));
+                }
+            }
+            else
+            {
+                postorder[block] = order.Count;
+                order.Add(block);
+            }
+        }
+
+        idom[0] = 0;
+
+        // Reverse postorder, excluding the entry root.
+        var reversePostorder = new List<int>(order.Count);
+        for (int i = order.Count - 1; i >= 0; i--)
+            if (order[i] != 0)
+                reversePostorder.Add(order[i]);
+
+        bool changed = true;
+        while (changed)
+        {
+            changed = false;
+            foreach (int block in reversePostorder)
+            {
+                int newIdom = undefined;
+                foreach (int predecessor in predecessors[block])
+                {
+                    if (idom[predecessor] == undefined)
+                        continue;
+                    newIdom = newIdom == undefined
+                        ? predecessor
+                        : Intersect(predecessor, newIdom, idom, postorder);
+                }
+                if (newIdom != undefined && idom[block] != newIdom)
+                {
+                    idom[block] = newIdom;
+                    changed = true;
+                }
+            }
+        }
+
+        return new Dominators(idom, undefined);
+    }
+
+    static int Intersect(int a, int b, int[] idom, int[] postorder)
+    {
+        while (a != b)
+        {
+            while (postorder[a] < postorder[b])
+                a = idom[a];
+            while (postorder[b] < postorder[a])
+                b = idom[b];
+        }
+        return a;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/DominatorsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DominatorsTests.cs
@@ -1,0 +1,127 @@
+using ILInspector.ControlFlow;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class DominatorsTests
+{
+    static readonly TypeRef I32 = TypeRef.CoreLib("System", "Int32");
+
+    static Block Term(int offset, IrNode terminator)
+    {
+        var block = new Block(offset);
+        block.Add(terminator);
+        return block;
+    }
+
+    static ConditionalBranch Cond(int targetOffset) =>
+        new(new Comparison(ComparisonKind.Equal, isUnsigned: false,
+            new Constant(1, I32), new Constant(0, I32)), targetOffset);
+
+    [Fact]
+    public void Diamond_SplitDominatesBothArms_MergeDoesNotDominateEitherArm()
+    {
+        // B0: if (c) goto B2;   B1: goto B3;   B2: <fallthrough>;   B3: return
+        var blocks = new List<Block>
+        {
+            Term(0, Cond(2)),
+            Term(1, new Branch(3)),
+            Term(2, new StoreLocal(0, I32, new Constant(7, I32))),  // falls through to B3
+            Term(3, new Return(null)),
+        };
+
+        var dom = Dominators.Of(Cfg.Build(blocks));
+
+        Assert.True(dom.Dominates(0, 1));
+        Assert.True(dom.Dominates(0, 2));
+        Assert.True(dom.Dominates(0, 3));
+        Assert.False(dom.Dominates(1, 2));
+        Assert.False(dom.Dominates(2, 1));
+    }
+
+    [Fact]
+    public void NestedDiamond_OuterSplitDominatesEveryDescendant()
+    {
+        // B0: if (c0) goto B4;   // outer split
+        // B1: if (c1) goto B3;   // nested split
+        // B2: goto B5;
+        // B3: goto B5;
+        // B4: goto B5;
+        // B5: return
+        var blocks = new List<Block>
+        {
+            Term(0, Cond(4)),
+            Term(1, Cond(3)),
+            Term(2, new Branch(5)),
+            Term(3, new Branch(5)),
+            Term(4, new Branch(5)),
+            Term(5, new Return(null)),
+        };
+
+        var dom = Dominators.Of(Cfg.Build(blocks));
+
+        for (int block = 1; block <= 5; block++)
+            Assert.True(dom.Dominates(0, block));
+        Assert.True(dom.Dominates(1, 2));
+        Assert.True(dom.Dominates(1, 3));
+        Assert.False(dom.Dominates(1, 4));  // the nested split does not dominate the outer arm
+        Assert.False(dom.Dominates(5, 0));  // the merge does not dominate the split that reaches it
+    }
+
+    [Fact]
+    public void LoopWithExit_HeaderDominatesBody_BodyDoesNotDominateHeader()
+    {
+        // B0: if (c) goto B2;   // header: exit to B2, else fall into body B1
+        // B1: goto B0;          // body back-edge to the header
+        // B2: return            // loop exit
+        var blocks = new List<Block>
+        {
+            Term(0, Cond(2)),
+            Term(1, new Branch(0)),
+            Term(2, new Return(null)),
+        };
+
+        var dom = Dominators.Of(Cfg.Build(blocks));
+
+        Assert.True(dom.Dominates(0, 1));
+        Assert.True(dom.Dominates(0, 2));
+        Assert.False(dom.Dominates(1, 0));  // the back-edge does not make the body dominate the header
+        Assert.False(dom.Dominates(2, 0));
+    }
+
+    [Fact]
+    public void UnreachableBlock_NeverDominatesAndIsNeverDominated()
+    {
+        // B0: return;   B1: goto B1 (unreachable self-loop, never reached from the entry)
+        var blocks = new List<Block>
+        {
+            Term(0, new Return(null)),
+            Term(1, new Branch(1)),
+        };
+
+        var dom = Dominators.Of(Cfg.Build(blocks));
+
+        Assert.False(dom.Dominates(1, 0));
+        Assert.False(dom.Dominates(0, 1));
+        Assert.True(dom.Dominates(1, 1));  // trivial self-dominance holds even for an unreached block
+    }
+
+    [Fact]
+    public void GuardChain_EachBlockDominatesItselfAndEverySuccessor()
+    {
+        var blocks = new List<Block>
+        {
+            Term(0, Cond(2)),
+            Term(1, new Branch(2)),
+            Term(2, new Return(null)),
+        };
+
+        var dom = Dominators.Of(Cfg.Build(blocks));
+
+        Assert.True(dom.Dominates(0, 0));
+        Assert.True(dom.Dominates(1, 1));
+        Assert.True(dom.Dominates(2, 2));
+        Assert.True(dom.Dominates(0, 1));
+        Assert.True(dom.Dominates(0, 2));
+    }
+}


### PR DESCRIPTION
## Summary

Item 3 of #2898: `ILInspector.Analysis` carried a private forward-dominator
`DominatorTree` (`LibraryBodyIndex.cs`) implementing the same
Cooper-Harvey-Kennedy fixpoint as `ILInspector.ControlFlow.PostDominators`.
`ControlFlow` (`docs/design/instruction-substrate.md`) is the shared kernel
layer built to hold exactly this dominance/dataflow algorithm; the private
copy is deleted risk of silent algorithmic drift between the two.

## Change

- Add `ILInspector.ControlFlow.Dominators`: the forward-CFG dual of
  `PostDominators`, over the same shared `BlockEdges` kernel, with no
  dependency on any IL representation (mirrors `PostDominators`'s doc
  comment and structure).
- Replace `AllocationPathConfidenceIndex.Create`'s
  `DominatorTree.Create(blockGraph)` call with `Dominators.Of(edges)` and
  delete the ~110-line private `DominatorTree` class.
- Add `DominatorsTests.cs`, mirroring `PostDominatorsTests.cs` coverage
  (diamond, nested diamond, loop with back-edge, unreachable block, guard
  chain).

Also folds in the minor companion note from the same issue:
`ReachingDefinitions.TryReadLocalSlot` re-read local/argument slot operands
from raw IL bytes (`ReadByteAt`/`ReadUInt16At`) even though
`DecodedInstruction.OperandValue` already carries the identically-decoded
value (`InstructionDecoder.cs:129-134`, same `ReadU8`/`UInt16LE` decode).
Changed `TryReadLocalSlot` to consume `OperandValue` directly and removed
the now-dead byte-reading helpers and the unused `System.Buffers.Binary`
using. Behavior-preserving — same decode, no algorithm change.

No behavior change: `Dominators` implements the identical fixpoint the
deleted `DominatorTree` did, just against the shared `BlockEdges` type
instead of `BlockGraph`.

## Evidence

```text
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config
Build succeeded

dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- \
  -class "ILInspector.Decompiler.Tests.DominatorsTests" \
  -class "ILInspector.Decompiler.Tests.PostDominatorsTests"
11 passed, 0 failed

dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build
485 total, 1 failed, 0 errors
```

The one Analysis failure
(`LibraryBodyIndexTests.CrossAssemblyMetadataResolver_ResolvesFrameworkTypeDefinition`)
is pre-existing and environment-dependent (framework-assembly resolution),
not caused by this change: reproduced identically by stashing this PR's
diff and re-running against unmodified `origin/main` (97f81456) in the same
worktree.

## Risk

Low. Mechanical substrate deduplication plus a redundant-decode removal;
both changes are behavior-preserving and covered by the full existing
Analysis suite plus new targeted `Dominators` tests. Per the repository's
adversarial-review policy, this is exempt as a small, contained,
non-heuristic refactor with no new shapes or judgment calls — the
`Dominators` fixpoint is a direct transcription of the deleted private
class (and the mirror-image of the already-reviewed `PostDominators`),
and the `ReachingDefinitions` change only swaps the operand source, not the
decode.

Refs #2898 — items 1 (Instructions charter drift) and 4 (`ILInspector.Text`
split) remain open follow-ups.