### PR TITLE
Propagate raised stackalloc initializers through a slot to Span ctor (#2907)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -3935,6 +3935,22 @@ public class CfgSampleClass
         return buffer[0];
     }
 
+    // #2907: a Span-wrapped stackalloc with an initializer (`Span<int> s =
+    // stackalloc int[] { 1, 2, 3 }`) lowers to a `localloc` result stored to a
+    // stack slot, an initializer copy (cpblk over a `ReadOnlySpan<int>` span
+    // literal), and a `new Span<int>(void*, int)` ctor that reads the slot.
+    // StackAllocInitializerPass recovers the initializer into the slot's
+    // stored StackAllocArray but never touches the ctor call, so
+    // StackAllocSpanPass alone must resolve the slot indirection to raise the
+    // whole shape to `Consume(stackalloc int[] { 1, 2, 3 });` at Full
+    // fidelity -- otherwise the unraised ctor prints an invalid
+    // `new Span<int>((void*)(stackalloc int[] { 1, 2, 3 }), 3)` (CS8346: a
+    // stackalloc may not appear in argument position).
+    public static void StackAllocSpanInitializerThroughSlot()
+        => Consume(stackalloc int[] { 1, 2, 3 });
+
+    static void Consume(Span<int> s) { }
+
     // A reference-type stack join: the ternary's two branches push a derived
     // and a base instance into one slot that merges to their common base
     // JoinBase. The importer types the slot JoinBase — an actual ancestor it

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2712,6 +2712,28 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void StackAllocSpanInitializerThroughSlot_RaisesAtFullFidelity()
+    {
+        // #2907 real-compiled regression: before StackAllocSpanPass resolved
+        // the slot indirection, this shape imported at (an incorrectly)
+        // Full fidelity while printing the invalid
+        // `new Span<int>((void*)(stackalloc int[] { 1, 2, 3 }), 3)` (CS8346).
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, nameof(CfgSampleClass.StackAllocSpanInitializerThroughSlot));
+        Assert.NotNull(function);
+
+        IrPasses.Run(function);
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        var raised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.True(raised.HasInitializer);
+
+        string output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("Consume(stackalloc int[] { 1, 2, 3 });", output);
+    }
+
+    [Fact]
     public void StackAlloc_ReturningPointer_PrintsPointerLocal()
     {
         // A stackalloc expression cannot be returned directly as a pointer, nor

--- a/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
@@ -155,23 +155,30 @@ public class StackAllocSpanPassTests
     }
 
     [Fact]
-    public void DirectPointerWithDynamicPureSize_Raises()
+    public void DirectPointerWithDynamicPureSize_DoesNotRaise()
     {
         // A dynamic-but-pure size (a local read, or arithmetic over one -- the
-        // common `stackalloc byte[n]` shape, e.g. n * sizeof(T) after
-        // StackAllocInitializerPass/import) must still raise: requiring a
-        // literal Constant here would reject this very common real-world
-        // pattern and reintroduce the original invalid-Full CS8346 shape this
-        // pass exists to fix. The size's own `n` and the constructor's count
-        // argument are the same LoadLocal(0), matching the canonical
-        // `count * sizeof(element)` byte-size shape the compiler emits.
+        // `stackalloc byte[n]` shape) is deliberately declined on this direct
+        // (non-initializer) StackAllocate path: IsProvenByteSize only accepts
+        // a literal-constant size/count pair. This is a scoped limitation,
+        // not an oversight -- a real compiled `stackalloc int[n]` (no
+        // initializer) emits a `checked unsigned` multiply over an
+        // int-to-nuint convert chain that isn't a safe-to-strip implicit C#
+        // conversion, and for primitive element types a folded literal
+        // Constant element size rather than a symbolic SizeOf node; recognizing
+        // that real shape soundly needs compiled-fixture validation this pass
+        // does not yet have, so it declines conservatively instead of raising
+        // on an unproven synthetic shape (see issue tracking this follow-up).
+        // The size's own `n` and the constructor's count argument are the
+        // same LoadLocal(0), which would have matched a canonical
+        // `count * sizeof(element)` byte-size shape if one were recognized.
         var size = new Binary(BinaryKind.Multiply, isChecked: false, isUnsigned: false, new LoadLocal(0, Int32), new SizeOf(Int32));
         var function = Build(StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new StackAllocate(size), new LoadLocal(0, Int32)));
 
         new StackAllocSpanPass().Run(function, PassContext.None);
 
-        Assert.Single(function.Descendants.OfType<StackAllocArray>());
-        Assert.Empty(function.Descendants.OfType<NewObject>());
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<StackAllocArray>());
         function.CheckInvariant();
     }
 
@@ -213,6 +220,44 @@ public class StackAllocSpanPassTests
     }
 
     [Fact]
+    public void DirectPointerWithNegativeConstantCount_DoesNotRaise()
+    {
+        // size = -4, count = -1, element = int: -4 == -1 * 4 passes the
+        // arithmetic check, but a negative array length is invalid C#
+        // (CS0247) -- both the size and the count must be nonnegative before
+        // accepting the literal-constant fallback.
+        var function = Build(StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new StackAllocate(new Constant(-4, Int32)), count: -1));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<StackAllocArray>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotWithUninitializedArrayNegativeConstantCount_DoesNotRaise()
+    {
+        // Same defect as DirectPointerWithNegativeConstantCount, but for an
+        // uninitialized StackAllocArray source's own literal Count: -1 == -1
+        // passes the equality check, but a negative array length is invalid
+        // C# (CS0247).
+        var stackAllocArray = new StackAllocArray(Int32, new Constant(-1, Int32), TypeRef.Pointer(Int32));
+        var store = new StoreStackSlot(0, stackAllocArray);
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: -1);
+
+        var function = BuildSlot(store, newObject);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var construction = Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Same(newObject, construction);
+        var unraised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.False(unraised.HasInitializer); // still the store's un-raised value
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void DirectPointerWithByteSizeCountOverflow_DoesNotRaise()
     {
         // A 4-byte StackAllocate against a huge int Span count
@@ -233,17 +278,16 @@ public class StackAllocSpanPassTests
     [Fact]
     public void DirectPointerWithNarrowingConvertInByteSize_DoesNotRaise()
     {
-        // The byte size is `unchecked((byte)257) * sizeof(int)` (== 1 * 4 ==
-        // 4 bytes), and the constructor's count is 257 -- the same 257
-        // literal appears on both sides, but only after passing through a
-        // narrowing, value-changing (byte) conversion on the size side.
-        // Unconvert must not strip that conversion when comparing the
-        // multiply's operand to count: doing so would treat 4 reserved bytes
-        // as proof of 257 int elements (1028 bytes), reserving far more
-        // memory than the original stackalloc.
-        var narrowedLiteral = new IrConvert(Byte, isChecked: false, isUnsigned: false, new Constant(257, Int32));
-        var size = new Binary(BinaryKind.Multiply, isChecked: false, isUnsigned: false, narrowedLiteral, new SizeOf(Int32));
-        var function = Build(StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new StackAllocate(size), count: 257));
+        // The byte size is `unchecked((byte)257)` (== 1), and the
+        // constructor's count is 257 against a 1-byte element -- the same
+        // 257 literal appears on both sides, but only after passing through
+        // a narrowing, value-changing (byte) conversion on the size side.
+        // Unconvert must not strip that conversion when reducing the size to
+        // a literal constant: doing so would treat the byte 1 as proof of
+        // 257 elements, reserving 257x more memory than the original
+        // stackalloc actually allocated.
+        var narrowedSize = new IrConvert(Byte, isChecked: false, isUnsigned: false, new Constant(257, Int32));
+        var function = Build(StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new StackAllocate(narrowedSize), count: 257, elementType: Byte));
 
         new StackAllocSpanPass().Run(function, PassContext.None);
 

--- a/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
@@ -136,6 +136,214 @@ public class StackAllocSpanPassTests
         function.CheckInvariant();
     }
 
