### PR TITLE
Complete dynamic stackalloc shape recognition

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/DynamicStackallocFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/DynamicStackallocFixtures.cs
@@ -1,0 +1,16 @@
+namespace ILInspector.Decompiler.Fixtures.LegacyUnsafe;
+
+public static class DynamicStackallocFixtures
+{
+    public static int ByteCount(int n)
+    {
+        Span<byte> values = stackalloc byte[n];
+        return values.Length;
+    }
+
+    public static int GuidCount(int n)
+    {
+        Span<Guid> values = stackalloc Guid[n];
+        return values.Length;
+    }
+}

--- a/src/ILInspector.Decompiler.Fixtures.NewUnsafe/DynamicStackallocFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.NewUnsafe/DynamicStackallocFixtures.cs
@@ -1,0 +1,16 @@
+namespace ILInspector.Decompiler.Fixtures.NewUnsafe;
+
+public static class DynamicStackallocFixtures
+{
+    public static int ByteCount(int n)
+    {
+        Span<byte> values = stackalloc byte[n];
+        return values.Length;
+    }
+
+    public static int GuidCount(int n)
+    {
+        Span<Guid> values = stackalloc Guid[n];
+        return values.Length;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
@@ -207,6 +207,218 @@ public class StackAllocSpanPassTests
     }
 
     [Fact]
+    public void DirectPointerWithDynamicOneByteSize_Raises()
+    {
+        // For one-byte elements csc emits the count directly as localloc's
+        // byte size, with no checked multiply or nuint conversion.
+        var function = Build(StackAllocSpanConstructor(
+            TypeRef.CoreLib("System", "Span`1"),
+            new StackAllocate(new LoadLocal(0, Int32)),
+            new LoadLocal(0, Int32),
+            elementType: Byte));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<StackAllocate>());
+        var raised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Equal(Byte, raised.ElementType);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void DirectPointerWithDirectDynamicSizeForWiderElement_DoesNotRaise()
+    {
+        // A direct byte count only represents an element count when the
+        // element is exactly one byte wide.
+        var function = Build(StackAllocSpanConstructor(
+            TypeRef.CoreLib("System", "Span`1"),
+            new StackAllocate(new LoadLocal(0, Int32)),
+            new LoadLocal(0, Int32)));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<StackAllocArray>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void DirectPointerWithCheckedMultiplyWithoutNuintConvert_DoesNotRaise()
+    {
+        // mul.ovf.un over int operands overflows at int width. The compiler's
+        // stackalloc lowering first converts the count to native unsigned
+        // width, so accepting this lookalike would change overflow behavior.
+        var size = new Binary(
+            BinaryKind.Multiply,
+            isChecked: true,
+            isUnsigned: true,
+            new LoadLocal(0, Int32),
+            new Constant(4, Int32));
+        var function = Build(StackAllocSpanConstructor(
+            TypeRef.CoreLib("System", "Span`1"),
+            new StackAllocate(size),
+            new LoadLocal(0, Int32)));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<StackAllocArray>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void DirectPointerWithUserUIntPtrLookalike_DoesNotRaise()
+    {
+        var count = new LoadLocal(0, Int32);
+        var lookalike = TypeRef.Definition("UserAssembly", "System", "UIntPtr");
+        var converted = new IrConvert(lookalike, isChecked: false, isUnsigned: false, count);
+        var size = new Binary(BinaryKind.Multiply, isChecked: true, isUnsigned: true, converted, new Constant(4, Int32));
+        var function = Build(StackAllocSpanConstructor(
+            TypeRef.CoreLib("System", "Span`1"),
+            new StackAllocate(size),
+            new LoadLocal(0, Int32)));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<StackAllocArray>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void DirectPointerWithUnsignedNuintConvert_DoesNotRaise()
+    {
+        var count = new LoadLocal(0, Int32);
+        var converted = new IrConvert(
+            TypeRef.CoreLib("System", "UIntPtr"),
+            isChecked: false,
+            isUnsigned: true,
+            count);
+        var size = new Binary(BinaryKind.Multiply, isChecked: true, isUnsigned: true, converted, new Constant(4, Int32));
+        var function = Build(StackAllocSpanConstructor(
+            TypeRef.CoreLib("System", "Span`1"),
+            new StackAllocate(size),
+            new LoadLocal(0, Int32)));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<StackAllocArray>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void DirectPointerWithCheckedNuintConvert_DoesNotRaise()
+    {
+        var count = new LoadLocal(0, Int32);
+        var converted = new IrConvert(
+            TypeRef.CoreLib("System", "UIntPtr"),
+            isChecked: true,
+            isUnsigned: false,
+            count);
+        var size = new Binary(BinaryKind.Multiply, isChecked: true, isUnsigned: true, converted, new Constant(4, Int32));
+        var function = Build(StackAllocSpanConstructor(
+            TypeRef.CoreLib("System", "Span`1"),
+            new StackAllocate(size),
+            new LoadLocal(0, Int32)));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<StackAllocArray>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void DirectPointerWithCheckedNuintCountMismatch_DoesNotRaise()
+    {
+        var converted = new IrConvert(
+            TypeRef.CoreLib("System", "UIntPtr"),
+            isChecked: false,
+            isUnsigned: false,
+            new LoadLocal(0, Int32));
+        var size = new Binary(BinaryKind.Multiply, isChecked: true, isUnsigned: true, converted, new Constant(4, Int32));
+        var function = Build(StackAllocSpanConstructor(
+            TypeRef.CoreLib("System", "Span`1"),
+            new StackAllocate(size),
+            new LoadLocal(1, Int32)));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<StackAllocArray>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void DirectPointerWithCheckedNuintElementSizeMismatch_DoesNotRaise()
+    {
+        var converted = new IrConvert(
+            TypeRef.CoreLib("System", "UIntPtr"),
+            isChecked: false,
+            isUnsigned: false,
+            new LoadLocal(0, Int32));
+        var size = new Binary(BinaryKind.Multiply, isChecked: true, isUnsigned: true, converted, new Constant(8, Int32));
+        var function = Build(StackAllocSpanConstructor(
+            TypeRef.CoreLib("System", "Span`1"),
+            new StackAllocate(size),
+            new LoadLocal(0, Int32)));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<StackAllocArray>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void DirectPointerWithCheckedNuintNegativeConstant_DoesNotRaise()
+    {
+        var converted = new IrConvert(
+            TypeRef.CoreLib("System", "UIntPtr"),
+            isChecked: false,
+            isUnsigned: false,
+            new Constant(-1, Int32));
+        var size = new Binary(BinaryKind.Multiply, isChecked: true, isUnsigned: true, converted, new Constant(4, Int32));
+        var function = Build(StackAllocSpanConstructor(
+            TypeRef.CoreLib("System", "Span`1"),
+            new StackAllocate(size),
+            count: -1));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<StackAllocArray>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void DirectPointerWithCheckedNuintStructSize_Raises()
+    {
+        var guid = TypeRef.CoreLib("System", "Guid");
+        var count = new LoadLocal(0, Int32);
+        var converted = new IrConvert(
+            TypeRef.CoreLib("System", "UIntPtr"),
+            isChecked: false,
+            isUnsigned: false,
+            count);
+        var size = new Binary(BinaryKind.Multiply, isChecked: true, isUnsigned: true, new SizeOf(guid), converted);
+        var function = Build(StackAllocSpanConstructor(
+            TypeRef.CoreLib("System", "Span`1"),
+            new StackAllocate(size),
+            new LoadLocal(0, Int32),
+            elementType: guid));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        var raised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Equal(guid, raised.ElementType);
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void DirectPointerWithByteSizeCountMismatch_DoesNotRaise()
     {
         // The raw StackAllocate reserves 4 bytes, but the constructor claims
@@ -1103,9 +1315,9 @@ public class StackAllocSpanPassTests
     static NewObject StackAllocSpanConstructor(TypeRef spanDefinition, IrExpression pointer, int count, TypeRef? elementType = null)
         => StackAllocSpanConstructorWithPointer(spanDefinition, pointer, count, elementType);
 
-    static NewObject StackAllocSpanConstructor(TypeRef spanDefinition, IrExpression pointer, IrExpression count)
+    static NewObject StackAllocSpanConstructor(TypeRef spanDefinition, IrExpression pointer, IrExpression count, TypeRef? elementType = null)
     {
-        var span = TypeRef.GenericInstance(spanDefinition, [Int32]);
+        var span = TypeRef.GenericInstance(spanDefinition, [elementType ?? Int32]);
         var ctor = new MethodRef(span, ".ctor", Void, [VoidPointer, Int32], HasThis: true);
         return new NewObject(ctor, [pointer, count]);
     }

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.CSharp;
 
 using LegacyFixtures = ILInspector.Decompiler.Fixtures.LegacyUnsafe.UnsafeFixtures;
 using NewFixtures = ILInspector.Decompiler.Fixtures.NewUnsafe.UnsafeFixtures;
+using NewDynamicStackallocFixtures = ILInspector.Decompiler.Fixtures.NewUnsafe.DynamicStackallocFixtures;
 using NewStackallocFixtures = ILInspector.Decompiler.Fixtures.NewUnsafe.StackallocInitializerResiduals;
 using ChainB = ILInspector.Decompiler.Fixtures.UnsafeChainB.LibraryB;
 using ChainC = ILInspector.Decompiler.Fixtures.UnsafeChainC.Program;
@@ -58,6 +59,9 @@ public class UnsafeEmitterTests
 
     static string DecompileNew(string method) =>
         Decompile(typeof(NewFixtures).Assembly.Location, typeof(NewFixtures).FullName!, method);
+
+    static string DecompileNewDynamicStackalloc(string method) =>
+        Decompile(typeof(NewDynamicStackallocFixtures).Assembly.Location, typeof(NewDynamicStackallocFixtures).FullName!, method);
 
     static string DecompileLegacy(string method) =>
         Decompile(typeof(LegacyFixtures).Assembly.Location, typeof(LegacyFixtures).FullName!, method);
@@ -736,6 +740,18 @@ public class UnsafeEmitterTests
         Assert.DoesNotContain("unsafe", output);
         // Safe case keeps the inline `Span<int> s = stackalloc int[n]` form.
         Assert.Contains("stackalloc int[", output);
+        Assert.DoesNotContain("new Span", output);
+    }
+
+    [Theory]
+    [InlineData(nameof(NewDynamicStackallocFixtures.ByteCount), "byte")]
+    [InlineData(nameof(NewDynamicStackallocFixtures.GuidCount), "Guid")]
+    public void NewRulesModule_DynamicStackAllocCompilerShapes_Raise(string method, string element)
+    {
+        var output = DecompileNewDynamicStackalloc(method);
+
+        Assert.DoesNotContain("unsafe", output);
+        Assert.Contains($"stackalloc {element}[", output);
         Assert.DoesNotContain("new Span", output);
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
@@ -71,7 +71,7 @@ public sealed class StackAllocSpanPass : IIrPass
             StoreStackSlot? ownedStore = null;
             IrExpression source;
 
-            if (TryNormalizeConstantStackAlloc(pointer, count, element, out var directSource))
+            if (TryNormalizeStackAllocSource(pointer, count, element, out var directSource))
             {
                 source = directSource;
             }
@@ -184,7 +184,7 @@ public sealed class StackAllocSpanPass : IIrPass
             return false;
 
         var store = stores[0];
-        if (!TryNormalizeConstantStackAlloc(store.Value, count, element, out var normalized) || store.Parent is not Block parentBlock)
+        if (!TryNormalizeStackAllocSource(store.Value, count, element, out var normalized) || store.Parent is not Block parentBlock)
             return false;
 
         var loadStatement = GetStatement(load);
@@ -311,12 +311,13 @@ public sealed class StackAllocSpanPass : IIrPass
     /// which for primitive element types the compiler folds to a literal
     /// <see cref="Constant"/> rather than emitting a symbolic
     /// <see cref="SizeOf"/> node (struct/generic element types still emit
-    /// <see cref="SizeOf"/>). Either operand order is accepted. Separately,
-    /// when both the size and count are literal constants (e.g.
-    /// <c>stackalloc byte[4]</c>, which the compiler folds to a bare
-    /// <see cref="Constant"/> with no multiply at all), a known fixed
-    /// primitive byte size for <paramref name="element"/> and an exact
-    /// arithmetic match is required.</para>
+    /// <see cref="SizeOf"/>). Either operand order is accepted. For one-byte
+    /// primitive elements, the compiler omits the multiply entirely and uses
+    /// the element count directly as the byte count; that shape requires the
+    /// two expressions to be structurally identical. Separately, when both
+    /// the size and count are literal constants, a known fixed primitive byte
+    /// size for <paramref name="element"/> and an exact arithmetic match is
+    /// required.</para>
     ///
     /// <para>A dynamic count reaching this pass through a <see cref="StackAllocArray"/>
     /// source (the initializer/slot path) is unaffected by any of this: that
@@ -327,6 +328,12 @@ public sealed class StackAllocSpanPass : IIrPass
     {
         var unwrappedSize = Unconvert(size);
         var unwrappedCount = Unconvert(count);
+
+        if (unwrappedCount is Constant { Value: int constantCount } && constantCount < 0)
+            return false;
+
+        if (GetSizeOf(element) == 1 && IsSameInt32Expression(unwrappedSize, unwrappedCount))
+            return true;
 
         if (unwrappedSize is Binary { Kind: BinaryKind.Multiply, IsChecked: true, IsUnsigned: true } multiply
             && (IsCheckedByteSizeProduct(multiply.Left, multiply.Right, unwrappedCount, element)
@@ -341,8 +348,9 @@ public sealed class StackAllocSpanPass : IIrPass
 
     /// <summary>
     /// One operand order of the checked-multiply byte-size proof: <paramref
-    /// name="countOperand"/> (after peeling an <c>int</c>-to-<c>nuint</c>
-    /// convert) must structurally equal <paramref name="count"/>, and
+    /// name="countOperand"/> must be the compiler's exact unchecked, signed
+    /// <c>int</c>-to-<c>nuint</c> conversion over <paramref name="count"/>,
+    /// and
     /// <paramref name="elementSizeOperand"/> must be a known byte size for
     /// <paramref name="element"/> -- either a symbolic <see cref="SizeOf"/>
     /// node or, for primitives, a folded literal <see cref="Constant"/>.
@@ -351,19 +359,31 @@ public sealed class StackAllocSpanPass : IIrPass
     {
         bool isElementSize = (elementSizeOperand is SizeOf sizeOf && sizeOf.Type.Equals(element))
             || (elementSizeOperand is Constant { Value: int sizeValue } && GetSizeOf(element) == sizeValue);
-        return isElementSize && StructurallyEqual(PeelNuintConvert(countOperand), count);
+        return isElementSize && IsCompilerNuintCount(countOperand, count);
     }
 
     /// <summary>
-    /// Peels a single <c>int</c>-to-<c>nuint</c> convert -- the conversion
-    /// the compiler emits to widen a dynamic stackalloc count before the
-    /// checked byte-size multiply. This is not an implicit C# conversion (so
-    /// <see cref="Unconvert"/> never strips it), but it is exactly the
-    /// conversion the compiler always inserts here, so it is safe to peel in
-    /// this one, specific structural position only.
+    /// Matches the exact conversion the compiler emits to widen a stackalloc
+    /// element count before the checked byte-size multiply. Requiring corelib
+    /// <c>System.UIntPtr</c>, an <c>int</c> operand, and the observed unchecked
+    /// signed-conversion flags prevents lookalike or width-changing converts
+    /// from being treated as the compiler's native-width count.
     /// </summary>
-    static IrExpression PeelNuintConvert(IrExpression expression)
-        => expression is Convert { Target: { Name: "UIntPtr" }, IsChecked: false } convert ? convert.Operand : expression;
+    static bool IsCompilerNuintCount(IrExpression expression, IrExpression count)
+        => expression is Convert
+        {
+            Target: { } target,
+            IsChecked: false,
+            IsUnsigned: false,
+            Operand: { } operand,
+        }
+        && MemberIdentity.IsCoreLibraryType(target, "System", "UIntPtr")
+        && IsSameInt32Expression(operand, count);
+
+    static bool IsSameInt32Expression(IrExpression left, IrExpression right)
+        => MemberIdentity.IsCoreLibraryType(left.ResultType, "System", "Int32")
+            && MemberIdentity.IsCoreLibraryType(right.ResultType, "System", "Int32")
+            && StructurallyEqual(left, right);
 
     /// <summary>
     /// Strips only <see cref="Convert"/> wrappers proven value-preserving --
@@ -420,14 +440,12 @@ public sealed class StackAllocSpanPass : IIrPass
     /// underlying <see cref="StackAllocate"/> or <see cref="StackAllocArray"/>
     /// node itself. Requires the discarded byte size (<see cref="StackAllocate.Size"/>)
     /// or element count (<see cref="StackAllocArray.Count"/>) to be provably
-    /// safe to drop: either generically <see cref="IsSideEffectFree"/>, or --
-    /// for a <see cref="StackAllocate"/> size only -- the real compiler's
-    /// checked byte-size product proven equal to <paramref name="count"/> *
-    /// <paramref name="element"/>'s size by <see cref="IsProvenByteSize"/>.
-    /// That proof, not mere purity, is what makes discarding this specific
-    /// shape sound: the checked multiply's only possible effect is the same
-    /// overflow throw the raised <c>stackalloc T[n]</c> form's own byte-size
-    /// computation reproduces, so nothing observable is silently erased.
+    /// safe to drop. A <see cref="StackAllocate"/> requires the compiler-shape
+    /// equivalence proof in <see cref="IsProvenByteSize"/>; generic purity is
+    /// insufficient because a pure but unrelated byte count would still
+    /// describe a different allocation. A <see cref="StackAllocArray"/> count
+    /// must be <see cref="IsSideEffectFree"/> and is checked separately for
+    /// count agreement below.
     /// For <see cref="StackAllocArray"/> that agreement is instead checked
     /// separately below (by count or by <see cref="StructurallyEqual"/>).
     /// Returning the unwrapped node (rather than a possibly-<c>Convert</c>-
@@ -436,7 +454,7 @@ public sealed class StackAllocSpanPass : IIrPass
     /// initializer count) see through the wrapper instead of silently skipping
     /// validation.
     /// </summary>
-    static bool TryNormalizeConstantStackAlloc(IrExpression pointer, IrExpression count, TypeRef element, out IrExpression normalized)
+    static bool TryNormalizeStackAllocSource(IrExpression pointer, IrExpression count, TypeRef element, out IrExpression normalized)
     {
         var candidate = pointer;
         if (candidate is Convert { IsChecked: false, Operand: StackAllocate or StackAllocArray, Target: { } target } converted && IsPointerLikeTarget(target))
@@ -444,7 +462,7 @@ public sealed class StackAllocSpanPass : IIrPass
 
         switch (candidate)
         {
-            case StackAllocate { Size: { } size } when IsSideEffectFree(size) || IsProvenByteSize(size, count, element):
+            case StackAllocate { Size: { } size } when IsProvenByteSize(size, count, element):
             case StackAllocArray { Count: { } arrayCount } when IsSideEffectFree(arrayCount):
                 normalized = candidate;
                 return true;


### PR DESCRIPTION
- Fixes #2969
- Completes dynamic `Span<T>` stackalloc recognition for one-byte elements and tightens the native-width count identity proof
- Card revision: `9dfe9fe0`

## Change

> Should we accept this change?

**Conclusion:** **ACCEPT** — real Debug and Release compiler shapes raise, close malformed lookalikes decline, the corpus gate passes, CI is green, and two isolated exact-head adversarial reviews are clean.

### Original source

```csharp
public static int ByteCount(int n)
{
    Span<byte> values = stackalloc byte[n];
    return values.Length;
}
```

### Before

```csharp
public static unsafe int ByteCount(int n)
{
    int V_1 = n;
    Span<byte> values = new Span<byte>((void*)(stackalloc byte[V_1]), V_1);
    return values.Length;
}
```

- Valid: False
- Correct: False

Roslyn rejects this output with CS8346. The merged matcher recognized the checked `nuint * sizeof(T)` shape but omitted csc's direct-count lowering for one-byte elements.

### After

```csharp
public static int ByteCount(int n)
{
    int V_1 = n;
    Span<byte> values = stackalloc byte[V_1];
    return values.Length;
}
```

- Valid: True
- Correct: True

### Fully raised

```csharp
public static int ByteCount(int n)
{
    Span<byte> values = stackalloc byte[n];
    return values.Length;
}
```

- Required tracking issue: #3029 — inline the compiler count spill that becomes single-use only after `stackalloc-span` removes the redundant byte-size expression.

## Evidence

- Added paired compiler-backed `byte` and `Guid` fixtures.
- Independently checked Debug and Release `byte`, `int`, `Guid`, and `unmanaged T` imports; `stackalloc-span` raises all eight methods.
- Added near-miss negatives for missing/native-width conversion, conversion flags, corelib identity, count identity, element size, negative constants, and wider direct-count elements.
- Product build: pass.
- Decompiler fast suite: 3,149 passed.
- Pass area: 1,179 passed.
- Full suite: one stable failure reproduces on unchanged `origin/main`; four shared-state failures pass when isolated.
- Render A/B: 89,065 methods, zero changed, added, or removed.

## Decompiler quality

The generated card passes. Its good movement includes baseline drift since the pinned corpus baseline; the explicit merge-base render A/B above shows this PR changes no methods in the fixed corpus. The generated “Fully raised” row is the harness's structural-gap metric (no residual unstructured control flow or unsupported nodes), not a claim that every compiler spill has reached the authored source endpoint above.

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity compiled 25,183 methods (compile-cap 4,000; per-sample, not corpus-wide); fidelity (compile-back) sampled 600 / 89,065 (0.67%)

| Metric | Change | Count delta |
| ------ | ------ | ----------- |
| Detected lowering residue (-) | 10,625 (11.93%) → 10,625 (11.93%) (neutral) | 0 |
| Conditional-branch residue (-) | 2,401 (2.70%) → 2,400 (2.69%) (good) | -1 |
| Forward-merge stops (-) | 2,286 (2.57%) → 2,285 (2.57%) (neutral) | -1 |
| Full malformed (-) | 0 → 0 (neutral) | 0 |
| Semantic defects (-) | 94 (0.37%) → 83 (0.33%) (good) | -11 |
| Fidelity opcode diffs (sampling differs) | 90 (15.00%) → 91 (15.17%) | n/a |
| Fidelity operand diffs (sampling differs) | 8 (1.33%) → 8 (1.33%) | n/a |
| Fidelity unavailable comparisons (sampling differs) | 0 (0.00%) → 0 (0.00%) | n/a |
| Fidelity recompile failures (sampling differs) | 0 (0.00%) → 0 (0.00%) | n/a |
| Fidelity context failures (sampling differs) | 0 (0.00%) → 0 (0.00%) | n/a |
| Pass bugs (-) | 0 → 0 (neutral) | 0 |
| Fidelity check coverage (+) | 600 (0.67%) → 600 (0.67%) (neutral) | 0 |
| Fidelity exact (sampling differs) | 502 (83.67%) → 501 (83.50%) | n/a |
| Fully raised (+) | 24,446 (89.73%) → 24,458 (89.78%) (good) | +12 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): detected lowering residue 11.93% -> 11.93% (0 pp); conditional-branch residue 2.70% -> 2.69% (-0.01 pp); Full malformed 0 -> 0 (0); semantic defects 94 -> 83 (-11); fidelity ungated (sampling differs; rely on changed-method fidelity).

Current measured debt: 10,625 methods with detected lowering residue; 83 semantic defects among 25,183 checked; 91 fidelity opcode diffs among 600 checked; 8 fidelity operand diffs among 600 checked.
Regression verdict: PASS — corpus sensor matched baseline tolerances.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*StackAlloc*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait "Area=Pass"
```
