### PR TITLE
Own decompiled-member layout in a CSharp primitive (#2996)

### DIFF
--- a/src/ILInspector.CSharp.Tests/CSharpMemberLayoutTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpMemberLayoutTests.cs
@@ -1,0 +1,63 @@
+using System.Text;
+
+namespace ILInspector.CSharp.Tests;
+
+public sealed class CSharpMemberLayoutTests
+{
+    static string Render(string head, string? body, int indent)
+    {
+        var sb = new StringBuilder();
+        CSharpMemberLayout.Append(sb, head, body, indent);
+        return sb.ToString().Replace("\r\n", "\n");
+    }
+
+    [Fact]
+    public void Append_NullBody_TerminatesDeclaration()
+        => Assert.Equal(
+            "    void M();\n",
+            Render("void M()", body: null, indent: 4));
+
+    [Fact]
+    public void Append_ThrowStub_RendersExpressionBodied()
+        => Assert.Equal(
+            "    int Foo() => throw new NotImplementedException();\n",
+            Render("int Foo()", "throw new NotImplementedException();", indent: 4));
+
+    [Fact]
+    public void Append_SingleReturn_RendersExpressionBodied()
+        => Assert.Equal(
+            "    int Length() => value.Length;\n",
+            Render("int Length()", "return value.Length;", indent: 4));
+
+    [Fact]
+    public void Append_MultiStatementBody_RendersBlockWithBodyOneLevelDeeper()
+        => Assert.Equal(
+            "    void M()\n    {\n        Foo();\n        Bar();\n    }\n",
+            Render("void M()", "Foo();\nBar();", indent: 4));
+
+    [Fact]
+    public void Append_PreservesBlankLinesInBlockBody()
+        => Assert.Equal(
+            "    void M()\n    {\n        Foo();\n\n        Bar();\n    }\n",
+            Render("void M()", "Foo();\n\nBar();", indent: 4));
+
+    [Fact]
+    public void Append_NestedAccessorBlock_UsesIndentPlusFour()
+        => Assert.Equal(
+            "        get\n        {\n            _touch();\n            return _x;\n        }\n",
+            Render("get", "_touch();\nreturn _x;", indent: 8));
+
+    [Fact]
+    public void Append_NestedAccessorExpression_RendersArrow()
+        => Assert.Equal(
+            "        set => _x = value;\n",
+            Render("set", "_x = value;", indent: 8));
+
+    [Fact]
+    public void AppendIndentedBody_PreservesBlankLinesAndTrimsTrailing()
+    {
+        var sb = new StringBuilder();
+        CSharpMemberLayout.AppendIndentedBody(sb, "a();  \n\nb();", indent: 8);
+        Assert.Equal("        a();\n\n        b();\n", sb.ToString().Replace("\r\n", "\n"));
+    }
+}

--- a/src/ILInspector.CSharp/CSharpMemberLayout.cs
+++ b/src/ILInspector.CSharp/CSharpMemberLayout.cs
@@ -1,0 +1,71 @@
+using System.Text;
+
+namespace ILInspector.CSharp;
+
+/// <summary>
+/// Lays out one decompiled member or accessor from a declaration head plus
+/// already-rendered body content: it owns the block-vs-expression-bodied
+/// decision and the brace/indent envelope, so the decompiler supplies body
+/// content and CSharp owns the member layout.
+/// </summary>
+/// <remarks>
+/// This is intentionally <em>not</em> unified with
+/// <see cref="CSharpTypePrinter"/>: that composer is block-only and drops blank
+/// lines, whereas decompiled bodies are expression-capable and preserve blank
+/// lines. The two encode different policies on purpose.
+/// </remarks>
+public static class CSharpMemberLayout
+{
+    /// <summary>
+    /// Appends <paramref name="head"/> at <paramref name="indent"/> spaces laid
+    /// out as: <c>head;</c> when <paramref name="body"/> is <see langword="null"/>;
+    /// <c>head =&gt; expr;</c> when the body is a single legal expression
+    /// statement (per <see cref="CSharpExpressionBody.FromSingleStatement"/>);
+    /// otherwise a brace block with the body content one level (four spaces)
+    /// deeper. Blank lines in the body are preserved.
+    /// </summary>
+    public static void Append(StringBuilder sb, string head, string? body, int indent)
+    {
+        ArgumentNullException.ThrowIfNull(sb);
+        ArgumentNullException.ThrowIfNull(head);
+
+        string pad = new(' ', indent);
+        if (body is null)
+        {
+            sb.AppendLine($"{pad}{head};");
+            return;
+        }
+        if (CSharpExpressionBody.FromSingleStatement(body) is { } expression)
+        {
+            sb.AppendLine($"{pad}{head} => {expression};");
+            return;
+        }
+        sb.AppendLine($"{pad}{head}");
+        sb.AppendLine($"{pad}{{");
+        AppendIndentedBody(sb, body, indent + 4);
+        sb.AppendLine($"{pad}}}");
+    }
+
+    /// <summary>
+    /// Appends <paramref name="body"/> content at <paramref name="indent"/>
+    /// spaces, trimming trailing whitespace and preserving blank lines (an empty
+    /// line stays an empty line). This blank-line-preserving policy is the
+    /// deliberate difference from <see cref="CSharpTypePrinter"/>, which drops
+    /// empty lines.
+    /// </summary>
+    public static void AppendIndentedBody(StringBuilder sb, string body, int indent)
+    {
+        ArgumentNullException.ThrowIfNull(sb);
+        ArgumentNullException.ThrowIfNull(body);
+
+        string pad = new(' ', indent);
+        foreach (var line in body.Split('\n'))
+        {
+            string trimmed = line.TrimEnd();
+            if (trimmed.Length == 0)
+                sb.AppendLine();
+            else
+                sb.AppendLine($"{pad}{trimmed}");
+        }
+    }
+}

--- a/src/ILInspector.Decompiler/MemberBodyProducer.cs
+++ b/src/ILInspector.Decompiler/MemberBodyProducer.cs
@@ -584,15 +584,7 @@ public static class MemberBodyProducer
                         {
                             sb.AppendLine(head);
                             sb.AppendLine("    {");
-                            if (CSharpExpressionBody.FromSingleStatement(body) is { } setExpr)
-                                sb.AppendLine($"        set => {setExpr};");
-                            else
-                            {
-                                sb.AppendLine("        set");
-                                sb.AppendLine("        {");
-                                AppendIndented(sb, body, "            ");
-                                sb.AppendLine("        }");
-                            }
+                            CSharpMemberLayout.Append(sb, "set", body, 8);
                             sb.AppendLine("    }");
                         }
                         else if (CSharpExpressionBody.FromSingleStatement(body) is { } getExpr)
@@ -603,10 +595,7 @@ public static class MemberBodyProducer
                         {
                             sb.AppendLine(head);
                             sb.AppendLine("    {");
-                            sb.AppendLine("        get");
-                            sb.AppendLine("        {");
-                            AppendIndented(sb, body, "            ");
-                            sb.AppendLine("        }");
+                            CSharpMemberLayout.Append(sb, "get", body, 8);
                             sb.AppendLine("    }");
                         }
                         break;
@@ -855,20 +844,7 @@ public static class MemberBodyProducer
         // An explicit base(...)/this(...) chain renders as a signature
         // initializer (the printer lifted it out of the body).
         string head = constructorChain is null ? signature : $"{signature} : {constructorChain}";
-        if (body is null)
-        {
-            sb.AppendLine($"    {head};");
-            return;
-        }
-        if (CSharpExpressionBody.FromSingleStatement(body) is { } expression)
-        {
-            sb.AppendLine($"    {head} => {expression};");
-            return;
-        }
-        sb.AppendLine($"    {head}");
-        sb.AppendLine("    {");
-        AppendIndented(sb, body, "        ");
-        sb.AppendLine("    }");
+        CSharpMemberLayout.Append(sb, head, body, 4);
     }
 
     static string TypeParameterDisplayName(TypeParameter typeParameter)
