### PR TITLE
Unify primitive-keyword spelling on PrimitiveTypeNames (#2891)

### DIFF
--- a/src/ILInspector.Analysis/TypeRef.cs
+++ b/src/ILInspector.Analysis/TypeRef.cs
@@ -222,7 +222,7 @@ public sealed class TypeRef : IEquatable<TypeRef>
 
     string DisplayName()
     {
-        if (Assembly == CoreLibrary && Namespace == "System" && s_keywords.TryGetValue(Name, out var keyword))
+        if (Assembly == CoreLibrary && Namespace == "System" && PrimitiveTypeNames.TryToKeywordForSystemType(Name, out var keyword))
             return keyword;
         // Preserve the full nested declaring-type path. Metadata joins a containing
         // type and its nested type with '+' (see TypeRefDecoder), so a name like
@@ -237,7 +237,7 @@ public sealed class TypeRef : IEquatable<TypeRef>
     string QualifiedDisplayName()
     {
         string display = DisplayName();
-        if (Assembly == CoreLibrary && Namespace == "System" && s_keywords.ContainsKey(Name))
+        if (Assembly == CoreLibrary && Namespace == "System" && PrimitiveTypeNames.TryToKeywordForSystemType(Name, out _))
             return display;
         return Namespace.Length == 0 || display.StartsWith('<') ? display : $"{Namespace}.{display}";
     }
@@ -271,15 +271,4 @@ public sealed class TypeRef : IEquatable<TypeRef>
         => assemblyName is "System.Private.CoreLib" or "System.Runtime" or "mscorlib" or "netstandard" or "System.Runtime.Extensions"
             ? CoreLibrary
             : assemblyName;
-
-    static readonly Dictionary<string, string> s_keywords = new()
-    {
-        ["Boolean"] = "bool", ["Byte"] = "byte", ["SByte"] = "sbyte",
-        ["Char"] = "char", ["Int16"] = "short", ["UInt16"] = "ushort",
-        ["Int32"] = "int", ["UInt32"] = "uint", ["Int64"] = "long",
-        ["UInt64"] = "ulong", ["Single"] = "float", ["Double"] = "double",
-        ["Decimal"] = "decimal",
-        ["IntPtr"] = "nint", ["UIntPtr"] = "nuint", ["String"] = "string",
-        ["Object"] = "object", ["Void"] = "void",
-    };
 }

--- a/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
@@ -507,7 +507,7 @@ public sealed class TypeRef : IEquatable<TypeRef>
 
     string DisplayName()
     {
-        if (Assembly == CoreLibrary && Namespace == "System" && s_keywords.TryGetValue(Name, out var keyword))
+        if (Assembly == CoreLibrary && Namespace == "System" && PrimitiveTypeNames.TryToKeywordForSystemType(Name, out var keyword))
             return keyword;
         // Nested types carry the metadata `Outer+Inner` name; C# refers to
         // them by the innermost simple name (the namespace-stripping
@@ -717,15 +717,4 @@ public sealed class TypeRef : IEquatable<TypeRef>
         int tick = name.IndexOf('`');
         return tick >= 0 && int.TryParse(name[(tick + 1)..], out int arity) ? arity : 0;
     }
-
-    static readonly Dictionary<string, string> s_keywords = new()
-    {
-        ["Boolean"] = "bool", ["Byte"] = "byte", ["SByte"] = "sbyte",
-        ["Char"] = "char", ["Int16"] = "short", ["UInt16"] = "ushort",
-        ["Int32"] = "int", ["UInt32"] = "uint", ["Int64"] = "long",
-        ["UInt64"] = "ulong", ["Single"] = "float", ["Double"] = "double",
-        ["Decimal"] = "decimal",
-        ["IntPtr"] = "nint", ["UIntPtr"] = "nuint", ["String"] = "string",
-        ["Object"] = "object", ["Void"] = "void",
-    };
 }

