### PR TITLE
Curate the library -D catalog with an @All/@Hidden taxonomy

### DIFF
--- a/docs/design/section-model.md
+++ b/docs/design/section-model.md
@@ -32,8 +32,11 @@ different function than a curated `@Performance`-style door:
 - **`@Hidden`** — the invisible pole, and the **computed complement** of `@All`.
   A section falls into `@Hidden` exactly when no *listed* category surfaces it.
   You never author `@Hidden` membership; it falls out. `@Hidden`'s own name is
-  not listed in `-D`; its members are reached only via `--schema` or an exact
-  request (`-S @Hidden`, `-D @Hidden`).
+  not listed in `-D`; its members are reached only via `--schema`, discovery
+  (`-D @Hidden`), or an exact-name request (`-S "SourceLink Integrity"`).
+  `@Hidden` is **discovery-only**: it is not a render selector, so `-S @Hidden`
+  is rejected. This guarantees its footgun-expensive members (SourceLink
+  Integrity) can never be executed as a group — only by exact name or `-v:d`.
 
 `--schema` is the union: `@All ∪ @Hidden` = the full section graph.
 
@@ -61,33 +64,44 @@ Expensive sections are not effectiveness-probed (see the cost gate below).
 | --- | --- |
 | `-v:q` / `-v:m` | primary `Default` section(s) |
 | `-v:n` | all `Default` + `Terse` sections (the clean default document) |
-| `-S @All` | adds `Noisy` sections — still cheap, still < 1s |
+| `-S @All` | adds `Noisy` sections; excludes expensive/unbounded sections. Its `Default` members (Signals, Symbols) may warm the PDB and run a bounded SourceLink-signal audit. |
 | `-v:d` | the cost axis: `Terse` document **plus** executed `Expensive`/`Network` sections |
 
-`@All` owns the **noise** axis (adds noisy, stays cheap). `-v:d` owns the
-**cost** axis (adds expensive/network work). They are orthogonal knobs.
+`@All` owns the **noise** axis (adds noisy, excludes expensive/unbounded work).
+`-v:d` owns the **cost** axis (adds expensive/network work). They are orthogonal knobs.
 
 ### Two orthogonal gates
 
 - **Cost is an execution gate, not a membership gate.** An `Expensive` section
   may still be *rooted* in a listed category (so it is discoverable by drilling
-  `-D @Category`), but it is **never executed** by category-expand, `--count`,
-  `@All`, or `-v:n`. It runs only via explicit `-S <name>` or `-v:d`. This keeps
-  every category cheap to expand and `--count`: expensive members are listed
-  structurally, never run. SourceLink Integrity is the canonical case — rooted
-  in `@Hidden`, expensive, skill-documented, never triggered by a category probe.
+  `-D @Category`), but **discovery never runs it**: `-D @Category`, `@All`, and
+  `-v:n` list it structurally and never execute it. It runs only via explicit
+  render selection (`-S <name>`, or `-S @Category` when the section is a member)
+  or `-v:d`. Because `-S @Category` is explicit selection, it executes its
+  members like exact names — so no render-selectable category may root an
+  *unbounded* member. SourceLink Integrity is the canonical unbounded case: it
+  is rooted only in `@Hidden`, which is **discovery-only** (`-S @Hidden` is
+  rejected), so it can never be executed as a group.
 - **Category listed/unlisted is the discovery gate.** A listed category's name
   appears in `-D` as a door. `@Hidden` is unlisted, so its members are
   `--schema`-only.
 
 ### Invariants
 
+- **Discovery** of any `@category` (`-D @Category`) is always cheap: it lists
+  member names and never executes them. `--count` and `-S @Category` are *render
+  selection*, not discovery — they execute the selected members like exact names.
+- No **render-selectable** category (`@All`, `@Source`, `@Performance`,
+  `@Surface`, `@Resources`, `@Audit`) roots an *unbounded* member. The one
+  unbounded standalone section, SourceLink Integrity, is rooted only in the
+  **discovery-only** `@Hidden` pole.
 - `-D` = `@All` members + listed category names. Computed, never hand-flagged.
-- A `@category` is always cheap to expand and `--count`. No member may trigger
-  network or heavy work during a category probe.
 - Every section is category-rooted; `@Hidden` is the catch-all for niche and
-  footgun-expensive standalone sections.
-- `@All` returns in < 1s: it excludes expensive sections and feeders.
+  footgun-expensive standalone sections, and is discovery-only (not a render selector).
+- `@All` excludes expensive sections and feeders; its `Default` members (Signals,
+  Symbols) may perform bounded PDB warming and a SourceLink-signal audit, so
+  `-S @All` is bounded (no source-content download, no integrity fan-out) rather
+  than strictly network-free.
 
 ### How the dimensions map
 

--- a/docs/design/section-model.md
+++ b/docs/design/section-model.md
@@ -8,6 +8,98 @@ There are three major aspects in play:
 - Filter (data to shave off / retain)
 - How to render the data
 
