### PR TITLE
Recompose static-target chained assignment (a = b = c = v) from dup idiom (#2994)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5247,6 +5247,14 @@ public class BackingFieldSample
 // literal is dup'd to each sink. The importer must re-materialize the dup'd constant
 // at each bool sink so it renders `A = false;`, not spill it into an int stack slot
 // (`int S = 0; A = S;`), which is CS0029 (cannot implicitly convert int to bool).
+// Regression + quality fixtures for #2982 / #2994: a value assigned in a chain
+// (`a = b = c = v`) compiles to a dup-of-value idiom — the rvalue is evaluated
+// once and dup'd to each sink (`ldc.i4.0; dup; call set_C; dup; call set_B; call
+// set_A`). ChainedAssignmentPass recomposes that run into `A = B = C = v;`,
+// keyed on the shared dup slot. A dup'd constant that is NOT part of a chain is
+// re-materialized at its sink so a bool/char/enum literal is recovered (#2982)
+// instead of spilling through an int32 slot (CS0029). Genuinely separate
+// statements carry no dup slot and must not collapse.
 public static class ChainedConstantAssignmentSamples
 {
     public static bool A { get; set; }
@@ -5255,5 +5263,50 @@ public static class ChainedConstantAssignmentSamples
 
     public static bool C { get; set; }
 
+    public static int I { get; set; }
+
+    public static long L { get; set; }
+
+    public static int P { get; set; }
+
+    public static int Q { get; set; }
+
+    public static int R { get; set; }
+
+    public static bool F;
+
+    public static bool G;
+
+    public static bool H;
+
+    static int Compute() => 42;
+
+    // The Dapper Settings.SetDefaults shape: a bool constant chained across
+    // static properties. Recomposes to `A = B = C = false;`.
     public static void ChainedBoolFalse() => A = B = C = false;
+
+    // A widening chain: the shared int constant lands in `I` (int) and widens
+    // implicitly into `L` (long). Recomposes to `L = I = -1;`.
+    public static void ChainedWiden() => L = I = -1;
+
+    // A non-constant chain: the shared call result flows to each static
+    // property. Recomposes to `P = Q = R = Compute();`.
+    public static void ChainedNonConstant() => P = Q = R = Compute();
+
+    // A bool constant chained across static fields. Recomposes to
+    // `F = G = H = true;`.
+    public static void ChainedStaticFields() => F = G = H = true;
+
+    // Negative: two independent statements with no dup — must stay two
+    // statements, never collapse into a chain.
+    public static void SeparateStatements()
+    {
+        A = false;
+        B = false;
+    }
+
+    // Negative: a single-target dup'd constant whose value escapes into an
+    // argument (`WriteLine(P = 5)`). Not a chain (one sink); the constant is
+    // re-materialized to `P = 5; Console.WriteLine(5);`.
+    public static void SideEffectValue() => System.Console.WriteLine(P = 5);
 }

--- a/src/ILInspector.Decompiler.Tests/ChainedConstantAssignmentTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ChainedConstantAssignmentTests.cs
@@ -3,11 +3,13 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
-// #2982: a constant assigned through a chain (`a = b = c = false`) is dup'd to each
-// sink in IL (`ldc.i4.0; dup; call set_C; dup; call set_B; call set_A`). The importer
-// must re-materialize the dup'd constant at each bool sink so per-sink constant
-// recovery fires and it renders `= false` — not spill it into an int stack slot
-// (`int S = 0; a = S;`), which is CS0029 (cannot implicitly convert int to bool).
+// #2982 / #2994: a value assigned through a chain (`a = b = c = v`) is dup'd to
+// each sink in IL (`ldc.i4.0; dup; call set_C; dup; call set_B; call set_A`).
+// ChainedAssignmentPass recomposes that run into a single `A = B = C = v;`,
+// keyed on the shared dup slot (real evidence — genuinely separate statements
+// carry no dup and never collapse). A dup'd constant that is not part of a chain
+// is re-materialized at its sink so a bool literal is recovered (`= false`), not
+// spilled into an int stack slot (`int S = 0; a = S;`), which is CS0029.
 public class ChainedConstantAssignmentTests
 {
     static string Render(string methodName)
@@ -21,16 +23,81 @@ public class ChainedConstantAssignmentTests
     }
 
     [Fact]
-    public void ChainedBoolConstant_RendersLiteralAtEachSink_NotIntSpill()
+    public void ChainedBoolConstant_RecomposesIntoOneChain_WithLiteralAtInnermostSink()
     {
         var output = Render(nameof(ChainedConstantAssignmentSamples.ChainedBoolFalse));
 
-        // Each of the three chained sinks receives the bool literal directly.
-        Assert.Equal(3, CountOccurrences(output, "= false;"));
+        // The three sinks collapse into one chained assignment, source order
+        // preserved, and the bool literal is recovered at the innermost sink.
+        Assert.Contains(
+            "ChainedConstantAssignmentSamples.A = ChainedConstantAssignmentSamples.B = ChainedConstantAssignmentSamples.C = false;",
+            output);
 
-        // The dup'd constant is not spilled into an int stack slot: the #2982 defect
-        // rendered `int S_256 = 0; ...A = S_256;` — CS0029 at every bool sink.
-        Assert.DoesNotContain("int S", output);
+        // The dup'd constant is not spilled into an int stack slot (the #2982
+        // defect rendered `int S_256 = 0; ...A = S_256;` — CS0029), and there is
+        // exactly one assignment statement.
+        Assert.DoesNotContain("S_", output);
+        Assert.Equal(1, CountOccurrences(output, "= false;"));
+    }
+
+    [Fact]
+    public void ChainedWiden_RecomposesWithImplicitWidening()
+    {
+        var output = Render(nameof(ChainedConstantAssignmentSamples.ChainedWiden));
+
+        // The shared int constant lands at `I` (int) and widens implicitly into
+        // `L` (long); the widening convert is dropped in the chained spelling.
+        Assert.Contains(
+            "ChainedConstantAssignmentSamples.L = ChainedConstantAssignmentSamples.I = -1;",
+            output);
+        Assert.DoesNotContain("S_", output);
+    }
+
+    [Fact]
+    public void ChainedNonConstant_RecomposesSharedCallResult()
+    {
+        var output = Render(nameof(ChainedConstantAssignmentSamples.ChainedNonConstant));
+
+        Assert.Contains(
+            "ChainedConstantAssignmentSamples.P = ChainedConstantAssignmentSamples.Q = ChainedConstantAssignmentSamples.R = Compute();",
+            output);
+        Assert.DoesNotContain("S_", output);
+    }
+
+    [Fact]
+    public void ChainedStaticFields_Recompose()
+    {
+        var output = Render(nameof(ChainedConstantAssignmentSamples.ChainedStaticFields));
+
+        Assert.Contains(
+            "ChainedConstantAssignmentSamples.F = ChainedConstantAssignmentSamples.G = ChainedConstantAssignmentSamples.H = true;",
+            output);
+        Assert.DoesNotContain("S_", output);
+    }
+
+    [Fact]
+    public void SeparateStatements_DoNotCollapse()
+    {
+        var output = Render(nameof(ChainedConstantAssignmentSamples.SeparateStatements));
+
+        // No dup slot backs these, so they stay two independent statements and
+        // never form a chain.
+        Assert.Contains("ChainedConstantAssignmentSamples.A = false;", output);
+        Assert.Contains("ChainedConstantAssignmentSamples.B = false;", output);
+        Assert.DoesNotContain(" = ChainedConstantAssignmentSamples.B = ", output);
+        Assert.Equal(2, CountOccurrences(output, "= false;"));
+    }
+
+    [Fact]
+    public void SideEffectValue_IsNotAChain_ConstantRematerialized()
+    {
+        var output = Render(nameof(ChainedConstantAssignmentSamples.SideEffectValue));
+
+        // One sink whose value escapes into an argument: not a chain. The dup'd
+        // constant is re-materialized, so both the assignment and the argument
+        // carry the literal, with no int spill slot.
+        Assert.Contains("ChainedConstantAssignmentSamples.P = 5;", output);
+        Assert.Contains("Console.WriteLine(5);", output);
         Assert.DoesNotContain("S_", output);
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2151,6 +2151,7 @@ public sealed partial class CSharpPrinter
             ? $"{DeclarationTypeText(s.Type, s.Value)} {LocalName(s.Index)} = {CoerceText(s.Value, s.Type)};"
             : AssignmentText($"{LocalName(s.Index)}", s.Value, left => left is LoadLocal load && load.Index == s.Index, s.Type),
         DeconstructionAssignment d => $"({string.Join(", ", d.Targets.Select(DeconstructionTargetText))}) = {Expression(d.Source)};",
+        ChainedAssignment c => $"{string.Join(" = ", c.Targets.Select(ChainedAssignmentTargetText))} = {CoerceText(c.Value, c.InnermostTargetType)};",
         NullCoalescingAssignment n => $"{LocalName(n.LocalIndex)} ??= {CoerceText(n.Value, n.LocalType)};",
         NullCoalescingFieldAssignment n => $"{FieldTarget(n.Field, n.Instance)} ??= {CoerceText(n.Value, n.Field.Type)};",
         NullCoalescingPropertyAssignment n => $"{PropertyTarget(n.Setter, n.Instance, n.IndexArguments, n.PropertyName, n.IsVirtual)} ??= {CoerceText(n.Value, n.PropertyType)};",
@@ -2246,6 +2247,13 @@ public sealed partial class CSharpPrinter
             target.Field!,
             target.IsThisInstance ? new LoadArgument(0, "this", target.Field!.DeclaringType) : null),
         _ => $"/* {target.Describe()} */",
+    };
+
+    string ChainedAssignmentTargetText(ChainedAssignmentTarget target) => target.Kind switch
+    {
+        ChainedAssignmentTargetKind.StaticProperty => PropertyTarget(target.Accessor!, null, [], target.PropertyName, target.IsVirtual),
+        ChainedAssignmentTargetKind.StaticField => FieldTarget(target.Field!, null),
+        _ => $"/* {target.Kind} */",
     };
 
     static TypeRef? StorePropertyTargetType(StoreProperty store)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1368,22 +1368,13 @@ public static class IrImporter
                 case ILOpCode.Dup:
                 {
                     var value = Pop(stack);
-                    // A pure constant has no identity or side effect to preserve,
-                    // so re-materializing it (a fresh clone per use) keeps the
-                    // tree-node invariant without a spill slot. A shared int slot
-                    // would fix the constant's stack type (int32) and strand each
-                    // consumer's semantic type: a dup'd bool constant threaded
-                    // into `set_X(bool)` sinks renders as `int S = 0; X = S;`
-                    // (CS0029, #2982), because per-sink identity recovery
-                    // (TypedConstantsPass) never reaches the slot store. Cloning
-                    // the constant to each sink lets that recovery fire per use.
-                    if (value is Constant)
-                    {
-                        stack.Push(value);
-                        stack.Push((IrExpression)value.Clone());
-                        break;
-                    }
                     // Trees cannot share nodes: dup materializes through a slot.
+                    // A dup'd pure constant that feeds a chained-assignment idiom
+                    // (`a = b = c = v`) is recomposed and its slot removed by
+                    // ChainedAssignmentPass; any non-chain dup'd constant slot is
+                    // re-materialized (cloned per use) by that same pass so the
+                    // per-sink typed literal is recovered (#2982) rather than
+                    // spilled through an int32-typed slot (CS0029).
                     int slot = state.NextDupSlot++;
                     body.Add(new StoreStackSlot(slot, value));
                     stack.Push(new LoadStackSlot(slot, value.ResultType));

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -2073,6 +2073,94 @@ public sealed class DeconstructionAssignment : IrNode
     }
 }
 
