### PR TITLE
Elide trailing optional-argument defaults at call sites (#3027)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/OptionalArgumentElisionFixtures.cs
+++ b/src/ILInspector.Decompiler.Tests/OptionalArgumentElisionFixtures.cs
@@ -1,0 +1,41 @@
+namespace ILInspector.Decompiler.Tests;
+
+// Fixtures for OptionalArgumentElisionPass. Each caller below is what the tests
+// decompile; the callees declare the C# optional parameters whose baked defaults
+// the pass tries to elide from the call site.
+public class OptionalArgumentElisionFixtures
+{
+    // Single overload, reference-type null default: the canonical elide case.
+    static int Speak(int count, string? note = null) => count + (note?.Length ?? 0);
+
+    // Single overload, enum default (mirrors the Humanizer ToWords witness).
+    static int Announce(int count, System.DayOfWeek day = System.DayOfWeek.Sunday) => count + (int)day;
+
+    // Overload pair whose shorter member ties the callee's leading signature, so
+    // eliding verbose would rebind Log(message, false) to the distinct Log(message).
+    static int Log(string message) => message.Length;
+    static int Log(string message, bool verbose = false) => verbose ? 1 : message.Length;
+
+    // Three defaulted parameters, to exercise the trailing-run boundary.
+    static int Triple(int a = 1, int b = 2, int c = 3) => a + b + c;
+
+    // Reference-subtype hazard: Feed(Dog) would win a shortened Feed((Animal)d),
+    // so the pass-time identity check must keep the explicit trailing argument.
+    class Animal { }
+    sealed class Dog : Animal { }
+    static int Feed(Animal a, int portion = 1) => portion;
+    static int Feed(Dog d) => 0;
+
+    // --- Callers under test ---
+
+    public int CallSpeakElidesNull() => Speak(3);
+    public int CallAnnounceElidesEnum() => Announce(3);
+    public int CallLogKeepsSiblingTie() => Log("x", false);
+    public int CallTripleTrailingRun() => Triple(1, 9, 3);
+    public int CallFeedKeepsSubtype()
+    {
+        Dog d = new Dog();
+        return Feed(d, 1);
+    }
+    public string[] CallSplitCrossAssembly(string s) => s.Split(';');
+}

--- a/src/ILInspector.Decompiler.Tests/OptionalArgumentElisionFixtures.cs
+++ b/src/ILInspector.Decompiler.Tests/OptionalArgumentElisionFixtures.cs
@@ -26,10 +26,24 @@ public class OptionalArgumentElisionFixtures
     static int Feed(Animal a, int portion = 1) => portion;
     static int Feed(Dog d) => 0;
 
+    // Instance method (HasThis) with a reference-type null default: the common
+    // real call shape, exercising the receiver-offset path in the pass.
+    string Greet(string name, string? title = null) => title ?? name;
+
+    // Receiver-subtype steal hazard: the optional method is on the base, and the
+    // derived receiver declares a shorter same-named overload that captures the
+    // shortened call. r.Emit("x", false) binds Reporter.Emit(string, bool) but
+    // r.Emit("x") would rebind to LoudReporter.Emit(string) — a different method.
+    // The importer's sibling scan only sees the callee's declaring type (Reporter),
+    // so the pass-time receiver-static-type guard must keep the explicit argument.
+    class Reporter { public virtual string Emit(string message, bool loud = false) => loud ? message : ""; }
+    sealed class LoudReporter : Reporter { public string Emit(string message) => message + "!"; }
+
     // --- Callers under test ---
 
     public int CallSpeakElidesNull() => Speak(3);
     public int CallAnnounceElidesEnum() => Announce(3);
+    public string CallGreetElidesNull() => Greet("Ada");
     public int CallLogKeepsSiblingTie() => Log("x", false);
     public int CallTripleTrailingRun() => Triple(1, 9, 3);
     public int CallFeedKeepsSubtype()
@@ -38,4 +52,10 @@ public class OptionalArgumentElisionFixtures
         return Feed(d, 1);
     }
     public string[] CallSplitCrossAssembly(string s) => s.Split(';');
+
+    public string CallReporterKeepsDerivedSteal()
+    {
+        LoudReporter r = new LoudReporter();
+        return r.Emit("x", false);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/OptionalArgumentElisionFixtures.cs
+++ b/src/ILInspector.Decompiler.Tests/OptionalArgumentElisionFixtures.cs
@@ -39,6 +39,13 @@ public class OptionalArgumentElisionFixtures
     class Reporter { public virtual string Emit(string message, bool loud = false) => loud ? message : ""; }
     sealed class LoudReporter : Reporter { public string Emit(string message) => message + "!"; }
 
+    // Generic-sibling steal hazard: Pick(5, 0) binds the non-generic
+    // Pick(int, int = 0), but eliding to Pick(5) would rebind to the generic
+    // Pick<int>(int) — the "fewer declared parameters" tie-break beats the
+    // optional-using candidate. Any same-named generic sibling declines elision.
+    static int Pick(int value, int seed = 0) => value + seed;
+    static int Pick<T>(T value) => value?.GetHashCode() ?? 0;
+
     // --- Callers under test ---
 
     public int CallSpeakElidesNull() => Speak(3);
@@ -58,4 +65,42 @@ public class OptionalArgumentElisionFixtures
         LoudReporter r = new LoudReporter();
         return r.Emit("x", false);
     }
+
+    // A lone extension on a cross-assembly receiver (string): the witness shape
+    // (ToWords is itself a static extension). No competing same-named extension
+    // exists, so the trailing null default drops in receiver syntax.
+    public string CallExtensionElidesTrailingNull(string s) => s.WithTag(2);
+
+    // Cross-class extension steal: eliding the trailing null would rebind
+    // s.Pin(2, null) to StealerExtensions.Pin(string, int). The assembly-wide
+    // extension scan finds the tie and keeps the explicit argument.
+    public string CallExtensionKeepsCrossClassSteal(string s) => s.Pin(2, null);
+
+    // Generic sibling present on the declaring type: the explicit trailing 0 stays.
+    public int CallPickKeepsGenericSibling() => Pick(5, 0);
+}
+
+// --- Extension-method fixtures (assembly-wide overload scan + receiver guard) ---
+// Extension methods must live in top-level, non-generic static classes, so these
+// sit beside the fixture class rather than nested inside it.
+
+internal static class TagExtensions
+{
+    public static string WithTag(this string value, int weight, string? tag = null)
+        => tag is null ? $"{value}:{weight}" : $"{value}:{weight}:{tag}";
+}
+
+// The intended callee: a trailing optional after one real parameter.
+internal static class IntendedExtensions
+{
+    public static string Pin(this string value, int weight, string? tag = null)
+        => tag is null ? $"{value}#{weight}" : $"{value}#{weight}#{tag}";
+}
+
+// The thief: a shorter same-named extension on the same receiver that ties the
+// intended callee's leading signature at the shortened arity, in a different
+// class the old declaring-type-only scan never saw.
+internal static class StealerExtensions
+{
+    public static string Pin(this string value, int weight) => $"{value}!{weight}";
 }

--- a/src/ILInspector.Decompiler.Tests/OptionalArgumentElisionFixtures.cs
+++ b/src/ILInspector.Decompiler.Tests/OptionalArgumentElisionFixtures.cs
@@ -1,5 +1,7 @@
 namespace ILInspector.Decompiler.Tests;
 
+using System.Runtime.CompilerServices;
+
 // Fixtures for OptionalArgumentElisionPass. Each caller below is what the tests
 // decompile; the callees declare the C# optional parameters whose baked defaults
 // the pass tries to elide from the call site.
@@ -46,6 +48,14 @@ public class OptionalArgumentElisionFixtures
     static int Pick(int value, int seed = 0) => value + seed;
     static int Pick<T>(T value) => value?.GetHashCode() ?? 0;
 
+    // OverloadResolutionPriority steal hazard: Rank(5, 0) binds Rank(int, int=0),
+    // but the attribute deprioritizes it, so eliding to Rank(5) would rebind to
+    // the differently-typed Rank(long) that AritySafe's leading-signature check
+    // ignores. Any candidate carrying the attribute declines the whole callee.
+    [OverloadResolutionPriority(-1)]
+    static string Rank(int value, int seed = 0) => $"int:{value + seed}";
+    static string Rank(long value) => $"long:{value}";
+
     // --- Callers under test ---
 
     public int CallSpeakElidesNull() => Speak(3);
@@ -78,6 +88,10 @@ public class OptionalArgumentElisionFixtures
 
     // Generic sibling present on the declaring type: the explicit trailing 0 stays.
     public int CallPickKeepsGenericSibling() => Pick(5, 0);
+
+    // Priority-deprioritized callee: the explicit trailing 0 stays because eliding
+    // would rebind to the differently-typed Rank(long).
+    public string CallRankKeepsPriorityOverload() => Rank(5, 0);
 }
 
 // --- Extension-method fixtures (assembly-wide overload scan + receiver guard) ---

