### PR TITLE
Pin wide-index fidelity fixtures and add cross-assembly enum coverage (#2981)

### DIFF
--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -33,6 +33,7 @@
     <Project Path="src/ILInspector.Findings/ILInspector.Findings.csproj" />
     <Project Path="src/ILInspector.Decompiler.Fixtures.CheckedArithmetic/ILInspector.Decompiler.Fixtures.CheckedArithmetic.csproj" />
     <Project Path="src/ILInspector.Decompiler.Fixtures.ClassicAsync/ILInspector.Decompiler.Fixtures.ClassicAsync.csproj" />
+    <Project Path="src/ILInspector.Decompiler.Fixtures.CrossAssemblyEnums/ILInspector.Decompiler.Fixtures.CrossAssemblyEnums.csproj" />
     <Project Path="src/ILInspector.Decompiler.Fixtures.ExpressionTreeSpoof/ILInspector.Decompiler.Fixtures.ExpressionTreeSpoof.csproj" />
     <Project Path="src/ILInspector.Decompiler.Fixtures.ClassicStateMachines/ILInspector.Decompiler.Fixtures.ClassicStateMachines.csproj" />
     <Project Path="src/ILInspector.Decompiler.Fixtures.Ladder/ILInspector.Decompiler.Fixtures.Ladder.csproj" />

--- a/src/ILInspector.Decompiler.Fixtures.CrossAssemblyEnums/ExternalEnums.cs
+++ b/src/ILInspector.Decompiler.Fixtures.CrossAssemblyEnums/ExternalEnums.cs
@@ -1,0 +1,27 @@
+namespace ILInspector.Decompiler.Fixtures.CrossAssemblyEnums;
+
+// Enums whose shape is unresolvable from CfgSampleClass's decompile (they live in
+// a different assembly). Each carries an explicit underlying type so the width of
+// the `ldelem` opcode CfgSampleClass emits over an array of them is fixed:
+//   ExternalULong / ExternalLong -> 8-byte (ldelem.i8), the `long`/`Int64` arm
+//   ExternalUInt                 -> 4-byte (ldelem.u4), the `int`/`Int32` arm
+// The high-bit members keep the enums from constant-folding to zero and pin the
+// unsigned/signed spelling of the largest member.
+
+public enum ExternalULong : ulong
+{
+    None = 0,
+    All = 18446744073709551615UL,
+}
+
+public enum ExternalLong : long
+{
+    Low = 0,
+    High = 2,
+}
+
+public enum ExternalUInt : uint
+{
+    None = 0,
+    Top = 0x80000000u,
+}

--- a/src/ILInspector.Decompiler.Fixtures.CrossAssemblyEnums/ILInspector.Decompiler.Fixtures.CrossAssemblyEnums.csproj
+++ b/src/ILInspector.Decompiler.Fixtures.CrossAssemblyEnums/ILInspector.Decompiler.Fixtures.CrossAssemblyEnums.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Cross-assembly enum fixtures for the wide-index / unary-negate fidelity gate
+    (#2981, PR #3012). These enums live in a SEPARATE assembly from CfgSampleClass
+    so the decompiler cannot resolve their shape: MetadataSource.EnsureTypeMaps
+    walks only the decompiled assembly's own type definitions, so a referenced
+    enum resolves to an Unknown shape and EnumUnderlyingType returns nothing.
+
+    That is exactly the finding-#10 scenario the printer's width fallback
+    (NegateWidthKeyword / IsUnresolvedEnumLike) must cover: a unary `neg` over an
+    unresolved enum array element recovers its signed-reinterpret cast width from
+    the masked `ldelem` opcode, not from the (unavailable) underlying type. A
+    ulong/long-backed enum here is the ONLY way to exercise the 8-byte
+    (`Int64`->`long`) arm of that fallback under the cross-assembly path — no
+    common core-library enum is 8-byte-backed, so DayOfWeek only covers the
+    4-byte arm.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -959,6 +959,28 @@ public class CfgSampleClass
     // neg; conv.i`.
     public static int NegCrossAssemblyEnumElementIndex(int[] a, System.DayOfWeek[] v, int j) => a[-(int)v[j]];
 
+    // The 8-byte cross-assembly mirror of the DayOfWeek case: a ulong-backed enum
+    // that lives in a REFERENCED assembly, so EnsureTypeMaps (this assembly's type
+    // defs only) leaves it Unknown-shaped and EnumUnderlyingType has nothing. No
+    // core-library enum is 8-byte-backed, so this is the ONLY automated coverage of
+    // the width fallback's `long`/Int64 arm under the cross-assembly path: the
+    // reinterpret is recovered from the masked `ldelem.i8`, not the unavailable
+    // underlying type. Used as a signed index it strips clean. Opcode-exact:
+    // `ldelem.i8; neg; conv.i`.
+    public static int NegExternalULongEnumElementIndex(int[] a, ILInspector.Decompiler.Fixtures.CrossAssemblyEnums.ExternalULong[] v, int j) => a[-(long)v[j]];
+
+    // The `long`-backed cross-assembly enum negated outside any index still needs
+    // the operand cast — no unary minus on the enum — recovered as `(long)` from
+    // the masked `ldelem.i8`. General printer path across the assembly boundary.
+    // Opcode-exact: `ldelem.i8; neg`.
+    public static long NegExternalLongEnumElementToLong(ILInspector.Decompiler.Fixtures.CrossAssemblyEnums.ExternalLong[] v, int j) => -(long)v[j];
+
+    // The 4-byte cross-assembly arm: a uint-backed referenced enum negate recovers
+    // `(int)` from the masked `ldelem` (sub-8-byte integers view as I4), mirroring
+    // NegEnumUIntElementToInt across the assembly boundary and pinning that the
+    // width fallback does not over-widen the narrow arm. Opcode-exact: `ldelem.*; neg`.
+    public static int NegExternalUIntEnumElementToInt(ILInspector.Decompiler.Fixtures.CrossAssemblyEnums.ExternalUInt[] v, int j) => -(int)v[j];
+
     // Genuinely-signed `long` neg/not indices recover as `long` and strip bare.
     public static int NegLongIndexBare(int[] a, long i) => a[-i];
 

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -289,6 +289,10 @@ public class FidelityGateTests
     /// AnonNamed, AnonSingle, AnonNested, and AnonDeepNested are likewise below
     /// Full with changed anonymous-type ordinals. DayNumber and
     /// DoubleViaLocalFunction moved to the V1 difference docket above.
+    /// The wide-index / unary-negate block (#2981, PR #3012) pins the idiomatic
+    /// long/ulong array-index and enum-negate rendering, including the
+    /// cross-assembly (Unknown-shape enum) width fallback exercised by the
+    /// Neg*External* fixtures.
     /// </summary>
     static readonly string[] PinnedExact =
     {
@@ -382,6 +386,51 @@ public class FidelityGateTests
         "SpanElementCompoundAdd",
         "BoolBitwiseOrWidened",
         "CrossAssemblyEnumSwitch",
+        // Wide (long/ulong) array-index and unary-negate rendering (#2981, PR #3012):
+        // each decompiles to an idiomatic bare or single-cast index that must
+        // recompile opcode-exact, so a regression to checked((nint)i) or a lost/extra
+        // signed reinterpret is caught on every fidelity-gate run, not left to the
+        // sampled corpus. The Neg*External* trio additionally pins the cross-assembly
+        // (Unknown-shape enum) width fallback, including the 8-byte `long` arm that no
+        // core-library enum can exercise (ExternalULong/ExternalLong are 8-byte-backed).
+        "CheckedULongSumIndexAsSigned",
+        "FirstElement",
+        "LongArrayIndex",
+        "LongArrayIndexAsUnsigned",
+        "LongArrayIndexExpr",
+        "LongArrayIndexRef",
+        "LongArrayIndexStore",
+        "LongCheckedSumIndexBare",
+        "LongEnumArrayIndex",
+        "LongEnumIndexChecked",
+        "LongEnumRefArrayIndex",
+        "LongIndexAsUnsignedChecked",
+        "LongShlIndexBare",
+        "NegCrossAssemblyEnumElementIndex",
+        "NegEnumLongElementToLong",
+        "NegEnumUIntElementToInt",
+        "NegEnumULongElementIndexAsSigned",
+        "NegExternalLongEnumElementToLong",
+        "NegExternalUIntEnumElementToInt",
+        "NegExternalULongEnumElementIndex",
+        "NegLongIndexBare",
+        "NegLongIndexInChecked",
+        "NegNuintElementToNint",
+        "NegULongElementIndexAsSigned",
+        "NegULongElementToLong",
+        "NotLongIndexBare",
+        "NotULongElementIndexAsSigned",
+        "ULongArrayElementIndex",
+        "ULongArrayIndex",
+        "ULongArrayIndexAsSigned",
+        "ULongDivIndexAsSigned",
+        "ULongElementSumIndexAsSigned",
+        "ULongIndexAsSignedChecked",
+        "ULongRefIndexAsSigned",
+        "ULongRemIndexAsSigned",
+        "ULongShrIndexAsSigned",
+        "ULongSumIndexAsSigned",
+        "ULongSumIndexBare",
         "Finalize",
     };
 

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -33,6 +33,7 @@
     <ProjectReference Include="..\ILInspector.Research\ILInspector.Research.csproj" />
     <ProjectReference Include="..\DotnetInspector.Services\DotnetInspector.Services.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LegacyUnsafe\ILInspector.Decompiler.Fixtures.LegacyUnsafe.csproj" />
+    <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.CrossAssemblyEnums\ILInspector.Decompiler.Fixtures.CrossAssemblyEnums.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.ClassicAsync\ILInspector.Decompiler.Fixtures.ClassicAsync.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.NewUnsafe\ILInspector.Decompiler.Fixtures.NewUnsafe.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.UnsafeChainA\ILInspector.Decompiler.Fixtures.UnsafeChainA.csproj" />

--- a/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
+++ b/src/ILInspector.Decompiler.Tests/WideArrayIndexTests.cs
@@ -305,4 +305,36 @@ public class WideArrayIndexTests
         // a signed index it strips clean. Recompiles to `ldelem.i4; neg; conv.i`.
         Assert.Equal("return a[-(int)v[j]];", Print(nameof(CfgSampleClass.NegCrossAssemblyEnumElementIndex)));
     }
+
+    [Fact]
+    public void NegExternalULongEnumElementIndex_CastsOperandToLong()
+    {
+        // The 8-byte cross-assembly mirror: a ulong-backed enum in a REFERENCED
+        // assembly is Unknown-shaped here, so its underlying width is unavailable via
+        // the enum map. The masked `ldelem.i8` still carries the width, so the width
+        // fallback recovers `(long)` — the only automated coverage of the 8-byte arm
+        // under the cross-assembly path (no core-library enum is 8-byte-backed). Used
+        // as a signed index it strips clean. Recompiles to `ldelem.i8; neg; conv.i`.
+        Assert.Equal("return a[-(long)v[j]];", Print(nameof(CfgSampleClass.NegExternalULongEnumElementIndex)));
+    }
+
+    [Fact]
+    public void NegExternalLongEnumElementToLong_CastsOperandToLong()
+    {
+        // The `long`-backed cross-assembly enum negated outside any index: the width
+        // fallback re-inserts `(long)` on the operand from the masked `ldelem.i8`.
+        // General printer path across the assembly boundary. Recompiles to
+        // `ldelem.i8; neg`.
+        Assert.Equal("return -(long)v[j];", Print(nameof(CfgSampleClass.NegExternalLongEnumElementToLong)));
+    }
+
+    [Fact]
+    public void NegExternalUIntEnumElementToInt_CastsOperandToInt()
+    {
+        // The 4-byte cross-assembly arm: a uint-backed referenced enum reinterprets
+        // the operand as `(int)` via the width fallback (sub-8-byte integers view as
+        // I4), mirroring the resolved NegEnumUIntElementToInt across the assembly
+        // boundary so the fallback does not over-widen the narrow arm.
+        Assert.Equal("return (int)(-(int)v[j]);", Print(nameof(CfgSampleClass.NegExternalUIntEnumElementToInt)));
+    }
 }


