### PR TITLE
Fix RTS Full-body evidence integrity for accessor targets (#3000)

### DIFF
--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -371,7 +371,7 @@ public sealed class CSharpTypePrinter
             if (body.Getter is not null)
                 accessors.Add(AccessorHead(member.Member, "get") + ";");
             if (body.Setter is not null)
-                accessors.Add(AccessorHead(member.Member, "set") + ";");
+                accessors.Add(AccessorHead(member.Member, SetterKeyword(member.Member)) + ";");
             return [$"{PadDeclaration(declaration, pad)} {{ {string.Join(" ", accessors)} }}"];
         }
 
@@ -381,10 +381,19 @@ public sealed class CSharpTypePrinter
             $"{pad}{{"
         };
         AddAccessor(lines, member.Member, "get", body.Getter, indent + 1);
-        AddAccessor(lines, member.Member, "set", body.Setter, indent + 1);
+        AddAccessor(lines, member.Member, SetterKeyword(member.Member), body.Setter, indent + 1);
         lines.Add($"{pad}}}");
         return lines;
     }
+
+    // An init-only property's write accessor is spelled `init`, not `set`. Honor the
+    // accessor model so full-body rendering does not silently downgrade `init` to a
+    // public `set` (dropping the required modreq(IsExternalInit)).
+    static string SetterKeyword(ApiMember member)
+        => member.SignatureModel?.Accessors is { } accessors
+            && accessors.Any(accessor => accessor.Kind == "init")
+            ? "init"
+            : "set";
 
     static IEnumerable<string> RenderEvent(
         PreparedType type,

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -332,6 +332,42 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_FullPreservesAutoPropertyWhenTargetIsAutoAccessor()
+    {
+        // Issue #3000 regression guard: when the target is an auto-property accessor, the property
+        // has no explicit accessor body to preserve. The target-aware branch must leave the base
+        // auto-property skeleton intact rather than replacing it with empty accessor bodies (which
+        // deletes the accessors -> `int Value {  }`, CS0548, forcing a floor fallback).
+        var assemblyPath = CompileFixture("""
+            public class Holder
+            {
+                public int Value { get; } = 42;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Holder", "get_Value", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            var getter = Assert.Single(result.FullBodies, body => body.Member == "Holder.get_Value");
+            Assert.Equal(MemberBodyProductionStatus.Complete, getter.Status);
+            Assert.Contains("Value { get; }", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("Value {  }", result.Source, StringComparison.Ordinal);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.True(
+                result.BodyComplete,
+                string.Join(Environment.NewLine, result.FullBodies.Select(body => $"{body.Member}: {body.Status}: {body.Failure}")));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_FullEventAccessorTargetSurfacesRecompileFailure()
     {
         // Issue #3000: a plain (non-explicit-interface) event accessor target is method-routed, so

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -554,6 +554,122 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_FullMemberSurfacePreservesSiblingInitAccessor()
+    {
+        // Issue #3000: targeting a plain method under Full adds the whole declaring type to the
+        // member surface, so its sibling explicit-body init property flows through the surface
+        // stub-selection path. That path hardcoded `set` (ThrowGetSet / AutoPropertyGetSet),
+        // silently downgrading the init-only setter to a public `set` while Enrich filled the real
+        // body and reported it Complete. The surface path must route init setters through the
+        // init-aware stub kind so the accessor is spelled `init`.
+        var assemblyPath = CompileFixture("""
+            public class Holder
+            {
+                private int _value;
+                public int Value
+                {
+                    get => _value;
+                    init => _value = value;
+                }
+
+                public int M() => 1;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Holder", "M", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Contains("init", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("set", result.Source, StringComparison.Ordinal);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.True(
+                result.BodyComplete,
+                string.Join(Environment.NewLine, result.FullBodies.Select(body => $"{body.Member}: {body.Status}: {body.Failure}")));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_RecordSurfacePreservesSiblingInitAccessor()
+    {
+        // Issue #3000: targeting a record's compiler ToString pulls the whole record onto the
+        // member surface, so a sibling auto init-property flows through the surface stub path.
+        // Before the fix that path emitted `{ get; set; }`, silently dropping the init-only shape
+        // while reporting BodyComplete. The surface path must spell the auto init accessor `init`.
+        var assemblyPath = CompileFixture("""
+            public record Holder(int A)
+            {
+                public int Value { get; init; }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Holder", "ToString", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Selected));
+
+            Assert.Contains("init", result.Source, StringComparison.Ordinal);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.True(
+                result.BodyComplete,
+                string.Join(Environment.NewLine, result.FullBodies.Select(body => $"{body.Member}: {body.Status}: {body.Failure}")));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_InterfaceSurfacePreservesInitAccessor()
+    {
+        // Issue #3000: pulling an interface dependency onto the surface routed its `init` property
+        // through the no-body (interface) stub branch, which emitted `{ get; set; }` and stripped
+        // the init-only shape. The no-body branch must also honor init and render `{ get; init; }`.
+        var assemblyPath = CompileFixture("""
+            public interface IHolder
+            {
+                int Value { get; init; }
+            }
+            public class Holder : IHolder
+            {
+                public int Value { get; init; }
+                public void Method(IHolder holder)
+                {
+                    var x = holder.Value;
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Holder", "Method", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Selected));
+
+            Assert.Contains("init", result.Source, StringComparison.Ordinal);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.True(
+                result.BodyComplete,
+                string.Join(Environment.NewLine, result.FullBodies.Select(body => $"{body.Member}: {body.Status}: {body.Failure}")));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_FullEventAccessorTargetSurfacesRecompileFailure()
     {
         // Issue #3000: a plain (non-explicit-interface) event accessor target is method-routed, so
@@ -4927,7 +5043,7 @@ public class ReturnToSenderPrototypeTests
                     Assert.True(
                         toString.Status == FidelityCheck.CompileBackStatus.Exact,
                         $"{toString.Status}: {toString.Detail}{Environment.NewLine}{toString.Source}");
-                    Assert.Contains("public string Name { get; set; }", toString.Source);
+                    Assert.Contains("public string Name { get; init; }", toString.Source);
                     Assert.DoesNotContain("public string Name;", toString.Source);
                 },
                 typedEquals =>

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -474,6 +474,86 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_FullPreservesExplicitInitAccessorWhenTargetIsGetter()
+    {
+        // Issue #3000: a non-auto (explicit-body) get/init property targeted at its getter was
+        // rendered with a public `set` accessor, silently downgrading the init-only property
+        // (dropping the required modreq(IsExternalInit)) while still reporting set_Value Complete.
+        // The getter compose path must route the sibling init setter through the init-aware stub
+        // kind so the accessor is spelled `init`, preserving the init-only shape.
+        var assemblyPath = CompileFixture("""
+            public class Holder
+            {
+                private int _value;
+                public int Value
+                {
+                    get => _value;
+                    init => _value = value;
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Holder", "get_Value", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(MemberBodyProductionStatus.Complete, Assert.Single(result.FullBodies, body => body.Member == "Holder.get_Value").Status);
+            Assert.Equal(MemberBodyProductionStatus.Complete, Assert.Single(result.FullBodies, body => body.Member == "Holder.set_Value").Status);
+            Assert.Contains("init", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("set", result.Source, StringComparison.Ordinal);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.True(
+                result.BodyComplete,
+                string.Join(Environment.NewLine, result.FullBodies.Select(body => $"{body.Member}: {body.Status}: {body.Failure}")));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_FullPreservesExplicitInitAccessorWhenTargetIsSetter()
+    {
+        // Issue #3000: targeting a non-auto (explicit-body) init setter itself must render an
+        // `init` accessor, not a public `set`. Flipping init to set loses the init-only shape.
+        var assemblyPath = CompileFixture("""
+            public class Holder
+            {
+                private int _value;
+                public int Value
+                {
+                    get => _value;
+                    init => _value = value;
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Holder", "set_Value", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(MemberBodyProductionStatus.Complete, Assert.Single(result.FullBodies, body => body.Member == "Holder.set_Value").Status);
+            Assert.Contains("init", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("set", result.Source, StringComparison.Ordinal);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.True(
+                result.BodyComplete,
+                string.Join(Environment.NewLine, result.FullBodies.Select(body => $"{body.Member}: {body.Status}: {body.Failure}")));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_FullEventAccessorTargetSurfacesRecompileFailure()
     {
         // Issue #3000: a plain (non-explicit-interface) event accessor target is method-routed, so

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -516,6 +516,79 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_FullAutoInitPropertySiblingStaysSkeletonNotRecursive()
+    {
+        // Issue #3000: under Full, a non-target auto init-property sibling was enriched by
+        // decompiling its compiler-synthesized accessors, which read/write the unspeakable
+        // backing field. The decompiler renders that as the property itself, producing recursive
+        // `get { return this.Value; }` / `init { this.Value = value; }` that compiles but is
+        // semantically wrong while the accessors were still reported Complete. The auto-property
+        // skeleton must be preserved so the compiler re-synthesizes faithful accessors.
+        var assemblyPath = CompileFixture("""
+            public readonly struct Holder
+            {
+                public int Value { get; init; }
+                public int M() => 1;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Holder", "M", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Contains("public int Value { get; init; }", result.Source);
+            Assert.DoesNotContain("return this.Value", result.Source);
+            Assert.DoesNotContain("this.Value = value", result.Source);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.True(
+                result.BodyComplete,
+                string.Join(Environment.NewLine, result.FullBodies.Select(body => $"{body.Member}: {body.Status}: {body.Failure}")));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_FullAutoSetPropertySiblingStaysSkeletonNotRecursive()
+    {
+        // Issue #3000: the same recursion downgrade affected plain `{ get; set; }` auto-property
+        // siblings under Full (this class of bug predates the init work); the skeleton must be
+        // preserved so the accessor bodies are not the recursive `return this.Value` shape.
+        var assemblyPath = CompileFixture("""
+            public struct Holder
+            {
+                public int Value { get; set; }
+                public int M() => 1;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Holder", "M", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Contains("public int Value { get; set; }", result.Source);
+            Assert.DoesNotContain("return this.Value", result.Source);
+            Assert.DoesNotContain("this.Value = value", result.Source);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.True(
+                result.BodyComplete,
+                string.Join(Environment.NewLine, result.FullBodies.Select(body => $"{body.Member}: {body.Status}: {body.Failure}")));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_FullPreservesExplicitInitAccessorWhenTargetIsSetter()
     {
         // Issue #3000: targeting a non-auto (explicit-body) init setter itself must render an

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -403,6 +403,77 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_FullPreservesInitAccessorWhenTargetIsGetter()
+    {
+        // Issue #3000: a get/init auto-property targeted at its getter was rendered get-only
+        // (`{ get; }`), silently dropping the init setter while still recording set_Value Complete.
+        // The getter compose path must render a get/init auto-property under Full so the
+        // compiler-synthesized init accessor faithfully reproduces the original setter and stays
+        // represented (not flipped to a public `set`, which would lose the init-only shape).
+        var assemblyPath = CompileFixture("""
+            public class Holder
+            {
+                public int Value { get; init; }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Holder", "get_Value", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(MemberBodyProductionStatus.Complete, Assert.Single(result.FullBodies, body => body.Member == "Holder.get_Value").Status);
+            Assert.Equal(MemberBodyProductionStatus.Complete, Assert.Single(result.FullBodies, body => body.Member == "Holder.set_Value").Status);
+            Assert.Contains("Value { get; init; }", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("Value { get; set; }", result.Source, StringComparison.Ordinal);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.True(
+                result.BodyComplete,
+                string.Join(Environment.NewLine, result.FullBodies.Select(body => $"{body.Member}: {body.Status}: {body.Failure}")));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_FullPreservesInitAccessorWhenTargetIsSetter()
+    {
+        // Issue #3000: targeting the init setter itself must render a get/init auto-property, not
+        // `{ get; set; }`. Flipping init to a public set loses the init-only shape and produces a
+        // setter whose IL diverges from the original init accessor.
+        var assemblyPath = CompileFixture("""
+            public class Holder
+            {
+                public int Value { get; init; }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Holder", "set_Value", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(MemberBodyProductionStatus.Complete, Assert.Single(result.FullBodies, body => body.Member == "Holder.set_Value").Status);
+            Assert.Contains("Value { get; init; }", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("Value { get; set; }", result.Source, StringComparison.Ordinal);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.True(
+                result.BodyComplete,
+                string.Join(Environment.NewLine, result.FullBodies.Select(body => $"{body.Member}: {body.Status}: {body.Failure}")));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_FullEventAccessorTargetSurfacesRecompileFailure()
     {
         // Issue #3000: a plain (non-explicit-interface) event accessor target is method-routed, so

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -281,6 +281,98 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_FullPreservesConcreteSiblingWhenTargetIsPropertyAccessor()
+    {
+        // Issue #3000: when the target is a property accessor, the sibling accessor's produced
+        // full body was silently dropped (kept a `throw null;` stub) while still reported Complete.
+        var assemblyPath = CompileFixture("""
+            public class Holder
+            {
+                private int _v;
+                public int Value
+                {
+                    get => _v;
+                    set { _v = value; }
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Holder", "get_Value", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            var getter = Assert.Single(result.FullBodies, body => body.Member == "Holder.get_Value");
+            var setter = Assert.Single(result.FullBodies, body => body.Member == "Holder.set_Value");
+            Assert.Equal(MemberBodyProductionStatus.Complete, getter.Status);
+            Assert.Equal(MemberBodyProductionStatus.Complete, setter.Status);
+
+            // Evidence reports the sibling Complete, so the emitted sibling body must be the produced
+            // body, not a `throw null;` stub, and the target accessor body must be preserved.
+            Assert.Contains("_v = value;", result.Source, StringComparison.Ordinal);
+            Assert.Contains("return _v;", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("throw null", result.Source, StringComparison.Ordinal);
+            Assert.True(
+                result.BodyComplete,
+                string.Join(Environment.NewLine, result.FullBodies.Select(body => $"{body.Member}: {body.Status}: {body.Failure}")));
+
+            Assert.NotNull(result.Comparison);
+            Assert.Equal(RoundTripComparisonStatus.Completed, result.Comparison.Status);
+            var setterComparison = Assert.Single(
+                result.Comparison.Members,
+                member => member.Target.Method == setter.Method);
+            Assert.Equal(RoundTripEvidenceStatus.Exact, setterComparison.CSharpStatus);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_FullEventAccessorTargetSurfacesRecompileFailure()
+    {
+        // Issue #3000: a plain (non-explicit-interface) event accessor target is method-routed, so
+        // under Full policy the reconstructed type surface re-declares the event, whose synthesized
+        // accessor collides (CS0082) with the standalone target method. The Full closure fails to
+        // recompile and falls back to the compile-back floor. This must be reported honestly:
+        // BodyComplete is false (the Full reconstruction did not compile), not masked as Complete.
+        // Coherent Full reconstruction of plain event-accessor targets is a separate follow-up.
+        var assemblyPath = CompileFixture("""
+            using System;
+
+            public class Holder
+            {
+                private Action? _changed;
+                public event Action Changed
+                {
+                    add { _changed += value; }
+                    remove { _changed -= value; }
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Holder", "add_Changed", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(result.UsedCompileBackFloor, result.Detail);
+            Assert.False(
+                result.BodyComplete,
+                string.Join(Environment.NewLine, result.FullBodies.Select(body => $"{body.Member}: {body.Status}: {body.Failure}")));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_AllSeedsEverySupportedTopLevelRoot()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -368,6 +368,41 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_FullPreservesReadWriteAutoPropertyWhenTargetIsGetter()
+    {
+        // Issue #3000: a read-write auto-property targeted at its getter was rendered get-only
+        // (`{ get; }`), silently dropping the setter while still recording set_Value Complete.
+        // The getter compose path must select AutoPropertyGetSet when a setter exists so the
+        // preserved skeleton keeps both accessors.
+        var assemblyPath = CompileFixture("""
+            public class Holder
+            {
+                public int Value { get; set; }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Holder", "get_Value", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(MemberBodyProductionStatus.Complete, Assert.Single(result.FullBodies, body => body.Member == "Holder.get_Value").Status);
+            Assert.Equal(MemberBodyProductionStatus.Complete, Assert.Single(result.FullBodies, body => body.Member == "Holder.set_Value").Status);
+            Assert.Contains("Value { get; set; }", result.Source, StringComparison.Ordinal);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.True(
+                result.BodyComplete,
+                string.Join(Environment.NewLine, result.FullBodies.Select(body => $"{body.Member}: {body.Status}: {body.Failure}")));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_FullEventAccessorTargetSurfacesRecompileFailure()
     {
         // Issue #3000: a plain (non-explicit-interface) event accessor target is method-routed, so

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -79,7 +79,8 @@ static class ReturnToSender
         public IReadOnlyList<FullBodyProduction> FullBodies { get; init; } = [];
         public bool BodyComplete
             => BodyPolicy != RoundTripBodyPolicy.Full
-               || FullBodies.All(body => body.Status == MemberBodyProductionStatus.Complete);
+               || (!UsedCompileBackFloor
+                   && FullBodies.All(body => body.Status == MemberBodyProductionStatus.Complete));
         public RoundTripComparisonResult? Comparison { get; init; }
         public RoundTripCompilationProvenance? Compilation { get; init; }
         [JsonIgnore]

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -650,10 +650,10 @@ public static class CompileBackSourceComposer
                         new CSharpPropertyBody(
                             getterIsTarget
                                 ? basePropertyBody?.Getter
-                                : getter.Body is { } getterBody ? CSharpAccessorBody.Block(getterBody.Source) : null,
+                                : getter.Body is { } getterBody ? CSharpAccessorBody.Block(getterBody.Source) : basePropertyBody?.Getter,
                             setterIsTarget
                                 ? basePropertyBody?.Setter
-                                : setter.Body is { } setterBody ? CSharpAccessorBody.Block(setterBody.Source) : null));
+                                : setter.Body is { } setterBody ? CSharpAccessorBody.Block(setterBody.Source) : basePropertyBody?.Setter));
                 }
             }
 

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -324,6 +324,7 @@ public enum CompileBackStubBodyKind
     TargetEventAccessorWithSibling,
     AutoProperty,
     AutoPropertyGetSet,
+    AutoPropertyGetInit,
     FieldInitializer,
 }
 
@@ -465,7 +466,8 @@ public static class CompileBackSourceComposer
                 request.SignatureText,
                 closure.Roots,
                 closure.Facts,
-                closure.MemberRequirements),
+                closure.MemberRequirements,
+                request.BodyPolicy),
             PropertySetterArtifactRequest setter => ComposePropertySetter(
                 request.AssemblyPath,
                 request.Reader,
@@ -1014,7 +1016,8 @@ public static class CompileBackSourceComposer
         string signatureText,
         IReadOnlySet<TypeDefinitionHandle> closureRoots,
         IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
-        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements)
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements,
+        RoundTripBodyPolicy bodyPolicy = RoundTripBodyPolicy.Selected)
     {
         var targetTypeDef = reader.GetTypeDefinition(targetType);
         var property = reader.GetPropertyDefinition(targetProperty);
@@ -1048,10 +1051,20 @@ public static class CompileBackSourceComposer
                 ToCompileBackParameters(propertyDeclaration.Signature.Parameters),
                 returnType,
                 TypeParameters: [],
+                // A read-write auto-property targeted at its getter must render both accessors so
+                // the compiler-synthesized sibling accessor faithfully reproduces the original
+                // setter rather than being silently dropped while still reported Complete (issue
+                // #3000 class). An init-only setter renders a get/init auto-property under Full so
+                // the init accessor is represented; the getter-only A/B path (Selected) keeps the
+                // minimal get-only shell (records rely on this).
                 targetIsAutoProperty
-                    ? accessors.Setter.IsNil || SetterIsInitOnly(reader, accessors.Setter)
+                    ? accessors.Setter.IsNil
                         ? CompileBackStubBodyKind.AutoProperty
-                        : CompileBackStubBodyKind.AutoPropertyGetSet
+                        : SetterIsInitOnly(reader, accessors.Setter)
+                            ? bodyPolicy == RoundTripBodyPolicy.Full
+                                ? CompileBackStubBodyKind.AutoPropertyGetInit
+                                : CompileBackStubBodyKind.AutoProperty
+                            : CompileBackStubBodyKind.AutoPropertyGetSet
                     : accessors.Setter.IsNil
                         ? CompileBackStubBodyKind.TargetBody
                         : CompileBackStubBodyKind.TargetGetterWithSetter,
@@ -1360,7 +1373,9 @@ public static class CompileBackSourceComposer
                 returnType,
                 TypeParameters: [],
                 targetIsAutoProperty
-                    ? CompileBackStubBodyKind.AutoPropertyGetSet
+                    ? SetterIsInitOnly(reader, targetSetter)
+                        ? CompileBackStubBodyKind.AutoPropertyGetInit
+                        : CompileBackStubBodyKind.AutoPropertyGetSet
                     : property.GetAccessors().Getter.IsNil
                         ? CompileBackStubBodyKind.TargetBody
                         : CompileBackStubBodyKind.TargetSetterWithGetter,
@@ -1831,14 +1846,20 @@ public static class CompileBackSourceComposer
 
     static List<ApiAccessor> PropertyAccessors(CompileBackMemberRequirement member)
     {
-        bool hasGetter = member.Kind == CompileBackMemberKind.PropertyGet
+        // AutoPropertyGetInit renders a get/init auto-property. The compiler-synthesized init
+        // accessor faithfully reproduces the original init setter body, so the sibling/target
+        // setter stays represented (not dropped) while remaining honest about its init-only shape.
+        bool isGetInit = member.StubBody is CompileBackStubBodyKind.AutoPropertyGetInit;
+        bool hasGetter = isGetInit
+            || member.Kind == CompileBackMemberKind.PropertyGet
             || member.StubBody is CompileBackStubBodyKind.AutoPropertyGetSet
                 or CompileBackStubBodyKind.ThrowGetSet
                 or CompileBackStubBodyKind.TargetSetterWithGetter;
-        bool hasSetter = member.Kind == CompileBackMemberKind.PropertySet
-            || member.StubBody is CompileBackStubBodyKind.AutoPropertyGetSet
-                or CompileBackStubBodyKind.ThrowGetSet
-                or CompileBackStubBodyKind.TargetGetterWithSetter;
+        bool hasSetter = !isGetInit
+            && (member.Kind == CompileBackMemberKind.PropertySet
+                || member.StubBody is CompileBackStubBodyKind.AutoPropertyGetSet
+                    or CompileBackStubBodyKind.ThrowGetSet
+                    or CompileBackStubBodyKind.TargetGetterWithSetter);
         var accessors = new List<ApiAccessor>();
         if (hasGetter)
         {
@@ -1850,6 +1871,8 @@ public static class CompileBackSourceComposer
         }
         if (hasSetter)
             accessors.Add(new ApiAccessor { Kind = "set" });
+        if (isGetInit)
+            accessors.Add(new ApiAccessor { Kind = "init" });
         return accessors;
     }
 
@@ -1865,6 +1888,8 @@ public static class CompileBackSourceComposer
             CompileBackStubBodyKind.AutoProperty
                 => new(member, CSharpBodyPolicy.Skeleton),
             CompileBackStubBodyKind.AutoPropertyGetSet
+                => new(member, CSharpBodyPolicy.Skeleton),
+            CompileBackStubBodyKind.AutoPropertyGetInit
                 => new(member, CSharpBodyPolicy.Skeleton),
             CompileBackStubBodyKind.Throw when requirement.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet
                 => new(member, CSharpBodyPolicy.Stub, PropertyBody(requirement, CSharpAccessorBody.Throw)),

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -649,7 +649,16 @@ public static class CompileBackSourceComposer
                     // and there is no explicit target body to extend. Leave that policy untouched
                     // rather than replacing it with empty accessor bodies, which would delete the
                     // property's accessors (e.g. auto-properties -> `int Value {  }`, CS0548).
-                    if (targetInvolved && basePropertyBody is null)
+                    //
+                    // The same applies to a NON-target auto-property sibling: producing explicit
+                    // bodies for it decompiles the compiler-synthesized accessors, which read/write
+                    // the unspeakable backing field. The decompiler renders that field access as the
+                    // property itself, yielding recursive `get { return this.P; }` / `init { this.P
+                    // = value; }`. That compiles but is semantically wrong while still reporting the
+                    // accessors Complete. Preserve the skeleton so the compiler re-synthesizes
+                    // faithful auto-property accessors.
+                    bool isAutoSkeleton = existingPropertyPolicy is { BodyPolicy: CSharpBodyPolicy.Skeleton };
+                    if (basePropertyBody is null && (targetInvolved || isAutoSkeleton))
                         continue;
                     policies[member] = new CSharpMemberPolicy(
                         member,

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -618,22 +618,34 @@ public static class CompileBackSourceComposer
                 bool concreteSetter = member.SetterToken is { } setterHandle && HasConcreteBody(setterHandle);
                 if (!concreteGetter && !concreteSetter)
                     continue;
-                var getter = member.GetterToken is { } getterToken && concreteGetter
+                bool getterIsTarget = member.GetterToken is { } getterTargetHandle && IsTargetToken(getterTargetHandle);
+                bool setterIsTarget = member.SetterToken is { } setterTargetHandle && IsTargetToken(setterTargetHandle);
+                var getter = member.GetterToken is { } getterToken && concreteGetter && !getterIsTarget
                     ? Produce(getterToken, $"{request.Type.FullName}.get_{member.Name}")
                     : default;
-                var setter = member.SetterToken is { } setterToken && concreteSetter
+                var setter = member.SetterToken is { } setterToken && concreteSetter && !setterIsTarget
                     ? Produce(setterToken, $"{request.Type.FullName}.set_{member.Name}")
                     : default;
-                bool getterReady = !concreteGetter || getter.Body is not null;
-                bool setterReady = !concreteSetter || setter.Body is not null;
+                // The target accessor's body is applied by the base Compose* path, not by Produce here;
+                // treat it as ready and preserve its already-applied body so the sibling's produced body
+                // is incorporated instead of clobbering the target with a null accessor.
+                bool getterReady = !concreteGetter || getterIsTarget || getter.Body is not null;
+                bool setterReady = !concreteSetter || setterIsTarget || setter.Body is not null;
                 if (getterReady && setterReady)
                 {
+                    var basePropertyBody = policies.TryGetValue(member, out var existingPropertyPolicy)
+                        ? existingPropertyPolicy.Body as CSharpPropertyBody
+                        : null;
                     policies[member] = new CSharpMemberPolicy(
                         member,
                         CSharpBodyPolicy.Full,
                         new CSharpPropertyBody(
-                            getter.Body is { } getterBody ? CSharpAccessorBody.Block(getterBody.Source) : null,
-                            setter.Body is { } setterBody ? CSharpAccessorBody.Block(setterBody.Source) : null));
+                            getterIsTarget
+                                ? basePropertyBody?.Getter
+                                : getter.Body is { } getterBody ? CSharpAccessorBody.Block(getterBody.Source) : null,
+                            setterIsTarget
+                                ? basePropertyBody?.Setter
+                                : setter.Body is { } setterBody ? CSharpAccessorBody.Block(setterBody.Source) : null));
                 }
             }
 
@@ -673,6 +685,9 @@ public static class CompileBackSourceComposer
             var handle = MetadataTokens.MethodDefinitionHandle(token & 0x00ffffff);
             return artifact.Reader.GetMethodDefinition(handle).RelativeVirtualAddress != 0;
         }
+
+        bool IsTargetToken(int token)
+            => MetadataTokens.MethodDefinitionHandle(token & 0x00ffffff) == artifact.TargetMethod;
     }
 
     public static CompileBackMemberRequirement? TryCreateClosureMemberRequirement(

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -320,7 +320,10 @@ public enum CompileBackStubBodyKind
     ThrowGetSet,
     TargetBody,
     TargetGetterWithSetter,
+    TargetGetterWithInitSetter,
     TargetSetterWithGetter,
+    TargetInitSetterWithGetter,
+    TargetInitBody,
     TargetEventAccessorWithSibling,
     AutoProperty,
     AutoPropertyGetSet,
@@ -1067,7 +1070,9 @@ public static class CompileBackSourceComposer
                             : CompileBackStubBodyKind.AutoPropertyGetSet
                     : accessors.Setter.IsNil
                         ? CompileBackStubBodyKind.TargetBody
-                        : CompileBackStubBodyKind.TargetGetterWithSetter,
+                        : SetterIsInitOnly(reader, accessors.Setter)
+                            ? CompileBackStubBodyKind.TargetGetterWithInitSetter
+                            : CompileBackStubBodyKind.TargetGetterWithSetter,
                 targetIsAutoProperty ? null : targetBody,
                 targetIsAutoProperty
                     ? [
@@ -1377,8 +1382,12 @@ public static class CompileBackSourceComposer
                         ? CompileBackStubBodyKind.AutoPropertyGetInit
                         : CompileBackStubBodyKind.AutoPropertyGetSet
                     : property.GetAccessors().Getter.IsNil
-                        ? CompileBackStubBodyKind.TargetBody
-                        : CompileBackStubBodyKind.TargetSetterWithGetter,
+                        ? SetterIsInitOnly(reader, targetSetter)
+                            ? CompileBackStubBodyKind.TargetInitBody
+                            : CompileBackStubBodyKind.TargetBody
+                        : SetterIsInitOnly(reader, targetSetter)
+                            ? CompileBackStubBodyKind.TargetInitSetterWithGetter
+                            : CompileBackStubBodyKind.TargetSetterWithGetter,
                 targetIsAutoProperty ? null : targetBody,
                 targetIsAutoProperty
                     ? [
@@ -1849,17 +1858,25 @@ public static class CompileBackSourceComposer
         // AutoPropertyGetInit renders a get/init auto-property. The compiler-synthesized init
         // accessor faithfully reproduces the original init setter body, so the sibling/target
         // setter stays represented (not dropped) while remaining honest about its init-only shape.
-        bool isGetInit = member.StubBody is CompileBackStubBodyKind.AutoPropertyGetInit;
-        bool hasGetter = isGetInit
+        bool isAutoGetInit = member.StubBody is CompileBackStubBodyKind.AutoPropertyGetInit;
+        // Explicit-body init accessors must be spelled `init`, not `set`; otherwise the round-trip
+        // silently downgrades an init-only property to a public setter (dropping the required
+        // modreq(IsExternalInit)) while still reporting the body Complete.
+        bool setterIsInit = member.StubBody is CompileBackStubBodyKind.TargetGetterWithInitSetter
+            or CompileBackStubBodyKind.TargetInitSetterWithGetter
+            or CompileBackStubBodyKind.TargetInitBody;
+        bool hasGetter = isAutoGetInit
             || member.Kind == CompileBackMemberKind.PropertyGet
             || member.StubBody is CompileBackStubBodyKind.AutoPropertyGetSet
                 or CompileBackStubBodyKind.ThrowGetSet
-                or CompileBackStubBodyKind.TargetSetterWithGetter;
-        bool hasSetter = !isGetInit
+                or CompileBackStubBodyKind.TargetSetterWithGetter
+                or CompileBackStubBodyKind.TargetInitSetterWithGetter;
+        bool hasSetter = !isAutoGetInit
             && (member.Kind == CompileBackMemberKind.PropertySet
                 || member.StubBody is CompileBackStubBodyKind.AutoPropertyGetSet
                     or CompileBackStubBodyKind.ThrowGetSet
-                    or CompileBackStubBodyKind.TargetGetterWithSetter);
+                    or CompileBackStubBodyKind.TargetGetterWithSetter
+                    or CompileBackStubBodyKind.TargetGetterWithInitSetter);
         var accessors = new List<ApiAccessor>();
         if (hasGetter)
         {
@@ -1870,8 +1887,8 @@ public static class CompileBackSourceComposer
             });
         }
         if (hasSetter)
-            accessors.Add(new ApiAccessor { Kind = "set" });
-        if (isGetInit)
+            accessors.Add(new ApiAccessor { Kind = setterIsInit ? "init" : "set" });
+        if (isAutoGetInit)
             accessors.Add(new ApiAccessor { Kind = "init" });
         return accessors;
     }
@@ -1922,6 +1939,11 @@ public static class CompileBackSourceComposer
                     member,
                     CSharpBodyPolicy.Full,
                     PropertyBody(requirement, CSharpAccessorBody.Block(requirement.TargetBody!))),
+            CompileBackStubBodyKind.TargetInitBody
+                => new(
+                    member,
+                    CSharpBodyPolicy.Full,
+                    PropertyBody(requirement, CSharpAccessorBody.Block(requirement.TargetBody!))),
             CompileBackStubBodyKind.TargetBody when requirement.Kind is CompileBackMemberKind.EventAdd or CompileBackMemberKind.EventRemove
                 => new(
                     member,
@@ -1960,7 +1982,21 @@ public static class CompileBackSourceComposer
                     new CSharpPropertyBody(
                         CSharpAccessorBody.Block(requirement.TargetBody!),
                         CSharpAccessorBody.Throw)),
+            CompileBackStubBodyKind.TargetGetterWithInitSetter
+                => new(
+                    member,
+                    CSharpBodyPolicy.Full,
+                    new CSharpPropertyBody(
+                        CSharpAccessorBody.Block(requirement.TargetBody!),
+                        CSharpAccessorBody.Throw)),
             CompileBackStubBodyKind.TargetSetterWithGetter
+                => new(
+                    member,
+                    CSharpBodyPolicy.Full,
+                    new CSharpPropertyBody(
+                        CSharpAccessorBody.Throw,
+                        CSharpAccessorBody.Block(requirement.TargetBody!))),
+            CompileBackStubBodyKind.TargetInitSetterWithGetter
                 => new(
                     member,
                     CSharpBodyPolicy.Full,

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Collections.Immutable;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -1048,7 +1049,9 @@ public static class CompileBackSourceComposer
                 returnType,
                 TypeParameters: [],
                 targetIsAutoProperty
-                    ? CompileBackStubBodyKind.AutoProperty
+                    ? accessors.Setter.IsNil || SetterIsInitOnly(reader, accessors.Setter)
+                        ? CompileBackStubBodyKind.AutoProperty
+                        : CompileBackStubBodyKind.AutoPropertyGetSet
                     : accessors.Setter.IsNil
                         ? CompileBackStubBodyKind.TargetBody
                         : CompileBackStubBodyKind.TargetGetterWithSetter,
@@ -2797,6 +2800,71 @@ public static class CompileBackSourceComposer
         }
 
         return false;
+    }
+
+    // An init-only setter carries a required custom modifier
+    // modreq(System.Runtime.CompilerServices.IsExternalInit) on its return type.
+    // Such properties (including record positional properties) must render as a
+    // get-only auto-property shell — the init assignment is expressed through the
+    // constructor, not a public `set` — so they must not be broadened to
+    // `{ get; set; }`.
+    static bool SetterIsInitOnly(MetadataReader reader, MethodDefinitionHandle setterHandle)
+    {
+        if (setterHandle.IsNil)
+            return false;
+        try
+        {
+            var setter = reader.GetMethodDefinition(setterHandle);
+            return setter.DecodeSignature(InitOnlyModifierDetector.Instance, genericContext: null).ReturnType;
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    sealed class InitOnlyModifierDetector : ISignatureTypeProvider<bool, object?>
+    {
+        public static readonly InitOnlyModifierDetector Instance = new();
+
+        public bool GetPrimitiveType(PrimitiveTypeCode typeCode) => false;
+
+        public bool GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
+        {
+            var type = reader.GetTypeDefinition(handle);
+            return IsExternalInit(reader.GetString(type.Name), reader.GetString(type.Namespace));
+        }
+
+        public bool GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+        {
+            var type = reader.GetTypeReference(handle);
+            return IsExternalInit(reader.GetString(type.Name), reader.GetString(type.Namespace));
+        }
+
+        public bool GetTypeFromSpecification(MetadataReader reader, object? context, TypeSpecificationHandle handle, byte rawTypeKind) => false;
+
+        public bool GetSZArrayType(bool elementType) => elementType;
+
+        public bool GetArrayType(bool elementType, ArrayShape shape) => elementType;
+
+        public bool GetByReferenceType(bool elementType) => elementType;
+
+        public bool GetPointerType(bool elementType) => elementType;
+
+        public bool GetGenericInstantiation(bool genericType, ImmutableArray<bool> typeArguments) => genericType;
+
+        public bool GetGenericMethodParameter(object? context, int index) => false;
+
+        public bool GetGenericTypeParameter(object? context, int index) => false;
+
+        public bool GetFunctionPointerType(MethodSignature<bool> signature) => false;
+
+        public bool GetModifiedType(bool modifier, bool unmodifiedType, bool isRequired) => (isRequired && modifier) || unmodifiedType;
+
+        public bool GetPinnedType(bool elementType) => elementType;
+
+        static bool IsExternalInit(string name, string ns)
+            => name == "IsExternalInit" && ns == "System.Runtime.CompilerServices";
     }
 
     static CompileBackTypeKind ShellKind(MetadataReader reader, TypeDefinition typeDef, IReadOnlyList<CompileBackFact>? facts = null)

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -318,6 +318,7 @@ public enum CompileBackStubBodyKind
     None,
     Throw,
     ThrowGetSet,
+    ThrowGetInit,
     TargetBody,
     TargetGetterWithSetter,
     TargetGetterWithInitSetter,
@@ -1864,17 +1865,20 @@ public static class CompileBackSourceComposer
         // modreq(IsExternalInit)) while still reporting the body Complete.
         bool setterIsInit = member.StubBody is CompileBackStubBodyKind.TargetGetterWithInitSetter
             or CompileBackStubBodyKind.TargetInitSetterWithGetter
-            or CompileBackStubBodyKind.TargetInitBody;
+            or CompileBackStubBodyKind.TargetInitBody
+            or CompileBackStubBodyKind.ThrowGetInit;
         bool hasGetter = isAutoGetInit
             || member.Kind == CompileBackMemberKind.PropertyGet
             || member.StubBody is CompileBackStubBodyKind.AutoPropertyGetSet
                 or CompileBackStubBodyKind.ThrowGetSet
+                or CompileBackStubBodyKind.ThrowGetInit
                 or CompileBackStubBodyKind.TargetSetterWithGetter
                 or CompileBackStubBodyKind.TargetInitSetterWithGetter;
         bool hasSetter = !isAutoGetInit
             && (member.Kind == CompileBackMemberKind.PropertySet
                 || member.StubBody is CompileBackStubBodyKind.AutoPropertyGetSet
                     or CompileBackStubBodyKind.ThrowGetSet
+                    or CompileBackStubBodyKind.ThrowGetInit
                     or CompileBackStubBodyKind.TargetGetterWithSetter
                     or CompileBackStubBodyKind.TargetGetterWithInitSetter);
         var accessors = new List<ApiAccessor>();
@@ -1928,6 +1932,11 @@ public static class CompileBackSourceComposer
             CompileBackStubBodyKind.Throw
                 => new(member, CSharpBodyPolicy.Stub),
             CompileBackStubBodyKind.ThrowGetSet
+                => new(
+                    member,
+                    CSharpBodyPolicy.Stub,
+                    new CSharpPropertyBody(CSharpAccessorBody.Throw, CSharpAccessorBody.Throw)),
+            CompileBackStubBodyKind.ThrowGetInit
                 => new(
                     member,
                     CSharpBodyPolicy.Stub,
@@ -3285,18 +3294,25 @@ public static class CompileBackSourceComposer
             bool isAutoProperty = !accessors.Getter.IsNil
                 && IsAutoProperty(reader, typeDef, property, accessors.Getter, returnType.DisplayName);
             bool hasSetter = !accessors.Setter.IsNil;
+            bool isInitSetter = hasSetter && SetterIsInitOnly(reader, accessors.Setter);
             bool isAbstractAccessor = !accessor.IsNil && propertyDeclaration.IsAbstract;
             var noBodyProperty = (typeDef.Attributes & TypeAttributes.Interface) != 0 || isAbstractAccessor;
             var stubBody = noBodyProperty
                 ? hasSetter
-                    ? CompileBackStubBodyKind.AutoPropertyGetSet
+                    ? isInitSetter
+                        ? CompileBackStubBodyKind.AutoPropertyGetInit
+                        : CompileBackStubBodyKind.AutoPropertyGetSet
                     : CompileBackStubBodyKind.None
                 : hasSetter && isAutoProperty
-                    ? CompileBackStubBodyKind.AutoPropertyGetSet
+                    ? isInitSetter
+                        ? CompileBackStubBodyKind.AutoPropertyGetInit
+                        : CompileBackStubBodyKind.AutoPropertyGetSet
                     : isAutoProperty
                         ? CompileBackStubBodyKind.AutoProperty
                         : hasSetter
-                            ? CompileBackStubBodyKind.ThrowGetSet
+                            ? isInitSetter
+                                ? CompileBackStubBodyKind.ThrowGetInit
+                                : CompileBackStubBodyKind.ThrowGetSet
                             : CompileBackStubBodyKind.Throw;
             return new CompileBackMemberRequirement(
                 new CompileBackMethodIdentity(typeIdentity.FullName, Identifier(propertyName), 0, $"property {propertyReturnType}"),
@@ -4057,18 +4073,25 @@ public static class CompileBackSourceComposer
                 bool isAutoProperty = !accessors.Getter.IsNil
                     && IsAutoProperty(reader, typeDef, property, accessors.Getter, returnType.DisplayName);
                 bool hasSetter = !accessors.Setter.IsNil;
+                bool isInitSetter = hasSetter && SetterIsInitOnly(reader, accessors.Setter);
                 bool isAbstractAccessor = !accessor.IsNil && propertyDeclaration.IsAbstract;
                 var noBodyProperty = requirement.RequiredKind == CompileBackTypeKind.Interface || isAbstractAccessor;
                 var stubBody = noBodyProperty
                     ? hasSetter
-                        ? CompileBackStubBodyKind.AutoPropertyGetSet
+                        ? isInitSetter
+                            ? CompileBackStubBodyKind.AutoPropertyGetInit
+                            : CompileBackStubBodyKind.AutoPropertyGetSet
                         : CompileBackStubBodyKind.None
                     : hasSetter && isAutoProperty
-                        ? CompileBackStubBodyKind.AutoPropertyGetSet
+                        ? isInitSetter
+                            ? CompileBackStubBodyKind.AutoPropertyGetInit
+                            : CompileBackStubBodyKind.AutoPropertyGetSet
                         : isAutoProperty
                             ? CompileBackStubBodyKind.AutoProperty
                             : hasSetter
-                                ? CompileBackStubBodyKind.ThrowGetSet
+                                ? isInitSetter
+                                    ? CompileBackStubBodyKind.ThrowGetInit
+                                    : CompileBackStubBodyKind.ThrowGetSet
                                 : CompileBackStubBodyKind.Throw;
                 members.Add(new CompileBackMemberRequirement(
                     new CompileBackMethodIdentity(requirement.Type.FullName, Identifier(propertyName), 0, $"property {propertyReturnType}"),

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -633,9 +633,17 @@ public static class CompileBackSourceComposer
                 bool setterReady = !concreteSetter || setterIsTarget || setter.Body is not null;
                 if (getterReady && setterReady)
                 {
+                    bool targetInvolved = getterIsTarget || setterIsTarget;
                     var basePropertyBody = policies.TryGetValue(member, out var existingPropertyPolicy)
                         ? existingPropertyPolicy.Body as CSharpPropertyBody
                         : null;
+                    // When the target accessor belongs to an auto/skeleton property, the base
+                    // Compose path already emitted the property's compiler-synthesized accessors
+                    // and there is no explicit target body to extend. Leave that policy untouched
+                    // rather than replacing it with empty accessor bodies, which would delete the
+                    // property's accessors (e.g. auto-properties -> `int Value {  }`, CS0548).
+                    if (targetInvolved && basePropertyBody is null)
+                        continue;
                     policies[member] = new CSharpMemberPolicy(
                         member,
                         CSharpBodyPolicy.Full,


### PR DESCRIPTION
## Summary

Fixes #3000 — an RTS (ReturnToSender) `Full`-body evidence-integrity bug where a property-accessor target silently dropped the sibling accessor's produced body (kept a `throw null;` stub) yet still reported it `Complete`, so `BodyComplete` falsely read `true`. A "keep failure visible" violation surfaced during adversarial review of #3001.

## Root cause

In `ApplyFullBodies`'s `Enrich` loop, the readiness gate `getterReady = !concreteGetter || getter.Body is not null` was `false` for the **target** accessor — it is concrete but has a null produced body here because the target body is applied by the base `Compose*` path, not by `Produce`. So `getterReady && setterReady` failed, the sibling's produced body was never applied, and the base `throw` stub survived — while a `Complete` `FullBodies` row was still recorded.

## Fix

- **`ReturnToSenderTypePlanner.cs`** — property branch of `Enrich` is now target-aware: it detects `getterIsTarget`/`setterIsTarget` (new `IsTargetToken` helper), skips `Produce` for the target accessor, treats it as ready, and **preserves** the base target-accessor body instead of clobbering it with null, so the sibling's produced body is incorporated. Behavior is unchanged when neither accessor is the target.
- **`ReturnToSender.cs`** — `BodyComplete` now also requires `!UsedCompileBackFloor`, so a `Full` closure that fails to recompile and falls back to the single-target floor is reported honestly (`false`) rather than masked as `Complete`. This surfaces the plain event-accessor target case (a CS0082 method/event-surface collision).

## Scope / follow-up

Coherent `Full` reconstruction of **plain event-accessor** targets requires event↔property symmetry in the target requirement (carry both accessor tokens) and TypeProducer's ctor/member surface — a deeper `TypeProducer` change with corpus-regression risk. Scoped out as **#3007**. This PR makes that case honest (floor + `BodyComplete=false`) and pins it with a regression test.

## Evidence

- New regression tests:
  - `CompileBackTargets_FullPreservesConcreteSiblingWhenTargetIsPropertyAccessor` — target `get_Value`; asserts sibling `_v = value;` emitted, no `throw null`, sibling `Complete`, comparison `Exact`, `BodyComplete=true`.
  - `CompileBackTargets_FullEventAccessorTargetSurfacesRecompileFailure` — target `add_Changed`; asserts `UsedCompileBackFloor=true`, `BodyComplete=false`.
- Full RoundTrip area: **299/299 pass** (297 baseline + 2 new), no regressions from the `BodyComplete` integrity gate.

## Adversarial review

Two-model fixed-head review (Gemini 3.1 Pro + GPT-5.6, excluding the authoring model) in progress; reconciliation to follow.
