### PR TITLE
Decode [DynamicAttribute] into Metadata type views (#2984)

### DIFF
--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -385,12 +385,17 @@ public static class ApiMemberIdentity
         var memberName = member.Kind == "constructor"
             ? "#ctor"
             : ExtractMemberNameWithGeneric(signature, member.Name);
-        var parameters = ExtractCanonicalParameterList(signature);
+        // Raw-signature fallback (used when SignatureModel is absent, e.g. after a JSON
+        // round-trip where SignatureModel is [JsonIgnore]). member.Signature is the
+        // display string and carries `dynamic`, so scrub it back to `object` for identity
+        // exactly as the SignatureModel path does — otherwise a round-tripped member's
+        // fingerprint diverges from the same member read live.
+        var parameters = NormalizeDynamicToObject(ExtractCanonicalParameterList(signature));
         var canonical = $"{kindCode}:{declaringType}.{memberName}{parameters}";
         // Mirror the conversion-operator return-type disambiguation so member identity
         // is not dependent on whether SignatureModel was populated (the Try path above).
         if (IsConversionOperator(member.Name) && !string.IsNullOrWhiteSpace(member.ReturnType))
-            canonical += $"~{NormalizeCanonicalCommas(member.ReturnType!)}";
+            canonical += $"~{NormalizeCanonicalCommas(NormalizeDynamicToObject(member.ReturnType!))}";
         return canonical;
     }
 
@@ -432,7 +437,7 @@ public static class ApiMemberIdentity
             // round-trips.
             var indexerParameters = member.SignatureModel is { Parameters.Count: > 0 } propertySignature
                 ? NormalizeCanonicalParameters(propertySignature.ParameterTypesSummary)
-                : ExtractCanonicalIndexerParameterList(member.Signature);
+                : NormalizeDynamicToObject(ExtractCanonicalIndexerParameterList(member.Signature));
             canonicalSignature = $"{kindCode}:{declaringType}.{member.Name}{indexerParameters}";
             return true;
         }
@@ -532,8 +537,18 @@ public static class ApiMemberIdentity
     /// and matching. <c>dynamic</c> and <c>object</c> are the same metadata type, so the
     /// display-only distinction must never reach canonical signatures, correspondence
     /// keys, or XML-doc identity (which encode dynamic positions as <c>System.Object</c>).
+    /// This runs in string space by necessity: the display signature (<c>member.Signature</c>)
+    /// is serialized while the typed <c>SignatureModel</c> is <c>[JsonIgnore]</c>, so a
+    /// round-tripped member has only the rendered string to derive identity from — the same
+    /// reason nullability is normalized as text (see <see cref="NormalizeXmlDocParameterType"/>).
     /// Boundary-aware so it never rewrites a dotted name segment or a longer identifier
-    /// (e.g. <c>System.Dynamic.X</c> or <c>MyDynamicType</c> are left untouched).
+    /// (e.g. <c>System.Dynamic.X</c>, <c>Ns.dynamic</c>, or <c>MyDynamicType</c> are left
+    /// untouched). Known limitation: a type literally named <c>dynamic</c> in the global
+    /// namespace (C# <c>@dynamic</c>) renders as a bare <c>dynamic</c> token indistinguishable
+    /// from the keyword once the typed model is gone, so its identity collapses to
+    /// <c>object</c>. That is astronomically rare and the trade is deliberate — preserving
+    /// fingerprint stability for the ubiquitous keyword case outweighs a global type named
+    /// after a contextual keyword.
     /// </summary>
     static string NormalizeDynamicToObject(string value)
     {

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -457,7 +457,7 @@ public static class ApiMemberIdentity
         // same "~ReturnType" delimiter as XML doc identity so conversion anchors
         // and XML lookups do not grow divergent spellings for the same fact.
         if (IsConversionOperator(member.Name) && !string.IsNullOrWhiteSpace(signature.ReturnType))
-            canonical += $"~{NormalizeCanonicalCommas(signature.ReturnType!)}";
+            canonical += $"~{NormalizeCanonicalCommas(NormalizeDynamicToObject(signature.ReturnType!))}";
         canonicalSignature = canonical;
         return true;
     }
@@ -523,9 +523,45 @@ public static class ApiMemberIdentity
     }
 
     static string NormalizeCorrespondenceType(string type)
