### PR TITLE
Drop redundant (dynamic) cast on dynamic-typed receivers (#2984)

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LadderRung9/LadderRung9.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung9/LadderRung9.cs
@@ -20,6 +20,15 @@ public class DynamicAndExpressionTrees
         return value.Length;
     }
 
+    // Close negative for #2984: the receiver is a genuine `object` parameter (no
+    // [DynamicAttribute]); the member access only becomes dynamic through the
+    // explicit `(dynamic)` cast in source. The redundant-cast drop must NOT fire
+    // here — the static type really is object — so `((dynamic)value)` is kept.
+    public object DynamicGetLengthOfObject(object value)
+    {
+        return ((dynamic)value).Length;
+    }
+
     public object DynamicInvoke(dynamic function, int value)
     {
         return function(value);

--- a/src/ILInspector.Decompiler.Fixtures.LadderRung9/LadderRung9MemberContexts.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung9/LadderRung9MemberContexts.cs
@@ -48,6 +48,18 @@ public class DynamicMemberContexts
         return Get();
     }
 
+    // Nested local-function body whose local function has its OWN top-level
+    // `dynamic` parameter (distinct from InLocalFunction, which captures the
+    // enclosing dynamic param). The raised body drops the redundant cast to
+    // `v.Length`, so the printer-owned local-function declaration must spell the
+    // parameter `dynamic v`, not its `object` TypeRef — otherwise
+    // `object Get(object v) => v.Length;` is CS1061 (#2984, PR #3032 review).
+    public object InLocalFunctionOwnParam(string input)
+    {
+        static object Get(dynamic v) => v.Length;
+        return Get(input);
+    }
+
     // Iterator state-machine body: csc lowers this to a MoveNext method whose
     // declaring type is the generated iterator state machine, while the
     // GetMember context remains the authored enclosing type (same bridge as

--- a/src/ILInspector.Decompiler.Tests/DynamicCallSitePassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DynamicCallSitePassTests.cs
@@ -219,7 +219,11 @@ public class DynamicCallSitePassTests
     {
         var f = LoadCanonicalFunction();
         var output = RaiseAndPrint(f);
-        Assert.Contains("((dynamic)value).Length", output);
+        // `value` is a top-level `dynamic` parameter, so the receiver's static
+        // type is already dynamic and the redundant `((dynamic)value)` cast is
+        // dropped (issue #2984).
+        Assert.Contains("value.Length", output);
+        Assert.DoesNotContain("((dynamic)value)", output);
     }
 
     [Fact]
@@ -238,7 +242,8 @@ public class DynamicCallSitePassTests
         var f = LoadCanonicalFunction();
         BinderCall(f).Arguments[1].ReplaceWith(new Constant("class", StringType));
         var output = RaiseAndPrint(f);
-        Assert.Contains("((dynamic)value).@class", output);
+        Assert.Contains("value.@class", output);
+        Assert.DoesNotContain("((dynamic)value)", output);
     }
 
     [Fact]
@@ -1416,9 +1421,11 @@ public class DynamicCallSitePassTests
     public void ImmediateUse_FieldAssignment_Raises()
     {
         // Compiler-backed: `_last = value.Length;` — the dynamic access is the
-        // value of a field store, not a return.
+        // value of a field store, not a return. `value` is a top-level dynamic
+        // parameter, so the redundant cast is dropped (#2984).
         var output = RaiseMemberContext("AssignToField");
-        Assert.Contains("_last = ((dynamic)value).Length;", output);
+        Assert.Contains("_last = value.Length;", output);
+        Assert.DoesNotContain("((dynamic)value)", output);
         Assert.DoesNotContain("Binder.GetMember", output);
     }
 
@@ -1427,18 +1434,22 @@ public class DynamicCallSitePassTests
     {
         // Compiler-backed: `return Identity(value.Length);` — the GetMember
         // access is a call argument (nested inside an unrelated InvokeMember
-        // site that legitimately stays explicit).
+        // site that legitimately stays explicit). `value` is a top-level
+        // dynamic parameter, so the redundant cast is dropped (#2984).
         var output = RaiseMemberContext("UseAsArgument");
-        Assert.Contains("((dynamic)value).Length", output);
+        Assert.Contains("value.Length", output);
+        Assert.DoesNotContain("((dynamic)value)", output);
         Assert.DoesNotContain("Binder.GetMember", output);
     }
 
     [Fact]
     public void ImmediateUse_LocalInitializer_Raises()
     {
-        // Compiler-backed: `object length = value.Length;` used twice.
+        // Compiler-backed: `object length = value.Length;` used twice. `value`
+        // is a top-level dynamic parameter, so the redundant cast is dropped.
         var output = RaiseMemberContext("AssignToLocal");
-        Assert.Contains("((dynamic)value).Length", output);
+        Assert.Contains("value.Length", output);
+        Assert.DoesNotContain("((dynamic)value)", output);
         Assert.DoesNotContain("Binder.GetMember", output);
     }
 
