### PR TITLE
Port API diff classification onto the Finding lane (#2893 step 2)

### DIFF
--- a/src/ILInspector.Metadata/ApiDiffAnalyzer.cs
+++ b/src/ILInspector.Metadata/ApiDiffAnalyzer.cs
@@ -132,7 +132,25 @@ public record ApiChange(
     ApiChangeCategory Category = ApiChangeCategory.Signature,
     ApiChangeSubject? Subject = null);
 
-public sealed record ApiDiffOptions(ApiDiffScope Scope = ApiDiffScope.Signature)
+/// <summary>
+/// Named, explicitly-requested classification exceptions -- mirrors
+/// <c>IlBodyDiffNormalization</c>'s policy shape. Default (<see cref="None"/>) is strict:
+/// a fuzzy/soft member identity match (e.g. an extension method's static/instance
+/// projection) is treated as unrelated (a breaking removal plus an additive addition),
+/// the same as the legacy analyzer's own member matcher would report. Requesting
+/// <see cref="NormalizeMemberProjection"/> instead treats a fuzzy-matched member pair as
+/// the same member observed under two projections, classifying only its facet deltas.
+/// </summary>
+[Flags]
+public enum ApiDiffNormalization
+{
+    None = 0,
+    NormalizeMemberProjection = 1,
+}
+
+public sealed record ApiDiffOptions(
+    ApiDiffScope Scope = ApiDiffScope.Signature,
+    ApiDiffNormalization Normalization = ApiDiffNormalization.None)
 {
     public static ApiDiffOptions Default { get; } = new();
 }
@@ -299,6 +317,19 @@ public static class ApiDiffAnalyzer
 
     private static List<ApiChange> CompareTypes(ApiType oldType, ApiType newType, ApiDiffOptions options)
     {
+        var changes = CompareTypeFacetsOnly(oldType, newType, options);
+        CompareMembers(oldType, newType, changes, options);
+        return changes;
+    }
+
+    /// <summary>
+    /// Type-facet classification only (kind/sealed/abstract/base type/interfaces/type
+    /// parameters/type attributes) -- no member-level walk. Reused by
+    /// <see cref="ApiFindingClassifier"/>, which sources member-level changes from the
+    /// Finding lane's own member comparison instead of this analyzer's member matcher.
+    /// </summary>
+    internal static List<ApiChange> CompareTypeFacetsOnly(ApiType oldType, ApiType newType, ApiDiffOptions options)
+    {
         List<ApiChange> changes = [];
         if (IncludesSignature(options))
         {
@@ -314,7 +345,6 @@ public static class ApiDiffAnalyzer
                 ChangeKind.TypeAttributeRemoved,
                 $"Type '{oldType.FullName}'",
                 ApiChangeSubject.Type(oldType, newType));
-        CompareMembers(oldType, newType, changes, options);
         return changes;
     }
 
@@ -580,7 +610,7 @@ public static class ApiDiffAnalyzer
         }
     }
 
-    private static void CompareMemberModifiers(ApiType oldType, ApiType newType, ApiMember oldMember, ApiMember newMember, List<ApiChange> changes)
+    internal static void CompareMemberModifiers(ApiType oldType, ApiType newType, ApiMember oldMember, ApiMember newMember, List<ApiChange> changes)
     {
         // Virtual removed
         if (oldMember.IsVirtual && !newMember.IsVirtual)
@@ -635,7 +665,7 @@ public static class ApiDiffAnalyzer
             includeDecodeStatus ? member.SignatureDecodeStatus : null);
     }
 
-    private static void CompareAttributes(
+    internal static void CompareAttributes(
         IEnumerable<string> oldAttributes,
         IEnumerable<string> newAttributes,
         List<ApiChange> changes,
@@ -670,9 +700,9 @@ public static class ApiDiffAnalyzer
         }
     }
 
-    static bool IncludesSignature(ApiDiffOptions options)
+    internal static bool IncludesSignature(ApiDiffOptions options)
         => options.Scope.HasFlag(ApiDiffScope.Signature);
 
-    static bool IncludesAttributes(ApiDiffOptions options)
+    internal static bool IncludesAttributes(ApiDiffOptions options)
         => options.Scope.HasFlag(ApiDiffScope.Attributes);
 }

