### PR TITLE
Fix annotated extension receiver emission order (#2964)

### DIFF
--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -1431,7 +1431,7 @@ internal static class CSharpDeclarationWriter
         var modifierStart = firstParameterStart;
         while (modifierStart < signature.Length && signature[modifierStart] == '[')
         {
-            var close = Matching(signature, modifierStart, '[', ']');
+            var close = MatchingAttributeList(signature, modifierStart);
             if (close < 0)
                 return signature;
             modifierStart = close + 1;
@@ -1443,6 +1443,45 @@ internal static class CSharpDeclarationWriter
             return signature;
 
         return signature.Insert(modifierStart, "this ");
+    }
+
+    static int MatchingAttributeList(string text, int start)
+    {
+        var depth = 0;
+        char quote = '\0';
+        bool escaped = false;
+        for (var i = start; i < text.Length; i++)
+        {
+            char c = text[i];
+            if (quote != '\0')
+            {
+                if (escaped)
+                {
+                    escaped = false;
+                    continue;
+                }
+                if (c == '\\')
+                {
+                    escaped = true;
+                    continue;
+                }
+                if (c == quote)
+                    quote = '\0';
+                continue;
+            }
+
+            if (c is '\'' or '"')
+            {
+                quote = c;
+                continue;
+            }
+            if (c == '[')
+                depth++;
+            else if (c == ']' && --depth == 0)
+                return i;
+        }
+
+        return -1;
     }
 
     static string AbbreviateSignature(string signature)

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -1424,10 +1424,25 @@ internal static class CSharpDeclarationWriter
         while (firstParameterStart < signature.Length && char.IsWhiteSpace(signature[firstParameterStart]))
             firstParameterStart++;
 
-        if (signature.AsSpan(firstParameterStart).StartsWith("this ".AsSpan(), StringComparison.Ordinal))
+        // Parameter attributes precede the extension receiver modifier in C#:
+        // [NotNull] this string value. The structured signature renderer has
+        // already attached those attributes, so insert `this` after every
+        // leading attribute list rather than at the raw parameter start.
+        var modifierStart = firstParameterStart;
+        while (modifierStart < signature.Length && signature[modifierStart] == '[')
+        {
+            var close = Matching(signature, modifierStart, '[', ']');
+            if (close < 0)
+                return signature;
+            modifierStart = close + 1;
+            while (modifierStart < signature.Length && char.IsWhiteSpace(signature[modifierStart]))
+                modifierStart++;
+        }
+
+        if (signature.AsSpan(modifierStart).StartsWith("this ".AsSpan(), StringComparison.Ordinal))
             return signature;
 
-        return signature.Insert(firstParameterStart, "this ");
+        return signature.Insert(modifierStart, "this ");
     }
 
     static string AbbreviateSignature(string signature)

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -1132,11 +1132,14 @@ public class ReturnToSenderFixtureCatalogTests
             namespace SourceProbe;
 
             [System.AttributeUsage(System.AttributeTargets.Parameter)]
