### PR TITLE
Decompose library Performance Triage into kind-scoped sections (#2833)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,11 +196,17 @@ as a curated group of kind-scoped sections — `Performance: Boxing`,
 `Performance: Enumerators`, `Performance: Loop hot paths`,
 `Performance: Allocation hotspots`, and `Performance: Async` — that you can
 request individually (`-S "Performance: Boxing"`) or as a group (`-S
-@Performance`, also reachable via the legacy name `-S Performance`). Each
+@Performance`, also reachable via the legacy name `-S Performance`). The
+kind sections are catalog-hidden: they do not appear in the top-level
+`-D`/`-D --schema` discovery catalog, which lists the `@Performance` category
+as their single entrypoint. Drill in with `-D @Performance` to list the kinds,
+or `-D "Performance: Boxing"` for one kind's columns. Each
 section is absent when it has no findings, so the group renders exactly the
 kinds that were found; `--count -S @Performance` returns a per-kind count map
 (including zero rows) as a cheap way to discover which kinds are present before
-requesting them. These sections rank in-loop (hot) and high-confidence
+requesting them. In flattened tabular output (`--table`/`--tsv`/`--jsonl`) the
+group renders as one self-describing table with a leading `Kind` column, so
+every row states which performance kind it belongs to. These sections rank in-loop (hot) and high-confidence
 opportunities first across actionable rewrite shapes (small non-escaping
 arrays, temporary or span-to-array copies, capturing and instance method-group
 delegates, async state-machine setup, loop-invariant materialization, and

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ context for copied DLLs. A future `--deps` source can represent runtime
 | API compatibility | `diff` | Version ranges, package or platform diffs, breaking/additive/potentially-breaking classification, type and member filters, plus opt-in decompiled C#/IL/checksum-verified authored Source evidence. |
 | Relationships | `depends`, `extensions`, `implements` | Type hierarchies, package dependencies, library reference graphs, extension methods/properties, implementors and subclasses. Add `--project` to search project-referenced packages. |
 | Source mapping | `type`/`library`/`package -S "Source Files"`, `member -S "Source Locations"` / `"Original Source"` | SourceLink URLs, member file/line locations, source fetching, URL verification, token+IL-offset to source-line resolution. |
-| Performance analysis *(experimental)* | `library`/`type`/`member -S "Top Leverage"`, `"Performance Triage"`, `"Resource Triage"`, `"Call Graph"`, `"Caller Graph"` | Whole-assembly call-graph leverage ranking — direct callers, root reach, fanout, depth, loop calls — with opt-in per-node cost signals (alloc, copy, unsafe, reflection, throw/exception, catch/finally), actionable rewrite-shape detection, and exception-path resource-lifecycle candidates. |
+| Performance analysis *(experimental)* | `library -S @Performance` (kind sections: `"Performance: Boxing"`, `"Performance: Arrays"`, …), `type`/`member -S "Performance Triage"`, `"Top Leverage"`, `"Resource Triage"`, `"Call Graph"`, `"Caller Graph"` | Whole-assembly call-graph leverage ranking — direct callers, root reach, fanout, depth, loop calls — with opt-in per-node cost signals (alloc, copy, unsafe, reflection, throw/exception, catch/finally), actionable rewrite-shape detection, and exception-path resource-lifecycle candidates. |
 | Decompiler *(experimental)* | `member -S @Source` (`Decompiled Source`, `Annotated Source`, `Original Source`, `Source Diff`, `IL`); `member -S "Fidelity Causes"` | Raises method bodies to C#, interleaves IL and hidden-fact annotations, diffs SourceLink-backed source against decompiled source, and exposes typed `DEC####` fidelity causes rather than emitting plausible-but-wrong source. |
 | Agent-friendly output | global flags | Markdown by default, compact `--table`, normalized `--tsv`, `--jsonl`, `--plaintext`, `--json`, Mermaid diagrams, section/field projection, `--count`, table row limiting, built-in head/tail limiting. |
 
@@ -190,29 +190,44 @@ names, and signal sets may change between releases.
 The whole-assembly call-graph analyzer ranks the members worth optimizing or
 hardening first. Select `Top Leverage` to rank members by direct callers,
 `Root Reach` (distinct entry points that transitively reach a member), fanout,
-depth, and loop calls; `Performance Triage` surfaces the highest-value
-allocation pay-dirt first — ranking in-loop (hot) and high-confidence
-opportunities ahead of raw leverage — across actionable rewrite shapes (small
-non-escaping arrays, temporary or span-to-array copies, capturing and instance
-method-group delegates, async state-machine setup, loop-invariant
-materialization, and value-type boxing) plus `allocation-hotspot` rows
-for methods that allocate heavily without matching a specific shape. Allocation
-rows also carry `Weight`, a coarse size x multiplicity x reach static prior that
-you can query or sort when choosing pre-profile instrumentation targets. Exact
-allocation and call-site rows also retain a `Candidate` id, their native
-`Finding` descriptor, `Provenance=exact`, `Operation`, and metadata `Token`.
-Aggregate rows are marked `Provenance=aggregate`; `unmatched` identifies an
-instruction-level row that could not be joined to a producer occurrence. Those fields let trace
-and version-diff tooling join a triage row to `analysis.allocation` or
-`analysis.call-site` evidence without parsing `Evidence` prose. Use
-`--top`, `--loop`, `--min-confidence`, and `--triage-shape` to ask the tool for
-the curated pay-dirt rows directly instead of post-processing. `--top` limits
-the ranked data before rendering; `-n N --rows` remains a renderer cap and is
-applied afterward if both are supplied. Drill candidates with `Call Graph`
-(bounded outbound tree) and `Caller Graph` (bounded reverse tree to entry
-points), and project per-node cost with `--fields`. Ranking rows carry a
-copyable `Stable` selector, `Visibility`, and `Selector`; add `--all` to drill
-non-public members.
+depth, and loop calls. At `library` scope the performance findings are surfaced
+as a curated group of kind-scoped sections — `Performance: Boxing`,
+`Performance: Arrays`, `Performance: Closures and delegates`,
+`Performance: Enumerators`, `Performance: Loop hot paths`,
+`Performance: Allocation hotspots`, and `Performance: Async` — that you can
+request individually (`-S "Performance: Boxing"`) or as a group (`-S
+@Performance`, also reachable via the legacy name `-S Performance`). Each
+section is absent when it has no findings, so the group renders exactly the
+kinds that were found; `--count -S @Performance` returns a per-kind count map
+(including zero rows) as a cheap way to discover which kinds are present before
+requesting them. These sections rank in-loop (hot) and high-confidence
+opportunities first across actionable rewrite shapes (small non-escaping
+arrays, temporary or span-to-array copies, capturing and instance method-group
+delegates, async state-machine setup, loop-invariant materialization, and
+value-type boxing) plus `allocation-hotspot` rows for methods that allocate
+heavily without matching a specific shape. The `type` and `member` commands keep
+the single `Performance Triage` lens.
+
+The tight markdown columns carry the ranked, human-facing fields; the full
+per-row diagnostics (shape, provenance, candidate id, native `Finding`, metadata
+`Token`, IL offset, allocation `Weight`, path/loop evidence, and the fix
+sentence) are preserved in the nested `performance` object of `--json`.
+Allocation rows carry `Weight`, a coarse size x multiplicity x reach static
+prior that you can query or sort when choosing pre-profile instrumentation
+targets. Exact allocation and call-site rows also retain a `Candidate` id, their
+native `Finding` descriptor, `Provenance=exact`, `Operation`, and metadata
+`Token`. Aggregate rows are marked `Provenance=aggregate`; `unmatched`
+identifies an instruction-level row that could not be joined to a producer
+occurrence. Those fields let trace and version-diff tooling join a triage row to
+`analysis.allocation` or `analysis.call-site` evidence without parsing
+`Evidence` prose. Use `--top`, `--loop`, `--min-confidence`, and
+`--triage-shape` to ask the tool for the curated pay-dirt rows directly instead
+of post-processing. `--top` limits the ranked data before rendering; `-n N`
+remains a renderer cap and is applied afterward if both are supplied. Drill
+candidates with `Call Graph` (bounded outbound tree) and `Caller Graph` (bounded
+reverse tree to entry points), and project per-node cost with `--fields`.
+Ranking rows carry a copyable `Stable` selector, `Visibility`, and `Selector`;
+add `--all` to drill non-public members.
 
 `CallerLoop`, `CallerLoopDepth`, and `CallerLoopWitness` expose a separate
 cross-method repetition fact. `CallerLoop=direct` means a resolved invocation
@@ -237,7 +252,9 @@ are not exposed in this curated section.
 ```bash
 dotnet-inspect library MyLib.dll -S "Top Leverage"
 dotnet-inspect type MyType --library MyLib.dll --all -S "Top Leverage"
-dotnet-inspect library MyLib.dll -S "Performance Triage"
+dotnet-inspect library MyLib.dll -S @Performance
+dotnet-inspect library MyLib.dll -S @Performance --count
+dotnet-inspect library MyLib.dll -S "Performance: Boxing" --json
 dotnet-inspect library MyLib.dll -S "Resource Triage" --jsonl
 dotnet-inspect library MyLib.dll --loop --min-confidence high --top 20 --tsv
 dotnet-inspect library MyLib.dll --triage-shape scan-method-in-loop-call,linq-scan-in-loop,string-build-in-loop --top 20 --tsv

--- a/docs/design/analysis-ux-scopes.md
+++ b/docs/design/analysis-ux-scopes.md
@@ -223,6 +223,14 @@ sections under the `@Performance` category (`Performance: Boxing`,
 `Performance: Other`). They follow the il-offset section model: opt-in, absent
 when empty, selectable individually or as a group, with a nested `performance`
 JSON object (one array per kind with rows) and a per-kind `--count` map. The
+kind sections are catalog-hidden (`ListedInCatalog = false`): the top-level
+`-D`/`--schema` catalog lists only the `@Performance` category as their
+entrypoint, keeping discovery noise low while the sections stay selectable and
+drillable (`-D @Performance`). `ListedInCatalog` is a general section-descriptor
+flag (orthogonal to `ExplicitOnly` render gating), so any future curated group
+can hide its members behind a category with the same mechanism. Flattened
+tabular output (`--table`/`--tsv`/`--jsonl`) renders the group as one table with
+a leading `Kind` column so each row is self-describing. The
 `type`/`member` `Performance Triage` lens is a different, single-member view and
 keeps that name.
 

--- a/docs/design/analysis-ux-scopes.md
+++ b/docs/design/analysis-ux-scopes.md
@@ -201,10 +201,10 @@ Future semantic sections should use the same facts and nouns across scopes.
 | --- | --- | --- | --- | --- |
 | Exception | `Exception Context` | `Exception Regions` | `Exception Regions` with member column | optional `Exception Triage` |
 | Callsite | `Callsite Context` / `Return Address Context` | `Calls` | `Calls` with member column | `Top Leverage` / call graph summaries |
-| Allocation | `Allocation Context` | `Allocation Facts` | `Allocation Facts` with member column | `Performance Triage` |
+| Allocation | `Allocation Context` | `Allocation Facts` | `Allocation Facts` with member column | `@Performance` kind sections |
 | Resource lifecycle | optional `Resource Context` | optional `Resource Facts` | resource rows with member column | `Resource Triage` |
 | Safety | `Safety Context` | `Safety Facts` | `Safety Facts` with member column | `Safety Triage` or `Correctness Triage` |
-| Cost | `Cost Context` | `Cost Facts` / `Cost Overlay` | cost rows with member column | `Performance Triage` |
+| Cost | `Cost Context` | `Cost Facts` / `Cost Overlay` | cost rows with member column | `@Performance` kind sections |
 
 Rules:
 
@@ -214,6 +214,17 @@ Rules:
 4. Library views use `* Triage` only when ranked or curated.
 5. New offset semantic sections should have a member/type/library story unless
    intentionally point-only.
+
+At `library` scope the performance findings are decomposed into kind-scoped
+sections under the `@Performance` category (`Performance: Boxing`,
+`Performance: Arrays`, `Performance: Closures and delegates`,
+`Performance: Enumerators`, `Performance: Loop hot paths`,
+`Performance: Allocation hotspots`, `Performance: Async`, plus a non-lossy
+`Performance: Other`). They follow the il-offset section model: opt-in, absent
+when empty, selectable individually or as a group, with a nested `performance`
+JSON object (one array per kind with rows) and a per-kind `--count` map. The
+`type`/`member` `Performance Triage` lens is a different, single-member view and
+keeps that name.
 
 ## Next semantic additions
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1007,6 +1007,67 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task PerformanceGroup_JsonlEmitsOnlyValidRecords_NoBlankSeparators()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "System.Text.Json", "-S", "@Performance", "--jsonl", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.NotEmpty(lines);
+        // The blank lines Markout inserts between sections are invalid jsonl records; they must be
+        // stripped so every emitted line parses.
+        foreach (var line in output.Replace("\r", "").Split('\n'))
+        {
+            if (line.Length == 0)
+                continue;
+            using var _ = JsonDocument.Parse(line);
+        }
+        Assert.DoesNotContain(output.TrimEnd('\n').Split('\n'), line => line.Length == 0);
+    }
+
+    [Fact]
+    public async Task PerformanceGroup_NoHeaderTabular_PreservesEveryRow_NoBlankSeparators()
+    {
+        // With --no-header the first line is a data row, not a header; header-collapse must not treat
+        // it as a header and drop identical data rows. Row count must match the with-header data-row
+        // count, and no blank section separators may leak into the stream.
+        var withHeader = await RunAppAsync(
+            "library", "System.Text.Json", "-S", "@Performance", "--tsv", "--order-by", "Allocation", "--tips", "q");
+        var noHeader = await RunAppAsync(
+            "library", "System.Text.Json", "-S", "@Performance", "--tsv", "--no-header", "--order-by", "Allocation", "--tips", "q");
+
+        Assert.Equal(0, withHeader.Exit);
+        Assert.Equal(0, noHeader.Exit);
+
+        var dataRows = withHeader.Output
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Count(line => !line.StartsWith("member\t", StringComparison.Ordinal));
+        var noHeaderRows = noHeader.Output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Equal(dataRows, noHeaderRows.Length);
+        Assert.DoesNotContain(noHeader.Output.TrimEnd('\n').Split('\n'), line => line.Length == 0);
+    }
+
+    [Fact]
+    public async Task PerformanceTriageShape_SectionMappingIsCaseInsensitive()
+    {
+        // A differently-cased --triage-shape is accepted by validation; it must resolve to the same
+        // kind section its findings bucket into, not silently route to Performance: Other.
+        var lower = await RunAppAsync(
+            "library", "System.Text.Json", "--triage-shape", "box-value-type", "--count", "--tips", "q");
+        var upper = await RunAppAsync(
+            "library", "System.Text.Json", "--triage-shape", "BOX-VALUE-TYPE", "--count", "--tips", "q");
+
+        Assert.Equal(0, lower.Exit);
+        Assert.Equal(0, upper.Exit);
+        Assert.True(int.TryParse(lower.Output.Trim(), out var lowerCount) && lowerCount > 0, lower.Output);
+        Assert.Equal(lower.Output.Trim(), upper.Output.Trim());
+    }
+
+    [Fact]
     public async Task PerformanceTriageWhere_UnknownFieldReportsSuggestion()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -8046,6 +8046,49 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task LibraryCommand_TfmAll_PerformanceGroupTabular_IsKindLabeledPerAssembly()
+    {
+        // Regression: the multi-assembly renderer (WriteLibraryResults, reached via `library --tfm
+        // all` when a library ships under several TFMs) must apply the same @Performance flattening
+        // as the single-assembly path — each assembly emits one self-describing Kind-labeled table,
+        // never per-kind headers without a Kind column.
+        var tempDir = Path.Combine(Path.GetTempPath(), $"perf-multitfm-{Guid.NewGuid():N}");
+        try
+        {
+            var content = Path.Combine(tempDir, "content");
+            foreach (var tfm in new[] { "net8.0", "net10.0" })
+            {
+                var dir = Path.Combine(content, "lib", tfm);
+                Directory.CreateDirectory(dir);
+                File.Copy(TestAssemblyPath, Path.Combine(dir, "Lib.dll"));
+            }
+            var packagePath = Path.Combine(tempDir, "Perf.MultiTfm.1.0.0.nupkg");
+            ZipFile.CreateFromDirectory(content, packagePath);
+
+            var (exit, output, _) = await RunAppAsync(
+                "library", "Lib.dll", "--package", packagePath, "--tfm", "all",
+                "-S", "@Performance", "--tsv", "--rows", "-n", "3", "--tips", "q");
+
+            Assert.Equal(0, exit);
+            var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+            // One flattened Kind-labeled table per TFM assembly; no bare per-kind "member\t" header.
+            Assert.Contains(lines, l => l.StartsWith("kind\tmember\t", StringComparison.Ordinal));
+            Assert.DoesNotContain(lines, l => l.StartsWith("member\t", StringComparison.Ordinal));
+            var kindHeaders = lines.Count(l => l.StartsWith("kind\tmember\t", StringComparison.Ordinal));
+            Assert.Equal(2, kindHeaders);
+            // Every data row is self-describing: its first field is a real kind label.
+            var kindLabels = PerformanceKinds.Sections.Select(PerformanceKinds.KindLabel).ToHashSet(StringComparer.Ordinal);
+            var dataRows = lines.Where(l => !l.StartsWith("kind\t", StringComparison.Ordinal)).ToArray();
+            Assert.NotEmpty(dataRows);
+            Assert.All(dataRows, l => Assert.Contains(l.Split('\t')[0], kindLabels));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task PackageCommand_AllLibraries_AggregatesIntegrationsWithLibraryProvenance()
     {
         var (packagePath, tempDir) = CreateLocalRefPackage(

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -550,15 +550,15 @@ public class CommandExecutionTests
             "--where", "Member=*CreateAllocationFanout*",
             "--where", "OncePaths>=4",
             "--order-by", "OncePaths desc",
-            "--jsonl",
+            "--json",
             "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
-        Assert.Contains("\"shape\":\"allocation-fanout\"", output);
-        Assert.Contains("\"provenance\":\"aggregate\"", output);
-        Assert.Contains("\"direct_sites\":\"1\"", output);
-        Assert.Contains("\"once_paths\":\"4\"", output);
+        Assert.Contains("\"shape\": \"allocation-fanout\"", output);
+        Assert.Contains("\"provenance\": \"aggregate\"", output);
+        Assert.Contains("\"direct_sites\": 1", output);
+        Assert.Contains("\"once_paths\": 4", output);
     }
 
     [Fact]
@@ -568,12 +568,12 @@ public class CommandExecutionTests
             "library", TestAssemblyPath,
             "-S", "Performance Triage",
             "--where", "Member=*CreateAllocationFanout*",
-            "--jsonl",
+            "--json",
             "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
-        Assert.DoesNotContain("\"shape\":\"allocation-fanout\"", output);
+        Assert.DoesNotContain("\"shape\": \"allocation-fanout\"", output);
     }
 
     [Fact]
@@ -585,15 +585,15 @@ public class CommandExecutionTests
             "--triage-shape", "allocation-fanout",
             "--where", "Member=*BoxDirect*",
             "--where", "CallerLoop=direct",
-            "--jsonl",
+            "--json",
             "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
-        Assert.Contains("\"shape\":\"allocation-fanout\"", output);
-        Assert.Contains("\"caller_loop\":\"direct\"", output);
-        Assert.Contains("\"caller_loop_depth\":\"1\"", output);
-        Assert.Contains("\"direct_sites\":\"1\"", output);
+        Assert.Contains("\"shape\": \"allocation-fanout\"", output);
+        Assert.Contains("\"caller_loop\": \"direct\"", output);
+        Assert.Contains("\"caller_loop_depth\": 1", output);
+        Assert.Contains("\"direct_sites\": 1", output);
     }
 
     [Fact]
@@ -679,14 +679,15 @@ public class CommandExecutionTests
             "-S", "Performance Triage",
             "--where", "Allocation=boxed *",
             "--where", "Path=straight-line",
-            "--tsv",
+            "--json",
             "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
-        Assert.Contains("\tbox-value-type\t", output);
-        Assert.Contains("\tboxed System.Int32\tstraight-line\t", output);
-        Assert.DoesNotContain("\tstackalloc-candidate\t", output);
+        Assert.Contains("\"shape\": \"box-value-type\"", output);
+        Assert.Contains("\"allocation\": \"boxed System.Int32\"", output);
+        Assert.Contains("\"path\": \"straight-line\"", output);
+        Assert.DoesNotContain("\"shape\": \"stackalloc-candidate\"", output);
     }
 
     [Fact]
