### PR TITLE
Add orthogonal Area trait dimension to decompiler tests (#2975)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,25 @@ Some CLI tests require `ilasm`/`ildasm` and skip when those tools are absent.
 The IL round-trip project has separate dependency restore and fast/full test
 commands; follow `tests/DotnetInspector.ILRoundtrip.Tests/README.md`.
 
+`ILInspector.Decompiler.Tests` carries two orthogonal `[Trait]` dimensions you
+can compose with xUnit's `-trait`/`-trait-` filters:
+
+- `Speed` (`Slow` marks the expensive corpus/fidelity/compile-back gates). Drop
+  them with `-trait- "Speed=Slow"`.
+- `Area` groups a functional slice — `RoundTrip`, `Fidelity`, `Corpus`,
+  `Validity`, and `Pass` — so you can run one area's tests (including its slow
+  gates) without every other area's slow gates.
+
+```bash
+# every RoundTrip test, fast and slow (includes its slow compile-back gates):
+dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait "Area=RoundTrip"
+# narrow to the fast RoundTrip tests only:
+dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait "Area=RoundTrip" -trait- "Speed=Slow"
+```
+
+The `Area` taxonomy and how classes map to it live with the decompiler test
+docket in `docs/decompiler-correctness-pipeline.md`.
+
 Pack and publish flows remain separate and build `src/dotnet-inspect`
 directly.
 

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -130,6 +130,41 @@ Notes:
 - A green entry gate is necessary, never sufficient: it says nothing about
   validity, fidelity, or corpus health. Do not report it as if it did.
 
+### Area trait: targeting a functional slice
+
+`Speed` is a cost split of *everything*; it cannot target a functional area.
+`ILInspector.Decompiler.Tests` therefore carries an orthogonal
+`[Trait("Area", "…")]` dimension (applied at the class level, or at the method
+level for a lone slow gate in an otherwise unrelated class) so a change author
+can run one area's tests —
+including that area's slow gates — without every other area's slow gates, and
+without hand-enumerating `-class` names. The two dimensions compose:
+`-trait "Area=X"` selects area X fast and slow; adding `-trait- "Speed=Slow"`
+narrows to X's fast tests.
+
+```bash
+# every Fidelity test, fast and slow:
+dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait "Area=Fidelity"
+# fast Fidelity tests only:
+dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait "Area=Fidelity" -trait- "Speed=Slow"
+```
+
+Areas and their member classes:
+
+| Area | Member test classes |
+| --- | --- |
+| `RoundTrip` | the compile-back / MemberBodyProducer seam: `ReturnToSender*`, `MemberBodyProducer*`, `CompileBackTypeIdentityTests`, `TypeBindGateTests`, `GeneratedFixtureCatalogTests`, `CompilerFeatureOptionsTests` |
+| `Fidelity` | the changed-method fidelity gates: `FidelityGateTests`, `LoweredFidelityGateTests`, `DiffFixtureFidelityTests`, `AuthoredRebuildFidelityTests`, `SkeletonEmitTests`, `ClusterCaptureTests`, `NestedTargetLookupTests`, plus the compile-back gate method in `PrinterPrecedenceTests` |
+| `Corpus` | corpus-wide sweeps: `CorpusSweepGateTests`, `CorpusSensorComparisonTests`, `SubstrateLeaderDifferentialTests` |
+| `Validity` | validity / ladder gates: `ValidityCoverageReportingTests`, `LadderIteratorGateTests`, `LadderRung*GateTests` |
+| `Pass` | the per-pass unit tests (`*PassTests`) |
+
+`Area` is a targeting aid, not a completeness contract: unclassified unit tests
+carry no `Area`, so `-trait "Area=X"` selects only tagged members. When you add
+a class that belongs to an area (especially a new slow gate), tag it with the
+matching `[Trait("Area", "…")]` so the area's group filter keeps finding it; add
+a new area value only when an expensive slice has no existing home.
+
 ## Vocabulary
 
 Use these names in issues and PRs when selecting evidence:

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -165,6 +165,25 @@ a class that belongs to an area (especially a new slow gate), tag it with the
 matching `[Trait("Area", "…")]` so the area's group filter keeps finding it; add
 a new area value only when an expensive slice has no existing home.
 
