### PR TITLE
Move API analysis composition out of the output layer (#2895)

### DIFF
--- a/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
+++ b/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
@@ -56,6 +56,12 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
     public AssemblyDependencyResolver(AssemblyDependencyResolutionOptions options)
         => _options = options;
 
+    /// <summary>
+    /// The resolution options this resolver was constructed with. Exposed for tests that pin how
+    /// callers forward inputs (e.g. project-assets/TFM) into the resolver.
+    /// </summary>
+    internal AssemblyDependencyResolutionOptions Options => _options;
+
     public IReadOnlyList<ResolvedAssemblyDependency> ResolveAll()
     {
         if (_resolved is not null)

--- a/src/dotnet-inspect.Tests/AnalysisScopeTests.cs
+++ b/src/dotnet-inspect.Tests/AnalysisScopeTests.cs
@@ -1,10 +1,10 @@
-using DotnetInspector.Output;
+using DotnetInspector.Inspectors;
 using DotnetInspector.Sections;
 
 namespace DotnetInspector.Tests;
 
 /// <summary>
-/// Locks the section -> index-build-phase mapping (<see cref="ApiOutputFormatter.AnalysisScopeFor"/>):
+/// Locks the section -> index-build-phase mapping (<see cref="ApiAnalysisInspection.AnalysisScopeFor"/>):
 /// only Allocation Facts and Performance Triage consume the two expensive whole-assembly phases, so
 /// every other analysis section builds the index without escape-classified allocations or
 /// optimization opportunities.
@@ -14,7 +14,7 @@ public class AnalysisScopeTests
     [Fact]
     public void PerformanceTriage_NeedsOpportunitiesAndAllocations()
     {
-        var (alloc, opp) = ApiOutputFormatter.AnalysisScopeFor([SectionNames.PerformanceTriage]);
+        var (alloc, opp) = ApiAnalysisInspection.AnalysisScopeFor([SectionNames.PerformanceTriage]);
         Assert.True(opp);
         Assert.True(alloc); // opportunities are synthesized from allocation hotspots
     }
@@ -22,7 +22,7 @@ public class AnalysisScopeTests
     [Fact]
     public void AllocationFacts_NeedsAllocationsButNotOpportunities()
     {
-        var (alloc, opp) = ApiOutputFormatter.AnalysisScopeFor([SectionNames.AllocationFacts]);
+        var (alloc, opp) = ApiAnalysisInspection.AnalysisScopeFor([SectionNames.AllocationFacts]);
         Assert.True(alloc);
         Assert.False(opp);
     }
@@ -39,7 +39,7 @@ public class AnalysisScopeTests
     [InlineData(SectionNames.CalledTypes)]
     public void OtherAnalysisSections_NeedNeitherExpensivePhase(string section)
     {
-        var (alloc, opp) = ApiOutputFormatter.AnalysisScopeFor([section]);
+        var (alloc, opp) = ApiAnalysisInspection.AnalysisScopeFor([section]);
         Assert.False(alloc);
         Assert.False(opp);
     }
@@ -47,7 +47,7 @@ public class AnalysisScopeTests
     [Fact]
     public void UnionOfSections_TakesTheBroadestScope()
     {
-        var (alloc, opp) = ApiOutputFormatter.AnalysisScopeFor(
+        var (alloc, opp) = ApiAnalysisInspection.AnalysisScopeFor(
             [SectionNames.TopLeverage, SectionNames.AllocationFacts]);
         Assert.True(alloc);
         Assert.False(opp);
@@ -56,7 +56,7 @@ public class AnalysisScopeTests
     [Fact]
     public void NullSections_DefaultsToFullBuild()
     {
-        var (alloc, opp) = ApiOutputFormatter.AnalysisScopeFor(null);
+        var (alloc, opp) = ApiAnalysisInspection.AnalysisScopeFor(null);
         Assert.True(alloc);
         Assert.True(opp);
     }

--- a/src/dotnet-inspect.Tests/ApiAnalysisReferenceResolverTests.cs
+++ b/src/dotnet-inspect.Tests/ApiAnalysisReferenceResolverTests.cs
@@ -1,0 +1,42 @@
+using DotnetInspector.Inspectors;
+using DotnetInspector.Options;
+
+namespace DotnetInspector.Tests;
+
+/// <summary>
+/// Pins that the API-analysis reference resolver forwards <see cref="ApiOptions"/> inputs. Issue
+/// #2895 deliberately makes the type-scoped analysis index (via
+/// <see cref="ApiAnalysisInspection.OpenTypeAnalysisIndex"/>) honor <c>--project</c> and
+/// <c>--tfm</c>, matching the member-analysis path; before the refactor the type path built its
+/// resolver with no options and silently ignored those inputs.
+/// </summary>
+public class ApiAnalysisReferenceResolverTests
+{
+    [Fact]
+    public void CreateReferenceResolver_ForwardsProjectAssetsAndTfm()
+    {
+        var options = new ApiOptions
+        {
+            ProjectAssetsPath = "/tmp/project.assets.json",
+            Tfm = "net8.0",
+        };
+
+        var resolver = ApiAnalysisInspection.CreateReferenceResolver("/tmp/Sample.dll", options);
+
+        Assert.Equal("/tmp/project.assets.json", resolver.Options.ProjectAssetsPath);
+        Assert.Equal("net8.0", resolver.Options.TargetFramework);
+        // Fixed policy the API path always applies, regardless of options.
+        Assert.False(resolver.Options.IncludeDepsJsonAssets);
+        Assert.False(resolver.Options.IncludeAspNetCoreSharedFramework);
+        Assert.True(resolver.Options.PreferImplementationAssemblies);
+    }
+
+    [Fact]
+    public void CreateReferenceResolver_WithoutOptions_LeavesProjectAssetsAndTfmUnset()
+    {
+        var resolver = ApiAnalysisInspection.CreateReferenceResolver("/tmp/Sample.dll");
+
+        Assert.Null(resolver.Options.ProjectAssetsPath);
+        Assert.Null(resolver.Options.TargetFramework);
+    }
+}

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 namespace DotnetInspector.Tests;
 
 /// <summary>
-/// Locks the <see cref="ApiOutputFormatter.SameType"/> matching used to scope
+/// Locks the <see cref="ApiAnalysisInspection.SameType"/> matching used to scope
 /// render rows (and, since #2233, the type-targeted decode gate) to a single
 /// type. The regression under test (#2238): the old predicate normalized nested
 /// names by blindly replacing '+' with '.', which dropped rows for a
@@ -40,7 +40,7 @@ public class ApiOutputFormatterTests
         var apiType = Type(ns: null, name: "A+B", metadataName: "A+B");
         var typeRef = TypeRef.Definition(Asm, "", "A+B");
 
-        Assert.True(ApiOutputFormatter.SameType(typeRef, apiType));
+        Assert.True(ApiAnalysisInspection.SameType(typeRef, apiType));
     }
 
     [Fact]
@@ -52,7 +52,7 @@ public class ApiOutputFormatterTests
         var apiType = Type(ns: "N", name: "Outer.Inner", metadataName: "Outer+Inner");
         var typeRef = TypeRef.Definition(Asm, "N", "Outer+Inner");
 
-        Assert.True(ApiOutputFormatter.SameType(typeRef, apiType));
+        Assert.True(ApiAnalysisInspection.SameType(typeRef, apiType));
     }
 
     [Fact]
@@ -63,7 +63,7 @@ public class ApiOutputFormatterTests
         var apiType = Type(ns: "N", name: "Outer.Inner", metadataName: null);
         var typeRef = TypeRef.Definition(Asm, "N", "Outer+Inner");
 
-        Assert.True(ApiOutputFormatter.SameType(typeRef, apiType));
+        Assert.True(ApiAnalysisInspection.SameType(typeRef, apiType));
     }
 
     [Fact]
@@ -74,7 +74,7 @@ public class ApiOutputFormatterTests
         var apiType = Type(ns: null, name: "A+B", metadataName: "A+B");
         var typeRef = TypeRef.Definition(Asm, "", "A+B");
 
-        Assert.True(ApiOutputFormatter.SameType(typeRef, apiType));
+        Assert.True(ApiAnalysisInspection.SameType(typeRef, apiType));
     }
 
     [Fact]
