### PR TITLE
Render wide array index as bare index, not checked((nint)i) (#2981)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -951,6 +951,14 @@ public class CfgSampleClass
     // value-preserving no-op view the `neg` operated on. Opcode-exact: `ldelem.*; neg`.
     public static int NegEnumUIntElementToInt(CfgFlags[] v, int j) => -(int)v[j];
 
+    // A cross-assembly (CoreLib) enum used as an array index: DayOfWeek resolves
+    // to an Unknown shape (EnsureTypeMaps walks only this assembly's type defs),
+    // so the enum underlying is unavailable. C# still has no unary minus on the
+    // enum, but the masked stack width IS in the `ldelem.i4` opcode, so the
+    // reinterpret is recovered from it: `a[-(int)v[j]]`. Opcode-exact: `ldelem.i4;
+    // neg; conv.i`.
+    public static int NegCrossAssemblyEnumElementIndex(int[] a, System.DayOfWeek[] v, int j) => a[-(int)v[j]];
+
     // Genuinely-signed `long` neg/not indices recover as `long` and strip bare.
     public static int NegLongIndexBare(int[] a, long i) => a[-i];
 

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -921,6 +921,13 @@ public class CfgSampleClass
 
     public static int NotLongIndexBare(int[] a, long i) => a[~i];
 
+    // Negate stripped bare inside a `checked` array-index context (#2981
+    // adversarial review): the index conv is dropped (signed `long` matches),
+    // but the bare `-i` would recompile as a checked negate (`0 - i` as
+    // `sub.ovf`) where the IL has an unchecked `neg`, so the negate is wrapped
+    // in `unchecked(...)`.
+    public static int NegLongIndexInChecked(int[] a, long i) => checked(a[unchecked(-i)] + 1);
+
     public static void SetFirstElement(int[] a, int v) => a[0] = v;
 
     // stelem.i1 stores into byte[], sbyte[], and bool[] alike, and stelem.i2 into

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -881,6 +881,34 @@ public class CfgSampleClass
     // sum just like a scalar `ulong`, with no redundant `(ulong)` cast.
     public static int ULongSumIndexBare(int[] a, ulong[] v, ulong[] w, int j, int k) => a[v[j] + w[k]];
 
+    // Checked-context inner binary (#2981 adversarial review): `checked(v[j] + x)`
+    // over a `ulong` element is a `ulong` add, but the compiler-inserted index
+    // conv is still signed (`conv.ovf.i`) because the *outer* cast is `(long)`.
+    // The operand-type recovery must see through the binary regardless of its
+    // checkedness — `checked` never changes an expression's C# type — and keep
+    // the `(long)` cast; stripping bare would re-insert `conv.ovf.i.un`.
+    public static int CheckedULongSumIndexAsSigned(int[] a, ulong[] v, int j, ulong x) => a[unchecked((long)checked(v[j] + x))];
+
+    // Unsigned shift-right (`shr.un`): `ulong >> count` is a `ulong`. The result
+    // type is the shifted (left) operand's, recovered through the mask, so a
+    // signed index keeps the `(long)` cast (bare would flip to `conv.ovf.i.un`).
+    public static int ULongShrIndexAsSigned(int[] a, ulong[] v, int j) => a[unchecked((long)(v[j] >> 1))];
+
+    // Unsigned divide (`div.un`) / remainder (`rem.un`): the signedness lives in
+    // the opcode variant, not the sign-erased Int64 stack type. A `ulong`
+    // quotient/remainder used as a signed index keeps the `(long)` cast.
+    public static int ULongDivIndexAsSigned(int[] a, ulong[] v, int j, ulong d) => a[unchecked((long)(v[j] / d))];
+
+    public static int ULongRemIndexAsSigned(int[] a, ulong[] v, int j, ulong d) => a[unchecked((long)(v[j] % d))];
+
+    // Negatives for the finding #5 recovery: a genuinely-signed `long` shift-left
+    // and a `checked` signed `long` add must still strip to the bare index — the
+    // recovered `long` type matches the signed `conv.ovf.i`, so no spurious
+    // `(long)` cast is emitted.
+    public static int LongShlIndexBare(int[] a, long i) => a[i << 1];
+
+    public static int LongCheckedSumIndexBare(int[] a, long i, long j) => a[checked(i + j)];
+
     public static void SetFirstElement(int[] a, int v) => a[0] = v;
 
     // stelem.i1 stores into byte[], sbyte[], and bool[] alike, and stelem.i2 into

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -865,6 +865,22 @@ public class CfgSampleClass
     // `(long)`), so it stays bare with no spurious `unchecked(...)` wrapper.
     public static int LongEnumIndexChecked(int[] a, CfgLongPriority[] values, int j) => checked(a[(long)values[j]] + 1);
 
+    // Compound wide index (#2981 adversarial review): a sign-neutral wide binary
+    // reports Int64 stack storage even when it renders `ulong`, so the operand
+    // type must be recovered through the binary from its unmasked operands. A
+    // `ulong` sum used as a *signed* index keeps an explicit `(long)` cast around
+    // the whole expression — stripping it bare would re-insert `conv.ovf.i.un`.
+    public static int ULongSumIndexAsSigned(int[] a, ulong[] v, int j, ulong x) => a[unchecked((long)(v[j] + x))];
+
+    // Both operands are masked `ulong` elements (`ldelem.i8`): the recovery must
+    // see through the masking on each side, not just when one operand is a bare
+    // `ulong`. Still a signed index, so it keeps the `(long)` cast.
+    public static int ULongElementSumIndexAsSigned(int[] a, ulong[] v, ulong[] w, int j, int k) => a[unchecked((long)(v[j] + w[k]))];
+
+    // A bare `ulong` compound index (unsigned `conv.ovf.i.un`) strips to the bare
+    // sum just like a scalar `ulong`, with no redundant `(ulong)` cast.
+    public static int ULongSumIndexBare(int[] a, ulong[] v, ulong[] w, int j, int k) => a[v[j] + w[k]];
+
     public static void SetFirstElement(int[] a, int v) => a[0] = v;
 
     // stelem.i1 stores into byte[], sbyte[], and bool[] alike, and stelem.i2 into

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -852,6 +852,19 @@ public class CfgSampleClass
     // element type matches the unsigned `conv.ovf.i.un`, so it is opcode-exact.
     public static int ULongArrayElementIndex(int[] a, ulong[] v, int j) => a[v[j]];
 
+    // Wide index cast inside a lexical `checked` region (#2981 adversarial
+    // review): the emitted `(long)`/`(ulong)` reinterpret is a no-op in IL (only
+    // the always-checked native-int index conv is checked). A SIGN-CHANGING cast
+    // must be wrapped in `unchecked(...)` — spelled bare inside `checked` it would
+    // recompile to a `conv.ovf.i8.un` / `conv.ovf.u8` the original never had.
+    public static int ULongIndexAsSignedChecked(int[] a, ulong[] v, int j) => checked(a[unchecked((long)v[j])] + 1);
+
+    public static int LongIndexAsUnsignedChecked(int[] a, long[] v, int j) => checked(a[unchecked((ulong)v[j])] + 1);
+
+    // A same-sign cast emits no conv even inside `checked` (a long-backed enum's
+    // `(long)`), so it stays bare with no spurious `unchecked(...)` wrapper.
+    public static int LongEnumIndexChecked(int[] a, CfgLongPriority[] values, int j) => checked(a[(long)values[j]] + 1);
+
     public static void SetFirstElement(int[] a, int v) => a[0] = v;
 
     // stelem.i1 stores into byte[], sbyte[], and bool[] alike, and stelem.i2 into

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -834,6 +834,24 @@ public class CfgSampleClass
     // `a[(long)(r)]` rather than a CS0266 bare index.
     public static int LongEnumRefArrayIndex(int[] a, ref CfgLongPriority r) => a[(long)r];
 
+    // Signedness masking (#2981 adversarial review): `ldelem.i8` / `ldind.i8`
+    // report Int64 storage even for a `ulong` element/pointee, so the index
+    // conversion's own signedness (`conv.ovf.i` signed / `conv.ovf.i.un`
+    // unsigned) is the only witness of the source type. A `ulong` element used as
+    // a *signed* index must keep an explicit `(long)` cast — stripping it bare
+    // would re-insert `conv.ovf.i.un` and change overflow semantics.
+    public static int ULongArrayIndexAsSigned(int[] a, ulong[] v, int j) => a[(long)v[j]];
+
+    public static int ULongRefIndexAsSigned(int[] a, ref ulong r) => a[(long)r];
+
+    // The mirror: a `long` element used as an *unsigned* index keeps `(ulong)`.
+    public static int LongArrayIndexAsUnsigned(int[] a, long[] v, int j) => a[(ulong)v[j]];
+
+    // A plain `ulong` array element index strips to the bare index just like a
+    // `long` one — `ldelem.i8` masks it as Int64, but the recovered `ulong`
+    // element type matches the unsigned `conv.ovf.i.un`, so it is opcode-exact.
+    public static int ULongArrayElementIndex(int[] a, ulong[] v, int j) => a[v[j]];
+
     public static void SetFirstElement(int[] a, int v) => a[0] = v;
 
     // stelem.i1 stores into byte[], sbyte[], and bool[] alike, and stelem.i2 into

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -934,6 +934,23 @@ public class CfgSampleClass
     // `ldelem.i; neg`.
     public static nint NegNuintElementToNint(nuint[] v, int j) => -(nint)v[j];
 
+    // Enum mirror (#2981 adversarial review): C# has no unary minus for ANY enum,
+    // regardless of its underlying type. A negate over an enum element likewise
+    // came from a signed reinterpret that vanished, so the operand cast is
+    // re-inserted keyed on the underlying width — an 8-byte-backed enum as
+    // `(long)`, a narrower one as `(int)`. An 8-byte-backed enum used as a signed
+    // index strips clean. Opcode-exact: `ldelem.i8; neg; conv.ovf.i`.
+    public static int NegEnumULongElementIndexAsSigned(int[] a, CfgULong[] v, int j) => a[-(long)v[j]];
+
+    // A `long`-backed enum negated outside any index: still no unary minus on the
+    // enum, so `(long)` is re-inserted on the operand. Opcode-exact: `ldelem.i8; neg`.
+    public static long NegEnumLongElementToLong(CfgLongPriority[] v, int j) => -(long)v[j];
+
+    // A 4-byte (`uint`-backed) enum negate reinterprets the operand as `(int)` —
+    // sub-8-byte integers are `I4` on the eval stack, so `(int)` is the
+    // value-preserving no-op view the `neg` operated on. Opcode-exact: `ldelem.*; neg`.
+    public static int NegEnumUIntElementToInt(CfgFlags[] v, int j) => -(int)v[j];
+
     // Genuinely-signed `long` neg/not indices recover as `long` and strip bare.
     public static int NegLongIndexBare(int[] a, long i) => a[-i];
 

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -822,6 +822,18 @@ public class CfgSampleClass
 
     public static int LongArrayIndexExpr(int[] a, long i, long j) => a[i + j];
 
+    // A long-backed enum array element in wide array-index position (#2981
+    // adversarial review): `ldelem.i8` reports Int64 storage, masking the enum,
+    // so a bare `a[values[j]]` is CS0266. The printer casts to the underlying
+    // wide primitive — `a[(long)values[j]]` — which is idiomatic and re-inserts
+    // the same implicit conv.ovf.i (opcode-exact).
+    public static int LongEnumArrayIndex(int[] a, CfgLongPriority[] values, int j) => a[(long)values[j]];
+
+    // The ref/pointee analog: a long-backed enum read through `ldind.i8`. The
+    // pointee's enum type must survive the same opcode-width masking, rendering
+    // `a[(long)(r)]` rather than a CS0266 bare index.
+    public static int LongEnumRefArrayIndex(int[] a, ref CfgLongPriority r) => a[(long)r];
+
     public static void SetFirstElement(int[] a, int v) => a[0] = v;
 
     // stelem.i1 stores into byte[], sbyte[], and bool[] alike, and stelem.i2 into

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -909,6 +909,18 @@ public class CfgSampleClass
 
     public static int LongCheckedSumIndexBare(int[] a, long i, long j) => a[checked(i + j)];
 
+    // Unary neg/not (#2981 adversarial review): a unary preserves its operand's
+    // type but reports that operand's *masked* stack type, so the recovery must
+    // recurse into the unmasked operand. A `~ulong` element used as a signed
+    // index keeps the `(long)` cast — stripping bare would flip `conv.ovf.i` to
+    // `conv.ovf.i.un`.
+    public static int NotULongElementIndexAsSigned(int[] a, ulong[] v, int j) => a[unchecked((long)(~v[j]))];
+
+    // Genuinely-signed `long` neg/not indices recover as `long` and strip bare.
+    public static int NegLongIndexBare(int[] a, long i) => a[-i];
+
+    public static int NotLongIndexBare(int[] a, long i) => a[~i];
+
     public static void SetFirstElement(int[] a, int v) => a[0] = v;
 
     // stelem.i1 stores into byte[], sbyte[], and bool[] alike, and stelem.i2 into

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -808,6 +808,20 @@ public class CfgSampleClass
 
     public static int SpanLastHandWritten(System.Span<int> span) => span[span.Length - 1];
 
+    // Wide (long/ulong) array index: the compiler inserts a checked native-int
+    // range conversion (conv.ovf.i / conv.ovf.i.un) that C# spells implicitly,
+    // so the decompiled index must read as the bare source expression, not
+    // `a[checked((nint)i)]`. Kept opcode-exact by the fidelity gate.
+    public static int LongArrayIndex(int[] a, long i) => a[i];
+
+    public static int ULongArrayIndex(int[] a, ulong i) => a[i];
+
+    public static void LongArrayIndexStore(int[] a, long i, int v) => a[i] = v;
+
+    public static ref int LongArrayIndexRef(int[] a, long i) => ref a[i];
+
+    public static int LongArrayIndexExpr(int[] a, long i, long j) => a[i + j];
+
     public static void SetFirstElement(int[] a, int v) => a[0] = v;
 
     // stelem.i1 stores into byte[], sbyte[], and bool[] alike, and stelem.i2 into

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -916,6 +916,24 @@ public class CfgSampleClass
     // `conv.ovf.i.un`.
     public static int NotULongElementIndexAsSigned(int[] a, ulong[] v, int j) => a[unchecked((long)(~v[j]))];
 
+    // Negate over a masked `ulong` element (#2981 adversarial review): C# has no
+    // unary minus for `ulong` (`-v[j]` is CS0023), so the IL `neg` came from a
+    // signed reinterpret cast that is a no-op in IL and vanished from the masked
+    // stack type. The printer must re-insert it on the negate's OPERAND
+    // (`-(long)v[j]`), not around the whole negate — `(long)(-v[j])` would still
+    // negate a `ulong`. Opcode-exact: `ldelem.i8; neg; conv.ovf.i`.
+    public static int NegULongElementIndexAsSigned(int[] a, ulong[] v, int j) => a[-(long)v[j]];
+
+    // The same signed reinterpret is a GENERAL printer concern, not array-index
+    // specific: a masked `ulong` element negated outside any index still needs the
+    // `(long)` on the operand. Opcode-exact: `ldelem.i8; neg`.
+    public static long NegULongElementToLong(ulong[] v, int j) => -(long)v[j];
+
+    // The `nuint` mirror: unary minus is likewise illegal on `nuint`, so a masked
+    // `nuint` element negate re-inserts `(nint)` on the operand. Opcode-exact:
+    // `ldelem.i; neg`.
+    public static nint NegNuintElementToNint(nuint[] v, int j) => -(nint)v[j];
+
     // Genuinely-signed `long` neg/not indices recover as `long` and strip bare.
     public static int NegLongIndexBare(int[] a, long i) => a[-i];
 

--- a/src/ILInspector.Decompiler.Tests/CheckedUncheckedInsertTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CheckedUncheckedInsertTests.cs
@@ -90,6 +90,34 @@ public class CheckedUncheckedInsertTests
             "return checked(a + unchecked(b++));",
             Render(Checked(BinaryKind.Add, A, new IncrementDecrement(B, isIncrement: true, isPrefix: false))));
 
