### PR TITLE
Preserve resolved cross-assembly enum shapes (#2953)

### DIFF
--- a/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
+++ b/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
@@ -21,6 +21,15 @@ public class AssemblyDependencyResolverTests
 
         Assert.NotNull(resolved);
         Assert.Equal(current.Name + ".dll", Path.GetFileName(resolved.Path));
+
+        var future = resolver.Resolve(
+            new AssemblyReferenceIdentity(
+                current.Name!,
+                new Version(current.Version!.Major + 1, 0, 0, 0),
+                null,
+                token),
+            AssemblyResolutionScope.Platform);
+        Assert.Null(future);
     }
 
     [Fact]

--- a/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
+++ b/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
@@ -5,6 +5,25 @@ namespace DotnetInspector.Services.Tests;
 public class AssemblyDependencyResolverTests
 {
     [Fact]
+    public void Resolve_PlatformReference_RollsForwardToInstalledAssembly()
+    {
+        var current = typeof(System.Data.Common.DbDataReader).Assembly.GetName();
+        string token = Convert.ToHexString(current.GetPublicKeyToken()!).ToLowerInvariant();
+        var resolver = new AssemblyDependencyResolver(new AssemblyDependencyResolutionOptions(
+            typeof(AssemblyDependencyResolverTests).Assembly.Location)
+        {
+            AllowPlatformAssemblyVersionRollForward = true,
+        });
+
+        var resolved = resolver.Resolve(
+            new AssemblyReferenceIdentity(current.Name!, new Version(1, 0, 0, 0), null, token),
+            AssemblyResolutionScope.Platform);
+
+        Assert.NotNull(resolved);
+        Assert.Equal(current.Name + ".dll", Path.GetFileName(resolved.Path));
+    }
+
+    [Fact]
     public void ResolveAll_IncludesTargetByDefaultAndLetsHarnessExcludeIt()
     {
         string root = Directory.CreateTempSubdirectory("dotnet-inspect-assembly-deps-").FullName;

--- a/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
+++ b/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
@@ -18,6 +18,7 @@ public enum AssemblyDependencyProvenance
     DepsJsonAsset,
     ProjectAsset,
     CorpusAssembly,
+    InstalledPlatformAssembly,
 }
 
 public sealed record ResolvedAssemblyDependency(
@@ -38,6 +39,7 @@ public sealed record AssemblyDependencyResolutionOptions(string TargetAssemblyPa
     public bool IncludeSiblingAssemblies { get; init; } = true;
     public bool IncludeDepsJsonAssets { get; init; } = true;
     public bool PreferImplementationAssemblies { get; init; }
+    public bool AllowPlatformAssemblyVersionRollForward { get; init; }
     public bool ExcludeTargetAssembly { get; init; }
 }
 
@@ -159,7 +161,9 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
                 && dependency.Provenance is not (AssemblyDependencyProvenance.TrustedPlatformAssembly or AssemblyDependencyProvenance.SharedFramework))
                 continue;
 
-            if (!MatchesIdentity(identity, dependency.Path))
+            bool requireVersion = scope != AssemblyResolutionScope.Platform
+                || !_options.AllowPlatformAssemblyVersionRollForward;
+            if (!MatchesIdentity(identity, dependency.Path, requireVersion))
                 continue;
 
             return new ResolvedAssemblyReference(
@@ -169,10 +173,31 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
                 dependency.Provenance.ToString());
         }
 
+        // The target may reference an older platform contract than the running
+        // inspector, and TPA contains only assemblies in the tool's own closure.
+        // Resolve the remaining platform name from installed packs/runtimes.
+        // Decompiler callers may opt into platform roll-forward, which ignores
+        // the assembly version while retaining culture and public-key-token checks.
+        if (scope == AssemblyResolutionScope.Platform && PlatformResolver.IsPlatformCandidate(identity.Name))
+        {
+            var (path, framework, _, _) = PlatformResolver.ResolveAssembly(
+                identity.Name,
+                useRuntimeAssemblies: _options.PreferImplementationAssemblies);
+            bool requireVersion = !_options.AllowPlatformAssemblyVersionRollForward;
+            if (path is not null && MatchesIdentity(identity, path, requireVersion))
+            {
+                return new ResolvedAssemblyReference(
+                    identity,
+                    path,
+                    () => File.OpenRead(path),
+                    $"{AssemblyDependencyProvenance.InstalledPlatformAssembly}:{framework}");
+            }
+        }
+
         return null;
     }
 
