### PR TITLE
Share switch region admission and tiling invariants

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SwitchRaisingSharedMissHandlerTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwitchRaisingSharedMissHandlerTests.cs
@@ -66,13 +66,14 @@ public class SwitchRaisingSharedMissHandlerTests
 
     // The same shape, but reached through the string-equality-chain raiser
     // (RaiseStringEqualityChain -> FinishSwitchRaise) rather than the IL
-    // `switch` opcode raiser (Raise): FinishSwitchRaise has its own,
-    // independently-tiled Unify and must recognize the shared-miss-handler
-    // chain too, not just Raise's.
-    [Fact]
-    public void StringEqualityChainWithSharedMissHandler_StillRaisesToSwitch()
+    // `switch` opcode raiser (Raise). Both entry paths must preserve the shared
+    // region helper's one-hop and multi-hop exit-chain behavior.
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void StringEqualityChainWithSharedMissHandler_StillRaisesToSwitch(int chainLength)
     {
-        var function = BuildStringEqualityChainWithSharedMissHandler();
+        var function = BuildStringEqualityChainWithSharedMissHandler(chainLength);
 
         new SwitchRaisingPass().Run(function, PassContext.None);
         function.CheckInvariant();
@@ -81,6 +82,31 @@ public class SwitchRaisingSharedMissHandlerTests
         Assert.Equal(2, node.Sections.Count);
         Assert.DoesNotContain(node.Sections, s => s.IsDefault);
         Assert.Single(function.Descendants.OfType<Return>());
+
+        if (chainLength >= 2)
+        {
+            var output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n");
+            Assert.Contains("V_0 = -1;\nV_1 = 0;\nIL_0070:\nreturn V_0;", output);
+            Assert.Equal(2, output.Split("V_1 = 0;", StringSplitOptions.None).Length);
+        }
+    }
+
+    [Fact]
+    public void IlSwitch_MissHandlerChainCrossingCaseEntry_RemainsFlat()
+        => AssertMissHandlerChainCrossingCaseEntryRemainsFlat(
+            BuildTwoCaseSwitchWithSharedMissHandler(missCrossesCaseEntry: true));
+
+    [Fact]
+    public void StringEqualityChain_MissHandlerChainCrossingCaseEntry_RemainsFlat()
+        => AssertMissHandlerChainCrossingCaseEntryRemainsFlat(
+            BuildStringEqualityChainWithSharedMissHandler(missCrossesCaseEntry: true));
+
+    static void AssertMissHandlerChainCrossingCaseEntryRemainsFlat(IrFunction function)
+    {
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Empty(function.Descendants.OfType<Switch>());
     }
 
     // A longer transparent chain between the miss-handler and the join (two
@@ -113,7 +139,9 @@ public class SwitchRaisingSharedMissHandlerTests
     // miss-handler falls straight into the join; 2 inserts one extra
     // transparent pass-through block, exercising ChasesTo over a multi-hop
     // chain rather than a single hop.
