### PR TITLE
Duplicate scattered shared returns into each guard in structuring (#2959)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ValidityCoverageReportingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ValidityCoverageReportingTests.cs
@@ -42,13 +42,16 @@ public class ValidityCoverageReportingTests
             .ToArray();
 
         // Release census refreshed against the merged head (verified by dumping
-        // the live CS0161 population). Three entries were added relative to the
-        // prior pin: TupleSwitchExpressionPass::TryNumericValue and
-        // YieldBreakLoopIteratorReconstruction::TryNormalizeContinueCondition
-        // were pre-existing drift (present on base, unrelated to fluent chains;
-        // see #2959), and FluentChainRecompositionPass::SinkStatement is this
-        // change's new pattern-matching helper that the decompiler renders with
-        // a missing-return path (same idiom as the other census members).
+        // the live CS0161 population). #2959 removed six scattered-return
+        // dispatch defects — the shared return is now duplicated into each guard
+        // instead of dropping an edge: TupleSwitchExpressionPass::TryNumericValue,
+        // IsPatternPass::IsPatternLocalNull, NullConditionalPass::MemberReceiver,
+        // UnionSwitchExpressionPass::SameTailNode,
+        // DynamicCallSitePass::TryGuardCacheLoad, and
+        // FluentChainRecompositionPass::SinkStatement.
+        // YieldBreakLoopIteratorReconstruction::TryNormalizeContinueCondition is a
+        // distinct result-temp switch-expression shape the fix does not cover and
+        // remains pinned as tracked follow-up.
         string[] expected =
 #if DEBUG
         [
@@ -60,15 +63,9 @@ public class ValidityCoverageReportingTests
             "ILInspector.Decompiler.Pipeline.BooleanFoldingPass::IsNullableCoalesceExpressionContext",
             "ILInspector.Decompiler.Pipeline.CSharpPrinter::ForLoopIncrementText",
             "ILInspector.Decompiler.Pipeline.DeconstructionAssignmentPass::TryMatchTupleSeed",
-            "ILInspector.Decompiler.Pipeline.DynamicCallSitePass::TryGuardCacheLoad",
             "ILInspector.Decompiler.Pipeline.FixedArrayRaising::SameLoadPlace",
-            "ILInspector.Decompiler.Pipeline.FluentChainRecompositionPass::SinkStatement",
             "ILInspector.Decompiler.Pipeline.IndexFromEndPass::LengthReceiver",
             "ILInspector.Decompiler.Pipeline.InlineArrayCollectionPass::PlaceFromAddress",
-            "ILInspector.Decompiler.Pipeline.IsPatternPass::IsPatternLocalNull",
-            "ILInspector.Decompiler.Pipeline.NullConditionalPass::MemberReceiver",
-            "ILInspector.Decompiler.Pipeline.TupleSwitchExpressionPass::TryNumericValue",
-            "ILInspector.Decompiler.Pipeline.UnionSwitchExpressionPass::SameTailNode",
             "ILInspector.Decompiler.Pipeline.YieldBreakLoopIteratorReconstruction::TryNormalizeContinueCondition",
         ];
 #endif

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -179,7 +179,7 @@ public sealed class StructuringPass : IIrPass
             {
                 continue;
             }
-            if (IsScatteredDispatch(blocks, conditionalPredecessorIndices[offset], fallenInto, branchTargets))
+            if (IsScatteredDispatch(blocks, conditionalPredecessorIndices[offset], branchTargets))
                 scatteredReturnDispatchTargets.Add(offset);
         }
 
@@ -1122,20 +1122,21 @@ public sealed class StructuringPass : IIrPass
     /// Whether the conditional predecessors of a shared return are scattered
     /// across nesting levels (a <c>return</c>/<c>throw</c> dispatch arm sits
     /// between two of them in block order) rather than forming a single