@@ -984,20 +960,7 @@ public static class MemberBodyProducer
         {
             var (keyword, body, _) = accessors[i];
             if (i > 0) sb.AppendLine();
-            if (body is null)
-            {
-                sb.AppendLine($"        {keyword};");
-                continue;
-            }
-            if (CSharpExpressionBody.FromSingleStatement(body) is { } accessorExpr)
-            {
-                sb.AppendLine($"        {keyword} => {accessorExpr};");
-                continue;
-            }
-            sb.AppendLine($"        {keyword}");
-            sb.AppendLine("        {");
-            AppendIndented(sb, body, "            ");
-            sb.AppendLine("        }");
+            CSharpMemberLayout.Append(sb, keyword, body, 8);
         }
         sb.AppendLine("    }");
     }
@@ -1233,18 +1196,6 @@ public static class MemberBodyProducer
 
     static string DiagnosticComment(DecompilerResult result)
         => string.Join("\n", result.Diagnostics.Select(d => $"// {d}"));
-
-    static void AppendIndented(StringBuilder sb, string body, string indent)
-    {
-        foreach (var line in body.Split('\n'))
-        {
-            string trimmed = line.TrimEnd();
-            if (trimmed.Length == 0)
-                sb.AppendLine();
-            else
-                sb.AppendLine($"{indent}{trimmed}");
-        }
-    }
 
     /// <summary>
     /// Shortens qualified type names against the assembly's own metadata