--- a/src/ILInspector.Metadata/PrimitiveTypeNames.cs
+++ b/src/ILInspector.Metadata/PrimitiveTypeNames.cs
@@ -2,9 +2,10 @@ namespace ILInspector.Metadata;
 
 /// <summary>
 /// Maps C# primitive/keyword type names to their CLR <c>System.*</c> full names. Single source of
-/// truth shared by user type-query normalization, XML-doc match keys, and extension-method match
-/// keys, so a keyword like <c>nint</c> normalizes identically everywhere (previously each site had
-/// its own partial table and they disagreed).
+/// truth shared by user type-query normalization, XML-doc match keys, extension-method match keys,
+/// and Analysis/Decompiler type-reference display (via <see cref="TryToKeywordForSystemType"/>), so
+/// a keyword like <c>nint</c> normalizes identically everywhere (previously each site had its own
+/// partial table and they disagreed).
 /// </summary>
 public static class PrimitiveTypeNames
 {
@@ -33,6 +34,12 @@ public static class PrimitiveTypeNames
     private static readonly Dictionary<string, string> ReverseMap =
         Map.ToDictionary(static pair => pair.Value, static pair => pair.Key, StringComparer.Ordinal);
 
+    private static readonly Dictionary<string, string> SystemTypeReverseMap =
+        Map.ToDictionary(
+            static pair => pair.Value[(pair.Value.LastIndexOf('.') + 1)..],
+            static pair => pair.Key,
+            StringComparer.Ordinal);
+
     /// <summary>Returns the CLR full name for a primitive keyword, or the input unchanged.</summary>
     public static string ToClrFullName(string keyword)
         => Map.TryGetValue(keyword, out var full) ? full : keyword;
@@ -48,4 +55,14 @@ public static class PrimitiveTypeNames
     /// </summary>
     public static bool TryToKeyword(string clrFullName, out string keyword)
         => ReverseMap.TryGetValue(clrFullName, out keyword!);
+
+    /// <summary>
+    /// Tries to map a namespace-stripped <c>System</c> primitive type name (e.g.
+    /// <c>Int32</c>) to its C# keyword (e.g. <c>int</c>). Type-reference display that
+    /// has already split off the <c>System</c> namespace uses this to avoid rebuilding
+    /// a full name; it draws from the one alias table shared with
+    /// <see cref="TryToKeyword"/>, so simple-name and full-name lookups never disagree.
+    /// </summary>
+    public static bool TryToKeywordForSystemType(string systemTypeName, out string keyword)
+        => SystemTypeReverseMap.TryGetValue(systemTypeName, out keyword!);
 }