-    static IrFunction BuildTwoCaseSwitchWithSharedMissHandler(int chainLength = 1)
+    static IrFunction BuildTwoCaseSwitchWithSharedMissHandler(
+        int chainLength = 1,
+        bool missCrossesCaseEntry = false)
     {
         var body = new BlockContainer();
 
@@ -141,20 +169,28 @@ public class SwitchRaisingSharedMissHandlerTests
         body.Add(case0Leaf);
 
         var case1 = new Block(0x20);
-        case1.Add(new ConditionalBranch(IntEqual(1, "k", 9), targetOffset: 0x28));
+        if (missCrossesCaseEntry)
+            case1.Add(new Branch(joinOffset));
+        else
+            case1.Add(new ConditionalBranch(IntEqual(1, "k", 9), targetOffset: 0x28));
         body.Add(case1);
 
-        var case1Miss = new Block(0x24);
-        case1Miss.Add(new Branch(0x30));
-        body.Add(case1Miss);
+        if (!missCrossesCaseEntry)
+        {
+            var case1Miss = new Block(0x24);
+            case1Miss.Add(new Branch(0x30));
+            body.Add(case1Miss);
 
-        var case1Leaf = new Block(0x28);
-        case1Leaf.Add(new StoreLocal(0, s_int, new Constant(200, s_int)));
-        case1Leaf.Add(new Branch(joinOffset));
-        body.Add(case1Leaf);
+            var case1Leaf = new Block(0x28);
+            case1Leaf.Add(new StoreLocal(0, s_int, new Constant(200, s_int)));
+            case1Leaf.Add(new Branch(joinOffset));
+            body.Add(case1Leaf);
+        }
 
         var sharedMiss = new Block(0x30);
         sharedMiss.Add(new StoreLocal(0, s_int, new Constant(-1, s_int)));   // falls through
+        if (missCrossesCaseEntry)
+            sharedMiss.Add(new Branch(0x20));
         body.Add(sharedMiss);
 
         if (chainLength >= 2)
@@ -183,10 +219,11 @@ public class SwitchRaisingSharedMissHandlerTests
     // bodies each have a case-local "no match" arm chaining into one shared
     // miss-handler that falls through into the method's single return, and a
     // matching arm that jumps straight to that return, skipping the
-    // miss-handler. FinishSwitchRaise ties its own separate Unify/tiling
-    // logic, mirroring Raise's, so it must recognize the same chained-exit
-    // shape independently.
-    static IrFunction BuildStringEqualityChainWithSharedMissHandler()
+    // miss-handler. This drives the same shared region logic through
+    // FinishSwitchRaise rather than Raise.
+    static IrFunction BuildStringEqualityChainWithSharedMissHandler(
+        int chainLength = 1,
+        bool missCrossesCaseEntry = false)
     {
         var body = new BlockContainer();
         var eq = new MethodRef(s_string, "op_Equality", s_bool, [s_string, s_string], HasThis: false);
@@ -219,21 +256,36 @@ public class SwitchRaisingSharedMissHandlerTests
         body.Add(caseALeaf);
 
         var caseB = new Block(0x50);
-        caseB.Add(new ConditionalBranch(IntEqual(1, "k", 2), targetOffset: 0x58));
+        if (missCrossesCaseEntry)
+            caseB.Add(new Branch(0x70));
+        else
+            caseB.Add(new ConditionalBranch(IntEqual(1, "k", 2), targetOffset: 0x58));
         body.Add(caseB);
 
-        var caseBMiss = new Block(0x54);
-        caseBMiss.Add(new Branch(0x60));
-        body.Add(caseBMiss);
+        if (!missCrossesCaseEntry)
+        {
+            var caseBMiss = new Block(0x54);
+            caseBMiss.Add(new Branch(0x60));
+            body.Add(caseBMiss);
 
-        var caseBLeaf = new Block(0x58);
-        caseBLeaf.Add(new StoreLocal(0, s_int, new Constant(2, s_int)));
-        caseBLeaf.Add(new Branch(0x70));
-        body.Add(caseBLeaf);
+            var caseBLeaf = new Block(0x58);
+            caseBLeaf.Add(new StoreLocal(0, s_int, new Constant(2, s_int)));
+            caseBLeaf.Add(new Branch(0x70));
+            body.Add(caseBLeaf);
+        }
 
         var sharedMiss = new Block(0x60);
         sharedMiss.Add(new StoreLocal(0, s_int, new Constant(-1, s_int)));   // falls through into the join
+        if (missCrossesCaseEntry)
+            sharedMiss.Add(new Branch(0x50));
         body.Add(sharedMiss);
+
+        if (chainLength >= 2)
+        {
+            var passThrough = new Block(0x68);
+            passThrough.Add(new StoreLocal(1, s_int, new Constant(0, s_int)));
+            body.Add(passThrough);
+        }
 
         var join = new Block(0x70);
         join.Add(new Return(new LoadLocal(0, s_int)));
@@ -243,7 +295,7 @@ public class SwitchRaisingSharedMissHandlerTests
             "M",
             TypeRef.Definition("Synthetic", "", "T"),
             new MethodSignature(s_int, [new Parameter("s", s_string), new Parameter("k", s_int)], HasThis: false, GenericParameterCount: 0),
-            [s_int],
+            chainLength >= 2 ? [s_int, s_int] : [s_int],
             body);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/SwitchRaisingSharedMissHandlerTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwitchRaisingSharedMissHandlerTests.cs
@@ -10,6 +10,7 @@ namespace ILInspector.Decompiler.Tests;
 // required literal equality between a case's exits, so a case whose two exits
 // were the miss-handler and the return it falls into (not the same block)
 // failed to unify and the whole table was left flat as an if-ladder.
+[Trait("Area", "Pass")]
 public class SwitchRaisingSharedMissHandlerTests
 {
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -104,25 +104,13 @@ public sealed class SwitchRaisingPass : IIrPass
         var owned = new HashSet<int>();
         int? join = null;
 
-        // See TryUnify's doc comment for the exit-unification rule (shared with
-        // FinishSwitchRaise's identical need below).
-        bool Unify(int j) => TryUnify(blocks, caseTargets, offsetToIndex, owned, ref join, j);
-
         // Each distinct case target grows into its single-entry region; the
         // region's exits unify to the shared join (or it terminates).
         var regions = new Dictionary<int, List<int>>();
         foreach (int target in caseTargets.Distinct())
-        {
-            if (!GrowRegion(blocks, target, s, offsetToIndex, preds, out var region, out var exits))
+            if (!TryAddOwnedRegion(blocks, target, s, caseTargets, offsetToIndex,
+                    preds, regions, owned, ref join))
                 return false;
-            if (owned.Overlaps(region))
-                return false;
-            foreach (int e in exits)
-                if (!Unify(e))
-                    return false;
-            regions[target] = region;
-            owned.UnionWith(region);
-        }
 
         // The default: a bare dispatch to a separate body laid out after the
         // cases, a bare jump to the join (omitted), an inline section, or — when
@@ -157,16 +145,10 @@ public sealed class SwitchRaisingPass : IIrPass
             else if (!isCase)
             {
                 // A separate default body laid out after the cases.
-                if (!GrowRegion(blocks, dt, s, offsetToIndex, preds, out var region, out var exits))
+                if (!TryAddOwnedRegion(blocks, dt, s, caseTargets, offsetToIndex,
+                        preds, regions, owned, ref join))
                     return false;
-                if (owned.Overlaps(region))
-                    return false;
-                foreach (int e in exits)
-                    if (!Unify(e))
-                        return false;
                 owned.Add(defaultIndex);
-                owned.UnionWith(region);
-                regions[dt] = region;
                 defaultBodyHead = dt;
             }
             else
@@ -177,28 +159,17 @@ public sealed class SwitchRaisingPass : IIrPass
         else
         {
             // An inline default section beginning right after the switch.
-            if (!GrowRegion(blocks, defaultIndex, s, offsetToIndex, preds, out var region, out var exits))
+            if (!TryAddOwnedRegion(blocks, defaultIndex, s, caseTargets, offsetToIndex,
+                    preds, regions, owned, ref join))
                 return false;
-            if (owned.Overlaps(region))
-                return false;
-            foreach (int e in exits)
-                if (!Unify(e))
-                    return false;
-            owned.UnionWith(region);
-            regions[defaultIndex] = region;
             defaultBodyHead = defaultIndex;
         }
 
         // The owned blocks must tile the contiguous span [s+1, regionEnd): the
         // join (if any) lies just past them, and no foreign block is interleaved.
         int regionEnd = join ?? owned.Max() + 1;
-        if (join is { } j2 && (j2 <= s || owned.Contains(j2)))
+        if (!OwnsTiledRegion(owned, defaultIndex, join, regionEnd))
             return false;
-        if (owned.Count != regionEnd - defaultIndex)
-            return false;
-        foreach (int idx in owned)
-            if (idx < defaultIndex || idx >= regionEnd)
-                return false;
 
         // Every section escapes to the join only through an unconditional branch,
         // a fall-through, or a terminator — never a conditional/switch (which
@@ -589,6 +560,45 @@ public sealed class SwitchRaisingPass : IIrPass
                 Add(idx, t);
         }
         return preds;
+    }
+
+    static bool TryAddOwnedRegion(
+        IReadOnlyList<Block> blocks,
+        int head,
+        int dispatchBoundary,
+        int[] caseTargets,
+        Dictionary<int, int> offsetToIndex,
+        Dictionary<int, List<int>> predecessors,
+        Dictionary<int, List<int>> regions,
+        HashSet<int> owned,
+        ref int? join)
+    {
+        if (!GrowRegion(blocks, head, dispatchBoundary, offsetToIndex, predecessors, out var region, out var exits))
+            return false;
+        if (owned.Overlaps(region))
+            return false;
+        int? originalJoin = join;
+        foreach (int exit in exits)
+            if (!TryUnify(blocks, caseTargets, offsetToIndex, owned, ref join, exit))
+            {
+                join = originalJoin;
+                return false;
+            }
+        regions[head] = region;
+        owned.UnionWith(region);
+        return true;
+    }
+
+    static bool OwnsTiledRegion(HashSet<int> owned, int firstBody, int? join, int regionEnd)
+    {
+        if (join is { } j && (j < firstBody || owned.Contains(j)))
+            return false;
+        if (owned.Count != regionEnd - firstBody)
+            return false;
+        foreach (int index in owned)
+            if (index < firstBody || index >= regionEnd)
+                return false;
+        return true;
     }
 
     /// <summary>
