### PR TITLE
Fix unbox pointer conversion spelling

### DIFF
--- a/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
@@ -13,6 +13,8 @@ public class PrinterPrecedenceTests
     static readonly TypeRef s_bool = TypeRef.CoreLib("System", "Boolean");
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef s_uint = TypeRef.CoreLib("System", "UInt32");
+    static readonly TypeRef s_nuint = TypeRef.CoreLib("System", "UIntPtr");
+    static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
     static readonly TypeRef s_string = TypeRef.CoreLib("System", "String");
 
     static IrFunction Raised(string methodName)
@@ -361,6 +363,49 @@ public class PrinterPrecedenceTests
         AssertCompiles("public static int M(int x, int y)", output);
     }
 
+    // Issue #2929: unbox yields a managed reference into the box. Converting
+    // that reference to nuint must preserve the address, not read and convert
+    // the boxed value.
+    [Fact]
+    public void ConvertNativeUInt_Unbox_SpellsPointerIntoBox()
+    {
+        var result = PrintReturnResult(
+            new ILInspector.Decompiler.Pipeline.Convert(
+                s_nuint,
+                isChecked: false,
+                isUnsigned: false,
+                new Unbox(s_int, new LoadArgument(0, "o", s_object))),
+            s_nuint,
+            [new Parameter("o", s_object)]);
+        string output = result.Output!;
+
+        Assert.Contains(
+            "return (nuint)System.Runtime.CompilerServices.Unsafe.AsPointer(ref System.Runtime.CompilerServices.Unsafe.Unbox<int>(o));",
+            output);
+        Assert.DoesNotContain("(nuint)(ref (int)o)", output);
+        Assert.True(result.RequiresUnsafeBodyModifier);
+        AssertCompiles("public static unsafe nuint M(object o)", output);
+    }
+
+    [Fact]
+    public void ConvertNativeUInt_Value_RemainsOrdinarySafeCast()
+    {
+        var result = PrintReturnResult(
+            new ILInspector.Decompiler.Pipeline.Convert(
+                s_nuint,
+                isChecked: false,
+                isUnsigned: false,
+                new LoadArgument(0, "value", s_uint)),
+            s_nuint,
+            [new Parameter("value", s_uint)]);
+        string output = result.Output!;
+
+        Assert.Contains("return (nuint)value;", output);
+        Assert.DoesNotContain("Unsafe.", output);
+        Assert.False(result.RequiresUnsafeBodyModifier);
+        AssertCompiles("public static nuint M(uint value)", output);
+    }
+
     // AssertCompiles/Recompile shape already used by DataflowFactsTests,
     // EnumCastPrinterTests, and MixedSignComparisonTests; reused here rather
     // than reimplemented.
@@ -394,6 +439,12 @@ public class PrinterPrecedenceTests
     }
 
     static string PrintReturn(IrExpression value, TypeRef returnType, ImmutableArray<Parameter> parameters)
+        => PrintReturnResult(value, returnType, parameters).Output!;
+
+    static DecompilerResult PrintReturnResult(
+        IrExpression value,
+        TypeRef returnType,
+        ImmutableArray<Parameter> parameters)
     {
         var block = new Block();
         block.Add(new Return(value));
@@ -405,6 +456,6 @@ public class PrinterPrecedenceTests
             new MethodSignature(returnType, parameters, HasThis: false, GenericParameterCount: 0),
             [],
             body);
-        return CSharpPrinter.Print(function).Output!;
+        return CSharpPrinter.Print(function);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1890,7 +1890,9 @@ public sealed partial class CSharpPrinter
     /// <c>extern</c> — or, by the compat heuristic, one with a pointer in its
     /// signature), or a <c>stackalloc</c> converted to a <c>Span</c> with no
     /// initializer in a <c>[SkipLocalsInit]</c> body. Dereferencing a managed
-    /// reference (<c>ByRef</c>) is safe and excluded. Creating pointers, the
+    /// reference (<c>ByRef</c>) is safe and excluded. Converting an unbox
+    /// reference to a native integer is included because its faithful spelling
+    /// uses <c>Unsafe.AsPointer</c>. Creating pointers, the
     /// String-pin fixed statements raised through a synthesized stack-slot
     /// pointer need an unsafe context for their header. Creating pointers,
     /// ordinary <c>fixed</c> statements, and <c>sizeof</c> are safe under the new
@@ -1908,6 +1910,7 @@ public sealed partial class CSharpPrinter
         NewObject n => n.Constructor.RequiresUnsafe || SignatureRequiresUnsafe(n.Constructor),
         Binary b => IsPointerArithmetic(b),
         Comparison c => IsPointerComparison(c),
+        Convert c => IsUnboxPointerConversion(c),
         FixedBufferElementAddress => true,
         LoadIndirect { Address: FixedBufferElementAddress } => true,
         StoreIndirect { Address: FixedBufferElementAddress } => true,
