### PR TITLE
Extract shared Unify decision from Raise/FinishSwitchRaise into TryUnify

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -104,31 +104,9 @@ public sealed class SwitchRaisingPass : IIrPass
         var owned = new HashSet<int>();
         int? join = null;
 
-        // Two exits unify not only when identical, but when one flows into the
-        // other through a chain of plain, unclaimed, single-successor blocks —
-        // e.g. a case-local "no match" arm and a shared miss-handler that falls
-        // into the same terminating return. The upstream (earlier) block becomes
-        // the join, so the chain is naturally emitted once as switch-trailing
-        // code; the tiling check below still rejects the join if some other
-        // owned block ends up past it.
-        bool Unify(int j)
-        {
-            if (join is not { } existing)
-            {
-                join = j;
-                return true;
-            }
-            if (existing == j)
-                return true;
-            if (ChasesTo(blocks, existing, j, caseTargets, offsetToIndex, owned))
-                return true;   // existing join already flows into j — keep it
-            if (ChasesTo(blocks, j, existing, caseTargets, offsetToIndex, owned))
-            {
-                join = j;   // j is upstream of the existing join — adopt it
-                return true;
-            }
-            return false;
-        }
+        // See TryUnify's doc comment for the exit-unification rule (shared with
+        // FinishSwitchRaise's identical need below).
+        bool Unify(int j) => TryUnify(blocks, caseTargets, offsetToIndex, owned, ref join, j);
 
         // Each distinct case target grows into its single-entry region; the
         // region's exits unify to the shared join (or it terminates).
@@ -611,6 +589,41 @@ public sealed class SwitchRaisingPass : IIrPass
                 Add(idx, t);
         }
         return preds;
+    }
+
+    /// <summary>
+    /// Decides whether exit <paramref name="j"/> unifies with the current
+    /// candidate join in <paramref name="join"/>: two exits unify not only when
+    /// identical, but when one flows into the other through a chain of plain,
+    /// unclaimed, single-successor blocks (see <see cref="ChasesTo"/>) — e.g. a
+    /// case-local "no match" arm and a shared miss-handler that falls into the
+    /// same terminating return. The upstream (earlier) block becomes the join,
+    /// so the chain is naturally emitted once as trailing code after the switch;
+    /// the caller's own tiling check afterward still rejects the join if some
+    /// other owned block ends up past it.
+    ///
+    /// Shared by <see cref="Raise"/> and <see cref="FinishSwitchRaise"/> — the
+    /// two independent case-region-growing raisers — so a fix to this decision
+    /// applies to both instead of risking the two drifting out of sync (see
+    /// issue #2971).
+    /// </summary>
+    static bool TryUnify(IReadOnlyList<Block> blocks, int[] caseTargets, Dictionary<int, int> offsetToIndex, HashSet<int> owned, ref int? join, int j)
+    {
+        if (join is not { } existing)
+        {
+            join = j;
+            return true;
+        }
+        if (existing == j)
+            return true;
+        if (ChasesTo(blocks, existing, j, caseTargets, offsetToIndex, owned))
+            return true;   // existing join already flows into j — keep it
+        if (ChasesTo(blocks, j, existing, caseTargets, offsetToIndex, owned))
+        {
+            join = j;   // j is upstream of the existing join — adopt it
+            return true;
+        }
+        return false;
     }
 
     /// <summary>
@@ -1202,28 +1215,11 @@ public sealed class SwitchRaisingPass : IIrPass
         var owned = new HashSet<int>();
         int? join = null;
 
-        // See the matching comment on Unify in Raise: two exits also unify when
-        // one flows into the other through a chain of plain, unclaimed,
-        // single-successor blocks (a case-local miss arm chaining into a shared
-        // miss-handler that falls into the same terminating join).
-        bool Unify(int j)
-        {
-            if (join is not { } existing)
-            {
-                join = j;
-                return true;
-            }
-            if (existing == j)
-                return true;
-            if (ChasesTo(blocks, existing, j, caseTargets, offsetToIndex, owned))
-                return true;   // existing join already flows into j — keep it
-            if (ChasesTo(blocks, j, existing, caseTargets, offsetToIndex, owned))
-            {
-                join = j;   // j is upstream of the existing join — adopt it
-                return true;
-            }
-            return false;
-        }
+        // Uses the same exit-unification rule as Raise (see TryUnify's doc
+        // comment) — this is the fix for issue #2954/#2971: FinishSwitchRaise
+        // ties its own region-growing/tiling logic and previously had a
+        // separately-drifted copy of this decision.
+        bool Unify(int j) => TryUnify(blocks, caseTargets, offsetToIndex, owned, ref join, j);
         var regions = new Dictionary<int, List<int>>();
 
         foreach (int target in caseTargets.Distinct())


