### PR TITLE
Suppress stray auto-property backing field on RTS Full member surface (#3036)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -540,6 +540,7 @@ public class ReturnToSenderPrototypeTests
                 RoundTripBodyPolicy.Full));
 
             Assert.Contains("public int Value { get; init; }", result.Source);
+            Assert.DoesNotContain("k__BackingField", result.Source);
             Assert.DoesNotContain("return this.Value", result.Source);
             Assert.DoesNotContain("this.Value = value", result.Source);
             Assert.False(result.UsedCompileBackFloor, result.Detail);
@@ -575,12 +576,50 @@ public class ReturnToSenderPrototypeTests
                 RoundTripBodyPolicy.Full));
 
             Assert.Contains("public int Value { get; set; }", result.Source);
+            Assert.DoesNotContain("k__BackingField", result.Source);
             Assert.DoesNotContain("return this.Value", result.Source);
             Assert.DoesNotContain("this.Value = value", result.Source);
             Assert.False(result.UsedCompileBackFloor, result.Detail);
             Assert.True(
                 result.BodyComplete,
                 string.Join(Environment.NewLine, result.FullBodies.Select(body => $"{body.Member}: {body.Status}: {body.Failure}")));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_FullSuppressesStrayAutoPropertyBackingField()
+    {
+        // Issue #3036: when a type is pulled onto the RTS Full member surface and one of its
+        // members is a compiler-synthesized auto-property, the reconstruction preserved the
+        // auto-property skeleton but *also* emitted the raw `<Value>k__BackingField` (sanitized to
+        // `__Value_k__BackingField`) as a separate stray field. The compiler re-synthesizes the
+        // backing field for the auto-property, so the raw field must be suppressed to avoid a
+        // duplicate.
+        var assemblyPath = CompileFixture("""
+            public struct Holder
+            {
+                public int Value { get; init; }
+                public int M() => 1;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Holder", "M", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Contains("public int Value { get; init; }", result.Source);
+            Assert.DoesNotContain("k__BackingField", result.Source);
+            var type = Assert.Single(result.Plan.Types);
+            Assert.DoesNotContain(type.Members, member => member.Name.Contains("k__BackingField", StringComparison.Ordinal));
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
         }
         finally
         {

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -2800,6 +2800,43 @@ public static class CompileBackSourceComposer
         return false;
     }
 
+    // Backing field metadata names (`<Name>k__BackingField`) for every auto-property on the
+    // type whose skeleton the member surface re-emits. The compiler re-synthesizes each such
+    // backing field, so the raw field must be suppressed to avoid a stray duplicate (issue #3036).
+    static HashSet<string> AutoPropertyBackingFieldNames(MetadataReader reader, TypeDefinition typeDef)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var propertyHandle in typeDef.GetProperties())
+        {
+            var property = reader.GetPropertyDefinition(propertyHandle);
+            string propertyName = reader.GetString(property.Name);
+            if (propertyName.Contains('<', StringComparison.Ordinal)
+                || propertyName.Contains('.', StringComparison.Ordinal))
+                continue;
+
+            string returnTypeDisplay;
+            try
+            {
+                var declaration = MetadataDeclarationQuery.GetProperty(reader, typeDef, property);
+                if (declaration.Signature.ReturnType is not { } propertyReturnType)
+                    continue;
+                returnTypeDisplay = CompileBackTypeSignature.Display(propertyReturnType).DisplayName;
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+            {
+                continue;
+            }
+
+            var accessors = property.GetAccessors();
+            bool isAuto = (!accessors.Getter.IsNil && IsAutoProperty(reader, typeDef, property, accessors.Getter, returnTypeDisplay))
+                || (!accessors.Setter.IsNil && IsAutoPropertySetter(reader, typeDef, property, accessors.Setter, returnTypeDisplay));
+            if (isAuto)
+                names.Add($"<{propertyName}>k__BackingField");
+        }
+
+        return names;
+    }
+
     static bool IsAutoProperty(
         MetadataReader reader,
         TypeDefinition typeDef,
@@ -3985,6 +4022,12 @@ public static class CompileBackSourceComposer
                 || requirement.IncludeMemberSurface;
             var accessorMethods = new HashSet<MethodDefinitionHandle>();
             var typeContext = GenericContext.ForType(reader, typeDef);
+            // The compiler re-synthesizes the backing field for each auto-property skeleton this
+            // surface emits, so the raw `<Name>k__BackingField` must not also be emitted as a
+            // field. Its unspeakable name is sanitized to a legal identifier (e.g.
+            // `__Name_k__BackingField`), which would otherwise compile as a stray duplicate field
+            // sitting next to the reconstructed auto-property (issue #3036).
+            var autoPropertyBackingFields = AutoPropertyBackingFieldNames(reader, typeDef);
             foreach (var fieldHandle in typeDef.GetFields())
             {
                 var field = reader.GetFieldDefinition(fieldHandle);
@@ -3993,6 +4036,8 @@ public static class CompileBackSourceComposer
                 {
                     continue;
                 }
+                if (autoPropertyBackingFields.Contains(fieldName))
+                    continue;
                 if (members.Any(member => member.Kind == CompileBackMemberKind.Field && member.Identity.Method == Identifier(fieldName)))
                     continue;
 


### PR DESCRIPTION
## Summary

Fixes #3036. Under the `Full` body policy, when a type is pulled onto the RTS reconstruction member surface and one of its members is a compiler-synthesized auto-property, the reconstruction correctly preserves the auto-property skeleton (per #3008) but *also* emitted the compiler-generated `<Value>k__BackingField` as a separate field. Its unspeakable name was sanitized to a legal identifier (`__Value_k__BackingField`), producing a stray duplicate field next to the reconstructed auto-property:

```csharp
public struct Holder
{
    public int M() { return 1; }
    public int __Value_k__BackingField;   // stray duplicate
    public int Value { get; init; }
}
```

## Fix

`AddClosureMemberSurface`'s field loop now collects the backing-field names (`<Name>k__BackingField`) of every auto-property on the type — via the existing `IsAutoProperty` / `IsAutoPropertySetter` checks — and skips them. The compiler re-synthesizes its own backing field for each emitted auto-property skeleton, so the raw field is redundant.

## Why this is safe

- Backing-field reads/writes by the target body are already expressed through the property (`this.Value`, and the `target-backing-field-read`/`write` requirement path adds a `Value` member), never through the mangled field identifier, so no evidence is lost.
- Fields whose corresponding property is filtered out (unsupported/pointer signature) are independently skipped by the field loop's own guards, so suppression never drops a needed field.
- Suppression is keyed to auto-properties only; explicit-body properties (whose accessors touch a private `_value`) are untouched.

## Evidence

- New regression test `CompileBackTargets_FullSuppressesStrayAutoPropertyBackingField`: asserts no `k__BackingField` in the reconstructed source, no `k__BackingField` member in the plan, `Status == Exact`, no compile-back floor.
- Strengthened the two existing `Holder` auto-property sibling tests with `Assert.DoesNotContain("k__BackingField", ...)`.
- Reproduced the stray field before the fix (`public int __Value_k__BackingField;`), confirmed gone after.
- RoundTrip area: **312/312 pass**. Corpus area: **61/61 pass**.

## Adversarial review

Two-model fixed-head review to follow.