### PR TITLE
Spell enum constant args inside raised nested local functions (#2983)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4565,6 +4565,25 @@ public class CfgSampleClass
             sb.Append('y');
         return sb.Length;
     }
+
+    // #2983: a static local function that both needs a nested print scope (its own
+    // local `y` survives to a stack slot in Release) and passes an enum constant
+    // into an enum parameter position. The nested scope prints through a freshly
+    // reconstructed IrFunction, which must carry the raised body's resolved enum
+    // member map or the constant renders as a bare int (`TakesPriority(2)` — CS1503)
+    // instead of `TakesPriority(CfgPriority.High)` — the same value the enclosing
+    // body spells correctly.
+    public static int EnumArgInLocalFunctionWithLocal(int x)
+    {
+        return Classify(x);
+
+        static int Classify(int v)
+        {
+            int y = v + 1;
+            TakesPriority(CfgPriority.High);
+            return y * y;
+        }
+    }
 }
 
 internal static class AwaitOrderingHelpers

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4584,6 +4584,24 @@ public class CfgSampleClass
             return y * y;
         }
     }
+
+    // #2983 (inline path): a static local function with no locals or surviving
+    // stack slots prints INLINE through the enclosing function's scope, not a
+    // reconstructed one. `CfgPriority` is referenced only inside the local
+    // function, so the host method never materialized its member map; the raise
+    // must merge the imported body's resolved maps into the enclosing function or
+    // the constant renders as a bare int (`TakesPriority(0)` — CS1503) instead of
+    // `TakesPriority(CfgPriority.Low)`.
+    public static int EnumArgInInlineLocalFunction(int x)
+    {
+        return Classify(x);
+
+        static int Classify(int v)
+        {
+            TakesPriority(CfgPriority.Low);
+            return v + 1;
+        }
+    }
 }
 
 internal static class AwaitOrderingHelpers

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -193,6 +193,13 @@ public class FidelityGateTests
         // observes — the same benign reconstruction-ordinal diff as its sibling
         // StaticLocalFunctionWithLocal below.
         "EnumArgInLocalFunctionWithLocal",
+        // #2983 (inline path): the enum-argument-in-inline-local-function fixture.
+        // Its raised body has no locals or stack slots, so it prints inline through
+        // the enclosing scope and now spells the enum constant by member (the fix
+        // under test); the call opcodes stay identical (`ldarg call ret`), but
+        // recompiling reassigns the local function's synthesized ordinal, the same
+        // benign reconstruction-ordinal diff as its sibling below.
+        "EnumArgInInlineLocalFunction",
         "InvokeLocalCapture",
         "JustBreak",
         "LocalBodyLambda",

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -185,6 +185,14 @@ public class FidelityGateTests
         "CountPositive",
         "DayNumber",
         "DoubleViaLocalFunction",
+        // #2983: the enum-argument-in-nested-local-function fixture. Its raised
+        // body prints through a freshly reconstructed nested scope and now spells
+        // the enum constant by member (the fix under test); the call opcodes stay
+        // identical (`ldarg call ret`), but recompiling reassigns the local
+        // function's synthesized ordinal (g__Classify|N_0), which contract V1
+        // observes — the same benign reconstruction-ordinal diff as its sibling
+        // StaticLocalFunctionWithLocal below.
+        "EnumArgInLocalFunctionWithLocal",
         "InvokeLocalCapture",
         "JustBreak",
         "LocalBodyLambda",

--- a/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
@@ -66,6 +66,21 @@ public class LocalFunctionRaisingPassTests
     }
 
     [Fact]
+    public void InlineLocalFunction_SpellsEnumConstantArgumentByMember()
+    {
+        // #2983 (inline path): a local function with no locals or stack slots
+        // prints INLINE through the enclosing function's scope. The enum is
+        // referenced only inside the local function, so the raise must merge the
+        // imported body's resolved maps into the enclosing function, or the enum
+        // constant argument renders as a bare int (`TakesPriority(0)` — CS1503).
+        string output = PrintRaised(nameof(CfgSampleClass.EnumArgInInlineLocalFunction));
+
+        Assert.Contains("TakesPriority(CfgPriority.Low)", output);
+        Assert.DoesNotContain("TakesPriority(0)", output);       // never a bare int
+        Assert.DoesNotContain("g__", output);
+    }
+
+    [Fact]
     public void CapturingLocalFunctionCalledTwice_RecoversSingleDeclarationAcrossBothCalls()
     {
         string output = PrintRaised(nameof(CfgSampleClass.CapturingCalledTwice));

--- a/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
@@ -50,6 +50,22 @@ public class LocalFunctionRaisingPassTests
     }
 
     [Fact]