+Which area to run while iterating on a change:
+
+| Change surface | Iterate against |
+| --- | --- |
+| `MemberBodyProducer`, changed-method emit, skeleton, type binding, the compile-back oracle | `Area=RoundTrip` (add `Area=Fidelity` — skeleton/compile-back overlap both) |
+| The changed-method fidelity path, cluster capture, nested-target lookup, a printer/typing change that can alter recompiled output | `Area=Fidelity` |
+| Validity ladder or iterator-reconstruction behavior | `Area=Validity` |
+| A single raising / structuring / lowering / printer pass | `Area=Pass` for the pass's own `*PassTests`, then the fidelity/validity/corpus gates below |
+| Corpus-sweep or sensor tooling | `Area=Corpus` |
+
+`Area` narrows the *iteration* loop, not the pre-review gate. A raising,
+structuring, typing, or printer change can shift any corpus row, so it is not
+covered by its `Area=Pass` unit tests alone: before requesting review still run
+the full slow suite locally (unfiltered `ILInspector.Decompiler.Tests`, which
+Deep Inspect and release also run). `Area` does not change what CI runs — PR CI
+keys on `Speed` (`-trait- "Speed=Slow"`) and Deep Inspect/release run the whole
+slow set — so every area's slow gates already run before merge without any
+per-area CI wiring.
+
 ## Vocabulary
 
 Use these names in issues and PRs when selecting evidence:

