### PR TITLE
--repo: read authored source from a local git clone (member Original Source + Implementation Diff)

### DIFF
--- a/src/DotnetInspector.Services.Tests/LocalRepoSourceReadTests.cs
+++ b/src/DotnetInspector.Services.Tests/LocalRepoSourceReadTests.cs
@@ -1,0 +1,299 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace DotnetInspector.Services.Tests;
+
+public class LocalRepoSourceReadTests
+{
+    const string Source =
+        "class Sample\n{\n    public int M()\n    {\n        return 1;\n    }\n}\n";
+
+    const string RelativePath = "src/Sample.cs";
+
+    // ---------- URL parsing (no git required) ----------
+
+    [Fact]
+    public void ParsesGitHubRawUrl_IntoShaAndPath()
+    {
+        bool ok = LocalRepoSourceAcquisition.TryParseGitHubRawUrl(
+            "https://raw.githubusercontent.com/dotnet/runtime/0123456789abcdef0123456789abcdef01234567/src/libraries/Foo.cs",
+            out string sha, out string path);
+
+        Assert.True(ok);
+        Assert.Equal("0123456789abcdef0123456789abcdef01234567", sha);
+        Assert.Equal("src/libraries/Foo.cs", path);
+    }
+
+    [Fact]
+    public void ParsesGitHubRawUrl_UnescapesPath()
+    {
+        bool ok = LocalRepoSourceAcquisition.TryParseGitHubRawUrl(
+            "https://raw.githubusercontent.com/o/r/0123456789abcdef0123456789abcdef01234567/src/My%20File.cs",
+            out _, out string path);
+
+        Assert.True(ok);
+        Assert.Equal("src/My File.cs", path);
+    }
+
+    [Theory]
+    // Wrong host: never address a non-GitHub URL as a github raw blob.
+    [InlineData("https://example.com/o/r/0123456789abcdef0123456789abcdef01234567/a.cs")]
+    // Non-hex commit segment.
+    [InlineData("https://raw.githubusercontent.com/o/r/not-a-sha/a.cs")]
+    // Missing path segment.
+    [InlineData("https://raw.githubusercontent.com/o/r/0123456789abcdef0123456789abcdef01234567")]
+    // Not an absolute URL.
+    [InlineData("raw.githubusercontent.com/o/r/0123456789abcdef0123456789abcdef01234567/a.cs")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void RejectsNonAddressableUrls(string? url)
+    {
+        Assert.False(LocalRepoSourceAcquisition.TryParseGitHubRawUrl(url, out _, out _));
+    }
+
+    // ---------- git blob read (requires git) ----------
+
+    [Fact]
+    public void ReadsBlob_WhenChecksumMatches()
+    {
+        RequireGit();
+        byte[] content = Encoding.UTF8.GetBytes(Source);
+        var (repo, sha) = InitRepoWithFile(RelativePath, content);
+        try
+        {
+            byte[]? result = LocalRepoSourceAcquisition.TryReadVerifiedRepoBlob(
+                RawUrl(sha, RelativePath), "SHA256", SHA256.HashData(content), [repo]);
+
+            Assert.NotNull(result);
+            Assert.Equal(content, result);
+        }
+        finally
+        {
+            TryDeleteDirectory(repo);
+        }
+    }
+
+    [Fact]
+    public void ReturnsNull_WhenChecksumMismatches()
+    {
+        RequireGit();
+        byte[] content = Encoding.UTF8.GetBytes(Source);
+        var (repo, sha) = InitRepoWithFile(RelativePath, content);
+        try
+        {
+            // Bytes exist in the repo but do not match the recorded hash: refuse, so the caller
+            // falls back to the network rather than surfacing an unverified blob.
+            byte[]? result = LocalRepoSourceAcquisition.TryReadVerifiedRepoBlob(
+                RawUrl(sha, RelativePath), "SHA256",
+                SHA256.HashData(Encoding.UTF8.GetBytes(Source + "tampered")), [repo]);
+
+            Assert.Null(result);
+        }
+        finally
+        {
+            TryDeleteDirectory(repo);
+        }
+    }
+
+    [Fact]
+    public void ReturnsNull_WhenCommitNotPresent()
+    {
+        RequireGit();
+        byte[] content = Encoding.UTF8.GetBytes(Source);
+        var (repo, _) = InitRepoWithFile(RelativePath, content);
+        try
+        {
+            byte[]? result = LocalRepoSourceAcquisition.TryReadVerifiedRepoBlob(
+                RawUrl("0000000000000000000000000000000000000000", RelativePath),
+                "SHA256", SHA256.HashData(content), [repo]);
+
+            Assert.Null(result);
+        }
+        finally
+        {
+            TryDeleteDirectory(repo);
+        }
+    }
+
+    [Fact]
+    public void ReturnsNull_WhenPathNotPresent()
+    {
+        RequireGit();
+        byte[] content = Encoding.UTF8.GetBytes(Source);
+        var (repo, sha) = InitRepoWithFile(RelativePath, content);
+        try
+        {
+            byte[]? result = LocalRepoSourceAcquisition.TryReadVerifiedRepoBlob(
+                RawUrl(sha, "src/Missing.cs"), "SHA256", SHA256.HashData(content), [repo]);
+
+            Assert.Null(result);
+        }
+        finally
+        {
+            TryDeleteDirectory(repo);
+        }
+    }
+
+    [Fact]
+    public void ReturnsNull_WhenDirectoryIsNotAGitRepo()
+    {
+        RequireGit();
+        byte[] content = Encoding.UTF8.GetBytes(Source);
+        string dir = Path.Combine(Path.GetTempPath(), $"dotnet-inspect-notrepo-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            byte[]? result = LocalRepoSourceAcquisition.TryReadVerifiedRepoBlob(
+                RawUrl("0123456789abcdef0123456789abcdef01234567", RelativePath),
+                "SHA256", SHA256.HashData(content), [dir]);
+
+            Assert.Null(result);
+        }
+        finally
+        {
+            TryDeleteDirectory(dir);
+        }
+    }
+
+    [Fact]
+    public void ReadsBlob_FromSecondRepo_WhenFirstLacksCommit()
+    {
+        RequireGit();
+        byte[] content = Encoding.UTF8.GetBytes(Source);
+        var (emptyRepo, _) = InitRepoWithFile("other/Unrelated.cs", Encoding.UTF8.GetBytes("// noise\n"));
+        var (goodRepo, sha) = InitRepoWithFile(RelativePath, content);
+        try
+        {
+            byte[]? result = LocalRepoSourceAcquisition.TryReadVerifiedRepoBlob(
+                RawUrl(sha, RelativePath), "SHA256", SHA256.HashData(content),
+                [emptyRepo, goodRepo]);
+
+            Assert.NotNull(result);
+            Assert.Equal(content, result);
+        }
+        finally
+        {
+            TryDeleteDirectory(emptyRepo);
+            TryDeleteDirectory(goodRepo);
+        }
+    }
+
+    [Fact]
+    public void ReturnsNull_WhenNoReposProvided()
+    {
+        byte[] content = Encoding.UTF8.GetBytes(Source);
+        byte[]? result = LocalRepoSourceAcquisition.TryReadVerifiedRepoBlob(
+            RawUrl("0123456789abcdef0123456789abcdef01234567", RelativePath),
+            "SHA256", SHA256.HashData(content), []);
+
+        Assert.Null(result);
+    }
+
+    // ---------- helpers ----------
+
+    static string RawUrl(string sha, string path)
+        => $"https://raw.githubusercontent.com/owner/repo/{sha}/{path}";
+
+    static void RequireGit()
+    {
+        if (!GitAvailable())
+            Assert.Skip("git is not available on PATH.");
+    }
+
+    static bool GitAvailable()
+    {
+        try
+        {
+            using Process? p = Process.Start(new ProcessStartInfo("git", "--version")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            });
+            if (p is null)
+                return false;
+            p.WaitForExit(5000);
+            return p.HasExited && p.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    static (string Repo, string Sha) InitRepoWithFile(string relativePath, byte[] content)
+    {
+        string repo = Path.Combine(Path.GetTempPath(), $"dotnet-inspect-repo-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(repo);
+        Git(repo, "init", "-q");
+        Git(repo, "config", "user.email", "test@example.com");
+        Git(repo, "config", "user.name", "Test");
+        Git(repo, "config", "commit.gpgsign", "false");
+        // Keep the stored blob byte-identical to what we write so the checksum is deterministic.
+        Git(repo, "config", "core.autocrlf", "false");
+
+        string full = Path.Combine(repo, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllBytes(full, content);
+
+        Git(repo, "add", relativePath);
+        Git(repo, "commit", "-q", "-m", "add source");
+        string sha = GitCapture(repo, "rev-parse", "HEAD").Trim();
+        return (repo, sha);
+    }
+
+    static void Git(string repo, params string[] args)
+    {
+        var (exit, _, stderr) = RunGit(repo, args);
+        if (exit != 0)
+            throw new InvalidOperationException($"git {string.Join(' ', args)} failed ({exit}): {stderr}");
+    }
+
+    static string GitCapture(string repo, params string[] args)
+    {
+        var (exit, stdout, stderr) = RunGit(repo, args);
+        if (exit != 0)
+            throw new InvalidOperationException($"git {string.Join(' ', args)} failed ({exit}): {stderr}");
+        return stdout;
+    }
+
+    static (int Exit, string StdOut, string StdErr) RunGit(string repo, string[] args)
+    {
+        var startInfo = new ProcessStartInfo("git")
+        {
+            WorkingDirectory = repo,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (string arg in args)
+            startInfo.ArgumentList.Add(arg);
+
+        using Process process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start git.");
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit(30_000);
+        return (process.ExitCode, stdout, stderr);
+    }
+
+    static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            foreach (string file in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))
+            {
+                try { File.SetAttributes(file, FileAttributes.Normal); }
+                catch { /* best effort */ }
+            }
+            Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // Temp directory cleanup is best-effort.
+        }
+    }
+}

--- a/src/DotnetInspector.Services/AuthoredSourceAcquisition.cs
+++ b/src/DotnetInspector.Services/AuthoredSourceAcquisition.cs
@@ -40,6 +40,7 @@ public static class AuthoredSourceAcquisition
         string methodName,
         FindingSubject subject,
         SourceFetcher fetcher,
+        IReadOnlyList<string>? repositoryPaths = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(source);
@@ -103,6 +104,17 @@ public static class AuthoredSourceAcquisition
         // builds, whose normalized document paths are not local reads in the first place.
         if (TryReadVerifiedLocalSource(document) is { } localBytes)
             return FromContent(mapping, document, localBytes, methodName, subject);
+
+        // Opt-in (--repo): read the committed blob at the SourceLink commit from a user-named local
+        // clone, authenticated by the same portable-PDB checksum, before touching the network. This
+        // is the path that matters for reproducible (published) builds, whose normalized document
+        // paths are not local reads, yet whose exact source lives in a clone the user already has.
+        if (repositoryPaths is { Count: > 0 }
+            && LocalRepoSourceAcquisition.TryReadVerifiedRepoBlob(document, repositoryPaths)
+                is { } repoBytes)
+        {
+            return FromContent(mapping, document, repoBytes, methodName, subject);
+        }
 
         if (document.ResolvedUrl is not { Length: > 0 } url)
         {

--- a/src/DotnetInspector.Services/LocalRepoSourceAcquisition.cs
+++ b/src/DotnetInspector.Services/LocalRepoSourceAcquisition.cs
@@ -3,6 +3,8 @@ using System.Diagnostics;
 using System.IO;
 using System.Text.RegularExpressions;
 
+using ILInspector.Metadata;
+
 namespace DotnetInspector.Services;
 
 /// <summary>
@@ -66,6 +68,36 @@ public static partial class LocalRepoSourceAcquisition
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Convenience overload that reads a checksum-verified blob from one of
+    /// <paramref name="repositoryPaths"/> using a resolved <see cref="SourceDocumentObservation"/>
+    /// (its SourceLink URL, checksum algorithm, and hex checksum).
+    /// </summary>
+    public static byte[]? TryReadVerifiedRepoBlob(
+        SourceDocumentObservation document,
+        IReadOnlyList<string> repositoryPaths)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        if (document.Checksum is not { Length: > 0 })
+            return null;
+
+        byte[] checksum;
+        try
+        {
+            checksum = Convert.FromHexString(document.Checksum);
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+
+        return TryReadVerifiedRepoBlob(
+            document.ResolvedUrl,
+            document.ChecksumAlgorithm,
+            checksum,
+            repositoryPaths);
     }
 
     /// <summary>

--- a/src/DotnetInspector.Services/LocalRepoSourceAcquisition.cs
+++ b/src/DotnetInspector.Services/LocalRepoSourceAcquisition.cs
@@ -1,0 +1,201 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace DotnetInspector.Services;
+
+/// <summary>
+/// Reads a single authored source file from a user-specified local git clone, keyed on the
+/// SourceLink commit + repo-relative path and authenticated against the portable-PDB checksum.
+///
+/// This is the opt-in local-repository counterpart to <see cref="AuthoredSourceAcquisition"/>'s
+/// remote SourceLink fetch. For a reproducible (published) build the PDB records a normalized,
+/// non-local document path plus a raw.githubusercontent URL that encodes the commit SHA and the
+/// repo-relative path. When the user names one or more local clones (<c>--repo</c>), we read the
+/// committed blob at that exact SHA from the git object store — the committed object, not the
+/// working tree — and accept it only when its bytes match the PDB checksum. A wrong repo, commit,
+/// or path therefore self-rejects and the caller falls back to the network. The checksum is the
+/// arbiter, so no repo-URL matching is required.
+/// </summary>
+public static partial class LocalRepoSourceAcquisition
+{
+    // The blob spec handed to git is "<sha>:<repo-relative-path>". The SHA is taken from the
+    // (untrusted) PDB SourceLink URL, so require a plain hex object id before shelling out.
+    [GeneratedRegex("^[0-9a-fA-F]{7,64}$")]
+    private static partial Regex CommitShaRegex();
+
+    private const int GitTimeoutMs = 15_000;
+
+    // Upper bound on a blob we are willing to buffer; authored source files are small.
+    private const long MaxBlobBytes = 64L * 1024 * 1024;
+
+    /// <summary>
+    /// Attempts to read the authored source blob referenced by <paramref name="rawSourceUrl"/> from
+    /// one of <paramref name="repositoryPaths"/>, returning the raw bytes only when they match the
+    /// portable-PDB checksum. Returns <c>null</c> when the URL is not a parseable GitHub raw URL, no
+    /// candidate repo has the commit/path, git is unavailable, or nothing matches the checksum.
+    /// </summary>
+    public static byte[]? TryReadVerifiedRepoBlob(
+        string? rawSourceUrl,
+        string? checksumAlgorithm,
+        byte[]? checksum,
+        IReadOnlyList<string> repositoryPaths)
+    {
+        if (repositoryPaths is null || repositoryPaths.Count == 0)
+            return null;
+        if (checksum is not { Length: > 0 } || string.IsNullOrEmpty(checksumAlgorithm))
+            return null;
+        if (!TryParseGitHubRawUrl(rawSourceUrl, out string sha, out string relativePath))
+            return null;
+
+        foreach (var repositoryPath in repositoryPaths)
+        {
+            if (string.IsNullOrWhiteSpace(repositoryPath))
+                continue;
+
+            byte[]? bytes = TryReadBlob(repositoryPath, sha, relativePath);
+            if (bytes is null)
+                continue;
+
+            if (AuthoredSourceAcquisition.VerifyChecksum(checksumAlgorithm, checksum, bytes)
+                is SourceChecksumVerification.Exact or SourceChecksumVerification.LineEndingNormalized)
+            {
+                return bytes;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Parses a <c>https://raw.githubusercontent.com/&lt;org&gt;/&lt;repo&gt;/&lt;sha&gt;/&lt;path&gt;</c>
+    /// URL into the commit SHA and repo-relative path used to address a git blob. Rejects any other
+    /// host, a non-hex SHA, and a path that is empty, contains a NUL, or would be read as an option.
+    /// </summary>
+    internal static bool TryParseGitHubRawUrl(string? url, out string sha, out string relativePath)
+    {
+        sha = string.Empty;
+        relativePath = string.Empty;
+
+        if (string.IsNullOrEmpty(url)
+            || !Uri.TryCreate(url, UriKind.Absolute, out Uri? uri)
+            || !uri.Host.Equals("raw.githubusercontent.com", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        // /<org>/<repo>/<sha>/<relpath...>
+        string[] parts = uri.AbsolutePath.TrimStart('/').Split('/', 4);
+        if (parts.Length != 4)
+            return false;
+
+        string candidateSha = parts[2];
+        if (!CommitShaRegex().IsMatch(candidateSha))
+            return false;
+
+        string candidatePath = Uri.UnescapeDataString(parts[3]);
+        if (candidatePath.Length == 0
+            || candidatePath.Contains('\0')
+            || candidatePath.StartsWith('-'))
+        {
+            return false;
+        }
+
+        sha = candidateSha;
+        relativePath = candidatePath;
+        return true;
+    }
+
+    private static byte[]? TryReadBlob(string repositoryPath, string sha, string relativePath)
+    {
+        string fullRepo;
+        try
+        {
+            if (!Path.IsPathFullyQualified(repositoryPath))
+                return null;
+            fullRepo = Path.GetFullPath(repositoryPath);
+            if (!Directory.Exists(fullRepo))
+                return null;
+        }
+        catch (Exception ex) when (ex is ArgumentException
+            or NotSupportedException
+            or PathTooLongException
+            or System.Security.SecurityException)
+        {
+            return null;
+        }
+
+        var startInfo = new ProcessStartInfo("git")
+        {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            WorkingDirectory = fullRepo,
+        };
+        startInfo.ArgumentList.Add("-C");
+        startInfo.ArgumentList.Add(fullRepo);
+        startInfo.ArgumentList.Add("cat-file");
+        startInfo.ArgumentList.Add("blob");
+        startInfo.ArgumentList.Add($"{sha}:{relativePath}");
+        // Never let git block on a credential prompt or take a repo lock for this read-only lookup.
+        startInfo.Environment["GIT_TERMINAL_PROMPT"] = "0";
+        startInfo.Environment["GIT_OPTIONAL_LOCKS"] = "0";
+
+        Process? process;
+        try
+        {
+            process = Process.Start(startInfo);
+        }
+        catch (Exception ex) when (ex is Win32Exception or InvalidOperationException)
+        {
+            // git is not installed / not on PATH.
+            return null;
+        }
+
+        if (process is null)
+            return null;
+
+        using (process)
+        {
+            Task<byte[]?> stdoutTask = Task.Run(() => ReadCappedStdout(process.StandardOutput.BaseStream));
+            Task<string> stderrTask = process.StandardError.ReadToEndAsync();
+
+            if (!process.WaitForExit(GitTimeoutMs))
+            {
+                try { process.Kill(entireProcessTree: true); }
+                catch { /* best effort */ }
+                return null;
+            }
+
+            // Ensure the redirected streams are fully drained before inspecting the exit code.
+            process.WaitForExit();
+
+            byte[]? bytes;
+            try { bytes = stdoutTask.GetAwaiter().GetResult(); }
+            catch { return null; }
+            try { _ = stderrTask.GetAwaiter().GetResult(); }
+            catch { /* ignore stderr read failure */ }
+
+            return process.ExitCode == 0 ? bytes : null;
+        }
+    }
+
+    private static byte[]? ReadCappedStdout(Stream stream)
+    {
+        using var buffer = new MemoryStream();
+        byte[] chunk = new byte[81920];
+        long total = 0;
+        int read;
+        while ((read = stream.Read(chunk, 0, chunk.Length)) > 0)
+        {
+            total += read;
+            if (total > MaxBlobBytes)
+                return null;
+            buffer.Write(chunk, 0, read);
+        }
+
+        return buffer.ToArray();
+    }
+}

--- a/src/DotnetInspector.Services/LocalRepoSourceAcquisition.cs
+++ b/src/DotnetInspector.Services/LocalRepoSourceAcquisition.cs
@@ -191,7 +191,7 @@ public static partial class LocalRepoSourceAcquisition
 
         using (process)
         {
-            Task<byte[]?> stdoutTask = Task.Run(() => ReadCappedStdout(process.StandardOutput.BaseStream));
+            Task<byte[]?> stdoutTask = Task.Run(() => ReadCappedStdout(process, process.StandardOutput.BaseStream));
             Task<string> stderrTask = process.StandardError.ReadToEndAsync();
 
             if (!process.WaitForExit(GitTimeoutMs))
@@ -214,7 +214,7 @@ public static partial class LocalRepoSourceAcquisition
         }
     }
 
-    private static byte[]? ReadCappedStdout(Stream stream)
+    private static byte[]? ReadCappedStdout(Process process, Stream stream)
     {
         using var buffer = new MemoryStream();
         byte[] chunk = new byte[81920];
@@ -224,7 +224,13 @@ public static partial class LocalRepoSourceAcquisition
         {
             total += read;
             if (total > MaxBlobBytes)
+            {
+                // Stop reading immediately and tear down git rather than leaving it blocked on a
+                // full stdout pipe until the 15s timeout: an oversized blob is already rejected.
+                try { process.Kill(entireProcessTree: true); }
+                catch { /* best effort */ }
                 return null;
+            }
             buffer.Write(chunk, 0, read);
         }
 

--- a/src/dotnet-inspect.Tests/Parsers/DiffOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/DiffOptionsParserTests.cs
@@ -1,0 +1,116 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using DotnetInspector.CommandLine;
+using DotnetInspector.Commands;
+using DotnetInspector.Options;
+using DotnetInspector.Services;
+
+namespace DotnetInspector.Tests.Parsers;
+
+/// <summary>
+/// Focused tests for <see cref="DiffOptionsParser"/> covering the <c>--repo</c> plumbing that
+/// threads local git clones into the Implementation Diff authored-source acquisition.
+/// </summary>
+[Collection("Console")]
+public class DiffOptionsParserTests
+{
+    /// <summary>
+    /// Creates the diff command with shared options and args for testing.
+    /// Mirrors InspectionCommandDefinitions.CreateDiffCommand but exposes the args.
+    /// </summary>
+    private static (Command Root, SharedOptions Opts, DiffOptionsParser.DiffCommandArgs Args) CreateTestCommand()
+    {
+        var opts = new SharedOptions();
+        var diffCommand = new Command("diff", "test");
+
+        var argsArg = new Argument<string[]>("args") { Arity = ArgumentArity.ZeroOrMore };
+        var packageOption = new Option<string?>("--package");
+        var platformOption = new Option<string?>("--platform");
+        var libraryOption = new Option<string?>("--library");
+        var frameworkOption = new Option<string?>("--framework");
+        var tfmOption = new Option<string?>("--tfm");
+        var allOption = new Option<bool>("--all");
+        var typeFilterOption = new Option<string[]>("-t") { AllowMultipleArgumentsPerToken = false };
+        typeFilterOption.Aliases.Add("--type");
+        var memberFilterOption = new Option<string[]>("-m") { AllowMultipleArgumentsPerToken = false };
+        memberFilterOption.Aliases.Add("--member");
+        var nameOnlyOption = new Option<bool>("--name-only");
+        var breakingOption = new Option<bool>("--breaking");
+        var additiveOption = new Option<bool>("--additive");
+        var changedOption = new Option<bool>("--changed");
+        var allocRegressionsOption = new Option<bool>("--alloc-regressions");
+        var authoredSourceOption = new Option<bool>("--authored-source");
+        var repoOption = new Option<string[]>("--repo") { AllowMultipleArgumentsPerToken = false };
+        var findingOption = new Option<string?>("--finding");
+        var legendOption = new Option<bool>("--legend");
+
+        diffCommand.Arguments.Add(argsArg);
+        diffCommand.Options.Add(packageOption);
+        diffCommand.Options.Add(platformOption);
+        diffCommand.Options.Add(libraryOption);
+        diffCommand.Options.Add(frameworkOption);
+        diffCommand.Options.Add(tfmOption);
+        diffCommand.Options.Add(allOption);
+        diffCommand.Options.Add(typeFilterOption);
+        diffCommand.Options.Add(memberFilterOption);
+        opts.AddTableOptionsTo(diffCommand);
+        diffCommand.Options.Add(opts.Json);
+        diffCommand.Options.Add(opts.Markdown);
+        diffCommand.Options.Add(nameOnlyOption);
+        diffCommand.Options.Add(breakingOption);
+        diffCommand.Options.Add(additiveOption);
+        diffCommand.Options.Add(changedOption);
+        diffCommand.Options.Add(allocRegressionsOption);
+        diffCommand.Options.Add(authoredSourceOption);
+        diffCommand.Options.Add(repoOption);
+        diffCommand.Options.Add(findingOption);
+        diffCommand.Options.Add(legendOption);
+        opts.AddOutputOptionsTo(diffCommand);
+        opts.AddNuGetOptionsTo(diffCommand);
+        diffCommand.Options.Add(opts.Discover);
+        diffCommand.Options.Add(opts.Tree);
+        diffCommand.Options.Add(opts.Select);
+
+        diffCommand.SetAction((_, _) => Task.FromResult(0));
+
+        var root = new RootCommand { diffCommand };
+        var args = new DiffOptionsParser.DiffCommandArgs(
+            argsArg, packageOption, platformOption, libraryOption, frameworkOption, tfmOption, allOption,
+            typeFilterOption, memberFilterOption, opts.NoHeaders, nameOnlyOption, breakingOption, additiveOption,
+            changedOption, allocRegressionsOption, authoredSourceOption, findingOption, legendOption, repoOption);
+
+        return (root, opts, args);
+    }
+
+    private static DiffOptions ParseSuccess(params string[] args)
+    {
+        ArgumentPreprocessor.Reset();
+        var (root, opts, cmdArgs) = CreateTestCommand();
+        var parseResult = root.Parse(args);
+        Assert.Empty(parseResult.Errors);
+
+        var result = DiffOptionsParser.Parse(parseResult, opts, cmdArgs);
+        var success = Assert.IsType<DiffOptionsParser.Success>(result);
+        return success.Options;
+    }
+
+    [Fact]
+    public void RepoOption_PopulatesSourceRepositories()
+    {
+        var options = ParseSuccess(
+            "diff",
+            "--package", "System.Text.Json@8.0.0..9.0.0",
+            "--repo", @"C:\clone-a",
+            "--repo", @"C:\clone-b");
+
+        Assert.Equal([@"C:\clone-a", @"C:\clone-b"], options.SourceRepositories);
+    }
+
+    [Fact]
+    public void RepoOption_DefaultsToEmpty()
+    {
+        var options = ParseSuccess("diff", "--package", "System.Text.Json@8.0.0..9.0.0");
+
+        Assert.Empty(options.SourceRepositories);
+    }
+}

--- a/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
@@ -43,6 +43,7 @@ public class MemberOptionsParserTests
         binOption.Aliases.Add("--directory");
         var callerProjectOption = new Option<string[]>("--project") { AllowMultipleArgumentsPerToken = true };
         var callerPackageOption = new Option<string[]>("--caller-package") { AllowMultipleArgumentsPerToken = true };
+        var repoOption = new Option<string[]>("--repo") { AllowMultipleArgumentsPerToken = true };
 
         memberCommand.Arguments.Add(argsArg);
         memberCommand.Options.Add(packageOption);
@@ -65,6 +66,7 @@ public class MemberOptionsParserTests
         memberCommand.Options.Add(binOption);
         memberCommand.Options.Add(callerProjectOption);
         memberCommand.Options.Add(callerPackageOption);
+        memberCommand.Options.Add(repoOption);
         opts.AddSectionOptionsTo(memberCommand);
         memberCommand.Options.Add(opts.Markdown);
         memberCommand.Options.Add(opts.PlainText);
@@ -79,7 +81,7 @@ public class MemberOptionsParserTests
             argsArg, packageOption, assemblyOption, platformOption, frameworkOption, tfmOption,
             allOption, memberOption, ctorOption, compactOption, opts.NoHeaders,
             unsafeOption, indexOption, selectOption, kindOption,
-            binOption, callerProjectOption, callerPackageOption, atOption);
+            binOption, callerProjectOption, callerPackageOption, repoOption, atOption);
 
         return (root, opts, args);
     }
@@ -968,5 +970,25 @@ public class MemberOptionsParserTests
         var result = await MemberOptionsParser.ParseAsync(parseResult, opts, cmdArgs);
 
         Assert.IsType<MemberOptionsParser.Success>(result);
+    }
+
+    [Fact]
+    public async Task RepoOption_PopulatesSourceRepositories()
+    {
+        var options = await ParseSuccessAsync(
+            "member", "Some.Type.Method:1",
+            "--library", "x.dll",
+            "--repo", @"C:\clone-a",
+            "--repo", @"C:\clone-b");
+
+        Assert.Equal([@"C:\clone-a", @"C:\clone-b"], options.SourceRepositories);
+    }
+
+    [Fact]
+    public async Task RepoOption_DefaultsToEmpty()
+    {
+        var options = await ParseSuccessAsync("member", "Some.Type.Method:1", "--library", "x.dll");
+
+        Assert.Empty(options.SourceRepositories);
     }
 }

--- a/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
@@ -200,6 +200,11 @@ public static class ApiCommandDefinitions
             Description = "Download and scan package(s) for inbound callers (Callers section). Can repeat.",
             AllowMultipleArgumentsPerToken = false
         };
+        var repoOption = new Option<string[]>("--repo")
+        {
+            Description = "Read authored source from local git clone(s) by SourceLink commit + PDB checksum, before the network (Original Source). Can repeat.",
+            AllowMultipleArgumentsPerToken = false
+        };
         var kindOption = new Option<string[]>("-k")
         {
             Description = "Filter by member kind (method, property, field, event, constructor)",
@@ -229,6 +234,7 @@ public static class ApiCommandDefinitions
         memberCommand.Options.Add(binOption);
         memberCommand.Options.Add(callerProjectOption);
         memberCommand.Options.Add(callerPackageOption);
+        memberCommand.Options.Add(repoOption);
         memberCommand.Options.Add(kindOption);
         opts.AddSectionOptionsTo(memberCommand);
         opts.AddCountOptionTo(memberCommand);
@@ -246,7 +252,7 @@ public static class ApiCommandDefinitions
             allOption, memberOption, ctorOption,
             compactOption, opts.NoHeaders,
             unsafeOption, indexOption, selectOption, kindOption,
-            binOption, callerProjectOption, callerPackageOption, atOption);
+            binOption, callerProjectOption, callerPackageOption, repoOption, atOption);
 
         memberCommand.SetAction(async (parseResult, ct) =>
         {

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -203,6 +203,11 @@ public static class InspectionCommandDefinitions
         var changedOption = new Option<bool>("--changed") { Description = "Analysis Diff only: show only in-place changes to members present in both versions (drop added/removed members)" };
         var allocRegressionsOption = new Option<bool>("--alloc-regressions") { Description = "Analysis Diff focus: show only allocation increases on members present in both versions (the file-able set), in-loop (hot) ones first" };
         var authoredSourceOption = new Option<bool>("--authored-source") { Description = "Implementation Diff only: acquire checksum-verified authored SourceLink evidence" };
+        var repoOption = new Option<string[]>("--repo")
+        {
+            Description = "Implementation Diff: read authored source from local git clone(s) by SourceLink commit + PDB checksum, before the network. Can repeat.",
+            AllowMultipleArgumentsPerToken = false
+        };
         var findingOption = new Option<string?>("--finding") { Description = "Finding Transitions producer: api.type, api.member, api.attribute, analysis.allocation, or analysis.call-site" };
         var legendOption = new Option<bool>("--legend") { Description = "Show legend explaining change symbols" };
 
@@ -224,6 +229,7 @@ public static class InspectionCommandDefinitions
         diffCommand.Options.Add(changedOption);
         diffCommand.Options.Add(allocRegressionsOption);
         diffCommand.Options.Add(authoredSourceOption);
+        diffCommand.Options.Add(repoOption);
         diffCommand.Options.Add(findingOption);
         diffCommand.Options.Add(legendOption);
         opts.AddOutputOptionsTo(diffCommand);
@@ -234,7 +240,7 @@ public static class InspectionCommandDefinitions
 
         var commandArgs = new DiffOptionsParser.DiffCommandArgs(
             argsArg, packageOption, platformOption, libraryOption, frameworkOption, tfmOption, allOption,
-            typeFilterOption, memberFilterOption, opts.NoHeaders, nameOnlyOption, breakingOption, additiveOption, changedOption, allocRegressionsOption, authoredSourceOption, findingOption, legendOption);
+            typeFilterOption, memberFilterOption, opts.NoHeaders, nameOnlyOption, breakingOption, additiveOption, changedOption, allocRegressionsOption, authoredSourceOption, findingOption, legendOption, repoOption);
 
         diffCommand.SetAction(async (parseResult, ct) =>
         {

--- a/src/dotnet-inspect/CommandLine/Parsers/DiffOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/DiffOptionsParser.cs
@@ -34,7 +34,8 @@ public static class DiffOptionsParser
         Option<bool> AllocRegressionsOption,
         Option<bool> AuthoredSourceOption,
         Option<string?> FindingOption,
-        Option<bool> LegendOption);
+        Option<bool> LegendOption,
+        Option<string[]> RepoOption);
 
     /// <summary>
     /// Result of parsing diff command options.
@@ -131,6 +132,7 @@ public static class DiffOptionsParser
             IncludeAuthoredSource = parseResult.GetValue(args.AuthoredSourceOption),
             Finding = parseResult.GetValue(args.FindingOption),
             Legend = parseResult.GetValue(args.LegendOption),
+            SourceRepositories = parseResult.GetValue(args.RepoOption) ?? [],
             SourceOptions = opts.ParseNuGetSourceOptions(parseResult),
             Discover = opts.ParseDiscover(parseResult),
             Tree = parseResult.GetValue(opts.Tree),

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -35,6 +35,7 @@ public static class MemberOptionsParser
         Option<string[]> BinOption,
         Option<string[]> ProjectOption,
         Option<string[]> CallerPackageOption,
+        Option<string[]> RepoOption,
         Option<string?> AtOption);
 
     /// <summary>
