### PR TITLE
Use CopyOutputSymbolsToPublishDirectory instead of a .dSYM strip target

### DIFF
--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -32,6 +32,9 @@
     <!-- RID-specific tool packaging: Native AOT for common platforms, CoreCLR fallback for others -->
     <ToolPackageRuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-arm64;any</ToolPackageRuntimeIdentifiers>
     <PublishAot>true</PublishAot>
+    <!-- Keep debug symbols (.pdb/.dbg and the macOS .dSYM bundle) out of the
+         published tool package. -->
+    <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">
@@ -79,17 +82,5 @@
     <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>
-
-  <Target Name="StripSymbolsFromPublishOutput" AfterTargets="Publish" Condition="'$(PublishAot)' == 'true' and '$(PackAsTool)' == 'true'">
-    <ItemGroup>
-      <PublishSymbolFiles Include="$(PublishDir)**/*.pdb" />
-      <PublishSymbolFiles Include="$(PublishDir)**/*.dbg" />
-      <!-- macOS Native AOT emits a .dSYM debug bundle (a directory, so it needs
-           RemoveDir rather than the file glob above). -->
-      <PublishSymbolBundles Include="$([System.IO.Directory]::GetDirectories('$(PublishDir)', '*.dSYM'))" />
-    </ItemGroup>
-    <Delete Files="@(PublishSymbolFiles)" />
-    <RemoveDir Directories="@(PublishSymbolBundles)" />
-  </Target>
 
 </Project>


### PR DESCRIPTION
## What

Replace the `StripSymbolsFromPublishOutput` target with a single MSBuild
property:

```xml
<CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
```

## Why

The strip target (merged in #2986) had to `Delete` `.pdb`/`.dbg` files *and*
`RemoveDir` the macOS `.dSYM` bundle (a directory the file glob can't match).
`CopyOutputSymbolsToPublishDirectory=false` keeps all debug symbols out of the
publish directory — and thus the tool package — in one platform-agnostic line,
with no post-publish file/directory gymnastics.

Follow-up to #2986. No version bump. Mirrors the same change in
dotnet-install and dotnet-runtimeinfo.

## Verified

`osx-arm64` package contains only `DotnetToolSettings.xml` + the stripped native
binary; `dSYM` and `pdb` entries: 0 (validated on the sibling tools with
identical csproj wiring).