+    // checked(a + unchecked(-b)) — a plain unary negate (`neg`) nested in a checked
+    // region recompiles as an overflow-checked negate (`0 - b` as `sub.ovf`) unless
+    // wrapped, mirroring the plain add/sub/mul inserts above.
+    [Fact]
+    public void CheckedAdd_PlainNegateChild_WrapsInnerUnchecked()
+        => Assert.Equal(
+            "return checked(a + unchecked(-b));",
+            Render(Checked(BinaryKind.Add, A, Negate(B))));
+
+    // Positive canary: a bitwise complement (`not`) never overflows, so it stays
+    // bare even inside a checked region — no spurious unchecked wrapper.
+    [Fact]
+    public void CheckedAdd_BitwiseNotChild_StaysBare()
+        => Assert.Equal(
+            "return checked(a + ~b);",
+            Render(Checked(BinaryKind.Add, A, BitwiseNot(B))));
+
+    // Positive canary: a plain negate with no enclosing checked context is untouched.
+    [Fact]
+    public void PlainNegate_NoCheckedContext_Untouched()
+        => Assert.Equal(
+            "return -a;",
+            Render(Negate(A)));
+
+    static Unary Negate(IrExpression operand) => new(UnaryKind.Negate, operand);
+
+    static Unary BitwiseNot(IrExpression operand) => new(UnaryKind.BitwiseNot, operand);
+
     static Binary Checked(BinaryKind kind, IrExpression left, IrExpression right)
         => new(kind, isChecked: true, isUnsigned: false, left, right);
 

--- a/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
+++ b/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
@@ -209,4 +209,28 @@ public class WideArrayIndexTests
         // strips bare — checkedness does not force a cast.
         Assert.Equal("return a[checked(i + j)];", Print(nameof(CfgSampleClass.LongCheckedSumIndexBare)));
     }
+
+    [Fact]
+    public void NotULongElementIndexAsSigned_KeepsLongCast()
+    {
+        // A unary reports its operand's masked stack type; recovering through it
+        // types `~v[j]` (over a `ulong` element) as `ulong`, so a signed index
+        // keeps the `(long)` cast (bare would flip to `conv.ovf.i.un`).
+        Assert.Equal("return a[(long)(~v[j])];", Print(nameof(CfgSampleClass.NotULongElementIndexAsSigned)));
+    }
+
+    [Fact]
+    public void NegLongIndexBare_StripsBare()
+    {
+        // A genuinely-signed `long` negate index recovers as `long` and strips
+        // bare with no spurious `(long)` cast.
+        Assert.Equal("return a[-i];", Print(nameof(CfgSampleClass.NegLongIndexBare)));
+    }
+
+    [Fact]
+    public void NotLongIndexBare_StripsBare()
+    {
+        // The bitwise-not analog of the signed-negate strip.
+        Assert.Equal("return a[~i];", Print(nameof(CfgSampleClass.NotLongIndexBare)));
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
+++ b/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
@@ -293,4 +293,16 @@ public class WideArrayIndexTests
         // enum-to-underlying conversion the source spelled, unrelated to the fix).
         Assert.Equal("return (int)(-(int)v[j]);", Print(nameof(CfgSampleClass.NegEnumUIntElementToInt)));
     }
+
+    [Fact]
+    public void NegCrossAssemblyEnumElementIndex_CastsOperandToInt()
+    {
+        // A cross-assembly (CoreLib) enum resolves to an Unknown shape, so its
+        // underlying width is unavailable via the enum map. The enum still has no
+        // unary minus, but the masked stack width is in the `ldelem.i4` opcode, so
+        // the reinterpret is recovered from it: `a[-(int)v[j]]`. The width fallback
+        // covers unresolved enums the underlying-based path cannot see, and used as
+        // a signed index it strips clean. Recompiles to `ldelem.i4; neg; conv.i`.
+        Assert.Equal("return a[-(int)v[j]];", Print(nameof(CfgSampleClass.NegCrossAssemblyEnumElementIndex)));
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
+++ b/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
@@ -59,4 +59,22 @@ public class WideArrayIndexTests
         // An int index needs no range conversion, so there is nothing to strip.
         Assert.Equal("return a[0];", Print(nameof(CfgSampleClass.FirstElement)));
     }
+
+    [Fact]
+    public void LongEnumArrayElementIndex_CastsToUnderlyingPrimitive()
+    {
+        // A long-backed enum array element (`ldelem.i8`) reports Int64 storage,
+        // but the rendered `values[j]` is enum-typed; a bare `a[values[j]]` is
+        // CS0266. The printer casts to the underlying wide primitive, which is
+        // idiomatic and opcode-exact.
+        Assert.Equal("return a[(long)values[j]];", Print(nameof(CfgSampleClass.LongEnumArrayIndex)));
+    }
+
+    [Fact]
+    public void LongEnumRefIndex_CastsToUnderlyingPrimitive()
+    {
+        // The ref/pointee analog (`ldind.i8`): the enum pointee is cast to its
+        // underlying wide primitive, not stripped bare (CS0266).
+        Assert.Equal("return a[(long)(r)];", Print(nameof(CfgSampleClass.LongEnumRefArrayIndex)));
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
+++ b/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
@@ -109,4 +109,29 @@ public class WideArrayIndexTests
         // matches the unsigned conversion, so it strips to the bare index.
         Assert.Equal("return a[v[j]];", Print(nameof(CfgSampleClass.ULongArrayElementIndex)));
     }
+
+    [Fact]
+    public void ULongIndexAsSignedChecked_WrapsCastInUnchecked()
+    {
+        // Inside a `checked` region the sign-changing `(long)` reinterpret would
+        // recompile to a `conv.ovf.i8.un` the original never had, so it is wrapped
+        // in `unchecked(...)`; the always-checked index conv stays outside.
+        Assert.Equal("return checked(a[unchecked((long)v[j])] + 1);", Print(nameof(CfgSampleClass.ULongIndexAsSignedChecked)));
+    }
+
+    [Fact]
+    public void LongIndexAsUnsignedChecked_WrapsCastInUnchecked()
+    {
+        // The mirror: a `long` element used as an unsigned index inside `checked`
+        // wraps its sign-changing `(ulong)` cast in `unchecked(...)`.
+        Assert.Equal("return checked(a[unchecked((ulong)v[j])] + 1);", Print(nameof(CfgSampleClass.LongIndexAsUnsignedChecked)));
+    }
+
+    [Fact]
+    public void LongEnumIndexChecked_KeepsBareCast()
+    {
+        // A same-sign cast (a long-backed enum's `(long)`) emits no conv even
+        // inside `checked`, so it stays bare with no spurious `unchecked(...)`.
+        Assert.Equal("return checked(a[(long)values[j]] + 1);", Print(nameof(CfgSampleClass.LongEnumIndexChecked)));
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
+++ b/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
@@ -134,4 +134,31 @@ public class WideArrayIndexTests
         // inside `checked`, so it stays bare with no spurious `unchecked(...)`.
         Assert.Equal("return checked(a[(long)values[j]] + 1);", Print(nameof(CfgSampleClass.LongEnumIndexChecked)));
     }
+
+    [Fact]
+    public void ULongSumIndexAsSigned_CastsWholeExpressionToLong()
+    {
+        // A `ulong` sum used as a signed index reports Int64 stack storage; the
+        // operand type is recovered through the binary as `ulong`, so it does not
+        // strip bare (which would re-insert `conv.ovf.i.un`) but casts the whole
+        // expression to `(long)`.
+        Assert.Equal("return a[(long)((ulong)v[j] + x)];", Print(nameof(CfgSampleClass.ULongSumIndexAsSigned)));
+    }
+
+    [Fact]
+    public void ULongElementSumIndexAsSigned_CastsWholeExpressionToLong()
+    {
+        // Both operands are masked `ulong` elements: the recovery sees through the
+        // `ldelem.i8` masking on each side, still typing the sum `ulong` and
+        // keeping the `(long)` cast.
+        Assert.Equal("return a[(long)(v[j] + w[k])];", Print(nameof(CfgSampleClass.ULongElementSumIndexAsSigned)));
+    }
+
+    [Fact]
+    public void ULongSumIndexBare_StripsBare()
+    {
+        // A bare `ulong` compound index matches the unsigned conversion, so it
+        // strips to the bare sum with no redundant `(ulong)` cast.
+        Assert.Equal("return a[v[j] + w[k]];", Print(nameof(CfgSampleClass.ULongSumIndexBare)));
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
+++ b/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
@@ -242,4 +242,29 @@ public class WideArrayIndexTests
         // `unchecked(...)` to keep the original unchecked `neg`.
         Assert.Equal("return checked(a[unchecked(-i)] + 1);", Print(nameof(CfgSampleClass.NegLongIndexInChecked)));
     }
