### PR TITLE
Add per-member whole-render API to MemberBodyProducer (#2996)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MemberBodyProducerMemberRenderTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberBodyProducerMemberRenderTests.cs
@@ -1,0 +1,111 @@
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Decompiler;
+using ILInspector.Metadata;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Pins the per-member whole render (<see cref="MemberBodyProducer.ProduceMember"/>)
+/// against the whole-type listing (<see cref="MemberBodyProducer.Project"/>): the
+/// text produced for a single member is byte-identical to that member's segment
+/// in the listing — one composition, no drift. This is the #2996 output-contract
+/// enabler: CSharp-owned signature + decompiler-owned body, per member.
+/// </summary>
+[Trait("Area", "RoundTrip")]
+public sealed class MemberBodyProducerMemberRenderTests
+{
+    static string AssemblyPath => typeof(MemberBodyProducerMemberRenderTests).Assembly.Location;
+
+    static ApiType Specimen()
+    {
+        using var pe = new PEReader(File.OpenRead(AssemblyPath));
+        var api = ApiSurfaceExtractor.Extract(pe);
+        return Assert.Single(api.Types, t => t.FullName == typeof(MemberRenderSpecimen).FullName);
+    }
+
+    [Fact]
+    public void ProduceMember_ByteIdenticalToWholeTypeSegment_ForEveryMember()
+    {
+        var type = Specimen();
+        var listing = MemberBodyProducer.Project(type, AssemblyPath, pdbPath: null).Output;
+        Assert.NotNull(listing);
+
+        Assert.NotEmpty(type.Members);
+        foreach (var member in type.Members)
+        {
+            var rendered = MemberBodyProducer.ProduceMember(type, member, AssemblyPath, pdbPath: null);
+
+            Assert.Equal(MemberBodyProductionStatus.Complete, rendered.Status);
+            Assert.True(rendered.IsComplete);
+            Assert.NotNull(rendered.Text);
+            // The per-member text is exactly the member's segment in the
+            // whole-type listing — no separate signature implementation.
+            Assert.Contains(rendered.Text!, listing);
+        }
+    }
+
+    [Fact]
+    public void ProduceMember_RendersExpressionBodiedArrow()
+    {
+        var type = Specimen();
+        var increment = Assert.Single(type.Members, m => m.Name == nameof(MemberRenderSpecimen.Increment));
+
+        var rendered = MemberBodyProducer.ProduceMember(type, increment, AssemblyPath, pdbPath: null);
+
+        Assert.Equal(MemberBodyProductionStatus.Complete, rendered.Status);
+        // Whole member: CSharp-owned signature + decompiler body, arrow layout.
+        Assert.Contains("int Increment(", rendered.Text);
+        Assert.Contains("=> ", rendered.Text);
+    }
+
+    [Fact]
+    public void ProduceMember_RendersThrowStubAsExpressionBody()
+    {
+        var type = Specimen();
+        var stub = Assert.Single(type.Members, m => m.Name == nameof(MemberRenderSpecimen.ThrowStub));
+
+        var rendered = MemberBodyProducer.ProduceMember(type, stub, AssemblyPath, pdbPath: null);
+
+        Assert.Equal(MemberBodyProductionStatus.Complete, rendered.Status);
+        // The canonical #2996 case: a throwing stub is one expression-bodied
+        // member spelled by the shared CSharp layout, not a block.
+        Assert.Contains("=> throw", rendered.Text);
+    }
+
+    [Fact]
+    public void ProduceMember_RendersBlockBodiedMethod()
+    {
+        var type = Specimen();
+        var log = Assert.Single(type.Members, m => m.Name == nameof(MemberRenderSpecimen.Log));
+
+        var rendered = MemberBodyProducer.ProduceMember(type, log, AssemblyPath, pdbPath: null);
+
+        Assert.Equal(MemberBodyProductionStatus.Complete, rendered.Status);
+        Assert.Contains("void Log(", rendered.Text);
+        // Two side-effecting statements cannot fold to an expression body.
+        Assert.Contains("{", rendered.Text);
+        Assert.DoesNotContain("=>", rendered.Text);
+    }
+}
+
+#pragma warning disable CA1822 // members are instance to exercise real signatures
+public sealed class MemberRenderSpecimen
+{
+    public MemberRenderSpecimen(int seed) => Value = seed;
+
+    public int Value { get; }
+
+    public string Name { get; set; } = "";
+
+    public int Increment(int n) => n + 1;
+
+    public void Log(int n)
+    {
+        Console.WriteLine(n);
+        Console.WriteLine(n + 1);
+    }
+
+    public void ThrowStub() => throw new NotImplementedException();
+}
+#pragma warning restore CA1822

--- a/src/ILInspector.Decompiler/MemberBodyProducer.cs
+++ b/src/ILInspector.Decompiler/MemberBodyProducer.cs
@@ -42,6 +42,25 @@ public sealed record MemberBodyProductionResult(
 }
 
 /// <summary>
+/// Product-owned result for one whole rendered member: the CSharp-owned
+/// signature (spelled from the Metadata rich model) composed with the
+/// decompiler-owned body — <c>signature { body }</c> / <c>signature =&gt; expr;</c>
+/// / <c>signature;</c>. This is the per-member analog of the whole-type
+/// <see cref="MemberBodyProducer.Project(ApiType, string, string?, IAssemblyReferenceResolver, ILInspector.Decompiler.Pipeline.MetadataContext?)"/>
+/// listing: <see cref="Text"/> is byte-identical to the member's segment in that
+/// listing (indented one level for a type body, with no surrounding blank-line
+/// separators). Consumers that wrap the member in their own type shell add
+/// <see cref="Namespaces"/> as using directives.
+/// </summary>
+public sealed record MemberRenderResult(
+    MemberBodyProductionStatus Status,
+    string? Text,
+    IReadOnlyList<string> Namespaces)
+{
+    public bool IsComplete => Status == MemberBodyProductionStatus.Complete;
+}
+
+/// <summary>
 /// Projects a whole type as one C# listing: the type declaration, field
 /// declarations (including non-public fields, for context the bodies
 /// reference), and every member's decompiled body — the reading unit for
@@ -198,6 +217,45 @@ public static class MemberBodyProducer
             : DecompilerResult.Success(composed);
     }
 
