### PR TITLE
docs: require Original source in raise issues/PRs, acquire renders via dotnet-inspect

### DIFF
--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -864,6 +864,29 @@ work.
   **hits** — the methods that exercise it, copied from the report, with a couple
   of example renders. The hits are the owner's ready-made test set and definition
   of done (the count goes to zero).
+- **Acquire every code block with `dotnet-inspect`, not by hand.** Both the
+  current render and the authoritative endpoint should be verbatim tool output
+  for the same member, so the owner and reviewers judge the raise against real
+  code instead of a paraphrase:
+  - Current render: `-S "Decompiled Source"` (the lowered C# the product emits
+    today).
+  - **Original source** (the endpoint the raise aims at): prefer C# via
+    `-S "Original Source"` (SourceLink-backed); when SourceLink cannot supply it
+    (no PDB, no source server, or a non-C# source language), fall back to the raw
+    `IL` section (`-S "IL"`) — IL is a valid, if lower-level, authoritative
+    anchor.
+
+  ```bash
+  dnx dotnet-inspect -y -- member {Type} {MethodSelector} {scope} -S "Original Source"
+  ```
+
+  A raise issue is a before→after comparison, so include the Original source
+  section — the same anchor the
+  [decompiler PR template](templates/decompiler-pr.md) requires — not just the
+  current render and a hand-written "fully raised" goal. An issue with only those
+  two is the common failure mode: it leaves reviewers unable to check the goal
+  against ground truth. State explicitly when neither C# source nor IL is
+  obtainable and why.
 - **One pattern, one agent, end to end.** A pattern maps to one pass family, so an
   agent can own building out that raise — discovery, the pass, the fixtures, the
   bring-down — without touching another agent's area. Where a pattern's

--- a/docs/templates/decompiler-pr.md
+++ b/docs/templates/decompiler-pr.md
@@ -20,13 +20,24 @@ makes this a before→after comparison, not a snapshot of only the raised output
 a snapshot cannot reveal a regression that leaves the After invalid or
 behavior-changing.
 
-Look for the authoritative original source with `dotnet-inspect`, including
-through SourceLink:
+Acquire each code block from `dotnet-inspect` rather than paraphrasing or
+hand-transcribing, so every render in the PR is verbatim product output for the
+same `{Type} {MethodSelector} {scope}`:
+
+- Original source: `-S "Original Source"` (SourceLink-backed C#). Prefer C#;
+  when SourceLink cannot supply it (no PDB, no source server, or a non-C# source
+  language), fall back to the raw `IL` section (`-S "IL"`) — IL is a valid, if
+  lower-level, authoritative anchor.
+- Before: `-S "Decompiled Source"` at the base commit (the pre-change output).
+- After: `-S "Decompiled Source"` at this PR's head (the post-change output).
+
+Only Fully raised is authored by hand — it is the intended endpoint, not a
+current render.
 
 dnx dotnet-inspect -y -- member {Type} {MethodSelector} {scope} -S "Original Source"
 
-When original source is available, keep Original source immediately before
-Before and include the relevant C#.
+Keep Original source immediately before Before. Omit the Original source section
+only when neither C# source nor IL is obtainable, and say so explicitly.
 
 Adversarial review evidence belongs in a separate PR comment, not this
 description. Before marking the PR ready, post a comment that names each
@@ -50,19 +61,24 @@ For focused invalid-Full / burndown row fixes, prefer
 ### Original source
 
 <!--
-Required when authoritative original source is available. Delete this section
-only after checking with dotnet-inspect (relying on SourceLink).
+Expected for every raise PR. Acquire with dotnet-inspect: prefer C# via
+`-S "Original Source"` (SourceLink); fall back to the raw IL section
+(`-S "IL"`) when SourceLink cannot supply C#. Omit only after checking and
+finding neither C# source nor IL is obtainable — say so explicitly rather than
+silently deleting this section.
 -->
 
 ```csharp
-// authoritative original source
+// authoritative original source (C# preferred; raw IL is an acceptable fallback)
 ```
 
 ### Before
 
 <!--
-Include the method signature line, matching Original source's shape, not just
-the body — a bare body is harder to line up against Original source.
+Acquire with `dotnet-inspect -S "Decompiled Source"` at the base commit, rather
+than hand-transcribing. Include the method signature line, matching Original
+source's shape, not just the body — a bare body is harder to line up against
+Original source.
 -->
 
 ```csharp
@@ -76,7 +92,10 @@ the body — a bare body is harder to line up against Original source.
 
 ### After
 
-<!-- Include the method signature line here too, for the same reason. -->
+<!--
+Acquire with `dotnet-inspect -S "Decompiled Source"` at this PR's head. Include
+the method signature line here too, for the same reason.
+-->
 
 ```csharp
 // output produced by this PR, including an honest fallback when not fully raised, with its method signature


### PR DESCRIPTION
## Why

Decompiler raise **issues** frequently omit the authoritative **Original source**. Root cause: the two guidance sources diverged.

- The issue-writing guidance (`docs/decompiler-quality.md`, "From report to ownable issues") only asked for the pattern's hits "with a couple of example renders" — the current render and a hand-written "fully raised" goal. It never mentioned Original source, so authors dutifully omitted it (e.g. #2907: *Current state* + *Fully raised goal*, no Original source).
- The PR template (`docs/templates/decompiler-pr.md`) treated Original source as optional (*"Required when available… Delete this section only after checking"*) and mentioned only **C#**, with no IL fallback.

## Changes

- **`docs/templates/decompiler-pr.md`**
  - Original source is now expected for every raise PR (omit only when neither C# nor IL is obtainable, and say so).
  - Acquire **all** code blocks with `dotnet-inspect` rather than hand-transcribing: Before/After via `-S "Decompiled Source"` (base commit / PR head), Original source via `-S "Original Source"`. Only *Fully raised* is authored by hand.
  - **C# preferred**; raw `-S "IL"` is an acceptable authoritative fallback when SourceLink cannot supply C#.
- **`docs/decompiler-quality.md`**
  - New bullet requiring an Original source section in raise issues, with the same acquire-via-`dotnet-inspect` and C#-preferred / IL-OK rules, cross-linked to the PR template.

## Evidence

Documentation-only. `markdownlint-cli` passes on both files. No behavior claim, so no product build/tests required.

Low risk (docs-only), so no adversarial review.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>