### PR TITLE
Raise capturing lambdas over locals read in the outer body (#2945)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -579,6 +579,34 @@ public class CfgSampleClass
     public static (System.Func<int, int>, System.Func<int, int>) SharedCaptureLambdas(int n)
         => (x => x + n, y => y - n);
 
+    // The captured parameter is also read in the outer body (the null-check),
+    // which the compiler routes through the hoisted field (`V_0.map is null`).
+    // That outer field read is neither a capture store nor a lambda target, so
+    // the environment is elided by substituting the read back to the captured
+    // source. Passing the delegate as a later argument (after `7`) forces the
+    // compiler to spill the display class to a local (`stloc`), reproducing the
+    // #2945 EVIL CS1001 closure-stall shape (System.CommandLine Command.SetAction,
+    // Command.GetCompletions) rather than the dup-carried stack form.
+    public static int CapturedParamReadInOuterBody(System.Func<int, int> map)
+    {
+        if (map is null)
+            throw new System.ArgumentNullException(nameof(map));
+        return ApplySeed(7, x => map(x) + 1);
+    }
+
+    static int ApplySeed(int seed, System.Func<int, int> f) => f(seed);
+
+    // Negative: the captured parameter is reassigned in the outer body after the
+    // lambda captures it. The reassignment is a second store to the hoisted
+    // field, so the single-store guard must keep the environment lowered even
+    // though an outer read is present.
+    public static int CapturedParamReassignedInOuterBody(System.Func<int, int> map)
+    {
+        int first = ApplySeed(7, x => map(x) + 1);
+        map = static x => x;
+        return first + ApplySeed(8, map);
+    }
+
     // Boundary fixtures for the lambda surface: each exercises a distinct
     // LambdaRaisingPass guard. When a later slice lifts a guard, flip its
     // scorecard entry to recovered in that PR.

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -175,6 +175,11 @@ public class FidelityGateTests
         "CachedDelegateChain",
         "CapturingLambda",
         "CapturingLocalBodyLambda",
+        // #2945: outer-body reads of a hoisted capture field are substituted back
+        // to the captured source and the display class elides, so this fully
+        // raises; recompiling regenerates a fresh display class whose synthesized
+        // ordinals differ under contract V1.
+        "CapturedParamReadInOuterBody",
         "ClosureCapture",
         "CountPositive",
         "DayNumber",

--- a/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
@@ -128,6 +128,34 @@ public class LambdaRaisingPassTests
         Assert.DoesNotContain("new Func", output);
     }
 
+    // #2945: a hoisted field read in the outer body (`if (map is null)`) is
+    // substituted back to the captured source, so the whole environment elides
+    // and the lambda raises — the SetAction/GetCompletions CS1001 closure-stall.
+    [Fact]
+    public void CapturedFieldReadInOuterBody_ElidesEnvironmentAndSubstitutesRead()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.CapturedParamReadInOuterBody));
+
+        Assert.Contains("if (map is null)", output);        // outer read substituted map <- V_0.map
+        Assert.Contains("=>", output);                       // lambda raised
+        Assert.DoesNotContain("DisplayClass", output);       // environment elided
+        Assert.DoesNotContain("new Func", output);
+        Assert.DoesNotContain("b__", output);                // no un-raised lambda-method reference
+    }
+
+    // Negative: the captured parameter is reassigned in the outer body, a second
+    // store to the hoisted field. The single-store guard must keep the
+    // environment lowered so the mutation is not lost to value substitution.
+    [Fact]
+    public void CapturedFieldReassignedInOuterBody_StaysLowered()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.CapturedParamReassignedInOuterBody));
+
+        Assert.Contains("DisplayClass", output);   // environment kept
+        Assert.Contains("new Func", output);        // delegate creation survives
+        Assert.Contains("b__", output);             // lambda method reference not raised
+    }
+
     [Fact]
     public void LambdaNameLookalikeWithoutCompilerGeneratedMetadata_IsNotRaised()
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
@@ -108,7 +108,11 @@ public sealed class LambdaRaisingPass : IIrPass
     // up across statements: `dc = new DC(); dc.f = v; ... use(new Func(dc.b__N))`.
     // Each delegate creation over the local is raised by substituting the captured
     // values, then the allocation and capture stores are elided so the environment