+    /// <summary>
+    /// Legacy path-only entry point. Prefer the <see cref="IAssemblyReferenceResolver"/>
+    /// overload for new product and harness code.
+    /// </summary>
+    public static MemberRenderResult ProduceMember(ApiType type, ApiMember member, string dllPath, string? pdbPath, AssemblyLocator? locateAssembly = null, Pipeline.MetadataContext? context = null)
+    {
+        var resolver = locateAssembly?.ToAssemblyReferenceResolver()
+            ?? Pipeline.MetadataSource.DefaultAssemblyReferenceResolver(dllPath);
+        return ProduceMember(type, member, dllPath, pdbPath, resolver, context);
+    }
+
+    /// <summary>
+    /// Renders one member of <paramref name="type"/> as a whole member —
+    /// CSharp-owned signature composed with the decompiler-owned body — reusing
+    /// the exact per-member composition of the whole-type
+    /// <see cref="Project(ApiType, string, string?, IAssemblyReferenceResolver, Pipeline.MetadataContext?)"/>
+    /// listing, so the rendered text is byte-identical to that member's segment.
+    /// <paramref name="member"/> must be an instance from
+    /// <see cref="ApiType.Members"/> (matched by reference). Enum values, and
+    /// members that produce no listing output, return
+    /// <see cref="MemberBodyProductionStatus.Absent"/>.
+    /// </summary>
+    public static MemberRenderResult ProduceMember(ApiType type, ApiMember member, string dllPath, string? pdbPath, IAssemblyReferenceResolver resolver, Pipeline.MetadataContext? context = null)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        ArgumentNullException.ThrowIfNull(member);
+        var start = new ResolvedAssemblyReference(
+            new AssemblyReferenceIdentity(Path.GetFileNameWithoutExtension(dllPath), Version: null, Culture: null, PublicKeyToken: null),
+            dllPath,
+            () => File.OpenRead(dllPath),
+            Provenance: "StartAssembly");
+        return ComposeMemberCore(
+            type,
+            member,
+            () => TypeForwardResolver.LocateType(start, type.FullName, resolver),
+            (location, ctx) => Pipeline.MetadataSource.Open(location.ToResolvedAssemblyReference(), pdbPath, resolver, ctx),
+            context);
+    }
+
     static string? ComposeCore(
         ApiType type,
         string dllPath,
@@ -298,6 +356,81 @@ public static class MemberBodyProducer
             // Degrade honestly: the section renders the reason instead of
             // silently disappearing.
             return $"// {DiagnosticIds.InternalError}: type source unavailable: {ex.GetType().Name}: {ex.Message}";
+        }
+    }
+
+    static MemberRenderResult ComposeMemberCore(
+        ApiType type,
+        ApiMember member,
+        Func<TypeLocation?> locateType,
+        Func<TypeLocation, Pipeline.MetadataContext?, Pipeline.MetadataSource> openPipelineSource,
+        Pipeline.MetadataContext? context)
+    {
+        if (type.Kind is "delegate")
+            return new MemberRenderResult(MemberBodyProductionStatus.Absent, Text: null, []);
+
+        try
+        {
+            if (locateType() is not { } location)
+                return new MemberRenderResult(MemberBodyProductionStatus.Absent, Text: null, []);
+
+            Stream? stream = null;
+            PEReader? peReader = null;
+            try
+            {
+                stream = location.OpenRead();
+                peReader = new PEReader(stream);
+                MetadataReader reader = peReader.GetMetadataReader();
+
+                TypeDefinitionHandle typeHandle = default;
+                foreach (var h in reader.TypeDefinitions)
+                {
+                    if (reader.GetFullTypeName(reader.GetTypeDefinition(h)) == type.FullName)
+                    {
+                        typeHandle = h;
+                        break;
+                    }
+                }
+                if (typeHandle.IsNil)
+                    return new MemberRenderResult(MemberBodyProductionStatus.Absent, Text: null, []);
+
+                using var pipelineSource = openPipelineSource(location, context);
+                var union = TryUnionDeclaration(reader, typeHandle, type);
+
+                // The same body/attribute namespaces the whole-type listing
+                // collects for this member — a wrapping consumer emits them as
+                // using directives.
+                var bodyNamespaces = new SortedSet<string>(StringComparer.Ordinal);
+                var sb = new StringBuilder();
+                bool any = false;
+                ComposeMembers(sb, type, pipelineSource, reader, typeHandle, union, bodyNamespaces, ref any, only: member);
+
+                if (!any)
+                    return new MemberRenderResult(MemberBodyProductionStatus.Absent, Text: null, bodyNamespaces.ToArray());
+
+                // Shorten qualified names and normalize newlines exactly as the
+                // whole-type Project listing does, so the per-member text is
+                // byte-identical to this member's segment there. The harvested
+                // imports (body namespaces + qualified prefixes) are returned for
+                // the wrapping consumer to emit; directives are not prepended.
+                var imports = new SortedSet<string>(bodyNamespaces, StringComparer.Ordinal);
+                string text = ShortenQualifiedNames(sb.ToString(), reader, imports);
+                return new MemberRenderResult(MemberBodyProductionStatus.Complete, text, imports.ToArray());
+            }
+            finally
+            {
+                peReader?.Dispose();
+                stream?.Dispose();
+            }
+        }
+        catch (Exception ex)
+        {
+            // Degrade honestly, matching ComposeCore: the failure reason is the
+            // rendered text instead of silently disappearing.
+            return new MemberRenderResult(
+                MemberBodyProductionStatus.Failed,
+                $"// {DiagnosticIds.InternalError}: member source unavailable: {ex.GetType().Name}: {ex.Message}",
+                []);
         }
     }
 
