### PR TITLE
Filter native DLLs out of the test Roslyn reference set (#2942)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CompilerFeatureOptionsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompilerFeatureOptionsTests.cs
@@ -76,7 +76,7 @@ public class CompilerFeatureOptionsTests
         var compilation = CSharpCompilation.Create(
             "CompilerFeatureOptionsTests",
             [CSharpSyntaxTree.ParseText(source, options)],
-            RuntimeReferences(),
+            RoslynTestReferences.TrustedPlatform,
             new CSharpCompilationOptions(
                 OutputKind.DynamicallyLinkedLibrary,
                 allowUnsafe: true,
@@ -93,12 +93,6 @@ public class CompilerFeatureOptionsTests
             new PEReader(stream, PEStreamOptions.LeaveOpen),
             diagnostics);
     }
-
-    static ImmutableArray<MetadataReference> RuntimeReferences()
-        => ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
-            .Split(Path.PathSeparator)
-            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
-            .ToImmutableArray();
 
     sealed class CompiledAssembly(
         MemoryStream stream,

--- a/src/ILInspector.Decompiler.Tests/RoslynTestReferences.cs
+++ b/src/ILInspector.Decompiler.Tests/RoslynTestReferences.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Reflection.PortableExecutable;
 using Microsoft.CodeAnalysis;
 
 namespace ILInspector.Decompiler.Tests;
@@ -25,9 +26,31 @@ static class RoslynTestReferences
                 continue;
             if (!seen.Add(path))
                 continue;
+            if (!IsManagedAssembly(path))
+                continue;
             try { builder.Add(MetadataReference.CreateFromFile(path)); }
             catch { }
         }
         return builder.ToImmutable();
     });
+
+    // True only for a managed PE: an SDK layout can enumerate native / unmanaged
+    // DLLs (coreclr, clrjit, *.Native.dll, ...) in TRUSTED_PLATFORM_ASSEMBLIES, and
+    // handing those to Roslyn as metadata references fails every compile with CS0009
+    // ("PE image doesn't contain managed metadata"). MetadataReference.CreateFromFile
+    // is lazy and does not reject them, so filter by the presence of the CLR header
+    // here, before the reference is built (issue #2942).
+    internal static bool IsManagedAssembly(string path)
+    {
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var pe = new PEReader(stream);
+            return pe.PEHeaders.CorHeader is not null;
+        }
+        catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/RoslynTestReferencesTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RoslynTestReferencesTests.cs
@@ -1,0 +1,41 @@
+using Xunit;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Guards the managed-only filter that keeps native / unmanaged DLLs enumerated in
+// TRUSTED_PLATFORM_ASSEMBLIES out of the Roslyn reference set (issue #2942): passing
+// an unmanaged PE to Roslyn fails every compile with CS0009.
+public class RoslynTestReferencesTests
+{
+    [Fact]
+    public void IsManagedAssembly_TrueForManagedAssembly()
+    {
+        string managed = typeof(object).Assembly.Location;
+        Assert.False(string.IsNullOrEmpty(managed));
+        Assert.True(RoslynTestReferences.IsManagedAssembly(managed));
+    }
+
+    [Fact]
+    public void IsManagedAssembly_FalseForNonPeFile()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"ii-2942-{Guid.NewGuid():N}.dll");
+        File.WriteAllBytes(path, [0x4D, 0x5A, 0x00, 0x01, 0x02, 0x03]); // "MZ" then junk — not a valid PE
+        try
+        {
+            Assert.False(RoslynTestReferences.IsManagedAssembly(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void IsManagedAssembly_FalseForMissingFile()
+        => Assert.False(RoslynTestReferences.IsManagedAssembly(
+            Path.Combine(Path.GetTempPath(), $"ii-2942-missing-{Guid.NewGuid():N}.dll")));
+
+    [Fact]
+    public void TrustedPlatform_IsNonEmpty()
+        => Assert.NotEmpty(RoslynTestReferences.TrustedPlatform);
+}

--- a/src/ILInspector.Decompiler.Tests/TestAssemblyReferenceResolvers.cs
+++ b/src/ILInspector.Decompiler.Tests/TestAssemblyReferenceResolvers.cs
@@ -8,6 +8,7 @@ static class TestAssemblyReferenceResolvers
         (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
         .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
         .Where(path => path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+        .Where(RoslynTestReferences.IsManagedAssembly)
         .GroupBy(Path.GetFileNameWithoutExtension, StringComparer.OrdinalIgnoreCase)
         .ToDictionary(group => group.Key!, group => group.First(), StringComparer.OrdinalIgnoreCase));
 


### PR DESCRIPTION
Fixes #2942.

## Problem

The in-process Roslyn compile-fixture helpers build their metadata-reference set by enumerating `TRUSTED_PLATFORM_ASSEMBLIES` (TPA) and filtering only by the `.dll` extension. On SDK layouts whose TPA enumerates the full shared-runtime directory (`coreclr.dll`, `clrjit.dll`, `*.Native.dll`, `mscordbi.dll`, `hostpolicy.dll`, ...), those native/unmanaged DLLs get handed to Roslyn as metadata references. `MetadataReference.CreateFromFile` is lazy and does not reject them, so the failure surfaces later as **CS0009** ("PE image doesn't contain managed metadata") on every compile-back — ~51 failures on the Windows .NET 11 daily SDK, making the suite effectively unrunnable locally. CI is green because its (Linux) TPA lists no native DLLs.

## Fix

Add a shared managed-PE filter `RoslynTestReferences.IsManagedAssembly(path)` — true iff the PE has a CLR header (`PEReader.PEHeaders.CorHeader is not null`), guarded against I/O and bad-image exceptions — and apply it across every TPA-derived reference reader:

- `RoslynTestReferences` (the shared cache) — skip non-managed paths before building the reference.
- `TestAssemblyReferenceResolvers` (the platform-resolver dictionary) — add `.Where(IsManagedAssembly)`.
- `CompilerFeatureOptionsTests` — it read TPA inline and **unfiltered**; routed through `RoslynTestReferences.TrustedPlatform`, fixing and deduplicating it in one move.

R2R / crossgen'd / reference assemblies keep their COR header, so they remain included; only truly native modules are dropped. The filter is a **no-op** on all-managed TPA layouts (e.g. Linux CI: 182/182 managed), so behavior there is unchanged.

## Evidence

| Check | Result |
| --- | --- |
| Product build (test project, Release) | Pass |
| New `RoslynTestReferencesTests` (predicate positive/negative + non-empty cache) | 4/4 pass |
| `CompilerFeatureOptionsTests` (now via shared cache) | 2/2 pass |
| Issue-named affected consumers (`ReturnToSenderFixtureCatalogTests`, `FidelityCheckGeneratedFilterTests`, `TypeSourceCheckTests`) | 142/142 pass |
| Decompiler fast suite | 2947, 0 failed |

Verification boundary: this change cannot be reproduced on Linux (its TPA is all-managed, so the filter is a no-op here); it targets the Windows-daily-SDK layout whose TPA lists native DLLs. Correctness of the predicate is covered by the new unit tests (a managed/R2R assembly is accepted; a non-PE and a missing file are rejected).

## Validation

```bash
dotnet build src/ILInspector.Decompiler.Tests -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/RoslynTestReferencesTests/*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
```