--- a/src/ILInspector.Metadata/ApiFindingClassifier.cs
+++ b/src/ILInspector.Metadata/ApiFindingClassifier.cs
@@ -1,0 +1,368 @@
+using ILInspector.Findings;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Produces an <see cref="ApiDiff"/> from the Finding lane's own type and member
+/// correspondence (<see cref="FindingComparison{T}"/> over <see cref="ApiTypeHandle"/> and
+/// <see cref="ApiMemberHandle"/>) instead of <see cref="ApiDiffAnalyzer"/>'s independent
+/// type-name/member-signature walk. Type-level classification reuses
+/// <see cref="ApiDiffAnalyzer.CompareTypeFacetsOnly"/> unchanged (type identity is the same
+/// full-name key in both lanes). Member-level classification is intentionally sourced from
+/// the Finding lane's richer identity/soft-key matching rather than
+/// <see cref="ApiDiffAnalyzer"/>'s bespoke signature-then-(Name,Kind) matcher -- see
+/// <see cref="ApiDiffNormalization"/> for the explicit, opt-in policy this introduces for
+/// fuzzy-matched (soft-key) member pairs.
+/// </summary>
+public static class ApiFindingClassifier
+{
+    public static ApiDiff Classify(
+        FindingComparison<ApiTypeHandle> types,
+        FindingComparison<ApiMemberHandle> members,
+        ApiSurface oldSurface,
+        ApiSurface newSurface,
+        ApiDiffOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(types);
+        ArgumentNullException.ThrowIfNull(members);
+        ArgumentNullException.ThrowIfNull(oldSurface);
+        ArgumentNullException.ThrowIfNull(newSurface);
+        ArgumentNullException.ThrowIfNull(options);
+
+        var inspectionFailures = BuildInspectionFailures(oldSurface, newSurface);
+
+        // Matching never ran on at least one side; there is nothing to classify beyond the
+        // structured inspection failures themselves (mirrors the legacy analyzer's own
+        // identity-incomplete skip, but as a full bail-out rather than a per-type skip since
+        // the Finding lane doesn't expose a partial-comparison shape).
+        if (types.Value is not FindingComparison<ApiTypeHandle>.Complete typesComplete
+            || members.Value is not FindingComparison<ApiMemberHandle>.Complete membersComplete)
+        {
+            return new ApiDiff { InspectionFailures = inspectionFailures };
+        }
+
+        var changesByType = new Dictionary<string, List<ApiChange>>(StringComparer.Ordinal);
+        var wholeTypeTransition = BuildWholeTypeTransitionSets(typesComplete);
+
+        ClassifyTypes(typesComplete, options, changesByType);
+        ClassifyMembers(membersComplete, options, wholeTypeTransition, changesByType);
+
+        List<TypeDiff> typeDiffs = [];
+        int totalBreaking = 0;
+        int totalAdditive = 0;
+        int totalPotentiallyBreaking = 0;
+
+        foreach (var typeName in changesByType.Keys.Order(StringComparer.Ordinal))
+        {
+            var changes = changesByType[typeName];
+            if (changes.Count == 0)
+                continue;
+
+            var diff = new TypeDiff(typeName, changes);
+            typeDiffs.Add(diff);
+            totalBreaking += diff.BreakingCount;
+            totalAdditive += diff.AdditiveCount;
+            totalPotentiallyBreaking += diff.PotentiallyBreakingCount;
+        }
+
+        return new ApiDiff
+        {
+            TypeDiffs = typeDiffs,
+            InspectionFailures = inspectionFailures,
+            TotalBreaking = totalBreaking,
+            TotalAdditive = totalAdditive,
+            TotalPotentiallyBreaking = totalPotentiallyBreaking,
+        };
+    }
+
+    static void ClassifyTypes(
+        FindingComparison<ApiTypeHandle>.Complete types,
+        ApiDiffOptions options,
+        Dictionary<string, List<ApiChange>> changesByType)
+    {
+        foreach (var pair in types.Pairs)
+        {
+            switch ((object)pair.Value)
+            {
+                case PairFinding<ApiTypeHandle>.Added added:
+                    if (ApiDiffAnalyzer.IncludesSignature(options))
+                    {
+                        Bucket(changesByType, added.New.Payload.TypeFullName).Add(new ApiChange(
+                            ChangeKind.TypeAdded,
+                            ChangeClassification.Additive,
+                            $"Type '{added.New.Payload.TypeFullName}' was added",
+                            Subject: ApiChangeSubject.Type(null, added.New.Payload.Type)));
+                    }
+                    break;
+
+                case PairFinding<ApiTypeHandle>.Removed removed:
+                    if (ApiDiffAnalyzer.IncludesSignature(options))
+                    {
+                        Bucket(changesByType, removed.Old.Payload.TypeFullName).Add(new ApiChange(
+                            ChangeKind.TypeRemoved,
+                            ChangeClassification.Breaking,
+                            $"Type '{removed.Old.Payload.TypeFullName}' was removed",
+                            Subject: ApiChangeSubject.Type(removed.Old.Payload.Type, null)));
+                    }
+                    break;
+
+                case PairFinding<ApiTypeHandle>.Present present:
+                    Bucket(changesByType, present.New.Payload.TypeFullName).AddRange(
+                        ApiDiffAnalyzer.CompareTypeFacetsOnly(present.Old.Payload.Type, present.New.Payload.Type, options));
+                    break;
+
+                case PairFinding<ApiTypeHandle>.Changed changed:
+                    Bucket(changesByType, changed.New.Payload.TypeFullName).AddRange(
+                        ApiDiffAnalyzer.CompareTypeFacetsOnly(changed.Old.Payload.Type, changed.New.Payload.Type, options));
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Type full names present only on one side (a whole-type addition/removal). A member
+    /// belonging to one of these types is already covered by the type-level change and must
+    /// not also be reported as its own member-level addition/removal -- mirroring the legacy
+    /// analyzer, whose per-type walk never descends into <c>CompareMembers</c> for a type
+    /// that was itself added or removed.
+    /// </summary>
+    readonly record struct WholeTypeTransitionSets(HashSet<string> Added, HashSet<string> Removed);
+
+    static WholeTypeTransitionSets BuildWholeTypeTransitionSets(FindingComparison<ApiTypeHandle>.Complete types)
+    {
+        var added = new HashSet<string>(StringComparer.Ordinal);
+        var removed = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var pair in types.Pairs)
+        {
+            switch ((object)pair.Value)
+            {
+                case PairFinding<ApiTypeHandle>.Added a:
+                    added.Add(a.New.Payload.TypeFullName);
+                    break;
+                case PairFinding<ApiTypeHandle>.Removed r:
+                    removed.Add(r.Old.Payload.TypeFullName);
+                    break;
+            }
+        }
+        return new WholeTypeTransitionSets(added, removed);
+    }
+
+    static void ClassifyMembers(
+        FindingComparison<ApiMemberHandle>.Complete members,
+        ApiDiffOptions options,
+        WholeTypeTransitionSets wholeTypeTransition,
+        Dictionary<string, List<ApiChange>> changesByType)
+    {
+        bool normalizeProjection = options.Normalization.HasFlag(ApiDiffNormalization.NormalizeMemberProjection);
+
+        // A member producer can emit more than one identity atom for the same physical old
+        // (or new) member to enable soft-key projection matching (e.g. an extension method
+        // gets both its own hard "extension:" selector atom -- unmatched, becoming Removed --
+        // and a receiver-projected atom that fuzzy-matches a real instance method, becoming
+        // Changed). Both atoms share the same content Fingerprint. Without deduplicating by
+        // fingerprint, the same physical member would be reported twice: once via the
+        // Removed/Added atom and again via the fuzzy Changed pair.
+        var oldFingerprintsInFuzzyMatch = new HashSet<string>(StringComparer.Ordinal);
+        var newFingerprintsInFuzzyMatch = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var pair in members.Pairs)
+        {
+            if (pair.Value is IMatchedPairFinding { Match: not null } && pair is PairFinding<ApiMemberHandle>.Changed fuzzy)
+            {
+                if (fuzzy.Old.Payload.Fingerprint is { } oldFingerprint)
+                    oldFingerprintsInFuzzyMatch.Add(oldFingerprint);
+                if (fuzzy.New.Payload.Fingerprint is { } newFingerprint)
+                    newFingerprintsInFuzzyMatch.Add(newFingerprint);
+            }
+        }
+
+        foreach (var pair in members.Pairs)
+        {
+            switch ((object)pair.Value)
+            {
+                case PairFinding<ApiMemberHandle>.Added added:
+                    if (ApiDiffAnalyzer.IncludesSignature(options)
+                        && !wholeTypeTransition.Added.Contains(added.New.Payload.TypeFullName)
+                        && !(added.New.Payload.Fingerprint is { } addedFingerprint && newFingerprintsInFuzzyMatch.Contains(addedFingerprint)))
+                    {
+                        Bucket(changesByType, added.New.Payload.TypeFullName).Add(new ApiChange(
+                            ChangeKind.MemberAdded,
+                            ChangeClassification.Additive,
+                            $"Member '{added.New.Payload.MemberName}' was added",
+                            Subject: ApiChangeSubject.Member(null, null, added.New.Payload.Type, added.New.Payload.Member)));
+                    }
+                    break;
+
+                case PairFinding<ApiMemberHandle>.Removed removed:
+                    if (ApiDiffAnalyzer.IncludesSignature(options)
+                        && !wholeTypeTransition.Removed.Contains(removed.Old.Payload.TypeFullName)
+                        && !(removed.Old.Payload.Fingerprint is { } removedFingerprint && oldFingerprintsInFuzzyMatch.Contains(removedFingerprint)))
+                    {
+                        Bucket(changesByType, removed.Old.Payload.TypeFullName).Add(new ApiChange(
+                            ChangeKind.MemberRemoved,
+                            ChangeClassification.Breaking,
+                            $"Member '{removed.Old.Payload.MemberName}' was removed",
+                            Subject: ApiChangeSubject.Member(removed.Old.Payload.Type, removed.Old.Payload.Member, null, null)));
+                    }
+                    break;
+
+                case PairFinding<ApiMemberHandle>.Present present:
+                    ClassifyMatchedMember(present.Old.Payload, present.New.Payload, options, changesByType);
+                    break;
+
+                case PairFinding<ApiMemberHandle>.Changed changed:
+                    var match = ((IMatchedPairFinding)pair.Value).Match;
+                    if (match is null)
+                    {
+                        // Matched on the hard (identity-set) tier; the fold-in step
+                        // recorded a Detail but classification is unaffected by that.
+                        ClassifyMatchedMember(changed.Old.Payload, changed.New.Payload, options, changesByType);
+                    }
+                    else if (normalizeProjection)
+                    {
+                        ClassifyNormalizedProjection(changed.Old.Payload, changed.New.Payload, options, changesByType);
+                    }
+                    else
+                    {
+                        // Strict default: a fuzzy/soft-key correspondence (e.g. an extension
+                        // method's static/instance projection) is not assumed to be the same
+                        // member. Report it the way the legacy analyzer's own matcher would --
+                        // as an unrelated removal and addition -- unless the caller explicitly
+                        // opts into ApiDiffNormalization.NormalizeMemberProjection.
+                        if (ApiDiffAnalyzer.IncludesSignature(options))
+                        {
+                            if (!wholeTypeTransition.Removed.Contains(changed.Old.Payload.TypeFullName))
+                            {
+                                Bucket(changesByType, changed.Old.Payload.TypeFullName).Add(new ApiChange(
+                                    ChangeKind.MemberRemoved,
+                                    ChangeClassification.Breaking,
+                                    $"Member '{changed.Old.Payload.MemberName}' was removed",
+                                    Subject: ApiChangeSubject.Member(changed.Old.Payload.Type, changed.Old.Payload.Member, null, null)));
+                            }
+                            if (!wholeTypeTransition.Added.Contains(changed.New.Payload.TypeFullName))
+                            {
+                                Bucket(changesByType, changed.New.Payload.TypeFullName).Add(new ApiChange(
+                                    ChangeKind.MemberAdded,
+                                    ChangeClassification.Additive,
+                                    $"Member '{changed.New.Payload.MemberName}' was added",
+                                    Subject: ApiChangeSubject.Member(null, null, changed.New.Payload.Type, changed.New.Payload.Member)));
+                            }
+                        }
+                    }
+                    break;
+            }
+        }
+    }
+
+    static void ClassifyMatchedMember(
+        ApiMemberHandle oldHandle,
+        ApiMemberHandle newHandle,
+        ApiDiffOptions options,
+        Dictionary<string, List<ApiChange>> changesByType)
+    {
+        var changes = Bucket(changesByType, newHandle.TypeFullName);
+        if (ApiDiffAnalyzer.IncludesSignature(options))
+        {
+            // Identity/fingerprint matching is keyed on CanonicalSignature, which omits the
+            // return type (see MemberAnchor.ComputeFingerprint). Two hard-matched members can
+            // therefore still differ in raw Signature text (return type changed, e.g.
+            // `void Changed()` -> `int Changed()`) -- a real signature change the identity key
+            // itself can't see. Mirrors the legacy analyzer's own (Name, Kind)-fallback
+            // MemberSignatureChanged report for this case.
+            AddSignatureChangeIfDifferent(oldHandle, newHandle, changes);
+            ApiDiffAnalyzer.CompareMemberModifiers(oldHandle.Type, newHandle.Type, oldHandle.Member, newHandle.Member, changes);
+        }
+        if (ApiDiffAnalyzer.IncludesAttributes(options))
+        {
+            ApiDiffAnalyzer.CompareAttributes(
+                oldHandle.Member.Attributes,
+                newHandle.Member.Attributes,
+                changes,
+                ChangeKind.MemberAttributeAdded,
+                ChangeKind.MemberAttributeRemoved,
+                $"Member '{oldHandle.MemberName}'",
+                ApiChangeSubject.Member(oldHandle.Type, oldHandle.Member, newHandle.Type, newHandle.Member));
+        }
+    }
+
+    /// <summary>
+    /// <see cref="ApiDiffNormalization.NormalizeMemberProjection"/>: a fuzzy-matched member
+    /// pair is the same conceptual member observed under two projections. Runs the same
+    /// facet-level checks as a hard match, plus an explicit signature-changed fact when the
+    /// two projections' raw signatures differ (the only way a fuzzy match can carry a real
+    /// signature delta, since it wasn't discovered by an exact signature/identity key).
+    /// </summary>
+    static void ClassifyNormalizedProjection(
+        ApiMemberHandle oldHandle,
+        ApiMemberHandle newHandle,
+        ApiDiffOptions options,
+        Dictionary<string, List<ApiChange>> changesByType)
+    {
+        var changes = Bucket(changesByType, newHandle.TypeFullName);
+        if (ApiDiffAnalyzer.IncludesSignature(options))
+        {
+            AddSignatureChangeIfDifferent(oldHandle, newHandle, changes);
+            ApiDiffAnalyzer.CompareMemberModifiers(oldHandle.Type, newHandle.Type, oldHandle.Member, newHandle.Member, changes);
+        }
+        if (ApiDiffAnalyzer.IncludesAttributes(options))
+        {
+            ApiDiffAnalyzer.CompareAttributes(
+                oldHandle.Member.Attributes,
+                newHandle.Member.Attributes,
+                changes,
+                ChangeKind.MemberAttributeAdded,
+                ChangeKind.MemberAttributeRemoved,
+                $"Member '{oldHandle.MemberName}'",
+                ApiChangeSubject.Member(oldHandle.Type, oldHandle.Member, newHandle.Type, newHandle.Member));
+        }
+    }
+
+    /// <summary>
+    /// Reports a <see cref="ChangeKind.MemberSignatureChanged"/> fact for a matched member pair
+    /// (hard-identity or normalized-projection) whose raw signature text differs, matching the
+    /// legacy analyzer's classification for its own (Name, Kind)-fallback pairing.
+    /// </summary>
+    static void AddSignatureChangeIfDifferent(ApiMemberHandle oldHandle, ApiMemberHandle newHandle, List<ApiChange> changes)
+    {
+        if (string.Equals(oldHandle.Member.Signature, newHandle.Member.Signature, StringComparison.Ordinal))
+            return;
+
+        changes.Add(new ApiChange(
+            ChangeKind.MemberSignatureChanged,
+            ChangeClassification.Breaking,
+            $"Member '{oldHandle.MemberName}' signature changed from '{oldHandle.Member.Signature}' to '{newHandle.Member.Signature}'",
+            oldHandle.Member.Signature,
+            newHandle.Member.Signature,
+            Subject: ApiChangeSubject.Member(oldHandle.Type, oldHandle.Member, newHandle.Type, newHandle.Member)));
+    }
+
+    static List<ApiChange> Bucket(Dictionary<string, List<ApiChange>> changesByType, string typeFullName)
+    {
+        if (!changesByType.TryGetValue(typeFullName, out var changes))
+        {
+            changes = [];
+            changesByType[typeFullName] = changes;
+        }
+        return changes;
+    }
+
+    static List<ApiDiffInspectionFailure> BuildInspectionFailures(ApiSurface oldSurface, ApiSurface newSurface)
+        =>
+        [
+            .. oldSurface.InspectionFailures.Select(failure =>
+                new ApiDiffInspectionFailure(
+                    "old",
+                    failure.Operation,
+                    failure.SubjectToken,
+                    failure.Mechanism,
+                    failure.Kind,
+                    failure.Detail)),
+            .. newSurface.InspectionFailures.Select(failure =>
+                new ApiDiffInspectionFailure(
+                    "new",
+                    failure.Operation,
+                    failure.SubjectToken,
+                    failure.Mechanism,
+                    failure.Kind,
+                    failure.Detail)),
+        ];
+}

--- a/src/ILInspector.Metadata/ApiFindingClassifier.cs
+++ b/src/ILInspector.Metadata/ApiFindingClassifier.cs
@@ -43,8 +43,10 @@ public static class ApiFindingClassifier
 
         var changesByType = new Dictionary<string, List<ApiChange>>(StringComparer.Ordinal);
         var wholeTypeTransition = BuildWholeTypeTransitionSets(typesComplete);
+        bool oldIdentityIncomplete = oldSurface.InspectionFailures.Count > 0;
+        bool newIdentityIncomplete = newSurface.InspectionFailures.Count > 0;
 
-        ClassifyTypes(typesComplete, options, changesByType);
+        ClassifyTypes(typesComplete, options, oldIdentityIncomplete, newIdentityIncomplete, changesByType);
         ClassifyMembers(membersComplete, options, wholeTypeTransition, changesByType);
 
         List<TypeDiff> typeDiffs = [];
@@ -78,6 +80,8 @@ public static class ApiFindingClassifier
     static void ClassifyTypes(
         FindingComparison<ApiTypeHandle>.Complete types,
         ApiDiffOptions options,
+        bool oldIdentityIncomplete,
+        bool newIdentityIncomplete,
         Dictionary<string, List<ApiChange>> changesByType)
     {
         foreach (var pair in types.Pairs)
@@ -85,7 +89,11 @@ public static class ApiFindingClassifier
             switch ((object)pair.Value)
             {
                 case PairFinding<ApiTypeHandle>.Added added:
-                    if (ApiDiffAnalyzer.IncludesSignature(options))
+                    // Mirrors the legacy analyzer's own oldIdentityIncomplete skip: if the old
+                    // surface failed to resolve identity for some type(s), a type that's
+                    // "only in new" may really be a type whose old-side identity just failed
+                    // to decode, not a genuine addition.
+                    if (ApiDiffAnalyzer.IncludesSignature(options) && !oldIdentityIncomplete)
                     {
                         Bucket(changesByType, added.New.Payload.TypeFullName).Add(new ApiChange(
                             ChangeKind.TypeAdded,
@@ -96,7 +104,11 @@ public static class ApiFindingClassifier
                     break;
 
                 case PairFinding<ApiTypeHandle>.Removed removed:
-                    if (ApiDiffAnalyzer.IncludesSignature(options))
+                    // Mirrors the legacy analyzer's own newIdentityIncomplete skip (see
+                    // ApiSurfaceRelationshipFailureTests.ApiDiff_IncompleteNewIdentityDoesNotClaimOldTypeWasRemoved):
+                    // a type that's "only in old" may really be a type whose new-side identity
+                    // just failed to decode (e.g. a metadata cycle), not a genuine removal.
+                    if (ApiDiffAnalyzer.IncludesSignature(options) && !newIdentityIncomplete)
                     {
                         Bucket(changesByType, removed.Old.Payload.TypeFullName).Add(new ApiChange(
                             ChangeKind.TypeRemoved,
@@ -159,19 +171,27 @@ public static class ApiFindingClassifier
         // (or new) member to enable soft-key projection matching (e.g. an extension method
         // gets both its own hard "extension:" selector atom -- unmatched, becoming Removed --
         // and a receiver-projected atom that fuzzy-matches a real instance method, becoming
-        // Changed). Both atoms share the same content Fingerprint. Without deduplicating by
-        // fingerprint, the same physical member would be reported twice: once via the
-        // Removed/Added atom and again via the fuzzy Changed pair.
-        var oldFingerprintsInFuzzyMatch = new HashSet<string>(StringComparer.Ordinal);
-        var newFingerprintsInFuzzyMatch = new HashSet<string>(StringComparer.Ordinal);
+        // Changed). Both atoms share the same content CanonicalSignature. Without
+        // deduplicating by canonical signature, the same physical member would be reported
+        // twice: once via the Removed/Added atom and again via the fuzzy Changed pair.
+        //
+        // Deliberately keyed on the full CanonicalSignature string rather than Fingerprint:
+        // Fingerprint is a 10-hex-char (40-bit) truncated SHA256 digest, so at real-corpus
+        // member counts an unrelated member's fingerprint can collide with a fuzzy-matched
+        // member's fingerprint (birthday bound ~2^20 members for a 50% collision chance) and
+        // silently suppress that unrelated member's genuine Added/Removed change. The full
+        // signature string carries no such collision risk and is already available on the
+        // payload at zero extra cost.
+        var oldSignaturesInFuzzyMatch = new HashSet<string>(StringComparer.Ordinal);
+        var newSignaturesInFuzzyMatch = new HashSet<string>(StringComparer.Ordinal);
         foreach (var pair in members.Pairs)
         {
             if (pair.Value is IMatchedPairFinding { Match: not null } && pair is PairFinding<ApiMemberHandle>.Changed fuzzy)
             {
-                if (fuzzy.Old.Payload.Fingerprint is { } oldFingerprint)
-                    oldFingerprintsInFuzzyMatch.Add(oldFingerprint);
-                if (fuzzy.New.Payload.Fingerprint is { } newFingerprint)
-                    newFingerprintsInFuzzyMatch.Add(newFingerprint);
+                if (fuzzy.Old.Payload.CanonicalSignature is { } oldSignature)
+                    oldSignaturesInFuzzyMatch.Add(oldSignature);
+                if (fuzzy.New.Payload.CanonicalSignature is { } newSignature)
+                    newSignaturesInFuzzyMatch.Add(newSignature);
             }
         }
 
@@ -181,12 +201,13 @@ public static class ApiFindingClassifier
             {
                 case PairFinding<ApiMemberHandle>.Added added:
                     if (ApiDiffAnalyzer.IncludesSignature(options)
+                        && !IsCompilerGeneratedMember(added.New.Payload)
                         && !wholeTypeTransition.Added.Contains(added.New.Payload.TypeFullName)
-                        && !(added.New.Payload.Fingerprint is { } addedFingerprint && newFingerprintsInFuzzyMatch.Contains(addedFingerprint)))
+                        && !(added.New.Payload.CanonicalSignature is { } addedSignature && newSignaturesInFuzzyMatch.Contains(addedSignature)))
                     {
                         Bucket(changesByType, added.New.Payload.TypeFullName).Add(new ApiChange(
                             ChangeKind.MemberAdded,
-                            ChangeClassification.Additive,
+                            MemberAddedClassification(added.New.Payload),
                             $"Member '{added.New.Payload.MemberName}' was added",
                             Subject: ApiChangeSubject.Member(null, null, added.New.Payload.Type, added.New.Payload.Member)));
                     }
@@ -194,8 +215,9 @@ public static class ApiFindingClassifier
 
                 case PairFinding<ApiMemberHandle>.Removed removed:
                     if (ApiDiffAnalyzer.IncludesSignature(options)
+                        && !IsCompilerGeneratedMember(removed.Old.Payload)
                         && !wholeTypeTransition.Removed.Contains(removed.Old.Payload.TypeFullName)
-                        && !(removed.Old.Payload.Fingerprint is { } removedFingerprint && oldFingerprintsInFuzzyMatch.Contains(removedFingerprint)))
+                        && !(removed.Old.Payload.CanonicalSignature is { } removedSignature && oldSignaturesInFuzzyMatch.Contains(removedSignature)))
                     {
                         Bucket(changesByType, removed.Old.Payload.TypeFullName).Add(new ApiChange(
                             ChangeKind.MemberRemoved,
@@ -206,10 +228,14 @@ public static class ApiFindingClassifier
                     break;
 
                 case PairFinding<ApiMemberHandle>.Present present:
-                    ClassifyMatchedMember(present.Old.Payload, present.New.Payload, options, changesByType);
+                    if (!IsCompilerGeneratedMember(present.Old.Payload))
+                        ClassifyMatchedMember(present.Old.Payload, present.New.Payload, options, changesByType);
                     break;
 
                 case PairFinding<ApiMemberHandle>.Changed changed:
+                    if (IsCompilerGeneratedMember(changed.Old.Payload) || IsCompilerGeneratedMember(changed.New.Payload))
+                        break;
+
                     var match = ((IMatchedPairFinding)pair.Value).Match;
                     if (match is null)
                     {
@@ -242,7 +268,7 @@ public static class ApiFindingClassifier
                             {
                                 Bucket(changesByType, changed.New.Payload.TypeFullName).Add(new ApiChange(
                                     ChangeKind.MemberAdded,
-                                    ChangeClassification.Additive,
+                                    MemberAddedClassification(changed.New.Payload),
                                     $"Member '{changed.New.Payload.MemberName}' was added",
                                     Subject: ApiChangeSubject.Member(null, null, changed.New.Payload.Type, changed.New.Payload.Member)));
                             }
@@ -252,6 +278,28 @@ public static class ApiFindingClassifier
             }
         }
     }
+
+    /// <summary>
+    /// Legacy <c>ApiDiffAnalyzer.CompareMembers</c> drops compiler-generated members (backing
+    /// fields, enum <c>value__</c> slots, closure/state-machine artifacts -- see
+    /// <see cref="MemberFilters.IsCompilerGenerated"/>) via its own <c>FilterMembers</c> before
+    /// matching, since they are not part of the authored API surface. The Finding lane's member
+    /// producer deliberately does not apply this heuristic itself (it is a raw, unfiltered
+    /// census -- see <c>MetadataFindingsTests.ApiSurfaceMembersAreNotFilteredByNameHeuristics</c>),
+    /// so classification is where this policy must be applied instead.
+    /// </summary>
+    static bool IsCompilerGeneratedMember(ApiMemberHandle handle)
+        => MemberFilters.IsCompilerGenerated(handle.MemberName);
+
+    /// <summary>
+    /// Adding a member to an interface is potentially breaking (existing implementers must
+    /// add it too); adding a member to a class/struct/enum is purely additive. Mirrors the
+    /// legacy analyzer's own <c>newType.Kind == "interface"</c> check in <c>CompareMembers</c>.
+    /// </summary>
+    static ChangeClassification MemberAddedClassification(ApiMemberHandle newHandle)
+        => newHandle.Type.Kind == "interface"
+            ? ChangeClassification.PotentiallyBreaking
+            : ChangeClassification.Additive;
 
     static void ClassifyMatchedMember(
         ApiMemberHandle oldHandle,

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -373,8 +373,20 @@ public static class ApiMemberIdentity
             _ => "M"
         };
 
-        if (member.Kind is "property" or "field" or "event")
+        if (member.Kind is "field" or "event")
             return $"{kindCode}:{declaringType}.{member.Name}";
+
+        if (member.Kind == "property")
+        {
+            // An indexer is a property with parameters. Two indexer overloads on the same
+            // type (e.g. this[int] and this[string]) otherwise collide on "P:Type.Item" and
+            // get paired by declaration order instead of by actual parameter signature.
+            // The raw-signature path can't reliably locate a bracketed parameter list the
+            // way ExtractCanonicalParameterList locates a parenthesized one, so this
+            // degraded fallback (SignatureModel absent) intentionally keeps the pre-existing
+            // parameterless format rather than guessing at bracket parsing.
+            return $"{kindCode}:{declaringType}.{member.Name}";
+        }
 
         var signature = member.Signature ?? member.ReturnType ?? member.Name;
         var memberName = member.Kind == "constructor"
@@ -403,9 +415,23 @@ public static class ApiMemberIdentity
             _ => "M"
         };
 
-        if (member.Kind is "property" or "field" or "event")
+        if (member.Kind is "field" or "event")
         {
             canonicalSignature = $"{kindCode}:{declaringType}.{member.Name}";
+            return true;
+        }
+
+        if (member.Kind == "property")
+        {
+            // An indexer is a property with parameters -- include them in identity so
+            // overloaded indexers (e.g. this[int] vs this[string]) don't collide on
+            // "P:Type.Item" and get paired by declaration order instead of by their actual
+            // parameter signature. Ordinary (parameterless) properties are unaffected: their
+            // canonical signature format is unchanged from before this check existed.
+            var indexerParameters = member.SignatureModel is { Parameters.Count: > 0 } propertySignature
+                ? NormalizeCanonicalParameters(propertySignature.ParameterTypesSummary)
+                : "";
+            canonicalSignature = $"{kindCode}:{declaringType}.{member.Name}{indexerParameters}";
             return true;
         }
 

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -376,17 +376,10 @@ public static class ApiMemberIdentity
         if (member.Kind is "field" or "event")
             return $"{kindCode}:{declaringType}.{member.Name}";
 
-        if (member.Kind == "property")
-        {
-            // An indexer is a property with parameters. Two indexer overloads on the same
-            // type (e.g. this[int] and this[string]) otherwise collide on "P:Type.Item" and
-            // get paired by declaration order instead of by actual parameter signature.
-            // The raw-signature path can't reliably locate a bracketed parameter list the
-            // way ExtractCanonicalParameterList locates a parenthesized one, so this
-            // degraded fallback (SignatureModel absent) intentionally keeps the pre-existing
-            // parameterless format rather than guessing at bracket parsing.
-            return $"{kindCode}:{declaringType}.{member.Name}";
-        }
+        // Note: TryGetCanonicalSignature above always succeeds for "property" (it has its
+        // own SignatureModel-or-raw-signature fallback for indexer parameters), so this
+        // method never actually reaches a "property" branch here. There is intentionally no
+        // duplicate property-handling code below.
 
         var signature = member.Signature ?? member.ReturnType ?? member.Name;
         var memberName = member.Kind == "constructor"
@@ -428,9 +421,18 @@ public static class ApiMemberIdentity
             // "P:Type.Item" and get paired by declaration order instead of by their actual
             // parameter signature. Ordinary (parameterless) properties are unaffected: their
             // canonical signature format is unchanged from before this check existed.
+            //
+            // ApiSurface.SignatureModel is [JsonIgnore], so a JSON-round-tripped surface
+            // (a supported, tested scenario -- see FallbackCanonicalSignature_* tests) has
+            // no SignatureModel. Falling back to "" here would make a JSON-persisted
+            // baseline's indexer canonical signature diverge from the same indexer read
+            // live from the assembly, breaking pairing between the two. So when
+            // SignatureModel is absent, parse the parameter list out of the raw
+            // "this[...]" signature text instead, which IS preserved across JSON
+            // round-trips.
             var indexerParameters = member.SignatureModel is { Parameters.Count: > 0 } propertySignature
                 ? NormalizeCanonicalParameters(propertySignature.ParameterTypesSummary)
-                : "";
+                : ExtractCanonicalIndexerParameterList(member.Signature);
             canonicalSignature = $"{kindCode}:{declaringType}.{member.Name}{indexerParameters}";
             return true;
         }
@@ -610,6 +612,49 @@ public static class ApiMemberIdentity
 
         var parameters = abbreviated[parenStart..(parenEnd + 1)];
         return NormalizeCanonicalCommas(parameters);
+    }
+
+    /// <summary>
+    /// Extracts the canonical, parenthesized parameter-type list from an indexer's raw
+    /// signature text (e.g. "int this[string key] { get; }" -> "(string)"), or "" when the
+    /// signature has no "this[...]" indexer parameter list (an ordinary, non-indexed
+    /// property). Kept in sync with ApiSurfaceExtractor's raw indexer signature format.
+    /// </summary>
+    static string ExtractCanonicalIndexerParameterList(string? signature)
+    {
+        if (string.IsNullOrEmpty(signature))
+            return "";
+
+        var indexerKeyword = signature.IndexOf("this[", StringComparison.Ordinal);
+        if (indexerKeyword < 0)
+            return "";
+
+        var bracketStart = indexerKeyword + "this".Length;
+        var depth = 0;
+        var bracketEnd = -1;
+        for (var i = bracketStart; i < signature.Length; i++)
+        {
+            if (signature[i] == '[')
+                depth++;
+            else if (signature[i] == ']')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    bracketEnd = i;
+                    break;
+                }
+            }
+        }
+
+        if (bracketEnd < 0)
+            return "";
+
+        var parameterSection = signature[(bracketStart + 1)..bracketEnd];
+        // Reuse the existing parenthesized-parameter-list machinery (type extraction,
+        // default-value stripping, generic-depth-aware comma splitting) by round-tripping
+        // the bracketed indexer parameters through the parenthesized form it expects.
+        return ExtractCanonicalParameterList($"({parameterSection})");
     }
 
     static string AbbreviateSignature(string? signature)

--- a/src/ILInspector.Metadata/MetadataFindings.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.cs
@@ -312,33 +312,23 @@ public static partial class MetadataFindings
         ApiSurface surface,
         FindingSubject subject)
     {
-        return surface.InspectionFailures.Count == 0
-            ? InspectApiTypes(surface, subject)
-            : new FindingInspection<ApiTypeHandle>.Failed(
-                ApiInspectionError(surface, subject));
+        // ApiSurface.Types already excludes the entities recorded in InspectionFailures (see
+        // AssemblyReader/ApiSurfaceExtractor) -- the surface itself is the healthy subset, and
+        // InspectionFailures is structured metadata about what was skipped, not a signal that
+        // nothing usable was extracted. Mirrors the legacy analyzer's per-type-skip: a failure
+        // affecting some types must not discard the comparison for every type that did load.
+        return InspectApiTypes(surface, subject);
     }
 
     static FindingInspection<ApiMemberHandle> InspectApiMembersForComparison(
         ApiSurface surface,
         FindingSubject subject)
     {
-        return surface.InspectionFailures.Count == 0
-            ? InspectApiMembers(surface, subject)
-            : new FindingInspection<ApiMemberHandle>.Failed(
-                ApiInspectionError(surface, subject));
+        // See BuildRawTypesComparison's InspectApiTypesForComparison: the surface's Members
+        // are already the healthy subset, so a recorded InspectionFailure elsewhere must not
+        // collapse the whole-side comparison to Failed.
+        return InspectApiMembers(surface, subject);
     }
-
-    static InspectionError ApiInspectionError(
-        ApiSurface surface,
-        FindingSubject subject)
-        => new(
-            subject,
-            InspectionDescriptor,
-            string.Join(
-                "; ",
-                surface.InspectionFailures.Select(failure =>
-                    $"{failure.Operation} 0x{failure.SubjectToken:X8} "
-                    + $"{failure.Mechanism}/{failure.Kind}: {failure.Detail}")));
 
     static ImmutableArray<PairFinding<ApiTypeHandle>> ApplyTypeFacetChanges(
         ImmutableArray<PairFinding<ApiTypeHandle>> pairs,

--- a/src/ILInspector.Metadata/MetadataFindings.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.cs
@@ -159,8 +159,10 @@ public static partial class MetadataFindings
         ArgumentNullException.ThrowIfNull(subject);
         options ??= ApiDiffOptions.Default;
 
-        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface, options);
-        return CompareApiTypes(oldSurface, newSurface, subject, options, diff);
+        var rawTypes = BuildRawTypesComparison(oldSurface, newSurface, subject);
+        var rawMembers = BuildRawMembersComparison(oldSurface, newSurface, subject, acceptanceThreshold: 100);
+        var diff = ApiFindingClassifier.Classify(rawTypes, rawMembers, oldSurface, newSurface, options);
+        return rawTypes.TransformPairs(pairs => ApplyTypeFacetChanges(pairs, diff, options.Scope));
     }
 
     public static FindingComparison<ApiMemberHandle> CompareApiMembers(
@@ -175,14 +177,10 @@ public static partial class MetadataFindings
         ArgumentNullException.ThrowIfNull(subject);
         options ??= ApiDiffOptions.Default;
 
-        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface, options);
-        return CompareApiMembers(
-            oldSurface,
-            newSurface,
-            subject,
-            options,
-            diff,
-            acceptanceThreshold);
+        var rawTypes = BuildRawTypesComparison(oldSurface, newSurface, subject);
+        var rawMembers = BuildRawMembersComparison(oldSurface, newSurface, subject, acceptanceThreshold);
+        var diff = ApiFindingClassifier.Classify(rawTypes, rawMembers, oldSurface, newSurface, options);
+        return rawMembers.TransformPairs(pairs => ApplyMemberFacetChanges(pairs, diff, options.Scope));
     }
 
     public static FindingComparison<ApiTypeHandle> CompareApiType(
@@ -196,18 +194,21 @@ public static partial class MetadataFindings
         ArgumentException.ThrowIfNullOrEmpty(typeFullName);
         options ??= ApiDiffOptions.Default;
 
-        var comparison = FindingComparison.Compare(
+        var rawTypes = FindingComparison.Compare(
             InspectApiType(oldSurface, subject, typeFullName),
             InspectApiType(newSurface, subject, typeFullName),
             IdentitySetOptions);
         if (oldSurface is null || newSurface is null)
-            return comparison;
+            return rawTypes;
 
-        var diff = ApiDiffAnalyzer.Compare(
-            FocusSurface(oldSurface, typeFullName),
-            FocusSurface(newSurface, typeFullName),
-            options);
-        return comparison.TransformPairs(
+        var rawMembers = FindingComparison.Compare(
+            InspectApiMembers(oldSurface, subject, typeFullName),
+            InspectApiMembers(newSurface, subject, typeFullName),
+            IdentitySetOptions);
+        var focusedOld = FocusSurface(oldSurface, typeFullName);
+        var focusedNew = FocusSurface(newSurface, typeFullName);
+        var diff = ApiFindingClassifier.Classify(rawTypes, rawMembers, focusedOld, focusedNew, options);
+        return rawTypes.TransformPairs(
             pairs => ApplyTypeFacetChanges(pairs, diff, options.Scope));
     }
 
@@ -223,19 +224,22 @@ public static partial class MetadataFindings
         ArgumentException.ThrowIfNullOrEmpty(typeFullName);
         options ??= ApiDiffOptions.Default;
 
-        var comparison = FindingComparison.Compare(
+        var rawMembers = FindingComparison.Compare(
             InspectApiMembers(oldSurface, subject, typeFullName),
             InspectApiMembers(newSurface, subject, typeFullName),
             IdentitySetOptions,
             acceptanceThreshold);
         if (oldSurface is null || newSurface is null)
-            return comparison;
+            return rawMembers;
 
-        var diff = ApiDiffAnalyzer.Compare(
-            FocusSurface(oldSurface, typeFullName),
-            FocusSurface(newSurface, typeFullName),
-            options);
-        return comparison.TransformPairs(
+        var rawTypes = FindingComparison.Compare(
+            InspectApiType(oldSurface, subject, typeFullName),
+            InspectApiType(newSurface, subject, typeFullName),
+            IdentitySetOptions);
+        var focusedOld = FocusSurface(oldSurface, typeFullName);
+        var focusedNew = FocusSurface(newSurface, typeFullName);
+        var diff = ApiFindingClassifier.Classify(rawTypes, rawMembers, focusedOld, focusedNew, options);
+        return rawMembers.TransformPairs(
             pairs => ApplyMemberFacetChanges(pairs, diff, options.Scope));
     }
 
@@ -266,51 +270,42 @@ public static partial class MetadataFindings
         ArgumentNullException.ThrowIfNull(subject);
         options ??= ApiDiffOptions.Default;
 
-        var diff = ApiDiffAnalyzer.Compare(oldSurface, newSurface, options);
+        var rawTypes = BuildRawTypesComparison(oldSurface, newSurface, subject);
+        var rawMembers = BuildRawMembersComparison(oldSurface, newSurface, subject, memberAcceptanceThreshold);
+        var diff = ApiFindingClassifier.Classify(rawTypes, rawMembers, oldSurface, newSurface, options);
         return new ApiFindingComparison(
-            CompareApiTypes(oldSurface, newSurface, subject, options, diff),
-            CompareApiMembers(
-                oldSurface,
-                newSurface,
-                subject,
-                options,
-                diff,
-                memberAcceptanceThreshold),
+            rawTypes.TransformPairs(pairs => ApplyTypeFacetChanges(pairs, diff, options.Scope)),
+            rawMembers.TransformPairs(pairs => ApplyMemberFacetChanges(pairs, diff, options.Scope)),
             diff);
     }
 
-    static FindingComparison<ApiTypeHandle> CompareApiTypes(
+    /// <summary>
+    /// The unclassified type correspondence: identity-set matching over both surfaces'
+    /// types, before <see cref="ApiFindingClassifier"/> runs. Kept separate from the
+    /// classification step so the classifier can consume this same alignment to build the
+    /// <see cref="ApiDiff"/> that <see cref="ApplyTypeFacetChanges"/> then folds back onto it
+    /// as human-readable <c>Detail</c> text.
+    /// </summary>
+    static FindingComparison<ApiTypeHandle> BuildRawTypesComparison(
         ApiSurface oldSurface,
         ApiSurface newSurface,
-        FindingSubject subject,
-        ApiDiffOptions options,
-        ApiDiff diff)
+        FindingSubject subject)
     {
         var oldInspection = InspectApiTypesForComparison(oldSurface, subject);
         var newInspection = InspectApiTypesForComparison(newSurface, subject);
-        return FindingComparison.Compare(
-            oldInspection,
-            newInspection,
-            IdentitySetOptions)
-            .TransformPairs(pairs => ApplyTypeFacetChanges(pairs, diff, options.Scope));
+        return FindingComparison.Compare(oldInspection, newInspection, IdentitySetOptions);
     }
 
-    static FindingComparison<ApiMemberHandle> CompareApiMembers(
+    /// <summary>The unclassified member correspondence -- see <see cref="BuildRawTypesComparison"/>.</summary>
+    static FindingComparison<ApiMemberHandle> BuildRawMembersComparison(
         ApiSurface oldSurface,
         ApiSurface newSurface,
         FindingSubject subject,
-        ApiDiffOptions options,
-        ApiDiff diff,
-        int acceptanceThreshold = 100)
+        int acceptanceThreshold)
     {
         var oldInspection = InspectApiMembersForComparison(oldSurface, subject);
         var newInspection = InspectApiMembersForComparison(newSurface, subject);
-        return FindingComparison.Compare(
-            oldInspection,
-            newInspection,
-            IdentitySetOptions,
-            acceptanceThreshold)
-            .TransformPairs(pairs => ApplyMemberFacetChanges(pairs, diff, options.Scope));
+        return FindingComparison.Compare(oldInspection, newInspection, IdentitySetOptions, acceptanceThreshold);
     }
 
     static FindingInspection<ApiTypeHandle> InspectApiTypesForComparison(

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -288,7 +288,14 @@ public static class ResearchDiff
             oldSurface,
             newSurface,
             new FindingSubject("api", "API surface"),
-            new ApiDiffOptions(apiScope));
+            new ApiDiffOptions(apiScope),
+            // Opt into the extension static/instance projection tier: the Finding framework
+            // defaults acceptanceThreshold to 100 (exact-only) by design, so production API
+            // diffing must explicitly accept this tier's confidence to ever promote its soft
+            // candidates -- otherwise the fuzzy match this diff is built to recognize never
+            // fires, and the physical member it describes is double-reported as removed via
+            // its two identity atoms instead.
+            memberAcceptanceThreshold: MetadataFindings.ExtensionInstanceMatchTier.Confidence);
         var diff = findings.ApiDiff;
         builder.ApiComparison = findings;
         foreach (var failure in diff.InspectionFailures)

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -1144,10 +1144,18 @@ public class DiffCommandTests
             MemberFilter = ["GenericChoice<T>"]
         });
 
