### PR TITLE
Strip macOS .dSYM debug bundle from Native AOT packages

### DIFF
--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -84,8 +84,12 @@
     <ItemGroup>
       <PublishSymbolFiles Include="$(PublishDir)**/*.pdb" />
       <PublishSymbolFiles Include="$(PublishDir)**/*.dbg" />
+      <!-- macOS Native AOT emits a .dSYM debug bundle (a directory, so it needs
+           RemoveDir rather than the file glob above). -->
+      <PublishSymbolBundles Include="$([System.IO.Directory]::GetDirectories('$(PublishDir)', '*.dSYM'))" />
     </ItemGroup>
     <Delete Files="@(PublishSymbolFiles)" />
+    <RemoveDir Directories="@(PublishSymbolBundles)" />
   </Target>
 
 </Project>


### PR DESCRIPTION
## What

Keep debug symbols out of the Native AOT tool packages via a single MSBuild
property:

```xml
<CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
```

## Why

The packages previously shipped debug symbols. On macOS, Native AOT emits a
`.dSYM` bundle (a *directory*, ~8.9 MB of DWARF — several times larger than the
executable itself); Windows/Linux emit `.pdb`/`.dbg`. Rather than delete these
post-publish (a target that had to `Delete` files *and* `RemoveDir` the `.dSYM`
directory), `CopyOutputSymbolsToPublishDirectory=false` simply keeps them out of
the publish directory — and thus out of the package — in one platform-agnostic
line, with no post-publish file gymnastics.

## Verified

`osx-arm64` package now contains only `DotnetToolSettings.xml` + the stripped
native binary; `dSYM` and `pdb` entries: 0. Applied identically across the three
sibling tools (dotnet-install, dotnet-inspect, dotnet-runtimeinfo).
