### PR TITLE
Raise spilled array-fill run into an array literal (#2877)

### DIFF
--- a/docs/templates/decompiler-pr.md
+++ b/docs/templates/decompiler-pr.md
@@ -60,8 +60,13 @@ only after checking with dotnet-inspect (relying on SourceLink).
 
 ### Before
 
+<!--
+Include the method signature line, matching Original source's shape, not just
+the body — a bare body is harder to line up against Original source.
+-->
+
 ```csharp
-// short failing or lower-quality output
+// short failing or lower-quality output, with its method signature
 ```
 
 - Valid: {True/False}
@@ -71,8 +76,10 @@ only after checking with dotnet-inspect (relying on SourceLink).
 
 ### After
 
+<!-- Include the method signature line here too, for the same reason. -->
+
 ```csharp
-// output produced by this PR, including an honest fallback when not fully raised
+// output produced by this PR, including an honest fallback when not fully raised, with its method signature
 ```
 
 - Valid: {True/False}

--- a/src/ILInspector.Decompiler.Tests/ArrayLiteralFromStoresPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ArrayLiteralFromStoresPassTests.cs
@@ -11,6 +11,8 @@ public class ArrayLiteralFromStoresPassTests
 {
     static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
     static readonly TypeRef ObjectArray = TypeRef.SzArray(Object);
+    static readonly TypeRef StringType = TypeRef.CoreLib("System", "String");
+    static readonly TypeRef StringArray = TypeRef.SzArray(StringType);
     static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
     static readonly TypeRef Derived = TypeRef.CoreLib("System", "MyType");
 
@@ -202,6 +204,64 @@ public class ArrayLiteralFromStoresPassTests
 
         Assert.Equal(0, ArrayLiteralCount(function));
         Assert.Equal(1, NewArrayCount(function));
+        function.CheckInvariant();
+    }
+
+    // A fill value that reads the place itself (a self-referential
+    // `tmp[0] = tmp;`) must not fold: ArrayLiteral evaluates every element
+    // before the combined store commits the array reference, so a folded
+    // element reading the place would observe the place's *prior* value
+    // instead of the array being built (adversarial review finding).
+    [Fact]
+    public void FillValueReadsThePlaceItself_DoesNotFold()
+    {
+        var call = new ExpressionStatement(new Call(Sink(1), isVirtual: false, [new LoadLocal(0, ObjectArray)]));
+        var function = Build(
+            new StoreLocal(0, ObjectArray, new NewArray(Object, new Constant(1, TypeRef.CoreLib("System", "Int32")))),
+            new StoreElement(Object, new LoadLocal(0, ObjectArray), new Constant(0, TypeRef.CoreLib("System", "Int32")), new LoadLocal(0, ObjectArray)),
+            call);
+
+        RunPass(function);
+
+        Assert.Equal(0, ArrayLiteralCount(function));
+        function.CheckInvariant();
+    }
+
+    // Array covariance: `object[] tmp = new string[1];` is legal C#, and each
+    // stelem is runtime-checked (ArrayTypeMismatchException on a non-string
+    // value). Folding to `object[] tmp = new string[] { value };` would
+    // require every value to typecheck against string, which the pass cannot
+    // prove — decline whenever the declared local's array type differs from
+    // the allocated array's element type (adversarial review finding).
+    [Fact]
+    public void CovariantArrayDeclaredTypeDiffersFromAllocatedElementType_DoesNotFold()
+    {
+        var call = new ExpressionStatement(new Call(Sink(1), isVirtual: false, [new LoadLocal(0, ObjectArray)]));
+        var function = Build(
+            new StoreLocal(0, ObjectArray, new NewArray(StringType, new Constant(1, TypeRef.CoreLib("System", "Int32")))),
+            new StoreElement(Object, new LoadLocal(0, ObjectArray), new Constant(0, TypeRef.CoreLib("System", "Int32")), new Call(Effect("A"), isVirtual: false, [])),
+            call);
+
+        RunPass(function);
+
+        Assert.Equal(0, ArrayLiteralCount(function));
+        function.CheckInvariant();
+    }
+
+    // The non-covariant case (declared local type matches the allocated
+    // element type exactly, here both string[]) still folds normally.
+    [Fact]
+    public void MatchingDeclaredAndAllocatedElementType_StillFolds()
+    {
+        var call = new ExpressionStatement(new Call(Sink(1), isVirtual: false, [new LoadLocal(0, StringArray)]));
+        var function = Build(
+            new StoreLocal(0, StringArray, new NewArray(StringType, new Constant(1, TypeRef.CoreLib("System", "Int32")))),
+            new StoreElement(StringType, new LoadLocal(0, StringArray), new Constant(0, TypeRef.CoreLib("System", "Int32")), new Call(new MethodRef(Derived, "S", StringType, [], HasThis: false), isVirtual: false, [])),
+            call);
+
+        RunPass(function);
+
+        Assert.Equal(1, ArrayLiteralCount(function));
         function.CheckInvariant();
     }
 }

--- a/src/ILInspector.Decompiler.Tests/ArrayLiteralFromStoresPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ArrayLiteralFromStoresPassTests.cs
@@ -265,6 +265,29 @@ public class ArrayLiteralFromStoresPassTests
         function.CheckInvariant();
     }
 