+
+    [Fact]
+    public void NegULongElementIndexAsSigned_CastsNegateOperand()
+    {
+        // C# cannot negate a `ulong`, so the dropped signed reinterpret is
+        // re-inserted on the OPERAND (`-(long)v[j]`), not around the negate —
+        // `(long)(-v[j])` would be CS0023. Recompiles to `ldelem.i8; neg`.
+        Assert.Equal("return a[-(long)v[j]];", Print(nameof(CfgSampleClass.NegULongElementIndexAsSigned)));
+    }
+
+    [Fact]
+    public void NegULongElementToLong_CastsNegateOperand_OutsideIndex()
+    {
+        // The fix is in the general printer, not array indexing: a masked `ulong`
+        // element negated outside any index still gets the operand cast.
+        Assert.Equal("return -(long)v[j];", Print(nameof(CfgSampleClass.NegULongElementToLong)));
+    }
+
+    [Fact]
+    public void NegNuintElementToNint_CastsNegateOperand()
+    {
+        // The `nuint` mirror: unary minus is illegal on `nuint`, so the operand is
+        // reinterpreted `(nint)` before the negate.
+        Assert.Equal("return -(nint)v[j];", Print(nameof(CfgSampleClass.NegNuintElementToNint)));
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
+++ b/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
@@ -233,4 +233,13 @@ public class WideArrayIndexTests
         // The bitwise-not analog of the signed-negate strip.
         Assert.Equal("return a[~i];", Print(nameof(CfgSampleClass.NotLongIndexBare)));
     }
+
+    [Fact]
+    public void NegLongIndexInChecked_WrapsNegateInUnchecked()
+    {
+        // The stripped bare `-i` index would recompile as an overflow-checked
+        // negate inside the enclosing `checked`, so the negate is wrapped in
+        // `unchecked(...)` to keep the original unchecked `neg`.
+        Assert.Equal("return checked(a[unchecked(-i)] + 1);", Print(nameof(CfgSampleClass.NegLongIndexInChecked)));
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
+++ b/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
@@ -77,4 +77,36 @@ public class WideArrayIndexTests
         // underlying wide primitive, not stripped bare (CS0266).
         Assert.Equal("return a[(long)(r)];", Print(nameof(CfgSampleClass.LongEnumRefArrayIndex)));
     }
+
+    [Fact]
+    public void ULongArrayElementAsSigned_KeepsExplicitLongCast()
+    {
+        // `ldelem.i8` masks the `ulong` element as Int64, but the conversion is
+        // signed (`conv.ovf.i`). Stripping bare would spell a `ulong` index and
+        // re-insert `conv.ovf.i.un`, so the `(long)` cast must be kept.
+        Assert.Equal("return a[(long)v[j]];", Print(nameof(CfgSampleClass.ULongArrayIndexAsSigned)));
+    }
+
+    [Fact]
+    public void ULongRefAsSigned_KeepsExplicitLongCast()
+    {
+        // The ref analog (`ldind.i8`) of the masked-`ulong`-as-signed index.
+        Assert.Equal("return a[(long)(r)];", Print(nameof(CfgSampleClass.ULongRefIndexAsSigned)));
+    }
+
+    [Fact]
+    public void LongArrayElementAsUnsigned_KeepsExplicitULongCast()
+    {
+        // The mirror: a `long` element used as an unsigned index (`conv.ovf.i.un`)
+        // keeps a `(ulong)` cast, not stripped bare (which would be signed).
+        Assert.Equal("return a[(ulong)v[j]];", Print(nameof(CfgSampleClass.LongArrayIndexAsUnsigned)));
+    }
+
+    [Fact]
+    public void ULongArrayElementIndex_StripsBareLikeLong()
+    {
+        // A plain `ulong` element index: the recovered `ulong` element type
+        // matches the unsigned conversion, so it strips to the bare index.
+        Assert.Equal("return a[v[j]];", Print(nameof(CfgSampleClass.ULongArrayElementIndex)));
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
+++ b/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
@@ -267,4 +267,30 @@ public class WideArrayIndexTests
         // reinterpreted `(nint)` before the negate.
         Assert.Equal("return -(nint)v[j];", Print(nameof(CfgSampleClass.NegNuintElementToNint)));
     }
+
+    [Fact]
+    public void NegEnumULongElementIndex_CastsOperandToLong()
+    {
+        // Unary minus is illegal on EVERY enum, not just `ulong`/`nuint`. An
+        // 8-byte-backed enum negate re-inserts `(long)` on the operand and, used as
+        // a signed index, strips clean. `(long)(-v[j])` would be CS0023.
+        Assert.Equal("return a[-(long)v[j]];", Print(nameof(CfgSampleClass.NegEnumULongElementIndexAsSigned)));
+    }
+
+    [Fact]
+    public void NegEnumLongElementToLong_CastsOperandToLong()
+    {
+        // A `long`-backed enum negated outside any index still needs the operand
+        // cast — the enum has no unary minus. General printer path, not indexing.
+        Assert.Equal("return -(long)v[j];", Print(nameof(CfgSampleClass.NegEnumLongElementToLong)));
+    }
+
+    [Fact]
+    public void NegEnumUIntElementToInt_CastsOperandToInt()
+    {
+        // A 4-byte (`uint`-backed) enum reinterprets the operand as `(int)`, the
+        // value-preserving `I4` view the `neg` ran on (the outer `(int)` is the
+        // enum-to-underlying conversion the source spelled, unrelated to the fix).
+        Assert.Equal("return (int)(-(int)v[j]);", Print(nameof(CfgSampleClass.NegEnumUIntElementToInt)));
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
+++ b/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
@@ -161,4 +161,52 @@ public class WideArrayIndexTests
         // strips to the bare sum with no redundant `(ulong)` cast.
         Assert.Equal("return a[v[j] + w[k]];", Print(nameof(CfgSampleClass.ULongSumIndexBare)));
     }