-    /// contiguous <c>&amp;&amp;</c>/<c>||</c> guard chain. A qualifying arm must be
-    /// reached only by its guard falling through (in <paramref name="fallenInto"/>
-    /// and not a <paramref name="branchTargets"/> target); a terminator reached as
-    /// a branch target is an arm of a reconverging diamond nested inside a
-    /// short-circuit condition (e.g. a <c>throw</c> expression), which combines
-    /// cleanly under one guard and must not force duplication. An interleaved
-    /// dispatch arm means at least one guard reaches the return from a region
-    /// strict nesting would close before the return, so the return must be
-    /// duplicated into each guard.
+    /// contiguous <c>&amp;&amp;</c>/<c>||</c> guard chain. For each interleaved
+    /// terminator, the guard that produced it (found by walking back over the
+    /// arm's plain fall-through statement blocks) must branch forward PAST the
+    /// predecessor span — to the shared return or another downstream terminal —
+    /// which marks a genuine dispatch arm closing a region strict nesting cannot
+    /// keep open, so the return must be duplicated into each guard. A
+    /// <c>throw</c>/<c>return</c> sub-expression nested inside a short-circuit
+    /// condition is instead the fall-through arm of a test that branches forward
+    /// WITHIN the span to continue evaluating the same condition; that arm stays
+    /// combined under one guard (the #640-style fidelity canary), so it is
+    /// excluded.
     /// </summary>
     static bool IsScatteredDispatch(
         IReadOnlyList<Block> blocks,
         List<int> predecessorIndices,
-        HashSet<int> fallenInto,
         HashSet<int> branchTargets)
     {
         int lo = int.MaxValue;
@@ -1145,25 +1146,37 @@ public sealed class StructuringPass : IIrPass
             if (index < lo) lo = index;
             if (index > hi) hi = index;
         }
+        int spanEndOffset = blocks[hi].StartOffset;
         for (int i = lo + 1; i < hi; i++)
         {
-            if (predecessorIndices.Contains(i))
-                continue;
             var block = blocks[i];
             if (block.Children.Count == 0 || block.Children[^1] is not (Return or Throw))
                 continue;
-            // A genuine dispatch arm is the fall-through else of its own guard:
-            // control reaches it only by the preceding guard's conditional branch
-            // falling through, never by an explicit branch that targets it. A
-            // terminator reached as a branch target is instead an arm of a
-            // reconverging diamond nested inside a short-circuit `&&`/`||`
-            // condition (e.g. a `throw` expression), which combines cleanly under
-            // one guard and must not force duplication (the #640-style canary).
-            if (fallenInto.Contains(block.StartOffset)
-                && !branchTargets.Contains(block.StartOffset))
+            // Find the guard that produced this interleaved terminator: walk back
+            // over the arm's plain fall-through statement blocks (last child is
+            // not a control-flow node and the block is not a merge target) to the
+            // nearest conditional-branch guard.
+            int j = i - 1;
+            while (j > lo
+                && blocks[j].Children.Count > 0
+                && blocks[j].Children[^1] is not (Return or Throw or Branch or Leave or ConditionalBranch or SwitchBranch or EndFinally or EndFilter)
+                && !branchTargets.Contains(blocks[j].StartOffset))
             {
-                return true;
+                j--;
             }
+            if (blocks[j].Children.Count == 0 || blocks[j].Children[^1] is not ConditionalBranch guard)
+                continue;
+            // A genuine dispatch arm's guard leads to a separate outcome: it
+            // branches forward PAST the predecessor span (to the shared return
+            // itself or another downstream terminal), so the arm terminates a
+            // region strict nesting closes before the shared return. A `throw`/
+            // `return` sub-expression nested inside a short-circuit `&&`/`||`/
+            // ternary condition is instead the fall-through arm of a test that
+            // branches forward WITHIN the span to continue evaluating the same
+            // condition; that arm must stay combined under one guard (the
+            // #640-style fidelity canary), so it is excluded.
+            if (guard.TargetOffset > spanEndOffset)
+                return true;
         }
         return false;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -41,6 +41,15 @@ public sealed class StructuringPass : IIrPass
         public required Dictionary<int, IReadOnlyList<IrNode>> TerminatorSnapshots { get; init; }
         public required HashSet<int> FallenInto { get; init; }
         public required bool IsComparisonTree { get; init; }