+    // A catch clause that (re)binds a pre-existing local index to the caught
+    // exception is another structured write hazard: if the array's local
+    // index is reused as the exception variable between the allocation and
+    // the fill run, folding onto it would discard the caught exception
+    // (adversarial review finding, second pass).
+    [Fact]
+    public void CatchClauseRebindsPlaceBeforeFillRun_DoesNotFold()
+    {
+        var call = new ExpressionStatement(new Call(Sink(1), isVirtual: false, [new LoadLocal(0, ObjectArray)]));
+        var catchClause = new CatchClause(Object, new BlockContainer()) { VariableIndex = 0 };
+        var tryCatch = new TryCatch(new BlockContainer(), [catchClause]);
+        var function = Build(
+            new StoreLocal(0, ObjectArray, new NewArray(Object, new Constant(1, TypeRef.CoreLib("System", "Int32")))),
+            tryCatch,
+            new StoreElement(Object, new LoadLocal(0, ObjectArray), new Constant(0, TypeRef.CoreLib("System", "Int32")), new Constant("A", StringType)),
+            call);
+
+        RunPass(function);
+
+        Assert.Equal(0, ArrayLiteralCount(function));
+        function.CheckInvariant();
+    }
+
     // A deconstruction assignment re-targeting a pre-existing local (not a
     // StoreLocal) between the allocation and the fill run overwrites the
     // place through a structured node the pass must also recognize as a

--- a/src/ILInspector.Decompiler.Tests/ArrayLiteralFromStoresPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ArrayLiteralFromStoresPassTests.cs
@@ -264,4 +264,28 @@ public class ArrayLiteralFromStoresPassTests
         Assert.Equal(1, ArrayLiteralCount(function));
         function.CheckInvariant();
     }