@@ -698,16 +699,16 @@ public class CommandExecutionTests
             "--where", "Finding=analysis.allocation",
             "--where", "Operation=box",
             "--top", "1",
-            "--jsonl",
+            "--json",
             "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
-        Assert.Contains("\"candidate\":\"pt~", output);
-        Assert.Contains("\"finding\":\"analysis.allocation\"", output);
-        Assert.Contains("\"provenance\":\"exact\"", output);
-        Assert.Contains("\"operation\":\"box\"", output);
-        Assert.Contains("\"token\":\"0x", output);
+        Assert.Contains("\"candidate\": \"pt~", output);
+        Assert.Contains("\"finding\": \"analysis.allocation\"", output);
+        Assert.Contains("\"provenance\": \"exact\"", output);
+        Assert.Contains("\"operation\": \"box\"", output);
+        Assert.Contains("\"token\": \"0x", output);
     }
 
     [Theory]
@@ -733,18 +734,23 @@ public class CommandExecutionTests
                 "--where", "CallerLoop=direct",
                 "--where", "CallerLoopDepth>=1",
                 "--order-by", "CallerLoopDepth desc",
-                "--jsonl",
+                command == "library" ? "--json" : "--jsonl",
                 "--tips", "q",
             ]);
+
+        // Library scope surfaces rich diagnostics in the nested `performance` JSON (pretty-printed);
+        // type/member scope keeps the flat triage row (compact JSONL).
+        string sep = command == "library" ? ": " : ":";
+        string depth = command == "library" ? "\"caller_loop_depth\": 1" : "\"caller_loop_depth\":\"1\"";
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
         Assert.Contains("BoxDirect(int)", output);
-        Assert.Contains("\"caller_loop\":\"direct\"", output);
-        Assert.Contains("\"caller_loop_depth\":\"1\"", output);
+        Assert.Contains($"\"caller_loop\"{sep}\"direct\"", output);
+        Assert.Contains(depth, output);
         Assert.Contains("InvokeDirectInLoop", output);
-        Assert.Contains("\"loop\":\"\"", output);
-        Assert.Contains("\"candidate\":\"pt~", output);
+        Assert.Contains($"\"loop\"{sep}\"\"", output);
+        Assert.Contains($"\"candidate\"{sep}\"pt~", output);
     }
 
     [Theory]
@@ -758,13 +764,13 @@ public class CommandExecutionTests
             "-S", "Performance Triage",
             "--order-by", $"CallerLoopDepth {direction}",
             "--top", "1",
-            "--jsonl",
+            "--json",
             "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
-        Assert.Contains("\"caller_loop\":\"direct\"", output);
-        Assert.Contains("\"caller_loop_depth\":\"1\"", output);
+        Assert.Contains("\"caller_loop\": \"direct\"", output);
+        Assert.Contains("\"caller_loop_depth\": 1", output);
     }
 
     [Fact]
@@ -775,25 +781,24 @@ public class CommandExecutionTests
             "-S", "Performance Triage",
             "--where", "Finding=analysis.allocation",
             "--top", "1",
-            "--jsonl",
+            "--json",
             "--tips", "q");
 
         Assert.Equal(0, baseline.Exit);
         Assert.Empty(baseline.Error);
-        using var document = JsonDocument.Parse(baseline.Output.Trim());
-        string token = document.RootElement.GetProperty("token").GetString()!;
+        string token = FirstPerformanceRow(baseline.Output).GetProperty("token").GetString()!;
         string unpaddedToken = $"0x{token[2..].TrimStart('0')}";
 
         var filtered = await RunAppAsync(
             "library", TestAssemblyPath,
             "-S", "Performance Triage",
             "--where", $"Token={unpaddedToken}",
-            "--jsonl",
+            "--json",
             "--tips", "q");
 
         Assert.Equal(0, filtered.Exit);
         Assert.Empty(filtered.Error);
-        Assert.Contains($"\"token\":\"{token}\"", filtered.Output);
+        Assert.Contains($"\"token\": \"{token}\"", filtered.Output);
     }
 
     [Fact]
@@ -818,18 +823,19 @@ public class CommandExecutionTests
     {
         var (exit, output, error) = await RunAppAsync(
             "library", TestAssemblyPath,
-            "-S", "Performance Triage",
+            "-S", "Performance: Boxing",
             "--where", "Shape=box-value-type",
             "--order-by", "RootReach desc",
             "--top", "1",
-            "--tsv",
+            "--json",
             "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
-        var rows = output.TrimEnd().Split('\n');
-        Assert.Single(rows.Skip(1));
-        Assert.Contains("\tbox-value-type\t", rows[1]);
+        using var document = JsonDocument.Parse(output.Trim());
+        var boxing = document.RootElement.GetProperty("performance").GetProperty("boxing");
+        Assert.Equal(1, boxing.GetArrayLength());
+        Assert.Equal("box-value-type", boxing[0].GetProperty("shape").GetString());
     }
 
     [Fact]
@@ -858,14 +864,16 @@ public class CommandExecutionTests
             "-S", "Performance Triage",
             "--where", "Post Dominance=return-post-dominates",
             "--order-by", "PostDominance desc,RootReach desc",
-            "--tsv",
+            "--json",
             "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
-        var rows = output.TrimEnd().Split('\n').Skip(1).ToArray();
+        var rows = PerformanceRows(output);
         Assert.NotEmpty(rows);
-        Assert.All(rows, row => Assert.Contains("\treturn-post-dominates\t", row));
+        Assert.All(rows, row => Assert.Equal(
+            "return-post-dominates",
+            row.GetProperty("post_dominance").GetString()));
     }
 
     [Fact]
@@ -873,7 +881,7 @@ public class CommandExecutionTests
     {
         var (exit, output, error) = await RunAppAsync(
             "library", TestAssemblyPath,
-            "-S", "Performance Triage",
+            "-S", "Performance: Boxing",
             "--where", "Shape=box-value-type",
             "--top", "1",
             "--count",
@@ -883,6 +891,119 @@ public class CommandExecutionTests
         Assert.Empty(error);
         Assert.True(int.TryParse(output.Trim(), out var count), output);
         Assert.True(count > 1, $"expected post-filter count before --top, got {count}");
+    }
+
+    // ===== Performance sections (kind-scoped decomposition of the library "Performance Triage" monolith) =====
+
+    [Fact]
+    public async Task PerformanceSections_NotInDefaultView()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "System.Text.Json", "-v:m", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("## Performance", output);
+        Assert.DoesNotContain("Tip:", error);
+    }
+
+    [Fact]
+    public async Task PerformanceSection_SingleKind_RendersOnlyThatKind()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "System.Text.Json", "-S", "Performance: Boxing", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Performance: Boxing", output);
+        Assert.DoesNotContain("## Performance: Arrays", output);
+        Assert.DoesNotContain("## Performance: Closures", output);
+    }
+
+    [Fact]
+    public async Task PerformanceGroup_RendersMultipleKindSections()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "System.Text.Json", "-S", "@Performance", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Performance: Boxing", output);
+        Assert.Contains("## Performance: Arrays", output);
+        Assert.Contains("## Performance: Closures and delegates", output);
+    }
+
+    [Fact]
+    public async Task PerformanceGroup_JsonEmitsNestedProjection_NotRetiredMonolithKey()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "System.Text.Json", "-S", "@Performance", "--json", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+
+        using var document = JsonDocument.Parse(output.Trim());
+        Assert.False(
+            document.RootElement.TryGetProperty("optimization_opportunities", out _),
+            "retired monolith key must be absent");
+
+        var performance = document.RootElement.GetProperty("performance");
+        Assert.True(performance.TryGetProperty("boxing", out var boxing));
+        Assert.True(boxing.GetArrayLength() > 0);
+        Assert.True(performance.TryGetProperty("arrays", out _));
+    }
+
+    [Fact]
+    public async Task PerformanceKind_AbsentWhenEmpty()
+    {
+        // A tiny fixture assembly with no async candidates: the async kind must be absent, not an
+        // empty section (il-offset gating parity).
+        var (exit, output, error) = await RunAppAsync(
+            "library", FixtureCatalog.AnalysisCallerLoop.AssemblyPath(),
+            "-S", "Performance: Async", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.DoesNotContain("## Performance: Async", output);
+    }
+
+    [Fact]
+    public async Task PerformanceGroup_CountEmitsPerKindMap()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "System.Text.Json", "-S", "@Performance", "--count", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("| Section | Count |", output);
+        Assert.Contains("Performance: Boxing", output);
+        // Empty kinds still report a zero row so agents can cheaply probe the whole category.
+        Assert.Contains("Performance: Other", output);
+    }
+
+    [Fact]
+    public async Task PerformanceLegacyName_RedirectsToGroup()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "System.Text.Json", "-S", "Performance", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Performance: Boxing", output);
+        Assert.Contains("## Performance: Arrays", output);
+    }
+
+    [Fact]
+    public async Task PerformanceGroup_TabularRendersSingleCollapsedHeader()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "System.Text.Json", "-S", "@Performance", "--tsv", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        var headerCount = output
+            .Split('\n')
+            .Count(line => line.StartsWith("member\t", StringComparison.Ordinal));
+        Assert.Equal(1, headerCount);
     }
 
     [Fact]
