### PR TITLE
Fix stale _statementIndent in DoWhileLoop/TryCatch/Switch

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CSharpPrinterStatementIndentTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpPrinterStatementIndentTests.cs
@@ -1,0 +1,123 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Printer-only regression coverage for the #2952 follow-up (PR #2987 adversarial
+// review): _statementIndent is set unconditionally at AppendStatement entry with
+// no general save/restore, which is only safe when a statement's own expression
+// composition happens entirely *before* any nested child-block render. DoWhileLoop
+// (condition evaluated after the body) and TryCatch (catch header/filter evaluated
+// after the try body and each preceding catch body) are the two counterexamples —
+// both are fixed by resetting _statementIndent right before the subsequent
+// expression composes. These tests build the IR directly (bypassing
+// LambdaRaisingPass, which does not raise a lambda passed as a delegate-cache
+// argument inside a loop condition or catch filter in this environment) so the
+// printer's indent bookkeeping is exercised in isolation.
+[Trait("Area", "Pass")]
+public class CSharpPrinterStatementIndentTests
+{
+    static readonly TypeRef Holder = TypeRef.Definition("synthetic", "", "Holder");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef ListOfInt = TypeRef.GenericInstance(TypeRef.Definition("System.Private.CoreLib", "System.Collections.Generic", "List`1"), [Int32]);
+
+    static Lambda MultiStatementPredicate()
+    {
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new ExpressionStatement(new Call(new MethodRef(Holder, "Log", Void, [Int32], HasThis: false), isVirtual: false, [new LoadArgument(0, "x", Int32)])));
+        block.Add(new Return(new Comparison(ComparisonKind.GreaterThan, isUnsigned: false, new LoadArgument(0, "x", Int32), new Constant(0, Int32))));
+        body.Add(block);
+        return new Lambda(
+            TypeRef.GenericInstance(TypeRef.Definition("System.Private.CoreLib", "System", "Predicate`1"), [Int32]),
+            [new Parameter("x", Int32)],
+            [], [], usesUpdatedMemorySafetyRules: false, skipLocalsInit: false,
+            body);
+    }
+
+    [Fact]
+    public void MultiStatementLambda_InDoWhileCondition_AlignsBracesToLoopStatementIndent()
+    {
+        // The do/while's own body is the deeper (indent-1) container that
+        // renders first; the condition (holding the multi-statement lambda)
+        // renders after it, so a stale _statementIndent would misalign the
+        // lambda's braces to the body's indent instead of the loop's own.
+        var loopBody = new BlockContainer();
+        var loopBlock = new Block(0);
+        loopBlock.Add(new ExpressionStatement(new Call(new MethodRef(Holder, "Tick", Void, [], HasThis: false), isVirtual: false, [])));
+        loopBody.Add(loopBlock);
+
+        var condition = new Call(
+            new MethodRef(ListOfInt, "Exists", Bool, [TypeRef.GenericInstance(TypeRef.Definition("System.Private.CoreLib", "System", "Predicate`1"), [Int32])], HasThis: true),
+            isVirtual: false,
+            [new LoadArgument(0, "items", ListOfInt), MultiStatementPredicate()]);
+
+        var doWhile = new DoWhileLoop(loopBody, condition);
+        var function = Function(SingleStatement(doWhile));
+
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n");
+
+        Assert.Contains(
+            "while (items.Exists(x =>\n" +
+            "{\n" +
+            "    Log(x);\n" +
+            "    return x > 0;\n" +
+            "}));",
+            output);
+    }
+
+    [Fact]
+    public void MultiStatementLambda_InCatchFilter_AlignsBracesToCatchStatementIndent()
+    {
+        // The preceding try body renders before the catch clause's own header
+        // (the exception type/`when` filter), so a stale _statementIndent left
+        // over from the try body would misalign the filter's lambda braces.
+        var tryBody = new BlockContainer();
+        var tryBlock = new Block(0);
+        tryBlock.Add(new ExpressionStatement(new Call(new MethodRef(Holder, "Tick", Void, [], HasThis: false), isVirtual: false, [])));
+        tryBody.Add(tryBlock);
+
+        var filter = new Call(
+            new MethodRef(ListOfInt, "Exists", Bool, [TypeRef.GenericInstance(TypeRef.Definition("System.Private.CoreLib", "System", "Predicate`1"), [Int32])], HasThis: true),
+            isVirtual: false,
+            [new LoadArgument(0, "items", ListOfInt), MultiStatementPredicate()]);
+
+        var catchBody = new BlockContainer();
+        var catchBlock = new Block(0);
+        catchBlock.Add(new ExpressionStatement(new Call(new MethodRef(Holder, "Handle", Void, [], HasThis: false), isVirtual: false, [])));
+        catchBody.Add(catchBlock);
+
+        var catchClause = new CatchClause(TypeRef.CoreLib("System", "Exception"), catchBody, filter);
+        var tryCatch = new TryCatch(tryBody, [catchClause]);
+        var function = Function(SingleStatement(tryCatch));
+
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n");
+
+        Assert.Contains(
+            "catch (Exception) when (items.Exists(x =>\n" +
+            "{\n" +
+            "    Log(x);\n" +
+            "    return x > 0;\n" +
+            "}))",
+            output);
+    }
+
+    static BlockContainer SingleStatement(IrNode statement)
+    {
+        var container = new BlockContainer();
+        var block = new Block(0);
+        block.Add(statement);
+        container.Add(block);
+        return container;
+    }
+
+    static IrFunction Function(BlockContainer body)
+        => new(
+            "M",
+            Holder,
+            new MethodSignature(Void, [new Parameter("items", ListOfInt)], HasThis: false, GenericParameterCount: 0),
+            ImmutableArray<TypeRef>.Empty,
+            body);
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1641,6 +1641,11 @@ public sealed partial class CSharpPrinter
             sb.Append(pad).AppendLine("do");
             sb.Append(pad).AppendLine("{");
             AppendContainer(sb, doWhile.Body, indent + 1);
