### PR TITLE
Rename synthetic switch-dispatch temp __dotnet_inspect_switch -> __switchValue

### DIFF
--- a/src/ILInspector.Decompiler.Tests/NestedScopeNameCollisionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NestedScopeNameCollisionTests.cs
@@ -176,9 +176,9 @@ public class NestedScopeNameCollisionTests
             new SwitchBranch(new Constant(0, Int32), ImmutableArray.Create(4)),
             new StoreLocal(0, Action, innerLambda));
 
-        Assert.Contains("int __dotnet_inspect_switch0 = default;", body);
-        Assert.Contains("int __dotnet_inspect_switch0_1 = default;", body);
-        Assert.DoesNotContain("() => { int __dotnet_inspect_switch0 = default;", body);
+        Assert.Contains("int __switchValue0 = default;", body);
+        Assert.Contains("int __switchValue0_1 = default;", body);
+        Assert.DoesNotContain("() => { int __switchValue0 = default;", body);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/SwitchBranchRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwitchBranchRenderingTests.cs
@@ -84,11 +84,11 @@ public class SwitchBranchRenderingTests
         var output = result.Output ?? "";
 
         Assert.DoesNotContain("goto [", output);
-        Assert.Contains("int __dotnet_inspect_switch0 = default;", output);
-        Assert.Contains("__dotnet_inspect_switch0 = (int)(x);", output);
-        Assert.Contains("if (__dotnet_inspect_switch0 == 0) goto IL_0010;", output);
-        Assert.Contains("if (__dotnet_inspect_switch0 == 1) goto IL_0020;", output);
-        Assert.Contains("if (__dotnet_inspect_switch0 == 2) goto IL_0030;", output);
+        Assert.Contains("int __switchValue0 = default;", output);
+        Assert.Contains("__switchValue0 = (int)(x);", output);
+        Assert.Contains("if (__switchValue0 == 0) goto IL_0010;", output);
+        Assert.Contains("if (__switchValue0 == 1) goto IL_0020;", output);
+        Assert.Contains("if (__switchValue0 == 2) goto IL_0030;", output);
     }
 
     [Fact]
@@ -99,9 +99,9 @@ public class SwitchBranchRenderingTests
         var result = RenderSwitch(0x10, 0x20, 0x10);
         var output = result.Output ?? "";
 
-        Assert.Contains("if (__dotnet_inspect_switch0 == 0) goto IL_0010;", output);
-        Assert.Contains("if (__dotnet_inspect_switch0 == 1) goto IL_0020;", output);
-        Assert.Contains("if (__dotnet_inspect_switch0 == 2) goto IL_0010;", output);
+        Assert.Contains("if (__switchValue0 == 0) goto IL_0010;", output);
+        Assert.Contains("if (__switchValue0 == 1) goto IL_0020;", output);
+        Assert.Contains("if (__switchValue0 == 2) goto IL_0010;", output);
     }
 
     [Fact]
@@ -116,7 +116,7 @@ public class SwitchBranchRenderingTests
         var result = CSharpPrinter.PrintRaised(function);
         string output = result.Output ?? "";
 
-        Assert.Contains("if (__dotnet_inspect_switch", output);
+        Assert.Contains("if (__switchValue", output);
         Assert.DoesNotContain("case 0: goto", output);
         AssertGotoTargetsHaveLabels(output);
     }
@@ -160,7 +160,7 @@ public class SwitchBranchRenderingTests
         function.CheckInvariant();
         string output = CSharpPrinter.Print(function).Output ?? "";
 
-        Assert.Contains("if (__dotnet_inspect_switch0 == 0) goto IL_0010;", output);
+        Assert.Contains("if (__switchValue0 == 0) goto IL_0010;", output);
         Assert.DoesNotContain("goto IL_0014;", output);
         Assert.Contains("IL_0010:", output);
     }
@@ -199,7 +199,7 @@ public class SwitchBranchRenderingTests
         function.CheckInvariant();
         string output = CSharpPrinter.Print(function).Output ?? "";
 