@@ -5382,7 +5503,7 @@ public class CommandExecutionTests
 
         Assert.Equal(1, exit);
         Assert.Empty(output);
-        Assert.Contains(CountOutput.SingleSectionRequiredMessage, error);
+        Assert.Contains(CountOutput.SectionRequiredMessage, error);
     }
 
     [Fact]
@@ -5865,7 +5986,14 @@ public class CommandExecutionTests
                 "OpenAPI",
                 "OpenTelemetry",
                 "Options",
-                "Performance Triage",
+                "Performance: Allocation hotspots",
+                "Performance: Arrays",
+                "Performance: Async",
+                "Performance: Boxing",
+                "Performance: Closures and delegates",
+                "Performance: Enumerators",
+                "Performance: Loop hot paths",
+                "Performance: Other",
                 "Resource Triage",
                 "Resources",
                 "Return Address Context",
@@ -5890,23 +6018,24 @@ public class CommandExecutionTests
     public async Task LibraryCommand_DiscoverPerformanceTriage_ListsRenderableColumns()
     {
         var (exit, output, error) = await RunAppAsync(
-            "library", TestAssemblyPath, "-D", "Performance Triage", "--tips", "q");
+            "library", TestAssemblyPath, "-D", "Performance: Boxing", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.DoesNotContain("not found", error);
+        // Tight markdown columns (rich diagnostics moved to nested --json).
         Assert.Contains("| Member | column |", output);
-        Assert.Contains("| Root Reach | column |", output);
-        Assert.Contains("| Shape | column |", output);
-        Assert.Contains("| Fix | column |", output);
-        Assert.Contains("| Confidence | column |", output);
+        Assert.Contains("| Evidence | column |", output);
+        Assert.Contains("| Allocation | column |", output);
         Assert.Contains("| Loop | column |", output);
+        Assert.Contains("| Reach | column |", output);
+        Assert.Contains("| Weight | column |", output);
+        Assert.Contains("| Confidence | column |", output);
+        // Row-query fields remain discoverable (shared triage filter/sort engine).
         Assert.Contains("| Triage desc | default-order |", output);
         Assert.Contains("| Loop desc | order-step |", output);
-        Assert.Contains("| Allocation | filterable |", output);
+        Assert.Contains("| Shape | filterable |", output);
         Assert.Contains("| RootReach | sortable |", output);
-        Assert.Contains("| Once Paths | column |", output);
         Assert.Contains("| OncePaths | sortable |", output);
-        Assert.Contains("| IL | column |", output);
     }
 
     [Fact]
@@ -7437,6 +7566,35 @@ public class CommandExecutionTests
 
         var marker = line.IndexOf("  section", StringComparison.Ordinal);
         return marker >= 0 ? line[..marker].TrimEnd() : line.TrimEnd();
+    }
+
+    private static JsonElement FirstPerformanceRow(string json)
+    {
+        var rows = PerformanceRows(json);
+        return rows.Count > 0
+            ? rows[0]
+            : throw new InvalidOperationException("no performance rows in output");
+    }
+
+    private static List<JsonElement> PerformanceRows(string json)
+    {
+        using var document = JsonDocument.Parse(json.Trim());
+        List<JsonElement> rows = [];
+        if (document.RootElement.TryGetProperty("performance", out var performance))
+        {
+            foreach (var kind in performance.EnumerateObject())
+            {
+                if (kind.Value.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var row in kind.Value.EnumerateArray())
+                    {
+                        rows.Add(row.Clone());
+                    }
+                }
+            }
+        }
+
+        return rows;
     }
 
     private static List<(string Name, string Kind)> ExtractDiscoveryRows(string output)

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -993,17 +993,23 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task PerformanceGroup_TabularRendersSingleCollapsedHeader()
+    public async Task PerformanceGroup_TabularRendersSingleKindLabeledTable()
     {
         var (exit, output, error) = await RunAppAsync(
             "library", "System.Text.Json", "-S", "@Performance", "--tsv", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
-        var headerCount = output
-            .Split('\n')
-            .Count(line => line.StartsWith("member\t", StringComparison.Ordinal));
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        // The flattened group renders as one self-describing table: exactly one header, and its
+        // leading column is the kind label so each row says which performance kind it belongs to.
+        var headerCount = lines.Count(line => line.StartsWith("kind\t", StringComparison.Ordinal));
         Assert.Equal(1, headerCount);
+        Assert.StartsWith("kind\tmember\t", lines[0]);
+        // Rows from more than one kind are present and labeled (e.g. Boxing and Arrays).
+        var kinds = lines.Skip(1).Select(l => l.Split('\t')[0]).Distinct().ToList();
+        Assert.Contains("Boxing", kinds);
+        Assert.Contains("Arrays", kinds);
     }
 
     [Fact]
@@ -1017,13 +1023,14 @@ public class CommandExecutionTests
 
         var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
         Assert.NotEmpty(lines);
-        // The blank lines Markout inserts between sections are invalid jsonl records; they must be
-        // stripped so every emitted line parses.
+        // Every emitted line must parse as JSON (no blank inter-section separators), and each record
+        // must carry its kind label so the flattened stream is self-describing.
         foreach (var line in output.Replace("\r", "").Split('\n'))
         {
             if (line.Length == 0)
                 continue;
-            using var _ = JsonDocument.Parse(line);
+            using var doc = JsonDocument.Parse(line);
+            Assert.True(doc.RootElement.TryGetProperty("kind", out _));
         }
         Assert.DoesNotContain(output.TrimEnd('\n').Split('\n'), line => line.Length == 0);
     }
@@ -1031,9 +1038,9 @@ public class CommandExecutionTests
     [Fact]
     public async Task PerformanceGroup_NoHeaderTabular_PreservesEveryRow_NoBlankSeparators()
     {
-        // With --no-header the first line is a data row, not a header; header-collapse must not treat
-        // it as a header and drop identical data rows. Row count must match the with-header data-row
-        // count, and no blank section separators may leak into the stream.
+        // With --no-header the flattened table emits no header line, so every line is a data row and
+        // identical rows must all survive. Row count must match the with-header data-row count, and
+        // no blank section separators may leak into the stream.
         var withHeader = await RunAppAsync(
             "library", "System.Text.Json", "-S", "@Performance", "--tsv", "--order-by", "Allocation", "--tips", "q");
         var noHeader = await RunAppAsync(
@@ -1044,7 +1051,7 @@ public class CommandExecutionTests
 
         var dataRows = withHeader.Output
             .Split('\n', StringSplitOptions.RemoveEmptyEntries)
-            .Count(line => !line.StartsWith("member\t", StringComparison.Ordinal));
+            .Count(line => !line.StartsWith("kind\t", StringComparison.Ordinal));
         var noHeaderRows = noHeader.Output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
         Assert.Equal(dataRows, noHeaderRows.Length);
@@ -1065,6 +1072,49 @@ public class CommandExecutionTests
         Assert.Equal(0, upper.Exit);
         Assert.True(int.TryParse(lower.Output.Trim(), out var lowerCount) && lowerCount > 0, lower.Output);
         Assert.Equal(lower.Output.Trim(), upper.Output.Trim());
+    }
+
+    [Fact]
+    public async Task PerformanceSections_CatalogHidden_CategoryDiscoverableAndDrillable()
+    {
+        // Bare -D (effective discovery) must not list the kind-scoped performance sections at the top
+        // level — the @Performance category is their single discoverable entrypoint — yet they must
+        // stay reachable by drilling into that category.
+        var bare = await RunAppAsync("library", "System.Text.Json", "-D", "--tips", "q");
+        Assert.Equal(0, bare.Exit);
+        var bareSectionNames = bare.Output
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Where(l => l.Contains("| section", StringComparison.Ordinal))
+            .Select(ExtractSectionName)
+            .ToArray();
+        Assert.DoesNotContain(bareSectionNames, n => n.StartsWith("Performance: ", StringComparison.Ordinal));
+        Assert.Contains(bare.Output.Split('\n', StringSplitOptions.RemoveEmptyEntries),
+            l => ExtractSectionName(l) == "@Performance" && l.Contains("category", StringComparison.Ordinal));
+
+        var drill = await RunAppAsync("library", "System.Text.Json", "-D", "@Performance", "--tips", "q");
+        Assert.Equal(0, drill.Exit);
+        Assert.Contains("Performance: Boxing", drill.Output);
+        Assert.Contains("Performance: Other", drill.Output);
+    }
+
+    [Fact]
+    public async Task PerformanceGroup_TableRendersOneHeader_AndRowsCapCountsDataRowsOnly()
+    {
+        // The flattened pretty table must be one aligned table: exactly one header regardless of how
+        // many kinds contribute, and a --rows cap must yield header + N data rows (embedded per-kind
+        // headers previously inflated the count and stole a row slot).
+        const int cap = 5;
+        var (exit, output, error) = await RunAppAsync(
+            "library", "System.Text.Json", "-S", "@Performance", "--table", "--rows", "-n", cap.ToString(),
+            "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var headerCount = lines.Count(l => l.StartsWith("Kind", StringComparison.Ordinal) && l.Contains("Member", StringComparison.Ordinal));
+        Assert.Equal(1, headerCount);
+        // One header + cap data rows.
+        Assert.Equal(cap + 1, lines.Length);
     }
 
     [Fact]
@@ -6047,14 +6097,6 @@ public class CommandExecutionTests
                 "OpenAPI",
                 "OpenTelemetry",
                 "Options",
-                "Performance: Allocation hotspots",
-                "Performance: Arrays",
-                "Performance: Async",
-                "Performance: Boxing",
-                "Performance: Closures and delegates",
-                "Performance: Enumerators",
-                "Performance: Loop hot paths",
-                "Performance: Other",
                 "Resource Triage",
                 "Resources",
                 "Return Address Context",
@@ -6071,6 +6113,12 @@ public class CommandExecutionTests
                 "Unsafe Members"
             ],
             optInNames);
+        // The kind-scoped performance sections are catalog-hidden (ListedInCatalog=false): the
+        // @Performance category is their single discoverable entrypoint, so they must not appear in
+        // the top-level catalog even though they remain selectable and drillable via -D @Performance.
+        Assert.DoesNotContain(names, name => name.StartsWith("Performance: ", StringComparison.Ordinal));
+        Assert.Contains(output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries),
+            line => ExtractSectionName(line) == "@Performance" && line.Contains("category", StringComparison.Ordinal));
         Assert.DoesNotContain(lines, line => line.StartsWith("Missing Source Files", StringComparison.Ordinal));
         Assert.DoesNotContain(lines, line => line.StartsWith("Source Integrity", StringComparison.Ordinal));
     }

--- a/src/dotnet-inspect.Tests/PerformanceKindsTests.cs
+++ b/src/dotnet-inspect.Tests/PerformanceKindsTests.cs
@@ -1,0 +1,71 @@
+using DotnetInspector.Options;
+using DotnetInspector.Sections;
+
+namespace DotnetInspector.Tests;
+
+public class PerformanceKindsTests
+{
+    [Fact]
+    public void Sections_MatchStructuredKeyOrdering()
+    {
+        Assert.Equal(
+            [
+                SectionNames.PerformanceBoxing,
+                SectionNames.PerformanceArrays,
+                SectionNames.PerformanceClosures,
+                SectionNames.PerformanceEnumerators,
+                SectionNames.PerformanceLoops,
+                SectionNames.PerformanceHotspots,
+                SectionNames.PerformanceAsync,
+                SectionNames.PerformanceOther,
+            ],
+            PerformanceKinds.Sections);
+    }
+
+    [Fact]
+    public void EveryKnownShape_MapsToNonOtherSection()
+    {
+        foreach (var shape in PerformanceTriageOptions.KnownShapes)
+        {
+            var section = PerformanceKinds.SectionForShape(shape);
+            Assert.NotEqual(SectionNames.PerformanceOther, section);
+            Assert.Contains(section, PerformanceKinds.Sections);
+        }
+    }
+
+    [Fact]
+    public void UnmappedShape_RoutesToOther_SoScanIsNeverLossy()
+    {
+        Assert.Equal(SectionNames.PerformanceOther, PerformanceKinds.SectionForShape("brand-new-shape"));
+        Assert.Equal(SectionNames.PerformanceOther, PerformanceKinds.SectionForShape(null));
+    }
+
+    [Fact]
+    public void StructuredKeys_AreUniquePerSection()
+    {
+        var keys = PerformanceKinds.Sections
+            .Select(PerformanceKinds.StructuredKey)
+            .ToArray();
+
+        Assert.Equal(keys.Length, keys.Distinct().Count());
+    }
+
+    [Fact]
+    public void StructuredKey_HasNoAmpersand_SoJsonAndMarkdownMatch()
+    {
+        // The closures section name intentionally drops "&" (markout HTML-escapes it); the JSON key
+        // stays snake_case.
+        Assert.Equal("closures_and_delegates", PerformanceKinds.StructuredKey(SectionNames.PerformanceClosures));
+        Assert.DoesNotContain('&', SectionNames.PerformanceClosures);
+    }
+
+    [Fact]
+    public void AllShareCommonView_TrueForPerformanceKinds_FalseOtherwise()
+    {
+        Assert.True(PerformanceKinds.AllShareCommonView(PerformanceKinds.Sections));
+        Assert.True(PerformanceKinds.AllShareCommonView([SectionNames.PerformanceBoxing]));
+        Assert.False(PerformanceKinds.AllShareCommonView([]));
+        Assert.False(PerformanceKinds.AllShareCommonView(
+            [SectionNames.PerformanceBoxing, "Top Leverage"]));
+    }
+}

--- a/src/dotnet-inspect.Tests/PerformanceKindsTests.cs
+++ b/src/dotnet-inspect.Tests/PerformanceKindsTests.cs
@@ -73,6 +73,21 @@ public class PerformanceKindsTests
     }
 
     [Fact]