### PR DESCRIPTION
## What

Test-only follow-up to #3012 (issue #2981). Two changes:

1. **Pin the wide-index / unary-negate fixtures** to `FidelityGateTests.PinnedExact`.
   The 35 `long`/`ulong` array-index and enum-negate fixtures that #3012 added
   (covered by the fast `WideArrayIndexTests` printer suite) were only guarded by
   the weaker "no new diff beyond the docket" gate. Pinning them means
   `PinnedFixesStayExact` now asserts each one **stays opcode-exact on recompile**
   on every slow fidelity-gate run — a regression to `checked((nint)i)` or a
   lost/extra signed reinterpret fails the gate directly, not by sampling drift.

2. **Add automated cross-assembly coverage of the finding-#10 width fallback.**
   New referenced fixture assembly `ILInspector.Decompiler.Fixtures.CrossAssemblyEnums`
   holds `ulong`/`long`/`uint`-backed enums. Because the decompiler builds type maps
   from **only the decompiled assembly's own** type definitions, a referenced enum
   resolves to an Unknown shape and `EnumUnderlyingType` returns nothing — exactly
   the path the printer's width fallback (`NegateWidthKeyword` / `IsUnresolvedEnumLike`)
   must cover by recovering the signed-reinterpret width from the masked `ldelem`
   opcode. `DayOfWeek` already covers the 4-byte arm, but **no core-library enum is
   8-byte-backed**, so `ExternalULong`/`ExternalLong` give the first automated
   coverage of the `long`/`Int64` arm. Three `CfgSampleClass` fixtures, three fast
   `WideArrayIndexTests` printer assertions, all added to `PinnedExact`.