+        /// <summary>
+        /// Return-terminator offsets reached by two or more conditional guards
+        /// scattered across nesting levels (a return arm sits between their
+        /// blocks) — a shared join strict nesting cannot express, so its return
+        /// is duplicated into each guard. Distinct from the contiguous
+        /// <c>&amp;&amp;</c>/<c>||</c> false-exit chain (adjacent guards, no arm
+        /// between them), which is left to combine (the #640 fidelity canary).
+        /// </summary>
+        public required HashSet<int> ScatteredReturnDispatchTargets { get; init; }
         public int? RegionExitLeaveTarget { get; init; }
 
         /// <summary>
@@ -95,9 +104,11 @@ public sealed class StructuringPass : IIrPass
         // the standard forms already raise cleanly stays untouched.
         var unconditionalTargets = new HashSet<int>();
         var conditionalTargetCounts = new Dictionary<int, int>();
+        var conditionalPredecessorIndices = new Dictionary<int, List<int>>();
         var branchTargets = new HashSet<int>();
-        foreach (var block in blocks)
+        for (int blockIndex = 0; blockIndex < blocks.Count; blockIndex++)
         {
+            var block = blocks[blockIndex];
             foreach (var child in block.Children)
             {
                 if (child is Branch branch)
@@ -113,6 +124,9 @@ public sealed class StructuringPass : IIrPass
                 {
                     conditionalTargetCounts[conditional.TargetOffset] =
                         conditionalTargetCounts.GetValueOrDefault(conditional.TargetOffset) + 1;
+                    if (!conditionalPredecessorIndices.TryGetValue(conditional.TargetOffset, out var preds))
+                        conditionalPredecessorIndices[conditional.TargetOffset] = preds = new List<int>();
+                    preds.Add(blockIndex);
                     branchTargets.Add(conditional.TargetOffset);
                 }
                 else if (child is SwitchBranch switchBranch)
@@ -146,11 +160,34 @@ public sealed class StructuringPass : IIrPass
         // small selections keep their ternary/boolean shape.
         bool isComparisonTree = ComparisonTrees.IsLikely(container);
 
+        // A shared return reached by two or more conditional guards scattered
+        // across nesting levels — a return arm sits between the guard blocks — is
+        // a join strict nesting cannot express (each guard reaches it from a
+        // different region), so structuring must duplicate the return into each
+        // guard. The contiguous `&&`/`||` false-exit chain (adjacent guards, no
+        // arm between them) is deliberately excluded so it still combines into a
+        // single condition (the #640 fidelity canary).
+        var scatteredReturnDispatchTargets = new HashSet<int>();
+        foreach (var block in blocks)
+        {
+            int offset = block.StartOffset;
+            if (unconditionalTargets.Contains(offset)
+                || fallenInto.Contains(offset)
+                || conditionalTargetCounts.GetValueOrDefault(offset) < 2
+                || !IsTerminatorBlock(block)
+                || block.Children[^1] is not Return)
+            {
+                continue;
+            }
+            if (IsScatteredDispatch(blocks, conditionalPredecessorIndices[offset]))
+                scatteredReturnDispatchTargets.Add(offset);
+        }
+
         var droppable = new HashSet<int>();
         var snapshots = new Dictionary<int, IReadOnlyList<IrNode>>();
         for (int i = 0; i < blocks.Count; i++)
         {
-            if (!IsSharedTerminator(blocks[i], unconditionalTargets, conditionalTargetCounts, fallenInto, isComparisonTree))
+            if (!IsSharedTerminator(blocks[i], unconditionalTargets, conditionalTargetCounts, fallenInto, isComparisonTree, scatteredReturnDispatchTargets))
                 continue;
             snapshots[i] = blocks[i].Children.ToList();
             if (i > 0 && !FallsThrough(blocks[i - 1]))
@@ -169,6 +206,7 @@ public sealed class StructuringPass : IIrPass
             TerminatorSnapshots = snapshots,
             FallenInto = fallenInto,
             IsComparisonTree = isComparisonTree,
+            ScatteredReturnDispatchTargets = scatteredReturnDispatchTargets,
             RegionExitLeaveTarget = NormalEhContinuationTarget(container),
             Recorder = recorder,
         };
@@ -925,6 +963,7 @@ public sealed class StructuringPass : IIrPass
             TerminatorSnapshots = new Dictionary<int, IReadOnlyList<IrNode>>(),
             FallenInto = fallenInto,
             IsComparisonTree = false,
+            ScatteredReturnDispatchTargets = [],
             RegionExitLeaveTarget = null,
             Recorder = null,
         };
@@ -1027,7 +1066,7 @@ public sealed class StructuringPass : IIrPass
     ///     reached only by its one equality test, jumping past its region to the
     ///     (now dissolved) tail. Inlining it is what lets the tree nest at all.
     /// </summary>
-    static bool IsSharedTerminator(Block block, HashSet<int> unconditionalTargets, Dictionary<int, int> conditionalTargetCounts, HashSet<int> fallenInto, bool isComparisonTree)
+    static bool IsSharedTerminator(Block block, HashSet<int> unconditionalTargets, Dictionary<int, int> conditionalTargetCounts, HashSet<int> fallenInto, bool isComparisonTree, HashSet<int> scatteredReturnDispatchTargets)
     {
         if (!IsTerminatorBlock(block) || unconditionalTargets.Contains(block.StartOffset))
             return false;
@@ -1052,25 +1091,59 @@ public sealed class StructuringPass : IIrPass
             //     standard-guard raising untouched.
             Throw => conditionalPredecessors >= 2
                 || (conditionalPredecessors >= 1 && fallenInto.Contains(block.StartOffset)),
-            // A shared return-tail merge is NOT inlined here: a return block with
-            // two or more conditional predecessors is also exactly the false-exit
-            // of an `&&`/`||` short-circuit guard chain (`if (a > 0 && b > 0)
-            // return X; return Y;` lowers to two conditionals both targeting the
-            // `return Y` block). Inlining the shared return into each guard splits
-            // the chain before it can combine into a single `if (a && b)`,
-            // changing the recompiled opcodes (the #640 fidelity canary). A
-            // genuine shared return-tail merge (String::Trim) needs the combiner
-            // to defer to it first — a separate slice, not this terminator rule.
-            // A comparison-tree case body: a return leaf reached only by its
-            // equality test and never by fallthrough, in a container that is a
-            // genuine multi-way tree. Inlining it as a guard clause is what lets
-            // the tree nest. Gated to trees so a small selection's return is left
-            // to the ternary/boolean passes rather than duplicated into guards.
-            Return => isComparisonTree
-                && conditionalPredecessors >= 1
-                && !fallenInto.Contains(block.StartOffset),
+            // A shared return-tail merge with two or more conditional
+            // predecessors is normally left standing: it is also exactly the
+            // false-exit of an `&&`/`||` short-circuit guard chain
+            // (`if (a > 0 && b > 0) return X; return Y;` lowers to two
+            // conditionals both targeting the `return Y` block). Inlining the
+            // shared return into each guard splits the chain before it can
+            // combine into a single `if (a && b)`, changing the recompiled
+            // opcodes (the #640 fidelity canary). Two shapes override that:
+            //   • A comparison-tree case body: a return leaf reached only by its
+            //     equality test and never by fallthrough, in a container that is
+            //     a genuine multi-way tree. Inlining it as a guard clause is what
+            //     lets the tree nest.
+            //   • A scattered dispatch: a return reached by two or more
+            //     conditional guards at different nesting levels (a return arm
+            //     sits between them). Strict nesting can only place it after one
+            //     guard and would drop the others off the end of a non-void
+            //     method (CS0161, issue #2959); duplicating the return into each
+            //     guard is the only sound structuring. The contiguous
+            //     short-circuit chain (adjacent guards, no arm between them) is
+            //     not scattered, so the canary is preserved.
+            Return => !fallenInto.Contains(block.StartOffset)
+                && ((isComparisonTree && conditionalPredecessors >= 1)
+                    || scatteredReturnDispatchTargets.Contains(block.StartOffset)),
             _ => false,
         };
+    }
+
+    /// <summary>
+    /// Whether the conditional predecessors of a shared return are scattered
+    /// across nesting levels (a <c>return</c>/<c>throw</c> arm sits between two of
+    /// them in block order) rather than forming a single contiguous
+    /// <c>&amp;&amp;</c>/<c>||</c> guard chain. An interleaved terminator means at
+    /// least one guard reaches the return from a region strict nesting would
+    /// close before the return, so the return must be duplicated into each guard.
+    /// </summary>
+    static bool IsScatteredDispatch(IReadOnlyList<Block> blocks, List<int> predecessorIndices)
+    {
+        int lo = int.MaxValue;
+        int hi = int.MinValue;
+        foreach (int index in predecessorIndices)
+        {
+            if (index < lo) lo = index;
+            if (index > hi) hi = index;
+        }
+        for (int i = lo + 1; i < hi; i++)
+        {
+            if (predecessorIndices.Contains(i))
+                continue;
+            var block = blocks[i];
+            if (block.Children.Count > 0 && block.Children[^1] is Return or Throw)
+                return true;
+        }
+        return false;
     }
 
     /// <summary>
