### PR TITLE
Raise switches with shared miss-handler/return exit chains (#2954)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SwitchRaisingSharedMissHandlerTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwitchRaisingSharedMissHandlerTests.cs
@@ -1,0 +1,97 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Issue #2954: a real two-tier string-switch lowering (e.g.
+// Humanizer.MalteseFormatter.GetResourceKey) has every case's "no match" arm
+// jump into one shared miss-handler block that itself falls through into the
+// method's single return, while each case's matching arm jumps straight to
+// that same return, skipping the miss-handler. Raise's exit-unify previously
+// required literal equality between a case's exits, so a case whose two exits
+// were the miss-handler and the return it falls into (not the same block)
+// failed to unify and the whole table was left flat as an if-ladder.
+public class SwitchRaisingSharedMissHandlerTests
+{
+    static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+
+    [Fact]
+    public void CaseWithMissArmChainingIntoTheReturnItFallsInto_StillRaisesToSwitch()
+    {
+        var function = BuildTwoCaseSwitchWithSharedMissHandler();
+
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        var node = Assert.Single(function.Descendants.OfType<Switch>());
+        // Two case sections; the default is an empty jump straight to the
+        // (shared) join, so C# omits it entirely.
+        Assert.Equal(2, node.Sections.Count);
+        Assert.DoesNotContain(node.Sections, s => s.IsDefault);
+
+        // The shared miss-handler and the return it falls into print once,
+        // as ordinary code after the switch — not duplicated per case.
+        Assert.Single(function.Descendants.OfType<Return>());
+    }
+
+    static Comparison IntEqual(int argIndex, string argName, int value)
+        => new(ComparisonKind.Equal, isUnsigned: false, new LoadArgument(argIndex, argName, s_int), new Constant(value, s_int));
+
+    // switch (n) { case 0: if (k == 7) goto leaf0; break; case 1: if (k == 9)
+    // goto leaf1; break; } goto sharedMiss; leaf0: v = 100; goto join; leaf1:
+    // v = 200; goto join; sharedMiss: v = -1; join: return v; — laid out the
+    // way csc places case bodies (and their "no match" arms) before a shared
+    // tail, exactly like the real Humanizer method's two-tier dispatch.
+    static IrFunction BuildTwoCaseSwitchWithSharedMissHandler()
+    {
+        var body = new BlockContainer();
+
+        var entry = new Block(0);
+        entry.Add(new SwitchBranch(new LoadArgument(0, "n", s_int), [0x10, 0x20]));
+        body.Add(entry);
+
+        var defaultBlock = new Block(4);
+        defaultBlock.Add(new Branch(0x30));   // bare jump into the shared miss-handler
+        body.Add(defaultBlock);
+
+        var case0 = new Block(0x10);
+        case0.Add(new ConditionalBranch(IntEqual(1, "k", 7), targetOffset: 0x18));
+        body.Add(case0);
+
+        var case0Miss = new Block(0x14);
+        case0Miss.Add(new Branch(0x30));
+        body.Add(case0Miss);
+
+        var case0Leaf = new Block(0x18);
+        case0Leaf.Add(new StoreLocal(0, s_int, new Constant(100, s_int)));
+        case0Leaf.Add(new Branch(0x34));   // straight to the join, skipping the miss-handler
+        body.Add(case0Leaf);
+
+        var case1 = new Block(0x20);
+        case1.Add(new ConditionalBranch(IntEqual(1, "k", 9), targetOffset: 0x28));
+        body.Add(case1);
+
+        var case1Miss = new Block(0x24);
+        case1Miss.Add(new Branch(0x30));
+        body.Add(case1Miss);
+
+        var case1Leaf = new Block(0x28);
+        case1Leaf.Add(new StoreLocal(0, s_int, new Constant(200, s_int)));
+        case1Leaf.Add(new Branch(0x34));
+        body.Add(case1Leaf);
+
+        var sharedMiss = new Block(0x30);
+        sharedMiss.Add(new StoreLocal(0, s_int, new Constant(-1, s_int)));   // falls through into the join
+        body.Add(sharedMiss);
+
+        var join = new Block(0x34);
+        join.Add(new Return(new LoadLocal(0, s_int)));
+        body.Add(join);
+
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "", "T"),
+            new MethodSignature(s_int, [new Parameter("n", s_int), new Parameter("k", s_int)], HasThis: false, GenericParameterCount: 0),
+            [s_int],
+            body);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/SwitchRaisingSharedMissHandlerTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwitchRaisingSharedMissHandlerTests.cs
@@ -13,6 +13,8 @@ namespace ILInspector.Decompiler.Tests;
 public class SwitchRaisingSharedMissHandlerTests
 {
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_string = TypeRef.CoreLib("System", "String");
+    static readonly TypeRef s_bool = TypeRef.CoreLib("System", "Boolean");
 
     [Fact]
     public void CaseWithMissArmChainingIntoTheReturnItFallsInto_StillRaisesToSwitch()
@@ -31,6 +33,70 @@ public class SwitchRaisingSharedMissHandlerTests
         // The shared miss-handler and the return it falls into print once,
         // as ordinary code after the switch — not duplicated per case.
         Assert.Single(function.Descendants.OfType<Return>());
+
+        // Render the actual text: a technically-raised-but-garbled body (e.g.
+        // a duplicated or dropped miss-handler assignment) would slip past the
+        // node-shape assertions above but must be caught here.
+        var output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").Trim();
+        Assert.Equal(
+            """
+            int V_0;
+
+            switch (n)
+            {
+                case 0:
+                    if (k == 7) goto IL_0018;
+                    break;
+                    IL_0018:
+                    V_0 = 100;
+                    goto IL_0034;
+                case 1:
+                    if (k == 9) goto IL_0028;
+                    break;
+                    IL_0028:
+                    V_0 = 200;
+                    goto IL_0034;
+            }
+            V_0 = -1;
+            IL_0034:
+            return V_0;
+            """.ReplaceLineEndings("\n"),
+            output);
+    }
+
+    // The same shape, but reached through the string-equality-chain raiser
+    // (RaiseStringEqualityChain -> FinishSwitchRaise) rather than the IL
+    // `switch` opcode raiser (Raise): FinishSwitchRaise has its own,
+    // independently-tiled Unify and must recognize the shared-miss-handler
+    // chain too, not just Raise's.
+    [Fact]
+    public void StringEqualityChainWithSharedMissHandler_StillRaisesToSwitch()
+    {
+        var function = BuildStringEqualityChainWithSharedMissHandler();
+
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        var node = Assert.Single(function.Descendants.OfType<Switch>());
+        Assert.Equal(2, node.Sections.Count);
+        Assert.DoesNotContain(node.Sections, s => s.IsDefault);
+        Assert.Single(function.Descendants.OfType<Return>());
+    }
+
+    // A longer transparent chain between the miss-handler and the join (two
+    // plain single-successor blocks instead of one), to confirm ChasesTo
+    // walks a chain of length > 1, not just a single hop.
+    [Fact]
+    public void MissHandlerChainOfTwoBlocksBeforeJoin_StillRaisesToSwitch()
+    {
+        var function = BuildTwoCaseSwitchWithSharedMissHandler(chainLength: 2);
+
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        var node = Assert.Single(function.Descendants.OfType<Switch>());
+        Assert.Equal(2, node.Sections.Count);
+        Assert.Single(function.Descendants.OfType<Return>());
     }
 
     static Comparison IntEqual(int argIndex, string argName, int value)
@@ -41,7 +107,13 @@ public class SwitchRaisingSharedMissHandlerTests
     // v = 200; goto join; sharedMiss: v = -1; join: return v; — laid out the
     // way csc places case bodies (and their "no match" arms) before a shared
     // tail, exactly like the real Humanizer method's two-tier dispatch.
-    static IrFunction BuildTwoCaseSwitchWithSharedMissHandler()
+    //
+    // chainLength controls how many plain, single-successor blocks sit
+    // between the shared miss-handler and the join: 1 (default) means the
+    // miss-handler falls straight into the join; 2 inserts one extra
+    // transparent pass-through block, exercising ChasesTo over a multi-hop
+    // chain rather than a single hop.
+    static IrFunction BuildTwoCaseSwitchWithSharedMissHandler(int chainLength = 1)
     {
         var body = new BlockContainer();
 
@@ -61,9 +133,11 @@ public class SwitchRaisingSharedMissHandlerTests
         case0Miss.Add(new Branch(0x30));
         body.Add(case0Miss);
 
+        var joinOffset = chainLength >= 2 ? 0x38 : 0x34;
+
         var case0Leaf = new Block(0x18);
         case0Leaf.Add(new StoreLocal(0, s_int, new Constant(100, s_int)));
-        case0Leaf.Add(new Branch(0x34));   // straight to the join, skipping the miss-handler
+        case0Leaf.Add(new Branch(joinOffset));   // straight to the join, skipping the miss-handler
         body.Add(case0Leaf);
 
         var case1 = new Block(0x20);
@@ -76,14 +150,23 @@ public class SwitchRaisingSharedMissHandlerTests
 
         var case1Leaf = new Block(0x28);
         case1Leaf.Add(new StoreLocal(0, s_int, new Constant(200, s_int)));
-        case1Leaf.Add(new Branch(0x34));
+        case1Leaf.Add(new Branch(joinOffset));
         body.Add(case1Leaf);
 
         var sharedMiss = new Block(0x30);
-        sharedMiss.Add(new StoreLocal(0, s_int, new Constant(-1, s_int)));   // falls through into the join
+        sharedMiss.Add(new StoreLocal(0, s_int, new Constant(-1, s_int)));   // falls through
         body.Add(sharedMiss);
 
-        var join = new Block(0x34);
+        if (chainLength >= 2)
+        {
+            // An extra plain pass-through hop between the miss-handler and
+            // the join — still no branch, just falls through in turn.
+            var passThrough = new Block(0x34);
+            passThrough.Add(new StoreLocal(1, s_int, new Constant(0, s_int)));
+            body.Add(passThrough);
+        }
+
+        var join = new Block(joinOffset);
         join.Add(new Return(new LoadLocal(0, s_int)));
         body.Add(join);
 
@@ -91,6 +174,75 @@ public class SwitchRaisingSharedMissHandlerTests
             "M",
             TypeRef.Definition("Synthetic", "", "T"),
             new MethodSignature(s_int, [new Parameter("n", s_int), new Parameter("k", s_int)], HasThis: false, GenericParameterCount: 0),
+            [s_int, s_int],
+            body);
+    }
+
+    // switch (s) { case "a": ...; case "b": ...; } — an equality-chain
+    // dispatch (RaiseStringEqualityChain -> FinishSwitchRaise) whose two case
+    // bodies each have a case-local "no match" arm chaining into one shared
+    // miss-handler that falls through into the method's single return, and a
+    // matching arm that jumps straight to that return, skipping the
+    // miss-handler. FinishSwitchRaise ties its own separate Unify/tiling
+    // logic, mirroring Raise's, so it must recognize the same chained-exit
+    // shape independently.
+    static IrFunction BuildStringEqualityChainWithSharedMissHandler()
+    {
+        var body = new BlockContainer();
+        var eq = new MethodRef(s_string, "op_Equality", s_bool, [s_string, s_string], HasThis: false);
+        IrExpression StrEq(string literal) => new Call(eq, isVirtual: false,
+            [new LoadArgument(0, "s", s_string), new Constant(literal, s_string)]);
+
+        var chain0 = new Block(0);
+        chain0.Add(new ConditionalBranch(StrEq("a"), targetOffset: 0x40));
+        body.Add(chain0);
+
+        var chain1 = new Block(8);
+        chain1.Add(new ConditionalBranch(StrEq("b"), targetOffset: 0x50));
+        body.Add(chain1);
+
+        var afterChain = new Block(0x10);
+        afterChain.Add(new Branch(0x60));   // bare jump into the shared miss-handler (the default)
+        body.Add(afterChain);
+
+        var caseA = new Block(0x40);
+        caseA.Add(new ConditionalBranch(IntEqual(1, "k", 1), targetOffset: 0x48));
+        body.Add(caseA);
+
+        var caseAMiss = new Block(0x44);
+        caseAMiss.Add(new Branch(0x60));
+        body.Add(caseAMiss);
+
+        var caseALeaf = new Block(0x48);
+        caseALeaf.Add(new StoreLocal(0, s_int, new Constant(1, s_int)));
+        caseALeaf.Add(new Branch(0x70));   // straight to the join, skipping the miss-handler
+        body.Add(caseALeaf);
+
+        var caseB = new Block(0x50);
+        caseB.Add(new ConditionalBranch(IntEqual(1, "k", 2), targetOffset: 0x58));
+        body.Add(caseB);
+
+        var caseBMiss = new Block(0x54);
+        caseBMiss.Add(new Branch(0x60));
+        body.Add(caseBMiss);
+
+        var caseBLeaf = new Block(0x58);
+        caseBLeaf.Add(new StoreLocal(0, s_int, new Constant(2, s_int)));
+        caseBLeaf.Add(new Branch(0x70));
+        body.Add(caseBLeaf);
+
+        var sharedMiss = new Block(0x60);
+        sharedMiss.Add(new StoreLocal(0, s_int, new Constant(-1, s_int)));   // falls through into the join
+        body.Add(sharedMiss);
+
+        var join = new Block(0x70);
+        join.Add(new Return(new LoadLocal(0, s_int)));
+        body.Add(join);
+
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "", "T"),
+            new MethodSignature(s_int, [new Parameter("s", s_string), new Parameter("k", s_int)], HasThis: false, GenericParameterCount: 0),
             [s_int],
             body);
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -103,7 +103,32 @@ public sealed class SwitchRaisingPass : IIrPass
 
         var owned = new HashSet<int>();
         int? join = null;