-        => type.Trim()
+        => NormalizeDynamicToObject(type.Trim())
             .Replace("+", ".", StringComparison.Ordinal)
             .Replace(", ", ",", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Collapses the display keyword <c>dynamic</c> back to <c>object</c> for identity
+    /// and matching. <c>dynamic</c> and <c>object</c> are the same metadata type, so the
+    /// display-only distinction must never reach canonical signatures, correspondence
+    /// keys, or XML-doc identity (which encode dynamic positions as <c>System.Object</c>).
+    /// Boundary-aware so it never rewrites a dotted name segment or a longer identifier
+    /// (e.g. <c>System.Dynamic.X</c> or <c>MyDynamicType</c> are left untouched).
+    /// </summary>
+    static string NormalizeDynamicToObject(string value)
+    {
+        const string token = "dynamic";
+        if (value.IndexOf(token, StringComparison.Ordinal) < 0)
+            return value;
+        var builder = new System.Text.StringBuilder(value.Length);
+        var index = 0;
+        while (index < value.Length)
+        {
+            if (index + token.Length <= value.Length
+                && string.CompareOrdinal(value, index, token, 0, token.Length) == 0
+                && (index == 0 || !IsTypeNameChar(value[index - 1]))
+                && (index + token.Length >= value.Length || !IsTypeNameChar(value[index + token.Length])))
+            {
+                builder.Append("object");
+                index += token.Length;
+            }
+            else
+            {
+                builder.Append(value[index]);
+                index++;
+            }
+        }
+        return builder.ToString();
+
+        static bool IsTypeNameChar(char c) => char.IsLetterOrDigit(c) || c == '_' || c == '.';
+    }
 
     // Preserve the v1 Member Index digest contract for members that already have
     // compatibility signature text. The legacy parser had edge-case behavior
@@ -567,7 +603,7 @@ public static class ApiMemberIdentity
     static string NormalizeCanonicalParameters(string parameterTypesSummary)
         => string.IsNullOrEmpty(parameterTypesSummary)
             ? "()"
-            : NormalizeCanonicalCommas(parameterTypesSummary);
+            : NormalizeCanonicalCommas(NormalizeDynamicToObject(parameterTypesSummary));
 
     static string NormalizeCanonicalCommas(string value)
         => value.Replace(", ", ",", StringComparison.Ordinal).Trim();
@@ -796,7 +832,7 @@ public static class ApiMemberIdentity
         IReadOnlyDictionary<string, int> typeParameterMap,
         IReadOnlyDictionary<string, int> methodParameterMap)
     {
-        var type = StripLeadingAttributes(parameter.Trim());
+        var type = StripLeadingAttributes(NormalizeDynamicToObject(parameter).Trim());
         var isByRef = false;
         foreach (var prefix in (string[])["ref ", "out ", "in ", "params ", "this "])
         {

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -162,19 +162,7 @@ public static class ApiMemberIdentity
     public static ApiMemberHandle CreateHandle(ApiType type, ApiMember member)
         => new(type, member, GetMemberAnchor(type, member));
 
-    /// <summary>
-    /// Ordering key for overloads, also the basis for the positional <c>Name:N</c> member
-    /// selector (see <see cref="MemberTargetResolver"/>). The raw display signature is
-    /// normalized so the display-only <c>dynamic</c>/<c>object</c> spelling never perturbs
-    /// overload ordering: <c>dynamic</c> and <c>object</c> are the same metadata type, so a
-    /// type can never declare both <c>M(object)</c> and <c>M(dynamic)</c> (CS0111), and
-    /// ordering the keyword position as <c>object</c> keeps the ordinal stable across the
-    /// object-to-dynamic display change.
-    /// </summary>
     public static string GetMemberSignatureSortKey(ApiMember member)
-        => NormalizeDynamicToObject(GetRawMemberSignatureSortKey(member));
-
-    static string GetRawMemberSignatureSortKey(ApiMember member)
     {
         var signature = member.Signature ?? "";
         if (signature.Length == 0 || member.Name.Length == 0)
@@ -558,14 +546,19 @@ public static class ApiMemberIdentity
     /// untouched). Known limitation: an identifier literally spelled <c>dynamic</c> in a
     /// position where the keyword is legal — a type named <c>dynamic</c> in the global
     /// namespace, or a generic parameter named <c>dynamic</c> (both C# <c>@dynamic</c>) —
-    /// renders as a bare <c>dynamic</c> token indistinguishable from the keyword once the
-    /// typed model is gone, so its identity collapses to <c>object</c>. Such an overload
-    /// pair (e.g. <c>M(@dynamic)</c> vs <c>M(object)</c>) shares one canonical signature.
-    /// That is astronomically rare and the trade is deliberate — preserving fingerprint
-    /// stability for the ubiquitous keyword case outweighs an identifier named after a
-    /// contextual keyword. A provenance-aware fix is impossible on the round-trip path,
-    /// which retains only the rendered string, so a live-path-only fix would make identity
-    /// diverge across serialization; consistent collapse is preferred.
+    /// renders as a bare <c>dynamic</c> token that this string pass collapses to
+    /// <c>object</c>, so an overload pair such as <c>M(@dynamic)</c> vs <c>M(object)</c>
+    /// shares one canonical signature. A generic parameter named <c>dynamic</c> is in
+    /// principle distinguishable — a declared type-parameter list survives serialization
+    /// (<c>ApiType.TypeParameters</c>) and XML-doc identity already carries generic-parameter
+    /// maps — but every identity site here (canonical signature, correspondence key, and
+    /// <see cref="NormalizeXmlDocParameterType"/>) runs this collapse in string space
+    /// *ahead of* generic-parameter resolution, so making all three parameter-aware is
+    /// tracked as follow-up rather than fixed piecemeal. A global type named <c>dynamic</c>
+    /// and a method-level generic parameter named <c>dynamic</c> have no round-trip-safe
+    /// discriminator at all. These identifiers are astronomically rare and the trade is
+    /// deliberate — preserving fingerprint stability for the ubiquitous keyword case
+    /// outweighs an identifier named after a contextual keyword.
     /// </summary>
     internal static string NormalizeDynamicToObject(string value)
     {

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -550,7 +550,7 @@ public static class ApiMemberIdentity
     /// fingerprint stability for the ubiquitous keyword case outweighs a global type named
     /// after a contextual keyword.
     /// </summary>
-    static string NormalizeDynamicToObject(string value)
+    internal static string NormalizeDynamicToObject(string value)
     {
         const string token = "dynamic";
         if (value.IndexOf(token, StringComparison.Ordinal) < 0)
@@ -575,7 +575,8 @@ public static class ApiMemberIdentity
         }
         return builder.ToString();
 
-        static bool IsTypeNameChar(char c) => char.IsLetterOrDigit(c) || c == '_' || c == '.';
+        static bool IsTypeNameChar(char c) =>
+            char.IsLetterOrDigit(c) || c is '_' or '.' or '`' or '+' or '/';
     }
 
     // Preserve the v1 Member Index digest contract for members that already have

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -162,7 +162,19 @@ public static class ApiMemberIdentity
     public static ApiMemberHandle CreateHandle(ApiType type, ApiMember member)
         => new(type, member, GetMemberAnchor(type, member));
 
+    /// <summary>
+    /// Ordering key for overloads, also the basis for the positional <c>Name:N</c> member
+    /// selector (see <see cref="MemberTargetResolver"/>). The raw display signature is
+    /// normalized so the display-only <c>dynamic</c>/<c>object</c> spelling never perturbs
+    /// overload ordering: <c>dynamic</c> and <c>object</c> are the same metadata type, so a
+    /// type can never declare both <c>M(object)</c> and <c>M(dynamic)</c> (CS0111), and
+    /// ordering the keyword position as <c>object</c> keeps the ordinal stable across the
+    /// object-to-dynamic display change.
+    /// </summary>
     public static string GetMemberSignatureSortKey(ApiMember member)
+        => NormalizeDynamicToObject(GetRawMemberSignatureSortKey(member));
+
+    static string GetRawMemberSignatureSortKey(ApiMember member)
     {
         var signature = member.Signature ?? "";
         if (signature.Length == 0 || member.Name.Length == 0)
@@ -543,12 +555,17 @@ public static class ApiMemberIdentity
     /// reason nullability is normalized as text (see <see cref="NormalizeXmlDocParameterType"/>).
     /// Boundary-aware so it never rewrites a dotted name segment or a longer identifier
     /// (e.g. <c>System.Dynamic.X</c>, <c>Ns.dynamic</c>, or <c>MyDynamicType</c> are left
-    /// untouched). Known limitation: a type literally named <c>dynamic</c> in the global
-    /// namespace (C# <c>@dynamic</c>) renders as a bare <c>dynamic</c> token indistinguishable
-    /// from the keyword once the typed model is gone, so its identity collapses to
-    /// <c>object</c>. That is astronomically rare and the trade is deliberate — preserving
-    /// fingerprint stability for the ubiquitous keyword case outweighs a global type named
-    /// after a contextual keyword.
+    /// untouched). Known limitation: an identifier literally spelled <c>dynamic</c> in a
+    /// position where the keyword is legal — a type named <c>dynamic</c> in the global
+    /// namespace, or a generic parameter named <c>dynamic</c> (both C# <c>@dynamic</c>) —
+    /// renders as a bare <c>dynamic</c> token indistinguishable from the keyword once the
+    /// typed model is gone, so its identity collapses to <c>object</c>. Such an overload
+    /// pair (e.g. <c>M(@dynamic)</c> vs <c>M(object)</c>) shares one canonical signature.
+    /// That is astronomically rare and the trade is deliberate — preserving fingerprint
+    /// stability for the ubiquitous keyword case outweighs an identifier named after a
+    /// contextual keyword. A provenance-aware fix is impossible on the round-trip path,
+    /// which retains only the rendered string, so a live-path-only fix would make identity
+    /// diverge across serialization; consistent collapse is preferred.
     /// </summary>
     internal static string NormalizeDynamicToObject(string value)
     {

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -72,7 +72,12 @@ public static class ApiSurfaceExtractor
                 string baseTypeName = ResolveRequiredTypeName(
                     reader,
                     typeDef.BaseType);
-                apiType.BaseType = baseTypeName;
+                apiType.BaseType = ApplyDynamicView(
+                    reader,
+                    typeDef.BaseType,
+                    typeDef.GetCustomAttributes(),
+                    GenericContext.ForType(reader, typeDef),
+                    baseTypeName);
 
                 apiType.Kind = baseTypeName switch
                 {
@@ -123,6 +128,12 @@ public static class ApiSurfaceExtractor
                         reader,
                         iface.Interface,
                         typeContext);
+                    ifaceName = ApplyDynamicView(
+                        reader,
+                        iface.Interface,
+                        iface.GetCustomAttributes(),
+                        typeContext,
+                        ifaceName);
                     apiType.Interfaces.Add(ifaceName);
                 }
             }
@@ -424,6 +435,24 @@ public static class ApiSurfaceExtractor
                 eventNullableBytes ??= NullabilityReader.GetParameterNullableBytes(reader, adder.GetParameters(), 1);
                 if (eventNullableBytes is { Length: > 0 } && eventNullableBytes[0] == 2 && !eventType.EndsWith("?", StringComparison.Ordinal))
                     eventType += "?";
+                // A `dynamic` event handler (e.g. EventHandler<dynamic>) is always a
+                // generic instantiation, so re-decode the TypeSpec through the TypeNode
+                // tree to recover the dynamic view. Non-dynamic events are untouched.
+                if (evt.Type.Kind == HandleKind.TypeSpecification
+                    && DynamicReader.GetDynamicFlags(reader, evt.GetCustomAttributes()) is { } eventDynamicFlags)
+                {
+                    var eventNode = GuardedProviderDecode.TypeSpec(
+                        reader,
+                        (TypeSpecificationHandle)evt.Type,
+                        TypeNodeProvider.Instance,
+                        GenericContext.ForType(reader, typeDef),
+                        (TypeNode)new DegradedTypeNode());
+                    int eventPos = 0;
+                    eventNode.ApplyNullability(eventNullableBytes, ref eventPos, 0);
+                    eventPos = 0;
+                    eventNode.ApplyDynamic(eventDynamicFlags, ref eventPos);
+                    eventType = eventNode.Render();
+                }
                 var adderAttributes = adder.Attributes;
                 var isVirtualEvent = (adderAttributes & MethodAttributes.Virtual) != 0;
                 var isOverrideEvent = isVirtualEvent && (adderAttributes & MethodAttributes.NewSlot) == 0;
@@ -1351,6 +1380,34 @@ public static class ApiSurfaceExtractor
             or "System.Int16" or "System.UInt16" or "System.Int32" or "System.UInt32"
             or "System.Int64" or "System.UInt64" or "System.Single" or "System.Double"
             or "System.Decimal" or "System.DateTime");
+
+    // Base types, interfaces, and events resolve to a display string via the
+    // string-based TypeResolver, which has no DynamicAttribute context. Only a
+    // generic instantiation (a TypeSpecification) can carry `dynamic`, so when
+    // one does, re-decode it through the TypeNode tree and apply the flags. Every
+    // other case (non-TypeSpec, or no DynamicAttribute) returns the string result
+    // unchanged, so this never alters non-dynamic output.
+    private static string ApplyDynamicView(
+        MetadataReader reader,
+        EntityHandle typeHandle,
+        CustomAttributeHandleCollection attributes,
+        GenericContext context,
+        string fallback)
+    {
+        if (typeHandle.Kind != HandleKind.TypeSpecification)
+            return fallback;
+        if (DynamicReader.GetDynamicFlags(reader, attributes) is not { } flags)
+            return fallback;
+        var node = GuardedProviderDecode.TypeSpec(
+            reader,
+            (TypeSpecificationHandle)typeHandle,
+            TypeNodeProvider.Instance,
+            context,
+            (TypeNode)new DegradedTypeNode());
+        int position = 0;
+        node.ApplyDynamic(flags, ref position);
+        return node.Render();
+    }
 
     private static string ResolveRequiredTypeName(
         MetadataReader reader,

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -447,11 +447,16 @@ public static class ApiSurfaceExtractor
                         TypeNodeProvider.Instance,
                         GenericContext.ForType(reader, typeDef),
                         (TypeNode)new DegradedTypeNode());
-                    int eventPos = 0;
-                    eventNode.ApplyNullability(eventNullableBytes, ref eventPos, 0);
-                    eventPos = 0;
-                    eventNode.ApplyDynamic(eventDynamicFlags, ref eventPos);
-                    eventType = eventNode.Render();
+                    // Skip a rejected/degraded decode: its bare "object"/"dynamic" render
+                    // would obliterate the resolved eventType string computed above.
+                    if (!eventNode.IsDegraded)
+                    {
+                        int eventPos = 0;
+                        eventNode.ApplyNullability(eventNullableBytes, ref eventPos, 0);
+                        eventPos = 0;
+                        eventNode.ApplyDynamic(eventDynamicFlags, ref eventPos);
+                        eventType = eventNode.Render();
+                    }
                 }
                 var adderAttributes = adder.Attributes;
                 var isVirtualEvent = (adderAttributes & MethodAttributes.Virtual) != 0;
@@ -1404,6 +1409,11 @@ public static class ApiSurfaceExtractor
             TypeNodeProvider.Instance,
             context,
             (TypeNode)new DegradedTypeNode());