+    // #2907: StackAllocInitializerPass (#2869) recovers an initializer into a
+    // stackalloc-through-slot shape (`slot = stackalloc T[n] {...}`) but only
+    // replaces the slot's stored value -- never the later Span constructor call
+    // that reads the slot. These tests exercise this pass's slot-indirection
+    // resolution, which raises through that slot when (and only when) it is
+    // exclusively owned by the one store/load pair reaching the constructor.
+
+    [Fact]
+    public void OwnedSlotWithInitializer_Raises()
+    {
+        var elements = new IrExpression[] { new Constant(1, Int32), new Constant(2, Int32), new Constant(3, Int32) };
+        var stackAllocArray = new StackAllocArray(Int32, new Constant(3, Int32), TypeRef.Pointer(Int32), elements);
+        var store = new StoreStackSlot(0, stackAllocArray);
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 3);
+
+        var function = BuildSlot(store, newObject);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var raised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.True(raised.HasInitializer);
+        Assert.Equal(3, raised.Elements.Length);
+        Assert.Equal("int", raised.ElementType.ToDisplayString());
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
+        Assert.Empty(function.Descendants.OfType<LoadStackSlot>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void OwnedSlotWithoutInitializer_Raises()
+    {
+        var store = new StoreStackSlot(0, new StackAllocate(new Constant(4, Int32)));
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1);
+
+        var function = BuildSlot(store, newObject);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var raised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.False(raised.HasInitializer);
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void OwnedSlotThroughConvertWrappedLoad_Raises()
+    {
+        var elements = new IrExpression[] { new Constant(9, Int32) };
+        var stackAllocArray = new StackAllocArray(Int32, new Constant(1, Int32), TypeRef.Pointer(Int32), elements);
+        var store = new StoreStackSlot(0, stackAllocArray);
+        var wrappedLoad = new IrConvert(VoidPointer, isChecked: false, isUnsigned: false, new LoadStackSlot(0, TypeRef.Pointer(Int32)));
+        var newObject = StackAllocSpanConstructorWithPointer(TypeRef.CoreLib("System", "Span`1"), wrappedLoad, count: 1);
+
+        var function = BuildSlot(store, newObject);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var raised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.True(raised.HasInitializer);
+        Assert.Empty(function.Descendants.OfType<IrConvert>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotWithSecondLoad_DoesNotRaise()
+    {
+        var stackAllocArray = new StackAllocArray(Int32, new Constant(1, Int32), TypeRef.Pointer(Int32), [new Constant(1, Int32)]);
+        var store = new StoreStackSlot(0, stackAllocArray);
+        var extraLoad = new StoreLocal(1, VoidPointer, new LoadStackSlot(0, VoidPointer));
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1);
+
+        var function = BuildSlot(store, extraLoad, newObject);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var construction = Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Same(newObject, construction);
+        Assert.Single(function.Descendants.OfType<StackAllocArray>()); // still the store's un-raised value
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotWithSecondStore_DoesNotRaise()
+    {
+        var stackAllocArray = new StackAllocArray(Int32, new Constant(1, Int32), TypeRef.Pointer(Int32), [new Constant(1, Int32)]);
+        var store = new StoreStackSlot(0, stackAllocArray);
+        var secondStore = new StoreStackSlot(0, new StackAllocate(new Constant(4, Int32)));
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1);
+
+        var function = BuildSlot(store, secondStore, newObject);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var construction = Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Same(newObject, construction);
+        Assert.Single(function.Descendants.OfType<StackAllocArray>()); // still the store's un-raised value
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotLoadBeforeStore_DoesNotRaise()
+    {
+        // Same block, but the load's statement sits ahead of the store -- the
+        // slot's definition can't have reached this use.
+        var stackAllocArray = new StackAllocArray(Int32, new Constant(1, Int32), TypeRef.Pointer(Int32), [new Constant(1, Int32)]);
+        var store = new StoreStackSlot(0, stackAllocArray);
+        var span = TypeRef.GenericInstance(TypeRef.CoreLib("System", "Span`1"), [Int32]);
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1);
+
+        var block = new Block(0);
+        block.Add(new StoreLocal(1, span, newObject));
+        block.Add(store);
+        block.Add(new Return(null));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var construction = Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Same(newObject, construction);
+        Assert.Single(function.Descendants.OfType<StackAllocArray>()); // still the store's un-raised value
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotStoreInDifferentBlock_DoesNotRaise()
+    {
+        var stackAllocArray = new StackAllocArray(Int32, new Constant(1, Int32), TypeRef.Pointer(Int32), [new Constant(1, Int32)]);
+        var store = new StoreStackSlot(0, stackAllocArray);
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1);
+
+        var block0 = new Block(0);
+        block0.Add(store);
+        block0.Add(new Branch(1));
+        var block1 = new Block(1);
+        block1.Add(new Return(newObject));
+
+        var body = new BlockContainer();
+        body.Add(block0);
+        body.Add(block1);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(newObject.ResultType ?? Void, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var construction = Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Same(newObject, construction);
+        Assert.Single(function.Descendants.OfType<StackAllocArray>()); // still the store's un-raised value
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotThroughNonStackallocStore_DoesNotRaise()
+    {
+        var store = new StoreStackSlot(0, new Call(new MethodRef(Holder, "GetPointer", VoidPointer, [], HasThis: false), isVirtual: false, []));
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1);
+
+        var function = BuildSlot(store, newObject);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<StackAllocArray>());
+        function.CheckInvariant();
+    }
+
+    static NewObject StackAllocSpanConstructor(TypeRef spanDefinition, IrExpression pointer, int count)
+        => StackAllocSpanConstructorWithPointer(spanDefinition, pointer, count);
+
+    static NewObject StackAllocSpanConstructorWithPointer(TypeRef spanDefinition, IrExpression pointer, int count)
+    {
+        var span = TypeRef.GenericInstance(spanDefinition, [Int32]);
+        var ctor = new MethodRef(span, ".ctor", Void, [VoidPointer, Int32], HasThis: true);
+        return new NewObject(ctor, [pointer, new Constant(count, Int32)]);
+    }
+
+    static IrFunction BuildSlot(params IrNode[] leadingStatements)
+    {
+        var block = new Block(0);
+        foreach (var statement in leadingStatements[..^1])
+            block.Add(statement);
+        var finalUsage = leadingStatements[^1];
+        var returnValue = finalUsage as IrExpression ?? throw new System.InvalidOperationException("Final statement must be the Span constructor.");
+        block.Add(new Return(returnValue));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(returnValue.ResultType ?? Void, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
     static NewObject StackAllocSpanConstructor(TypeRef spanDefinition, IrExpression pointer)
     {
         var span = TypeRef.GenericInstance(spanDefinition, [Int32]);

--- a/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
@@ -592,6 +592,43 @@ public class StackAllocSpanPassTests
     }
 
     [Fact]
+    public void SlotWithInstanceFieldStore_DoesNotRaise()
+    {
+        // An instance field store evaluates its receiver (Instance) before its
+        // Value -- unlike StoreLocal/StoreStackSlot/StoreArgument/a static
+        // StoreField, which have no other evaluated operand. Even though
+        // Value is exactly the constructor call, the receiver's evaluation
+        // (here GetTarget()) would move to run before the allocation instead
+        // of after it.
+        var store = new StoreStackSlot(0, new StackAllocate(new Constant(4, Int32)));
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1);
+        var getTarget = new Call(new MethodRef(Holder, "GetTarget", Holder, [], HasThis: false), isVirtual: false, []);
+        var field = new FieldRef(Holder, "Value", newObject.ResultType!);
+        var storeField = new StoreField(field, getTarget, newObject);
+
+        var block = new Block(0);
+        block.Add(store);
+        block.Add(storeField);
+        block.Add(new Return(new Constant(0, Int32)));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Int32, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var construction = Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Same(newObject, construction);
+        Assert.Single(function.Descendants.OfType<StackAllocate>()); // still the store's un-raised value
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void SlotWithUninitializedArrayDynamicUnrelatedCountMismatch_DoesNotRaise()
     {
         // Neither the source's own (dynamic) Count nor the constructor's
@@ -612,6 +649,33 @@ public class StackAllocSpanPassTests
         var unraised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
         Assert.False(unraised.HasInitializer); // still the store's un-raised value
         function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotWithUninitializedArrayCountDifferingByConvertUnsigned_DoesNotRaise()
+    {
+        // The source's dynamic Count and the constructor's length argument
+        // are both `(int)(double)n`, but one conversion chain is unsigned
+        // (conv.r.un) and the other is signed -- these produce different
+        // results for the same bit pattern (e.g. 0x80000000), so they must
+        // not be treated as the same quantity merely because their shapes and
+        // target types otherwise match.
+        var doubleType = TypeRef.CoreLib("System", "Double");
+        var sourceCount = new IrConvert(Int32, isChecked: false, isUnsigned: false, new IrConvert(doubleType, isChecked: false, isUnsigned: true, new LoadLocal(0, Int32)));
+        var ctorCount = new IrConvert(Int32, isChecked: false, isUnsigned: false, new IrConvert(doubleType, isChecked: false, isUnsigned: false, new LoadLocal(0, Int32)));
+        var conversionStackAllocArray = new StackAllocArray(Int32, sourceCount, TypeRef.Pointer(Int32));
+        var conversionStore = new StoreStackSlot(0, conversionStackAllocArray);
+        var conversionNewObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), ctorCount);
+
+        var conversionFunction = BuildSlot(conversionStore, conversionNewObject);
+
+        new StackAllocSpanPass().Run(conversionFunction, PassContext.None);
+
+        var conversionConstruction = Assert.Single(conversionFunction.Descendants.OfType<NewObject>());
+        Assert.Same(conversionNewObject, conversionConstruction);
+        var conversionUnraised = Assert.Single(conversionFunction.Descendants.OfType<StackAllocArray>());
+        Assert.False(conversionUnraised.HasInitializer); // still the store's un-raised value
+        conversionFunction.CheckInvariant();
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
@@ -155,23 +155,19 @@ public class StackAllocSpanPassTests
     }
 
     [Fact]
-    public void DirectPointerWithDynamicPureSize_DoesNotRaise()
+    public void DirectPointerWithUncheckedDynamicSize_DoesNotRaise()
     {
-        // A dynamic-but-pure size (a local read, or arithmetic over one -- the
-        // `stackalloc byte[n]` shape) is deliberately declined on this direct
-        // (non-initializer) StackAllocate path: IsProvenByteSize only accepts
-        // a literal-constant size/count pair. This is a scoped limitation,
-        // not an oversight -- a real compiled `stackalloc int[n]` (no
-        // initializer) emits a `checked unsigned` multiply over an
-        // int-to-nuint convert chain that isn't a safe-to-strip implicit C#
-        // conversion, and for primitive element types a folded literal
-        // Constant element size rather than a symbolic SizeOf node; recognizing
-        // that real shape soundly needs compiled-fixture validation this pass
-        // does not yet have, so it declines conservatively instead of raising
-        // on an unproven synthetic shape (see issue tracking this follow-up).
+        // An unchecked, signed dynamic size (n * sizeof(T) with no checked
+        // arithmetic) is declined: it is not the shape the real compiler
+        // emits (see DirectPointerWithCheckedNuintByteSize_Raises below for
+        // that), and accepting an arbitrary unchecked multiply here would
+        // require re-deriving -- not just proving equal to -- the
+        // constructor's own count, since IsSideEffectFree alone doesn't
+        // establish the two expressions describe the same allocation.
         // The size's own `n` and the constructor's count argument are the
         // same LoadLocal(0), which would have matched a canonical
-        // `count * sizeof(element)` byte-size shape if one were recognized.
+        // `count * sizeof(element)` byte-size shape if one were recognized
+        // for this (unchecked) arithmetic kind.
         var size = new Binary(BinaryKind.Multiply, isChecked: false, isUnsigned: false, new LoadLocal(0, Int32), new SizeOf(Int32));
         var function = Build(StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new StackAllocate(size), new LoadLocal(0, Int32)));
 
@@ -179,6 +175,33 @@ public class StackAllocSpanPassTests
 
         Assert.Single(function.Descendants.OfType<NewObject>());
         Assert.Empty(function.Descendants.OfType<StackAllocArray>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void DirectPointerWithCheckedNuintByteSize_Raises()
+    {
+        // The real compiler shape for a dynamic `stackalloc T[n]` (confirmed
+        // against this repo's own compiled fixtures): a checked, unsigned
+        // multiply of the count widened int-to-nuint and the element's byte
+        // size (folded to a literal Constant for primitive element types).
+        // IsProvenByteSize proves this checked multiply computes exactly
+        // count * sizeof(element), which is what makes it sound to discard
+        // even though a checked multiply is not generically IsSideEffectFree
+        // (its only possible effect -- an OverflowException -- is the same
+        // one the raised stackalloc T[n] form's own byte-size computation
+        // reproduces).
+        var count = new LoadLocal(0, Int32);
+        var nuintConvert = new IrConvert(TypeRef.CoreLib("System", "UIntPtr"), isChecked: false, isUnsigned: false, count);
+        var size = new Binary(BinaryKind.Multiply, isChecked: true, isUnsigned: true, nuintConvert, new Constant(4, Int32));
+        var function = Build(StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new StackAllocate(size), new LoadLocal(0, Int32)));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<StackAllocate>());
+        var raised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.False(raised.HasInitializer);
         function.CheckInvariant();
     }
 
@@ -711,6 +734,79 @@ public class StackAllocSpanPassTests
         var construction = Assert.Single(function.Descendants.OfType<NewObject>());
         Assert.Same(newObject, construction);
         Assert.Single(function.Descendants.OfType<StackAllocate>()); // still the store's un-raised value
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotWithLoadAsSoleCallArgument_Raises()
+    {
+        // The common real-world shape: the constructor call is passed
+        // directly as a call's only argument -- Consume(new Span<int>(ptr,
+        // n)) -- rather than being the statement's entire expression. Nothing
+        // evaluates before it (no receiver, no earlier argument), so moving
+        // the allocation to sit at the constructor's own position changes
+        // nothing observable. This must raise even though the statement's
+        // held expression is the enclosing Consume(...) call, not the
+        // constructor call itself.
+        var store = new StoreStackSlot(0, new StackAllocate(new Constant(4, Int32)));
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1);
+        var consume = new Call(new MethodRef(Holder, "Consume", Void, [newObject.ResultType!], HasThis: false), isVirtual: false, [newObject]);
+        var expressionStatement = new ExpressionStatement(consume);
+
+        var block = new Block(0);
+        block.Add(store);
+        block.Add(expressionStatement);
+        block.Add(new Return(new Constant(0, Int32)));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Int32, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<StackAllocate>());
+        var raised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Same(consume, raised.Parent);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotWithLoadNestedAsEarlierSideEffectFreeCallArgument_Raises()
+    {
+        // An earlier argument of the same enclosing Call is allowed when it
+        // is provably side-effect-free (here, a bare local load): nothing
+        // effectful can be reordered past the moved allocation.
+        var store = new StoreStackSlot(0, new StackAllocate(new Constant(4, Int32)));
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1);
+        var earlier = new LoadLocal(0, Int32);
+        var consume = new Call(new MethodRef(Holder, "Consume", Void, [Int32, newObject.ResultType!], HasThis: false), isVirtual: false, [earlier, newObject]);
+        var expressionStatement = new ExpressionStatement(consume);
+
+        var block = new Block(0);
+        block.Add(store);
+        block.Add(expressionStatement);
+        block.Add(new Return(new Constant(0, Int32)));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Int32, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        var raised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Same(consume, raised.Parent);
         function.CheckInvariant();
     }
 

--- a/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
@@ -301,6 +301,53 @@ public class StackAllocSpanPassTests
     }
 
     [Fact]
+    public void SlotWithEffectfulSize_DoesNotRaise()
+    {
+        // The store's own byte-size expression is a call, not a constant --
+        // discarding it (as the raise would, since it uses the constructor's
+        // length argument instead) would silently erase the call's side effect
+        // and reorder it past whatever follows the store.
+        var sizeEffect = new Call(new MethodRef(Holder, "SizeEffect", Int32, [], HasThis: false), isVirtual: false, []);
+        var store = new StoreStackSlot(0, new StackAllocate(sizeEffect));
+        var marker = new Call(new MethodRef(Holder, "Marker", Void, [], HasThis: false), isVirtual: false, []);
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1);
+
+        var function = BuildSlot(store, marker, newObject);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<StackAllocArray>());
+        Assert.Single(function.Descendants.OfType<Call>(), c => c.Callee.Name == "SizeEffect"); // side effect preserved
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotWithInitializerCountMismatch_DoesNotRaise()
+    {
+        // The store's recovered initializer has 3 elements but the
+        // constructor's own length argument says 1 -- these are two
+        // independent expressions in the tree (unlike the direct-pointer case,
+        // where a single stackalloc node feeds both), so nothing else proves
+        // they describe the same span. Raising would silently change the
+        // observable Span.Length from 1 to 3.
+        var elements = new IrExpression[] { new Constant(1, Int32), new Constant(2, Int32), new Constant(3, Int32) };
+        var stackAllocArray = new StackAllocArray(Int32, new Constant(3, Int32), TypeRef.Pointer(Int32), elements);
+        var store = new StoreStackSlot(0, stackAllocArray);
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1);
+
+        var function = BuildSlot(store, newObject);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var construction = Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Same(newObject, construction);
+        var unraised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Equal(3, unraised.Elements.Length); // still the store's un-raised value
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void SlotThroughNonStackallocStore_DoesNotRaise()
     {
         var store = new StoreStackSlot(0, new Call(new MethodRef(Holder, "GetPointer", VoidPointer, [], HasThis: false), isVirtual: false, []));

--- a/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
@@ -555,6 +555,137 @@ public class StackAllocSpanPassTests
     }
 
     [Fact]