@@ -83,7 +83,7 @@ public class ApiOutputFormatterTests
         var apiType = Type(ns: "N1", name: "A+B", metadataName: "A+B");
         var typeRef = TypeRef.Definition(Asm, "N2", "A+B");
 
-        Assert.False(ApiOutputFormatter.SameType(typeRef, apiType));
+        Assert.False(ApiAnalysisInspection.SameType(typeRef, apiType));
     }
 
     [Fact]
@@ -92,7 +92,7 @@ public class ApiOutputFormatterTests
         var apiType = Type(ns: null, name: "A+B", metadataName: "A+B");
         var typeRef = TypeRef.SzArray(TypeRef.Definition(Asm, "", "A+B"));
 
-        Assert.False(ApiOutputFormatter.SameType(typeRef, apiType));
+        Assert.False(ApiAnalysisInspection.SameType(typeRef, apiType));
     }
 
     [Fact]
@@ -436,7 +436,7 @@ public class ApiOutputFormatterTests
         // The reconstructed metadata name is exactly what a TypeRef would carry,
         // so SameType reconciles the two without any string surgery.
         var typeRef = TypeRef.Definition(Asm, inner.Namespace ?? "", "PlusFixtureOuter+Inner");
-        Assert.True(ApiOutputFormatter.SameType(typeRef, inner));
+        Assert.True(ApiAnalysisInspection.SameType(typeRef, inner));
     }
 
     // --- Filtered projections must carry MetadataName to the analysis path ---
@@ -454,7 +454,7 @@ public class ApiOutputFormatterTests
         var filtered = ApiCommand.BuildFilteredTypeForSections(type, new ApiOptions());
 
         Assert.Equal("A+B", filtered.MetadataName);
-        Assert.True(ApiOutputFormatter.SameType(TypeRef.Definition(Asm, "", "A+B"), filtered));
+        Assert.True(ApiAnalysisInspection.SameType(TypeRef.Definition(Asm, "", "A+B"), filtered));
     }
 
     // --- Extraction: non-nested type with a literal '+' (requires ilasm) ---
@@ -508,7 +508,7 @@ public class ApiOutputFormatterTests
             // End-to-end: the row would previously be dropped because
             // "A+B".Replace('+','.') == "A.B" != "A+B". It now matches.
             var typeRef = TypeRef.Definition(Asm, "", "A+B");
-            Assert.True(ApiOutputFormatter.SameType(typeRef, apiType));
+            Assert.True(ApiAnalysisInspection.SameType(typeRef, apiType));
         }
         finally
         {

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -200,7 +200,7 @@ public class OutputFormatterTests
         ApiOutputFormatter.PopulateOptimizationOpportunities(
             view,
             type,
-            ApiOutputFormatter.OpenTypeAnalysisIndex(typeof(OutputFormatterTests).Assembly.Location),
+            ApiAnalysisInspection.OpenTypeAnalysisIndex(typeof(OutputFormatterTests).Assembly.Location),
             new HashSet<string>(StringComparer.OrdinalIgnoreCase) { SectionNames.PerformanceTriage });
 
         var rows = Assert.IsType<List<OptimizationOpportunityRow>>(view.OptimizationOpportunityRows);
@@ -229,7 +229,7 @@ public class OutputFormatterTests
         ApiOutputFormatter.PopulateOptimizationOpportunities(
             view,
             type,
-            ApiOutputFormatter.OpenTypeAnalysisIndex(typeof(OutputFormatterTests).Assembly.Location),
+            ApiAnalysisInspection.OpenTypeAnalysisIndex(typeof(OutputFormatterTests).Assembly.Location),
             new HashSet<string>(StringComparer.OrdinalIgnoreCase) { SectionNames.PerformanceTriage },
             new PerformanceTriageOptions { Shapes = ["allocation-fanout"] });
 

--- a/src/dotnet-inspect.Tests/SearchJsonResultTests.cs
+++ b/src/dotnet-inspect.Tests/SearchJsonResultTests.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using DotnetInspector.Models;
+using DotnetInspector.Output;
+
+namespace DotnetInspector.Tests;
+
+public class SearchJsonResultTests
+{
+    [Fact]
+    public void ExtensionResult_PreservesPublicJsonFieldNames()
+    {
+        var result = ExtensionMethodJsonResult.From(new ExtensionMethodResult
+        {
+            MethodName = "Select",
+            ExtensionClass = "Enumerable",
+            ExtendedType = "IEnumerable<T>",
+            Assembly = "System.Linq",
+            SourceVersion = "11.0.0",
+        });
+
+        var json = JsonSerializer.Serialize(
+            new List<ExtensionMethodJsonResult> { result },
+            ExtensionsJsonContext.Default.ListExtensionMethodJsonResult);
+        using var document = JsonDocument.Parse(json);
+        var item = document.RootElement[0];
+
+        Assert.Equal("Select", item.GetProperty("method").GetString());
+        Assert.Equal("Enumerable", item.GetProperty("class").GetString());
+        Assert.Equal("IEnumerable<T>", item.GetProperty("extended_type").GetString());
+        Assert.Equal("System.Linq", item.GetProperty("library").GetString());
+        Assert.Equal("11.0.0", item.GetProperty("source_version").GetString());
+        Assert.False(item.TryGetProperty("method_name", out _));
+    }
+
+    [Fact]
+    public void ImplementerResult_PreservesPublicJsonFieldNames()
+    {
+        var result = ImplementerJsonResult.From(new ImplementerResult
+        {
+            TypeName = "Widget",
+            Namespace = "Example",
+            Kind = "class",
+            Relationship = "implements",
+            Assembly = "Example.dll",
+        });
+
+        var json = JsonSerializer.Serialize(
+            new List<ImplementerJsonResult> { result },
+            ImplementsJsonContext.Default.ListImplementerJsonResult);
+        using var document = JsonDocument.Parse(json);
+        var item = document.RootElement[0];
+
+        Assert.Equal("Widget", item.GetProperty("type").GetString());
+        Assert.Equal("Example.dll", item.GetProperty("library").GetString());
+        Assert.False(item.TryGetProperty("type_name", out _));
+    }
+}

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -521,18 +521,6 @@ public class ApiCommand
 
     // ===== Method Source Resolution =====
 
-    internal static AssemblyDependencyResolver PlatformAssemblyResolver(string startingDll, string? projectAssetsPath = null, string? targetFramework = null)
-    {
-        return new AssemblyDependencyResolver(new AssemblyDependencyResolutionOptions(startingDll)
-        {
-            ProjectAssetsPath = projectAssetsPath,
-            TargetFramework = targetFramework,
-            IncludeDepsJsonAssets = false,
-            IncludeAspNetCoreSharedFramework = false,
-            PreferImplementationAssemblies = true,
-        });
-    }
-
     internal sealed record ResolvedMethodSource(MethodSourceContext? Source, string? PdbPath);
 
     internal static async Task<ResolvedMethodSource> ResolveMethodSourceAsync(
@@ -681,17 +669,21 @@ public class ApiCommand
                         && (!m.IsAbstract || requestedSections.Contains(SectionNames.UnsafeOperations)))
                     .ToList();
                 if (methods.Count > 0)
+                {
+                    var analysisInspection = new ApiMemberAnalysisInspection(
+                        mo4.DllPath!, methods, requestedSections, mo4.CallerScopeAssemblies, mo4);
                     ApiOutputFormatter.PopulateIndexSections(view, type, methods, mo4.DllPath!,
                         mo4.OverloadIndex.HasValue ? mo4.OverloadIndex.Value - 1 : null,
-                        requestedSections, mo4.PdbPath, mo4.IncludeSections,
-                        mo4.CallerScopeAssemblies, mo4);
+                        requestedSections, analysisInspection, mo4.PdbPath, mo4.IncludeSections, mo4);
+                }
             }
 
             // Type-scope analysis sections share one index build per type (built lazily, only
             // when such a section is requested) instead of opening one session per section.
             Analysis.LibraryBodyIndex? typeAnalysisIndex = null;
             Analysis.LibraryBodyIndex TypeAnalysisIndex() =>