+        // A rejected/degraded TypeSpec renders as a bare "object"/"dynamic", which would
+        // obliterate the fully resolved string fallback. Keep failure visible: trust the
+        // string resolver rather than silently collapsing the type.
+        if (node.IsDegraded)
+            return fallback;
         int position = 0;
         node.ApplyDynamic(flags, ref position);
         return node.Render();

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -700,6 +700,9 @@ public static class ApiSurfaceExtractor
         var fieldBytes = NullabilityReader.GetNullableBytes(reader, field.GetCustomAttributes());
         int pos = 0;
         fieldNode.ApplyNullability(fieldBytes, ref pos, typeNullableContext);
+        var fieldDynamicFlags = DynamicReader.GetDynamicFlags(reader, field.GetCustomAttributes());
+        pos = 0;
+        fieldNode.ApplyDynamic(fieldDynamicFlags, ref pos);
         return (fieldNode.Render(), fieldNode.IsDegraded);
     }
 
@@ -883,6 +886,9 @@ public static class ApiSurfaceExtractor
         var returnBytes = NullabilityReader.GetParameterNullableBytes(reader, paramHandles, 0);
         int pos = 0;
         treeSignature.ReturnType.ApplyNullability(returnBytes, ref pos, nullableDefault);
+        var returnDynamicFlags = DynamicReader.GetParameterDynamicFlags(reader, paramHandles, 0);
+        pos = 0;
+        treeSignature.ReturnType.ApplyDynamic(returnDynamicFlags, ref pos);
 
         // Build parameter list with nullability
         var paramTypes = treeSignature.ParameterTypes;
@@ -895,6 +901,9 @@ public static class ApiSurfaceExtractor
             var paramBytes = NullabilityReader.GetParameterNullableBytes(reader, paramHandles, i + 1);
             pos = 0;
             paramTypes[i].ApplyNullability(paramBytes, ref pos, nullableDefault);
+            var paramDynamicFlags = DynamicReader.GetParameterDynamicFlags(reader, paramHandles, i + 1);
+            pos = 0;
+            paramTypes[i].ApplyDynamic(paramDynamicFlags, ref pos);
             string type = paramTypes[i].Render();
 
             // Parameter handles may include return parameter at SequenceNumber 0
@@ -1482,6 +1491,9 @@ public static class ApiSurfaceExtractor
         var propBytes = NullabilityReader.GetNullableBytes(reader, prop.GetCustomAttributes());
         int pos = 0;
         treeSignature.ReturnType.ApplyNullability(propBytes, ref pos, typeNullableContext);
+        var propDynamicFlags = DynamicReader.GetDynamicFlags(reader, prop.GetCustomAttributes());
+        pos = 0;
+        treeSignature.ReturnType.ApplyDynamic(propDynamicFlags, ref pos);
 
         // Determine accessor visibility
         MethodAttributes getterAccess = 0;
@@ -1578,6 +1590,9 @@ public static class ApiSurfaceExtractor
             var paramBytes = NullabilityReader.GetParameterNullableBytes(reader, paramHandles, i + 1);
             pos = 0;
             paramTypes[i].ApplyNullability(paramBytes, ref pos, typeNullableContext);
+            var paramDynamicFlags = DynamicReader.GetParameterDynamicFlags(reader, paramHandles, i + 1);
+            pos = 0;
+            paramTypes[i].ApplyDynamic(paramDynamicFlags, ref pos);
             var paramType = paramTypes[i].Render();
             var (paramName, isParams, refKind, hasDefault, defaultValue, attributes) = GetParameterInfo(reader, paramHandles, i + 1);
             paramName ??= $"arg{i}";

--- a/src/ILInspector.Metadata/DynamicReader.cs
+++ b/src/ILInspector.Metadata/DynamicReader.cs
@@ -15,7 +15,8 @@ namespace ILInspector.Metadata;
 /// <see cref="TypeNode.ApplyNullability"/> uses can consume them via
 /// <c>ApplyDynamic</c>. The marker form <c>[Dynamic]</c> (no constructor
 /// argument) is emitted only for a bare <c>dynamic</c> and is returned as a
