### PR TITLE
Rename corpora to EVIL/CIVIL

### DIFF
--- a/eng/prepare-evil-corpus.sh
+++ b/eng/prepare-evil-corpus.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Prepares the broad-source assembly pool for the hard-IL decompiler corpus.
+# Prepares the broad-source assembly pool for the EVIL decompiler corpus
+# (Edge-case Verification of IL Legibility).
 # Requires an output directory and writes:
 #   <outdir>/assemblies.txt      the deduped managed assembly path list
 #   <outdir>/sweep/              the extracted sweep packages (durable)
@@ -9,7 +10,7 @@
 # records those paths, so the sweep output MUST live in the durable output
 # directory (not a temp dir) or the emitted paths would dangle after cleanup.
 #
-# The hard-IL corpus is an adversarial stress set: the most diabolical real
+# The EVIL corpus is an adversarial stress set: the most diabolical real
 # methods, ranked by IL difficulty, drawn from a much broader pool than the fixed
 # real-world corpus. The pool is the union of:
 #
@@ -20,14 +21,14 @@
 #
 # Feed the emitted list to the harvester's difficulty-ranked mode:
 #
-#   bash eng/prepare-hard-il-corpus.sh /tmp/hard-il-pool
+#   bash eng/prepare-evil-corpus.sh /tmp/evil-pool
 #   dotnet run --project tools/DecompilerHarness -c Release -- \
-#     --harvest-hard-il-corpus /tmp/hard-il-corpus.jsonl --harvest-target 12000 \
-#     $(cat /tmp/hard-il-pool/assemblies.txt)
+#     --harvest-evil-corpus /tmp/evil-corpus.jsonl --harvest-target 12000 \
+#     $(cat /tmp/evil-pool/assemblies.txt)
 set -euo pipefail
 
 # Number of top NuGet ranks to sweep (the package list currently holds 100).
-PACKAGE_COUNT="${HARD_IL_PACKAGE_COUNT:-100}"
+PACKAGE_COUNT="${EVIL_PACKAGE_COUNT:-100}"
 
 outdir="${1:-}"
 if [ -z "$outdir" ]; then
@@ -71,5 +72,5 @@ if [ -f "$outdir/sweep/manifest.json" ]; then
 fi
 
 count="$(wc -l < "$outdir/assemblies.txt" | tr -d ' ')"
-echo "Hard-IL pool: $count assemblies ($PACKAGE_COUNT-rank sweep + real-world)." >&2
+echo "EVIL pool: $count assemblies ($PACKAGE_COUNT-rank sweep + real-world)." >&2
 echo "Wrote $outdir/assemblies.txt (sweep packages under $outdir/sweep)." >&2

--- a/tools/DecompilerHarness/AuthoredSourceHarvest.cs
+++ b/tools/DecompilerHarness/AuthoredSourceHarvest.cs
@@ -22,11 +22,12 @@ namespace ILInspector.DecompilerHarness;
 /// both round-robin across declaring types so no single type dominates a
 /// library's contribution. They differ only in what each type contributes next:
 /// <list type="bullet">
-/// <item>The <em>real-world</em> corpus (identity-only) keeps candidates in
-/// enumeration order.</item>
-/// <item>The <em>hard-IL</em> corpus orders each type's candidates by descending
-/// IL difficulty score, so each library contributes its most diabolical methods
-/// first, and attaches the difficulty profile to every emitted row.</item>
+/// <item>The <em>CIVIL</em> corpus (Curated Index of Varied IL, identity-only)
+/// keeps candidates in enumeration order.</item>
+/// <item>The <em>EVIL</em> corpus (Edge-case Verification of IL Legibility)
+/// orders each type's candidates by descending IL difficulty score, so each
+/// library contributes its most diabolical methods first, and attaches the
+/// difficulty profile to every emitted row.</item>
 /// </list>
 /// Source content is fetched last, only to snapshot and verify; a failed or
 /// unavailable fetch simply advances to the next candidate, so every emitted row
@@ -49,8 +50,8 @@ static class AuthoredSourceHarvest
         string? ChecksumAlgorithm,
         string? Checksum,
         string AuthoredBody,
-        // Omitted for the identity (real-world) corpus so its rows stay
-        // schema-identical to the vendored corpus; populated only for hard-IL.
+        // Omitted for the CIVIL (identity) corpus so its rows stay
+        // schema-identical to the vendored corpus; populated only for EVIL.
         [property: System.Text.Json.Serialization.JsonIgnore(
             Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         IlDifficulty? Difficulty = null);
@@ -65,10 +66,10 @@ static class AuthoredSourceHarvest
         public required Queue<RealMethodTargetEnumerator.RealMethodTarget> Candidates { get; init; }
     }
 
