### PR TITLE
Fold negated equality/inequality operator-spelled calls (#2955)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -5552,12 +5552,12 @@ public class EnumConstantTests
     }
 
     [Fact]
-    public void NotOverOperatorCall_Parenthesizes()
+    public void NotOverEqualityOperatorCall_FoldsToDirectComparison()
     {
-        // !(a != b) — an operator-spelled call renders as a compound `a != b`,
-        // so the enclosing `!` must parenthesize it; a bare `!a != b` binds as
-        // `(!a) != b` (CS0023). The C# compiler folds this source form, so the
-        // node is built directly.
+        // !(a != b) is an exact logical negation of a != b for any type (including
+        // NaN-like partial orders: NaN != NaN is true, so !(NaN != NaN) and
+        // NaN == NaN agree), so the printer folds it directly to `a == b` rather
+        // than parenthesizing the un-folded operator-spelled call (#2955).
         var type = TypeRef.CoreLib("System", "Type");
         var boolType = TypeRef.CoreLib("System", "Boolean");
         var callee = new MethodRef(type, "op_Inequality", boolType, [type, type], HasThis: false)
@@ -5576,8 +5576,105 @@ public class EnumConstantTests
 
         string output = CSharpPrinter.Print(function).Output!.Trim();
 
-        Assert.Contains("!(a != b)", output);
+        Assert.Contains("a == b", output);
+        Assert.DoesNotContain("!(a != b)", output);
         Assert.DoesNotContain("!a != b", output);
+    }
+
+    [Fact]
+    public void NotOverRelationalOperatorCall_Parenthesizes()
+    {
+        // !(a > b) — a relational operator-spelled call renders as a compound
+        // `a > b`, so the enclosing `!` must parenthesize it; a bare `!a > b`
+        // binds as `(!a) > b` (CS0023). Unlike equality/inequality, relational
+        // operator calls are NOT folded (!(a>b) is not always a<=b for a
+        // user-defined partial order), so the un-folded node must still be
+        // built and parenthesized directly (#2955).
+        var type = TypeRef.CoreLib("System", "Type");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var callee = new MethodRef(type, "op_GreaterThan", boolType, [type, type], HasThis: false)
+        {
+            IsSpecialName = true,
+            IsOperator = MetadataFactState.Yes,
+        };
+        var greaterThan = new Call(callee, isVirtual: false,
+            [new LoadArgument(0, "a", type), new LoadArgument(1, "b", type)]);
+        var block = new Block(0);
+        block.Add(new Return(new LogicalNot(greaterThan)));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(boolType, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        string output = CSharpPrinter.Print(function).Output!.Trim();
+
+        Assert.Contains("!(a > b)", output);
+        Assert.DoesNotContain("!a > b", output);
+    }
+
+    [Fact]
+    public void NotOverEqualityOperatorCall_WithoutOperatorMetadata_DoesNotFold()
+    {
+        // A method literally named "op_Equality" that is NOT flagged as an
+        // operator (no specialname/operator metadata, not a recognized core
+        // operator type) must not be mistaken for the real operator and must
+        // not be folded or spelled with `==` (#2955 scope guard).
+        var declaring = TypeRef.Definition("ExternalFacts.Library", "ExternalFacts", "NotAnOperatorLibrary");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var type = TypeRef.CoreLib("System", "Type");
+        var callee = new MethodRef(declaring, "op_Equality", boolType, [type, type], HasThis: false)
+        {
+            IsSpecialName = false,
+            IsOperator = MetadataFactState.No,
+        };
+        var equality = new Call(callee, isVirtual: false,
+            [new LoadArgument(0, "a", type), new LoadArgument(1, "b", type)]);
+        var block = new Block(0);
+        block.Add(new Return(new LogicalNot(equality)));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(boolType, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        string output = CSharpPrinter.Print(function).Output!.Trim();
+
+        Assert.DoesNotContain("a != b", output);
+        Assert.Contains("op_Equality", output);
+    }
+
+    [Fact]
+    public void NotOverEqualityOperatorCall_OnUserDefinedType_DoesNotFold()
+    {
+        // C# requires `==`/`!=` to be declared as a pair, but does NOT
+        // require their implementations to be logical inverses of each
+        // other — a user-defined `operator ==`/`operator !=` pair could
+        // legally implement unrelated semantics. The BCL guarantees
+        // String/Type's op_Equality/op_Inequality genuinely are exact
+        // inverses (MemberIdentity.IsKnownCoreLibraryOperator), but an
+        // arbitrary user type carrying real specialname/operator metadata
+        // is NOT in that trusted set, so `!(a == b)` must stay un-folded
+        // and parenthesized here even though it still spells as `a == b`
+        // via the pre-existing operator-call spelling (#2955 scope guard).
+        var declaring = TypeRef.Definition("UserAssembly", "UserAssembly", "Vector");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var callee = new MethodRef(declaring, "op_Equality", boolType, [declaring, declaring], HasThis: false)
+        {
+            IsSpecialName = true,
+            IsOperator = MetadataFactState.Yes,
+        };
+        var equality = new Call(callee, isVirtual: false,
+            [new LoadArgument(0, "a", declaring), new LoadArgument(1, "b", declaring)]);
+        var block = new Block(0);
+        block.Add(new Return(new LogicalNot(equality)));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(boolType, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        string output = CSharpPrinter.Print(function).Output!.Trim();
+
+        Assert.Contains("!(a == b)", output);
+        Assert.DoesNotContain("a != b", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/MemberBodyProducerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberBodyProducerUnionTests.cs
@@ -1323,7 +1323,7 @@ public class MemberBodyProducerUnionTests
         Assert.Equal("""
             return pet switch
             {
-                Cat cat when !(cat.Name == "cat") => "z",
+                Cat cat when cat.Name != "cat" => "z",
                 Dog dog => dog.Name,
                 _ => "other",
             };
@@ -1585,7 +1585,7 @@ public class MemberBodyProducerUnionTests
             """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueSwitchNotNull"));
         var classValueSwitchNotNamedCat = RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueSwitchNotNamedCat");
         Assert.Contains("pet.Value as Cat", classValueSwitchNotNamedCat);
-        Assert.Contains("V_1.Name == \"cat\"", classValueSwitchNotNamedCat);
+        Assert.Contains("V_1.Name != \"cat\"", classValueSwitchNotNamedCat);
         var classValueSwitchNull = RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueSwitchNull");
         Assert.Contains("pet.Value", classValueSwitchNull);
         Assert.DoesNotContain("return pet switch", classValueSwitchNull);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2200,6 +2200,7 @@ public sealed partial class CSharpPrinter
             Conditions.Inverse(c.Kind),
             IsFloatComparison(c.Left, c.Right) ? !c.IsUnsigned : c.IsUnsigned,
             c.Left, c.Right),
+        LogicalNot { Operand: Call { Callee.Name: "op_Equality" or "op_Inequality" } call } when InvertedEqualityOperatorCallText(call) is { } invertedEquality => invertedEquality,
         LogicalNot { Operand: LogicalBinary logical } when TryPropertyPatternText(logical, negated: true) is { } negatedPattern => negatedPattern,
         LogicalNot { Operand: { } operand } when Truthiness(operand) is { } negated => negated.Inverted,
         LogicalNot n => $"!{Operand(n.Operand)}",
@@ -2370,6 +2371,7 @@ public sealed partial class CSharpPrinter
             Conditions.Inverse(c.Kind),
             IsFloatComparison(c.Left, c.Right) ? !c.IsUnsigned : c.IsUnsigned,
             c.Left, c.Right),
+        LogicalNot { Operand: Call { Callee.Name: "op_Equality" or "op_Inequality" } call } when InvertedEqualityOperatorCallText(call) is { } invertedEquality => invertedEquality,
         LogicalNot { Operand: LogicalBinary logical } when TryPropertyPatternText(logical, negated: true) is { } negatedPattern => negatedPattern,
         LogicalNot { Operand: Call { Callee.Name: "op_True", Arguments: [var value] } } => InvertedUserTruthiness(value),
         LogicalNot { Operand: Call { Callee.Name: "op_False", Arguments: [var value] } } => OperatorOperand(value),
@@ -3405,6 +3407,44 @@ public sealed partial class CSharpPrinter
             && (call.Callee.IsOperator != MetadataFactState.No && call.Callee.IsSpecialName
                 || MemberIdentity.IsKnownCoreLibraryOperator(call.Callee))
             && OperatorSpelling(call) is not null;
+
+    /// <summary>
+    /// The direct idiom for a negated operator-spelled equality/inequality
+    /// CALL (`!(Type.op_Equality(a, b))` -> `a != b`, and the reverse), the
+    /// call-shaped counterpart of the native <c>ceq</c>-opcode fold above
+    /// (#2955). Restricted to <see cref="MemberIdentity.IsKnownCoreLibraryOperator"/>
+    /// (currently <see cref="string"/>/<see cref="Type"/>), where the BCL
+    /// guarantees op_Equality and op_Inequality are each other's exact logical
+    /// inverse for every input — including IEEE-754 float/double, where
+    /// <c>NaN == NaN</c> is false and <c>NaN != NaN</c> is true, so the two
+    /// remain consistent negations with no unordered-NaN special case to
+    /// guard, unlike <c>&lt;</c>/<c>&lt;=</c>/<c>&gt;</c>/<c>&gt;=</c>. C#
+    /// requires `==`/`!=` to be declared as a pair but does NOT require their
+    /// implementations to be logical inverses of each other, so an arbitrary
+    /// user-defined operator pair (recognized by the broader
+    /// <see cref="IsOperatorCall"/> spelling guard) is deliberately excluded
+    /// here: folding would substitute a call to one method with a call to a
+    /// different method, which can observably change behavior for a
+    /// maliciously or buggily inconsistent pair. Unlike the relational
+    /// operator-call family (`op_LessThan` and friends, also NOT folded
+    /// here), a relational operator call CAN implement partial-order
+    /// (NaN-like) semantics the native float-comparison guard already
+    /// special-cases, so that family is deliberately left unfolded pending
+    /// its own analysis. Returns null when the call does not actually spell
+    /// as `==`/`!=` (an unrelated method that happens to be named
+    /// op_Equality/op_Inequality without the metadata operator flag renders
+    /// as a plain call, and `!` negating its result is already correct
+    /// as-is).
+    /// </summary>
+    string? InvertedEqualityOperatorCallText(Call call)
+        => call is { Arguments: [var left, var right] } && MemberIdentity.IsKnownCoreLibraryOperator(call.Callee)
+            ? call.Callee.Name switch
+            {
+                "op_Equality" => $"{OperatorOperand(left)} != {OperatorOperand(right)}",
+                "op_Inequality" => $"{OperatorOperand(left)} == {OperatorOperand(right)}",
+                _ => null,
+            }
+            : null;
 
     /// <summary>
     /// True when an expression is legal as a C# expression statement: an


### PR DESCRIPTION
- Fixes/advances #2955
- Changes decompiler folds `LogicalNot` over an operator-spelled `op_Equality`/`op_Inequality` call into a direct `!=`/`==` comparison
- Card revision: `13587a2e`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — closes a fidelity+readability gap that also fixes inverted branch polarity on recompile, with a deliberately narrow, verified-safe scope.

### Original source

SourceLink-backed, from [dotnet/command-line-api](https://raw.githubusercontent.com/dotnet/dotnet/f7d90799ce4ef09a0bb257852a57248d2a8fb8dd/src/command-line-api/src/System.CommandLine/Binding/TypeExtensions.cs):

```csharp
internal static bool IsEnumerable(this Type type)
{
    if (type == typeof(string))
    {
        return false;
    }

    return
        type.IsArray
        ||
        typeof(IEnumerable).IsAssignableFrom(type);
}
```

### Before

```csharp
internal static bool IsEnumerable(this System.Type type) => !(type == typeof(string)) && (type.IsArray || typeof(IEnumerable).IsAssignableFrom(type));
```

- Valid: True
- Correct: True

Compiles and behaves correctly, but doesn't match the idiomatic source spelling. `Type` doesn't use the native `ceq` opcode for `==`; it compiles to `call System.Type::op_Equality(Type, Type)`. The existing `LogicalNot{Operand:Comparison}` negation fold only pattern-matches native comparison opcodes (`ceq`/`clt`/`cgt`), so it never applied to this `Call`-based path — falling through to the generic `!{Operand}` fallback and rendering `!(type == typeof(string))` instead of the idiomatic `type != typeof(string)`. Recompiling this shape also produces inverted branch polarity (`brtrue`/`brfalse` swap, relocated basic block) relative to the original IL, even though behavior is unchanged.

### After

```csharp
internal static bool IsEnumerable(this System.Type type) => type != typeof(string) && (type.IsArray || typeof(IEnumerable).IsAssignableFrom(type));
```

- Valid: True
- Correct: True

Matches the idiomatic spelling and recompiles with the original branch polarity.

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `IrImporterTests`/`MemberBodyProducerUnionTests` (new/updated cases): 6 passed | 6 passed |
| Decompiler fast suite | 2958 total, 54 failed | 2961 total, 54 failed (same 54, pre-existing; 3 new tests added) |
| Real witness | `System.CommandLine.Binding.TypeExtensions::IsEnumerable` broken | fixed |

Baseline's 54 failures are unchanged (same tests, same reasons) between base commit `0f38240a` and this PR's head — confirmed via a full diff of `[FAIL]` line sets from `-trait- "Speed=Slow"` runs on both.

## Scope

This PR folds only the equality/inequality operator-call family (`op_Equality`/`op_Inequality`), and only for `MemberIdentity.IsKnownCoreLibraryOperator` (currently `System.String`/`System.Type`). `!(a==b)` and `!(a!=b)` are exact logical negations of each other for any type, including IEEE-754 floats (`NaN==NaN` is false, `NaN!=NaN` is true — no "unordered" edge case exists for equality specifically), but C# only requires `==`/`!=` to be declared as a pair, not that their implementations are each other's logical inverse. An adversarial review round caught that gating on the broader "is this genuinely operator-spelled" check (`IsOperatorCall`) would let the fold silently substitute a call to one user-defined operator method for a call to a different one, which can change behavior for an inconsistent (buggy or adversarial) pair. The fold is therefore restricted to the BCL-guaranteed-consistent `String`/`Type` pair; any other operator-spelled equality call — even one with genuine operator metadata — stays parenthesized (`!(a == b)`), covered by `NotOverEqualityOperatorCall_OnUserDefinedType_DoesNotFold`.

The relational operator-call family (`op_LessThan`, `op_LessThanOrEqual`, `op_GreaterThan`, `op_GreaterThanOrEqual`) is deliberately left un-folded: `!(a<b)` is not always `a>=b` for a user-defined type with partial-order/NaN-like semantics via a custom operator, and a generic `Call` node doesn't carry the native-`Comparison` path's float-based safety guard. A regression test (`NotOverRelationalOperatorCall_Parenthesizes`) locks in the current (safe) un-folded behavior for this family. Generalizing to the relational family, if wanted, should be tracked as a separate follow-up issue with its own safety analysis.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*NotOverEqualityOperatorCall*" -method "*NotOverRelationalOperatorCall*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
```