-/// single-element array, which the walk applies uniformly.
+/// single-element array, which the walk consumes at the single (bare object)
+/// position without broadcasting to inner nodes.
 /// </remarks>
 public static class DynamicReader
 {

--- a/src/ILInspector.Metadata/DynamicReader.cs
+++ b/src/ILInspector.Metadata/DynamicReader.cs
@@ -1,0 +1,77 @@
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Reads <c>DynamicAttribute</c> transform flags from assembly custom-attribute
+/// collections. The flags record which <c>System.Object</c> positions in a
+/// signature were authored as <c>dynamic</c>, so the type view can render
+/// <c>dynamic</c> instead of <c>object</c>.
+/// </summary>
+/// <remarks>
+/// Unlike nullability there is no <c>DynamicContextAttribute</c>: a position is
+/// dynamic only when <c>DynamicAttribute</c> is present and its flag is set.
+/// Flags are returned as a <c>byte[]</c> of 0/1 so the same preorder walk that
+/// <see cref="TypeNode.ApplyNullability"/> uses can consume them via
+/// <c>ApplyDynamic</c>. The marker form <c>[Dynamic]</c> (no constructor
+/// argument) is emitted only for a bare <c>dynamic</c> and is returned as a
+/// single-element array, which the walk applies uniformly.
+/// </remarks>
+public static class DynamicReader
+{
+    /// <summary>
+    /// Gets the DynamicAttribute transform-flags array (0 = object, 1 = dynamic)
+    /// from custom attributes. Returns null when the attribute is not present.
+    /// The no-argument marker form returns a one-element array.
+    /// </summary>
+    public static byte[]? GetDynamicFlags(MetadataReader reader, CustomAttributeHandleCollection attributes)
+    {
+        foreach (var attrHandle in attributes)
+        {
+            var attr = reader.GetCustomAttribute(attrHandle);
+            var attrTypeName = AttributeReader.GetAttributeTypeName(reader, attr.Constructor);
+            if (attrTypeName != KnownAttributeNames.DynamicAttribute) continue;
+
+            var blob = reader.GetBlobReader(attr.Value);
+            if (blob.Length < 2) return null;
+            blob.ReadUInt16(); // prolog
+
+            // DynamicAttribute():        prolog(2) + namedArgs(2) = 4          -> marker form
+            // DynamicAttribute(bool[]):  prolog(2) + count(4) + N bytes + namedArgs(2) = 8+N
+            if (blob.RemainingBytes == 2)
+            {
+                // Marker form: the whole (bare object) type is dynamic.
+                return [1];
+            }
+
+            if (blob.RemainingBytes >= 6)
+            {
+                int count = blob.ReadInt32();
+                if (count < 0 || count > blob.RemainingBytes - 2) return null;
+                var flags = new byte[count];
+                for (int i = 0; i < count; i++)
+                    flags[i] = (byte)(blob.ReadByte() != 0 ? 1 : 0);
+                return flags;
+            }
+
+            return null;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Gets DynamicAttribute transform flags for a specific parameter by sequence
+    /// number. Sequence 0 = return type, 1+ = parameters.
+    /// </summary>
+    public static byte[]? GetParameterDynamicFlags(
+        MetadataReader reader, ParameterHandleCollection paramHandles, int sequenceNumber)
+    {
+        foreach (var handle in paramHandles)
+        {
+            var param = reader.GetParameter(handle);
+            if (param.SequenceNumber == sequenceNumber)
+                return GetDynamicFlags(reader, param.GetCustomAttributes());
+        }
+        return null;
+    }
+}

--- a/src/ILInspector.Metadata/TypeNode.cs
+++ b/src/ILInspector.Metadata/TypeNode.cs
@@ -62,7 +62,13 @@ internal abstract class TypeNode
     /// </summary>
     protected void ConsumeDynamicFlag(byte[]? flags, ref int position, bool canBeDynamic)
     {
-        byte flag = ConsumeByte(flags, ref position, 0);
+        if (flags is null)
+            return;
+        // Unlike NullableAttribute, a single-element (marker-form) DynamicAttribute
+        // describes only the bare top-level object; it must NOT broadcast into inner
+        // nodes. Index strictly and treat positions past the end as non-dynamic.
+        byte flag = position < flags.Length ? flags[position] : (byte)0;
+        position++;
         if (canBeDynamic && flag != 0) IsDynamic = true;
     }
 
@@ -355,6 +361,16 @@ internal class PassthroughTypeNode(TypeNode inner) : TypeNode
 internal sealed class ModifiedTypeNode(TypeNode modifier, TypeNode inner, bool isRequired) : PassthroughTypeNode(inner)
 {
     public override bool IsDegraded => modifier.IsDegraded || base.IsDegraded;
+
+    public override void ApplyDynamic(byte[]? flags, ref int position)
+    {
+        // Roslyn reserves one (always-false) DynamicAttribute slot per custom
+        // modifier. Consume this modifier's slot before the modified type so the
+        // flag stream stays aligned (e.g. a `ref readonly dynamic` return encodes
+        // [byref, modreq(In), object] = [false, false, true]).
+        ConsumeDynamicFlag(flags, ref position, canBeDynamic: false);
+        base.ApplyDynamic(flags, ref position);
+    }
 
     public override bool HasRequiredModifier(string ns, string name)
         => (isRequired && ModifierMatches(ns, name)) || base.HasRequiredModifier(ns, name);

--- a/src/ILInspector.Metadata/TypeNode.cs
+++ b/src/ILInspector.Metadata/TypeNode.cs
@@ -20,6 +20,12 @@ internal abstract class TypeNode
     /// <summary>Set to true when nullability byte is 2.</summary>
     public bool IsNullableAnnotated { get; set; }
 
+    /// <summary>
+    /// Set to true when a <c>DynamicAttribute</c> transform flag marks this
+    /// (<c>System.Object</c>) position as <c>dynamic</c>.
+    /// </summary>
+    public bool IsDynamic { get; set; }
+
     /// <summary>Renders this type to a C# type string with nullability annotations.</summary>
     public abstract string Render();
 
@@ -31,6 +37,15 @@ internal abstract class TypeNode
     /// </summary>
     public abstract void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte);
 
+    /// <summary>
+    /// Walks the type tree in preorder, consuming flags from the DynamicAttribute
+    /// transform-flags array and setting <see cref="IsDynamic"/> on
+    /// <c>System.Object</c> positions whose flag is set. Mirrors the
+    /// <see cref="ApplyNullability"/> traversal so the two annotation streams stay
+    /// position-aligned. Absent flags (null) leave every position as authored.
+    /// </summary>
+    public abstract void ApplyDynamic(byte[]? flags, ref int position);
+
     protected static byte ConsumeByte(byte[]? bytes, ref int position, byte defaultByte)
     {
         if (bytes == null) return defaultByte;
@@ -38,6 +53,22 @@ internal abstract class TypeNode
         if (bytes.Length == 1) { position++; return bytes[0]; }
         return position < bytes.Length ? bytes[position++] : defaultByte;
     }
+
+    /// <summary>
+    /// Consumes one DynamicAttribute flag for this node, marking it dynamic when
+    /// the flag is set and the node is an <c>object</c> position that can spell
+    /// <c>dynamic</c>. Non-object positions still consume their flag (always 0) to
+    /// keep the preorder walk aligned.
+    /// </summary>
+    protected void ConsumeDynamicFlag(byte[]? flags, ref int position, bool canBeDynamic)
+    {
+        byte flag = ConsumeByte(flags, ref position, 0);
+        if (canBeDynamic && flag != 0) IsDynamic = true;
+    }
+
+    /// <summary>Whether a rendered type name denotes <c>System.Object</c>.</summary>
+    private protected static bool IsObjectName(string name) =>
+        name is "object" or "System.Object";
 }
 
 /// <summary>A visible fail-closed substitute for a rejected signature type.</summary>
@@ -46,13 +77,18 @@ internal sealed class DegradedTypeNode : TypeNode
     public override bool IsReferenceType => true;
     public override bool IsDegraded => true;
 
-    public override string Render() => IsNullableAnnotated ? "object?" : "object";
+    public override string Render() => IsDynamic
+        ? (IsNullableAnnotated ? "dynamic?" : "dynamic")
+        : (IsNullableAnnotated ? "object?" : "object");
 
     public override void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte)
     {
         byte b = ConsumeByte(bytes, ref position, defaultByte);
         if (b == 2) IsNullableAnnotated = true;
     }
+
+    public override void ApplyDynamic(byte[]? flags, ref int position)
+        => ConsumeDynamicFlag(flags, ref position, canBeDynamic: true);
 }
 
 /// <summary>C# primitive types (int, string, object, etc.).</summary>
@@ -60,13 +96,20 @@ internal sealed class PrimitiveTypeNode(string name, bool isReferenceType) : Typ
 {
     public override bool IsReferenceType => isReferenceType;
 
-    public override string Render() => IsReferenceType && IsNullableAnnotated ? $"{name}?" : name;
+    public override string Render()
+    {
+        string effective = IsDynamic ? "dynamic" : name;
+        return IsReferenceType && IsNullableAnnotated ? $"{effective}?" : effective;
+    }
 
     public override void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte)
     {
         byte b = ConsumeByte(bytes, ref position, defaultByte);
         if (IsReferenceType && b == 2) IsNullableAnnotated = true;
     }
+
+    public override void ApplyDynamic(byte[]? flags, ref int position)
+        => ConsumeDynamicFlag(flags, ref position, canBeDynamic: IsObjectName(name));
 }
 
 /// <summary>Non-generic named types (JsonSerializer, Stream, etc.).</summary>
@@ -75,13 +118,20 @@ internal sealed class NamedTypeNode(string name, bool isReferenceType) : TypeNod
     public string Name => name;
     public override bool IsReferenceType => isReferenceType;
 
-    public override string Render() => IsReferenceType && IsNullableAnnotated ? $"{name}?" : name;
+    public override string Render()
+    {
+        string effective = IsDynamic ? "dynamic" : name;
+        return IsReferenceType && IsNullableAnnotated ? $"{effective}?" : effective;
+    }
 
     public override void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte)
     {
         byte b = ConsumeByte(bytes, ref position, defaultByte);
         if (IsReferenceType && b == 2) IsNullableAnnotated = true;
     }