@@ -1447,9 +1458,11 @@ public class DynamicCallSitePassTests
     {
         // A local function is declared on the authored enclosing type, so the
         // GetMember context typeof matches the body's declaring type and the
-        // nested site raises.
+        // nested site raises. `value` is captured into a display-class field
+        // that carries [DynamicAttribute], so the redundant cast is dropped.
         var output = RaiseMemberContext("InLocalFunction");
-        Assert.Contains("((dynamic)value).Length", output);
+        Assert.Contains("value.Length", output);
+        Assert.DoesNotContain("((dynamic)value)", output);
     }
 
     [Fact]
@@ -1472,7 +1485,11 @@ public class DynamicCallSitePassTests
             }
         }
         Assert.NotNull(displayClassOutput);
-        Assert.Contains("((dynamic)value).Length", displayClassOutput);
+        // The captured `value` is hoisted into a display-class field that
+        // carries [DynamicAttribute] (csc emits the attribute on lambda
+        // display-class fields), so the redundant cast is dropped (#2984).
+        Assert.Contains("value.Length", displayClassOutput);
+        Assert.DoesNotContain("((dynamic)value)", displayClassOutput);
         Assert.DoesNotContain("Binder.GetMember", displayClassOutput);
     }
 
@@ -1607,7 +1624,12 @@ public class DynamicCallSitePassTests
             }
         }
         Assert.NotNull(displayClassOutput);
-        Assert.Contains("((dynamic)value).Length", displayClassOutput);
+        // The captured `value` is hoisted into a generic display-class field
+        // (Host<T>'s environment) accessed via a generic-instance MemberReference;
+        // its underlying FieldDefinition carries [DynamicAttribute], so the
+        // redundant cast is dropped through the MemberReference decode (#2984).
+        Assert.Contains("value.Length", displayClassOutput);
+        Assert.DoesNotContain("((dynamic)value)", displayClassOutput);
         Assert.DoesNotContain("Binder.GetMember", displayClassOutput);
     }
 

--- a/src/ILInspector.Decompiler.Tests/DynamicCallSitePassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DynamicCallSitePassTests.cs
@@ -1466,6 +1466,23 @@ public class DynamicCallSitePassTests
     }
 
     [Fact]