+    public void NestedScopeLocalFunction_SpellsEnumConstantArgumentByMember()
+    {
+        // #2983: a local function with its own local prints through a freshly
+        // reconstructed IrFunction (a nested metadata-free scope). That scope must
+        // carry the raised body's enum member map, or the enum constant argument
+        // renders as a bare int (`TakesPriority(2)` — CS1503) even though the
+        // enclosing body spells the same value correctly.
+        string output = PrintRaised(nameof(CfgSampleClass.EnumArgInLocalFunctionWithLocal));
+
+        Assert.Contains("static int Classify(int v)", output);   // raised into a nested scope
+        Assert.Contains("TakesPriority(CfgPriority.High)", output);
+        Assert.DoesNotContain("TakesPriority(2)", output);       // never a bare int
+        Assert.DoesNotContain("g__", output);
+    }
+
+    [Fact]
     public void CapturingLocalFunctionCalledTwice_RecoversSingleDeclarationAcrossBothCalls()
     {
         string output = PrintRaised(nameof(CfgSampleClass.CapturingCalledTwice));

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1465,12 +1465,14 @@ public sealed partial class CSharpPrinter
             UsesUpdatedMemorySafetyRules = localFunction.UsesUpdatedMemorySafetyRules,
             SkipLocalsInit = localFunction.SkipLocalsInit,
             // The nested scope is metadata-free like the enclosing one; carry the
-            // body's resolved type maps so an enum constant renders by member
-            // name, not a bare int (issue #2983).
-            TypeShapes = localFunction.TypeShapes,
-            EnumMembers = localFunction.EnumMembers,
-            EnumUnderlyingTypes = localFunction.EnumUnderlyingTypes,
-            UnionTypes = localFunction.UnionTypes,
+            // enclosing function's resolved type maps so an enum constant renders
+            // by member name, not a bare int (issue #2983). LocalFunctionRaisingPass
+            // merges each raised body's maps into the enclosing function, so these
+            // include the definitions this local function references.
+            TypeShapes = _function.TypeShapes,
+            EnumMembers = _function.EnumMembers,
+            EnumUnderlyingTypes = _function.EnumUnderlyingTypes,
+            UnionTypes = _function.UnionTypes,
         };
 
         string pad = new(' ', indent * 4);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1464,6 +1464,13 @@ public sealed partial class CSharpPrinter
             LocalNames = localFunction.LocalNames,
             UsesUpdatedMemorySafetyRules = localFunction.UsesUpdatedMemorySafetyRules,
             SkipLocalsInit = localFunction.SkipLocalsInit,
+            // The nested scope is metadata-free like the enclosing one; carry the
+            // body's resolved type maps so an enum constant renders by member
+            // name, not a bare int (issue #2983).
+            TypeShapes = localFunction.TypeShapes,
+            EnumMembers = localFunction.EnumMembers,
+            EnumUnderlyingTypes = localFunction.EnumUnderlyingTypes,
+            UnionTypes = localFunction.UnionTypes,
         };
 
         string pad = new(' ', indent * 4);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -2533,24 +2533,6 @@ public sealed class LocalFunctionStatement : IrNode
     public bool SkipLocalsInit { get; }
     public BlockContainer Body => (BlockContainer)Children[0];
 