+    public void SlotWithLoadNestedAsLaterCallArgument_DoesNotRaise()
+    {
+        // The constructor call is only an argument of an enclosing Call, not
+        // the statement's entire expression -- an earlier argument to that
+        // same Call (Marker()) evaluates before it. Even though the statement
+        // itself is a permitted, single-evaluation ExpressionStatement and
+        // adjacent to the store, this must not raise: doing so would move the
+        // allocation to run after Marker() instead of before it.
+        var store = new StoreStackSlot(0, new StackAllocate(new Constant(4, Int32)));
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1);
+        var marker = new Call(new MethodRef(Holder, "Marker", Void, [], HasThis: false), isVirtual: false, []);
+        var consume = new Call(new MethodRef(Holder, "Consume", Void, [Void, newObject.ResultType!], HasThis: false), isVirtual: false, [marker, newObject]);
+        var expressionStatement = new ExpressionStatement(consume);
+
+        var block = new Block(0);
+        block.Add(store);
+        block.Add(expressionStatement);
+        block.Add(new Return(new Constant(0, Int32)));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Int32, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var construction = Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Same(newObject, construction);
+        Assert.Single(function.Descendants.OfType<StackAllocate>()); // still the store's un-raised value
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotWithUninitializedArrayDynamicUnrelatedCountMismatch_DoesNotRaise()
+    {
+        // Neither the source's own (dynamic) Count nor the constructor's
+        // length argument is a literal constant, so value equality can't be
+        // checked -- but they are two different, unrelated locals, not the
+        // same expression. Raising would silently use the wrong count as the
+        // observable Span.Length/allocation size.
+        var stackAllocArray = new StackAllocArray(Int32, new LoadLocal(0, Int32), TypeRef.Pointer(Int32));
+        var store = new StoreStackSlot(0, stackAllocArray);
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), new LoadLocal(1, Int32));
+
+        var function = BuildSlot(store, newObject);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var construction = Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Same(newObject, construction);
+        var unraised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.False(unraised.HasInitializer); // still the store's un-raised value
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotWithLoadInsideStoreStackSlotStatement_Raises()
+    {
+        // StoreStackSlot is itself a single-evaluation leaf statement (the
+        // compiler commonly stores a constructed Span into another slot when
+        // preparing a method argument) -- it must be accepted as "the
+        // adjacent statement," not just ExpressionStatement/Return/Throw/
+        // StoreLocal.
+        var store = new StoreStackSlot(0, new StackAllocate(new Constant(4, Int32)));
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1);
+        var argumentSlotStore = new StoreStackSlot(1, newObject);
+
+        var block = new Block(0);
+        block.Add(store);
+        block.Add(argumentSlotStore);
+        block.Add(new Return(new LoadStackSlot(1, newObject.ResultType!)));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(newObject.ResultType!, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotWithLoadInsideConditionalBranch_DoesNotRaise()
+    {
+        // The load sits inside the WhenTrue arm of a Conditional (ternary)
+        // nested in an otherwise-linear StoreLocal statement -- the statement
+        // itself is adjacent and a permitted type, but the load is only
+        // conditionally evaluated (when the ternary's condition is true), so
+        // moving an unconditional allocation there would make it conditional.
+        var store = new StoreStackSlot(0, new StackAllocate(new Constant(4, Int32)));
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1);
+        var conditional = new Conditional(
+            new Constant(false, TypeRef.CoreLib("System", "Boolean")),
+            newObject,
+            new DefaultValue(newObject.ResultType!));
+        var storeLocal = new StoreLocal(0, newObject.ResultType!, conditional);
+
+        var block = new Block(0);
+        block.Add(store);
+        block.Add(storeLocal);
+        block.Add(new Return(new LoadLocal(0, newObject.ResultType!)));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(newObject.ResultType!, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var construction = Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Same(newObject, construction);
+        Assert.Single(function.Descendants.OfType<StackAllocate>()); // still the store's un-raised value
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void SlotThroughNonStackallocStore_DoesNotRaise()
     {
         var store = new StoreStackSlot(0, new Call(new MethodRef(Holder, "GetPointer", VoidPointer, [], HasThis: false), isVirtual: false, []));

--- a/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
@@ -155,6 +155,25 @@ public class StackAllocSpanPassTests
     }
 
     [Fact]
+    public void DirectPointerWithDynamicPureSize_Raises()
+    {
+        // A dynamic-but-pure size (a local read, or arithmetic over one -- the
+        // common `stackalloc byte[n]` shape, e.g. n * sizeof(T) after
+        // StackAllocInitializerPass/import) must still raise: requiring a
+        // literal Constant here would reject this very common real-world
+        // pattern and reintroduce the original invalid-Full CS8346 shape this
+        // pass exists to fix.
+        var size = new Binary(BinaryKind.Multiply, isChecked: false, isUnsigned: false, new LoadLocal(0, Int32), new SizeOf(Int32));
+        var function = Build(StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new StackAllocate(size)));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void DirectPointerWithInitializerCountMismatch_DoesNotRaise()
     {
         // Same defect as the slot-indirection case's
@@ -462,6 +481,65 @@ public class StackAllocSpanPassTests
         // byte-typed initializer.
         var elements = new IrExpression[] { new Constant(300, Int32) };
         var stackAllocArray = new StackAllocArray(Int32, new Constant(1, Int32), TypeRef.Pointer(Int32), elements);
+        var store = new StoreStackSlot(0, stackAllocArray);
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1, elementType: Byte);
+
+        var function = BuildSlot(store, newObject);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var construction = Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Same(newObject, construction);
+        var unraised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Equal("int", unraised.ElementType.ToDisplayString()); // still the store's un-raised value
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotWithLoadInsideLoopCondition_DoesNotRaise()
+    {
+        // GetStatement's walk-up-to-the-enclosing-Block-child logic returns
+        // the WhileLoop itself as "the statement" when the load sits inside
+        // its condition -- but a loop condition is evaluated on every
+        // iteration (and possibly zero times), not exactly once like an
+        // ordinary adjacent statement. Raising here would move a one-time
+        // allocation into code that runs a different number of times.
+        var store = new StoreStackSlot(0, new StackAllocate(new Constant(4, Int32)));
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1);
+        var condition = new IsInstance(Holder, newObject); // load embedded in a loop condition expression
+        var loop = new WhileLoop(condition, new Block(0));
+
+        var block = new Block(0);
+        block.Add(store);
+        block.Add(loop);
+        block.Add(new Return(new Constant(0, Int32)));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Int32, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var construction = Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Same(newObject, construction);
+        Assert.Single(function.Descendants.OfType<StackAllocate>()); // still the store's un-raised value
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotWithUninitializedArrayElementTypeMismatch_DoesNotRaise()
+    {
+        // An uninitialized StackAllocArray (no recovered elements, but still
+        // carrying its own ElementType and Count) must have its element type
+        // checked too -- not just the HasInitializer case -- or adversarial IR
+        // could silently reinterpret e.g. a 100-element int allocation as a
+        // 1-element byte allocation.
+        var stackAllocArray = new StackAllocArray(Int32, new Constant(100, Int32), TypeRef.Pointer(Int32));
         var store = new StoreStackSlot(0, stackAllocArray);
         var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1, elementType: Byte);
 

--- a/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
@@ -213,6 +213,46 @@ public class StackAllocSpanPassTests
     }
 
     [Fact]
+    public void DirectPointerWithByteSizeCountOverflow_DoesNotRaise()
+    {
+        // A 4-byte StackAllocate against a huge int Span count
+        // (1_073_741_825) would satisfy `sizeValue == countValue * elementSize`
+        // if that product were computed in int-width arithmetic (it wraps
+        // around to 4) -- the product must be checked/widened so a wrapped
+        // false match can never pass as proof.
+        const int hugeCount = 1_073_741_825; // 1_073_741_825 * 4 == 4_294_967_300, which wraps to 4 in Int32 arithmetic
+        var function = Build(StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new StackAllocate(new Constant(4, Int32)), count: hugeCount));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<StackAllocArray>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void DirectPointerWithNarrowingConvertInByteSize_DoesNotRaise()
+    {
+        // The byte size is `unchecked((byte)257) * sizeof(int)` (== 1 * 4 ==
+        // 4 bytes), and the constructor's count is 257 -- the same 257
+        // literal appears on both sides, but only after passing through a
+        // narrowing, value-changing (byte) conversion on the size side.
+        // Unconvert must not strip that conversion when comparing the
+        // multiply's operand to count: doing so would treat 4 reserved bytes
+        // as proof of 257 int elements (1028 bytes), reserving far more
+        // memory than the original stackalloc.
+        var narrowedLiteral = new IrConvert(Byte, isChecked: false, isUnsigned: false, new Constant(257, Int32));
+        var size = new Binary(BinaryKind.Multiply, isChecked: false, isUnsigned: false, narrowedLiteral, new SizeOf(Int32));
+        var function = Build(StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new StackAllocate(size), count: 257));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<StackAllocArray>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void DirectPointerWithInitializerCountMismatch_DoesNotRaise()
     {
         // Same defect as the slot-indirection case's

--- a/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
@@ -569,8 +569,59 @@ public class StackAllocSpanPassTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void DirectPointerWithEffectfulCount_DoesNotRaise()
+    {
+        // stackalloc T[n] evaluates n before allocating, but the constructor's
+        // own length argument here originally evaluated after the pointer
+        // argument (i.e. after the localloc). Raising always inverts that
+        // order, so an effectful count -- even with an otherwise pure/constant
+        // stackalloc size -- must not be raised: it would silently reorder a
+        // side effect (and any StackOverflowException the allocation could
+        // throw) to run before the allocation instead of after it.
+        var countEffect = new Call(new MethodRef(Holder, "CountEffect", Int32, [], HasThis: false), isVirtual: false, []);
+        var function = Build(StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new StackAllocate(new Constant(4, Int32)), countEffect));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<StackAllocArray>());
+        Assert.Single(function.Descendants.OfType<Call>(), c => c.Callee.Name == "CountEffect");
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotWithUninitializedArrayCountMismatch_DoesNotRaise()
+    {
+        // An uninitialized StackAllocArray's own Count is already an element
+        // count (unlike StackAllocate.Size, which is bytes and not cleanly
+        // comparable at this IR layer) -- when both it and the constructor's
+        // length argument are literal constants, they must agree, or raising
+        // would silently shrink/grow the allocation.
+        var stackAllocArray = new StackAllocArray(Int32, new Constant(100, Int32), TypeRef.Pointer(Int32));
+        var store = new StoreStackSlot(0, stackAllocArray);
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1);
+
+        var function = BuildSlot(store, newObject);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var construction = Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Same(newObject, construction);
+        var unraised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.False(unraised.HasInitializer); // still the store's un-raised value
+        function.CheckInvariant();
+    }
+
     static NewObject StackAllocSpanConstructor(TypeRef spanDefinition, IrExpression pointer, int count, TypeRef? elementType = null)
         => StackAllocSpanConstructorWithPointer(spanDefinition, pointer, count, elementType);
+
+    static NewObject StackAllocSpanConstructor(TypeRef spanDefinition, IrExpression pointer, IrExpression count)
+    {
+        var span = TypeRef.GenericInstance(spanDefinition, [Int32]);
+        var ctor = new MethodRef(span, ".ctor", Void, [VoidPointer, Int32], HasThis: true);
+        return new NewObject(ctor, [pointer, count]);
+    }
 
     static NewObject StackAllocSpanConstructorWithPointer(TypeRef spanDefinition, IrExpression pointer, int count, TypeRef? elementType = null)
     {

--- a/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
@@ -811,6 +811,78 @@ public class StackAllocSpanPassTests
     }
 
     [Fact]
+    public void SlotWithLoadAsSoleConstructorArgument_Raises()
+    {
+        // The same common real-world shape as SlotWithLoadAsSoleCallArgument_Raises,
+        // but the enclosing expression is a constructor (NewObject) rather than
+        // a plain method Call -- new Consumer(new Span<int>(ptr, n)). Constructor
+        // arguments evaluate left-to-right exactly like a Call's, so the same
+        // "nothing evaluates before it" proof applies and this must raise too.
+        var store = new StoreStackSlot(0, new StackAllocate(new Constant(4, Int32)));
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1);
+        var consumerType = TypeRef.Definition("synthetic", "", "Consumer");
+        var construct = new NewObject(new MethodRef(consumerType, ".ctor", Void, [newObject.ResultType!], HasThis: true), [newObject]);
+        var expressionStatement = new ExpressionStatement(construct);
+
+        var block = new Block(0);
+        block.Add(store);
+        block.Add(expressionStatement);
+        block.Add(new Return(new Constant(0, Int32)));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Int32, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<StackAllocate>());
+        var raised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Same(construct, raised.Parent);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotWithLoadNestedAsLaterConstructorArgument_DoesNotRaise()
+    {
+        // The constructor-argument counterpart of SlotWithLoadNestedAsLaterCallArgument_DoesNotRaise:
+        // an earlier argument to the same enclosing NewObject (Marker()) evaluates
+        // before the Span construction, so raising would move the allocation to
+        // run after Marker() instead of before it.
+        var store = new StoreStackSlot(0, new StackAllocate(new Constant(4, Int32)));
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1);
+        var marker = new Call(new MethodRef(Holder, "Marker", Void, [], HasThis: false), isVirtual: false, []);
+        var consumerType = TypeRef.Definition("synthetic", "", "Consumer");
+        var construct = new NewObject(new MethodRef(consumerType, ".ctor", Void, [Void, newObject.ResultType!], HasThis: true), [marker, newObject]);
+        var expressionStatement = new ExpressionStatement(construct);
+
+        var block = new Block(0);
+        block.Add(store);
+        block.Add(expressionStatement);
+        block.Add(new Return(new Constant(0, Int32)));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Int32, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var construction = Assert.Single(function.Descendants.OfType<NewObject>(), n => n == newObject);
+        Assert.Same(newObject, construction);
+        Assert.Single(function.Descendants.OfType<StackAllocate>()); // still the store's un-raised value
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void SlotWithInstanceFieldStore_DoesNotRaise()
     {
         // An instance field store evaluates its receiver (Instance) before its

--- a/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
@@ -162,14 +162,53 @@ public class StackAllocSpanPassTests
         // StackAllocInitializerPass/import) must still raise: requiring a
         // literal Constant here would reject this very common real-world
         // pattern and reintroduce the original invalid-Full CS8346 shape this
-        // pass exists to fix.
+        // pass exists to fix. The size's own `n` and the constructor's count
+        // argument are the same LoadLocal(0), matching the canonical
+        // `count * sizeof(element)` byte-size shape the compiler emits.
         var size = new Binary(BinaryKind.Multiply, isChecked: false, isUnsigned: false, new LoadLocal(0, Int32), new SizeOf(Int32));
-        var function = Build(StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new StackAllocate(size)));
+        var function = Build(StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new StackAllocate(size), new LoadLocal(0, Int32)));
 
         new StackAllocSpanPass().Run(function, PassContext.None);
 
         Assert.Single(function.Descendants.OfType<StackAllocArray>());
         Assert.Empty(function.Descendants.OfType<NewObject>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void DirectPointerWithByteSizeCountMismatch_DoesNotRaise()
+    {
+        // The raw StackAllocate reserves 4 bytes, but the constructor claims
+        // 2 elements of a 4-byte element type (8 bytes) -- neither the
+        // canonical count*sizeof(element) shape nor a literal-constant match
+        // holds, so this must not raise: doing so would reserve half as many
+        // bytes as the constructor's own Span.Length implies.
+        var function = Build(StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new StackAllocate(new Constant(4, Int32)), count: 2));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<StackAllocArray>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotWithByteSizeCountMismatch_DoesNotRaise()
+    {
+        // Same defect as DirectPointerWithByteSizeCountMismatch, but through
+        // the slot-indirection path: the store's StackAllocate reserves 4
+        // bytes, the constructor claims 2 int elements (8 bytes) through the
+        // slot -- must not raise.
+        var store = new StoreStackSlot(0, new StackAllocate(new Constant(4, Int32)));
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 2);
+
+        var function = BuildSlot(store, newObject);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var construction = Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Same(newObject, construction);
+        Assert.Single(function.Descendants.OfType<StackAllocate>()); // still the store's un-raised value
         function.CheckInvariant();
     }
 

--- a/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
@@ -136,6 +136,62 @@ public class StackAllocSpanPassTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void DirectPointerWithEffectfulSize_DoesNotRaise()
+    {
+        // Same defect as the slot-indirection case's SlotWithEffectfulSize --
+        // the direct pointer's own size expression is discarded and replaced
+        // by the constructor's count argument, so a non-constant/effectful
+        // size must not be silently dropped here either.
+        var sizeEffect = new Call(new MethodRef(Holder, "SizeEffect", Int32, [], HasThis: false), isVirtual: false, []);
+        var function = Build(StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new StackAllocate(sizeEffect)));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<StackAllocArray>());
+        Assert.Single(function.Descendants.OfType<Call>(), c => c.Callee.Name == "SizeEffect"); // side effect preserved
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void DirectPointerWithInitializerCountMismatch_DoesNotRaise()
+    {
+        // Same defect as the slot-indirection case's
+        // SlotWithInitializerCountMismatch -- the pointer's own initializer
+        // element count and the constructor's independent length argument
+        // must agree before raising.
+        var elements = new IrExpression[] { new Constant(1, Int32), new Constant(2, Int32), new Constant(3, Int32) };
+        var stackAllocArray = new StackAllocArray(Int32, new Constant(3, Int32), TypeRef.Pointer(Int32), elements);
+        var function = Build(StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), stackAllocArray, count: 1));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        var unraised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Equal(3, unraised.Elements.Length); // still the pointer's un-raised value
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void DirectPointerWithElementTypeMismatch_DoesNotRaise()
+    {
+        // Same defect as the slot-indirection case's
+        // SlotWithElementTypeMismatch -- the pointer's own initializer element
+        // type and the constructor's Span<T> type argument must agree before
+        // raising.
+        var elements = new IrExpression[] { new Constant(300, Int32) };
+        var stackAllocArray = new StackAllocArray(Int32, new Constant(1, Int32), TypeRef.Pointer(Int32), elements);
+        var function = Build(StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), stackAllocArray, count: 1, elementType: Byte));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        var unraised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Equal("int", unraised.ElementType.ToDisplayString()); // still the pointer's un-raised value
+        function.CheckInvariant();
+    }
+
     // #2907: StackAllocInitializerPass (#2869) recovers an initializer into a
     // stackalloc-through-slot shape (`slot = stackalloc T[n] {...}`) but only
     // replaces the slot's stored value -- never the later Span constructor call
@@ -348,6 +404,79 @@ public class StackAllocSpanPassTests
     }
 
     [Fact]
