### PR TITLE
Drop redundant (dynamic) cast on by-ref dynamic receivers (#3035)

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LadderRung9/LadderRung9.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung9/LadderRung9.cs
@@ -105,6 +105,36 @@ public class DynamicAndExpressionTrees
         return input;
     }
 
+    // By-ref `dynamic` receivers (#3035). csc emits [DynamicAttribute({ false,
+    // true })] on these parameters — the leading `false` is the ByRef modifier
+    // and the element dynamic-ness sits at flags[1] — and the receiver renders as
+    // a deref of the by-ref parameter rather than a bare argument load. The
+    // redundant `(dynamic)` cast must still drop, since the element static type
+    // is provably `dynamic`.
+    public object DynamicGetLengthByRef(ref dynamic value)
+    {
+        return value.Length;
+    }
+
+    public object DynamicGetLengthIn(in dynamic value)
+    {
+        return value.Length;
+    }
+
+    public object DynamicGetLengthOut(out dynamic value)
+    {
+        value = "abc";
+        return value.Length;
+    }
+
+    // Negative control: a by-ref `object` receiver (not dynamic). The member
+    // access only becomes dynamic through the explicit `(dynamic)` cast, so the
+    // drop must NOT fire — the element static type really is `object`.
+    public object DynamicGetLengthByRefObject(ref object value)
+    {
+        return ((dynamic)value).Length;
+    }
+
     public Expression<Func<int, int>> SimpleExpressionTree()
     {
         return x => x + 1;

--- a/src/ILInspector.Decompiler.Fixtures.LadderRung9/LadderRung9MemberContexts.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung9/LadderRung9MemberContexts.cs
@@ -60,6 +60,17 @@ public class DynamicMemberContexts
         return Get(input);
     }
 
+    // Nested local function whose OWN parameter is a by-ref `dynamic`
+    // (`ref dynamic v`). The raised body drops the redundant cast to `v.Length`,
+    // and the printer-owned local-function declaration must keep the by-ref
+    // modifier — spelling `ref dynamic v`, not bare `dynamic v` — otherwise the
+    // `Get(ref value)` call site is CS1615 (#3035).
+    public object InLocalFunctionByRefOwnParam(dynamic value)
+    {
+        static object Get(ref dynamic v) => v.Length;
+        return Get(ref value);
+    }
+
     // Iterator state-machine body: csc lowers this to a MoveNext method whose
     // declaring type is the generated iterator state machine, while the
     // GetMember context remains the authored enclosing type (same bridge as

--- a/src/ILInspector.Decompiler.Tests/DynamicCallSitePassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DynamicCallSitePassTests.cs
@@ -226,6 +226,34 @@ public class DynamicCallSitePassTests
         Assert.DoesNotContain("((dynamic)value)", output);
     }
 
+    [Theory]
+    [InlineData("DynamicGetLengthByRef")] // ref dynamic
+    [InlineData("DynamicGetLengthIn")]    // in dynamic
+    [InlineData("DynamicGetLengthOut")]   // out dynamic
+    public void ByRefDynamicReceiver_DropsRedundantCast(string method)
+    {
+        // A by-ref `dynamic` parameter reads its receiver through a deref of the
+        // by-ref argument. The [DynamicAttribute] transform flags carry a leading
+        // ByRef modifier, so the element dynamic-ness sits at flags[1]; once the
+        // parameter is recognized as dynamic, the referenced element's static type
+        // is provably `dynamic`, so the redundant `(dynamic)` cast is dropped and
+        // the deref renders as the bare place `value.Length` (#3035).
+        var output = RaiseAndPrint(LoadCanonicalFunction(method));
+        Assert.Contains("value.Length", output);
+        Assert.DoesNotContain("(dynamic)", output);
+    }
+
+    [Fact]
+    public void ByRefObjectReceiver_KeepsCast()
+    {
+        // Negative control: `ref object value` has no DynamicAttribute, so the
+        // element static type really is `object`. The `(dynamic)` cast is the only
+        // thing making the member access dynamic, so it must be kept (#3035).
+        var output = RaiseAndPrint(LoadCanonicalFunction("DynamicGetLengthByRefObject"));
+        Assert.Contains("(dynamic)", output);
+        Assert.Contains(".Length", output);
+    }
+
     [Fact]
     public void KeywordMemberName_RaisesAndKeepsRawName()
     {

--- a/src/ILInspector.Decompiler.Tests/DynamicCallSitePassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DynamicCallSitePassTests.cs
@@ -1511,6 +1511,21 @@ public class DynamicCallSitePassTests
     }
 
     [Fact]