+## Section taxonomy
+
+Sections grew organically into a tangle of overlapping flags — `Info`,
+`ExplicitOnly`, `ListedInCatalog`, an inferred "verbose" annotation, plus
+`IsExpensive`, `ProbeEffectiveness`, and `Capabilities`. One boolean
+(`ExplicitOnly`) was made to stand for three unrelated reasons a section stays
+out of the default view (expensive, feeder, niche), and catalog visibility was
+computed inconsistently across mechanisms. This section defines the principled
+model that replaces that tangle.
+
+### One primitive: the category
+
+**Every section is rooted by at least one category.** There are no homeless
+sections. Categories are the universal organizing and discovery unit.
+
+Two categories are poles rather than ordinary groupings, because they serve a
+different function than a curated `@Performance`-style door:
+
+- **`@All`** — the visible pole. Its members are every section worth showing on
+  its own. `@All` owns the top-level discovery catalog: **`-D` lists exactly
+  `@All`'s members plus the names of every other *listed* category.**
+- **`@Hidden`** — the invisible pole, and the **computed complement** of `@All`.
+  A section falls into `@Hidden` exactly when no *listed* category surfaces it.
+  You never author `@Hidden` membership; it falls out. `@Hidden`'s own name is
+  not listed in `-D`; its members are reached only via `--schema` or an exact
+  request (`-S @Hidden`, `-D @Hidden`).
+
+`--schema` is the union: `@All ∪ @Hidden` = the full section graph.
+
+### Two per-section declarations
+
+A section declares only two things. Everything else (`-D` contents, catalog
+visibility, the old "verbose"/"opt-in" annotations) is computed.
+
+1. **Render tier** — when the section auto-renders without `-S`:
+   - `Default` — the hero document (`-v:m`).
+   - `Terse` — the fuller document (`-v:n`); effective and low-noise.
+   - `Noisy` — cheap and effective but low signal-to-noise (Async Methods,
+     Custom Attributes, Extension Methods). Never auto-renders in the `-v`
+     ladder; shown only by `-S @All` or explicit selection.
+2. **Cost bit** — `Cheap` or `Expensive` (with a `Network` refinement for the
+   inherent-network exception).
+
+`Effective` is not a declared axis — it is the existing `CanRender` render
+filter: an auto-selected section that would produce zero rows is suppressed.
+Expensive sections are not effectiveness-probed (see the cost gate below).
+
+### The render ladder
+
+| Selector | Shows |
+| --- | --- |
+| `-v:q` / `-v:m` | primary `Default` section(s) |
+| `-v:n` | all `Default` + `Terse` sections (the clean default document) |
+| `-S @All` | adds `Noisy` sections — still cheap, still < 1s |
+| `-v:d` | the cost axis: `Terse` document **plus** executed `Expensive`/`Network` sections |
+
+`@All` owns the **noise** axis (adds noisy, stays cheap). `-v:d` owns the
+**cost** axis (adds expensive/network work). They are orthogonal knobs.
+
+### Two orthogonal gates
+
+- **Cost is an execution gate, not a membership gate.** An `Expensive` section
+  may still be *rooted* in a listed category (so it is discoverable by drilling
+  `-D @Category`), but it is **never executed** by category-expand, `--count`,
+  `@All`, or `-v:n`. It runs only via explicit `-S <name>` or `-v:d`. This keeps
+  every category cheap to expand and `--count`: expensive members are listed
+  structurally, never run. SourceLink Integrity is the canonical case — rooted
+  in `@Hidden`, expensive, skill-documented, never triggered by a category probe.
+- **Category listed/unlisted is the discovery gate.** A listed category's name
+  appears in `-D` as a door. `@Hidden` is unlisted, so its members are
+  `--schema`-only.
+
+### Invariants
+
+- `-D` = `@All` members + listed category names. Computed, never hand-flagged.
+- A `@category` is always cheap to expand and `--count`. No member may trigger
+  network or heavy work during a category probe.
+- Every section is category-rooted; `@Hidden` is the catch-all for niche and
+  footgun-expensive standalone sections.
+- `@All` returns in < 1s: it excludes expensive sections and feeders.
+
+### How the dimensions map
+
+| Section kind | Render tier | Cost | Category root |
+| --- | --- | --- | --- |
+| Hero (Signals, Symbols) | Default | cheap | `@All` |
+| Structural (Dependencies, References) | Terse | cheap | `@All` |
+| Noisy (Async / Custom Attributes / Extension Methods) | Noisy | cheap | `@All` + `@Surface` |
+| Feeder (Allocation Context) | — (opt-in) | cheap | `@Performance` / `@Audit` (listed door, not `@All`) |
+| Niche (Non-normalized Paths) | — (opt-in) | cheap | `@Hidden` |
+| Expensive (SourceLink Integrity, Vulnerabilities) | — (opt-in) | expensive | `@Hidden` or a listed door (listed, never auto-run) |
+
 ## Query paths
 
 There are three query paths, each offering a different level of curation and customization:

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -6101,6 +6101,26 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task LibraryCommand_RenderSelectHidden_IsRejectedAsDiscoveryOnly()
+    {
+        // @Hidden is a discovery-only pole: -S @Hidden must be rejected (exit 1) so it cannot
+        // fan out to the unbounded SourceLink Integrity check as a group. Discovery (-D @Hidden)
+        // and exact-name render (-S "SourceLink Integrity") remain the supported entrypoints.
+        var (exit, _, error) = await RunAppAsync(
+            "library", TestAssemblyPath, "-S", "@Hidden", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Contains("discovery-only", error);
+
+        // -D @Hidden still lists the pole's members (no rejection).
+        var (discoverExit, discoverOutput, _) = await RunAppAsync(
+            "library", TestAssemblyPath, "-D", "@Hidden", "--table", "--tips", "q");
+
+        Assert.Equal(0, discoverExit);
+        Assert.Contains("SourceLink Integrity", discoverOutput);
+    }
+
+    [Fact]
     public async Task LibraryCommand_DiscoverSchema_GroupsOptInSections()
     {
         var (exit, output, _) = await RunAppAsync("library", "System.Text.Json", "-D", "--schema");

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -6066,25 +6066,38 @@ public class CommandExecutionTests
     ];
 
     [Fact]
-    public async Task LibraryCommand_DiscoverEffective_ListsSourceLinkAuditSections()
+    public async Task LibraryCommand_DiscoverEffective_GroupsSourceLinkUnderSourceAndHidden()
     {
+        // Curated catalog: SourceLink audit sections are not @All members, so bare -D lists
+        // them under the @Source door (Availability/Missing/Files) and the @Hidden pole (Integrity),
+        // never at the top level.
         var (exit, output, error) = await RunAppAsync(
             "library", "--package", "Newtonsoft.Json", "-D", "--table", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.DoesNotContain("Tip:", error);
-        Assert.Contains("SourceLink Availability", output);
-        Assert.Contains("SourceLink Missing Files", output);
-        Assert.Contains("SourceLink Integrity", output);
+        Assert.DoesNotContain("SourceLink Availability", output);
+        Assert.DoesNotContain("SourceLink Missing Files", output);
+        Assert.DoesNotContain("SourceLink Integrity", output);
+        Assert.Contains("@Source", output);
+        // @Hidden is a schema-only pole: it never appears as a bare -D category row.
+        Assert.DoesNotContain("@Hidden", output);
 
-        var (allExit, allOutput, allError) = await RunAppAsync(
-            "library", "--package", "Newtonsoft.Json", "-D", "@All", "--table", "--tips", "q");
+        var (sourceExit, sourceOutput, sourceError) = await RunAppAsync(
+            "library", "--package", "Newtonsoft.Json", "-D", "@Source", "--table", "--tips", "q");
 
-        Assert.Equal(0, allExit);
-        Assert.DoesNotContain("Tip:", allError);
-        Assert.Contains("SourceLink Availability", allOutput);
-        Assert.Contains("SourceLink Missing Files", allOutput);
-        Assert.Contains("SourceLink Integrity", allOutput);
+        Assert.Equal(0, sourceExit);
+        Assert.DoesNotContain("Tip:", sourceError);
+        Assert.Contains("Source Files", sourceOutput);
+        Assert.Contains("SourceLink Availability", sourceOutput);
+        Assert.Contains("SourceLink Missing Files", sourceOutput);
+
+        var (hiddenExit, hiddenOutput, hiddenError) = await RunAppAsync(
+            "library", "--package", "Newtonsoft.Json", "-D", "@Hidden", "--table", "--tips", "q");
+
+        Assert.Equal(0, hiddenExit);
+        Assert.DoesNotContain("Tip:", hiddenError);
+        Assert.Contains("SourceLink Integrity", hiddenOutput);
     }
 
     [Fact]
@@ -6109,55 +6122,30 @@ public class CommandExecutionTests
         var optInNames = lines
             .Where(line => line.Contains("section (opt-in)", StringComparison.Ordinal))
             .Select(ExtractSectionName)
-            .ToArray();
-        Assert.Equal(
-            [
-                "AI",
-                "Allocation Context",
-                "ASP.NET Core",
-                "Aspire",
-                "Async Methods",
-                "Authentication",
-                "Callsite Context",
-                "Configuration",
-                "Cost Context",
-                "Custom Attributes",
-                "Dependency Injection",
-                "Exception Context",
-                "Extension Methods",
-                "Health Checks",
-                "Hosting",
-                "HTTP Client",
-                "Instruction Context",
-                "Integration Opportunities",
-                "Integrations",
-                "Logging",
-                "Member Context",
-                "OpenAPI",
-                "OpenTelemetry",
-                "Options",
-                "Resource Triage",
-                "Resources",
-                "Return Address Context",
-                "Safety Context",
-                "Source Files",
-                "Source Location",
-                "SourceLink Availability",
-                "SourceLink Integrity",
-                "SourceLink Missing Files",
-                "Switches",
-                "Top Leverage",
-                "Type Forwarders",
-                "Union Types",
-                "Unsafe Members"
-            ],
-            optInNames);
-        // The kind-scoped performance sections are catalog-hidden (ListedInCatalog=false): the
-        // @Performance category is their single discoverable entrypoint, so they must not appear in
-        // the top-level catalog even though they remain selectable and drillable via -D @Performance.
-        Assert.DoesNotContain(names, name => name.StartsWith("Performance: ", StringComparison.Ordinal));
+            .ToHashSet(StringComparer.Ordinal);
+
+        // The full --schema catalog is the exhaustive escape hatch: every non-default section is
+        // listed as opt-in, including the surface opt-ins, the source/hidden-pole sections, and the
+        // sections whose default rendering changed under the curated model (P/Invoke, Non-normalized).
+        foreach (var expected in new[]
+                 {
+                     "Async Methods", "Custom Attributes", "Extension Methods", "Type Forwarders",
+                     "Union Types", "P/Invoke Methods", "Non-normalized Paths", "Top Leverage",
+                     "Source Files", "SourceLink Availability", "SourceLink Missing Files",
+                     "SourceLink Integrity", "Member Context", "Integration Opportunities"
+                 })
+        {
+            Assert.Contains(expected, optInNames);
+        }
+
+        // --schema is exhaustive: unlike the -D top level, it also surfaces the kind-scoped
+        // performance sections (their runtime entrypoint remains the @Performance category door).
+        Assert.Contains(names, name => name.StartsWith("Performance: ", StringComparison.Ordinal));
         Assert.Contains(output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries),
             line => ExtractSectionName(line) == "@Performance" && line.Contains("category", StringComparison.Ordinal));
+        // The computed @Hidden pole is revealed by --schema (but not by a bare -D catalog).
+        Assert.Contains(output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries),
+            line => ExtractSectionName(line) == "@Hidden" && line.Contains("category", StringComparison.Ordinal));
         Assert.DoesNotContain(lines, line => line.StartsWith("Missing Source Files", StringComparison.Ordinal));
         Assert.DoesNotContain(lines, line => line.StartsWith("Source Integrity", StringComparison.Ordinal));
     }

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -8051,6 +8051,28 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task PackageCommand_AllLibraries_RejectsHiddenRenderSelector()
+    {
+        // The embedded-library render path resolves -S against the same curated LibrarySections
+        // pipeline, so it enforces the same @Hidden discovery-only guard as the direct library
+        // command: -S @Hidden must be rejected before any resolution/fetch, while exact-name
+        // render of a @Hidden member stays allowed.
+        var (packagePath, tempDir) = CreateLocalLibPackage();
+        try
+        {
+            var (exit, _, error) = await RunAppAsync(
+                "package", packagePath, "--all-libraries", "-S", "@Hidden", "--tips", "q");
+
+            Assert.Equal(1, exit);
+            Assert.Contains("discovery-only", error);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task PackageCommand_AllLibraries_RendersLibraryInfoPerHighestTfmLibrary()
     {
         var (packagePath, tempDir) = CreateLocalLibPackage();

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -344,18 +344,42 @@ public class SectionPipelineTests
     }
 
     [Fact]
-    public void LibraryPipeline_CatalogHiddenSections_AreExactlyThePerformanceKinds()
+    public void LibraryPipeline_CatalogHiddenSections_ExcludeAllMembersIncludeFeeders()
     {
         var pipeline = LibrarySections.CreatePipeline();
 
         var hidden = pipeline.GetCatalogHiddenSections();
 
-        // Catalog-hidden sections (ListedInCatalog=false) are still registered/selectable, but must
-        // be exactly the kind-scoped performance sections whose entrypoint is the @Performance
-        // category. This keeps discovery-list suppression a single, general mechanism.
-        Assert.Equal(
-            PerformanceKinds.Sections.OrderBy(n => n, StringComparer.Ordinal).ToArray(),
-            hidden.OrderBy(n => n, StringComparer.Ordinal).ToArray());
+        // Curated catalog: the -D top level lists only @All members (default-rendered
+        // sections plus Noisy cheap-but-verbose opt-ins) and real category doors.
+        // Everything else is catalog-hidden: reached through a category door (@Performance,
+        // @Source, @Audit, ...), the computed @Hidden pole, or --schema — never the -D top level.
+
+        // @All members are never catalog-hidden.
+        foreach (var allMember in new[]
+                 {
+                     "Library Info", "Symbols", "Signals", "References", "Dependencies",
+                     "Async Methods", "Custom Attributes", "Extension Methods",
+                     "P/Invoke Methods", "Type Forwarders", "Union Types"
+                 })
+        {
+            Assert.DoesNotContain(allMember, hidden);
+        }
+
+        // Feeders (category-doored), the @Hidden pole, and coordinate sections ARE catalog-hidden.
+        foreach (var kind in PerformanceKinds.Sections)
+            Assert.Contains(kind, hidden);
+        foreach (var feeder in new[]
+                 {
+                     "Top Leverage", "Non-normalized Paths", "SourceLink Integrity",
+                     "Source Files", "SourceLink Availability", "SourceLink Missing Files",
+                     "Switches", "Member Context"
+                 })
+        {
+            Assert.Contains(feeder, hidden);
+        }
+
+        // Every catalog-hidden section is still registered and selectable by name.
         foreach (var name in hidden)
         {
             Assert.Contains(name, pipeline.AllSectionNames);
@@ -1050,8 +1074,11 @@ public class SectionPipelineTests
         };
 
         var effective = pipeline.GetEffectiveSections(model, Verbosity.Detailed);
+        var selected = pipeline.GetEffectiveSections(model, Verbosity.Detailed,
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "P/Invoke Methods" });
 
-        Assert.Contains("P/Invoke Methods", effective);
+        Assert.DoesNotContain("P/Invoke Methods", effective);
+        Assert.Contains("P/Invoke Methods", selected);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -74,12 +74,8 @@ public class LibraryCommand
         // @Hidden is a discovery-only pole: it lists via -D @Hidden / --schema and its members
         // render by exact name, but it is not a render selector. This keeps -S from fanning out to
         // the unbounded SourceLink Integrity check (and other @Hidden members) as a group.
-        if (options.Select is { Length: > 0 }
-            && options.Select.Any(v => v.Equals(SectionPipeline<LibraryInspection>.HiddenCategory, StringComparison.OrdinalIgnoreCase)))
-        {
-            Console.Error.WriteLine("Error: @Hidden is discovery-only. List it with -D @Hidden or --schema, and render its members by exact name (for example -S \"SourceLink Integrity\").");
+        if (RejectHiddenRenderSelector(options.Select))
             return 1;
-        }
 
         // -S/--select with values: resolve as section filter for backpressure
         var selectResult = SelectResolver.ResolveSelectAsSections(
@@ -692,6 +688,23 @@ public class LibraryCommand
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
         hidden.ExceptWith(ILCoordinateSections);
         return hidden;
+    }
+
+    // @Hidden is a discovery-only pole: it lists via -D @Hidden / --schema and its members
+    // render by exact name, but it is not a render selector. Rejecting -S @Hidden keeps render
+    // selection from fanning out to the unbounded SourceLink Integrity check (and other @Hidden
+    // members) as a group. Shared with the package embedded-library render path, which resolves
+    // -S against the same curated LibrarySections pipeline.
+    internal static bool RejectHiddenRenderSelector(string[]? select)
+    {
+        if (select is { Length: > 0 }
+            && select.Any(v => v.Equals(SectionPipeline<LibraryInspection>.HiddenCategory, StringComparison.OrdinalIgnoreCase)))
+        {
+            Console.Error.WriteLine("Error: @Hidden is discovery-only. List it with -D @Hidden or --schema, and render its members by exact name (for example -S \"SourceLink Integrity\").");
+            return true;
+        }
+
+        return false;
     }
 
     private static readonly string[] ILCoordinateSections =

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -50,7 +50,9 @@ public class LibraryCommand
                     verbosity: (int)options.Verbosity,
                     sectionCostAnnotations: pipeline.GetCostAnnotations(),
                     sectionCategories: pipeline.GetCategoryMap(),
-                    catalogHiddenSections: pipeline.GetCatalogHiddenSections());
+                    // --schema reveals the full catalog including the @Hidden pole; a static -D
+                    // without --schema keeps the curated top-level view.
+                    catalogHiddenSections: options.Schema ? null : pipeline.GetCatalogHiddenSections());
             }
         }
 