-        bool Unify(int j) => (join ??= j) == j;
+
+        // Two exits unify not only when identical, but when one flows into the
+        // other through a chain of plain, unclaimed, single-successor blocks —
+        // e.g. a case-local "no match" arm and a shared miss-handler that falls
+        // into the same terminating return. The upstream (earlier) block becomes
+        // the join, so the chain is naturally emitted once as switch-trailing
+        // code; the tiling check below still rejects the join if some other
+        // owned block ends up past it.
+        bool Unify(int j)
+        {
+            if (join is not { } existing)
+            {
+                join = j;
+                return true;
+            }
+            if (existing == j)
+                return true;
+            if (ChasesTo(blocks, existing, j, caseTargets, offsetToIndex, owned))
+                return true;   // existing join already flows into j — keep it
+            if (ChasesTo(blocks, j, existing, caseTargets, offsetToIndex, owned))
+            {
+                join = j;   // j is upstream of the existing join — adopt it
+                return true;
+            }
+            return false;
+        }
 
         // Each distinct case target grows into its single-entry region; the
         // region's exits unify to the shared join (or it terminates).
@@ -586,6 +611,30 @@ public sealed class SwitchRaisingPass : IIrPass
                 Add(idx, t);
         }
         return preds;
+    }
+
+    /// <summary>
+    /// True if, walking forward from <paramref name="from"/> through blocks that
+    /// are plain single-successor pass-through (not a case's own entry point, and
+    /// not already claimed by another section), we reach <paramref name="to"/>.
+    /// Used to recognize a case-local "miss" arm chaining into a shared
+    /// miss-handler that itself falls into the true join, so the two exits
+    /// still unify (the earlier one becomes the join and the chain prints once,
+    /// as ordinary code after the switch).
+    /// </summary>
+    static bool ChasesTo(IReadOnlyList<Block> blocks, int from, int to, int[] caseTargets, Dictionary<int, int> offsetToIndex, HashSet<int> owned)
+    {
+        var visited = new HashSet<int>();
+        int cur = from;
+        while (cur != to)
+        {
+            if (!visited.Add(cur) || caseTargets.Contains(cur) || owned.Contains(cur))
+                return false;
+            if (!TrySuccessors(blocks, cur, offsetToIndex, out var succs) || succs.Count != 1)
+                return false;
+            cur = succs[0];
+        }
+        return true;
     }
 
     /// <summary>Successor block indices (including the conditional / no-terminator fall-through), or false for an unsupported section shape.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -1201,7 +1201,29 @@ public sealed class SwitchRaisingPass : IIrPass
 
         var owned = new HashSet<int>();
         int? join = null;
