### PR TITLE
Re-materialize a dup'd constant instead of spilling to a slot (#2982)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5225,3 +5225,19 @@ public class BackingFieldSample
     // Reads no field, so the walk reports nothing.
     public int NoFieldAccess(int x) => x + 1;
 }
+
+// Regression fixtures for #2982: a constant assigned in a chain (`a = b = c = false`)
+// compiles to `ldc.i4.0; dup; call set_C; dup; call set_B; call set_A` — the shared
+// literal is dup'd to each sink. The importer must re-materialize the dup'd constant
+// at each bool sink so it renders `A = false;`, not spill it into an int stack slot
+// (`int S = 0; A = S;`), which is CS0029 (cannot implicitly convert int to bool).
+public static class ChainedConstantAssignmentSamples
+{
+    public static bool A { get; set; }
+
+    public static bool B { get; set; }
+
+    public static bool C { get; set; }
+
+    public static void ChainedBoolFalse() => A = B = C = false;
+}

--- a/src/ILInspector.Decompiler.Tests/ChainedConstantAssignmentTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ChainedConstantAssignmentTests.cs
@@ -1,0 +1,49 @@
+using System;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// #2982: a constant assigned through a chain (`a = b = c = false`) is dup'd to each
+// sink in IL (`ldc.i4.0; dup; call set_C; dup; call set_B; call set_A`). The importer
+// must re-materialize the dup'd constant at each bool sink so per-sink constant
+// recovery fires and it renders `= false` — not spill it into an int stack slot
+// (`int S = 0; a = S;`), which is CS0029 (cannot implicitly convert int to bool).
+public class ChainedConstantAssignmentTests
+{
+    static string Render(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(ChainedConstantAssignmentSamples).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(ChainedConstantAssignmentSamples).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void ChainedBoolConstant_RendersLiteralAtEachSink_NotIntSpill()
+    {
+        var output = Render(nameof(ChainedConstantAssignmentSamples.ChainedBoolFalse));
+
+        // Each of the three chained sinks receives the bool literal directly.
+        Assert.Equal(3, CountOccurrences(output, "= false;"));
+
+        // The dup'd constant is not spilled into an int stack slot: the #2982 defect
+        // rendered `int S_256 = 0; ...A = S_256;` — CS0029 at every bool sink.
+        Assert.DoesNotContain("int S", output);
+        Assert.DoesNotContain("S_", output);
+    }
+
+    static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1367,8 +1367,23 @@ public static class IrImporter
 
                 case ILOpCode.Dup:
                 {
-                    // Trees cannot share nodes: dup materializes through a slot.
                     var value = Pop(stack);
+                    // A pure constant has no identity or side effect to preserve,
+                    // so re-materializing it (a fresh clone per use) keeps the
+                    // tree-node invariant without a spill slot. A shared int slot
+                    // would fix the constant's stack type (int32) and strand each
+                    // consumer's semantic type: a dup'd bool constant threaded
+                    // into `set_X(bool)` sinks renders as `int S = 0; X = S;`
+                    // (CS0029, #2982), because per-sink identity recovery
+                    // (TypedConstantsPass) never reaches the slot store. Cloning
+                    // the constant to each sink lets that recovery fire per use.
+                    if (value is Constant)
+                    {
+                        stack.Push(value);
+                        stack.Push((IrExpression)value.Clone());
+                        break;
+                    }
+                    // Trees cannot share nodes: dup materializes through a slot.
                     int slot = state.NextDupSlot++;
                     body.Add(new StoreStackSlot(slot, value));
                     stack.Push(new LoadStackSlot(slot, value.ResultType));


### PR DESCRIPTION
- Fixes #2982
- Changes the IL importer to re-materialize a dup'd pure constant (clone per use) instead of spilling it to an int stack slot, so per-sink constant recovery renders the correctly typed literal
- Card revision: `1d8d9a7a`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — a dup'd `bool` constant now renders `= false` at each sink instead of `int S = 0; X = S;` (CS0029), fixing the reported invalid output with no new fidelity or corpus regression.

### Original source

Acquired with `dotnet-inspect member "Dapper.SqlMapper.Settings" "SetDefaults" --package Dapper@2.1.79 --all -S "Original Source"` (SourceLink C#):

```csharp
public static void SetDefaults()
{
    CommandTimeout = null;
    ApplyNullValues = PadListExpansions = UseIncrementalPseudoPositionalParameterNames = PreferTypeHandlersForEnums = false;
    AllowedCommandBehaviors = DefaultAllowedCommandBehaviors;
    FetchSize = InListStringSplitCount = -1;
}
```

### Before

Acquired with `-S "Decompiled Source"` at the base commit (`origin/main`, 317b8dff):

```csharp
public static void SetDefaults()
{
    Nullable<int> V_0 = default;
    Settings.CommandTimeout = V_0;
    int S_256 = 0;
    Settings.PreferTypeHandlersForEnums = S_256;
    int S_257 = S_256;
    Settings.UseIncrementalPseudoPositionalParameterNames = S_257;
    int S_258 = S_257;
    Settings.PadListExpansions = S_258;
    Settings.ApplyNullValues = S_258;
    Settings.AllowedCommandBehaviors = unchecked((CommandBehavior)(-10));
    int S_259 = -1;
    Settings.InListStringSplitCount = S_259;
    Settings.FetchSize = (long)S_259;
}
```

- Valid: **False**
- Correct: **False**

`Settings.PreferTypeHandlersForEnums = S_256;` assigns `int` to a `bool` member — CS0029 at all four bool sinks, so the method does not compile.

### After

Acquired with `-S "Decompiled Source"` at this PR's head (`1d8d9a7a`):

```csharp
public static void SetDefaults()
{
    Nullable<int> V_0 = default;
    Settings.CommandTimeout = V_0;
    Settings.PreferTypeHandlersForEnums = false;
    Settings.UseIncrementalPseudoPositionalParameterNames = false;
    Settings.PadListExpansions = false;
    Settings.ApplyNullValues = false;
    Settings.AllowedCommandBehaviors = unchecked((CommandBehavior)(-10));
    Settings.InListStringSplitCount = -1;
    Settings.FetchSize = (long)-1;
}
```

- Valid: **True**
- Correct: **True**

Each bool sink now receives the `false` literal directly; the int stack-slot copy chain (`S_256`..`S_259`) is gone, including the `-1` shared by the `int` and `long` sinks. Independent field assignments in any order have the same observable effect as the source chain. Verified compilable against stub types matching the real member types.

### Fully raised

This PR reaches **valid + correct**, not the fully-raised endpoint: it does not
reconstruct the source-level chained assignment (`A = B = C = false;`) — the sinks
render as separate, IL-order statements.

```csharp
CommandTimeout = null;
ApplyNullValues = PadListExpansions = UseIncrementalPseudoPositionalParameterNames = PreferTypeHandlersForEnums = false;
AllowedCommandBehaviors = DefaultAllowedCommandBehaviors;
FetchSize = InListStringSplitCount = (long)-1;
```

- Required tracking issue: #2994 — reconstruct chained/embedded assignment from the dup-of-value idiom (`a = b = c = v`).

## Evidence

| Check | Baseline (317b8dff) | Head (1d8d9a7a) |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused test `ChainedConstantAssignmentTests` | 1 failed (0 literal sinks; int spill) | 1 passed |
| Decompiler fast suite (`-trait- "Speed=Slow"`) | 3092, 0 failed | 3093, 0 failed |
| CS0161 census pin `DecompilerAssembly_MissingReturnPopulationIsPinned` | 8 | 8 |
| FidelityGate diff-set (`NoNewFidelityDiffsBeyondKnownDocket`) | 72 entries; 1 fail `StatementBodyLambdaInsideIf` | byte-identical 72 entries; same 1 fail |
| CorpusSweepGate (CoreLib, 41,159 methods) | 0 pass-bugs; floors held | 0 pass-bugs; floors held |
| Real witness `Dapper.SqlMapper.Settings::SetDefaults` | CS0029 (invalid) | valid |

The one FidelityGate failure (`StatementBodyLambdaInsideIf` — a compiler-generated
lambda-cache field ordinal `<>9__100_0` -> `<>9__121_0`; opcode streams identical)
is **pre-existing on `origin/main`**: base and head produce byte-identical full
diff-sets, so this PR introduces zero new fidelity diffs. It is unrelated to
this change (the unchanged declaring-type recompile skeleton assigns lambda
ordinals from sibling ordering) and out of scope here.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — breadth (CorpusSweepGate: 0 pass-bugs, Full and fully-raised
floors held over 41,159 CoreLib methods) and depth (FidelityGate diff-set byte-identical
to base) both hold; the change can only remove redundant int-slot residue for dup'd
constants, never add it.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.ChainedConstantAssignmentTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.CorpusSweepGateTests"
```