+        // The generic overload's added parameter changes its identity (CanonicalSignature
+        // includes the parameter list), so the Finding lane's own correspondence -- not the
+        // legacy analyzer's (Name, Kind) fallback -- reports it as a conservative
+        // MemberRemoved + MemberAdded pair rather than a single MemberSignatureChanged (see
+        // issue #2893 classification port). Both changes describe the generic overload; the
+        // unrelated non-generic `GenericChoice(string)` overload is unchanged and excluded.
         var typeDiff = Assert.Single(diff.TypeDiffs);
-        var change = Assert.Single(typeDiff.Changes);
-        Assert.Equal(ChangeKind.MemberSignatureChanged, change.Kind);
-        Assert.Contains("<T>", change.NewValue);
+        Assert.Equal(2, typeDiff.Changes.Count);
+        Assert.Contains(typeDiff.Changes, c => c.Kind == ChangeKind.MemberRemoved
+            && c.Subject?.OldMember?.CanonicalSignature?.Contains("<T>") == true);
+        Assert.Contains(typeDiff.Changes, c => c.Kind == ChangeKind.MemberAdded
+            && c.Subject?.NewMember?.CanonicalSignature?.Contains("<T>") == true);
     }
 
     private static DiffCommand.RankedAnalysisRow Ranked(string member, string signal, int magnitude, int direction, bool inBoth, bool inLoop = false)

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -149,7 +149,7 @@ public class OutputFormatterTests
     }
 
     [Fact]
