### PR TITLE
Normalize composed source newlines

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceCheckTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceCheckTests.cs
@@ -547,6 +547,8 @@ public class TypeSourceCheckTests
         var source = MemberBodyProducer.Project(type, path, pdbPath: null).Output;
         Assert.NotNull(source);
 
+        Assert.DoesNotContain('\r', source);
+        Assert.Contains("using System.Runtime.InteropServices;\n\nnamespace", source);
         Assert.Contains("[StructLayout(LayoutKind.Explicit, Size = 4)]", source);
         Assert.Contains("[FieldOffset(0)]\n    public byte B;", source);
         Assert.Contains("[FieldOffset(1)]\n    public byte G;", source);

--- a/src/ILInspector.Decompiler/MemberBodyProducer.cs
+++ b/src/ILInspector.Decompiler/MemberBodyProducer.cs
@@ -1168,7 +1168,8 @@ public static class MemberBodyProducer
             var segments = line.Split('"');
             for (int i = 0; i < segments.Length; i += 2)
                 segments[i] = ShortenSegment(segments[i], prefixes, nsToNames, shortNameOwners, usings);
-            output.AppendLine(string.Join('"', segments));
+            // Generated source uses one deterministic newline on every host.
+            output.Append(string.Join('"', segments)).Append('\n');
         }
 
         // Implicit usings (and the type's own namespace) need no directive.


### PR DESCRIPTION
Fixes #2941

## Change

**Conclusion:** **PASS** - composed type source now uses canonical LF on every
host instead of mixing LF using directives with host-native declaration lines.

`MemberBodyProducer.HoistUsings` already parses either LF or CRLF input and
trims carriage returns. It now rebuilds each line with explicit `\n`, matching
the using-directive separator and `CSharpPrinter` output.

On Windows:

```text
Before: using ...;\n\nnamespace ...;\r\n...\r\n
After:  using ...;\n\nnamespace ...;\n...\n
```

The explicit-layout product-path test now pins both the canonical no-`\r`
contract and the LF boundary between generated using directives and the
namespace declaration. The already-normalized string-switch test is unchanged.

## Evidence

Head: `19034d1e9a890a579bdea2037d9cffb25e0aec76`

| Check | Result |
| --- | --- |
| Solution build | Pass |
| `TypeSourceCheckTests` | 34 passed |
| Decompiler fast suite | 3,067 passed |
| CLI fast suite | 1,409 passed, 10 skipped |

The full decompiler suite was also run before the final main refresh: 3,125 of
3,127 tests passed. After rebasing, one of those baseline failures was resolved
by main. The remaining
`LadderIteratorGateTests.IteratorFixture_RecoveredRowsCompileBackOpcodeExact`
failure (`Expected: Exact`, `Actual: OperandDiff`) reproduces identically on
exact base `2269483d` and head; it is unrelated to newline composition.

## Compatibility

This intentionally makes generated type source byte-stable across platforms.
The C# tokens, indentation, ordering, and final-newline behavior are unchanged;
only CRLF declaration separators on Windows become LF.

## Review

Adversarial review is not required: this is a mechanical one-character
separator change at an existing line-normalization boundary, paired with a
direct product-path invariant test.
