### PR TITLE
Raise dynamic member access inside a generic enclosing type (#2968)

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LadderRung9/LadderRung9MemberContexts.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung9/LadderRung9MemberContexts.cs
@@ -62,3 +62,26 @@ public class DynamicMemberContexts
     public object Last => _last;
 }
 
+// Same nested-body dynamic GetMember shapes as DynamicMemberContexts, but
+// authored inside a GENERIC enclosing type. csc emits the GetMember binder
+// context as typeof(GenericDynamicMemberContexts<T>) — a generic instantiation
+// of the enclosing definition with its own type parameter in scope — while the
+// lowered display-class / state-machine declaring type's metadata-decoded
+// EnclosingType is the bare generic definition. The dynamic-callsite raise must
+// recognize that self-instantiation and still raise rather than declining on the
+// GenericInstance-vs-Definition kind mismatch (#2968).
+public class GenericDynamicMemberContexts<T>
+{
+    // Nested lambda body inside a generic enclosing type.
+    public Func<object> InGenericLambda(dynamic value)
+    {
+        return () => value.Length;
+    }
+
+    // Iterator state-machine body inside a generic enclosing type.
+    public IEnumerable<object> InGenericIterator(dynamic value)
+    {
+        yield return value.Length;
+    }
+}
+

--- a/src/ILInspector.Decompiler.Tests/DynamicCallSitePassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DynamicCallSitePassTests.cs
@@ -1557,6 +1557,126 @@ public class DynamicCallSitePassTests
         Assert.False(RunPass(mutated));
     }
 
+    /// <summary>Imports the InGenericLambda display-class method (a lambda inside a generic enclosing type), running every pass up to (not including) dynamic-callsite so tests can mutate the binder context before proving the pass's own decision.</summary>
+    static IrFunction LoadGenericLambdaDisplayClassFunction()
+    {
+        var path = typeof(LadderRung9.DynamicMemberContexts).Assembly.Location;
+        using var source = MetadataSource.Open(path);
+        IrFunction? found = null;
+        foreach (var (_, methodName, function) in IrImporter.ImportAssembly(source))
+        {
+            if (methodName.Contains("InGenericLambda") && methodName.Contains("b__"))
+            {
+                found = function;
+                break;
+            }
+        }
+        Assert.NotNull(found);
+
+        var context = new PassContext(new Stepper(enabled: false));
+        foreach (var pass in IrPasses.Default)
+        {
+            if (pass.Name == "dynamic-callsite")
+                break;
+            pass.Run(found!, context);
+        }
+        return found!;
+    }
+
+    [Fact]
+    public void NestedContext_GenericEnclosingLambda_Raises()
+    {
+        // A capturing lambda authored inside a generic type Host<T> is lowered
+        // into a display-class method whose GetMember binder context is
+        // typeof(Host<T>) — a GenericInstance of the enclosing definition with
+        // its own type parameter — while the declaring type's decoded
+        // EnclosingType is the bare generic definition. The self-instantiation
+        // bridge (IsGenericSelfInstantiation) proves the context, so the site
+        // raises rather than declining on the GenericInstance-vs-Definition
+        // kind mismatch (#2968).
+        var path = typeof(LadderRung9.DynamicMemberContexts).Assembly.Location;
+        using var source = MetadataSource.Open(path);
+        string? displayClassOutput = null;
+        foreach (var (_, methodName, function) in IrImporter.ImportAssembly(source))
+        {
+            if (methodName.Contains("InGenericLambda") && methodName.Contains("b__"))
+            {
+                displayClassOutput = CSharpPrinter.PrintRaised(function, mr => IrImporter.Import(source, mr)).Output;
+                break;
+            }
+        }
+        Assert.NotNull(displayClassOutput);
+        Assert.Contains("((dynamic)value).Length", displayClassOutput);
+        Assert.DoesNotContain("Binder.GetMember", displayClassOutput);
+    }
+
+    [Fact]
+    public void NestedContext_GenericEnclosingIterator_Raises()
+    {
+        // The iterator variant of the generic-enclosing case: an iterator inside
+        // Host<T> is lowered into a MoveNext method whose binder context is
+        // likewise typeof(Host<T>), proven through the same self-instantiation
+        // bridge but via the iterator state-machine predicate (#2968).
+        var path = typeof(LadderRung9.DynamicMemberContexts).Assembly.Location;
+        using var source = MetadataSource.Open(path);
+        string? moveNextOutput = null;
+        foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+        {
+            if (methodName == "MoveNext" && typeName.Contains("InGenericIterator"))
+            {
+                moveNextOutput = CSharpPrinter.PrintRaised(function, mr => IrImporter.Import(source, mr)).Output;
+                break;
+            }
+        }
+        Assert.NotNull(moveNextOutput);
+        Assert.Contains("((dynamic)value).Length", moveNextOutput);
+        Assert.DoesNotContain("Binder.GetMember", moveNextOutput);
+    }
+
+    [Fact]
+    public void NestedContext_GenericEnclosingConcreteArgument_Declines()
+    {
+        // Close negative: the binder context is a GenericInstance of the true
+        // enclosing definition, but instantiated with a concrete argument
+        // (typeof(Host<int>)) rather than the type's own parameter. That denotes
+        // a different accessibility context, so the self-instantiation bridge
+        // must reject it — proving the fix does not naively strip type arguments.
+        var f = LoadGenericLambdaDisplayClassFunction();
+        var enclosing = f.DeclaringType.EnclosingType!;
+        var concrete = TypeRef.GenericInstance(enclosing, ImmutableArray.Create(Int32Type));
+        ContextDefStore(f).Value.ReplaceWith(new TypeOf(concrete));
+        Assert.False(RunPass(f));
+    }
+
+    [Fact]
+    public void NestedContext_GenericEnclosingReorderedParameter_Declines()
+    {
+        // Close negative: a GenericInstance of the true enclosing definition
+        // whose single argument is the type parameter at index 1 rather than the
+        // position-0 parameter the self-instantiation requires. A parameter that
+        // is not the declaration-order self parameter denotes a different context
+        // and must decline.
+        var f = LoadGenericLambdaDisplayClassFunction();
+        var enclosing = f.DeclaringType.EnclosingType!;
+        var reordered = TypeRef.GenericInstance(enclosing, ImmutableArray.Create(TypeRef.GenericParameter(1)));
+        ContextDefStore(f).Value.ReplaceWith(new TypeOf(reordered));
+        Assert.False(RunPass(f));
+    }
+
+    [Fact]
+    public void NestedContext_GenericEnclosingMethodParameter_Declines()
+    {
+        // Close negative: a GenericInstance of the true enclosing definition
+        // instantiated with a *method* generic parameter rather than a *type*
+        // generic parameter. Only the type's own type parameters instantiate its
+        // self-context, so a method type parameter must decline.
+        var f = LoadGenericLambdaDisplayClassFunction();
+        var enclosing = f.DeclaringType.EnclosingType!;
+        var methodParam = TypeRef.GenericInstance(enclosing, ImmutableArray.Create(TypeRef.MethodGenericParameter(0)));
+        ContextDefStore(f).Value.ReplaceWith(new TypeOf(methodParam));
+        Assert.False(RunPass(f));
+    }
+
     [Fact]
     public void ImmediateUse_InterveningStatement_Declines()
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/DynamicCallSitePass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/DynamicCallSitePass.cs
@@ -107,7 +107,9 @@ public sealed class DynamicCallSitePass : IIrPass
     /// generated type's <c>+</c>-joined name), and only once the declaring
     /// type's <c>[CompilerGenerated]</c> attribute evidence
     /// (<see cref="IrFunction.DeclaringTypeCompilerGenerated"/>) and a