@@ -1214,26 +1224,12 @@ public sealed class SwitchRaisingPass : IIrPass
 
         var owned = new HashSet<int>();
         int? join = null;
-
-        // Uses the same exit-unification rule as Raise (see TryUnify's doc
-        // comment) — this is the fix for issue #2954/#2971: FinishSwitchRaise
-        // ties its own region-growing/tiling logic and previously had a
-        // separately-drifted copy of this decision.
-        bool Unify(int j) => TryUnify(blocks, caseTargets, offsetToIndex, owned, ref join, j);
         var regions = new Dictionary<int, List<int>>();
 
         foreach (int target in caseTargets.Distinct())
-        {
-            if (!GrowRegion(blocks, target, dispatchEnd, offsetToIndex, preds, out var region, out var exits))
+            if (!TryAddOwnedRegion(blocks, target, dispatchEnd, caseTargets, offsetToIndex,
+                    preds, regions, owned, ref join))
                 return false;
-            if (owned.Overlaps(region))
-                return false;
-            foreach (int e in exits)
-                if (!Unify(e))
-                    return false;
-            regions[target] = region;
-            owned.UnionWith(region);
-        }
 
         int? defaultBodyHead = null;
         int? defaultSharesTarget = null;
@@ -1248,28 +1244,17 @@ public sealed class SwitchRaisingPass : IIrPass
         }
         else
         {
-            if (!GrowRegion(blocks, defaultIndex, dispatchEnd, offsetToIndex, preds, out var region, out var exits))
+            if (!TryAddOwnedRegion(blocks, defaultIndex, dispatchEnd, caseTargets, offsetToIndex,
+                    preds, regions, owned, ref join))
                 return false;
-            if (owned.Overlaps(region))
-                return false;
-            foreach (int e in exits)
-                if (!Unify(e))
-                    return false;
-            owned.UnionWith(region);
-            regions[defaultIndex] = region;
             defaultBodyHead = defaultIndex;
         }
 
         // The body blocks must tile the contiguous span [dispatchEnd+1, regionEnd).
         int regionEnd = join ?? (owned.Count == 0 ? dispatchEnd + 1 : owned.Max() + 1);