+    public void NestedContext_LocalFunctionOwnParam_SpellsDynamicDeclaration()
+    {
+        // The local function has its OWN top-level `dynamic` parameter. The body
+        // drops the redundant cast (`v.Length`), so the printer-owned
+        // local-function declaration must spell the parameter `dynamic v`, not
+        // its `object` TypeRef — else `object Get(object v) => v.Length;` is
+        // CS1061 (#2984, PR #3032 review). Both the dynamic declaration and the
+        // dropped-cast body must be present, and the invalid `object`-declared
+        // form must not appear.
+        var output = RaiseMemberContext("InLocalFunctionOwnParam");
+        Assert.Contains("dynamic v", output);
+        Assert.Contains("v.Length", output);
+        Assert.DoesNotContain("object v", output);
+        Assert.DoesNotContain("((dynamic)v)", output);
+    }
+
+    [Fact]
     public void NestedContext_LambdaDisplayClass_Raises()
     {
         // csc lowers the lambda body into a display-class method whose

--- a/src/ILInspector.Decompiler.Tests/LadderRung9GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung9GateTests.cs
@@ -35,6 +35,7 @@ public class LadderRung9GateTests
         "DynamicEventRemove",
         "DynamicGetIndex",
         "DynamicGetLength",
+        "DynamicGetLengthOfObject",
         "DynamicInvoke",
         "DynamicInvokeMember",
         "DynamicNamedOut",
@@ -95,7 +96,23 @@ public class LadderRung9GateTests
         var members = LoadRaisedMembers();
         var member = members.Single(m => m.Name == "DynamicGetLength");
         Assert.Equal(DecompilationFidelity.Full, member.Function.Fidelity);
-        Assert.Contains("((dynamic)value).Length;", member.Body);
+        // `value` is a top-level `dynamic` parameter, so the redundant
+        // `((dynamic)value)` cast is dropped and the access spells `value.Length`
+        // (issue #2984).
+        Assert.Contains("value.Length;", member.Body);
+        Assert.DoesNotContain("((dynamic)value)", member.Body);
+    }
+
+    [Fact]
+    public void Rung9Fixture_KeepsCastForObjectReceiver()
+    {
+        // Close negative for #2984: the receiver is a genuine `object` parameter
+        // (no [DynamicAttribute]); the access is dynamic only through the explicit
+        // source cast, so the `((dynamic)value)` cast must be preserved.
+        var members = LoadRaisedMembers();
+        var member = members.Single(m => m.Name == "DynamicGetLengthOfObject");
+        Assert.Equal(DecompilationFidelity.Full, member.Function.Fidelity);
+        Assert.Contains("((dynamic)value).Length", member.Body);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2547,7 +2547,7 @@ public sealed partial class CSharpPrinter
         AddressOfMethod m => AddressOfMethodText(m),
         LoadFunctionPointer p => $"/* {p.Describe()} */",
         LoadProperty p => PropertyTarget(p.Accessor, p.HasInstance ? p.Instance : null, p.IndexArguments, p.PropertyName, p.IsVirtual),
-        DynamicGetMember d => $"((dynamic){Operand(d.Receiver)}).{CSharpNaming.EscapeIdentifier(d.PropertyName)}",
+        DynamicGetMember d => DynamicGetMemberText(d),
         NewObject n when MultiDimArrayCreationText(n) is { } text => text,
         NewObject n => $"new {TypeText(n.Constructor.DeclaringType)}({Arguments(n.Arguments, n.Constructor.ParameterTypes, n.Constructor.ParameterRefKinds)})",
         TupleExpression t => $"({Arguments(t.Elements)})",
@@ -2611,6 +2611,29 @@ public sealed partial class CSharpPrinter
             RuntimeTokenKind.Method => $"/* {token.Describe()} */ default(System.RuntimeMethodHandle)",
             _ => $"/* {token.Describe()} */ null",
         };
+
+    string DynamicGetMemberText(DynamicGetMember d)
+    {
+        string member = CSharpNaming.EscapeIdentifier(d.PropertyName);
+        // A dynamic member access needs no member signature — the name is a
+        // string handed to Binder.GetMember and resolved at runtime — so a
+        // receiver whose static type is already `dynamic` binds `receiver.Member`
+        // with no cast. The `(dynamic)` cast is only required to coerce an
+        // `object`-typed operand (or a mixed expression) into dynamic dispatch.
+        // Drop it when the operand's source (a dynamic parameter, or a hoisted
+        // display-class field carrying [DynamicAttribute]) recovers a dynamic
+        // type view.
+        if (IsDynamicTypedReceiver(d.Receiver))
+            return $"{Operand(d.Receiver)}.{member}";
+        return $"((dynamic){Operand(d.Receiver)}).{member}";
+    }
+
+    static bool IsDynamicTypedReceiver(IrExpression receiver) => receiver switch
+    {
+        LoadArgument { IsDynamic: true } => true,
+        LoadField { Field.IsDynamic: true } => true,
+        _ => false,
+    };
 
     string CoalesceText(Coalesce co, TypeRef? target = null)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1496,7 +1496,7 @@ public sealed partial class CSharpPrinter
         if (node is LocalFunctionStatement localFunction)
         {
             string modifier = localFunction.IsStatic ? "static " : "";
-            string parameters = string.Join(", ", localFunction.Parameters.Select(p => $"{TypeText(p.Type)} {CSharpNaming.EscapeIdentifier(p.Name)}"));
+            string parameters = string.Join(", ", localFunction.Parameters.Select(p => $"{ParameterTypeText(p)} {CSharpNaming.EscapeIdentifier(p.Name)}"));
             string header = $"{modifier}{TypeText(localFunction.ReturnType)} {CSharpNaming.EscapeIdentifier(localFunction.Name)}({parameters})";
             if (localFunction.ExpressionBody is { } body)
             {
@@ -2634,6 +2634,15 @@ public sealed partial class CSharpPrinter
         LoadField { Field.IsDynamic: true } => true,
         _ => false,
     };
+
+    // A parameter authored as top-level `dynamic` must be spelled `dynamic` in
+    // the declaration, not `object` (its TypeRef). This keeps a local-function
+    // header consistent with a body that drops the redundant `(dynamic)` cast on
+    // the parameter: `object Get(object v) => v.Length;` is CS1061, whereas
+    // `object Get(dynamic v) => v.Length;` binds. Top-level method signatures are
+    // spelled by the metadata signature printer; this covers the printer-owned
+    // local-function declaration path.
+    string ParameterTypeText(Parameter p) => p.IsDynamic ? "dynamic" : TypeText(p.Type);
 
     string CoalesceText(Coalesce co, TypeRef? target = null)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1964,10 +1964,10 @@ public static class IrImporter
             if (index == 0)
                 return new LoadArgument(0, "this", method.DeclaringType);
             var p = method.Signature.Parameters[index - 1];
-            return new LoadArgument(index, p.Name, p.Type);
+            return new LoadArgument(index, p.Name, p.Type) { IsDynamic = p.IsDynamic };
         }
         var parameter = method.Signature.Parameters[index];