### PR DESCRIPTION
## Summary

- Advances #2996 step 1 (whole member as the decompiler's natural unit).
- Extracts the decompiled **member layout** — the block-vs-`=> expr;` decision and the brace/indent envelope — out of `MemberBodyProducer` (decompiler layer) into a **CSharp-owned** `CSharpMemberLayout` primitive, and routes every member/accessor composition site through it.
- Output-preserving refactor: **CSharp owns member layout; the decompiler supplies body content.**

## Change

Today `MemberBodyProducer` (in the decompiler assembly) hand-assembles the C# member envelope at five places — method/constructor, the per-accessor loop, and the explicit-interface get/set sub-blocks — each duplicating the same "`head;` / `head => expr;` / `head { block }`" decision plus a blank-line-preserving body indenter (`AppendIndented`). That is C# layout living in the decompiler.

This PR introduces `ILInspector.CSharp.CSharpMemberLayout`:

- `Append(sb, head, body, indent)` — owns the block-vs-expression-bodied decision (via the already-relocated `CSharpExpressionBody`) and the brace/indent envelope; body content renders one level (four spaces) deeper.
- `AppendIndentedBody(sb, body, indent)` — the blank-line-preserving body indenter, relocated from `MemberBodyProducer`.

All five sites now call the primitive; the local `AppendMember` block/expr logic and `AppendIndented` helper are gone.

**Intentionally NOT unified with `CSharpTypePrinter`.** That composer is block-only and drops blank lines; decompiled bodies are expression-capable and preserve blank lines. The two encode different policies on purpose (documented on the primitive).

## Why this is low risk

Pure relocation + routing with **no behavior change** — no new heuristic, shape, or decision; every site maps to the primitive at identical indentation.

## Evidence

- **Controlled A/B (same worktree, `git stash` base vs head, identical inputs, full fast Decompiler suite `-notrait Speed=Slow`, 3237 tests):** identical **56/56** failing set — **zero head-only failures** (no regressions). The 56 failures are all pre-existing Windows-local #3018 compile-back env issues (CS0009 native-DLL recompile), present identically at base.
- **Output oracles:** `MemberBodyProducerTypedBodyTests` + `MemberBodyProducerAsyncTests` + `MemberBodyProducerUnionTests` + `MemberBodyProducerOverloadAddressingTests` + `CSharpFindingsTests` — 52 pass (these snapshot whole-member text: expression-bodied, block, accessors).
- **New unit tests:** `CSharpMemberLayoutTests` — 8 tests (throw-stub `=> throw ...;` (canonical), single-return expression, multi-statement block, null-body `head;`, blank-line preservation, nested-accessor indent + arrow, `AppendIndentedBody` trailing-trim/blank-line). The 19 existing `CSharpExpressionBodyTests` still pass (27 total in `ILInspector.CSharp.Tests`).

## Validation

```powershell
dotnet build src\ILInspector.CSharp.Tests\ILInspector.CSharp.Tests.csproj -c Release --configfile .\nuget.config
dotnet run --project src\ILInspector.CSharp.Tests -c Release --no-build -- -class "ILInspector.CSharp.Tests.CSharpMemberLayoutTests" -class "ILInspector.CSharp.Tests.CSharpExpressionBodyTests"
dotnet build src\ILInspector.Decompiler.Tests\ILInspector.Decompiler.Tests.csproj -c Release --configfile .\nuget.config
dotnet run --project src\ILInspector.Decompiler.Tests -c Release --no-build -- -notrait "Speed=Slow"
```

## Follow-ups (not this PR)

- pr5: point the compile-back harness at the product whole member and retire its skeleton signature builder (depends on this).
- Property lone-getter and explicit-interface get keep a property-level `=> expr;` special-case above the primitive (asymmetric with set by design); left as-is.