-        if (join is { } j2 && (j2 <= dispatchEnd || owned.Contains(j2)))
-            return false;
         int firstBody = dispatchEnd + 1;
-        if (owned.Count != regionEnd - firstBody)
+        if (!OwnsTiledRegion(owned, firstBody, join, regionEnd))
             return false;
-        foreach (int o in owned)
-            if (o < firstBody || o >= regionEnd)
-                return false;
 
         foreach (var region in regions.Values)
             if (!ExitsAreUnconditional(blocks, region, offsetToIndex))


### PR DESCRIPTION
Fixes #2997.

## Change

**Conclusion: PASS** — completes the bounded invariant extraction started by
#2988 without combining the two switch raisers' intentionally different
dispatch semantics.

`Raise` and `FinishSwitchRaise` now share:

- `TryAddOwnedRegion`, which grows a candidate region, rejects overlap,
  processes every exit through #2988's shared `TryUnify`, and registers the
  region only after all exits succeed;
- `OwnsTiledRegion`, which verifies that owned blocks exactly cover the
  contiguous body span and that the join remains outside it.

Region admission snapshots and restores `join` on failure, so the helper is
transactional even when a later exit cannot unify. Predecessor construction,
default recognition and ownership, external-ingress validation, and final
switch emission remain path-specific.

The focused fixture now drives one-hop and multi-hop shared tails through both
the IL-switch and string-equality-chain paths, checks rendered trailing-code
order, and pins the close negative where a chase would cross another case
entry. The class is included in the new `Area=Pass` slice from #2979.

## Behavior boundary

No decompiled output change is intended. Exact-base render A/B evaluated
41,952 methods with 0 changed, added, or removed methods.

## Evidence

Exact baseline: `4f0c0ad1`.

| Check | Baseline | Head |
| --- | ---: | ---: |
| Solution build | Pass | Pass |
| `SwitchRaisingSharedMissHandlerTests` | 3 passed | 6 passed |
| `Area=Pass` | 1,125 passed | 1,131 passed |
| Render A/B | — | 41,952 evaluated; 0 changed |

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile ./nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "*SwitchRaisingSharedMissHandlerTests*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -trait "Area=Pass"
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --render-ab <exact-base.json> --workers 2
```