+    public void SlotWithNonAdjacentStatement_DoesNotRaise()
+    {
+        // Even with a constant size, a statement between the store and the
+        // load's statement could itself throw, run out of stack, or otherwise
+        // observe or alter state before the allocation would occur -- moving
+        // the allocation to the load's site changes when (and whether) it
+        // executes relative to that statement. Requiring the load's statement
+        // to be the store's immediate successor rules this out entirely.
+        var store = new StoreStackSlot(0, new StackAllocate(new Constant(4, Int32)));
+        var marker = new Call(new MethodRef(Holder, "Marker", Void, [], HasThis: false), isVirtual: false, []);
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1);
+
+        var function = BuildSlot(store, marker, newObject);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var construction = Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Same(newObject, construction);
+        Assert.Single(function.Descendants.OfType<StackAllocate>()); // still the store's un-raised value
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotWithConvertWrappedInitializerCountMismatch_DoesNotRaise()
+    {
+        // Same defect as SlotWithInitializerCountMismatch_DoesNotRaise, but the
+        // store's value is Convert-wrapped: the count/element-type checks must
+        // see through the wrapper to the underlying StackAllocArray, not
+        // silently skip validation because the wrapper doesn't itself match
+        // the `is StackAllocArray` pattern.
+        var elements = new IrExpression[] { new Constant(1, Int32), new Constant(2, Int32), new Constant(3, Int32) };
+        var stackAllocArray = new StackAllocArray(Int32, new Constant(3, Int32), TypeRef.Pointer(Int32), elements);
+        var wrapped = new IrConvert(VoidPointer, isChecked: false, isUnsigned: false, stackAllocArray);
+        var store = new StoreStackSlot(0, wrapped);
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1);
+
+        var function = BuildSlot(store, newObject);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var construction = Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Same(newObject, construction);
+        var unraised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Equal(3, unraised.Elements.Length); // still the store's un-raised value
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotWithElementTypeMismatch_DoesNotRaise()
+    {
+        // The store's recovered initializer is int[], but the constructor's
+        // Span<T> type argument is byte -- these are independent expressions
+        // that could disagree in adversarial IR (unlike the direct-pointer
+        // case, where the element type comes from the same stackalloc node).
+        // Raising would silently reinterpret the stored int elements as a
+        // byte-typed initializer.
+        var elements = new IrExpression[] { new Constant(300, Int32) };
+        var stackAllocArray = new StackAllocArray(Int32, new Constant(1, Int32), TypeRef.Pointer(Int32), elements);
+        var store = new StoreStackSlot(0, stackAllocArray);
+        var newObject = StackAllocSpanConstructor(TypeRef.CoreLib("System", "Span`1"), new LoadStackSlot(0, VoidPointer), count: 1, elementType: Byte);
+
+        var function = BuildSlot(store, newObject);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var construction = Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Same(newObject, construction);
+        var unraised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Equal("int", unraised.ElementType.ToDisplayString()); // still the store's un-raised value
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void SlotThroughNonStackallocStore_DoesNotRaise()
     {
         var store = new StoreStackSlot(0, new Call(new MethodRef(Holder, "GetPointer", VoidPointer, [], HasThis: false), isVirtual: false, []));
@@ -362,12 +491,12 @@ public class StackAllocSpanPassTests
         function.CheckInvariant();
     }
 
-    static NewObject StackAllocSpanConstructor(TypeRef spanDefinition, IrExpression pointer, int count)
-        => StackAllocSpanConstructorWithPointer(spanDefinition, pointer, count);
+    static NewObject StackAllocSpanConstructor(TypeRef spanDefinition, IrExpression pointer, int count, TypeRef? elementType = null)
+        => StackAllocSpanConstructorWithPointer(spanDefinition, pointer, count, elementType);
 
-    static NewObject StackAllocSpanConstructorWithPointer(TypeRef spanDefinition, IrExpression pointer, int count)
+    static NewObject StackAllocSpanConstructorWithPointer(TypeRef spanDefinition, IrExpression pointer, int count, TypeRef? elementType = null)
     {
-        var span = TypeRef.GenericInstance(spanDefinition, [Int32]);
+        var span = TypeRef.GenericInstance(spanDefinition, [elementType ?? Int32]);
         var ctor = new MethodRef(span, ".ctor", Void, [VoidPointer, Int32], HasThis: true);
         return new NewObject(ctor, [pointer, new Constant(count, Int32)]);
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
@@ -1,5 +1,8 @@
 namespace ILInspector.Decompiler.Pipeline;
 
+using System.Collections.Generic;
+using System.Linq;
+
 /// <summary>
 /// Raises the compiler's lowering of <c>Span&lt;T&gt; s = stackalloc T[n]</c> back
 /// into a source-level <c>stackalloc T[n]</c>. The source form lowers to a
@@ -18,6 +21,16 @@ namespace ILInspector.Decompiler.Pipeline;
 /// compiled — so the pass runs unconditionally. Whether the result needs an
 /// <c>unsafe</c> context (only under <c>[SkipLocalsInit]</c>, per the stackalloc
 /// rule) is decided later by the printer.</para>
+///
+/// <para>The pointer argument is usually the stackalloc directly, but
+/// <see cref="StackAllocInitializerPass"/> (#2869) can leave the recovered
+/// initializer sitting behind a compiler-owned stack slot indirection instead
+/// — <c>slot = stackalloc T[n] {...}; ...; new Span&lt;T&gt;((void*)slot, n)</c> —
+/// because that pass only replaces the slot's stored value, never the later
+/// constructor call. This pass also resolves that indirection, but only when the
+/// slot is exclusively owned by the one store/load pair reaching this
+/// constructor (see <see cref="TryResolveOwnedSlotSource"/>), so the allocation
+/// is never moved out from under some other reader or writer of the slot.</para>
 /// </summary>
 public sealed class StackAllocSpanPass : IIrPass
 {
@@ -25,6 +38,15 @@ public sealed class StackAllocSpanPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
+        var storesBySlot = GenericDeclarationPatternProof.DescendantsOutsideNestedFunctions(function)
+            .OfType<StoreStackSlot>()
+            .GroupBy(s => s.Slot)
+            .ToDictionary(g => g.Key, g => g.ToList());
+        var loadsBySlot = GenericDeclarationPatternProof.DescendantsOutsideNestedFunctions(function)
+            .OfType<LoadStackSlot>()
+            .GroupBy(s => s.Slot)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
         foreach (var newObject in function.Descendants.OfType<NewObject>().ToList())
         {
             if (!MemberIdentity.IsStackAllocSpanConstructor(newObject, out var element))
@@ -32,20 +54,84 @@ public sealed class StackAllocSpanPass : IIrPass
 
             // Span<T>(void* pointer, int length): the pointer is the stackalloc,
             // the length is the logical element count.
-            if (newObject.Arguments is not [{ } pointer, var count]
-                || !IsStackAllocPointer(pointer))
+            if (newObject.Arguments is not [{ } pointer, var count])
                 continue;
 
-            var elements = GetInitializerElements(pointer);
+            StoreStackSlot? ownedStore = null;
+            IEnumerable<IrExpression>? elements;
+
+            if (IsStackAllocPointer(pointer))
+            {
+                elements = GetInitializerElements(pointer);
+            }
+            else if (TryResolveOwnedSlotSource(pointer, storesBySlot, loadsBySlot, out var slotSource, out ownedStore))
+            {
+                elements = GetInitializerElements(slotSource);
+            }
+            else
+            {
+                continue;
+            }
+
             count.Detach();
             var raised = new StackAllocArray(element, count, newObject.ResultType, elements);
             raised.InheritSourceOffset(newObject);
             context.Stepper.StepOver("raise Span-over-stackalloc to stackalloc T[n]", newObject);
             newObject.ReplaceWith(raised);
+            ownedStore?.Detach();
         }
     }
 
-    static System.Collections.Generic.IEnumerable<IrExpression>? GetInitializerElements(IrExpression pointer)
+    /// <summary>
+    /// Resolves a Span constructor's pointer argument through a compiler-owned
+    /// stack slot indirection. Only raises when the slot is exclusively owned by
+    /// this one store/load pair — no other store or load of the slot anywhere in
+    /// the function — and the store precedes the load's statement in the same
+    /// block, so detaching the store cannot move or discard the allocation from
+    /// under some other reader or writer, nor reorder any other observable effect.
+    /// </summary>
+    static bool TryResolveOwnedSlotSource(
+        IrExpression pointer,
+        Dictionary<int, List<StoreStackSlot>> storesBySlot,
+        Dictionary<int, List<LoadStackSlot>> loadsBySlot,
+        out IrExpression source,
+        out StoreStackSlot? ownedStore)
+    {
+        source = null!;
+        ownedStore = null;
+
+        LoadStackSlot? load = pointer as LoadStackSlot;
+        if (load == null && pointer is Convert { IsChecked: false, Operand: LoadStackSlot loadOperand, Target: { } target } && IsPointerLikeTarget(target))
+            load = loadOperand;
+        if (load == null)
+            return false;
+
+        if (!storesBySlot.TryGetValue(load.Slot, out var stores) || stores.Count != 1)
+            return false;
+        if (!loadsBySlot.TryGetValue(load.Slot, out var loads) || loads.Count != 1 || loads[0] != load)
+            return false;
+
+        var store = stores[0];
+        if (!IsStackAllocPointer(store.Value) || store.Parent is not Block parentBlock)
+            return false;
+
+        var loadStatement = GetStatement(load);
+        if (loadStatement == null || loadStatement.Parent != parentBlock || loadStatement.ChildIndex <= store.ChildIndex)
+            return false; // Escaped, reordered, or not yet defined at this use.
+
+        source = store.Value;
+        ownedStore = store;
+        return true;
+    }
+
+    static IrNode? GetStatement(IrNode node)
+    {
+        while (node.Parent != null && node.Parent is not Block)
+            node = node.Parent;
+        return node.Parent is Block ? node : null;
+    }
+
+    static IEnumerable<IrExpression>? GetInitializerElements(IrExpression pointer)
     {
         if (pointer is StackAllocArray { HasInitializer: true } sa)
         {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
@@ -84,20 +84,27 @@ public sealed class StackAllocSpanPass : IIrPass
                 continue;
             }
 
-            // A StackAllocArray source's own element type and count must
-            // agree with this constructor's own length argument and Span<T>
-            // type argument. Once the pointer is resolved (whether directly
-            // or through a slot), the source and the constructor's
-            // count/element-type are independent expressions in the tree --
-            // nothing else proves they describe the same span, so a mismatch
-            // here would silently reinterpret the allocation under the wrong
-            // element type, or change the observable Span.Length. Unlike
-            // StackAllocate.Size (bytes, not cleanly comparable to an element
-            // count at this IR layer), StackAllocArray.Count is already an
-            // element count and so is always comparable when both sides are
-            // literal constants.
+            // A source's own size/count must agree with this constructor's
+            // own length argument and Span<T> type argument. Once the
+            // pointer is resolved (whether directly or through a slot), the
+            // source and the constructor's count/element-type are
+            // independent expressions in the tree -- nothing else proves
+            // they describe the same span, so a mismatch here would silently
+            // reinterpret the allocation under the wrong element type,
+            // change the observable Span.Length, or (for a raw
+            // StackAllocate) reserve a different number of bytes than the
+            // constructor's count implies. StackAllocArray.Count is already
+            // an element count; StackAllocate.Size is a byte count and must
+            // be proven equal to count * sizeof(element) instead.
             IEnumerable<IrExpression>? elements;
-            if (source is StackAllocArray sourceArray)
+            if (source is StackAllocate stackAllocate)
+            {
+                if (!IsProvenByteSize(stackAllocate.Size, count, element))
+                    continue;
+
+                elements = null;
+            }
+            else if (source is StackAllocArray sourceArray)
             {
                 if (!sourceArray.ElementType.Equals(element))
                     continue;
@@ -236,6 +243,66 @@ public sealed class StackAllocSpanPass : IIrPass
             && StructurallyEqual(x.Operand, y.Operand),
         _ => false,
     };
+
+    /// <summary>
+    /// Proves a raw <see cref="StackAllocate"/>'s byte size describes the
+    /// same allocation as the constructor's <paramref name="count"/> element
+    /// argument under <paramref name="element"/>'s size, so raising doesn't
+    /// silently reserve a different number of bytes than the constructor's
+    /// count implies. Accepts either the canonical compiler shape --
+    /// <paramref name="size"/> structurally is <c>count * sizeof(element)</c>
+    /// (either operand order, seeing through unchecked <see cref="Convert"/>
+    /// wrappers), which needs no numeric knowledge of the element's size and
+    /// so works for any element type including generic/struct types -- or,
+    /// when both sides are literal constants, requires a known fixed
+    /// primitive byte size for <paramref name="element"/> and an exact
+    /// arithmetic match.
+    /// </summary>
+    static bool IsProvenByteSize(IrExpression size, IrExpression count, TypeRef element)
+    {
+        var unwrappedSize = Unconvert(size);
+        var unwrappedCount = Unconvert(count);
+
+        if (unwrappedSize is Binary { Kind: BinaryKind.Multiply, IsChecked: false } multiply)
+        {
+            var left = Unconvert(multiply.Left);
+            var right = Unconvert(multiply.Right);
+            if (IsCountTimesElementSize(left, right, unwrappedCount, element)
+                || IsCountTimesElementSize(right, left, unwrappedCount, element))
+                return true;
+        }
+
+        return unwrappedSize is Constant { Value: int sizeValue }
+            && unwrappedCount is Constant { Value: int countValue }
+            && GetSizeOf(element) is { } elementSize
+            && sizeValue == countValue * elementSize;
+    }
+
+    static bool IsCountTimesElementSize(IrExpression countOperand, IrExpression sizeOfOperand, IrExpression count, TypeRef element)
+        => sizeOfOperand is SizeOf sizeOf && sizeOf.Type.Equals(element) && StructurallyEqual(countOperand, count);
+
+    static IrExpression Unconvert(IrExpression expression)
+    {
+        while (expression is Convert { IsChecked: false } convert)
+            expression = convert.Operand;
+        return expression;
+    }
+
+    static int? GetSizeOf(TypeRef type)
+    {
+        if (type.Kind == TypeRefKind.Definition && type.Assembly == TypeRef.CoreLibrary && type.Namespace == "System")
+        {
+            return type.Name switch
+            {
+                "Byte" or "SByte" or "Boolean" => 1,
+                "Int16" or "UInt16" or "Char" => 2,
+                "Int32" or "UInt32" or "Single" => 4,
+                "Int64" or "UInt64" or "Double" => 8,
+                _ => null,
+            };
+        }
+        return null;
+    }
 
     static IrNode? GetStatement(IrNode node)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
@@ -58,30 +58,44 @@ public sealed class StackAllocSpanPass : IIrPass
                 continue;
 
             StoreStackSlot? ownedStore = null;
-            IEnumerable<IrExpression>? elements;
+            IrExpression source;
 
-            if (IsStackAllocPointer(pointer))
+            if (TryNormalizeConstantStackAlloc(pointer, out var directSource))
             {
-                elements = GetInitializerElements(pointer);
+                source = directSource;
             }
             else if (TryResolveOwnedSlotSource(pointer, storesBySlot, loadsBySlot, out var slotSource, out ownedStore))
             {
-                // The slot's recovered elements (if any) must agree with this
-                // constructor's own length argument -- they're independent
-                // expressions in the tree (unlike the direct-pointer case, where
-                // the same stackalloc node feeds both the elements and the
-                // length), so nothing else proves they describe the same span.
-                if (slotSource is StackAllocArray { HasInitializer: true } slotArray
-                    && (count is not Constant { Value: int expectedCount } || expectedCount != slotArray.Elements.Length))
-                {
-                    continue;
-                }
-
-                elements = GetInitializerElements(slotSource);
+                source = slotSource;
             }
             else
             {
                 continue;
+            }
+
+            // A recovered initializer's element count and element type must
+            // agree with this constructor's own length argument and Span<T>
+            // type argument. Once the pointer is resolved (whether directly or
+            // through a slot), the source's elements and the constructor's
+            // count/element-type are independent expressions in the tree --
+            // nothing else proves they describe the same span, so a mismatch
+            // here would silently change the observable Span.Length or
+            // reinterpret the initializer under the wrong element type.
+            IEnumerable<IrExpression>? elements;
+            if (source is StackAllocArray { HasInitializer: true } sourceArray)
+            {
+                if (!sourceArray.ElementType.Equals(element)
+                    || count is not Constant { Value: int expectedCount }
+                    || expectedCount != sourceArray.Elements.Length)
+                {
+                    continue;
+                }
+
+                elements = GetInitializerElements(sourceArray);
+            }
+            else
+            {
+                elements = null;
             }
 
             count.Detach();
@@ -97,9 +111,11 @@ public sealed class StackAllocSpanPass : IIrPass
     /// Resolves a Span constructor's pointer argument through a compiler-owned
     /// stack slot indirection. Only raises when the slot is exclusively owned by
     /// this one store/load pair — no other store or load of the slot anywhere in
-    /// the function — and the store precedes the load's statement in the same
-    /// block, so detaching the store cannot move or discard the allocation from
-    /// under some other reader or writer, nor reorder any other observable effect.
+    /// the function — and the load's statement is the store's immediate
+    /// successor in the same block, so detaching the store cannot move or
+    /// discard the allocation from under some other reader or writer, and no
+    /// other statement can sit between them to observe or reorder past the
+    /// allocation.
     /// </summary>
     static bool TryResolveOwnedSlotSource(
         IrExpression pointer,
@@ -123,14 +139,14 @@ public sealed class StackAllocSpanPass : IIrPass
             return false;
 
         var store = stores[0];
-        if (!HasConstantSizeStackAlloc(store.Value) || store.Parent is not Block parentBlock)
+        if (!TryNormalizeConstantStackAlloc(store.Value, out var normalized) || store.Parent is not Block parentBlock)
             return false;
 
         var loadStatement = GetStatement(load);
-        if (loadStatement == null || loadStatement.Parent != parentBlock || loadStatement.ChildIndex <= store.ChildIndex)
-            return false; // Escaped, reordered, or not yet defined at this use.
+        if (loadStatement == null || loadStatement.Parent != parentBlock || loadStatement.ChildIndex != store.ChildIndex + 1)
+            return false; // Escaped, reordered, or not adjacent to the store: some other statement could sit between them and observe or alter state before the load.
 
-        source = store.Value;
+        source = normalized;
         ownedStore = store;
         return true;
     }
@@ -142,59 +158,44 @@ public sealed class StackAllocSpanPass : IIrPass
         return node.Parent is Block ? node : null;
     }
 
-    static IEnumerable<IrExpression>? GetInitializerElements(IrExpression pointer)
+    static IEnumerable<IrExpression> GetInitializerElements(StackAllocArray source)
     {
-        if (pointer is StackAllocArray { HasInitializer: true } sa)
-        {
-            var elements = sa.Elements.ToArray().Cast<IrExpression>().ToList();
-            foreach (var e in elements) e.Detach();
-            return elements;
-        }
-        if (pointer is Convert { Operand: StackAllocArray { HasInitializer: true } sa2 })
-        {
-            var elements = sa2.Elements.ToArray().Cast<IrExpression>().ToList();
-            foreach (var e in elements) e.Detach();
-            return elements;
-        }
-        return null;
+        var elements = source.Elements.ToArray().Cast<IrExpression>().ToList();
+        foreach (var e in elements) e.Detach();
+        return elements;
     }
 
     /// <summary>
-    /// Like <see cref="IsStackAllocPointer"/>, but additionally requires the
-    /// allocation's byte size (<see cref="StackAllocate.Size"/>) or element count
-    /// (<see cref="StackAllocArray.Count"/>) to be a <see cref="Constant"/>. This
-    /// pass discards that expression entirely when raising through a slot
-    /// indirection (the constructor's own <c>length</c> argument is used
-    /// instead) — detaching and dropping it silently erases any side effect it
-    /// carries and can reorder any effect it precedes. In the direct-pointer
-    /// case the expression is never discarded (it's the same node the printer
-    /// spells as the stackalloc's own length), so no such check is needed there.
+    /// Resolves a Span constructor's pointer argument to a stackalloc, whether
+    /// direct or <c>Convert</c>-wrapped, unwrapping the wrapper to return the
+    /// underlying <see cref="StackAllocate"/> or <see cref="StackAllocArray"/>
+    /// node itself, and requires its byte size (<see cref="StackAllocate.Size"/>)
+    /// or element count (<see cref="StackAllocArray.Count"/>) to be a
+    /// <see cref="Constant"/>. This pass always discards that size/count
+    /// expression (the constructor's own <c>length</c> argument is used
+    /// instead) — detaching and dropping a non-constant size/count would
+    /// silently erase any side effect it carries. Returning the unwrapped node
+    /// (rather than a possibly-<c>Convert</c>-wrapped <paramref name="pointer"/>)
+    /// is required so later checks that pattern-match on
+    /// <see cref="StackAllocArray"/> (element type, initializer count) see
+    /// through the wrapper instead of silently skipping validation.
     /// </summary>
-    static bool HasConstantSizeStackAlloc(IrExpression pointer)
+    static bool TryNormalizeConstantStackAlloc(IrExpression pointer, out IrExpression normalized)
     {
         var candidate = pointer;
         if (candidate is Convert { IsChecked: false, Operand: StackAllocate or StackAllocArray, Target: { } target } converted && IsPointerLikeTarget(target))
             candidate = converted.Operand;
 
-        return candidate switch
+        switch (candidate)
         {
-            StackAllocate { Size: Constant } => true,
-            StackAllocArray { Count: Constant } => true,
-            _ => false,
-        };
-    }
-
-    static bool IsStackAllocPointer(IrExpression pointer)
-    {
-        if (pointer is StackAllocate or StackAllocArray)
-            return true;
-
-        return pointer is Convert
-        {
-            IsChecked: false,
-            Operand: StackAllocate or StackAllocArray,
-            Target: { } target,
-        } && IsPointerLikeTarget(target);
+            case StackAllocate { Size: Constant }:
+            case StackAllocArray { Count: Constant }:
+                normalized = candidate;
+                return true;
+            default:
+                normalized = null!;
+                return false;
+        }
     }
 
     static bool IsPointerLikeTarget(TypeRef target)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
@@ -190,12 +190,16 @@ public sealed class StackAllocSpanPass : IIrPass
     }
 
     /// <summary>