-    /// <summary>
-    /// The raised body's own resolved type info (shapes, enum members and
-    /// underlying types, union types), materialized when the body was imported.
-    /// A local function with its own locals or stack slots prints through a
-    /// freshly reconstructed <see cref="IrFunction"/> (a separate metadata-free
-    /// printer scope), so it must carry these maps forward or an enum-typed
-    /// constant in its body would render as a bare int (CS1503/CS0266) even
-    /// though the enclosing body spells the same value correctly.
-    /// </summary>
-    public IReadOnlyDictionary<TypeRef, TypeShape> TypeShapes { get; init; }
-        = ImmutableDictionary<TypeRef, TypeShape>.Empty;
-    public IReadOnlyDictionary<TypeRef, IReadOnlyDictionary<long, string>> EnumMembers { get; init; }
-        = ImmutableDictionary<TypeRef, IReadOnlyDictionary<long, string>>.Empty;
-    public IReadOnlyDictionary<TypeRef, TypeRef> EnumUnderlyingTypes { get; init; }
-        = ImmutableDictionary<TypeRef, TypeRef>.Empty;
-    public IReadOnlySet<TypeRef> UnionTypes { get; init; }
-        = ImmutableHashSet<TypeRef>.Empty;
-
     public override IEnumerable<TypeRef> DirectTypes => Parameters.Select(p => p.Type).Append(ReturnType);
 
     /// <summary>The single returned expression when the body is one block ending in a bare <c>return expr;</c>.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -2532,6 +2532,25 @@ public sealed class LocalFunctionStatement : IrNode
     public bool UsesUpdatedMemorySafetyRules { get; }
     public bool SkipLocalsInit { get; }
     public BlockContainer Body => (BlockContainer)Children[0];
+
+    /// <summary>
+    /// The raised body's own resolved type info (shapes, enum members and
+    /// underlying types, union types), materialized when the body was imported.
+    /// A local function with its own locals or stack slots prints through a
+    /// freshly reconstructed <see cref="IrFunction"/> (a separate metadata-free
+    /// printer scope), so it must carry these maps forward or an enum-typed
+    /// constant in its body would render as a bare int (CS1503/CS0266) even
+    /// though the enclosing body spells the same value correctly.
+    /// </summary>
+    public IReadOnlyDictionary<TypeRef, TypeShape> TypeShapes { get; init; }
+        = ImmutableDictionary<TypeRef, TypeShape>.Empty;
+    public IReadOnlyDictionary<TypeRef, IReadOnlyDictionary<long, string>> EnumMembers { get; init; }
+        = ImmutableDictionary<TypeRef, IReadOnlyDictionary<long, string>>.Empty;
+    public IReadOnlyDictionary<TypeRef, TypeRef> EnumUnderlyingTypes { get; init; }
+        = ImmutableDictionary<TypeRef, TypeRef>.Empty;
+    public IReadOnlySet<TypeRef> UnionTypes { get; init; }
+        = ImmutableHashSet<TypeRef>.Empty;
+
     public override IEnumerable<TypeRef> DirectTypes => Parameters.Select(p => p.Type).Append(ReturnType);
 
     /// <summary>The single returned expression when the body is one block ending in a bare <c>return expr;</c>.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
@@ -120,7 +120,18 @@ public sealed class LocalFunctionRaisingPass : IIrPass
                     body.LocalNames,
                     body.UsesUpdatedMemorySafetyRules,
                     body.SkipLocalsInit,
-                    container));
+                    container)
+                {
+                    // Carry the imported body's resolved type info so a nested
+                    // print scope (a local function with its own locals/slots)
+                    // still spells enum constants by member instead of a bare
+                    // int — the loss reported when the body prints through a
+                    // freshly reconstructed IrFunction.
+                    TypeShapes = body.TypeShapes,
+                    EnumMembers = body.EnumMembers,
+                    EnumUnderlyingTypes = body.EnumUnderlyingTypes,
+                    UnionTypes = body.UnionTypes,
+                });
                 environment?.Elide();
             }
         }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
@@ -120,18 +120,23 @@ public sealed class LocalFunctionRaisingPass : IIrPass
                     body.LocalNames,
                     body.UsesUpdatedMemorySafetyRules,
                     body.SkipLocalsInit,