-                typeAnalysisIndex ??= ApiOutputFormatter.OpenTypeAnalysisIndex(options.DllPath!, GetRequestedMemberSections(type, options), type);
+                typeAnalysisIndex ??= ApiAnalysisInspection.OpenTypeAnalysisIndex(
+                    options.DllPath!, GetRequestedMemberSections(type, options), type, options);
 
             if (options.DllPath is not null
                 && GetRequestedMemberSections(type, options).Contains(SectionNames.UnsafeMembers))
@@ -703,7 +695,11 @@ public class ApiCommand
                 && (GetRequestedMemberSections(type, options).Contains(SectionNames.ExceptionRegions)
                     || options.IncludeSections?.Contains(SectionNames.ExceptionRegions) == true))
             {
-                ApiOutputFormatter.PopulateTypeExceptionRegions(view, type, exceptionRegionsDllPath, options.IncludeSections);
+                var exceptionRegions = ApiAnalysisInspection.ResolveExceptionRegions(
+                    exceptionRegionsDllPath,
+                    type.Members.Where(member => member.MetadataToken is not null
+                        && ApiMemberSectionDescriptors.IsMethodLike(member)));
+                ApiOutputFormatter.PopulateTypeExceptionRegions(view, type, exceptionRegions, options.IncludeSections);
             }
 
             if (options.DllPath is not null
@@ -760,7 +756,7 @@ public class ApiCommand
             && options.IncludeSections is { Count: > 0 }
             && GetRequestedMemberSections(type, options).Contains(SectionNames.DecompiledSource))
         {
-            var resolver = PlatformAssemblyResolver(typeDllPath, options.ProjectAssetsPath, options.Tfm);
+            var resolver = ApiAnalysisInspection.CreateReferenceResolver(typeDllPath, options);
             using var metadata = new Decompiler.Pipeline.MetadataContext(resolver);
             var listing = Decompiler.MemberBodyProducer.Project(
                 type, typeDllPath, options.PdbPath, resolver, metadata).Output;
@@ -1352,11 +1348,16 @@ public class ApiCommand
                         && (!m.IsAbstract || requestedSections.Contains(SectionNames.UnsafeOperations)))
                     .ToList();
                 if (methods.Count > 0)
+                {
+                    var analysisInspection = new ApiMemberAnalysisInspection(
+                        memberOptions.DllPath!, methods, requestedSections,
+                        memberOptions.CallerScopeAssemblies, memberOptions);
                     ApiOutputFormatter.PopulateIndexSections(view, type, methods,
                         memberOptions.DllPath!,
                         memberOptions.OverloadIndex.HasValue ? memberOptions.OverloadIndex.Value - 1 : null,
-                        requestedSections, memberOptions.PdbPath, memberOptions.IncludeSections,
-                        memberOptions.CallerScopeAssemblies, memberOptions);
+                        requestedSections, analysisInspection, memberOptions.PdbPath,
+                        memberOptions.IncludeSections, memberOptions);
+                }
 
                 if (memberOptions.MethodSource != null && requestedSections.Overlaps([SectionNames.OriginalSource, SectionNames.SourceDiff]))
                 {
@@ -1368,7 +1369,8 @@ public class ApiCommand
 
             Analysis.LibraryBodyIndex? typeAnalysisIndex = null;
             Analysis.LibraryBodyIndex TypeAnalysisIndex() =>
-                typeAnalysisIndex ??= ApiOutputFormatter.OpenTypeAnalysisIndex(renderOptions.DllPath!, GetRequestedMemberSections(type, renderOptions), type);
+                typeAnalysisIndex ??= ApiAnalysisInspection.OpenTypeAnalysisIndex(
+                    renderOptions.DllPath!, GetRequestedMemberSections(type, renderOptions), type, renderOptions);
 
             if (renderOptions.DllPath is not null
                 && GetRequestedMemberSections(type, renderOptions).Contains(SectionNames.UnsafeMembers))
@@ -1380,7 +1382,12 @@ public class ApiCommand
                 && (GetRequestedMemberSections(type, renderOptions).Contains(SectionNames.ExceptionRegions)
                     || renderOptions.IncludeSections?.Contains(SectionNames.ExceptionRegions) == true))
             {
-                ApiOutputFormatter.PopulateTypeExceptionRegions(view, type, exceptionRegionsDllPath, renderOptions.IncludeSections);
+                var exceptionRegions = ApiAnalysisInspection.ResolveExceptionRegions(
+                    exceptionRegionsDllPath,
+                    type.Members.Where(member => member.MetadataToken is not null
+                        && ApiMemberSectionDescriptors.IsMethodLike(member)));
+                ApiOutputFormatter.PopulateTypeExceptionRegions(
+                    view, type, exceptionRegions, renderOptions.IncludeSections);
             }
 
             if (renderOptions.DllPath is not null

--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -1,5 +1,4 @@
 using DotnetInspector.Packages;
-using System.Text.Json.Serialization;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Models;
 using ILInspector.Findings;
@@ -229,7 +228,9 @@ public class ExtensionsCommand
 
     private static void WriteJsonOutput(List<ExtensionMethodResult> results, bool compact)
     {
-        JsonOutputHelper.Write(results, ExtensionsJsonContext.Default.ListExtensionMethodResult, ExtensionsCompactJsonContext.Default.ListExtensionMethodResult, compact);
+        var jsonResults = results.Select(ExtensionMethodJsonResult.From).ToList();
+        JsonOutputHelper.Write(jsonResults, ExtensionsJsonContext.Default.ListExtensionMethodJsonResult,
+            ExtensionsCompactJsonContext.Default.ListExtensionMethodJsonResult, compact);
     }
 
     private static void WriteCount(List<ExtensionMethodResult> results)
@@ -275,46 +276,4 @@ public class ExtensionsCommand
             })
             .ToList();
     }
-}
-
-/// <summary>
-/// Result of extension method search.
-/// </summary>
-public record class ExtensionMethodResult
-{
-    [JsonPropertyName("method")]
-    public string MethodName { get; set; } = "";
-
-    [JsonPropertyName("class")]
-    public string ExtensionClass { get; set; } = "";
-
-    [JsonPropertyName("extended_type")]
-    public string ExtendedType { get; set; } = "";
-
-    [JsonPropertyName("library")]
-    public string Assembly { get; set; } = "";
-
-    [JsonPropertyName("signature")]
-    public string? Signature { get; set; }
-
-    [JsonPropertyName("signatures")]
-    public List<string>? Signatures { get; set; }
-
-    [JsonPropertyName("overloads")]
-    public int? Overloads { get; set; }
-
-    [JsonPropertyName("kind")]
-    public string Kind { get; set; } = "method";
-
-    [JsonPropertyName("source")]
-    public string? Source { get; set; }
-
-    [JsonPropertyName("source_version")]
-    public string? SourceVersion { get; set; }
-
-    [JsonPropertyName("reachable_path")]
-    public string? ReachablePath { get; set; }
-
-    [JsonPropertyName("reachable_from_type")]
-    public string? ReachableFromType { get; set; }
 }

--- a/src/dotnet-inspect/Commands/ImplementsCommand.cs
+++ b/src/dotnet-inspect/Commands/ImplementsCommand.cs
@@ -1,6 +1,6 @@
 using DotnetInspector.Packages;
-using System.Text.Json.Serialization;
 using DotnetInspector.Inspectors;
+using DotnetInspector.Models;
 using ILInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
@@ -133,7 +133,9 @@ public class ImplementsCommand
 
     private static void WriteJsonOutput(List<ImplementerResult> results, bool compact)
     {
-        JsonOutputHelper.Write(results, ImplementsJsonContext.Default.ListImplementerResult, ImplementsCompactJsonContext.Default.ListImplementerResult, compact);
+        var jsonResults = results.Select(ImplementerJsonResult.From).ToList();
+        JsonOutputHelper.Write(jsonResults, ImplementsJsonContext.Default.ListImplementerJsonResult,
+            ImplementsCompactJsonContext.Default.ListImplementerJsonResult, compact);
     }
 
     private static void WriteCount(List<ImplementerResult> results)
@@ -164,31 +166,4 @@ public class ImplementsCommand
                 MarkoutSerializer.Serialize(view, SearchViewContext.Default), rows);
         }
     }