+
+    // A deconstruction assignment re-targeting a pre-existing local (not a
+    // StoreLocal) between the allocation and the fill run overwrites the
+    // place through a structured node the pass must also recognize as a
+    // write, or it would fold the fill run onto the wrong array reference
+    // (adversarial review finding).
+    [Fact]
+    public void DeconstructionAssignmentOverwritesPlaceBeforeFillRun_DoesNotFold()
+    {
+        var call = new ExpressionStatement(new Call(Sink(1), isVirtual: false, [new LoadLocal(0, ObjectArray)]));
+        var deconstruct = new DeconstructionAssignment(
+            [DeconstructionTarget.Local(0, ObjectArray, isDeclared: false), DeconstructionTarget.Local(1, Object, isDeclared: true)],
+            new Call(new MethodRef(Derived, "MethodReturningTuple", Object, [], HasThis: false), isVirtual: false, []));
+        var function = Build(
+            new StoreLocal(0, ObjectArray, new NewArray(Object, new Constant(1, TypeRef.CoreLib("System", "Int32")))),
+            deconstruct,
+            new StoreElement(Object, new LoadLocal(0, ObjectArray), new Constant(0, TypeRef.CoreLib("System", "Int32")), new Constant("A", StringType)),
+            call);
+
+        RunPass(function);
+
+        Assert.Equal(0, ArrayLiteralCount(function));
+        function.CheckInvariant();
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/ArrayLiteralFromStoresPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ArrayLiteralFromStoresPassTests.cs
@@ -1,0 +1,207 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// #2877: ArrayLiteralFromStoresPass folds a compiler-emitted array allocation
+// plus a later contiguous index-store run (the ubiquitous params-array spill)
+// into one ArrayLiteral, placed at the fill run's position. These tests cover
+// the fold's happy path and the guards that keep it from misfiring on shapes
+// that are not a faithful array-literal initializer.
+public class ArrayLiteralFromStoresPassTests
+{
+    static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
+    static readonly TypeRef ObjectArray = TypeRef.SzArray(Object);
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef Derived = TypeRef.CoreLib("System", "MyType");
+
+    static MethodRef Sink(int argCount) => new(Derived, "Sink", Void, [.. Enumerable.Repeat(Object, argCount)], HasThis: false);
+    static MethodRef Effect(string name) => new(Derived, name, Object, [], HasThis: false);
+
+    static IrFunction Build(params IrNode[] statements)
+    {
+        var block = new Block(0);
+        foreach (var statement in statements)
+            block.Add(statement);
+        block.Add(new Return(null));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(Void, [], HasThis: true, GenericParameterCount: 0);
+        return new IrFunction("M", Derived, signature, [], container);
+    }
+
+    static void RunPass(IrFunction function) => new ArrayLiteralFromStoresPass().Run(function, PassContext.None);
+
+    static int NewArrayCount(IrFunction function) => function.Descendants.OfType<NewArray>().Count();
+    static int ArrayLiteralCount(IrFunction function) => function.Descendants.OfType<ArrayLiteral>().Count();
+
+    // T[] tmp = new T[2]; tmp[0] = A(); tmp[1] = B(); Sink(tmp);
+    // folds to T[] tmp = new T[] { A(), B() }; Sink(tmp); at the fill run's position.
+    [Fact]
+    public void ContiguousFillRun_FoldsToArrayLiteral()
+    {
+        var call = new ExpressionStatement(new Call(Sink(1), isVirtual: false, [new LoadLocal(0, ObjectArray)]));
+        var function = Build(
+            new StoreLocal(0, ObjectArray, new NewArray(Object, new Constant(2, TypeRef.CoreLib("System", "Int32")))),
+            new StoreElement(Object, new LoadLocal(0, ObjectArray), new Constant(0, TypeRef.CoreLib("System", "Int32")), new Call(Effect("A"), isVirtual: false, [])),
+            new StoreElement(Object, new LoadLocal(0, ObjectArray), new Constant(1, TypeRef.CoreLib("System", "Int32")), new Call(Effect("B"), isVirtual: false, [])),
+            call);
+
+        RunPass(function);
+
+        Assert.Equal(0, NewArrayCount(function));
+        Assert.Equal(1, ArrayLiteralCount(function));
+        var literal = function.Descendants.OfType<ArrayLiteral>().Single();
+        Assert.Equal(2, literal.Elements.Count);
+        Assert.Equal("A", ((Call)literal.Elements[0]).Callee.Name);
+        Assert.Equal("B", ((Call)literal.Elements[1]).Callee.Name);
+        function.CheckInvariant();
+    }
+
+    // The combined literal store must land at the fill run's position, not the
+    // allocation's — the fill run may sit past an intervening effectful call
+    // (e.g. a chained receiver call), and only the allocation is reorder-safe.
+    [Fact]
+    public void FillRunPastInterveningEffect_FoldsAtFillRunPosition()
+    {
+        var call = new ExpressionStatement(new Call(Sink(1), isVirtual: false, [new LoadLocal(0, ObjectArray)]));
+        var between = new ExpressionStatement(new Call(Effect("Between"), isVirtual: false, []));
+        var function = Build(
+            new StoreLocal(0, ObjectArray, new NewArray(Object, new Constant(1, TypeRef.CoreLib("System", "Int32")))),
+            between,
+            new StoreElement(Object, new LoadLocal(0, ObjectArray), new Constant(0, TypeRef.CoreLib("System", "Int32")), new Call(Effect("A"), isVirtual: false, [])),
+            call);
+
+        RunPass(function);
+
+        Assert.Equal(1, ArrayLiteralCount(function));
+        var statements = function.Descendants.OfType<Block>().First().Children.ToList();
+        int betweenIndex = statements.IndexOf(between);
+        int literalIndex = statements.FindIndex(n => n is StoreLocal { Value: ArrayLiteral });
+        Assert.True(literalIndex > betweenIndex, "the combined literal must fold at the fill run's position, after the intervening effect");
+        function.CheckInvariant();
+    }
+
+    // A write to the array place between the allocation and the fill run means
+    // the fill run is not filling the original allocation unmutated — decline.
+    [Fact]
+    public void WriteBetweenAllocationAndFillRun_DoesNotFold()
+    {
+        var call = new ExpressionStatement(new Call(Sink(1), isVirtual: false, [new LoadLocal(0, ObjectArray)]));
+        var function = Build(
+            new StoreLocal(0, ObjectArray, new NewArray(Object, new Constant(1, TypeRef.CoreLib("System", "Int32")))),
+            new StoreLocal(0, ObjectArray, new LoadLocal(0, ObjectArray)),
+            new StoreElement(Object, new LoadLocal(0, ObjectArray), new Constant(0, TypeRef.CoreLib("System", "Int32")), new Call(Effect("A"), isVirtual: false, [])),
+            call);
+
+        RunPass(function);
+
+        Assert.Equal(0, ArrayLiteralCount(function));
+        function.CheckInvariant();
+    }
+
+    // Non-contiguous / out-of-order element indices are not a faithful
+    // array-literal initializer shape — decline.
+    [Fact]
+    public void OutOfOrderIndices_DoesNotFold()
+    {
+        var call = new ExpressionStatement(new Call(Sink(1), isVirtual: false, [new LoadLocal(0, ObjectArray)]));
+        var function = Build(
+            new StoreLocal(0, ObjectArray, new NewArray(Object, new Constant(2, TypeRef.CoreLib("System", "Int32")))),
+            new StoreElement(Object, new LoadLocal(0, ObjectArray), new Constant(1, TypeRef.CoreLib("System", "Int32")), new Call(Effect("B"), isVirtual: false, [])),
+            new StoreElement(Object, new LoadLocal(0, ObjectArray), new Constant(0, TypeRef.CoreLib("System", "Int32")), new Call(Effect("A"), isVirtual: false, [])),
+            call);
+
+        RunPass(function);
+
+        Assert.Equal(0, ArrayLiteralCount(function));
+        function.CheckInvariant();
+    }
+
+    // A second read of the array between the allocation and the fill run
+    // observes a partially-built array — decline.
+    [Fact]
+    public void ExtraLoadBeforeFillRun_DoesNotFold()
+    {
+        var early = new ExpressionStatement(new Call(Sink(1), isVirtual: false, [new LoadLocal(0, ObjectArray)]));
+        var call = new ExpressionStatement(new Call(Sink(1), isVirtual: false, [new LoadLocal(0, ObjectArray)]));
+        var function = Build(
+            new StoreLocal(0, ObjectArray, new NewArray(Object, new Constant(1, TypeRef.CoreLib("System", "Int32")))),
+            early,
+            new StoreElement(Object, new LoadLocal(0, ObjectArray), new Constant(0, TypeRef.CoreLib("System", "Int32")), new Call(Effect("A"), isVirtual: false, [])),
+            call);
+
+        RunPass(function);
+
+        Assert.Equal(0, ArrayLiteralCount(function));
+        function.CheckInvariant();
+    }
+
+    // A second read after the fill run (beyond the one expected consuming use)
+    // means the array is used more than once downstream — the shared reference
+    // could observe further mutation, so this is not a faithful literal — decline.
+    [Fact]
+    public void ExtraLoadAfterFillRun_DoesNotFold()
+    {
+        var call1 = new ExpressionStatement(new Call(Sink(1), isVirtual: false, [new LoadLocal(0, ObjectArray)]));
+        var call2 = new ExpressionStatement(new Call(Sink(1), isVirtual: false, [new LoadLocal(0, ObjectArray)]));
+        var function = Build(
+            new StoreLocal(0, ObjectArray, new NewArray(Object, new Constant(1, TypeRef.CoreLib("System", "Int32")))),
+            new StoreElement(Object, new LoadLocal(0, ObjectArray), new Constant(0, TypeRef.CoreLib("System", "Int32")), new Call(Effect("A"), isVirtual: false, [])),
+            call1,
+            call2);
+
+        RunPass(function);
+
+        Assert.Equal(0, ArrayLiteralCount(function));
+        function.CheckInvariant();
+    }
+
+    // No consuming read at all after the fill run: nothing to fold toward — decline.
+    [Fact]
+    public void NoConsumingLoad_DoesNotFold()
+    {
+        var function = Build(
+            new StoreLocal(0, ObjectArray, new NewArray(Object, new Constant(1, TypeRef.CoreLib("System", "Int32")))),
+            new StoreElement(Object, new LoadLocal(0, ObjectArray), new Constant(0, TypeRef.CoreLib("System", "Int32")), new Call(Effect("A"), isVirtual: false, [])));
+
+        RunPass(function);
+
+        Assert.Equal(0, ArrayLiteralCount(function));
+        function.CheckInvariant();
+    }
+
+    // A stack-slot-backed allocation (StoreStackSlot) folds the same way as a
+    // local-backed one.
+    [Fact]
+    public void StackSlotBackedAllocation_FoldsToArrayLiteral()
+    {
+        var call = new ExpressionStatement(new Call(Sink(1), isVirtual: false, [new LoadStackSlot(0, ObjectArray)]));
+        var function = Build(
+            new StoreStackSlot(0, new NewArray(Object, new Constant(1, TypeRef.CoreLib("System", "Int32")))),
+            new StoreElement(Object, new LoadStackSlot(0, ObjectArray), new Constant(0, TypeRef.CoreLib("System", "Int32")), new Call(Effect("A"), isVirtual: false, [])),
+            call);
+
+        RunPass(function);
+
+        Assert.Equal(1, ArrayLiteralCount(function));
+        function.CheckInvariant();
+    }
+
+    // A zero-length array allocation has no fill run to look for — decline
+    // (nothing to fold; the NewArray shape stays as-is, not a degenerate
+    // zero-element ArrayLiteral).
+    [Fact]
+    public void ZeroLengthArray_DoesNotFold()
+    {
+        var call = new ExpressionStatement(new Call(Sink(1), isVirtual: false, [new LoadLocal(0, ObjectArray)]));
+        var function = Build(
+            new StoreLocal(0, ObjectArray, new NewArray(Object, new Constant(0, TypeRef.CoreLib("System", "Int32")))),
+            call);
+
+        RunPass(function);
+
+        Assert.Equal(0, ArrayLiteralCount(function));
+        Assert.Equal(1, NewArrayCount(function));
+        function.CheckInvariant();
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/SubstratePredicateCensusTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SubstratePredicateCensusTests.cs
@@ -36,6 +36,8 @@ public class SubstratePredicateCensusTests
             "List form of the pass-owned duplicated-tail comparison; kept local with SameTailExpression so the admitted tail expression set stays tied to this rewrite.",
         [new("UnionSwitchExpressionPass.cs", "SameTailNode")] =
             "Statement form of the pass-owned duplicated-tail comparison; it accepts only StoreLocal/ExpressionStatement/Return tails for this rewrite.",
+        [new("ArrayLiteralFromStoresPass.cs", "IsInsideRange")] =
+            "Position-based containment over one block's direct-child index range (the array-literal fill run), not a subtree/place-identity check — distinct from ReferenceOwnership.IsInside.",
     };
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ArrayLiteralFromStoresPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ArrayLiteralFromStoresPass.cs
@@ -213,8 +213,10 @@ public sealed class ArrayLiteralFromStoresPass : IIrPass
             // Structured nodes past this point in the pipeline (after
             // structuring/pattern-raising) can also (re)bind a local index
             // without going through StoreLocal — e.g. a deconstruction target,
-            // ??=, a bound is-pattern/recursive-property-pattern local, or a
-            // foreach/using iteration/resource variable. Any of these binding
+            // ??=, a bound is-pattern/recursive-property-pattern local, a
+            // foreach/using iteration/resource variable, a catch-clause
+            // exception variable, a union-switch-arm pattern local, or a
+            // fixed-pointer variable. Any of these binding
             // the place's index between the allocation and the fill run (or
             // after it, before the one expected read) is as much a hazard as
             // an ordinary StoreLocal (adversarial review finding).
@@ -224,6 +226,9 @@ public sealed class ArrayLiteralFromStoresPass : IIrPass
             (false, RecursivePropertyDeclarationPattern pattern) => pattern.LocalIndex == place.Index,
             (false, ForeachStatement foreachStatement) => foreachStatement.LocalIndex == place.Index,
             (false, UsingStatement usingStatement) => usingStatement.LocalIndex == place.Index,
+            (false, CatchClause catchClause) => catchClause.VariableIndex == place.Index,
+            (false, UnionSwitchExpressionArm arm) => arm.LocalIndex == place.Index,
+            (_, Fixed fixedStatement) => fixedStatement.LocalIsStackSlot == place.IsSlot && fixedStatement.LocalIndex == place.Index,
             _ => false,
         };
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ArrayLiteralFromStoresPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ArrayLiteralFromStoresPass.cs
@@ -1,0 +1,198 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises a compiler-emitted array construction-then-fill sequence — an
+/// allocation (<c>T[] tmp = new T[n];</c>) followed, later in the same block,
+/// by a contiguous run of index stores in increasing order (<c>tmp[0] = e0;
+/// ... tmp[n-1] = e_{n-1};</c>) — into a single <see cref="ArrayLiteral"/> store
+/// (<c>T[] tmp = new T[] { e0, ..., e_{n-1} };</c>). This is the general,
+/// element-by-element counterpart to <see cref="RvaSpanPass"/>'s RVA-backed
+/// blob decode: it covers arrays the compiler fills with computed values rather
+/// than a compile-time-embedded byte blob — most commonly a <c>params object[]</c>
+/// argument array spilled ahead of the call it feeds.
+///
+/// <para>The allocation and the fill run need not be adjacent: <c>csc</c>
+/// allocates the params array early (receiver/earlier-argument evaluation
+/// order) but stores each element only at the point the source actually reads
+/// it, which can sit past intervening statements with real effects (a chained
+/// call). Moving only the allocation — never an element value — past those
+/// statements is safe: an array reference newly allocated and not yet readable
+/// from anywhere else has no observable identity or ordering effect, so the
+/// combined literal is placed at the position of the fill run (where the
+/// element values were actually evaluated), not the original allocation site.
+/// </para>
+/// </summary>
+public sealed class ArrayLiteralFromStoresPass : IIrPass
+{
+    public string Name => "array-literal-from-stores";
+
+    // A defensive cap: real params/initializer arrays are small (single digits
+    // to a few dozen elements). An absurd compile-time length is not a
+    // realistic array-literal shape and would otherwise walk a huge run.
+    const int MaxLength = 4096;
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        bool changed = true;
+        while (changed)
+        {
+            changed = false;
+            foreach (var block in function.Descendants.OfType<Block>().ToList())
+            {
+                for (int i = 0; i < block.Children.Count; i++)
+                {
+                    if (TryFold(function, block, i, context))
+                    {
+                        changed = true;
+                        break;  // block's children shifted; rescan next outer loop
+                    }
+                }
+                if (changed)
+                    break;
+            }
+        }
+    }
+
+    static bool TryFold(IrFunction function, Block block, int seedIndex, PassContext context)
+    {
+        (bool IsSlot, int Index, IrExpression Value) place;
+        switch (block.Children[seedIndex])
+        {
+            case StoreLocal { Value: NewArray } sl: place = (false, sl.Index, sl.Value); break;
+            case StoreStackSlot { Value: NewArray } ss: place = (true, ss.Slot, ss.Value); break;
+            default: return false;
+        }
+        var newArray = (NewArray)place.Value;
+        if (newArray.Length is not Constant { Value: int length } || length is <= 0 or > MaxLength)
+            return false;
+
+        // Find the contiguous fill run somewhere later in the same block: n
+        // consecutive StoreElement statements targeting this place, in
+        // increasing constant-index order starting at 0.
+        int? runStart = null;
+        for (int i = seedIndex + 1; i + length <= block.Children.Count; i++)
+        {
+            if (!IsElementStore(block.Children[i], place, 0))
+                continue;
+            runStart = i;
+            break;
+        }
+        if (runStart is not { } start)
+            return false;
+        for (int k = 0; k < length; k++)
+        {
+            if (!IsElementStore(block.Children[start + k], place, k))
+                return false;
+        }
+
+        // Nothing between the allocation and the fill run may write the place,
+        // take its address, or even read it — the array reference reaching the
+        // fill run must be exactly this allocation, unmutated and unaliased,
+        // and no earlier statement may observe the not-yet-filled array (the
+        // combined literal's declaration moves to the fill run's position, so
+        // an earlier read would otherwise reference the place before its
+        // folded declaration).
+        for (int i = seedIndex + 1; i < start; i++)
+        {
+            var statement = block.Children[i];
+            if (WritesOrAddresses(statement, place))
+                return false;
+            if (statement.Descendants.Prepend(statement).Any(n => IsLoad(n, place)))
+                return false;
+        }
+
+        // After the fill run, the place must escape exactly once more (the
+        // real read of the fully-built array) and never be written or
+        // addressed again — including another element store into the same
+        // array reference, which would mean the fill run is not the array's
+        // only mutation.
+        int loads = 0;
+        foreach (var node in function.Descendants)
+        {
+            bool outsideRun = !IsInsideRange(node, block, seedIndex, start + length);
+            if (outsideRun && (IsAddressOrWrite(node, place) || IsElementStoreArrayLoad(node, place)))
+                return false;
+            if (outsideRun && IsLoad(node, place))
+                loads++;
+        }
+        if (loads != 1)
+            return false;
+
+        context.Stepper.StepOver(
+            $"raise array-literal fill of {(place.IsSlot ? "stack slot" : "local")} {place.Index}", block.Children[start]);
+
+        var elementType = newArray.ElementType;
+        var arrayType = newArray.ResultType!;
+        var detachedElements = new IrExpression[length];
+        for (int k = 0; k < length; k++)
+        {
+            var storeElement = (StoreElement)block.Children[start + k];
+            detachedElements[k] = (IrExpression)storeElement.DetachChildren()[2];
+        }
+        var literal = new ArrayLiteral(elementType, arrayType, detachedElements);
+        IrNode combined = place.IsSlot ? new StoreStackSlot(place.Index, literal) : new StoreLocal(place.Index, ArrayLocalType(block, seedIndex), literal);
+
+        // Replace the first fill statement with the combined declaration, drop
+        // the remaining fill statements and the original (now-redundant)
+        // allocation.
+        block.Children[start].ReplaceWith(combined);
+        for (int k = length - 1; k >= 1; k--)
+            block.Children[start + k].Detach();
+        block.Children[seedIndex].Detach();
+        return true;
+    }
+
+    static TypeRef ArrayLocalType(Block block, int seedIndex)
+        => ((StoreLocal)block.Children[seedIndex]).Type;
+
+    static bool IsElementStore(IrNode node, (bool IsSlot, int Index, IrExpression Value) place, int expectedIndex)
+        => node is StoreElement { Index: Constant { Value: int idx } } store
+            && idx == expectedIndex
+            && IsLoadOf(store.Array, place);
+
+    static bool IsLoadOf(IrExpression expr, (bool IsSlot, int Index, IrExpression Value) place)
+        => (place.IsSlot, expr) switch
+        {
+            (true, LoadStackSlot load) => load.Slot == place.Index,
+            (false, LoadLocal load) => load.Index == place.Index,
+            _ => false,
+        };
+
+    static bool IsLoad(IrNode node, (bool IsSlot, int Index, IrExpression Value) place)
+        => (place.IsSlot, node) switch
+        {
+            (true, LoadStackSlot load) => load.Slot == place.Index,
+            (false, LoadLocal load) => load.Index == place.Index,
+            _ => false,
+        };
+
+    static bool IsAddressOrWrite(IrNode node, (bool IsSlot, int Index, IrExpression Value) place)
+        => (place.IsSlot, node) switch
+        {
+            (true, StoreStackSlot store) => store.Slot == place.Index,
+            (false, StoreLocal store) => store.Index == place.Index,
+            (false, LoadLocalAddress address) => address.Index == place.Index,
+            _ => false,
+        };
+
+    static bool WritesOrAddresses(IrNode statement, (bool IsSlot, int Index, IrExpression Value) place)
+        => statement.Descendants.Prepend(statement).Any(n => IsAddressOrWrite(n, place) || IsElementStoreArrayLoad(n, place));
+
+    // The array-ref load feeding an element store (inside the fill run) is not
+    // itself a hazard, but any OTHER read of the place between allocation and
+    // the fill run's start — e.g. an unrelated statement that happens to read
+    // the not-yet-filled array — means the place is observed prematurely.
+    static bool IsElementStoreArrayLoad(IrNode node, (bool IsSlot, int Index, IrExpression Value) place)
+        => node is StoreElement { Array: var array } && IsLoadOf(array, place);
+
+    static bool IsInsideRange(IrNode node, Block block, int startIndex, int endIndexExclusive)
+    {
+        for (var current = node; current is not null; current = current.Parent)
+        {
+            if (!ReferenceEquals(current.Parent, block))
+                continue;
+            return current.ChildIndex >= startIndex && current.ChildIndex < endIndexExclusive;
+        }
+        return false;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ArrayLiteralFromStoresPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ArrayLiteralFromStoresPass.cs
@@ -66,6 +66,16 @@ public sealed class ArrayLiteralFromStoresPass : IIrPass
         if (newArray.Length is not Constant { Value: int length } || length is <= 0 or > MaxLength)
             return false;
 
+        // The place's declared element type must match the allocated array's
+        // element type. Arrays are covariant (T[] tmp = new U[n]; is legal
+        // when U : T), so a store element's value can be a T that is not a
+        // valid U — folding into `new U[] { ... }` would spell an initializer
+        // whose elements don't typecheck against U, or silently drop the
+        // runtime ArrayTypeMismatchException the original stelem could throw.
+        var placeElementType = PlaceElementType(block, seedIndex, place);
+        if (placeElementType is null || !placeElementType.Equals(newArray.ElementType))
+            return false;
+
         // Find the contiguous fill run somewhere later in the same block: n
         // consecutive StoreElement statements targeting this place, in
         // increasing constant-index order starting at 0.
@@ -82,6 +92,19 @@ public sealed class ArrayLiteralFromStoresPass : IIrPass
         for (int k = 0; k < length; k++)
         {
             if (!IsElementStore(block.Children[start + k], place, k))
+                return false;
+        }
+
+        // No fill value may itself read, write, or address the place: an
+        // ArrayLiteral evaluates every element before the combined store
+        // commits the array reference, so a value that observes the place
+        // (e.g. a self-referential `tmp[0] = tmp;`) would read whatever the
+        // place held before this statement — not the array being built —
+        // once folded.
+        for (int k = 0; k < length; k++)
+        {
+            var value = ((StoreElement)block.Children[start + k]).Value;
+            if (value.Descendants.Prepend(value).Any(n => IsLoad(n, place) || IsAddressOrWrite(n, place)))
                 return false;
         }
 
@@ -144,6 +167,21 @@ public sealed class ArrayLiteralFromStoresPass : IIrPass
 
     static TypeRef ArrayLocalType(Block block, int seedIndex)
         => ((StoreLocal)block.Children[seedIndex]).Type;
+
+    // The place's element type as declared at the allocation site. Stack
+    // slots carry no independent declared array type (only the allocation's
+    // own type reaches every load), so they always match trivially. A local
+    // declares its own array type, which — thanks to array covariance — can
+    // differ from the allocated array's element type (e.g. `object[] tmp =
+    // new string[n];`); folding must decline rather than spell an initializer
+    // whose elements don't typecheck against the narrower declared type.
+    static TypeRef? PlaceElementType(Block block, int seedIndex, (bool IsSlot, int Index, IrExpression Value) place)
+    {
+        if (place.IsSlot)
+            return ((NewArray)place.Value).ElementType;
+        var local = (StoreLocal)block.Children[seedIndex];
+        return local.Type is { Kind: TypeRefKind.SzArray, ElementType: { } element } ? element : null;
+    }
 
     static bool IsElementStore(IrNode node, (bool IsSlot, int Index, IrExpression Value) place, int expectedIndex)
         => node is StoreElement { Index: Constant { Value: int idx } } store

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ArrayLiteralFromStoresPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ArrayLiteralFromStoresPass.cs
@@ -210,6 +210,20 @@ public sealed class ArrayLiteralFromStoresPass : IIrPass
             (true, StoreStackSlot store) => store.Slot == place.Index,
             (false, StoreLocal store) => store.Index == place.Index,
             (false, LoadLocalAddress address) => address.Index == place.Index,
+            // Structured nodes past this point in the pipeline (after
+            // structuring/pattern-raising) can also (re)bind a local index
+            // without going through StoreLocal — e.g. a deconstruction target,
+            // ??=, a bound is-pattern/recursive-property-pattern local, or a
+            // foreach/using iteration/resource variable. Any of these binding
+            // the place's index between the allocation and the fill run (or
+            // after it, before the one expected read) is as much a hazard as
+            // an ordinary StoreLocal (adversarial review finding).
+            (false, DeconstructionTarget { Kind: DeconstructionTargetKind.Local } target) => target.LocalIndex == place.Index,
+            (false, NullCoalescingAssignment assignment) => assignment.LocalIndex == place.Index,
+            (false, IsPattern isPattern) => isPattern.LocalIndex == place.Index,
+            (false, RecursivePropertyDeclarationPattern pattern) => pattern.LocalIndex == place.Index,
+            (false, ForeachStatement foreachStatement) => foreachStatement.LocalIndex == place.Index,
+            (false, UsingStatement usingStatement) => usingStatement.LocalIndex == place.Index,
             _ => false,
         };
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -251,6 +251,11 @@ public static class IrPasses
         // printer lifts it to a signature initializer rather than an invalid
         // base(temp); body call (CS0175).
         new ConstructorChainArgumentPass(),
+        // Fold a compiler-emitted array construction-then-fill sequence (an
+        // allocation plus a later contiguous run of index stores — the
+        // ubiquitous params-array-argument spill) into a single ArrayLiteral
+        // store.
+        new ArrayLiteralFromStoresPass(),
         // Any direct .ctor call still standing after the constructor-chain and
         // struct-constructor raises has no faithful C# statement spelling. Mark
         // it as an explicit residual before the printer can leak invalid

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -91,6 +91,8 @@ internal static class NativePasses
     public static PatternGuardedShortCircuitPass PatternGuardedShortCircuit => new();
     [Native(NativeCategory.EmitArtifact, "a folded catch-entry store whose local lives outside the surviving clause un-folded back to a distinct catch variable plus the entry assignment (issue #2828)")]
     public static CatchVariableScopePass CatchVariableScope => new();
+    [Native(NativeCategory.EmitArtifact, "a spilled array allocation plus its later contiguous element-store run (e.g. a params array) folded back to one array-literal expression, placed at the fill run's position")]
+    public static ArrayLiteralFromStoresPass ArrayLiteralFromStores => new();
 
     // ───────── IlErasure — reconstruct information the IL type system dropped ─────────
     [Native(NativeCategory.IlErasure, "int constants re-typed to bool/char/enum at typed positions")]


### PR DESCRIPTION
- Advances #2877
- Changes decompiler `IrPasses.Default` to fold a spilled array-allocation-then-fill run into a single `ArrayLiteral`
- Card revision: `e107469e`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — a well-scoped, unit-tested raise that removes a real spilled-array shape with no measured regression (clean-baseline diff over the fast decompiler suite and the whole FluentAssertions assembly's validity docket are identical before/after).

### Original source

```csharp
public AndConstraint<TAssertions> BePositive([StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
{
    CurrentAssertionChain
        .ForCondition(Subject is T subject && subject.CompareTo(default) > 0)
        .BecauseOf(because, becauseArgs)
        .FailWith("Expected {context:value} to be positive{reason}, but found {0}.", Subject);

    return new AndConstraint<TAssertions>((TAssertions)this);
}
```

### Before

```csharp
public AndConstraint<TAssertions> BePositive([StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
{
    AssertionChain S_256 = CurrentAssertionChain;
    bool S_1 = Subject is T subject && subject.CompareTo(default(T)) > 0;
    object[] S_257 = new object[1];
    AssertionChain S_258 = S_256.ForCondition(S_1).BecauseOf(because, becauseArgs);
    S_257[0] = Subject;
    S_258.FailWith("Expected {context:value} to be positive{reason}, but found {0}.", S_257);
    return new AndConstraint<TAssertions>((TAssertions)(object)this);
}
```

- Valid: True
- Correct: True

The spilled `new object[1]` allocation plus its trailing `S_257[0] = Subject;` fill store are the compiler's params-array spill; correct but low-quality (the array's construction is split from its content across an intervening chained call).

### After

```csharp
public AndConstraint<TAssertions> BePositive([StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
{
    AssertionChain S_256 = CurrentAssertionChain;
    bool S_1 = Subject is T subject && subject.CompareTo(default(T)) > 0;
    AssertionChain S_258 = S_256.ForCondition(S_1).BecauseOf(because, becauseArgs);
    object[] S_257 = new object[] { Subject };
    S_258.FailWith("Expected {context:value} to be positive{reason}, but found {0}.", S_257);
    return new AndConstraint<TAssertions>((TAssertions)(object)this);
}
```

- Valid: True
- Correct: True

The allocation and its fill run collapse into one `ArrayLiteral`, placed at the fill run's position (after `ForCondition`/`BecauseOf`) — the allocation itself is reorder-safe (a fresh, not-yet-observable reference) but the element value is not, since `csc` can store it well past the allocation.

### Fully raised

```csharp
public AndConstraint<TAssertions> BePositive([StringSyntax("CompositeFormat")] string because = "", params object[] becauseArgs)
{
    CurrentAssertionChain
        .ForCondition(Subject is T subject && subject.CompareTo(default(T)) > 0)
        .BecauseOf(because, becauseArgs)
        .FailWith("Expected {context:value} to be positive{reason}, but found {0}.", Subject);

    return new AndConstraint<TAssertions>((TAssertions)(object)this);
}
```

- Required tracking issue: #2935 — re-composing the fluent call chain itself (collapsing each chained call's spilled receiver/argument temp into the next call), rendering the recomposed chain with one call per line to match the original (a pure printer-formatting concern, tracked in the same issue), plus a separate params-array-unwrap step (`new object[] { Subject }` → bare `Subject`, needing new `MethodRef`-level metadata plumbing)

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `ArrayLiteralFromStoresPassTests`: n/a (new) | `ArrayLiteralFromStoresPassTests`: 9 passed |
| Decompiler fast suite | 2913 total, 54 failed | 2922 total, 54 failed |
| Real witness | `NumericAssertionsBase::BePositive` spilled array | `NumericAssertionsBase::BePositive` array-literal collapsed |

Baseline's 54 failures are unchanged by this PR (same tests, same reasons — confirmed via a diff of the full `[FAIL]` line set between a clean `origin/main` checkout and this PR's head; the only difference is the 9 new passing focused tests this PR adds).

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — no validity-defect-class change across the whole FluentAssertions assembly.