-        Assert.Contains("if (__dotnet_inspect_switch0 == 0) goto IL_0010;", output);
+        Assert.Contains("if (__switchValue0 == 0) goto IL_0010;", output);
         Assert.Contains("while (true)", output);
         Assert.True(
             output.IndexOf("IL_0010:", StringComparison.Ordinal)
@@ -245,7 +245,7 @@ public class SwitchBranchRenderingTests
         function.CheckInvariant();
         string output = CSharpPrinter.Print(function).Output ?? "";
 
-        Assert.Contains("if (__dotnet_inspect_switch0 == 0) goto IL_0020;", output);
+        Assert.Contains("if (__switchValue0 == 0) goto IL_0020;", output);
         Assert.Contains("while (flag)", output);
         Assert.True(
             output.IndexOf("IL_0020:", StringComparison.Ordinal)
@@ -380,7 +380,7 @@ public class SwitchBranchRenderingTests
         function.CheckInvariant();
         string output = CSharpPrinter.Print(function).Output ?? "";
 
-        Assert.Contains("if (__dotnet_inspect_switch0 == 0) goto IL_0010;", output);
+        Assert.Contains("if (__switchValue0 == 0) goto IL_0010;", output);
         Assert.Contains("IL_0010:", output);
         AssertGotoTargetsHaveLabels(output);
     }
@@ -399,7 +399,7 @@ public class SwitchBranchRenderingTests
         string output = result.Output ?? "";
 
         Assert.Equal(DecompilationFidelity.Full, result.Fidelity);
-        Assert.Contains("if (__dotnet_inspect_switch", output);
+        Assert.Contains("if (__switchValue", output);
         AssertGotoTargetsHaveLabels(output);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -538,7 +538,7 @@ public sealed partial class CSharpPrinter
         int switchIndex = 0;
         foreach (var switchBranch in DescendantsOutsideNestedFunctions(function).OfType<SwitchBranch>())
         {
-            string name = ReserveName($"__dotnet_inspect_switch{switchIndex++}", new HashSet<string>(CurrentScopeNames(), StringComparer.Ordinal));
+            string name = ReserveName($"__switchValue{switchIndex++}", new HashSet<string>(CurrentScopeNames(), StringComparer.Ordinal));
             _switchTemps.TryAdd(switchBranch, name);
             yield return $"int {name} = default;";
         }
@@ -1747,7 +1747,7 @@ public sealed partial class CSharpPrinter
             // switch, so render an if-chain over a single-evaluated temp instead
             // of `case i: goto IL_xxxx;`. Fall-through preserves out-of-range
             // behavior.
-            string temp = _switchTemps.TryGetValue(switchBranch, out var name) ? name : "__dotnet_inspect_switch";
+            string temp = _switchTemps.TryGetValue(switchBranch, out var name) ? name : "__switchValue";
             sb.Append(pad).Append(temp).Append(" = ")
                 .Append("(int)(").Append(Expression(switchBranch.Value)).AppendLine(");");
             for (int t = 0; t < switchBranch.TargetOffsets.Length; t++)


### PR DESCRIPTION
## Change

Mechanical rename only, no behavior change: `CSharpPrinter`'s synthesized
if-ladder dispatch temp (emitted when `SwitchRaisingPass` cannot raise an IL
`switch` opcode into a real C# `switch`) was named `__dotnet_inspect_switch{n}`
— baking the tool''s own name into emitted C#.

This is inconsistent with the other synthesized identifiers in the same file,
which name the *construct* they represent rather than the tool:
`__stackalloc`, `__exception`. It also lives in `ILInspector.Decompiler`
(shared by any caller, not just the CLI), so hardcoding the CLI''s name into
output rendered by any embedder was unnecessary coupling.

Renamed to `__switchValue{n}`, matching the internal `_switchTemps` dictionary
already used to track these names (`CSharpPrinter.cs`).

No product logic changed — only the literal name passed to `ReserveName` and
the fallback default string. Test assertions on the literal string were
updated to match.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile ./nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "*SwitchBranchRenderingTests*" -class "*NestedScopeNameCollisionTests*" -class "*SwitchRaisingSharedMissHandlerTests*" -class "*StringSwitchRaisingTests*"
```

29 tests, 1 failed (`StringSwitchRaisingTests.SmallStringSwitch_RendersSwitchOnString`
— pre-existing CRLF-vs-LF line-ending mismatch, unrelated to this change,
also present on `main`).

Simple, mechanical, string-literal-only rename with no behavior change and no
new heuristics — does not require adversarial review per AGENTS.md.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>