@@ -2938,6 +2941,9 @@ public sealed partial class CSharpPrinter
     static bool IsNativeInteger(TypeRef? type)
         => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "IntPtr" or "UIntPtr" };
 
+    static bool IsUnboxPointerConversion(Convert convert)
+        => IsNativeInteger(convert.Target) && convert.Operand is Unbox;
+
     /// <summary>
     /// The C# type a store-indirect writes through. A primitive <c>stind</c>
     /// opcode carries its own signed type (<c>stind.i4</c> → <c>int</c>) which
@@ -3749,6 +3755,14 @@ public sealed partial class CSharpPrinter
 
     string ConvertBody(Convert convert, bool wrap, bool uncheckedOverflow)
     {
+        if (IsUnboxPointerConversion(convert) && convert.Operand is Unbox unbox)
+        {
+            string pointer = $"System.Runtime.CompilerServices.Unsafe.AsPointer(ref System.Runtime.CompilerServices.Unsafe.Unbox<{TypeText(unbox.Type)}>({Operand(unbox.Operand)}))";
+            string pointerCast = $"({TypeText(convert.Target)}){pointer}";
+            if (wrap)
+                return $"checked({pointerCast})";
+            return uncheckedOverflow ? $"unchecked({pointerCast})" : pointerCast;
+        }
         // An address-of node (ldloca/ldarga/ldflda/ldelema) converted to a
         // pointer or native integer (conv.u/conv.i) is C#'s address-of operator,
         // not a `ref` place: `(nuint)(ref x)` is CS1525 — the faithful unsafe


### PR DESCRIPTION
Fixes #2929

- Changes native-integer conversion of `Unbox` from invalid `ref`-cast syntax
  to a faithful pointer-to-box spelling.
- Card revision: `1c09592e0f912e4b8b6739ec518a6839d47f605f`

## Change

> Should we accept this change?

**Conclusion:** **PASS** - the new spelling compiles, preserves the managed
reference's address rather than reading the boxed value, and is limited to
native-integer conversions whose operand is `Unbox`.

### Original source

There is no authoritative C# source for this compiler-independent IL seam. The
original artifact is the `unbox` followed by `conv.u` shape from #2929:

```il
.method static native unsigned int M(object o) cil managed
{
    ldarg.0
    unbox int32
    conv.u
    ret
}
```

### Before

```csharp
static unsafe nuint M(object o)
{
    return (nuint)(ref (int)o);
}
```

- Valid: False
- Correct: False

The cast operand is syntactically invalid (CS1525), so the decompilation cannot
represent the original `unbox int; conv.u` behavior.

### After

```csharp
static unsafe nuint M(object o)
{
    return (nuint)System.Runtime.CompilerServices.Unsafe.AsPointer(
        ref System.Runtime.CompilerServices.Unsafe.Unbox<int>(o));
}
```

- Valid: True
- Correct: True

`Unsafe.Unbox<int>` returns the managed reference into the boxed payload;
`Unsafe.AsPointer` preserves that address, and the final cast models `conv.u`.
The same typed discriminator also projects the required `unsafe` body modifier.

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

Baseline: `45585f9c`. Head: `1c09592e`.

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused regression | Direct reproduction emits invalid `(nuint)(ref (int)o)` | 2 passed |
| Decompiler fast suite | 2,939 passed | 2,941 passed |
| Render A/B, System.Private.CoreLib | 41,952-method snapshot | 0 changed, 0 added, 0 removed |
| Real compiler witness | Invalid spelling reports CS1525 | File-based app compiles, runs, and prints `True` |

The target IL shape is not present in the 41,952-method CoreLib render corpus,
so the hand-built IR regression pins the exact `Convert(UIntPtr, Unbox)` seam
and compiles its rendered body with Roslyn. A close negative confirms an
ordinary `uint`-to-`nuint` conversion remains a safe cast and does not gain
`Unsafe` calls or an unsafe-body requirement.

The full decompiler suite completed 3,125 tests with two failures unrelated to
this change:

- `LadderIteratorGateTests.IteratorFixture_RecoveredRowsCompileBackOpcodeExact`
  expects `Exact` and receives `OperandDiff`.
- `ValidityCoverageReportingTests.DecompilerAssembly_MissingReturnPopulationIsPinned`
  has a pinned census mismatch.

Both exact failures reproduce unchanged on clean baseline `45585f9c`; all other
full-suite tests passed.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** - render A/B reports no changed methods in the
41,952-method CoreLib population, while the exact previously uncovered IR seam
is compiler-gated by the focused regression.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --no-restore
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -method "*ConvertNativeUInt_*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -trait- "Speed=Slow"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --render-ab <baseline.json> --workers 2
dotnet run /tmp/check.cs
```
