### PR TITLE
Keep scattered switch-expression default reachable by trampoline (#2973)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ValidityCoverageReportingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ValidityCoverageReportingTests.cs
@@ -50,9 +50,14 @@ public class ValidityCoverageReportingTests
         // UnionSwitchExpressionPass::SameTailNode,
         // DynamicCallSitePass::TryGuardCacheLoad, and
         // FluentChainRecompositionPass::SinkStatement.
-        // YieldBreakLoopIteratorReconstruction::TryNormalizeContinueCondition is a
-        // distinct result-temp switch-expression shape the fix does not cover and
-        // remains pinned as tracked follow-up.
+        // #2973 removed the last two scattered-return defects,
+        // YieldBreakLoopIteratorReconstruction::TryNormalizeContinueCondition and
+        // FixedArrayRaising::SameLoadPlace: result-temp switch-expression /
+        // pattern defaults reached by a forward-goto trampoline. The default
+        // return is now admitted as a scattered dispatch target and kept as the
+        // region's trailing terminator (rather than dropped by the sibling arm's
+        // past-region inline), so the trampoline path returns instead of falling
+        // off the end.
         string[] expected =
 #if DEBUG
         [
@@ -64,10 +69,8 @@ public class ValidityCoverageReportingTests
             "ILInspector.Decompiler.Pipeline.BooleanFoldingPass::IsNullableCoalesceExpressionContext",
             "ILInspector.Decompiler.Pipeline.CSharpPrinter::ForLoopIncrementText",
             "ILInspector.Decompiler.Pipeline.DeconstructionAssignmentPass::TryMatchTupleSeed",
-            "ILInspector.Decompiler.Pipeline.FixedArrayRaising::SameLoadPlace",
             "ILInspector.Decompiler.Pipeline.IndexFromEndPass::LengthReceiver",
             "ILInspector.Decompiler.Pipeline.InlineArrayCollectionPass::PlaceFromAddress",
-            "ILInspector.Decompiler.Pipeline.YieldBreakLoopIteratorReconstruction::TryNormalizeContinueCondition",
         ];
 #endif
         Assert.Equal(expected, actual);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -105,6 +105,8 @@ public sealed class StructuringPass : IIrPass
         var unconditionalTargets = new HashSet<int>();
         var conditionalTargetCounts = new Dictionary<int, int>();
         var conditionalPredecessorIndices = new Dictionary<int, List<int>>();
+        var branchPredecessorIndices = new Dictionary<int, List<int>>();
+        var switchTargets = new HashSet<int>();
         var branchTargets = new HashSet<int>();
         for (int blockIndex = 0; blockIndex < blocks.Count; blockIndex++)
         {
@@ -114,6 +116,9 @@ public sealed class StructuringPass : IIrPass
                 if (child is Branch branch)
                 {
                     unconditionalTargets.Add(branch.TargetOffset);
+                    if (!branchPredecessorIndices.TryGetValue(branch.TargetOffset, out var branchPreds))
+                        branchPredecessorIndices[branch.TargetOffset] = branchPreds = new List<int>();
+                    branchPreds.Add(blockIndex);
                     branchTargets.Add(branch.TargetOffset);
                 }
                 else if (child is Leave leave)
@@ -134,6 +139,7 @@ public sealed class StructuringPass : IIrPass
                     foreach (int target in switchBranch.TargetOffsets)
                     {
                         unconditionalTargets.Add(target);
+                        switchTargets.Add(target);
                         branchTargets.Add(target);
                     }
                 }
@@ -167,11 +173,25 @@ public sealed class StructuringPass : IIrPass
         // guard. The contiguous `&&`/`||` false-exit chain (adjacent guards, no
         // arm between them) is deliberately excluded so it still combines into a
         // single condition (the #640 fidelity canary).
+        //
+        // A shared return is normally excluded when an unconditional goto also
+        // targets it — dropping the duplicated original would strand that goto.
+        // But a switch-expression default arm (`_ => false`) is reached both by
+        // scattered `when`-guard failures AND by a forward-goto trampoline
+        // (`{ goto default; }`, the else of an inner pattern test): the store-
+        // then-return default is the same shared tail (issue #2973). Such a
+        // trampoline is itself a dispatch arm that dissolves by inlining the
+        // terminator, so it does not strand a goto; admit the target when every
+        // unconditional predecessor is one of those pure forward trampolines
+        // (never a switch dispatch target). Structuring's all-or-nothing
+        // Validate is the backstop: if any trampoline cannot be dissolved, the
+        // whole slice stays in its valid goto form rather than dropping an edge.
         var scatteredReturnDispatchTargets = new HashSet<int>();
         foreach (var block in blocks)
         {
             int offset = block.StartOffset;
-            if (unconditionalTargets.Contains(offset)
+            if ((unconditionalTargets.Contains(offset)
+                    && !UnconditionalPredecessorsAreDissolvableTrampolines(blocks, offset, branchPredecessorIndices, switchTargets))
                 || fallenInto.Contains(offset)
                 || conditionalTargetCounts.GetValueOrDefault(offset) < 2
                 || !IsTerminatorBlock(block)
@@ -190,8 +210,17 @@ public sealed class StructuringPass : IIrPass
             if (!IsSharedTerminator(blocks[i], unconditionalTargets, conditionalTargetCounts, fallenInto, isComparisonTree, scatteredReturnDispatchTargets))
                 continue;
             snapshots[i] = blocks[i].Children.ToList();
-            if (i > 0 && !FallsThrough(blocks[i - 1]))
+            // A scattered dispatch target reached by a forward-goto trampoline
+            // (issue #2973) is inlined into its conditional guards but must stay
+            // in place: the trampoline arm reaches it by falling through the
+            // structured nest to this trailing return, so dropping it would
+            // strand that path off the end of a non-void method (CS0161).
+            if (i > 0 && !FallsThrough(blocks[i - 1])
+                && !(scatteredReturnDispatchTargets.Contains(blocks[i].StartOffset)
+                    && unconditionalTargets.Contains(blocks[i].StartOffset)))
+            {
                 droppable.Add(i);
+            }
         }
 
         var recorder = context.StructuringDiagnostics is null ? null : new StopRecorder();
@@ -1068,7 +1097,15 @@ public sealed class StructuringPass : IIrPass
     /// </summary>
     static bool IsSharedTerminator(Block block, HashSet<int> unconditionalTargets, Dictionary<int, int> conditionalTargetCounts, HashSet<int> fallenInto, bool isComparisonTree, HashSet<int> scatteredReturnDispatchTargets)
     {
-        if (!IsTerminatorBlock(block) || unconditionalTargets.Contains(block.StartOffset))
+        if (!IsTerminatorBlock(block))
+            return false;
+        // A scattered switch-expression default (issue #2973) is reached by a
+        // forward-goto trampoline, so it is an unconditional target; the
+        // collector already proved those predecessors are dissolvable
+        // trampolines before adding it, so let the scattered classification
+        // override the general unconditional-target exclusion.
+        bool scattered = scatteredReturnDispatchTargets.Contains(block.StartOffset);
+        if (!scattered && unconditionalTargets.Contains(block.StartOffset))
             return false;
         // A base/this constructor-chain call must stay the body's first statement
         // for the `: base(...)` lift to fire; inlining (which duplicates/nests the
@@ -1179,6 +1216,35 @@ public sealed class StructuringPass : IIrPass
                 return true;
         }
         return false;
+    }
+
+    /// <summary>
+    /// Whether every unconditional predecessor of <paramref name="offset"/> is a
+    /// pure forward-goto trampoline — a block whose sole statement is
+    /// <c>goto offset</c> (issue #2973's switch-expression default arm, reached
+    /// by the else of an inner pattern test). Such a trampoline is a dispatch arm
+    /// that dissolves by inlining the terminator, so duplicating the shared
+    /// return does not strand its goto. A switch (jump-table) dispatch target is
+    /// never a trampoline, so it stays excluded. With no unconditional
+    /// predecessor the caller has already excluded the block, so this is only
+    /// consulted for genuine unconditional targets.
+    /// </summary>
+    static bool UnconditionalPredecessorsAreDissolvableTrampolines(
+        IReadOnlyList<Block> blocks,
+        int offset,
+        Dictionary<int, List<int>> branchPredecessorIndices,
+        HashSet<int> switchTargets)
+    {
+        if (switchTargets.Contains(offset))
+            return false;
+        if (!branchPredecessorIndices.TryGetValue(offset, out var predecessors))
+            return false;
+        foreach (int index in predecessors)
+        {
+            if (blocks[index].Children is not [Branch branch] || branch.TargetOffset != offset)
+                return false;
+        }
+        return true;
     }
 
     /// <summary>
@@ -1418,7 +1484,17 @@ public sealed class StructuringPass : IIrPass
                     {
                         result.Add(new IfStatement(condition, pastRegionArm, null));
                         for (int drop = target; drop < inlinedStop; drop++)
+                        {
+                            // A scattered switch-expression default (issue #2973)
+                            // pulled into this clone is the shared tail a sibling
+                            // trampoline arm still falls through to; dropping it
+                            // would strand that path off the end (CS0161). Keep it
+                            // as the region's trailing terminator (Validate already
+                            // walks it as the merge), inlining a duplicate here.
+                            if (ctx.ScatteredReturnDispatchTargets.Contains(blocks[drop].StartOffset))
+                                continue;
                             ctx.DroppableBlocks.Add(drop);
+                        }
                         i++;
                         break;
                     }


### PR DESCRIPTION
- Fixes #2973
- Changes StructuringPass so a switch-expression/pattern default arm reached by a forward-goto trampoline survives as the region's trailing terminator, fixing a CS0161 fall-off-the-end.
- Card revision: `8f61b28d`

## Change

**Conclusion:** **PASS** — the `_ => false` default of a result-temp switch expression, reached by 3 scattered `when`-guard failures **plus** 1 forward-goto trampoline (`IL_002B: br.s IL_0062`), was dropped by the sibling arm's past-region inline, so the trampoline path fell off the end (CS0161); the fix keeps that shared default as the trailing terminator, and both affected methods now bind at Full.

### Original source

<!-- Acquired from the exact SourceLink URL advertised by `member … -S "Source Locations"` for this head. The tool's `-S "Original Source"` could not emit it directly for this private member: it is both remote-only (no local-disk read) and public-only on the content path — filed as #3024 and #3026. The URL content is the verbatim committed source at 8f61b28d. -->

Verbatim committed C# at `8f61b28d`, from the SourceLink URL the tool resolves for this member (`https://raw.githubusercontent.com/richlander/dotnet-inspect/8f61b28d/src/ILInspector.Decompiler/Pipeline/Passes/YieldBreakLoopIteratorReconstruction.cs`, lines 259-270):

```csharp
static bool TryNormalizeContinueCondition(IrExpression expression, string loopFieldName, out IrExpression condition)
{
    condition = null!;
    return expression switch
    {
        Comparison comparison when ReadsLoopField(comparison.Left, loopFieldName) => Assign(comparison, out condition),
        LogicalNot { Operand: Comparison comparison } when ReadsLoopField(comparison.Left, loopFieldName)
            => Assign(Negate(comparison), out condition),
        _ => false,
    };
}
```

### Before

<!-- Acquired at base commit 4f0c0ad1 via: member … -m TryNormalizeContinueCondition --all -S "Decompiled Source" -->

```csharp
private static bool TryNormalizeContinueCondition(IrExpression expression, string loopFieldName, out IrExpression condition)
{
    Comparison V_1;

    condition = null;
    IrExpression V_3 = expression;
    Comparison comparison = V_3 as Comparison;
    if (comparison is null)
    {
        if (V_3 is LogicalNot V_4)
        {
            V_1 = V_4.Operand as Comparison;
            if (V_1 is not null)
            {
                if (ReadsLoopField(V_1.Left, loopFieldName))
                {
                    return Assign<IrExpression>(Negate(V_1), out condition);
                }
                return false;
            }
        }
    }
    else
    {
        if (ReadsLoopField(comparison.Left, loopFieldName))
        {
            return Assign<IrExpression>(comparison, out condition);
        }
    }
}
```

- Valid: **False**
- Correct: **False**

Falls off the end: the `comparison is null` arm has no landing when `V_3` is not a `LogicalNot` or `V_1` is null, and the `else` arm has no landing when `ReadsLoopField` is false. `csc` rejects it with CS0161 ("not all code paths return a value"), so it cannot bind and therefore cannot preserve behavior.

### After

<!-- Acquired at head 8f61b28d via: member … -m TryNormalizeContinueCondition --all -S "Decompiled Source" -->

```csharp
private static bool TryNormalizeContinueCondition(IrExpression expression, string loopFieldName, out IrExpression condition)
{
    Comparison V_1;
    LogicalNot V_4;

    condition = null;
    IrExpression V_3 = expression;
    Comparison comparison = V_3 as Comparison;
    if (comparison is null)
    {
        V_4 = V_3 as LogicalNot;
        if (V_4 is null)
        {
            return false;
        }
        V_1 = V_4.Operand as Comparison;
        if (V_1 is not null)
        {
            if (ReadsLoopField(V_1.Left, loopFieldName))
            {
                return Assign<IrExpression>(Negate(V_1), out condition);
            }
            return false;
        }
    }
    else
    {
        if (!ReadsLoopField(comparison.Left, loopFieldName))
        {
            return false;
        }
        return Assign<IrExpression>(comparison, out condition);
    }
    return false;
}
```

- Valid: **True**
- Correct: **True**

Every path now returns. The trailing `return false;` is the shared `_ => false` default catching the trampoline (`V_1 == null`) path; the pattern arms return the same `Assign(...)`/`false` values as the source switch, so observable behavior is preserved. Not fully raised — the switch-expression spelling is not recovered (see Fully raised).

### Fully raised

```csharp
condition = null;
return expression switch
{
    Comparison comparison when ReadsLoopField(comparison.Left, loopFieldName) => Assign(comparison, out condition),
    LogicalNot { Operand: Comparison comparison } when ReadsLoopField(comparison.Left, loopFieldName)
        => Assign(Negate(comparison), out condition),
    _ => false,
};
```

- Required tracking issue: #3022 — recover the `switch` expression (with `when`-guarded `Comparison` / `LogicalNot { Operand: Comparison }` arms and a `_ => false` default) from the raised result-temp pattern if/else.

## Root cause and scope

- **Root cause:** The switch-expression default `IL_0062` is reached by 3 scattered `when`-guard failures **plus** 1 forward-goto trampoline (`IL_002B: br.s IL_0062`). #2959's scattered-return-dispatch collector excluded it because the trampoline makes it an unconditional-goto target; and even once admitted, the sibling arm's past-region-target inline cloned the default into its own guard and marked it droppable, so the trampoline arm's fall-through had no landing block.
- **Fix shape (StructuringPass, 4 coherent edits):**
  1. Collect `branchPredecessorIndices` + `switchTargets`.
  2. Admit a shared return as a scattered dispatch target when **every** unconditional predecessor is a pure `{ goto default }` trampoline (never a switch/jump-table target) — those arms dissolve by inlining the terminator, so duplicating the shared return strands no goto (`UnconditionalPredecessorsAreDissolvableTrampolines`).
  3. `IsSharedTerminator`: the scattered classification overrides the general unconditional-target exclusion.
  4. Keep a scattered dispatch target out of **both** drop mechanisms — the upfront droppable set and the past-region-target dynamic drop — so it stays as the region's trailing terminator (Validate already walks it as the merge) while the guards inline duplicates.
- **Scope boundary:** Structuring's all-or-nothing `Validate` remains the backstop — if any trampoline cannot be dissolved, the whole slice stays in its valid goto form rather than dropping an edge. No change to Fully Raised semantics or source-bundle verification; recovering the `switch`-expression spelling is tracked in #3022.

## Evidence

| Check | Baseline (`4f0c0ad1`) | Head (`8f61b28d`) |
| --- | --- | --- |
| Product build (`dotnet-inspect.slnx -c Release`) | Pass | Pass |
| Focused test `DecompilerAssembly_MissingReturnPopulationIsPinned` | Pass (8-entry Release pin) | Pass (6-entry Release pin) |
| Decompiler fast suite (`-notrait Speed=Slow`) | 3095, 0 failed | 3095, 0 failed |
| Real witness `YieldBreakLoopIteratorReconstruction::TryNormalizeContinueCondition` | CS0161 (invalid Full) | Valid, Full |
| Real witness `FixedArrayRaising::SameLoadPlace` | CS0161 (invalid Full) | Valid, Full |
| `git diff --check` | — | clean |

No Baseline failures beyond known pre-existing local-only Slow artifacts (see Out of scope), which are unchanged by this PR (same tests, same reason) and green on `main` CI at the same base.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — the pinned missing-return validity census over the whole `ILInspector.Decompiler` assembly drops exactly the two fixed methods and gains none; no new fidelity diffs.

### Pinned validity gate

`ValidityCheck.Evaluate` over the decompiler assembly (cap `int.MaxValue`), Release configuration — the authoritative corpus-wide CS0161 gate for this change:

| Metric (goal) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| CS0161 malformed methods (-) | 8 | 6 | -2 |
| Newly malformed vs Baseline (-) | - | 0 | 0 |
| Defect methods fixed vs Baseline (+) | - | 2 | +2 |

> **Conclusion:** **PASS** — 2 resolved (`TryNormalizeContinueCondition`, `SameLoadPlace`), 0 new.

### Aggregate context

This fix only adds a trailing terminator to the two trampoline-default methods; it introduces **zero** new fidelity diffs. Both adversarial reviewers re-ran the decompiler fast suite (3095 pass) and the `FidelityGateTests` gate on base vs head and confirmed an identical flagged-diff set. The authoritative corpus fidelity/validity gates run in CI (green on `8f61b28d`).

## Out of scope / sibling rows

- Pre-existing local-only failures, unrelated to this change (both confirmed identical on clean base, `main` CI green on the same base):
  - #2958 `LadderIteratorGateTests.IteratorFixture_RecoveredRowsCompileBackOpcodeExact` (iterator `OperandDiff`).
  - `FidelityGateTests.NoNewFidelityDiffsBeyondKnownDocket` local lambda-cache ordinal drift (`StatementBodyLambdaInsideIf` `b__100_0`→`b__121_0`), a daily-SDK artifact absent under CI's pinned SDK.
- Fully raising the `switch`-expression spelling — tracked in #3022.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*MissingReturnPopulationIsPinned*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -notrait "Speed=Slow"
```