+/// <summary>The kind of lvalue a <see cref="ChainedAssignmentTarget"/> writes.</summary>
+public enum ChainedAssignmentTargetKind
+{
+    /// <summary>A static property setter (<c>Type.Name = …</c>).</summary>
+    StaticProperty,
+
+    /// <summary>A static field (<c>Type.Name = …</c>).</summary>
+    StaticField,
+}
+
+/// <summary>
+/// One lvalue of a raised chained assignment (<c>A = B = C = value</c>). The
+/// first slice covers receiver-free targets — static properties and static
+/// fields — where the dup'd value is written directly with no receiver or index
+/// to re-evaluate. Payload only (no child expressions), so the enclosing
+/// <see cref="ChainedAssignment"/> carries a single value child.
+/// </summary>
+public sealed record ChainedAssignmentTarget
+{
+    ChainedAssignmentTarget(ChainedAssignmentTargetKind kind, TypeRef targetType)
+    {
+        Kind = kind;
+        TargetType = targetType;
+    }
+
+    public static ChainedAssignmentTarget StaticProperty(MethodRef accessor, bool isVirtual)
+        => new(ChainedAssignmentTargetKind.StaticProperty, accessor.ParameterTypes[^1])
+        {
+            Accessor = accessor,
+            IsVirtual = isVirtual,
+        };
+
+    public static ChainedAssignmentTarget StaticField(FieldRef field)
+        => new(ChainedAssignmentTargetKind.StaticField, field.Type)
+        {
+            Field = field,
+        };
+
+    public ChainedAssignmentTargetKind Kind { get; }
+
+    /// <summary>The lvalue's type — the setter parameter type or the field type.</summary>
+    public TypeRef TargetType { get; }
+    public MethodRef? Accessor { get; private init; }
+    public bool IsVirtual { get; private init; }
+    public FieldRef? Field { get; private init; }
+    public string PropertyName => Accessor?.Name["set_".Length..] ?? "";
+
+    public IEnumerable<TypeRef> DirectTypes => Kind switch
+    {
+        ChainedAssignmentTargetKind.StaticProperty => Accessor!.ParameterTypes.Append(Accessor.DeclaringType),
+        ChainedAssignmentTargetKind.StaticField => [Field!.DeclaringType, Field.Type],
+        _ => [TargetType],
+    };
+}
+
+/// <summary>
+/// A raised C# chained (embedded) assignment: <c>A = B = C = value;</c>. The
+/// compiler lowers the chain to a dup-of-value idiom — the rvalue is evaluated
+/// once and <c>dup</c>'d to each successive sink, right to left — so the
+/// importer sees a run of independent stores of the same slot-carried value.
+/// <see cref="ChainedAssignmentPass"/> recomposes that run, keying on the shared
+/// dup slot (real evidence, not equal-value coincidence, so genuinely separate
+/// statements <c>A = v; B = v;</c> are never collapsed). <see cref="Targets"/>
+/// are in source order (outermost first); the single value child is the rvalue,
+/// typed at the innermost (rightmost) target so a bool/char/enum literal is
+/// recovered there and the outer assignments' implicit conversions stay implicit.
+/// </summary>
+public sealed class ChainedAssignment : IrNode
+{
+    public ChainedAssignment(IReadOnlyList<ChainedAssignmentTarget> targets, IrExpression value)
+    {
+        Targets = [.. targets];
+        AddChild(value);
+    }
+
+    /// <summary>Targets in source order (<c>A</c>, then <c>B</c>, then <c>C</c> for <c>A = B = C = v</c>).</summary>
+    public ImmutableArray<ChainedAssignmentTarget> Targets { get; }
+
+    public IrExpression Value => (IrExpression)Children[0];
+
+    /// <summary>The rightmost (innermost) target's type — the type the shared value flows into first.</summary>
+    public TypeRef InnermostTargetType => Targets[^1].TargetType;
+
+    public override IEnumerable<TypeRef> DirectTypes => Targets.SelectMany(target => target.DirectTypes);
+
+    public override string Describe() => $"ChainedAssignment ({Targets.Length} targets)";
+}
+
 /// <summary>
 /// A raised C# object or collection initializer, produced by
 /// <see cref="ObjectInitializerPass"/> from the compiler's lowering of

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ChainedAssignmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ChainedAssignmentPass.cs
@@ -1,0 +1,218 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Recomposes a C# chained (embedded) assignment — <c>A = B = C = value;</c> —
+/// from the compiler's dup-of-value lowering. The rvalue is evaluated once and
+/// <c>dup</c>'d to each successive sink (right to left), which the importer sees
+/// as a run of independent stores of one slot-carried value. This pass keys on
+/// that shared dup slot — <em>real</em> evidence — so genuinely separate
+/// statements <c>A = v; B = v;</c> (no dup, no slot) are never collapsed.
+///
+/// <para>Slice scope: receiver-free sinks (static properties and static fields),
+/// which is the Dapper <c>Settings.SetDefaults</c> shape (issue #2994) and needs
+/// no receiver or index re-evaluation. Instance and local targets — which drag
+/// in a receiver dup or a compiler temp and local-declaration tracking — are out
+/// of scope and never match the strict pattern below, so they fall through
+/// untouched.</para>
+///
+/// <para>Runs after <see cref="PropertySugarPass"/> (so setters are already
+/// <see cref="StoreProperty"/> nodes, uniform with field stores) and before
+/// <see cref="ObjectInitializerPass"/> (whose <see cref="NewObject"/>-seeded
+/// chains never overlap a constant/value-seeded assignment chain).</para>
+///
+/// <para>After recomposition, any remaining dup'd <em>constant</em> slot that was
+/// not part of a chain is re-materialized — cloned into each of its loads and the
+/// store dropped — so a per-sink typed literal is recovered (issue #2982) instead
+/// of being spilled through an int32-typed slot (CS0029). This preserves the
+/// validity fix #2995 landed in the importer, now that the importer keeps dup'd
+/// constants on the slot path so a chain retains its dup evidence.</para>
+/// </summary>
+public sealed class ChainedAssignmentPass : IIrPass
+{
+    public string Name => "chained-assignment";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        foreach (var seed in function.Descendants.OfType<StoreStackSlot>().ToList())
+        {
+            // A seed is the origin of a dup chain: a dup slot whose value is the
+            // rvalue itself (not a load — that would be a copy of another slot).
+            if (seed.Parent is not Block)
+                continue;
+            if (seed.Slot < StoreStackSlot.DupSlotBase)
+                continue;
+            if (seed.Value is LoadStackSlot)
+                continue;
+
+            if (TryBuild(function, seed) is not { } plan)
+                continue;
+
+            context.Stepper.StepOver($"raise chained assignment ({plan.Targets.Count} targets)", seed);
+            Apply(plan);
+        }
+
+        RematerializeConstantDupSlots(function);
+    }
+
+    sealed record Plan(
+        StoreStackSlot Seed,
+        IReadOnlyList<IrNode> Consumed,
+        IReadOnlyList<ChainedAssignmentTarget> Targets,
+        IrExpression Value);
+
+    static Plan? TryBuild(IrFunction function, StoreStackSlot seed)
+    {
+        var statements = seed.Parent!.Children;
+        var aliasSlots = new HashSet<int> { seed.Slot };
+        var consumed = new List<IrNode> { seed };
+
+        // Sinks collected in document order, which is innermost-first: the
+        // rightmost source target (`C` in `A = B = C = v`) is written first.
+        var sinks = new List<ChainedAssignmentTarget>();
+
+        for (int i = seed.ChildIndex + 1; i < statements.Count; i++)
+        {
+            var statement = statements[i];
+
+            // A dup of the threaded value: sNew = LoadStackSlot(sKnown).
+            if (statement is StoreStackSlot { Value: LoadStackSlot source } copy
+                && copy.Slot >= StoreStackSlot.DupSlotBase
+                && aliasSlots.Contains(source.Slot))
+            {
+                aliasSlots.Add(copy.Slot);
+                consumed.Add(copy);
+                continue;
+            }
+
+            // A static property/field sink whose value is (bare or an implicit
+            // widening convert of) a load of the threaded value.
+            if (TryStaticTarget(statement, aliasSlots) is { } target)
+            {
+                sinks.Add(target);
+                consumed.Add(statement);
+                continue;
+            }
+
+            break;
+        }
+
+        // A chain needs at least two targets; one store is an ordinary assignment.
+        if (sinks.Count < 2)
+            return null;
+
+        var consumedSet = consumed.ToHashSet();
+
+        // Clobber guard: the threaded value must not be re-stored to an alias slot
+        // outside the consumed run (a reused slot is a different value).
+        foreach (var store in function.Descendants.OfType<StoreStackSlot>())
+            if (aliasSlots.Contains(store.Slot) && !consumedSet.Contains(store))
+                return null;
+
+        // Full-consumption guard: the chain is a statement, so the threaded value
+        // must not escape. Any alias-slot load outside the consumed run (e.g.
+        // WriteLine(P = 5)) leaves the chain to the constant-rematerialization
+        // fallback instead of an unsound expression-position fold.
+        foreach (var load in function.Descendants.OfType<LoadStackSlot>())
+            if (aliasSlots.Contains(load.Slot) && !HasAncestorIn(load, consumedSet))
+                return null;
+
+        // Source order is the reverse of the innermost-first document order.
+        var targets = ((IEnumerable<ChainedAssignmentTarget>)sinks).Reverse().ToList();
+
+        // Type staircase: each outer target must accept the next-inner target's
+        // type (the value of `B = C = v` has C's type), else the chain would not
+        // typecheck on recompile.
+        for (int i = 0; i < targets.Count - 1; i++)
+            if (!IsAssignable(targets[i].TargetType, targets[i + 1].TargetType))
+                return null;
+
+        // The rvalue must reach the innermost target. A constant adapts to its
+        // sink type (retyped downstream), so it is exempt; anything else must be
+        // an identity or an implicit widening.
+        var value = seed.Value;
+        if (value is not Constant
+            && value.ResultType is { } valueType
+            && !IsAssignable(targets[^1].TargetType, valueType))
+            return null;
+
+        return new Plan(seed, consumed, targets, value);
+    }
+
+    static ChainedAssignmentTarget? TryStaticTarget(IrNode statement, HashSet<int> aliasSlots)
+        => statement switch
+        {
+            StoreProperty { HasInstance: false, IndexArguments.Count: 0 } property
+                when LoadsAliasSlot(property.Value, aliasSlots)
+                => ChainedAssignmentTarget.StaticProperty(property.Accessor, property.IsVirtual),
+
+            StoreField { HasInstance: false } field
+                when LoadsAliasSlot(field.Value, aliasSlots)
+                => ChainedAssignmentTarget.StaticField(field.Field),
+
+            _ => null,
+        };
+
+    // A sink value reads the threaded slot either bare or through a single
+    // implicit numeric widening (the compiler's conv on a wider target); the
+    // widening becomes implicit in the chained assignment, so it is dropped.
+    static bool LoadsAliasSlot(IrExpression value, HashSet<int> aliasSlots)
+        => value switch
+        {
+            LoadStackSlot load => aliasSlots.Contains(load.Slot),
+            Convert { Operand: LoadStackSlot { Type: { } operandType } load, Target: { } target }
+                => aliasSlots.Contains(load.Slot)
+                    && CSharpConversionRules.IsImplicitNumericAssignment(operandType, target),
+            _ => false,
+        };
+
+    static bool IsAssignable(TypeRef target, TypeRef source)
+        => target.Equals(source) || CSharpConversionRules.IsImplicitNumericAssignment(source, target);
+
+    static void Apply(Plan plan)
+    {
+        var value = plan.Value;
+        value.Detach();
+
+        var chain = new ChainedAssignment(plan.Targets, value);
+        chain.InheritSourceOffset(plan.Seed);
+        plan.Seed.ReplaceWith(chain);
+
+        foreach (var statement in plan.Consumed)
+            if (!ReferenceEquals(statement, plan.Seed))
+                statement.Detach();
+    }
+
+    // A dup'd constant left over after recomposition is re-materialized: pure
+    // constants are safe to duplicate, so clone into each load and drop the
+    // store. Iterated to a fixpoint because a copy slot (S1 = S0) turns into a
+    // constant store once its source is re-materialized. Restricted to dup slots
+    // (>= DupSlotBase) so join/edge slots are left to slot materialization.
+    static void RematerializeConstantDupSlots(IrFunction function)
+    {
+        bool changed = true;
+        while (changed)
+        {
+            changed = false;
+            foreach (var store in function.Descendants.OfType<StoreStackSlot>().ToList())
+            {
+                if (store.Parent is null || store.Slot < StoreStackSlot.DupSlotBase)
+                    continue;
+                if (store.Value is not Constant constant)
+                    continue;
+
+                foreach (var load in function.Descendants.OfType<LoadStackSlot>().Where(l => l.Slot == store.Slot).ToList())
+                    load.ReplaceWith((Constant)constant.Clone());
+                store.Detach();
+                changed = true;
+            }
+        }
+    }
+
+    static bool HasAncestorIn(IrNode node, HashSet<IrNode> set)
+    {
+        for (var parent = node.Parent; parent is not null; parent = parent.Parent)
+            if (set.Contains(parent))
+                return true;
+        return false;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
@@ -207,6 +207,12 @@ public static class CoercionSinks
                     when store.Accessor.ParameterTypes is { IsDefault: false, Length: > 0 } setter:
                     yield return new(value, setter[^1]);
                     break;
+                // A chained assignment's single value lands at the innermost
+                // sink; coerce it there so the shared literal is decided at that
+                // type (the same sink TypedConstantsPass retypes it to).
+                case ChainedAssignment { Value: { } value } chain:
+                    yield return new(value, chain.InnermostTargetType);
+                    break;
                 case NullCoalescingAssignment { Value: { } value, LocalType: { } type }:
                     yield return new(value, type);
                     break;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -70,6 +70,14 @@ public static class IrPasses
         // Raise ValueTuple receiver-spill + ItemN target stores back into tuple
         // deconstruction after property-sugar has normalized setter calls.
         new DeconstructionAssignmentPass(),
+        // Raise the dup-of-value lowering of a chained assignment (a = b = c = v)
+        // into one ChainedAssignment, keyed on the shared dup slot. Runs after
+        // property-sugar so setters are StoreProperty nodes and before the
+        // object-initializer pass (whose NewObject-seeded chains never overlap).
+        // Also re-materializes any leftover dup'd constant slot to preserve the
+        // per-sink typed literal (#2982) now that the importer keeps dup'd
+        // constants on the slot path.
+        new ChainedAssignmentPass(),
         // Raise the object/collection-initializer lowering (a NewObject threaded
         // through a dup chain and mutated by a run of member stores or Add calls)
         // back into new T { X = a, ... }. Runs after property-sugar so the member

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LoweringCoverage.cs
@@ -48,7 +48,8 @@ internal static class LoweringCoverage
     [Completeness(CompletenessLevel.Partial, "new { a = x, ... } from the generated anonymous-type constructor, with projection shorthand and nested anonymous-object members recovered recursively; the anonymous type's compiler-generated equality/ToString members are not part of the literal and are unaffected")]
     public static AnonymousObjectPass AnonymousObjectCreation => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative AsOperator => default!;
-    [Completeness(CompletenessLevel.Full)] public static ImporterNative AssignmentOperator => default!;
+    [Completeness(CompletenessLevel.Partial, "embedded/chained assignment (a = b = c = v) recomposed from the dup-of-value idiom into one statement for static-property and static-field targets, source order preserved and the innermost sink's per-sink literal/coercion recovered; simple single-target assignments are importer-native, and instance-member, local, and expression-position (escaping) chains are not raised — a non-chain dup'd constant is still re-materialized at its sink")]
+    public static ChainedAssignmentPass AssignmentOperator => new();
     [Completeness(CompletenessLevel.Partial, "runtime-async (async v2) exact corelib AsyncHelpers.Await call sites and the exact AwaitAwaiter/UnsafeAwaitAwaiter guard-helper-GetResult scaffold recovered to `await`, multi-await order preserved; classic state-machine async fixture overlay raised for single, sequential, branch, loop, and try/finally awaits")]
     public static AwaitRecoveryPass Await => new();
     [Completeness(CompletenessLevel.Full)] public static ImporterNative BasePatternSwitchLocalRewriter => default!;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
@@ -65,6 +65,13 @@ public sealed class TypedConstantsPass : IIrPass
                 case StoreProperty { Value: { } value } store:
                     Retype(value, store.Accessor.ParameterTypes is { IsDefault: false, Length: > 0 } setter ? setter[^1] : null, shapes, stepper);
                     break;
+                // A chained assignment shares one value across every target; the
+                // innermost (rightmost) sink is where it first lands, so its type
+                // recovers the literal (a bool chain's `0` is `false`). The outer
+                // targets' implicit widenings stay implicit in the spelling.
+                case ChainedAssignment { Value: { } value } chain:
+                    Retype(value, chain.InnermostTargetType, shapes, stepper);
+                    break;
                 case NullCoalescingAssignment { Value: { } value } assign:
                     Retype(value, assign.LocalType, shapes, stepper);
                     break;


### PR DESCRIPTION
- Fixes #2994
- Changes: static-target chained assignment (`a = b = c = v`) is recomposed from the IL dup-of-value idiom instead of being emitted as reordered, independent statements.
- Card revision: `28279a45`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — static property/field chains now render as a single right-associative `A = B = C = v;`, matching source order and per-sink coercion, while genuinely-separate statements and non-chain constant dups are provably left untouched.

### Original source

Synthetic witness fixture (no SourceLink; source shown verbatim from the compiled fixture):

```csharp
public static class Props
{
    public static bool A { get; set; }
    public static bool B { get; set; }
    public static bool C { get; set; }
    public static int  I { get; set; }
    public static long L { get; set; }

    public static void ChainBool()       => A = B = C = false;
    public static void ChainMixedWiden() => L = I = -1;
    public static void Separate()        { A = false; B = false; }
}
```

### Before

`dotnet-inspect member lib.dll Props.ChainBool -S "Decompiled Source"` at base (`c04c2345`):

```csharp
public static void ChainBool()
{
    Props.C = false;
    Props.B = false;
    Props.A = false;
}
```

- Valid: True
- Correct: True

Behavior-preserving here, but the chain intent is lost and the sinks are reordered to sink/document order (C, B, A). `ChainMixedWiden` similarly split to `Props.I = -1; Props.L = (long)-1;`.

### After

`dotnet-inspect member lib.dll Props.ChainBool -S "Decompiled Source"` at head (`28279a45`):

```csharp
public static void ChainBool() => Props.A = Props.B = Props.C = false;
```

- Valid: True
- Correct: True

`ChainMixedWiden` → `public static void ChainMixedWiden() => Props.L = Props.I = -1;` (the `long` widen becomes implicit in the chain spelling). Static-field chains render identically (`StaticFields.A = StaticFields.B = StaticFields.C = true;`). Non-constant chains recompose too (`P = Q = R = Compute();`).

Negative control — `Props.Separate()` is byte-identical Before and After (no dup evidence, so no recomposition):

```csharp
public static void Separate()
{
    Props.A = false;
    Props.B = false;
}
```

### Fully raised

The After decompilation is in the fully raised state for static-target chains.

- Required tracking issue: #2994 — instance-property/field and local chains (compiler-temp `V_0` shapes) remain out of scope for this slice and fall through to the existing per-sink rendering.

## Evidence

| Check | Baseline (`c04c2345`) | Head (`28279a45`) |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `ChainedConstantAssignmentTests`: net-new | `ChainedConstantAssignmentTests`: 6 passed |
| Decompiler fast suite | 0 failed | 3142 passed, 0 failed |
| Reduced fixture validity | `ValidityCoverageReportingTests`: 3 passed (no CS0161 pin shift) | 3 passed |
| Lowering coverage | `LoweringCoverageTests`: 6 passed | 6 passed |
| CfgSampleClass fidelity | provably unaffected | provably unaffected |
| Real witness | `Props.ChainBool` reordered/split | `Props.ChainBool` chained |

**CfgSampleClass fidelity is provably unaffected.** The importer change only touches the constant-dup branch (`StoreStackSlot` with slot ≥ `DupSlotBase` whose value is a `Constant`). A direct probe imported all **613** `CfgSampleClass` methods and found **0** such shapes, so every fidelity-gate fixture method imports byte-identically to baseline and no `FidelityGateTests.KnownDiffs` edit is required.

### Slow gates (deferred to CI)

The slow corpus / compile-back fidelity gates could not complete locally due to sustained machine contention (load avg ~20 from unrelated worktrees; individual compile-back tests ran 30+ min without finishing). They are unaffected by this change on inspection (recomposed `A = B = C = v` is the canonical Roslyn inverse of the dup lowering, so it recompiles to bit-identical IL), but **CI must confirm the full slow corpus/fidelity suite**.

## Design

#2995 (validity fix for #2982) re-materialized dup'd constants as clones **in the importer**, which discarded the shared-dup-slot provenance — making a real constant chain byte-indistinguishable from genuinely separate `A = false; B = false;`. This PR:

1. Reverts the importer to uniform slot-materialization for all dups, restoring the shared-slot evidence a sound chain detector needs.
2. Adds `ChainedAssignmentPass`, which recomposes dup-slot chains (≥2 static-target sinks, with clobber/full-consumption guards and a widening type-staircase check) into a new `ChainedAssignment` IR node, and **re-materializes remaining non-chain constant dups as a fallback** — preserving #2995's validity fix (#2982).
3. Adds printer, `TypedConstantsPass`, and `CoercionInsertionPass` support for the new node.

Scope is deliberately limited to static property/field sinks (slice 1); instance/local chains fall through untouched.

## Validation

```bash
dotnet build src/dotnet-inspect/dotnet-inspect.csproj -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.ChainedConstantAssignmentTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
```