--- a/src/ILInspector.Decompiler.Tests/AnonymousObjectPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnonymousObjectPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class AnonymousObjectPassTests
 {
     static IrFunction Raised(string methodName)

--- a/src/ILInspector.Decompiler.Tests/ArrayLiteralFromStoresPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ArrayLiteralFromStoresPassTests.cs
@@ -7,6 +7,7 @@ namespace ILInspector.Decompiler.Tests;
 // into one ArrayLiteral, placed at the fill run's position. These tests cover
 // the fold's happy path and the guards that keep it from misfiring on shapes
 // that are not a faithful array-literal initializer.
+[Trait("Area", "Pass")]
 public class ArrayLiteralFromStoresPassTests
 {
     static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");

--- a/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis;
 
 namespace ILInspector.DecompilerHarness;
 
+[Trait("Area", "Fidelity")]
 public sealed class AuthoredRebuildFidelityTests
 {
     static readonly FindingSubject Subject = new("test", "test");

--- a/src/ILInspector.Decompiler.Tests/AwaitRecoveryPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AwaitRecoveryPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class AwaitRecoveryPassTests
 {
     static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "AwaitHolder");

--- a/src/ILInspector.Decompiler.Tests/BoolToIntNormalizationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/BoolToIntNormalizationPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class BoolToIntNormalizationPassTests
 {
     static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");

--- a/src/ILInspector.Decompiler.Tests/CallIndirectSpellabilityPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CallIndirectSpellabilityPassTests.cs
@@ -3,6 +3,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class CallIndirectSpellabilityPassTests
 {
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler.Tests/ClassicAsyncReconstructionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ClassicAsyncReconstructionPassTests.cs
@@ -29,6 +29,7 @@ namespace ILInspector.Decompiler.Tests;
 // the pass, so its test pins the observable behavior rather than one clause.
 // These are synthetic-IR pins; the positive reconstruction shapes are covered by
 // the Fixtures.ClassicAsync overlay referenced in AwaitRecoveryFacts.
+[Trait("Area", "Pass")]
 public class ClassicAsyncReconstructionPassTests
 {
     static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");

--- a/src/ILInspector.Decompiler.Tests/ClusterCaptureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ClusterCaptureTests.cs
@@ -24,6 +24,7 @@ namespace ILInspector.Decompiler.Tests;
 ///    the closure always bailed).
 /// </summary>
 [Trait("Speed", "Slow")]
+[Trait("Area", "Fidelity")]
 public class ClusterCaptureTests
 {
     const string FixtureType = "ILInspector.Decompiler.Tests.CfgSampleClass";

--- a/src/ILInspector.Decompiler.Tests/ComparisonTreeBoolArmPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ComparisonTreeBoolArmPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class ComparisonTreeBoolArmPassTests
 {
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler.Tests/CompileBackTypeIdentityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompileBackTypeIdentityTests.cs
@@ -14,6 +14,7 @@ namespace ILInspector.Decompiler.Tests;
 // (issue #2778). Each case pins index-key == CSharpIdentifier.Sanitize(<arity-stripped
 // metadata name>) against the real compiled type-identity fixture assembly
 // (FixtureIds.DecompilerTypeIdentity), whose source retains the exact type shapes.
+[Trait("Area", "RoundTrip")]
 public class CompileBackTypeIdentityTests
 {
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/CompilerFeatureOptionsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompilerFeatureOptionsTests.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CSharp;
 namespace ILInspector.Decompiler.Tests;
 
 [Trait("Speed", "Slow")]
+[Trait("Area", "RoundTrip")]
 public class CompilerFeatureOptionsTests
 {
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ConditionalStoreChainPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ConditionalStoreChainPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class ConditionalStoreChainPassTests
 {
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler.Tests/ConstructorCallDiagnosticsPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ConstructorCallDiagnosticsPassTests.cs
@@ -3,6 +3,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class ConstructorCallDiagnosticsPassTests
 {
     static readonly TypeRef Owner = TypeRef.CoreLib("Synthetic", "Owner");

--- a/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSensorComparisonTests.cs
@@ -9,6 +9,7 @@ using ILInspector.Metadata;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Corpus")]
 public class CorpusSensorComparisonTests
 {
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/CorpusSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CorpusSweepGateTests.cs
@@ -25,6 +25,7 @@ namespace ILInspector.Decompiler.Tests;
 /// remains the depth signal; this is the breadth signal.
 /// </summary>
 [Trait("Speed", "Slow")]
+[Trait("Area", "Corpus")]
 public class CorpusSweepGateTests
 {
     // Measured over net11 CoreLib (41,159 methods): 0 pass-bugs, 98.12% Full

--- a/src/ILInspector.Decompiler.Tests/DeconstructionAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DeconstructionAssignmentPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class DeconstructionAssignmentPassTests
 {
     static IrFunction Raised(string methodName, Type? type = null)

--- a/src/ILInspector.Decompiler.Tests/DelegateConstructionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DelegateConstructionPassTests.cs
@@ -3,6 +3,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class DelegateConstructionPassTests
 {
     static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");

--- a/src/ILInspector.Decompiler.Tests/DestructorRecoveryPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DestructorRecoveryPassTests.cs
@@ -5,6 +5,7 @@ namespace ILInspector.Decompiler.Tests;
 // A C# destructor lowers to a Finalize override whose body is
 // try { BODY } finally { base.Finalize(); }. DestructorRecoveryPass strips that
 // scaffold back to BODY and marks the function a destructor.
+[Trait("Area", "Pass")]
 public class DestructorRecoveryPassTests
 {
     static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "HasFinalizer");

--- a/src/ILInspector.Decompiler.Tests/DiffFixtureFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DiffFixtureFidelityTests.cs
@@ -4,6 +4,7 @@ using ILInspector.DecompilerHarness;
 namespace ILInspector.Decompiler.Tests;
 
 [Trait("Speed", "Slow")]
+[Trait("Area", "Fidelity")]
 public class DiffFixtureFidelityTests
 {
     static readonly string[] DiffFocusedMethods =

--- a/src/ILInspector.Decompiler.Tests/DynamicCallSitePassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DynamicCallSitePassTests.cs
@@ -18,6 +18,7 @@ namespace ILInspector.Decompiler.Tests;
 /// additionally prove the pass declines without throwing. The
 /// <see cref="IrNode.CheckInvariant"/> assertions bracket every pass run.
 /// </summary>
+[Trait("Area", "Pass")]
 public class DynamicCallSitePassTests
 {
     static readonly TypeRef ObjectType = TypeRef.CoreLib("System", "Object");

--- a/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EhStructuringPassTests.cs
@@ -10,6 +10,7 @@ namespace ILInspector.Decompiler.Tests;
 /// rather than emit a partial or illegal structuring — which is why those methods
 /// surface as the "eh-entangled" shape instead of a structured (but wrong) shell.
 /// </summary>
+[Trait("Area", "Pass")]
 public class EhStructuringPassTests
 {
     static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");

--- a/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
@@ -3,6 +3,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class ExpressionInliningPassTests
 {
     static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -13,6 +13,7 @@ namespace ILInspector.Decompiler.Tests;
 /// </summary>
 [Trait("Speed", "Slow")]
 [Collection(FidelityGateCollection.Name)]
+[Trait("Area", "Fidelity")]
 public class FidelityGateTests
 {
     const string FixtureType = "ILInspector.Decompiler.Tests.CfgSampleClass";

--- a/src/ILInspector.Decompiler.Tests/FixedBufferElementAccessPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FixedBufferElementAccessPassTests.cs
@@ -10,6 +10,7 @@ using NewPrimitiveFixedBuffer = ILInspector.Decompiler.Fixtures.NewUnsafe.FixedB
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class FixedBufferElementAccessPassTests
 {
     static readonly string NewUnsafePath = FixtureCatalog.DecompilerUnsafeNew.AssemblyPath();

--- a/src/ILInspector.Decompiler.Tests/FluentChainRecompositionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FluentChainRecompositionPassTests.cs
@@ -8,6 +8,7 @@ namespace ILInspector.Decompiler.Tests;
 // It reuses ConstructorChainArgumentPass's effect-order proof, so it must make
 // the fold only when it reorders no effect, and must leave a re-used receiver
 // (e.g. a lock copy) or a non-chain-link head untouched.
+[Trait("Area", "Pass")]
 public class FluentChainRecompositionPassTests
 {
     static readonly TypeRef Chain = TypeRef.Definition("synthetic", "", "AssertionChain");

--- a/src/ILInspector.Decompiler.Tests/ForLoopPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForLoopPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class ForLoopPassTests
 {
     static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");

--- a/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class ForeachStatementPassTests
 {
     static IrFunction Raised(string methodName)

--- a/src/ILInspector.Decompiler.Tests/FunctionPointerDiagnosticsPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FunctionPointerDiagnosticsPassTests.cs
@@ -5,6 +5,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class FunctionPointerDiagnosticsPassTests
 {
     private static readonly TypeRef Owner = TypeRef.CoreLib("Synthetic", "Owner");

--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -14,6 +14,7 @@ namespace ILInspector.Decompiler.Tests;
 /// report by stable fixture ID instead of only by metadata method name.
 /// </summary>
 [Trait("Speed", "Slow")]
+[Trait("Area", "RoundTrip")]
 public class GeneratedFixtureCatalogTests
 {
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/IdentityConvertPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdentityConvertPassTests.cs
@@ -3,6 +3,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class IdentityConvertPassTests
 {
     static IrFunction Raised(string methodName)

--- a/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
@@ -4,6 +4,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class IncrementDecrementPassTests
 {
     static readonly TypeRef Boolean = TypeRef.CoreLib("System", "Boolean");

--- a/src/ILInspector.Decompiler.Tests/IndexFromEndPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IndexFromEndPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class IndexFromEndPassTests
 {
     static IrFunction Raised(string methodName)

--- a/src/ILInspector.Decompiler.Tests/InlineArrayElementRefPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InlineArrayElementRefPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class InlineArrayElementRefPassTests
 {
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler.Tests/IsPatternPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IsPatternPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class IsPatternPassTests
 {
     static IrFunction Raised(string methodName)

--- a/src/ILInspector.Decompiler.Tests/IteratorAcknowledgmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorAcknowledgmentPassTests.cs
@@ -3,6 +3,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class IteratorAcknowledgmentPassTests
 {
     static IrFunction Raised(string methodName)

--- a/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.CSharp;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class IteratorReconstructionPassTests
 {
     // Reconstruction needs the cross-method seam (to import the state machine's

--- a/src/ILInspector.Decompiler.Tests/LadderIteratorGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderIteratorGateTests.cs
@@ -29,6 +29,7 @@ namespace ILInspector.Decompiler.Tests;
 /// shapes. They are tracked as the restriction frontier rather than synthesized
 /// into impossible fixtures.
 /// </summary>
+[Trait("Area", "Validity")]
 public class LadderIteratorGateTests
 {
     static string FixturePath => typeof(LadderIterator.IteratorSamples).Assembly.Location;

--- a/src/ILInspector.Decompiler.Tests/LadderRung1CombinedFrontierGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung1CombinedFrontierGateTests.cs
@@ -24,6 +24,7 @@ namespace ILInspector.Decompiler.Tests;
 /// path raises it, guarded by <see cref="LadderRung1ProductPathGateTests"/>. That
 /// remaining residual is the lambda, not structuring.)</para>
 /// </summary>
+[Trait("Area", "Validity")]
 public class LadderRung1CombinedFrontierGateTests
 {
     static string FixturePath => typeof(LadderRung1.CombinedFrontier).Assembly.Location;

--- a/src/ILInspector.Decompiler.Tests/LadderRung1FoundationGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung1FoundationGateTests.cs
@@ -28,6 +28,7 @@ namespace ILInspector.Decompiler.Tests;
 /// Like <see cref="LadderRung1GateTests"/> this is the fast depth-scoped bar, not
 /// a corpus sweep or compile-back opcode check.
 /// </summary>
+[Trait("Area", "Validity")]
 public class LadderRung1FoundationGateTests
 {
     static string FixturePath => typeof(LadderRung1.Foundation).Assembly.Location;

--- a/src/ILInspector.Decompiler.Tests/LadderRung1GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung1GateTests.cs
@@ -26,6 +26,7 @@ namespace ILInspector.Decompiler.Tests;
 /// (<see cref="FidelityGateTests"/>), not the rung 1 bar — <c>IsPositive</c>
 /// recompiles its branch as <c>cgt</c> while still rendering valid C#.
 /// </summary>
+[Trait("Area", "Validity")]
 public class LadderRung1GateTests
 {
     static string FixturePath => typeof(LadderRung1.Program).Assembly.Location;

--- a/src/ILInspector.Decompiler.Tests/LadderRung1ProductPathGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung1ProductPathGateTests.cs
@@ -28,6 +28,7 @@ namespace ILInspector.Decompiler.Tests;
 /// cross-assembly out-variable to <c>out</c>. It is the reusable model for any
 /// rung that needs to guard seam-sensitive constructs at product fidelity.</para>
 /// </summary>
+[Trait("Area", "Validity")]
 public class LadderRung1ProductPathGateTests
 {
     static string FixturePath => typeof(LadderRung1.ProductSurface).Assembly.Location;

--- a/src/ILInspector.Decompiler.Tests/LadderRung1ResidualGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung1ResidualGateTests.cs
@@ -14,6 +14,7 @@ namespace ILInspector.Decompiler.Tests;
 /// the current lower-altitude shape so a future raise that improves the altitude
 /// is a deliberate, visible change.
 /// </summary>
+[Trait("Area", "Validity")]
 public class LadderRung1ResidualGateTests
 {
     static string FixturePath => typeof(LadderRung1.OwnedResiduals).Assembly.Location;

--- a/src/ILInspector.Decompiler.Tests/LadderRung2GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung2GateTests.cs
@@ -29,6 +29,7 @@ namespace ILInspector.Decompiler.Tests;
 /// source-recoverable at the type-declaration level. A future change that recovers it
 /// to <c>Full</c> should update this guard deliberately.
 /// </summary>
+[Trait("Area", "Validity")]
 public class LadderRung2GateTests
 {
     static string FixturePath => typeof(LadderRung2.Program).Assembly.Location;

--- a/src/ILInspector.Decompiler.Tests/LadderRung3GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung3GateTests.cs
@@ -15,6 +15,7 @@ namespace ILInspector.Decompiler.Tests;
 /// members, so this guard treats their arrow spelling as a whole-type
 /// type-source rendering preference, not as independent source recovery proof.
 /// </summary>
+[Trait("Area", "Validity")]
 public class LadderRung3GateTests
 {
     static string FixturePath => typeof(LadderRung3.Program).Assembly.Location;

--- a/src/ILInspector.Decompiler.Tests/LadderRung4GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung4GateTests.cs
@@ -14,6 +14,7 @@ namespace ILInspector.Decompiler.Tests;
 /// locals/returns so they keep rendering as valid or honestly degraded output in
 /// the fast PR gate.
 /// </summary>
+[Trait("Area", "Validity")]
 public class LadderRung4GateTests
 {
     static string FixturePath => typeof(LadderRung4.CSharp7LocalSyntax).Assembly.Location;

--- a/src/ILInspector.Decompiler.Tests/LadderRung5GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung5GateTests.cs
@@ -30,6 +30,7 @@ namespace ILInspector.Decompiler.Tests;
 /// <c>op_Checked*</c> method call, which is CS0571 invalid <c>Full</c> (#1706).</item>
 /// </list>
 /// </summary>
+[Trait("Area", "Validity")]
 public class LadderRung5GateTests
 {
     static string FixturePath => typeof(LadderRung5.Program).Assembly.Location;

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -31,6 +31,7 @@ namespace ILInspector.Decompiler.Tests;
 /// memory-safety module attribute, while synthetic canaries pin unspellable
 /// volatile/pinned residuals that C# cannot compile directly.
 /// </summary>
+[Trait("Area", "Validity")]
 public class LadderRung6GateTests
 {
     static readonly string NewUnsafePath = FixtureCatalog.DecompilerUnsafeNew.AssemblyPath();

--- a/src/ILInspector.Decompiler.Tests/LadderRung9GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung9GateTests.cs
@@ -17,6 +17,7 @@ namespace ILInspector.Decompiler.Tests;
 /// as explicit <c>Expression.*</c> calls where supported, and prohibited
 /// expression-tree forms stay documented as the row's honesty frontier.
 /// </summary>
+[Trait("Area", "Validity")]
 public class LadderRung9GateTests
 {
     static string FixturePath => typeof(LadderRung9.DynamicAndExpressionTrees).Assembly.Location;

--- a/src/ILInspector.Decompiler.Tests/LambdaCachePassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LambdaCachePassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class LambdaCachePassTests
 {
     static string PrintRaised(string methodName)

--- a/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class LambdaRaisingPassTests
 {
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler.Tests/ListPatternPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ListPatternPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class ListPatternPassTests
 {
     static IrFunction Raised(string methodName)

--- a/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class LocalFunctionRaisingPassTests
 {
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -14,6 +14,7 @@ namespace ILInspector.Decompiler.Tests;
 /// </summary>
 [Trait("Speed", "Slow")]
 [Collection(FidelityGateCollection.Name)]
+[Trait("Area", "Fidelity")]
 public class LoweredFidelityGateTests
 {
     const string FixtureType = "ILInspector.Decompiler.Tests.CfgSampleClass";

--- a/src/ILInspector.Decompiler.Tests/MemberBodyProducerAsyncTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberBodyProducerAsyncTests.cs
@@ -3,6 +3,7 @@ using ILInspector.Metadata;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "RoundTrip")]
 public sealed class MemberBodyProducerAsyncTests
 {
     [Theory]

--- a/src/ILInspector.Decompiler.Tests/MemberBodyProducerOverloadAddressingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberBodyProducerOverloadAddressingTests.cs
@@ -16,6 +16,7 @@ namespace ILInspector.Decompiler.Tests;
 /// the hidden overload's body (invalid); handle addressing renders each member's
 /// own body. See docs/design/member-body-substrate.md.
 /// </summary>
+[Trait("Area", "RoundTrip")]
 public class MemberBodyProducerOverloadAddressingTests
 {
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/MemberBodyProducerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberBodyProducerUnionTests.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "RoundTrip")]
 public class MemberBodyProducerUnionTests
 {
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/NestedTargetLookupTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NestedTargetLookupTests.cs
@@ -10,6 +10,7 @@ namespace ILInspector.Decompiler.Tests;
 /// <c>target-method-not-found</c> bucket and the check silently stopped measuring
 /// that part of the changed population.
 /// </summary>
+[Trait("Area", "Fidelity")]
 public class NestedTargetLookupTests
 {
     const string Outer = "ILInspector.Decompiler.Tests.NestedTargetFixture";

--- a/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
@@ -3,6 +3,7 @@ using ILInspector.DecompilerHarness;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class NullCoalescingAssignmentPassTests
 {
     static IrFunction Raised(string methodName)

--- a/src/ILInspector.Decompiler.Tests/NullConditionalCoalescePassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NullConditionalCoalescePassTests.cs
@@ -3,6 +3,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class NullConditionalCoalescePassTests
 {
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -3,6 +3,7 @@ using ILInspector.Metadata;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class ObjectInitializerPassTests
 {
     static IrFunction Raised(string methodName)

--- a/src/ILInspector.Decompiler.Tests/PatternGuardedShortCircuitPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PatternGuardedShortCircuitPassTests.cs
@@ -11,6 +11,7 @@ namespace ILInspector.Decompiler.Tests;
 /// recovering <c>target = subject is T x &amp;&amp; x.CompareTo(default(T)) &gt; 0</c>
 /// (the FluentAssertions <c>BePositive</c> shape).
 /// </summary>
+[Trait("Area", "Pass")]
 public class PatternGuardedShortCircuitPassTests
 {
     static string Print(Type declaringType, string methodName)

--- a/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
@@ -44,6 +44,7 @@ public class PrinterPrecedenceTests
 
     [Fact]
     [Trait("Speed", "Slow")]
+    [Trait("Area", "Fidelity")]
     public void StoreElement_CompoundArrayReceiver_RecompilesExactly()
     {
         var result = Assert.Single(

--- a/src/ILInspector.Decompiler.Tests/PrologueGuardReturnPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrologueGuardReturnPassTests.cs
@@ -9,6 +9,7 @@ namespace ILInspector.Decompiler.Tests;
 /// makes a later block a leave-target). The fold must touch only the pristine
 /// prologue and stand down whenever the arm could reach into the EH residue.
 /// </summary>
+[Trait("Area", "Pass")]
 public class PrologueGuardReturnPassTests
 {
     static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");

--- a/src/ILInspector.Decompiler.Tests/PropertySugarPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PropertySugarPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class PropertySugarPassTests
 {
     static readonly TypeRef Holder = TypeRef.Definition("SyntheticAssembly", "Synthetic", "Holder");

--- a/src/ILInspector.Decompiler.Tests/RangeFromGetSubArrayPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RangeFromGetSubArrayPassTests.cs
@@ -3,6 +3,7 @@ using ILInspector.DecompilerHarness;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class RangeFromGetSubArrayPassTests
 {
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler.Tests/RedundantBranchEliminationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RedundantBranchEliminationPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class RedundantBranchEliminationPassTests
 {
     static readonly TypeRef s_bool = TypeRef.CoreLib("System", "Boolean");

--- a/src/ILInspector.Decompiler.Tests/ReturnDispatchPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnDispatchPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class ReturnDispatchPassTests
 {
     static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");

--- a/src/ILInspector.Decompiler.Tests/ReturnMergePassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnMergePassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class ReturnMergePassTests
 {
     static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");

--- a/src/ILInspector.Decompiler.Tests/ReturnSinkingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnSinkingPassTests.cs
@@ -3,6 +3,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class ReturnSinkingPassTests
 {
     static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderEvidenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderEvidenceTests.cs
@@ -6,6 +6,7 @@ using ILInspector.Research;
 namespace ILInspector.Decompiler.Tests;
 
 [Trait("Speed", "Slow")]
+[Trait("Area", "RoundTrip")]
 public class ReturnToSenderEvidenceTests
 {
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -17,6 +17,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "RoundTrip")]
 public class ReturnToSenderFixtureCatalogTests
 {
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -14,6 +14,7 @@ namespace ILInspector.Decompiler.Tests;
 
 [Trait("Speed", "Slow")]
 [Collection(ConsoleMutatorCollection.Name)]
+[Trait("Area", "RoundTrip")]
 public class ReturnToSenderPrototypeTests
 {
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/RuntimeAsyncAwaiterPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RuntimeAsyncAwaiterPassTests.cs
@@ -3,6 +3,7 @@ using ILInspector.DecompilerHarness;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class RuntimeAsyncAwaiterPassTests
 {
     static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");

--- a/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class RvaSpanPassTests
 {
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler.Tests/SkeletonEmitTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SkeletonEmitTests.cs
@@ -12,6 +12,7 @@ namespace ILInspector.Decompiler.Tests;
 /// on the offending type only compiles back when every hazard is handled.
 /// </summary>
 [Trait("Speed", "Slow")]
+[Trait("Area", "Fidelity")]
 public class SkeletonEmitTests
 {
     const string FixtureType = "ILInspector.Decompiler.Tests.SkeletonEmitFixture";

--- a/src/ILInspector.Decompiler.Tests/SlotMaterializationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SlotMaterializationPassTests.cs
@@ -3,6 +3,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class SlotMaterializationPassTests
 {
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler.Tests/SlotStoreDiamondPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SlotStoreDiamondPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class SlotStoreDiamondPassTests
 {
     static readonly TypeRef UInt32 = TypeRef.CoreLib("System", "UInt32");

--- a/src/ILInspector.Decompiler.Tests/StackAllocInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackAllocInitializerPassTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class StackAllocInitializerPassTests
 {
     static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");

--- a/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
@@ -3,6 +3,7 @@ using IrConvert = ILInspector.Decompiler.Pipeline.Convert;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class StackAllocSpanPassTests
 {
     static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");

--- a/src/ILInspector.Decompiler.Tests/StackSlotCopyPropagationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackSlotCopyPropagationPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class StackSlotCopyPropagationPassTests
 {
     static readonly TypeRef Holder = TypeRef.Definition("Synthetic", "Samples", "Holder", ValueTypeHint.ReferenceType);

--- a/src/ILInspector.Decompiler.Tests/StringInterpolationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StringInterpolationPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class StringInterpolationPassTests
 {
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler.Tests/SubstrateLeaderDifferentialTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SubstrateLeaderDifferentialTests.cs
@@ -19,6 +19,7 @@ namespace ILInspector.Decompiler.Tests;
 /// refactor would move to an Analysis Layer-1 concern.
 /// </summary>
 [Trait("Speed", "Slow")]
+[Trait("Area", "Corpus")]
 public class SubstrateLeaderDifferentialTests
 {
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/TupleBinaryOperatorPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TupleBinaryOperatorPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class TupleBinaryOperatorPassTests
 {
     static IrFunction Raised(string methodName, Type? type = null)

--- a/src/ILInspector.Decompiler.Tests/TupleCreationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TupleCreationPassTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class TupleCreationPassTests
 {
     static IrFunction Raised(string methodName)

--- a/src/ILInspector.Decompiler.Tests/TupleSwitchExpressionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TupleSwitchExpressionPassTests.cs
@@ -3,6 +3,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class TupleSwitchExpressionPassTests
 {
     static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");

--- a/src/ILInspector.Decompiler.Tests/TypeBindGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeBindGateTests.cs
@@ -23,6 +23,7 @@ namespace ILInspector.Decompiler.Tests;
 /// </para>
 /// </summary>
 [Trait("Speed", "Slow")]
+[Trait("Area", "RoundTrip")]
 public class TypeBindGateTests
 {
     static string CoreLibPath => typeof(object).Assembly.Location;

--- a/src/ILInspector.Decompiler.Tests/TypedConstantsPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypedConstantsPassTests.cs
@@ -4,6 +4,7 @@ using Convert = ILInspector.Decompiler.Pipeline.Convert;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class TypedConstantsPassTests
 {
     static IrFunction Raised(string methodName)

--- a/src/ILInspector.Decompiler.Tests/UnboxValueReadPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnboxValueReadPassTests.cs
@@ -12,6 +12,7 @@ namespace ILInspector.Decompiler.Tests;
 // unbox place, a boxed Nullable<T> value read spelled Unsafe.Unbox<Nullable<T>>
 // is CS0453 (the intrinsic requires `where T : struct`), even though the cast
 // (int?)o compiles to unbox.any and is correct.
+[Trait("Area", "Pass")]
 public class UnboxValueReadPassTests
 {
     static readonly TypeRef Int32Type = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler.Tests/UsingStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UsingStatementPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class UsingStatementPassTests
 {
     static IrFunction Raised(string methodName)

--- a/src/ILInspector.Decompiler.Tests/ValidityCoverageReportingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ValidityCoverageReportingTests.cs
@@ -4,6 +4,7 @@ using ILInspector.Decompiler.Pipeline;
 namespace ILInspector.Decompiler.Tests;
 
 [Collection(ConsoleMutatorCollection.Name)]
+[Trait("Area", "Validity")]
 public class ValidityCoverageReportingTests
 {
     static readonly object ConsoleGate = new();

--- a/src/ILInspector.Decompiler.Tests/WithExpressionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/WithExpressionPassTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Area", "Pass")]
 public class WithExpressionPassTests
 {
     static readonly TypeRef Point = TypeRef.Definition("SyntheticAssembly", "Synthetic", "Point");


### PR DESCRIPTION
Closes #2975.

## What

Adds an orthogonal `[Trait("Area", "…")]` dimension to
`ILInspector.Decompiler.Tests`, independent of the existing `Speed`
(Fast/Slow) trait, so a change author can run one functional slice —
including that slice's slow gates — without every other area's slow gates
and without hand-enumerating `-class` names.

Area values and members:

| Area | Members |
| --- | --- |
| `RoundTrip` | `ReturnToSender*`, `MemberBodyProducer*`, `CompileBackTypeIdentityTests`, `TypeBindGateTests`, `GeneratedFixtureCatalogTests`, `CompilerFeatureOptionsTests` |
| `Fidelity` | `FidelityGateTests`, `LoweredFidelityGateTests`, `DiffFixtureFidelityTests`, `AuthoredRebuildFidelityTests`, `SkeletonEmitTests`, `ClusterCaptureTests`, `NestedTargetLookupTests`, and the lone slow compile-back method in `PrinterPrecedenceTests` |
| `Corpus` | `CorpusSweepGateTests`, `CorpusSensorComparisonTests`, `SubstrateLeaderDifferentialTests` |
| `Validity` | `ValidityCoverageReportingTests`, `LadderIteratorGateTests`, `LadderRung*GateTests` |
| `Pass` | the per-pass unit tests (`*PassTests`) |

The two dimensions compose:

```bash
# every RoundTrip test, fast and slow (incl. its slow compile-back gates):
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait "Area=RoundTrip"
# narrow to fast RoundTrip only:
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait "Area=RoundTrip" -trait- "Speed=Slow"
```

## Acceptance criteria

- [x] Documented `Area` taxonomy applied to the decompiler test classes, covering **every** `Speed=Slow` gate so an area's slow gates are selectable as a group.
- [x] Dimensions compose: `-trait "Area=X"` selects X fast+slow; `+ -trait- "Speed=Slow"` narrows to X-fast.
- [x] Documented in `AGENTS.md` "Building and testing" next to the existing command guidance and the `Speed=Slow` split; taxonomy detail lives with the decompiler docket in `docs/decompiler-correctness-pipeline.md`.
- [x] No change to which tests exist or their assertions — classification/targeting only (90 single-line trait additions + 2 docs).

## Evidence

- `ILInspector.Decompiler.Tests` builds clean (Release).
- `-trait "Area=Pass" -trait- "Speed=Slow"` → 1114 fast tests across all `*PassTests`, 0 failures.
- Single-class checks: `Area=Pass` matches the class (29), wrong `Area=Corpus` selects 0, composes with `-trait- "Speed=Slow"`.
- Method-level Fidelity tag on `PrinterPrecedenceTests` is scoped to the one slow method: fast-only `Area=Fidelity` on that class selects 0; its 20 fast printer tests carry no Area.

## Risk

Low: purely additive test metadata (`[Trait]`) plus documentation. No test
logic, assertion, fixture, or product code changes. Mechanical
classification change — adversarial review not required per AGENTS.md.