-    // disappears (the now-unreferenced local prints nothing).
+    // disappears (the now-unreferenced local prints nothing). A capture field may
+    // also be read directly in the outer body (`if (dc.f is null)`): once a
+    // variable is hoisted the compiler routes every source reference through the
+    // field, so those outer reads are substituted back to the captured source
+    // alongside the lambda bodies' `this.f` reads (#2945).
     static void RaiseLocalDisplayClasses(IrFunction function, PassContext context)
     {
         foreach (var alloc in function.Descendants.OfType<StoreLocal>().ToList())
@@ -124,11 +128,13 @@ public sealed class LambdaRaisingPass : IIrPass
             if (function.Descendants.OfType<StoreLocal>().Count(s => s.Index == slot) != 1)
                 continue;
 
-            // Classify every read of the local: a capture store's receiver, or a
-            // lambda delegate target. Any other use means we cannot elide it.
+            // Classify every read of the local: a capture store's receiver, a
+            // lambda delegate target, or an outer-body read of a capture field.
+            // Any other use means we cannot elide it.
             var captures = new Dictionary<string, IrExpression>(StringComparer.Ordinal);
             var captureStores = new List<StoreField>();
             var creations = new List<DelegateCreation>();
+            var outerReads = new List<LoadField>();
             bool elidable = true;
             foreach (var load in function.Descendants.OfType<LoadLocal>().Where(l => l.Index == slot))
             {
@@ -155,6 +161,14 @@ public sealed class LambdaRaisingPass : IIrPass
                     && Equals(creation.Method.DeclaringType, dcType))
                 {
                     creations.Add(creation);
+                }
+                else if (load.Parent is LoadField outerRead
+                    && ReferenceEquals(outerRead.Instance, load)
+                    && Equals(outerRead.Field.DeclaringType, dcType))
+                {
+                    // An outer-body read of a hoisted field (e.g. `dc.f is null`).
+                    // Validated and substituted below once every capture is known.
+                    outerReads.Add(outerRead);
                 }
                 else
                 {
@@ -192,6 +206,26 @@ public sealed class LambdaRaisingPass : IIrPass
             if (!layoutOk)
                 continue;
 
+            // Every outer-body read must reference a known capture field and sit
+            // in the setup block after that field's single store. The read then
+            // observes exactly the stored source, so substituting `dc.f` with that
+            // source is sound. A read that is unstored, or nested under control
+            // flow / before its store (StatementIndex -1 or <= the store), is not
+            // provably dominated by the store, so the whole environment stays
+            // lowered rather than risk substituting a default/stale value.
+            bool outerReadsOk = true;
+            foreach (var outerRead in outerReads)
+            {
+                if (!storeIndexByField.TryGetValue(outerRead.Field.Name, out int storeIndex)
+                    || StatementIndex(outerRead, setupBlock) is var readIndex && readIndex <= storeIndex)
+                {
+                    outerReadsOk = false;
+                    break;
+                }
+            }
+            if (!outerReadsOk)
+                continue;
+
             // Raise every lambda first; commit nothing unless all succeed and each
             // lambda's read fields are stored before its creation. The environment
             // allocation is each lambda's outer provenance anchor.
@@ -216,6 +250,8 @@ public sealed class LambdaRaisingPass : IIrPass
                 context.Stepper.StepOver($"raise captured lambda {creation.Method.Name}", creation);
                 creation.ReplaceWith(lambda);
             }
+            foreach (var outerRead in outerReads)
+                outerRead.ReplaceWith(captures[outerRead.Field.Name].Clone());
             foreach (var store in captureStores)
                 store.Detach();
             alloc.Detach();


### PR DESCRIPTION
- Fixes #2945
- Changes `LambdaRaisingPass` to raise capturing lambdas whose display-class environment is also read directly in the outer method body, instead of stalling on the illegal `V_0.<M>b__N` identifier (CS1001).
- Card revision: `b8fd7db5`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the outer-body read of a hoisted capture field is now substituted back to the captured source, so the whole `<>c__DisplayClass` environment elides and the lambda raises to valid, behavior-preserving C#; every existing guard is retained and no corpus method regresses.

### Original source

```csharp
public void SetAction(Action<ParseResult> action)
{
    if (action is null)
    {
        throw new ArgumentNullException(nameof(action));
    }

    Action = new AnonymousSynchronousCommandLineAction(context =>
    {
        action(context);
        return 0;
    });
}
```

### Before

```csharp
public void SetAction(System.Action<System.CommandLine.ParseResult> action)
{
    ___c__DisplayClass30_0 V_0 = new ___c__DisplayClass30_0();
    V_0.action = action;
    if (V_0.action is null)
    {
        throw new ArgumentNullException("action");
    }
    Action = new AnonymousSynchronousCommandLineAction(new Func<ParseResult, int>(V_0.<SetAction>b__0));
}
```

- Valid: False
- Correct: False

The outer-body read `if (V_0.action is null)` kept the display-class local live, so the delegate creation never folded and the printer emitted the illegal `V_0.<SetAction>b__0` identifier — a parse error (CS1001), the largest EVIL invalid bucket (780 rows).

### After

```csharp
public void SetAction(System.Action<System.CommandLine.ParseResult> action)
{
    if (action is null)
    {
        throw new ArgumentNullException("action");
    }
    Action = new AnonymousSynchronousCommandLineAction(context => { action.Invoke(context); return 0; });
}
```

- Valid: True
- Correct: True

The outer read `V_0.action` is substituted back to the captured `action` source, the environment allocation and capture store elide, and the lambda raises with the captured value threaded through its body.

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build (`.slnx`, Release) | Pass | Pass |
| Focused tests | `LambdaRaisingPassTests`: 17 passed | `LambdaRaisingPassTests`: 19 passed (+2 new) |
| Decompiler fast suite | 2939, 0 failed | 2941, 0 failed |
| Reduced fixture validity | Pass | Pass |
| Reduced fixture fidelity | `FidelityGateTests`: PASS | `FidelityGateTests`: PASS (docket +1: `CapturedParamReadInOuterBody`) |
| Real witness | `Command::SetAction:1` broken (CS1001) | `Command::SetAction:1` fixed (valid, fully raised) |

Baseline focused-test count is lower by exactly the two tests this PR adds; no baseline test regresses.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — on System.CommandLine `3.0.0-preview.5.26302.115` (the EVIL corpus version), methods whose raised output still leaks the illegal `>b__` identifier fall **30 → 26 (−4)**; every remaining head leak is a strict subset of the baseline set, so nothing regresses.

### Raw illegal-identifier flip

Rendered every method of the assembly with `CSharpPrinter.PrintRaised` and counted those whose output contains `>b__` (an un-raised delegate reference ⇒ CS1001):

| Metric (goal) | Baseline | Head | Delta |
| --- | ---: | ---: | ---: |
| Methods (total) | 977 | 977 | 0 |
| Methods leaking `>b__` (−) | 30 | 26 | −4 |

Resolved (base→head): `Command::SetAction` (1 overload), `CompletionSourceExtensions::Add` (2 overloads), `ParseResult::<GetCompletions>g__OptionsWithArgumentLimitReached|44_1`.

Remaining slice (tracked by #2945): display classes that host a hoisted local function or capture a freshly-constructed value (`GetCompletions`-shaped), and display classes allocated under a conditional rather than a straight-line setup block (`WriteColumns`-shaped), still stay lowered.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LambdaRaisingPassTests/*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
```