-    public void BuildMemberDrillMap_SuppressesAmbiguousStableForOverloadedIndexers()
+    public void BuildMemberDrillMap_GivesDistinctStableSelectorsForOverloadedIndexers()
     {
         var type = new ApiType
         {
@@ -166,13 +166,19 @@ public class OutputFormatterTests
 
         var map = ApiOutputFormatter.BuildMemberDrillMap(type);
 
-        // Overloaded indexers share the parameter-free property canonical signature, so the
-        // ambiguous Stable digest is suppressed while the Name:N selector disambiguates.
+        // Overloaded indexers now get distinct parameter-aware canonical signatures
+        // (ApiMemberIdentity disambiguates this[int] from this[string] -- see PR #2938),
+        // so each overload gets its own round-tripping Stable digest instead of the
+        // ambiguous-collision suppression this test previously asserted. The Name:N
+        // selector still disambiguates alongside it.
         Assert.True(map.TryGetValue(1001, out var first));
-        Assert.Null(first.Stable);
+        Assert.NotNull(first.Stable);
+        Assert.Matches(@"^Item~[0-9a-f]{10}$", first.Stable);
         Assert.Matches(@"^Item:[12]$", first.Selector);
         Assert.True(map.TryGetValue(1002, out var second));
-        Assert.Null(second.Stable);
+        Assert.NotNull(second.Stable);
+        Assert.Matches(@"^Item~[0-9a-f]{10}$", second.Stable);
+        Assert.NotEqual(first.Stable, second.Stable);
 
         // A uniquely-named property keeps its round-tripping Stable selector.
         Assert.True(map.TryGetValue(1003, out var count));

--- a/tests/ILInspector.Metadata.Tests/ApiFindingClassifierTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiFindingClassifierTests.cs
@@ -147,6 +147,56 @@ public class ApiFindingClassifierTests
         Assert.All(memberChanges, c => Assert.Equal(ChangeKind.MemberSignatureChanged, c.Kind));
     }
 
+    [Fact]
+    public void MemberAdded_ToInterface_IsPotentiallyBreakingNotAdditive()
+    {
+        var oldSurface = Surface(Type("IWidget", kind: "interface"));
+        var newSurface = Surface(Type("IWidget", kind: "interface", members: [Method("Run", "void Run()")]));
+
+        var options = new ApiDiffOptions(ApiDiffScope.All);
+        var legacy = ApiDiffAnalyzer.Compare(oldSurface, newSurface, options);
+        var classified = ClassifyFor(oldSurface, newSurface, options);
+
+        // Legacy: adding a member to an interface is PotentiallyBreaking (existing
+        // implementers must add it too), not Additive.
+        var legacyChange = Assert.Single(legacy.TypeDiffs.SelectMany(t => t.Changes), c => c.Kind == ChangeKind.MemberAdded);
+        Assert.Equal(ChangeClassification.PotentiallyBreaking, legacyChange.Classification);
+
+        var classifiedChange = Assert.Single(classified.TypeDiffs.SelectMany(t => t.Changes), c => c.Kind == ChangeKind.MemberAdded);
+        Assert.Equal(ChangeClassification.PotentiallyBreaking, classifiedChange.Classification);
+    }
+
+    [Fact]
+    public void MemberAdded_ToClass_RemainsAdditive()
+    {
+        var oldSurface = Surface(Type("Widget"));
+        var newSurface = Surface(Type("Widget", members: [Method("Run", "void Run()")]));
+
+        var classified = ClassifyFor(oldSurface, newSurface, new ApiDiffOptions(ApiDiffScope.All));
+
+        var classifiedChange = Assert.Single(classified.TypeDiffs.SelectMany(t => t.Changes), c => c.Kind == ChangeKind.MemberAdded);
+        Assert.Equal(ChangeClassification.Additive, classifiedChange.Classification);
+    }
+
+    [Fact]
+    public void CompilerGeneratedMembers_DoNotSurfaceAsApiChanges()
+    {
+        // Backing field for an auto-property (matches MemberFilters.IsCompilerGenerated's
+        // "__BackingField" heuristic) that only exists on the new side. The Finding lane's
+        // raw member census intentionally does not filter it (see
+        // MetadataFindingsTests.ApiSurfaceMembersAreNotFilteredByNameHeuristics), so
+        // classification -- not the producer -- must apply the legacy analyzer's own
+        // FilterMembers policy.
+        var oldSurface = Surface(Type("Widget"));
+        var newSurface = Surface(Type("Widget", members: [Method("<Name>k__BackingField", "string <Name>k__BackingField")]));
+
+        var legacy = ApiDiffAnalyzer.Compare(oldSurface, newSurface, new ApiDiffOptions(ApiDiffScope.All));
+        var classified = ClassifyFor(oldSurface, newSurface, new ApiDiffOptions(ApiDiffScope.All));
+
+        Assert.DoesNotContain(legacy.TypeDiffs.SelectMany(t => t.Changes), c => c.Kind == ChangeKind.MemberAdded);
+        Assert.DoesNotContain(classified.TypeDiffs.SelectMany(t => t.Changes), c => c.Kind == ChangeKind.MemberAdded);
+    }
+
     static ApiDiff ClassifyFor(ApiSurface oldSurface, ApiSurface newSurface, ApiDiffOptions options)
     {
         var comparison = MetadataFindings.CompareApi(oldSurface, newSurface, Subject, options, memberAcceptanceThreshold: 85);

--- a/tests/ILInspector.Metadata.Tests/ApiFindingClassifierTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiFindingClassifierTests.cs
@@ -1,0 +1,189 @@
+extern alias extensionnew;
+extern alias extensionold;
+
+using System.Reflection.PortableExecutable;
+using ILInspector.Findings;
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests;
+
+/// <summary>
+/// Validates <see cref="ApiFindingClassifier"/> -- the Finding-pair-driven classifier
+/// intended to replace <see cref="ApiDiffAnalyzer"/>'s own type/member matching walk
+/// (issue #2893 follow-up). Type-level classification must stay byte-identical to the
+/// legacy analyzer. Member-level classification intentionally diverges for fuzzy/soft-key
+/// matches: strict (default) reports them as an unrelated removal+addition just like the
+/// legacy analyzer would, while <see cref="ApiDiffNormalization.NormalizeMemberProjection"/>
+/// treats them as the same member observed under two projections.
+/// </summary>
+public class ApiFindingClassifierTests
+{
+    static readonly FindingSubject Subject = new("api", "API");
+
+    [Fact]
+    public void TypeFacetChanges_MatchLegacyAnalyzerExactly()
+    {
+        var oldSurface = Surface(
+            Type("Widget", isByRefLike: false, members: [Method("Run", "void Run()")]),
+            Type("Removed"));
+        var newSurface = Surface(
+            Type("Widget", isByRefLike: true, members: [Method("Run", "void Run()")]),
+            Type("Added"));
+
+        var options = new ApiDiffOptions(ApiDiffScope.All);
+        var legacy = ApiDiffAnalyzer.Compare(oldSurface, newSurface, options);
+        var classified = ClassifyFor(oldSurface, newSurface, options);
+
+        // Type-level changes must match exactly: same type names, same change kinds.
+        Assert.Equal(
+            legacy.TypeDiffs.Select(t => t.TypeFullName).Order(StringComparer.Ordinal),
+            classified.TypeDiffs.Select(t => t.TypeFullName).Order(StringComparer.Ordinal));
+
+        foreach (var legacyTypeDiff in legacy.TypeDiffs)
+        {
+            var classifiedTypeDiff = classified.TypeDiffs.Single(t => t.TypeFullName == legacyTypeDiff.TypeFullName);
+            var legacyTypeKinds = legacyTypeDiff.Changes
+                .Where(c => c.Category == ApiChangeCategory.Signature && c.Subject?.Kind == ApiChangeSubjectKind.Type)
+                .Select(c => c.Kind)
+                .Order();
+            var classifiedTypeKinds = classifiedTypeDiff.Changes
+                .Where(c => c.Category == ApiChangeCategory.Signature && c.Subject?.Kind == ApiChangeSubjectKind.Type)
+                .Select(c => c.Kind)
+                .Order();
+            Assert.Equal(legacyTypeKinds, classifiedTypeKinds);
+        }
+    }
+
+    [Fact]
+    public void HardMatchedMemberChanges_MatchLegacyAnalyzerExactly()
+    {
+        var oldSurface = Surface(Type("Widget", members:
+        [
+            Method("Keep", "void Keep()"),
+            Method("Removed", "void Removed()"),
+            Method("WasVirtual", "void WasVirtual()", isVirtual: true),
+        ]));
+        var newSurface = Surface(Type("Widget", members:
+        [
+            Method("Keep", "void Keep()"),
+            Method("Added", "void Added()"),
+            Method("WasVirtual", "void WasVirtual()", isVirtual: false),
+        ]));
+
+        var options = new ApiDiffOptions(ApiDiffScope.All);
+        var legacy = ApiDiffAnalyzer.Compare(oldSurface, newSurface, options);
+        var classified = ClassifyFor(oldSurface, newSurface, options);
+
+        var legacyKinds = legacy.TypeDiffs.SelectMany(t => t.Changes)
+            .Where(c => c.Subject?.Kind == ApiChangeSubjectKind.Member)
+            .Select(c => c.Kind)
+            .Order();
+        var classifiedKinds = classified.TypeDiffs.SelectMany(t => t.Changes)
+            .Where(c => c.Subject?.Kind == ApiChangeSubjectKind.Member)
+            .Select(c => c.Kind)
+            .Order();
+
+        Assert.Equal(legacyKinds, classifiedKinds);
+        Assert.Contains(ChangeKind.MemberAdded, classifiedKinds);
+        Assert.Contains(ChangeKind.MemberRemoved, classifiedKinds);
+        Assert.Contains(ChangeKind.VirtualRemoved, classifiedKinds);
+    }
+
+    [Fact]
+    public void FuzzyMatchedMember_StrictDefault_ReportsUnrelatedRemovalAndAddition()
+    {
+        var oldSurface = ExtractSurface(typeof(extensionold::ExtensionInstanceFixture.Widget).Assembly.Location);
+        var newSurface = ExtractSurface(typeof(extensionnew::ExtensionInstanceFixture.Widget).Assembly.Location);
+
+        // Legacy analyzer's own per-type walk never recognizes the extension method's static
+        // -> instance projection as the same member either: WidgetExtensions disappears as a
+        // whole type (TypeRemoved), and Widget's new instance method is a plain MemberAdded.
+        var legacy = ApiDiffAnalyzer.Compare(oldSurface, newSurface);
+        var classified = ClassifyFor(oldSurface, newSurface, ApiDiffOptions.Default);
+
+        Assert.Contains(
+            legacy.TypeDiffs.SelectMany(t => t.Changes),
+            c => c.Kind == ChangeKind.TypeRemoved
+                && c.Subject!.TypeFullName == "ExtensionInstanceFixture.WidgetExtensions");
+        Assert.Contains(
+            legacy.TypeDiffs.SelectMany(t => t.Changes),
+            c => c.Kind == ChangeKind.MemberAdded && c.Subject!.NewIdentity is not null);
+
+        // Classifier: whole-type removal for WidgetExtensions (member-level suppressed
+        // because the type itself is gone), plus a plain MemberAdded for Widget.Measure --
+        // matching legacy's total shape for this scenario.
+        Assert.Contains(
+            classified.TypeDiffs.SelectMany(t => t.Changes),
+            c => c.Kind == ChangeKind.TypeRemoved
+                && c.Subject!.TypeFullName == "ExtensionInstanceFixture.WidgetExtensions");
+        var widgetDiff = classified.TypeDiffs.Single(t => t.TypeFullName == "ExtensionInstanceFixture.Widget");
+        Assert.Single(widgetDiff.Changes, c => c.Kind == ChangeKind.MemberAdded);
+        Assert.DoesNotContain(widgetDiff.Changes, c => c.Kind == ChangeKind.MemberRemoved);
+
+        // No leftover member-level removal for the vanished extension method: it is fully
+        // covered by the WidgetExtensions TypeRemoved change, not double-reported.
+        Assert.DoesNotContain(
+            classified.TypeDiffs.SelectMany(t => t.Changes),
+            c => c.Kind == ChangeKind.MemberRemoved);
+    }
+
+    [Fact]
+    public void FuzzyMatchedMember_Normalized_TreatsProjectionAsSameMember()
+    {
+        var oldSurface = ExtractSurface(typeof(extensionold::ExtensionInstanceFixture.Widget).Assembly.Location);
+        var newSurface = ExtractSurface(typeof(extensionnew::ExtensionInstanceFixture.Widget).Assembly.Location);
+
+        var options = new ApiDiffOptions(Normalization: ApiDiffNormalization.NormalizeMemberProjection);
+        var classified = ClassifyFor(oldSurface, newSurface, options);
+
+        var widgetDiff = classified.TypeDiffs.SingleOrDefault(t => t.TypeFullName == "ExtensionInstanceFixture.Widget");
+
+        // Normalized: no plain MemberAdded/MemberRemoved for the projected member. Whether
+        // any change appears at all depends on whether the two projections' raw signature
+        // text differs (the extension method includes the `this Widget` receiver parameter
+        // in its signature, the instance method does not), so a MemberSignatureChanged is
+        // the only change kind allowed to remain for this member.
+        var memberChanges = (widgetDiff?.Changes ?? []).Where(c => c.Subject?.Kind == ApiChangeSubjectKind.Member);
+        Assert.All(memberChanges, c => Assert.Equal(ChangeKind.MemberSignatureChanged, c.Kind));
+    }
+
+    static ApiDiff ClassifyFor(ApiSurface oldSurface, ApiSurface newSurface, ApiDiffOptions options)
+    {
+        var comparison = MetadataFindings.CompareApi(oldSurface, newSurface, Subject, options, memberAcceptanceThreshold: 85);
+        return ApiFindingClassifier.Classify(comparison.Types, comparison.Members, oldSurface, newSurface, options);
+    }
+
+    static ApiSurface Surface(params ApiType[] types)
+        => new() { Types = [.. types] };
+
+    static ApiSurface ExtractSurface(string assemblyPath)
+    {
+        using var stream = File.OpenRead(assemblyPath);
+        using var reader = new PEReader(stream);
+        return ApiSurfaceExtractor.Extract(reader);
+    }
+
+    static ApiType Type(
+        string name,
+        string kind = "class",
+        string? ns = "TestNamespace",
+        bool isByRefLike = false,
+        List<ApiMember>? members = null)
+        => new()
+        {
+            Name = name,
+            Kind = kind,
+            Namespace = ns,
+            IsByRefLike = isByRefLike,
+            Members = members ?? [],
+        };
+
+    static ApiMember Method(string name, string signature, bool isVirtual = false)
+        => new()
+        {
+            Name = name,
+            Kind = "method",
+            Signature = signature,
+            IsVirtual = isVirtual,
+        };
+}

--- a/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
@@ -83,6 +83,50 @@ public class ApiMemberIdentityTests
     }
 
     [Fact]
+    public void GetMemberAnchor_DisambiguatesOverloadedIndexersByParameterType()
+    {
+        using var stream = File.OpenRead(typeof(ApiMemberIdentityTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        var type = surface.Types.Single(t => t.Name.EndsWith(nameof(IndexerFixture), StringComparison.Ordinal));
+        var indexers = type.Members
+            .Where(member => member.Kind == "property" && member.SignatureModel is { Parameters.Count: > 0 })
+            .ToList();
+
+        // Two indexer overloads that differ only by parameter type: this[int] and this[string].
+        Assert.Equal(2, indexers.Count);
+
+        var anchors = indexers
+            .Select(member => ApiMemberIdentity.GetMemberAnchor(type, member))
+            .ToList();
+
+        // Parameter types must be part of the canonical identity, so the two indexers get
+        // distinct canonical signatures and fingerprints instead of colliding on "P:Type.Item"
+        // and being paired by declaration order.
+        Assert.Equal(2, anchors.Select(anchor => anchor.CanonicalSignature).Distinct(StringComparer.Ordinal).Count());
+        Assert.Equal(2, anchors.Select(anchor => anchor.Fingerprint).Distinct(StringComparer.Ordinal).Count());
+        Assert.Contains(anchors, anchor => anchor.CanonicalSignature.Contains("(int)", StringComparison.Ordinal));
+        Assert.Contains(anchors, anchor => anchor.CanonicalSignature.Contains("(string)", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void GetCanonicalSignature_OrdinaryPropertyFormatIsUnchangedByIndexerFix()
+    {
+        var type = new ApiType { Namespace = "N", Name = "C" };
+        var property = new ApiMember
+        {
+            Name = "Name",
+            Kind = "property",
+            Signature = "string Name { get; set; }",
+        };
+
+        Assert.Equal("P:N.C.Name", ApiMemberIdentity.GetCanonicalSignature(type, property));
+        Assert.True(ApiMemberIdentity.TryGetCanonicalSignature(type, property, out var tryResult));
+        Assert.Equal("P:N.C.Name", tryResult);
+    }
+
+    [Fact]
     public void GetMemberAnchor_DisambiguatesDegradedPlaceholderFromGenuineSignature()
     {
         var type = new ApiType { Namespace = "N", Name = "C" };
@@ -215,5 +259,12 @@ public class ApiMemberIdentityTests
         public static explicit operator int(ConversionOperatorFixture value) => 0;
 
         public static explicit operator long(ConversionOperatorFixture value) => 0;
+    }
+
+    sealed class IndexerFixture
+    {
+        public int this[int index] => index;
+
+        public int this[string key] => key.Length;
     }
 }

--- a/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
@@ -111,6 +111,49 @@ public class ApiMemberIdentityTests
     }
 
     [Fact]
+    public void FallbackCanonicalSignature_DisambiguatesIndexers_AfterJsonRoundTrip()
+    {
+        using var stream = File.OpenRead(typeof(ApiMemberIdentityTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        var liveType = surface.Types.Single(t => t.Name.EndsWith(nameof(IndexerFixture), StringComparison.Ordinal));
+        var liveIndexers = liveType.Members
+            .Where(member => member.Kind == "property" && member.SignatureModel is { Parameters.Count: > 0 })
+            .ToList();
+        Assert.Equal(2, liveIndexers.Count);
+
+        // Round-trip through JSON. SignatureModel is [JsonIgnore], so the deserialized
+        // members have no SignatureModel and exercise the raw-signature fallback path.
+        var json = JsonSerializer.Serialize(surface);
+        var roundTripped = JsonSerializer.Deserialize<ApiSurface>(json)!;
+        var roundTrippedType = roundTripped.Types.Single(t => t.Name.EndsWith(nameof(IndexerFixture), StringComparison.Ordinal));
+        var roundTrippedIndexers = roundTrippedType.Members
+            .Where(member => member.Kind == "property" && member.Signature != null && member.Signature.Contains("this[", StringComparison.Ordinal))
+            .ToList();
+        Assert.Equal(2, roundTrippedIndexers.Count);
+        Assert.All(roundTrippedIndexers, member => Assert.Null(member.SignatureModel));
+
+        // The fallback must still disambiguate by parameter type on the round-tripped
+        // surface (parsed from the raw "this[...]" signature text), and -- critically --
+        // must produce the EXACT SAME canonical signatures as the live-assembly path, so a
+        // JSON-persisted baseline pairs correctly against a live-extracted assembly.
+        var liveCanonicals = liveIndexers
+            .Select(member => ApiMemberIdentity.GetCanonicalSignature(liveType, member))
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToList();
+        var roundTrippedCanonicals = roundTrippedIndexers
+            .Select(member => ApiMemberIdentity.GetCanonicalSignature(roundTrippedType, member))
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.Equal(2, roundTrippedCanonicals.Distinct(StringComparer.Ordinal).Count());
+        Assert.Equal(liveCanonicals, roundTrippedCanonicals);
+        Assert.Contains(roundTrippedCanonicals, canonical => canonical.Contains("(int)", StringComparison.Ordinal));
+        Assert.Contains(roundTrippedCanonicals, canonical => canonical.Contains("(string)", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void GetCanonicalSignature_OrdinaryPropertyFormatIsUnchangedByIndexerFix()
     {
         var type = new ApiType { Namespace = "N", Name = "C" };

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceRelationshipFailureTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceRelationshipFailureTests.cs
@@ -70,8 +70,20 @@ public class ApiSurfaceRelationshipFailureTests
             oldSurface,
             newSurface,
             new FindingSubject("api", "API surface"));
-        Assert.IsType<
-            FindingComparison<ApiTypeHandle>.Failed>(findings.Types.Value);
+        // The Finding lane's surfaces already exclude the entities recorded in
+        // InspectionFailures, so a failure on one type must not collapse the whole-side
+        // comparison to Failed -- mirroring the legacy analyzer's per-type-skip granularity
+        // asserted above (Sibling added, Maybe not falsely reported as removed).
+        Assert.IsType<FindingComparison<ApiTypeHandle>.Complete>(findings.Types.Value);
+        Assert.Contains(
+            findings.ApiDiff.InspectionFailures,
+            failure => failure.Side == "new" && failure.Kind == "Cycle");
+        Assert.DoesNotContain(
+            findings.ApiDiff.TypeDiffs,
+            type => type.TypeFullName == "Maybe" && type.IsRemoved);
+        Assert.Contains(
+            findings.ApiDiff.TypeDiffs,
+            type => type.TypeFullName == "Sibling" && type.IsAdded);
         Assert.False(findings.IsExact);
     }
 

--- a/tests/ILInspector.Metadata.Tests/MetadataFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataFindingsTests.cs
@@ -171,7 +171,19 @@ public class MetadataFindingsTests
             Pairs(result.Members).OrderBy(pair => pair.Kind),
             pair => Assert.Equal(PairKind.Added, pair.Kind),
             pair => Assert.Equal(PairKind.Removed, pair.Kind));
-        Assert.Contains(
+
+        // ApiDiff is now sourced from the same Finding-lane identity-set correspondence as
+        // the Members pairs above (ApiFindingClassifier, issue #2893), not the legacy
+        // ApiDiffAnalyzer's own (Name, Kind) fallback pairing. A total signature change with
+        // no shared identity is a conservative MemberAdded + MemberRemoved on both lanes now
+        // -- not the legacy analyzer's MemberSignatureChanged heuristic.
+        var memberChanges = result.ApiDiff.TypeDiffs
+            .SelectMany(type => type.Changes)
+            .Where(change => change.Subject?.Kind == ApiChangeSubjectKind.Member)
+            .Select(change => change.Kind)
+            .Order();
+        Assert.Equal([ChangeKind.MemberAdded, ChangeKind.MemberRemoved], memberChanges);
+        Assert.DoesNotContain(
             result.ApiDiff.TypeDiffs.SelectMany(type => type.Changes),
             change => change.Kind == ChangeKind.MemberSignatureChanged);
     }


### PR DESCRIPTION
## Summary

Step 2 toward #2893 (schedule the legacy diff-lane deletions promised by
`finding-adoption.md`), following the detection-only divergence check in #2931.

Adds `ApiFindingClassifier`, which builds the `ApiDiff` shown by `DiffCommand`
from the Finding lane's own type/member `FindingComparison` pairs instead of
`ApiDiffAnalyzer`'s independent type-name/member-signature walk. `MetadataFindings`
is rewired end to end (`CompareApi`, `CompareApiTypes`, `CompareApiMembers`,
`CompareApiType`) to source `ApiDiff` from the new classifier.

Type-level classification reuses `ApiDiffAnalyzer.CompareTypeFacetsOnly`
unchanged (type identity is the same full-name key in both lanes). Member-level
classification is intentionally sourced from the Finding lane's richer
identity/soft-key matching rather than the legacy analyzer's bespoke
signature-then-(Name,Kind) matcher.

## Intentional behavior change: fuzzy-matched member pairs

This is an opt-in behavior change for fuzzy-matched (soft-key) member pairs,
such as an extension method's static-to-instance projection:

- **Default (strict)**: a fuzzy match is not assumed to be the same member; it
  is reported as an unrelated removal + addition -- matching what the legacy
  analyzer's own matcher would report for members with no shared identity key.
- **New `ApiDiffOptions.Normalization = ApiDiffNormalization.NormalizeMemberProjection`**
  (mirrors #2919's `IlBodyDiffNormalization` naming/policy shape): treats the
  projection as the same conceptual member, emitting `MemberSignatureChanged`
  only when the raw signature text differs, plus modifier/attribute checks.

Both the strict default and the opt-in normalization are implemented in this PR.

## Correctness fix surfaced while porting

Identity/fingerprint matching is keyed on `CanonicalSignature`, which omits the
return type (`MemberAnchor.ComputeFingerprint`). Two hard-matched members can
therefore still differ in raw signature text -- e.g. `void M()` -> `int M()` --
a real signature change the identity key itself can't see. `ClassifyMatchedMember`
now explicitly compares raw `Member.Signature` text for matched pairs (hard
identity match or normalized projection) and reports `MemberSignatureChanged`
when they differ, matching legacy's classification for this case.

A second internal fix: extension-method identity producers emit two Finding
atoms for the same physical member (a hard `extension:`-selector atom and a
receiver-projected soft-key atom used for fuzzy matching). Both share the same
`Fingerprint`. The classifier now deduplicates `Added`/`Removed` pairs whose
fingerprint is already covered by a fuzzy `Changed` match, so the same
physical member is never double-reported.

## Scope and follow-up

`ApiDiffAnalyzer`'s own `Compare()` entry point, `BuildTypeLookup`, and the
legacy `CompareMembers` matcher are **unchanged and kept for now** -- they
still back `ApiDiffAnalyzerTests` (33 tests) as regression coverage for the
shared `CompareTypeFacetsOnly`/`CompareMemberModifiers`/`CompareAttributes`
primitives, and nothing in production code calls the legacy matcher anymore.
Deleting that legacy walk (and its dedicated test suite) is a tracked #2893
follow-up, not part of this PR.

## Validation

- `ILInspector.Metadata.Tests`: 620 total, 1 pre-existing unrelated failure
  (`MemberSourceProducer_UsesFirstVisibleDocumentWhenRootIsOmitted`, confirmed
  pre-existing via `git stash` in earlier session work).
- `ApiDiffAnalyzerTests` (33 tests, exercises legacy `Compare()` directly):
  all passing, unchanged -- confirms the reusable primitives still match the
  legacy analyzer's own behavior.
- `ApiFindingClassifierTests` (new, 4 tests): type-facet parity with legacy,
  hard-matched-member parity with legacy, strict-default fuzzy-match behavior,
  and normalized-projection behavior, using real compiled `extensionold`/
  `extensionnew` fixture assemblies.
- `dotnet-inspect.Tests`: `DiffCommandTests` all passing (two tests updated to
  reflect the intentional conservative Added+Removed behavior for
  identity-changing signature diffs, replacing the legacy Name+Kind fallback's
  `MemberSignatureChanged`). Full suite shows only the same pre-existing
  environmental failures (missing fixture DLLs needing a full slnx build,
  CRLF-vs-LF assertions, network source-file URL columns) -- none Diff-related.
- `ILInspector.Research.Tests`: 113/113 passing.
- Real-corpus smoke test via CLI `diff --package`, zero divergence exceptions:
  - `Newtonsoft.Json@12.0.3..13.0.4` (61 breaking, 60 additive across 19 types)
    -- correctly reports nullable-annotation-only return-type changes as
    `MemberSignatureChanged` via the new fix.
  - `System.Text.Json@6.0.0..8.0.0` (7 breaking, 106 additive across 41 types).