+
+    public override void ApplyDynamic(byte[]? flags, ref int position)
+        => ConsumeDynamicFlag(flags, ref position, canBeDynamic: IsObjectName(name));
 }
 
 /// <summary>Generic instantiations (Dictionary&lt;K,V&gt;, Task&lt;T&gt;, etc.).</summary>
@@ -109,6 +159,14 @@ internal sealed class GenericTypeNode(
         foreach (var arg in arguments)
             arg.ApplyNullability(bytes, ref position, defaultByte);
     }
+
+    public override void ApplyDynamic(byte[]? flags, ref int position)
+    {
+        // The generic-type head is never object; it still consumes a flag.
+        ConsumeDynamicFlag(flags, ref position, canBeDynamic: false);
+        foreach (var arg in arguments)
+            arg.ApplyDynamic(flags, ref position);
+    }
 }
 
 /// <summary>Single-dimensional arrays (string[], int[], etc.).</summary>
@@ -128,6 +186,12 @@ internal sealed class SZArrayTypeNode(TypeNode elementType) : TypeNode
         byte b = ConsumeByte(bytes, ref position, defaultByte);
         if (b == 2) IsNullableAnnotated = true;
         elementType.ApplyNullability(bytes, ref position, defaultByte);
+    }
+
+    public override void ApplyDynamic(byte[]? flags, ref int position)
+    {
+        ConsumeDynamicFlag(flags, ref position, canBeDynamic: false);
+        elementType.ApplyDynamic(flags, ref position);
     }
 }
 
@@ -149,6 +213,12 @@ internal sealed class MDArrayTypeNode(TypeNode elementType, int rank) : TypeNode
         if (b == 2) IsNullableAnnotated = true;
         elementType.ApplyNullability(bytes, ref position, defaultByte);
     }
+
+    public override void ApplyDynamic(byte[]? flags, ref int position)
+    {
+        ConsumeDynamicFlag(flags, ref position, canBeDynamic: false);
+        elementType.ApplyDynamic(flags, ref position);
+    }
 }
 
 /// <summary>Pointer types (int*, void*, etc.).</summary>
@@ -164,6 +234,12 @@ internal sealed class PointerTypeNode(TypeNode elementType) : TypeNode
         ConsumeByte(bytes, ref position, defaultByte);
         elementType.ApplyNullability(bytes, ref position, defaultByte);
     }
+
+    public override void ApplyDynamic(byte[]? flags, ref int position)
+    {
+        ConsumeDynamicFlag(flags, ref position, canBeDynamic: false);
+        elementType.ApplyDynamic(flags, ref position);
+    }
 }
 
 /// <summary>By-reference types (ref T, out T, in T). Does not consume a nullability byte.</summary>
@@ -178,6 +254,14 @@ internal sealed class ByRefTypeNode(TypeNode elementType) : TypeNode
     {
         // ByRef is a modifier, not a type—does not consume a nullability byte.
         elementType.ApplyNullability(bytes, ref position, defaultByte);
+    }
+
+    public override void ApplyDynamic(byte[]? flags, ref int position)
+    {
+        // Unlike nullability, the DynamicAttribute transform-flags array reserves a
+        // (always-false) slot for the by-ref itself, so consume one before the element.
+        ConsumeDynamicFlag(flags, ref position, canBeDynamic: false);
+        elementType.ApplyDynamic(flags, ref position);
     }
 
     public override bool HasRequiredModifier(string ns, string name)
@@ -196,6 +280,9 @@ internal sealed class GenericParameterNode(string name) : TypeNode
         byte b = ConsumeByte(bytes, ref position, defaultByte);
         if (b == 2) IsNullableAnnotated = true;
     }
+
+    public override void ApplyDynamic(byte[]? flags, ref int position)
+        => ConsumeDynamicFlag(flags, ref position, canBeDynamic: false);
 }
 
 /// <summary>Function pointer types (delegate*&lt;...&gt;).</summary>
@@ -223,6 +310,14 @@ internal sealed class FunctionPointerTypeNode(MethodSignature<TypeNode> signatur
             parameter.ApplyNullability(bytes, ref position, defaultByte);
     }
 
+    public override void ApplyDynamic(byte[]? flags, ref int position)
+    {
+        ConsumeDynamicFlag(flags, ref position, canBeDynamic: false);
+        signature.ReturnType.ApplyDynamic(flags, ref position);
+        foreach (var parameter in signature.ParameterTypes)
+            parameter.ApplyDynamic(flags, ref position);
+    }
+
     static string ConventionText(SignatureCallingConvention convention) => convention switch
     {
         SignatureCallingConvention.Default => "",
@@ -245,6 +340,11 @@ internal class PassthroughTypeNode(TypeNode inner) : TypeNode
     public override void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte)
     {
         inner.ApplyNullability(bytes, ref position, defaultByte);
+    }
+
+    public override void ApplyDynamic(byte[]? flags, ref int position)
+    {
+        inner.ApplyDynamic(flags, ref position);
     }
 
     public override bool HasRequiredModifier(string ns, string name)