+            // The body's own AppendStatement calls left _statementIndent at the
+            // deepest nested statement's level; restore it to this statement's
+            // own indent before the condition (itself part of this statement,
+            // not the body) renders, so a lambda inside it aligns correctly.
+            _statementIndent = indent;
             sb.Append(pad).Append("}").Append(Environment.NewLine).Append(pad)
                 .Append("while (").Append(Condition(doWhile.Condition)).AppendLine(");");
             return;
@@ -1653,6 +1658,11 @@ public sealed partial class CSharpPrinter
             sb.Append(pad).AppendLine("}");
             foreach (var clause in tryCatch.Clauses)
             {
+                // As in the do/while condition above, a preceding body (the try
+                // body, or an earlier catch's body) leaves _statementIndent
+                // deeper than this statement's own indent; restore it before
+                // CatchHeader (which may render a filter's `when (...)` lambda).
+                _statementIndent = indent;
                 sb.Append(pad).AppendLine(CatchHeader(clause));
                 sb.Append(pad).AppendLine("{");
                 AppendContainer(sb, clause.Body, indent + 1);
@@ -1740,6 +1750,11 @@ public sealed partial class CSharpPrinter
             var labelEnum = SwitchLabelEnumType(switchNode.Value);
             foreach (var section in switchNode.Sections)
             {
+                // A prior section's body (AppendContainer below) leaves
+                // _statementIndent deeper than this statement's own indent;
+                // restore it before this section's own labels render (a `when`
+                // pattern guard could, in principle, contain a lambda).
+                _statementIndent = indent;
                 foreach (var label in section.Labels)
                     sb.Append(labelPad).Append("case ").Append(SwitchLabelText(label, labelEnum)).AppendLine(":");
                 if (section.IsDefault)


### PR DESCRIPTION
## Context

PR #2987 (issue #2952: expand multi-statement lambda block bodies
across lines in the printer) added a _statementIndent field that
AppendStatement sets unconditionally at entry, with no general
save/restore. That is only safe when a statement's own expression
composition happens entirely *before* any nested child-block render.

Adversarial review (Gemini 3.1 Pro) on PR #2987 found three
counterexamples where that assumption doesn't hold, all still
unresolved because #2987 was merged before the fix landed:

- **DoWhileLoop**: the condition is evaluated *after* the body.
- **TryCatch**: each catch clause's header/filter is evaluated *after*
  the try body and after each preceding catch clause's body.
- **Switch**: each section's case labels render after the previous
  section's body (a ` when ` pattern guard could in principle hold a
  lambda).

A multi-statement lambda in a do/while condition, a ` catch when (...) `
filter, or (in principle) a switch case guard renders its block braces
at the stale, deeper indent left over from the preceding body instead
of the enclosing statement's own indent.

## Fix

Reset ` _statementIndent = indent; ` right before each of these three
locations composes its own expression, mirroring the existing pattern
already used elsewhere in the printer (e.g. \IfStatement\, \ForLoop\).

## Evidence

Added \CSharpPrinterStatementIndentTests\, which builds IR directly
(bypassing \LambdaRaisingPass\, which does not raise a lambda passed as
a delegate-cache argument inside a loop condition or catch filter in
this environment, so a compiled source fixture can't exercise this) to
regression-test the DoWhileLoop and TryCatch cases:

- Verified both new tests **fail** without the fix (confirmed by
  temporarily reverting the \_statementIndent\ resets) and **pass**
  with it.
- Full solution build: \dotnet build dotnet-inspect.slnx -c Release
  --configfile nuget.config\ — succeeded.
- Fast targeted suite: \ILInspector.Decompiler.Tests.exe -trait
  \"Area=Pass\" -trait- \"Speed=Slow\"\ — 1121/1122 passed; the 1 failure
  (\NullCoalescingAssignmentPassTests.LazyFieldGetter_RecompilesOpcodeExact\)
  is a pre-existing environment issue unrelated to this change (also
  fails on a clean \origin/main\ checkout).

Low-risk, mechanical fix scoped to three narrow indent-bookkeeping
sites with new regression tests proving both the bug and the fix;
adversarial review still requested per repo convention given the
non-trivial correctness nature of the original bug.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>