@@ -494,7 +627,7 @@ public static class MemberBodyProducer
     static void ComposeMembers(
         StringBuilder sb, ApiType type, Pipeline.MetadataSource pipelineSource,
         MetadataReader reader, TypeDefinitionHandle typeHandle, UnionDeclarationInfo? union,
-        SortedSet<string> bodyNamespaces, ref bool any)
+        SortedSet<string> bodyNamespaces, ref bool any, ApiMember? only = null)
     {
         // Per-name running overload index — the same positional pairing the
         // member command uses for Name:N — used only when a member carries no
@@ -515,6 +648,17 @@ public static class MemberBodyProducer
                 // Hidden union case constructors still occupy metadata overload
                 // slots. Keep fallback overload counting aligned for any
                 // original public members that are not synthesized below.
+                if (member.Kind is "constructor" or "method" or "operator" or "explicit-interface-implementation")
+                    overloadIndex[member.Name] = overloadIndex.GetValueOrDefault(member.Name) + 1;
+                continue;
+            }
+
+            // Single-member render (only is not null): advance the same overload
+            // counting a full pass would so the target's fallback index matches,
+            // but emit only the requested member. 'first' stays true, so the
+            // target renders with no leading blank-line separator.
+            if (only is not null && !ReferenceEquals(member, only))
+            {
                 if (member.Kind is "constructor" or "method" or "operator" or "explicit-interface-implementation")
                     overloadIndex[member.Name] = overloadIndex.GetValueOrDefault(member.Name) + 1;
                 continue;
@@ -642,6 +786,8 @@ public static class MemberBodyProducer
                 }
             }
 