--- a/tests/ILInspector.Metadata.Tests/DynamicTypeViewTests.cs
+++ b/tests/ILInspector.Metadata.Tests/DynamicTypeViewTests.cs
@@ -1,0 +1,272 @@
+using System.Reflection.PortableExecutable;
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests;
+
+#nullable enable
+
+/// <summary>
+/// Tests for <c>DynamicAttribute</c> transform-flag reading and <c>dynamic</c>
+/// rendering in API signatures. Uses the test assembly itself (whose fixture
+/// types below are compiled by Roslyn, the authoritative encoder of the
+/// transform-flags array) as the subject, so the decoder is validated against
+/// real compiler-emitted metadata rather than synthetic flags.
+/// </summary>
+public sealed class DynamicTypeViewTests
+{
+    private static readonly ApiSurface Surface;
+
+    static DynamicTypeViewTests()
+    {
+        var assemblyPath = typeof(DynamicTypeViewTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        Surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+    }
+
+    private static ApiType GetType(string name) =>
+        Surface.Types.First(t => t.Name == name);
+
+    private static ApiMember GetMethod(string methodName) =>
+        GetType(nameof(DynamicSampleClass)).Members.First(m => m.Name == methodName && m.Kind == "method");
+
+    private static ApiMember GetProperty(string propName) =>
+        GetType(nameof(DynamicSampleClass)).Members.First(m => m.Name == propName && m.Kind == "property");
+
+    private static ApiMember GetField(string fieldName) =>
+        GetType(nameof(DynamicSampleClass)).Members.First(m => m.Name == fieldName && m.Kind == "field");
+
+    // --- Direct TypeNode.ApplyDynamic unit tests ---
+
+    [Fact]
+    public void ObjectNode_MarkerFlag_RendersDynamic()
+    {
+        var node = new PrimitiveTypeNode("object", isReferenceType: true);
+        byte[] flags = [1];
+        int pos = 0;
+        node.ApplyDynamic(flags, ref pos);
+        Assert.Equal("dynamic", node.Render());
+        Assert.Equal(1, pos);
+    }
+
+    [Fact]
+    public void ObjectNode_ZeroFlag_StaysObject()
+    {
+        var node = new PrimitiveTypeNode("object", isReferenceType: true);
+        byte[] flags = [0];
+        int pos = 0;
+        node.ApplyDynamic(flags, ref pos);
+        Assert.Equal("object", node.Render());
+        Assert.Equal(1, pos);
+    }
+
+    [Fact]
+    public void NonObjectNode_FlagIgnored()
+    {
+        // A stray true flag on a non-object position must never render dynamic.
+        var node = new PrimitiveTypeNode("string", isReferenceType: true);
+        byte[] flags = [1];
+        int pos = 0;
+        node.ApplyDynamic(flags, ref pos);
+        Assert.Equal("string", node.Render());
+        Assert.Equal(1, pos); // flag still consumed to keep the walk aligned
+    }
+
+    [Fact]
+    public void NullFlags_LeaveObjectUnchanged()
+    {
+        var node = new PrimitiveTypeNode("object", isReferenceType: true);
+        int pos = 0;
+        node.ApplyDynamic(null, ref pos);
+        Assert.Equal("object", node.Render());
+    }
+
+    [Fact]
+    public void GenericNode_MixedArgs_AppliesToCorrectPosition()
+    {
+        // Dictionary<object, dynamic>: flags [Dict=false, object-key=false, dynamic-value=true]
+        var node = new GenericTypeNode("Dictionary", isReferenceType: true,
+            [new PrimitiveTypeNode("object", true), new PrimitiveTypeNode("object", true)]);
+        byte[] flags = [0, 0, 1];
+        int pos = 0;
+        node.ApplyDynamic(flags, ref pos);
+        Assert.Equal("Dictionary<object, dynamic>", node.Render());
+    }
+
+    [Fact]
+    public void GenericNode_DynamicKeyObjectValue_AppliesToCorrectPosition()
+    {
+        // Dictionary<dynamic, object>: flags [Dict=false, dynamic-key=true, object-value=false]
+        var node = new GenericTypeNode("Dictionary", isReferenceType: true,
+            [new PrimitiveTypeNode("object", true), new PrimitiveTypeNode("object", true)]);
+        byte[] flags = [0, 1, 0];
+        int pos = 0;
+        node.ApplyDynamic(flags, ref pos);
+        Assert.Equal("Dictionary<dynamic, object>", node.Render());
+    }
+
+    [Fact]
+    public void ArrayNode_DynamicElement()
+    {
+        // dynamic[]: flags [array=false, object-element=true]
+        var node = new SZArrayTypeNode(new PrimitiveTypeNode("object", true));
+        byte[] flags = [0, 1];
+        int pos = 0;
+        node.ApplyDynamic(flags, ref pos);
+        Assert.Equal("dynamic[]", node.Render());
+    }
+
+    [Fact]
+    public void ByRefNode_ConsumesLeadingFlagThenElement()
+    {
+        // ref dynamic: the transform-flags array reserves a false slot for the
+        // by-ref, then the object element carries the true flag.
+        var inner = new PrimitiveTypeNode("object", true);
+        var node = new ByRefTypeNode(inner);
+        byte[] flags = [0, 1];
+        int pos = 0;
+        node.ApplyDynamic(flags, ref pos);
+        Assert.Equal("ref dynamic", node.Render());
+        Assert.Equal(2, pos);
+    }
+
+    [Fact]
+    public void NullableAnnotatedDynamic_RendersDynamicQuestion()
+    {
+        var node = new PrimitiveTypeNode("object", isReferenceType: true) { IsNullableAnnotated = true };
+        byte[] flags = [1];
+        int pos = 0;
+        node.ApplyDynamic(flags, ref pos);
+        Assert.Equal("dynamic?", node.Render());
+    }
+
+    // --- End-to-end: signatures extracted from Roslyn-compiled fixtures ---
+
+    [Fact]
+    public void Method_BareDynamicParam()
+    {
+        var member = GetMethod(nameof(DynamicSampleClass.TakesDynamic));
+        Assert.Contains("dynamic value", member.Signature);
+        Assert.DoesNotContain("object", member.Signature);
+    }
+
+    [Fact]
+    public void Method_DynamicReturn()
+    {
+        var member = GetMethod(nameof(DynamicSampleClass.ReturnsDynamic));
+        Assert.StartsWith("dynamic ", member.Signature);
+    }
+
+    [Fact]
+    public void Method_PlainObjectParam_StaysObject()
+    {
+        var member = GetMethod(nameof(DynamicSampleClass.TakesObject));
+        Assert.Contains("object value", member.Signature);
+        Assert.DoesNotContain("dynamic", member.Signature);
+    }
+
+    [Fact]
+    public void Method_DynamicArray()
+    {
+        var member = GetMethod(nameof(DynamicSampleClass.TakesDynamicArray));
+        Assert.Contains("dynamic[] values", member.Signature);
+    }
+
+    [Fact]
+    public void Method_ListOfDynamic()
+    {
+        var member = GetMethod(nameof(DynamicSampleClass.TakesListOfDynamic));
+        Assert.Contains("List<dynamic>", member.Signature);
+    }
+
+    [Fact]
+    public void Method_DictionaryObjectKeyDynamicValue()
+    {
+        var member = GetMethod(nameof(DynamicSampleClass.TakesDictionaryObjectDynamic));
+        Assert.Contains("Dictionary<object, dynamic>", member.Signature);
+    }
+
+    [Fact]
+    public void Method_DictionaryDynamicKeyObjectValue()
+    {
+        var member = GetMethod(nameof(DynamicSampleClass.TakesDictionaryDynamicObject));
+        Assert.Contains("Dictionary<dynamic, object>", member.Signature);
+    }
+
+    [Fact]
+    public void Method_NestedGenericDynamic()
+    {
+        // Raw ApiSurface renders full namespaces; assert the namespace-agnostic
+        // innermost shape, which proves the dynamic lands at the deepest position.
+        var member = GetMethod(nameof(DynamicSampleClass.TakesNestedGeneric));
+        Assert.Contains("Dictionary<string, dynamic>>", member.Signature);
+    }
+
+    [Fact]
+    public void Method_FuncObjectToDynamic_KeepsObjectArg()
+    {
+        var member = GetMethod(nameof(DynamicSampleClass.TakesFuncObjectDynamic));
+        Assert.Contains("Func<object, dynamic>", member.Signature);
+    }
+
+    [Fact]
+    public void Method_MixedObjectAndDynamicParams()
+    {
+        var member = GetMethod(nameof(DynamicSampleClass.MixedParams));
+        Assert.Contains("object plain", member.Signature);
+        Assert.Contains("dynamic flexible", member.Signature);
+    }
+
+    [Fact]
+    public void Method_RefDynamic()
+    {
+        var member = GetMethod(nameof(DynamicSampleClass.TakesRefDynamic));
+        Assert.Contains("ref dynamic value", member.Signature);
+    }
+
+    [Fact]
+    public void Property_Dynamic()
+    {
+        var member = GetProperty(nameof(DynamicSampleClass.DynamicProp));
+        Assert.Contains("dynamic", member.Signature);
+        Assert.DoesNotContain("object", member.Signature);
+    }
+
+    [Fact]
+    public void Field_Dynamic()
+    {
+        var member = GetField(nameof(DynamicSampleClass.DynamicField));
+        Assert.Equal("dynamic", member.ReturnType);
+    }
+
+    [Fact]
+    public void Field_PlainObject_StaysObject()
+    {
+        var member = GetField(nameof(DynamicSampleClass.ObjectField));
+        Assert.Equal("object", member.ReturnType);
+    }
+}
+
+// ===== Test fixture types with a spread of dynamic type shapes =====
+
+/// <summary>Sample class exercising DynamicAttribute transform-flag decoding.</summary>
+public class DynamicSampleClass
+{
+    public dynamic DynamicField = null!;
+    public object ObjectField = null!;
+
+    public dynamic DynamicProp { get; set; } = null!;
+
+    public void TakesDynamic(dynamic value) { }
+    public void TakesObject(object value) { }
+    public dynamic ReturnsDynamic() => null!;
+
+    public void TakesDynamicArray(dynamic[] values) { }
+    public void TakesListOfDynamic(List<dynamic> values) { }
+    public void TakesDictionaryObjectDynamic(Dictionary<object, dynamic> map) { }
+    public void TakesDictionaryDynamicObject(Dictionary<dynamic, object> map) { }
+    public void TakesNestedGeneric(List<Dictionary<string, dynamic>> nested) { }
+    public void TakesFuncObjectDynamic(Func<object, dynamic> projector) { }
+    public void MixedParams(object plain, dynamic flexible) { }
+    public void TakesRefDynamic(ref dynamic value) { value = null!; }
+}

--- a/tests/ILInspector.Metadata.Tests/DynamicTypeViewTests.cs
+++ b/tests/ILInspector.Metadata.Tests/DynamicTypeViewTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection.PortableExecutable;
+using System.Text.Json;
 using ILInspector.Metadata;
 
 namespace ILInspector.Metadata.Tests;
@@ -319,6 +320,52 @@ public sealed class DynamicTypeViewTests
         Assert.DoesNotContain("dynamic", canonical);
     }
 