-            public sealed class ReceiverAttribute : System.Attribute;
+            public sealed class ReceiverAttribute(string marker) : System.Attribute
+            {
+                public string Marker { get; } = marker;
+            }
 
             public static class StringExtensions
             {
-                public static int Measure([Receiver] this string value) => value.Length;
+                public static int Measure([Receiver("]")] this string value) => value.Length;
             }
 
             public class Class1

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -1126,6 +1126,41 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_PlacesReceiverAttributesBeforeExtensionThisModifier()
+    {
+        var fixture = CompileSourceFixture(("Class1.cs", """
+            namespace SourceProbe;
+
+            [System.AttributeUsage(System.AttributeTargets.Parameter)]
+            public sealed class ReceiverAttribute : System.Attribute;
+
+            public static class StringExtensions
+            {
+                public static int Measure([Receiver] this string value) => value.Length;
+            }
+
+            public class Class1
+            {
+                public int M(string value) => value.Measure();
+            }
+            """));
+        try
+        {
+            var target = new ReturnToSender.RequestedTarget("SourceProbe.Class1", "M", Overload: 0);
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(fixture.AssemblyPath, [target]));
+
+            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.DoesNotContain("CS1031", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("] this string value", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("this [", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_ResolvesCs0234FullTypeClosureRoots()
     {
         var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(


### PR DESCRIPTION
- Advances #2964
- Changes the extension-receiver `this` modifier to be inserted **after** the parameter's leading attribute lists (`[Attr] this T x`, not `this [Attr] T x`), fixing CS1031 in reconstructed extension-method signatures
- Evidence revision: `cdb032e1`

## Change

> Should we accept this harness change?

**Conclusion:** **PASS** — the RTS compile-back skeleton emitted `this` before a receiver parameter's attribute list, producing `this [Attr] Type name`, which the C# parser rejects with CS1031 ("Type expected"). Inserting `this` after the leading attribute lists yields legal `[Attr] this Type name`, unblocking compile-back of annotated extension surfaces (the EVIL benchmark counted ~97 such rows as Invalid).

Before (reconstructed skeleton — malformed, CS1031):

```text
public static string ContinueJobWith(this [Hangfire.Annotations.NotNull] IBackgroundJobClient client, ...) { throw null; }
//                                   ^^^^ `this` before the attribute list => CS1031 "Type expected"
```

After (`this` placed after the attribute list — legal C#):

```text
public static string ContinueJobWith([Hangfire.Annotations.NotNull] this IBackgroundJobClient client, ...) { throw null; }
```

## Scope and safety

- **Root cause:** the extension-receiver renderer prepended a `this` modifier at the raw first-parameter start, but the structured signature renderer had already attached the parameter's attribute lists there, so `this` landed before `[Attr]`.
- **Fix shape:** in `CSharpDeclarationWriter`, skip over every leading `[...]` attribute list (via a new `MatchingAttributeList` bracket matcher that respects string/char literals) before inserting the `this` modifier. The literal-aware matcher is why the second commit handles a `]` inside an attribute argument.
- **Product impact:** yes — `CSharpDeclarationWriter` is product code (`src/ILInspector.CSharp`). Any product rendering of an extension method whose receiver carries parameter attributes now emits the legal `[Attr] this T` order. This is a rendering-correctness improvement; no other declaration shape changes.
- **Scope boundary:** parameters without leading attributes are unaffected (the loop is a no-op), and a signature already beginning with a `this` modifier after its attributes is left as-is.
- **RTS boundary:** RTS only orchestrates closure + Roslyn + skeleton composition; the malformed C# came from product signature rendering, and the fix stays in the product renderer rather than adding C# knowledge to RTS.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `ReturnToSenderFixtureCatalogTests.ReturnToSenderSourceProbe_PlacesReceiverAttributesBeforeExtensionThisModifier` passed at head |
| Real witness (before) | same probe run against base product code: fails with `RecompileFail ... CS1031: Type expected` |
| Real witness (after) | head: no CS1031; `Source` contains `] this string value` and never `this [` |
| Motivating population | ~97 EVIL Invalid rows (Hangfire.Core 1.8.24, StackExchange.Redis 3.0.17) per #2964; unblocked, not re-measured here |

The self-contained fixture uses a `[Receiver("]")]` attribute whose argument contains a literal `]`, exercising the literal-aware bracket matcher directly.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Full 97-row EVIL re-measurement | Not run here | Focused fixture proves the emission fix; broad re-run is corpus bookkeeping, not a correctness gate for this change |

## Build-event validation

**Conclusion:** not applicable — validated by the focused compile-back probe; no build-health claim.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus | No blocking findings | reviewed head `cdb032e1` |
| Gemini Pro | No blocking findings | reviewed head `cdb032e1` |

**Review conclusion:** **PASS** — both fixed-head reviews clean; see PR review comments for reconciliation.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*ReturnToSenderSourceProbe_PlacesReceiverAttributesBeforeExtensionThisModifier*"
```