@@ -302,6 +303,7 @@ public static class MemberOptionsParser
                 ? projectValues
                 : projectValues.Length > 1 ? projectValues[1..] : [],
             CallerScopePackages = parseResult.GetValue(args.CallerPackageOption) ?? [],
+            SourceRepositories = parseResult.GetValue(args.RepoOption) ?? [],
             Discover = opts.ParseDiscover(parseResult),
             Tree = parseResult.GetValue(opts.Tree),
             Select = select,

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -563,9 +563,21 @@ public class ApiCommand
             string? content = null;
             var localBytes = DotnetInspector.Services.AuthoredSourceAcquisition.TryReadVerifiedLocalSource(
                 methodInfo.FilePath, methodInfo.ChecksumAlgorithm, methodInfo.Checksum);
+            byte[]? repoBytes;
             if (localBytes != null)
             {
                 content = DotnetInspector.Services.AuthoredSourceAcquisition.DecodeSourceText(localBytes)
+                    .Replace("\r\n", "\n").Replace("\r", "\n");
+            }
+            // Opt-in (--repo): read the committed blob at the SourceLink commit from a local clone,
+            // authenticated by the same PDB checksum, before touching the network. Useful for a
+            // reproducible build whose sources are private or simply already cloned on this machine.
+            else if (options.SourceRepositories.Length > 0
+                && (repoBytes = DotnetInspector.Services.LocalRepoSourceAcquisition.TryReadVerifiedRepoBlob(
+                    methodInfo.SourceUrl, methodInfo.ChecksumAlgorithm, methodInfo.Checksum,
+                    options.SourceRepositories)) != null)
+            {
+                content = DotnetInspector.Services.AuthoredSourceAcquisition.DecodeSourceText(repoBytes)
                     .Replace("\r\n", "\n").Replace("\r", "\n");
             }
             else if (methodInfo.SourceUrl != null)

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -973,7 +973,8 @@ public class DiffCommand
                         target.Method.MetadataToken,
                         target.Method.Name,
                         new FindingSubject(subject.Id, subject.Display),