--- a/tests/ILInspector.Metadata.Tests/PrimitiveKeywordConsistencyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/PrimitiveKeywordConsistencyTests.cs
@@ -1,0 +1,69 @@
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata.Tests;
+
+public sealed class PrimitiveKeywordConsistencyTests
+{
+    // The byte-identical table formerly duplicated as a private s_keywords in
+    // ILInspector.Analysis.TypeRef and ILInspector.Decompiler.Pipeline.TypeRef now
+    // resolves through PrimitiveTypeNames. This pins that the shared simple-name
+    // lookup reproduces every former entry exactly, so collapsing the copies onto
+    // the single source of truth is behavior-preserving.
+    public static TheoryData<string, string> SystemTypeKeywords => new()
+    {
+        { "Boolean", "bool" }, { "Byte", "byte" }, { "SByte", "sbyte" },
+        { "Char", "char" }, { "Int16", "short" }, { "UInt16", "ushort" },
+        { "Int32", "int" }, { "UInt32", "uint" }, { "Int64", "long" },
+        { "UInt64", "ulong" }, { "Single", "float" }, { "Double", "double" },
+        { "Decimal", "decimal" },
+        { "IntPtr", "nint" }, { "UIntPtr", "nuint" }, { "String", "string" },
+        { "Object", "object" }, { "Void", "void" },
+    };
+
+    [Theory]
+    [MemberData(nameof(SystemTypeKeywords))]
+    public void TryToKeywordForSystemType_ReproducesFormerTypeRefTable(string systemName, string keyword)
+    {
+        Assert.True(PrimitiveTypeNames.TryToKeywordForSystemType(systemName, out var actual));
+        Assert.Equal(keyword, actual);
+    }
+
+    [Fact]
+    public void TryToKeywordForSystemType_RejectsNonPrimitiveSystemType()
+        => Assert.False(PrimitiveTypeNames.TryToKeywordForSystemType("DateTime", out _));
+
+    // SignatureDecoder lives in the bottom-layer MetadataPrimitives project and
+    // spells primitives from a PrimitiveTypeCode-keyed SRM provider switch, so it
+    // cannot reference PrimitiveTypeNames (a layer above). This binds its keyword
+    // spelling to the shared alias table so the two independent producers cannot
+    // silently disagree.
+    public static TheoryData<PrimitiveTypeCode, string> PrimitiveCodeFullNames => new()
+    {
+        { PrimitiveTypeCode.Boolean, "System.Boolean" },
+        { PrimitiveTypeCode.Char, "System.Char" },
+        { PrimitiveTypeCode.SByte, "System.SByte" },
+        { PrimitiveTypeCode.Byte, "System.Byte" },
+        { PrimitiveTypeCode.Int16, "System.Int16" },
+        { PrimitiveTypeCode.UInt16, "System.UInt16" },
+        { PrimitiveTypeCode.Int32, "System.Int32" },
+        { PrimitiveTypeCode.UInt32, "System.UInt32" },
+        { PrimitiveTypeCode.Int64, "System.Int64" },
+        { PrimitiveTypeCode.UInt64, "System.UInt64" },
+        { PrimitiveTypeCode.Single, "System.Single" },
+        { PrimitiveTypeCode.Double, "System.Double" },
+        { PrimitiveTypeCode.String, "System.String" },
+        { PrimitiveTypeCode.Object, "System.Object" },
+        { PrimitiveTypeCode.IntPtr, "System.IntPtr" },
+        { PrimitiveTypeCode.UIntPtr, "System.UIntPtr" },
+        { PrimitiveTypeCode.Void, "System.Void" },
+    };
+
+    [Theory]
+    [MemberData(nameof(PrimitiveCodeFullNames))]
+    public void SignatureDecoderKeyword_MatchesPrimitiveTypeNames(PrimitiveTypeCode code, string fullName)
+    {
+        var decoded = SignatureDecoder.Instance.GetPrimitiveType(code);
+        Assert.True(PrimitiveTypeNames.TryToKeyword(fullName, out var keyword));
+        Assert.Equal(keyword, decoded);
+    }
+}


### PR DESCRIPTION
## What

Item 2 of #2891: converge the duplicated primitive-keyword maps onto the existing single source of truth, `PrimitiveTypeNames`.

- Removes the two **byte-identical** private `s_keywords` tables in `ILInspector.Analysis.TypeRef` and `ILInspector.Decompiler.Pipeline.TypeRef`. Both now resolve through a new `PrimitiveTypeNames.TryToKeywordForSystemType`, a namespace-stripped simple-name lookup (`Int32` → `int`) drawn from the **same** alias table as `TryToKeyword`, so simple-name and full-name lookups can never disagree.
- Leaves `SignatureDecoder` (bottom-layer `MetadataPrimitives`, a `PrimitiveTypeCode`-keyed SRM `ISignatureTypeProvider` that cannot reference the layer above) with its own switch, but adds a **consistency guard test** binding its keyword spelling to `PrimitiveTypeNames` so the two independent producers cannot silently diverge.

Net: 3 product files (+/− ~28 lines), 1 new test. `EnumUnderlyingKeyword` (a semantically-scoped enum-underlying filter, not a byte-identical duplicate) and `SignatureDecoder`'s enum-keyed switch are intentionally left; see #2891 for the remaining ownership decision.