+
+    [Fact]
+    public void CheckedULongSumIndexAsSigned_CastsWholeExpressionToLong()
+    {
+        // `checked` never changes an expression's C# type: a `checked` `ulong` sum
+        // used as a signed index is still `ulong`, so the recovery keeps the
+        // `(long)` cast. Stripping bare would re-insert `conv.ovf.i.un`.
+        Assert.Equal("return a[(long)checked(v[j] + x)];", Print(nameof(CfgSampleClass.CheckedULongSumIndexAsSigned)));
+    }
+
+    [Fact]
+    public void ULongShrIndexAsSigned_KeepsLongCast()
+    {
+        // An unsigned shift-right (`shr.un`) result takes the shifted operand's
+        // `ulong` type; used as a signed index it keeps the `(long)` cast.
+        Assert.Equal("return a[(long)((ulong)v[j] >> 1)];", Print(nameof(CfgSampleClass.ULongShrIndexAsSigned)));
+    }
+
+    [Fact]
+    public void ULongDivIndexAsSigned_KeepsLongCast()
+    {
+        // An unsigned divide (`div.un`) carries its signedness in the opcode
+        // variant; a `ulong` quotient used as a signed index keeps the `(long)`.
+        Assert.Equal("return a[(long)((ulong)v[j] / d)];", Print(nameof(CfgSampleClass.ULongDivIndexAsSigned)));
+    }
+
+    [Fact]
+    public void ULongRemIndexAsSigned_KeepsLongCast()
+    {
+        // An unsigned remainder (`rem.un`) analog of the divide case.
+        Assert.Equal("return a[(long)((ulong)v[j] % d)];", Print(nameof(CfgSampleClass.ULongRemIndexAsSigned)));
+    }
+
+    [Fact]
+    public void LongShlIndexBare_StripsBare()
+    {
+        // A genuinely-signed `long` shift-left index recovers as `long`, matching
+        // the signed `conv.ovf.i`, so it strips bare with no spurious `(long)`.
+        Assert.Equal("return a[i << 1];", Print(nameof(CfgSampleClass.LongShlIndexBare)));
+    }
+
+    [Fact]
+    public void LongCheckedSumIndexBare_StripsBare()
+    {
+        // A `checked` signed `long` add index likewise recovers as `long` and
+        // strips bare — checkedness does not force a cast.
+        Assert.Equal("return a[checked(i + j)];", Print(nameof(CfgSampleClass.LongCheckedSumIndexBare)));
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
+++ b/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
@@ -1,0 +1,62 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+[Trait("Area", "Printer")]
+public class WideArrayIndexTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return function!;
+    }
+
+    static string Print(string methodName)
+        => CSharpPrinter.Print(Raised(methodName)).Output!.ReplaceLineEndings("\n").Trim();
+
+    [Fact]
+    public void LongArrayIndexLoad_RendersBareIndex()
+    {
+        // The compiler-inserted conv.ovf.i (checked (nint) range conversion) is
+        // implicit for a long index, so it must not be spelled explicitly.
+        Assert.Equal("return a[i];", Print(nameof(CfgSampleClass.LongArrayIndex)));
+    }
+
+    [Fact]
+    public void ULongArrayIndexLoad_RendersBareIndex()
+    {
+        // conv.ovf.i.un for a ulong index is likewise implicit.
+        Assert.Equal("return a[i];", Print(nameof(CfgSampleClass.ULongArrayIndex)));
+    }
+
+    [Fact]
+    public void LongArrayIndexStore_RendersBareIndex()
+    {
+        Assert.Equal("a[i] = v;", Print(nameof(CfgSampleClass.LongArrayIndexStore)));
+    }
+
+    [Fact]
+    public void LongArrayIndexRef_RendersBareIndex()
+    {
+        Assert.Equal("return ref a[i];", Print(nameof(CfgSampleClass.LongArrayIndexRef)));
+    }
+
+    [Fact]
+    public void LongArrayIndexExpression_RendersBareIndex()
+    {
+        // Only the outer index range conversion is stripped; the long operand
+        // expression is spelled as-is (its own add opcode is unaffected).
+        Assert.Equal("return a[i + j];", Print(nameof(CfgSampleClass.LongArrayIndexExpr)));
+    }
+
+    [Fact]
+    public void IntArrayIndexLoad_IsUnchanged()
+    {
+        // An int index needs no range conversion, so there is nothing to strip.
+        Assert.Equal("return a[0];", Print(nameof(CfgSampleClass.FirstElement)));
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -195,7 +195,7 @@ public sealed partial class CSharpPrinter
         // of a field/property/method on the element) spells the element place
         // itself — C# auto-takes the address. The bare `ref pairs[0]` spelling
         // would be CS1525 in this value position (`(ref pairs[0]).A`).
-        LoadElementAddress e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
+        LoadElementAddress e => $"{Operand(e.Array)}[{ArrayIndexText(e.Index)}]",
         // An unbox yields a managed pointer into the box; a member access must
         // reach that in-box place, not a copy. Unlike a ref/out/write place, a
         // receiver is a value position where the cast `((T)o)` compiles, so it is

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -64,33 +64,63 @@ public sealed partial class CSharpPrinter
 
     /// <summary>
     /// Renders a unary <c>neg</c> (<c>-x</c>) or <c>not</c> (<c>~x</c>). A bitwise
-    /// complement never overflows, so it is checked-insensitive. An integer negate,
-    /// like a plain <c>add</c>/<c>sub</c>/<c>mul</c>, would silently acquire
-    /// overflow-checked semantics if recompiled inside a lexical <c>checked</c>
-    /// region — C# lowers a checked <c>-x</c> to <c>0 - x</c> as <c>sub.ovf</c>,
-    /// where the IL <c>neg</c> wraps — so wrap it in <c>unchecked(...)</c> and clear
-    /// the context for its operand, mirroring <see cref="BinaryText"/>.
+    /// complement never overflows and is valid on every integer, so it is spelled
+    /// bare. An integer negate needs two guards. (1) C# has no unary minus for
+    /// <c>ulong</c>/<c>nuint</c> (they promote to no signed type, so <c>-x</c> is
+    /// CS0023); an IL <c>neg</c> over such a value came from a signed reinterpret
+    /// cast (<c>-(long)x</c>) that is a no-op in IL and so is invisible in the
+    /// operand's masked stack type — re-insert it via
+    /// <see cref="NegateReinterpretKeyword"/> so the negate is legal and the
+    /// <c>neg</c> round-trips. (2) Like a plain <c>add</c>/<c>sub</c>/<c>mul</c>, a
+    /// negate would silently acquire overflow-checked semantics inside a lexical
+    /// <c>checked</c> region — C# lowers a checked <c>-x</c> to <c>0 - x</c> as
+    /// <c>sub.ovf</c>, where the IL <c>neg</c> wraps — so wrap it in
+    /// <c>unchecked(...)</c> and clear the context for its operand, mirroring
+    /// <see cref="BinaryText"/>.
     /// </summary>
     string UnaryText(Unary unary)
     {
         string op = unary.Kind == UnaryKind.Negate ? "-" : "~";
+        string cast = unary.Kind == UnaryKind.Negate
+            && NegateReinterpretKeyword(WideIndexOperandType(unary.Operand)) is { } keyword
+            ? $"({keyword})"
+            : "";
         bool uncheckedOverflow = unary.Kind == UnaryKind.Negate
             && _checkedContext
             && TypeFamilies.IsInteger(unary.ResultType);
         if (!uncheckedOverflow)
-            return $"{op}{Operand(unary.Operand)}";
+            return $"{op}{cast}{Operand(unary.Operand)}";
 
         bool saved = _checkedContext;
         _checkedContext = false;
         try
         {
-            return $"unchecked({op}{Operand(unary.Operand)})";
+            return $"unchecked({op}{cast}{Operand(unary.Operand)})";
         }
         finally
         {
             _checkedContext = saved;
         }
     }
+
+    /// <summary>
+    /// The signed cast keyword that makes an IL <c>neg</c> over an otherwise
+    /// non-negatable unsigned operand legal C#: <c>ulong</c>→<c>long</c>,
+    /// <c>nuint</c>→<c>nint</c>. <c>uint</c> is deliberately excluded — C# unary
+    /// minus already promotes it to <c>long</c> value-preservingly, so a cast there
+    /// would truncate. Every other type (already signed, sub-int, float, unknown)
+    /// needs no cast. The reinterpret is a no-op in IL, so re-inserting it keeps the
+    /// <c>neg</c> opcode-exact.
+    /// </summary>
+    static string? NegateReinterpretKeyword(TypeRef? operandType)
+        => operandType is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" } named
+            ? named.Name switch
+            {
+                "UInt64" => "long",
+                "UIntPtr" => "nint",
+                _ => null,
+            }
+            : null;
 
     /// <summary>
     /// Renders pointer additive arithmetic (<c>p + i</c>, <c>p - i</c>,

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -63,6 +63,36 @@ public sealed partial class CSharpPrinter
             && TypeFamilies.IsInteger(binary.ResultType);
 
     /// <summary>
+    /// Renders a unary <c>neg</c> (<c>-x</c>) or <c>not</c> (<c>~x</c>). A bitwise
+    /// complement never overflows, so it is checked-insensitive. An integer negate,
+    /// like a plain <c>add</c>/<c>sub</c>/<c>mul</c>, would silently acquire
+    /// overflow-checked semantics if recompiled inside a lexical <c>checked</c>
+    /// region — C# lowers a checked <c>-x</c> to <c>0 - x</c> as <c>sub.ovf</c>,
+    /// where the IL <c>neg</c> wraps — so wrap it in <c>unchecked(...)</c> and clear
+    /// the context for its operand, mirroring <see cref="BinaryText"/>.
+    /// </summary>
+    string UnaryText(Unary unary)
+    {
+        string op = unary.Kind == UnaryKind.Negate ? "-" : "~";
+        bool uncheckedOverflow = unary.Kind == UnaryKind.Negate
+            && _checkedContext
+            && TypeFamilies.IsInteger(unary.ResultType);
+        if (!uncheckedOverflow)
+            return $"{op}{Operand(unary.Operand)}";
+
+        bool saved = _checkedContext;
+        _checkedContext = false;
+        try
+        {
+            return $"unchecked({op}{Operand(unary.Operand)})";
+        }
+        finally
+        {
+            _checkedContext = saved;
+        }
+    }
+
+    /// <summary>
     /// Renders pointer additive arithmetic (<c>p + i</c>, <c>p - i</c>,
     /// <c>a - b</c>) without C#'s implicit <c>sizeof(element)</c> scaling. An IL
     /// pointer <c>add</c>/<c>sub</c> is byte-address arithmetic and already

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -64,13 +64,13 @@ public sealed partial class CSharpPrinter
 
     /// <summary>
     /// Renders a unary <c>neg</c> (<c>-x</c>) or <c>not</c> (<c>~x</c>). A bitwise
-    /// complement never overflows and is valid on every integer, so it is spelled
-    /// bare. An integer negate needs two guards. (1) C# has no unary minus for
-    /// <c>ulong</c>/<c>nuint</c> (they promote to no signed type, so <c>-x</c> is
-    /// CS0023); an IL <c>neg</c> over such a value came from a signed reinterpret
-    /// cast (<c>-(long)x</c>) that is a no-op in IL and so is invisible in the
-    /// operand's masked stack type — re-insert it via
-    /// <see cref="NegateReinterpretKeyword"/> so the negate is legal and the
+    /// complement never overflows and is valid on every integer and every enum, so
+    /// it is spelled bare. An integer negate needs two guards. (1) C# has no unary
+    /// minus for <c>ulong</c>/<c>nuint</c> or for <em>any</em> enum (they promote to
+    /// no signed type, so <c>-x</c> is CS0023); an IL <c>neg</c> over such a value
+    /// came from a signed reinterpret cast (<c>-(long)x</c>) that is a no-op in IL
+    /// and so is invisible in the operand's masked stack type — re-insert it via
+    /// <see cref="NegateOperandReinterpretKeyword"/> so the negate is legal and the
     /// <c>neg</c> round-trips. (2) Like a plain <c>add</c>/<c>sub</c>/<c>mul</c>, a
     /// negate would silently acquire overflow-checked semantics inside a lexical
     /// <c>checked</c> region — C# lowers a checked <c>-x</c> to <c>0 - x</c> as
@@ -82,7 +82,7 @@ public sealed partial class CSharpPrinter
     {
         string op = unary.Kind == UnaryKind.Negate ? "-" : "~";
         string cast = unary.Kind == UnaryKind.Negate
-            && NegateReinterpretKeyword(WideIndexOperandType(unary.Operand)) is { } keyword
+            && NegateOperandReinterpretKeyword(WideIndexOperandType(unary.Operand)) is { } keyword
             ? $"({keyword})"
             : "";
         bool uncheckedOverflow = unary.Kind == UnaryKind.Negate
@@ -104,13 +104,33 @@ public sealed partial class CSharpPrinter
     }
 
     /// <summary>
+    /// The signed cast keyword that makes an IL <c>neg</c> legal on an operand whose
+    /// rendered type has no C# unary minus, or null when the operand's unary minus
+    /// is already legal. C# forbids unary minus on <c>ulong</c>, <c>nuint</c>, and
+    /// <em>every</em> enum (an enum has no unary minus regardless of its underlying
+    /// type). A primitive is handled by <see cref="NegateReinterpretKeyword"/>
+    /// (<c>ulong</c>→<c>long</c>, <c>nuint</c>→<c>nint</c>; <c>uint</c> and the
+    /// signed/sub-int types negate directly). An enum always needs the reinterpret,
+    /// keyed on its underlying width: an 8-byte-backed enum reinterprets as
+    /// <c>long</c>, any narrower enum as <c>int</c> — all sub-8-byte integers are
+    /// <c>I4</c> on the eval stack, so <c>(int)</c> is the value-preserving view the
+    /// <c>neg</c> operated on. Every reinterpret here is an IL no-op, so re-inserting
+    /// it keeps the <c>neg</c> opcode-exact.
+    /// </summary>
+    string? NegateOperandReinterpretKeyword(TypeRef? operandType)
+        => EnumUnderlyingType(operandType) is { } underlying
+            ? (Is8ByteInteger(underlying) ? "long" : "int")
+            : NegateReinterpretKeyword(operandType);
+
+    /// <summary>
     /// The signed cast keyword that makes an IL <c>neg</c> over an otherwise
-    /// non-negatable unsigned operand legal C#: <c>ulong</c>→<c>long</c>,
-    /// <c>nuint</c>→<c>nint</c>. <c>uint</c> is deliberately excluded — C# unary
-    /// minus already promotes it to <c>long</c> value-preservingly, so a cast there
-    /// would truncate. Every other type (already signed, sub-int, float, unknown)
-    /// needs no cast. The reinterpret is a no-op in IL, so re-inserting it keeps the
-    /// <c>neg</c> opcode-exact.
+    /// non-negatable unsigned <em>primitive</em> operand legal C#: <c>ulong</c>→
+    /// <c>long</c>, <c>nuint</c>→<c>nint</c>. <c>uint</c> is deliberately excluded —
+    /// C# unary minus already promotes it to <c>long</c> value-preservingly, so a
+    /// cast there would truncate. Every other type (already signed, sub-int, float,
+    /// unknown) needs no cast. Enum operands are handled by
+    /// <see cref="NegateOperandReinterpretKeyword"/>. The reinterpret is a no-op in
+    /// IL, so re-inserting it keeps the <c>neg</c> opcode-exact.
     /// </summary>
     static string? NegateReinterpretKeyword(TypeRef? operandType)
         => operandType is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" } named

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -82,7 +82,7 @@ public sealed partial class CSharpPrinter
     {
         string op = unary.Kind == UnaryKind.Negate ? "-" : "~";
         string cast = unary.Kind == UnaryKind.Negate
-            && NegateOperandReinterpretKeyword(WideIndexOperandType(unary.Operand)) is { } keyword
+            && NegateOperandReinterpretKeyword(WideIndexOperandType(unary.Operand), unary.ResultType) is { } keyword
             ? $"({keyword})"
             : "";
         bool uncheckedOverflow = unary.Kind == UnaryKind.Negate
@@ -110,17 +110,55 @@ public sealed partial class CSharpPrinter
     /// <em>every</em> enum (an enum has no unary minus regardless of its underlying
     /// type). A primitive is handled by <see cref="NegateReinterpretKeyword"/>
     /// (<c>ulong</c>→<c>long</c>, <c>nuint</c>→<c>nint</c>; <c>uint</c> and the
-    /// signed/sub-int types negate directly). An enum always needs the reinterpret,
-    /// keyed on its underlying width: an 8-byte-backed enum reinterprets as
-    /// <c>long</c>, any narrower enum as <c>int</c> — all sub-8-byte integers are
-    /// <c>I4</c> on the eval stack, so <c>(int)</c> is the value-preserving view the
-    /// <c>neg</c> operated on. Every reinterpret here is an IL no-op, so re-inserting
-    /// it keeps the <c>neg</c> opcode-exact.
+    /// signed/sub-int types negate directly). A resolved enum always needs the
+    /// reinterpret, keyed on its underlying width: an 8-byte-backed enum
+    /// reinterprets as <c>long</c>, any narrower enum as <c>int</c> — all sub-8-byte
+    /// integers are <c>I4</c> on the eval stack, so <c>(int)</c> is the
+    /// value-preserving view the <c>neg</c> operated on. An enum whose shape did not
+    /// resolve (a cross-assembly enum renders as its type name but not as an enum
+    /// shape) still has no unary minus, so the reinterpret is recovered from
+    /// <paramref name="stackType"/> — the masked stack width the <c>neg</c> ran on
+    /// (an IL <c>neg</c> only ever applies to a numeric or enum operand, so a
+    /// non-primitive rendered type under one is always an enum). Every reinterpret
+    /// here is an IL no-op, so re-inserting it keeps the <c>neg</c> opcode-exact.
     /// </summary>
-    string? NegateOperandReinterpretKeyword(TypeRef? operandType)
+    string? NegateOperandReinterpretKeyword(TypeRef? operandType, TypeRef? stackType)
         => EnumUnderlyingType(operandType) is { } underlying
             ? (Is8ByteInteger(underlying) ? "long" : "int")
-            : NegateReinterpretKeyword(operandType);
+            : NegateReinterpretKeyword(operandType)
+                ?? (IsUnresolvedEnumLike(operandType) ? NegateWidthKeyword(stackType) : null);
+
+    /// <summary>
+    /// True for a rendered type that an IL <c>neg</c> can only be spelling as an
+    /// enum whose shape did not resolve: a type <c>Definition</c> that is not a
+    /// known numeric primitive (<see cref="TypeFamilies.Of"/> returns null for a
+    /// bare definition it cannot classify). A same-assembly enum resolves through
+    /// <c>EnumUnderlyingType</c> and a primitive is classified by
+    /// <see cref="TypeFamilies.Of"/>, so what remains under a <c>neg</c> is a
+    /// referenced-assembly enum or a core-library enum (both unresolved to a shape)
+    /// — a struct never reaches here because its unary minus is an
+    /// <c>op_UnaryNegation</c> call, not an IL <c>neg</c>.
+    /// </summary>
+    static bool IsUnresolvedEnumLike(TypeRef? type)
+        => type is { Kind: TypeRefKind.Definition } && TypeFamilies.Of(type) is null;
+
+    /// <summary>
+    /// The signed reinterpret keyword for a masked stack width: an 8-byte
+    /// (<c>Int64</c>/<c>UInt64</c>) value as <c>long</c>, a native integer as
+    /// <c>nint</c>, and any 4-byte-or-narrower integer (all <c>I4</c> on the eval
+    /// stack) as <c>int</c>. Null for a stack type that is not a recognised integer
+    /// primitive, so an unresolvable width emits no (possibly wrong) cast.
+    /// </summary>
+    static string? NegateWidthKeyword(TypeRef? stackType)
+        => stackType is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" } named
+            ? named.Name switch
+            {
+                "Int64" or "UInt64" => "long",
+                "IntPtr" or "UIntPtr" => "nint",
+                "Int32" or "UInt32" or "Int16" or "UInt16" or "SByte" or "Byte" or "Char" => "int",
+                _ => null,
+            }
+            : null;
 
     /// <summary>
     /// The signed cast keyword that makes an IL <c>neg</c> over an otherwise

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2481,8 +2481,7 @@ public sealed partial class CSharpPrinter
         NullCoalescingFieldAssignmentExpression n => $"{FieldTarget(n.Field, n.Instance)} ??= {CoerceText(n.Value, n.Field.Type)}",
         Coalesce co => CoalesceText(co),
         NullConditional nc => NullConditionalText(nc),
-        Unary { Kind: UnaryKind.Negate } u => $"-{Operand(u.Operand)}",
-        Unary u => $"~{Operand(u.Operand)}",
+        Unary u => UnaryText(u),
         AwaitExpression aw => $"await {Operand(aw.Operand)}",
         IncrementDecrement id => IncrementDecrementText(id),
         // The coercion node renders through the one rule — the node IS the

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2355,8 +2355,9 @@ public sealed partial class CSharpPrinter
     /// element or ref/pointer pointee type that a typed load opcode
     /// (<c>ldelem.i8</c> / <c>ldind.i8</c>) reports only as its <c>Int64</c> storage
     /// width — masking a <c>ulong</c> element or a wide enum — and propagating that
-    /// through a wide binary (whose stack <c>ResultType</c> keeps a signed operand
-    /// type even when the rendered expression is <c>ulong</c>). The bare-rendered
+    /// through a wide binary or a unary neg/not (whose stack <c>ResultType</c>
+    /// keeps a signed operand type even when the rendered expression is
+    /// <c>ulong</c>). The bare-rendered
     /// operand is spelled with that type, so it is the type whose signedness drives
     /// the re-inserted index conversion; for any other operand the load carries no
     /// masking and its own <c>ResultType</c> is used.
@@ -2403,6 +2404,11 @@ public sealed partial class CSharpPrinter
                         return binary.ResultType;
                 }
             }
