### PR TITLE
Expand multi-statement lambda block bodies across lines in printer

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -635,6 +635,20 @@ public class CfgSampleClass
         return x => { int y = x + z; return y * y; };
     }
 
+    // Multi-statement lambda block body returned from inside a nested `if`, so
+    // the enclosing `return` statement sits one indent level deeper than the
+    // method body — exercises that the expanded block's braces track the
+    // enclosing statement's own indentation (via _statementIndent) rather than
+    // always aligning to column 0.
+    public static System.Func<int, int>? StatementBodyLambdaInsideIf(bool flag)
+    {
+        if (flag)
+        {
+            return x => { System.Console.WriteLine(x); return x + 1; };
+        }
+        return null;
+    }
+
     public static int DoWhileSum(int n)
     {
         int s = 0;

--- a/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
@@ -30,7 +30,10 @@ public class LambdaRaisingPassTests
     {
         string output = PrintRaised(nameof(CfgSampleClass.StatementBodyLambda));
 
-        Assert.Contains("return x => {", output);
+        // A multi-statement block body now expands across lines, matching how
+        // every other statement block prints (issue #2952), instead of staying
+        // collapsed onto the lambda's own line.
+        Assert.Contains("return x =>\n{", output);
         Assert.Contains("Console.WriteLine(x);", output);
         Assert.Contains("return x + 1;", output);
         Assert.DoesNotContain("new Func", output);
@@ -41,11 +44,30 @@ public class LambdaRaisingPassTests
     {
         string output = PrintRaised(nameof(CfgSampleClass.CapturingLocalBodyLambda));
 
-        Assert.Contains("return x => {", output);
+        Assert.Contains("return x =>\n{", output);
         Assert.Contains(" = x + n;", output);
         Assert.Contains("return ", output);
         Assert.Contains(" * ", output);
         Assert.DoesNotContain("new Func", output);
+    }
+
+    // The printer #2952 shape at a deeper nesting level: a multi-statement
+    // lambda block body returned from inside an `if`, one indent level below
+    // the method body. The expanded block's braces must align to the
+    // *enclosing statement's* own indentation (4 spaces, matching the `if`
+    // body) rather than always aligning to column 0.
+    [Fact]
+    public void MultiStatementLambda_InsideNestedIf_AlignsBracesToEnclosingStatementIndent()
+    {
+        string output = PrintRaised(nameof(CfgSampleClass.StatementBodyLambdaInsideIf));
+
+        Assert.Contains(
+            "    return x =>\n" +
+            "    {\n" +
+            "        Console.WriteLine(x);\n" +
+            "        return x + 1;\n" +
+            "    };",
+            output);
     }
 
     [Fact]
@@ -101,7 +123,7 @@ public class LambdaRaisingPassTests
     {
         string output = PrintRaised(nameof(CfgSampleClass.LocalBodyLambda));
 
-        Assert.Contains("return x => {", output);
+        Assert.Contains("return x =>\n{", output);
         Assert.Contains(" = x + 1;", output);
         Assert.Contains("return ", output);
         Assert.Contains(" * ", output);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
@@ -91,7 +91,10 @@ public sealed partial class CSharpPrinter
     /// expression body or <c>=&gt; { ... }</c> otherwise. A single parameter
     /// drops the parentheses. Zero-local bodies reuse the current printer so
     /// capture substitutions still bind to the outer scope; local-bearing bodies
-    /// are non-capturing and print through an isolated lambda scope.
+    /// are non-capturing and print through an isolated lambda scope. A block body
+    /// with more than one statement expands across lines like any other
+    /// statement block (see <see cref="LambdaBlockText"/>); a single-statement
+    /// block stays inline, matching a developer's own shorthand for a trivial body.
     /// </summary>
     string LambdaText(Lambda lambda)
     {
@@ -102,19 +105,73 @@ public sealed partial class CSharpPrinter
         if (lambda.ExpressionBody is { } expr)
             return $"{parameters} => {ExpressionTreeBodyText(lambda, expr)}";
 
-        if (NeedsNestedLambdaScope(lambda))
-            return $"{parameters} => {{ {LambdaBodyWithLocalScope(lambda)} }}";
-
-        var statements = lambda.Body.Blocks
-            .SelectMany(b => b.Children)
-            .Select(LambdaStatement)
-            .Where(s => s is not null);
-        if (LambdaReturnType(lambda) is { } returnType
-            && NeedsUnsupportedFallbackReturn(returnType, requiresAsyncBodyModifier: false, lambda.Body))
+        int statementCount = lambda.Body.Blocks.SelectMany(b => b.Children).Count();
+        if (LambdaReturnType(lambda) is { } fallbackReturnType
+            && NeedsUnsupportedFallbackReturn(fallbackReturnType, requiresAsyncBodyModifier: false, lambda.Body))
         {
-            statements = statements.Append("return default;");
+            statementCount++;
         }
-        return $"{parameters} => {{ {string.Join(" ", statements)} }}";
+
+        if (NeedsNestedLambdaScope(lambda))
+        {
+            string bodyText = LambdaBodyTextWithLocalScope(lambda);
+            return statementCount > 1
+                ? LambdaBlockText(parameters, bodyText)
+                : $"{parameters} => {{ {FlattenLambdaBodyText(bodyText)} }}";
+        }
+
+        // Building the child statement texts one indent level deeper keeps any
+        // nested lambda block expansion (a lambda-in-lambda) aligned to where
+        // that statement will actually land once LambdaBlockText re-applies
+        // _statementIndent for the outer braces below.
+        int enclosingIndent = _statementIndent;
+        _statementIndent = enclosingIndent + 1;
+        List<string> statements;
+        try
+        {
+            statements = lambda.Body.Blocks
+                .SelectMany(b => b.Children)
+                .Select(LambdaStatement)
+                .Where(s => s is not null)
+                .Select(s => s!)
+                .ToList();
+            if (LambdaReturnType(lambda) is { } returnType
+                && NeedsUnsupportedFallbackReturn(returnType, requiresAsyncBodyModifier: false, lambda.Body))
+            {
+                statements.Add("return default;");
+            }
+        }
+        finally
+        {
+            _statementIndent = enclosingIndent;
+        }
+
+        return statements.Count > 1
+            ? LambdaBlockText(parameters, string.Join(Environment.NewLine, statements))
+            : $"{parameters} => {{ {string.Join(" ", statements)} }}";
+    }
+
+    /// <summary>
+    /// Renders a multi-statement lambda block body expanded across lines, the
+    /// way every other statement block prints, instead of collapsed onto the
+    /// lambda's own line. <paramref name="bodyText"/> is one statement per line,
+    /// already indented relative to column 0 (as <see cref="Statement"/> output or
+    /// a nested <see cref="PrintBody"/> render is); braces align to <see
+    /// cref="_statementIndent"/> — the enclosing statement's own indentation —
+    /// rather than wherever the lambda happens to start inside that statement's
+    /// expression tree, matching how a developer would have written the block.
+    /// </summary>
+    string LambdaBlockText(string parameters, string bodyText)
+    {
+        string pad = new(' ', _statementIndent * 4);
+        string innerPad = new(' ', (_statementIndent + 1) * 4);
+        var sb = new StringBuilder();
+        sb.Append(parameters).Append(" =>").Append(Environment.NewLine);
+        sb.Append(pad).Append('{').Append(Environment.NewLine);
+        foreach (var line in bodyText.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries))
+            sb.Append(innerPad).Append(line).Append(Environment.NewLine);
+        sb.Append(pad).Append('}');
+        return sb.ToString();
     }
 
     // An expression-tree lambda body compiles (at the consuming site) into an
@@ -157,7 +214,8 @@ public sealed partial class CSharpPrinter
         => !lambda.Locals.IsEmpty
             || lambda.Body.Descendants.Any(node => node is LoadStackSlot or StoreStackSlot);
 
-    string LambdaBodyWithLocalScope(Lambda lambda)
+    /// <summary>Renders a locals-bearing lambda body through an isolated nested printer, trimmed but not yet flattened.</summary>
+    string LambdaBodyTextWithLocalScope(Lambda lambda)
     {
         var body = lambda.Body;
         body.Detach();
@@ -174,8 +232,7 @@ public sealed partial class CSharpPrinter
                 UsesUpdatedMemorySafetyRules = lambda.UsesUpdatedMemorySafetyRules,
                 SkipLocalsInit = lambda.SkipLocalsInit,
             };
-            var text = new CSharpPrinter(function, _options, CurrentScopeNames()).PrintBody(function).Trim();
-            return string.Join(" ", text.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Select(line => line.Trim()));
+            return new CSharpPrinter(function, _options, CurrentScopeNames()).PrintBody(function).Trim();
         }
         finally
         {
@@ -183,6 +240,9 @@ public sealed partial class CSharpPrinter
             lambda.ResetBody(body);
         }
     }