--- a/src/ILInspector.Decompiler.Tests/OptionalArgumentElisionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/OptionalArgumentElisionPassTests.cs
@@ -109,4 +109,39 @@ public class OptionalArgumentElisionPassTests
 
         Assert.Contains(", false)", output);
     }
+
+    [Fact]
+    public void LoneExtensionTrailingNullDefault_IsElided()
+    {
+        // A static extension callee (like the ToWords witness) with no competing
+        // same-named extension in the assembly: the trailing null default drops
+        // while the receiver and the real argument stay.
+        string output = PrintRaised(nameof(OptionalArgumentElisionFixtures.CallExtensionElidesTrailingNull));
+
+        Assert.Contains("WithTag", output);
+        Assert.DoesNotContain("null", output);
+    }
+
+    [Fact]
+    public void CrossClassExtensionStealsShortenedCall_KeepsExplicitArgument()
+    {
+        // IntendedExtensions.Pin(string, int, string = null) is the callee, but a
+        // shorter StealerExtensions.Pin(string, int) in a different class ties it
+        // at arity 2. The assembly-wide extension scan (not just the declaring
+        // class) must see the tie and keep the explicit trailing null.
+        string output = PrintRaised(nameof(OptionalArgumentElisionFixtures.CallExtensionKeepsCrossClassSteal));
+
+        Assert.Contains("null", output);
+    }
+
+    [Fact]
+    public void GenericSiblingOverload_KeepsExplicitArgument()
+    {
+        // Pick(int, int = 0) has a generic sibling Pick<T>(T). Eliding to Pick(5)
+        // would rebind to Pick<int>(int), so any same-named generic sibling
+        // declines elision and the explicit trailing 0 stays.
+        string output = PrintRaised(nameof(OptionalArgumentElisionFixtures.CallPickKeepsGenericSibling));
+
+        Assert.Contains(", 0)", output);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/OptionalArgumentElisionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/OptionalArgumentElisionPassTests.cs
@@ -1,0 +1,90 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class OptionalArgumentElisionPassTests
+{
+    // Cross-assembly enum spelling (DayOfWeek, StringSplitOptions) and the
+    // cross-assembly String.Split callee need the running-runtime resolver, the
+    // same pattern ExtensionMethodCallTests uses.
+    static readonly ILInspector.Metadata.IAssemblyReferenceResolver RuntimeResolver =
+        TestAssemblyReferenceResolvers.RuntimeAssemblies();
+
+    static string PrintRaised(string methodName)
+    {
+        using var context = new MetadataContext(RuntimeResolver);
+        using var source = MetadataSource.Open(typeof(OptionalArgumentElisionFixtures).Assembly.Location, null, RuntimeResolver, context);
+        var function = IrImporter.Import(source, typeof(OptionalArgumentElisionFixtures).FullName!, methodName);
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(function!, method => IrImporter.Import(source, method));
+        Assert.True(result.Succeeded, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+        Assert.NotNull(result.Output);
+        return result.Output!.ReplaceLineEndings("\n").Trim();
+    }
+
+    [Fact]
+    public void TrailingNullDefault_IsElided()
+    {
+        string output = PrintRaised(nameof(OptionalArgumentElisionFixtures.CallSpeakElidesNull));
+
+        Assert.Contains("Speak(3)", output);
+        Assert.DoesNotContain("null", output);
+    }
+
+    [Fact]
+    public void TrailingEnumDefault_IsElided()
+    {
+        // The Humanizer ToWords witness reduced to a fixture: the trailing enum
+        // constant equal to the declared default drops.
+        string output = PrintRaised(nameof(OptionalArgumentElisionFixtures.CallAnnounceElidesEnum));
+
+        Assert.Contains("Announce(3)", output);
+        Assert.DoesNotContain("DayOfWeek", output);
+    }
+
+    [Fact]
+    public void SiblingOverloadTiesLeadingSignature_KeepsExplicitArgument()
+    {
+        // Log(message) has the callee's leading signature at the shorter arity, so
+        // eliding verbose would rebind to a different method. The trailing false
+        // must stay explicit.
+        string output = PrintRaised(nameof(OptionalArgumentElisionFixtures.CallLogKeepsSiblingTie));
+
+        Assert.Contains(", false)", output);
+    }
+
+    [Fact]
+    public void NonDefaultArgumentStopsTrailingRun()
+    {
+        // Triple(1, 9, 3): c==3 matches its default and drops, but b==9 breaks the
+        // run, so a==1 must stay even though it also equals its default (Triple(9)
+        // would bind 9 to a).
+        string output = PrintRaised(nameof(OptionalArgumentElisionFixtures.CallTripleTrailingRun));
+
+        Assert.Contains("Triple(1, 9)", output);
+        Assert.DoesNotContain("Triple(1, 9, 3)", output);
+        Assert.DoesNotContain("Triple(9)", output);
+    }
+
+    [Fact]
+    public void RetainedSubtypeArgument_KeepsExplicitArgument()
+    {
+        // Feed(Animal, int=1) is called with a Dog. Eliding to Feed(d) would rebind
+        // to the better-matching Feed(Dog) overload, so the identity check keeps
+        // the explicit trailing 1.
+        string output = PrintRaised(nameof(OptionalArgumentElisionFixtures.CallFeedKeepsSubtype));
+
+        Assert.Contains(", 1)", output);
+    }
+
+    [Fact]
+    public void CrossAssemblyCallee_IsNotElided()
+    {
+        // String.Split(char, StringSplitOptions.None) is cross-assembly; v1 only
+        // stamps same-assembly MethodDef callees, so the baked default stays.
+        string output = PrintRaised(nameof(OptionalArgumentElisionFixtures.CallSplitCrossAssembly));
+
+        Assert.Contains("StringSplitOptions", output);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/OptionalArgumentElisionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/OptionalArgumentElisionPassTests.cs
@@ -44,6 +44,17 @@ public class OptionalArgumentElisionPassTests
     }
 
     [Fact]
+    public void InstanceMethodTrailingNullDefault_IsElided()
+    {
+        // An instance (HasThis) callee: the receiver stays and only the baked
+        // trailing null default drops, exercising the receiver-offset path.
+        string output = PrintRaised(nameof(OptionalArgumentElisionFixtures.CallGreetElidesNull));
+
+        Assert.Contains("Greet(\"Ada\")", output);
+        Assert.DoesNotContain("null", output);
+    }
+
+    [Fact]
     public void SiblingOverloadTiesLeadingSignature_KeepsExplicitArgument()
     {
         // Log(message) has the callee's leading signature at the shorter arity, so
@@ -86,5 +97,16 @@ public class OptionalArgumentElisionPassTests
         string output = PrintRaised(nameof(OptionalArgumentElisionFixtures.CallSplitCrossAssembly));
 
         Assert.Contains("StringSplitOptions", output);
+    }
+
+    [Fact]
+    public void DerivedReceiverStealsShortenedCall_KeepsExplicitArgument()
+    {
+        // The optional method is on the base (Reporter.Emit(string, bool = false)),
+        // but a shorter LoudReporter.Emit(string) would capture Emit("x") through
+        // the derived receiver. The receiver-static-type guard keeps false explicit.
+        string output = PrintRaised(nameof(OptionalArgumentElisionFixtures.CallReporterKeepsDerivedSteal));
+
+        Assert.Contains(", false)", output);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/OptionalArgumentElisionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/OptionalArgumentElisionPassTests.cs
@@ -144,4 +144,16 @@ public class OptionalArgumentElisionPassTests
 
         Assert.Contains(", 0)", output);
     }
+
+    [Fact]
+    public void OverloadResolutionPrioritySibling_KeepsExplicitArgument()
+    {
+        // Rank(int, int = 0) carries [OverloadResolutionPriority(-1)]; eliding to
+        // Rank(5) would rebind to Rank(long) because priority reorders candidates
+        // ahead of betterness. Any candidate carrying the attribute declines, so
+        // the explicit trailing 0 stays.
+        string output = PrintRaised(nameof(OptionalArgumentElisionFixtures.CallRankKeepsPriorityOverload));
+
+        Assert.Contains(", 0)", output);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1136,7 +1136,8 @@ public static class IrImporter
 
                 case ILOpCode.Call or ILOpCode.Callvirt:
                 {
-                    var callee = ResolveMethod(source.Reader, MetadataTokens.EntityHandle(reader.ReadILToken()), callerScope);
+                    var methodHandle = MetadataTokens.EntityHandle(reader.ReadILToken());
+                    var callee = ResolveMethod(source.Reader, methodHandle, callerScope);
                     if (callee.DeclaringType.Kind == TypeRefKind.Unsupported)
                     {
                         // Unknown arity would mis-pop the stack and corrupt
@@ -1147,6 +1148,11 @@ public static class IrImporter
                     // MemberRefs carry no MethodDef rows; resolve only the
                     // missing cross-assembly facts this callee can consume.
                     callee = source.CrossAssembly.Upgrade(callee, function.UsesUpdatedMemorySafetyRules);
+                    // A same-assembly MethodDef exposes its parameters' C# defaults
+                    // and sibling overloads; recover the overload-safe trailing
+                    // elision facts for the optional-argument elision pass.
+                    if (methodHandle.Kind == HandleKind.MethodDefinition)
+                        callee = OptionalArgumentFacts.Stamp(source, (MethodDefinitionHandle)methodHandle, callee);
                     int argumentCount = callee.ParameterTypes.Length + (callee.HasThis ? 1 : 0);
                     var arguments = new IrExpression[argumentCount];
                     for (int i = argumentCount - 1; i >= 0; i--)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -13,6 +13,19 @@ public enum MetadataFactState { Unknown, No, Yes }
 /// <summary>Whether by-ref parameter keyword metadata was needed and recovered.</summary>
 public enum ParameterRefKindFacts { Unknown, NotRequired, Known }
 
+/// <summary>
+/// A callee parameter's declared C# default (<c>[Optional]</c> + a <c>Constant</c>
+/// row), recovered from metadata and aligned 1:1 with
+/// <see cref="MethodRef.ParameterTypes"/>. <see cref="HasDefault"/> is false for a
+/// required parameter (and <see cref="Value"/> is then meaningless). When true,
+/// <see cref="Value"/> is the typed constant the compiler bakes into every call
+/// site (an integral/bool/char/enum arrives boxed as its underlying primitive,
+/// a reference/nullable <c>= null</c> default arrives as <see langword="null"/>).
+/// The optional-argument elision pass compares a trailing constant argument to
+/// this value; equality means the source omitted the argument.
+/// </summary>
+public readonly record struct ParameterDefault(bool HasDefault, object? Value);
+
 /// <summary>Positive metadata evidence that a method is a property/event accessor.</summary>
 public enum AccessorKind { Unknown, None, PropertyGet, PropertySet, EventAdd, EventRemove }
 
@@ -42,6 +55,27 @@ public sealed record MethodRef(
     /// parameters needed spelling facts" from "a MemberRef did not expose rows."
     /// </summary>
     public ParameterRefKindFacts ParameterRefKindsFacts { get; init; } = ParameterRefKindFacts.Unknown;
+
+    /// <summary>
+    /// Per-parameter C# defaults (<c>[Optional]</c> + <c>Constant</c>), aligned
+    /// 1:1 with <see cref="ParameterTypes"/>. Empty means the defaults were not
+    /// resolved (the pipeline populates this only for same-assembly
+    /// <c>MethodDefinition</c> callees; cross-assembly and generic callees stay
+    /// empty and never elide). Consumed by the optional-argument elision pass.
+    /// </summary>
+    public ImmutableArray<ParameterDefault> ParameterDefaults { get; init; } = [];
+
+    /// <summary>
+    /// How many trailing arguments the optional-argument elision pass may drop:
+    /// the length of the trailing run of defaulted parameters that is also
+    /// <em>overload-safe</em> — no other same-named overload on the declaring
+    /// type could rebind the shortened call. Zero (the default) disables elision.
+    /// A sound conservative under-approximation: the count only rises when every
+    /// competing overload is confidently rejected, so an unresolved or ambiguous
+    /// case declines. The recompile/corpus fidelity gate is the empirical
+    /// backstop for any residual overload-resolution miss.
+    /// </summary>
+    public int SafeTrailingElidableCount { get; init; }
 
     /// <summary>
     /// The callee is <em>requires-unsafe</em>: under the updated memory-safety

--- a/src/ILInspector.Decompiler/Pipeline/MethodDefinitionFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodDefinitionFacts.cs
@@ -54,6 +54,13 @@ internal static class MethodDefinitionFacts
     internal static bool HasExtensionAttribute(MetadataReader reader, MethodDefinition method)
         => HasAttribute(reader, method.GetCustomAttributes(), "System.Runtime.CompilerServices", "ExtensionAttribute");
 
+    // [OverloadResolutionPriority] (C# 13) reorders applicable candidates before
+    // betterness, so a differently-typed sibling can win a shortened call the
+    // callee would otherwise take. Callers that reason from leading-signature
+    // ties must decline when this attribute is in play.
+    internal static bool HasOverloadResolutionPriorityAttribute(MetadataReader reader, MethodDefinition method)
+        => HasAttribute(reader, method.GetCustomAttributes(), "System.Runtime.CompilerServices", "OverloadResolutionPriorityAttribute");
+
     internal static bool IsPInvoke(MethodDefinition method)
         => (method.Attributes & System.Reflection.MethodAttributes.PinvokeImpl) != 0;
 

--- a/src/ILInspector.Decompiler/Pipeline/OptionalArgumentFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/OptionalArgumentFacts.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Reflection;
 using System.Reflection.Metadata;
+using System.Runtime.CompilerServices;
 
 using SrmConstant = System.Reflection.Metadata.Constant;
 
@@ -25,9 +26,17 @@ namespace ILInspector.Decompiler.Pipeline;
 /// same-named sibling can rebind the shortened call only by <em>tying</em> the
 /// callee — sharing its leading parameter types. <see cref="SafeTrailingElidableCount"/>
 /// counts the trailing defaulted run for which no such leading-signature
-/// duplicate exists on the declaring type; a generic callee declines to zero. The
-/// recompile/corpus fidelity gate is the empirical backstop for any residual
-/// overload-resolution miss.</para>
+/// duplicate exists among the callee's rebind candidates; any same-named generic
+/// sibling declines the whole callee (a generic candidate can unify with the
+/// retained arguments and win the fewer-declared-parameters tie-break). For a
+/// non-extension callee the candidate set is the declaring type's own methods
+/// (static calls are fully qualified; instance calls are pinned by the pass-time
+/// receiver guard). An extension callee renders in receiver syntax, so its
+/// candidates are <em>every</em> extension method of the same name in the
+/// assembly, and elision additionally requires the receiver type to live in
+/// another assembly (a same-assembly instance method would beat the extension).
+/// Extensions and instance methods in referenced assemblies are the residual the
+/// recompile/corpus fidelity gate backstops.</para>
 /// </summary>
 internal static class OptionalArgumentFacts
 {
@@ -134,56 +143,177 @@ internal static class OptionalArgumentFacts
 
         // A generic declaring type or generic method makes cross-instantiation
         // reasoning unsound here; decline in v1.
-        if (callee.DeclaringType.Kind == TypeRefKind.GenericInstance || !callee.TypeArguments.IsDefaultOrEmpty)
+        if (callee.DeclaringType.Kind == TypeRefKind.GenericInstance
+            || !callee.TypeArguments.IsDefaultOrEmpty
+            || method.GetGenericParameters().Count > 0)
             return 0;
 
-        var siblings = SiblingOverloads(reader, method, handle, callee.Name);
+        List<SiblingSignature> siblings;
+        if (MethodDefinitionFacts.HasExtensionAttribute(reader, method))
+        {
+            // An extension call renders in receiver syntax (r.M(args)), so the
+            // recompiler resolves M across every extension class in scope plus the
+            // receiver type's own instance methods — not just the callee's
+            // declaring class. Bound what we can prove locally: (1) the receiver
+            // type must live in another assembly, so no same-assembly instance
+            // method can capture the shortened call, and (2) no same-assembly
+            // extension named M may tie the callee's leading signature. Extensions
+            // and instance methods in referenced assemblies stay the residual the
+            // corpus fidelity gate backstops.
+            if (!ReceiverIsCrossAssembly(reader, callee.ParameterTypes[0]))
+                return 0;
+            siblings = AssemblyExtensionSiblings(reader, callee.Name);
+        }
+        else
+        {
+            // A non-extension call resolves within the callee's declaring type:
+            // static calls are fully qualified, and instance calls use the
+            // receiver's static type, which the pass-time receiver guard pins to
+            // the declaring type. Its own methods are the only rebind candidates.
+            siblings = DeclaringTypeSiblings(reader, method, callee.Name);
+        }
+
+        // A same-named generic sibling can unify with the retained arguments and
+        // win the "fewer declared parameters" tie-break over an optional-using
+        // callee (verified: Pick(int, int = 0) loses Pick(v) to Pick<T>(T)). The
+        // leading-signature identity check below cannot model unification, so
+        // decline the whole callee when any generic sibling shares the name.
+        foreach (var sibling in siblings)
+            if (sibling.Handle != handle && sibling.IsGeneric)
+                return 0;
 
         int safe = 0;
         for (int k = 1; k <= trailingDefaults; k++)
         {
-            if (!AritySafe(callee, siblings, n - k))
+            if (!AritySafe(callee, siblings, handle, n - k))
                 break;
             safe = k;
         }
         return safe;
     }
 
-    static List<ImmutableArray<TypeRef>> SiblingOverloads(MetadataReader reader, MethodDefinition self, MethodDefinitionHandle selfHandle, string name)
+    /// <summary>
+    /// A same-named overload candidate: its handle (to exclude the callee itself),
+    /// its decoded parameter types (leading-signature comparison), and whether it
+    /// is generic (a generic candidate declines the whole callee).
+    /// </summary>
+    readonly record struct SiblingSignature(MethodDefinitionHandle Handle, ImmutableArray<TypeRef> ParameterTypes, bool IsGeneric);
+
+    static readonly List<SiblingSignature> NoSiblings = [];
+
+    // The assembly-wide extension index is a full metadata scan; cache it per
+    // reader so a corpus run pays for it once per assembly.
+    static readonly ConditionalWeakTable<MetadataReader, Dictionary<string, List<SiblingSignature>>> ExtensionSiblingCache = new();
+
+    static List<SiblingSignature> DeclaringTypeSiblings(MetadataReader reader, MethodDefinition self, string name)
     {
-        var siblings = new List<ImmutableArray<TypeRef>>();
+        var siblings = new List<SiblingSignature>();
         var declaringType = reader.GetTypeDefinition(self.GetDeclaringType());
         var typeScope = new GenericScope(MethodDefinitionFacts.GenericParameterNames(reader, declaringType.GetGenericParameters()), []);
         foreach (var handle in declaringType.GetMethods())
         {
-            if (handle == selfHandle)
-                continue;
             var method = reader.GetMethodDefinition(handle);
             if (!string.Equals(reader.GetString(method.Name), name, StringComparison.Ordinal))
                 continue;
-            siblings.Add(GuardedDecode.MethodSignature(reader, method, typeScope).ParameterTypes);
+            siblings.Add(new SiblingSignature(
+                handle,
+                GuardedDecode.MethodSignature(reader, method, typeScope).ParameterTypes,
+                method.GetGenericParameters().Count > 0));
         }
         return siblings;
     }
 
     /// <summary>
-    /// Whether dropping the callee down to <paramref name="arity"/> leading
-    /// arguments is safe: no sibling with at least that many parameters shares the
-    /// callee's first <paramref name="arity"/> parameter types. A sibling that
-    /// differs at any leading position cannot rebind (the callee's identity match
-    /// on the retained arguments is strictly better), so only a leading-signature
-    /// duplicate blocks.
+    /// Every extension method named <paramref name="name"/> anywhere in the
+    /// assembly — the candidate set a shortened extension call's receiver-syntax
+    /// overload resolution draws from. Built once per reader and cached.
     /// </summary>
-    static bool AritySafe(MethodRef callee, List<ImmutableArray<TypeRef>> siblings, int arity)
+    static List<SiblingSignature> AssemblyExtensionSiblings(MetadataReader reader, string name)
+    {
+        var index = ExtensionSiblingCache.GetValue(reader, BuildExtensionSiblingIndex);
+        return index.TryGetValue(name, out var siblings) ? siblings : NoSiblings;
+    }
+
+    static Dictionary<string, List<SiblingSignature>> BuildExtensionSiblingIndex(MetadataReader reader)
+    {
+        var index = new Dictionary<string, List<SiblingSignature>>(StringComparer.Ordinal);
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var type = reader.GetTypeDefinition(typeHandle);
+            // The compiler marks an extension method's declaring class with
+            // [Extension] as well; skip classes that hold no extensions.
+            if (!ILInspector.Metadata.AttributeReader.HasExtensionAttribute(reader, type.GetCustomAttributes()))
+                continue;
+            var typeScope = new GenericScope(MethodDefinitionFacts.GenericParameterNames(reader, type.GetGenericParameters()), []);
+            foreach (var handle in type.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(handle);
+                if (!MethodDefinitionFacts.HasExtensionAttribute(reader, method))
+                    continue;
+                string name = reader.GetString(method.Name);
+                if (!index.TryGetValue(name, out var siblings))
+                {
+                    siblings = [];
+                    index[name] = siblings;
+                }
+                siblings.Add(new SiblingSignature(
+                    handle,
+                    GuardedDecode.MethodSignature(reader, method, typeScope).ParameterTypes,
+                    method.GetGenericParameters().Count > 0));
+            }
+        }
+        return index;
+    }
+
+    /// <summary>
+    /// Whether an extension callee's receiver type is rooted in another assembly.
+    /// A same-assembly receiver could declare an instance method (possibly
+    /// inherited) that captures the shortened call — instance methods beat
+    /// extensions — and clearing its full method set is not cheap, so decline. A
+    /// receiver rooted elsewhere has its instance methods there too, out of this
+    /// assembly's reach. Arrays and generic instances are cleared through their
+    /// element type.
+    /// </summary>
+    static bool ReceiverIsCrossAssembly(MetadataReader reader, TypeRef receiver)
+    {
+        string? rootAssembly = RootAssembly(receiver);
+        if (string.IsNullOrEmpty(rootAssembly))
+            return false;
+        string current = reader.IsAssembly
+            ? TypeRefDecoder.Canonical(reader.GetString(reader.GetAssemblyDefinition().Name))
+            : "";
+        return !string.Equals(rootAssembly, current, StringComparison.Ordinal);
+    }
+
+    static string? RootAssembly(TypeRef type) => type.Kind switch
+    {
+        TypeRefKind.Definition => type.Assembly,
+        TypeRefKind.GenericInstance or TypeRefKind.SzArray or TypeRefKind.Array
+            or TypeRefKind.Pointer or TypeRefKind.ByRef or TypeRefKind.Pinned
+            => type.ElementType is { } element ? RootAssembly(element) : null,
+        _ => null,
+    };
+
+    /// <summary>
+    /// Whether dropping the callee down to <paramref name="arity"/> leading
+    /// arguments is safe: no candidate (other than the callee itself) with at
+    /// least that many parameters shares the callee's first <paramref name="arity"/>
+    /// parameter types. A candidate that differs at any leading position cannot
+    /// rebind (the callee's identity match on the retained arguments is strictly
+    /// better), so only a leading-signature duplicate blocks.
+    /// </summary>
+    static bool AritySafe(MethodRef callee, List<SiblingSignature> siblings, MethodDefinitionHandle selfHandle, int arity)
     {
         foreach (var sibling in siblings)
         {
-            if (sibling.Length < arity)
+            if (sibling.Handle == selfHandle)
+                continue;  // the callee cannot rebind to itself
+            if (sibling.ParameterTypes.Length < arity)
                 continue;  // too few parameters to tie the callee at this arity
             bool sharesLeadingSignature = true;
             for (int i = 0; i < arity; i++)
             {
-                if (!sibling[i].Equals(callee.ParameterTypes[i]))
+                if (!sibling.ParameterTypes[i].Equals(callee.ParameterTypes[i]))
                 {
                     sharesLeadingSignature = false;
                     break;

--- a/src/ILInspector.Decompiler/Pipeline/OptionalArgumentFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/OptionalArgumentFacts.cs
@@ -163,13 +163,18 @@ internal static class OptionalArgumentFacts
             // extension named M may tie the callee's leading signature. Extensions
             // and instance methods in referenced assemblies stay the residual the
             // corpus fidelity gate backstops.
-            // The assembly-wide extension scan below reads only this manifest
-            // module's TypeDefinitions. In a multi-module assembly a competing
-            // extension can live in a linked netmodule the scan never sees (a
-            // same-assembly steal, not the accepted cross-assembly residual), so
-            // decline extension elision whenever the manifest carries code-bearing
-            // module files.
-            if (!ReceiverIsCrossAssembly(reader, callee.ParameterTypes[0]) || AssemblyHasMetadataModules(reader))
+            // The assembly-wide extension scan below reads only this reader's
+            // TypeDefinitions, so it sees the whole candidate set only for a
+            // single-module assembly manifest. Two multi-module shapes escape it,
+            // both same-assembly steals rather than the accepted cross-assembly
+            // residual, so decline extension elision in either: (a) a manifest that
+            // links code-bearing module files, whose netmodule extensions the scan
+            // never sees; and (b) a bare netmodule input (reader is not an
+            // assembly), whose sibling modules and assembly identity are unknowable
+            // from the module alone.
+            if (!reader.IsAssembly
+                || AssemblyHasMetadataModules(reader)
+                || !ReceiverIsCrossAssembly(reader, callee.ParameterTypes[0]))
                 return 0;
             siblings = AssemblyExtensionSiblings(reader, callee.Name);
         }

--- a/src/ILInspector.Decompiler/Pipeline/OptionalArgumentFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/OptionalArgumentFacts.cs
@@ -28,14 +28,16 @@ namespace ILInspector.Decompiler.Pipeline;
 /// counts the trailing defaulted run for which no such leading-signature
 /// duplicate exists among the callee's rebind candidates; any same-named generic
 /// sibling declines the whole callee (a generic candidate can unify with the
-/// retained arguments and win the fewer-declared-parameters tie-break). For a
-/// non-extension callee the candidate set is the declaring type's own methods
-/// (static calls are fully qualified; instance calls are pinned by the pass-time
-/// receiver guard). An extension callee renders in receiver syntax, so its
-/// candidates are <em>every</em> extension method of the same name in the
-/// assembly, and elision additionally requires the receiver type to live in
-/// another assembly (a same-assembly instance method would beat the extension).
-/// Extensions and instance methods in referenced assemblies are the residual the
+/// retained arguments and win the fewer-declared-parameters tie-break), as does
+/// any candidate carrying <c>[OverloadResolutionPriority]</c> (which reorders
+/// applicable candidates ahead of betterness). For a non-extension callee the
+/// candidate set is the declaring type's own methods (static calls are fully
+/// qualified; instance calls are pinned by the pass-time receiver guard). An
+/// extension callee renders in receiver syntax, so its candidates are
+/// <em>every</em> extension method of the same name in the assembly, and elision
+/// additionally requires the receiver type to live in another assembly (a
+/// same-assembly instance method would beat the extension). Extensions and
+/// instance methods in referenced assemblies are the residual the
 /// recompile/corpus fidelity gate backstops.</para>
 /// </summary>
 internal static class OptionalArgumentFacts
@@ -175,12 +177,19 @@ internal static class OptionalArgumentFacts
 
         // A same-named generic sibling can unify with the retained arguments and
         // win the "fewer declared parameters" tie-break over an optional-using
-        // callee (verified: Pick(int, int = 0) loses Pick(v) to Pick<T>(T)). The
-        // leading-signature identity check below cannot model unification, so
-        // decline the whole callee when any generic sibling shares the name.
+        // callee (verified: Pick(int, int = 0) loses Pick(v) to Pick<T>(T)). And
+        // [OverloadResolutionPriority] reorders applicable candidates ahead of
+        // betterness, so even a differently-typed sibling can steal the shortened
+        // call. The leading-signature identity check below models neither, so
+        // decline the whole callee when any candidate carries priority, or when
+        // any non-self sibling shares the name and is generic.
         foreach (var sibling in siblings)
+        {
+            if (sibling.HasPriority)
+                return 0;
             if (sibling.Handle != handle && sibling.IsGeneric)
                 return 0;
+        }
 
         int safe = 0;
         for (int k = 1; k <= trailingDefaults; k++)
@@ -194,10 +203,11 @@ internal static class OptionalArgumentFacts
 
     /// <summary>
     /// A same-named overload candidate: its handle (to exclude the callee itself),
-    /// its decoded parameter types (leading-signature comparison), and whether it
-    /// is generic (a generic candidate declines the whole callee).
+    /// its decoded parameter types (leading-signature comparison), whether it is
+    /// generic (a generic sibling declines the whole callee), and whether it
+    /// carries <c>[OverloadResolutionPriority]</c> (any priority candidate declines).
     /// </summary>
-    readonly record struct SiblingSignature(MethodDefinitionHandle Handle, ImmutableArray<TypeRef> ParameterTypes, bool IsGeneric);
+    readonly record struct SiblingSignature(MethodDefinitionHandle Handle, ImmutableArray<TypeRef> ParameterTypes, bool IsGeneric, bool HasPriority);
 
     static readonly List<SiblingSignature> NoSiblings = [];
 
@@ -218,7 +228,8 @@ internal static class OptionalArgumentFacts
             siblings.Add(new SiblingSignature(
                 handle,
                 GuardedDecode.MethodSignature(reader, method, typeScope).ParameterTypes,
-                method.GetGenericParameters().Count > 0));
+                method.GetGenericParameters().Count > 0,
+                MethodDefinitionFacts.HasOverloadResolutionPriorityAttribute(reader, method)));
         }
         return siblings;
     }
@@ -259,7 +270,8 @@ internal static class OptionalArgumentFacts
                 siblings.Add(new SiblingSignature(
                     handle,
                     GuardedDecode.MethodSignature(reader, method, typeScope).ParameterTypes,
-                    method.GetGenericParameters().Count > 0));
+                    method.GetGenericParameters().Count > 0,
+                    MethodDefinitionFacts.HasOverloadResolutionPriorityAttribute(reader, method)));
             }
         }
         return index;

--- a/src/ILInspector.Decompiler/Pipeline/OptionalArgumentFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/OptionalArgumentFacts.cs
@@ -36,8 +36,9 @@ namespace ILInspector.Decompiler.Pipeline;
 /// extension callee renders in receiver syntax, so its candidates are
 /// <em>every</em> extension method of the same name in the assembly, and elision
 /// additionally requires the receiver type to live in another assembly (a
-/// same-assembly instance method would beat the extension). Extensions and
-/// instance methods in referenced assemblies are the residual the
+/// same-assembly instance method would beat the extension) and the manifest to
+/// carry no code-bearing netmodules (whose extensions the scan cannot see).
+/// Extensions and instance methods in referenced assemblies are the residual the
 /// recompile/corpus fidelity gate backstops.</para>
 /// </summary>
 internal static class OptionalArgumentFacts
@@ -162,7 +163,13 @@ internal static class OptionalArgumentFacts
             // extension named M may tie the callee's leading signature. Extensions
             // and instance methods in referenced assemblies stay the residual the
             // corpus fidelity gate backstops.
-            if (!ReceiverIsCrossAssembly(reader, callee.ParameterTypes[0]))
+            // The assembly-wide extension scan below reads only this manifest
+            // module's TypeDefinitions. In a multi-module assembly a competing
+            // extension can live in a linked netmodule the scan never sees (a
+            // same-assembly steal, not the accepted cross-assembly residual), so
+            // decline extension elision whenever the manifest carries code-bearing
+            // module files.
+            if (!ReceiverIsCrossAssembly(reader, callee.ParameterTypes[0]) || AssemblyHasMetadataModules(reader))
                 return 0;
             siblings = AssemblyExtensionSiblings(reader, callee.Name);
         }
