### PR TITLE
Honor verified local source and direct private members for member Original Source (#3024, #3026)

### DIFF
--- a/src/DotnetInspector.Services.Tests/VerifiedLocalSourceReadTests.cs
+++ b/src/DotnetInspector.Services.Tests/VerifiedLocalSourceReadTests.cs
@@ -178,4 +178,58 @@ public class VerifiedLocalSourceReadTests
             SourceChecksumVerification.Unavailable,
             AuthoredSourceAcquisition.VerifyChecksum(null, SHA256.HashData(content), content));
     }
+
+    [Theory]
+    [InlineData(@"\\attacker\share\Sample.cs")]
+    [InlineData(@"\\?\C:\Sample.cs")]
+    [InlineData(@"\\.\C:\Sample.cs")]
+    [InlineData("relative/Sample.cs")]
+    public void ReturnsNull_ForNonLocalOrRelativePath_WithoutIo(string path)
+    {
+        // The document path originates in an untrusted PDB. A UNC share or Win32 device path must
+        // be rejected before any filesystem access so it cannot trigger outbound SMB/network I/O,
+        // and a relative path is never honored — independent of the (here matching) checksum.
+        byte[] content = Encoding.UTF8.GetBytes(Source);
+        Assert.Null(AuthoredSourceAcquisition.TryReadVerifiedLocalSource(
+            path, "SHA256", SHA256.HashData(content)));
+    }
+
+    [Fact]
+    public void DecodeSourceText_HonorsByteOrderMarkEncoding()
+    {
+        // Non-ASCII content makes the encoding observable. A checksum-verified local file may be
+        // UTF-8 (with or without BOM) or UTF-16; each must decode correctly, not as raw UTF-8.
+        const string text = "héllo wörld";
+        Assert.Equal(text, AuthoredSourceAcquisition.DecodeSourceText(Encoding.UTF8.GetBytes(text)));
+        Assert.Equal(text, AuthoredSourceAcquisition.DecodeSourceText(
+            [.. Encoding.UTF8.GetPreamble(), .. Encoding.UTF8.GetBytes(text)]));
+        Assert.Equal(text, AuthoredSourceAcquisition.DecodeSourceText(
+            [.. Encoding.Unicode.GetPreamble(), .. Encoding.Unicode.GetBytes(text)]));
+        Assert.Equal(text, AuthoredSourceAcquisition.DecodeSourceText(
+            [.. Encoding.BigEndianUnicode.GetPreamble(), .. Encoding.BigEndianUnicode.GetBytes(text)]));
+    }
+
+    [Fact]
+    public void Utf16LocalFile_VerifiesAgainstRawBytes_AndDecodesToText()
+    {
+        // csc records the checksum over the raw file bytes regardless of encoding, so a UTF-16
+        // source verifies against those bytes and must then decode as UTF-16 (Finding 2 regression).
+        byte[] utf16 = [.. Encoding.Unicode.GetPreamble(), .. Encoding.Unicode.GetBytes(Source)];
+        string path = WriteTemp(".cs", utf16);
+        try
+        {
+            byte[]? result = AuthoredSourceAcquisition.TryReadVerifiedLocalSource(
+                path, "SHA256", SHA256.HashData(utf16));
+
+            Assert.NotNull(result);
+            Assert.Equal(utf16, result);
+            Assert.Equal(
+                Source.ReplaceLineEndings("\n"),
+                AuthoredSourceAcquisition.DecodeSourceText(result).ReplaceLineEndings("\n"));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
 }

--- a/src/DotnetInspector.Services.Tests/VerifiedLocalSourceReadTests.cs
+++ b/src/DotnetInspector.Services.Tests/VerifiedLocalSourceReadTests.cs
@@ -1,0 +1,181 @@
+using System.Security.Cryptography;
+using System.Text;
+
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Services.Tests;
+
+public class VerifiedLocalSourceReadTests
+{
+    const string Source = """
+        class Sample
+        {
+            public int M()
+            {
+                return 1;
+            }
+        }
+        """;
+
+    static string WriteTemp(string extension, byte[] content)
+    {
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-src-{Guid.NewGuid():N}{extension}");
+        File.WriteAllBytes(path, content);
+        return path;
+    }
+
+    [Fact]
+    public void ReturnsBytes_WhenChecksumMatches()
+    {
+        byte[] content = Encoding.UTF8.GetBytes(Source);
+        string path = WriteTemp(".cs", content);
+        try
+        {
+            byte[]? result = AuthoredSourceAcquisition.TryReadVerifiedLocalSource(
+                path, "SHA256", SHA256.HashData(content));
+
+            Assert.NotNull(result);
+            Assert.Equal(content, result);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void ReturnsNull_WhenChecksumMismatches()
+    {
+        byte[] content = Encoding.UTF8.GetBytes(Source);
+        string path = WriteTemp(".cs", content);
+        try
+        {
+            // The on-disk bytes do not match the recorded hash: the read must be refused so the
+            // caller falls back to the remote URL rather than surfacing unverified content.
+            byte[]? result = AuthoredSourceAcquisition.TryReadVerifiedLocalSource(
+                path, "SHA256", SHA256.HashData(Encoding.UTF8.GetBytes(Source + "tampered")));
+
+            Assert.Null(result);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void ReturnsNull_ForNonCompilerSourceExtension_EvenWhenChecksumMatches()
+    {
+        // A malicious PDB could name a non-source local file (e.g. a secret). The extension gate
+        // plus the checksum gate keep the reader from disclosing arbitrary local files.
+        byte[] content = Encoding.UTF8.GetBytes(Source);
+        string path = WriteTemp(".txt", content);
+        try
+        {
+            byte[]? result = AuthoredSourceAcquisition.TryReadVerifiedLocalSource(
+                path, "SHA256", SHA256.HashData(content));
+
+            Assert.Null(result);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void ReturnsNull_WhenChecksumAbsent()
+    {
+        byte[] content = Encoding.UTF8.GetBytes(Source);
+        string path = WriteTemp(".cs", content);
+        try
+        {
+            Assert.Null(AuthoredSourceAcquisition.TryReadVerifiedLocalSource(path, "SHA256", null));
+            Assert.Null(AuthoredSourceAcquisition.TryReadVerifiedLocalSource(path, null, SHA256.HashData(content)));
+            Assert.Null(AuthoredSourceAcquisition.TryReadVerifiedLocalSource(path, "SHA256", []));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void ReturnsNull_WhenFileAbsent()
+    {
+        byte[] content = Encoding.UTF8.GetBytes(Source);
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-missing-{Guid.NewGuid():N}.cs");
+
+        Assert.Null(AuthoredSourceAcquisition.TryReadVerifiedLocalSource(
+            path, "SHA256", SHA256.HashData(content)));
+    }
+
+    [Fact]
+    public void AcceptsCrlfNormalizedChecksum()
+    {
+        // The recorded hash is over LF content; the on-disk file is CRLF. Line-ending
+        // normalization must still authenticate it.
+        byte[] lf = Encoding.UTF8.GetBytes(Source.ReplaceLineEndings("\n"));
+        byte[] crlf = Encoding.UTF8.GetBytes(Source.ReplaceLineEndings("\r\n"));
+        string path = WriteTemp(".cs", crlf);
+        try
+        {
+            byte[]? result = AuthoredSourceAcquisition.TryReadVerifiedLocalSource(
+                path, "SHA256", SHA256.HashData(lf));
+
+            Assert.NotNull(result);
+            Assert.Equal(crlf, result);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void ObservationOverload_ReadsOriginalPath_WhenVerified()
+    {
+        byte[] content = Encoding.UTF8.GetBytes(Source);
+        string path = WriteTemp(".cs", content);
+        try
+        {
+            var document = new SourceDocumentObservation(
+                CanonicalPath: "Sample.cs",
+                OriginalPath: path,
+                DocumentRowId: 1,
+                Storage: SourceDocumentStorage.SourceLink,
+                ResolvedUrl: "https://example.test/Sample.cs",
+                ChecksumAlgorithm: "SHA256",
+                Checksum: Convert.ToHexString(SHA256.HashData(content)));
+
+            byte[]? result = AuthoredSourceAcquisition.TryReadVerifiedLocalSource(document);
+
+            Assert.NotNull(result);
+            Assert.Equal(content, result);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void VerifyChecksum_Overload_ReportsExactAndMismatch()
+    {
+        byte[] content = Encoding.UTF8.GetBytes(Source);
+
+        Assert.Equal(
+            SourceChecksumVerification.Exact,
+            AuthoredSourceAcquisition.VerifyChecksum("SHA256", SHA256.HashData(content), content));
+        Assert.Equal(
+            SourceChecksumVerification.Mismatch,
+            AuthoredSourceAcquisition.VerifyChecksum("SHA256", SHA256.HashData(content), Encoding.UTF8.GetBytes("other")));
+        Assert.Equal(
+            SourceChecksumVerification.Unavailable,
+            AuthoredSourceAcquisition.VerifyChecksum(null, SHA256.HashData(content), content));
+    }
+}

--- a/src/DotnetInspector.Services/AuthoredSourceAcquisition.cs
+++ b/src/DotnetInspector.Services/AuthoredSourceAcquisition.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -93,6 +94,13 @@ public static class AuthoredSourceAcquisition
                 document,
                 SourceChecksumVerification.Unavailable);
         }
+
+        // Prefer a checksum-verified local file (e.g. a local build whose commit is not yet
+        // pushed) before reaching for the remote SourceLink URL. The checksum gate authenticates
+        // the on-disk bytes against the portable PDB, so this cannot surface unrelated content.
+        if (TryReadVerifiedLocalSource(document) is { } localBytes)
+            return FromContent(mapping, document, localBytes, methodName, subject);
+
         if (document.ResolvedUrl is not { Length: > 0 } url)
         {
             return Absent(document.Storage == SourceDocumentStorage.Embedded
@@ -206,20 +214,105 @@ public static class AuthoredSourceAcquisition
             return SourceChecksumVerification.Unsupported;
         }
 
-        if (HashMatches(document.ChecksumAlgorithm, content, expected))
-            return SourceChecksumVerification.Exact;
-        if (HashMatchesAfterLineEndingNormalization(
-            document.ChecksumAlgorithm,
-            content,
-            expected))
-        {
-            return SourceChecksumVerification.LineEndingNormalized;
-        }
+        return VerifyChecksum(document.ChecksumAlgorithm, expected, content);
+    }
 
-        return IsSupportedAlgorithm(document.ChecksumAlgorithm)
+    /// <summary>
+    /// Verifies fetched or on-disk source <paramref name="content"/> against a portable-PDB
+    /// document hash. Accepts an exact match or one recovered after CR/LF normalization. Returns
+    /// <see cref="SourceChecksumVerification.Unavailable"/> when no usable checksum is supplied.
+    /// </summary>
+    public static SourceChecksumVerification VerifyChecksum(
+        string? algorithm,
+        byte[]? expectedChecksum,
+        ReadOnlySpan<byte> content)
+    {
+        if (algorithm is not { Length: > 0 } || expectedChecksum is not { Length: > 0 })
+            return SourceChecksumVerification.Unavailable;
+
+        if (HashMatches(algorithm, content, expectedChecksum))
+            return SourceChecksumVerification.Exact;
+        if (HashMatchesAfterLineEndingNormalization(algorithm, content, expectedChecksum))
+            return SourceChecksumVerification.LineEndingNormalized;
+
+        return IsSupportedAlgorithm(algorithm)
             ? SourceChecksumVerification.Mismatch
             : SourceChecksumVerification.Unsupported;
     }
+
+    /// <summary>
+    /// Reads authored source from a local file, but only when its bytes authenticate against the
+    /// portable-PDB document checksum. The document path originates in an untrusted PDB, so the
+    /// checksum — not the path — authorizes the read: an attacker cannot precompute a matching hash
+    /// for an unknown local file, so a mismatched or absent checksum yields null. Returns null (the
+    /// caller falls back to the remote SourceLink URL) when the path is not a compiler source file,
+    /// is absent or unreadable, carries no usable checksum, or the content does not verify.
+    /// </summary>
+    public static byte[]? TryReadVerifiedLocalSource(
+        string? localPath,
+        string? checksumAlgorithm,
+        byte[]? checksum)
+    {
+        if (string.IsNullOrEmpty(localPath)
+            || checksumAlgorithm is not { Length: > 0 }
+            || checksum is not { Length: > 0 }
+            || !IsCompilerLanguageSourcePath(localPath))
+        {
+            return null;
+        }
+
+        byte[] content;
+        try
+        {
+            if (!File.Exists(localPath))
+                return null;
+            content = File.ReadAllBytes(localPath);
+        }
+        catch (Exception ex) when (ex is IOException
+            or UnauthorizedAccessException
+            or ArgumentException
+            or NotSupportedException)
+        {
+            return null;
+        }
+
+        return VerifyChecksum(checksumAlgorithm, checksum, content)
+            is SourceChecksumVerification.Exact
+                or SourceChecksumVerification.LineEndingNormalized
+            ? content
+            : null;
+    }
+
+    /// <summary>
+    /// Convenience overload that authenticates a local source file against a resolved
+    /// <see cref="SourceDocumentObservation"/> (its original PDB document path and checksum).
+    /// </summary>
+    public static byte[]? TryReadVerifiedLocalSource(SourceDocumentObservation document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        if (document.Checksum is not { Length: > 0 })
+            return null;
+
+        byte[] checksum;
+        try
+        {
+            checksum = Convert.FromHexString(document.Checksum);
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+
+        return TryReadVerifiedLocalSource(
+            document.OriginalPath,
+            document.ChecksumAlgorithm,
+            checksum);
+    }
+
+    static bool IsCompilerLanguageSourcePath(string path)
+        => path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)
+            || path.EndsWith(".vb", StringComparison.OrdinalIgnoreCase)
+            || path.EndsWith(".fs", StringComparison.OrdinalIgnoreCase);
 
     static AuthoredMemberSourceInspection Absent(string detail)
         => new(

--- a/src/DotnetInspector.Services/AuthoredSourceAcquisition.cs
+++ b/src/DotnetInspector.Services/AuthoredSourceAcquisition.cs
@@ -95,9 +95,12 @@ public static class AuthoredSourceAcquisition
                 SourceChecksumVerification.Unavailable);
         }
 
-        // Prefer a checksum-verified local file (e.g. a local build whose commit is not yet
-        // pushed) before reaching for the remote SourceLink URL. The checksum gate authenticates
-        // the on-disk bytes against the portable PDB, so this cannot surface unrelated content.
+        // Honor the source the portable PDB points at when it is present locally. A non-reproducible
+        // (local dev) build records a real local path, and the exact bytes that produced this binary
+        // may exist only here, so the remote SourceLink URL would 404 or serve different bytes. The
+        // checksum gate authenticates the on-disk bytes against the portable PDB, so this cannot
+        // surface unrelated content; remote SourceLink stays the fallback for reproducible (published)
+        // builds, whose normalized document paths are not local reads in the first place.
         if (TryReadVerifiedLocalSource(document) is { } localBytes)
             return FromContent(mapping, document, localBytes, methodName, subject);
 

--- a/src/DotnetInspector.Services/AuthoredSourceAcquisition.cs
+++ b/src/DotnetInspector.Services/AuthoredSourceAcquisition.cs
@@ -164,9 +164,7 @@ public static class AuthoredSourceAcquisition
 
         try
         {
-            string sourceText = Encoding.UTF8.GetString(content);
-            if (sourceText.Length > 0 && sourceText[0] == '\uFEFF')
-                sourceText = sourceText[1..];
+            string sourceText = DecodeSourceText(content);
             string memberText = SourceLinkResolver.ExtractMethodBody(
                 sourceText,
                 mapping.StartLine,
@@ -256,7 +254,8 @@ public static class AuthoredSourceAcquisition
         if (string.IsNullOrEmpty(localPath)
             || checksumAlgorithm is not { Length: > 0 }
             || checksum is not { Length: > 0 }
-            || !IsCompilerLanguageSourcePath(localPath))
+            || !IsCompilerLanguageSourcePath(localPath)
+            || !IsLocalFileSystemPath(localPath))
         {
             return null;
         }
@@ -264,14 +263,23 @@ public static class AuthoredSourceAcquisition
         byte[] content;
         try
         {
-            if (!File.Exists(localPath))
+            // The document path is attacker-influenced, so bound the I/O even though the checksum
+            // authenticates the content: skip missing files, reparse points (symlinks that could
+            // redirect the read), and oversized files.
+            var info = new FileInfo(localPath);
+            if (!info.Exists
+                || (info.Attributes & FileAttributes.ReparsePoint) != 0
+                || info.Length > MaxLocalSourceBytes)
+            {
                 return null;
+            }
             content = File.ReadAllBytes(localPath);
         }
         catch (Exception ex) when (ex is IOException
             or UnauthorizedAccessException
             or ArgumentException
-            or NotSupportedException)
+            or NotSupportedException
+            or System.Security.SecurityException)
         {
             return null;
         }
@@ -313,6 +321,52 @@ public static class AuthoredSourceAcquisition
         => path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)
             || path.EndsWith(".vb", StringComparison.OrdinalIgnoreCase)
             || path.EndsWith(".fs", StringComparison.OrdinalIgnoreCase);
+
+    // Upper bound on a local source file we are willing to read. Authored source files are small;
+    // this only guards against an attacker-directed path pointing at a pathologically large file.
+    const long MaxLocalSourceBytes = 64L * 1024 * 1024;
+
+    /// <summary>
+    /// True only for a plain, fully-qualified local filesystem path. Rejects relative paths, UNC
+    /// shares (<c>\\server\share</c>), and Win32 device paths (<c>\\?\</c>, <c>\\.\</c>) so an
+    /// untrusted PDB document name cannot trigger outbound SMB/network I/O before the checksum is
+    /// even evaluated.
+    /// </summary>
+    internal static bool IsLocalFileSystemPath(string path)
+    {
+        if (!Path.IsPathFullyQualified(path))
+            return false;
+
+        string full;
+        try
+        {
+            full = Path.GetFullPath(path);
+        }
+        catch (Exception ex) when (ex is ArgumentException
+            or NotSupportedException
+            or PathTooLongException
+            or System.Security.SecurityException)
+        {
+            return false;
+        }
+
+        return !full.StartsWith(@"\\", StringComparison.Ordinal)
+            && !full.StartsWith("//", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Decodes source bytes to text using the byte-order mark to select the encoding
+    /// (UTF-8/UTF-16/UTF-32), defaulting to UTF-8 when no BOM is present, and strips the BOM.
+    /// This mirrors the remote path's <see cref="System.Net.Http.HttpContent.ReadAsStringAsync()"/>
+    /// decoding so a checksum-verified local file in any of those encodings renders identically.
+    /// </summary>
+    public static string DecodeSourceText(byte[] content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        using var stream = new MemoryStream(content, writable: false);
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+        return reader.ReadToEnd();
+    }
 
     static AuthoredMemberSourceInspection Absent(string detail)
         => new(

--- a/src/DotnetInspector.Services/AuthoredSourceAcquisition.cs
+++ b/src/DotnetInspector.Services/AuthoredSourceAcquisition.cs
@@ -328,9 +328,9 @@ public static class AuthoredSourceAcquisition
 
     /// <summary>
     /// True only for a plain, fully-qualified local filesystem path. Rejects relative paths, UNC
-    /// shares (<c>\\server\share</c>), and Win32 device paths (<c>\\?\</c>, <c>\\.\</c>) so an
-    /// untrusted PDB document name cannot trigger outbound SMB/network I/O before the checksum is
-    /// even evaluated.
+    /// shares (<c>\\server\share</c>), Win32 device paths (<c>\\?\</c>, <c>\\.\</c>), and paths on a
+    /// network-mapped drive so an untrusted PDB document name cannot trigger outbound SMB/network
+    /// I/O before the checksum is even evaluated.
     /// </summary>
     internal static bool IsLocalFileSystemPath(string path)
     {
@@ -350,8 +350,30 @@ public static class AuthoredSourceAcquisition
             return false;
         }
 
-        return !full.StartsWith(@"\\", StringComparison.Ordinal)
-            && !full.StartsWith("//", StringComparison.Ordinal);
+        if (full.StartsWith(@"\\", StringComparison.Ordinal)
+            || full.StartsWith("//", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // Reject paths on a network-mapped drive (e.g. Z: -> \\server\share): reading one reaches
+        // the network even though the leading form is a local drive letter. GetDriveType is a local
+        // lookup and does not connect to the share.
+        try
+        {
+            var root = Path.GetPathRoot(full);
+            if (!string.IsNullOrEmpty(root) && new DriveInfo(root).DriveType == DriveType.Network)
+                return false;
+        }
+        catch (Exception ex) when (ex is ArgumentException
+            or IOException
+            or UnauthorizedAccessException
+            or System.Security.SecurityException)
+        {
+            // Indeterminate drive type: fall through to the reparse/size gates and the checksum.
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/ILInspector.Metadata/PdbContext.cs
+++ b/src/ILInspector.Metadata/PdbContext.cs
@@ -849,7 +849,7 @@ public class PdbContext : IDisposable
     private static readonly Guid s_hashSha1 = new("ff1816ec-aa5e-4d10-87f7-6f4963833460");
     private static readonly Guid s_hashSha256 = new("8829d00f-11b8-4213-878b-770e8597ac16");
 
-    private static string? MapHashAlgorithm(Guid algorithm)
+    internal static string? MapHashAlgorithm(Guid algorithm)
     {
         if (algorithm == s_hashSha256) return "SHA256";
         if (algorithm == s_hashSha1) return "SHA1";

--- a/src/ILInspector.Metadata/SourceLinkResolver.cs
+++ b/src/ILInspector.Metadata/SourceLinkResolver.cs
@@ -63,12 +63,18 @@ public class SourceLinkResolver
 
     /// <summary>
     /// Source location for a method, including the full line range from sequence points.
+    /// <paramref name="Checksum"/> is the portable-PDB document hash and
+    /// <paramref name="ChecksumAlgorithm"/> its algorithm name (e.g. "SHA256"); both may be null
+    /// when the PDB records no document hash. They let callers authenticate a local source file
+    /// on disk before preferring it over the remote SourceLink URL.
     /// </summary>
     public record MethodSourceInfo(
         string FilePath,
         string? SourceUrl,
         int StartLine,
-        int EndLine
+        int EndLine,
+        byte[]? Checksum = null,
+        string? ChecksumAlgorithm = null
     );
 
     /// <summary>
@@ -461,8 +467,16 @@ public class SourceLinkResolver
             if (minLine == int.MaxValue)
                 return null;
 
+            byte[]? checksum = null;
+            string? checksumAlgorithm = null;
+            if (!document.Hash.IsNil)
+            {
+                checksum = pdb.GetBlobBytes(document.Hash);
+                checksumAlgorithm = PdbContext.MapHashAlgorithm(pdb.GetGuid(document.HashAlgorithm));
+            }
+
             string? sourceUrl = ApplySourceLinkMapping(filePath);
-            return new MethodSourceInfo(filePath, sourceUrl, minLine, maxLine);
+            return new MethodSourceInfo(filePath, sourceUrl, minLine, maxLine, checksum, checksumAlgorithm);
         }
         catch
         {

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -553,18 +553,36 @@ public class ApiCommand
                 return new ResolvedMethodSource(null, pdbPath);
 
             var methodInfo = service.ResolveMethodSource(typeName, methodName, overloadIndex, publicOnly);
-            if (methodInfo?.SourceUrl == null)
+            if (methodInfo == null)
                 return new ResolvedMethodSource(null, pdbPath);
 
-            var fetcher = new SourceFetcher(DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch);
-            var content = await fetcher.FetchSourceAsync(methodInfo.SourceUrl);
+            // Prefer a checksum-verified local source file (e.g. a local build whose commit is not
+            // yet pushed, so the remote SourceLink URL would 404) before fetching the remote URL.
+            // The checksum authenticates the on-disk bytes against the portable PDB.
+            string? content = null;
+            var localBytes = DotnetInspector.Services.AuthoredSourceAcquisition.TryReadVerifiedLocalSource(
+                methodInfo.FilePath, methodInfo.ChecksumAlgorithm, methodInfo.Checksum);
+            if (localBytes != null)
+            {
+                var text = System.Text.Encoding.UTF8.GetString(localBytes);
+                if (text.Length > 0 && text[0] == '\uFEFF')
+                    text = text[1..];
+                content = text.Replace("\r\n", "\n").Replace("\r", "\n");
+            }
+            else if (methodInfo.SourceUrl != null)
+            {
+                var fetcher = new SourceFetcher(DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch);
+                content = await fetcher.FetchSourceAsync(methodInfo.SourceUrl);
+            }
+
             if (content == null)
                 return new ResolvedMethodSource(null, pdbPath);
 
             var sourceCode = SourceLinkResolver.ExtractMethodBody(
                 content, methodInfo.StartLine, methodInfo.EndLine, methodName);
 
-            return new ResolvedMethodSource(new MethodSourceContext(sourceCode, methodInfo.SourceUrl), pdbPath);
+            return new ResolvedMethodSource(
+                new MethodSourceContext(sourceCode, methodInfo.SourceUrl ?? methodInfo.FilePath), pdbPath);
         }
         catch (Exception ex)
         {

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -564,10 +564,8 @@ public class ApiCommand
                 methodInfo.FilePath, methodInfo.ChecksumAlgorithm, methodInfo.Checksum);
             if (localBytes != null)
             {
-                var text = System.Text.Encoding.UTF8.GetString(localBytes);
-                if (text.Length > 0 && text[0] == '\uFEFF')
-                    text = text[1..];
-                content = text.Replace("\r\n", "\n").Replace("\r", "\n");
+                content = DotnetInspector.Services.AuthoredSourceAcquisition.DecodeSourceText(localBytes)
+                    .Replace("\r\n", "\n").Replace("\r", "\n");
             }
             else if (methodInfo.SourceUrl != null)
             {

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -556,9 +556,10 @@ public class ApiCommand
             if (methodInfo == null)
                 return new ResolvedMethodSource(null, pdbPath);
 
-            // Prefer a checksum-verified local source file (e.g. a local build whose commit is not
-            // yet pushed, so the remote SourceLink URL would 404) before fetching the remote URL.
-            // The checksum authenticates the on-disk bytes against the portable PDB.
+            // Honor the source the portable PDB records when it is present locally: a non-reproducible
+            // (local dev) build keeps a real local path whose exact compiled bytes may exist only here,
+            // so the remote SourceLink URL would 404 or differ. The checksum authenticates the on-disk
+            // bytes against the portable PDB; remote SourceLink is the fallback for reproducible builds.
             string? content = null;
             var localBytes = DotnetInspector.Services.AuthoredSourceAcquisition.TryReadVerifiedLocalSource(
                 methodInfo.FilePath, methodInfo.ChecksumAlgorithm, methodInfo.Checksum);

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -282,7 +282,13 @@ public static class MemberCommand
                 var selectedMember = apiType.Members.Count == 1 ? apiType.Members[0] : null;
                 var sourceTypeName = selectedMember?.DeclaringType ?? apiType.FullName;
                 var sourceOverloadIndex = (selectedMember?.DeclaringOverloadIndex ?? effectiveOptions.OverloadIndex.Value) - 1;
-                var publicOnly = selectedMember?.Kind != "explicit-interface-implementation";
+                // A directly-requested single member (name + overload) is already explicitly named
+                // by the caller. When non-public members are in scope (--all), honor that request
+                // for Original Source / Source Diff regardless of accessibility; member inventories
+                // keep the public-only default. Explicit interface implementations stay resolvable.
+                var directRequest = selectedMember != null && effectiveOptions.IncludeAll;
+                var publicOnly = !directRequest
+                    && selectedMember?.Kind != "explicit-interface-implementation";
                 var resolved = await ApiCommand.ResolveMethodSourceAsync(
                     pdbLookupPath, sourceTypeName,
                     effectiveOptions.MemberFilter.First(),


### PR DESCRIPTION
## Summary

Fixes the `member` command's **Original Source** / **Source Diff** content path, which had two gaps for a directly-requested member:

- **#3026** — a directly-requested *private* member (name + overload) with `--all` still resolved source with `publicOnly:true`, so `PdbContext.ResolveMethodSource` skipped it and the section rendered empty.
- **#3024** — source was fetched remote-only from the SourceLink URL, so a local build whose commit is not yet pushed showed empty Original Source even though the exact source is on disk at the PDB document path.

Both target the same content path and are fixed together.

## Changes

- **#3026 (`MemberCommand.cs`)** — in the single-member source-resolution branch, when a member is directly selected **and** non-public members are in scope (`--all`/`IncludeAll`), pass `publicOnly:false`. Member *inventories* keep the public-only default; explicit interface implementations stay resolvable.
- **#3024 (local-first, checksum-gated)** — prefer a checksum-verified local file before the remote URL:
  - `SourceLinkResolver.MethodSourceInfo` now carries the portable-PDB document `Checksum` + `ChecksumAlgorithm` (populated in `ResolveMethodSourceRange`, reusing `PdbContext.MapHashAlgorithm`).
  - `AuthoredSourceAcquisition` gains one shared `TryReadVerifiedLocalSource(path, alg, checksum)` helper + a public `VerifyChecksum(algorithm, expected, content)` overload. The local read is gated on **checksum match** (the PDB document hash authenticates the on-disk bytes; an attacker cannot precompute a matching hash for an unknown victim file) **plus** a compiler-source extension (`.cs`/`.vb`/`.fs`) as defense-in-depth. Any mismatch/absent checksum/missing file returns `null` → unchanged remote fallback.
  - Wired into **both** the member path (`ApiCommand.ResolveMethodSourceAsync`) and the diff path (`AuthoredSourceAcquisition.AcquireMemberAsync`).

## Security

Reading a file whose path comes from an (untrusted) PDB document name is a recognized threat (`docs/design/untrusted-data-threat-model.md`). The **checksum gate is the mitigation**: the on-disk bytes must hash to the value embedded in the portable PDB, so an attacker cannot substitute arbitrary local content. Extension gating is defense-in-depth. No behavior change to remote fetch.

## Evidence

- **Unit tests** (`VerifiedLocalSourceReadTests`, 8, all pass): checksum match, mismatch rejection, non-source-extension rejection, absent-checksum rejection, absent-file → `null`, CRLF-normalized match, observation overload, `VerifyChecksum` overload.
- **Dogfood (proves both fixes in one run):** built `ILInspector.Decompiler` with SourceLink at an **unpushed** commit, then ran `member` on a **private** method (`WithExpressionPass.IsRecordCloneCall:1 --all -S "Original Source"`). Original Source **rendered** (was empty before). Its SourceLink URL pointed at the unpushed SHA and returns **404** remotely — so the content came solely from the checksum-verified local file. This exercises both #3026 (private direct request) and #3024 (local-first).
- **Sanity:** public method `--all` still renders; a private method **without** `--all` still errors "non-public; pass --all to include it" (inventory default preserved).
- **Suites:** `DotnetInspector.Services.Tests` 276/276 pass. All failures in `dotnet-inspect.Tests` (5) and `Metadata.Tests` (1) were confirmed **pre-existing at `origin/main`** (network-data drift, `\r`/CRLF artifacts, a section-naming baseline, and a Windows path-separator assertion) — this PR introduces **zero** regressions.

## Compatibility

Behavior-safe: remote fetch is unchanged and remains the fallback; local read is additive and strictly checksum+extension gated. Member inventories keep the public-only default.

Adversarial review (two models) to follow — behavior change + new local-file read + security-sensitive.

Fixes #3026
Fixes #3024