+    public void NestedContext_LocalFunctionByRefOwnParam_SpellsRefDynamicDeclaration()
+    {
+        // The local function has its OWN `ref dynamic` parameter. The body drops
+        // the redundant cast (`v.Length`), and the printer-owned local-function
+        // declaration must keep the by-ref modifier — spelling `ref dynamic v`,
+        // not bare `dynamic v` (which drops `ref` and makes the `Get(ref value)`
+        // call site CS1615) (#3035).
+        var output = RaiseMemberContext("InLocalFunctionByRefOwnParam");
+        Assert.Contains("ref dynamic v", output);
+        Assert.Contains("v.Length", output);
+        Assert.DoesNotContain("(dynamic v)", output);
+        Assert.DoesNotContain("((dynamic)v)", output);
+    }
+
+    [Fact]
     public void NestedContext_LambdaDisplayClass_Raises()
     {
         // csc lowers the lambda body into a display-class method whose

--- a/src/ILInspector.Decompiler.Tests/LadderRung9GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung9GateTests.cs
@@ -35,7 +35,11 @@ public class LadderRung9GateTests
         "DynamicEventRemove",
         "DynamicGetIndex",
         "DynamicGetLength",
+        "DynamicGetLengthByRef",
+        "DynamicGetLengthByRefObject",
+        "DynamicGetLengthIn",
         "DynamicGetLengthOfObject",
+        "DynamicGetLengthOut",
         "DynamicInvoke",
         "DynamicInvokeMember",
         "DynamicNamedOut",
@@ -113,6 +117,36 @@ public class LadderRung9GateTests
         var member = members.Single(m => m.Name == "DynamicGetLengthOfObject");
         Assert.Equal(DecompilationFidelity.Full, member.Function.Fidelity);
         Assert.Contains("((dynamic)value).Length", member.Body);
+    }
+
+    [Theory]
+    [InlineData("DynamicGetLengthByRef")] // ref dynamic
+    [InlineData("DynamicGetLengthIn")]    // in dynamic
+    [InlineData("DynamicGetLengthOut")]   // out dynamic
+    public void Rung9Fixture_DropsCastForByRefDynamicReceiver(string method)
+    {
+        // A by-ref `dynamic` parameter carries its [DynamicAttribute] element flag
+        // behind a leading ByRef modifier; once recognized, the referenced element
+        // is provably `dynamic`, so the redundant `(dynamic)` cast is dropped and
+        // the by-ref deref renders as the bare place `value.Length` (#3035).
+        var members = LoadRaisedMembers();
+        var member = members.Single(m => m.Name == method);
+        Assert.Equal(DecompilationFidelity.Full, member.Function.Fidelity);
+        Assert.Contains("value.Length;", member.Body);
+        Assert.DoesNotContain("(dynamic)", member.Body);
+    }
+
+    [Fact]
+    public void Rung9Fixture_KeepsCastForByRefObjectReceiver()
+    {
+        // Close negative for #3035: a `ref object` receiver has no
+        // [DynamicAttribute], so the access is dynamic only through the explicit
+        // source cast; the `(dynamic)` cast must be preserved.
+        var members = LoadRaisedMembers();
+        var member = members.Single(m => m.Name == "DynamicGetLengthByRefObject");
+        Assert.Equal(DecompilationFidelity.Full, member.Function.Fidelity);
+        Assert.Contains("(dynamic)", member.Body);
+        Assert.Contains(".Length", member.Body);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2647,7 +2647,7 @@ public sealed partial class CSharpPrinter
         // display-class field carrying [DynamicAttribute]) recovers a dynamic
         // type view.
         if (IsDynamicTypedReceiver(d.Receiver))
-            return $"{Operand(d.Receiver)}.{member}";
+            return $"{DynamicDroppedCastReceiverText(d.Receiver)}.{member}";
         return $"((dynamic){Operand(d.Receiver)}).{member}";
     }
 