-        bool Unify(int j) => (join ??= j) == j;
+
+        // See the matching comment on Unify in Raise: two exits also unify when
+        // one flows into the other through a chain of plain, unclaimed,
+        // single-successor blocks (a case-local miss arm chaining into a shared
+        // miss-handler that falls into the same terminating join).
+        bool Unify(int j)
+        {
+            if (join is not { } existing)
+            {
+                join = j;
+                return true;
+            }
+            if (existing == j)
+                return true;
+            if (ChasesTo(blocks, existing, j, caseTargets, offsetToIndex, owned))
+                return true;   // existing join already flows into j — keep it
+            if (ChasesTo(blocks, j, existing, caseTargets, offsetToIndex, owned))
+            {
+                join = j;   // j is upstream of the existing join — adopt it
+                return true;
+            }
+            return false;
+        }
         var regions = new Dictionary<int, List<int>>();
 
         foreach (int target in caseTargets.Distinct())


### PR DESCRIPTION
- Fixes #2954
- Changes SwitchRaisingPass to raise switches whose case regions have a shared miss-handler that chains into a shared return, instead of falling back to an if-ladder
- Card revision: `5cb72d80`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — generalizes an existing join/tiling invariant to a legitimate real-world CFG shape, verified against a real Humanizer method and a synthetic regression test, with no other pass logic touched.