-        return new LoadArgument(index, parameter.Name, parameter.Type);
+        return new LoadArgument(index, parameter.Name, parameter.Type) { IsDynamic = parameter.IsDynamic };
     }
 
     static LoadArgumentAddress MakeLoadArgumentAddress(ImportedMethod method, int index)
@@ -2555,6 +2555,7 @@ public static class IrImporter
                     BackingPropertyName = BackingPropertyName(reader, declaringType, name),
                     DeclaringTypeCompilerGenerated = FactState(MethodDefinitionFacts.HasCompilerGeneratedAttribute(reader, declaringType.GetCustomAttributes())),
                     FixedBuffer = FixedBufferFieldInfo(reader, field.GetCustomAttributes()),
+                    IsDynamic = DynamicReader.IsTopLevelDynamic(DynamicReader.GetDynamicFlags(reader, field.GetCustomAttributes())),
                 };
             }
             case HandleKind.MemberReference:
@@ -2569,6 +2570,7 @@ public static class IrImporter
                 {
                     BackingPropertyName = MemberReferenceBackingPropertyName(reader, member, name),
                     DeclaringTypeCompilerGenerated = MemberReferenceDefinitionFacts(reader, member, name, false, []).DeclaringTypeCompilerGenerated,
+                    IsDynamic = MemberReferenceFieldIsDynamic(reader, member, name),
                 };
             }
             default:
@@ -2634,6 +2636,26 @@ public static class IrImporter
         if (DeclaringTypeDefinition(reader, member.Parent) is not { } typeHandle)
             return null;
         return BackingPropertyName(reader, reader.GetTypeDefinition(typeHandle), fieldName);