-    public static int Run(IReadOnlyList<string> assemblies, string outputPath, int target, bool hardIl = false)
-        => RunAsync(assemblies, outputPath, target, hardIl).GetAwaiter().GetResult();
+    public static int Run(IReadOnlyList<string> assemblies, string outputPath, int target, bool evil = false)
+        => RunAsync(assemblies, outputPath, target, evil).GetAwaiter().GetResult();
 
-    static async Task<int> RunAsync(IReadOnlyList<string> assemblies, string outputPath, int target, bool hardIl)
+    static async Task<int> RunAsync(IReadOnlyList<string> assemblies, string outputPath, int target, bool evil)
     {
         if (assemblies.Count == 0)
         {
@@ -85,7 +86,7 @@ static class AuthoredSourceHarvest
         {
             foreach (string assemblyPath in assemblies)
             {
-                var library = TryOpenLibrary(assemblyPath, httpClient, hardIl).GetAwaiter().GetResult();
+                var library = TryOpenLibrary(assemblyPath, httpClient, evil).GetAwaiter().GetResult();
                 if (library is not null)
                     libraries.Add(library);
             }
@@ -127,7 +128,7 @@ static class AuthoredSourceHarvest
                     var candidate = library.Candidates.Dequeue();
                     attempts++;
 
-                    var record = await TryHarvestAsync(library, candidate, fetcher, hardIl);
+                    var record = await TryHarvestAsync(library, candidate, fetcher, evil);
                     if (record is null)
                     {
                         skipped++;
@@ -143,7 +144,7 @@ static class AuthoredSourceHarvest
 
             await writer.FlushAsync();
 
-            Console.WriteLine($"{(hardIl ? "HARD-IL" : "AUTHORED-SOURCE")} HARVEST -> {outputPath}");
+            Console.WriteLine($"{(evil ? "EVIL" : "AUTHORED-SOURCE")} HARVEST -> {outputPath}");
             Console.WriteLine($"  target        : {target}");
             Console.WriteLine($"  resolved      : {resolved}");
             Console.WriteLine($"  attempts      : {attempts}");
@@ -162,7 +163,7 @@ static class AuthoredSourceHarvest
         }
     }
 
-    static async Task<LibraryState?> TryOpenLibrary(string assemblyPath, HttpClient httpClient, bool hardIl)
+    static async Task<LibraryState?> TryOpenLibrary(string assemblyPath, HttpClient httpClient, bool evil)
     {
         IReadOnlyList<RealMethodTargetEnumerator.RealMethodTarget> targets;
         try
@@ -198,7 +199,7 @@ static class AuthoredSourceHarvest
                 Tfm = InferTfm(assemblyPath),
                 Source = source,
                 Candidates = new Queue<RealMethodTargetEnumerator.RealMethodTarget>(
-                    DiversifyByDeclaringType(targets, hardIl)),
+                    DiversifyByDeclaringType(targets, evil)),
             };
             ownershipTransferred = true;
             return state;
@@ -227,7 +228,7 @@ static class AuthoredSourceHarvest
         LibraryState library,
         RealMethodTargetEnumerator.RealMethodTarget candidate,
         SourceFetcher fetcher,
-        bool hardIl)
+        bool evil)
     {
         var subject = new FindingSubject(
             $"{candidate.Type}::{candidate.Method}#{candidate.Overload}",
@@ -281,11 +282,11 @@ static class AuthoredSourceHarvest
             ChecksumAlgorithm: authored.Document?.ChecksumAlgorithm,
             Checksum: authored.Document?.Checksum,
             AuthoredBody: body,
-            Difficulty: hardIl ? candidate.Difficulty : null);
+            Difficulty: evil ? candidate.Difficulty : null);
     }
 
     // Round-robin across declaring types so no single type dominates a library's
-    // contribution to the corpus. For the hard-IL corpus, each type's candidates
+    // contribution to the corpus. For the EVIL corpus, each type's candidates
     // are ordered by descending IL difficulty first, so a type contributes its
     // most diabolical methods before its easy ones while the round-robin still
     // spreads the budget across types.

--- a/tools/DecompilerHarness/IlDifficultyScorer.cs
+++ b/tools/DecompilerHarness/IlDifficultyScorer.cs
@@ -7,7 +7,7 @@ namespace ILInspector.DecompilerHarness;
 
 /// <summary>
 /// A per-method IL difficulty profile plus a single composite <see cref="Score"/>