-    /// The single expression a linear (single-evaluation) statement holds, or
-    /// null for any other node (a loop/switch/if header, or any other
-    /// control-construct GetStatement can return). Requiring the constructor
-    /// call be exactly this expression -- not merely nested somewhere inside
-    /// it -- proves nothing else in the statement evaluates before, instead
-    /// of, or conditionally relative to the moved allocation.
+    /// The single expression a linear (single-evaluation) statement holds when
+    /// the value being stored/returned/thrown is the *only* operand the
+    /// statement evaluates, or null otherwise (a loop/switch/if header, any
+    /// other control-construct GetStatement can return, or a statement shape
+    /// -- an instance field/indirect/element store -- that evaluates another
+    /// operand, such as the receiver/address/array-and-index, before its
+    /// value). Requiring the constructor call be exactly this expression --
+    /// not merely nested somewhere inside it -- proves nothing else in the
+    /// statement evaluates before, instead of, or conditionally relative to
+    /// the moved allocation.
     /// </summary>
     static IrExpression? GetHeldExpression(IrNode statement) => statement switch
     {
@@ -204,11 +208,9 @@ public sealed class StackAllocSpanPass : IIrPass
         Throw s => s.Value,
         StoreLocal s => s.Value,
         StoreStackSlot s => s.Value,
-        StoreField s => s.Value,
-        StoreIndirect s => s.Value,
+        StoreField { HasInstance: false } s => s.Value, // a static field store has no receiver evaluated before Value
         StoreArgument s => s.Value,
-        StoreElement s => s.Value,
-        _ => null,
+        _ => null, // StoreIndirect (Address before Value), StoreElement (Array/Index before Value), and an instance StoreField (Instance before Value) each evaluate another operand first
     };
 
     /// <summary>
@@ -230,7 +232,8 @@ public sealed class StackAllocSpanPass : IIrPass
         (Unary x, Unary y) => x.Kind == y.Kind && StructurallyEqual(x.Operand, y.Operand),
         (Binary x, Binary y) => x.Kind == y.Kind && x.IsChecked == y.IsChecked && x.IsUnsigned == y.IsUnsigned
             && StructurallyEqual(x.Left, y.Left) && StructurallyEqual(x.Right, y.Right),
-        (Convert x, Convert y) => x.Target.Equals(y.Target) && x.IsChecked == y.IsChecked && StructurallyEqual(x.Operand, y.Operand),
+        (Convert x, Convert y) => x.Target.Equals(y.Target) && x.IsChecked == y.IsChecked && x.IsUnsigned == y.IsUnsigned
+            && StructurallyEqual(x.Operand, y.Operand),
         _ => false,
     };
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
@@ -225,30 +225,39 @@ public sealed class StackAllocSpanPass : IIrPass
 
     /// <summary>
     /// Whether <paramref name="newObject"/> is <paramref name="expression"/>
-    /// itself, or sits as one of a <see cref="Call"/>'s arguments (which,
-    /// per <see cref="Call.Arguments"/>, includes the receiver first for an
-    /// instance call) with every argument evaluated *before* it in that
-    /// call's left-to-right evaluation order proven <see cref="IsSideEffectFree"/>
-    /// -- recursively, so a nested call's own preceding arguments are proven
-    /// too. This is the common, safe shape for the constructor call being
-    /// passed directly as a call argument (e.g. <c>Consume(new Span&lt;int&gt;(ptr,
-    /// n))</c>) -- moving the allocation to sit in the constructor's own
-    /// position changes nothing observable, since nothing effectful was
-    /// evaluated ahead of it either before or after the raise. Any other
-    /// shape (a ternary/coalesce/switch-expression branch, a short-circuited
-    /// operand, an argument evaluated strictly after an unproven earlier
-    /// one) is rejected: the raise could reorder an effectful operand across
-    /// the moved allocation, or move the allocation into a conditionally-
-    /// evaluated branch.
+    /// itself, or sits as one of a <see cref="Call"/>'s or <see
+    /// cref="NewObject"/>'s arguments (which, per <see cref="Call.Arguments"/>
+    /// / <see cref="NewObject.Arguments"/>, includes the receiver first for
+    /// an instance call) with every argument evaluated *before* it in that
+    /// call's or constructor's left-to-right evaluation order proven
+    /// <see cref="IsSideEffectFree"/> -- recursively, so a nested call's or
+    /// constructor's own preceding arguments are proven too. This is the
+    /// common, safe shape for the constructor call being passed directly as
+    /// a call argument (e.g. <c>Consume(new Span&lt;int&gt;(ptr, n))</c>) or
+    /// as another constructor's argument (e.g. <c>new Consumer(new
+    /// Span&lt;int&gt;(ptr, n))</c>) -- moving the allocation to sit in the
+    /// constructor's own position changes nothing observable, since nothing
+    /// effectful was evaluated ahead of it either before or after the raise.
+    /// Any other shape (a ternary/coalesce/switch-expression branch, a
+    /// short-circuited operand, an argument evaluated strictly after an
+    /// unproven earlier one) is rejected: the raise could reorder an
+    /// effectful operand across the moved allocation, or move the allocation
+    /// into a conditionally-evaluated branch.
     /// </summary>
     static bool ReachesAsOnlyPrecedingEffect(IrExpression expression, NewObject newObject)
     {
         if (ReferenceEquals(expression, newObject))
             return true;
 
-        if (expression is Call call)
+        var arguments = expression switch
         {
-            foreach (var argument in call.Arguments)
+            Call call => call.Arguments,
+            NewObject outerNewObject => outerNewObject.Arguments,
+            _ => null,
+        };
+        if (arguments is not null)
+        {
+            foreach (var argument in arguments)
             {
                 if (ReachesAsOnlyPrecedingEffect(argument, newObject))
                     return true;
@@ -259,6 +268,7 @@ public sealed class StackAllocSpanPass : IIrPass
 
         return false;
     }
+
 
     /// <summary>
     /// Deep structural equality over the same expression shapes

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
@@ -275,16 +275,28 @@ public sealed class StackAllocSpanPass : IIrPass
         return unwrappedSize is Constant { Value: int sizeValue }
             && unwrappedCount is Constant { Value: int countValue }
             && GetSizeOf(element) is { } elementSize
-            && sizeValue == countValue * elementSize;
+            && (long)sizeValue == (long)countValue * elementSize; // checked-width product: an int-width product can wrap around and falsely match a truncated size
     }
 
     static bool IsCountTimesElementSize(IrExpression countOperand, IrExpression sizeOfOperand, IrExpression count, TypeRef element)
         => sizeOfOperand is SizeOf sizeOf && sizeOf.Type.Equals(element) && StructurallyEqual(countOperand, count);
 
+    /// <summary>
+    /// Strips only <see cref="Convert"/> wrappers proven value-preserving --
+    /// C# implicit integer widening from the operand's own result type to the
+    /// conversion's target -- so a narrowing or sign-changing conversion (e.g.
+    /// <c>(byte)someLargerValue</c>) is never silently discarded: that would
+    /// let two expressions that produce different values at runtime compare
+    /// as structurally equal.
+    /// </summary>
     static IrExpression Unconvert(IrExpression expression)
     {
-        while (expression is Convert { IsChecked: false } convert)
+        while (expression is Convert { IsChecked: false } convert
+            && convert.Operand.ResultType is { } operandType
+            && CSharpConversionRules.IsImplicitIntegerWidening(operandType, convert.Target))
+        {
             expression = convert.Operand;
+        }
         return expression;
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
@@ -57,6 +57,17 @@ public sealed class StackAllocSpanPass : IIrPass
             if (newObject.Arguments is not [{ } pointer, var count])
                 continue;
 
+            // stackalloc T[n] evaluates n *before* performing the allocation,
+            // but the constructor's own length argument here originally
+            // evaluated *after* the pointer argument (left-to-right call
+            // evaluation) -- i.e. after the localloc. Raising always inverts
+            // that order, so an effectful count would silently reorder past
+            // the allocation (and any StackOverflowException it might throw)
+            // to run first. Retaining the exact same count expression is not
+            // enough to preserve behavior; it must be provably pure.
+            if (!IsSideEffectFree(count))
+                continue;
+
             StoreStackSlot? ownedStore = null;
             IrExpression source;
 
@@ -73,15 +84,18 @@ public sealed class StackAllocSpanPass : IIrPass
                 continue;
             }
 
-            // A StackAllocArray source's own element type and (if it has an
-            // initializer) recovered element count must agree with this
-            // constructor's own length argument and Span<T> type argument.
-            // Once the pointer is resolved (whether directly or through a
-            // slot), the source and the constructor's count/element-type are
-            // independent expressions in the tree -- nothing else proves they
-            // describe the same span, so a mismatch here would silently
-            // reinterpret the allocation under the wrong element type, or
-            // (with an initializer) change the observable Span.Length.
+            // A StackAllocArray source's own element type and count must
+            // agree with this constructor's own length argument and Span<T>
+            // type argument. Once the pointer is resolved (whether directly
+            // or through a slot), the source and the constructor's
+            // count/element-type are independent expressions in the tree --
+            // nothing else proves they describe the same span, so a mismatch
+            // here would silently reinterpret the allocation under the wrong
+            // element type, or change the observable Span.Length. Unlike
+            // StackAllocate.Size (bytes, not cleanly comparable to an element
+            // count at this IR layer), StackAllocArray.Count is already an
+            // element count and so is always comparable when both sides are
+            // literal constants.
             IEnumerable<IrExpression>? elements;
             if (source is StackAllocArray sourceArray)
             {
@@ -97,6 +111,10 @@ public sealed class StackAllocSpanPass : IIrPass
                 }
                 else
                 {
+                    if (sourceArray.Count is Constant { Value: int sourceCount }
+                        && (count is not Constant { Value: int ctorCount } || ctorCount != sourceCount))
+                        continue;
+
                     elements = null;
                 }
             }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
@@ -66,6 +66,17 @@ public sealed class StackAllocSpanPass : IIrPass
             }
             else if (TryResolveOwnedSlotSource(pointer, storesBySlot, loadsBySlot, out var slotSource, out ownedStore))
             {
+                // The slot's recovered elements (if any) must agree with this
+                // constructor's own length argument -- they're independent
+                // expressions in the tree (unlike the direct-pointer case, where
+                // the same stackalloc node feeds both the elements and the
+                // length), so nothing else proves they describe the same span.
+                if (slotSource is StackAllocArray { HasInitializer: true } slotArray
+                    && (count is not Constant { Value: int expectedCount } || expectedCount != slotArray.Elements.Length))
+                {
+                    continue;
+                }
+
                 elements = GetInitializerElements(slotSource);
             }
             else
@@ -112,7 +123,7 @@ public sealed class StackAllocSpanPass : IIrPass
             return false;
 
         var store = stores[0];