@@ -2655,8 +2655,19 @@ public sealed partial class CSharpPrinter
     {
         LoadArgument { IsDynamic: true } => true,
         LoadField { Field.IsDynamic: true } => true,
+        // A by-ref `dynamic` parameter (`ref`/`in`/`out dynamic`) reads through a
+        // deref of the by-ref argument; the referenced element's static type is
+        // still `dynamic`, so the `(dynamic)` cast is equally redundant (#3035).
+        LoadIndirect { Address: LoadArgument { IsDynamic: true } } => true,
         _ => false,
     };
+
+    // Bare place text for a dynamic-typed receiver whose redundant `(dynamic)` cast
+    // is dropped. A by-ref deref reads back as the underlying argument identifier
+    // (`value`), so its `Operand` receiver-parentheses (`(value).Member`) are
+    // dropped to match the plain-parameter form (`value.Member`) (#3035).
+    string DynamicDroppedCastReceiverText(IrExpression receiver)
+        => receiver is LoadIndirect load ? DerefLoad(load) : Operand(receiver);
 
     // A parameter authored as top-level `dynamic` must be spelled `dynamic` in
     // the declaration, not `object` (its TypeRef). This keeps a local-function

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2673,10 +2673,18 @@ public sealed partial class CSharpPrinter
     // the declaration, not `object` (its TypeRef). This keeps a local-function
     // header consistent with a body that drops the redundant `(dynamic)` cast on
     // the parameter: `object Get(object v) => v.Length;` is CS1061, whereas
-    // `object Get(dynamic v) => v.Length;` binds. Top-level method signatures are
+    // `object Get(dynamic v) => v.Length;` binds. A by-ref `dynamic` parameter
+    // keeps its by-ref modifier — only the referenced element is `dynamic` — so
+    // it is spelled `ref dynamic`, not bare `dynamic` (which would drop `ref` and
+    // yield CS1615 at the call site) (#3035). Top-level method signatures are
     // spelled by the metadata signature printer; this covers the printer-owned
     // local-function declaration path.
-    string ParameterTypeText(Parameter p) => p.IsDynamic ? "dynamic" : TypeText(p.Type);
+    string ParameterTypeText(Parameter p)
+    {
+        if (!p.IsDynamic)
+            return TypeText(p.Type);
+        return p.Type.Kind == TypeRefKind.ByRef ? "ref dynamic" : "dynamic";
+    }
 
     string CoalesceText(Coalesce co, TypeRef? target = null)
     {

--- a/src/ILInspector.Decompiler/Pipeline/MethodImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodImporter.cs
@@ -68,10 +68,19 @@ public static class MethodImporter
             var parameter = reader.GetParameter(parameterHandle);
             if (parameter.SequenceNumber > 0)
             {
-                namesByIndex[parameter.SequenceNumber - 1] = reader.GetString(parameter.Name);
-                hasDefaultByIndex[parameter.SequenceNumber - 1] = HasDefault(reader, parameter);
-                dynamicByIndex[parameter.SequenceNumber - 1] = DynamicReader.IsTopLevelDynamic(
-                    DynamicReader.GetDynamicFlags(reader, parameter.GetCustomAttributes()));
+                int index = parameter.SequenceNumber - 1;
+                namesByIndex[index] = reader.GetString(parameter.Name);
+                hasDefaultByIndex[index] = HasDefault(reader, parameter);
+                // A by-ref parameter (`ref`/`in`/`out`) carries the ByRef modifier
+                // at DynamicAttribute flag index 0, so the element dynamic-ness sits
+                // at index 1; a non-by-ref parameter is dynamic only at index 0
+                // (#3035).
+                var dynamicFlags = DynamicReader.GetDynamicFlags(reader, parameter.GetCustomAttributes());
+                bool isByRef = index < decoded.ParameterTypes.Length
+                    && decoded.ParameterTypes[index].Kind == TypeRefKind.ByRef;
+                dynamicByIndex[index] = isByRef
+                    ? DynamicReader.IsByRefElementDynamic(dynamicFlags)
+                    : DynamicReader.IsTopLevelDynamic(dynamicFlags);
             }
         }
         for (int i = 0; i < decoded.ParameterTypes.Length; i++)