`dotnet run --project tools/DecompilerHarness -c Release -- FluentAssertions.dll --library-report --top-patterns 5` on FluentAssertions 8.10.0 (net6.0) reports the identical validity docket before and after this PR:

| Metric | Baseline | PR |
| --- | ---: | ---: |
| validity: CS0023 | 4 | 4 |
| validity: VLD0001 | 3 | 3 |
| validity: CS0019 | 2 | 2 |
| validity: CS0308 | 1 | 1 |
| validity: CS0413 | 1 | 1 |
| validity: malformed:CS1525 | 1 | 1 |
| Full malformed methods | 1 | 1 |
| Bound Full defect methods | 8 | 8 |

## Scope note (why StatementRunInliningPass is not in this PR)

The remaining #2877 slice — re-composing the fluent call chain itself — was
prototyped as a general `StatementRunInliningPass` generalizing
`ConstructorChainArgumentPass`'s effect-order-preserving argument-run fold from
"the base/this constructor chain call" to *any* statement sink. It fully
collapses the `BePositive` witness to the "Fully raised" shape above, but a
clean-baseline diff showed it also regresses ~22 unrelated tests (lock-statement
receiver-copy preservation, char-element-store slot naming, merged-slot naming,
calli/unmanaged-function-pointer preservation, fixed-buffer/string-pinning
ladder tests) — applying the fold to *any* statement sink is too broad; those
other decompiler features rely on the same temps staying as distinct,
separately-named locals. Filed as #2935 for a narrower, sink-typed design.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --configfile ./nuget.config --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.ArrayLiteralFromStoresPassTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
```