### Original source

<!-- No PDB/SourceLink available for Humanizer.core 3.0.10 on NuGet; falling back to raw IL per the template. -->

```il
IL_0000: ldarg.2
IL_0001: ldc.i4.2
IL_0002: beq.s        IL_0006
IL_0004: ldarg.1
IL_0005: ret
IL_0006: ldarg.1
IL_0007: brfalse      IL_0226
IL_000C: ldarg.1
IL_000D: callvirt     instance int32 [System.Runtime]System.String::get_Length()
IL_0012: ldc.i4.s     28
IL_0014: sub
IL_0015: switch       (IL_00B9, IL_003D, IL_0081, IL_01AF, IL_00CE, IL_0063, IL_01A0)
... (full body: two-tier string-switch lowering — outer int dispatch on
    resourceKey.Length - 28, seven buckets each doing a char/string
    sub-discriminator, all funneling into one of ~19 "miss" arms that share a
    single miss-handler block, which falls through into the method's one
    return block; matched arms jump directly to that same return, skipping
    the miss-handler)
```

### Before

```csharp
protected override string GetResourceKey(string resourceKey, int number)
{
    int __dotnet_inspect_switch0 = default;
    string V_0;
    char V_2;

    if (number == 2) goto IL_0006;
    return resourceKey;
    IL_0006:
    if (resourceKey is null) goto IL_0226;
    __dotnet_inspect_switch0 = (int)(resourceKey.Length - 28);
    if (__dotnet_inspect_switch0 == 0) goto IL_00B9;
    if (__dotnet_inspect_switch0 == 1) goto IL_003D;
    if (__dotnet_inspect_switch0 == 2) goto IL_0081;
    if (__dotnet_inspect_switch0 == 3) goto IL_01AF;
    if (__dotnet_inspect_switch0 == 4) goto IL_00CE;
    if (__dotnet_inspect_switch0 == 5) goto IL_0063;
    if (__dotnet_inspect_switch0 == 6) goto IL_01A0;
    V_0 = resourceKey;
    return V_0;
    IL_003D:
    V_2 = resourceKey[21];
    if (V_2 == 'H') goto IL_00E3;
    if (V_2 == 'Y') goto IL_00F8;
    if (V_2 == 'i') goto IL_010D;
    V_0 = resourceKey;
    return V_0;
    // ... 13 more IL_xxxx-labeled blocks, each repeating the same
    // "V_0 = resourceKey; return V_0;" miss pattern or a match-and-return
}
```

