### PR TITLE
Move CSharpExpressionBody into the CSharp layer

### DIFF
--- a/src/ILInspector.CSharp.Tests/CSharpExpressionBodyTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpExpressionBodyTests.cs
@@ -1,0 +1,36 @@
+namespace ILInspector.CSharp.Tests;
+
+public sealed class CSharpExpressionBodyTests
+{
+    [Theory]
+    [InlineData("return value.Length;", "value.Length")]
+    [InlineData("return _field;", "_field")]
+    [InlineData("_last = value;", "_last = value")]
+    [InlineData("_count += 1;", "_count += 1")]
+    [InlineData("_map ??= new();", "_map ??= new()")]
+    [InlineData("i++;", "i++")]
+    [InlineData("--i;", "--i")]
+    [InlineData("Console.WriteLine(value);", "Console.WriteLine(value)")]
+    [InlineData("new Widget();", "new Widget()")]
+    [InlineData("await LoadAsync();", "await LoadAsync()")]
+    public void FromSingleStatement_ProducesExpression(string body, string expected)
+        => Assert.Equal(expected, CSharpExpressionBody.FromSingleStatement(body));
+
+    [Fact]
+    public void FromSingleStatement_KeepsThrowVerbatim()
+        => Assert.Equal(
+            "throw new NotImplementedException()",
+            CSharpExpressionBody.FromSingleStatement("throw new NotImplementedException();"));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("return;")]
+    [InlineData("no semicolon")]
+    [InlineData("// a comment;")]
+    [InlineData("/* block */ Foo();")]
+    [InlineData("int x = 1;")]
+    [InlineData("if (x) Foo();")]
+    [InlineData("Foo();\nBar();")]
+    public void FromSingleStatement_RejectsNonExpressionForms(string body)
+        => Assert.Null(CSharpExpressionBody.FromSingleStatement(body));
+}

--- a/src/ILInspector.CSharp/CSharpExpressionBody.cs
+++ b/src/ILInspector.CSharp/CSharpExpressionBody.cs
@@ -1,4 +1,4 @@
-namespace ILInspector.Decompiler;
+namespace ILInspector.CSharp;
 
 /// <summary>
 /// Converts a rendered single-statement body to the expression used by C#

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -2223,7 +2223,7 @@ public static class ApiOutputFormatter
             return body;
 
         bool hasLeadingComments = leadingBodyComments is { Count: > 0 };
-        if (!hasLeadingComments && preferExpressionBodied && Decompiler.CSharpExpressionBody.FromSingleStatement(body) is { } expressionBody)
+        if (!hasLeadingComments && preferExpressionBodied && CSharpExpressionBody.FromSingleStatement(body) is { } expressionBody)
             return $"{declaration} => {expressionBody};";
 
         var formattedBodyLines = body.ReplaceLineEndings("\n").Split('\n');


### PR DESCRIPTION
## Summary

Relocate `CSharpExpressionBody` from `ILInspector.Decompiler` into
`ILInspector.CSharp`, with **no logic change**. The expression-bodied-vs-block
member layout decision is C# spelling and composition, which the CSharp layer
owns — not the decompiler. This puts the class in the correct layer and adds the
focused contract tests it previously lacked.

First step of #2996 (render whole members / unify the signature-shape model):
give the CSharp layer ownership of whole-member body layout so signature
spelling and body layout share one owner. Follow-ups introduce a single CSharp
whole-member layout primitive and route both current composers
(`MemberBodyProducer` and `CSharpTypePrinter`) through it.

## What changed

- `src/ILInspector.Decompiler/CSharpExpressionBody.cs` → moved verbatim to
  `src/ILInspector.CSharp/CSharpExpressionBody.cs` (namespace only; git records a
  rename).
- `src/dotnet-inspect/Output/ApiOutputFormatter.cs`: drop the `Decompiler.`
  qualifier (already imports `ILInspector.CSharp`).
- New `src/ILInspector.CSharp.Tests/CSharpExpressionBodyTests.cs`: 19 tests
  pinning the layout contract (`return`/`throw`/assignment/compound/increment/
  call/`new`/`await` accepted; empty, `return;`, comment-led, declaration,
  keyword-led, multiline rejected).

All six consumers (five in `MemberBodyProducer`, one in `ApiOutputFormatter`)
resolve the class through their existing `using ILInspector.CSharp;` — no
call-site logic changes.

## Why it's low risk

Mechanical, verbatim relocation with no behavior change (git detects it as a
rename). Per the repository convention, mechanical changes do not require
adversarial review.

## Validation

- Clean `Release` build across `ILInspector.CSharp`, `ILInspector.Metadata`,
  `ILInspector.Decompiler`, and `dotnet-inspect` (0 warnings, 0 errors).
- New tests: `CSharpExpressionBodyTests` — 19/19 pass.
- The 14 pre-existing `CSharpTypePrinterTests` failures on this base
  (`4f0c0ad1`) are unrelated: reproduced identically with this change stashed
  (same 14), and `CSharpTypePrinter` does not reference `CSharpExpressionBody`.
- End-to-end smoke check unchanged:
  `member -m "ILInspector.CSharp.CSharpAccessorBody.Block" -S "Decompiled Source"`
  still renders
  `public static ... Block(string source) => new CSharpAccessorBody(...);`.

Refs #2996.