-}
-
-/// <summary>
-/// Result of implementer search.
-/// </summary>
-public record class ImplementerResult
-{
-    [JsonPropertyName("type")]
-    public string TypeName { get; set; } = "";
-
-    [JsonPropertyName("namespace")]
-    public string? Namespace { get; set; }
-
-    [JsonPropertyName("kind")]
-    public string Kind { get; set; } = "";
-
-    [JsonPropertyName("relationship")]
-    public string Relationship { get; set; } = "";
-
-    [JsonPropertyName("library")]
-    public string? Assembly { get; set; }
-
-    [JsonPropertyName("source")]
-    public string? Source { get; set; }
-
-    [JsonPropertyName("source_version")]
-    public string? SourceVersion { get; set; }
 }

--- a/src/dotnet-inspect/Inspectors/ApiAnalysisInspection.cs
+++ b/src/dotnet-inspect/Inspectors/ApiAnalysisInspection.cs
@@ -39,7 +39,11 @@ internal static class ApiAnalysisInspection
     }
 
     /// <summary>
-    /// Opens the command-scoped Analysis index used by type and library sections.
+    /// Opens the command-scoped Analysis index used by type and library sections. The resolver is
+    /// built from <paramref name="options"/> so this type-scoped index honors <c>--project</c>
+    /// (project-assets) and <c>--tfm</c> reference resolution, consistent with the member-analysis
+    /// path (<see cref="ApiMemberAnalysisInspection"/>); passing <see langword="null"/> falls back to
+    /// bare-assembly resolution.
     /// </summary>
     internal static Analysis.LibraryBodyIndex OpenTypeAnalysisIndex(
         string assemblyPath,

--- a/src/dotnet-inspect/Inspectors/ApiAnalysisInspection.cs
+++ b/src/dotnet-inspect/Inspectors/ApiAnalysisInspection.cs
@@ -1,0 +1,92 @@
+using DotnetInspector.Options;
+using DotnetInspector.Sections;
+using DotnetInspector.Services;
+using ILInspector.Metadata;
+using Analysis = ILInspector.Analysis;
+
+namespace DotnetInspector.Inspectors;
+
+/// <summary>
+/// Owns API-command policy for resolving analysis references and opening method-body indexes.
+/// Output formatters consume the resulting immutable analysis facts and do not acquire sessions.
+/// </summary>
+internal static class ApiAnalysisInspection
+{
+    internal sealed record MemberExceptionRegion(ApiMember Member, MethodExceptionRegionInfo Region);
+
+    internal static AssemblyDependencyResolver CreateReferenceResolver(string assemblyPath, ApiOptions? options = null)
+        => new(new AssemblyDependencyResolutionOptions(assemblyPath)
+        {
+            ProjectAssetsPath = options?.ProjectAssetsPath,
+            TargetFramework = options?.Tfm,
+            IncludeDepsJsonAssets = false,
+            IncludeAspNetCoreSharedFramework = false,
+            PreferImplementationAssemblies = true,
+        });
+
+    /// <summary>
+    /// Maps requested CLI sections to the expensive Analysis phases they consume.
+    /// </summary>
+    internal static (bool IncludeAllocations, bool IncludeOpportunities) AnalysisScopeFor(
+        IReadOnlyCollection<string>? requestedSections)
+    {
+        if (requestedSections is null)
+            return (true, true);
+
+        bool opportunities = requestedSections.Contains(SectionNames.PerformanceTriage);
+        bool allocations = opportunities || requestedSections.Contains(SectionNames.AllocationFacts);
+        return (allocations, opportunities);
+    }
+
+    /// <summary>
+    /// Opens the command-scoped Analysis index used by type and library sections.
+    /// </summary>
+    internal static Analysis.LibraryBodyIndex OpenTypeAnalysisIndex(
+        string assemblyPath,
+        IReadOnlyCollection<string>? requestedSections = null,
+        ApiType? type = null,
+        ApiOptions? options = null)
+    {
+        var (allocations, opportunities) = AnalysisScopeFor(requestedSections);
+        Func<Analysis.TypeRef, bool>? bodyTypeScope = null;
+        if (type is not null && requestedSections is not null
+            && !requestedSections.Contains(SectionNames.TopLeverage)
+            && !requestedSections.Contains(SectionNames.PerformanceTriage))
+        {
+            bodyTypeScope = typeRef => SameType(typeRef, type);
+        }
+
+        return MethodBodyInspectionSession.Open(
+            assemblyPath,
+            CreateReferenceResolver(assemblyPath, options),
+            allocations,
+            opportunities,
+            bodyScope: null,
+            bodyTypeScope: bodyTypeScope).BodyIndex;
+    }
+
+    internal static bool SameType(Analysis.TypeRef typeRef, ApiType type)
+    {
+        if (typeRef.Kind != Analysis.TypeRefKind.Definition)
+            return false;
+        if (!string.Equals(typeRef.Namespace, type.Namespace ?? "", StringComparison.Ordinal))
+            return false;
+
+        if (type.MetadataName != null)
+            return string.Equals(typeRef.Name, type.MetadataName, StringComparison.Ordinal);
+
+        return string.Equals(typeRef.Name.Replace('+', '.'), type.Name, StringComparison.Ordinal);
+    }
+
+    internal static IReadOnlyList<MemberExceptionRegion> ResolveExceptionRegions(
+        string assemblyPath,
+        IEnumerable<ApiMember> members)
+    {
+        using var context = PdbContext.Open(assemblyPath);
+        return members
+            .Where(member => member.MetadataToken is not null)
+            .SelectMany(member => context.ResolveExceptionRegions(member.MetadataToken!.Value, out _)
+                .Select(region => new MemberExceptionRegion(member, region)))
+            .ToList();
+    }
+}

--- a/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
+++ b/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
@@ -1,0 +1,112 @@
+using System.Collections.Immutable;
+using DotnetInspector.Options;
+using DotnetInspector.Sections;
+using ILInspector.Metadata;
+using Analysis = ILInspector.Analysis;
+
+namespace DotnetInspector.Inspectors;
+
+/// <summary>
+/// Command-configured, lazily acquired analysis/PDB state for one member rendering operation.
+/// Keeps acquisition, capability selection, body scoping, and cross-assembly caller composition
+/// out of the output layer.
+/// </summary>
+internal sealed class ApiMemberAnalysisInspection
+{
+    readonly string _assemblyPath;
+    readonly ApiOptions? _options;
+    readonly IReadOnlyList<string>? _callerScopeAssemblies;
+    readonly bool _includeAllocations;
+    readonly bool _includeOpportunities;
+    readonly IReadOnlySet<int>? _bodyScope;
+    MethodBodyInspectionSession? _session;
+    List<MethodBodyInspectionSession>? _callerScopes;
+    List<MethodBodyInspectionSession>? _graphScopes;
+
+    internal ApiMemberAnalysisInspection(
+        string assemblyPath,
+        IReadOnlyList<ApiMember> methods,
+        IReadOnlySet<string> requestedSections,
+        IReadOnlyList<string>? callerScopeAssemblies,
+        ApiOptions? options)
+    {
+        _assemblyPath = assemblyPath;
+        _options = options;
+        _callerScopeAssemblies = callerScopeAssemblies;
+
+        (_includeAllocations, _includeOpportunities) =
+            ApiAnalysisInspection.AnalysisScopeFor(requestedSections);
+        if ((requestedSections.Contains(SectionNames.CallGraph)
+                || requestedSections.Contains(SectionNames.CallerGraph))
+            && (options?.Fields is { Length: > 0 } || options?.Columns is { Length: > 0 }))
+        {
+            _includeAllocations = true;
+        }
+
+        bool needsWholeAssemblyBody = requestedSections.Contains(SectionNames.Callers)
+            || requestedSections.Contains(SectionNames.CallGraph)
+            || requestedSections.Contains(SectionNames.CallerGraph);
+        if (!needsWholeAssemblyBody)
+        {
+            var memberTokens = methods
+                .Where(member => member.MetadataToken.HasValue)
+                .Select(member => member.MetadataToken!.Value)
+                .ToHashSet();
+            if (memberTokens.Count > 0 && memberTokens.Count == methods.Count)
+                _bodyScope = memberTokens;
+        }
+    }
+
+    internal Analysis.LibraryBodyIndex BodyIndex => Session.BodyIndex;
+
+    internal IReadOnlyList<MethodExceptionRegionInfo> ResolveExceptionRegions(int methodToken, out string? error)
+    {
+        using var context = PdbContext.Open(_assemblyPath);
+        return context.ResolveExceptionRegions(methodToken, out error);
+    }
+
+    internal ImmutableArray<CallerEdge> CallerEdges(int methodToken)
+        => Session.CallerEdges(methodToken, CallerScopes(includeAllocations: false));
+
+    internal Analysis.CallTreeNode BuildCallTree(int methodToken)
+        => BodyIndex.BuildCallTree(methodToken);
+
+    internal Analysis.CallTreeNode BuildCallerTree(int methodToken)
+        => Session.CallerTree(methodToken, CallerScopes(includeAllocations: _includeAllocations));
+
+    MethodBodyInspectionSession Session => _session ??= MethodBodyInspectionSession.Open(
+        _assemblyPath,
+        ApiAnalysisInspection.CreateReferenceResolver(_assemblyPath, _options),
+        _includeAllocations,
+        _includeOpportunities,
+        _bodyScope);
+
+    IReadOnlyList<MethodBodyInspectionSession> CallerScopes(bool includeAllocations)
+    {
+        ref var cached = ref includeAllocations ? ref _graphScopes : ref _callerScopes;
+        if (cached is not null)
+            return cached;
+
+        cached = [];
+        if (_callerScopeAssemblies is null)
+            return cached;
+
+        foreach (var scopePath in _callerScopeAssemblies)
+        {
+            try
+            {
+                cached.Add(MethodBodyInspectionSession.Open(
+                    scopePath,
+                    ApiAnalysisInspection.CreateReferenceResolver(scopePath, _options),
+                    includeAllocations,
+                    includeOpportunities: false));
+            }
+            catch
+            {
+                // Caller scope is best-effort; unreadable assemblies do not contribute edges.
+            }
+        }
+
+        return cached;
+    }
+}

--- a/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
+++ b/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
@@ -50,7 +50,7 @@ public sealed class MethodBodyInspectionSession
     /// and <paramref name="includeOpportunities"/> gate the two expensive whole-assembly analysis
     /// phases (escape-classified allocation occurrences and optimization opportunities); leave them
     /// on unless the caller knows no requested section consumes them (see
-    /// <c>ApiOutputFormatter.AnalysisScopeFor</c>). <paramref name="bodyScope"/>, when non-null,
+    /// <see cref="ApiAnalysisInspection.AnalysisScopeFor"/>). <paramref name="bodyScope"/>, when non-null,
     /// restricts body decoding to the given method tokens (a single-member "targeted" build); it is
     /// only valid when every requested section's facts are local to those members (Calls / Unsafe
     /// Operations / Allocation-Safety-Cost facts) — reverse/aggregate sections require a full build.

--- a/src/dotnet-inspect/JsonContext.cs
+++ b/src/dotnet-inspect/JsonContext.cs
@@ -1,9 +1,9 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
-using DotnetInspector.Commands;
 using ILInspector.Metadata;
 using DotnetInspector.Models;
+using DotnetInspector.Output;
 using DotnetInspector.Packages;
 using DotnetInspector.Views;
 
@@ -121,14 +121,14 @@ public partial class ApiTypeCompactJsonContext : JsonSerializerContext
     WriteIndented = true,
     PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
-[JsonSerializable(typeof(List<ExtensionMethodResult>))]
+[JsonSerializable(typeof(List<ExtensionMethodJsonResult>))]
 internal partial class ExtensionsJsonContext : JsonSerializerContext { }
 
 [JsonSourceGenerationOptions(
     WriteIndented = false,
     PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
-[JsonSerializable(typeof(List<ExtensionMethodResult>))]
+[JsonSerializable(typeof(List<ExtensionMethodJsonResult>))]
 internal partial class ExtensionsCompactJsonContext : JsonSerializerContext { }
 
 // Implements command JSON contexts
@@ -136,14 +136,14 @@ internal partial class ExtensionsCompactJsonContext : JsonSerializerContext { }
     WriteIndented = true,
     PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
-[JsonSerializable(typeof(List<ImplementerResult>))]
+[JsonSerializable(typeof(List<ImplementerJsonResult>))]
 internal partial class ImplementsJsonContext : JsonSerializerContext { }
 
 [JsonSourceGenerationOptions(
     WriteIndented = false,
     PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
-[JsonSerializable(typeof(List<ImplementerResult>))]
+[JsonSerializable(typeof(List<ImplementerJsonResult>))]
 internal partial class ImplementsCompactJsonContext : JsonSerializerContext { }
 
 // Depends command JSON contexts

--- a/src/dotnet-inspect/Models/SearchResults.cs
+++ b/src/dotnet-inspect/Models/SearchResults.cs
@@ -1,0 +1,51 @@
+namespace DotnetInspector.Models;
+
+/// <summary>
+/// Result of extension method search.
+/// </summary>
+public record class ExtensionMethodResult
+{
+    public string MethodName { get; set; } = "";
+
+    public string ExtensionClass { get; set; } = "";
+
+    public string ExtendedType { get; set; } = "";
+
+    public string Assembly { get; set; } = "";
+
+    public string? Signature { get; set; }
+
+    public List<string>? Signatures { get; set; }
+
+    public int? Overloads { get; set; }
+
+    public string Kind { get; set; } = "method";
+
+    public string? Source { get; set; }
+
+    public string? SourceVersion { get; set; }
+
+    public string? ReachablePath { get; set; }
+
+    public string? ReachableFromType { get; set; }
+}
+
+/// <summary>
+/// Result of implementer search.
+/// </summary>
+public record class ImplementerResult
+{
+    public string TypeName { get; set; } = "";
+
+    public string? Namespace { get; set; }
+
+    public string Kind { get; set; } = "";
+
+    public string Relationship { get; set; } = "";
+
+    public string? Assembly { get; set; }
+
+    public string? Source { get; set; }
+
+    public string? SourceVersion { get; set; }
+}

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1,5 +1,4 @@
 using DotnetInspector.Inspectors;
-using DotnetInspector.Commands;
 using DotnetInspector.Core;
 using ILInspector.CSharp;
 using ILInspector.Findings;
@@ -30,53 +29,6 @@ public static class ApiOutputFormatter
         new CSharpFormatOptions { AbbreviateSignature = true });
     static readonly CSharpFormatter CSharpFormatterWithoutObsolete = new(
         new CSharpFormatOptions { IncludeObsoleteAttribute = false });
-
-    static IAssemblyReferenceResolver AnalysisReferenceResolver(string dllPath, ApiOptions? options = null)
-        => ApiCommand.PlatformAssemblyResolver(dllPath, options?.ProjectAssetsPath, options?.Tfm);
-
-    /// <summary>
-    /// Which expensive whole-assembly analysis phases the requested sections actually consume.
-    /// Escape-classified allocation occurrences feed Allocation Facts (and, transitively,
-    /// optimization opportunities); optimization opportunities feed Performance Triage. Every other
-    /// analysis section (Calls / Callers / Call Graph / Top Leverage / Cost / Safety / Unsafe /
-    /// Called Types) needs neither, so the index build can skip both. A null/unknown set is treated
-    /// as "needs everything" (safe default).
-    /// </summary>
-    internal static (bool IncludeAllocations, bool IncludeOpportunities) AnalysisScopeFor(IReadOnlyCollection<string>? requestedSections)
-    {
-        if (requestedSections is null)
-            return (true, true);
-        bool opportunities = requestedSections.Contains(SectionNames.PerformanceTriage);
-        bool allocations = opportunities || requestedSections.Contains(SectionNames.AllocationFacts);
-        return (allocations, opportunities);
-    }
-
-    /// <summary>
-    /// Opens a type-scope analysis index for the type/library sections. Callers memoize this per
-    /// type so the five type-analysis populators share one index build instead of opening five. The
-    /// build is narrowed to the phases <paramref name="requestedSections"/> consumes, and — when
-    /// <paramref name="type"/> is supplied and no requested section needs the whole-assembly reverse
-    /// graph (Top Leverage / Performance Triage) — to only that type's method bodies.
-    /// </summary>
-    internal static Analysis.LibraryBodyIndex OpenTypeAnalysisIndex(string dllPath, IReadOnlyCollection<string>? requestedSections = null, ApiType? type = null)
-    {
-        var (allocations, opportunities) = AnalysisScopeFor(requestedSections);
-        // Unsafe Members, Called Types, and the Allocation/Safety/Cost facts read only the type's
-        // own method bodies; Top Leverage (whole-assembly fanin) and Performance Triage (leverage
-        // join) need every method, so their presence forces a full build.
-        Func<Analysis.TypeRef, bool>? bodyTypeScope = null;
-        if (type is not null && requestedSections is not null
-            && !requestedSections.Contains(SectionNames.TopLeverage)
-            && !requestedSections.Contains(SectionNames.PerformanceTriage))
-            bodyTypeScope = typeRef => SameType(typeRef, type);
-        return MethodBodyInspectionSession.Open(
-            dllPath,
-            AnalysisReferenceResolver(dllPath),
-            allocations,
-            opportunities,
-            bodyScope: null,
-            bodyTypeScope: bodyTypeScope).BodyIndex;
-    }
 
     // ===== Full API View Model Factory =====
 
@@ -1188,7 +1140,17 @@ public static class ApiOutputFormatter
         return parenStart < 0 ? "()" : declaration[parenStart..];
     }
 
-    internal static void PopulateIndexSections(TypeView view, ApiType type, List<ApiMember> methods, string dllPath, int? overloadIndex, IReadOnlySet<string> requestedSections, string? pdbPath = null, IReadOnlySet<string>? explicitSections = null, IReadOnlyList<string>? callerScopeAssemblies = null, ApiOptions? options = null)
+    internal static void PopulateIndexSections(
+        TypeView view,
+        ApiType type,
+        List<ApiMember> methods,
+        string dllPath,
+        int? overloadIndex,
+        IReadOnlySet<string> requestedSections,
+        ApiMemberAnalysisInspection analysisInspection,
+        string? pdbPath = null,
+        IReadOnlySet<string>? explicitSections = null,
+        ApiOptions? options = null)
     {
         var request = new MemberCodeProvider.Request(
             DecompiledSource: requestedSections.Contains(SectionNames.DecompiledSource)
@@ -1215,44 +1177,6 @@ public static class ApiOutputFormatter
 
         var memberCode = new MemberCodeView();
         bool hasCode = false;
-        var assemblyResolver = AnalysisReferenceResolver(dllPath, options);
-
-        // Build the analysis body index at most once per command, and only when an
-        // index-backed section is actually requested (sections like decompiled source / IL
-        // go through MemberCodeProvider and never touch it). Every index-backed block below
-        // shares this one session instead of re-opening and re-analyzing every method body.
-        // The build is narrowed to the phases the requested sections actually consume.
-        var (indexInclAllocations, indexInclOpportunities) = AnalysisScopeFor(requestedSections);
-        // Call Graph / Caller Graph allocation and IL-evidence annotations (opt-in via
-        // --fields/--columns) read allocation-derived method signals, so the escape-classified
-        // allocation phase must run when those graphs are rendered with explicit fields.
-        if ((requestedSections.Contains(SectionNames.CallGraph) || requestedSections.Contains(SectionNames.CallerGraph))
-            && (options?.Fields is { Length: > 0 } || options?.Columns is { Length: > 0 }))
-            indexInclAllocations = true;
-
-        // Targeted (single-member) build: when no requested index-backed section needs the
-        // whole-assembly reverse graph (Callers / Call Graph / Caller Graph), the shared index only
-        // decodes the selected member(s) instead of every method body. The remaining index-backed
-        // member sections — Calls, Unsafe Operations, and the Allocation/Safety/Cost facts — read
-        // only the selected member's own body, so their output is identical to a full build (verified
-        // across the DirectCalls / UnsafeEvidence / UnsafetyOccurrences / AllocationOccurrences facts).
-        IReadOnlySet<int>? bodyScope = null;
-        bool needsWholeAssemblyBody = requestedSections.Contains(SectionNames.Callers)
-            || requestedSections.Contains(SectionNames.CallGraph)
-            || requestedSections.Contains(SectionNames.CallerGraph);
-        if (!needsWholeAssemblyBody)
-        {
-            var memberTokens = methods.Where(m => m.MetadataToken.HasValue).Select(m => m.MetadataToken!.Value).ToHashSet();
-            // Only target when every selected member carries a token (a missing token would mean a
-            // rendered member is absent from the scope); otherwise fall back to a full build.
-            if (memberTokens.Count > 0 && memberTokens.Count == methods.Count)
-                bodyScope = memberTokens;
-        }
-
-        MethodBodyInspectionSession? indexSession = null;
-        MethodBodyInspectionSession IndexSession() =>
-            indexSession ??= MethodBodyInspectionSession.Open(dllPath, assemblyResolver, indexInclAllocations, indexInclOpportunities, bodyScope);
-
         // For sections that require a single selected method (Calls, CallGraph, decompiled source, etc.),
         // filter to that specific overload. Callers can aggregate across all overloads.
         var singleMethod = overloadIndex.HasValue
@@ -1267,7 +1191,7 @@ public static class ApiOutputFormatter
         if (request.Calls && singleMethodList is [{ MetadataToken: { } token } callsMethod])
         {
             RequestTelemetry.Breadcrumb("il-analysis.calls", callsMethod.Name);
-            var callsByCaller = IndexSession().BodyIndex.GetDirectCallsByCaller();
+            var callsByCaller = analysisInspection.BodyIndex.GetDirectCallsByCaller();
             var calls = callsByCaller.TryGetValue(token, out var directCalls)
                 ? directCalls
                 : ImmutableArray<Analysis.DirectCall>.Empty;
@@ -1293,8 +1217,7 @@ public static class ApiOutputFormatter
         if (requestedSections.Contains(SectionNames.ExceptionRegions) && singleMethodList is [{ MetadataToken: { } exceptionToken } exceptionMethod])
         {
             RequestTelemetry.Breadcrumb("il-analysis.exception-regions", exceptionMethod.Name);
-            using var pdbContext = PdbContext.Open(dllPath);
-            var regions = pdbContext.ResolveExceptionRegions(exceptionToken, out var error)
+            var regions = analysisInspection.ResolveExceptionRegions(exceptionToken, out var error)
                 .Select(region => new ExceptionRegionRow(
                     region.Region,
                     region.Clause,
@@ -1315,32 +1238,13 @@ public static class ApiOutputFormatter
         if (request.Callers && methods.Count > 0)
         {
             RequestTelemetry.Breadcrumb("il-analysis.callers", $"{methods.Count} member(s)");
-            var callerSession = IndexSession();
             var rows = new List<CallerSiteRow>();
-
-            // Open each caller-scope assembly once as its own session (skipping any that fail to
-            // load); the edge facet attributes cross-assembly hits to each scope's SourceName.
-            var scopeSessions = new List<MethodBodyInspectionSession>();
-            if (callerScopeAssemblies is { Count: > 0 })
-            {
-                foreach (var scopePath in callerScopeAssemblies)
-                {
-                    try
-                    {
-                        scopeSessions.Add(MethodBodyInspectionSession.Open(scopePath, AnalysisReferenceResolver(scopePath, options), includeAllocations: false, includeOpportunities: false));
-                    }
-                    catch
-                    {
-                        // Unreadable scope assembly: skip, matching the prior per-method open behavior.
-                    }
-                }
-            }
 
             // Collect callers for each method (all overloads if multiple methods selected)
             foreach (var method in methods.Where(m => m.MetadataToken.HasValue))
             {
                 var targetToken = method.MetadataToken!.Value;
-                rows.AddRange(callerSession.CallerEdges(targetToken, scopeSessions)
+                rows.AddRange(analysisInspection.CallerEdges(targetToken)
                     .Select(edge => CreateCallerRow(edge.Source, edge.Call)));
             }
 
@@ -1364,7 +1268,7 @@ public static class ApiOutputFormatter
         {
             RequestTelemetry.Breadcrumb("il-analysis.call-graph", graphMethod.Name);
             var root = ToCallGraphNode(
-                IndexSession().BodyIndex.BuildCallTree(graphToken),
+                analysisInspection.BuildCallTree(graphToken),
                 GetRequestedCallGraphFields(options));
             if (root.Children is { Count: > 0 })
             {
@@ -1382,29 +1286,7 @@ public static class ApiOutputFormatter
         if (requestedSections.Contains(SectionNames.CallerGraph) && singleMethodList is [{ MetadataToken: { } callerGraphToken } callerGraphMethod])
         {
             RequestTelemetry.Breadcrumb("il-analysis.caller-graph", callerGraphMethod.Name);
-            var callerSession = IndexSession();
-            // Extend the reverse graph across the caller scope (--bin/--project/--caller-package)
-            // so a dependency member surfaces the product entry points and callers that reach it.
-            var scopeSessions = new List<MethodBodyInspectionSession>();
-            if (callerScopeAssemblies is { Count: > 0 })
-            {
-                foreach (var scopePath in callerScopeAssemblies)
-                {
-                    try
-                    {
-                        // External caller nodes carry their scope assembly's method signals, so the
-                        // scope build needs allocations whenever this graph renders allocation/IL
-                        // fields (indexInclAllocations already captures that). Opportunities are never
-                        // read from the reverse graph.
-                        scopeSessions.Add(MethodBodyInspectionSession.Open(scopePath, AnalysisReferenceResolver(scopePath, options), includeAllocations: indexInclAllocations, includeOpportunities: false));
-                    }
-                    catch
-                    {
-                        // Best-effort: an unreadable scope assembly just doesn't contribute callers.
-                    }
-                }
-            }
-            var callerTree = callerSession.CallerTree(callerGraphToken, scopeSessions);
+            var callerTree = analysisInspection.BuildCallerTree(callerGraphToken);
             var root = ToCallGraphNode(callerTree, GetRequestedCallGraphFields(options));
             if (root.Children is { Count: > 0 } || ExplicitlySelected(SectionNames.CallerGraph))
             {
@@ -1416,7 +1298,7 @@ public static class ApiOutputFormatter
         if (request.UnsafeOperations && singleMethodList is [{ MetadataToken: { } unsafeToken } unsafeMethod])
         {
             RequestTelemetry.Breadcrumb("il-analysis.unsafe", unsafeMethod.Name);
-            var evidence = InspectSafetyFindings(IndexSession().BodyIndex, unsafeToken)
+            var evidence = InspectSafetyFindings(analysisInspection.BodyIndex, unsafeToken)
                 .Evidence
                 .Select(static finding => finding.Payload)
                 .OrderBy(evidence => evidence.ILOffset ?? -1)
@@ -1458,12 +1340,10 @@ public static class ApiOutputFormatter
         if (requestedSections.Overlaps(SemanticFactSections) && singleMethodList is [{ MetadataToken: { } semanticToken } semanticMethod])
         {
             RequestTelemetry.Breadcrumb("il-analysis.semantic-facts", semanticMethod.Name);
-            var bodySession = IndexSession();
-
             if (requestedSections.Contains(SectionNames.AllocationFacts))
             {
                 var rows = Analysis.SemanticFactProjection.AllocationFacts(
-                        bodySession.BodyIndex.GetAllocationOccurrences(),
+                        analysisInspection.BodyIndex.GetAllocationOccurrences(),
                         semanticToken)
                     .Select(fact => ToAllocationFactRow(fact, includeMember: false))
                     .ToList();
@@ -1476,7 +1356,7 @@ public static class ApiOutputFormatter
 
             if (requestedSections.Contains(SectionNames.SafetyFacts))
             {
-                var safety = InspectSafetyFindings(bodySession.BodyIndex, semanticToken);
+                var safety = InspectSafetyFindings(analysisInspection.BodyIndex, semanticToken);
                 var rows = Analysis.SemanticFactProjection.SafetyFacts(
                         safety.Evidence,
                         safety.Operations)
@@ -1492,7 +1372,7 @@ public static class ApiOutputFormatter
             if (requestedSections.Contains(SectionNames.CostFacts))
             {
                 var rows = Analysis.SemanticFactProjection.CostFacts(
-                        bodySession.BodyIndex.GetDirectCallsByCaller(),
+                        analysisInspection.BodyIndex.GetDirectCallsByCaller(),
                         semanticToken)
                     .Select(fact => ToCostFactRow(fact, includeMember: false))
                     .ToList();
@@ -1905,7 +1785,7 @@ public static class ApiOutputFormatter
     {
         var rows = index
             .UnsafeEvidence
-            .Where(evidence => SameType(evidence.Member.DeclaringType, type))
+            .Where(evidence => ApiAnalysisInspection.SameType(evidence.Member.DeclaringType, type))
             .GroupBy(evidence => evidence.Member.MetadataToken)
             .SelectMany(group =>
             {
@@ -1928,26 +1808,23 @@ public static class ApiOutputFormatter
     internal static void PopulateTypeExceptionRegions(
         TypeView view,
         ApiType type,
-        string dllPath,
+        IReadOnlyList<ApiAnalysisInspection.MemberExceptionRegion> exceptionRegions,
         IReadOnlySet<string>? explicitSections = null)
     {
-        using var pdbContext = PdbContext.Open(dllPath);
-        var rows = type.Members
-            .Where(member => member.MetadataToken is not null && ApiMemberSectionDescriptors.IsMethodLike(member))
-            .OrderBy(member => GetMemberSortOrder(member.Kind))
-            .ThenBy(member => member.Name, StringComparer.Ordinal)
-            .ThenBy(GetMemberSignatureSortKey, StringComparer.Ordinal)
-            .SelectMany(member => pdbContext.ResolveExceptionRegions(member.MetadataToken!.Value, out _)
-                .Select(region => new TypeExceptionRegionRow(
-                    MarkoutInline.Code(GetMemberDisplaySignature(type, member)),
-                    region.Region,
-                    region.Clause,
-                    FormatILRange(region.TryStart, region.TryEnd),
-                    FormatILRange(region.HandlerStart, region.HandlerEnd),
-                    region.FilterStart is { } filterStart && region.FilterEnd is { } filterEnd
+        var rows = exceptionRegions
+                .OrderBy(item => GetMemberSortOrder(item.Member.Kind))
+                .ThenBy(item => item.Member.Name, StringComparer.Ordinal)
+                .ThenBy(item => GetMemberSignatureSortKey(item.Member), StringComparer.Ordinal)
+                .Select(item => new TypeExceptionRegionRow(
+                    MarkoutInline.Code(GetMemberDisplaySignature(type, item.Member)),
+                    item.Region.Region,
+                    item.Region.Clause,
+                    FormatILRange(item.Region.TryStart, item.Region.TryEnd),
+                    FormatILRange(item.Region.HandlerStart, item.Region.HandlerEnd),
+                    item.Region.FilterStart is { } filterStart && item.Region.FilterEnd is { } filterEnd
                         ? FormatILRange(filterStart, filterEnd)
                         : null,
-                    region.CaughtType)))
+                    item.Region.CaughtType))
             .ToList();
 
         if (rows.Count > 0 || explicitSections is not null && explicitSections.Contains(SectionNames.ExceptionRegions))
@@ -1961,7 +1838,7 @@ public static class ApiOutputFormatter
         IReadOnlySet<string>? explicitSections = null)
     {
         var rows = index
-            .CalledTypes(method => SameType(method.DeclaringType, type))
+            .CalledTypes(method => ApiAnalysisInspection.SameType(method.DeclaringType, type))
             .Select(summary => new CalledTypeRow(
                 MarkoutInline.Code(summary.Type.ToQualifiedDisplayString()),
                 string.IsNullOrEmpty(summary.Assembly) ? null : summary.Assembly,
@@ -2038,7 +1915,7 @@ public static class ApiOutputFormatter
             : null;
         var rows = LibraryMetadataService.FilterAndOrderTriageOpportunities(
                 LibraryMetadataService.TriageOpportunities(index, options)
-                    .Where(opportunity => SameType(opportunity.Method.DeclaringType, type))
+                    .Where(opportunity => ApiAnalysisInspection.SameType(opportunity.Method.DeclaringType, type))
                     .Where(opportunity => !LibraryMetadataService.IsGeneratedMethod(opportunity.Method, index.GeneratedFrameworkTypeNames))
                     .Where(opportunity => memberTokens is null || memberTokens.Contains(opportunity.Method.MetadataToken)),
                 options)
@@ -2148,7 +2025,7 @@ public static class ApiOutputFormatter
         // limiter (`-n`/`--rows`) trims the rendered table. In member-detail/overload
         // contexts `type.Members` is narrowed to the selected member(s), so restrict the
         // ranked rows to those tokens (mirrors PopulateOptimizationOpportunities).
-        var rows = index.TopLeverage(count: int.MaxValue, scope: method => SameType(method.DeclaringType, type))
+        var rows = index.TopLeverage(count: int.MaxValue, scope: method => ApiAnalysisInspection.SameType(method.DeclaringType, type))
             .Where(entry => !restrictToModelMembers || drillByToken.ContainsKey(entry.Method.MetadataToken))
             .Select(entry =>
             {
@@ -2241,22 +2118,6 @@ public static class ApiOutputFormatter
             name += $"<{string.Join(", ", typeArgs.Select(t => t.ToQualifiedDisplayString()))}>";
         string signature = $"{name}({string.Join(", ", parameterTypes.Select(p => p.ToQualifiedDisplayString()))})";
         return declaringType is null ? signature : $"{declaringType.ToQualifiedDisplayString()}.{signature}";
-    }
-
-    internal static bool SameType(Analysis.TypeRef typeRef, ApiType type)
-    {
-        if (typeRef.Kind != Analysis.TypeRefKind.Definition)
-            return false;
-        if (!string.Equals(typeRef.Namespace, type.Namespace ?? "", StringComparison.Ordinal))
-            return false;
-
-        if (type.MetadataName != null)
-            return string.Equals(typeRef.Name, type.MetadataName, StringComparison.Ordinal);
-
-        // Fallback for older serialized JSON where MetadataName is absent.
-        // Nested types use the metadata '+' separator in the analysis TypeRef
-        // (Outer+Inner) but the '.' separator in the API surface (Outer.Inner).
-        return string.Equals(typeRef.Name.Replace('+', '.'), type.Name, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/src/dotnet-inspect/Output/ExtensionsOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ExtensionsOutputFormatter.cs
@@ -1,4 +1,4 @@
-using DotnetInspector.Commands;
+using DotnetInspector.Models;
 using DotnetInspector.Options;
 using DotnetInspector.Views;
 

--- a/src/dotnet-inspect/Output/ImplementsOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ImplementsOutputFormatter.cs
@@ -1,4 +1,4 @@
-using DotnetInspector.Commands;
+using DotnetInspector.Models;
 using DotnetInspector.Views;
 
 namespace DotnetInspector.Output;

--- a/src/dotnet-inspect/Output/SearchJsonResults.cs
+++ b/src/dotnet-inspect/Output/SearchJsonResults.cs
@@ -1,0 +1,51 @@
+using DotnetInspector.Models;
+
+namespace DotnetInspector.Output;
+
+internal sealed record ExtensionMethodJsonResult(
+    string Method,
+    string Class,
+    string ExtendedType,
+    string Library,
+    string? Signature,
+    List<string>? Signatures,
+    int? Overloads,
+    string Kind,
+    string? Source,
+    string? SourceVersion,
+    string? ReachablePath,
+    string? ReachableFromType)
+{
+    internal static ExtensionMethodJsonResult From(ExtensionMethodResult result) => new(
+        result.MethodName,
+        result.ExtensionClass,
+        result.ExtendedType,
+        result.Assembly,
+        result.Signature,
+        result.Signatures,
+        result.Overloads,
+        result.Kind,
+        result.Source,
+        result.SourceVersion,
+        result.ReachablePath,
+        result.ReachableFromType);
+}
+
+internal sealed record ImplementerJsonResult(
+    string Type,
+    string? Namespace,
+    string Kind,
+    string Relationship,
+    string? Library,
+    string? Source,
+    string? SourceVersion)
+{
+    internal static ImplementerJsonResult From(ImplementerResult result) => new(
+        result.TypeName,
+        result.Namespace,
+        result.Kind,
+        result.Relationship,
+        result.Assembly,
+        result.Source,
+        result.SourceVersion);
+}


### PR DESCRIPTION
Closes #2895

## Change

Moves API analysis/session composition out of the Output layer, removing the inverted `Output → Commands` dependency called out in #2895.

- New `Inspectors/ApiAnalysisInspection.cs` (static policy): `CreateReferenceResolver`, `AnalysisScopeFor`, `OpenTypeAnalysisIndex`, `SameType`, `ResolveExceptionRegions`.
- New `Inspectors/ApiMemberAnalysisInspection.cs`: a per-member-render object that owns lazy session acquisition, caller-scope composition, exception-region resolution, and body/allocation scoping — previously inlined in `ApiOutputFormatter.PopulateIndexSections`.
- `ApiOutputFormatter` now consumes immutable analysis facts and no longer opens sessions/PDBs, decides analysis scope, or calls back into `ApiCommand`. `using DotnetInspector.Commands;` is gone from `ApiOutputFormatter`, `ExtensionsOutputFormatter`, and `ImplementsOutputFormatter`.
- `ApiCommand.PlatformAssemblyResolver` removed (now `ApiAnalysisInspection.CreateReferenceResolver`).
- `ExtensionMethodResult` / `ImplementerResult` moved from `Commands/*.cs` to `Models/SearchResults.cs`; JSON shaping moved to `Output/SearchJsonResults.cs` (`ExtensionMethodJsonResult` / `ImplementerJsonResult`), so serialization lives in the Output layer.

This is behavior-preserving **except** the one intentional consistency improvement below.

## Intentional behavior change (consistency)

`OpenTypeAnalysisIndex` now forwards `ApiOptions` to the reference resolver, so the **type-scoped** analysis index honors `--project` (project-assets) and `--tfm`. Previously the type path built its resolver with no options and silently ignored those inputs, while the member path already honored them. This is an add-only change (it can only make more references resolvable; it cannot displace an already-selected sibling/package/TPA reference — project assets are appended and simple-name-deduplicated). Documented on `OpenTypeAnalysisIndex` and pinned by a focused test.

## Evidence

| Check | Result |
| --- | --- |
| Full solution build (`dotnet build dotnet-inspect.slnx -c Release`) | Green |
| `dotnet-inspect.Tests` full suite | 1954 total, **2 failed (pre-existing on `origin/main`)**, 10 skipped |
| New `ApiAnalysisReferenceResolverTests` | 2 passed |
| `AnalysisScopeTests`, `ApiOutputFormatterTests`, `OutputFormatterTests`, `SearchJsonResultTests` | passed |
| JSON contract (`extensions`/`implements`, `--json` + `--compact`) | Field names byte-identical to before (verified via real CLI runs) |

The 2 failures (`PInvokeMethods_DeclaringTypeAndSignature_RenderAsCodeSpansWithFunctionPointerPunctuation`, `PInvokeMethods_MachineOutput_KeepsRawValuesWithoutCodeMarkup`) reproduce on pristine `origin/main` and are unrelated to this change (PInvoke code-span rendering under the preview SDK).

## Adversarial review

Two clean fixed-head reviews (both re-verified on the exact head after the test/doc commit):

- **Gemini 3.1 Pro** — flagged the `OpenTypeAnalysisIndex` resolver-options change; kept as intentional (documented + tested). Re-review: VERIFIED-CLEAN.
- **GPT-5.6** — verified the JSON contract byte-identical; confirmed exception-region ordering (LINQ stable sort), caller-scope allocation-cache split, body targeting, and PdbContext lifetime all behavior-preserving. Its "public API move" note was dismissed: `dotnet-inspect` is a CLI tool (`OutputType=Exe`, `PackAsTool=true`) with no shipped library API or PublicAPI baseline; the real external contract (JSON field names) is unchanged. Re-review: VERIFIED-CLEAN.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config
dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- \
  -class "DotnetInspector.Tests.ApiAnalysisReferenceResolverTests" \
  -class "DotnetInspector.Tests.AnalysisScopeTests" \
  -class "DotnetInspector.Tests.SearchJsonResultTests"
```
