### PR TITLE
Inline dynamic stackalloc count spills

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/DynamicStackallocFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/DynamicStackallocFixtures.cs
@@ -13,4 +13,37 @@ public static class DynamicStackallocFixtures
         Span<Guid> values = stackalloc Guid[n];
         return values.Length;
     }
+
+    public static int ByteExpression(int n)
+    {
+        Span<byte> values = stackalloc byte[n + 1];
+        return values.Length;
+    }
+
+    public static int ByteEffectful(int n)
+    {
+        Span<byte> values = stackalloc byte[Math.Abs(n)];
+        return values.Length;
+    }
+
+    public static int ByteExplicitLocal(int n)
+    {
+        int count = n + 1;
+        Span<byte> values = stackalloc byte[count];
+        return values.Length + count;
+    }
+
+    public static int ByteTwoCounts(int n, int m)
+    {
+        Span<byte> first = stackalloc byte[n];
+        Span<byte> second = stackalloc byte[m];
+        return first.Length + second.Length;
+    }
+
+    public static int ByteTwoEffectfulCounts(int n)
+    {
+        Span<byte> first = stackalloc byte[Math.Abs(n)];
+        Span<byte> second = stackalloc byte[Math.Abs(n + 1)];
+        return first.Length + second.Length;
+    }
 }

--- a/src/ILInspector.Decompiler.Fixtures.NewUnsafe/DynamicStackallocFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.NewUnsafe/DynamicStackallocFixtures.cs
@@ -13,4 +13,37 @@ public static class DynamicStackallocFixtures
         Span<Guid> values = stackalloc Guid[n];
         return values.Length;
     }
