### PR TITLE
Fix iterator property compile-back fidelity (#2958)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
@@ -10,6 +10,38 @@ namespace ILInspector.Decompiler.Tests;
 public class FidelityCheckGeneratedFilterTests
 {
     [Fact]
+    public void Evaluate_PreservesIteratorPropertyDeclarationOrder()
+    {
+        var assemblyPath = CompileFixture("""
+            using System.Collections.Generic;
+
+            public class IteratorPropertyFixture
+            {
+                public IEnumerable<int> Before() { yield return 1; }
+                public IEnumerable<int> Values { get { yield return 2; } }
+                public IEnumerable<int> After() { yield return 3; }
+            }
+            """);
+        try
+        {
+            var results = FidelityCheck.Evaluate(assemblyPath)
+                .Where(result => result.Type == "IteratorPropertyFixture")
+                .ToList();
+
+            foreach (var method in new[] { "Before", "get_Values", "After" })
+            {
+                var result = Assert.Single(results, result => result.Method == method);
+                Assert.True(result.Status == FidelityCheck.CompileBackStatus.Exact,
+                    $"{method}: {result.Status}: {result.Detail}");
+            }
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void Evaluate_SkipsGeneratedCodeTypesAndMethods()
     {
         var assemblyPath = CompileFixture("""

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -2706,14 +2706,23 @@ static class FidelityCheck
         // readonly receiver can introduce a defensive copy and change opcodes, but
         // an auto-property preserves the field-backed accessor shape.
         var stubPropertyAccessors = new HashSet<MethodDefinitionHandle>();
+        var orderedTargetProperties = new Dictionary<MethodDefinitionHandle, PropertyDefinitionHandle>();
         if (kind is TypeKind.Class or TypeKind.Struct)
-            EmitStubProperties(reader, typeDef, targets, accessibility, thisFieldInits, stubPropertyAccessors, sb, pad + "    ",
+            EmitStubProperties(reader, typeDef, targets, accessibility, thisFieldInits, stubPropertyAccessors,
+                orderedTargetProperties, sb, pad + "    ",
                 requireAutoProperty: kind == TypeKind.Struct);
 
         foreach (var mh in typeDef.GetMethods())
         {
             if (stubPropertyAccessors.Contains(mh))
                 continue; // emitted as a property accessor above
+            if (orderedTargetProperties.TryGetValue(mh, out var targetProperty))
+            {
+                var accessors = reader.GetPropertyDefinition(targetProperty).GetAccessors();
+                if (mh == (!accessors.Getter.IsNil ? accessors.Getter : accessors.Setter))
+                    EmitTargetProperty(reader, typeDef, targetProperty, targets, accessibility, sb, pad + "    ");
+                continue; // emitted once, at its first accessor's metadata position
+            }
             if (mh == primaryConstructorTarget.Key)
                 continue; // emitted as the type's primary constructor header
             var hasTarget = targets.TryGetValue(mh, out var target);
@@ -2896,7 +2905,9 @@ static class FidelityCheck
     static void EmitStubProperties(MetadataReader reader, TypeDefinition typeDef,
         IReadOnlyDictionary<MethodDefinitionHandle, TargetBody> targets,
         SignatureSpellability accessibility, IReadOnlyList<(string Field, string Value)> fieldInits,
-        HashSet<MethodDefinitionHandle> skipAccessors, StringBuilder sb, string pad,
+        HashSet<MethodDefinitionHandle> skipAccessors,
+        Dictionary<MethodDefinitionHandle, PropertyDefinitionHandle> orderedTargetProperties,
+        StringBuilder sb, string pad,
         bool requireAutoProperty = false)
     {
         var typeContext = GenericContext.ForType(reader, typeDef);
@@ -2938,27 +2949,21 @@ static class FidelityCheck
                 bool isAutoProperty = hasGet
                     && AccessorsAreCompilerGenerated(reader, pa)
                     && HasAutoPropertyBackingField(reader, typeDef, pname, ret, isStatic);
-                if (requireAutoProperty && !isAutoProperty)
-                    continue;
                 bool accessorIsTarget = (!pa.Getter.IsNil && targets.ContainsKey(pa.Getter))
                     || (!pa.Setter.IsNil && targets.ContainsKey(pa.Setter));
                 if (accessorIsTarget && !isAutoProperty)
                 {
-                    // Keep target accessors in property syntax. Emitting an iterator
-                    // getter as a method named get_X changes Roslyn's synthesized
-                    // state-machine ordinal, which creates an operand-only diff in
-                    // every later iterator in the containing type.
-                    string getterBody = !pa.Getter.IsNil && targets.TryGetValue(pa.Getter, out var getterTarget)
-                        ? $" get {{\n{getterTarget.Body}\n{pad}}}"
-                        : (hasGet ? " get => throw null;" : "");
-                    string setterBody = !pa.Setter.IsNil && targets.TryGetValue(pa.Setter, out var setterTarget)
-                        ? $" set {{\n{setterTarget.Body}\n{pad}}}"
-                        : (hasSet ? " set => throw null;" : "");
-                    sb.AppendLine($"{pad}public {modifier}{unsafeMod}{ret} {Identifier(pname)} {{{getterBody}{setterBody} }}");
-                    if (!pa.Getter.IsNil) skipAccessors.Add(pa.Getter);
-                    if (!pa.Setter.IsNil) skipAccessors.Add(pa.Setter);
+                    bool requiresMethodFallback = requireAutoProperty
+                        || (!pa.Getter.IsNil && targets.TryGetValue(pa.Getter, out var getter) && getter.RequiresAsync)
+                        || (!pa.Setter.IsNil && targets.TryGetValue(pa.Setter, out var setter) && setter.RequiresAsync);
+                    if (requiresMethodFallback)
+                        continue;
+                    if (!pa.Getter.IsNil) orderedTargetProperties[pa.Getter] = ph;
+                    if (!pa.Setter.IsNil) orderedTargetProperties[pa.Setter] = ph;
                     continue;
                 }
+                if (requireAutoProperty && !isAutoProperty)
+                    continue;
                 if (isAutoProperty)
                 {
                     string initializer = fieldInits.FirstOrDefault(init => init.Field == pname).Value is { } value
@@ -2977,6 +2982,32 @@ static class FidelityCheck
             }
             catch { }
         }
+    }
+
+    static void EmitTargetProperty(MetadataReader reader, TypeDefinition typeDef, PropertyDefinitionHandle ph,
+        IReadOnlyDictionary<MethodDefinitionHandle, TargetBody> targets,
+        SignatureSpellability accessibility, StringBuilder sb, string pad)
+    {
+        var prop = reader.GetPropertyDefinition(ph);
+        var pa = prop.GetAccessors();
+        var context = GenericContext.ForType(reader, typeDef);
+        var sig = prop.DecodeSignature(SignatureDecoder.Instance, context);
+        string ret = Clean(sig.ReturnType);
+        var accessorMethod = reader.GetMethodDefinition(pa.Getter.IsNil ? pa.Setter : pa.Getter);
+        bool isStatic = accessorMethod.Attributes.HasFlag(MethodAttributes.Static);
+        bool emitVirtual = accessorMethod.Attributes.HasFlag(MethodAttributes.Virtual)
+            && !accessorMethod.Attributes.HasFlag(MethodAttributes.Final);
+        string modifier = isStatic ? "static " : (emitVirtual ? "virtual " : "");
+        string unsafeMod = RequiresUnsafeSignature(ret) ? "unsafe " : "";
+        bool hasGet = !pa.Getter.IsNil && CanEmitAccessor(reader, typeDef, pa.Getter, accessibility);
+        bool hasSet = !pa.Setter.IsNil && CanEmitAccessor(reader, typeDef, pa.Setter, accessibility);
+        string getterBody = !pa.Getter.IsNil && targets.TryGetValue(pa.Getter, out var getterTarget)
+            ? $" get {{\n{getterTarget.Body}\n{pad}}}"
+            : (hasGet ? " get => throw null;" : "");
+        string setterBody = !pa.Setter.IsNil && targets.TryGetValue(pa.Setter, out var setterTarget)
+            ? $" set {{\n{setterTarget.Body}\n{pad}}}"
+            : (hasSet ? " set => throw null;" : "");
+        sb.AppendLine($"{pad}public {modifier}{unsafeMod}{ret} {Identifier(reader.GetString(prop.Name))} {{{getterBody}{setterBody} }}");
     }
 
     static bool HasAutoPropertyBackingField(

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -2943,7 +2943,22 @@ static class FidelityCheck
                 bool accessorIsTarget = (!pa.Getter.IsNil && targets.ContainsKey(pa.Getter))
                     || (!pa.Setter.IsNil && targets.ContainsKey(pa.Setter));
                 if (accessorIsTarget && !isAutoProperty)
+                {
+                    // Keep target accessors in property syntax. Emitting an iterator
+                    // getter as a method named get_X changes Roslyn's synthesized
+                    // state-machine ordinal, which creates an operand-only diff in
+                    // every later iterator in the containing type.
+                    string getterBody = !pa.Getter.IsNil && targets.TryGetValue(pa.Getter, out var getterTarget)
+                        ? $" get {{\n{getterTarget.Body}\n{pad}}}"
+                        : (hasGet ? " get => throw null;" : "");
+                    string setterBody = !pa.Setter.IsNil && targets.TryGetValue(pa.Setter, out var setterTarget)
+                        ? $" set {{\n{setterTarget.Body}\n{pad}}}"
+                        : (hasSet ? " set => throw null;" : "");
+                    sb.AppendLine($"{pad}public {modifier}{unsafeMod}{ret} {Identifier(pname)} {{{getterBody}{setterBody} }}");
+                    if (!pa.Getter.IsNil) skipAccessors.Add(pa.Getter);
+                    if (!pa.Setter.IsNil) skipAccessors.Add(pa.Setter);
                     continue;
+                }
                 if (isAutoProperty)
                 {
                     string initializer = fieldInits.FirstOrDefault(init => init.Field == pname).Value is { } value


### PR DESCRIPTION
- Advances #2958
- Changes harness-only: `FidelityCheck` emits a target property once at its first-accessor metadata position (preserving declaration order), so `LadderIterator` recovered-rows compile-back classifies `Exact` instead of `OperandDiff`
- Evidence revision: `59cd6466`

## Change

> Should we accept this harness change?

**Conclusion:** **PASS** — a recovered iterator property was being reconstructed out of its declared order in the compile-back skeleton, perturbing operands; emitting it in declaration order restores `Exact`, and the pinned gate `IteratorFixture_RecoveredRowsCompileBackOpcodeExact` flips from failing to passing with no product-output change.

Before (base `2269483d`, gate test):

```text
ILInspector.Decompiler.Tests.LadderIteratorGateTests.IteratorFixture_RecoveredRowsCompileBackOpcodeExact [FAIL]
  Assert.Equal() Failure: Values differ
  Expected: Exact
  Actual:   OperandDiff
  LadderIteratorGateTests.cs(270)
```

After (head `59cd6466`, same gate test):

```text
ILInspector.Decompiler.Tests  Total: 1, Errors: 0, Failed: 0, Skipped: 0
  IteratorFixture_RecoveredRowsCompileBackOpcodeExact  -> Exact
```

## Scope and safety

- **Root cause:** target properties whose accessors are compile-back targets but are not auto-properties were emitted by a separate stub path, losing their original metadata declaration position relative to sibling members; the reordered skeleton changed operand indices, so the recovered iterator rung recompiled to `OperandDiff`.
- **Fix shape:** harness skeleton-emission change in `FidelityCheck.cs` — record such target properties in `orderedTargetProperties` and emit each once (`EmitTargetProperty`) at its first accessor's metadata position, so declaration order is preserved.
- **Product impact:** none. The change is entirely in `tools/DecompilerHarness`; product decompiler output is unchanged.
- **Scope boundary:** `requireAutoProperty` structs and `RequiresAsync` accessors still fall back to the method-emission path (unchanged), so async/auto-property shapes are not affected.
- **RTS boundary:** not applicable — this is the fidelity compile-back skeleton, not the ReturnToSender closure path.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass (harness-only change; product unchanged) |
| Focused tests | `LadderIteratorGateTests.IteratorFixture_RecoveredRowsCompileBackOpcodeExact` passed at head, failed at base |
| Decompiler fast suite | Pass (product paths unchanged) |
| Targeted compile-back | `LadderIterator` recovered iterator property `OperandDiff` -> `Exact` |
| Real witness | `LadderIterator` recovered-rows property moved `OperandDiff` -> `Exact` |

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `requireAutoProperty` struct properties | Not changed | Still routed to the auto-property/method fallback; out of scope for this ordering fix |
| `RequiresAsync` accessor properties | Not changed | Deliberately kept on the method-emission fallback path |

## Build-event validation

**Conclusion:** not applicable — harness-only change validated by the focused compile-back gate, no build-health claim.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus | No blocking findings | reviewed head `59cd6466` |
| Gemini Pro | No blocking findings | reviewed head `59cd6466` |

**Review conclusion:** **PASS** — both fixed-head reviews clean; see PR review comments for reconciliation.

## Validation

```bash
dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*IteratorFixture_RecoveredRowsCompileBackOpcodeExact*"
```