-/// used to rank the "diabolical" methods for the hard-IL corpus. Every component
+/// used to rank the "diabolical" methods for the EVIL corpus. Every component
 /// is a structural fact read off the shared <see cref="MethodInstructions"/>
 /// substrate (decode + EH-aware block graph) — no inspected-assembly loading, no
 /// abstract interpretation. Ranking, not the absolute scale, is what matters; the
@@ -33,7 +33,7 @@ internal sealed record IlDifficulty(
 /// Scores a method body's IL difficulty from the shared instruction substrate.
 /// The composite weighting deliberately biases toward the shapes that stress the
 /// decompiler's raise the most — exception-handler nesting, jump tables, and rare
-/// unsafe/typed-reference lowerings — rather than raw size, so the hard-IL corpus
+/// unsafe/typed-reference lowerings — rather than raw size, so the EVIL corpus
 /// fills with genuinely hard puzzles instead of merely long trivial methods.
 /// </summary>
 static class IlDifficultyScorer
@@ -70,7 +70,7 @@ static class IlDifficultyScorer
     {
         // A body that did not fully decode yields unreliable control-flow facts
         // (empty or partial blocks and instructions). Scoring it on raw size
-        // alone would float undecodable junk to the top of the hard-IL ranking,
+        // alone would float undecodable junk to the top of the EVIL ranking,
         // so it is recorded with its true size/local/stack scalars but a zero
         // score to sink it — a decode failure must never inflate a rank.
         if (!decoded.IsComplete)

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -70,7 +70,7 @@ static class Program
         string? emitHarnessReport = null;
         bool enumerateRealMethods = false;
         bool harvestAuthoredCorpus = false;
-        bool harvestHardIlCorpus = false;
+        bool harvestEvilCorpus = false;
         string? harvestOutputPath = null;
         bool benchmarkAuthoredCorpus = false;
         string? benchmarkCorpusPath = null;
@@ -195,8 +195,8 @@ static class Program
                         harvestAuthoredCorpus = true;
                         harvestOutputPath = NextArg(args, ref i, flag);
                         break;
-                    case "--harvest-hard-il-corpus":
-                        harvestHardIlCorpus = true;
+                    case "--harvest-evil-corpus":
+                        harvestEvilCorpus = true;
                         harvestOutputPath = NextArg(args, ref i, flag);
                         break;
                     case "--harvest-target": harvestTarget = int.Parse(NextArg(args, ref i, flag)); break;
@@ -444,8 +444,8 @@ static class Program
         if (harvestAuthoredCorpus)
             return AuthoredSourceHarvest.Run(assemblies, harvestOutputPath!, harvestTarget);
 
-        if (harvestHardIlCorpus)
-            return AuthoredSourceHarvest.Run(assemblies, harvestOutputPath!, harvestTarget, hardIl: true);
+        if (harvestEvilCorpus)
+            return AuthoredSourceHarvest.Run(assemblies, harvestOutputPath!, harvestTarget, evil: true);
 
         if (benchmarkAuthoredCorpus)
             return AuthoredCorpusBenchmark.Run(assemblies, benchmarkCorpusPath!, json);
@@ -678,7 +678,7 @@ static class Program
             grandTotal += targets.Count;
             Console.WriteLine($"{Path.GetFileName(assemblyPath)}: {targets.Count} real-method targets");
             // Surface the hardest methods first: the difficulty ranking is the
-            // whole point of the enumeration for the hard-IL corpus.
+            // whole point of the enumeration for the EVIL corpus.
             foreach (var target in targets
                 .OrderByDescending(target => target.Difficulty.Score)
                 .Take(maxExamples))

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -258,8 +258,8 @@ diversification so a few large libraries do not drown out the small ones, then
 resolves each target's authoritative authored source through SourceLink and
 snapshots the member-only body with its `sourceUrl`, checksum algorithm, and
 checksum. A target whose source does not resolve is skipped, so every emitted
-row has real, verified source. The real-world corpus is harvested from the same
-14 pinned assemblies as the fixed real-world corpus
+row has real, verified source. The CIVIL corpus (Curated Index of Varied IL) is
+harvested from the same 14 pinned assemblies as the fixed real-world corpus
 (`eng/prepare-decompiler-corpus.sh`), keeping the two in lock step:
 
 ```bash
@@ -303,17 +303,18 @@ Every corpus row must be checked, so an empty or partially-unmatched run is neve
 a success. `Not-Full` alone does not fail.
 
 The corpus is vendored on the `vendor/authored-source-corpus` orphan branch so
-the harvested third-party source snapshots never enter main's history. Restore it
-with `bash eng/restore-authored-source-corpus.sh`, which adds a git worktree at
-`external/authored-source-corpus`.
+the harvested third-party source snapshots never enter main's history (as
+`civil/corpus.jsonl`). Restore it with `bash eng/restore-authored-source-corpus.sh`,
+which adds a git worktree at `external/authored-source-corpus`.
 
-#### Hard-IL difficulty ranking (`--enumerate-real-methods`)
+#### EVIL difficulty ranking (`--enumerate-real-methods`)
 
-The real-world corpus tracks the 14 pinned assemblies for affinity. The
-companion *hard-IL* corpus is instead an adversarial stress set — the
-"diabolical" real methods drawn from a much broader assembly pool and ranked by
-how hard their IL is to raise. `--enumerate-real-methods [--max-examples N]
-<assembly...>` is the inspection command behind that ranking: it enumerates the
+The CIVIL corpus tracks the 14 pinned assemblies for affinity. The companion
+*EVIL* corpus (Edge-case Verification of IL Legibility) is instead an adversarial
+stress set — the "diabolical" real methods drawn from a much broader assembly
+pool and ranked by how hard their IL is to raise. `--enumerate-real-methods
+[--max-examples N] <assembly...>` is the inspection command behind that ranking:
+it enumerates the
 real-method targets in each assembly, scores every body, and prints the top
 `N` by difficulty (highest first) with the full component breakdown, e.g.:
 
@@ -357,10 +358,10 @@ nesting each other; a `finally` that protects its sibling `catch` does deepen th
 chain, so `try/catch/finally` nested inside another `try/catch/finally` reports
 `ehDepth=4`.
 
-#### Hard-IL corpus harvest (`--harvest-hard-il-corpus`)
+#### EVIL corpus harvest (`--harvest-evil-corpus`)
 
-`--harvest-hard-il-corpus <out.jsonl> [--harvest-target N]` (default 12000) builds
-the hard-IL corpus. It shares the whole authored-source harvest pipeline with
+`--harvest-evil-corpus <out.jsonl> [--harvest-target N]` (default 12000) builds
+the EVIL corpus. It shares the whole authored-source harvest pipeline with
 `--harvest-authored-corpus` — the same SourceLink resolution, member-only body
 snapshot, checksum, and smallest-library-first fairness — but changes the
 *selection order*: within each library, candidates are ranked hardest-first by the
@@ -368,30 +369,30 @@ difficulty score above (score, then IL size, as a tiebreak) before the per-type
 round-robin, so each declaring type contributes its most diabolical methods first.
 Every emitted row also carries the full `difficulty` object (the same components
 `--enumerate-real-methods` prints), so a later selection pass can re-rank or filter
-on any single axis without re-scoring. The identity (real-world) corpus omits that
+on any single axis without re-scoring. The CIVIL (identity) corpus omits that
 field entirely, keeping its rows schema-identical to the vendored real-world
-corpus; only hard-IL rows populate it.
+corpus; only EVIL rows populate it.
 
-The hard-IL corpus draws from a much broader assembly pool than the 14 pinned
-real-world libraries. `eng/prepare-hard-il-corpus.sh` composes that pool: it runs
+The EVIL corpus draws from a much broader assembly pool than the 14 pinned
+real-world libraries. `eng/prepare-evil-corpus.sh` composes that pool: it runs
 the package sweep (`eng/prepare-decompiler-package-sweep.cs`, ranks 1..N from
-`docs/data/nuget-top-packages.json`, `HARD_IL_PACKAGE_COUNT` default 100) and
+`docs/data/nuget-top-packages.json`, `EVIL_PACKAGE_COUNT` default 100) and
 unions it with the 14 pinned real-world assemblies
 (`eng/prepare-decompiler-corpus.sh`) into a single deduped `assemblies.txt`,
 preserving the sweep `manifest.json` as `sweep-manifest.json`:
 
 ```bash
-bash eng/prepare-hard-il-corpus.sh /tmp/hard-il-pool
+bash eng/prepare-evil-corpus.sh /tmp/evil-pool
 dotnet run --project tools/DecompilerHarness -c Release -- \
-  --harvest-hard-il-corpus /tmp/hard-il-corpus.jsonl --harvest-target 12000 \
-  $(cat /tmp/hard-il-pool/assemblies.txt)
+  --harvest-evil-corpus /tmp/evil-corpus.jsonl --harvest-target 12000 \
+  $(cat /tmp/evil-pool/assemblies.txt)
 ```
 
-The result is vendored as `hard-il/corpus.jsonl` on the same
-`vendor/authored-source-corpus` orphan branch, a sibling of the real-world
-`real-world/corpus.jsonl`, and `bash eng/restore-authored-source-corpus.sh`
-restores both. Because it reuses `CorpusRecord`, the hard-IL corpus is consumable
-by `--benchmark-authored-corpus` exactly like the real-world corpus; the
+The result is vendored as `evil/corpus.jsonl` on the same
+`vendor/authored-source-corpus` orphan branch, a sibling of the CIVIL
+`civil/corpus.jsonl`, and `bash eng/restore-authored-source-corpus.sh`
+restores both. Because it reuses `CorpusRecord`, the EVIL corpus is consumable
+by `--benchmark-authored-corpus` exactly like the CIVIL corpus; the
 difficulty profile is selection/analysis metadata the oracle ignores.
 
 The generated fixture ladder is intentionally staged:

--- a/tools/DecompilerHarness/RealMethodTargetEnumerator.cs
+++ b/tools/DecompilerHarness/RealMethodTargetEnumerator.cs
@@ -43,9 +43,9 @@ static class RealMethodTargetEnumerator
     /// <param name="ParameterCount">Parameter count, used when extracting the
     /// authored member body.</param>
     /// <param name="IlSize">Method body IL byte length, used by difficulty
-    /// scoring for the hard-IL corpus.</param>
+    /// scoring for the EVIL corpus.</param>
     /// <param name="Difficulty">Structural IL difficulty profile plus composite
-    /// score used to rank the hard-IL corpus.</param>
+    /// score used to rank the EVIL corpus.</param>
     internal sealed record RealMethodTarget(
         string Type,
         string Method,


### PR DESCRIPTION
## What / why

Rebrands the two authored-source corpora with the acronyms you chose:

- **EVIL** = *Edge-case Verification of IL Legibility* → the hard-IL adversarial corpus.
- **CIVIL** = *Curated Index of Varied IL* → the real-world authored-source corpus.

## Scope

Renames the two **corpora** (their dirs + corpus-specific flags/scripts + docs). The shared `authored-source` harvest/benchmark **plumbing keeps its names**, and the unrelated `--diff-corpus-baseline` real-world sensor / the 14 pinned real-world assembly *set* are untouched.

**Renamed (EVIL):**
- `--harvest-hard-il-corpus` → `--harvest-evil-corpus`
- `eng/prepare-hard-il-corpus.sh` → `eng/prepare-evil-corpus.sh`
- `HARD_IL_PACKAGE_COUNT` → `EVIL_PACKAGE_COUNT`
- internal harvest flag (`hardIl` → `evil`) + console banner (`HARD-IL` → `EVIL`)
- vendored path `hard-il/corpus.jsonl` → `evil/corpus.jsonl`

**Renamed (CIVIL):**
- vendored artifact `real-world/corpus.jsonl` → `civil/corpus.jsonl`
- the docs that name that corpus

**Kept (shared plumbing / not the corpus):** `AuthoredSourceHarvest`, `AuthoredCorpusBenchmark`, `--harvest-authored-corpus`, `--benchmark-authored-corpus`, `eng/restore-authored-source-corpus.sh`, the `--diff-corpus-baseline` sensor / `real-world-baseline.json`, and the "14 pinned real-world assemblies" source set.

## Vendor branch

The directory rename `real-world/` → `civil/` landed directly on `vendor/authored-source-corpus` (`dc981dbd`, per that branch's commit-directly policy). `git mv` only — 12,000 rows and schema unchanged, verified valid JSON. The (future) EVIL corpus will vendor as the `evil/` sibling.

## Evidence

- Harness builds clean (0 warn / 0 err).
- `--harvest-evil-corpus` smoke: banner prints `EVIL HARVEST`, 3 rows resolved, `difficulty` present.
- `eng/prepare-evil-corpus.sh` smoke (`EVIL_PACKAGE_COUNT=1`): `EVIL pool: 14 assemblies`, all listed paths exist after exit (`missing=0`).
- `git grep` for `hard-il`/`hardil`/`hard_il` across tracked files: no matches.
- markdownlint clean (harness README + vendor branch README).

## Risk

Low-risk mechanical rename — no behavior/logic change (the C# delta is a parameter/flag-string rename). Per the adversarial-review policy, mechanical renames don't require adversarial review. Do **not** self-merge — awaiting @richlander approval.