-                        fetcher);
+                        fetcher,
+                        options.SourceRepositories);
                     results[subject.Id] = inspection.Lines;
                 }
             }
@@ -2064,6 +2065,12 @@ public record DiffOptions
     public string[]? Fields { get; init; }
     public RowWindow? Rows { get; init; }
     public NuGetSourceOptions? SourceOptions { get; init; }
+
+    /// <summary>
+    /// Local git clone paths consulted for authored source (Implementation Diff), by SourceLink
+    /// commit + PDB checksum, before the network. Empty = network only. Set via <c>--repo</c>.
+    /// </summary>
+    public string[] SourceRepositories { get; init; } = [];
 
     /// <summary>
     /// True when output is raw text (not rendered markdown).

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -23,6 +23,13 @@ public partial record ApiOptions
     public string? PlatformAssembly { get; init; }
     public string? ProjectPath { get; init; }
     public string? ProjectAssetsPath { get; init; }
+
+    /// <summary>
+    /// Local git clone(s) to read authored source from (keyed on the SourceLink commit and
+    /// authenticated by the portable-PDB checksum) before falling back to the remote SourceLink
+    /// URL. Empty = network only. Set via <c>--repo</c>; can repeat.
+    /// </summary>
+    public string[] SourceRepositories { get; init; } = [];
     public string? PlatformFramework { get; init; }
     public string? Tfm { get; init; }
     public bool IncludeAll { get; init; }


