### PR TITLE
Scope switch-arm pattern-variable names per arm (#3033)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/PatternSwitchExpressionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PatternSwitchExpressionPassTests.cs
@@ -91,7 +91,12 @@ public class PatternSwitchExpressionPassTests
         string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").TrimEnd();
         Assert.Contains("return expression switch", output);
         Assert.Contains("Comparison comparison when ReadsLoopField(comparison.Left, loopFieldName)", output);
-        Assert.Contains("LogicalNot { Operand: Comparison", output);
+        // Issue #3033: both mutually-exclusive arms bind a source pattern variable
+        // named `comparison`. Each arm is its own scope, so the second arm reuses
+        // the source spelling rather than the printer's global name-dedup renaming
+        // it to a synthetic `V_1`.
+        Assert.Contains("LogicalNot { Operand: Comparison comparison } when ReadsLoopField(comparison.Left, loopFieldName)", output);
+        Assert.DoesNotContain("Comparison V_", output);
         Assert.Contains("_ => false,", output);
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -4005,13 +4005,43 @@ public sealed partial class CSharpPrinter
 
             var taken = CurrentReservedNames();
 
+            // Pattern-variable locals bound by mutually-exclusive switch-expression
+            // / union-switch arms each open their own scope, so sibling arms of one
+            // switch may legally bind the same source name (issue #3033). Map each
+            // such slot to its owning (switch, arm) and record, per switch and name,
+            // the set of arms already using it — so a sibling arm reuses the
+            // identical spelling instead of falling back to V_n, while a name shared
+            // with any wider-scoped binder (parameter, ordinary local, an enclosing
+            // switch's arm, or a second binding in the SAME arm) still dedups.
+            var armLocalOwners = ArmScopedPatternLocals();
+            var armNameUsers = new Dictionary<(object Switch, string Name), HashSet<object>>();
+
             var names = _function.LocalNames;
             if (!names.IsDefaultOrEmpty)
             {
                 for (int i = 0; i < count && i < names.Length; i++)
                 {
-                    if (names[i] is { } name && CSharpNaming.IsUsableIdentifier(name) && taken.Add(name))
+                    if (names[i] is not { } name || !CSharpNaming.IsUsableIdentifier(name))
+                        continue;
+                    bool isArmLocal = armLocalOwners.TryGetValue(i, out var owner);
+                    if (taken.Add(name))
                     {
+                        display[i] = name;
+                        sourceNamed[i] = true;
+                        if (isArmLocal)
+                            armNameUsers[(owner.Switch, name)] = [owner.Arm];
+                    }
+                    else if (isArmLocal
+                        && armNameUsers.TryGetValue((owner.Switch, name), out var users)
+                        && users.Add(owner.Arm))
+                    {
+                        // The name is already reserved, but only by a different
+                        // sibling arm of the same switch — a disjoint scope — so this
+                        // arm reuses the same source name rather than deduping to
+                        // V_n. `users.Add` gates on the owning arm: a reservation by
+                        // an enclosing switch's arm, a parameter, or an ordinary
+                        // local leaves no entry here, and a second binding in the
+                        // same arm is already in the set, so both still dedup.
                         display[i] = name;
                         sourceNamed[i] = true;
                     }
@@ -4047,6 +4077,33 @@ public sealed partial class CSharpPrinter
             _localDisplayNames = display;
         }
         return index >= 0 && index < _localDisplayNames.Length ? _localDisplayNames[index] : $"V_{index}";
+    }
+
+    /// <summary>
+    /// Maps each local slot bound as a pattern variable by a switch-expression or
+    /// union-switch arm — the arm's outer type-pattern binding and its single-level
+    /// property subpattern — to its owning <c>(switch node, arm node)</c>. Sibling
+    /// arms of one switch are disjoint scopes, so <see cref="LocalName"/> lets them
+    /// reuse the same source spelling instead of deduping the second to a synthetic
+    /// <c>V_n</c> (issue #3033). Keying reuse by the owning switch keeps an enclosing
+    /// switch's arm from being treated as a disjoint sibling of a nested one, and
+    /// keying by arm keeps two bindings of the same arm deduping.
+    /// </summary>
+    Dictionary<int, (object Switch, object Arm)> ArmScopedPatternLocals()
+    {
+        var owners = new Dictionary<int, (object, object)>();
+        foreach (var arm in DescendantsOutsideNestedFunctions(_function).OfType<PatternSwitchExpressionArm>())
+        {
+            object owningSwitch = arm.Parent ?? arm;
+            if (arm.LocalIndex is { } localIndex)
+                owners[localIndex] = (owningSwitch, arm);
+            if (arm.Subpattern is { } subpattern)
+                owners[subpattern.LocalIndex] = (owningSwitch, arm);
+        }
+        foreach (var arm in DescendantsOutsideNestedFunctions(_function).OfType<UnionSwitchExpressionArm>())
+            if (arm.LocalIndex is { } localIndex)
+                owners[localIndex] = (arm.Parent ?? arm, arm);
+        return owners;
     }
 
     static string ReserveName(string baseName, HashSet<string> taken)


### PR DESCRIPTION
## Summary

Closes #3033 — a cosmetic follow-up to #3034 (which raised a lowered if/return cascade to a C# `switch` expression).

The C# printer builds **one global set** of reserved local display names. When a raised `PatternSwitchExpression` has two mutually-exclusive arms that each bind a source pattern variable with the same name (e.g. `comparison` in both arms of the #3034 raise target `TryNormalizeContinueCondition`), the first arm won the name and the second was deduped to a synthetic `V_1`. Sibling switch-expression arms are **disjoint scopes** and may legally reuse the same C# identifier, so this was wrong.

## Change

- New `ArmScopedPatternLocals()` maps each arm-bound pattern local slot (`PatternSwitchExpressionArm.LocalIndex`, its `Subpattern.LocalIndex`, and each `UnionSwitchExpressionArm.LocalIndex`) to its owning `(switch node, arm node)`.
- `LocalName` now lets a **sibling arm of the same switch** reuse an already-reserved source name instead of deduping to `V_n`. Every collision with a wider-scoped binder still dedups: a parameter or ordinary local leaves no arm entry; an enclosing switch's arm keys a different switch; a second binding in the same arm is already recorded (guards against CS0136-style overlap on hand-crafted assemblies, which csc never emits).
- Non-switch methods have an empty arm map ⇒ identical to prior behavior.
- Strengthens the compiler-backed product-target test to assert the second arm prints `comparison` and to guard against `Comparison V_`.

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release`: 0 errors.
- `Area=Pass` incl. slow compile-back gates: **1192 passed, 0 failed**.
- All fast decompiler tests, every area: **3237 passed, 0 failed**.

## Adversarial review

Two-model review at exact head `47928f7c`, each in an isolated worktree:

- **Gemini Pro** — safe to merge, no findings. Verified reuse gate (params/lambdas pre-seeded, ordinary-local ordering, intra-arm dedup), key identity, nested-switch dedup, `taken`-set integrity, and regression surface.
- **GPT** — safe to merge, no findings. Verified sibling-only reuse, stable `Parent`/arm identities, ordering, non-switch behavior; ran fast (3237) + `Area=Pass` (1192).

Both fixed-head reviews were clean, so no fixes or re-review were required.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>