- Valid: True
- Correct: True

Compiles and preserves behavior, but every case of the outer two-tier dispatch
is flattened into a synthetic `__dotnet_inspect_switch0` temp compared with an
if-ladder — the real `switch` shape used by the original C# source is entirely
lost.

### After

```csharp
protected override string GetResourceKey(string resourceKey, int number)
{
    string V_0 = default;
    char V_2 = default;

    if (number != 2)
    {
        return resourceKey;
    }
    if (resourceKey is not null)
    {
        switch (resourceKey.Length - 28)
        {
            case 0:
                if (resourceKey == "DateHumanize_MultipleDaysAgo") goto IL_01BE;
                break;
                IL_01BE:
                V_0 = "DateHumanize_MultipleDaysAgo_Dual";
                goto IL_0228;
            case 1:
                V_2 = resourceKey[21];
                if (V_2 == 'H') goto IL_00E3;
                if (V_2 == 'Y') goto IL_00F8;
                if (V_2 == 'i') goto IL_010D;
                break;
                // ... (each bucket's own char/string sub-discriminator,
                // matched arms goto a local label that sets V_0 and jumps to
                // the shared return; unmatched paths break out of the switch)
            case 6:
                if (resourceKey == "DateHumanize_MultipleMonthsFromNow") goto IL_01E6;
                break;
                IL_01E6:
                V_0 = "DateHumanize_MultipleMonthsFromNow_Dual";
                goto IL_0228;
        }
    }
    V_0 = resourceKey;
    return V_0;
}
```