## Why this is the right shape

Follows the established `ILInspector.Decompiler.Fixtures.*` referenced-assembly
precedent. The slow fidelity harness auto-resolves the new assembly's reference
(`AssemblyDependencyResolver.ResolveAll`) and auto-enumerates every new
`CfgSampleClass` method, so no harness change was needed — the product capability
is exercised end-to-end (decompile + opcode-exact recompile), not reconstructed
by the harness.

## Evidence

- **Fast printer suite (local):** `WideArrayIndexTests` — 38/38 pass, including the
  three new `NegExternal*` assertions (verified the decompiled source exactly,
  e.g. `a[-(long)v[j]]` for the 8-byte index case, `(int)(-(int)v[j])` for the
  4-byte case).
- **Opcode-exact recompile:** proven for these external enum shapes by the #2981
  finding-#10 probe (external ulong/long/uint recompile opcode-exact), and the 35
  pinned fixtures were already green under #3012's fidelity gate.
- **Slow `FidelityGateTests` (`PinnedFixesStayExact`):** runs in CI (Linux). It
  cannot run on the author's Windows host (pre-existing, unrelated CS0009 on a
  native `aspnetcorev2_inprocess.dll` pulled into the Roslyn reference set).

## Risk

Low: test-only. No product code changes. New assembly is a fixture; new fixtures
and pins only strengthen an existing gate. No adversarial review needed under the
mechanical/test-only exemption.

Closes out the #2981 hardening follow-up discussed on #3012.