-    /// corroborating generated-name shape both hold.
+    /// corroborating generated-name shape both hold. When that enclosing type is
+    /// generic, the context is its self-instantiation (see
+    /// <see cref="IsGenericSelfInstantiation"/>).
     /// </summary>
     static bool IsProvenBinderContext(TypeRef context, IrFunction function)
     {
@@ -122,7 +124,46 @@ public sealed class DynamicCallSitePass : IIrPass
             && !GeneratedCodeIdentity.IsIteratorStateMachineTypeName(declaringType))
             return false;
 
-        return declaringType.EnclosingType is { } enclosing && context.Equals(enclosing);
+        return declaringType.EnclosingType is { } enclosing
+            && (context.Equals(enclosing) || IsGenericSelfInstantiation(context, enclosing));
+    }
+
+    /// <summary>
+    /// Recognizes the binder context a compiler-generated body carries when the
+    /// authored enclosing type is generic. For a lambda or iterator inside
+    /// <c>Host&lt;T&gt;</c>, csc emits the GetMember context as
+    /// <c>typeof(Host&lt;T&gt;)</c> — a <see cref="TypeRefKind.GenericInstance"/>
+    /// of the enclosing definition instantiated with the type's own type
+    /// parameters in declaration order — while
+    /// <see cref="TypeRef.EnclosingType"/> decodes to the bare generic
+    /// definition, so the exact-equality direct check declines on the
+    /// GenericInstance-vs-Definition kind mismatch. Only that self-instantiation
+    /// is accepted: the element type must equal the enclosing definition and
+    /// every argument must be the type generic parameter at its own position.
+    /// A concrete argument (<c>typeof(Host&lt;int&gt;)</c>), a reordered
+    /// parameter, or a method type parameter denotes a different accessibility
+    /// context and declines.
+    /// </summary>
+    static bool IsGenericSelfInstantiation(TypeRef context, TypeRef enclosing)
+    {
+        if (context.Kind != TypeRefKind.GenericInstance)
+            return false;
+
+        if (context.ElementType is not { } definition || !definition.Equals(enclosing))
+            return false;
+
+        var arguments = context.TypeArguments;
+        if (arguments.IsDefaultOrEmpty)
+            return false;
+
+        for (int i = 0; i < arguments.Length; i++)
+        {
+            var argument = arguments[i];
+            if (argument.Kind != TypeRefKind.GenericParameter || argument.GenericParameterIndex != i)
+                return false;
+        }
+
+        return true;
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #2968.

## Problem

`DynamicCallSitePass.IsProvenBinderContext` (added in #2917) bridges a
compiler-generated display-class / iterator body to its authored enclosing type
via `TypeRef.EnclosingType` and an exact `context.Equals(enclosing)` check.
When the authored enclosing type is **generic**, that exact-equality check fails
and the dynamic scaffolding is left explicit in exactly the lambda/iterator
scenarios the feature intends to raise.

For a capturing lambda or iterator inside `Host<T>` (ground-truthed on the
net11 daily compiler via a decode probe):

- the GetMember binder context is `typeof(Host<T>)` — a **GenericInstance**
  `TypeRef` (`ElementType` = the `Host` definition, args `[GenericParameter(0)]`);
- `declaringType.EnclosingType` decoded from the metadata nested-type chain is
  the bare **Definition** `Host`;
- `GenericInstance` != `Definition` → `Equals` is `false` → the pass
  declines and retains `CallSite` / `Binder.GetMember` scaffolding.

Completeness gap only, **not a regression** — the found-during-review follow-up
GPT-5.6 Sol filed against #2917. Output stayed valid (fully explicit), just not
fully raised.

## Fix

Add `IsGenericSelfInstantiation(context, enclosing)`: accept a
`GenericInstance` context whose `ElementType` equals the enclosing definition
and whose arguments are exactly the type's own generic parameters in declaration
order (`GenericParameter` with index `i` at position `i`).
`IsProvenBinderContext` accepts this in addition to the existing exact
`Equals`.

Only that self-instantiation is accepted. A concrete argument
(`typeof(Host<int>)`), a reordered parameter, or a method type parameter
denotes a different accessibility context and still declines — the fix does not
naively strip type arguments.

The issue anticipated this "likely needs generic-arity/provenance material on the
decoded enclosing `TypeRef`". It does not: the `GenericInstance` context's
`ElementType` already pins the enclosing definition's identity and its
arguments already carry `GenericParameter` positions, so the self-instantiation
is recognizable from the already-decoded shapes. No `TypeRef` or decoder
changes were required.


## Example

Fixture `LadderRung9.GenericDynamicMemberContexts<T>.InGenericLambda` — a
capturing lambda inside a generic type, lowered by csc to
`<>c__DisplayClass0_0.<InGenericLambda>b__0`.

### Original source

```csharp
public class GenericDynamicMemberContexts<T>
{
    public Func<object> InGenericLambda(dynamic value)
    {
        return () => value.Length;
    }
}
```

### Before

The display-class method's binder-context `typeof` is
`typeof(GenericDynamicMemberContexts<T>)` — a generic instantiation of the
authored enclosing type — while the declaring type's decoded `EnclosingType` is
the bare definition, so the prior exact-equality check declined and the
scaffolding stayed explicit (real product output):

```csharp
CSharpArgumentInfo[] S_256;
Type S_257;

if (___o__0.___p__0 is null)
{
    S_256 = new CSharpArgumentInfo[1];
    S_257 = typeof(GenericDynamicMemberContexts<T>);
    S_256[0] = CSharpArgumentInfo.Create((CSharpArgumentInfoFlags)0, null);
    ___o__0.___p__0 = CallSite<Func<CallSite, object, object>>.Create(Binder.GetMember((CSharpBinderFlags)0, "Length", S_257, S_256));
}
return ___o__0.___p__0.Target.Invoke(___o__0.___p__0, value);
```

### After

```csharp
return ((dynamic)value).Length;
```

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

- New compiled fixture `GenericDynamicMemberContexts<T>` (capturing lambda +
  iterator) in the LadderRung9 fixture assembly.
- Two real-fixture raise tests (`NestedContext_GenericEnclosingLambda_Raises`,
  `NestedContext_GenericEnclosingIterator_Raises`) and three synthetic
  close-negatives (concrete arg / reordered parameter / method parameter all
  decline).
- **Gap proven**: the two raise tests fail on the pre-fix gate (scaffolding
  retained); they pass after the fix. The three negatives pass with or without
  the fix (genuine negatives).
- Focused `DynamicCallSitePassTests` + `LadderRung9GateTests` +
  `TypeRefDecoderRecursionTests` **139/139**. The 105 pre-existing
  DynamicCallSitePass cases are unchanged.
- The 13 subset failures observed locally are the pre-existing #2942 Windows-env
  compile-back `RecompileFail` set — **identical on clean `main`** (same 13
  names, Total 192), i.e. zero new failures.

## Validation complete

- [x] Corpus A/B structural inventory: base `2077bab4` == head `c26a144a`
      **SHA-256 byte-identical** (128234/135595 Full 94.57%; 2 pre-existing
      importer bugs). Zero movement.
- [x] Two-family adversarial review (GPT-5.6 Sol + Gemini 3.1 Pro): **both CLEAN**
      on head `c26a144a`, reconciled in a PR comment.
- [x] CI green: Linux `test` pass, `build-net10` pass, `csharp-diff-smoke`
      pass, `changes` pass (il-diff/markdownlint/pack path-skipped).