## Layering

`PrimitiveTypeNames` lives in `Metadata`, the lowest layer reachable by `Analysis`, `Decompiler`, and `CSharp` — so routing the two `TypeRef` copies through it introduces no layer inversion. `SignatureDecoder` sits **below** `PrimitiveTypeNames` and structurally differs (enum-keyed SRM provider), which is why it's guarded rather than merged.

## Evidence

Behavior is identical by construction: the shared lookup reproduces every former `s_keywords` entry exactly (pinned by the new guard test).

- New guard test `PrimitiveKeywordConsistencyTests`: **36 pass** (former-table reproduction + `SignatureDecoder` ↔ `PrimitiveTypeNames` binding).
- `ILInspector.Metadata.Tests` **684**, `ILInspector.Analysis.Tests` **485** pass.
- Decompiler (via #2979 Area traits): `Area=RoundTrip` **268**, `Area=Pass` **1120**, fast `Area=Fidelity` **27** — all green.
- Two **slow** Fidelity gates (`LadderIteratorGateTests.IteratorFixture_RecoveredRowsCompileBackOpcodeExact` → `OperandDiff`; `FidelityGateTests.NoNewFidelityDiffsBeyondKnownDocket`) fail — **reproduced identically on a clean base worktree with no diff** (SDK/IL-docket drift on the local preview-6 SDK), so they are pre-existing and unrelated. This refactor is opcode-neutral.

## Risk

Low: mechanical, behavior-preserving refactor onto an existing SSOT, guard-tested identical, no product-output change. No `Roslyn`/loading introduced; layer ownership preserved.

Addresses item 2 of #2891.


## Before / after

`PrimitiveTypeNames` grows one lookup drawn from the existing alias table:

```csharp
// after — new, in ILInspector.Metadata/PrimitiveTypeNames.cs
private static readonly Dictionary<string, string> SystemTypeReverseMap =
    Map.ToDictionary(
        static pair => pair.Value[(pair.Value.LastIndexOf('.') + 1)..], // "System.Int32" -> "Int32"
        static pair => pair.Key,                                        // -> "int"
        StringComparer.Ordinal);

public static bool TryToKeywordForSystemType(string systemTypeName, out string keyword)
    => SystemTypeReverseMap.TryGetValue(systemTypeName, out keyword!);
```

Each `TypeRef` drops its private copy and calls the shared lookup:

```csharp
// before — ILInspector.Analysis/TypeRef.cs AND ILInspector.Decompiler/Pipeline/TypeRef.cs
// (two byte-identical private tables)
static readonly Dictionary<string, string> s_keywords = new()
{
    ["Boolean"] = "bool", ["Byte"] = "byte", ["SByte"] = "sbyte",
    ["Char"] = "char", ["Int16"] = "short", ["UInt16"] = "ushort",
    ["Int32"] = "int", ["UInt32"] = "uint", ["Int64"] = "long",
    ["UInt64"] = "ulong", ["Single"] = "float", ["Double"] = "double",
    ["Decimal"] = "decimal",
    ["IntPtr"] = "nint", ["UIntPtr"] = "nuint", ["String"] = "string",
    ["Object"] = "object", ["Void"] = "void",
};

if (Assembly == CoreLibrary && Namespace == "System" && s_keywords.TryGetValue(Name, out var keyword))
    return keyword;
```

```csharp
// after — the private table is gone; both files call the SSOT
if (Assembly == CoreLibrary && Namespace == "System" && PrimitiveTypeNames.TryToKeywordForSystemType(Name, out var keyword))
    return keyword;
```

The `Analysis.QualifiedDisplayName` existence check changes shape but not behavior:

```csharp
// before
if (Assembly == CoreLibrary && Namespace == "System" && s_keywords.ContainsKey(Name))
// after
if (Assembly == CoreLibrary && Namespace == "System" && PrimitiveTypeNames.TryToKeywordForSystemType(Name, out _))
```