@@ -670,6 +672,18 @@ public class LibraryCommand
         }, null);
     }
 
+    // Catalog-hidden set for the effective (real-assembly) -D flows. IL-offset
+    // coordinate sections are excluded so they remain discoverable at the -D top
+    // level exactly when a coordinate makes them applicable (FilterEffective drops
+    // them otherwise); they stay grouped under @Hidden for --schema / -S.
+    private static IReadOnlySet<string> EffectiveCatalogHidden(SectionPipeline<LibraryInspection> pipeline)
+    {
+        var hidden = pipeline.GetCatalogHiddenSections()
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        hidden.ExceptWith(ILCoordinateSections);
+        return hidden;
+    }
+
     private static readonly string[] ILCoordinateSections =
     [
         SectionNames.ILOffset,
@@ -1281,7 +1295,7 @@ public class LibraryCommand
             verbosity: (int)userVerbosity, rootLabel: rootLabel, fullSchema: schemaMap,
             sectionCostAnnotations: pipeline.GetCostAnnotations(),
             sectionCategories: pipeline.GetCategoryMap(),
-            catalogHiddenSections: pipeline.GetCatalogHiddenSections());
+            catalogHiddenSections: EffectiveCatalogHidden(pipeline));
     }
 
     // ── Effective sections cache ──
