### PR TITLE
Fix attributed-parameter identity leak in raw-signature fallback (#2940)

### DIFF
--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -680,27 +680,27 @@ public static class ApiMemberIdentity
         // identifiers may contain spaces, '=', quotes, brackets, angle brackets,
         // parentheses, and commas), array-rank/type spellings, and default-value
         // literals can all contain characters that look structural, so no parser can
-        // be fully robust here. This fallback therefore matches main's splitter
-        // exactly except for the one construct #2940 introduces: a comma inside a
-        // leading attribute list ("[Optional, DateTimeConstant(ticks)] type name").
+        // be fully robust here. Every deviation from main's splitter risks changing
+        // the canonical signature for some compiler-emittable name (e.g. splitting
+        // main's combined <(...)> depth into independent counters regresses an F#
+        // name like ``x<)`` where '<' and ')' cross-cancel). This fallback therefore
+        // reproduces main's splitter EXACTLY, adding only the one thing #2940 needs:
+        // it skips a leading attribute list ("[Optional, DateTimeConstant(ticks)]
+        // type name") so the comma inside it does not split the parameter list.
         //
-        // Bracket nesting is tracked ONLY inside a leading attribute list, at the
-        // very start of a parameter, so that comma does not split the list. Brackets
-        // appearing later — array types like "int[]" or an F# quoted-identifier name
-        // like ``x[`` — are left untracked, exactly as on main; tracking them would
-        // regress those compiler-emittable names. Angle/paren nesting is tracked as
-        // on main (to keep generic/tuple commas intact), and structural counting is
-        // frozen once a formatter-emitted default begins (the exact " = " separator)
-        // so a default's delimiters never suppress a real comma. String/char literal
-        // tracking is deliberately omitted: it is defeatable by a quote in a name
-        // pairing with a quote in a later parameter's default.
+        // Bracket nesting is tracked ONLY inside that leading attribute list, at the
+        // very start of a parameter. Once the first real (non-space, non-'[') type
+        // character is seen, tracking reverts to main's single combined depth counter
+        // over '<'/'>'/'('/')' , so brackets in array types ("int[]") or in F#
+        // quoted names ("x[") are ordinary text, and generic/tuple commas stay
+        // protected — identical to main. String/char literal and default-value
+        // tracking are deliberately omitted: any such heuristic is defeatable by a
+        // quote or delimiter inside a name, which main treats as ordinary.
         List<string> paramTypes = [];
-        int angleDepth = 0;
-        int parenDepth = 0;
+        int depth = 0;
         int attrBracketDepth = 0;
         int lastSplit = 0;
         bool inLeadingAttributes = true;
-        bool inDefaultValue = false;
         for (int i = 0; i < paramSection.Length; i++)
         {
             char c = paramSection[i];
@@ -714,30 +714,17 @@ public static class ApiMemberIdentity
                     continue; // characters inside the attribute list (incl. commas) are skipped
                 }
                 if (c == ' ') continue; // still in the leading region, between/after attribute lists
-                inLeadingAttributes = false; // first real type character; fall through to normal handling
+                inLeadingAttributes = false; // first real type character; fall through to main's logic
             }
 
-            if (!inDefaultValue && c == '<') angleDepth++;
-            else if (!inDefaultValue && c == '>') { if (angleDepth > 0) angleDepth--; }
-            else if (!inDefaultValue && c == '(') parenDepth++;
-            else if (!inDefaultValue && c == ')') { if (parenDepth > 0) parenDepth--; }
-            else if (angleDepth == 0 && parenDepth == 0)
+            if (c == '<' || c == '(') depth++;
+            else if (c == '>' || c == ')') depth--;
+            else if (c == ',' && depth == 0)
             {
-                if (!inDefaultValue && c == '=' && i > 0 && paramSection[i - 1] == ' '
-                    && i + 1 < paramSection.Length && paramSection[i + 1] == ' ')
-                {
-                    inDefaultValue = true;
-                }
-                else if (c == ',')
-                {
-                    paramTypes.Add(ExtractParamType(paramSection[lastSplit..i].Trim()));
-                    lastSplit = i + 1;
-                    angleDepth = 0;
-                    parenDepth = 0;
-                    attrBracketDepth = 0;
-                    inLeadingAttributes = true;
-                    inDefaultValue = false;
-                }
+                paramTypes.Add(ExtractParamType(paramSection[lastSplit..i].Trim()));
+                lastSplit = i + 1;
+                attrBracketDepth = 0;
+                inLeadingAttributes = true;
             }
         }
         paramTypes.Add(ExtractParamType(paramSection[lastSplit..].Trim()));

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -667,7 +667,7 @@ public static class ApiMemberIdentity
             return signature;
 
         int parenEnd = signature.LastIndexOf(')');
