### PR TITLE
Render Performance Evidence column as a code span

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -920,6 +920,45 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task PerformanceAsyncEvidence_RendersAsCodeSpan_WithoutHtmlEscapingCompilerName()
+    {
+        // Evidence embeds compiler-generated names with angle brackets (e.g. the async state
+        // machine <GetAsyncEnumerator>d__1). It must render as a code span like the Member and
+        // Allocation columns, showing the brackets literally — not HTML-escaped as &lt;/&gt;.
+        var (exit, output, error) = await RunAppAsync(
+            "library", "System.Text.Json", "-S", "Performance: Async", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Performance: Async", output);
+        Assert.Contains("async state-machine allocation (<", output);
+        Assert.DoesNotContain("async state-machine allocation (&lt;", output);
+
+        // Machine output stays raw (no code-span markup, unescaped brackets).
+        var (tsvExit, tsv, _) = await RunAppAsync(
+            "library", "System.Text.Json", "-S", "Performance: Async", "--tsv", "--tips", "q");
+        Assert.Equal(0, tsvExit);
+        Assert.Contains("async state-machine allocation (<", tsv);
+        Assert.DoesNotContain("&lt;", tsv);
+    }
+
+    [Fact]
+    public async Task PerformanceTriageEvidence_TypeScope_RendersAsCodeSpan_WithoutHtmlEscapingGenerics()
+    {
+        // The type/member Performance Triage lens has the same Evidence column; a generic value-type
+        // box (box System.Memory<T>) must render as a code span with literal angle brackets, not the
+        // HTML-escaped &lt;T&gt;. The Allocation column already renders it literally.
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.Text.Json.Serialization.Converters.MemoryConverter",
+            "--platform", "System.Text.Json", "--all", "-S", "Performance Triage", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("box System.Memory<T>", output);
+        Assert.DoesNotContain("box System.Memory&lt;T&gt;", output);
+    }
+
+    [Fact]
     public async Task PerformanceGroup_RendersMultipleKindSections()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1928,7 +1928,7 @@ public static class ApiOutputFormatter
                 opportunity.Shape,
                 opportunity.Operation,
                 opportunity.OperandToken is { } token ? MarkoutInline.Code($"0x{token:X8}") : null,
-                opportunity.Evidence,
+                MarkoutInline.Code(opportunity.Evidence),
                 opportunity.SafeFixDirection,
                 opportunity.Confidence,
                 LibraryMetadataService.IteratesInLoop(opportunity) ? "loop" : "",

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -795,7 +795,7 @@ public class LibraryInspectionView
             .Where(o => PerformanceKinds.SectionForShape(o.Shape) == section)
             .Select(o => new PerformanceRow(
                 MarkoutInline.Code(o.Member),
-                o.Evidence,
+                MarkoutInline.Code(o.Evidence),
                 o.Allocation is null ? null : MarkoutInline.Code(o.Allocation),
                 string.IsNullOrEmpty(o.Loop) ? null : o.Loop,
                 o.RootReach.ToString(),


### PR DESCRIPTION
## What

The `Evidence` column in the library `@Performance` kind sections and the type/member `Performance Triage` lens was emitted as plain text, so markdown HTML-escaped embedded compiler-generated and generic names while the neighboring `Member` and `Allocation` columns rendered them literally in code spans.

Example (before): the async state machine showed as `async state-machine allocation (&lt;GetAsyncEnumerator&gt;d__1)` — raw entities in a terminal — while the `Allocation` cell next to it rendered `<GetAsyncEnumerator>d__1` literally. `box System.Memory<T>` had the same problem at type scope (`box System.Memory&lt;T&gt;`).

## Fix

Wrap `Evidence` in the existing `MarkoutInline.Code(...)` helper in both renderers (`LibraryInspectionView.PerformanceRowsFor` and `ApiOutputFormatter`), matching the adjacent columns. The brackets now render literally inside a code span.

## Machine output unchanged

Markout strips the `<code>` wrapper for `--tsv`/`--jsonl`, so `Evidence` stays raw there (verified, and asserted in a test).

## Tests

- `PerformanceAsyncEvidence_RendersAsCodeSpan_WithoutHtmlEscapingCompilerName` — library async state-machine name; markdown literal `<`, no `&lt;`; tsv raw.
- `PerformanceTriageEvidence_TypeScope_RendersAsCodeSpan_WithoutHtmlEscapingGenerics` — type-scope `box System.Memory<T>`.

Full CLI suite: 1979 total, 2 failed (pre-existing Darwin PInvoke `Interop.User32`, unrelated), 10 skipped.

## Risk

Low-risk, mechanical rendering fix: wraps two fields in an existing helper to match adjacent columns, machine output unchanged, covered by regression tests. Per AGENTS.md, simple/mechanical changes don't require adversarial review.