--- a/src/ILInspector.Metadata/DynamicReader.cs
+++ b/src/ILInspector.Metadata/DynamicReader.cs
@@ -72,6 +72,19 @@ public static class DynamicReader
         => dynamicFlags is { Length: > 0 } flags && flags[0] == 1;
 
     /// <summary>
+    /// True when a transform-flags array marks the <em>element</em> of a by-ref
+    /// type as <c>dynamic</c>. The flags are a preorder walk over the type; for a
+    /// by-ref signature (<c>ref</c>/<c>in</c>/<c>out</c>) index 0 is the ByRef
+    /// modifier itself (never dynamic) and the referenced element sits at index 1,
+    /// so <c>ref dynamic</c> emits <c>{ false, true }</c>. Callers must only use
+    /// this for a position whose type is by-ref; for a non-by-ref position use
+    /// <see cref="IsTopLevelDynamic"/>. Null (attribute absent) means the element
+    /// is a plain object.
+    /// </summary>
+    public static bool IsByRefElementDynamic(byte[]? dynamicFlags)
+        => dynamicFlags is { Length: > 1 } flags && flags[1] == 1;
+
+    /// <summary>
     /// Gets DynamicAttribute transform flags for a specific parameter by sequence
     /// number. Sequence 0 = return type, 1+ = parameters.
     /// </summary>

--- a/tests/ILInspector.Metadata.Tests/DynamicTypeViewTests.cs
+++ b/tests/ILInspector.Metadata.Tests/DynamicTypeViewTests.cs
@@ -418,6 +418,20 @@ public sealed class DynamicTypeViewTests
     {
         Assert.Equal(expected, DynamicReader.IsTopLevelDynamic(flags));
     }
+
+    // --- IsByRefElementDynamic predicate: the element sits at index 1 ---------
+
+    [Theory]
+    [InlineData(null, false)]                 // attribute absent -> object element
+    [InlineData(new byte[] { }, false)]       // empty flags -> not dynamic
+    [InlineData(new byte[] { 0 }, false)]     // ByRef modifier only, no element flag
+    [InlineData(new byte[] { 1 }, false)]     // single flag is the top-level form, not by-ref element
+    [InlineData(new byte[] { 0, 1 }, true)]   // `ref dynamic` -> ByRef at 0, dynamic element at 1
+    [InlineData(new byte[] { 0, 0 }, false)]  // `ref object` (unusual explicit form) -> object element
+    public void IsByRefElementDynamic_ReadsElementPositionOnly(byte[]? flags, bool expected)
+    {
+        Assert.Equal(expected, DynamicReader.IsByRefElementDynamic(flags));
+    }
 }
 
 // ===== Test fixture types with a spread of dynamic type shapes =====