@@ -1095,7 +1168,7 @@ public sealed class StructuringPass : IIrPass
 
     /// <summary>A terminator block that may be inlined into a guard at <paramref name="index"/>.</summary>
     static bool IsInlinableTerminator(Ctx ctx, int index) =>
-        IsSharedTerminator(ctx.Blocks[index], ctx.UnconditionalTargets, ctx.ConditionalTargetCounts, ctx.FallenInto, ctx.IsComparisonTree);
+        IsSharedTerminator(ctx.Blocks[index], ctx.UnconditionalTargets, ctx.ConditionalTargetCounts, ctx.FallenInto, ctx.IsComparisonTree, ctx.ScatteredReturnDispatchTargets);
 
     /// <summary>Whether control reaching the end of this block continues into its successor (vs. returning, throwing, or branching away).</summary>
     static bool FallsThrough(Block block) =>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -179,7 +179,7 @@ public sealed class StructuringPass : IIrPass
             {
                 continue;
             }
-            if (IsScatteredDispatch(blocks, conditionalPredecessorIndices[offset]))
+            if (IsScatteredDispatch(blocks, conditionalPredecessorIndices[offset], fallenInto, branchTargets))
                 scatteredReturnDispatchTargets.Add(offset);
         }
 
@@ -1120,13 +1120,23 @@ public sealed class StructuringPass : IIrPass
 
     /// <summary>
     /// Whether the conditional predecessors of a shared return are scattered