+            if (only is not null)
+                return;
         }
     }
 
@@ -1207,6 +1353,39 @@ public static class MemberBodyProducer
     /// </summary>
     static string HoistUsings(string listing, MetadataReader reader, string? ownNamespace, SortedSet<string> seedNamespaces)
     {
+        // The IR-collected body namespaces seed the set; text shortening of
+        // the declaration lines adds any it harvests from qualified prefixes.
+        var usings = new SortedSet<string>(seedNamespaces, StringComparer.Ordinal);
+        string result = ShortenQualifiedNames(listing, reader, usings);
+
+        // Implicit usings (and the type's own namespace) need no directive.
+        usings.Remove(ownNamespace ?? "");
+        foreach (var implicitNs in (string[])
+            ["System", "System.Collections.Generic", "System.IO", "System.Linq",
+             "System.Net.Http", "System.Threading", "System.Threading.Tasks"])
+        {
+            usings.Remove(implicitNs);
+        }
+
+        if (usings.Count == 0)
+            return result;
+
+        // dotnet/runtime style: using directives precede the namespace.
+        string directives = string.Join('\n', usings.Select(ns => $"using {ns};"));
+        return $"{directives}\n\n{result}";
+    }
+
+    /// <summary>
+    /// Shortens qualified type names in <paramref name="listing"/> to simple
+    /// names, harvesting the namespaces that need importing into
+    /// <paramref name="usings"/>, and normalizes to one deterministic <c>\n</c>
+    /// newline per line. Shared by the whole-type <see cref="HoistUsings"/> (which
+    /// then prepends the directives) and the per-member
+    /// <see cref="ComposeMemberCore"/> (whose caller emits the imports), so a
+    /// single member renders byte-identically to its whole-type listing segment.
+    /// </summary>
+    static string ShortenQualifiedNames(string listing, MetadataReader reader, SortedSet<string> usings)
+    {
         // Namespace → simple type names (arity-stripped), from real metadata.
         var nsToNames = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
         void Register(string ns, string name)
@@ -1254,9 +1433,6 @@ public static class MemberBodyProducer
         // Longest first so System.Collections.Generic wins over System.Collections.
         prefixes.Sort((a, b) => b.Text.Length.CompareTo(a.Text.Length));
 
-        // The IR-collected body namespaces seed the set; text shortening of
-        // the declaration lines adds any it harvests from qualified prefixes.
-        var usings = new SortedSet<string>(seedNamespaces, StringComparer.Ordinal);
         var output = new StringBuilder(listing.Length);
         foreach (var rawLine in listing.Split('\n'))
         {
@@ -1270,22 +1446,7 @@ public static class MemberBodyProducer
             output.Append(string.Join('"', segments)).Append('\n');
         }
 
-        // Implicit usings (and the type's own namespace) need no directive.
-        usings.Remove(ownNamespace ?? "");
-        foreach (var implicitNs in (string[])
-            ["System", "System.Collections.Generic", "System.IO", "System.Linq",
-             "System.Net.Http", "System.Threading", "System.Threading.Tasks"])
-        {
-            usings.Remove(implicitNs);
-        }
-
-        string result = output.ToString().TrimEnd();
-        if (usings.Count == 0)
-            return result;
-
-        // dotnet/runtime style: using directives precede the namespace.
-        string directives = string.Join('\n', usings.Select(ns => $"using {ns};"));
-        return $"{directives}\n\n{result}";
+        return output.ToString().TrimEnd();
     }
 
     static string ShortenSegment(


### PR DESCRIPTION
## What & why

Umbrella #2996 makes the **whole member** the decompiler''s natural output unit — Metadata owns the signature model, CSharp owns spelling + layout, Decompiler owns only the body, with **one composition and no drift**.

The product already renders a whole **type** as one listing (`MemberBodyProducer.Project`) and a **body-only** block (`ProduceBody`), but had **no way to render a single member''s `signature { body }`**. That gap blocks the final track (**pr5**): retiring the compile-back harness''s private skeleton signature builder in `FidelityCheck.cs`, which today re-spells member signatures itself and therefore drifts from the product.

This PR adds that missing enabler.

## Change

- **New public API** `MemberBodyProducer.ProduceMember` (path-only + `IAssemblyReferenceResolver` overloads) returning `MemberRenderResult(Status, Text, Namespaces)`.
  - `Text` is **byte-identical** to the member''s segment in the whole-type `Project` listing (indent 4, no surrounding blank-line separators).
  - `Namespaces` are the imports a wrapping consumer emits as `using` directives.
  - `member` must be an instance from `type.Members` (matched by reference); non-emitting members (enum values, etc.) return `Absent`; failures degrade honestly to `Failed` + a `// DI_...` comment.

- **Reuses the existing whole-type composition** rather than adding a second path:
  - `ComposeMembers` gains `ApiMember? only = null`. When set, the loop does all bookkeeping (overload counting, union hidden-member skip) but emits only the reference-matched member with `first == true` (no leading blank line), then returns. When `null`, the whole-type hot path is a **strict no-op**.
  - `HoistUsings` is split: the shared **`ShortenQualifiedNames`** (qualified-name shortening + deterministic `\n` normalization + import harvest) is now used by **both** the whole-type `HoistUsings` (which then prepends directives) and the per-member `ComposeMemberCore` (whose caller emits imports). This is what guarantees the per-member text matches its whole-type segment.

## Evidence

- **Byte-identity oracle** (`MemberBodyProducerMemberRenderTests`): every specimen member''s `ProduceMember` `Text` is a substring of the `Project` listing, plus throw-stub (`=> throw`), arrow, and block-body witnesses. 4/4 green.
- **Controlled A/B over the full fast Decompiler suite** (base `f8f6a449` vs head, identical `-notrait Speed=Slow` selection): **identical 56-failure set — zero head-only regressions**. The 56 are the pre-existing **#3018-C** Windows-local CS0009 recompile-env failures (native runtime DLLs in Roslyn''s reference set); CI is green on these.

## Compatibility / scope

Purely **additive** public API + an **output-preserving** refactor of the shared using-hoist path. No behavior change to any existing whole-type or body-only output. Union-synthesized explicit constructors (not reachable via `type.Members`) are out of scope.

## Follow-up

Unblocks **pr5**: point `FidelityCheck.BuildUnit` at `ProduceMember`, delete the harness''s private target-member signature spelling, and re-triage the CS0305/CS1031/CS1750 EVIL false-`Invalid` cluster.

Part of #2996.