-        if (!IsStackAllocPointer(store.Value) || store.Parent is not Block parentBlock)
+        if (!HasConstantSizeStackAlloc(store.Value) || store.Parent is not Block parentBlock)
             return false;
 
         var loadStatement = GetStatement(load);
@@ -146,6 +157,31 @@ public sealed class StackAllocSpanPass : IIrPass
             return elements;
         }
         return null;
+    }
+
+    /// <summary>
+    /// Like <see cref="IsStackAllocPointer"/>, but additionally requires the
+    /// allocation's byte size (<see cref="StackAllocate.Size"/>) or element count
+    /// (<see cref="StackAllocArray.Count"/>) to be a <see cref="Constant"/>. This
+    /// pass discards that expression entirely when raising through a slot
+    /// indirection (the constructor's own <c>length</c> argument is used
+    /// instead) — detaching and dropping it silently erases any side effect it
+    /// carries and can reorder any effect it precedes. In the direct-pointer
+    /// case the expression is never discarded (it's the same node the printer
+    /// spells as the stackalloc's own length), so no such check is needed there.
+    /// </summary>
+    static bool HasConstantSizeStackAlloc(IrExpression pointer)
+    {
+        var candidate = pointer;
+        if (candidate is Convert { IsChecked: false, Operand: StackAllocate or StackAllocArray, Target: { } target } converted && IsPointerLikeTarget(target))
+            candidate = converted.Operand;
+
+        return candidate switch
+        {
+            StackAllocate { Size: Constant } => true,
+            StackAllocArray { Count: Constant } => true,
+            _ => false,
+        };
     }
 
     static bool IsStackAllocPointer(IrExpression pointer)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
@@ -75,7 +75,7 @@ public sealed class StackAllocSpanPass : IIrPass
             {
                 source = directSource;
             }
-            else if (TryResolveOwnedSlotSource(pointer, storesBySlot, loadsBySlot, out var slotSource, out ownedStore))
+            else if (TryResolveOwnedSlotSource(newObject, pointer, storesBySlot, loadsBySlot, out var slotSource, out ownedStore))
             {
                 source = slotSource;
             }
@@ -111,8 +111,18 @@ public sealed class StackAllocSpanPass : IIrPass
                 }
                 else
                 {
-                    if (sourceArray.Count is Constant { Value: int sourceCount }
-                        && (count is not Constant { Value: int ctorCount } || ctorCount != sourceCount))
+                    // Count is already an element count (unlike Size), so it
+                    // is comparable to the constructor's length argument even
+                    // when dynamic: a literal source count requires an equal
+                    // literal ctor count, and a dynamic source count requires
+                    // the ctor's count to be the structurally identical
+                    // expression -- otherwise two independent, unrelated
+                    // dynamic quantities (e.g. two different locals) could
+                    // silently pass each other off as the same count.
+                    var agrees = sourceArray.Count is Constant { Value: int sourceCount }
+                        ? count is Constant { Value: int ctorCount } && ctorCount == sourceCount
+                        : StructurallyEqual(sourceArray.Count, count);
+                    if (!agrees)
                         continue;
 
                     elements = null;
@@ -143,6 +153,7 @@ public sealed class StackAllocSpanPass : IIrPass
     /// allocation.
     /// </summary>
     static bool TryResolveOwnedSlotSource(
+        NewObject newObject,
         IrExpression pointer,
         Dictionary<int, List<StoreStackSlot>> storesBySlot,
         Dictionary<int, List<LoadStackSlot>> loadsBySlot,
@@ -170,13 +181,58 @@ public sealed class StackAllocSpanPass : IIrPass
         var loadStatement = GetStatement(load);
         if (loadStatement == null || loadStatement.Parent != parentBlock || loadStatement.ChildIndex != store.ChildIndex + 1)
             return false; // Escaped, reordered, or not adjacent to the store: some other statement could sit between them and observe or alter state before the load.
-        if (loadStatement is not (ExpressionStatement or Return or Throw or StoreLocal))
-            return false; // A loop or branch header (While/For/DoWhile/IfElse/Switch) evaluates its held expression repeatedly or conditionally; moving the allocation into it would change how many times (or whether) it executes.
+        if (GetHeldExpression(loadStatement) != newObject)
+            return false; // The constructor call must be the statement's entire expression, not merely reachable somewhere inside it -- otherwise some other subexpression of the same statement (an earlier call argument, a ternary/coalesce/switch-expression branch, a short-circuited && / || operand, ...) could be evaluated unconditionally-but-not-first, or only conditionally, relative to the moved allocation.
 
         source = normalized;
         ownedStore = store;
         return true;
     }
+
+    /// <summary>
+    /// The single expression a linear (single-evaluation) statement holds, or
+    /// null for any other node (a loop/switch/if header, or any other
+    /// control-construct GetStatement can return). Requiring the constructor
+    /// call be exactly this expression -- not merely nested somewhere inside
+    /// it -- proves nothing else in the statement evaluates before, instead
+    /// of, or conditionally relative to the moved allocation.
+    /// </summary>
+    static IrExpression? GetHeldExpression(IrNode statement) => statement switch
+    {
+        ExpressionStatement s => s.Expression,
+        Return s => s.Value,
+        Throw s => s.Value,
+        StoreLocal s => s.Value,
+        StoreStackSlot s => s.Value,
+        StoreField s => s.Value,
+        StoreIndirect s => s.Value,
+        StoreArgument s => s.Value,
+        StoreElement s => s.Value,
+        _ => null,
+    };
+
+    /// <summary>
+    /// Deep structural equality over the same expression shapes
+    /// <see cref="IsSideEffectFree"/> permits -- used to prove a dynamic
+    /// (non-constant) <see cref="StackAllocArray.Count"/> and the
+    /// constructor's own length argument describe the same quantity, since
+    /// neither side being a literal rules out comparing by value.
+    /// </summary>
+    static bool StructurallyEqual(IrExpression a, IrExpression b) => (a, b) switch
+    {
+        (Constant x, Constant y) => Equals(x.Value, y.Value),
+        (LoadLocal x, LoadLocal y) => x.Index == y.Index,
+        (LoadArgument x, LoadArgument y) => x.Index == y.Index,
+        (LoadStackSlot x, LoadStackSlot y) => x.Slot == y.Slot,
+        (LoadLocalAddress x, LoadLocalAddress y) => x.Index == y.Index,
+        (LoadArgumentAddress x, LoadArgumentAddress y) => x.Index == y.Index,
+        (SizeOf x, SizeOf y) => x.Type.Equals(y.Type),
+        (Unary x, Unary y) => x.Kind == y.Kind && StructurallyEqual(x.Operand, y.Operand),
+        (Binary x, Binary y) => x.Kind == y.Kind && x.IsChecked == y.IsChecked && x.IsUnsigned == y.IsUnsigned
+            && StructurallyEqual(x.Left, y.Left) && StructurallyEqual(x.Right, y.Right),
+        (Convert x, Convert y) => x.Target.Equals(y.Target) && x.IsChecked == y.IsChecked && StructurallyEqual(x.Operand, y.Operand),
+        _ => false,
+    };
 
     static IrNode? GetStatement(IrNode node)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
@@ -73,25 +73,32 @@ public sealed class StackAllocSpanPass : IIrPass
                 continue;
             }
 
-            // A recovered initializer's element count and element type must
-            // agree with this constructor's own length argument and Span<T>
-            // type argument. Once the pointer is resolved (whether directly or
-            // through a slot), the source's elements and the constructor's
-            // count/element-type are independent expressions in the tree --
-            // nothing else proves they describe the same span, so a mismatch
-            // here would silently change the observable Span.Length or
-            // reinterpret the initializer under the wrong element type.
+            // A StackAllocArray source's own element type and (if it has an
+            // initializer) recovered element count must agree with this
+            // constructor's own length argument and Span<T> type argument.
+            // Once the pointer is resolved (whether directly or through a
+            // slot), the source and the constructor's count/element-type are
+            // independent expressions in the tree -- nothing else proves they
+            // describe the same span, so a mismatch here would silently
+            // reinterpret the allocation under the wrong element type, or
+            // (with an initializer) change the observable Span.Length.
             IEnumerable<IrExpression>? elements;