-                    container)
-                {
-                    // Carry the imported body's resolved type info so a nested
-                    // print scope (a local function with its own locals/slots)
-                    // still spells enum constants by member instead of a bare
-                    // int — the loss reported when the body prints through a
-                    // freshly reconstructed IrFunction.
-                    TypeShapes = body.TypeShapes,
-                    EnumMembers = body.EnumMembers,
-                    EnumUnderlyingTypes = body.EnumUnderlyingTypes,
-                    UnionTypes = body.UnionTypes,
-                });
+                    container));
+                // Merge the raised body's resolved type info into the enclosing
+                // function. The body was imported from a separate method, so the
+                // host never materialized shapes/enum members/underlying types/
+                // union types for definitions only this local function references.
+                // The metadata-free printer reads these off the enclosing function
+                // for every local-function print path — inline (expression-bodied
+                // or block) and the reconstructed nested scope — so without the
+                // merge an enum-typed constant used only inside the local function
+                // renders as a bare int (CS1503/CS0266) even though the host body
+                // spells the same value correctly (issue #2983). Outer entries win
+                // on collision: a definition the host already resolved keeps its
+                // authoritative shape.
+                function.TypeShapes = MergeMap(function.TypeShapes, body.TypeShapes);
+                function.EnumMembers = MergeMap(function.EnumMembers, body.EnumMembers);
+                function.EnumUnderlyingTypes = MergeMap(function.EnumUnderlyingTypes, body.EnumUnderlyingTypes);
+                function.UnionTypes = MergeSet(function.UnionTypes, body.UnionTypes);
                 environment?.Elide();
             }
         }
@@ -320,5 +325,26 @@ public sealed class LocalFunctionRaisingPass : IIrPass
         yield return node;
         foreach (var descendant in node.Descendants)
             yield return descendant;
+    }
+
+    static IReadOnlyDictionary<TKey, TValue> MergeMap<TKey, TValue>(
+        IReadOnlyDictionary<TKey, TValue> outer, IReadOnlyDictionary<TKey, TValue> inner)
+        where TKey : notnull
+    {
+        if (inner.Count == 0)
+            return outer;
+        var result = outer as ImmutableDictionary<TKey, TValue> ?? ImmutableDictionary.CreateRange(outer);
+        foreach (var (key, value) in inner)
+            if (!result.ContainsKey(key))
+                result = result.SetItem(key, value);
+        return result;
+    }
+
+    static IReadOnlySet<TypeRef> MergeSet(IReadOnlySet<TypeRef> outer, IReadOnlySet<TypeRef> inner)
+    {
+        if (inner.Count == 0)
+            return outer;
+        var result = outer as ImmutableHashSet<TypeRef> ?? ImmutableHashSet.CreateRange(outer);
+        return result.Union(inner);
     }
 }


### PR DESCRIPTION
- Fixes #2983
- Changes: enum-typed constant arguments inside a raised local function now spell the enum member instead of a bare int, in every print path, so the C# compiles.
- Card revision: `5b0298b6`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — a raised local function is imported from a separate method, so the enclosing function's resolved type maps never learned about definitions referenced only inside it; an enum constant there fell back to a bare int (CS1503). The raise now merges the body's resolved maps into the enclosing function, so all three local-function print paths spell the enum member.

### Original source

`dnx dotnet-inspect -y -- member Humanizer.FrTimeOnlyToClockNotationConverter Convert --package Humanizer.Core@3.0.10 --all -S "Original Source"`

```csharp
public string Convert(TimeOnly time, ClockNotationRounding roundToNearestFive)
{
    // ...
    string GetHourExpression(int hour)
    {
        var value = hour.ToWords(GrammaticalGender.Feminine);
        // ...
    }
}
```

### Before

`-S "Decompiled Source"` at base (`c04c2345`), local function only:

```csharp
    static string GetHourExpression(int hour)
    {
        // ...
        string S_0 = hour.ToWords(1, null);
        // ...
    }
```

- Valid: False
- Correct: False

`ToWords(1, null)` does not bind — `ToWords` takes `GrammaticalGender`, so the bare `int` is CS1503. The enclosing `Convert` body renders the same value correctly as `normalizedMinutes.ToWords(GrammaticalGender.Feminine, null)`; only the local-function scope loses it.

### After

`-S "Decompiled Source"` at head (`5b0298b6`), local function only:

```csharp
    static string GetHourExpression(int hour)
    {
        // ...
        string S_0 = hour.ToWords(GrammaticalGender.Feminine, null);
        // ...
    }
```

- Valid: True
- Correct: True