### PR DESCRIPTION
- Fixes #3035 (advances #2984 / #3032)
- Drops the redundant `(dynamic)` cast on `ref`/`in`/`out dynamic` member-access receivers, matching plain `dynamic` params
- Card revision: `23a54bfa`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the by-ref `dynamic` receiver now spells the fully-raised `value.Length` (the cast was provably redundant), and the `ref object` negative control still keeps its cast.

### Original source

```csharp
public object DynamicGetLengthByRef(ref dynamic value)
{
    return value.Length;
}
```

### Before

```csharp
public object DynamicGetLengthByRef(ref dynamic value) => ((dynamic)(value)).Length;
```

- Valid: True
- Correct: True

Valid and behavior-preserving, but lower quality: the by-ref `dynamic` element's static type is already `dynamic`, so the `(dynamic)` cast (and its parentheses) are pure noise the plain-`dynamic` path already drops.

### After

```csharp
public object DynamicGetLengthByRef(ref dynamic value) => value.Length;
```

- Valid: True
- Correct: True

### Fully raised

The After decompilation is in the fully raised state.

## Root cause (two layers)

1. **Metadata decode.** A by-ref parameter carries the ByRef modifier at `DynamicAttribute` transform-flag index 0, so `ref dynamic` emits `{ false, true }` — the element dynamic-ness sits at index **1**. `DynamicReader.IsTopLevelDynamic` reads index 0, so the parameter was never marked `IsDynamic`. Added `DynamicReader.IsByRefElementDynamic` (index 1); `MethodImporter` selects it when `decoded.ParameterTypes[index].Kind == TypeRefKind.ByRef`.
2. **Printer.** A by-ref receiver reads through `LoadIndirect { Address: LoadArgument { IsDynamic } }` (deref), not a bare `LoadArgument`, so `IsDynamicTypedReceiver` never fired. Added that arm and render the dropped-cast receiver via the deref's underlying place so output is `value.Length`, not `(value).Length`. A follow-up (review finding) keeps the `ref` modifier on by-ref `dynamic` **local-function** parameter declarations (`ref dynamic v`) to avoid CS1615.

A `ref object` receiver has no `DynamicAttribute`, so its access is dynamic only through the explicit source cast and correctly keeps `((dynamic)value).Length`.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `DynamicCallSitePassTests`+`LadderRung9GateTests`: green (no by-ref cases) | 140 passed (adds ref/in/out + local-fn + negative controls) |
| Metadata unit | `DynamicTypeViewTests`: green | `IsByRefElementDynamic` theory added; 56 passed |
| Decompiler RoundTrip area | 312, 0 failed | 316, 0 failed |
| Reduced fixture validity | Pass (`Rung9Fixture_HasNoInvalidFull`) | Pass |
| Reduced fixture fidelity | Pass | Pass — cast-drop on an already-dynamic receiver recompiles to identical dynamic call-site IL |
| Corpus + Fidelity areas | 1 env red (`NoNewFidelityDiffsBeyondKnownDocket`) | 1 env red — same test, same lambda-cache field ordinal shift, identical opcodes, no new diff-set entries (CI-green) |

The single Corpus/Fidelity red is the pre-existing environmental `NoNewFidelityDiffsBeyondKnownDocket` (a compiler-synthesized lambda-cache field ordinal shift in `CfgSampleClass`, identical opcode streams); it is CI-green and orthogonal to this change.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — no corpus raise-rate impact. The change only affects the C# spelling of by-ref `dynamic` member-access receivers (redundant-cast drop); it adds no pass, alters no structuring, and leaves recompiled IL identical. Verified by the RoundTrip area (316/316) and the fixture validity/fidelity gates rather than a corpus rate delta.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -class "ILInspector.Decompiler.Tests.DynamicCallSitePassTests" -class "ILInspector.Decompiler.Tests.LadderRung9GateTests"
dotnet run --project tests/ILInspector.Metadata.Tests -c Release --no-build -- -class "ILInspector.Metadata.Tests.DynamicTypeViewTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -trait "Area=RoundTrip"
```

Adversarial review evidence is in a separate PR comment.