+            // A unary neg/not preserves its operand's type (`~v[j]` over a `ulong`
+            // element is a `ulong`), but its ResultType is that operand's masked
+            // stack type, so recover the rendered type from the unmasked operand.
+            case Unary unary:
+                return WideIndexOperandType(unary.Operand);
             default:
                 return operand.ResultType;
         }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2418,9 +2418,16 @@ public sealed partial class CSharpPrinter
                 var inner = WideIndexOperandType(negate.Operand);
                 if (EnumUnderlyingType(inner) is { } underlying)
                     return TypeRef.CoreLib("System", Is8ByteInteger(underlying) ? "Int64" : "Int32");
-                return NegateReinterpretKeyword(inner) is not null
-                    ? TypeFamilies.SignedCounterpart(inner) ?? inner
-                    : inner;
+                if (NegateReinterpretKeyword(inner) is not null)
+                    return TypeFamilies.SignedCounterpart(inner) ?? inner;
+                // An unresolved (cross-assembly) enum: UnaryText re-inserts the
+                // width-based reinterpret, so the negate renders signed at its
+                // masked stack width. Report that signed width so the strip is
+                // clean; SignedCounterpart maps a masked unsigned width to signed
+                // (Int64/Int32) and is a no-op on an already-signed width.
+                if (IsUnresolvedEnumLike(inner))
+                    return TypeFamilies.SignedCounterpart(negate.ResultType) ?? negate.ResultType;
+                return inner;
             }
             case Unary unary:
                 return WideIndexOperandType(unary.Operand);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2362,7 +2362,7 @@ public sealed partial class CSharpPrinter
     /// the re-inserted index conversion; for any other operand the load carries no
     /// masking and its own <c>ResultType</c> is used.
     /// </summary>
-    static TypeRef? WideIndexOperandType(IrExpression operand)
+    TypeRef? WideIndexOperandType(IrExpression operand)
     {
         switch (operand)
         {
@@ -2405,14 +2405,19 @@ public sealed partial class CSharpPrinter
                 }
             }
             // A bitwise `~` preserves its operand's type (`~v[j]` over a `ulong`