@@ -245,8 +252,7 @@ internal static class OptionalArgumentFacts
         return index.TryGetValue(name, out var siblings) ? siblings : NoSiblings;
     }
 
-    static Dictionary<string, List<SiblingSignature>> BuildExtensionSiblingIndex(MetadataReader reader)
-    {
+    static Dictionary<string, List<SiblingSignature>> BuildExtensionSiblingIndex(MetadataReader reader)    {
         var index = new Dictionary<string, List<SiblingSignature>>(StringComparer.Ordinal);
         foreach (var typeHandle in reader.TypeDefinitions)
         {
@@ -275,6 +281,22 @@ internal static class OptionalArgumentFacts
             }
         }
         return index;
+    }
+
+    /// <summary>
+    /// Whether the manifest assembly links code-bearing module files (netmodules).
+    /// The extension scan reads only this reader's <see cref="MetadataReader.TypeDefinitions"/>,
+    /// so a competing extension in another module of the same assembly is invisible
+    /// to it; the extension path declines outright in that case.
+    /// </summary>
+    static bool AssemblyHasMetadataModules(MetadataReader reader)
+    {
+        if (!reader.IsAssembly)
+            return false;
+        foreach (var handle in reader.AssemblyFiles)
+            if (reader.GetAssemblyFile(handle).ContainsMetadata)
+                return true;
+        return false;
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/OptionalArgumentFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/OptionalArgumentFacts.cs
@@ -1,0 +1,215 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+
+using SrmConstant = System.Reflection.Metadata.Constant;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Recovers the two facts the optional-argument elision pass consumes for a
+/// same-assembly <c>MethodDefinition</c> callee: each parameter's declared C#
+/// default (<c>[Optional]</c> + a <c>Constant</c> row) and how many trailing
+/// arguments may be dropped without a competing overload rebinding the shortened
+/// call.
+///
+/// <para>Optional parameters are a C# concept the IL type system erases — the
+/// compiler bakes the default into every call site (<c>ldnull</c>/<c>ldc</c>).
+/// Sourcing the default from metadata (mirroring the declaration-signature path
+/// in <c>ApiSurfaceExtractor</c>) keeps the decompiler from re-deriving its own
+/// view of the signature.</para>
+///
+/// <para>The overload guardrail is exact and local. Because the elision pass
+/// keeps only calls whose retained arguments already match their parameter types
+/// (identity conversions), the callee is the best match on those arguments, so a
+/// same-named sibling can rebind the shortened call only by <em>tying</em> the
+/// callee — sharing its leading parameter types. <see cref="SafeTrailingElidableCount"/>
+/// counts the trailing defaulted run for which no such leading-signature
+/// duplicate exists on the declaring type; a generic callee declines to zero. The
+/// recompile/corpus fidelity gate is the empirical backstop for any residual
+/// overload-resolution miss.</para>
+/// </summary>
+internal static class OptionalArgumentFacts
+{
+    /// <summary>
+    /// Stamps <see cref="MethodRef.ParameterDefaults"/> and
+    /// <see cref="MethodRef.SafeTrailingElidableCount"/> onto <paramref name="callee"/>
+    /// when the callee has an overload-safe trailing run of defaulted parameters;
+    /// returns the callee unchanged otherwise.
+    /// </summary>
+    internal static MethodRef Stamp(MetadataSource source, MethodDefinitionHandle handle, MethodRef callee)
+    {
+        try
+        {
+            int n = callee.ParameterTypes.Length;
+            if (n == 0)
+                return callee;
+
+            var reader = source.Reader;
+            var method = reader.GetMethodDefinition(handle);
+
+            var defaults = ReadDefaults(reader, method, n);
+            if (defaults.IsDefaultOrEmpty)
+                return callee;
+
+            int safe = SafeTrailingElidableCount(reader, method, handle, callee, defaults);
+            if (safe == 0)
+                return callee;
+
+            return callee with { ParameterDefaults = defaults, SafeTrailingElidableCount = safe };
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException)
+        {
+            return callee;
+        }
+    }
+
+    /// <summary>
+    /// Per-parameter defaults aligned 1:1 with the callee parameters. A C# default
+    /// is <c>[Optional]</c> together with a <c>Constant</c> row (<c>HasDefault</c>);
+    /// attributed decimal/DateTime defaults carry no <c>Constant</c> and are left
+    /// as "no default" (their call sites are <c>newobj</c>, never a plain constant,
+    /// so the pass would not match them anyway). Returns <see langword="default"/>
+    /// when no parameter carries a C# default.
+    /// </summary>
+    static ImmutableArray<ParameterDefault> ReadDefaults(MetadataReader reader, MethodDefinition method, int parameterCount)
+    {
+        var defaults = new ParameterDefault[parameterCount];
+        bool any = false;
+        foreach (var handle in method.GetParameters())
+        {
+            var parameter = reader.GetParameter(handle);
+            int index = parameter.SequenceNumber - 1;  // sequence 0 is the return parameter
+            if (index < 0 || index >= parameterCount)
+                continue;
+            const ParameterAttributes optionalWithDefault = ParameterAttributes.Optional | ParameterAttributes.HasDefault;
+            if ((parameter.Attributes & optionalWithDefault) != optionalWithDefault)
+                continue;
+            var constantHandle = parameter.GetDefaultValue();
+            if (constantHandle.IsNil)
+                continue;
+            defaults[index] = new ParameterDefault(true, ReadConstantValue(reader, reader.GetConstant(constantHandle)));
+            any = true;
+        }
+        return any ? ImmutableArray.Create(defaults) : default;
+    }
+
+    /// <summary>
+    /// The length of the trailing run of defaulted parameters that is also
+    /// overload-safe. The elision pass keeps a call only when every retained
+    /// argument's type equals its parameter type (an identity conversion), so the
+    /// callee is the best possible match on those arguments. A same-named sibling
+    /// can therefore rebind the shortened call only if it <em>ties</em> the callee
+    /// on the retained arguments — i.e. its leading parameter types are identical
+    /// to the callee's. (Any sibling that differs at a leading position forces a
+    /// non-identity conversion there and loses to the callee's exact match; a
+    /// generic sibling loses the non-generic tie-break; a <c>params</c> sibling
+    /// loses normal-vs-expanded.) So a shortened arity is unsafe exactly when some
+    /// sibling with at least that many parameters shares the callee's leading
+    /// parameter types.
+    /// </summary>
+    static int SafeTrailingElidableCount(
+        MetadataReader reader,
+        MethodDefinition method,
+        MethodDefinitionHandle handle,
+        MethodRef callee,
+        ImmutableArray<ParameterDefault> defaults)
+    {
+        int n = callee.ParameterTypes.Length;
+
+        int trailingDefaults = 0;
+        for (int k = 1; k <= n; k++)
+        {
+            if (!defaults[n - k].HasDefault)
+                break;
+            trailingDefaults = k;
+        }
+        if (trailingDefaults == 0)
+            return 0;
+
+        // A generic declaring type or generic method makes cross-instantiation
+        // reasoning unsound here; decline in v1.
+        if (callee.DeclaringType.Kind == TypeRefKind.GenericInstance || !callee.TypeArguments.IsDefaultOrEmpty)
+            return 0;
+
+        var siblings = SiblingOverloads(reader, method, handle, callee.Name);
+
+        int safe = 0;
+        for (int k = 1; k <= trailingDefaults; k++)
+        {
+            if (!AritySafe(callee, siblings, n - k))
+                break;
+            safe = k;
+        }
+        return safe;
+    }
+
+    static List<ImmutableArray<TypeRef>> SiblingOverloads(MetadataReader reader, MethodDefinition self, MethodDefinitionHandle selfHandle, string name)
+    {
+        var siblings = new List<ImmutableArray<TypeRef>>();
+        var declaringType = reader.GetTypeDefinition(self.GetDeclaringType());
+        var typeScope = new GenericScope(MethodDefinitionFacts.GenericParameterNames(reader, declaringType.GetGenericParameters()), []);
+        foreach (var handle in declaringType.GetMethods())
+        {
+            if (handle == selfHandle)
+                continue;
+            var method = reader.GetMethodDefinition(handle);
+            if (!string.Equals(reader.GetString(method.Name), name, StringComparison.Ordinal))
+                continue;
+            siblings.Add(GuardedDecode.MethodSignature(reader, method, typeScope).ParameterTypes);
+        }
+        return siblings;
+    }
+
+    /// <summary>
+    /// Whether dropping the callee down to <paramref name="arity"/> leading
+    /// arguments is safe: no sibling with at least that many parameters shares the
+    /// callee's first <paramref name="arity"/> parameter types. A sibling that
+    /// differs at any leading position cannot rebind (the callee's identity match
+    /// on the retained arguments is strictly better), so only a leading-signature
+    /// duplicate blocks.
+    /// </summary>
+    static bool AritySafe(MethodRef callee, List<ImmutableArray<TypeRef>> siblings, int arity)
+    {
+        foreach (var sibling in siblings)
+        {
+            if (sibling.Length < arity)
+                continue;  // too few parameters to tie the callee at this arity
+            bool sharesLeadingSignature = true;
+            for (int i = 0; i < arity; i++)
+            {
+                if (!sibling[i].Equals(callee.ParameterTypes[i]))
+                {
+                    sharesLeadingSignature = false;
+                    break;
+                }
+            }
+            if (sharesLeadingSignature)
+                return false;  // the sibling ties the callee and could rebind
+        }
+        return true;
+    }
+
+    static object? ReadConstantValue(MetadataReader reader, SrmConstant constant)
+    {
+        var blob = reader.GetBlobReader(constant.Value);
+        return constant.TypeCode switch
+        {
+            ConstantTypeCode.Boolean => blob.ReadBoolean(),
+            ConstantTypeCode.Char => blob.ReadChar(),
+            ConstantTypeCode.SByte => blob.ReadSByte(),
+            ConstantTypeCode.Byte => blob.ReadByte(),
+            ConstantTypeCode.Int16 => blob.ReadInt16(),
+            ConstantTypeCode.UInt16 => blob.ReadUInt16(),
+            ConstantTypeCode.Int32 => blob.ReadInt32(),
+            ConstantTypeCode.UInt32 => blob.ReadUInt32(),
+            ConstantTypeCode.Int64 => blob.ReadInt64(),
+            ConstantTypeCode.UInt64 => blob.ReadUInt64(),
+            ConstantTypeCode.Single => blob.ReadSingle(),
+            ConstantTypeCode.Double => blob.ReadDouble(),
+            ConstantTypeCode.String => blob.ReadUTF16(blob.Length),
+            ConstantTypeCode.NullReference => null,
+            _ => null,
+        };
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/OptionalArgumentFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/OptionalArgumentFacts.cs
@@ -88,7 +88,12 @@ internal static class OptionalArgumentFacts
             var constantHandle = parameter.GetDefaultValue();
             if (constantHandle.IsNil)
                 continue;
-            defaults[index] = new ParameterDefault(true, ReadConstantValue(reader, reader.GetConstant(constantHandle)));
+            // An undecodable constant type must not become a spurious null default
+            // (which would then match a null/0 argument); leave the parameter as
+            // "no default" so the pass keeps the explicit argument.
+            if (!TryReadConstantValue(reader, reader.GetConstant(constantHandle), out var value))
+                continue;
+            defaults[index] = new ParameterDefault(true, value);
             any = true;
         }
         return any ? ImmutableArray.Create(defaults) : default;
@@ -190,26 +195,29 @@ internal static class OptionalArgumentFacts
         return true;
     }
 
-    static object? ReadConstantValue(MetadataReader reader, SrmConstant constant)
+    static bool TryReadConstantValue(MetadataReader reader, SrmConstant constant, out object? value)
     {
         var blob = reader.GetBlobReader(constant.Value);
-        return constant.TypeCode switch
+        switch (constant.TypeCode)
         {
-            ConstantTypeCode.Boolean => blob.ReadBoolean(),
-            ConstantTypeCode.Char => blob.ReadChar(),
-            ConstantTypeCode.SByte => blob.ReadSByte(),
-            ConstantTypeCode.Byte => blob.ReadByte(),
-            ConstantTypeCode.Int16 => blob.ReadInt16(),
-            ConstantTypeCode.UInt16 => blob.ReadUInt16(),
-            ConstantTypeCode.Int32 => blob.ReadInt32(),
-            ConstantTypeCode.UInt32 => blob.ReadUInt32(),
-            ConstantTypeCode.Int64 => blob.ReadInt64(),
-            ConstantTypeCode.UInt64 => blob.ReadUInt64(),
-            ConstantTypeCode.Single => blob.ReadSingle(),
-            ConstantTypeCode.Double => blob.ReadDouble(),
-            ConstantTypeCode.String => blob.ReadUTF16(blob.Length),
-            ConstantTypeCode.NullReference => null,
-            _ => null,
-        };
+            case ConstantTypeCode.Boolean: value = blob.ReadBoolean(); return true;
+            case ConstantTypeCode.Char: value = blob.ReadChar(); return true;
+            case ConstantTypeCode.SByte: value = blob.ReadSByte(); return true;
+            case ConstantTypeCode.Byte: value = blob.ReadByte(); return true;
+            case ConstantTypeCode.Int16: value = blob.ReadInt16(); return true;
+            case ConstantTypeCode.UInt16: value = blob.ReadUInt16(); return true;
+            case ConstantTypeCode.Int32: value = blob.ReadInt32(); return true;
+            case ConstantTypeCode.UInt32: value = blob.ReadUInt32(); return true;
+            case ConstantTypeCode.Int64: value = blob.ReadInt64(); return true;
+            case ConstantTypeCode.UInt64: value = blob.ReadUInt64(); return true;
+            case ConstantTypeCode.Single: value = blob.ReadSingle(); return true;
+            case ConstantTypeCode.Double: value = blob.ReadDouble(); return true;
+            case ConstantTypeCode.String: value = blob.ReadUTF16(blob.Length); return true;
+            case ConstantTypeCode.NullReference: value = null; return true;
+            // Invalid / unrecognized (e.g. an attributed decimal/DateTime default
+            // never has a Constant row, so this is not reached for well-formed
+            // metadata): decline rather than record a guessed value.
+            default: value = null; return false;
+        }
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -411,6 +411,11 @@ public static class IrPasses
         // intrinsic. It stays BEFORE CoercionInsertionPass so the minted
         // UnboxAny value is coerced at its sink like any other.
         new UnboxValueReadPass(),
+        // Elide trailing arguments the compiler baked in for omitted C# optional
+        // parameters (ToWords(g, null) -> ToWords(g)); opcode-neutral taste, bounded
+        // by the importer's overload-safe count. Before coercion insertion so the
+        // trailing defaults are still bare constants, never wrapped sink values.
+        new OptionalArgumentElisionPass(),
         new CoercionInsertionPass(),
     ];
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -101,6 +101,8 @@ internal static class NativePasses
     public static ArrayLiteralFromStoresPass ArrayLiteralFromStores => new();
     [Native(NativeCategory.EmitArtifact, "a spilled fluent call chain re-composed by folding each single-use scratch receiver/argument temp back into the chained call it feeds")]
     public static FluentChainRecompositionPass FluentChainRecomposition => new();