The argument now spells the enum member, matching the original source and the enclosing body.

### Fully raised

The After decompilation is in the fully raised state.

## Root cause

A raised local function is imported from a *separate* compiler-synthesized method (`<Enclosing>g__Name|N_M`), with its own resolved type maps. The host method's maps (materialized at import by `IrImporter.ResolveTypeInfo`) never learned about definitions referenced only inside the local function. The metadata-free `CSharpPrinter` reads those maps to spell an enum constant as `EnumType.Member`, so with the map empty the constant fell back to raw text (`1`).

There are three local-function print paths, and the first revision fixed only one:

- Expression-bodied inline — prints through the enclosing `_function`.
- Block inline (no locals/slots) via `AppendContainer` — prints through the enclosing `_function`.
- Reconstructed nested scope (`AppendNestedLocalFunctionBody`, when the body has locals or stack slots) — prints through a fresh `IrFunction`.

Fix: `LocalFunctionRaisingPass` merges each raised body's resolved maps (`TypeShapes`, `EnumMembers`, `EnumUnderlyingTypes`, `UnionTypes`) up into the enclosing `IrFunction` (outer entries win on collision), and `AppendNestedLocalFunctionBody` reads the merged enclosing maps. One mechanism covers all three paths. `CollectionInitializerTypes` is pass-only (the printer never reads it; `ObjectInitializerPass` already ran on the body) and is not merged.

The merge is regression-safe: `IrImporter` already materialized the outer maps for every definition the outer IR references, so merged keys are exclusively for inner-only definitions the outer nodes never look up. Downstream passes only key-lookup these maps (never enumerate), so adding those keys is strictly monotonic.

## Evidence

| Check | Baseline (`c04c2345`) | Head (`5b0298b6`) |
| --- | --- | --- |
| Product build (`dotnet-inspect.csproj`) | Pass | Pass |
| Focused tests (`LocalFunctionRaisingPassTests`) | 19 passed | 21 passed (+ 2 regression tests: inline and nested) |
| Decompiler fast suite (`-trait- Speed=Slow`) | 3160 total, 54 failed | 3162 total, 54 failed |
| Nested-scope witness (`FrTimeOnlyToClockNotationConverter::Convert`) | `ToWords(1, null)` (CS1503) | `ToWords(GrammaticalGender.Feminine, null)` (valid) |
| Inline-path witness (min fixture) | `Takes(0)` (CS1503) | `Takes(MyEnum.Member)` (valid) |

The 54 fast-suite failures are **identical** on baseline and head — the pre-existing Windows-only environmental compile-back failure (native `aspnetcorev2_inprocess.dll` `CS0009`), tracked in #3015. None involve local functions or enums; the +2 total is the two new passing regression tests. On this Windows machine the `Speed=Slow` `FidelityGateTests` gate is blocked by the same environmental issue; the two new fixtures' compile-back is validated by CI (Linux) and docketed in `KnownDiffs` as benign reconstruction-ordinal diffs (opcode-identical `ldarg call ret`; only the synthesized ordinal differs), the same class as their siblings.

## Adversarial review

Two-model fixed-head review of `5b0298b6` (base `c04c2345`), each in an isolated worktree:

- **GPT-5.6** — first revision (`106703c5`): found the inline-path gap (Medium/High) and suggested the merge-up fix. Fixed head: **clean** ("No significant issues found"; verified inline/nested paths, sibling/collision isolation, structural `TypeRef` equality, Humanizer E2E, 113 targeted tests).
- **Gemini 3.1 Pro** — first revision: independently found the same inline-path gap (High). Fixed head: **clean** ("No defects"; validated merge-up monotonicity, collision correctness, multiple local functions, doubly-nested exclusion, comparer preservation).

## Decompiler quality

> Should the corpus signal block this PR?

**Not applicable** — this is a print-scope/type-resolution validity fix, not a raising/structuring change. It does not alter which nodes raise or any control-flow shape; the only observable difference is spelling an already-raised enum constant by member across all local-function print paths.

## Validation

```powershell
dotnet build src/dotnet-inspect/dotnet-inspect.csproj -c Release --configfile .\nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.LocalFunctionRaisingPassTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
```