-            // element is a `ulong`); a unary `-` cannot apply to `ulong`/`nuint`,
-            // so UnaryText re-inserts a signed reinterpret (`-(long)v[j]`) and the
-            // negate then renders signed. Recover the rendered type from the
-            // unmasked operand (its ResultType is the masked stack type), mapping a
-            // negate over a non-negatable unsigned operand to its signed counterpart.
+            // element is a `ulong`, `~e` over an enum is that enum); a unary `-`
+            // cannot apply to `ulong`/`nuint` or to any enum, so UnaryText
+            // re-inserts a signed reinterpret (`-(long)v[j]`) and the negate then
+            // renders signed. Recover the rendered type from the unmasked operand
+            // (its ResultType is the masked stack type), mapping a negate over a
+            // non-negatable operand to the signed integer it now renders as: an
+            // enum to `long`/`int` by its underlying width, else the unsigned
+            // primitive's signed counterpart.
             case Unary { Kind: UnaryKind.Negate } negate:
             {
                 var inner = WideIndexOperandType(negate.Operand);
+                if (EnumUnderlyingType(inner) is { } underlying)
+                    return TypeRef.CoreLib("System", Is8ByteInteger(underlying) ? "Int64" : "Int32");
                 return NegateReinterpretKeyword(inner) is not null
                     ? TypeFamilies.SignedCounterpart(inner) ?? inner
                     : inner;
@@ -2426,6 +2431,16 @@ public sealed partial class CSharpPrinter
 
     static TypeRef? WideIndexPointee(IrExpression address)
         => address.ResultType is { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer } indirect ? indirect.ElementType : null;
+
+    /// <summary>
+    /// True for the two 8-byte integer primitives (<c>long</c>/<c>ulong</c>) — the
+    /// only enum underlying types wide enough to load through an <c>ldelem.i8</c>/
+    /// <c>ldind.i8</c> mask and the ones whose negate reinterprets as <c>long</c>
+    /// rather than <c>int</c>. Enums cannot be <c>nint</c>/<c>nuint</c>-backed, so
+    /// native integers are not considered here.
+    /// </summary>
+    static bool Is8ByteInteger(TypeRef? type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Int64" or "UInt64" };
 
     /// <summary>
     /// True when the emitted wide index cast <c>(long)</c>/<c>(ulong)</c> flips the

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2263,19 +2263,24 @@ public sealed partial class CSharpPrinter
     /// <summary>
     /// The C# text for a single-dimension array element index. C# implicitly
     /// converts a wide (<c>long</c>/<c>ulong</c>) array index to native int with
-    /// a checked range conversion (<c>conv.ovf.i</c> / <c>conv.ovf.i.un</c>) that
-    /// is always overflow-checked, regardless of the enclosing
-    /// <c>checked</c>/<c>unchecked</c> context. Spelling that conversion
-    /// explicitly (<c>a[checked((nint)i)]</c>) is verbose, unidiomatic, and
-    /// round-trips to a redundant widen-then-renarrow, so it is elided:
+    /// a checked range conversion (<c>conv.ovf.i</c> for a signed index,
+    /// <c>conv.ovf.i.un</c> for an unsigned one) that is always overflow-checked,
+    /// regardless of the enclosing <c>checked</c>/<c>unchecked</c> context.
+    /// Spelling that conversion explicitly (<c>a[checked((nint)i)]</c>) is
+    /// verbose, unidiomatic, and round-trips to a redundant widen-then-renarrow,
+    /// so it is elided:
     /// <list type="bullet">
-    /// <item>an operand that already spells as <c>long</c>/<c>ulong</c> strips to
-    /// the bare index (<c>a[i]</c>);</item>
-    /// <item>a wide (8-byte) <b>enum</b> operand — whose typed load opcode
-    /// (<c>ldelem.i8</c> / <c>ldind.i8</c>) masks it as <c>Int64</c> storage, so
-    /// a bare <c>a[values[j]]</c> is CS0266 — is cast to its underlying wide
-    /// primitive (<c>a[(long)values[j]]</c> / <c>a[(ulong)values[j]]</c>), which
-    /// re-inserts the same implicit index conversion.</item>
+    /// <item>an operand that already spells with the conversion's signedness
+    /// (<c>long</c> for <c>conv.ovf.i</c>, <c>ulong</c> for <c>conv.ovf.i.un</c>)
+    /// strips to the bare index (<c>a[i]</c>);</item>
+    /// <item>any other wide (8-byte) operand is cast to the primitive matching the
+    /// conversion (<c>(long)</c> / <c>(ulong)</c>), because its bare spelling would
+    /// carry the wrong signedness or no integer type at all: a typed load opcode
+    /// (<c>ldelem.i8</c> / <c>ldind.i8</c>) masks a <c>ulong</c> element or a wide
+    /// enum as <c>Int64</c> storage, so a bare <c>a[values[j]]</c> would be CS0266
+    /// (enum) or re-insert <c>conv.ovf.i.un</c> where the original was signed
+    /// (<c>ulong</c> read as a signed index). The cast re-inserts the same
+    /// implicit conversion, e.g. <c>a[(long)values[j]]</c>.</item>
     /// </list>
     /// Both forms recompile to the identical IL. Any other index expression is
     /// spelled unchanged.
@@ -2291,26 +2296,30 @@ public sealed partial class CSharpPrinter
             return Expression(index);
         }
 
-        var operandType = WideIndexOperandType(convert.Operand);
-        string? primitive = operandType is
+        // The bare index expression's own C# type. A typed load opcode
+        // (ldelem.i8 / ldind.i8) reports only its Int64 storage width, so recover
+        // the array element or ref/pointer pointee type it masks — that is the
+        // type whose signedness C# uses when it re-inserts the index conversion.
+        var indexType = WideIndexOperandType(convert.Operand);
+        string? primitive = indexType is
             { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" } named
             ? named.Name
             : null;
 
-        // The operand already spells as long/ulong: the checked native-int index
-        // conversion is implicit, so drop it to the bare operand. The signed
-        // conv.ovf.i pairs with an Int64 operand, the unsigned conv.ovf.i.un with
-        // UInt64 — any other source type would recompile to different IL.
+        // The operand already spells with the signedness the conversion needs, so
+        // the checked native-int index conversion is implicit: drop to the bare
+        // operand. A signed conv.ovf.i re-appears for a `long` index, an unsigned
+        // conv.ovf.i.un for a `ulong` index.
         if ((!convert.IsUnsigned && primitive == "Int64") || (convert.IsUnsigned && primitive == "UInt64"))
             return Expression(convert.Operand);
 
-        // The operand is a wide (8-byte) enum whose typed load opcode reports only
-        // its Int64 storage: a bare index is CS0266, so cast to the underlying
-        // wide primitive. C# re-inserts the same implicit index conversion, so the
-        // signed conv.ovf.i keeps `(long)` and the unsigned conv.ovf.i.un `(ulong)`
-        // — opcode-exact either way.
-        if (operandType is { } enumType && IsEnumLikeDefinition(enumType)
-            && convert.Operand.ResultType is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Int64" or "UInt64" })
+        // The operand is a wide (8-byte) value whose bare spelling would carry the
+        // wrong signedness or no integer type at all: a masked enum (a bare index
+        // is CS0266), a `ulong` element used as a signed index, or a `long`
+        // element used as an unsigned one. Cast to the primitive matching the
+        // conversion so C# re-inserts the same conv.ovf.i / conv.ovf.i.un — the
+        // signed conv keeps `(long)`, the unsigned conv `(ulong)`, opcode-exact.
+        if (convert.Operand.ResultType is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Int64" or "UInt64" })
             return $"({(convert.IsUnsigned ? "ulong" : "long")}){Operand(convert.Operand)}";
 
         // Any other checked (nint) conversion recompiles to different IL: spell it.
@@ -2318,30 +2327,23 @@ public sealed partial class CSharpPrinter
     }
 
     /// <summary>
-    /// The operand's real C# type, recovering the enum element/pointee type that
-    /// a typed load opcode (<c>ldelem.i8</c> / <c>ldind.i8</c>) reports only as
-    /// its <c>Int64</c> storage width. Mirrors
-    /// <see cref="CoercionSinks.StoreElementTarget"/>'s enum-element reasoning so
-    /// the wide-index decision agrees with the array-store cast decision: the
-    /// array's own element type (or a ref/pointer pointee) wins exactly when it
-    /// is an enum-like definition — a named type with no primitive stack family
-    /// that the shape map does not class as a reference or non-enum struct.
+    /// The index operand's real C# type, recovering the array element or
+    /// ref/pointer pointee type that a typed load opcode (<c>ldelem.i8</c> /
+    /// <c>ldind.i8</c>) reports only as its <c>Int64</c> storage width — masking a
+    /// <c>ulong</c> element or a wide enum. The bare-rendered <c>values[j]</c> /
+    /// <c>r</c> is spelled with that element/pointee type, so it is the type whose
+    /// signedness drives the re-inserted index conversion; for any other operand
+    /// the load carries no masking and its own <c>ResultType</c> is used.
     /// </summary>
-    TypeRef? WideIndexOperandType(IrExpression operand) => operand switch
+    static TypeRef? WideIndexOperandType(IrExpression operand) => operand switch
     {
-        LoadElement { Array.ResultType: { Kind: TypeRefKind.SzArray or TypeRefKind.Array, ElementType: { } element } }
-            when IsEnumLikeDefinition(element) => element,
-        LoadIndirect load when WideIndexPointee(load.Address) is { } pointee && IsEnumLikeDefinition(pointee) => pointee,
+        LoadElement { Array.ResultType: { Kind: TypeRefKind.SzArray or TypeRefKind.Array, ElementType: { } element } } => element,
+        LoadIndirect load when WideIndexPointee(load.Address) is { } pointee => pointee,
         _ => operand.ResultType,
     };
 
     static TypeRef? WideIndexPointee(IrExpression address)
         => address.ResultType is { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer } indirect ? indirect.ElementType : null;
-
-    bool IsEnumLikeDefinition(TypeRef type)
-        => type is { Kind: TypeRefKind.Definition }
-            && TypeFamilies.Of(type) is null
-            && _function.TypeShapes.GetValueOrDefault(type) is not (TypeShape.Reference or TypeShape.ValueType);
 
     string Expression(IrExpression node) => node switch
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2355,11 +2355,10 @@ public sealed partial class CSharpPrinter
     /// element or ref/pointer pointee type that a typed load opcode
     /// (<c>ldelem.i8</c> / <c>ldind.i8</c>) reports only as its <c>Int64</c> storage
     /// width — masking a <c>ulong</c> element or a wide enum — and propagating that
-    /// through a sign-neutral wide binary (<c>add</c>/<c>sub</c>/<c>mul</c> and the
-    /// bitwise ops, whose stack <c>ResultType</c> keeps a signed operand type even
-    /// when the rendered expression is <c>ulong</c>). The bare-rendered operand is
-    /// spelled with that type, so it is the type whose signedness drives the
-    /// re-inserted index conversion; for any other operand the load carries no
+    /// through a wide binary (whose stack <c>ResultType</c> keeps a signed operand
+    /// type even when the rendered expression is <c>ulong</c>). The bare-rendered
+    /// operand is spelled with that type, so it is the type whose signedness drives
+    /// the re-inserted index conversion; for any other operand the load carries no
     /// masking and its own <c>ResultType</c> is used.
     /// </summary>
     static TypeRef? WideIndexOperandType(IrExpression operand)
@@ -2372,19 +2371,37 @@ public sealed partial class CSharpPrinter
                 return pointee;
             // A sign-neutral wide binary renders unsigned whenever an operand
             // renders unsigned at the same width (`v[j] + x` over a `ulong`
-            // element and a `ulong` is a `ulong` add). Its own stack ResultType
-            // keeps the signed operand type, so recover the rendered type from the
-            // unmasked operands — mirroring EffectiveType/RendersUnsigned, but
-            // seeing through the element/pointee masking those miss.
-            case Binary { IsChecked: false, Kind: BinaryKind.Add or BinaryKind.Subtract or BinaryKind.Multiply or BinaryKind.And or BinaryKind.Or or BinaryKind.Xor } binary:
+            // element and a `ulong` is a `ulong` add), regardless of checkedness —
+            // `checked` never changes an expression's C# type. Its own stack
+            // ResultType keeps the signed operand type, so recover the rendered
+            // type from the unmasked operands. Add/Subtract/Multiply and the
+            // bitwise ops are sign-neutral; a shift's result type is its (unmasked)
+            // left operand's; Divide/Remainder/ShiftRight carry the sign in their
+            // opcode variant (div/div.un, rem/rem.un, shr/shr.un) via IsUnsigned.
+            case Binary binary:
             {
-                var left = WideIndexOperandType(binary.Left);
-                var right = WideIndexOperandType(binary.Right);
-                if (IsWideInteger(left) && IsWideInteger(right) && TypeFamilies.Of(left) == TypeFamilies.Of(right))
-                    return TypeFamilies.IsUnsignedIntegerPrimitive(left) ? left
-                        : TypeFamilies.IsUnsignedIntegerPrimitive(right) ? right
-                        : left;
-                return binary.ResultType;
+                switch (binary.Kind)
+                {
+                    case BinaryKind.Add or BinaryKind.Subtract or BinaryKind.Multiply
+                        or BinaryKind.And or BinaryKind.Or or BinaryKind.Xor:
+                    {
+                        var left = WideIndexOperandType(binary.Left);
+                        var right = WideIndexOperandType(binary.Right);
+                        if (IsWideInteger(left) && IsWideInteger(right) && TypeFamilies.Of(left) == TypeFamilies.Of(right))
+                            return TypeFamilies.IsUnsignedIntegerPrimitive(left) ? left
+                                : TypeFamilies.IsUnsignedIntegerPrimitive(right) ? right
+                                : left;
+                        return binary.ResultType;
+                    }
+                    case BinaryKind.ShiftLeft:
+                        return WideIndexOperandType(binary.Left);
+                    case BinaryKind.Divide or BinaryKind.Remainder or BinaryKind.ShiftRight:
+                        return binary.IsUnsigned
+                            ? TypeFamilies.UnsignedCounterpart(binary.ResultType) ?? binary.ResultType
+                            : binary.ResultType;
+                    default:
+                        return binary.ResultType;
+                }
             }
             default:
                 return operand.ResultType;

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2267,25 +2267,20 @@ public sealed partial class CSharpPrinter
     /// is always overflow-checked, regardless of the enclosing
     /// <c>checked</c>/<c>unchecked</c> context. Spelling that conversion
     /// explicitly (<c>a[checked((nint)i)]</c>) is verbose, unidiomatic, and
-    /// round-trips to a redundant widen-then-renarrow, so a compiler-inserted
-    /// wide-index conversion is stripped to the bare index (<c>a[i]</c>), which
-    /// recompiles to the identical IL. Any other index expression is spelled
-    /// unchanged.
+    /// round-trips to a redundant widen-then-renarrow, so it is elided:
+    /// <list type="bullet">
+    /// <item>an operand that already spells as <c>long</c>/<c>ulong</c> strips to
+    /// the bare index (<c>a[i]</c>);</item>
+    /// <item>a wide (8-byte) <b>enum</b> operand — whose typed load opcode
+    /// (<c>ldelem.i8</c> / <c>ldind.i8</c>) masks it as <c>Int64</c> storage, so
+    /// a bare <c>a[values[j]]</c> is CS0266 — is cast to its underlying wide
+    /// primitive (<c>a[(long)values[j]]</c> / <c>a[(ulong)values[j]]</c>), which
+    /// re-inserts the same implicit index conversion.</item>
+    /// </list>
+    /// Both forms recompile to the identical IL. Any other index expression is
+    /// spelled unchanged.
     /// </summary>
     string ArrayIndexText(IrExpression index)
-        => WideArrayIndexOperand(index) is { } operand ? Expression(operand) : Expression(index);
-
-    /// <summary>
-    /// The source operand of a compiler-inserted wide array-index conversion, or
-    /// null when <paramref name="index"/> is not one. Matches only the exact
-    /// conversions the C# compiler emits for a <c>long</c>/<c>ulong</c>
-    /// single-dimension array index: a checked conversion to
-    /// <see cref="System.IntPtr"/> whose operand is <c>Int64</c>
-    /// (<c>conv.ovf.i</c>) or, when unsigned, <c>UInt64</c>
-    /// (<c>conv.ovf.i.un</c>). A conversion from any other source type would
-    /// recompile to different IL, so it is left spelled.
-    /// </summary>
-    static IrExpression? WideArrayIndexOperand(IrExpression index)
     {
         if (index is not Convert
             {
@@ -2293,21 +2288,60 @@ public sealed partial class CSharpPrinter
                 Target: { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "IntPtr" },
             } convert)
         {
-            return null;
+            return Expression(index);
         }
 
-        string? source = convert.Operand.ResultType is
-            { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" } type
-            ? type.Name
+        var operandType = WideIndexOperandType(convert.Operand);
+        string? primitive = operandType is
+            { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" } named
+            ? named.Name
             : null;
 
-        return (convert.IsUnsigned, source) switch
-        {
-            (false, "Int64") => convert.Operand,
-            (true, "UInt64") => convert.Operand,
-            _ => null,
-        };
+        // The operand already spells as long/ulong: the checked native-int index
+        // conversion is implicit, so drop it to the bare operand. The signed
+        // conv.ovf.i pairs with an Int64 operand, the unsigned conv.ovf.i.un with
+        // UInt64 — any other source type would recompile to different IL.
+        if ((!convert.IsUnsigned && primitive == "Int64") || (convert.IsUnsigned && primitive == "UInt64"))
+            return Expression(convert.Operand);
+
+        // The operand is a wide (8-byte) enum whose typed load opcode reports only
+        // its Int64 storage: a bare index is CS0266, so cast to the underlying
+        // wide primitive. C# re-inserts the same implicit index conversion, so the
+        // signed conv.ovf.i keeps `(long)` and the unsigned conv.ovf.i.un `(ulong)`
+        // — opcode-exact either way.
+        if (operandType is { } enumType && IsEnumLikeDefinition(enumType)
+            && convert.Operand.ResultType is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Int64" or "UInt64" })
+            return $"({(convert.IsUnsigned ? "ulong" : "long")}){Operand(convert.Operand)}";
+
+        // Any other checked (nint) conversion recompiles to different IL: spell it.
+        return Expression(index);
     }
+
+    /// <summary>
+    /// The operand's real C# type, recovering the enum element/pointee type that
+    /// a typed load opcode (<c>ldelem.i8</c> / <c>ldind.i8</c>) reports only as
+    /// its <c>Int64</c> storage width. Mirrors
+    /// <see cref="CoercionSinks.StoreElementTarget"/>'s enum-element reasoning so
+    /// the wide-index decision agrees with the array-store cast decision: the
+    /// array's own element type (or a ref/pointer pointee) wins exactly when it
+    /// is an enum-like definition — a named type with no primitive stack family
+    /// that the shape map does not class as a reference or non-enum struct.
+    /// </summary>
+    TypeRef? WideIndexOperandType(IrExpression operand) => operand switch
+    {
+        LoadElement { Array.ResultType: { Kind: TypeRefKind.SzArray or TypeRefKind.Array, ElementType: { } element } }
+            when IsEnumLikeDefinition(element) => element,
+        LoadIndirect load when WideIndexPointee(load.Address) is { } pointee && IsEnumLikeDefinition(pointee) => pointee,
+        _ => operand.ResultType,
+    };
+
+    static TypeRef? WideIndexPointee(IrExpression address)
+        => address.ResultType is { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer } indirect ? indirect.ElementType : null;
+
+    bool IsEnumLikeDefinition(TypeRef type)
+        => type is { Kind: TypeRefKind.Definition }
+            && TypeFamilies.Of(type) is null
+            && _function.TypeShapes.GetValueOrDefault(type) is not (TypeShape.Reference or TypeShape.ValueType);
 
     string Expression(IrExpression node) => node switch
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2351,20 +2351,45 @@ public sealed partial class CSharpPrinter
     }
 
     /// <summary>
-    /// The index operand's real C# type, recovering the array element or
-    /// ref/pointer pointee type that a typed load opcode (<c>ldelem.i8</c> /
-    /// <c>ldind.i8</c>) reports only as its <c>Int64</c> storage width — masking a
-    /// <c>ulong</c> element or a wide enum. The bare-rendered <c>values[j]</c> /
-    /// <c>r</c> is spelled with that element/pointee type, so it is the type whose
-    /// signedness drives the re-inserted index conversion; for any other operand
-    /// the load carries no masking and its own <c>ResultType</c> is used.
+    /// The index operand's real, rendered wide C# type, recovering the array
+    /// element or ref/pointer pointee type that a typed load opcode
+    /// (<c>ldelem.i8</c> / <c>ldind.i8</c>) reports only as its <c>Int64</c> storage
+    /// width — masking a <c>ulong</c> element or a wide enum — and propagating that
+    /// through a sign-neutral wide binary (<c>add</c>/<c>sub</c>/<c>mul</c> and the
+    /// bitwise ops, whose stack <c>ResultType</c> keeps a signed operand type even
+    /// when the rendered expression is <c>ulong</c>). The bare-rendered operand is
+    /// spelled with that type, so it is the type whose signedness drives the
+    /// re-inserted index conversion; for any other operand the load carries no
+    /// masking and its own <c>ResultType</c> is used.
     /// </summary>
-    static TypeRef? WideIndexOperandType(IrExpression operand) => operand switch
+    static TypeRef? WideIndexOperandType(IrExpression operand)
     {
-        LoadElement { Array.ResultType: { Kind: TypeRefKind.SzArray or TypeRefKind.Array, ElementType: { } element } } => element,
-        LoadIndirect load when WideIndexPointee(load.Address) is { } pointee => pointee,
-        _ => operand.ResultType,
-    };
+        switch (operand)
+        {
+            case LoadElement { Array.ResultType: { Kind: TypeRefKind.SzArray or TypeRefKind.Array, ElementType: { } element } }:
+                return element;
+            case LoadIndirect load when WideIndexPointee(load.Address) is { } pointee:
+                return pointee;
+            // A sign-neutral wide binary renders unsigned whenever an operand
+            // renders unsigned at the same width (`v[j] + x` over a `ulong`
+            // element and a `ulong` is a `ulong` add). Its own stack ResultType
+            // keeps the signed operand type, so recover the rendered type from the
+            // unmasked operands — mirroring EffectiveType/RendersUnsigned, but
+            // seeing through the element/pointee masking those miss.
+            case Binary { IsChecked: false, Kind: BinaryKind.Add or BinaryKind.Subtract or BinaryKind.Multiply or BinaryKind.And or BinaryKind.Or or BinaryKind.Xor } binary:
+            {
+                var left = WideIndexOperandType(binary.Left);
+                var right = WideIndexOperandType(binary.Right);
+                if (IsWideInteger(left) && IsWideInteger(right) && TypeFamilies.Of(left) == TypeFamilies.Of(right))
+                    return TypeFamilies.IsUnsignedIntegerPrimitive(left) ? left
+                        : TypeFamilies.IsUnsignedIntegerPrimitive(right) ? right
+                        : left;
+                return binary.ResultType;
+            }
+            default:
+                return operand.ResultType;
+        }
+    }
 
     static TypeRef? WideIndexPointee(IrExpression address)
         => address.ResultType is { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer } indirect ? indirect.ElementType : null;

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2180,8 +2180,8 @@ public sealed partial class CSharpPrinter
                 && PlaceIdentity.SameOperands(load.IndexArguments, s.IndexArguments),
             StorePropertyTargetType(s)),
         EventSubscription e => $"{PropertyTarget(e.Accessor, e.HasInstance ? e.Instance : null, [], e.EventName, e.IsVirtual)} {(e.IsAdd ? "+=" : "-=")} {CoerceText(e.Value, e.Accessor.ParameterTypes[0])};",
-        StoreElement s when InlineReceiverTempStoreValue(s) is { } value => $"{Operand(s.Array)}[{Expression(s.Index)}] = {value};",
-        StoreElement s => $"{Operand(s.Array)}[{Expression(s.Index)}] = {CoerceText(s.Value, StoreElementTargetType(s))};",
+        StoreElement s when InlineReceiverTempStoreValue(s) is { } value => $"{Operand(s.Array)}[{ArrayIndexText(s.Index)}] = {value};",
+        StoreElement s => $"{Operand(s.Array)}[{ArrayIndexText(s.Index)}] = {CoerceText(s.Value, StoreElementTargetType(s))};",
         StoreIndirect s => AssignmentText(
             IndirectTarget(s.Address, IndirectStoreType(s.Address, s.Type)),
             s.Value,
@@ -2260,6 +2260,55 @@ public sealed partial class CSharpPrinter
     TypeRef? StoreElementTargetType(StoreElement store)
         => CoercionSinks.StoreElementTarget(store, _function.TypeShapes);
 
+    /// <summary>
+    /// The C# text for a single-dimension array element index. C# implicitly
+    /// converts a wide (<c>long</c>/<c>ulong</c>) array index to native int with
+    /// a checked range conversion (<c>conv.ovf.i</c> / <c>conv.ovf.i.un</c>) that
+    /// is always overflow-checked, regardless of the enclosing
+    /// <c>checked</c>/<c>unchecked</c> context. Spelling that conversion
+    /// explicitly (<c>a[checked((nint)i)]</c>) is verbose, unidiomatic, and
+    /// round-trips to a redundant widen-then-renarrow, so a compiler-inserted
+    /// wide-index conversion is stripped to the bare index (<c>a[i]</c>), which
+    /// recompiles to the identical IL. Any other index expression is spelled
+    /// unchanged.
+    /// </summary>
+    string ArrayIndexText(IrExpression index)
+        => WideArrayIndexOperand(index) is { } operand ? Expression(operand) : Expression(index);
+
+    /// <summary>
+    /// The source operand of a compiler-inserted wide array-index conversion, or
+    /// null when <paramref name="index"/> is not one. Matches only the exact
+    /// conversions the C# compiler emits for a <c>long</c>/<c>ulong</c>
+    /// single-dimension array index: a checked conversion to
+    /// <see cref="System.IntPtr"/> whose operand is <c>Int64</c>
+    /// (<c>conv.ovf.i</c>) or, when unsigned, <c>UInt64</c>
+    /// (<c>conv.ovf.i.un</c>). A conversion from any other source type would
+    /// recompile to different IL, so it is left spelled.
+    /// </summary>
+    static IrExpression? WideArrayIndexOperand(IrExpression index)
+    {
+        if (index is not Convert
+            {
+                IsChecked: true,
+                Target: { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "IntPtr" },
+            } convert)
+        {
+            return null;
+        }
+
+        string? source = convert.Operand.ResultType is
+            { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" } type
+            ? type.Name
+            : null;
+
+        return (convert.IsUnsigned, source) switch
+        {
+            (false, "Int64") => convert.Operand,
+            (true, "UInt64") => convert.Operand,
+            _ => null,
+        };
+    }
+
     string Expression(IrExpression node) => node switch
     {
         LoadArgument { Index: 0, Name: "this" } => "this",
@@ -2337,7 +2386,7 @@ public sealed partial class CSharpPrinter
         RangeExpression r => $"{(r.HasStart ? Operand(r.Start!) : "")}..{(r.HasEnd ? Operand(r.End!) : "")}",
         IndexFromEnd i => $"^{Operand(i.Offset)}",
         LoadElement e when MultiDimArrayElementText(e) is { } text => text,
-        LoadElement e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
+        LoadElement e => $"{Operand(e.Array)}[{ArrayIndexText(e.Index)}]",
         NewArray n => ArrayCreationText(n.ElementType, [n.Length]),
         SpanLiteral s => $"new {TypeText(s.ElementType)}[] {{ {string.Join(", ", s.Elements.Select(Expression))} }}",
         ArrayLiteral a => $"new {TypeText(a.ElementType)}[] {{ {string.Join(", ", a.Elements.Select(Expression))} }}",
@@ -2362,7 +2411,7 @@ public sealed partial class CSharpPrinter
         LoadFieldAddress f => $"ref {FieldTarget(f.Field, f.Instance)}",
         FixedBufferElementAddress f => $"ref {FixedBufferElementText(f)}",
         LoadElementAddress e when MultiDimArrayElementAddressText(e) is { } text => $"ref {text}",
-        LoadElementAddress e => $"ref {Operand(e.Array)}[{Expression(e.Index)}]",
+        LoadElementAddress e => $"ref {Operand(e.Array)}[{ArrayIndexText(e.Index)}]",
         LoadIndirect l => DerefLoad(l),
         SizeOf s => $"sizeof({TypeText(s.Type)})",
         DefaultValue d => $"default({TypeText(d.Type)})",
@@ -2829,7 +2878,7 @@ public sealed partial class CSharpPrinter
         LoadArgumentAddress a => CSharpNaming.EscapeIdentifier(a.Name),
         LoadFieldAddress f => FieldTarget(f.Field, f.Instance),
         FixedBufferElementAddress f => FixedBufferElementText(f),
-        LoadElementAddress e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
+        LoadElementAddress e => $"{Operand(e.Array)}[{ArrayIndexText(e.Index)}]",
         // `unbox T` yields a managed pointer *into* the box. C#'s only spelling
         // for that place is `System.Runtime.CompilerServices.Unsafe.Unbox<T>(o)`
         // — a `ref T`-returning intrinsic. A *pure value read* of that place

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2404,9 +2404,19 @@ public sealed partial class CSharpPrinter
                         return binary.ResultType;
                 }
             }
-            // A unary neg/not preserves its operand's type (`~v[j]` over a `ulong`
-            // element is a `ulong`), but its ResultType is that operand's masked
-            // stack type, so recover the rendered type from the unmasked operand.
+            // A bitwise `~` preserves its operand's type (`~v[j]` over a `ulong`
+            // element is a `ulong`); a unary `-` cannot apply to `ulong`/`nuint`,
+            // so UnaryText re-inserts a signed reinterpret (`-(long)v[j]`) and the
+            // negate then renders signed. Recover the rendered type from the
+            // unmasked operand (its ResultType is the masked stack type), mapping a
+            // negate over a non-negatable unsigned operand to its signed counterpart.
+            case Unary { Kind: UnaryKind.Negate } negate:
+            {
+                var inner = WideIndexOperandType(negate.Operand);
+                return NegateReinterpretKeyword(inner) is not null
+                    ? TypeFamilies.SignedCounterpart(inner) ?? inner
+                    : inner;
+            }
             case Unary unary:
                 return WideIndexOperandType(unary.Operand);
             default:

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2320,7 +2320,31 @@ public sealed partial class CSharpPrinter
         // conversion so C# re-inserts the same conv.ovf.i / conv.ovf.i.un — the
         // signed conv keeps `(long)`, the unsigned conv `(ulong)`, opcode-exact.
         if (convert.Operand.ResultType is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Int64" or "UInt64" })
-            return $"({(convert.IsUnsigned ? "ulong" : "long")}){Operand(convert.Operand)}";
+        {
+            string keyword = convert.IsUnsigned ? "ulong" : "long";
+            // The (long)/(ulong) reinterpret is a no-op in IL (source and target
+            // are both 8-byte); the only checked conversion here is the always-
+            // checked native-int index conv that stays outside the operand. Inside
+            // a lexical `checked` region a SIGN-CHANGING reinterpret would instead
+            // recompile to a conv.ovf.i8.un / conv.ovf.u8 the original never had, so
+            // wrap it in `unchecked(...)` and render the operand plain. A same-sign
+            // cast (a long-backed enum's `(long)`, a ulong-backed enum's `(ulong)`)
+            // emits no conv even when checked, so it stays bare to avoid noise.
+            if (_checkedContext && WideIndexCastSignChanges(indexType, convert.IsUnsigned))
+            {
+                bool saved = _checkedContext;
+                _checkedContext = false;
+                try
+                {
+                    return $"unchecked(({keyword}){Operand(convert.Operand)})";
+                }
+                finally
+                {
+                    _checkedContext = saved;
+                }
+            }
+            return $"({keyword}){Operand(convert.Operand)}";
+        }
 
         // Any other checked (nint) conversion recompiles to different IL: spell it.
         return Expression(index);
@@ -2344,6 +2368,30 @@ public sealed partial class CSharpPrinter
 
     static TypeRef? WideIndexPointee(IrExpression address)
         => address.ResultType is { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer } indirect ? indirect.ElementType : null;
+
+    /// <summary>
+    /// True when the emitted wide index cast <c>(long)</c>/<c>(ulong)</c> flips the
+    /// operand's signedness, so recompiling it inside a <c>checked</c> region would
+    /// add a <c>conv.ovf.i8.un</c>/<c>conv.ovf.u8</c> the original never had. Both
+    /// source and target are 8-byte, so only a sign change is checked-sensitive.
+    /// The operand's real signedness comes from the recovered index type: its
+    /// underlying type when it is an enum (an <c>ldelem.i8</c>/<c>ldind.i8</c> load
+    /// carries an 8-byte-backed enum), else the type itself. An unknown or
+    /// unclassifiable type is treated as a flip — wrapping is always
+    /// behavior-preserving, so it is the safe default.
+    /// </summary>
+    bool WideIndexCastSignChanges(TypeRef? indexType, bool castUnsigned)
+    {
+        var underlying = EnumUnderlyingType(indexType) ?? indexType;
+        if (underlying is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" } named)
+        {
+            if (named.Name == "Int64")
+                return castUnsigned;    // signed operand, unsigned cast → flip
+            if (named.Name == "UInt64")
+                return !castUnsigned;   // unsigned operand, signed cast → flip
+        }
+        return true;                    // unknown backing: wrap to be safe
+    }
 
     string Expression(IrExpression node) => node switch
     {


### PR DESCRIPTION
- Fixes #2981
- Renders wide (`long`/`ulong`) array indices idiomatically instead of `array[checked((nint)i)]`, spelling the exact signedness/checked shape C# re-inserts so every affected member recompiles to identical IL.
- Card revision: `8c657d01`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the printer now spells a wide array index as the shape
whose re-inserted native-int index conversion is opcode-identical to the
original, reading idiomatically while staying round-trip exact across enum,
signedness, and `checked`-context edge cases surfaced in adversarial review.

C# converts a `long`/`ulong` array index to native int with a checked range
conversion (`conv.ovf.i` / `conv.ovf.i.un`) that it inserts implicitly and
always emits, independent of the enclosing `checked`/`unchecked` context. The
printer was spelling that conversion explicitly (`array[checked((nint)i)]`). The
fix strips or restates it at the single-dimension element-access sites
(`LoadElement`, `StoreElement`, `LoadElementAddress`) through one shared
`ArrayIndexText` helper, matching a checked conversion to `IntPtr` whose operand
is `Int64`/`UInt64`; any other source is left spelled.

The helper resolves the operand's **real** C# type — a typed load
(`ldelem.i8` / `ldind.i8`) reports only `Int64` storage, masking a `ulong`
element or a wide enum, and a wide binary or unary neg/not keeps a signed stack
`ResultType` even when it renders `ulong` — via `WideIndexOperandType` (array
element / ref / pointer pointee; recursing through the unmasked operands of a
sign-neutral wide binary — `+`/`-`/`*` and bitwise — regardless of checkedness;
taking a shift-left's left-operand type; reading a divide/remainder/shift-right's
signedness from its opcode variant `div.un`/`rem.un`/`shr.un`; recursing through a
unary bitwise `~` into its operand, and reporting a unary `-` as the signed type
it renders as once its operand's reinterpret cast is re-inserted — including an
enum negate, which reports `Int64`/`Int32` by the enum's underlying width, or —
when the enum shape does not resolve (cross-assembly) — by the negate's masked
stack `ResultType`; else the operand's own type). From that it
renders:

| Operand shape | Rendered index | Re-inserted conv |
| --- | --- | --- |
| `long[]` / `ulong[]` element, matching sign | bare `v[j]` | `conv.ovf.i` / `conv.ovf.i.un` |
| `long`/`ulong` param, matching sign | bare `i` | `conv.ovf.i` / `conv.ovf.i.un` |
| wide-enum element/ref (masked, bare is CS0266) | `(long)`/`(ulong)` cast | matching conv |
| `ulong` element as a **signed** index | `(long)` cast | `conv.ovf.i` |
| `long` element as an **unsigned** index | `(ulong)` cast | `conv.ovf.i.un` |
| `ulong` **sum** as a signed index | `(long)(… + …)` cast | `conv.ovf.i` |
| `ulong` `checked` sum / `>>`/`/`/`%` / `~` as a signed index | `(long)(…)` cast | `conv.ovf.i` |
| sign-changing cast inside `checked(...)` | `unchecked((long)/(ulong) …)` | matching conv, no spurious overflow |
| stripped bare negate inside `checked(...)` | `checked(a[unchecked(-i)] …)` | matching conv, unchecked `neg` |
| negate over a masked `ulong`/`nuint` element | `-(long)v[j]` / `-(nint)v[j]` | matching conv, `neg` |
| negate over a masked/wide enum element | `-(long)v[j]` (8-byte) / `-(int)v[j]` | matching conv, `neg` |
| negate over a cross-assembly enum element (width from opcode) | `-(long)v[j]` / `-(int)v[j]` | matching conv, `neg` |

The last row is the `checked`-context guard: the `(long)`/`(ulong)` reinterpret
is a no-op in IL (both sides 8-byte; only the always-checked index conv is
checked), but spelled bare inside a lexical `checked` region a **sign-changing**
cast recompiles to a `conv.ovf.i8.un` / `conv.ovf.u8` the original never had.
It is wrapped in `unchecked(...)` only when it flips sign
(`WideIndexCastSignChanges` reads the enum underlying / primitive signedness;
unknown backing wraps to be safe); a same-sign cast (a long-backed enum's
`(long)`) emits no conv even when checked and stays bare.

The same `checked`-context hazard applies once a bare wide index operand is
stripped and routed back through the general expression printer: a bare unary
negate `-i` spelled inside a lexical `checked` region recompiles as an
overflow-checked negate (C# lowers `checked(-i)` to `0 - i` as `sub.ovf`) where
the original IL has an unchecked `neg`. The general printer's new `UnaryText`
wraps an integer negate in `unchecked(...)` when in a `checked` context,
mirroring the existing add/sub/mul handling in `BinaryText`; a bitwise
complement (`~`) never overflows and stays bare, and a genuine checked negate is
raised as a Binary subtract-from-zero and is unaffected.

A second `neg` hazard is signedness, not overflow: C# has no unary minus for
`ulong`/`nuint` (they promote to no signed type, so `-x` is CS0023). An IL `neg`
over such a value came from a signed reinterpret cast (`-(long)x`) that is a
no-op in IL — invisible in the operand's stack type, and doubly so for a
`ulong[]` element whose `ldelem.i8` masks it as `Int64`. `UnaryText` re-inserts
that cast on the negate's **operand** (`-(long)v[j]`, `-(nint)v[j]`), not around
the whole negate — `(long)(-v[j])` would still negate a `ulong`. `uint` is
excluded because its unary minus already promotes to `long` value-preservingly.
The same hazard applies to **every enum** — C# has no unary minus on any enum
regardless of its underlying type — so an enum negate operand is reinterpreted by
its underlying width (`(long)` for an 8-byte-backed enum, `(int)` for a narrower
one, since sub-8-byte integers are `I4` on the eval stack). When the enum's shape
does not resolve — a cross-assembly or core-library enum whose type maps are not
walked — the underlying width is unavailable, but the negate's masked stack width
(`ldelem.i8`→`long`, `ldelem.i4`→`int`) is, and an IL `neg` over a non-primitive
rendered type can only be an enum (a struct's unary minus is an
`op_UnaryNegation` call), so the reinterpret is recovered from that width. A
scalar cross-assembly enum negate carries no width in its opcode and stays
uncast (its width is genuinely unresolvable).

### Original source

`Humanizer.GermanNumberToWordsConverterBase.GetTens` (Humanizer.Core@3.0.10):

```csharp
protected virtual string GetTens(long tens) => TensMap[tens];
```

### Before

```csharp
protected virtual string GetTens(long tens) => TensMap[checked((nint)tens)];
```

- Valid: True
- Correct: True

The explicit `checked((nint)…)` is valid and behavior-preserving, but verbose,
unidiomatic, and round-trips to a redundant `conv.i8`/`conv.ovf.i`
widen-then-renarrow (`valid_different.semantic_opcode_diff.checked_context`).

### After

```csharp
protected virtual string GetTens(long tens) => TensMap[tens];
```

- Valid: True
- Correct: True

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | n/a (new) | `WideArrayIndexTests`: 35 passed |
| Related printer suites | Pass | EnumCast 25, MultiDim 23, EnumUnderlying 9, IndexFromEnd 15, CheckedUncheckedInsert 17, InlineArrayElementRef 12, EnumConstant 21, + others all green |
| Decompiler compile-back gates | RecompileFail (env) | RecompileFail (env) |
| Real witness (IL round-trip) | `a[checked((nint)i)]` | idiomatic index — all shapes opcode-exact |

**Compile-back gate note.** `FidelityGateTests`/`LoweredFidelityGateTests`
regress **wholesale** to `RecompileFail` on this Windows host — all 87 recompile
failures share one cause: `CS0009: … Microsoft.AspNetCore.App\…\aspnetcorev2_inprocess.dll
… PE image doesn't contain managed metadata` (the harness runtime-reference
resolver enumerates the ASP.NET Core shared framework and hands Roslyn a native
DLL). This is a pre-existing, machine-specific environment failure, identical on
Baseline; this change never touches reference resolution or any failing fixture.
CI validates these gates.

**Machine-robust round-trip proof (self-contained, no harness references).**
Each decompiled body was compiled and its IL opcode stream diffed against the
original fixture — **exact across every shape**, covering `long`/`ulong` load,
store, `ref`, a `long` add expression, `checked`/`unchecked` contexts
(`add`/`add.ovf` preserved), `nint`/`nuint`, wide enums, signedness, and the
`checked`-context wrap:

| Case | Original spelling | Decompiled | IL |
| --- | --- | --- | --- |
| `a[i]` (long) | `a[checked((nint)i)]` | `a[i]` | exact |
| `a[i]` (ulong) | `a[checked((nint)i)]` | `a[i]` | exact |
| `a[i] = v` | `a[checked((nint)i)] = v` | `a[i] = v` | exact |
| `ref a[i]` | `ref a[checked((nint)i)]` | `ref a[i]` | exact |
| `a[i + j]` | `a[checked((nint)(i + j))]` | `a[i + j]` | exact |
| `a[nintVar]` | `a[checked((nint)(long)i)]` | `a[(long)i]` | exact |
| wide-enum element | (bare CS0266) | `a[(long)values[j]]` | exact |
| wide-enum `ref` | (bare CS0266) | `a[(long)(r)]` | exact |
| `ulong` element as signed | `a[(long)v[j]]` | `a[(long)v[j]]` | exact |
| `long` element as unsigned | `a[(ulong)v[j]]` | `a[(ulong)v[j]]` | exact |
| plain `ulong` element | `a[v[j]]` | `a[v[j]]` | exact |
| `ulong` sum as signed | `a[(long)((ulong)v[j] + x)]` | same | exact |
| `ulong` element sum as signed | `a[(long)(v[j] + w[k])]` | same | exact |
| bare `ulong` sum | `a[v[j] + w[k]]` | same | exact |
| `ulong`-as-signed in `checked` | `checked(a[unchecked((long)v[j])] + 1)` | same | exact |
| `long`-as-unsigned in `checked` | `checked(a[unchecked((ulong)v[j])] + 1)` | same | exact |
| long-enum `(long)` in `checked` | `checked(a[(long)values[j]] + 1)` | same (no wrap) | exact |
| `ulong` `checked` sum as signed | `a[unchecked((long)checked(v[j] + x))]` | `a[(long)checked(v[j] + x)]` | exact |
| `ulong >> 1` (shr.un) as signed | `a[unchecked((long)(v[j] >> 1))]` | `a[(long)((ulong)v[j] >> 1)]` | exact |
| `ulong / d` (div.un) as signed | `a[unchecked((long)(v[j] / d))]` | `a[(long)((ulong)v[j] / d)]` | exact |
| `ulong % d` (rem.un) as signed | `a[unchecked((long)(v[j] % d))]` | `a[(long)((ulong)v[j] % d)]` | exact |
| signed `long << 1` | `a[i << 1]` | same (bare) | exact |
| signed `checked` `long` sum | `a[checked(i + j)]` | same (bare) | exact |
| `~ulong` element as signed | `a[unchecked((long)(~v[j]))]` | `a[(long)(~v[j])]` | exact |
| signed `long` negate | `a[-i]` | same (bare) | exact |
| `long` negate inside `checked` | `checked(a[unchecked(-i)] + 1)` | same | exact |
| general negate inside `checked` | `checked(x + unchecked(-i))` | same | exact |
| signed `long` bitwise-not | `a[~i]` | same (bare) | exact |
| bitwise-not inside `checked` | `checked(a[~i] + 1)` | same (bare, no wrap) | exact |
| negate of masked `ulong` element (signed index) | `a[-(long)v[j]]` | same (not `(long)(-v[j])`, CS0023) | exact |
| negate of masked `ulong` element (general, non-index) | `-(long)v[j]` | same | exact |
| negate of masked `nuint` element | `-(nint)v[j]` | same | exact |
| negate of masked `ulong`-backed enum (signed index) | `a[-(long)v[j]]` | same (not `(long)(-v[j])`, CS0023) | exact |
| negate of masked `long`-backed enum (general) | `-(long)v[j]` | same | exact |
| negate of `uint`-backed enum (general) | `-(int)v[j]` | same (outer `(int)` is the enum→underlying conv) | exact |
| negate of cross-assembly `ulong`-backed enum (signed index) | `a[-(long)v[j]]` | same (width from `ldelem.i8`) | exact |
| negate of cross-assembly `long`-backed enum (general) | `-(long)v[j]` | same | exact |
| negate of cross-assembly `uint`-backed enum (general) | `(int)(-(int)v[j])` | same (width from `ldelem.u4`) | exact |
| negate of core-library enum (`DayOfWeek`) index | `a[-(int)v[j]]` | same (width from `ldelem.i4`) | exact |
| `~` of masked `ulong` element (unsigned index) | `a[~v[j]]` | same (bare) | exact |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — printer-only change; the IR is untouched, so
structural corpus metrics (Full%, lowering/branch residue, stop reasons, pass
bugs) are unchanged by construction. The only corpus movement is intended:
wide-indexed members leave `valid_different.semantic_opcode_diff.checked_context`
for exact round-trip.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.WideArrayIndexTests"
```