-        if (parenEnd < 0)
+        if (parenEnd < parenStart + 1)
             return signature;
 
         string prefix = signature[..(parenStart + 1)];

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -707,7 +707,8 @@ public static class ApiMemberIdentity
             else if (c == ']') { if (bracketDepth > 0) bracketDepth--; }
             else if (angleDepth == 0 && parenDepth == 0 && bracketDepth == 0)
             {
-                if (c == '=')
+                if (c == '=' && i > 0 && paramSection[i - 1] == ' '
+                    && i + 1 < paramSection.Length && paramSection[i + 1] == ' ')
                 {
                     inDefaultValue = true;
                 }

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -683,6 +683,7 @@ public static class ApiMemberIdentity
         int lastSplit = 0;
         bool inString = false;
         bool inChar = false;
+        bool inDefaultValue = false;
         for (int i = 0; i < paramSection.Length; i++)
         {
             char c = paramSection[i];
@@ -696,18 +697,26 @@ public static class ApiMemberIdentity
                 if (c == '\\') i++;
                 else if (c == '\'') inChar = false;
             }
-            else if (c == '"') inString = true;
-            else if (c == '\'') inChar = true;
+            else if (inDefaultValue && c == '"') inString = true;
+            else if (inDefaultValue && c == '\'') inChar = true;
             else if (c == '<') angleDepth++;
             else if (c == '>') { if (angleDepth > 0) angleDepth--; }
             else if (c == '(') parenDepth++;
             else if (c == ')') { if (parenDepth > 0) parenDepth--; }
             else if (c == '[') bracketDepth++;
             else if (c == ']') { if (bracketDepth > 0) bracketDepth--; }
-            else if (c == ',' && angleDepth == 0 && parenDepth == 0 && bracketDepth == 0)
+            else if (angleDepth == 0 && parenDepth == 0 && bracketDepth == 0)
             {
-                paramTypes.Add(ExtractParamType(paramSection[lastSplit..i].Trim()));
-                lastSplit = i + 1;
+                if (c == '=')
+                {
+                    inDefaultValue = true;
+                }
+                else if (c == ',')
+                {
+                    paramTypes.Add(ExtractParamType(paramSection[lastSplit..i].Trim()));
+                    lastSplit = i + 1;
+                    inDefaultValue = false;
+                }
             }
         }
         paramTypes.Add(ExtractParamType(paramSection[lastSplit..].Trim()));

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -702,61 +702,7 @@ public static class ApiMemberIdentity
     }
 
     static string ExtractParamType(string param)