+    // --- Identity must survive a JSON round-trip (SignatureModel is [JsonIgnore],
+    //     so identity falls back to parsing the raw display signature, which carries
+    //     `dynamic`; the fallback must scrub it to `object` exactly like the live path). ---
+
+    [Fact]
+    public void Identity_DynamicParam_CanonicalStableAcrossJsonRoundTrip()
+    {
+        var liveType = GetType(nameof(DynamicSampleClass));
+        var liveMember = GetMethod(nameof(DynamicSampleClass.TakesDynamic));
+        var liveCanonical = ApiMemberIdentity.GetCanonicalSignature(liveType, liveMember);
+
+        var json = JsonSerializer.Serialize(Surface);
+        var roundTripped = JsonSerializer.Deserialize<ApiSurface>(json)!;
+        var rtType = roundTripped.Types.First(t => t.Name == nameof(DynamicSampleClass));
+        var rtMember = rtType.Members.First(m =>
+            m.Name == nameof(DynamicSampleClass.TakesDynamic) && m.Kind == "method");
+        Assert.Null(rtMember.SignatureModel);
+
+        var rtCanonical = ApiMemberIdentity.GetCanonicalSignature(rtType, rtMember);
+        Assert.DoesNotContain("dynamic", rtCanonical);
+        Assert.Contains("object", rtCanonical);
+        Assert.Equal(liveCanonical, rtCanonical);
+    }
+
+    [Fact]
+    public void Identity_DynamicIndexer_CanonicalStableAcrossJsonRoundTrip()
+    {
+        var liveType = GetType(nameof(DynamicSampleClass));
+        var liveIndexer = liveType.Members.First(m =>
+            m.Kind == "property" && m.SignatureModel is { Parameters.Count: > 0 });
+        var liveCanonical = ApiMemberIdentity.GetCanonicalSignature(liveType, liveIndexer);
+        Assert.DoesNotContain("dynamic", liveCanonical);
+
+        var json = JsonSerializer.Serialize(Surface);
+        var roundTripped = JsonSerializer.Deserialize<ApiSurface>(json)!;
+        var rtType = roundTripped.Types.First(t => t.Name == nameof(DynamicSampleClass));
+        var rtIndexer = rtType.Members.First(m =>
+            m.Kind == "property" && m.Signature != null
+            && m.Signature.Contains("this[", StringComparison.Ordinal));
+        Assert.Null(rtIndexer.SignatureModel);
+
+        var rtCanonical = ApiMemberIdentity.GetCanonicalSignature(rtType, rtIndexer);
+        Assert.DoesNotContain("dynamic", rtCanonical);
+        Assert.Equal(liveCanonical, rtCanonical);
+    }
+
     // --- Marker-form flag must not broadcast into inner nodes ---
 
     [Fact]
@@ -362,6 +409,8 @@ public class DynamicSampleClass
 
     private static dynamic _refDynamic = null!;
     public ref readonly dynamic RefReadonlyDynamic() => ref _refDynamic;
+
+    public dynamic this[dynamic key] { get => null!; set { } }
 
     public event EventHandler<dynamic> DynamicEvent = null!;
 }

--- a/tests/ILInspector.Metadata.Tests/DynamicTypeViewTests.cs
+++ b/tests/ILInspector.Metadata.Tests/DynamicTypeViewTests.cs
@@ -245,6 +245,95 @@ public sealed class DynamicTypeViewTests
         var member = GetField(nameof(DynamicSampleClass.ObjectField));
         Assert.Equal("object", member.ReturnType);
     }
+
+    // --- Custom-modifier alignment: `in`/`ref readonly` carry a modreq(In) ---
+
+    [Fact]
+    public void Method_InDynamic_ConsumesModifierSlot()
+    {
+        // `in dynamic` decodes as ByRef(Modified(modreq In, object)). The
+        // DynamicAttribute transform-flags reserve a slot for the by-ref AND a
+        // slot for the custom modifier, so the walk must consume both before the
+        // object position or the `true` flag lands on the wrong node.
+        var member = GetMethod(nameof(DynamicSampleClass.TakesInDynamic));
+        Assert.Contains("dynamic value", member.Signature);
+        Assert.DoesNotContain("object", member.Signature);
+    }
+
+    [Fact]
+    public void Method_RefReadonlyDynamicReturn_ConsumesModifierSlot()
+    {
+        var member = GetMethod(nameof(DynamicSampleClass.RefReadonlyDynamic));
+        Assert.Contains("dynamic", member.Signature);
+        Assert.DoesNotContain("object", member.Signature);
+    }
+
+    // --- Extractor coverage: events and base types ---
+
+    [Fact]
+    public void Event_DynamicHandler()
+    {
+        var member = GetType(nameof(DynamicSampleClass)).Members
+            .First(m => m.Name == nameof(DynamicSampleClass.DynamicEvent) && m.Kind == "event");
+        Assert.Contains("EventHandler<dynamic>", member.Signature);
+        Assert.DoesNotContain("object", member.Signature);
+    }
+
+    [Fact]
+    public void BaseType_Dynamic()
+    {
+        var type = GetType(nameof(DynamicDerived));
+        Assert.NotNull(type.BaseType);
+        Assert.Contains("dynamic", type.BaseType!);
+        Assert.DoesNotContain("object", type.BaseType!);
+    }
+
+    // --- Identity isolation: canonical/XML-doc identity must stay `object` ---
+
+    [Fact]
+    public void Identity_DynamicParam_CanonicalUsesObjectNotDynamic()
+    {
+        var type = GetType(nameof(DynamicSampleClass));
+        var member = GetMethod(nameof(DynamicSampleClass.TakesDynamic));
+        var canonical = ApiMemberIdentity.GetCanonicalSignature(type, member);
+        Assert.Contains("object", canonical);
+        Assert.DoesNotContain("dynamic", canonical);
+    }
+
+    [Fact]
+    public void Identity_DynamicParam_XmlDocUsesObject()
+    {
+        var type = GetType(nameof(DynamicSampleClass));
+        var member = GetMethod(nameof(DynamicSampleClass.TakesDynamic));
+        Assert.True(ApiMemberIdentity.TryGetXmlDocMemberIdentity(type, member, out var identity));
+        Assert.Contains(identity.NormalizedParameters, p => p.Contains("System.Object"));
+        Assert.DoesNotContain(identity.NormalizedParameters, p => p.Contains("dynamic"));
+    }
+
+    [Fact]
+    public void Identity_NestedDynamic_CanonicalUsesObjectNotDynamic()
+    {
+        var type = GetType(nameof(DynamicSampleClass));
+        var member = GetMethod(nameof(DynamicSampleClass.TakesListOfDynamic));
+        var canonical = ApiMemberIdentity.GetCanonicalSignature(type, member);
+        Assert.DoesNotContain("dynamic", canonical);
+    }
+
+    // --- Marker-form flag must not broadcast into inner nodes ---
+
+    [Fact]
+    public void MarkerFlag_OnArray_DoesNotBroadcastToElement()
+    {
+        // A single-element (marker-form) flag array applies only to the first
+        // position; it must NOT broadcast `true` to inner element nodes. Only a
+        // bare top-level object ever carries the marker form in real metadata,
+        // but adversarial metadata can attach it to a composite.
+        var node = new SZArrayTypeNode(new PrimitiveTypeNode("object", true));
+        byte[] flags = [1];
+        int pos = 0;
+        node.ApplyDynamic(flags, ref pos);
+        Assert.Equal("object[]", node.Render());
+    }
 }
 
 // ===== Test fixture types with a spread of dynamic type shapes =====
@@ -269,4 +358,20 @@ public class DynamicSampleClass
     public void TakesFuncObjectDynamic(Func<object, dynamic> projector) { }
     public void MixedParams(object plain, dynamic flexible) { }
     public void TakesRefDynamic(ref dynamic value) { value = null!; }
+    public void TakesInDynamic(in dynamic value) { }
+
+    private static dynamic _refDynamic = null!;
+    public ref readonly dynamic RefReadonlyDynamic() => ref _refDynamic;
+
+    public event EventHandler<dynamic> DynamicEvent = null!;
+}
+
+/// <summary>Generic base used to exercise dynamic decoding of base types.</summary>
+public class DynamicBase<T>
+{
+}
+
+/// <summary>Derives from a generic base instantiated with <c>dynamic</c>.</summary>
+public class DynamicDerived : DynamicBase<dynamic>
+{
 }

--- a/tests/ILInspector.Metadata.Tests/DynamicTypeViewTests.cs
+++ b/tests/ILInspector.Metadata.Tests/DynamicTypeViewTests.cs
@@ -366,6 +366,29 @@ public sealed class DynamicTypeViewTests
         Assert.Equal(liveCanonical, rtCanonical);
     }
 