+
+    static string FlattenLambdaBodyText(string bodyText)
+        => string.Join(" ", bodyText.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Select(line => line.Trim()));
 
     string? LambdaStatement(IrNode node) => node switch
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -40,6 +40,15 @@ public sealed partial class CSharpPrinter
     /// </summary>
     int _unsafeDepth;
 
+    /// <summary>
+    /// Indentation level of the statement currently being emitted by <see
+    /// cref="AppendStatement"/>. A multi-statement lambda block body found while
+    /// rendering that statement's expression tree (however deeply nested inside
+    /// argument lists, assignments, etc.) expands its braces to this level rather
+    /// than staying on one line, matching how every other statement block prints.
+    /// </summary>
+    int _statementIndent;
+
     readonly PrinterOptions _options;
     readonly HashSet<string> _reservedScopeNames;
     readonly List<DecompilerDecision> _decisions = [];
@@ -1465,6 +1474,7 @@ public sealed partial class CSharpPrinter
     /// <summary>Recursive statement emission with indentation — structured nodes (IfStatement) nest, flat statements render through <see cref="Statement"/>.</summary>
     void AppendStatement(StringBuilder sb, IrNode node, int indent)
     {
+        _statementIndent = indent;
         if (_statementLines is not null)
         {
             int startLine = 0;


### PR DESCRIPTION
## What

Fixes #2952: the C# printer previously always rendered a lambda's block body
as a single line (`x => { stmt1 stmt2 }`), regardless of statement count,
because lambda expression text is composed inline with no indent awareness.
This did not match the shape a developer wrote, or the shape the printer
already uses for every other statement block.

Real witness: `System.CommandLine.Command::SetAction:1`:

```csharp
// before
Action = new AnonymousSynchronousCommandLineAction(context => { action.Invoke(context); return 0; });

// after
Action = new AnonymousSynchronousCommandLineAction(context =>
{
    action.Invoke(context);
    return 0;
});
```

## How

- Added `int _statementIndent`, mirroring the existing `_checkedContext` /
  `_unsafeDepth` ambient-context pattern: `AppendStatement` sets it to the
  indent of the statement currently being emitted.
- `LambdaText` now counts top-level statements in the lambda body (both the
  locals-bearing nested-scope path and the plain non-capturing path) and,
  when there is more than one, expands the block across lines via a new
  `LambdaBlockText` helper whose braces align to `_statementIndent` — the
  enclosing statement's own indentation — rather than wherever the lambda
  happens to start inside that statement's expression tree.
- A single-statement block body, and expression-bodied lambdas, stay inline
  (per the issue's guidance that only clearly multi-statement blocks need to
  expand).
- The non-nested-scope path also temporarily bumps `_statementIndent` while
  composing its own child-statement texts, so a lambda nested inside another
  expanding lambda's block aligns correctly at the deeper level.

## Testing

- Updated three existing `LambdaRaisingPassTests` golden-string assertions to
  the new multi-line shape (`StatementBodyLambda`, `LocalBodyLambda`,
  `CapturingLocalBodyLambda`).
- Added `StatementBodyLambdaInsideIf` fixture + test exercising a lambda
  returned from inside a nested `if` (one indent level deeper than the method
  body), confirming the expanded block's braces track the enclosing
  statement's indentation rather than always aligning to column 0.
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config` —
  clean.
- `ILInspector.Decompiler.Tests -trait "Area=Pass" -trait- "Speed=Slow"` — 1120
  tests, 1 failure (`NullCoalescingAssignmentPassTests.LazyFieldGetter_RecompilesOpcodeExact`,
  a Roslyn compile-back environment failure reproduced identically on a clean
  `origin/main` checkout in this environment — unrelated to this change).
- `ILInspector.Decompiler.Tests -class "*LambdaRaisingPassTests*"` — 20/20
  pass.

## Risk

Moderate: changes real printer output shape for multi-statement lambda block
bodies (not just an internal kernel). Adversarial review planned.