- Valid: True
- Correct: True

The outer dispatch is now a real C# `switch` over `resourceKey.Length - 28`
with `case 0` through `case 6` and no default (the switch's own literal
default and every bucket's "no match" arm converge on the same
`V_0 = resourceKey; return V_0;` tail, matching the omitted-default pattern).
Each case body still uses local `goto`/label pairs for its sub-discriminator,
since a matched leaf must skip straight to the shared return while an
unmatched leaf must fall into that same tail — this is valid, behavior
-preserving C#, not a printer defect.

### Fully raised

```csharp
protected override string GetResourceKey(string resourceKey, int number)
{
    if (number != 2 || resourceKey is null)
    {
        return resourceKey;
    }

    switch (resourceKey.Length - 28)
    {
        case 0:
            return resourceKey == "DateHumanize_MultipleDaysAgo"
                ? "DateHumanize_MultipleDaysAgo_Dual"
                : resourceKey;
        // ... one case per bucket, each case's own nested char/string switch
        // collapsed to a single expression instead of goto/label pairs
    }

    return resourceKey;
}
```

- Required tracking issue: #2954 — collapsing the remaining per-case
  goto/label pairs (matched-leaf-skips-miss-handler shape) into structured
  case bodies is a separate, follow-on raising improvement; not required to
  fix the missing-switch regression this PR addresses.

## Evidence

| Check | Baseline (`2269483d`) | Head (`5cb72d80`) |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests (`SwitchRaisingSharedMissHandlerTests`, `StringSwitchRaisingTests`, `SwitchExpressionRaisingTests`, `SwitchDuplicateLabelTests`, `IdiomShapeScorecard`) | 18 total, 1 failed (pre-existing CRLF mismatch in `SmallStringSwitch_RendersSwitchOnString`, unrelated) | 19 total, 1 failed (same pre-existing CRLF mismatch) |
| Broader regression sweep (13 classes incl. above + `SparseIntSwitchRaisingTests`, `IrImporterTests`, `SwitchBranchRenderingTests`, `IteratorReconstructionPassTests`, `StructuringGotoScopeTests`, `StackSlotCopyPropagationPassTests`, `NestedScopeNameCollisionTests`, `ReturnSinkingPassTests`, `PrinterPrecedenceTests`) | not fully re-run (see note) | 219 total, 2 failed |
| Real witness | `Humanizer.MalteseFormatter.GetResourceKey` (Humanizer.core 3.0.10): flat if-ladder over synthetic `__dotnet_inspect_switch0` | fixed: raises a real `switch (resourceKey.Length - 28)` with `case 0`..`case 6` |

Both Head failures in the broader sweep are confirmed pre-existing and
unrelated to this change, verified independently on Baseline:

- `StringSwitchRaisingTests.SmallStringSwitch_RendersSwitchOnString`: `\r\n`
  vs `\n` line-ending mismatch (Windows test runner vs. `\n`-authored
  expectation), reproduces identically on Baseline.
- `PrinterPrecedenceTests.StoreElement_CompoundArrayReceiver_RecompilesExactly`:
  reproduces identically (same `RecompileFail`) on an isolated Baseline run
  with no other change applied — confirmed unrelated to `SwitchRaisingPass`.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile ./nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "*SwitchRaisingSharedMissHandlerTests*" -class "*StringSwitchRaisingTests*" -class "*SwitchExpressionRaisingTests*" -class "*SwitchDuplicateLabelTests*" -class "*IdiomShapeScorecard*"
```