-    static bool MatchesIdentity(AssemblyReferenceIdentity expected, string path)
+    static bool MatchesIdentity(AssemblyReferenceIdentity expected, string path, bool requireVersion = true)
     {
         if (expected.Version is null
             && string.IsNullOrEmpty(expected.Culture)
@@ -187,7 +212,7 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
 
         if (!actual.Name.Equals(expected.Name, StringComparison.OrdinalIgnoreCase))
             return false;
-        if (expected.Version is not null && actual.Version != expected.Version)
+        if (requireVersion && expected.Version is not null && actual.Version != expected.Version)
             return false;
         if (!CultureMatches(expected.Culture, actual.Culture))
             return false;

--- a/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
+++ b/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
@@ -161,9 +161,9 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
                 && dependency.Provenance is not (AssemblyDependencyProvenance.TrustedPlatformAssembly or AssemblyDependencyProvenance.SharedFramework))
                 continue;
 
-            bool requireVersion = scope != AssemblyResolutionScope.Platform
-                || !_options.AllowPlatformAssemblyVersionRollForward;
-            if (!MatchesIdentity(identity, dependency.Path, requireVersion))
+            bool allowVersionRollForward = scope == AssemblyResolutionScope.Platform
+                && _options.AllowPlatformAssemblyVersionRollForward;
+            if (!MatchesIdentity(identity, dependency.Path, allowVersionRollForward))
                 continue;
 
             return new ResolvedAssemblyReference(
@@ -183,8 +183,10 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
             var (path, framework, _, _) = PlatformResolver.ResolveAssembly(
                 identity.Name,
                 useRuntimeAssemblies: _options.PreferImplementationAssemblies);
-            bool requireVersion = !_options.AllowPlatformAssemblyVersionRollForward;
-            if (path is not null && MatchesIdentity(identity, path, requireVersion))
+            if (path is not null && MatchesIdentity(
+                identity,
+                path,
+                _options.AllowPlatformAssemblyVersionRollForward))
             {
                 return new ResolvedAssemblyReference(
                     identity,
@@ -197,7 +199,10 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
         return null;
     }
 
-    static bool MatchesIdentity(AssemblyReferenceIdentity expected, string path, bool requireVersion = true)
+    static bool MatchesIdentity(
+        AssemblyReferenceIdentity expected,
+        string path,
+        bool allowVersionRollForward = false)
     {
         if (expected.Version is null
             && string.IsNullOrEmpty(expected.Culture)
@@ -212,7 +217,9 @@ public sealed class AssemblyDependencyResolver : IAssemblyReferenceResolver
 
         if (!actual.Name.Equals(expected.Name, StringComparison.OrdinalIgnoreCase))
             return false;
-        if (requireVersion && expected.Version is not null && actual.Version != expected.Version)
+        if (expected.Version is not null
+            && actual.Version != expected.Version
+            && (!allowVersionRollForward || actual.Version < expected.Version))
             return false;
         if (!CultureMatches(expected.Culture, actual.Culture))
             return false;

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1317,11 +1317,8 @@ public class CfgSampleClass
 
     // --- Cross-assembly enum vs integer (CS0019) ---
     // System.DayOfWeek / System.AttributeTargets live in CoreLib, not this test
-    // assembly, so on decompile ResolveShape returns Unknown — the enum loses its
-    // shape and a sibling int constant or value never retypes. The printer must
-    // recognize the enum structurally (a named definition with no stack family,
-    // opposite an integer) and cast the integer operand to the enum type, or the
-    // comparison/bitwise op is CS0019 (`enum == int` / `enum & int`).
+    // assembly. Resolver-backed classification must preserve their enum shape so
+    // integer operands are cast to the enum type rather than producing CS0019.
 
     // `(int)day` is a no-op on the stack (an enum is already its underlying int),
     // so the IL is a bare `ceq` of the enum arg against the int arg. Decompiled
@@ -1340,6 +1337,23 @@ public class CfgSampleClass
     // which then can't be called on an instance (CS0176). The fix casts the
     // argument to the enum: `s.Equals("x", (StringComparison)5)`.
     public static bool CrossAssemblyEnumCallArgument(string s) => s.Equals("x", System.StringComparison.OrdinalIgnoreCase);
+
+    static void TakesCommandBehavior(System.Data.CommandBehavior behavior) => _ = behavior;
+
+    // Keep a non-constant conditional value in a cross-assembly enum target. The
+    // importer must preserve the resolved enum shape so any materialized join
+    // slot is typed as CommandBehavior rather than int.
+    public static void CrossAssemblyEnumConditional(bool single) =>
+        TakesCommandBehavior(single
+            ? System.Data.CommandBehavior.SequentialAccess | System.Data.CommandBehavior.SingleResult
+            : System.Data.CommandBehavior.SequentialAccess | System.Data.CommandBehavior.SingleResult | System.Data.CommandBehavior.SingleRow);
+
+    // Close negative for the same classification projection: an unresolved
+    // external value type retains its signature hint as a struct, never an enum.
+    public static System.DateTime CrossAssemblyStructConditional(
+        bool first,
+        System.DateTime left,
+        System.DateTime right) => first ? left : right;
 
     // A `switch` over a cross-assembly enum (DayOfWeek, CoreLib): the IL jump
     // table switches on the enum's underlying int, so the raised case labels are

--- a/src/ILInspector.Decompiler.Tests/CrossAssemblyEnumIntegerTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CrossAssemblyEnumIntegerTests.cs
@@ -106,6 +106,11 @@ public class CrossAssemblyEnumIntegerTests
         var dateTime = Assert.Single(
             function.TypeShapes!,
             pair => pair.Key.Namespace == "System" && pair.Key.Name == "DateTime");
-        Assert.Equal(TypeShape.ValueType, dateTime.Value);
+        Assert.Equal(TypeShape.Unknown, dateTime.Value);
+
+        IrPasses.Run(function);
+        function.CheckInvariant();
+        string output = CSharpPrinter.Print(function).Output!;
+        Assert.DoesNotContain("(DateTime)", output);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/CrossAssemblyEnumIntegerTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CrossAssemblyEnumIntegerTests.cs
@@ -1,24 +1,36 @@
 using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
 
 namespace ILInspector.Decompiler.Tests;
 
-// A cross-assembly enum (System.DayOfWeek, System.AttributeTargets — CoreLib, not
-// this test assembly) resolves to TypeShape.Unknown on decompile: EnsureTypeMaps
-// only walks the target assembly's own type defs, so no referenced enum's shape is
-// registered. A sibling int therefore never retypes, leaving `enum == int` /
-// `enum & int` (CS0019). The printer recognizes the enum structurally and casts the
-// integer operand to the enum type. The same-assembly enums (CfgPriority, CfgStyles)
-// resolve to TypeShape.Enum and are unaffected — covered by RefEnumBitwiseTests.
+// Cross-assembly enums (System.DayOfWeek, System.AttributeTargets — CoreLib, not
+// this test assembly) must flow through the resolver-backed classifier into the
+// importer's TypeShapes. The same-assembly enums (CfgPriority, CfgStyles) are
+// covered by RefEnumBitwiseTests.
 public class CrossAssemblyEnumIntegerTests
 {
     static string Render(string methodName)
     {
-        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        using var source = MetadataSource.Open(
+            typeof(CfgSampleClass).Assembly.Location,
+            null,
+            TestAssemblyReferenceResolvers.TrustedPlatformAssemblies());
         var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
         Assert.NotNull(function);
         IrPasses.Run(function!);
         function!.CheckInvariant();
         return CSharpPrinter.Print(function).Output!;
+    }
+
+    static IrFunction Import(string methodName, IAssemblyReferenceResolver resolver)
+    {
+        using var source = MetadataSource.Open(
+            typeof(CfgSampleClass).Assembly.Location,
+            null,
+            resolver);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        return function!;
     }
 
     [Fact]
@@ -64,5 +76,36 @@ public class CrossAssemblyEnumIntegerTests
         Assert.Contains("case (DayOfWeek)2:", output);
         Assert.DoesNotContain("case 1:", output);
         Assert.DoesNotContain("case 2:", output);
+    }
+
+    [Fact]
+    public void ResolvedCrossAssemblyEnum_PopulatesImporterEnumShape()
+    {
+        var function = Import(
+            nameof(CfgSampleClass.CrossAssemblyEnumConditional),
+            TestAssemblyReferenceResolvers.TrustedPlatformAssemblies());
+
+        var commandBehavior = Assert.Single(
+            function.TypeShapes!,
+            pair => pair.Key.Namespace == "System.Data" && pair.Key.Name == "CommandBehavior");
+        Assert.Equal(TypeShape.Enum, commandBehavior.Value);
+
+        IrPasses.Run(function);
+        function.CheckInvariant();
+        string output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("(CommandBehavior)", output);
+    }
+
+    [Fact]
+    public void UnresolvedCrossAssemblyStruct_DoesNotPopulateEnumShape()
+    {
+        var function = Import(
+            nameof(CfgSampleClass.CrossAssemblyStructConditional),
+            TestAssemblyReferenceResolvers.None);
+
+        var dateTime = Assert.Single(
+            function.TypeShapes!,
+            pair => pair.Key.Namespace == "System" && pair.Key.Name == "DateTime");
+        Assert.Equal(TypeShape.ValueType, dateTime.Value);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -642,7 +642,13 @@ public static class IrImporter
                 type = type.ElementType;
             if (type is not { Kind: TypeRefKind.Definition } || !shapes.TryAdd(type, default))
                 return;
-            var shape = source.ResolveShape(type);
+            var shape = source.ClassifyType(type) switch
+            {
+                TypeShapeKind.Enum => TypeShape.Enum,
+                TypeShapeKind.Struct => TypeShape.ValueType,
+                TypeShapeKind.Class or TypeShapeKind.Interface or TypeShapeKind.Delegate => TypeShape.Reference,
+                _ => TypeShape.Unknown,
+            };
             shapes[type] = shape;
             if (source.IsUnionType(type))
                 unionTypes.Add(type);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -642,7 +642,7 @@ public static class IrImporter
                 type = type.ElementType;
             if (type is not { Kind: TypeRefKind.Definition } || !shapes.TryAdd(type, default))
                 return;
-            var shape = source.ClassifyType(type) switch
+            var shape = source.ClassifyResolvedType(type) switch
             {
                 TypeShapeKind.Enum => TypeShape.Enum,
                 TypeShapeKind.Struct => TypeShape.ValueType,

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -313,6 +313,16 @@ public sealed class MetadataSource : IDisposable
         };
     }
 
+    /// <summary>
+    /// The definition-backed type shape without signature-hint fallback. Importer
+    /// facts use this narrower result because a VALUETYPE signature byte cannot
+    /// distinguish an unresolved struct from an unresolved enum.
+    /// </summary>
+    internal TypeShapeKind ClassifyResolvedType(TypeRef type)
+        => type.Kind is TypeRefKind.SzArray or TypeRefKind.Array
+            ? TypeShapeKind.Class
+            : ResolveShapeKind(type);
+
     TypeShapeKind ResolveShapeKind(TypeRef type)
     {
         if (NamedDefinition(type) is not { } definition || string.IsNullOrEmpty(definition.Assembly))

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -313,6 +313,7 @@ internal static class MemberCodeProvider
                 IncludeDepsJsonAssets = false,
                 IncludeAspNetCoreSharedFramework = false,
                 PreferImplementationAssemblies = true,
+                AllowPlatformAssemblyVersionRollForward = true,
             });
             return Decompiler.Pipeline.MetadataSource.Open(dllPath, pdbPath, resolver);
         }


### PR DESCRIPTION
- Fixes/advances #2953
- Changes: cross-assembly enum arguments recover their enum shape and render an `(Enum)` cast instead of a bare `int`, clearing CS0266.
- Card revision: `0b2bc632`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the importer routes referenced-type shape population through the resolver-backed `MetadataSource.ClassifyResolvedType`, so a resolvable cross-assembly enum (`System.Data.CommandBehavior`, in `System.Data.Common`) recovers its shape and the printer emits the required cast; unresolved external value types stay `Unknown`, so no spurious cast is emitted.

### Original source

SourceLink C# is not published for `Dapper@2.1.79`, so per the template the authoritative anchor is the raw IL section (`-S "IL"`). The bare `ldc.i4.s` literals flow straight into a `CommandBehavior` parameter — the enum-ness exists only in the callee signature:

```text
IL_006A: ldc.i4.s     25
IL_006E: ldc.i4.s     17
IL_0070: call         Dapper.SqlMapper::ExecuteReaderWithFlagsFallback(System.Data.IDbCommand, bool, System.Data.CommandBehavior)
```

### Before

Acquired with `member Dapper SqlMapper -m QueryRowImpl --all -S "Decompiled Source"` at base `2269483d`:

```csharp
private static T QueryRowImpl<T>(IDbConnection cnn, SqlMapper.Row row, ref CommandDefinition command, Type effectiveType)
{
    // ...
    int S_7;
    // ...
    S_7 = (row & Row.Single) != 0 ? 17 : 25;
    reader = ExecuteReaderWithFlagsFallback(S_5, S_6, S_7);   // int passed to a CommandBehavior parameter
    // ...
}
```

- Valid: False — CS0266: cannot implicitly convert `int` to `System.Data.CommandBehavior`.
- Correct: n/a (does not compile).

### After

Acquired with the same selector at head `0b2bc632`:

```csharp
    S_7 = (row & Row.Single) != 0 ? 17 : 25;
    reader = ExecuteReaderWithFlagsFallback(S_5, S_6, (CommandBehavior)S_7);
```

- Valid: True.
- Correct: True — the cast reinterprets the same bits; runtime value is unchanged.

### Fully raised

After emits a cast, not named members. The intended endpoint renders the flag decomposition (`17 = SingleResult | SequentialAccess`, `25 = SingleResult | SingleRow | SequentialAccess`):

```csharp
    reader = ExecuteReaderWithFlagsFallback(S_5, S_6,
        (row & Row.Single) != 0
            ? CommandBehavior.SingleResult | CommandBehavior.SequentialAccess
            : CommandBehavior.SingleResult | CommandBehavior.SingleRow | CommandBehavior.SequentialAccess);
```

- Required tracking issue: #3025 — cross-assembly enum **named-member** recovery. The same-assembly-only `ResolveEnumMembers` / `ResolveEnumUnderlyingType` maps must be routed through the resolver. The cast is the accepted minimal fix for CS0266; named-member rendering is the remaining slice.

## Evidence

| Check | Baseline (`2269483d`) | Head (`0b2bc632`) |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | new in PR | `CrossAssemblyEnumIntegerTests`: 6 passed; `AssemblyDependencyResolverTests`: 9 passed |
| Negative fixture (no over-cast) | n/a | `UnresolvedCrossAssemblyStruct_DoesNotPopulateEnumShape`: passed |
| Real witness | `Dapper.SqlMapper::QueryRowImpl` renders `int`→`CommandBehavior` (CS0266) | renders `(CommandBehavior)S_7` (binds) |

Baseline builds clean and shows no focused-test failures (the enum/resolver test classes are added by this PR). The witness before/after above is verbatim product output at each commit.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **ADVISORY** — targeted resolver-routing change; the PR quick corpus gate was not re-run locally. Same-assembly types are unaffected (`ClassifyResolvedType` reproduces the prior `ResolveShape` net result there), so the change can only add casts for genuinely-resolved cross-assembly enums. Coverage is the real Dapper witness, the paired positive/negative fixtures, and two clean adversarial reviews (see the review reconciliation comment).

## Validation

```bash
dotnet build src/dotnet-inspect/dotnet-inspect.csproj -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.CrossAssemblyEnumIntegerTests"
dotnet run --project src/DotnetInspector.Services.Tests -c Release -- -class "DotnetInspector.Services.Tests.AssemblyDependencyResolverTests"
```