+    public void KindLabel_StripsPerformancePrefix_ForFlattenedTabularColumn()
+    {
+        Assert.Equal("Boxing", PerformanceKinds.KindLabel(SectionNames.PerformanceBoxing));
+        Assert.Equal("Closures and delegates", PerformanceKinds.KindLabel(SectionNames.PerformanceClosures));
+        Assert.Equal("Allocation hotspots", PerformanceKinds.KindLabel(SectionNames.PerformanceHotspots));
+        // A label for every section, and none retains the "Performance: " prefix.
+        foreach (var section in PerformanceKinds.Sections)
+        {
+            var label = PerformanceKinds.KindLabel(section);
+            Assert.False(string.IsNullOrEmpty(label));
+            Assert.DoesNotContain("Performance: ", label, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
     public void AllShareCommonView_TrueForPerformanceKinds_FalseOtherwise()
     {
         Assert.True(PerformanceKinds.AllShareCommonView(PerformanceKinds.Sections));

--- a/src/dotnet-inspect.Tests/PerformanceKindsTests.cs
+++ b/src/dotnet-inspect.Tests/PerformanceKindsTests.cs
@@ -41,6 +41,19 @@ public class PerformanceKindsTests
     }
 
     [Fact]
+    public void SectionForShape_IsCaseInsensitive()
+    {
+        // Shape validation and row filtering are case-insensitive; the section mapping must agree so
+        // a differently-cased shape does not silently route to Performance: Other.
+        foreach (var shape in PerformanceTriageOptions.KnownShapes)
+        {
+            Assert.Equal(
+                PerformanceKinds.SectionForShape(shape),
+                PerformanceKinds.SectionForShape(shape.ToUpperInvariant()));
+        }
+    }
+
+    [Fact]
     public void StructuredKeys_AreUniquePerSection()
     {
         var keys = PerformanceKinds.Sections

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -343,6 +343,25 @@ public class SectionPipelineTests
         Assert.Contains("Union Types", pipeline.AllSectionNames);
     }
 
+    [Fact]
+    public void LibraryPipeline_CatalogHiddenSections_AreExactlyThePerformanceKinds()
+    {
+        var pipeline = LibrarySections.CreatePipeline();
+
+        var hidden = pipeline.GetCatalogHiddenSections();
+
+        // Catalog-hidden sections (ListedInCatalog=false) are still registered/selectable, but must
+        // be exactly the kind-scoped performance sections whose entrypoint is the @Performance
+        // category. This keeps discovery-list suppression a single, general mechanism.
+        Assert.Equal(
+            PerformanceKinds.Sections.OrderBy(n => n, StringComparer.Ordinal).ToArray(),
+            hidden.OrderBy(n => n, StringComparer.Ordinal).ToArray());
+        foreach (var name in hidden)
+        {
+            Assert.Contains(name, pipeline.AllSectionNames);
+        }
+    }
+
     [Theory]
     [MemberData(nameof(DiscoverablePipelineCases))]
     public void DiscoverableSections_ContainEverySelectableSection(

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -299,7 +299,7 @@ public class SectionPipelineTests
     {
         var pipeline = LibrarySections.CreatePipeline();
 
-        Assert.Equal(47, pipeline.AllSectionNames.Length);
+        Assert.Equal(54, pipeline.AllSectionNames.Length);
         Assert.Contains("AI", pipeline.AllSectionNames);
         Assert.Contains("ASP.NET Core", pipeline.AllSectionNames);
         Assert.Contains("Aspire", pipeline.AllSectionNames);
@@ -329,7 +329,15 @@ public class SectionPipelineTests
         Assert.Contains("SourceLink Integrity", pipeline.AllSectionNames);
         Assert.Contains("Switches", pipeline.AllSectionNames);
         Assert.Contains("Top Leverage", pipeline.AllSectionNames);
-        Assert.Contains("Performance Triage", pipeline.AllSectionNames);
+        Assert.Contains("Performance: Boxing", pipeline.AllSectionNames);
+        Assert.Contains("Performance: Arrays", pipeline.AllSectionNames);
+        Assert.Contains("Performance: Closures and delegates", pipeline.AllSectionNames);
+        Assert.Contains("Performance: Enumerators", pipeline.AllSectionNames);
+        Assert.Contains("Performance: Loop hot paths", pipeline.AllSectionNames);
+        Assert.Contains("Performance: Allocation hotspots", pipeline.AllSectionNames);
+        Assert.Contains("Performance: Async", pipeline.AllSectionNames);
+        Assert.Contains("Performance: Other", pipeline.AllSectionNames);
+        Assert.DoesNotContain("Performance Triage", pipeline.AllSectionNames);
         Assert.Contains("Resource Triage", pipeline.AllSectionNames);
         Assert.Contains("Return Address Context", pipeline.AllSectionNames);
         Assert.Contains("Union Types", pipeline.AllSectionNames);
@@ -505,12 +513,14 @@ public class SectionPipelineTests
             ]
         };
 
+        // capturing-delegate buckets into the "Closures and delegates" kind section.
+        const string section = "Performance: Closures and delegates";
         var effective = pipeline.GetEffectiveSections(model, Verbosity.Detailed);
         var selected = pipeline.GetEffectiveSections(model, Verbosity.Detailed,
-            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Performance Triage" });
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { section });
 
-        Assert.DoesNotContain("Performance Triage", effective);
-        Assert.Contains("Performance Triage", selected);
+        Assert.DoesNotContain(section, effective);
+        Assert.Contains(section, selected);
     }
 
     [Fact]

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -386,11 +386,26 @@ public static class InspectionCommandDefinitions
             }
             if (!string.IsNullOrWhiteSpace(typeFilter))
                 select = [.. select ?? [], "Source Files"];
-            // Only surface Performance Triage from row filters when the user did not select sections
-            // with -S; an explicit selection like -S "Top Leverage" must not silently gain a second
-            // section and break single-section formats (--table/--tsv/--jsonl).
+            // Only surface performance sections from row filters when the user did not select
+            // sections with -S; an explicit selection like -S "Top Leverage" must not silently gain
+            // a second section and break single-section formats (--table/--tsv/--jsonl). When the
+            // filter is a single --triage-shape that maps to one kind section, target that section
+            // directly so tabular output stays single-section; otherwise surface the @Performance
+            // group (via the "Performance Triage" category alias).
             if (performanceTriage.HasFilters && !opts.IsDiscoveryMode(parseResult) && !hasExplicitSelect)
-                select = [.. select ?? [], SectionNames.PerformanceTriage];
+            {
+                var target = SectionNames.PerformanceTriage;
+                if (performanceTriage.Shapes is { Length: > 0 })
+                {
+                    var kinds = performanceTriage.Shapes
+                        .Select(PerformanceKinds.SectionForShape)
+                        .Distinct(StringComparer.Ordinal)
+                        .ToArray();
+                    if (kinds.Length == 1)
+                        target = kinds[0];
+                }
+                select = [.. select ?? [], target];
+            }
 
             var options = new LibraryOptions
             {

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -49,7 +49,8 @@ public class LibraryCommand
                     tree: options.Tree, json: options.JsonOutput, tsv: options.Tsv, jsonl: options.Jsonl, markdown: !options.Tabular && !options.JsonOutput,
                     verbosity: (int)options.Verbosity,
                     sectionCostAnnotations: pipeline.GetCostAnnotations(),
-                    sectionCategories: pipeline.GetCategoryMap());
+                    sectionCategories: pipeline.GetCategoryMap(),
+                    catalogHiddenSections: pipeline.GetCatalogHiddenSections());
             }
         }
 
@@ -1279,7 +1280,8 @@ public class LibraryCommand
             tree: options.Tree, json: options.JsonOutput, tsv: options.Tsv, jsonl: options.Jsonl, markdown: !options.Tabular && !options.JsonOutput,
             verbosity: (int)userVerbosity, rootLabel: rootLabel, fullSchema: schemaMap,
             sectionCostAnnotations: pipeline.GetCostAnnotations(),
-            sectionCategories: pipeline.GetCategoryMap());
+            sectionCategories: pipeline.GetCategoryMap(),
+            catalogHiddenSections: pipeline.GetCatalogHiddenSections());
     }
 
     // ── Effective sections cache ──
@@ -1350,7 +1352,8 @@ public class LibraryCommand
             tree: options.Tree, json: options.JsonOutput, tsv: options.Tsv, jsonl: options.Jsonl, markdown: !options.Tabular && !options.JsonOutput,
             verbosity: (int)userVerbosity, rootLabel: rootLabel,
             sectionCostAnnotations: LibrarySections.CreatePipeline().GetCostAnnotations(),
-            sectionCategories: LibrarySections.CreatePipeline().GetCategoryMap());
+            sectionCategories: LibrarySections.CreatePipeline().GetCategoryMap(),
+            catalogHiddenSections: LibrarySections.CreatePipeline().GetCatalogHiddenSections());
     }
 
     /// <summary>

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -106,7 +106,7 @@ public class LibraryCommand
             return 1;
         }
 
-        if (options.Count && !CountOutput.ValidateSingleSection(options.IncludeSections))
+        if (options.Count && !CountOutput.ValidateSectionsSelected(options.IncludeSections))
             return 1;
 
         if (options.Count && (options.Print || options.PrintAll))

--- a/src/dotnet-inspect/JsonContext.cs
+++ b/src/dotnet-inspect/JsonContext.cs
@@ -17,6 +17,7 @@ namespace DotnetInspector;
 [JsonSerializable(typeof(InspectionResult[]))]
 [JsonSerializable(typeof(LibraryInspection))]
 [JsonSerializable(typeof(LibraryInspection[]))]
+[JsonSerializable(typeof(PerformanceProjection))]
 [JsonSerializable(typeof(AuditSignal))]
 [JsonSerializable(typeof(List<AuditSignal>))]
 [JsonSerializable(typeof(LibraryIntegrationSummaryJson))]

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using DotnetInspector.Options;
+using DotnetInspector.Sections;
 using ILInspector.Analysis;
 using ILInspector.Findings;
 using ILInspector.Metadata;
@@ -329,10 +330,22 @@ public class LibraryInspection
     public List<MethodLeverageSummary>? TopLeverage { get; set; }
 
     /// <summary>
-    /// Safe, local optimization opportunities inferred from IL/body evidence.
+    /// Safe, local optimization opportunities inferred from IL/body evidence. Internal backing
+    /// for the kind-scoped performance sections and the nested <see cref="Performance"/> JSON
+    /// projection; not serialized directly (see <see cref="Performance"/>).
     /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonIgnore]
     public List<OptimizationOpportunitySummary>? OptimizationOpportunities { get; set; }
