### PR TITLE
Fix build break: duplicate s_object field in PrinterPrecedenceTests

### DIFF
--- a/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
@@ -16,7 +16,6 @@ public class PrinterPrecedenceTests
     static readonly TypeRef s_nuint = TypeRef.CoreLib("System", "UIntPtr");
     static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
     static readonly TypeRef s_string = TypeRef.CoreLib("System", "String");
-    static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
 
     static IrFunction Raised(string methodName)
     {


### PR DESCRIPTION
PR #2925 (\Spell Unbox as ref Unsafe.Unbox<T> across all C# printer substrates\) introduced a second \static readonly TypeRef s_object\ field declaration in \PrinterPrecedenceTests.cs\, which is CS0102 and breaks the \src/ILInspector.Decompiler.Tests\ build on \main\ entirely (no test-only PR could build/run since).

Trivial, mechanical, one-line duplicate removal — no behavior change, no adversarial review needed per repo policy (simple/mechanical fix).

## Validation

\\\ash
dotnet build src/ILInspector.Decompiler.Tests -c Release --configfile ./nuget.config
\\\

Build succeeded, 0 errors (previously failed with CS0102).