### PR TITLE
Fix CS0019 in 64-bit flags-enum OR/AND accumulation (#2990)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5267,7 +5267,7 @@ public static class ChainedConstantAssignmentSamples
 // bare-constant flag arms render as `... | (long)32768` — CS0019 (operator '|'
 // cannot be applied to 'FlagCaps64' and 'long').
 [System.Flags]
-public enum FlagCaps64 : ulong
+public enum FlagCaps64 : long
 {
     None = 0,
     Protocol = 512,

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5257,3 +5257,37 @@ public static class ChainedConstantAssignmentSamples
 
     public static void ChainedBoolFalse() => A = B = C = false;
 }
+
+// Regression fixtures for #2990: a 64-bit-backed [Flags] enum OR/AND accumulation.
+// The compiler lowers the flag arithmetic into the enum's Int64 underlying space
+// (`ldc.i4 N; conv.i8; or/and`) and spills the intermediate accumulator into long
+// stack slots. When an enum operand sits on the RIGHT of an `or`/`and` (the IL
+// accumulation order), TypeFamilies.BinaryResult must still surface the enum type
+// so the OR chain stays enum-typed. Otherwise the chain collapses to `long` and the
+// bare-constant flag arms render as `... | (long)32768` — CS0019 (operator '|'
+// cannot be applied to 'FlagCaps64' and 'long').
+[System.Flags]
+public enum FlagCaps64 : ulong
+{
+    None = 0,
+    Protocol = 512,
+    Interactive = 1024,
+    LoadLocal = 128,
+    Secure = 32768,
+    MultiStatements = 65536,
+    MultiResults = 131072,
+}
+
+public static class FlagsEnumAccumulatorSamples
+{
+    public static int Accumulate(FlagCaps64 server, bool interactive)
+    {
+        FlagCaps64 caps = FlagCaps64.Protocol
+            | (interactive ? (server & FlagCaps64.Interactive) : FlagCaps64.None)
+            | (server & FlagCaps64.LoadLocal)
+            | FlagCaps64.Secure
+            | (server & FlagCaps64.MultiStatements)
+            | FlagCaps64.MultiResults;
+        return (int)caps;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/FlagsEnumAccumulatorTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FlagsEnumAccumulatorTests.cs
@@ -1,0 +1,39 @@
+using System;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// #2990: a 64-bit-backed [Flags] enum OR/AND accumulation lowers into the enum's
+// Int64 underlying space and spills long accumulator slots. When an enum operand
+// sits on the RIGHT of an `or`/`and` (the IL accumulation order), the OR chain must
+// stay enum-typed. The pre-fix behavior collapsed the chain to `long`, so bare
+// flag arms rendered as `... | (long)32768` — CS0019 (operator '|' cannot be applied
+// to 'FlagCaps64' and 'long').
+public class FlagsEnumAccumulatorTests
+{
+    static string Render(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(FlagsEnumAccumulatorSamples).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(FlagsEnumAccumulatorSamples).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void FlagsEnumAccumulator_KeepsEnumTyping_NoBareLongOrEnum()
+    {
+        var output = Render(nameof(FlagsEnumAccumulatorSamples.Accumulate));
+
+        // The constant flag arms must render as enum members, not bare long constants
+        // OR'd against the enum. The #2990 defect produced `... | (long)32768` (CS0019).
+        Assert.DoesNotContain("| (long)", output);
+        Assert.DoesNotContain("(long)32768", output);
+
+        // The OR chain surfaces the enum type: the flag members appear by name.
+        Assert.Contains("FlagCaps64.Secure", output);
+        Assert.Contains("FlagCaps64.MultiStatements", output);
+        Assert.Contains("FlagCaps64.MultiResults", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
@@ -64,6 +64,20 @@ public static class TypeFamilies
     {
         var leftFamily = Of(left);
         var rightFamily = Of(right);
+        // A binary op mixing a resolved primitive with an unresolved Definition
+        // is the flags-enum idiom: the enum's underlying integer drives the IL
+        // `or`/`and`/`add`, but the C# result type is the enum, on whichever side
+        // it sits. `flags | 0x20` and `0x20 | flags` are both `flags`-typed. Only
+        // an enum reaches a Binary opcode as a Definition operand — a struct or
+        // decimal `|`/`+` lowers to an operator-overload call, not this node — so
+        // preferring the Definition keeps a flags-enum OR/AND accumulation
+        // enum-typed instead of collapsing to the underlying integer, which would
+        // then need a cast on every arm and break at the next bare-integer arm
+        // (CS0019, #2990). Symmetric to the both-null fallthrough below.
+        if (left is { Kind: TypeRefKind.Definition } && leftFamily is null && rightFamily is not null)
+            return left;
+        if (right is { Kind: TypeRefKind.Definition } && rightFamily is null && leftFamily is not null)
+            return right;
         if (leftFamily is not { } lf || rightFamily is not { } rf)
             return left;
         // A bitwise And/Or/Xor that mixes a bool comparison with an integer


### PR DESCRIPTION
- Fixes #2990
- Changes decompiler `BinaryResult` typing so a 64-bit `[Flags]` enum OR/AND accumulation stays enum-typed instead of collapsing to the underlying integer (CS0019 → valid C#)
- Card revision: `36bcdde5`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — a null-family `Definition` operand of a `Binary` opcode node is only ever an enum (struct/decimal operators lower to method calls, not `or`/`and`/`add`; pointers/byref/generic-params are not `Kind: Definition`; bool/char/nint have non-null families), so preferring it makes the flags-enum idiom valid on both operand orders while leaving every resolved-family pair unchanged.

The primary Before/After below uses the reduced regression fixture, which isolates the #2990 defect and reaches a **fully valid** After. The real-world MySqlConnector witness that motivated the issue is covered under [Real-world witness](#real-world-witness); it advances but retains a **separate, pre-existing** defect (#3011) unrelated to this fix.

### Original source

Reduced fixture `ILInspector.Decompiler.Tests.FlagsEnumAccumulatorSamples.Accumulate`, mirroring the witness idiom (a 64-bit-backed `[Flags]` enum accumulation). Authored C# (fixture source):

```csharp
[Flags] public enum FlagCaps64 : long
{ None = 0, Protocol = 512, Interactive = 1024, LoadLocal = 128, Secure = 32768, MultiStatements = 65536, MultiResults = 131072 }

public static int Accumulate(FlagCaps64 server, bool interactive)
{
    FlagCaps64 caps = FlagCaps64.Protocol
        | (interactive ? (server & FlagCaps64.Interactive) : FlagCaps64.None)
        | (server & FlagCaps64.LoadLocal)
        | FlagCaps64.Secure
        | (server & FlagCaps64.MultiStatements)
        | FlagCaps64.MultiResults;
    return (int)caps;
}
```

### Before

<!-- base decompiler (32961ac6) over the fixture IL, via -S "Decompiled Source" -->

```csharp
public static int Accumulate(FlagCaps64 server, bool interactive)
{
    long S_0 = (long)512;
    FlagCaps64 S_1 = interactive ? (server & FlagCaps64.Interactive) : FlagCaps64.None;
    return (int)((FlagCaps64)((FlagCaps64)((FlagCaps64)S_0 | S_1) | (server & FlagCaps64.LoadLocal) | (long)32768) | (server & FlagCaps64.MultiStatements) | (long)131072);
}
```

- Valid: False
- Correct: False

The enum-typed OR chain is mixed with bare `(long)32768` / `(long)131072` arms → CS0019 (`operator '|' cannot be applied to operands of type 'FlagCaps64' and 'long'`). Does not compile.

### After

<!-- this PR head (36bcdde5), via -S "Decompiled Source" -->

```csharp
public static int Accumulate(FlagCaps64 server, bool interactive)
{
    long S_0 = (long)512;
    FlagCaps64 S_1 = interactive ? (server & FlagCaps64.Interactive) : FlagCaps64.None;
    return (int)((FlagCaps64)S_0 | S_1 | server & FlagCaps64.LoadLocal | FlagCaps64.Secure | server & FlagCaps64.MultiStatements | FlagCaps64.MultiResults);
}
```

- Valid: True
- Correct: True

The OR chain is now enum-typed; the bare-constant arms render as enum members (`FlagCaps64.Secure`/`MultiStatements`/`MultiResults`). Verified by compiling the exact output against the `FlagCaps64` type — builds with 0 warnings. A pure type-annotation change over the same integer arithmetic (C# `&` binds tighter than `|`, so precedence and bit values are preserved).

### Fully raised

The After is valid and correct but not maximally raised: the `long S_0 = (long)512;` slot and `(FlagCaps64)S_0` cast remain. Fully raised, the accumulator itself is enum-typed:

```csharp
FlagCaps64 caps = FlagCaps64.Protocol
    | (interactive ? (server & FlagCaps64.Interactive) : FlagCaps64.None)
    | (server & FlagCaps64.LoadLocal)
    | FlagCaps64.Secure | FlagCaps64.MultiStatements | FlagCaps64.MultiResults;
```

- Required tracking issue: #3009 — propagate the enum type into the spilled `long` accumulator slot so it is declared as the enum instead of `long` with a cast.

## Real-world witness

`MySqlConnector.Protocol.Payloads.HandshakeResponse41Payload.CreateCapabilitiesPayload` (`--package MySqlConnector@2.6.1`, `ProtocolCapabilities : Int64`) is the real case behind #2990. SourceLink cannot supply C# for it (the `Original Source` section renders empty); the authoritative anchor is the raw `IL` (`-S "IL"`), whose flag arithmetic runs in the enum's 64-bit underlying space (`ldc.i4 N; conv.i8; and/or`).

Before (base) — the accumulation mixes the enum chain with bare `(long)` arms (CS0019):

```csharp
S_0 = (ProtocolCapabilities)(... | (serverCapabilities & ProtocolCapabilities.Transactions) | (long)32768) | ... | (long)65536 | (long)131072;
```

After (head) — the #2990 `enum | (long)const` defect is resolved; those arms render as `ProtocolCapabilities.SecureConnection` / `MultiStatements` / `MultiResults`:

```csharp
ProtocolCapabilities S_2 = (ProtocolCapabilities)(S_0 | S_1) | (serverCapabilities & ProtocolCapabilities.LongPassword) | ... | ProtocolCapabilities.SecureConnection | ... | ProtocolCapabilities.MultiStatements | ProtocolCapabilities.MultiResults;
```

- Valid: False — a **separate, pre-existing** defect remains, unrelated to #2990: `writer.Write((int)(clientCapabilities >> 32));` shifts an enum-typed value (`enum >> int` is CS0019). This is present **identically on base and head** (`clientCapabilities` is enum-typed in both; this PR does not change enum-on-left shift typing), and is tracked in **#3011**. This PR removes one CS0019 class (the #2990 accumulator) but does not claim to fix the shift defect.
- Correct: True for the accumulation semantics (bit values unchanged).

## Evidence

| Check | Baseline (`32961ac6`) | Head (`36bcdde5`) |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `FlagsEnumAccumulatorTests`: 1 failed (`(long)32768`/`(long)131072` present) | `FlagsEnumAccumulatorTests`: 1 passed |
| Reduced fixture compile-back | n/a (invalid: CS0019) | Pass (compiles, 0 warnings) |
| Decompiler fast suite | 3137, 0 failed | 3138, 0 failed |
| CorpusSweepGate (CoreLib) | Pass | Pass |
| FidelityGate (`NoNewFidelityDiffsBeyondKnownDocket`) | 1 failed (`StatementBodyLambdaInsideIf [OperandDiff]`) | 1 failed (same) — 0 new diffs |
| Real witness (`CreateCapabilitiesPayload`) | #2990 `enum \| long` CS0019 present | #2990 defect resolved; residual pre-existing `enum >> int` CS0019 tracked in #3011 |

The single FidelityGate failure `StatementBodyLambdaInsideIf [OperandDiff]` is **pre-existing on `main`** (a lambda-ordinal rename, unrelated to enum typing): it fails identically on the base worktree `32961ac6` with the same diff and is not in the KnownDiffs docket. This PR introduces **zero** new fidelity diffs.

The new regression fixture `FlagsEnumAccumulatorSamples` is a sibling class (not a `CfgSampleClass` method), so it is not swept by FidelityGate.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.FlagsEnumAccumulatorTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.CorpusSweepGateTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.FidelityGateTests"
```