+
+    /// <summary>
+    /// Nested performance projection: the optimization opportunities bucketed by kind, mirroring
+    /// the kind-scoped sections and the il-offset nested model. Null (absent) when the scan did
+    /// not run; each kind array is absent when it has no findings.
+    /// </summary>
+    [JsonPropertyName("performance")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public PerformanceProjection? Performance =>
+        PerformanceProjection.FromOpportunities(OptimizationOpportunities);
 
     private FindingInspection<ResourceLifecycleOccurrence>?
         _resourceLifecycleInspection;
@@ -1028,6 +1041,79 @@ public record class OptimizationOpportunitySummary
     public long? OpaquePaths { get; init; }
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Saturated { get; init; }
+}
+
+/// <summary>
+/// Nested performance projection: the optimization opportunities bucketed by kind, one array per
+/// kind-scoped section. Mirrors the il-offset nested model — each kind is absent (null) when it
+/// has no findings, so a consumer selecting the <c>@Performance</c> group receives exactly the
+/// kinds that were found.
+/// </summary>
+public sealed class PerformanceProjection
+{
+    [JsonPropertyName("boxing")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<OptimizationOpportunitySummary>? Boxing { get; set; }
+
+    [JsonPropertyName("arrays")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<OptimizationOpportunitySummary>? Arrays { get; set; }
+
+    [JsonPropertyName("closures_and_delegates")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<OptimizationOpportunitySummary>? ClosuresAndDelegates { get; set; }
+
+    [JsonPropertyName("enumerators")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<OptimizationOpportunitySummary>? Enumerators { get; set; }
+
+    [JsonPropertyName("loop_hot_paths")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<OptimizationOpportunitySummary>? LoopHotPaths { get; set; }
+
+    [JsonPropertyName("allocation_hotspots")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<OptimizationOpportunitySummary>? AllocationHotspots { get; set; }
+
+    [JsonPropertyName("async")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<OptimizationOpportunitySummary>? Async { get; set; }
+
+    [JsonPropertyName("other")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<OptimizationOpportunitySummary>? Other { get; set; }
+
+    /// <summary>
+    /// Buckets a flat opportunity list into the nested projection. Returns null (absent) when the
+    /// list is null or empty. Preserves the scanner's pre-ordering within each bucket.
+    /// </summary>
+    public static PerformanceProjection? FromOpportunities(
+        List<OptimizationOpportunitySummary>? opportunities)
+    {
+        if (opportunities is not { Count: > 0 })
+        {
+            return null;
+        }
+
+        var projection = new PerformanceProjection();
+        foreach (var opportunity in opportunities)
+        {
+            var bucket = PerformanceKinds.SectionForShape(opportunity.Shape) switch
+            {
+                SectionNames.PerformanceBoxing => projection.Boxing ??= [],
+                SectionNames.PerformanceArrays => projection.Arrays ??= [],
+                SectionNames.PerformanceClosures => projection.ClosuresAndDelegates ??= [],
+                SectionNames.PerformanceEnumerators => projection.Enumerators ??= [],
+                SectionNames.PerformanceLoops => projection.LoopHotPaths ??= [],
+                SectionNames.PerformanceHotspots => projection.AllocationHotspots ??= [],
+                SectionNames.PerformanceAsync => projection.Async ??= [],
+                _ => projection.Other ??= [],
+            };
+            bucket.Add(opportunity);
+        }
+
+        return projection;
+    }
 }
 
 /// <summary>

--- a/src/dotnet-inspect/Options/OutputFormat.cs
+++ b/src/dotnet-inspect/Options/OutputFormat.cs
@@ -120,6 +120,11 @@ public static class OutputFormatResolver
         if (!tabularExplicitlySet || includeSections is not { Count: > 1 })
             return true;
 
+        // Sections that share a single row view (currently the @Performance kind sections) can be
+        // rendered as one concatenated tabular table, so multi-section tabular is allowed for them.
+        if (DotnetInspector.Sections.PerformanceKinds.AllShareCommonView(includeSections))
+            return true;
+
         Console.Error.WriteLine($"Error: Selection matches {includeSections.Count} sections: {string.Join(", ", includeSections)}.");
         Console.Error.WriteLine();
         Console.Error.WriteLine("--table, --tsv, and --jsonl display one section at a time.");

--- a/src/dotnet-inspect/Output/CountOutput.cs
+++ b/src/dotnet-inspect/Output/CountOutput.cs
@@ -6,6 +6,7 @@ namespace DotnetInspector.Output;
 public static class CountOutput
 {
     public const string SingleSectionRequiredMessage = "Error: --count requires -S/--select to match exactly one section.";
+    public const string SectionRequiredMessage = "Error: --count requires -S/--select to match at least one section.";
 
     public static bool ValidateSingleSection(HashSet<string>? includeSections)
     {
@@ -13,6 +14,20 @@ public static class CountOutput
             return true;
 
         Console.Error.WriteLine(SingleSectionRequiredMessage);
+        return false;
+    }
+
+    /// <summary>
+    /// Validates that <c>--count</c> has selected at least one section. Unlike
+    /// <see cref="ValidateSingleSection"/> this permits multi-section selection (e.g. a
+    /// category such as <c>@Performance</c>), which renders a per-section count map.
+    /// </summary>
+    public static bool ValidateSectionsSelected(HashSet<string>? includeSections)
+    {
+        if (includeSections is { Count: >= 1 })
+            return true;
+
+        Console.Error.WriteLine(SectionRequiredMessage);
         return false;
     }
 
@@ -52,5 +67,70 @@ public static class CountOutput
     public static void WriteCountFromMarkdown(string markdown)
     {
         Console.WriteLine(CountMarkdownTableRows(markdown));
+    }
+
+    /// <summary>
+    /// Counts markdown table rows attributed to the nearest preceding <c>## Section</c> heading.
+    /// Empty (absent) sections do not appear in the returned map.
+    /// </summary>
+    public static Dictionary<string, int> CountMarkdownTableRowsBySection(string markdown)
+    {
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        var lines = markdown.ReplaceLineEndings("\n").Split('\n');
+        var inCodeFence = false;
+        string? currentSection = null;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+
+            if (MarkdownScan.IsCodeFence(line))
+            {
+                inCodeFence = !inCodeFence;
+                continue;
+            }
+
+            if (inCodeFence)
+                continue;
+
+            if (line.StartsWith("## ", StringComparison.Ordinal))
+            {
+                currentSection = line[3..].Trim();
+                continue;
+            }
+
+            if (currentSection is null || i + 1 >= lines.Length)
+                continue;
+
+            if (!MarkdownScan.IsTableLine(line) || !MarkdownScan.IsSeparatorLine(lines[i + 1]))
+                continue;
+
+            i += 2;
+            var rows = 0;
+            while (i < lines.Length && MarkdownScan.IsTableLine(lines[i]))
+            {
+                if (!MarkdownScan.IsSeparatorLine(lines[i]))
+                    rows++;
+                i++;
+            }
+            i--;
+
+            counts[currentSection] = counts.GetValueOrDefault(currentSection) + rows;
+        }
+
+        return counts;
+    }
+
+    /// <summary>
+    /// Emits a per-section count map (<c>| Section | Count |</c>) over <paramref name="orderedSections"/>,
+    /// reporting 0 for sections absent from the rendered markdown.
+    /// </summary>
+    public static void WriteCountMapFromMarkdown(string markdown, IReadOnlyList<string> orderedSections)
+    {
+        var counts = CountMarkdownTableRowsBySection(markdown);
+        Console.WriteLine("| Section | Count |");
+        Console.WriteLine("| ------- | ----- |");
+        foreach (var section in orderedSections)
+            Console.WriteLine($"| {section} | {counts.GetValueOrDefault(section)} |");
     }
 }

--- a/src/dotnet-inspect/Output/DiscoverOutput.cs
+++ b/src/dotnet-inspect/Output/DiscoverOutput.cs
@@ -21,7 +21,8 @@ public static class DiscoverOutput
     public static int Execute(string[]? discover, DocumentSchema schema,
         bool tree = false, bool markdown = false, bool json = false, bool tsv = false, bool jsonl = false, int verbosity = 0,
         string? rootLabel = null, IReadOnlyDictionary<string, string>? sectionCostAnnotations = null,
-        IReadOnlyDictionary<string, string[]>? sectionCategories = null)
+        IReadOnlyDictionary<string, string[]>? sectionCategories = null,
+        IReadOnlySet<string>? catalogHiddenSections = null)
     {
         sectionCategories = FilterCategories(sectionCategories, schema.SectionNames);
 
@@ -37,9 +38,9 @@ public static class DiscoverOutput
             tree = true;
 
         if (tree)
-            return WriteTree(discover, schema, rootLabel, sectionCostAnnotations, sectionCategories);
+            return WriteTree(discover, schema, rootLabel, sectionCostAnnotations, sectionCategories, catalogHiddenSections);
 
-        var rows = GetDiscoveryRows(discover, schema, sectionCostAnnotations, sectionCategories);
+        var rows = GetDiscoveryRows(discover, schema, sectionCostAnnotations, sectionCategories, catalogHiddenSections);
         if (rows == null)
             return 1;
 
@@ -74,7 +75,8 @@ public static class DiscoverOutput
         bool tree = false, bool markdown = false, bool json = false, bool tsv = false, bool jsonl = false, int verbosity = 0,
         string? rootLabel = null, DocumentSchema? fullSchema = null,
         IReadOnlyDictionary<string, string>? sectionCostAnnotations = null,
-        IReadOnlyDictionary<string, string[]>? sectionCategories = null)
+        IReadOnlyDictionary<string, string[]>? sectionCategories = null,
+        IReadOnlySet<string>? catalogHiddenSections = null)
     {
         // Build a filtered schema with only effective sections
         var filtered = new DocumentSchema();
@@ -98,7 +100,7 @@ public static class DiscoverOutput
             discover = remaining;
         }
 
-        return Execute(discover, filtered, tree, markdown, json, tsv, jsonl, verbosity, rootLabel, sectionCostAnnotations, sectionCategories);
+        return Execute(discover, filtered, tree, markdown, json, tsv, jsonl, verbosity, rootLabel, sectionCostAnnotations, sectionCategories, catalogHiddenSections);
     }
 
     /// <summary>
@@ -303,7 +305,8 @@ public static class DiscoverOutput
         string[]? discover,
         DocumentSchema schema,
         IReadOnlyDictionary<string, string>? sectionCostAnnotations = null,
-        IReadOnlyDictionary<string, string[]>? sectionCategories = null)
+        IReadOnlyDictionary<string, string[]>? sectionCategories = null,
+        IReadOnlySet<string>? catalogHiddenSections = null)
     {
         // Bare -D: regular sections, @categories, then opt-in sections.
         // Each group is alpha sorted.
@@ -315,6 +318,10 @@ public static class DiscoverOutput
                 .ToList() ?? new List<DiscoveryRow>();
 
             var sectionRows = items
+                // Catalog-hidden sections (ListedInCatalog=false) are omitted from the top-level
+                // listing so their curated @category is the single discoverable entrypoint; they
+                // remain reachable by drilling into that category (-D @Category) or by exact name.
+                .Where(i => catalogHiddenSections is null || !catalogHiddenSections.Contains(i.Name))
                 .Select(i => new DiscoveryRow(i.Name, AnnotateKind(i.Kind, i.Name, sectionCostAnnotations)))
                 .ToList();
 
@@ -458,7 +465,8 @@ public static class DiscoverOutput
 
     private static int WriteTree(string[]? discover, DocumentSchema schema, string? rootLabel = null,
         IReadOnlyDictionary<string, string>? sectionCostAnnotations = null,
-        IReadOnlyDictionary<string, string[]>? sectionCategories = null)
+        IReadOnlyDictionary<string, string[]>? sectionCategories = null,
+        IReadOnlySet<string>? catalogHiddenSections = null)
     {
         var nodes = new List<TreeNode>();
 
@@ -504,6 +512,9 @@ public static class DiscoverOutput
         else
         {
             var sectionRows = schema.SectionNames
+                // Catalog-hidden sections appear only under their category node (drill-in), not as
+                // top-level entries — same entrypoint model as the flat bare -D listing.
+                .Where(name => catalogHiddenSections is null || !catalogHiddenSections.Contains(name))
                 .Select(name => new DiscoveryRow(name, AnnotateKind("section", name, sectionCostAnnotations)))
                 .ToList();
             var categoryRows = sectionCategories?

--- a/src/dotnet-inspect/Output/DiscoverOutput.cs
+++ b/src/dotnet-inspect/Output/DiscoverOutput.cs
@@ -351,7 +351,8 @@ public static class DiscoverOutput
                 foreach (var item in items)
                     rows.Add(new DiscoveryRow(item.Name, item.Kind));
             }
-            if (string.Equals(resolved, SectionNames.PerformanceTriage, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(resolved, SectionNames.PerformanceTriage, StringComparison.OrdinalIgnoreCase)
+                || PerformanceKinds.Sections.Contains(resolved, StringComparer.OrdinalIgnoreCase))
                 rows.AddRange(PerformanceTriageQueryRows());
         }
 

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -26,42 +26,6 @@ public static class OutputFormatter
         return sw.ToString();
     }
 
-    /// <summary>
-    /// Collapses the repeated per-section header that Markout emits when several sections sharing
-    /// one row view (the @Performance kind sections) are rendered as tabular output, producing a
-    /// single header followed by continuous rows. The blank lines Markout emits between sections
-    /// are dropped for every table format — for jsonl and headerless tsv they would otherwise be
-    /// invalid records / empty rows. Header de-duplication runs only when <paramref name="hasHeader"/>
-    /// is true; otherwise the first line is a data row (jsonl object or headerless tsv row) and must
-    /// never be treated as a header to strip, which would silently drop identical data rows.
-    /// </summary>
-    internal static string CollapseRepeatedTabularHeaders(string rendered, bool hasHeader)
-    {
-        if (string.IsNullOrEmpty(rendered))
-            return rendered;
-
-        var trailingNewline = rendered.EndsWith('\n');
-        var lines = rendered.ReplaceLineEndings("\n").TrimEnd('\n').Split('\n');
-        var header = hasHeader ? lines[0] : null;
-
-        var kept = new List<string>();
-        for (var i = 0; i < lines.Length; i++)
-        {
-            // Drop the blank lines Markout inserts between sections (invalid in jsonl/headerless
-            // tsv, and never meaningful in a tsv/markdown table).
-            if (lines[i].Length == 0)
-                continue;
-            // Keep the first header, drop each repeated per-section header. Only runs when a header
-            // exists, so identical data rows are never mistaken for a header.
-            if (header is not null && i > 0 && lines[i] == header)
-                continue;
-            kept.Add(lines[i]);
-        }
-
-        var result = string.Join('\n', kept);
-        return trailingNewline ? result + '\n' : result;
-    }
-
     public static void WriteTable(TextWriter output, bool showHeader, Action<TextWriter, IMarkoutFormatter> serialize, RowWindow? maxRows = null)
     {
         // Row-limiting operates on the rendered text, so the capped path must materialize
@@ -332,16 +296,16 @@ public static class OutputFormatter
                 && Sections.PerformanceKinds.AllShareCommonView(writerOpts.IncludeSections))
             {
                 // The @Performance kind sections share one row view, so render them as a single
-                // tabular table by collapsing the repeated per-section header. jsonl and headerless
-                // tsv have no header line, so only the inter-section blank lines are stripped.
-                var hasHeader = !options.Jsonl && !options.NoHeader;
-                var sw = new StringWriter();
-                MarkoutSerializer.Serialize(auditView, sw, new TableFormatter(!options.NoHeader), InspectionContext.Default, writerOpts);
-                var collapsed = CollapseRepeatedTabularHeaders(sw.ToString(), hasHeader);
-                collapsed = LimitRenderedTableRows(collapsed, options.Rows, hasHeader);
-                Console.Out.Write(collapsed);
-                if (collapsed.Length > 0 && !collapsed.EndsWith('\n'))
-                    Console.Out.WriteLine();
+                // self-describing table: flatten the selected kinds into one kind-labeled list and
+                // emit one table (one header, aligned columns, correct --rows accounting). The
+                // leading Kind column replaces the per-section headings that markdown uses.
+                var groupRows = auditView.PerformanceGroupRows(writerOpts.IncludeSections);
+                var groupView = new PerformanceGroupView(groupRows);
+                var groupOpts = ConfigureTableWriterOptions(
+                    new MarkoutWriterOptions { Projection = writerOpts.Projection }, options.Tsv, options.Jsonl);
+                WriteTable(Console.Out, !options.NoHeader,
+                    (writer, formatter) => MarkoutSerializer.Serialize(groupView, writer, formatter, InspectionContext.Default, groupOpts),
+                    options.Rows);
             }
             else
             {

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -29,27 +29,31 @@ public static class OutputFormatter
     /// <summary>
     /// Collapses the repeated per-section header that Markout emits when several sections sharing
     /// one row view (the @Performance kind sections) are rendered as tabular output, producing a
-    /// single header followed by continuous rows. jsonl output has no header line and is returned
-    /// unchanged.
+    /// single header followed by continuous rows. The blank lines Markout emits between sections
+    /// are dropped for every table format — for jsonl and headerless tsv they would otherwise be
+    /// invalid records / empty rows. Header de-duplication runs only when <paramref name="hasHeader"/>
+    /// is true; otherwise the first line is a data row (jsonl object or headerless tsv row) and must
+    /// never be treated as a header to strip, which would silently drop identical data rows.
     /// </summary>
-    internal static string CollapseRepeatedTabularHeaders(string rendered)
+    internal static string CollapseRepeatedTabularHeaders(string rendered, bool hasHeader)
     {
         if (string.IsNullOrEmpty(rendered))
             return rendered;
 
         var trailingNewline = rendered.EndsWith('\n');
         var lines = rendered.ReplaceLineEndings("\n").TrimEnd('\n').Split('\n');
-        var header = lines[0];
-        if (header.Length == 0 || header[0] == '{')
-            return rendered;
+        var header = hasHeader ? lines[0] : null;
 
-        var kept = new List<string> { header };
-        for (var i = 1; i < lines.Length; i++)
+        var kept = new List<string>();
+        for (var i = 0; i < lines.Length; i++)
         {
-            // Drop a blank line that only separates a repeated header block.
-            if (lines[i].Length == 0 && i + 1 < lines.Length && lines[i + 1] == header)
+            // Drop the blank lines Markout inserts between sections (invalid in jsonl/headerless
+            // tsv, and never meaningful in a tsv/markdown table).
+            if (lines[i].Length == 0)
                 continue;
-            if (lines[i] == header)
+            // Keep the first header, drop each repeated per-section header. Only runs when a header
+            // exists, so identical data rows are never mistaken for a header.
+            if (header is not null && i > 0 && lines[i] == header)
                 continue;
             kept.Add(lines[i]);
         }
@@ -328,11 +332,13 @@ public static class OutputFormatter
                 && Sections.PerformanceKinds.AllShareCommonView(writerOpts.IncludeSections))
             {
                 // The @Performance kind sections share one row view, so render them as a single
-                // tabular table by collapsing the repeated per-section header.
+                // tabular table by collapsing the repeated per-section header. jsonl and headerless
+                // tsv have no header line, so only the inter-section blank lines are stripped.
+                var hasHeader = !options.Jsonl && !options.NoHeader;
                 var sw = new StringWriter();
                 MarkoutSerializer.Serialize(auditView, sw, new TableFormatter(!options.NoHeader), InspectionContext.Default, writerOpts);
-                var collapsed = CollapseRepeatedTabularHeaders(sw.ToString());
-                collapsed = LimitRenderedTableRows(collapsed, options.Rows, hasHeader: !options.Jsonl && !options.NoHeader);
+                var collapsed = CollapseRepeatedTabularHeaders(sw.ToString(), hasHeader);
+                collapsed = LimitRenderedTableRows(collapsed, options.Rows, hasHeader);
                 Console.Out.Write(collapsed);
                 if (collapsed.Length > 0 && !collapsed.EndsWith('\n'))
                     Console.Out.WriteLine();

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -292,27 +292,37 @@ public static class OutputFormatter
         else
         {
             ConfigureTableWriterOptions(writerOpts, options.Tsv, options.Jsonl);
-            if (writerOpts.IncludeSections is { Count: > 1 }
-                && Sections.PerformanceKinds.AllShareCommonView(writerOpts.IncludeSections))
-            {
-                // The @Performance kind sections share one row view, so render them as a single
-                // self-describing table: flatten the selected kinds into one kind-labeled list and
-                // emit one table (one header, aligned columns, correct --rows accounting). The
-                // leading Kind column replaces the per-section headings that markdown uses.
-                var groupRows = auditView.PerformanceGroupRows(writerOpts.IncludeSections);
-                var groupView = new PerformanceGroupView(groupRows);
-                var groupOpts = ConfigureTableWriterOptions(
-                    new MarkoutWriterOptions { Projection = writerOpts.Projection }, options.Tsv, options.Jsonl);
-                WriteTable(Console.Out, !options.NoHeader,
-                    (writer, formatter) => MarkoutSerializer.Serialize(groupView, writer, formatter, InspectionContext.Default, groupOpts),
-                    options.Rows);
-            }
-            else
-            {
-                WriteTable(Console.Out, !options.NoHeader,
-                    (writer, formatter) => MarkoutSerializer.Serialize(auditView, writer, formatter, InspectionContext.Default, writerOpts),
-                    options.Rows);
-            }
+            WriteLibraryTabular(auditView, writerOpts, options);
+        }
+    }
+
+    /// <summary>
+    /// Renders one library inspection as tabular output (TSV/JSONL/pretty table). When the selected
+    /// sections are the kind-scoped <c>@Performance</c> group (all sharing one row view), they are
+    /// flattened into a single self-describing table with a leading <c>Kind</c> column — one header,
+    /// aligned columns, and correct <c>--rows</c> accounting — instead of concatenated per-kind
+    /// tables. This path is shared by the single- and multi-assembly renderers so both stay
+    /// consistent. <paramref name="writerOpts"/> must already have its TSV/JSONL format configured.
+    /// </summary>
+    private static void WriteLibraryTabular(
+        LibraryInspectionView auditView, MarkoutWriterOptions writerOpts, LibraryOptions options)
+    {
+        if (writerOpts.IncludeSections is { Count: > 1 }
+            && Sections.PerformanceKinds.AllShareCommonView(writerOpts.IncludeSections))
+        {
+            var groupRows = auditView.PerformanceGroupRows(writerOpts.IncludeSections);
+            var groupView = new PerformanceGroupView(groupRows);
+            var groupOpts = ConfigureTableWriterOptions(
+                new MarkoutWriterOptions { Projection = writerOpts.Projection }, options.Tsv, options.Jsonl);
+            WriteTable(Console.Out, !options.NoHeader,
+                (writer, formatter) => MarkoutSerializer.Serialize(groupView, writer, formatter, InspectionContext.Default, groupOpts),
+                options.Rows);
+        }
+        else
+        {
+            WriteTable(Console.Out, !options.NoHeader,
+                (writer, formatter) => MarkoutSerializer.Serialize(auditView, writer, formatter, InspectionContext.Default, writerOpts),
+                options.Rows);
         }
     }
 
@@ -382,9 +392,7 @@ public static class OutputFormatter
                     Projection = BuildProjection(options.Columns, options.Fields),
                 };
                 ConfigureTableWriterOptions(writerOpts, options.Tsv, options.Jsonl);
-                WriteTable(Console.Out, !options.NoHeader,
-                    (writer, formatter) => MarkoutSerializer.Serialize(auditView, writer, formatter, InspectionContext.Default, writerOpts),
-                    options.Rows);
+                WriteLibraryTabular(auditView, writerOpts, options);
             }
         }
     }

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -26,6 +26,38 @@ public static class OutputFormatter
         return sw.ToString();
     }
 