+    }
+
+    // A field referenced through a MemberReference (e.g. a captured `dynamic`
+    // hoisted into a generic display-class field, accessed via a generic-instance
+    // TypeSpec parent) carries its [DynamicAttribute] on the underlying same-
+    // assembly FieldDefinition, not on the reference. Resolve to the definition
+    // and decode the top-level dynamic flag so the printer can drop the redundant
+    // ((dynamic)x) cast for the generic-enclosing case too (issue #2984).
+    static bool MemberReferenceFieldIsDynamic(MetadataReader reader, MemberReference member, string fieldName)
+    {
+        if (DeclaringTypeDefinition(reader, member.Parent) is not { } typeHandle)
+            return false;
+        var declaringType = reader.GetTypeDefinition(typeHandle);
+        foreach (var fieldHandle in declaringType.GetFields())
+        {
+            var field = reader.GetFieldDefinition(fieldHandle);
+            if (string.Equals(reader.GetString(field.Name), fieldName, StringComparison.Ordinal))
+                return DynamicReader.IsTopLevelDynamic(DynamicReader.GetDynamicFlags(reader, field.GetCustomAttributes()));
+        }
+        return false;
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -197,6 +197,16 @@ public sealed record FieldRef(TypeRef DeclaringType, string Name, TypeRef Type)
     public MetadataFactState DeclaringTypeCompilerGenerated { get; init; } = MetadataFactState.Unknown;
 
     /// <summary>
+    /// True when this field's top-level type was authored as <c>dynamic</c> (a
+    /// <c>System.Object</c> position carrying <c>[DynamicAttribute]</c>) — most
+    /// notably a captured <c>dynamic</c> local/parameter hoisted into a
+    /// <c>&lt;&gt;c__DisplayClass</c> field. The printer uses this to drop a
+    /// redundant <c>(dynamic)</c> cast when a load of this field is the receiver
+    /// of a raised dynamic member access.
+    /// </summary>
+    public bool IsDynamic { get; init; }
+
+    /// <summary>
     /// Positive metadata evidence that this field is a C# fixed buffer source
     /// field. Null means no proof, not proof of absence.
     /// </summary>
@@ -1521,6 +1531,14 @@ public sealed class LoadArgument : IrExpression
     public int Index { get; }
     public string Name { get; }
     public TypeRef Type { get; }
+
+    /// <summary>
+    /// True when this parameter's top-level type was authored as <c>dynamic</c>
+    /// (a <c>System.Object</c> position carrying <c>[DynamicAttribute]</c>). The
+    /// printer uses this to drop a redundant <c>(dynamic)</c> cast when this load
+    /// is the receiver of a raised dynamic member access.
+    /// </summary>
+    public bool IsDynamic { get; init; }
     public override TypeRef? ResultType => Type;
 
     public override string Describe() => $"LoadArgument {Index} ({Type.ToDisplayString()} {Name})";

--- a/src/ILInspector.Decompiler/Pipeline/MethodBody.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodBody.cs
@@ -26,8 +26,14 @@ public sealed record MethodBody(
     ImmutableArray<HandlerRegion> Handlers,
     bool SkipLocalsInit = false);
 
-/// <summary>A parameter: name, symbolic type, and whether metadata declares an optional default.</summary>
-public sealed record Parameter(string Name, TypeRef Type, bool HasDefault = false);
+/// <summary>
+/// A parameter: name, symbolic type, whether metadata declares an optional
+/// default, and whether the top-level type was authored as <c>dynamic</c>
+/// (a <c>System.Object</c> position carrying <c>[DynamicAttribute]</c>). The
+/// dynamic view lets the printer drop a redundant <c>(dynamic)</c> cast on a
+/// raised dynamic member access whose receiver is this parameter.
+/// </summary>
+public sealed record Parameter(string Name, TypeRef Type, bool HasDefault = false, bool IsDynamic = false);
 
 /// <summary>A method signature with symbolic types throughout.</summary>
 public sealed record MethodSignature(

--- a/src/ILInspector.Decompiler/Pipeline/MethodImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodImporter.cs
@@ -62,6 +62,7 @@ public static class MethodImporter
         var parameters = ImmutableArray.CreateBuilder<Parameter>(decoded.ParameterTypes.Length);
         var namesByIndex = new Dictionary<int, string>();
         var hasDefaultByIndex = new Dictionary<int, bool>();
+        var dynamicByIndex = new Dictionary<int, bool>();
         foreach (var parameterHandle in method.GetParameters())
         {
             var parameter = reader.GetParameter(parameterHandle);
@@ -69,13 +70,16 @@ public static class MethodImporter
             {
                 namesByIndex[parameter.SequenceNumber - 1] = reader.GetString(parameter.Name);
                 hasDefaultByIndex[parameter.SequenceNumber - 1] = HasDefault(reader, parameter);
+                dynamicByIndex[parameter.SequenceNumber - 1] = DynamicReader.IsTopLevelDynamic(
+                    DynamicReader.GetDynamicFlags(reader, parameter.GetCustomAttributes()));
             }
         }
         for (int i = 0; i < decoded.ParameterTypes.Length; i++)
             parameters.Add(new Parameter(
                 namesByIndex.GetValueOrDefault(i, $"arg{i}"),
                 decoded.ParameterTypes[i],
-                hasDefaultByIndex.GetValueOrDefault(i)));
+                hasDefaultByIndex.GetValueOrDefault(i),
+                dynamicByIndex.GetValueOrDefault(i)));
 
         var signature = new MethodSignature(
             decoded.ReturnType,

--- a/src/ILInspector.Metadata/DynamicReader.cs
+++ b/src/ILInspector.Metadata/DynamicReader.cs
@@ -61,6 +61,17 @@ public static class DynamicReader
     }
 
     /// <summary>
