### PR TITLE
Fold negated total-order relational operator-spelled calls (#2955)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -5604,13 +5604,14 @@ public class EnumConstantTests
     }
 
     [Fact]
-    public void NotOverRelationalOperatorCall_Parenthesizes()
+    public void NotOverRelationalOperatorCall_OutsideTotalOrderAllowlist_Parenthesizes()
     {
         // !(a > b) — a relational operator-spelled call renders as a compound
         // `a > b`, so the enclosing `!` must parenthesize it; a bare `!a > b`
-        // binds as `(!a) > b` (CS0023). Unlike equality/inequality, relational
-        // operator calls are NOT folded (!(a>b) is not always a<=b for a
-        // user-defined partial order), so the un-folded node must still be
+        // binds as `(!a) > b` (CS0023). System.Type is NOT in the total-order
+        // relational allowlist (MemberIdentity.IsTotalOrderRelationalOperator —
+        // decimal/DateTime/DateTimeOffset/TimeSpan/DateOnly/TimeOnly), so this
+        // relational call is NOT folded and the un-folded node must still be
         // built and parenthesized directly (#2955).
         var type = TypeRef.CoreLib("System", "Type");
         var boolType = TypeRef.CoreLib("System", "Boolean");
@@ -5697,6 +5698,120 @@ public class EnumConstantTests
 
         Assert.Contains("!(a == b)", output);
         Assert.DoesNotContain("a != b", output);
+    }
+
+    static string PrintNegatedRelationalReturn(TypeRef declaringType, string operatorName)
+    {
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var callee = new MethodRef(declaringType, operatorName, boolType, [declaringType, declaringType], HasThis: false)
+        {
+            IsSpecialName = true,
+            IsOperator = MetadataFactState.Yes,
+        };
+        var call = new Call(callee, isVirtual: false,
+            [new LoadArgument(0, "a", declaringType), new LoadArgument(1, "b", declaringType)]);
+        var block = new Block(0);
+        block.Add(new Return(new LogicalNot(call)));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(boolType, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+        return CSharpPrinter.Print(function).Output!.Trim();
+    }
+
+    [Theory]
+    [InlineData("op_LessThan", "a >= b")]
+    [InlineData("op_LessThanOrEqual", "a > b")]
+    [InlineData("op_GreaterThan", "a <= b")]
+    [InlineData("op_GreaterThanOrEqual", "a < b")]
+    public void NotOverRelationalOperatorCall_OnTotalOrderType_FoldsToDualComparison(string operatorName, string expected)
+    {
+        // For a total-order core-library value type (here System.DateTime), the
+        // four relational operators are exact De Morgan duals for every input —
+        // there is no unordered/NaN pair — so the printer folds a negated
+        // relational operator-spelled call directly to the dual comparison:
+        // !(a < b) -> a >= b, !(a <= b) -> a > b, !(a > b) -> a <= b,
+        // !(a >= b) -> a < b (#2955).
+        string output = PrintNegatedRelationalReturn(TypeRef.CoreLib("System", "DateTime"), operatorName);
+
+        Assert.Contains($"return {expected};", output);
+        Assert.DoesNotContain("op_", output);
+        Assert.DoesNotContain("!(", output);
+    }
+
+    [Fact]
+    public void NotOverRelationalOperatorCall_OnDecimal_FoldsToDualComparison()
+    {
+        // decimal is a total order (no NaN), so !(a < b) is exactly a >= b.
+        // Confirms the fold is keyed on the whole allowlist, not one type (#2955).
+        string output = PrintNegatedRelationalReturn(TypeRef.CoreLib("System", "Decimal"), "op_LessThan");
+
+        Assert.Contains("return a >= b;", output);
+        Assert.DoesNotContain("!(a < b)", output);
+    }
+
+    [Fact]
+    public void NotOverRelationalOperatorCall_InCondition_FoldsToDualComparison()
+    {
+        // The value-position (return) and condition-position (if) switches share
+        // the same fold; an `if (!(a < b))` on a total-order type spells
+        // `if (a >= b)` (#2955).
+        var timeSpan = TypeRef.CoreLib("System", "TimeSpan");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var callee = new MethodRef(timeSpan, "op_LessThan", boolType, [timeSpan, timeSpan], HasThis: false)
+        {
+            IsSpecialName = true,
+            IsOperator = MetadataFactState.Yes,
+        };
+        var call = new Call(callee, isVirtual: false,
+            [new LoadArgument(0, "a", timeSpan), new LoadArgument(1, "b", timeSpan)]);
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        var then = new Block(4);
+        then.Add(new Return(null));
+        block.Add(new IfStatement(new LogicalNot(call), then, null));
+        block.Add(new Return(null));
+        var signature = new MethodSignature(voidType,
+            [new Parameter("a", timeSpan), new Parameter("b", timeSpan)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        string output = CSharpPrinter.Print(function).Output!.Trim();
+
+        Assert.Contains("if (a >= b)", output);
+        Assert.DoesNotContain("!(a < b)", output);
+    }
+
+    [Fact]
+    public void NotOverRelationalOperatorCall_OnHalf_DoesNotFold()
+    {
+        // System.Half uses operator CALLS (not native clt/cgt) AND is an
+        // IEEE-754 partial order: NaN is unordered, so when a or b is NaN,
+        // !(a < b) is true while a >= b is false. Folding !(a < b) to a >= b
+        // would therefore change behavior, so Half is deliberately EXCLUDED
+        // from the total-order allowlist and the negated relational call must
+        // stay un-folded and parenthesized (#2955 soundness guard).
+        string output = PrintNegatedRelationalReturn(TypeRef.CoreLib("System", "Half"), "op_LessThan");
+
+        Assert.Contains("!(a < b)", output);
+        Assert.DoesNotContain("a >= b", output);
+    }
+
+    [Fact]
+    public void NotOverRelationalOperatorCall_OnUserDefinedType_DoesNotFold()
+    {
+        // A user-defined type's operator < and >= need not be exact duals (they
+        // can implement a partial order or unrelated semantics), so an arbitrary
+        // user type carrying real specialname/operator metadata is NOT in the
+        // trusted total-order allowlist; the negated relational call must stay
+        // un-folded and parenthesized even though it still spells `a < b` via the
+        // operator-call spelling (#2955 scope guard).
+        var declaring = TypeRef.Definition("UserAssembly", "UserAssembly", "Vector");
+        string output = PrintNegatedRelationalReturn(declaring, "op_LessThan");
+
+        Assert.Contains("!(a < b)", output);
+        Assert.DoesNotContain("a >= b", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2541,6 +2541,7 @@ public sealed partial class CSharpPrinter
             IsFloatComparison(c.Left, c.Right) ? !c.IsUnsigned : c.IsUnsigned,
             c.Left, c.Right),
         LogicalNot { Operand: Call { Callee.Name: "op_Equality" or "op_Inequality" } call } when InvertedEqualityOperatorCallText(call) is { } invertedEquality => invertedEquality,
+        LogicalNot { Operand: Call { Callee.Name: "op_LessThan" or "op_LessThanOrEqual" or "op_GreaterThan" or "op_GreaterThanOrEqual" } call } when InvertedRelationalOperatorCallText(call) is { } invertedRelational => invertedRelational,
         LogicalNot { Operand: LogicalBinary logical } when TryPropertyPatternText(logical, negated: true) is { } negatedPattern => negatedPattern,
         LogicalNot { Operand: { } operand } when Truthiness(operand) is { } negated => negated.Inverted,
         LogicalNot n => $"!{Operand(n.Operand)}",
@@ -2745,6 +2746,7 @@ public sealed partial class CSharpPrinter
             IsFloatComparison(c.Left, c.Right) ? !c.IsUnsigned : c.IsUnsigned,
             c.Left, c.Right),
         LogicalNot { Operand: Call { Callee.Name: "op_Equality" or "op_Inequality" } call } when InvertedEqualityOperatorCallText(call) is { } invertedEquality => invertedEquality,
+        LogicalNot { Operand: Call { Callee.Name: "op_LessThan" or "op_LessThanOrEqual" or "op_GreaterThan" or "op_GreaterThanOrEqual" } call } when InvertedRelationalOperatorCallText(call) is { } invertedRelational => invertedRelational,
         LogicalNot { Operand: LogicalBinary logical } when TryPropertyPatternText(logical, negated: true) is { } negatedPattern => negatedPattern,
         LogicalNot { Operand: Call { Callee.Name: "op_True", Arguments: [var value] } } => InvertedUserTruthiness(value),
         LogicalNot { Operand: Call { Callee.Name: "op_False", Arguments: [var value] } } => OperatorOperand(value),
@@ -3798,12 +3800,11 @@ public sealed partial class CSharpPrinter
     /// <see cref="IsOperatorCall"/> spelling guard) is deliberately excluded
     /// here: folding would substitute a call to one method with a call to a
     /// different method, which can observably change behavior for a
-    /// maliciously or buggily inconsistent pair. Unlike the relational
-    /// operator-call family (`op_LessThan` and friends, also NOT folded
-    /// here), a relational operator call CAN implement partial-order
-    /// (NaN-like) semantics the native float-comparison guard already
-    /// special-cases, so that family is deliberately left unfolded pending
-    /// its own analysis. Returns null when the call does not actually spell
+    /// maliciously or buggily inconsistent pair. The relational
+    /// operator-call family (`op_LessThan` and friends) is folded separately
+    /// by <see cref="InvertedRelationalOperatorCallText"/>, restricted to the
+    /// total-order core-library value types where the four operators are exact
+    /// duals. Returns null when the call does not actually spell
     /// as `==`/`!=` (an unrelated method that happens to be named
     /// op_Equality/op_Inequality without the metadata operator flag renders
     /// as a plain call, and `!` negating its result is already correct
@@ -3815,6 +3816,37 @@ public sealed partial class CSharpPrinter
             {
                 "op_Equality" => $"{OperatorOperand(left)} != {OperatorOperand(right)}",
                 "op_Inequality" => $"{OperatorOperand(left)} == {OperatorOperand(right)}",
+                _ => null,
+            }
+            : null;
+
+    /// <summary>
+    /// The direct idiom for a negated relational operator-spelled CALL on a
+    /// known total-order core-library value type:
+    /// <c>!(decimal.op_LessThan(a, b))</c> -> <c>a &gt;= b</c>, with the De Morgan
+    /// duals for <c>&lt;=</c>/<c>&gt;</c>/<c>&gt;=</c>. The relational counterpart of
+    /// the equality fold above and the native <c>clt</c>/<c>cgt</c> fold (#2955),
+    /// gated on <see cref="MemberIdentity.IsTotalOrderRelationalOperator"/> —
+    /// <see cref="decimal"/>, <see cref="System.DateTime"/>,
+    /// <see cref="System.DateTimeOffset"/>, <see cref="System.TimeSpan"/>,
+    /// <see cref="System.DateOnly"/>, <see cref="System.TimeOnly"/> — the total
+    /// orders whose four relational operators are exact duals for every input.
+    /// <see cref="System.Half"/> (IEEE-754 partial order: <c>NaN</c> is unordered,
+    /// so <c>!(a &lt; b)</c> can differ from <c>a &gt;= b</c>) and every
+    /// user-defined operator type are excluded there, so a relational negation is
+    /// never rewritten for a type where the operators can disagree;
+    /// <see cref="float"/>/<see cref="double"/> never reach this path (native
+    /// <c>clt</c>/<c>cgt</c>, folded with the unordered-flag guard). Returns null
+    /// off the allowlist, leaving the un-folded operator call to be parenthesized.
+    /// </summary>
+    string? InvertedRelationalOperatorCallText(Call call)
+        => call is { Arguments: [var left, var right] } && MemberIdentity.IsTotalOrderRelationalOperator(call.Callee)
+            ? call.Callee.Name switch
+            {
+                "op_LessThan" => $"{OperatorOperand(left)} >= {OperatorOperand(right)}",
+                "op_LessThanOrEqual" => $"{OperatorOperand(left)} > {OperatorOperand(right)}",
+                "op_GreaterThan" => $"{OperatorOperand(left)} <= {OperatorOperand(right)}",
+                "op_GreaterThanOrEqual" => $"{OperatorOperand(left)} < {OperatorOperand(right)}",
                 _ => null,
             }
             : null;

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -624,6 +624,53 @@ public static class MemberIdentity
         };
     }
 
+    /// <summary>
+    /// True for a relational operator-spelled CALL — <c>op_LessThan</c>,
+    /// <c>op_LessThanOrEqual</c>, <c>op_GreaterThan</c>, or
+    /// <c>op_GreaterThanOrEqual</c> — declared on a known core-library value
+    /// type whose natural order is TOTAL: <see cref="decimal"/>,
+    /// <see cref="System.DateTime"/>, <see cref="System.DateTimeOffset"/>,
+    /// <see cref="System.TimeSpan"/>, <see cref="System.DateOnly"/>, or
+    /// <see cref="System.TimeOnly"/>. For these types the four relational
+    /// operators are exact De Morgan duals for EVERY pair of inputs — there is
+    /// no unordered/NaN pair — so <c>!(a &lt; b)</c> is always <c>a &gt;= b</c>.
+    /// This is the safety gate for the relational negation fold (#2955). It
+    /// deliberately EXCLUDES partial-order operator types — most notably
+    /// <see cref="System.Half"/>, whose IEEE-754 order is partial (<c>NaN</c> is
+    /// unordered, so <c>!(a &lt; b)</c> can differ from <c>a &gt;= b</c>) — and
+    /// every user-defined operator type, whose <c>&lt;</c>/<c>&gt;=</c> need not
+    /// be duals. <see cref="float"/>/<see cref="double"/> never reach this path:
+    /// they compile to native <c>clt</c>/<c>cgt</c>, folded (with the
+    /// unordered-flag guard) by the comparison path. The declaring type is
+    /// assembly-gated through <see cref="IsCoreLibraryType"/>, so a user type
+    /// masquerading as <c>System.Decimal</c> in its own assembly is not matched.
+    /// </summary>
+    public static bool IsTotalOrderRelationalOperator(MethodRef method)
+    {
+        if (method.HasThis || !method.TypeArguments.IsEmpty)
+            return false;
+
+        return method is
+        {
+            Name: "op_LessThan" or "op_LessThanOrEqual" or "op_GreaterThan" or "op_GreaterThanOrEqual",
+            DeclaringType: var declaringType,
+            ParameterTypes: [var left, var right],
+            ReturnType: var returnType,
+        }
+            && returnType.Equals(s_bool)
+            && left.Equals(declaringType)
+            && right.Equals(declaringType)
+            && IsTotalOrderValueType(declaringType);
+    }
+
+    static bool IsTotalOrderValueType(TypeRef declaringType)
+        => IsCoreLibraryType(declaringType, "System", "Decimal")
+            || IsCoreLibraryType(declaringType, "System", "DateTime")
+            || IsCoreLibraryType(declaringType, "System", "DateTimeOffset")
+            || IsCoreLibraryType(declaringType, "System", "TimeSpan")
+            || IsCoreLibraryType(declaringType, "System", "DateOnly")
+            || IsCoreLibraryType(declaringType, "System", "TimeOnly");
+
     static bool IsStringBinaryOperator(TypeRef declaringType, TypeRef left, TypeRef right)
         => IsCoreLibraryType(declaringType, "System", "String")
             && left.Equals(s_string)


### PR DESCRIPTION
## What

Continues the negated-comparison idiom recovery from #2961 into the relational De Morgan pairs that issue #2955 explicitly deferred:

- `!(a < b)` → `a >= b`
- `!(a <= b)` → `a > b`
- `!(a > b)` → `a <= b`
- `!(a >= b)` → `a < b`

## Why

The branch-polarity raiser renders a negated relational operator-spelled call as `!(a < b)` instead of the idiomatic `a >= b`, which Roslyn then re-lowers with an inverted `brtrue`/`brfalse` and a relocated block (the `valid_different.semantic_opcode_diff.syntax` frontier in #2955). Folding to the dual comparison reads naturally and aligns the recompiled branch polarity with the source — the same mechanism #2961 fixed for `op_Equality`/`op_Inequality`.

## Soundness (the critical property)

The fold is gated on a **narrow, purpose-built allowlist** `MemberIdentity.IsTotalOrderRelationalOperator`, restricted to core-library value types whose natural order is **total** — `decimal`, `DateTime`, `DateTimeOffset`, `TimeSpan`, `DateOnly`, `TimeOnly` — where the four relational operators are exact De Morgan duals for **every** input, so `!(a < b)` is always `a >= b`.

Deliberately **excluded**:

- **`System.Half`** — uses operator CALLS (not native `clt`/`cgt`) **and** is an IEEE-754 partial order: `NaN` is unordered, so `!(a < b)` can differ from `a >= b`. This is the key negative case.
- **`float`/`double`** — never reach this path (native `clt`/`cgt`, folded with the unordered-flag guard by the comparison path).
- **every user-defined operator type** — a user `<`/`>=` pair need not be exact duals; folding could substitute one method call for a different one (the scope guard #2961's adversarial review established for the equality pair).

The declaring type is assembly-gated through `IsCoreLibraryType`, so a user type masquerading as `System.Decimal` in its own assembly is not matched. (Adversarial review surfaced that this corelib gate is name-forgeable; that is a pre-existing, systemic property shared with the merged #2961 fold, tracked separately in #3045 — see the reconciliation comment below.)

## Evidence

### Real-world before/after (NodaTime)

`NodaTime.TimeZones.BclDateTimeZone.BclAdjustmentRule::IsStandardOffsetOnlyRule` (package `NodaTime` 3.1.11, `net6.0`). Authored source ([`BclDateTimeZone.cs` L434-L442](https://github.com/nodatime/nodatime/blob/3.1.11/src/NodaTime/TimeZones/BclDateTimeZone.cs#L434-L442)):

```csharp
return daylight.IsFixedDateRule && daylight.Day == 1 && daylight.Month == 1 &&
       daylight.TimeOfDay.TimeOfDay < TimeSpan.FromMinutes(1) &&
       standard.IsFixedDateRule && standard.Day == 1 && standard.Month == 1 &&
       standard.TimeOfDay.TimeOfDay < TimeSpan.FromMinutes(1);
```

**How to read the decompiled output.** This single `return` is an eight-operand `&&` chain. A short-circuit `&&` chain compiles to early-exit guards — *bail out (`return false`) when an operand is **not** satisfied*, then return the final operand directly:

```text
if (!A) return false;   // operand 1
...
if (!(a < b)) return false;   // operand 4 — the "!" is added by the && lowering, NOT in the source
...
return (a < b);   // operand 8 — final operand returned directly, no "!"
```

So the eight `&&` operands map one-for-one, top to bottom, onto the eight statements below. The locals are named `daylight`/`standard` after the source; note that `TimeZoneInfo.TransitionTime.TimeOfDay` is itself a `DateTime` (spilled to `V_2`), whose `.TimeOfDay` is the `TimeSpan`-of-day — hence the doubled `.TimeOfDay`.

**Why operand 4 shows `>=` when the source says `<`.** The `>=` is not a different comparison — it is the *negation* of the source `<`, and that negation is the early-exit test introduced by the `&&` lowering above. Operand 4's guard is `if (!(a < b)) return false;`; this PR folds `!(a < b)` to its exact De Morgan dual for a total-order type, `a >= b`, giving `if (a >= b) return false;` — the **same condition**, idiomatically spelled. The **eighth** operand keeps `<` because the final `&&` operand becomes `return … < …;` directly, with no early-exit negation to fold — which is exactly why only operand 4 changes. Full decompiled method, base vs this PR (product command `member "NodaTime.TimeZones.BclDateTimeZone+BclAdjustmentRule" -m IsStandardOffsetOnlyRule --library NodaTime.dll --all -S "Decompiled Source"`):

```diff
 private static bool IsStandardOffsetOnlyRule(System.TimeZoneInfo.AdjustmentRule rule)
 {
     TimeZoneInfo.TransitionTime daylight = rule.DaylightTransitionStart;
     TimeZoneInfo.TransitionTime standard = rule.DaylightTransitionEnd;
     if (!daylight.IsFixedDateRule)      // && operand 1
     {
         return false;
     }
     if (daylight.Day != 1)              // && operand 2
     {
         return false;
     }
     if (daylight.Month != 1)            // && operand 3
     {
         return false;
     }
     DateTime V_2 = daylight.TimeOfDay;
-    if (!(V_2.TimeOfDay < TimeSpan.FromMinutes(1d)))   // && operand 4 — base (pre-fold)
+    if (V_2.TimeOfDay >= TimeSpan.FromMinutes(1d))     // && operand 4 — this PR
     {
         return false;
     }
     if (!standard.IsFixedDateRule)      // && operand 5
     {
         return false;
     }
     if (standard.Day != 1)              // && operand 6
     {
         return false;
     }
     if (standard.Month != 1)            // && operand 7
     {
         return false;
     }
     V_2 = standard.TimeOfDay;
     return V_2.TimeOfDay < TimeSpan.FromMinutes(1d);   // && operand 8 — not negated, unchanged
 }
```

(The `// && operand N` comments are annotations for this write-up; the tool output is otherwise verbatim.) The fold changes exactly one line — operand 4 — from `!(V_2.TimeOfDay < …)` to `V_2.TimeOfDay >= …`; operand 8's non-negated `<` is untouched, confirming the fold targets only the negated operand. This is the direct relational analogue of #2961's `!(type == typeof(string)) && (…)` short-circuit shape.

Both are valid and semantically identical. On the isolated two-condition shape (`a < FromMinutes(1) && b < FromMinutes(1)`), an opcode dump confirms the branch direction: the original source `<` compiles to `op_LessThan; brfalse`, the base `!(a < …)` recompiles to `op_LessThan; brtrue` (branch flipped), and the folded `a >= …` recompiles to `op_GreaterThanOrEqual; brfalse` — recovering the source branch polarity.

### Fixture before/after (type coverage + `Half` exclusion)

Product `member … -S "Decompiled Source"` on a compiled `net11.0` fixture, exercising the value position, the condition position, and the `Half` negative case:

| Source | base (pre-fold) | head (this PR) |
| --- | --- | --- |
| `!(a < b)` (DateTime) | `!(a < b)` | `a >= b` |
| `if (!(a >= b))` (DateTime) | `if (!(a >= b))` | `if (a < b)` |
| `!(a < b)` (**Half**) | `!(a < b)` | `!(a < b)` (unchanged) |

### Total-order duality (empirical)

Reflection probe over the six allowlist types + `Half`: all six live in `System.Private.CoreLib`, declare all four relational operators, and satisfy `!(a<b) == a>=b` for every sample (including the equality boundary). `Half`'s dual **breaks** on `NaN` (`!(a<b)=true`, `a>=b=false`), confirming the exclusion.

### Unit tests

`IrImporterTests` (xUnit v3, run locally green): the four folds (Theory), `decimal`, the condition position, the `Half` partial-order exclusion, and the user-defined-type scope guard. Renames the prior `NotOverRelationalOperatorCall_Parenthesizes` → `_OutsideTotalOrderAllowlist_Parenthesizes` (`System.Type` carries no relational operators, stays un-folded and parenthesized).

## Fidelity tradeoff (same family as #2961)

For a genuine literal `!(a < b)` source (origin `op_LessThan; ceq`), the fold renders `a >= b` (recompiles to `op_GreaterThanOrEqual`), i.e. valid-but-different for that origin; for the mis-raised short-circuit shape it recovers the source `brfalse` branch polarity. Output is always valid and semantically identical. Full-corpus fidelity/no-regression is validated by the CI fidelity gates (local compile-back is blocked by a pre-existing Windows env issue).

## Follow-up

The NodaTime witness also shows the decompiler emitting the lowered early-exit guard sequence rather than recomposing the source's single `return A && B && … ;` boolean `&&`-chain. That guard-sequence → `&&`-return recomposition is a distinct readability raise, tracked in #3051 (out of scope here).

Closes #2955.