+    /// <summary>
+    /// Collapses the repeated per-section header that Markout emits when several sections sharing
+    /// one row view (the @Performance kind sections) are rendered as tabular output, producing a
+    /// single header followed by continuous rows. jsonl output has no header line and is returned
+    /// unchanged.
+    /// </summary>
+    internal static string CollapseRepeatedTabularHeaders(string rendered)
+    {
+        if (string.IsNullOrEmpty(rendered))
+            return rendered;
+
+        var trailingNewline = rendered.EndsWith('\n');
+        var lines = rendered.ReplaceLineEndings("\n").TrimEnd('\n').Split('\n');
+        var header = lines[0];
+        if (header.Length == 0 || header[0] == '{')
+            return rendered;
+
+        var kept = new List<string> { header };
+        for (var i = 1; i < lines.Length; i++)
+        {
+            // Drop a blank line that only separates a repeated header block.
+            if (lines[i].Length == 0 && i + 1 < lines.Length && lines[i + 1] == header)
+                continue;
+            if (lines[i] == header)
+                continue;
+            kept.Add(lines[i]);
+        }
+
+        var result = string.Join('\n', kept);
+        return trailingNewline ? result + '\n' : result;
+    }
+
     public static void WriteTable(TextWriter output, bool showHeader, Action<TextWriter, IMarkoutFormatter> serialize, RowWindow? maxRows = null)
     {
         // Row-limiting operates on the rendered text, so the capped path must materialize
@@ -240,7 +272,15 @@ public static class OutputFormatter
             else if (selectInfo)
                 markdown = MarkdownSectionOrderer.Apply(markdown, pipeline.InfoSectionNames);
             markdown = MarkdownTableRowLimiter.Apply(markdown, options.Rows);
-            CountOutput.WriteCountFromMarkdown(markdown);
+            if (options.IncludeSections is { Count: > 1 })
+            {
+                var ordered = pipeline.AllSectionNames.Where(options.IncludeSections.Contains).ToList();
+                CountOutput.WriteCountMapFromMarkdown(markdown, ordered);
+            }
+            else
+            {
+                CountOutput.WriteCountFromMarkdown(markdown);
+            }
             return;
         }
 
@@ -284,9 +324,25 @@ public static class OutputFormatter
         else
         {
             ConfigureTableWriterOptions(writerOpts, options.Tsv, options.Jsonl);
-            WriteTable(Console.Out, !options.NoHeader,
-                (writer, formatter) => MarkoutSerializer.Serialize(auditView, writer, formatter, InspectionContext.Default, writerOpts),
-                options.Rows);
+            if (writerOpts.IncludeSections is { Count: > 1 }
+                && Sections.PerformanceKinds.AllShareCommonView(writerOpts.IncludeSections))
+            {
+                // The @Performance kind sections share one row view, so render them as a single
+                // tabular table by collapsing the repeated per-section header.
+                var sw = new StringWriter();
+                MarkoutSerializer.Serialize(auditView, sw, new TableFormatter(!options.NoHeader), InspectionContext.Default, writerOpts);
+                var collapsed = CollapseRepeatedTabularHeaders(sw.ToString());
+                collapsed = LimitRenderedTableRows(collapsed, options.Rows, hasHeader: !options.Jsonl && !options.NoHeader);
+                Console.Out.Write(collapsed);
+                if (collapsed.Length > 0 && !collapsed.EndsWith('\n'))
+                    Console.Out.WriteLine();
+            }
+            else
+            {
+                WriteTable(Console.Out, !options.NoHeader,
+                    (writer, formatter) => MarkoutSerializer.Serialize(auditView, writer, formatter, InspectionContext.Default, writerOpts),
+                    options.Rows);
+            }
         }
     }
 
@@ -316,7 +372,15 @@ public static class OutputFormatter
             else if (selectInfo)
                 markdown = MarkdownSectionOrderer.Apply(markdown, pipeline.InfoSectionNames);
             markdown = MarkdownTableRowLimiter.Apply(markdown, options.Rows);
-            CountOutput.WriteCountFromMarkdown(markdown);
+            if (options.IncludeSections is { Count: > 1 })
+            {
+                var ordered = pipeline.AllSectionNames.Where(options.IncludeSections.Contains).ToList();
+                CountOutput.WriteCountMapFromMarkdown(markdown, ordered);
+            }
+            else
+            {
+                CountOutput.WriteCountFromMarkdown(markdown);
+            }
             return;
         }
 

--- a/src/dotnet-inspect/Output/SelectResolver.cs
+++ b/src/dotnet-inspect/Output/SelectResolver.cs
@@ -42,6 +42,20 @@ public static class SelectResolver
         ["Package README"] = DotnetInspector.Views.PackageSections.PackageReadme,
     };
 
+    /// <summary>
+    /// Bare names that expand to a whole category. Used so the retired library "Performance
+    /// Triage" monolith, and the ergonomic bare "Performance", resolve to the curated
+    /// <c>@Performance</c> group. Only applied when the category exists in the current command's
+    /// section set and the value is not itself an exact section name (so the type/member
+    /// "Performance Triage" section still resolves directly).
+    /// </summary>
+    static readonly Dictionary<string, string> CategoryAliases = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Performance"] = SectionCategoryNames.Performance,
+        ["Performance Triage"] = SectionCategoryNames.Performance,
+        ["Optimization Opportunities"] = SectionCategoryNames.Performance,
+    };
+
     public static bool IsAllSelector(string[]? select)
         => select?.Any(value => value.Equals(AllSelector, StringComparison.OrdinalIgnoreCase)) == true;
 
@@ -143,7 +157,21 @@ public static class SelectResolver
             foreach (var m in matches)
                 matched.Add(m);
             if (miss != null)
+            {
+                // Fall back to a category alias (e.g. retired "Performance Triage" / bare
+                // "Performance" -> @Performance) when the value is not an exact section here.
+                var isExact = knownSections.Any(s => s.Equals(value, StringComparison.OrdinalIgnoreCase));
+                if (!isExact
+                    && CategoryAliases.TryGetValue(value, out var aliasCategory)
+                    && categories.TryGetValue(aliasCategory, out var aliasSections))
+                {
+                    foreach (var section in aliasSections)
+                        matched.Add(section);
+                    continue;
+                }
+
                 unresolved.Add(miss);
+            }
         }
 
         return new(matched.Count > 0 ? matched : null, unresolved);

--- a/src/dotnet-inspect/Sections/ISectionDescriptor.cs
+++ b/src/dotnet-inspect/Sections/ISectionDescriptor.cs
@@ -34,6 +34,15 @@ public interface ISectionDescriptor<TModel>
     static virtual bool Info => false;
 
     /// <summary>
+    /// When false, this section is omitted from the top-level discovery catalog (bare <c>-D</c> /
+    /// <c>-D --schema</c>) so a curated <c>@category</c> is the single discoverable entrypoint for it.
+    /// The section stays fully selectable and stays visible when drilling into its category
+    /// (<c>-D @Category</c>) or when named exactly. Use for large curated sub-groups (e.g. the
+    /// per-kind performance sections) that would otherwise flood the catalog with often-empty rows.
+    /// </summary>
+    static virtual bool ListedInCatalog => true;
+
+    /// <summary>
     /// When false, effective discovery (<c>-D</c>) lists this section using only its
     /// section pipeline's structural applicability gate and never renders it to confirm it produces
     /// content. Use for sections whose content probe is heavy (e.g. opening a whole-assembly

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -530,6 +530,7 @@ public static class LibrarySections
         public static string Name => SectionNames.PerformanceBoxing;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
+        public static bool ListedInCatalog => false;
         public static string? ScannerKey => ScannerOptimizationOpportunities;
         public static bool CanRender(LibraryInspection model)
             => HasPerformanceKind(model, SectionNames.PerformanceBoxing) || model.HasMethodBodies;
@@ -540,6 +541,7 @@ public static class LibrarySections
         public static string Name => SectionNames.PerformanceArrays;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
+        public static bool ListedInCatalog => false;
         public static string? ScannerKey => ScannerOptimizationOpportunities;
         public static bool CanRender(LibraryInspection model)
             => HasPerformanceKind(model, SectionNames.PerformanceArrays) || model.HasMethodBodies;
@@ -550,6 +552,7 @@ public static class LibrarySections
         public static string Name => SectionNames.PerformanceClosures;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
+        public static bool ListedInCatalog => false;
         public static string? ScannerKey => ScannerOptimizationOpportunities;
         public static bool CanRender(LibraryInspection model)
             => HasPerformanceKind(model, SectionNames.PerformanceClosures) || model.HasMethodBodies;
@@ -560,6 +563,7 @@ public static class LibrarySections
         public static string Name => SectionNames.PerformanceEnumerators;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
+        public static bool ListedInCatalog => false;
         public static string? ScannerKey => ScannerOptimizationOpportunities;
         public static bool CanRender(LibraryInspection model)
             => HasPerformanceKind(model, SectionNames.PerformanceEnumerators) || model.HasMethodBodies;
@@ -570,6 +574,7 @@ public static class LibrarySections
         public static string Name => SectionNames.PerformanceLoops;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
+        public static bool ListedInCatalog => false;
         public static string? ScannerKey => ScannerOptimizationOpportunities;
         public static bool CanRender(LibraryInspection model)
             => HasPerformanceKind(model, SectionNames.PerformanceLoops) || model.HasMethodBodies;
@@ -580,6 +585,7 @@ public static class LibrarySections
         public static string Name => SectionNames.PerformanceHotspots;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
+        public static bool ListedInCatalog => false;
         public static string? ScannerKey => ScannerOptimizationOpportunities;
         public static bool CanRender(LibraryInspection model)
             => HasPerformanceKind(model, SectionNames.PerformanceHotspots) || model.HasMethodBodies;
@@ -590,6 +596,7 @@ public static class LibrarySections
         public static string Name => SectionNames.PerformanceAsync;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
+        public static bool ListedInCatalog => false;
         public static string? ScannerKey => ScannerOptimizationOpportunities;
         public static bool CanRender(LibraryInspection model)
             => HasPerformanceKind(model, SectionNames.PerformanceAsync) || model.HasMethodBodies;
@@ -600,6 +607,7 @@ public static class LibrarySections
         public static string Name => SectionNames.PerformanceOther;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
+        public static bool ListedInCatalog => false;
         public static string? ScannerKey => ScannerOptimizationOpportunities;
         public static bool CanRender(LibraryInspection model)
             => HasPerformanceKind(model, SectionNames.PerformanceOther) || model.HasMethodBodies;

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -71,7 +71,14 @@ public static class LibrarySections
             .Add<ExtensionMethods>()
             .Add<UnsafeMembers>()
             .Add<TopLeverage>()