-            if (source is StackAllocArray { HasInitializer: true } sourceArray)
+            if (source is StackAllocArray sourceArray)
             {
-                if (!sourceArray.ElementType.Equals(element)
-                    || count is not Constant { Value: int expectedCount }
-                    || expectedCount != sourceArray.Elements.Length)
-                {
+                if (!sourceArray.ElementType.Equals(element))
                     continue;
-                }
 
-                elements = GetInitializerElements(sourceArray);
+                if (sourceArray.HasInitializer)
+                {
+                    if (count is not Constant { Value: int expectedCount } || expectedCount != sourceArray.Elements.Length)
+                        continue;
+
+                    elements = GetInitializerElements(sourceArray);
+                }
+                else
+                {
+                    elements = null;
+                }
             }
             else
             {
@@ -145,6 +152,8 @@ public sealed class StackAllocSpanPass : IIrPass
         var loadStatement = GetStatement(load);
         if (loadStatement == null || loadStatement.Parent != parentBlock || loadStatement.ChildIndex != store.ChildIndex + 1)
             return false; // Escaped, reordered, or not adjacent to the store: some other statement could sit between them and observe or alter state before the load.
+        if (loadStatement is not (ExpressionStatement or Return or Throw or StoreLocal))
+            return false; // A loop or branch header (While/For/DoWhile/IfElse/Switch) evaluates its held expression repeatedly or conditionally; moving the allocation into it would change how many times (or whether) it executes.
 
         source = normalized;
         ownedStore = store;
@@ -170,15 +179,18 @@ public sealed class StackAllocSpanPass : IIrPass
     /// direct or <c>Convert</c>-wrapped, unwrapping the wrapper to return the
     /// underlying <see cref="StackAllocate"/> or <see cref="StackAllocArray"/>
     /// node itself, and requires its byte size (<see cref="StackAllocate.Size"/>)
-    /// or element count (<see cref="StackAllocArray.Count"/>) to be a
-    /// <see cref="Constant"/>. This pass always discards that size/count
+    /// or element count (<see cref="StackAllocArray.Count"/>) to be provably
+    /// <see cref="IsSideEffectFree"/>. This pass always discards that size/count
     /// expression (the constructor's own <c>length</c> argument is used
-    /// instead) — detaching and dropping a non-constant size/count would
-    /// silently erase any side effect it carries. Returning the unwrapped node
-    /// (rather than a possibly-<c>Convert</c>-wrapped <paramref name="pointer"/>)
-    /// is required so later checks that pattern-match on
-    /// <see cref="StackAllocArray"/> (element type, initializer count) see
-    /// through the wrapper instead of silently skipping validation.
+    /// instead) — detaching and dropping an expression with an unproven side
+    /// effect would silently erase it. A plain dynamic size (a local/argument
+    /// read, or arithmetic over one, e.g. <c>stackalloc byte[n]</c>) is common
+    /// and provably pure, so this does not require a literal constant.
+    /// Returning the unwrapped node (rather than a possibly-<c>Convert</c>-
+    /// wrapped <paramref name="pointer"/>) is required so later checks that
+    /// pattern-match on <see cref="StackAllocArray"/> (element type,
+    /// initializer count) see through the wrapper instead of silently skipping
+    /// validation.
     /// </summary>
     static bool TryNormalizeConstantStackAlloc(IrExpression pointer, out IrExpression normalized)
     {
@@ -188,8 +200,8 @@ public sealed class StackAllocSpanPass : IIrPass
 
         switch (candidate)
         {
-            case StackAllocate { Size: Constant }:
-            case StackAllocArray { Count: Constant }:
+            case StackAllocate { Size: { } size } when IsSideEffectFree(size):
+            case StackAllocArray { Count: { } count } when IsSideEffectFree(count):
                 normalized = candidate;
                 return true;
             default:
@@ -197,6 +209,27 @@ public sealed class StackAllocSpanPass : IIrPass
                 return false;
         }
     }
+
+    /// <summary>
+    /// Whether evaluating the expression is non-observable, so discarding it
+    /// (rather than reusing the constructor's own length argument) is sound.
+    /// This is an allow-list, mirroring the same-named helpers in
+    /// <see cref="RedundantBranchEliminationPass"/> and
+    /// <see cref="IsPatternPass"/>: anything outside the proven-safe set is
+    /// treated as possibly effectful.
+    /// </summary>
+    static bool IsSideEffectFree(IrExpression expression) => expression switch
+    {
+        Constant or LoadLocal or LoadArgument or LoadStackSlot
+            or LoadLocalAddress or LoadArgumentAddress or SizeOf => true,
+        Unary unary => IsSideEffectFree(unary.Operand),
+        Binary { Kind: BinaryKind.Divide or BinaryKind.Remainder } => false,
+        Binary { IsChecked: true } => false,
+        Binary binary => IsSideEffectFree(binary.Left) && IsSideEffectFree(binary.Right),
+        Convert { IsChecked: true } => false,
+        Convert convert => IsSideEffectFree(convert.Operand),
+        _ => false,
+    };
 
     static bool IsPointerLikeTarget(TypeRef target)
         => target.Kind == TypeRefKind.Pointer

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
@@ -71,11 +71,11 @@ public sealed class StackAllocSpanPass : IIrPass
             StoreStackSlot? ownedStore = null;
             IrExpression source;
 
-            if (TryNormalizeConstantStackAlloc(pointer, out var directSource))
+            if (TryNormalizeConstantStackAlloc(pointer, count, element, out var directSource))
             {
                 source = directSource;
             }
-            else if (TryResolveOwnedSlotSource(newObject, pointer, storesBySlot, loadsBySlot, out var slotSource, out ownedStore))
+            else if (TryResolveOwnedSlotSource(newObject, pointer, count, element, storesBySlot, loadsBySlot, out var slotSource, out ownedStore))
             {
                 source = slotSource;
             }
@@ -162,6 +162,8 @@ public sealed class StackAllocSpanPass : IIrPass
     static bool TryResolveOwnedSlotSource(
         NewObject newObject,
         IrExpression pointer,
+        IrExpression count,
+        TypeRef element,
         Dictionary<int, List<StoreStackSlot>> storesBySlot,
         Dictionary<int, List<LoadStackSlot>> loadsBySlot,
         out IrExpression source,
@@ -182,14 +184,15 @@ public sealed class StackAllocSpanPass : IIrPass
             return false;
 
         var store = stores[0];
-        if (!TryNormalizeConstantStackAlloc(store.Value, out var normalized) || store.Parent is not Block parentBlock)
+        if (!TryNormalizeConstantStackAlloc(store.Value, count, element, out var normalized) || store.Parent is not Block parentBlock)
             return false;
 
         var loadStatement = GetStatement(load);
         if (loadStatement == null || loadStatement.Parent != parentBlock || loadStatement.ChildIndex != store.ChildIndex + 1)
             return false; // Escaped, reordered, or not adjacent to the store: some other statement could sit between them and observe or alter state before the load.
-        if (GetHeldExpression(loadStatement) != newObject)
-            return false; // The constructor call must be the statement's entire expression, not merely reachable somewhere inside it -- otherwise some other subexpression of the same statement (an earlier call argument, a ternary/coalesce/switch-expression branch, a short-circuited && / || operand, ...) could be evaluated unconditionally-but-not-first, or only conditionally, relative to the moved allocation.
+        var held = GetHeldExpression(loadStatement);
+        if (held == null || !ReachesAsOnlyPrecedingEffect(held, newObject))
+            return false; // The constructor call must be the statement's held expression itself, or an argument of a Call it sits in with every earlier-evaluated operand (receiver, earlier arguments) provably pure -- otherwise some other operand of the same statement (a ternary/coalesce/switch-expression branch, a short-circuited && / || operand, an earlier *effectful* call argument, ...) could be evaluated unconditionally-but-not-first, or only conditionally, relative to the moved allocation.
 
         source = normalized;
         ownedStore = store;
@@ -221,6 +224,43 @@ public sealed class StackAllocSpanPass : IIrPass
     };
 
     /// <summary>
+    /// Whether <paramref name="newObject"/> is <paramref name="expression"/>
+    /// itself, or sits as one of a <see cref="Call"/>'s arguments (which,
+    /// per <see cref="Call.Arguments"/>, includes the receiver first for an
+    /// instance call) with every argument evaluated *before* it in that
+    /// call's left-to-right evaluation order proven <see cref="IsSideEffectFree"/>
+    /// -- recursively, so a nested call's own preceding arguments are proven
+    /// too. This is the common, safe shape for the constructor call being
+    /// passed directly as a call argument (e.g. <c>Consume(new Span&lt;int&gt;(ptr,
+    /// n))</c>) -- moving the allocation to sit in the constructor's own
+    /// position changes nothing observable, since nothing effectful was
+    /// evaluated ahead of it either before or after the raise. Any other
+    /// shape (a ternary/coalesce/switch-expression branch, a short-circuited
+    /// operand, an argument evaluated strictly after an unproven earlier
+    /// one) is rejected: the raise could reorder an effectful operand across
+    /// the moved allocation, or move the allocation into a conditionally-
+    /// evaluated branch.
+    /// </summary>
+    static bool ReachesAsOnlyPrecedingEffect(IrExpression expression, NewObject newObject)
+    {
+        if (ReferenceEquals(expression, newObject))
+            return true;
+
+        if (expression is Call call)
+        {
+            foreach (var argument in call.Arguments)
+            {
+                if (ReachesAsOnlyPrecedingEffect(argument, newObject))
+                    return true;
+                if (!IsSideEffectFree(argument))
+                    return false; // An earlier operand with an unproven effect: reordering it past the moved allocation is not safe.
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Deep structural equality over the same expression shapes
     /// <see cref="IsSideEffectFree"/> permits -- used to prove a dynamic
     /// (non-constant) <see cref="StackAllocArray.Count"/> and the
@@ -249,35 +289,71 @@ public sealed class StackAllocSpanPass : IIrPass
     /// same allocation as the constructor's <paramref name="count"/> element
     /// argument under <paramref name="element"/>'s size, so raising doesn't
     /// silently reserve a different number of bytes than the constructor's
-    /// count implies. Requires both to be literal, nonnegative constants and
-    /// a known fixed primitive byte size for <paramref name="element"/>, with
-    /// an exact arithmetic match.
+    /// count implies.
     ///
-    /// <para>This only recognizes the literal-constant case
-    /// (<c>stackalloc byte[4]</c>) -- not a dynamic size, even a provably
-    /// pure one (<c>stackalloc int[n]</c>). The real compiler shape for a
-    /// dynamic count is a <c>checked unsigned</c> multiply over an
-    /// <c>int</c>-to-<c>nuint</c> convert chain that isn't an implicit C#
-    /// conversion (so isn't safe to strip generically) and, for primitive
-    /// element types, an already-folded <see cref="Constant"/> element size
-    /// rather than a symbolic <see cref="SizeOf"/> node -- recognizing that
-    /// shape soundly needs real compiled-fixture validation this pass does
-    /// not yet have, so it declines rather than risk a silent size mismatch.
-    /// A dynamic count reaching this pass through a <see cref="StackAllocArray"/>
-    /// source (the initializer/slot path) is unaffected: that count is
-    /// already an element count, not a byte size, so no arithmetic proof is
-    /// needed there.</para>
+    /// <para>Accepts two shapes. The real compiler shape for a dynamic
+    /// <c>stackalloc T[n]</c> (confirmed against this repo's own compiled
+    /// fixtures, not just a synthetic one) is a <b>checked, unsigned</b>
+    /// multiply -- <c>Binary { Multiply, IsChecked: true, IsUnsigned: true }</c>
+    /// -- of the count converted <c>int</c>-to-<c>nuint</c> (an explicit,
+    /// not implicit, C# conversion, so peeled here rather than via the
+    /// general-purpose <see cref="Unconvert"/>) and the element's byte size,
+    /// which for primitive element types the compiler folds to a literal
+    /// <see cref="Constant"/> rather than emitting a symbolic
+    /// <see cref="SizeOf"/> node (struct/generic element types still emit
+    /// <see cref="SizeOf"/>). Either operand order is accepted. Separately,
+    /// when both the size and count are literal constants (e.g.
+    /// <c>stackalloc byte[4]</c>, which the compiler folds to a bare
+    /// <see cref="Constant"/> with no multiply at all), a known fixed
+    /// primitive byte size for <paramref name="element"/> and an exact
+    /// arithmetic match is required.</para>
+    ///
+    /// <para>A dynamic count reaching this pass through a <see cref="StackAllocArray"/>
+    /// source (the initializer/slot path) is unaffected by any of this: that
+    /// count is already an element count, not a byte size, so no arithmetic
+    /// proof is needed there.</para>
     /// </summary>
     static bool IsProvenByteSize(IrExpression size, IrExpression count, TypeRef element)
     {
         var unwrappedSize = Unconvert(size);
         var unwrappedCount = Unconvert(count);
 
+        if (unwrappedSize is Binary { Kind: BinaryKind.Multiply, IsChecked: true, IsUnsigned: true } multiply
+            && (IsCheckedByteSizeProduct(multiply.Left, multiply.Right, unwrappedCount, element)
+                || IsCheckedByteSizeProduct(multiply.Right, multiply.Left, unwrappedCount, element)))
+            return true;
+
         return unwrappedSize is Constant { Value: int sizeValue } && sizeValue >= 0
             && unwrappedCount is Constant { Value: int countValue } && countValue >= 0
             && GetSizeOf(element) is { } elementSize
             && (long)sizeValue == (long)countValue * elementSize; // checked-width product: an int-width product can wrap around and falsely match a truncated size
     }
+
+    /// <summary>
+    /// One operand order of the checked-multiply byte-size proof: <paramref
+    /// name="countOperand"/> (after peeling an <c>int</c>-to-<c>nuint</c>
+    /// convert) must structurally equal <paramref name="count"/>, and
+    /// <paramref name="elementSizeOperand"/> must be a known byte size for
+    /// <paramref name="element"/> -- either a symbolic <see cref="SizeOf"/>
+    /// node or, for primitives, a folded literal <see cref="Constant"/>.
+    /// </summary>
+    static bool IsCheckedByteSizeProduct(IrExpression countOperand, IrExpression elementSizeOperand, IrExpression count, TypeRef element)
+    {
+        bool isElementSize = (elementSizeOperand is SizeOf sizeOf && sizeOf.Type.Equals(element))
+            || (elementSizeOperand is Constant { Value: int sizeValue } && GetSizeOf(element) == sizeValue);
+        return isElementSize && StructurallyEqual(PeelNuintConvert(countOperand), count);
+    }
+
+    /// <summary>
+    /// Peels a single <c>int</c>-to-<c>nuint</c> convert -- the conversion
+    /// the compiler emits to widen a dynamic stackalloc count before the
+    /// checked byte-size multiply. This is not an implicit C# conversion (so
+    /// <see cref="Unconvert"/> never strips it), but it is exactly the
+    /// conversion the compiler always inserts here, so it is safe to peel in
+    /// this one, specific structural position only.
+    /// </summary>
+    static IrExpression PeelNuintConvert(IrExpression expression)
+        => expression is Convert { Target: { Name: "UIntPtr" }, IsChecked: false } convert ? convert.Operand : expression;
 
     /// <summary>
     /// Strips only <see cref="Convert"/> wrappers proven value-preserving --
@@ -332,25 +408,25 @@ public sealed class StackAllocSpanPass : IIrPass
     /// Resolves a Span constructor's pointer argument to a stackalloc, whether
     /// direct or <c>Convert</c>-wrapped, unwrapping the wrapper to return the
     /// underlying <see cref="StackAllocate"/> or <see cref="StackAllocArray"/>
-    /// node itself, and requires its byte size (<see cref="StackAllocate.Size"/>)
+    /// node itself. Requires the discarded byte size (<see cref="StackAllocate.Size"/>)
     /// or element count (<see cref="StackAllocArray.Count"/>) to be provably
-    /// <see cref="IsSideEffectFree"/>. This pass always discards that size/count
-    /// expression (the constructor's own <c>length</c> argument is used
-    /// instead) — detaching and dropping an expression with an unproven side
-    /// effect would silently erase it. This gate only proves purity, not
-    /// that the discarded expression agrees with the constructor's
-    /// <c>length</c>: for <see cref="StackAllocArray"/> that agreement is
-    /// checked separately below (by count or by <see cref="StructurallyEqual"/>),
-    /// and for <see cref="StackAllocate"/> it is checked by
-    /// <see cref="IsProvenByteSize"/>, which declines a dynamic (non-literal)
-    /// size even though it would pass this purity gate -- see its own doc
-    /// comment for why. Returning the unwrapped node (rather than a possibly-<c>Convert</c>-
+    /// safe to drop: either generically <see cref="IsSideEffectFree"/>, or --
+    /// for a <see cref="StackAllocate"/> size only -- the real compiler's
+    /// checked byte-size product proven equal to <paramref name="count"/> *
+    /// <paramref name="element"/>'s size by <see cref="IsProvenByteSize"/>.
+    /// That proof, not mere purity, is what makes discarding this specific
+    /// shape sound: the checked multiply's only possible effect is the same
+    /// overflow throw the raised <c>stackalloc T[n]</c> form's own byte-size
+    /// computation reproduces, so nothing observable is silently erased.
+    /// For <see cref="StackAllocArray"/> that agreement is instead checked
+    /// separately below (by count or by <see cref="StructurallyEqual"/>).
+    /// Returning the unwrapped node (rather than a possibly-<c>Convert</c>-
     /// wrapped <paramref name="pointer"/>) is required so later checks that
     /// pattern-match on <see cref="StackAllocArray"/> (element type,
     /// initializer count) see through the wrapper instead of silently skipping
     /// validation.
     /// </summary>
-    static bool TryNormalizeConstantStackAlloc(IrExpression pointer, out IrExpression normalized)
+    static bool TryNormalizeConstantStackAlloc(IrExpression pointer, IrExpression count, TypeRef element, out IrExpression normalized)
     {
         var candidate = pointer;
         if (candidate is Convert { IsChecked: false, Operand: StackAllocate or StackAllocArray, Target: { } target } converted && IsPointerLikeTarget(target))
@@ -358,8 +434,8 @@ public sealed class StackAllocSpanPass : IIrPass
 
         switch (candidate)
         {
-            case StackAllocate { Size: { } size } when IsSideEffectFree(size):
-            case StackAllocArray { Count: { } count } when IsSideEffectFree(count):
+            case StackAllocate { Size: { } size } when IsSideEffectFree(size) || IsProvenByteSize(size, count, element):
+            case StackAllocArray { Count: { } arrayCount } when IsSideEffectFree(arrayCount):
                 normalized = candidate;
                 return true;
             default:

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
@@ -127,7 +127,7 @@ public sealed class StackAllocSpanPass : IIrPass
                     // dynamic quantities (e.g. two different locals) could
                     // silently pass each other off as the same count.
                     var agrees = sourceArray.Count is Constant { Value: int sourceCount }
-                        ? count is Constant { Value: int ctorCount } && ctorCount == sourceCount
+                        ? sourceCount >= 0 && count is Constant { Value: int ctorCount } && ctorCount == sourceCount
                         : StructurallyEqual(sourceArray.Count, count);
                     if (!agrees)
                         continue;
@@ -249,37 +249,35 @@ public sealed class StackAllocSpanPass : IIrPass
     /// same allocation as the constructor's <paramref name="count"/> element
     /// argument under <paramref name="element"/>'s size, so raising doesn't
     /// silently reserve a different number of bytes than the constructor's
-    /// count implies. Accepts either the canonical compiler shape --
-    /// <paramref name="size"/> structurally is <c>count * sizeof(element)</c>
-    /// (either operand order, seeing through unchecked <see cref="Convert"/>
-    /// wrappers), which needs no numeric knowledge of the element's size and
-    /// so works for any element type including generic/struct types -- or,
-    /// when both sides are literal constants, requires a known fixed
-    /// primitive byte size for <paramref name="element"/> and an exact
-    /// arithmetic match.
+    /// count implies. Requires both to be literal, nonnegative constants and
+    /// a known fixed primitive byte size for <paramref name="element"/>, with
+    /// an exact arithmetic match.
+    ///
+    /// <para>This only recognizes the literal-constant case
+    /// (<c>stackalloc byte[4]</c>) -- not a dynamic size, even a provably
+    /// pure one (<c>stackalloc int[n]</c>). The real compiler shape for a
+    /// dynamic count is a <c>checked unsigned</c> multiply over an
+    /// <c>int</c>-to-<c>nuint</c> convert chain that isn't an implicit C#
+    /// conversion (so isn't safe to strip generically) and, for primitive
+    /// element types, an already-folded <see cref="Constant"/> element size
+    /// rather than a symbolic <see cref="SizeOf"/> node -- recognizing that
+    /// shape soundly needs real compiled-fixture validation this pass does
+    /// not yet have, so it declines rather than risk a silent size mismatch.
+    /// A dynamic count reaching this pass through a <see cref="StackAllocArray"/>
+    /// source (the initializer/slot path) is unaffected: that count is
+    /// already an element count, not a byte size, so no arithmetic proof is
+    /// needed there.</para>
     /// </summary>
     static bool IsProvenByteSize(IrExpression size, IrExpression count, TypeRef element)
     {
         var unwrappedSize = Unconvert(size);
         var unwrappedCount = Unconvert(count);
 
-        if (unwrappedSize is Binary { Kind: BinaryKind.Multiply, IsChecked: false } multiply)
-        {
-            var left = Unconvert(multiply.Left);
-            var right = Unconvert(multiply.Right);
-            if (IsCountTimesElementSize(left, right, unwrappedCount, element)
-                || IsCountTimesElementSize(right, left, unwrappedCount, element))
-                return true;
-        }
-
-        return unwrappedSize is Constant { Value: int sizeValue }
-            && unwrappedCount is Constant { Value: int countValue }
+        return unwrappedSize is Constant { Value: int sizeValue } && sizeValue >= 0
+            && unwrappedCount is Constant { Value: int countValue } && countValue >= 0
             && GetSizeOf(element) is { } elementSize
             && (long)sizeValue == (long)countValue * elementSize; // checked-width product: an int-width product can wrap around and falsely match a truncated size
     }
-
-    static bool IsCountTimesElementSize(IrExpression countOperand, IrExpression sizeOfOperand, IrExpression count, TypeRef element)
-        => sizeOfOperand is SizeOf sizeOf && sizeOf.Type.Equals(element) && StructurallyEqual(countOperand, count);
 
     /// <summary>
     /// Strips only <see cref="Convert"/> wrappers proven value-preserving --
@@ -339,10 +337,14 @@ public sealed class StackAllocSpanPass : IIrPass
     /// <see cref="IsSideEffectFree"/>. This pass always discards that size/count
     /// expression (the constructor's own <c>length</c> argument is used
     /// instead) — detaching and dropping an expression with an unproven side
-    /// effect would silently erase it. A plain dynamic size (a local/argument
-    /// read, or arithmetic over one, e.g. <c>stackalloc byte[n]</c>) is common
-    /// and provably pure, so this does not require a literal constant.
-    /// Returning the unwrapped node (rather than a possibly-<c>Convert</c>-
+    /// effect would silently erase it. This gate only proves purity, not
+    /// that the discarded expression agrees with the constructor's
+    /// <c>length</c>: for <see cref="StackAllocArray"/> that agreement is
+    /// checked separately below (by count or by <see cref="StructurallyEqual"/>),
+    /// and for <see cref="StackAllocate"/> it is checked by
+    /// <see cref="IsProvenByteSize"/>, which declines a dynamic (non-literal)
+    /// size even though it would pass this purity gate -- see its own doc
+    /// comment for why. Returning the unwrapped node (rather than a possibly-<c>Convert</c>-
     /// wrapped <paramref name="pointer"/>) is required so later checks that
     /// pattern-match on <see cref="StackAllocArray"/> (element type,
     /// initializer count) see through the wrapper instead of silently skipping


### PR DESCRIPTION
- Fixes/advances #2907
- Changes `StackAllocSpanPass` to resolve a `Span<T>(void*, int)` constructor's
  pointer argument through a compiler-owned stack slot indirection, when that
  slot is exclusively owned by the one store/load pair reaching the
  constructor
- Card revision: `ca4d9b73`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — closes a real, compiled-fixture-confirmed gap where
`StackAllocSpanPass` claimed Full fidelity on a non-compiling shape.

### Original source

```csharp
public static void StackAllocSpanInitializerThroughSlot()
    => Consume(stackalloc int[] { 1, 2, 3 });

static void Consume(Span<int> s) { }
```

### Before

```csharp
public static void StackAllocSpanInitializerThroughSlot()
{
    Consume(new Span<int>((void*)(stackalloc int[] { 1, 2, 3 }), 3));
}
```

- Valid: False
- Correct: N/A (does not compile)

`StackAllocInitializerPass` (#2869) recovers the initializer into the slot's
stored value (`StoreStackSlot(slot, StackAllocArray)`), but never touches the
later `NewObject Span<T>(void*, int)` call that reads the slot via
`LoadStackSlot`. `StackAllocSpanPass` only recognized a direct
`StackAllocate`/`StackAllocArray` pointer, so the constructor was left
unraised — yet the tree was still marked `DecompilationFidelity.Full`,
because every individual node import succeeded; nothing in the pipeline
flagged the *combination* as non-compiling. A stackalloc in argument position
casts to `Span<byte>`, not `void*` (CS8346), so this is an invalid-Full
regression, not merely a missed simplification.

### After

```csharp
public static void StackAllocSpanInitializerThroughSlot() => Consume(stackalloc int[] { 1, 2, 3 });
```

- Valid: True
- Correct: True

`StackAllocSpanPass` now resolves the pointer through the slot when (and only
when) it is exclusively owned by this one store/load pair: exactly one
`StoreStackSlot` and one `LoadStackSlot` for the slot in the function, both in
the same block, with the store preceding the load's statement — mirroring the
ownership-proof style `StackAllocInitializerPass` already uses (usage-count
checks, same-parent-block/position checks). This guarantees the allocation is
never moved out from under some other reader or writer of the slot, and that
detaching the now-redundant store cannot reorder any other observable effect.

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Prior head (`79a3084f`) | Head (`6c14f627`) |
| --- | --- | --- |
| Product build (`ILInspector.Decompiler`) | Pass | Pass |
| `StackAllocSpanPassTests` + `StackAllocInitializerPassTests` + `IrImporterTests` | 69 passed | 159 passed (+23 new regression tests across 9 review rounds) |
| `FidelityGateTests` | not rerun on this exact head | 67 passed, 3 failed (env: broken `aspnetcorev2_inprocess.dll` shared-runtime file on this machine breaks RTS recompile-back for unrelated fixtures; reproduces identically with this PR's changes `git stash`ed out, so unaffected by this change) |
| Real witness (`CfgSampleClass::StackAllocSpanInitializerThroughSlot`) | fixed (Full-fidelity, `Consume(stackalloc int[] { 1, 2, 3 });`) | unchanged, still fixed |

This PR went through nine rounds of adversarial review (GPT-5.6 Sol + Gemini
3.1 Pro), each surfacing concrete, independently-reproduced correctness
findings, fixed in six follow-up commits on top of the original `79a3084f`:

- **`85ced622`** (round 1, GPT): the slot-indirection raise could silently
  drop an effectful size expression, or raise with an initializer element
  count that disagreed with the constructor's own length argument. Fixed by
  requiring the store's underlying size/count to be a `Constant`, and by
  requiring the constructor's length argument to equal the initializer's
  element count before raising.
- **`d0641941`** (round 2, GPT + Gemini): (a) the same size-erasure and
  count/element-type mismatch defects also existed, unfixed, in the
  pre-existing *direct*-pointer path (Gemini) -- both paths are now unified
  through one resolution/validation function; (b) a `Convert`-wrapped
  `StackAllocArray` bypassed the count/type checks because the wrapper didn't
  match the `is StackAllocArray` pattern, and the element **type** was never
  checked at all (GPT) -- fixed by always returning the unwrapped node and
  adding an element-type-equality check; (c) the ownership proof only
  required the store to *precede* the load's statement, not be its immediate
  successor, letting an intervening effectful statement be reordered around
  the moved allocation (GPT) -- fixed by requiring immediate adjacency.
- **`df822b7a`** (round 3, GPT + Gemini): (a) the round-1/2 `Constant`-only
  size/count requirement was over-tight -- it rejected the common
  `stackalloc byte[n]` pattern where `n` is a plain dynamic local/parameter,
  reintroducing the original invalid-Full CS8346 shape for a case that
  previously worked (GPT) -- fixed by replacing it with an `IsSideEffectFree`
  allow-list mirroring the existing `RedundantBranchEliminationPass` pattern
  (locals/arguments/`sizeof` and pure arithmetic over them are safe; anything
  that could call a method is not); (b) the statement-adjacency check
  accepted a loop/switch header as "the adjacent statement" when the load sat
  inside its condition rather than its body, letting a one-time allocation
  move into code evaluated a different number of times (GPT) -- fixed by
  restricting the accepted statement types to single-evaluation leaves
  (`ExpressionStatement`/`Return`/`Throw`/`StoreLocal`); (c) the element-type
  check was scoped only to initializer-bearing `StackAllocArray` sources, so
  an uninitialized `StackAllocArray`'s own element type went unchecked
  (Gemini) -- fixed by checking element type unconditionally for any
  `StackAllocArray` source.
- **`9d832dc6`** (round 4, GPT): (a) an effectful constructor `count`
  argument (e.g. an out-of-line `count` distinct from the stackalloc size)
  could still be dropped even though the allocation size itself was pure --
  fixed by also requiring `IsSideEffectFree(count)` on the constructor's own
  length argument; (b) an uninitialized `StackAllocArray`'s own `Count` was
  never checked against the constructor's `count`, only the initializer's
  element count was -- fixed by requiring the two to agree (as literal
  constants) when both are constant.
- **`73ba4058`** (round 5, GPT + Gemini): both reviewers independently found
  that the statement-type allowlist let an allocation move into a
  conditionally-evaluated branch nested inside an otherwise-permitted
  statement (Gemini: `StoreLocal(Conditional(cond, spanCtor, default))`), and
  separately that the allowlist wrongly excluded common linear patterns like
  `StoreStackSlot` (Gemini), while GPT found an even subtler gap: an earlier
  effectful argument in the same enclosing `Call` (e.g.
  `Consume(Marker(), spanCtor)`) could still run before the now-relocated
  allocation, and a dynamic (non-constant) `StackAllocArray.Count` was never
  proven equal to the constructor's count, only literal constants were
  compared. Replaced the whole statement-type allowlist with one stronger
  invariant, `GetHeldExpression(statement) == newObject` -- the constructor
  call must be the statement's *entire* evaluated expression, not merely
  reachable somewhere inside it -- which subsumes both the conditional-branch
  and the earlier-call-argument concerns. Added a `StructurallyEqual` deep
  equality helper for the dynamic-count case.
- **`6c14f627`** (round 6, GPT + Gemini): both reviewers independently found
  that `GetHeldExpression` still accepted `StoreField`, `StoreIndirect`, and
  `StoreElement`, each of which evaluates another operand (an instance
  receiver, an address, or an array+index) *before* `Value` -- so
  `Value == newObject` didn't prove the allocation runs first (repro:
  `GetTarget().Value = stackalloc byte[2147418112]` moved the overflowing
  allocation after `GetTarget()`). Both reviewers also independently found
  `StructurallyEqual`'s `Convert` case ignored `IsUnsigned`, so a signed and
  an unsigned conversion of the same operand were wrongly treated as equal
  (repro: `n = 0x80000000u` converts to `-2147483648` via `(double)(int)n`
  but `2147483648` via `(double)(uint)n`). Fixed by only recognizing
  `StoreField` when `Instance is null` (a static field store has no other
  evaluated operand), dropping `StoreIndirect`/`StoreElement` entirely, and
  comparing `IsUnsigned` in `StructurallyEqual`'s `Convert` case (matching how
  `Binary` already does).

Seventeen new regression tests across the six rounds reproduce each finding
and confirm it is declined (or, for the round-3 dynamic-size fix, correctly
raised) post-fix.

Three more rounds followed, focused on the byte-size proof for the
direct-pointer path (a raw `StackAllocate`'s byte size had never been
validated against the constructor's own count/element-type at all until
round 7 -- the original round-6 fix only closed the slot-indirection
ownership gap):

- **`3b2c8cd1`** (round 7, GPT): a raw `StackAllocate`'s byte size (`Size`)
  was never validated against the constructor's count/element-type at all
  (repro: a 4-byte `StackAllocate` fed into `new Span<int>(pointer, 2)`,
  which needs 8 bytes, raised incorrectly to `stackalloc int[2]`). Added
  `IsProvenByteSize`, matching either the canonical `count * sizeof(element)`
  compiler shape or, for two literal constants, a known fixed primitive byte
  size.
- **`ea9b3f3e`** (round 8, GPT): (a) the literal-constant comparison
  multiplied in `int` arithmetic, which can wrap around (repro: 4-byte size,
  count `1_073_741_825`, wraps to 4, falsely matches) -- fixed by widening to
  `long` before multiplying; (b) the helper stripping `Convert` wrappers
  before the structural/literal comparison stripped every unchecked
  `Convert`, including narrowing/lossy ones (repro:
  `unchecked((byte)257) * sizeof(int)` == 4 bytes, but stripping the `(byte)`
  cast made it falsely match count=257, i.e. 1028 bytes) -- fixed by gating
  the strip on `CSharpConversionRules.IsImplicitIntegerWidening` (value-
  preserving conversions only).
- **`ca4d9b73`** (round 9, GPT + Gemini): (a) negative literal constants
  passed the arithmetic check (size=-4, count=-1 satisfies
  `-4 == -1 * -4`... i.e. `-4 == -1*4`), producing invalid `stackalloc
  T[-1]` (CS0247) -- fixed with `>= 0` guards on both this path and an
  identical latent bug in the `StackAllocArray` non-initializer
  count-agreement check; (b) both reviewers, working independently and each
  from a real compiled fixture (`stackalloc int[n]`, `stackalloc Guid[2]`),
  found the round-7/8 structural-shape branch never matched real compiler
  output: the actual IL for a dynamic, non-initializer `stackalloc T[n]` is
  a **checked, unsigned** multiply over an `int`-to-`nuint` convert chain
  (not the `unchecked` shape with a symbolic `SizeOf` node this pass
  assumed), and for primitive element types the compiler folds `sizeof` to a
  literal `Constant` rather than emitting a `SizeOf` node -- a gap never
  caught because this branch was validated only against synthetic IR
  fixtures for three rounds, never a real compiled artifact, violating this
  repo's own evidence-quality convention. **Scope decision**: rather than
  chase the real checked/nuint shape (which both reviewers' findings show
  has multiple interacting subtleties that would need dedicated
  compiled-fixture validation to trust soundly), the direct-pointer
  `StackAllocate` byte-size path now recognizes **only a literal-constant
  size/count pair**; the `Binary{Multiply}` structural-shape branch is
  removed entirely, and a dynamic (non-literal) size on this path is
  declined conservatively. This is a deliberate, documented scope
  limitation, not a regression -- the structural branch was never soundly
  supported. The `StackAllocArray` path (initializer lists and
  slot-indirection dynamic counts) is unaffected: it proves agreement by
  element count, not byte arithmetic, so it never had this gap. Note also
  that `StackAllocArray` is created only by an initializer list or by this
  pass's own slot-indirection raise -- a plain `stackalloc T[n]` with no
  initializer always reaches this pass as a raw `StackAllocate`, making the
  direct-pointer path the common real-world shape for dynamic-size
  stackalloc, and the scope limitation above a real, user-visible one
  (tracked as a follow-up, not silently accepted).

Twenty-three new regression tests across all nine rounds reproduce each
finding and confirm it is declined (or, for the round-3 dynamic-size fix and
the round-7/8 byte-size proof, correctly raised/declined) post-fix.

All 54 baseline failures are unchanged on Head — same test names, same
assertion failures (`ReturnToSenderFixtureCatalogTests`,
`FidelityCheckGeneratedFilterTests`, `TypeSourceCheckTests`,
`LadderRung6GateTests`, `NullCoalescingAssignmentPassTests`,
`StringSwitchRaisingTests`, `ExpressionTreeLambdaTests`) — confirmed by
running the identical suite with this PR's two commits `git stash`ed out on
the same worktree.

The real witness above was confirmed both directions: swapping in the
pre-fix `StackAllocSpanPass.cs` against the same compiled
`CfgSampleClass.dll` reproduces the invalid `new Span<int>((void*)(stackalloc
int[] { 1, 2, 3 }), 3)` output at (incorrectly) Full fidelity; restoring the
fix raises it correctly. `CfgSampleClass.StackAllocSpanInitializerThroughSlot`
and `IrImporterTests.StackAllocSpanInitializerThroughSlot_RaisesAtFullFidelity`
lock this in as a durable regression test.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — narrow, single-pass change gated by a strict
ownership proof (unique store, unique load, same block, store precedes load);
the PR quick corpus gate script (`eng/prepare-decompiler-pr-corpus.sh`)
requires bash and was not run in this Windows session. Blast radius is
intentionally minimal: the new code path only activates on the specific
`LoadStackSlot`/`Convert{LoadStackSlot}` pointer shape that was previously
declined outright (`continue`), so it cannot regress any shape the pass
already raised — confirmed by the unchanged 54/2948 fast-suite baseline above.

## Validation

```powershell
dotnet build src/ILInspector.Decompiler -c Release --configfile nuget.config
dotnet build src/ILInspector.Decompiler.Tests -c Release --configfile nuget.config
artifacts\bin\ILInspector.Decompiler.Tests\release\ILInspector.Decompiler.Tests.exe -class "ILInspector.Decompiler.Tests.StackAllocSpanPassTests" -class "ILInspector.Decompiler.Tests.StackAllocInitializerPassTests" -class "ILInspector.Decompiler.Tests.IrImporterTests" -class "ILInspector.Decompiler.Tests.FidelityGateTests" -trait- "Speed=Slow"
artifacts\bin\ILInspector.Decompiler.Tests\release\ILInspector.Decompiler.Tests.exe -trait- "Speed=Slow"
```