+
+    public static int ByteExpression(int n)
+    {
+        Span<byte> values = stackalloc byte[n + 1];
+        return values.Length;
+    }
+
+    public static int ByteEffectful(int n)
+    {
+        Span<byte> values = stackalloc byte[Math.Abs(n)];
+        return values.Length;
+    }
+
+    public static int ByteExplicitLocal(int n)
+    {
+        int count = n + 1;
+        Span<byte> values = stackalloc byte[count];
+        return values.Length + count;
+    }
+
+    public static int ByteTwoCounts(int n, int m)
+    {
+        Span<byte> first = stackalloc byte[n];
+        Span<byte> second = stackalloc byte[m];
+        return first.Length + second.Length;
+    }
+
+    public static int ByteTwoEffectfulCounts(int n)
+    {
+        Span<byte> first = stackalloc byte[Math.Abs(n)];
+        Span<byte> second = stackalloc byte[Math.Abs(n + 1)];
+        return first.Length + second.Length;
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 using ILInspector.Decompiler.Pipeline;
 using IrConvert = ILInspector.Decompiler.Pipeline.Convert;
 
@@ -223,6 +225,272 @@ public class StackAllocSpanPassTests
         Assert.Empty(function.Descendants.OfType<StackAllocate>());
         var raised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
         Assert.Equal(Byte, raised.ElementType);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void AdjacentOwnedCountSpill_InlinesArgument()
+    {
+        var function = BuildCountSpill(new LoadArgument(0, "n", Int32));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        Assert.DoesNotContain(function.Descendants.OfType<StoreLocal>(), store => store.Index == 0);
+        Assert.DoesNotContain(function.Descendants.OfType<LoadLocal>(), load => load.Index == 0);
+        var raised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.IsType<LoadArgument>(raised.Count);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void AdjacentOwnedCountSpill_InlinesExpression()
+    {
+        var expression = new Binary(
+            BinaryKind.Add,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadArgument(0, "n", Int32),
+            new Constant(1, Int32));
+        var function = BuildCountSpill(expression);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.DoesNotContain(function.Descendants.OfType<StoreLocal>(), store => store.Index == 0);
+        Assert.IsType<Binary>(Assert.Single(function.Descendants.OfType<StackAllocArray>()).Count);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void AdjacentOwnedCountSpill_InlinesEffectfulCountAtAllocation()
+    {
+        var countEffect = new Call(
+            new MethodRef(Holder, "CountEffect", Int32, [], HasThis: false),
+            isVirtual: false,
+            []);
+        var function = BuildCountSpill(countEffect);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.DoesNotContain(function.Descendants.OfType<StoreLocal>(), store => store.Index == 0);
+        var raised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Same(countEffect, raised.Count);
+        Assert.Single(function.Descendants.OfType<Call>(), call => call.Callee.Name == "CountEffect");
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void AdjacentOwnedCountSpill_ForWiderElement_InlinesArgument()
+    {
+        var function = BuildCountSpill(
+            new LoadArgument(0, "n", Int32),
+            elementType: TypeRef.CoreLib("System", "Guid"));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.DoesNotContain(function.Descendants.OfType<StoreLocal>(), store => store.Index == 0);
+        var raised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.IsType<LoadArgument>(raised.Count);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SequentialOwnedCountSpills_ReusingLocal_InlineEachLiveRange()
+    {
+        var first = BuildCountSpillConstruction(new LoadArgument(0, "n", Int32));
+        var second = BuildCountSpillConstruction(new LoadArgument(1, "m", Int32));
+        var block = new Block(0);
+        block.Add(first.Store);
+        block.Add(new StoreLocal(1, first.Construction.ResultType!, first.Construction));
+        block.Add(second.Store);
+        block.Add(new StoreLocal(2, second.Construction.ResultType!, second.Construction));
+        block.Add(new Return(new Constant(0, Int32)));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(
+                Int32,
+                [new Parameter("n", Int32), new Parameter("m", Int32)],
+                HasThis: false,
+                GenericParameterCount: 0),
+            [Int32, first.Construction.ResultType!, second.Construction.ResultType!],
+            body);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.DoesNotContain(function.Descendants.OfType<StoreLocal>(), store => store.Index == 0);
+        var raised = function.Descendants.OfType<StackAllocArray>().ToList();
+        Assert.Collection(
+            raised,
+            item => Assert.Equal(0, Assert.IsType<LoadArgument>(item.Count).Index),
+            item => Assert.Equal(1, Assert.IsType<LoadArgument>(item.Count).Index));
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void CountSpillWithAdditionalUse_RaisesButDoesNotInlineSpill()
+    {
+        var use = new MethodRef(Holder, "Use", Void, [Int32], HasThis: false);
+        var function = BuildCountSpill(
+            new LoadArgument(0, "n", Int32),
+            construction => [
+                new StoreLocal(1, construction.ResultType!, construction),
+                new ExpressionStatement(new Call(use, isVirtual: false, [new LoadLocal(0, Int32)])),
+                new Return(new LoadLocal(1, construction.ResultType!)),
+            ]);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Contains(function.Descendants.OfType<StoreLocal>(), store => store.Index == 0);
+        Assert.Equal(2, function.Descendants.OfType<LoadLocal>().Count(load => load.Index == 0));
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void CountSpillWithAdditionalStore_RaisesButDoesNotInlineSpill()
+    {
+        var function = BuildCountSpill(
+            new LoadArgument(0, "n", Int32),
+            construction => [
+                new StoreLocal(0, Int32, new Constant(2, Int32)),
+                new Return(construction),
+            ]);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Equal(2, function.Descendants.OfType<StoreLocal>().Count(store => store.Index == 0));
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void AddressTakenCountSpill_RaisesButDoesNotInlineSpill()
+    {
+        var consume = new MethodRef(Holder, "Consume", Void, [TypeRef.Pointer(Int32)], HasThis: false);
+        var function = BuildCountSpill(
+            new LoadArgument(0, "n", Int32),
+            construction => [
+                new StoreLocal(1, construction.ResultType!, construction),
+                new ExpressionStatement(new Call(consume, isVirtual: false, [new LoadLocalAddress(0, Int32)])),
+                new Return(new LoadLocal(1, construction.ResultType!)),
+            ]);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Contains(function.Descendants.OfType<StoreLocal>(), store => store.Index == 0);
+        Assert.Single(function.Descendants.OfType<LoadLocalAddress>(), address => address.Index == 0);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void NonAdjacentCountSpill_RaisesButDoesNotInlineSpill()
+    {
+        var effect = new MethodRef(Holder, "Effect", Void, [], HasThis: false);
+        var function = BuildCountSpill(
+            new LoadArgument(0, "n", Int32),
+            construction => [
+                new ExpressionStatement(new Call(effect, isVirtual: false, [])),
+                new Return(construction),
+            ]);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Contains(function.Descendants.OfType<StoreLocal>(), store => store.Index == 0);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void CountSpillAfterEffectfulCallArgument_RaisesButDoesNotInlineSpill()
+    {
+        var effect = new MethodRef(Holder, "Effect", Int32, [], HasThis: false);
+        var span = TypeRef.GenericInstance(TypeRef.CoreLib("System", "Span`1"), [Byte]);
+        var consume = new MethodRef(Holder, "Consume", span, [Int32, span], HasThis: false);
+        var function = BuildCountSpill(
+            new LoadArgument(0, "n", Int32),
+            construction => [
+                new Return(new Call(
+                    consume,
+                    isVirtual: false,
+                    [new Call(effect, isVirtual: false, []), construction])),
+            ]);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Contains(function.Descendants.OfType<StoreLocal>(), store => store.Index == 0);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void ConditionalCountSpillUse_RaisesButDoesNotInlineSpill()
+    {
+        var function = BuildCountSpill(
+            new LoadArgument(0, "n", Int32),
+            construction => [
+                new Return(new Conditional(
+                    new LoadArgument(1, "condition", TypeRef.CoreLib("System", "Boolean")),
+                    construction,
+                    new DefaultValue(construction.ResultType!))),
+            ],
+            parameterTypes: [Int32, TypeRef.CoreLib("System", "Boolean")]);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Contains(function.Descendants.OfType<StoreLocal>(), store => store.Index == 0);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void CountSpillWithTypeWitness_RaisesButDoesNotInlineSpill()
+    {
+        var function = BuildCountSpill(new Constant((byte)1, Byte));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Contains(function.Descendants.OfType<StoreLocal>(), store => store.Index == 0);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SlotIndirectCountSpill_RaisesButDoesNotInlineSpill()
+    {
+        var countStore = new StoreLocal(0, Int32, new LoadArgument(0, "n", Int32));
+        var stackStore = new StoreStackSlot(0, new StackAllocate(new LoadLocal(0, Int32)));
+        var construction = StackAllocSpanConstructor(
+            TypeRef.CoreLib("System", "Span`1"),
+            new LoadStackSlot(0, VoidPointer),
+            new LoadLocal(0, Int32),
+            Byte);
+
+        var block = new Block(0);
+        block.Add(countStore);
+        block.Add(stackStore);
+        block.Add(new Return(construction));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(
+                construction.ResultType!,
+                [new Parameter("n", Int32)],
+                HasThis: false,
+                GenericParameterCount: 0),
+            [Int32],
+            body);
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Contains(function.Descendants.OfType<StoreLocal>(), store => store.Index == 0);
+        Assert.Single(function.Descendants.OfType<LoadLocal>(), load => load.Index == 0);
         function.CheckInvariant();
     }
 
@@ -1368,4 +1636,59 @@ public class StackAllocSpanPassTests
             [],
             body);
     }
+
+    static IrFunction BuildCountSpill(
+        IrExpression storedCount,
+        Func<NewObject, IReadOnlyList<IrNode>>? statements = null,
+        TypeRef? elementType = null,
+        IReadOnlyList<TypeRef>? parameterTypes = null)
+    {
+        var (store, construction) = BuildCountSpillConstruction(storedCount, elementType);
+
+        var block = new Block(0);
+        block.Add(store);
+        foreach (var statement in statements?.Invoke(construction) ?? [new Return(construction)])
+            block.Add(statement);
+
+        var body = new BlockContainer();
+        body.Add(block);
+        var parameters = (parameterTypes ?? [Int32])
+            .Select((type, index) => new Parameter(index == 0 ? "n" : $"arg{index}", type))
+            .ToImmutableArray();
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(construction.ResultType!, parameters, HasThis: false, GenericParameterCount: 0),
+            [Int32, construction.ResultType!],
+            body);
+    }
+
+    static (StoreLocal Store, NewObject Construction) BuildCountSpillConstruction(
+        IrExpression storedCount,
+        TypeRef? elementType = null)
+    {
+        elementType ??= Byte;
+        var countForSize = new LoadLocal(0, Int32);
+        IrExpression byteSize = GetElementSize(elementType) is 1
+            ? countForSize
+            : new Binary(
+                BinaryKind.Multiply,
+                isChecked: true,
+                isUnsigned: true,
+                new IrConvert(
+                    TypeRef.CoreLib("System", "UIntPtr"),
+                    isChecked: false,
+                    isUnsigned: false,
+                    countForSize),
+                new SizeOf(elementType));
+        var construction = StackAllocSpanConstructor(
+            TypeRef.CoreLib("System", "Span`1"),
+            new StackAllocate(byteSize),
+            new LoadLocal(0, Int32),
+            elementType);
+        return (new StoreLocal(0, Int32, storedCount), construction);
+    }
+
+    static int? GetElementSize(TypeRef type)
+        => type.Equals(Byte) ? 1 : null;
 }

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
 using LegacyFixtures = ILInspector.Decompiler.Fixtures.LegacyUnsafe.UnsafeFixtures;
+using LegacyDynamicStackallocFixtures = ILInspector.Decompiler.Fixtures.LegacyUnsafe.DynamicStackallocFixtures;
 using NewFixtures = ILInspector.Decompiler.Fixtures.NewUnsafe.UnsafeFixtures;
 using NewDynamicStackallocFixtures = ILInspector.Decompiler.Fixtures.NewUnsafe.DynamicStackallocFixtures;
 using NewStackallocFixtures = ILInspector.Decompiler.Fixtures.NewUnsafe.StackallocInitializerResiduals;
@@ -65,6 +66,9 @@ public class UnsafeEmitterTests
 
     static string DecompileLegacy(string method) =>
         Decompile(typeof(LegacyFixtures).Assembly.Location, typeof(LegacyFixtures).FullName!, method);
+
+    static string DecompileLegacyDynamicStackalloc(string method) =>
+        Decompile(typeof(LegacyDynamicStackallocFixtures).Assembly.Location, typeof(LegacyDynamicStackallocFixtures).FullName!, method);
 
     static string DecompileNewStackalloc(string method) =>
         Decompile(typeof(NewStackallocFixtures).Assembly.Location, typeof(NewStackallocFixtures).FullName!, method);
@@ -744,15 +748,39 @@ public class UnsafeEmitterTests
     }
 
     [Theory]
-    [InlineData(nameof(NewDynamicStackallocFixtures.ByteCount), "byte")]
-    [InlineData(nameof(NewDynamicStackallocFixtures.GuidCount), "Guid")]
-    public void NewRulesModule_DynamicStackAllocCompilerShapes_Raise(string method, string element)
+    [InlineData(nameof(NewDynamicStackallocFixtures.ByteCount), "stackalloc byte[n]")]
+    [InlineData(nameof(NewDynamicStackallocFixtures.GuidCount), "stackalloc Guid[n]")]
+    [InlineData(nameof(NewDynamicStackallocFixtures.ByteExpression), "stackalloc byte[n + 1]")]
+    [InlineData(nameof(NewDynamicStackallocFixtures.ByteEffectful), "stackalloc byte[Math.Abs(n)]")]
+    [InlineData(nameof(NewDynamicStackallocFixtures.ByteExplicitLocal), "stackalloc byte[count]")]
+    [InlineData(nameof(NewDynamicStackallocFixtures.ByteTwoCounts), "stackalloc byte[m]")]
+    [InlineData(nameof(NewDynamicStackallocFixtures.ByteTwoEffectfulCounts), "stackalloc byte[Math.Abs(n + 1)]")]
+    public void NewRulesModule_DynamicStackAllocCompilerShapes_Raise(string method, string expected)
     {
         var output = DecompileNewDynamicStackalloc(method);
 
         Assert.DoesNotContain("unsafe", output);
-        Assert.Contains($"stackalloc {element}[", output);
+        Assert.Contains(expected, output);
         Assert.DoesNotContain("new Span", output);
+        Assert.DoesNotContain("int V_", output);
+    }
+
+    [Theory]
+    [InlineData(nameof(LegacyDynamicStackallocFixtures.ByteCount), "stackalloc byte[n]")]
+    [InlineData(nameof(LegacyDynamicStackallocFixtures.GuidCount), "stackalloc Guid[n]")]
+    [InlineData(nameof(LegacyDynamicStackallocFixtures.ByteExpression), "stackalloc byte[n + 1]")]
+    [InlineData(nameof(LegacyDynamicStackallocFixtures.ByteEffectful), "stackalloc byte[Math.Abs(n)]")]
+    [InlineData(nameof(LegacyDynamicStackallocFixtures.ByteExplicitLocal), "stackalloc byte[count]")]
+    [InlineData(nameof(LegacyDynamicStackallocFixtures.ByteTwoCounts), "stackalloc byte[m]")]
+    [InlineData(nameof(LegacyDynamicStackallocFixtures.ByteTwoEffectfulCounts), "stackalloc byte[Math.Abs(n + 1)]")]
+    public void LegacyModule_DynamicStackAllocCompilerShapes_Raise(string method, string expected)
+    {
+        var output = DecompileLegacyDynamicStackalloc(method);
+
+        Assert.DoesNotContain("unsafe", output);
+        Assert.Contains(expected, output);
+        Assert.DoesNotContain("new Span", output);
+        Assert.DoesNotContain("int V_", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
@@ -38,13 +38,18 @@ public sealed class StackAllocSpanPass : IIrPass
 
     public void Run(IrFunction function, PassContext context)
     {
-        var storesBySlot = GenericDeclarationPatternProof.DescendantsOutsideNestedFunctions(function)
+        var bodyNodes = GenericDeclarationPatternProof.DescendantsOutsideNestedFunctions(function).ToList();
+        var storesBySlot = bodyNodes
             .OfType<StoreStackSlot>()
             .GroupBy(s => s.Slot)
             .ToDictionary(g => g.Key, g => g.ToList());
-        var loadsBySlot = GenericDeclarationPatternProof.DescendantsOutsideNestedFunctions(function)
+        var loadsBySlot = bodyNodes
             .OfType<LoadStackSlot>()
             .GroupBy(s => s.Slot)
+            .ToDictionary(g => g.Key, g => g.ToList());
+        var storesByLocal = bodyNodes
+            .OfType<StoreLocal>()
+            .GroupBy(s => s.Index)
             .ToDictionary(g => g.Key, g => g.ToList());
 
         foreach (var newObject in function.Descendants.OfType<NewObject>().ToList())
@@ -140,13 +145,137 @@ public sealed class StackAllocSpanPass : IIrPass
                 elements = null;
             }
 
-            count.Detach();
-            var raised = new StackAllocArray(element, count, newObject.ResultType, elements);
+            StoreLocal? ownedCountStore = null;
+            if (source is StackAllocate)
+                TryResolveOwnedCountSpill(function, newObject, count, storesByLocal, bodyNodes, out ownedCountStore);
+
+            context.Stepper.StepOver(
+                ownedCountStore is null
+                    ? "raise Span-over-stackalloc to stackalloc T[n]"
+                    : "raise Span-over-stackalloc and inline its compiler count spill",
+                newObject);
+
+            IrExpression raisedCount;
+            if (ownedCountStore is null)
+            {
+                count.Detach();
+                raisedCount = count;
+            }
+            else
+            {
+                raisedCount = (IrExpression)ownedCountStore.DetachChildren()[0];
+                ownedCountStore.Detach();
+            }
+
+            var raised = new StackAllocArray(element, raisedCount, newObject.ResultType, elements);
             raised.InheritSourceOffset(newObject);
-            context.Stepper.StepOver("raise Span-over-stackalloc to stackalloc T[n]", newObject);
             newObject.ReplaceWith(raised);
             ownedStore?.Detach();
         }
+    }
+
+    /// <summary>
+    /// Consumes csc's duplicated dynamic-count local after the stackalloc raise
+    /// makes it redundant. The compiler evaluates the source count once into a
+    /// local, then reads that local for both localloc's byte-size calculation
+    /// and the Span constructor's length. This proof requires exactly that one
+    /// store/two-load ownership shape, with the store immediately before the
+    /// constructor statement and no earlier effectful operand in that statement.
+    /// Replacing the two reads with the stored expression therefore restores its
+    /// source position: count evaluation immediately before allocation.
+    ///
+    /// <para>An explicit source local remains intact. csc still copies that local
+    /// into a second count local for the duplicated lowering, so this method
+    /// consumes only the adjacent copy and leaves the source local one layer
+    /// earlier. No PDB discriminator is required.</para>
+    /// </summary>
+    static bool TryResolveOwnedCountSpill(
+        IrFunction function,
+        NewObject newObject,
+        IrExpression count,
+        Dictionary<int, List<StoreLocal>> storesByLocal,
+        IReadOnlyList<IrNode> bodyNodes,
+        out StoreLocal? ownedStore)
+    {
+        ownedStore = null;
+        if (count is not LoadLocal load
+            || !MemberIdentity.IsCoreLibraryType(load.ResultType, "System", "Int32")
+            || !storesByLocal.TryGetValue(load.Index, out var indexedStores))
+        {
+            return false;
+        }
+
+        var stores = indexedStores
+            .Where(candidate => ReferenceOwnership.IsInside(candidate, function))
+            .ToList();
+        if (stores.Count == 0)
+            return false;
+
+        // Process reused compiler slots one live range at a time. The current
+        // definition must be the first still-live store; after it is consumed,
+        // the next stackalloc using the same slot becomes eligible.
+        var store = stores[0];
+        if (!MemberIdentity.IsCoreLibraryType(store.Type, "System", "Int32")
+            || !store.Type.Equals(store.Value.ResultType)
+            || store.Parent is not Block block)
+        {
+            return false;
+        }
+
+        var references = bodyNodes
+            .Where(node => ReferenceOwnership.IsInside(node, function)
+                && ReferenceOwnership.ReferencesOrBindsLocal(node, load.Index))
+            .ToList();
+        var ownedReferences = references
+            .Where(node => ReferenceOwnership.IsInsideAny(node, [store, newObject]))
+            .ToList();
+        if (ownedReferences.Count != 3
+            || ownedReferences.Count(node => node is LoadLocal) != 2
+            || ownedReferences.Count(node => node is StoreLocal) != 1)
+        {
+            return false;
+        }
+
+        var statement = GetStatement(newObject);
+        if (statement?.Parent != block || statement.ChildIndex != store.ChildIndex + 1)
+            return false;
+
+        var held = GetHeldExpression(statement);
+        if (held == null || !ReachesAsOnlyPrecedingEffect(held, newObject))
+            return false;
+
+        var outsideReferences = references
+            .Where(node => !ReferenceOwnership.IsInsideAny(node, [store, newObject]))
+            .ToList();
+        if (outsideReferences.Count != 0)
+        {
+            if (stores.Count < 2
+                || stores[1].Parent != block
+                || stores[1].ChildIndex <= statement.ChildIndex
+                || ReferenceOwnership.SubtreeReferencesOrBindsLocal(stores[1].Value, load.Index))
+            {
+                return false;
+            }
+
+            var nextStoreIndex = stores[1].ChildIndex;
+            if (outsideReferences.Any(reference =>
+                    GetDirectBlockChild(block, reference) is not { } child
+                    || child.ChildIndex < nextStoreIndex))
+            {
+                return false;
+            }
+        }
+
+        ownedStore = store;
+        return true;
+    }
+
+    static IrNode? GetDirectBlockChild(Block block, IrNode node)
+    {
+        var current = node;
+        while (current.Parent is { } parent && parent != block)
+            current = parent;
+        return current.Parent == block ? current : null;
     }
 
     /// <summary>


### PR DESCRIPTION
- Fixes #3029
- Removes csc's duplicated dynamic stackalloc count spill when ownership and evaluation order are proven
- Card revision: `4caeedc9`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the pass now reaches the source-level dynamic `stackalloc` endpoint, including effectful counts and sequential Release-csc slot reuse, while exact ownership and evaluation-order gates retain explicit source locals and decline close negatives.

### Original source

```csharp
public static int ByteCount(int n)
{
    Span<byte> values = stackalloc byte[n];
    return values.Length;
}
```

### Before

```csharp
public static int ByteCount(int n)
{
    int V_1 = n;
    Span<byte> values = stackalloc byte[V_1];
    return values.Length;
}
```

- Valid: True
- Correct: True

The stackalloc raise was already correct, but the compiler-owned duplicated count spill remained visible.

### After

```csharp
public static int ByteCount(int n)
{
    Span<byte> values = stackalloc byte[n];
    return values.Length;
}
```

- Valid: True
- Correct: True

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass (3 existing nullable warnings) | Pass (same 3 warnings) |
| `StackAllocSpanPassTests` | 56 passed | 69 passed |
| Decompiler fast suite | 3,237 passed | 3,262 passed |
| Compiler-backed fixtures | 2 Release cases passed | 14 Release + 14 Debug cases passed |
| Reduced fixture validity | Pass | Pass |
| Reduced fixture fidelity | Not applicable | Real render-changed method attempted; uncheckable due unrelated skeleton `CS0311` |
| Real witness | `RawNameToHashString` retains `int V_3` | emits `stackalloc short[charSpan.Length]` |

Final-head targeted traits:

- `Area=Pass`, excluding slow: 1,202 passed
- `Area=RoundTrip`: 312 passed
- `Area=Validity`: 99 passed
- `Area=Fidelity`, excluding slow: 27 passed
- `Area=Corpus`, excluding slow: 59 passed

Render-text A/B against merge base `f8f6a449`: 89,065 methods; 1 structural change, semantic `valid->valid`; 0 added, removed, or `valid->invalid` methods. The sole changed method is `Microsoft.CodeAnalysis.CSharp.Symbols.SourceNamedTypeSymbol::RawNameToHashString`.

Changed-method compile-back attempted that exact method. It is not currently checkable because the reconstructed Roslyn skeleton fails independently with `CS0311` on `SyntaxList<AttributeListSyntax>`; this is reported as `RecompileFail`, not success.

The stepper records spill recovery atomically with the stackalloc raise. Compiler canaries cover argument, arithmetic, effectful, explicit-source-local, wider-element, and sequential reused-slot shapes in Debug and Release. Synthetic negatives cover extra uses/stores, address-taking, non-adjacency, conditional placement, preceding effectful operands, type witnesses, and stack-slot indirection.

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity compiled 25,183 methods (compile-cap 4,000; per-sample, not corpus-wide); fidelity (compile-back) sampled 600 / 89,065 (0.67%)
Risk guidance: add targeted improved examples and still-flat near misses; aggregate numbers are not sufficient alone.

| Metric | Change | Count delta |
| ------ | ------ | ----------- |
| Detected lowering residue (-) | 10,625 (11.93%) → 10,623 (11.93%) (neutral) | -2 |
| Conditional-branch residue (-) | 2,401 (2.70%) → 2,398 (2.69%) (good) | -3 |
| Forward-merge stops (-) | 2,286 (2.57%) → 2,283 (2.56%) (good) | -3 |
| Full malformed (-) | 0 → 0 (neutral) | 0 |
| Semantic defects (sampling differs) | 94 (0.37%) → 79 (0.31%) | n/a |
| Fidelity opcode diffs (sampling differs) | 90 (15.00%) → 92 (15.33%) | n/a |
| Fidelity operand diffs (sampling differs) | 8 (1.33%) → 7 (1.17%) | n/a |
| Fidelity unavailable comparisons (sampling differs) | 0 (0.00%) → 0 (0.00%) | n/a |
| Fidelity recompile failures (sampling differs) | 0 (0.00%) → 0 (0.00%) | n/a |
| Fidelity context failures (sampling differs) | 0 (0.00%) → 0 (0.00%) | n/a |
| Pass bugs (-) | 0 → 0 (neutral) | 0 |
| Fidelity check coverage (+) | 600 (0.67%) → 600 (0.67%) (neutral) | 0 |
| Fidelity exact (sampling differs) | 502 (83.67%) → 501 (83.50%) | n/a |
| Fully raised (sampling differs) | 24,446 (89.73%) → 24,462 (89.79%) | n/a |

Pinned-subset gate (PR quick rate/count regressions evaluated here): detected lowering residue 11.93% -> 11.93% (0 pp); conditional-branch residue 2.70% -> 2.69% (-0.01 pp); Full malformed 0 -> 0 (0); semantic defects ungated (sampling differs); fidelity ungated (sampling differs; rely on changed-method fidelity).

Current measured debt: 10,623 methods with detected lowering residue; 79 semantic defects among 25,183 checked; 92 fidelity opcode diffs among 600 checked; 7 fidelity operand diffs among 600 checked.
Regression verdict: PASS — corpus sensor matched baseline tolerances.

Per-method delta artifact: `/tmp/spill-corpus-delta-final.json`