-    /// across nesting levels (a <c>return</c>/<c>throw</c> arm sits between two of
-    /// them in block order) rather than forming a single contiguous
-    /// <c>&amp;&amp;</c>/<c>||</c> guard chain. An interleaved terminator means at
-    /// least one guard reaches the return from a region strict nesting would
-    /// close before the return, so the return must be duplicated into each guard.
+    /// across nesting levels (a <c>return</c>/<c>throw</c> dispatch arm sits
+    /// between two of them in block order) rather than forming a single
+    /// contiguous <c>&amp;&amp;</c>/<c>||</c> guard chain. A qualifying arm must be
+    /// reached only by its guard falling through (in <paramref name="fallenInto"/>
+    /// and not a <paramref name="branchTargets"/> target); a terminator reached as
+    /// a branch target is an arm of a reconverging diamond nested inside a
+    /// short-circuit condition (e.g. a <c>throw</c> expression), which combines
+    /// cleanly under one guard and must not force duplication. An interleaved
+    /// dispatch arm means at least one guard reaches the return from a region
+    /// strict nesting would close before the return, so the return must be
+    /// duplicated into each guard.
     /// </summary>
-    static bool IsScatteredDispatch(IReadOnlyList<Block> blocks, List<int> predecessorIndices)
+    static bool IsScatteredDispatch(
+        IReadOnlyList<Block> blocks,
+        List<int> predecessorIndices,
+        HashSet<int> fallenInto,
+        HashSet<int> branchTargets)
     {
         int lo = int.MaxValue;
         int hi = int.MinValue;
@@ -1140,8 +1150,20 @@ public sealed class StructuringPass : IIrPass
             if (predecessorIndices.Contains(i))
                 continue;
             var block = blocks[i];
-            if (block.Children.Count > 0 && block.Children[^1] is Return or Throw)
+            if (block.Children.Count == 0 || block.Children[^1] is not (Return or Throw))
+                continue;
+            // A genuine dispatch arm is the fall-through else of its own guard:
+            // control reaches it only by the preceding guard's conditional branch
+            // falling through, never by an explicit branch that targets it. A
+            // terminator reached as a branch target is instead an arm of a
+            // reconverging diamond nested inside a short-circuit `&&`/`||`
+            // condition (e.g. a `throw` expression), which combines cleanly under
+            // one guard and must not force duplication (the #640-style canary).
+            if (fallenInto.Contains(block.StartOffset)
+                && !branchTargets.Contains(block.StartOffset))
+            {
                 return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
- Fixes #2959
- Duplicates a scattered shared `return` into each conditional guard in `StructuringPass` instead of dropping edges, resolving CS0161 self-decompilation defects.
- Card revision: `39bfb88fc754bddb2b6ad47791c38e252d729a6a`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the structuring fix turns six invalid (CS0161) self-decompilations into valid, fully-raised C#, with no corpus regression and the #640 canary preserved.

A shared `return` reached by two or more conditional guards scattered across *different nesting levels* (a return/throw arm sits between the guard blocks) is a join strict nesting cannot express. `StructuringPass` placed the return after one guard and dropped the other edges, so a non-void method fell off its end. The new `IsScatteredDispatch` discriminator fires only when a `return`/`throw` arm is interleaved between predecessor blocks, so the contiguous `&&`/`||` false-exit chain (adjacent guards, no arm between them) still combines into a single condition (the #640 fidelity canary), and `!fallenInto` keeps union-switch defaults untouched.

### Original source

Authoritative source from this repository (`TupleSwitchExpressionPass.TryNumericValue`); the local PDB has no SourceLink to fetch it via `dotnet-inspect`.

```csharp
static bool TryNumericValue(Constant constant, out long value)
{
    switch (constant.Value)
    {
        case sbyte sb: value = sb; return true;
        case byte b: value = b; return true;
        case short s: value = s; return true;
        case ushort us: value = us; return true;
        case int i: value = i; return true;
        case uint u: value = u; return true;
        case long l: value = l; return true;
        case ulong ul when ul <= long.MaxValue: value = (long)ul; return true;
        case char c: value = c; return true;
        default:
            value = 0;
            return false;
    }
}
```

### Before

The failed `when` guard of `case ulong` and the top-level `ul > MaxValue` guard both share the `default` `return false`, at different nesting levels. Structuring kept only one edge; after the final `if (ul <= MaxValue) { … return true; }` there is no `else` and no trailing return, so the method falls off its end.

```csharp
private static bool TryNumericValue(Constant constant, out long value)
{
    // … sbyte/byte/short/ushort/int/uint/long cases identical to After …
    if (V_9 is ulong)
    {
        ul = (ulong)V_9;
    }
    else
    {
        if (V_9 is not char)
        {
            value = (long)0;
            return false;
        }
        c = (char)V_9;
        value = (long)c;
        return true;
    }
    if (ul <= (ulong)9223372036854775807)
    {
        value = (long)ul;
        return true;
    }
}   // <- falls off the end: the ul > MaxValue edge was dropped
```

- Valid: False
- Correct: False

CS0161 "not all code paths return a value".

### After

```csharp
private static bool TryNumericValue(Constant constant, out long value)
{
    // … sbyte/byte/short/ushort/int/uint/long cases identical to Before …
    if (V_9 is ulong)
    {
        ul = (ulong)V_9;
    }
    else
    {
        if (V_9 is not char)
        {
            value = (long)0;
            return false;
        }
        c = (char)V_9;
        value = (long)c;
        return true;
    }
    if (ul > (ulong)9223372036854775807)
    {
        value = (long)0;
        return false;
    }
    value = (long)ul;
    return true;
}
```

- Valid: True
- Correct: True

The dropped edge's `return false` is duplicated into the `ul > MaxValue` guard; all paths return and behavior matches the original switch. This output is valid and behavior-correct but **not fully raised**: the decompiler emits a flat `if (V_9 is …)` type-test chain (with the `ulong` `when` guard split into a nested `if (ul > MaxValue)` early return) rather than reconstructing the original `switch`.

### Fully raised

Not reached by this PR. The intended endpoint reconstructs the original
`switch` (type-pattern `case`s, the `ulong … when` guard, and the `default`
arm) — i.e. the Original source shape:

```csharp
static bool TryNumericValue(Constant constant, out long value)
{
    switch (constant.Value)
    {
        case sbyte sb: value = sb; return true;
        case byte b: value = b; return true;
        case short s: value = s; return true;
        case ushort us: value = us; return true;
        case int i: value = i; return true;
        case uint u: value = u; return true;
        case long l: value = l; return true;
        case ulong ul when ul <= long.MaxValue: value = (long)ul; return true;
        case char c: value = c; return true;
        default:
            value = 0;
            return false;
    }
}
```

- Required tracking issue: #2974 — reconstruct type-pattern `is`-test if-chains back to `switch` statements (incl. `when` guards). This PR's scope is validity (CS0161), not switch reconstruction.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Census pin (`DecompilerAssembly_MissingReturnPopulationIsPinned`) | 14 methods (fails) | 8 methods (passes) |
| Decompiler fast suite | 3083, 0 failed | 3083, 0 failed |
| Real witness | `TupleSwitchExpressionPass::TryNumericValue` (+5) broken | fixed |
| Validity (`--validity-check`) | — | Full malformed 0; no new CS0161 |

Six self-decompilation CS0161 defects resolved (all the same scattered-return shape): `TupleSwitchExpressionPass::TryNumericValue`, `IsPatternPass::IsPatternLocalNull`, `NullConditionalPass::MemberReceiver`, `UnionSwitchExpressionPass::SameTailNode`, `DynamicCallSitePass::TryGuardCacheLoad`, `FluentChainRecompositionPass::SinkStatement`. `YieldBreakLoopIteratorReconstruction::TryNormalizeContinueCondition` is a distinct result-temp switch-expression shape not covered here — tracked as follow-up (#2973).

No compiled fixture is included: the defect emerges from pass interaction (a standalone compiled method with the same C# shape does not reproduce it), so the product-owned census pin — which fails on base and passes at head — is the faithful regression guard.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — pinned-subset gate flat (0 pp), aggregate residue improves, 0 pass bugs.

### PR quick gate

| Metric (goal) | Baseline | PR | Rate delta |
| --- | ---: | ---: | ---: |
| Detected lowering residue (-) | 17.67% | 17.67% | 0 pp |
| Conditional-branch residue (-) | 3.00% | 3.00% | 0 pp |
| Pass bugs (-) | 0 | 0 | 0 |

> **Conclusion:** **PASS** — corpus sensor matched baseline tolerances.

### Aggregate context

Corpus: 15 assemblies, 1,500 sampled methods.

| Metric (goal) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Detected lowering residue (-) | 251 (16.73%) | 250 (16.67%) | -1 |
| Conditional-branch residue (-) | 46 (3.07%) | 45 (3.00%) | -1 |
| Forward-merge stops (-) | 32 (2.13%) | 30 (2.00%) | -2 |

> **Conclusion:** **PASS** — residue only decreases; no new pass bugs.