-            .Add<OptimizationOpportunities>()
+            .Add<PerformanceBoxing>()
+            .Add<PerformanceArrays>()
+            .Add<PerformanceClosures>()
+            .Add<PerformanceEnumerators>()
+            .Add<PerformanceLoops>()
+            .Add<PerformanceHotspots>()
+            .Add<PerformanceAsync>()
+            .Add<PerformanceOther>()
             .Add<ResourceTriage>()
             .Add<PInvokeMethods>()
             .Add<AsyncMethods>()
@@ -84,6 +91,7 @@ public static class LibrarySections
                 SectionNames.UnsafeMembers,
                 "P/Invoke Methods",
                 "Switches")
+            .AddCategory(SectionCategoryNames.Performance, PerformanceKinds.Sections)
             .AddCategory("@Integrations", [.. LibraryIntegrationCatalog.CategorySections, "Integration Opportunities", "Union Types"])
             .AddCategory("@Switches", "Switches");
     }
@@ -509,14 +517,92 @@ public static class LibrarySections
             => model.TopLeverage is { Count: > 0 } || model.HasMethodBodies;
     }
 
-    public sealed class OptimizationOpportunities : ISectionDescriptor<LibraryInspection>
+    // Kind-scoped performance sections. Each shares the holistic optimization-opportunity scan
+    // and gates render on its own bucket having rows (via the view's ShowWhenProperty). The
+    // `|| HasMethodBodies` applicability keeps the section selectable/scannable pre-scan, exactly
+    // as the retired monolith did; the empty-when-no-rows suppression is the view's job.
+    private static bool HasPerformanceKind(LibraryInspection model, string section)
+        => model.OptimizationOpportunities is { } rows
+           && rows.Any(o => PerformanceKinds.SectionForShape(o.Shape) == section);
+
+    public sealed class PerformanceBoxing : ISectionDescriptor<LibraryInspection>
     {
-        public static string Name => SectionNames.PerformanceTriage;
+        public static string Name => SectionNames.PerformanceBoxing;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
         public static string? ScannerKey => ScannerOptimizationOpportunities;
         public static bool CanRender(LibraryInspection model)
-            => model.OptimizationOpportunities is { Count: > 0 } || model.HasMethodBodies;
+            => HasPerformanceKind(model, SectionNames.PerformanceBoxing) || model.HasMethodBodies;
+    }
+
+    public sealed class PerformanceArrays : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => SectionNames.PerformanceArrays;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static string? ScannerKey => ScannerOptimizationOpportunities;
+        public static bool CanRender(LibraryInspection model)
+            => HasPerformanceKind(model, SectionNames.PerformanceArrays) || model.HasMethodBodies;
+    }
+
+    public sealed class PerformanceClosures : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => SectionNames.PerformanceClosures;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static string? ScannerKey => ScannerOptimizationOpportunities;
+        public static bool CanRender(LibraryInspection model)
+            => HasPerformanceKind(model, SectionNames.PerformanceClosures) || model.HasMethodBodies;
+    }
+
+    public sealed class PerformanceEnumerators : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => SectionNames.PerformanceEnumerators;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static string? ScannerKey => ScannerOptimizationOpportunities;
+        public static bool CanRender(LibraryInspection model)
+            => HasPerformanceKind(model, SectionNames.PerformanceEnumerators) || model.HasMethodBodies;
+    }
+
+    public sealed class PerformanceLoops : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => SectionNames.PerformanceLoops;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static string? ScannerKey => ScannerOptimizationOpportunities;
+        public static bool CanRender(LibraryInspection model)
+            => HasPerformanceKind(model, SectionNames.PerformanceLoops) || model.HasMethodBodies;
+    }
+
+    public sealed class PerformanceHotspots : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => SectionNames.PerformanceHotspots;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static string? ScannerKey => ScannerOptimizationOpportunities;
+        public static bool CanRender(LibraryInspection model)
+            => HasPerformanceKind(model, SectionNames.PerformanceHotspots) || model.HasMethodBodies;
+    }
+
+    public sealed class PerformanceAsync : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => SectionNames.PerformanceAsync;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static string? ScannerKey => ScannerOptimizationOpportunities;
+        public static bool CanRender(LibraryInspection model)
+            => HasPerformanceKind(model, SectionNames.PerformanceAsync) || model.HasMethodBodies;
+    }
+
+    public sealed class PerformanceOther : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => SectionNames.PerformanceOther;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static string? ScannerKey => ScannerOptimizationOpportunities;
+        public static bool CanRender(LibraryInspection model)
+            => HasPerformanceKind(model, SectionNames.PerformanceOther) || model.HasMethodBodies;
     }
 
     public sealed class ResourceTriage : ISectionDescriptor<LibraryInspection>

--- a/src/dotnet-inspect/Sections/PerformanceKinds.cs
+++ b/src/dotnet-inspect/Sections/PerformanceKinds.cs
@@ -25,7 +25,7 @@ public static class PerformanceKinds
     /// Resolves the section that renders a given opportunity shape. Unmapped shapes route to
     /// <see cref="SectionNames.PerformanceOther"/> so the scan is never silently lossy.
     /// </summary>
-    public static string SectionForShape(string? shape) => shape switch
+    public static string SectionForShape(string? shape) => NormalizeShape(shape) switch
     {
         "box-value-type" => SectionNames.PerformanceBoxing,
 
@@ -51,6 +51,11 @@ public static class PerformanceKinds
 
         _ => SectionNames.PerformanceOther,
     };
+
+    // Shape validation and row filtering are case-insensitive, so a differently-cased shape (e.g.
+    // "BOX-VALUE-TYPE") must resolve to the same kind section its findings bucket into; otherwise
+    // the accepted shape would silently route to Performance: Other and hide the matching rows.
+    private static string? NormalizeShape(string? shape) => shape?.ToLowerInvariant();
 
     /// <summary>The snake_case JSON key for a performance section under the nested <c>performance</c> object.</summary>
     public static string StructuredKey(string section) => section switch

--- a/src/dotnet-inspect/Sections/PerformanceKinds.cs
+++ b/src/dotnet-inspect/Sections/PerformanceKinds.cs
@@ -57,6 +57,19 @@ public static class PerformanceKinds
     // the accepted shape would silently route to Performance: Other and hide the matching rows.
     private static string? NormalizeShape(string? shape) => shape?.ToLowerInvariant();
 
+    /// <summary>
+    /// The short kind label for a performance section (the part after <c>"Performance: "</c>), used
+    /// as the leading <c>Kind</c> column when the sections are flattened into one self-describing
+    /// tabular table. Markdown keeps the full <c>## Performance: Kind</c> heading instead.
+    /// </summary>
+    public static string KindLabel(string section)
+    {
+        const string prefix = "Performance: ";
+        return section.StartsWith(prefix, StringComparison.Ordinal)
+            ? section[prefix.Length..]
+            : section;
+    }
+
     /// <summary>The snake_case JSON key for a performance section under the nested <c>performance</c> object.</summary>
     public static string StructuredKey(string section) => section switch
     {

--- a/src/dotnet-inspect/Sections/PerformanceKinds.cs
+++ b/src/dotnet-inspect/Sections/PerformanceKinds.cs
@@ -1,0 +1,82 @@
+namespace DotnetInspector.Sections;
+
+/// <summary>
+/// Maps optimization-opportunity shapes onto the kind-scoped performance sections and
+/// provides the canonical ordered section list plus the structured (JSON) key per section.
+/// This is the single source of truth shared by the view (bucketing), the model projection
+/// (nested <c>performance</c> JSON), and the <c>--count</c> summary.
+/// </summary>
+public static class PerformanceKinds
+{
+    /// <summary>The kind-scoped performance sections, in curated display order.</summary>
+    public static readonly string[] Sections =
+    [
+        SectionNames.PerformanceBoxing,
+        SectionNames.PerformanceArrays,
+        SectionNames.PerformanceClosures,
+        SectionNames.PerformanceEnumerators,
+        SectionNames.PerformanceLoops,
+        SectionNames.PerformanceHotspots,
+        SectionNames.PerformanceAsync,
+        SectionNames.PerformanceOther,
+    ];
+
+    /// <summary>
+    /// Resolves the section that renders a given opportunity shape. Unmapped shapes route to
+    /// <see cref="SectionNames.PerformanceOther"/> so the scan is never silently lossy.
+    /// </summary>
+    public static string SectionForShape(string? shape) => shape switch
+    {
+        "box-value-type" => SectionNames.PerformanceBoxing,
+
+        "small-array"
+        or "temporary-byte-array-copy"
+        or "span-to-array-copy"
+        or "stackalloc-candidate" => SectionNames.PerformanceArrays,
+
+        "capturing-delegate"
+        or "instance-method-group-delegate" => SectionNames.PerformanceClosures,
+
+        "enumerator-allocation" => SectionNames.PerformanceEnumerators,
+
+        "linq-scan-in-loop"
+        or "materialize-in-loop"
+        or "scan-method-in-loop-call"
+        or "string-build-in-loop" => SectionNames.PerformanceLoops,
+
+        "allocation-hotspot"
+        or "allocation-fanout" => SectionNames.PerformanceHotspots,
+
+        "async-state-machine" => SectionNames.PerformanceAsync,
+
+        _ => SectionNames.PerformanceOther,
+    };
+
+    /// <summary>The snake_case JSON key for a performance section under the nested <c>performance</c> object.</summary>
+    public static string StructuredKey(string section) => section switch
+    {
+        SectionNames.PerformanceBoxing => "boxing",
+        SectionNames.PerformanceArrays => "arrays",
+        SectionNames.PerformanceClosures => "closures_and_delegates",
+        SectionNames.PerformanceEnumerators => "enumerators",
+        SectionNames.PerformanceLoops => "loop_hot_paths",
+        SectionNames.PerformanceHotspots => "allocation_hotspots",
+        SectionNames.PerformanceAsync => "async",
+        _ => "other",
+    };
+
+    /// <summary>
+    /// True when every section in <paramref name="sections"/> is a performance kind section. These
+    /// sections share the single <c>PerformanceRow</c> view, so they can be rendered as one
+    /// concatenated tabular table (<c>--table</c>/<c>--tsv</c>/<c>--jsonl</c>).
+    /// </summary>
+    public static bool AllShareCommonView(IReadOnlyCollection<string> sections)
+    {
+        if (sections.Count == 0)
+            return false;
+        foreach (var section in sections)
+            if (Array.IndexOf(Sections, section) < 0)
+                return false;
+        return true;
+    }
+}

--- a/src/dotnet-inspect/Sections/SectionCategoryNames.cs
+++ b/src/dotnet-inspect/Sections/SectionCategoryNames.cs
@@ -7,4 +7,7 @@ public static class SectionCategoryNames
 {
     public const string Audit = "@Audit";
     public const string Source = "@Source";
+
+    /// <summary>Curated group of the kind-scoped performance sections (library scope).</summary>
+    public const string Performance = "@Performance";
 }

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -178,6 +178,33 @@ public static class SectionNames
     /// <summary>Section for safe, local optimization opportunities inferred from IL/body evidence.</summary>
     public const string PerformanceTriage = "Performance Triage";
 
+    // Kind-scoped performance sections (library scope). Each renders one family of the
+    // optimization-opportunity scan, is explicit-only, and is absent when its family has no
+    // findings — following the il-offset context-section model. Grouped under @Performance.
+    /// <summary>Boxing (value type heap-allocated) performance findings.</summary>
+    public const string PerformanceBoxing = "Performance: Boxing";
+
+    /// <summary>Array-allocation performance findings (small arrays, byte-copies, span/stackalloc candidates).</summary>
+    public const string PerformanceArrays = "Performance: Arrays";
+
+    /// <summary>Closure/delegate-allocation performance findings.</summary>
+    public const string PerformanceClosures = "Performance: Closures and delegates";
+
+    /// <summary>Enumerator-allocation performance findings.</summary>
+    public const string PerformanceEnumerators = "Performance: Enumerators";
+
+    /// <summary>Loop hot-path performance findings (scan/materialize/build inside loops).</summary>
+    public const string PerformanceLoops = "Performance: Loop hot paths";
+
+    /// <summary>Aggregate allocation hotspot/fanout performance findings.</summary>
+    public const string PerformanceHotspots = "Performance: Allocation hotspots";
+
+    /// <summary>Async state-machine performance findings.</summary>
+    public const string PerformanceAsync = "Performance: Async";
+
+    /// <summary>Catch-all for performance findings whose shape has no dedicated section (keeps the scan non-lossy).</summary>
+    public const string PerformanceOther = "Performance: Other";
+
     /// <summary>Section for curated exception-path resource lifecycle candidates.</summary>
     public const string ResourceTriage = "Resource Triage";
 

--- a/src/dotnet-inspect/Sections/SectionPipeline.cs
+++ b/src/dotnet-inspect/Sections/SectionPipeline.cs
@@ -12,6 +12,7 @@ public sealed class SectionEntry<TModel>
     public required bool IsExpensive { get; init; }
     public bool ExplicitOnly { get; init; }
     public bool Info { get; init; }
+    public bool ListedInCatalog { get; init; } = true;
     public bool ProbeEffectiveness { get; init; } = true;
     public SectionCapabilities Capabilities { get; init; }
     public required string? ScannerKey { get; init; }
@@ -58,6 +59,7 @@ public sealed class SectionPipeline<TModel>
             IsExpensive = TDescriptor.IsExpensive,
             ExplicitOnly = TDescriptor.ExplicitOnly,
             Info = TDescriptor.Info,
+            ListedInCatalog = TDescriptor.ListedInCatalog,
             ProbeEffectiveness = TDescriptor.ProbeEffectiveness,
             Capabilities = TDescriptor.Capabilities,
             ScannerKey = TDescriptor.ScannerKey,
@@ -122,6 +124,16 @@ public sealed class SectionPipeline<TModel>
 
         return categories;
     }
