### PR TITLE
Fix result-temp return-tail structuring (#2973)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnMergePassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnMergePassTests.cs
@@ -59,9 +59,23 @@ public class ReturnMergePassTests
     [Fact]
     public void SwitchAndGotoPredecessors_StayForSwitchRaising()
     {
-        var (function, defaultArm) = BuildMixedReturnTailCandidate(conditionalPredecessors: 0);
-        function.Body.Blocks[0].Children[0].ReplaceWith(
+        var (function, defaultArm) = BuildMixedReturnTailCandidate(conditionalPredecessors: 2);
+        var success = Assert.Single(function.Body.Blocks, block => block.StartOffset == 0x0003);
+        success.Children[0].ReplaceWith(
             new SwitchBranch(new Constant(0, Int32), [0x0005, 0x0005]));
+
+        new ReturnMergePass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.IsType<Branch>(Assert.Single(defaultArm.Children));
+    }
+
+    [Fact]
+    public void MixedPredecessorsWithFallthrough_StayForExistingStructuringRules()
+    {
+        var (function, defaultArm) = BuildMixedReturnTailCandidate(conditionalPredecessors: 2);
+        var success = Assert.Single(function.Body.Blocks, block => block.StartOffset == 0x0003);
+        success.Children[0].ReplaceWith(new StoreLocal(1, Int32, new Constant(1, Int32)));
 
         new ReturnMergePass().Run(function, PassContext.None);
         function.CheckInvariant();

--- a/src/ILInspector.Decompiler.Tests/ReturnMergePassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnMergePassTests.cs
@@ -75,7 +75,7 @@ public class ReturnMergePassTests
     {
         var (function, defaultArm) = BuildMixedReturnTailCandidate(conditionalPredecessors: 2);
         var success = Assert.Single(function.Body.Blocks, block => block.StartOffset == 0x0003);
-        success.Children[0].ReplaceWith(new StoreLocal(1, Int32, new Constant(1, Int32)));
+        success.Children[0].ReplaceWith(new StoreLocal(0, Int32, new Constant(1, Int32)));
 
         new ReturnMergePass().Run(function, PassContext.None);
         function.CheckInvariant();

--- a/src/ILInspector.Decompiler.Tests/ReturnMergePassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnMergePassTests.cs
@@ -32,6 +32,89 @@ public class ReturnMergePassTests
         Assert.All(function.Body.Blocks, block => Assert.IsType<Return>(Assert.Single(block.Children)));
     }
 
+    [Fact]
+    public void MixedConditionalAndGotoPredecessors_InlineDefaultGotoButKeepSharedTail()
+    {
+        var (function, defaultArm) = BuildMixedReturnTailCandidate(conditionalPredecessors: 2);
+
+        new ReturnMergePass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.IsType<StoreLocal>(defaultArm.Children[0]);
+        Assert.IsType<Return>(defaultArm.Children[1]);
+        Assert.Contains(function.Body.Blocks, block => block.StartOffset == 0x0005);
+    }
+
+    [Fact]
+    public void SingleConditionalAndGotoPredecessors_StayForDiamondStructuring()
+    {
+        var (function, defaultArm) = BuildMixedReturnTailCandidate(conditionalPredecessors: 1);
+
+        new ReturnMergePass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.IsType<Branch>(Assert.Single(defaultArm.Children));
+    }
+
+    [Fact]
+    public void SwitchAndGotoPredecessors_StayForSwitchRaising()
+    {
+        var (function, defaultArm) = BuildMixedReturnTailCandidate(conditionalPredecessors: 0);
+        function.Body.Blocks[0].Children[0].ReplaceWith(
+            new SwitchBranch(new Constant(0, Int32), [0x0005, 0x0005]));
+
+        new ReturnMergePass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.IsType<Branch>(Assert.Single(defaultArm.Children));
+    }
+
+    [Fact]
+    public void MixedPredecessorsWithDirectReturn_StayForExistingStructuringRules()
+    {
+        var (function, defaultArm) = BuildMixedReturnTailCandidate(conditionalPredecessors: 2);
+        var merge = Assert.Single(function.Body.Blocks, block => block.StartOffset == 0x0005);
+        merge.Children[0].Detach();
+        var ret = Assert.IsType<Return>(merge.Children[0]);
+        Assert.NotNull(ret.Value);
+        ret.Value.ReplaceWith(new Constant(0, Int32));
+
+        new ReturnMergePass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.IsType<Branch>(Assert.Single(defaultArm.Children));
+    }
+
+    static (IrFunction Function, Block DefaultArm) BuildMixedReturnTailCandidate(int conditionalPredecessors)
+    {
+        var body = new BlockContainer();
+        var firstGuard = new Block(0x0000);
+        firstGuard.Add(new ConditionalBranch(new Constant(true, TypeRef.CoreLib("System", "Boolean")), 0x0005));
+        body.Add(firstGuard);
+        var defaultArm = new Block(0x0001);
+        defaultArm.Add(new Branch(0x0005));
+        body.Add(defaultArm);
+        if (conditionalPredecessors == 2)
+        {
+            var secondGuard = new Block(0x0002);
+            secondGuard.Add(new ConditionalBranch(new Constant(false, TypeRef.CoreLib("System", "Boolean")), 0x0005));
+            body.Add(secondGuard);
+        }
+        var success = new Block(0x0003);
+        success.Add(new Return(new Constant(1, Int32)));
+        body.Add(success);
+        var merge = new Block(0x0005);
+        merge.Add(new StoreLocal(0, Int32, new Constant(0, Int32)));
+        merge.Add(new Return(new LoadLocal(0, Int32)));
+        body.Add(merge);
+        return (new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Int32, [], HasThis: false, GenericParameterCount: 0),
+            [Int32],
+            body), defaultArm);
+    }
+
     static IrFunction BuildReturnTailCandidate(bool includeLeaveTarget)
     {
         var body = new BlockContainer();

--- a/src/ILInspector.Decompiler.Tests/ValidityCoverageReportingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ValidityCoverageReportingTests.cs
@@ -50,9 +50,10 @@ public class ValidityCoverageReportingTests
         // UnionSwitchExpressionPass::SameTailNode,
         // DynamicCallSitePass::TryGuardCacheLoad, and
         // FluentChainRecompositionPass::SinkStatement.
-        // YieldBreakLoopIteratorReconstruction::TryNormalizeContinueCondition is a
-        // distinct result-temp switch-expression shape the fix does not cover and
-        // remains pinned as tracked follow-up.
+        // #2973 removed the result-temp scattered-dispatch defect in
+        // YieldBreakLoopIteratorReconstruction::TryNormalizeContinueCondition
+        // and the existing InlineArrayCollectionPass::PlaceFromAddress sibling
+        // with the same single interleaved default-goto shape.
         string[] expected =
 #if DEBUG
         [
@@ -66,8 +67,6 @@ public class ValidityCoverageReportingTests
             "ILInspector.Decompiler.Pipeline.DeconstructionAssignmentPass::TryMatchTupleSeed",
             "ILInspector.Decompiler.Pipeline.FixedArrayRaising::SameLoadPlace",
             "ILInspector.Decompiler.Pipeline.IndexFromEndPass::LengthReceiver",
-            "ILInspector.Decompiler.Pipeline.InlineArrayCollectionPass::PlaceFromAddress",
-            "ILInspector.Decompiler.Pipeline.YieldBreakLoopIteratorReconstruction::TryNormalizeContinueCondition",
         ];
 #endif
         Assert.Equal(expected, actual);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ReturnMergePass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ReturnMergePass.cs
@@ -108,6 +108,8 @@ public sealed class ReturnMergePass : IIrPass
                 // terminator StructuringPass needs to prove the dispatch.
                 bool mixedScatteredCandidate = branchPreds.Count == 1
                     && conditionalPreds >= 2
+                    && !hasSwitchPred
+                    && fallthroughPred is null
                     && branchPredIndices[0] > conditionalPredIndices.Min()
                     && branchPredIndices[0] < conditionalPredIndices.Max()
                     && IsResultTempReturnTail(merge);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ReturnMergePass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ReturnMergePass.cs
@@ -18,14 +18,21 @@ namespace ILInspector.Decompiler.Pipeline;
 /// the immediate post-dominator of its arms, so duplicating it is a pure copy of
 /// a <c>return</c> that reorders nothing.
 ///
+/// A mixed scattered dispatch is the one additional shape: one explicit
+/// default-arm goto sits between at least two conditional guards that reach the
+/// same tail. The goto is inlined while the shared tail remains for
+/// StructuringPass; the materialized default arm then proves that the
+/// conditional predecessors are scattered rather than a contiguous
+/// short-circuit chain.
+///
 /// Conservative by construction:
 ///   • only short tails (the terminator-inlining budget) are duplicated;
-///   • a merge needs two or more <em>unconditional</em> predecessors — a
-///     two-way <c>if/else</c> join (one goto + one fallthrough) is left to the
-///     structuring pass's diamond form, which already nests it without
-///     duplicating the tail;
-///   • a conditional <c>if (c) goto tail</c> predecessor is left in place for
-///     the structuring pass to raise as a guard.
+///   • outside the mixed shape, a merge needs two or more
+///     <em>unconditional</em> predecessors — a two-way <c>if/else</c> join (one
+///     goto + one fallthrough) is left to the structuring pass's diamond form,
+///     which already nests it without duplicating the tail;
+///   • conditional predecessors are never rewritten here; fewer than two cannot
+///     establish the mixed scattered-dispatch shape.
 /// Runs before structuring.
 /// </summary>
 public sealed class ReturnMergePass : IIrPass
@@ -60,21 +67,27 @@ public sealed class ReturnMergePass : IIrPass
                     continue;
 
                 var branchPreds = new List<Block>();
-                bool hasConditionalOrSwitchPred = false;
-                foreach (var block in blocks)
+                var branchPredIndices = new List<int>();
+                int conditionalPreds = 0;
+                var conditionalPredIndices = new List<int>();
+                bool hasSwitchPred = false;
+                for (int blockIndex = 0; blockIndex < blocks.Count; blockIndex++)
                 {
+                    var block = blocks[blockIndex];
                     if (ReferenceEquals(block, merge) || block.Children.Count == 0)
                         continue;
                     switch (block.Children[^1])
                     {
                         case Branch b when b.TargetOffset == merge.StartOffset:
                             branchPreds.Add(block);
+                            branchPredIndices.Add(blockIndex);
                             break;
                         case ConditionalBranch c when c.TargetOffset == merge.StartOffset:
-                            hasConditionalOrSwitchPred = true;
+                            conditionalPreds++;
+                            conditionalPredIndices.Add(blockIndex);
                             break;
                         case SwitchBranch s when s.TargetOffsets.Contains(merge.StartOffset):
-                            hasConditionalOrSwitchPred = true;
+                            hasSwitchPred = true;
                             break;
                     }
                 }
@@ -86,8 +99,19 @@ public sealed class ReturnMergePass : IIrPass
                 // cannot split a short-circuit false-exit merge.
                 bool isolatedSingleGoto = branchPreds.Count == 1
                     && fallthroughPred is null
-                    && !hasConditionalOrSwitchPred;
-                if (branchPreds.Count < 2 && !isolatedSingleGoto)
+                    && conditionalPreds == 0
+                    && !hasSwitchPred;
+                // A mixed scattered dispatch can have one explicit default-arm
+                // goto plus several conditional guards reaching the same return
+                // tail. Inline the goto arm while leaving the shared tail for the
+                // guards; this turns the default arm into the interleaved
+                // terminator StructuringPass needs to prove the dispatch.
+                bool mixedScatteredCandidate = branchPreds.Count == 1
+                    && conditionalPreds >= 2
+                    && branchPredIndices[0] > conditionalPredIndices.Min()
+                    && branchPredIndices[0] < conditionalPredIndices.Max()
+                    && IsResultTempReturnTail(merge);
+                if (branchPreds.Count < 2 && !isolatedSingleGoto && !mixedScatteredCandidate)
                     continue;
 
                 var tail = merge.Children.ToList();   // snapshot before any mutation
@@ -109,7 +133,7 @@ public sealed class ReturnMergePass : IIrPass
                 // tail; if no conditional guard or surviving leave still targets
                 // the merge, nothing reaches it (and the block before it now
                 // terminates), so drop it.
-                if (!hasConditionalOrSwitchPred && !leaveTargets.Contains(merge.StartOffset))
+                if (conditionalPreds == 0 && !hasSwitchPred && !leaveTargets.Contains(merge.StartOffset))
                     merge.Detach();
 
                 changed = true;
@@ -131,6 +155,16 @@ public sealed class ReturnMergePass : IIrPass
                 return false;
         return true;
     }
+
+    /// <summary>
+    /// The switch-expression/result-temp tail this mixed slice owns:
+    /// <c>V = value; return V;</c>. A direct shared return belongs to the existing
+    /// structuring rules and must not acquire this additional rewrite.
+    /// </summary>
+    static bool IsResultTempReturnTail(Block block)
+        => block.Children is
+        [StoreLocal store, Return { Value: LoadLocal load }]
+        && store.Index == load.Index;
 
     /// <summary>Whether control reaching the end of this block continues into its successor.</summary>
     static bool FallsThrough(Block block) =>


### PR DESCRIPTION
- Fixes/advances #2973
- Changes `ReturnMergePass` to keep an interleaved default-goto default as its region's trailing terminator, so a mixed return-tail candidate returns on every path instead of falling off the end
- Card revision: `e985fe80`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — this brings `InlineArrayCollectionPass::PlaceFromAddress` from invalid (CS0161, falls off the end) to valid (all paths return); the pinned missing-return population drops it and the decompiler fast suite stays at 0 failures.

> Scope note: #2973's original witness, `YieldBreakLoopIteratorReconstruction::TryNormalizeContinueCondition`, was already raised on `main` by #3017 (a forward-goto trampoline). After merging `origin/main`, this PR's remaining product effect is raising the sibling `InlineArrayCollectionPass::PlaceFromAddress`, which #3017's trampoline left as CS0161. This is a **validity** improvement, not a full idiomatic raise (see Fully raised).

### Original source

<!-- Self-decompilation target: repo source of the decompiler's own assembly.
SourceLink C# is not published for a locally built ILInspector.Decompiler.dll,
so the authoritative original is the repository source itself. -->

```csharp
static IrExpression? PlaceFromAddress(IrExpression address, TypeRef arrayType) => address switch
{
    LoadLocalAddress local => new LoadLocal(local.Index, local.Type),
    LoadArgumentAddress argument => new LoadArgument(argument.Index, argument.Name, argument.Type),
    LoadFieldAddress field => new LoadField(
        field.Field,
        field.Instance is null ? null : (IrExpression)field.DetachChildren()[0]),
    LoadElementAddress element => element,
    LoadLocal { ResultType: { Kind: TypeRefKind.ByRef, ElementType: { } element } } local when element.Equals(arrayType)
        => new LoadIndirect(arrayType, local),
    _ => null,
};
```

### Before

<!-- Acquired at base origin/main (0d58c390, has #3017, lacks this PR):
dotnet-inspect member --library ILInspector.Decompiler.dll
  ILInspector.Decompiler.Pipeline.InlineArrayCollectionPass -m PlaceFromAddress --all -S "Decompiled Source" -->

```csharp
private static IrExpression? PlaceFromAddress(IrExpression address, TypeRef arrayType)
{
    TypeRef V_5;
    TypeRef V_8;
    FieldRef S_0;
    IrExpression S_1;

    IrExpression V_7 = address;
    LoadLocalAddress local = V_7 as LoadLocalAddress;
    if (local is null)
    {
        if (V_7 is LoadArgumentAddress argument)
        {
            return new LoadArgument(argument.Index, argument.Name, argument.Type);
        }
        if (V_7 is LoadFieldAddress field)
        {
            S_0 = field.Field;
            S_1 = field.Instance is null ? null : ((IrExpression)field.DetachChildren()[0]);
            return new LoadField(S_0, S_1);
        }
        if (V_7 is LoadElementAddress element)
        {
            return element;
        }
        if (V_7 is LoadLocal V_4)
        {
            V_8 = V_4.ResultType;
            if (V_8 is not null && V_8.Kind == TypeRefKind.ByRef)
            {
                V_5 = V_8.ElementType;
                if (V_5 is not null)
                {
                    if (V_5.Equals(arrayType))
                    {
                        return new LoadIndirect(arrayType, V_4);
                    }
                    return null;
                }
            }
        }
    }
    else
    {
        return new LoadLocal(local.Index, local.Type);
    }
}
```

- Valid: False
- Correct: False

The `LoadLocal` branch falls off the end when `V_8` is null, `Kind != ByRef`, or `V_5` is null, and the outer `if (local is null)` has no trailing return — so the method reaches its closing brace without returning: **CS0161** ("not all code paths return a value"). It is pinned in the base missing-return population.

### After

<!-- Acquired at this PR's head (e985fe80, origin/main merged in):
dotnet-inspect member --library ILInspector.Decompiler.dll
  ILInspector.Decompiler.Pipeline.InlineArrayCollectionPass -m PlaceFromAddress --all -S "Decompiled Source" -->

```csharp
private static IrExpression? PlaceFromAddress(IrExpression address, TypeRef arrayType)
{
    LoadLocal V_4;
    TypeRef V_5;
    TypeRef V_8;
    FieldRef S_0;
    IrExpression S_1;

    IrExpression V_7 = address;
    LoadLocalAddress local = V_7 as LoadLocalAddress;
    if (local is null)
    {
        if (V_7 is LoadArgumentAddress argument)
        {
            return new LoadArgument(argument.Index, argument.Name, argument.Type);
        }
        if (V_7 is LoadFieldAddress field)
        {
            S_0 = field.Field;
            S_1 = field.Instance is null ? null : ((IrExpression)field.DetachChildren()[0]);
            return new LoadField(S_0, S_1);
        }
        if (V_7 is LoadElementAddress element)
        {
            return element;
        }
        V_4 = V_7 as LoadLocal;
        if (V_4 is null)
        {
            return null;
        }
        V_8 = V_4.ResultType;
        if (V_8 is null)
        {
            return null;
        }
        if (V_8.Kind != TypeRefKind.ByRef)
        {
            return null;
        }
        V_5 = V_8.ElementType;
        if (V_5 is not null)
        {
            if (V_5.Equals(arrayType))
            {
                return new LoadIndirect(arrayType, V_4);
            }
            return null;
        }
        return null;
    }
    return new LoadLocal(local.Index, local.Type);
}
```

- Valid: True
- Correct: True

Every path now returns (the previously-missing default is admitted as the region's trailing terminator), so the method compiles and binds. Behavior is preserved — the added returns are all `return null`, matching the original switch's `_ => null` fall-through arm. This is a validity/structuring fix; the output is still a scaffolded if-ladder with decompiler temporaries (`V_4, V_5, V_7, V_8, S_0, S_1`), **not** the original switch expression.

### Fully raised

The After decompilation is **not** in the fully raised state: it reaches validity but keeps the invented temporaries and a nested if-ladder rather than recovering the type-pattern switch expression.

```csharp
static IrExpression? PlaceFromAddress(IrExpression address, TypeRef arrayType) => address switch
{
    LoadLocalAddress local => new LoadLocal(local.Index, local.Type),
    LoadArgumentAddress argument => new LoadArgument(argument.Index, argument.Name, argument.Type),
    LoadFieldAddress field => new LoadField(
        field.Field,
        field.Instance is null ? null : (IrExpression)field.DetachChildren()[0]),
    LoadElementAddress element => element,
    LoadLocal { ResultType: { Kind: TypeRefKind.ByRef, ElementType: { } element } } local when element.Equals(arrayType)
        => new LoadIndirect(arrayType, local),
    _ => null,
};
```

- Required tracking issue: #3028 — recover the type-pattern switch arms (including the nested `ByRef`/`ElementType` pattern with the `when` guard) and eliminate the invented temporaries.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `ValidityCoverageReportingTests` + `ReturnMergePassTests`: pin lists `PlaceFromAddress` (raise not yet applied) | `ValidityCoverageReportingTests` + `ReturnMergePassTests`: 10 passed |
| Decompiler fast suite | 3174, 0 failed | 3174, 0 failed |
| Reduced fixture validity | Pass | Pass |
| Real witness | `InlineArrayCollectionPass::PlaceFromAddress` CS0161 (pinned) | `InlineArrayCollectionPass::PlaceFromAddress` valid (dropped from pin) |

Baseline = `origin/main` `0d58c390` (has #3017's trampoline, lacks this PR). Head = `e985fe80` (this PR with `origin/main` merged in). The full fast suite is 0 failures on both; the pinned missing-return population is the discriminating signal (`PlaceFromAddress` present at Baseline, absent at Head).

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — the pinned missing-return gate (`DecompilerAssembly_MissingReturnPopulationIsPinned`) is green at Head with `PlaceFromAddress` removed, and no other fast-suite test regresses. This PR raises one method to validity; it makes no aggregate corpus claim, and full idiomatic raising is tracked as a frontier in #3028.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.ValidityCoverageReportingTests" -class "ILInspector.Decompiler.Tests.ReturnMergePassTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
```