@@ -1353,7 +1367,7 @@ public class LibraryCommand
             verbosity: (int)userVerbosity, rootLabel: rootLabel,
             sectionCostAnnotations: LibrarySections.CreatePipeline().GetCostAnnotations(),
             sectionCategories: LibrarySections.CreatePipeline().GetCategoryMap(),
-            catalogHiddenSections: LibrarySections.CreatePipeline().GetCatalogHiddenSections());
+            catalogHiddenSections: EffectiveCatalogHidden(LibrarySections.CreatePipeline()));
     }
 
     /// <summary>

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -71,6 +71,16 @@ public class LibraryCommand
         }
         options = normalized.Options;
 
+        // @Hidden is a discovery-only pole: it lists via -D @Hidden / --schema and its members
+        // render by exact name, but it is not a render selector. This keeps -S from fanning out to
+        // the unbounded SourceLink Integrity check (and other @Hidden members) as a group.
+        if (options.Select is { Length: > 0 }
+            && options.Select.Any(v => v.Equals(SectionPipeline<LibraryInspection>.HiddenCategory, StringComparison.OrdinalIgnoreCase)))
+        {
+            Console.Error.WriteLine("Error: @Hidden is discovery-only. List it with -D @Hidden or --schema, and render its members by exact name (for example -S \"SourceLink Integrity\").");
+            return 1;
+        }
+
         // -S/--select with values: resolve as section filter for backpressure
         var selectResult = SelectResolver.ResolveSelectAsSections(
             options.Select, pipeline.SelectableSectionNames, pipeline.InfoSectionNames, pipeline.GetCategoryMap());

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -1840,6 +1840,12 @@ public class PackageCommand
         string version,
         InspectionOptions options)
     {
+        // The embedded-library path resolves -S against the same curated LibrarySections pipeline,
+        // so it enforces the same @Hidden discovery-only guard as the direct library command
+        // (the single-library path delegates to LibraryCommand.ExecuteAsync, which already guards).
+        if (LibraryCommand.RejectHiddenRenderSelector(options.Select))
+            return 1;
+
         var selected = ResolveAllPackageLibraries(extractPath, packageName, version, options);
         if (selected == null)
             return 1;

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -32,6 +32,13 @@ public class PackageCommand
         var sectionNames = pipeline.SelectableSectionNames;
         bool packageLibraryMode = options.PackageLibrary != null || options.AllLibraries;
 
+        // @Hidden is a discovery-only pole. For the embedded-library render modes (which resolve
+        // -S against the curated LibrarySections pipeline), reject it up front — before extracting
+        // or fetching the package — so an invalid render selector never pays acquisition cost and
+        // can never fan out to the unbounded SourceLink Integrity group.
+        if (packageLibraryMode && LibraryCommand.RejectHiddenRenderSelector(options.Select))
+            return 1;
+
         // Static discovery mode: -D --schema lists schema without resolving/loading the package.
         // Also keep no-target package discovery static because there is no target to make effective.
         if (!packageLibraryMode && options.Discover != null && (options.Schema || packageArgs.Length < 1))
@@ -1840,12 +1847,6 @@ public class PackageCommand
         string version,
         InspectionOptions options)
     {
-        // The embedded-library path resolves -S against the same curated LibrarySections pipeline,
-        // so it enforces the same @Hidden discovery-only guard as the direct library command
-        // (the single-library path delegates to LibraryCommand.ExecuteAsync, which already guards).
-        if (LibraryCommand.RejectHiddenRenderSelector(options.Select))
-            return 1;
-
         var selected = ResolveAllPackageLibraries(extractPath, packageName, version, options);
         if (selected == null)
             return 1;

--- a/src/dotnet-inspect/Output/DiscoverOutput.cs
+++ b/src/dotnet-inspect/Output/DiscoverOutput.cs
@@ -314,6 +314,11 @@ public static class DiscoverOutput
         {
             var items = schema.Discover()!;
             var categoryRows = sectionCategories?
+                // The @Hidden pole is the computed complement of the listed catalog. It is a
+                // --schema/exact-name entrypoint only: excluded from the curated top-level catalog
+                // (catalogHidden applied), but shown in the full schema (catalogHidden null).
+                .Where(category => catalogHiddenSections is null
+                    || !string.Equals(category.Key, SectionCategoryNames.Hidden, StringComparison.OrdinalIgnoreCase))
                 .Select(category => new DiscoveryRow(category.Key, "category"))
                 .ToList() ?? new List<DiscoveryRow>();
 
@@ -519,6 +524,9 @@ public static class DiscoverOutput
                 .ToList();
             var categoryRows = sectionCategories?
                 .Keys
+                // See the flat catalog: @Hidden is shown only in the full schema (catalogHidden null).
+                .Where(name => catalogHiddenSections is null
+                    || !string.Equals(name, SectionCategoryNames.Hidden, StringComparison.OrdinalIgnoreCase))
                 .Select(name => new DiscoveryRow(name, "category"))
                 .ToList() ?? new List<DiscoveryRow>();
 

--- a/src/dotnet-inspect/Sections/ISectionDescriptor.cs
+++ b/src/dotnet-inspect/Sections/ISectionDescriptor.cs
@@ -34,6 +34,15 @@ public interface ISectionDescriptor<TModel>
     static virtual bool Info => false;
 
     /// <summary>
+    /// When true (curated-catalog pipelines only), this section is cheap-but-verbose: low
+    /// signal-to-noise, never auto-rendered by verbosity (it is also <see cref="ExplicitOnly"/>),
+    /// yet a member of the visible <c>@All</c> pole so it stays discoverable at the top of
+    /// <c>-D</c> rather than hiding behind a category door. Distinguishes a noisy surface section
+    /// (e.g. Custom Attributes) from a feeder that only makes sense under its category.
+    /// </summary>
+    static virtual bool Noisy => false;
+
+    /// <summary>
     /// When false, this section is omitted from the top-level discovery catalog (bare <c>-D</c> /
     /// <c>-D --schema</c>) so a curated <c>@category</c> is the single discoverable entrypoint for it.
     /// The section stays fully selectable and stays visible when drilling into its category

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -647,7 +647,7 @@ public static class LibrarySections
         public static string Name => "P/Invoke Methods";
         public static bool IsExpensive => false;
         // Opt-in surface section: real but low signal-to-noise, so it stays out of the default
-        // document and renders only via -S (individually, or through @Surface/@Audit).
+        // document and the -v ladder; renders only via -S (individually, or through @All/@Surface/@Audit).
         public static bool ExplicitOnly => true;
         public static bool Noisy => true;
         public static string? ScannerKey => ScannerClassifiedMethods;

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -33,6 +33,7 @@ public static class LibrarySections
     public static SectionPipeline<LibraryInspection> CreatePipeline()
     {
         return new SectionPipeline<LibraryInspection>()
+            .UseCuratedCatalog()
             .Add<LibraryInfo>()
             .Add<InspectionFailures>(_ => true)
             .Add<ILOffset>()
@@ -92,6 +93,20 @@ public static class LibrarySections
                 "P/Invoke Methods",
                 "Switches")
             .AddCategory(SectionCategoryNames.Performance, PerformanceKinds.Sections)
+            .AddCategory(SectionCategoryNames.Surface,
+                "Async Methods",
+                "Custom Attributes",
+                "Extension Methods",
+                "Type Forwarders",
+                "Union Types",
+                "P/Invoke Methods")
+            .AddCategory(SectionCategoryNames.Resources,
+                "Resources",
+                SectionNames.ResourceTriage)
+            .AddCategory(SectionCategoryNames.Source,
+                "Source Files",
+                "SourceLink Availability",
+                "SourceLink Missing Files")
             .AddCategory("@Integrations", [.. LibraryIntegrationCatalog.CategorySections, "Integration Opportunities", "Union Types"])
             .AddCategory("@Switches", "Switches");
     }
@@ -490,6 +505,7 @@ public static class LibrarySections
         public static string Name => "Extension Methods";
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
+        public static bool Noisy => true;
         public static string? ScannerKey => ScannerExtensionMethods;
         public static bool CanRender(LibraryInspection model)
             => model.ExtensionMemberInspection.CanRenderWithPresence(model.HasExtensionTypes);
@@ -630,6 +646,10 @@ public static class LibrarySections
     {
         public static string Name => "P/Invoke Methods";
         public static bool IsExpensive => false;
+        // Opt-in surface section: real but low signal-to-noise, so it stays out of the default
+        // document and renders only via -S (individually, or through @Surface/@Audit).
+        public static bool ExplicitOnly => true;
+        public static bool Noisy => true;
         public static string? ScannerKey => ScannerClassifiedMethods;
         public static bool CanRender(LibraryInspection model)
             => model.ClassifiedMethodInspection.Failure() is null
@@ -641,6 +661,7 @@ public static class LibrarySections
         public static string Name => "Async Methods";
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
+        public static bool Noisy => true;
         public static string? ScannerKey => ScannerClassifiedMethods;
         public static bool CanRender(LibraryInspection model)
             => model.ClassifiedMethodInspection.Failure() is null
@@ -663,6 +684,7 @@ public static class LibrarySections
         public static string Name => "Custom Attributes";
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
+        public static bool Noisy => true;
         public static string? ScannerKey => ScannerCustomAttributes;
         public static bool CanRender(LibraryInspection model)
             => model.AssemblyAttributeInspection.CanRenderWithPresence(model.HasAssemblyAttributes);
@@ -673,6 +695,7 @@ public static class LibrarySections
         public static string Name => "Union Types";
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
+        public static bool Noisy => true;
         public static string? ScannerKey => ScannerUnionTypes;
         public static bool CanRender(LibraryInspection model)
             => model.UnionTypeInspection.CanRenderWithPresence(model.HasUnionTypes);
@@ -683,6 +706,7 @@ public static class LibrarySections
         public static string Name => "Type Forwarders";
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
+        public static bool Noisy => true;
         public static string? ScannerKey => ScannerTypeForwarders;
         public static bool CanRender(LibraryInspection model)
             => model.TypeForwarderInspection.CanRenderWithPresence(model.HasExportedTypeForwarders);
@@ -692,6 +716,9 @@ public static class LibrarySections
     {
         public static string Name => "Non-normalized Paths";
         public static bool IsExpensive => false;
+        // Opt-in @Hidden section: a niche path-hygiene audit with no category door, reachable only
+        // via --schema or exact name so it never clutters the default document or top-level catalog.
+        public static bool ExplicitOnly => true;
         public static string? ScannerKey => null; // data comes from PdbContext (always collected)
         public static bool CanRender(LibraryInspection model) => model.NonNormalizedPaths is { Count: > 0 };
     }

--- a/src/dotnet-inspect/Sections/SectionCategoryNames.cs
+++ b/src/dotnet-inspect/Sections/SectionCategoryNames.cs
@@ -8,6 +8,18 @@ public static class SectionCategoryNames
     public const string Audit = "@Audit";
     public const string Source = "@Source";
 
+    /// <summary>Cheap-but-verbose surface sections (Async Methods, Custom Attributes, etc.).</summary>
+    public const string Surface = "@Surface";
+
+    /// <summary>Manifest-resource sections (Resources, Resource Triage).</summary>
+    public const string Resources = "@Resources";
+
+    /// <summary>
+    /// Computed complement pole: sections surfaced by no listed category. Discovered only via
+    /// <c>--schema</c> or exact name; excluded from the top-level <c>-D</c> catalog.
+    /// </summary>
+    public const string Hidden = "@Hidden";
+
     /// <summary>Curated group of the kind-scoped performance sections (library scope).</summary>
     public const string Performance = "@Performance";
 }

--- a/src/dotnet-inspect/Sections/SectionPipeline.cs
+++ b/src/dotnet-inspect/Sections/SectionPipeline.cs
@@ -12,6 +12,7 @@ public sealed class SectionEntry<TModel>
     public required bool IsExpensive { get; init; }
     public bool ExplicitOnly { get; init; }
     public bool Info { get; init; }
+    public bool Noisy { get; init; }
     public bool ListedInCatalog { get; init; } = true;
     public bool ProbeEffectiveness { get; init; } = true;
     public SectionCapabilities Capabilities { get; init; }
@@ -42,9 +43,34 @@ public sealed class SectionPipeline<TModel>
 {
     private readonly List<SectionEntry<TModel>> _entries = [];
     private readonly List<SectionCategory> _categories = [];
+    private bool _curatedCatalog;
 
     public const string DefaultCategory = "@Default";
     public const string AllCategory = "@All";
+    public const string HiddenCategory = "@Hidden";
+
+    /// <summary>
+    /// Opts this pipeline into the curated-catalog taxonomy: <c>@All</c> is the visible pole
+    /// (Default + Terse + <see cref="SectionEntry{TModel}.Noisy"/> sections, excluding expensive and
+    /// feeder sections), the top-level <c>-D</c> catalog lists exactly the <c>@All</c> members, and
+    /// <c>@Hidden</c> is the computed complement (sections surfaced by no listed category), reachable
+    /// only via <c>--schema</c> or by exact name. Pipelines that do not opt in keep the legacy model
+    /// where <c>@All</c> is every renderable section. Transitional: removed once every command migrates.
+    /// </summary>
+    public SectionPipeline<TModel> UseCuratedCatalog()
+    {
+        _curatedCatalog = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Membership test for the visible <c>@All</c> pole (curated catalogs only), computed from flags
+    /// alone so it is independent of any model: a section is included when it is cheap and is either
+    /// auto-selectable by verbosity or an explicitly opt-in <see cref="SectionEntry{TModel}.Noisy"/>
+    /// surface section. Expensive sections and non-noisy feeders are excluded.
+    /// </summary>
+    private static bool IsAllMember(SectionEntry<TModel> entry)
+        => !entry.IsExpensive && (!entry.ExplicitOnly || entry.Noisy);
 
     /// <summary>
     /// Registers a section descriptor. The descriptor type is never instantiated —
@@ -59,6 +85,7 @@ public sealed class SectionPipeline<TModel>
             IsExpensive = TDescriptor.IsExpensive,
             ExplicitOnly = TDescriptor.ExplicitOnly,
             Info = TDescriptor.Info,
+            Noisy = TDescriptor.Noisy,
             ListedInCatalog = TDescriptor.ListedInCatalog,
             ProbeEffectiveness = TDescriptor.ProbeEffectiveness,
             Capabilities = TDescriptor.Capabilities,
@@ -116,14 +143,36 @@ public sealed class SectionPipeline<TModel>
         Dictionary<string, string[]> categories = new(StringComparer.OrdinalIgnoreCase)
         {
             [DefaultCategory] = InfoSectionNames,
-            [AllCategory] = SelectableSectionNames
+            [AllCategory] = _curatedCatalog
+                ? _entries.Where(e => IsSelectable(e) && IsAllMember(e)).Select(e => e.Name).ToArray()
+                : SelectableSectionNames
         };
 
         foreach (var category in _categories)
             categories[category.Name] = category.Sections;
 
+        if (_curatedCatalog)
+            categories[HiddenCategory] = GetHiddenSections().ToArray();
+
         return categories;
     }
+
+    /// <summary>
+    /// The computed <c>@Hidden</c> pole (curated catalogs only): selectable sections that are not
+    /// <see cref="IsAllMember"/> and are surfaced by no registered category door. They are reachable
+    /// only via <c>--schema</c>, <c>-S @Hidden</c>, or by exact name. Never hand-authored.
+    /// </summary>
+    private IEnumerable<SectionEntry<TModel>> GetHiddenSectionEntries()
+    {
+        var listed = _categories
+            .SelectMany(c => c.Sections)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return _entries.Where(e => IsSelectable(e) && !IsAllMember(e) && !listed.Contains(e.Name));
+    }
+
+    private IEnumerable<string> GetHiddenSections()
+        => GetHiddenSectionEntries().Select(e => e.Name);
 
     /// <summary>
     /// Names of sections omitted from the top-level discovery catalog
@@ -131,9 +180,13 @@ public sealed class SectionPipeline<TModel>
     /// under their curated <c>@category</c>; they remain selectable and drillable by exact name.
     /// </summary>
     public IReadOnlySet<string> GetCatalogHiddenSections()
-        => _entries.Where(e => !e.ListedInCatalog)
-            .Select(e => e.Name)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        => _curatedCatalog
+            ? _entries.Where(e => IsSelectable(e) && !IsAllMember(e))
+                .Select(e => e.Name)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase)
+            : _entries.Where(e => !e.ListedInCatalog)
+                .Select(e => e.Name)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Maps each section name to a short annotation for discovery output:
@@ -285,6 +338,7 @@ public sealed class SectionPipeline<TModel>
     {
         var all = _entries
             .Where(entry => entry.CanRender(model))
+            .Where(entry => !_curatedCatalog || IsAllMember(entry))
             .Select(entry => entry.Name)
             .Where(name => !string.Equals(name, "Summary", StringComparison.OrdinalIgnoreCase))
             .Distinct(StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
## What

PR1 of two. Replaces the organically-grown section-visibility flags for the **library** view with a principled curated-catalog taxonomy on the shared `SectionPipeline`, opted into only by `LibrarySections.CreatePipeline()` via `.UseCuratedCatalog()`. Type/member/package-level/diff pipelines are **untouched** (PR2 migrates everyone and removes the transitional flag). Package's embedded library rendering reuses this factory, so it inherits the same curated library view.

## Model (curated pipelines only)

- **New per-section flag `Noisy`** — cheap-but-verbose, never auto-rendered (also `ExplicitOnly`), yet an `@All` member so it stays discoverable at the `-D` top level rather than hiding behind a category door.
- `IsAllMember(entry) = !IsExpensive && (!ExplicitOnly || Noisy)` — flag-based, model-independent.
- **`@All`** = the visible pole (Default + Terse + Noisy). The `-D` top-level catalog = exactly the `@All` members + real category doors.
- **`@Hidden`** = the computed complement: selectable sections surfaced by no listed category. Reachable only via `--schema` or exact name; never hand-authored, never a bare-`-D` category row.
- **`--schema`** stays the exhaustive escape hatch — reveals every section plus the `@Hidden` row.

## Library re-flagging

- New categories: `@Surface` (Async Methods, Custom Attributes, Extension Methods, Type Forwarders, Union Types, P/Invoke Methods), `@Resources`, `@Source` (Source Files, SourceLink Availability, SourceLink Missing Files).
- SourceLink Integrity + Top Leverage + Non-normalized Paths + the IL-offset context sections fall into the computed `@Hidden` pole.

### Behavior changes (2, both intended)

1. **P/Invoke Methods -> opt-in** (was default-rendered). Now `Noisy` + `ExplicitOnly`: an `@All` member (discoverable at `-D` top level, under `@Surface`/`@Audit`) but no longer in the default document.
2. **Non-normalized Paths -> `@Hidden`** (was default-rendered). Niche path-hygiene audit, reachable via `--schema` or exact name only.

### Notes for reviewers

- **Top Leverage went to `@Hidden`, not `@Performance`.** Adding it to `@Performance` breaks the #2833 group-tabular "one shared view" invariant (`OutputFormatter.WriteLibraryTabular` collapses `-S @Performance --table` into a single table only when all selected sections share a common view; Top Leverage's view differs). Happy to add a dedicated `@Leverage` door or a Terse promotion instead if preferred.
- **`--schema` is now fully exhaustive** — it also lists the kind-scoped `Performance: *` sections and the `@Hidden` row (previously hidden from `--schema` too). Intended: schema is the escape hatch.
- **IL-offset coordinate sections** are excluded from the *effective* `-D` catalog-hidden set so they remain discoverable at the top level exactly when a coordinate makes them applicable, while staying `@Hidden`-grouped for `--schema`/`-S`.

## Verification

Empirically checked on `System.Text.Json` (cached platform) and `Newtonsoft.Json`:

- bare `-D` = `@All` members + real doors only (no `@Hidden` row, no opt-in spam)
- `-D @Source` lists Availability/Missing/Files; `-D @Hidden` lists Integrity + Top Leverage
- `-D --schema` reveals all sections + `@Hidden`
- Full CLI test suite green apart from the 2 pre-existing Darwin-only P/Invoke content tests (`Interop.User32`), unrelated to this change.

Design spec: `docs/design/section-model.md`.

## Follow-up

PR2: migrate type/member/package-level/diff pipelines to the curated model and remove the transitional `UseCuratedCatalog()` flag.


## `@Hidden` is discovery-only (adversarial-review outcome)

`@Hidden` is a computed pole for niche and footgun-expensive standalone sections
(SourceLink Integrity, Top Leverage). It is reachable for **discovery** (`-D
@Hidden`, `--schema`) and its members **render by exact name** (`-S "SourceLink
Integrity"`), but `-S @Hidden` is **rejected** so it can never fan out to the
unbounded SourceLink Integrity HEAD pass as a group. The guard applies to the
direct `library` command and both package embedded-library modes, and fires
before any package acquisition. See the reconciliation comment for the two-model
review (GPT-5.5 + Gemini 3.1 Pro, both clean at `5215d015`).