+
+    /// <summary>
+    /// Names of sections omitted from the top-level discovery catalog
+    /// (<see cref="SectionEntry{TModel}.ListedInCatalog"/> is false). Discovery lists these only
+    /// under their curated <c>@category</c>; they remain selectable and drillable by exact name.
+    /// </summary>
+    public IReadOnlySet<string> GetCatalogHiddenSections()
+        => _entries.Where(e => !e.ListedInCatalog)
+            .Select(e => e.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Maps each section name to a short annotation for discovery output:

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -449,6 +449,7 @@ public record PackageSourceFileRow(
 [MarkoutContext(typeof(PInvokeMethodRow))]
 [MarkoutContext(typeof(ResourceRow))]
 [MarkoutContext(typeof(ResourceTriageRow))]
+[MarkoutContext(typeof(PerformanceRow))]
 [MarkoutContext(typeof(CustomAttributeRow))]
 [MarkoutContext(typeof(TypeForwarderRow))]
 [MarkoutContext(typeof(AuditSignalRow))]

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -450,6 +450,8 @@ public record PackageSourceFileRow(
 [MarkoutContext(typeof(ResourceRow))]
 [MarkoutContext(typeof(ResourceTriageRow))]
 [MarkoutContext(typeof(PerformanceRow))]
+[MarkoutContext(typeof(PerformanceGroupRow))]
+[MarkoutContext(typeof(PerformanceGroupView))]
 [MarkoutContext(typeof(CustomAttributeRow))]
 [MarkoutContext(typeof(TypeForwarderRow))]
 [MarkoutContext(typeof(AuditSignalRow))]

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -784,44 +784,58 @@ public class LibraryInspectionView
                 Selector: m.Selector is { } selector ? MarkoutInline.Code(selector) : null))
             .ToList();
 
-    public bool HasOptimizationOpportunities => _data.OptimizationOpportunities is { Count: > 0 };
-
-    // Rows arrive pre-ordered from the scanner by triage priority (in-loop first, then
-    // confidence, then root reach), so the highest-value pay-dirt surfaces first.
-    [MarkoutSection(Name = "Performance Triage", ShowWhenProperty = nameof(HasOptimizationOpportunities))]
-    public List<OptimizationOpportunityRow>? OptimizationOpportunitiesSection =>
-        _data.OptimizationOpportunities?
-            .Select(o => new OptimizationOpportunityRow(
+    // Kind-scoped performance sections. The optimization-opportunity scan is holistic; each
+    // section renders the subset whose shape maps to it (see PerformanceKinds) with a tight,
+    // human column set. Rows arrive pre-ordered by triage priority (in-loop first, then
+    // confidence, then root reach). Deep per-row diagnostics remain in the JSON projection.
+    // Each section is absent when its kind has no findings (il-offset context-section model).
+    private List<PerformanceRow>? PerformanceRowsFor(string section)
+    {
+        var rows = _data.OptimizationOpportunities?
+            .Where(o => PerformanceKinds.SectionForShape(o.Shape) == section)
+            .Select(o => new PerformanceRow(
                 MarkoutInline.Code(o.Member),
-                o.Candidate is null ? null : MarkoutInline.Code(o.Candidate),
-                o.Finding,
-                o.Provenance,
-                o.RootReach.ToString(),
-                o.Shape,
-                o.Operation,
-                o.Token is null ? null : MarkoutInline.Code(o.Token),
                 o.Evidence,
-                o.Fix,
-                o.Confidence,
-                o.Loop,
-                o.CallerLoop,
-                o.CallerLoopDepth?.ToString(),
-                o.CallerLoopWitness,
                 o.Allocation is null ? null : MarkoutInline.Code(o.Allocation),
-                o.Path,
-                o.PathConfidence,
-                o.PostDominance,
-                o.IL is null ? null : MarkoutInline.Code(o.IL),
+                string.IsNullOrEmpty(o.Loop) ? null : o.Loop,
+                o.RootReach.ToString(),
                 o.Weight,
-                o.DirectSites?.ToString(),
-                o.OncePaths?.ToString(),
-                o.ConditionalPaths?.ToString(),
-                o.RepeatedPaths?.ToString(),
-                o.UnknownPaths?.ToString(),
-                o.CachedSites?.ToString(),
-                o.OpaquePaths?.ToString(),
-                o.Saturated))
+                o.Confidence))
             .ToList();
+        return rows is { Count: > 0 } ? rows : null;
+    }
+
+    [MarkoutIgnore] public bool HasPerformanceBoxing => PerformanceBoxingSection is not null;
+    [MarkoutSection(Name = SectionNames.PerformanceBoxing, ShowWhenProperty = nameof(HasPerformanceBoxing))]
+    public List<PerformanceRow>? PerformanceBoxingSection => PerformanceRowsFor(SectionNames.PerformanceBoxing);
+
+    [MarkoutIgnore] public bool HasPerformanceArrays => PerformanceArraysSection is not null;
+    [MarkoutSection(Name = SectionNames.PerformanceArrays, ShowWhenProperty = nameof(HasPerformanceArrays))]
+    public List<PerformanceRow>? PerformanceArraysSection => PerformanceRowsFor(SectionNames.PerformanceArrays);
+
+    [MarkoutIgnore] public bool HasPerformanceClosures => PerformanceClosuresSection is not null;
+    [MarkoutSection(Name = SectionNames.PerformanceClosures, ShowWhenProperty = nameof(HasPerformanceClosures))]
+    public List<PerformanceRow>? PerformanceClosuresSection => PerformanceRowsFor(SectionNames.PerformanceClosures);
+
+    [MarkoutIgnore] public bool HasPerformanceEnumerators => PerformanceEnumeratorsSection is not null;
+    [MarkoutSection(Name = SectionNames.PerformanceEnumerators, ShowWhenProperty = nameof(HasPerformanceEnumerators))]
+    public List<PerformanceRow>? PerformanceEnumeratorsSection => PerformanceRowsFor(SectionNames.PerformanceEnumerators);
+
+    [MarkoutIgnore] public bool HasPerformanceLoops => PerformanceLoopsSection is not null;
+    [MarkoutSection(Name = SectionNames.PerformanceLoops, ShowWhenProperty = nameof(HasPerformanceLoops))]
+    public List<PerformanceRow>? PerformanceLoopsSection => PerformanceRowsFor(SectionNames.PerformanceLoops);
+
+    [MarkoutIgnore] public bool HasPerformanceHotspots => PerformanceHotspotsSection is not null;
+    [MarkoutSection(Name = SectionNames.PerformanceHotspots, ShowWhenProperty = nameof(HasPerformanceHotspots))]
+    public List<PerformanceRow>? PerformanceHotspotsSection => PerformanceRowsFor(SectionNames.PerformanceHotspots);
+
+    [MarkoutIgnore] public bool HasPerformanceAsync => PerformanceAsyncSection is not null;
+    [MarkoutSection(Name = SectionNames.PerformanceAsync, ShowWhenProperty = nameof(HasPerformanceAsync))]
+    public List<PerformanceRow>? PerformanceAsyncSection => PerformanceRowsFor(SectionNames.PerformanceAsync);
+
+    [MarkoutIgnore] public bool HasPerformanceOther => PerformanceOtherSection is not null;
+    [MarkoutSection(Name = SectionNames.PerformanceOther, ShowWhenProperty = nameof(HasPerformanceOther))]
+    public List<PerformanceRow>? PerformanceOtherSection => PerformanceRowsFor(SectionNames.PerformanceOther);
 
     [MarkoutIgnore]
     public bool HasResourceTriage =>
@@ -1176,6 +1190,18 @@ public record ResourceTriageRow(
     string? Visibility,
     string? Stable,
     string? Selector);
+
+// Tight, human column set for the kind-scoped performance sections. Deep per-row diagnostics
+// (provenance, path counts, post-dominance, token, fix guidance) live in the JSON projection.
+[MarkoutSerializable]
+public record PerformanceRow(
+    string Member,
+    string Evidence,
+    [property: MarkoutSkipNull] string? Allocation,
+    [property: MarkoutSkipNull] string? Loop,
+    string Reach,
+    [property: MarkoutSkipNull] string? Weight,
+    string Confidence);
 
 [MarkoutSerializable]
 public record CustomAttributeRow(

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -805,6 +805,28 @@ public class LibraryInspectionView
         return rows is { Count: > 0 } ? rows : null;
     }
 
+    // Flattens the selected performance kind sections into one kind-labeled list for tabular group
+    // output. Iterates PerformanceKinds.Sections (curated order) so rows stay grouped by kind, and
+    // reuses PerformanceRowsFor so the per-kind rows, ordering, and inline-code spelling are identical
+    // to the markdown sections — only a leading Kind label is added.
+    internal List<PerformanceGroupRow> PerformanceGroupRows(IReadOnlyCollection<string> selectedSections)
+    {
+        var rows = new List<PerformanceGroupRow>();
+        foreach (var section in PerformanceKinds.Sections)
+        {
+            if (!selectedSections.Contains(section))
+                continue;
+            var kindRows = PerformanceRowsFor(section);
+            if (kindRows is null)
+                continue;
+            var label = PerformanceKinds.KindLabel(section);
+            foreach (var row in kindRows)
+                rows.Add(new PerformanceGroupRow(
+                    label, row.Member, row.Evidence, row.Allocation, row.Loop, row.Reach, row.Weight, row.Confidence));
+        }
+        return rows;
+    }
+
     [MarkoutIgnore] public bool HasPerformanceBoxing => PerformanceBoxingSection is not null;
     [MarkoutSection(Name = SectionNames.PerformanceBoxing, ShowWhenProperty = nameof(HasPerformanceBoxing))]
     public List<PerformanceRow>? PerformanceBoxingSection => PerformanceRowsFor(SectionNames.PerformanceBoxing);
@@ -1202,6 +1224,36 @@ public record PerformanceRow(
     string Reach,
     [property: MarkoutSkipNull] string? Weight,
     string Confidence);
+
+/// <summary>
+/// A <see cref="PerformanceRow"/> prefixed with its kind label, used to flatten the per-kind
+/// performance sections into one self-describing tabular table (<c>-S @Performance --tsv</c>/
+/// <c>--jsonl</c>/<c>--table</c>). The leading <c>Kind</c> column tells consumers which performance
+/// kind each row belongs to, since the flattened table has no per-section headings.
+/// </summary>
+public record PerformanceGroupRow(
+    string Kind,
+    string Member,
+    string Evidence,
+    [property: MarkoutSkipNull] string? Allocation,
+    [property: MarkoutSkipNull] string? Loop,
+    string Reach,
+    [property: MarkoutSkipNull] string? Weight,
+    string Confidence);
+
+/// <summary>
+/// Single-section view that renders the flattened, kind-labeled performance rows as one table.
+/// Used only for tabular group output; markdown keeps the per-kind sections of
+/// <see cref="LibraryInspectionView"/> with their <c>## Performance: Kind</c> headings.
+/// </summary>
+[MarkoutSerializable]
+public sealed class PerformanceGroupView
+{
+    public PerformanceGroupView(List<PerformanceGroupRow> rows) => Performance = rows;
+
+    [MarkoutSection(Name = "Performance")]
+    public List<PerformanceGroupRow> Performance { get; }
+}
 
 [MarkoutSerializable]
 public record CustomAttributeRow(

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -16,6 +16,18 @@
 - Adds Rung 7 `Performance Triage` shapes: `async-state-machine` (reported as
   amortized off-loop) and `materialize-in-loop` (loop-invariant
   `ToArray`/`ToList`), plus nested-type triage drilldown (#1948, #1889).
+- Decomposes the library `Performance Triage` monolith into kind-scoped
+  sections (`Performance: Boxing`, `Performance: Arrays`,
+  `Performance: Closures and delegates`, `Performance: Enumerators`,
+  `Performance: Loop hot paths`, `Performance: Allocation hotspots`,
+  `Performance: Async`) following the il-offset section model: each is opt-in
+  and absent when empty, selectable individually or as the `@Performance` group
+  (legacy `-S "Performance Triage"`/`Performance`/`Optimization Opportunities`
+  redirect to the group). Markdown carries tight ranked columns; full per-row
+  diagnostics move to the nested `performance` JSON object (retiring the
+  `optimization_opportunities` key). `--count -S @Performance` returns a
+  per-kind count map. The `type`/`member` `Performance Triage` lens is
+  unchanged (#2833).
 
 ### Output and projections
 

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -26,7 +26,11 @@
   redirect to the group). Markdown carries tight ranked columns; full per-row
   diagnostics move to the nested `performance` JSON object (retiring the
   `optimization_opportunities` key). `--count -S @Performance` returns a
-  per-kind count map. The `type`/`member` `Performance Triage` lens is
+  per-kind count map. The kind sections are catalog-hidden: the top-level
+  `-D`/`--schema` catalog lists only the `@Performance` category as their
+  entrypoint (drill in with `-D @Performance`), and flattened tabular output
+  (`--table`/`--tsv`/`--jsonl`) renders the group as one table with a leading
+  `Kind` column. The `type`/`member` `Performance Triage` lens is
   unchanged (#2833).
 
 ### Output and projections


### PR DESCRIPTION
## Summary

Fixes #2833. The library-scoped `Performance Triage` section packed every
optimization-opportunity shape into one wide, sparse table that was hard for
humans (and agents) to read. This decomposes it into **kind-scoped sections**
following the established **il-offset section model**.

Seven kind sections (plus a non-lossy `Performance: Other`):
`Performance: Boxing`, `Arrays`, `Closures and delegates`, `Enumerators`,
`Loop hot paths`, `Allocation hotspots`, `Async`.

Behavior:

- **Opt-in and absent when empty** (CanRender gates on that kind having ≥1
  finding), like offset-context sections. Not in the default `-v:m` view.
- **Selectable individually** (`-S "Performance: Boxing"`) or **as a group**
  (`-S @Performance`). Legacy `-S "Performance Triage"` / `Performance` /
  `Optimization Opportunities` **redirect to the group** at library scope.
- **Tight markdown columns** (Member, Evidence, Allocation, Loop, Reach,
  Weight, Confidence); full per-row diagnostics (shape, provenance, candidate,
  token, IL, path/loop evidence, fix) move to the **nested `performance` JSON
  object**, retiring the `optimization_opportunities` key.
- **`--count -S @Performance`** returns a per-kind count map (including zero
  rows) — a cheap way to probe which kinds are present before requesting them.
- **Group tabular** (`--tsv`/`--table`/`--jsonl`) renders one table because all
  kind sections share the `PerformanceRow` view (repeated headers collapsed).
- **Scope: library only.** The `type`/`member` `Performance Triage` lens (a
  single-member view) is unchanged.

## Evidence

- Full CLI suite: `dotnet run --project src/dotnet-inspect.Tests -c Release`
  → 1968 total, 2 failed, 10 skipped. The **2 failures are pre-existing and
  platform-specific** (`PInvokeMethods_*` assert Windows `Interop.User32`
  types; this run is on Darwin, which yields `mach_timebase_info`) and are
  untouched by this diff.
- New `PerformanceKindsTests` cover shape→section mapping (every
  `KnownShapes` entry maps to a non-`Other` section), structured-key
  uniqueness, and `AllShareCommonView`.
- New `CommandExecutionTests` cover: default-hidden, single-kind isolation,
  `@Performance` group union, absent-when-empty, `--count` per-kind map,
  legacy-name redirect, and single collapsed tabular header.
- Migrated the rich `--tsv`/`--jsonl` triage tests to observe the nested
  `--json` projection (the only place rich fields now live).
- Verified on a real `System.Text.Json.dll` (162 findings): group/single/count/
  redirect/nested-JSON all behave as described.

## Compatibility boundary

Library-only. The retired `optimization_opportunities` JSON key is replaced by
the nested `performance` object (experimental performance-analysis surface).
Legacy library section names redirect rather than error. Type/member triage is
untouched.

Adversarial review (two model families) to follow.