### PR DESCRIPTION
Fixes #2971

## Change

`SwitchRaisingPass` has two independent case-region-growing raisers,
`Raise` (drives the IL `switch` opcode raiser) and `FinishSwitchRaise`
(drives `RaiseStringEqualityChain` and the hash/length-bucket and
sparse-int raisers), each with its own local `Unify` function deciding
when two case-region exits converge on a shared join. The two were
byte-for-byte identical, and PR #2966 (issue #2954) had to fix the same
defect in both separately — the first commit only touched `Raise`''s copy,
and the gap in `FinishSwitchRaise` was caught only by adversarial review
(Gemini 3.1 Pro), not by the original implementer or the first-round Opus
review.

This PR extracts the identical decision logic into a single shared static
`TryUnify(..., ref int? join, int j)`, called by both `Raise`''s and
`FinishSwitchRaise`''s own `Unify` local functions as one-line forwarders.
`join` itself stays a local variable in each function (it's inherently
per-call-site state); only the decision/mutation logic is shared. This
makes a future fix to the unification rule structurally impossible to
apply to only one of the two raisers.

**No other logic in `Raise` or `FinishSwitchRaise` changed** — this is a
pure mechanical move: same inputs (`blocks`, `caseTargets`, `offsetToIndex`,
`owned`), same `ChasesTo` calls, same result, in the same order.

Region-growing/tiling logic *around* `Unify` in the two functions
(`GrowRegion` calls, default-handling branches, tiling/bounds checks,
`OnlyReachedByTable` vs `OnlyReachedByChain`) genuinely differs between the
two raisers (different dispatch models: table dispatch at a single block vs.
a chain of blocks) and was intentionally left alone — extracting that too
would be a much larger, riskier refactor for uncertain benefit. Per the
issue, at minimum this closes the exact gap that caused #2954''s missed fix.

## Evidence

- Build: clean, 0 errors.
- Fast broad sweep (`-trait "Area=Pass" -trait- "Speed=Slow"`, new in #2979):
  1006 of 1119 tests selected, 1 failed — `NullCoalescingAssignmentPassTests
  .LazyFieldGetter_RecompilesOpcodeExact` (`RecompileFail`), confirmed
  pre-existing by re-running the identical test with this change stashed out
  (fails identically pre-change).
- Targeted switch-raising suite (`SwitchRaisingSharedMissHandlerTests`,
  `StringSwitchRaisingTests`, `SwitchExpressionRaisingTests`,
  `SwitchDuplicateLabelTests`, `IdiomShapeScorecard`,
  `SparseIntSwitchRaisingTests`, `SwitchBranchRenderingTests`,
  `NestedScopeNameCollisionTests`): 41 tests, 1 failed — the known
  pre-existing `SmallStringSwitch_RendersSwitchOnString` CRLF-vs-LF mismatch,
  unrelated (also present on `main`).
- Real-world witness (`Humanizer.MalteseFormatter.GetResourceKey`,
  Humanizer.core 3.0.10): rendered output is byte-identical, before and
  after this change — confirms `Raise`''s behavior through the refactor.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile ./nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -trait "Area=Pass" -trait- "Speed=Slow"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "*SwitchRaisingSharedMissHandlerTests*" -class "*StringSwitchRaisingTests*" -class "*SwitchExpressionRaisingTests*" -class "*SwitchDuplicateLabelTests*" -class "*IdiomShapeScorecard*" -class "*SparseIntSwitchRaisingTests*" -class "*SwitchBranchRenderingTests*" -class "*NestedScopeNameCollisionTests*"
```

Touches core switch-raising logic (`SwitchRaisingPass.cs`), so per AGENTS.md
this will go through two-model adversarial review even though it is a
behavior-preserving mechanical extraction, not a new heuristic.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>