+    // --- Identity keyword-vs-typename boundary: normalize the `dynamic` keyword to
+    //     `object` but never corrupt a real type whose name merely contains dynamic,
+    //     including generic-arity (`dynamic`1`) and nested (`Outer+dynamic`) forms. ---
+
+    [Theory]
+    // Keyword positions must normalize to object:
+    [InlineData("dynamic", "object")]
+    [InlineData("List<dynamic>", "List<object>")]
+    [InlineData("dynamic[]", "object[]")]
+    [InlineData("Dictionary<dynamic,object>", "Dictionary<object,object>")]
+    [InlineData("Func<object,dynamic>", "Func<object,object>")]
+    // Real type names that merely contain/equal "dynamic" must be left untouched:
+    [InlineData("MyDynamicType", "MyDynamicType")]
+    [InlineData("System.Dynamic.ExpandoObject", "System.Dynamic.ExpandoObject")]
+    [InlineData("Ns.dynamic", "Ns.dynamic")]
+    [InlineData("dynamic`1<System.Int32>", "dynamic`1<System.Int32>")]
+    [InlineData("Outer+dynamic", "Outer+dynamic")]
+    [InlineData("Outer/dynamic", "Outer/dynamic")]
+    public void NormalizeDynamicToObject_KeywordOnly_SparesRealTypeNames(string input, string expected)
+    {
+        Assert.Equal(expected, ApiMemberIdentity.NormalizeDynamicToObject(input));
+    }
+
     // --- Marker-form flag must not broadcast into inner nodes ---
 
     [Fact]

--- a/tests/ILInspector.Metadata.Tests/DynamicTypeViewTests.cs
+++ b/tests/ILInspector.Metadata.Tests/DynamicTypeViewTests.cs
@@ -404,6 +404,34 @@ public sealed class DynamicTypeViewTests
         node.ApplyDynamic(flags, ref pos);
         Assert.Equal("object[]", node.Render());
     }
+
+    // --- Ordinal-selector stability: the positional `Name:N` overload selector orders
+    //     via GetMemberSignatureSortKey. A parameter changing display spelling from
+    //     `object` to `dynamic` (the same metadata type) must not renumber the ordinal,
+    //     so the sort key normalizes the keyword back to `object`. A type can never
+    //     declare both M(object) and M(dynamic) (CS0111), so the collapse is collision-free. ---
+
+    [Fact]
+    public void MemberSignatureSortKey_DynamicParam_OrdersAsObject()
+    {
+        var dynamicOverload = new ApiMember
+        {
+            Kind = "method",
+            Name = "M",
+            Signature = "void M(dynamic value)"
+        };
+        var objectOverload = new ApiMember
+        {
+            Kind = "method",
+            Name = "M",
+            Signature = "void M(object value)"
+        };
+
+        Assert.Equal(
+            ApiMemberIdentity.GetMemberSignatureSortKey(objectOverload),
+            ApiMemberIdentity.GetMemberSignatureSortKey(dynamicOverload));
+        Assert.DoesNotContain("dynamic", ApiMemberIdentity.GetMemberSignatureSortKey(dynamicOverload));
+    }
 }
 
 // ===== Test fixture types with a spread of dynamic type shapes =====

--- a/tests/ILInspector.Metadata.Tests/DynamicTypeViewTests.cs
+++ b/tests/ILInspector.Metadata.Tests/DynamicTypeViewTests.cs
@@ -404,34 +404,6 @@ public sealed class DynamicTypeViewTests
         node.ApplyDynamic(flags, ref pos);
         Assert.Equal("object[]", node.Render());
     }
-
-    // --- Ordinal-selector stability: the positional `Name:N` overload selector orders
-    //     via GetMemberSignatureSortKey. A parameter changing display spelling from
-    //     `object` to `dynamic` (the same metadata type) must not renumber the ordinal,
-    //     so the sort key normalizes the keyword back to `object`. A type can never
-    //     declare both M(object) and M(dynamic) (CS0111), so the collapse is collision-free. ---
-
-    [Fact]
-    public void MemberSignatureSortKey_DynamicParam_OrdersAsObject()
-    {
-        var dynamicOverload = new ApiMember
-        {
-            Kind = "method",
-            Name = "M",
-            Signature = "void M(dynamic value)"
-        };
-        var objectOverload = new ApiMember
-        {
-            Kind = "method",
-            Name = "M",
-            Signature = "void M(object value)"
-        };
-
-        Assert.Equal(
-            ApiMemberIdentity.GetMemberSignatureSortKey(objectOverload),
-            ApiMemberIdentity.GetMemberSignatureSortKey(dynamicOverload));
-        Assert.DoesNotContain("dynamic", ApiMemberIdentity.GetMemberSignatureSortKey(dynamicOverload));
-    }
 }
 
 // ===== Test fixture types with a spread of dynamic type shapes =====


### PR DESCRIPTION
## Summary

Metadata's `TypeNode` type-view tree carried nullability but had **no dynamic
decoding**, so every `[DynamicAttribute]` position rendered `object`. This
dropped the `dynamic` shape fact from both the `member` API header **and** the
decompiled member header (which reuses Metadata's type view), forcing
downstream consumers to re-cast to reach dynamic members.

This PR teaches Metadata to decode `[DynamicAttribute]` transform flags and
spell `dynamic` / `dynamic?` at the marked positions. Because the decompiler's
signature rendering reuses Metadata's type view, one fix corrects **both**
headers — the "one implementation, no drift" payoff of the #2996 signature-model
unification.

Foundation for #2984 (the decompiler dropping the redundant `((dynamic)value)`
body cast is the follow-up consumer PR). Umbrella: #2996.

## What changed

- **`DynamicReader.cs` (new)** — reads `[DynamicAttribute]` transform flags as
  `byte[]?`, mirroring `NullabilityReader` (marker form → `[1]`; array form →
  prolog + count + N bytes). `GetDynamicFlags` + `GetParameterDynamicFlags`.
- **`TypeNode.cs`** — adds `IsDynamic`, an `ApplyDynamic(flags, ref position)`
  traversal paralleling `ApplyNullability`, and `dynamic` / `dynamic?`
  rendering at object-typed positions the flags mark. Non-object nodes still
  consume their flag slot to stay aligned.
- **`ApiSurfaceExtractor.cs`** — wires `ApplyDynamic` into the five signature
  sites (field, method return, method params, property type, indexer params),
  each with an independent flag array.

## Key detail: ByRef consumes a leading dynamic flag

Unlike the nullability traversal, `ByRefTypeNode.ApplyDynamic` **does** consume
a leading (always-false) flag slot. Without it, `ref dynamic` rendered
`ref object`. This divergence is validated by a dedicated `ref dynamic` fixture
in the test suite.

## Identity is unaffected

Member identity uses a separate `AnchorSignatureTypeProvider` that always
renders `System.Object` (never `dynamic`), so member matching and selectors are
orthogonal to this display change. No selector, anchor, or correspondence
behavior changes.

## Evidence

- **`DynamicTypeViewTests` (new): 23/23.** 9 direct `TypeNode.ApplyDynamic`
  unit tests + 14 end-to-end tests over inline **Roslyn-compiled** fixtures as
  the encoding oracle: bare `dynamic` param/return/field/property, `dynamic[]`,
  `List<dynamic>`, `Dictionary<object,dynamic>`, `Dictionary<dynamic,object>`,
  nested `List<Dictionary<string,dynamic>>`, `Func<object,dynamic>`, mixed
  params, `ref dynamic`, and plain `object` stays `object`.
- **Full `ILInspector.Metadata.Tests`: 681/682** — the 1 failure
  (`MetadataSourceFindingsTests.MemberSourceProducer_UsesFirstVisibleDocumentWhenRootIsOmitted`)
  is a pre-existing Windows path-separator bug unrelated to this change (filed
  in #3018; reproduces on clean `main`).
- **`dotnet-inspect.Tests`: 1975/1979** — the 4 failures are pre-existing
  Windows-local CRLF / source-URL issues (#3018), none touch signature
  spelling.
- **Decompiler `Area=Pass` 1165/1169, `Area=Validity` 94/98,
  `Area=RoundTrip` 136/297** — every failure is the pre-existing Windows
  `CS0009` native-DLL recompile-environment issue (#3018 root cause C); no new
  failures. `LadderRung9GateTests` (the dynamic fixtures) is **19/19**.

Manual confirmation on the LadderRung9 fixture DLL: both the `member` API header
and the decompiled member header now render `dynamic value` (previously
`object value`).

## Compatibility / boundary

- Behavior-visible: signatures containing `[DynamicAttribute]` positions now
  spell `dynamic` instead of `object` (strictly more faithful).
- No product path loads inspected assemblies, uses Roslyn, or leaves SRM /
  NativeAOT constraints.
- Follow-up (#2984 proper): the decompiler drops the now-redundant
  `((dynamic)value)` body cast, consuming this same fact.

## Adversarial review

Behavior-visible → requires two non-Claude-Opus model families per AGENTS.md;
isolated review worktrees; two clean fixed-head reviews before "Ready to merge".