### PR DESCRIPTION
## `--repo`: read authored source from a local git clone

Opt-in local-repository source acquisition for the `member` (Original Source) **and** `diff` (Implementation Diff) commands, complementing the merged local-path read (#3031). **Draft** — two-model adversarial review in progress.

### What it does
For a **reproducible (published)** build the portable PDB records a normalized document path plus a `raw.githubusercontent.com/<org>/<repo>/<sha>/<relpath>` SourceLink URL. When the user names one or more local clones with `--repo`, we read the **committed blob at that exact SHA from the git object store** (the committed object, not the working tree) via `git cat-file blob <sha>:<relpath>`, and accept it **only when its bytes match the PDB checksum**. A wrong repo, commit, or path self-rejects and the caller falls back to the network — so the checksum is the arbiter and no repo-URL matching is required. It slots into the same acquisition ladder as #3031, one provider ahead of the remote fetch, on **both** the member Original Source path (`ApiCommand.ResolveMethodSourceAsync`) and the Implementation Diff path (`AuthoredSourceAcquisition.AcquireMemberAsync`).

### Why
- **Private repos** — skip SourceLink auth entirely when the source is already cloned.
- **Offline / air-gapped** inspection of published packages.
- Avoid rate limits / network for bulk inspection.
- Unblocks a cheaper test-harness authored-source oracle (delete the vendored orphan-branch corpus; re-acquire on demand via this same `AcquireMemberAsync(repositoryPaths)` path) — follow-up PR.

### Why opt-in (not automatic)
No registry maps a repo URL to a local clone, and filesystem scanning is slow, ambiguous (forks/multiple clones), and a side-effect concern. The checksum solves *content* trust but not *discovery*, so discovery is user-provided via `--repo` (repeatable).

### Security
The SHA and path come from an **untrusted PDB**, so before shelling out: the SHA is validated hex (`^[0-9a-fA-F]{7,64}$`); the path is rejected if empty, contains NUL, or is option-like. `git` is invoked with `ArgumentList` (no shell), `GIT_TERMINAL_PROMPT=0`, `GIT_OPTIONAL_LOCKS=0`, a 15s timeout, and a 64 MB output cap. If `git` is absent or the commit/path isn't present, we return null and fall back to the network. Only `raw.githubusercontent.com` URLs are addressed (other hosts fall back to remote).

### Evidence (dogfood A/B/C/D, member path)
Self-contained throwaway repo with a **GitHub SourceLink** build at an **unpushed** commit `eec9c10a` (fake `acme/widget` origin, so the remote raw URL 404s):

| Case | Command | Result |
| --- | --- | --- |
| A | `member Widget.Sample -m Add:1 -S "Original Source"` (no `--repo`) | **empty** (remote 404) |
| B | ...`--repo <clone>` | **renders `Add` body** from local blob at `eec9c10a`, checksum-verified |
| C | ...`--repo <repo lacking the commit>` | **empty** (no false content) |
| D | tamper the **working-tree** file, commit unchanged, `--repo <clone>` | **still renders committed `Add`** — proves we read the git object at the SourceLink commit, not the working tree |

The diff path reuses the exact same checksum-arbitered provider core via a new `AcquireMemberAsync(repositoryPaths)` overload.

### Tests
- `LocalRepoSourceReadTests` (Services): URL parse accept/reject; git-integration reads against a real temp repo — hit, checksum mismatch, missing commit, missing path, non-repo dir, second-repo fallthrough — guarded to skip when git is unavailable.
- `MemberOptionsParserTests` / `DiffOptionsParserTests`: `--repo` populates `SourceRepositories`; defaults empty (both commands).
- Full solution builds; Services repo tests green; 110 parser tests green; real `diff --help` / `member --help` expose `--repo`.

### Scope / follow-ups (not in this PR)
- Non-GitHub SourceLink hosts (Azure DevOps, GitLab) — currently fall back to remote.
- README/docs for `--repo`.
- Optional narrow "automatic" case: CWD-ancestor repo that already has the commit.
- Harness orphan-branch migration (manifest + on-demand acquisition) — separate PR that builds on this.