-    {
-        param = StripLeadingParameterAttributes(param);
-
-        int eqIndex = param.IndexOf('=');
-        if (eqIndex >= 0)
-            param = param[..eqIndex].Trim();
-
-        int depth = 0;
-        int lastSpace = -1;
-        for (int i = 0; i < param.Length; i++)
-        {
-            char c = param[i];
-            if (c == '<') depth++;
-            else if (c == '>') depth--;
-            else if (c == ' ' && depth == 0)
-                lastSpace = i;
-        }
-
-        return lastSpace > 0 ? param[..lastSpace] : param;
-    }
-
-    static string StripLeadingParameterAttributes(string param)
-    {
-        var start = 0;
-        while (start < param.Length)
-        {
-            while (start < param.Length && char.IsWhiteSpace(param[start]))
-                start++;
-            if (start >= param.Length || param[start] != '[')
-                break;
-
-            var depth = 0;
-            var end = -1;
-            for (var i = start; i < param.Length; i++)
-            {
-                if (param[i] == '[')
-                    depth++;
-                else if (param[i] == ']')
-                {
-                    depth--;
-                    if (depth == 0)
-                    {
-                        end = i + 1;
-                        break;
-                    }
-                }
-            }
-
-            if (end < 0)
-                break;
-            start = end;
-        }
-
-        return param[start..].TrimStart();
-    }
+        => ExtractSignatureParameterType(param);
 
     public static bool TryGetXmlDocMemberIdentity(ApiType type, ApiMember member, out XmlDocMemberIdentity identity)
     {

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -681,15 +681,29 @@ public static class ApiMemberIdentity
         int parenDepth = 0;
         int bracketDepth = 0;
         int lastSplit = 0;
+        bool inString = false;
+        bool inChar = false;
         for (int i = 0; i < paramSection.Length; i++)
         {
             char c = paramSection[i];
-            if (c == '<') angleDepth++;
-            else if (c == '>') angleDepth--;
+            if (inString)
+            {
+                if (c == '\\') i++;
+                else if (c == '"') inString = false;
+            }
+            else if (inChar)
+            {
+                if (c == '\\') i++;
+                else if (c == '\'') inChar = false;
+            }
+            else if (c == '"') inString = true;
+            else if (c == '\'') inChar = true;
+            else if (c == '<') angleDepth++;
+            else if (c == '>') { if (angleDepth > 0) angleDepth--; }
             else if (c == '(') parenDepth++;
-            else if (c == ')') parenDepth--;
+            else if (c == ')') { if (parenDepth > 0) parenDepth--; }
             else if (c == '[') bracketDepth++;
-            else if (c == ']') bracketDepth--;
+            else if (c == ']') { if (bracketDepth > 0) bracketDepth--; }
             else if (c == ',' && angleDepth == 0 && parenDepth == 0 && bracketDepth == 0)
             {
                 paramTypes.Add(ExtractParamType(paramSection[lastSplit..i].Trim()));

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -676,36 +676,52 @@ public static class ApiMemberIdentity
         if (string.IsNullOrEmpty(paramSection))
             return signature;
 
-        // The signature is a lossy display string, so parameter names (which F#
-        // quoted identifiers allow to contain spaces, '=', quotes, brackets, and
-        // commas) and default-value literals can both contain characters that look
-        // structural. We only need to protect the one construct #2940 introduces:
-        // the comma inside a DateTimeConstant attribute list ("[Optional,
-        // DateTimeConstant(ticks)] type name"). We therefore track angle/paren/
-        // bracket nesting to keep that comma intact, but stop counting structural
-        // delimiters once a formatter-emitted default value begins (the exact
-        // " = " separator that ApiSurfaceExtractor.FormatParameter writes). Inside a
-        // default we neither interpret nor balance its characters, matching the
-        // behavior on main so a default's brackets never suppress a real comma. We
-        // deliberately do not track string/char literals: any such heuristic is
-        // defeatable by a quote inside a parameter name pairing with a quote in a
-        // later parameter's default, and would regress compiler-emitted F# names.
+        // The signature is a lossy display string. Parameter names (F# quoted
+        // identifiers may contain spaces, '=', quotes, brackets, angle brackets,
+        // parentheses, and commas), array-rank/type spellings, and default-value
+        // literals can all contain characters that look structural, so no parser can
+        // be fully robust here. This fallback therefore matches main's splitter
+        // exactly except for the one construct #2940 introduces: a comma inside a
+        // leading attribute list ("[Optional, DateTimeConstant(ticks)] type name").
+        //
+        // Bracket nesting is tracked ONLY inside a leading attribute list, at the
+        // very start of a parameter, so that comma does not split the list. Brackets
+        // appearing later — array types like "int[]" or an F# quoted-identifier name
+        // like ``x[`` — are left untracked, exactly as on main; tracking them would
+        // regress those compiler-emittable names. Angle/paren nesting is tracked as
+        // on main (to keep generic/tuple commas intact), and structural counting is
+        // frozen once a formatter-emitted default begins (the exact " = " separator)
+        // so a default's delimiters never suppress a real comma. String/char literal
+        // tracking is deliberately omitted: it is defeatable by a quote in a name
+        // pairing with a quote in a later parameter's default.
         List<string> paramTypes = [];
         int angleDepth = 0;
         int parenDepth = 0;
-        int bracketDepth = 0;
+        int attrBracketDepth = 0;
         int lastSplit = 0;
+        bool inLeadingAttributes = true;
         bool inDefaultValue = false;
         for (int i = 0; i < paramSection.Length; i++)
         {
             char c = paramSection[i];
+
+            if (inLeadingAttributes)
+            {
+                if (c == '[') { attrBracketDepth++; continue; }
+                if (attrBracketDepth > 0)
+                {
+                    if (c == ']') attrBracketDepth--;
+                    continue; // characters inside the attribute list (incl. commas) are skipped
+                }
+                if (c == ' ') continue; // still in the leading region, between/after attribute lists
+                inLeadingAttributes = false; // first real type character; fall through to normal handling
+            }
+
             if (!inDefaultValue && c == '<') angleDepth++;
             else if (!inDefaultValue && c == '>') { if (angleDepth > 0) angleDepth--; }
             else if (!inDefaultValue && c == '(') parenDepth++;
             else if (!inDefaultValue && c == ')') { if (parenDepth > 0) parenDepth--; }
-            else if (!inDefaultValue && c == '[') bracketDepth++;
-            else if (!inDefaultValue && c == ']') { if (bracketDepth > 0) bracketDepth--; }
-            else if (angleDepth == 0 && parenDepth == 0 && bracketDepth == 0)
+            else if (angleDepth == 0 && parenDepth == 0)
             {
                 if (!inDefaultValue && c == '=' && i > 0 && paramSection[i - 1] == ' '
                     && i + 1 < paramSection.Length && paramSection[i + 1] == ' ')
@@ -716,6 +732,10 @@ public static class ApiMemberIdentity
                 {
                     paramTypes.Add(ExtractParamType(paramSection[lastSplit..i].Trim()));
                     lastSplit = i + 1;
+                    angleDepth = 0;
+                    parenDepth = 0;
+                    attrBracketDepth = 0;
+                    inLeadingAttributes = true;
                     inDefaultValue = false;
                 }
             }

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -677,14 +677,20 @@ public static class ApiMemberIdentity
             return signature;
 
         List<string> paramTypes = [];
-        int depth = 0;
+        int angleDepth = 0;
+        int parenDepth = 0;
+        int bracketDepth = 0;
         int lastSplit = 0;
         for (int i = 0; i < paramSection.Length; i++)
         {
             char c = paramSection[i];
-            if (c == '<' || c == '(') depth++;
-            else if (c == '>' || c == ')') depth--;
-            else if (c == ',' && depth == 0)
+            if (c == '<') angleDepth++;
+            else if (c == '>') angleDepth--;
+            else if (c == '(') parenDepth++;
+            else if (c == ')') parenDepth--;
+            else if (c == '[') bracketDepth++;
+            else if (c == ']') bracketDepth--;
+            else if (c == ',' && angleDepth == 0 && parenDepth == 0 && bracketDepth == 0)
             {
                 paramTypes.Add(ExtractParamType(paramSection[lastSplit..i].Trim()));
                 lastSplit = i + 1;
@@ -697,6 +703,8 @@ public static class ApiMemberIdentity
 
     static string ExtractParamType(string param)
     {
+        param = StripLeadingParameterAttributes(param);
+
         int eqIndex = param.IndexOf('=');
         if (eqIndex >= 0)
             param = param[..eqIndex].Trim();
@@ -713,6 +721,41 @@ public static class ApiMemberIdentity
         }
 
         return lastSpace > 0 ? param[..lastSpace] : param;
+    }
+
+    static string StripLeadingParameterAttributes(string param)
+    {
+        var start = 0;
+        while (start < param.Length)
+        {
+            while (start < param.Length && char.IsWhiteSpace(param[start]))
+                start++;
+            if (start >= param.Length || param[start] != '[')
+                break;
+
+            var depth = 0;
+            var end = -1;
+            for (var i = start; i < param.Length; i++)
+            {
+                if (param[i] == '[')
+                    depth++;
+                else if (param[i] == ']')
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        end = i + 1;
+                        break;
+                    }
+                }
+            }
+
+            if (end < 0)
+                break;
+            start = end;
+        }
+
+        return param[start..].TrimStart();
     }
 
     public static bool TryGetXmlDocMemberIdentity(ApiType type, ApiMember member, out XmlDocMemberIdentity identity)

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -676,38 +676,38 @@ public static class ApiMemberIdentity
         if (string.IsNullOrEmpty(paramSection))
             return signature;
 
+        // The signature is a lossy display string, so parameter names (which F#
+        // quoted identifiers allow to contain spaces, '=', quotes, brackets, and
+        // commas) and default-value literals can both contain characters that look
+        // structural. We only need to protect the one construct #2940 introduces:
+        // the comma inside a DateTimeConstant attribute list ("[Optional,
+        // DateTimeConstant(ticks)] type name"). We therefore track angle/paren/
+        // bracket nesting to keep that comma intact, but stop counting structural
+        // delimiters once a formatter-emitted default value begins (the exact
+        // " = " separator that ApiSurfaceExtractor.FormatParameter writes). Inside a
+        // default we neither interpret nor balance its characters, matching the
+        // behavior on main so a default's brackets never suppress a real comma. We
+        // deliberately do not track string/char literals: any such heuristic is
+        // defeatable by a quote inside a parameter name pairing with a quote in a
+        // later parameter's default, and would regress compiler-emitted F# names.
         List<string> paramTypes = [];
         int angleDepth = 0;
         int parenDepth = 0;
         int bracketDepth = 0;
         int lastSplit = 0;
-        bool inString = false;
-        bool inChar = false;
         bool inDefaultValue = false;
         for (int i = 0; i < paramSection.Length; i++)
         {
             char c = paramSection[i];
-            if (inString)
-            {
-                if (c == '\\') i++;
-                else if (c == '"') inString = false;
-            }
-            else if (inChar)
-            {
-                if (c == '\\') i++;
-                else if (c == '\'') inChar = false;
-            }
-            else if (inDefaultValue && c == '"') inString = true;
-            else if (inDefaultValue && c == '\'') inChar = true;
-            else if (c == '<') angleDepth++;
-            else if (c == '>') { if (angleDepth > 0) angleDepth--; }
-            else if (c == '(') parenDepth++;
-            else if (c == ')') { if (parenDepth > 0) parenDepth--; }
-            else if (c == '[') bracketDepth++;
-            else if (c == ']') { if (bracketDepth > 0) bracketDepth--; }
+            if (!inDefaultValue && c == '<') angleDepth++;
+            else if (!inDefaultValue && c == '>') { if (angleDepth > 0) angleDepth--; }
+            else if (!inDefaultValue && c == '(') parenDepth++;
+            else if (!inDefaultValue && c == ')') { if (parenDepth > 0) parenDepth--; }
+            else if (!inDefaultValue && c == '[') bracketDepth++;
+            else if (!inDefaultValue && c == ']') { if (bracketDepth > 0) bracketDepth--; }
             else if (angleDepth == 0 && parenDepth == 0 && bracketDepth == 0)
             {
-                if (c == '=' && i > 0 && paramSection[i - 1] == ' '
+                if (!inDefaultValue && c == '=' && i > 0 && paramSection[i - 1] == ' '
                     && i + 1 < paramSection.Length && paramSection[i + 1] == ' ')
                 {
                     inDefaultValue = true;

--- a/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
@@ -422,6 +422,22 @@ public class ApiMemberIdentityTests
         Assert.Equal(expected, ApiMemberIdentity.GetCanonicalSignature(type, member));
     }
 
+    [Theory]
+    // main uses a single combined depth counter over '<'/'>'/'('/')' , so an F#
+    // quoted name like ``x<)`` (emitted verbatim as "System.Int32 x<)") relies on
+    // '<' and ')' cross-cancelling to keep depth at 0 at the separator comma.
+    // Splitting that into independent angle/paren counters dropped the second
+    // parameter; the fallback must preserve main's combined-counter behavior.
+    [InlineData("void M(System.Int32 x<), System.Int32 y)", "M:N.C.M(System.Int32,System.Int32)")]
+    [InlineData("void M(System.Int32 x)<, System.Int32 y)", "M:N.C.M(System.Int32,System.Int32)")]
+    public void FallbackCanonicalSignature_PreservesCombinedAngleParenDepth(string signature, string expected)
+    {
+        var type = new ApiType { Namespace = "N", Name = "C" };
+        var member = new ApiMember { Name = "M", Kind = "method", Signature = signature };
+
+        Assert.Equal(expected, ApiMemberIdentity.GetCanonicalSignature(type, member));
+    }
+
     static (TypeDefinitionHandle TypeHandle, MethodDefinition Method) FindFixtureMethod(MetadataReader reader)
     {
         foreach (var typeHandle in reader.TypeDefinitions)

--- a/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
@@ -376,6 +376,18 @@ public class ApiMemberIdentityTests
         Assert.False(string.IsNullOrEmpty(canonical));
     }
 
+    [Theory]
+    [InlineData("void M(SetTree<T> t', FSharpList<T> acc)", "M:N.C.M(SetTree<T>,FSharpList<T>)")]
+    [InlineData("void M(System.Int32 x' = 5, System.Int32 y)", "M:N.C.M(System.Int32,System.Int32)")]
+    [InlineData("void M(System.String s\" = \"a,b\", System.Int32 y)", "M:N.C.M(System.String,System.Int32)")]
+    public void FallbackCanonicalSignature_TreatsQuotesOutsideDefaultsAsOrdinary(string signature, string expected)
+    {
+        var type = new ApiType { Namespace = "N", Name = "C" };
+        var member = new ApiMember { Name = "M", Kind = "method", Signature = signature };
+
+        Assert.Equal(expected, ApiMemberIdentity.GetCanonicalSignature(type, member));
+    }
+
     static (TypeDefinitionHandle TypeHandle, MethodDefinition Method) FindFixtureMethod(MetadataReader reader)
     {
         foreach (var typeHandle in reader.TypeDefinitions)

--- a/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
@@ -404,6 +404,24 @@ public class ApiMemberIdentityTests
         Assert.Equal(expected, ApiMemberIdentity.GetCanonicalSignature(type, member));
     }
 
+    [Theory]
+    // Brackets outside a leading attribute list must be treated as ordinary text so
+    // they never suppress the parameter-separating comma. This covers array types
+    // (int[]) and compiler-emittable F# double-backtick names that contain an
+    // unmatched bracket (e.g. ``x[``, emitted verbatim as "System.Int32 x["), which
+    // main handled and the fallback must not regress. Bracket nesting is tracked
+    // only inside the leading "[...]" attribute list.
+    [InlineData("void M(System.Int32 x[, System.Int32 y)", "M:N.C.M(System.Int32,System.Int32)")]
+    [InlineData("void M(System.Int32 x], System.Int32 y)", "M:N.C.M(System.Int32,System.Int32)")]
+    [InlineData("void M(System.Int32[] a, System.Int32[] b)", "M:N.C.M(System.Int32[],System.Int32[])")]
+    public void FallbackCanonicalSignature_TreatsBracketsOutsideAttributesAsOrdinary(string signature, string expected)
+    {
+        var type = new ApiType { Namespace = "N", Name = "C" };
+        var member = new ApiMember { Name = "M", Kind = "method", Signature = signature };
+
+        Assert.Equal(expected, ApiMemberIdentity.GetCanonicalSignature(type, member));
+    }
+
     static (TypeDefinitionHandle TypeHandle, MethodDefinition Method) FindFixtureMethod(MetadataReader reader)
     {
         foreach (var typeHandle in reader.TypeDefinitions)

--- a/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
@@ -379,6 +379,7 @@ public class ApiMemberIdentityTests
     [Theory]
     [InlineData("void M(SetTree<T> t', FSharpList<T> acc)", "M:N.C.M(SetTree<T>,FSharpList<T>)")]
     [InlineData("void M(System.Int32 x' = 5, System.Int32 y)", "M:N.C.M(System.Int32,System.Int32)")]
+    [InlineData("void M(System.Int32 x=', System.Int32 y)", "M:N.C.M(System.Int32,System.Int32)")]
     [InlineData("void M(System.String s\" = \"a,b\", System.Int32 y)", "M:N.C.M(System.String,System.Int32)")]
     public void FallbackCanonicalSignature_TreatsQuotesOutsideDefaultsAsOrdinary(string signature, string expected)
     {

--- a/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
@@ -251,6 +251,53 @@ public class ApiMemberIdentityTests
         Assert.Contains(canonicals, canonical => canonical.EndsWith("~long", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void FallbackCanonicalSignature_AttributedParameterMatchesLiveAfterJsonRoundTrip()
+    {
+        using var stream = File.OpenRead(typeof(ApiMemberIdentityTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        var liveType = surface.Types.Single(
+            type => type.Name.EndsWith(nameof(AttributedParameterFixture), StringComparison.Ordinal));
+        var liveMember = liveType.Members.Single(
+            member => member.Name == nameof(AttributedParameterFixture.M));
+        Assert.NotNull(liveMember.SignatureModel);
+        Assert.Contains("DateTimeConstant", liveMember.Signature, StringComparison.Ordinal);
+
+        var json = JsonSerializer.Serialize(surface);
+        var roundTripped = JsonSerializer.Deserialize<ApiSurface>(json)!;
+        var persistedType = roundTripped.Types.Single(
+            type => type.Name.EndsWith(nameof(AttributedParameterFixture), StringComparison.Ordinal));
+        var persistedMember = persistedType.Members.Single(
+            member => member.Name == nameof(AttributedParameterFixture.M));
+        Assert.Null(persistedMember.SignatureModel);
+
+        var liveCanonical = ApiMemberIdentity.GetCanonicalSignature(liveType, liveMember);
+        var persistedCanonical = ApiMemberIdentity.GetCanonicalSignature(persistedType, persistedMember);
+
+        Assert.Equal(liveCanonical, persistedCanonical);
+        Assert.EndsWith(".M(System.DateTime,int)", persistedCanonical, StringComparison.Ordinal);
+        Assert.DoesNotContain("Optional", persistedCanonical, StringComparison.Ordinal);
+        Assert.DoesNotContain("DateTimeConstant", persistedCanonical, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FallbackCanonicalSignature_StripsMultipleLeadingAttributeLists()
+    {
+        var type = new ApiType { Namespace = "N", Name = "C" };
+        var member = new ApiMember
+        {
+            Name = "M",
+            Kind = "method",
+            Signature = "void M([A][B(typeof(int[]))] System.DateTime when, int[] values)",
+        };
+
+        Assert.Equal(
+            "M:N.C.M(System.DateTime,int[])",
+            ApiMemberIdentity.GetCanonicalSignature(type, member));
+    }
+
     static (TypeDefinitionHandle TypeHandle, MethodDefinition Method) FindFixtureMethod(MetadataReader reader)
     {
         foreach (var typeHandle in reader.TypeDefinitions)
@@ -309,5 +356,16 @@ public class ApiMemberIdentityTests
         public int this[int index] => index;
 
         public int this[string key] => key.Length;
+    }
+
+    sealed class AttributedParameterFixture
+    {
+        public void M(
+            [System.Runtime.InteropServices.Optional]
+            [System.Runtime.CompilerServices.DateTimeConstant(630822816000000000L)]
+            DateTime when,
+            int count)
+        {
+        }
     }
 }

--- a/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
@@ -329,6 +329,39 @@ public class ApiMemberIdentityTests
             ApiMemberIdentity.GetCanonicalSignature(type, member));
     }
 
+    [Theory]
+    [InlineData("void M(System.String text = \"]\", System.Int32 count = 0)")]
+    [InlineData("void M(System.String text = \"[\", System.Int32 count = 0)")]
+    [InlineData("void M(System.String text = \"a,b\", System.Int32 count = 0)")]
+    [InlineData("void M(System.String text = \"<>()\", System.Int32 count = 0)")]
+    [InlineData("void M(System.String text = \"a\\\"]b\", System.Int32 count = 0)")]
+    [InlineData("void M(System.String text = \"ok\", System.Int32 count = 0)")]
+    public void FallbackCanonicalSignature_IgnoresDelimitersInsideStringDefaults(string signature)
+    {
+        var type = new ApiType { Namespace = "N", Name = "C" };
+        var member = new ApiMember { Name = "M", Kind = "method", Signature = signature };
+
+        Assert.Equal(
+            "M:N.C.M(System.String,System.Int32)",
+            ApiMemberIdentity.GetCanonicalSignature(type, member));
+    }
+
+    [Fact]
+    public void FallbackCanonicalSignature_IgnoresDelimitersInsideCharDefault()
+    {
+        var type = new ApiType { Namespace = "N", Name = "C" };
+        var member = new ApiMember
+        {
+            Name = "M",
+            Kind = "method",
+            Signature = "void M(System.Char sep = ']', System.Int32 count = 0)",
+        };
+
+        Assert.Equal(
+            "M:N.C.M(System.Char,System.Int32)",
+            ApiMemberIdentity.GetCanonicalSignature(type, member));
+    }
+
     static (TypeDefinitionHandle TypeHandle, MethodDefinition Method) FindFixtureMethod(MetadataReader reader)
     {
         foreach (var typeHandle in reader.TypeDefinitions)

--- a/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
@@ -362,6 +362,20 @@ public class ApiMemberIdentityTests
             ApiMemberIdentity.GetCanonicalSignature(type, member));
     }
 
+    [Theory]
+    [InlineData("void M)(int a")]
+    [InlineData("foo)bar(")]
+    [InlineData("void M) int a")]
+    public void FallbackCanonicalSignature_DoesNotThrowOnMalformedParentheses(string signature)
+    {
+        var type = new ApiType { Namespace = "N", Name = "C" };
+        var member = new ApiMember { Name = "M", Kind = "method", Signature = signature };
+
+        var canonical = ApiMemberIdentity.GetCanonicalSignature(type, member);
+
+        Assert.False(string.IsNullOrEmpty(canonical));
+    }
+
     static (TypeDefinitionHandle TypeHandle, MethodDefinition Method) FindFixtureMethod(MetadataReader reader)
     {
         foreach (var typeHandle in reader.TypeDefinitions)

--- a/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
@@ -332,7 +332,6 @@ public class ApiMemberIdentityTests
     [Theory]
     [InlineData("void M(System.String text = \"]\", System.Int32 count = 0)")]
     [InlineData("void M(System.String text = \"[\", System.Int32 count = 0)")]
-    [InlineData("void M(System.String text = \"a,b\", System.Int32 count = 0)")]
     [InlineData("void M(System.String text = \"<>()\", System.Int32 count = 0)")]
     [InlineData("void M(System.String text = \"a\\\"]b\", System.Int32 count = 0)")]
     [InlineData("void M(System.String text = \"ok\", System.Int32 count = 0)")]
@@ -380,8 +379,24 @@ public class ApiMemberIdentityTests
     [InlineData("void M(SetTree<T> t', FSharpList<T> acc)", "M:N.C.M(SetTree<T>,FSharpList<T>)")]
     [InlineData("void M(System.Int32 x' = 5, System.Int32 y)", "M:N.C.M(System.Int32,System.Int32)")]
     [InlineData("void M(System.Int32 x=', System.Int32 y)", "M:N.C.M(System.Int32,System.Int32)")]
-    [InlineData("void M(System.String s\" = \"a,b\", System.Int32 y)", "M:N.C.M(System.String,System.Int32)")]
     public void FallbackCanonicalSignature_TreatsQuotesOutsideDefaultsAsOrdinary(string signature, string expected)
+    {
+        var type = new ApiType { Namespace = "N", Name = "C" };
+        var member = new ApiMember { Name = "M", Kind = "method", Signature = signature };
+
+        Assert.Equal(expected, ApiMemberIdentity.GetCanonicalSignature(type, member));
+    }
+
+    [Theory]
+    // An F# double-backtick identifier can legally contain spaces, '=', and an
+    // apostrophe (e.g. ``x = '``), which the formatter emits verbatim. The default
+    // separator " = " inside such a name must not cause the following apostrophe to
+    // be read as a char literal that swallows the parameter-separating comma. This
+    // is compiler-emittable and was handled correctly on main; the fallback must not
+    // regress it.
+    [InlineData("void M(System.Int32 x = ', System.Int32 y)", "M:N.C.M(System.Int32,System.Int32)")]
+    [InlineData("void M(System.Int32 x = \", System.Int32 y)", "M:N.C.M(System.Int32,System.Int32)")]
+    public void FallbackCanonicalSignature_DoesNotInterpretQuotesInDefaultRegion(string signature, string expected)
     {
         var type = new ApiType { Namespace = "N", Name = "C" };
         var member = new ApiMember { Name = "M", Kind = "method", Signature = signature };

--- a/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
@@ -283,6 +283,37 @@ public class ApiMemberIdentityTests
     }
 
     [Fact]
+    public void FallbackCanonicalSignature_AttributedIndexerMatchesLiveAfterJsonRoundTrip()
+    {
+        using var stream = File.OpenRead(typeof(ApiMemberIdentityTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        var liveType = surface.Types.Single(
+            type => type.Name.EndsWith(nameof(AttributedParameterFixture), StringComparison.Ordinal));
+        var liveIndexer = liveType.Members.Single(
+            member => member.Kind == "property" && member.Name == "Item");
+        Assert.NotNull(liveIndexer.SignatureModel);
+        Assert.Contains("DateTimeConstant", liveIndexer.Signature, StringComparison.Ordinal);
+
+        var json = JsonSerializer.Serialize(surface);
+        var roundTripped = JsonSerializer.Deserialize<ApiSurface>(json)!;
+        var persistedType = roundTripped.Types.Single(
+            type => type.Name.EndsWith(nameof(AttributedParameterFixture), StringComparison.Ordinal));
+        var persistedIndexer = persistedType.Members.Single(
+            member => member.Kind == "property" && member.Name == "Item");
+        Assert.Null(persistedIndexer.SignatureModel);
+
+        var liveCanonical = ApiMemberIdentity.GetCanonicalSignature(liveType, liveIndexer);
+        var persistedCanonical = ApiMemberIdentity.GetCanonicalSignature(persistedType, persistedIndexer);
+
+        Assert.Equal(liveCanonical, persistedCanonical);
+        Assert.EndsWith(".Item(System.DateTime)", persistedCanonical, StringComparison.Ordinal);
+        Assert.DoesNotContain("Optional", persistedCanonical, StringComparison.Ordinal);
+        Assert.DoesNotContain("DateTimeConstant", persistedCanonical, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void FallbackCanonicalSignature_StripsMultipleLeadingAttributeLists()
     {
         var type = new ApiType { Namespace = "N", Name = "C" };
@@ -367,5 +398,10 @@ public class ApiMemberIdentityTests
             int count)
         {
         }
+
+        public int this[
+            [System.Runtime.InteropServices.Optional]
+            [System.Runtime.CompilerServices.DateTimeConstant(630822816000000000L)]
+            DateTime when] => when.Year;
     }
 }


### PR DESCRIPTION
## Problem

`ApiMemberIdentity`'s raw-signature-parsing **fallback** (used when `ApiSurface.SignatureModel` is absent — e.g. after JSON round-tripping a persisted `ApiSurface`) mis-parses parameters whose raw `Signature` text carries a leading attribute list. For a `[DateTimeConstant]`-defaulted optional parameter, `ApiSurfaceExtractor.FormatParameter` renders:

```
[System.Runtime.InteropServices.Optional, System.Runtime.CompilerServices.DateTimeConstant(630822816000000000)] System.DateTime
```

The comma inside `[Optional, DateTimeConstant(...)]` split the parameter list, and the attribute text leaked into the canonical signature — so a JSON-persisted baseline and the same assembly read **live** produced different canonical signatures / fingerprints for the member, breaking `FindingComparison` pairing. This is the same failure mode fixed for indexers in #2938, gated behind a rarer trigger, and is **pre-existing** (not introduced by #2938).

Fixes #2940.

## Observable before / after

The concrete effect is on the member's **canonical signature** — the identity `FindingComparison` uses to pair members across baselines. The live, `SignatureModel`-driven path is stable on both `main` and this PR:

```
M:...AttributedParameterFixture.M(System.DateTime,int)
```

After JSON round-tripping a persisted `ApiSurface` (`SignatureModel` is `[JsonIgnore]`, so the raw-signature **fallback** runs), the same member yields:

**Before (`main`)** — the leading attribute list leaks into the canonical type and the comma inside `[Optional, DateTimeConstant(...)]` inflates the parameter list, so the persisted identity diverges from live and pairing breaks:

```
M:...AttributedParameterFixture.M([System.Runtime.InteropServices.Optional,System.Runtime.CompilerServices.DateTimeConstant(630822816000000000L)] System.DateTime,int)
```

**After (this PR)** — the fallback matches the live path exactly, so the persisted and live fingerprints pair:

```
M:...AttributedParameterFixture.M(System.DateTime,int)
```

Reproduced by forcing the fallback (a persisted `ApiMember` with no `SignatureModel`) over the fixture signature `void M([Optional, DateTimeConstant(...)] System.DateTime when, int count)` on `origin/main` (`f8462478`) vs this head. (`M:...` abbreviates the full type name `ILInspector.Metadata.Tests.ApiMemberIdentityTests` for readability; the two canonicals differ only in the parameter list.)

## Fix (`src/ILInspector.Metadata/ApiMemberIdentity.cs`)

The fallback parses a lossy display string, and that display string is **not C#-only**: F# double-backtick identifiers (`` ``...`` ``) are emitted verbatim by `ApiSurfaceExtractor.FormatParameter` (its `EscapeIdentifier` only escapes C# keywords), so a parameter name can legally contain spaces, `=`, quotes, `[`, `]`, `<`, `>`, `(`, `)`, and commas. Adversarial review confirmed that **every** deviation from `main`'s splitter — independent angle/paren counters, clamping, a global bracket counter, or string/char/default literal tracking — regressed some compiler-emittable name.

So this change takes the tightest possible position and reproduces `main`'s splitter **exactly**, adding only what #2940 requires:

1. **`AbbreviateSignature`** — restores `main`'s exact loop: a single combined `int depth` incremented on `<` and `(`, decremented on `>` and `)`, splitting the parameter list on `,` only at `depth == 0`. No clamping, no independent counters, no string/char/default literal tracking. This preserves `main`'s delimiter cross-cancellation (e.g. an F# name `` ``x<)`` `` emitted as `System.Int32 x<)` keeps `depth` at 0 at the separator comma). The **only** added behavior is a leading-attribute skip: at the start of each parameter, a leading `[...]` attribute list is consumed via a separate `attrBracketDepth` so its inner comma cannot split the list.
2. **`StripLeadingAttributes` + `ExtractSignatureParameterType`** — the extracted parameter type strips a leading `[...]` attribute list (nested-bracket-aware) before trimming at the last top-level space, so leaked attribute text never reaches the canonical type. The fallback and the XML-doc parameter-type path share this helper.
3. **Malformed-signature guard** — `AbbreviateSignature` bails with `if (parenEnd < parenStart + 1) return signature;` instead of slicing, so a persisted signature whose `)` precedes its `(` returns gracefully rather than throwing `ArgumentOutOfRangeException` (the fallback's input domain is untrusted persisted signatures).

For every input that does **not** begin a parameter with a `[` attribute list, this head is byte-identical to `main`. The live (`SignatureModel`-driven) path is unaffected. Multidimensional-array (`int[,]`) and comma-inside-a-string-default (`string s = "a,b"`) fallback parsing remain **pre-existing best-effort limitations shared with `main`**; `SignatureModel` is the robust identity path and the raw-signature fallback exists only for legacy JSON baselines.

### Zero-regression evidence

A side-by-side probe ran `main`'s `AbbreviateSignature` and this head over 31 signature shapes (generics, tuples, arrays incl. `int[,]`, `ref`/`out`/`in`/`params`, string/char/numeric defaults, comma-in-string default, F# `` ``x = '`` `` / `` ``x[`` `` / `` ``x]`` `` / `` ``x<)`` `` / `` ``x>`` `` / `` ``x)`` `` quoted names, single and multiple leading attribute lists). Result: **28 identical to `main`**, **2 differences** = the intended #2940 attribute stripping, **1 case** where `main` throws `ArgumentOutOfRangeException` on reversed parens and this head returns gracefully. No output is worse than `main` on any compiler-emitted shape.

## Tests (`tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs`)

- `FallbackCanonicalSignature_AttributedParameterMatchesLiveAfterJsonRoundTrip` / `...AttributedIndexerMatchesLiveAfterJsonRoundTrip` — live vs JSON-persisted canonical parity with no leaked attribute text (method + indexer).
- `FallbackCanonicalSignature_StripsMultipleLeadingAttributeLists` — multiple leading attribute lists removed.
- `FallbackCanonicalSignature_IgnoresDelimitersInsideStringDefaults` (Theory, incl. `]`, `[`, `<>()`, escaped-quote `"a\"]b"`) and `...InsideCharDefault` (`= ']'`) — delimiters inside a default do not split the list.
- `FallbackCanonicalSignature_DoesNotThrowOnMalformedParentheses` (Theory) — reversed-paren guard.
- `FallbackCanonicalSignature_TreatsQuotesOutsideDefaultsAsOrdinary` (Theory, incl. F# `SetTree<T> t'`, `x' = 5`, `x='`) — quotes/apostrophes in names/types stay ordinary.
- `FallbackCanonicalSignature_DoesNotInterpretQuotesInDefaultRegion` (Theory) — compiler-emittable F# `` ``x = '`` `` / `` ``x = "`` `` names keep both parameters.
- `FallbackCanonicalSignature_TreatsBracketsOutsideAttributesAsOrdinary` (Theory, incl. F# `` ``x[`` ``, `` ``x]`` ``, and `int[]` array types) — brackets outside a leading attribute list stay ordinary.
- `FallbackCanonicalSignature_PreservesCombinedAngleParenDepth` (Theory, F# `` ``x<)`` `` / `` ``x)<`` ``) — combined angle/paren depth cross-cancellation matches `main`, keeping both parameters.

## Validation

| Check | Result |
| --- | --- |
| Build `ILInspector.Metadata.Tests` (`--configfile nuget.config`) | 0 errors |
| `ApiMemberIdentityTests` | 36/36 |
| Full `ILInspector.Metadata.Tests` suite | 648/648 |

Metadata-only change; layer ownership preserved (Metadata owns metadata/signature facts). Rebased on current `main`.