+    /// True when a transform-flags array marks the top-level (outermost) type
+    /// position as <c>dynamic</c>. The flags are a preorder walk over the type;
+    /// index 0 is the whole type, so only a bare <c>dynamic</c> (a
+    /// <c>System.Object</c> authored as <c>dynamic</c>) sets it — a nested
+    /// position such as <c>Func&lt;dynamic&gt;</c> leaves index 0 false. Null
+    /// (attribute absent) means the position is a plain object.
+    /// </summary>
+    public static bool IsTopLevelDynamic(byte[]? dynamicFlags)
+        => dynamicFlags is { Length: > 0 } flags && flags[0] == 1;
+
+    /// <summary>
     /// Gets DynamicAttribute transform flags for a specific parameter by sequence
     /// number. Sequence 0 = return type, 1+ = parameters.
     /// </summary>

--- a/tests/ILInspector.Metadata.Tests/DynamicTypeViewTests.cs
+++ b/tests/ILInspector.Metadata.Tests/DynamicTypeViewTests.cs
@@ -404,6 +404,20 @@ public sealed class DynamicTypeViewTests
         node.ApplyDynamic(flags, ref pos);
         Assert.Equal("object[]", node.Render());
     }
+
+    // --- IsTopLevelDynamic predicate: only the outermost (index-0) position ---
+
+    [Theory]
+    [InlineData(null, false)]              // attribute absent -> plain object
+    [InlineData(new byte[] { }, false)]    // empty flags -> not dynamic
+    [InlineData(new byte[] { 0 }, false)]  // object at the top-level position
+    [InlineData(new byte[] { 1 }, true)]   // bare `dynamic` (or marker form)
+    [InlineData(new byte[] { 0, 1 }, false)] // `Func<dynamic>` -> nested, not top-level
+    [InlineData(new byte[] { 1, 0 }, true)]  // `dynamic` outer with a non-dynamic arg
+    public void IsTopLevelDynamic_ReadsOutermostPositionOnly(byte[]? flags, bool expected)
+    {
+        Assert.Equal(expected, DynamicReader.IsTopLevelDynamic(flags));
+    }
 }
 
 // ===== Test fixture types with a spread of dynamic type shapes =====


### PR DESCRIPTION
- Advances #2984 (umbrella #2996)
- Drops the redundant `((dynamic)x)` cast on a raised dynamic member access when the receiver's static type is already `dynamic`
- Card revision: `a5ee9f18`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — a dynamic member access carries no member signature (the name is a string handed to the runtime binder), so `receiver.Member` binds directly when the receiver is already `dynamic`; the cast is only needed to coerce an `object`-typed operand, and the change drops it exactly when metadata proves the receiver dynamic and keeps it everywhere else.

### Original source

SourceLink cannot supply C# for the local fixture assembly, so the authoritative anchor is the raw IL (the C# author wrote `public object DynamicGetLength(dynamic value) => ((dynamic)value).Length;`). The IL is a call-site dynamic `GetMember("Length")` on `ldarg.1`:

```il
IL_0008: ldstr        "Length"
IL_0027: call         Microsoft.CSharp.RuntimeBinder.Binder::GetMember(...)
IL_002C: call         System.Runtime.CompilerServices.CallSite<System.Func<CallSite, object, object>>::Create(...)
IL_0040: ldsfld       ...<>o__1::<>p__0
IL_0045: ldarg.1
IL_0046: callvirt     System.Func<CallSite, object, object>::Invoke(CallSite, object)
```

### Before

```csharp
public object DynamicGetLength(dynamic value) => ((dynamic)value).Length;
```

- Valid: True
- Correct: True

Valid and correct, but the `(dynamic)` cast on a receiver that is already `dynamic` is redundant noise.

### After

```csharp
public object DynamicGetLength(dynamic value) => value.Length;
```

- Valid: True
- Correct: True

### Fully raised

The After decompilation is in the fully raised state.

## How

Recover the dynamic type view from metadata and let the printer decide:

- Decode `[DynamicAttribute]` at import time via the shared `DynamicReader.IsTopLevelDynamic` primitive (index 0 of the transform-flags preorder walk is the whole type; a nested `Func<dynamic>` leaves it false, so only a bare `dynamic` sets it).
- Thread the fact through three receiver paths: a dynamic parameter (`Parameter`/`LoadArgument.IsDynamic`), a hoisted display-class field (`FieldRef.IsDynamic` via `FieldDefinition`), and a generic-enclosing display-class field accessed through a `MemberReference` (`MemberReferenceFieldIsDynamic` resolves the underlying same-assembly definition).
- `CSharpPrinter.DynamicGetMemberText` drops the cast only for a receiver with a recovered dynamic view; every other receiver keeps it.

Conservative by construction: csc omits `[DynamicAttribute]` on iterator/async state-machine hoisted fields, and spilled-temp receivers are plain locals, so both keep the cast — no false drops. `FieldRef.IsDynamic` never affects the cache-field (`<>o__N`) identity checks in `DynamicCallSitePass` (cache fields are never dynamic).

## Evidence

Controlled A/B, identical `-notrait "Speed=Slow"` Decompiler suite, base `20f16b9a` (this commit's base) vs head `a5ee9f18`:

| Check | Baseline (`20f16b9a`) | Head (`a5ee9f18`) |
| --- | --- | --- |
| Product build (`src/dotnet-inspect`) | Pass | Pass |
| `DynamicCallSitePassTests` | 110 passed | 110 passed |
| `LadderRung9GateTests` | 19 passed | 20 passed (+1 new gate) |
| `DynamicTypeViewTests` (Metadata) | 50 passed | 50 passed |
| Decompiler fast suite | 55 failed (+1 unbuilt-fixture artifact) | 55 failed |
| Real witness `DynamicGetLength(dynamic)` | `((dynamic)value).Length` | `value.Length` |
| Real witness `DynamicGetLengthOfObject(object)` | n/a (new fixture) | `((dynamic)value).Length` (cast kept) |

Failing-test **set** diff: **zero head-only failures** (no regressions). The 55 head failures are all pre-existing Windows-local #3018 env issues (CS0009 native-DLL recompile / CRLF / path-sep) and fail identically at base. The single base-only failure (`ExpressionTreeLambdaTests.LookalikeExpressionAssembly_StaysFactoryCalls`) is a `FileNotFoundException` for an unbuilt fixture in the partial base worktree, not a product difference.

New tests: negative fixture `DynamicGetLengthOfObject(object) => ((dynamic)value).Length;` + gate `Rung9Fixture_KeepsCastForObjectReceiver` (object receiver keeps cast); `IsTopLevelDynamic` Theory (null/[0]/[1]/[0,1]/[1,0]); iterator/generic-iterator cases assert the cast is still kept.

## Validation

```powershell
dotnet build src\dotnet-inspect\dotnet-inspect.csproj -c Release --configfile .\nuget.config
dotnet run --project src\ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.DynamicCallSitePassTests"
dotnet run --project src\ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.LadderRung9GateTests"
dotnet run --project tests\ILInspector.Metadata.Tests -c Release -- -class "ILInspector.Metadata.Tests.DynamicTypeViewTests"
dotnet run --project src\ILInspector.Decompiler.Tests -c Release -- -notrait "Speed=Slow"
```



## Post-review update (head `6173567b`)

Adversarial review surfaced one real regression, now fixed (details in the reconciliation comment below):

- **Local-function own dynamic param** (GPT, High): a local function with its own `dynamic` parameter dropped the body cast but the printer-owned local-function declaration spelled the param from its `TypeRef` as `object`, yielding `static object Get(object v) => v.Length;` (CS1061). Fixed in `6173567b`: `CSharpPrinter` routes local-function param types through `ParameterTypeText` (spells `dynamic` when the param is dynamic) → `static object Get(dynamic v) => v.Length;` (valid, opcode-exact). New fixture `DynamicMemberContexts.InLocalFunctionOwnParam` + regression test `NestedContext_LocalFunctionOwnParam_SpellsDynamicDeclaration` (`DynamicCallSitePassTests` now 111/111).
- **`ref/in/out dynamic` receivers** (Gemini, Medium): the cast is conservatively **kept** (valid + correct); the `IsTopLevelDynamic` ByRef-slot offset has zero output effect because by-ref receivers render as deref nodes the printer never drops. Non-blocking; filed as follow-up **#3035**.

Post-fix A/B (head `6173567b` vs `a5ee9f18`): identical failing-test set — zero new failures, zero resolved.