+    [Native(NativeCategory.EmitArtifact, "trailing arguments the compiler baked in for omitted C# optional parameters (a constant equal to the parameter's default) elided back to the shorter call the source wrote")]
+    public static OptionalArgumentElisionPass OptionalArgumentElision => new();
 
     // ───────── IlErasure — reconstruct information the IL type system dropped ─────────
     [Native(NativeCategory.IlErasure, "int constants re-typed to bool/char/enum at typed positions")]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/OptionalArgumentElisionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/OptionalArgumentElisionPass.cs
@@ -1,0 +1,129 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Elides trailing call arguments that the compiler baked in for omitted C#
+/// optional parameters: an argument that is a compile-time constant equal to its
+/// parameter's declared default (<c>ToWords(gender, null)</c> →
+/// <c>ToWords(gender)</c>). Optional parameters are a C# concept the IL type
+/// system erases — the compiler emits the default at every call site — so
+/// dropping the argument is opcode-neutral: recompiling re-inserts the same
+/// default. It is a taste transform (valid-but-different), not a fidelity change.
+///
+/// <para>The one real hazard is overload resolution: a shorter argument list can
+/// rebind to a different same-named overload. The pass never decides safety
+/// itself — it is bounded by <see cref="MethodRef.SafeTrailingElidableCount"/>,
+/// the conservative overload-safe count the importer stamped from metadata
+/// (<see cref="OptionalArgumentFacts"/>). It only drops an argument that is still
+/// a bare <see cref="Constant"/> equal to the recovered default, and only when
+/// the call still carries the callee's full parameter list. Runs late, before
+/// <see cref="CoercionInsertionPass"/> wraps sink values, so the trailing
+/// defaults are still bare constants and never named/reshaped.</para>
+/// </summary>
+public sealed class OptionalArgumentElisionPass : IIrPass
+{
+    public string Name => "optional-argument-elision";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        foreach (var call in function.Descendants.OfType<Call>().ToList())
+        {
+            if (call.Parent is null)
+                continue;  // already detached by an outer rewrite this pass
+            int drop = ElidableTrailingCount(call);
+            if (drop == 0)
+                continue;
+
+            var detached = call.DetachChildren();
+            var kept = detached.Take(detached.Count - drop).Cast<IrExpression>();
+            var replacement = new Call(call.Callee, call.IsVirtual, kept) { ConstrainedTo = call.ConstrainedTo };
+            context.Stepper.StepOver(
+                $"elide {drop} default argument{(drop == 1 ? "" : "s")} of {call.Callee.Name}",
+                call);
+            call.ReplaceWith(replacement);
+        }
+    }
+
+    static int ElidableTrailingCount(Call call)
+    {
+        var callee = call.Callee;
+        int safe = callee.SafeTrailingElidableCount;
+        if (safe == 0 || callee.ParameterDefaults.IsDefaultOrEmpty)
+            return 0;
+
+        int n = callee.ParameterTypes.Length;
+        if (callee.ParameterDefaults.Length != n)
+            return 0;
+
+        var arguments = call.Arguments;
+        int receiverCount = callee.HasThis ? 1 : 0;
+        // Only elide when the argument list still matches the full parameter list;
+        // a pass that already reshaped the arguments is out of scope.
+        if (arguments.Count - receiverCount != n)
+            return 0;
+
+        int drop = 0;
+        for (int k = 1; k <= safe; k++)
+        {
+            var parameter = callee.ParameterDefaults[n - k];
+            if (!parameter.HasDefault)
+                break;
+            if (arguments[receiverCount + (n - k)] is not Constant constant)
+                break;
+            if (!DefaultMatches(constant, parameter.Value))
+                break;
+            drop = k;
+        }
+        if (drop == 0)
+            return 0;
+
+        // The overload guardrail (SafeTrailingElidableCount) assumes the callee is
+        // the best match on the retained arguments — true only when each retained
+        // argument's type equals its parameter type (an identity conversion). A
+        // widening/boxing/reference conversion at a retained position could let a
+        // sibling with that exact parameter type rebind the shortened call, so
+        // decline unless every retained parameter-aligned argument is identity.
+        for (int i = 0; i < n - drop; i++)
+        {
+            var argumentType = arguments[receiverCount + i].ResultType;
+            if (argumentType is null || !argumentType.Equals(callee.ParameterTypes[i]))
+                return 0;
+        }
+        return drop;
+    }
+
+    /// <summary>
+    /// Whether a constant argument equals a recovered parameter default. IL erases
+    /// the constant's C# type, so integral/bool/char/enum values are compared by
+    /// their two's-complement bits, floating point by exact bit pattern, and
+    /// strings ordinally; a mismatched or unrecognized pairing is conservatively
+    /// unequal so the argument stays explicit.
+    /// </summary>
+    static bool DefaultMatches(Constant argument, object? expected)
+    {
+        object? actual = argument.Value;
+        if (actual is null || expected is null)
+            return actual is null && expected is null;
+        if (TryToInt64(actual, out long actualBits) && TryToInt64(expected, out long expectedBits))
+            return actualBits == expectedBits;
+        if (actual is float actualSingle && expected is float expectedSingle)
+            return BitConverter.SingleToInt32Bits(actualSingle) == BitConverter.SingleToInt32Bits(expectedSingle);
+        if (actual is double actualDouble && expected is double expectedDouble)
+            return BitConverter.DoubleToInt64Bits(actualDouble) == BitConverter.DoubleToInt64Bits(expectedDouble);
+        if (actual is string actualString && expected is string expectedString)
+            return string.Equals(actualString, expectedString, StringComparison.Ordinal);
+        return false;
+    }
+
+    static bool TryToInt64(object value, out long result)
+    {
+        switch (value)
+        {
+            case bool b: result = b ? 1 : 0; return true;
+            case char c: result = c; return true;
+            case sbyte or byte or short or ushort or int or uint or long:
+                result = System.Convert.ToInt64(value); return true;
+            case ulong u: result = unchecked((long)u); return true;
+            default: result = 0; return false;
+        }
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/OptionalArgumentElisionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/OptionalArgumentElisionPass.cs
@@ -61,6 +61,22 @@ public sealed class OptionalArgumentElisionPass : IIrPass
         if (arguments.Count - receiverCount != n)
             return 0;
 
+        // Overload resolution on the shortened instance call uses the receiver's
+        // static type, not the callee's declaring type. If the receiver is a
+        // subtype of the declaring type, a shorter same-named overload introduced
+        // by that subtype can capture the shortened call — demonstrated: a base
+        // optional method (`Base.Log(string, bool = false)`) called through a
+        // derived receiver whose `Derived.Log(string)` steals `Log("x")`. The
+        // importer's sibling scan only sees the declaring type, so require the
+        // receiver to be exactly the declaring type; then no more-derived overload
+        // participates. (Static and extension callees have no receiver subtype.)
+        if (callee.HasThis)
+        {
+            var receiverType = arguments[0].ResultType;
+            if (receiverType is null || !receiverType.Equals(callee.DeclaringType))
+                return 0;
+        }
+
         int drop = 0;
         for (int k = 1; k <= safe; k++)
         {


### PR DESCRIPTION
## What

Class-3 taste transform (issue #3027): elide a trailing call argument when it is a compile-time constant equal to its parameter's declared C# default. IL-identical; renders `ToWords(GrammaticalGender.Feminine)` instead of `ToWords(GrammaticalGender.Feminine, null)`.

Optional parameters are a C# concept the IL type system erases (the compiler bakes the default into every call site). The default is sourced from **metadata** (`[Optional]` + `Constant`), mirroring the declaration-signature path in `ApiSurfaceExtractor` — the decompiler does not re-derive its own view of the signature.

## Witness (Humanizer `FrTimeOnlyToClockNotationConverter.Convert`)

- before: `hour.ToWords(GrammaticalGender.Feminine, null)`
- after:  `hour.ToWords(GrammaticalGender.Feminine)`

Overload: `ToWords(this int, GrammaticalGender, CultureInfo? culture = null)`.

## Guardrail (targeted conservative optimization, not a Roslyn overload-resolution clone)

Elision is declined whenever a same-named overload could rebind the shortened call. Sound over-approximation that declines when uncertain, validated by recompile/corpus fidelity.

**Import-time (`OptionalArgumentFacts`):**
- Only same-assembly `MethodDefinition` callees are stamped (cross-assembly/generic structurally decline).
- A shortened arity is unsafe if any same-named candidate ties the callee's leading parameter types (`TypeRef.Equals`).
- Candidate set = the declaring type's methods for a non-extension callee; **every extension method of that name across the assembly** (cached per reader) for an extension callee, because an extension call resolves in receiver syntax across all extension classes in scope.
- Any same-named **generic** sibling declines the whole callee (the "fewer declared parameters" tie-break lets a generic candidate unify and win, e.g. `Pick(v)` binds `Pick<T>(T)` over `Pick(int,int=0)`).
- Any candidate carrying **`[OverloadResolutionPriority]`** (C# 13) declines the whole callee — priority reorders applicable candidates ahead of betterness, so a differently-typed sibling can steal the shortened call.
- Extension callees additionally require the **receiver type to be rooted in another assembly** (`ReceiverIsCrossAssembly`), so no same-assembly instance method (which beats an extension) can capture the call, **and the input to be a single-module assembly manifest** — the assembly-wide scan reads only one reader's module, so it declines when `!reader.IsAssembly` (a bare netmodule hides its sibling modules) or `AssemblyHasMetadataModules` (a manifest links code-bearing netmodules the scan cannot see).

**Pass-time (`OptionalArgumentElisionPass`):**
- Every retained argument's `ResultType.Equals` its parameter type (guards reference-subtype rebinds, e.g. `Feed(Animal,int=1)` + `Feed(Dog)`).
- `HasThis` callees decline unless `arguments[0].ResultType.Equals(callee.DeclaringType)` (base/derived receiver steal).

**Accepted residual (corpus-backstopped):** cross-**assembly** extension competitors and cross-assembly instance methods on the receiver type. All same-assembly steal vectors are closed.

## Not elided (by design)

Every case below is IL-identical to the shorter spelling, yet the trailing argument is **kept** because eliding it would change binding or erase a real evaluation. Each is pinned by the named fixture in `OptionalArgumentElisionFixtures`.

**Overload steal — a same-named candidate would rebind the shortened call:**

- **Leading-signature tie (inert optional)** — `Log("x", false)` stays (not `Log("x")`). The exact one-argument overload `Log(string)` always wins over `Log(string, bool = false)` — a candidate that fills every parameter beats one that substitutes an optional default — so `verbose`'s default is **unreachable by omission**: no source could write `Log("x")` and land on the two-argument callee. The `false` is therefore necessarily explicit in source, and eliding it would silently retarget the call to the *other* method. The optional parameter is effectively dead here (arguably a poor API shape); the pass declines only so it is not fooled by it. _(`CallLogKeepsSiblingTie`)_

  ```csharp
  int Log(string message);                          // Log("x") always binds here
  int Log(string message, bool verbose = false);    // reachable only as Log("x", <bool>)
  ```

- **Reference-subtype receiver** — `Feed(d, 1)` where `d` is `Dog` stays; `Feed((Animal)d)` would rebind to the better-matching `Feed(Dog)`. _(`CallFeedKeepsSubtype`)_

  ```csharp
  int Feed(Animal a, int portion = 1);
  int Feed(Dog d);                                  // Feed(d, 1)  ↛  Feed(d)
  ```

- **Derived-receiver steal** — `r.Emit("x", false)` where `r` is `LoudReporter` stays; `r.Emit("x")` would bind `LoudReporter.Emit(string)`, a different method than the base `Reporter.Emit(string, bool = false)`. _(`CallReporterKeepsDerivedSteal`)_

- **Generic sibling** — `Pick(5, 0)` stays; `Pick(5)` would rebind to `Pick<T>(T)` under the "fewer declared parameters" tie-break. _(`CallPickKeepsGenericSibling`)_

  ```csharp
  int Pick(int value, int seed = 0);
  int Pick<T>(T value);                             // Pick(5, 0)  ↛  Pick(5)
  ```

- **`[OverloadResolutionPriority]`** — `Rank(5, 0)` stays; the attribute deprioritizes `Rank(int, int = 0)`, so `Rank(5)` would rebind to the differently-typed `Rank(long)`. _(`CallRankKeepsPriorityOverload`)_

- **Cross-class extension steal** — `s.Pin(2, null)` stays; `s.Pin(2)` would rebind to a same-named extension `Pin(this string, int)` declared in a *different* static class (found by the assembly-wide extension scan). _(`CallExtensionKeepsCrossClassSteal`)_

**Structural declines:**

- **Non-default breaks the run** — `Triple(1, 9, 3)` renders `Triple(1, 9)`: only the trailing `3` (equal to its default) drops. `9 ≠ 2` blocks eliding the leading `1` **even though `1` equals its own default**, because `Triple(9)` would misbind `9` to `a`. _(`CallTripleTrailingRun`)_

- **Cross-assembly callee** — `s.Split(';')` keeps the baked `StringSplitOptions.None`; v1 stamps same-assembly `MethodDefinition` callees only. _(`CallSplitCrossAssembly`)_

**Constant-only rule:** a trailing argument that merely *evaluates* to the default via a non-constant expression (e.g. `Speak(3, GetNote())` where `GetNote()` returns `null`) is a real evaluation the IL performs — it is never elided, since dropping it would erase a distinction the IL makes (class 2), not a spelling choice.

## Tests

`OptionalArgumentElisionPassTests` (12) over `OptionalArgumentElisionFixtures`: elides null/enum/instance-null trailing defaults; keeps sibling-tie, non-default-run, retained-subtype, cross-assembly, derived-receiver-steal, **cross-class extension steal**, **generic-sibling**, and **`[OverloadResolutionPriority]`** cases; lone-extension positive elides. The two multi-module (netmodule) declines are validated by a real `csc /addmodule` artifact canary (the test project is single-module).

## History

Adversarial review found four steal holes: cross-class extension steal + generic-sibling steal (round 1, fixed in `a0de48c5` — assembly-wide extension scan + receiver guard + generic-sibling decline), `[OverloadResolutionPriority]` steal (round 2, fixed in `0a2ee90a`), a manifest-links-netmodule extension steal (round 2, fixed in `422a3e49`), and a bare-netmodule extension steal (round 3, fixed in `326470b9` — decline extension elision when `!reader.IsAssembly`). Head `326470b9`.



