### PR TITLE
Recover int comparison-predicate expression-tree lambdas (#2864)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -556,6 +556,22 @@ public class CfgSampleClass
             x);
     }
 
+    // Near-miss: a constant-only comparison root (`GreaterThan(2, 3)`) with an
+    // unreferenced parameter. The C# compiler constant-folds `2 > 3` to a single
+    // Constant(false) when the recovered lambda is recompiled to an expression tree
+    // (verified: `x => 2 > 3` lowers to a Constant node, not GreaterThan), so
+    // recovering `x => 2 > 3` would rebuild a different tree. The comparison
+    // constant-fold guard declines it, keeping the honest factory calls.
+    public static System.Linq.Expressions.Expression<System.Func<int, bool>> ManualConstantOnlyComparisonFactory()
+    {
+        var x = System.Linq.Expressions.Expression.Parameter(typeof(int), "x");
+        return System.Linq.Expressions.Expression.Lambda<System.Func<int, bool>>(
+            System.Linq.Expressions.Expression.GreaterThan(
+                System.Linq.Expressions.Expression.Constant(2, typeof(int)),
+                System.Linq.Expressions.Expression.Constant(3, typeof(int))),
+            x);
+    }
+
     // Capturing: `n` is hoisted into a <>c__DisplayClass, so the delegate targets
     // an instance method on that class. LambdaRaisingPass substitutes the body's
     // `this.n` read with the captured value and recovers `x => x + n`.

--- a/src/ILInspector.Decompiler.Tests/DynamicCompilationSiteInventoryTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DynamicCompilationSiteInventoryTests.cs
@@ -59,7 +59,7 @@ public sealed class DynamicCompilationSiteInventoryTests
             ["CrossAssemblyMethodFactsTests.cs"] = (1, "Cross-assembly seam: constructs referencing compilations to test cross-assembly facts."),
 
             // Product-output validity under varying compilation options.
-            ["ExpressionTreeLambdaTests.cs"] = (2, "Product-output validity: compiles synthesized expression-tree source and checks diagnostics/emit under varying compilation options (e.g. overflow checks)."),
+            ["ExpressionTreeLambdaTests.cs"] = (3, "Product-output validity + compile-back oracle: compiles synthesized expression-tree source under varying compilation options (overflow checks) and recompiles recovered arithmetic/comparison lambdas to assert their expression-tree node identity."),
 
             // Bespoke positive-source gates sharing one helper, each asserting
             // many per-fact expectations over a runtime-varying compilation
@@ -78,11 +78,14 @@ public sealed class DynamicCompilationSiteInventoryTests
     //     unbox value-read source (cast vs Unsafe.Unbox) per case.
     //   #2935 adds FluentChainFormattingTests.cs (1 site): recompiles the
     //     printer's broken fluent-chain output.
-    //   This branch adds RoundTripComparisonTests.cs (1 site): compiles an exact
-    //     donor fixture for typed C# and IL comparison.
-    //   Combined: 32 files, 39 sites.
+    //   RoundTripComparisonTests.cs (1 site): compiles an exact donor fixture for
+    //     typed C# and IL comparison.
+    //   This branch (#2864 comparison slice) adds a second compile-back oracle
+    //     site to ExpressionTreeLambdaTests.cs (2 -> 3 sites): recompiles recovered
+    //     comparison lambdas to assert their expression-tree node identity.
+    //   Combined: 32 files, 40 sites.
     const int ExpectedDynamicFiles = 32;
-    const int ExpectedDynamicSites = 39;
+    const int ExpectedDynamicSites = 40;
 
     // Migrated away from Dynamic in this change; must not reappear in the scan.
     static readonly string[] MigratedFiles = ["CompileBackTypeIdentityTests.cs"];

--- a/src/ILInspector.Decompiler.Tests/ExpressionTreeFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExpressionTreeFidelityTests.cs
@@ -119,6 +119,77 @@ public class ExpressionTreeFidelityTests
         Assert.NotNull(output);
         Assert.Contains("GetFieldFromHandle", output);
     }
+    [Fact]
+    public void ComparisonPredicate_RecoversLambda_StaysFull()
+    {
+        var function = Raised(nameof(ExpressionTreeSamples.GreaterThanComparison));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Empty(FidelityRemarks.Collect(function));
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.Contains("return (x, y) => x > y;", output);
+        Assert.DoesNotContain("Expression.Lambda", output);
+        Assert.DoesNotContain("Expression.GreaterThan", output);
+        Assert.DoesNotContain("Expression.Parameter", output);
+    }
+
+    [Fact]
+    public void EqualityComparisonPredicate_RecoversLambda_StaysFull()
+    {
+        var function = Raised(nameof(ExpressionTreeSamples.EqualityComparison));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Empty(FidelityRemarks.Collect(function));
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("return (x, y) => x == y;", output);
+        Assert.DoesNotContain("Expression.Equal", output);
+    }
+
+    [Fact]
+    public void ComparisonOverArithmetic_RecoversLambda_KeepsUncheckedOperand()
+    {
+        var function = Raised(nameof(ExpressionTreeSamples.ComparisonOverArithmetic));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Empty(FidelityRemarks.Collect(function));
+
+        var output = CSharpPrinter.Print(function).Output;
+        // The comparison itself carries no overflow form, but its int-arithmetic
+        // operand recompiles to the unchecked Expression.Add, so it stays unchecked.
+        Assert.Contains("return (x, y) => unchecked(x + 1) > y;", output);
+        Assert.DoesNotContain("Expression.GreaterThan", output);
+        Assert.DoesNotContain("Expression.Add", output);
+    }
+
+    [Fact]
+    public void LogicalCompositionPredicate_StaysFactoryCalls()
+    {
+        var function = Raised(nameof(ExpressionTreeSamples.LogicalCompositionPredicate));
+
+        // A boolean AndAlso composition root is outside the single-comparison
+        // subset: no recovered lambda, honest factory calls.
+        Assert.Empty(function.Descendants.OfType<Lambda>());
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("Expression.Lambda<Func<int, bool>>", output);
+        Assert.DoesNotContain("=>", output);
+    }
+
+    [Fact]
+    public void LongComparisonPredicate_StaysFactoryCalls()
+    {
+        var function = Raised(nameof(ExpressionTreeSamples.LongComparison));
+
+        // Non-int parameters are outside the int slice: honest factory calls.
+        Assert.Empty(function.Descendants.OfType<Lambda>());
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("Expression.Lambda<Func<long, long, bool>>", output);
+        Assert.DoesNotContain("=>", output);
+    }
 }
 
 public static class ExpressionTreeSamples
@@ -142,6 +213,34 @@ public static class ExpressionTreeSamples
 
     public static Expression<Func<ExpressionTreeNode, bool>> Member()
         => n => n.Name != null && n.Count > 0;
+
+    // Comparison predicate slice: a single int comparison body recovers to the
+    // source `l OP r`. Each operator recompiles to exactly the 2-arg
+    // Expression.<Cmp> factory it matched, so the round-trip tree is identical.
+    public static Expression<Func<int, int, bool>> GreaterThanComparison() => (x, y) => x > y;
+
+    public static Expression<Func<int, int, bool>> LessThanOrEqualComparison() => (a, b) => a <= b;
+
+    public static Expression<Func<int, int, bool>> EqualityComparison() => (x, y) => x == y;
+
+    public static Expression<Func<int, int, bool>> InequalityComparison() => (x, y) => x != y;
+
+    // A comparison against a constant: recovers `x => x > 5` (the constant operand
+    // keeps identity because the other operand is parameter-dependent).
+    public static Expression<Func<int, bool>> ComparisonAgainstConstant() => x => x > 5;
+
+    // A comparison whose left operand is unchecked int arithmetic: the arithmetic
+    // operand still needs the explicit unchecked(...) spelling (it recompiles to the
+    // unchecked Expression.Add), while the comparison itself carries no overflow form.
+    public static Expression<Func<int, int, bool>> ComparisonOverArithmetic() => (x, y) => x + 1 > y;
+
+    // Near-miss: a boolean composition (AndAlso) root, not a single comparison.
+    // Outside the comparison subset, so it stays in honest factory-call form.
+    public static Expression<Func<int, bool>> LogicalCompositionPredicate() => x => x > 0 && x < 10;
+
+    // Near-miss: a non-int (long) comparison. The int-parameter guard rejects it, so
+    // it stays in honest factory-call form rather than an unproven recovery.
+    public static Expression<Func<long, long, bool>> LongComparison() => (x, y) => x > y;
 }
 
 public sealed class ExpressionTreeNode

--- a/src/ILInspector.Decompiler.Tests/ExpressionTreeLambdaTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExpressionTreeLambdaTests.cs
@@ -328,4 +328,81 @@ public class ExpressionTreeLambdaTests
         var lambda = (LambdaExpression)make.Invoke(null, null)!;
         return lambda.Body;
     }
+
+    // Constant-fold guard for comparisons: a hand-written constant-only comparison
+    // graph (`GreaterThan(2, 3)`) would be folded to a single Constant(false) by the
+    // compiler on recompile (proven by the oracle below), so recovering it as
+    // `x => 2 > 3` would change the tree. It stays in honest factory-call form.
+    [Fact]
+    public void ManualConstantOnlyComparisonFactory_StaysFactoryCalls()
+    {
+        var function = Raised(nameof(CfgSampleClass.ManualConstantOnlyComparisonFactory));
+
+        Assert.Empty(function.Descendants.OfType<Lambda>());
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.Contains("Expression.Lambda<Func<int, bool>>", output);
+        Assert.Contains("Expression.GreaterThan", output);
+        Assert.DoesNotContain("=>", output);
+    }
+
+    // Real compile-back tree oracle for the comparison subset. A parameter-dependent
+    // comparison keeps its 2-arg comparison node with no method/lift (so the
+    // recovered `l OP r` rebuilds the identical factory node), while a constant-only
+    // comparison is folded to a single Constant — which is exactly why the
+    // constant-fold guard declines the constant-only near miss.
+    [Theory]
+    [InlineData("Func<int, int, bool>", "(x, y) => x > y", ExpressionType.GreaterThan)]
+    [InlineData("Func<int, int, bool>", "(x, y) => x == y", ExpressionType.Equal)]
+    [InlineData("Func<int, int, bool>", "(x, y) => x != y", ExpressionType.NotEqual)]
+    [InlineData("Func<int, int, bool>", "(a, b) => a <= b", ExpressionType.LessThanOrEqual)]
+    [InlineData("Func<int, bool>", "x => x > 5", ExpressionType.GreaterThan)]
+    public void ComparisonOracle_ParameterDependent_KeepsComparisonNode(string delegateType, string lambda, ExpressionType expected)
+    {
+        var (nodeType, method, lifted) = BuildPredicateTree(delegateType, lambda);
+        Assert.Equal(expected, nodeType);
+        // The 2-arg factory the pass matches: no user-defined method, not lifted.
+        Assert.Null(method);
+        Assert.False(lifted);
+    }
+
+    [Fact]
+    public void ComparisonOracle_ConstantOnly_FoldsToConstant()
+    {
+        var (nodeType, _, _) = BuildPredicateTree("Func<int, bool>", "x => 2 > 3");
+        Assert.Equal(ExpressionType.Constant, nodeType);
+    }
+
+    static (ExpressionType NodeType, System.Reflection.MethodInfo? Method, bool Lifted) BuildPredicateTree(string delegateType, string lambda)
+    {
+        string source = $$"""
+            using System;
+            using System.Linq.Expressions;
+
+            public static class PredicateShell
+            {
+                public static Expression<{{delegateType}}> Make() => {{lambda}};
+            }
+            """;
+        var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview));
+        var compilation = CSharpCompilation.Create(
+            "expression-tree-predicate-shell",
+            [tree],
+            RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = new MemoryStream();
+        var emit = compilation.Emit(stream, cancellationToken: TestContext.Current.CancellationToken);
+        Assert.True(
+            emit.Success,
+            string.Join(Environment.NewLine, emit.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+
+        var assembly = System.Reflection.Assembly.Load(stream.ToArray());
+        var make = assembly.GetType("PredicateShell")!.GetMethod("Make")!;
+        var body = ((LambdaExpression)make.Invoke(null, null)!).Body;
+        return body is BinaryExpression binary
+            ? (body.NodeType, binary.Method, binary.IsLiftedToNull)
+            : (body.NodeType, null, false);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionTreeLambdaRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionTreeLambdaRaisingPass.cs
@@ -7,7 +7,9 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <c>ExpressionLambdaRewriter</c>'s lowering of
 /// <c>Expression&lt;Func&lt;…&gt;&gt; f = p =&gt; e</c> to a run of
 /// <c>System.Linq.Expressions</c> factory calls — back into the source lambda
-/// <c>p =&gt; e</c> (issue #2864, first slice: homogeneous <c>int</c> arithmetic).
+/// <c>p =&gt; e</c> (issue #2864). Two body subsets are recovered: homogeneous
+/// <c>int</c> arithmetic (a <c>Func&lt;…,int&gt;</c> body) and a single <c>int</c>
+/// comparison predicate (a <c>Func&lt;…,bool&gt;</c> body such as <c>x =&gt; x &gt; y</c>).
 ///
 /// <para>Unlike the delegate-lambda raise (<see cref="LambdaRaisingPass"/>) there
 /// is no synthesized closure method and no <c>[CompilerGenerated]</c> marker: the
@@ -27,11 +29,14 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <item>one <c>StoreLocal p_i = Expression.Parameter(typeof(int), "name")</c> per
 /// parameter — the parameter's <b>single</b> owning definition;</item>
 /// <item><c>StoreStackSlot arr = new ParameterExpression[N]</c>;</item>
-/// <item>the body <c>Expression.Add/Subtract/Multiply/Divide/Modulo</c> tree over
-/// parameter loads and <c>Expression.Constant(c, typeof(int))</c> leaves, spilled
-/// to a single-use slot or inlined into the <c>Lambda</c> call;</item>
+/// <item>the body <c>Expression.Add/Subtract/Multiply/Divide/Modulo</c> arithmetic
+/// tree (for an <c>int</c> result) or a single <c>Expression.Equal/NotEqual/
+/// LessThan/LessThanOrEqual/GreaterThan/GreaterThanOrEqual</c> comparison (for a
+/// <c>bool</c> result) over parameter loads and <c>Expression.Constant(c,
+/// typeof(int))</c> leaves, spilled to a single-use slot or inlined into the
+/// <c>Lambda</c> call;</item>
 /// <item><c>arr[i] = p_i</c> element stores registering each parameter;</item>
-/// <item><c>return Expression.Lambda&lt;Func&lt;int,…,int&gt;&gt;(body, arr);</c></item>
+/// <item><c>return Expression.Lambda&lt;Func&lt;int,…,int|bool&gt;&gt;(body, arr);</c></item>
 /// </list>
 ///
 /// <para>Every statement of the block must be one of those and nothing else, and
@@ -41,9 +46,10 @@ namespace ILInspector.Decompiler.Pipeline;
 /// and a local (the body reads the slot, the array reads the local): two
 /// independent value sources whose sameness cannot be proven, so the lambda's
 /// declared parameter and its body reference might not be the same node. Captured,
-/// member-token (<c>ldtoken</c>), method-call, comparison, conversion, non-<c>int</c>,
-/// shared, mutated, and multi-block graphs all fall outside the subset and stay in
-/// their honest factory-call / <c>Partial</c> form for later slices (#2864).</para>
+/// member-token (<c>ldtoken</c>), method-call, conversion, boolean-composition
+/// (<c>AndAlso/OrElse</c>), non-<c>int</c>, shared, mutated, and multi-block graphs
+/// all fall outside the subset and stay in their honest factory-call /
+/// <c>Partial</c> form for later slices (#2864).</para>
 /// </summary>
 public sealed class ExpressionTreeLambdaRaisingPass : IIrPass
 {
@@ -88,7 +94,7 @@ public sealed class ExpressionTreeLambdaRaisingPass : IIrPass
         if (!IsExpressionFactory(returnValue, "Lambda", out var lambdaCall)
             || lambdaCall.Callee.TypeArguments is not [var delegateType]
             || lambdaCall.Arguments.Count != 2
-            || !IsHomogeneousIntFunc(delegateType, out int arity))
+            || !IsIntParameterFunc(delegateType, out int arity, out var resultKind))
             return;
 
         // The rewrite emits a bare lambda literal in the return position, which C#
@@ -107,14 +113,19 @@ public sealed class ExpressionTreeLambdaRaisingPass : IIrPass
             return;
 
         // Rebuild the parameter list and the body over LoadArgument references, in
-        // parameter (array) order. RaiseBody rejects anything outside the int
-        // arithmetic subset, so a member/comparison/method-call/convert body bails.
+        // parameter (array) order. The body raiser rejects anything outside its
+        // subset — an int arithmetic body for a Func<…,int> delegate, or a single
+        // int comparison for a Func<…,bool> predicate — so a member/method-call/
+        // convert/boolean-composition body bails.
         var parameters = plan.Parameters;
         var indexByLocal = new Dictionary<int, int>();
         for (int i = 0; i < plan.ParameterLocals.Length; i++)
             indexByLocal[plan.ParameterLocals[i]] = i;
 
-        if (RaiseBody(plan.Body, parameters, indexByLocal) is not { } body)
+        var body = resultKind == ExpressionBodyResult.Int
+            ? RaiseBody(plan.Body, parameters, indexByLocal)
+            : RaiseComparisonBody(plan.Body, parameters, indexByLocal);
+        if (body is null)
             return;
 
         var lambdaBody = new BlockContainer();
@@ -134,7 +145,9 @@ public sealed class ExpressionTreeLambdaRaisingPass : IIrPass
             // Recovered from the unchecked Expression.Add/Subtract/Multiply
             // factories, so the printer must spell overflow-prone arithmetic in an
             // explicit unchecked(...) to keep the tree unchecked under a checked
-            // consuming project.
+            // consuming project. A pure comparison body carries no overflow form and
+            // is unaffected; a comparison over an arithmetic operand still needs the
+            // unchecked spelling on that operand.
             IsExpressionTree = true,
         };
         lambda.InheritSourceOffset(ret);
@@ -371,16 +384,78 @@ public sealed class ExpressionTreeLambdaRaisingPass : IIrPass
         }
     }
 
+    // Rebuild a predicate body: exactly one int comparison node (the recovered
+    // C# `l OP r`) whose operands are raised through the int arithmetic subset.
+    // The compiler emits the 2-arg Expression.Equal/NotEqual/LessThan/
+    // LessThanOrEqual/GreaterThan/GreaterThanOrEqual for a source `int` comparison;
+    // that recovered comparison recompiles to exactly that same 2-arg factory node,
+    // so the round-trip tree is identical. Anything else — a boolean composition
+    // (AndAlso/OrElse) root, a method-call/member/convert operand, the lifted/
+    // method-carrying 4-arg overload, or a non-int operand — bails, keeping the
+    // graph in its honest factory-call form.
+    static IrExpression? RaiseComparisonBody(IrExpression node, ImmutableArray<Parameter> parameters, IReadOnlyDictionary<int, int> indexByLocal)
+    {
+        if (!TryComparisonKind(node, out var kind, out var left, out var right))
+            return null;
+        if (RaiseBody(left, parameters, indexByLocal) is not { } raisedLeft
+            || RaiseBody(right, parameters, indexByLocal) is not { } raisedRight
+            || !IsInt(raisedLeft.ResultType) || !IsInt(raisedRight.ResultType))
+            return null;
+        // Constant-fold guard, mirroring RaiseBody's arithmetic case: a comparison
+        // of two compile-time constants (e.g. Equal(Constant(2), Constant(3))) is
+        // folded by the C# compiler to a single Constant(false) when the recovered
+        // lambda is recompiled to an expression tree, so the tree is NOT identical.
+        // Require at least one parameter-dependent operand; a bare int comparison
+        // against a constant (x > 5) or between parameters (x < y) keeps identity.
+        if (!DependsOnParameter(raisedLeft) && !DependsOnParameter(raisedRight))
+            return null;
+        // int comparisons are signed (the compiler emits the signed factory and C#
+        // `<`/`>` on int are signed); there is no unsigned int comparison factory to
+        // match here.
+        return new Comparison(kind, isUnsigned: false, raisedLeft, raisedRight);
+    }
+
     // A raised subtree is parameter-dependent when it transitively loads a lambda
     // parameter. Only such subtrees are safe operands for a recovered arithmetic
-    // node: a constant-only operand pair would be constant-folded on recompile,
-    // breaking exact expression-tree identity (see RaiseBody's arithmetic guard).
+    // or comparison node: a constant-only operand pair would be constant-folded on
+    // recompile, breaking exact expression-tree identity (see RaiseBody's arithmetic
+    // guard and RaiseComparisonBody's guard).
     static bool DependsOnParameter(IrExpression raised) => raised switch
     {
         LoadArgument => true,
         Binary binary => DependsOnParameter(binary.Left) || DependsOnParameter(binary.Right),
         _ => false,
     };
+
+    // Expression.<Comparison>(left, right) — the exact 2-arg int comparison shape
+    // ExpressionLambdaRewriter emits. The lifted/method-carrying 4-arg overload has
+    // a different argument count and bails, keeping any user-defined-operator or
+    // nullable-lifted comparison in factory form.
+    static bool TryComparisonKind(IrExpression node, out ComparisonKind kind, out IrExpression left, out IrExpression right)
+    {
+        left = right = null!;
+        kind = default;
+        if (node is not Call { Callee.Name: var factoryName })
+            return false;
+        var mapped = factoryName switch
+        {
+            "Equal" => ComparisonKind.Equal,
+            "NotEqual" => ComparisonKind.NotEqual,
+            "LessThan" => ComparisonKind.LessThan,
+            "LessThanOrEqual" => ComparisonKind.LessThanOrEqual,
+            "GreaterThan" => ComparisonKind.GreaterThan,
+            "GreaterThanOrEqual" => ComparisonKind.GreaterThanOrEqual,
+            _ => (ComparisonKind)(-1),
+        };
+        if ((int)mapped < 0)
+            return false;
+        if (!IsExpressionFactory(node, factoryName, out var call) || call.Arguments.Count != 2)
+            return false;
+        kind = mapped;
+        left = call.Arguments[0];
+        right = call.Arguments[1];
+        return true;
+    }
 
     static bool TryArithmeticKind(IrExpression node, out BinaryKind kind, out IrExpression left, out IrExpression right)
     {
@@ -421,21 +496,40 @@ public sealed class ExpressionTreeLambdaRaisingPass : IIrPass
         return true;
     }
 
-    // The delegate type is System.Func<T1,…,Tn,TResult> with every argument int.
-    // Homogeneous int keeps the recovered lambda's literals and operators binding
-    // to built-in int arithmetic with no promotion/Convert, so the round-trip tree
-    // is identical. arity is the parameter count (n).
-    static bool IsHomogeneousIntFunc(TypeRef delegateType, out int arity)
+    // The body result kind selected by the delegate's TResult: an int arithmetic
+    // body (Func<…,int>) or a bool comparison predicate (Func<…,bool>).
+    enum ExpressionBodyResult { Int, Bool }
+
+    static bool IsBool(TypeRef? type) => type is not null && type.Equals(TypeRef.CoreLib("System", "Boolean"));
+
+    // The delegate type is System.Func<T1,…,Tn,TResult> with every parameter int
+    // and TResult either int (an arithmetic body) or bool (a comparison predicate).
+    // Homogeneous int parameters keep the recovered lambda's literals and operators
+    // binding to built-in int arithmetic/comparison with no promotion/Convert, so
+    // the round-trip tree is identical. arity is the parameter count (n).
+    static bool IsIntParameterFunc(TypeRef delegateType, out int arity, out ExpressionBodyResult resultKind)
     {
         arity = 0;
+        resultKind = default;
         if (delegateType is not { Kind: TypeRefKind.GenericInstance, ElementType: { Namespace: "System", Name: var name }, TypeArguments: { Length: >= 2 } args }
             || !name.StartsWith("Func`", StringComparison.Ordinal)
             // The delegate family must be the real corelib System.Func: identity is
             // the (name-canonicalized) core-library assembly, not the simple name, so
             // a lookalike System.Func in a user assembly is not raised to framework
-            // lambda semantics. Every type argument is int (checked below).
-            || !MemberIdentity.IsKnownCoreLibraryDelegateType(delegateType)
-            || !args.All(IsInt))
+            // lambda semantics.
+            || !MemberIdentity.IsKnownCoreLibraryDelegateType(delegateType))
+            return false;
+        // Every parameter (all but the trailing TResult) is int.
+        for (int i = 0; i < args.Length - 1; i++)
+            if (!IsInt(args[i]))
+                return false;
+        // TResult decides the body subset: int arithmetic or a bool comparison.
+        var result = args[^1];
+        if (IsInt(result))
+            resultKind = ExpressionBodyResult.Int;
+        else if (IsBool(result))
+            resultKind = ExpressionBodyResult.Bool;
+        else
             return false;
         arity = args.Length - 1;
         return true;


### PR DESCRIPTION
- Advances #2864
- Recovers a single `int` comparison-predicate expression-tree factory graph
  (a `Func<…,bool>` body such as `x => x > y`) back to a source lambda
- Card revision: `d8ad8fb3`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the delegate's `TResult` selects the body raiser
(`int` → arithmetic, `bool` → a single comparison); the comparison raiser matches
only the exact 2-arg `Expression.Equal/NotEqual/LessThan/LessThanOrEqual/
GreaterThan/GreaterThanOrEqual` factory the compiler emits for a source `int`
comparison, raises both operands through the proven `int` arithmetic subset, and
requires ≥1 parameter-dependent operand. The recovered `l OP r` recompiles to
exactly that same 2-arg factory node, so the round-trip tree is identical.

### Original source

```csharp
public static Expression<Func<int, int, bool>> GreaterThanComparison()
    => (x, y) => x > y;
```

### Before

```csharp
public static System.Linq.Expressions.Expression<System.Func<int, int, bool>> GreaterThanComparison()
{
    ParameterExpression V_0 = Expression.Parameter(typeof(int), "x");
    ParameterExpression V_1 = Expression.Parameter(typeof(int), "y");
    ParameterExpression[] S_256 = new ParameterExpression[2];
    BinaryExpression S_257 = Expression.GreaterThan(V_0, V_1);
    S_256[0] = V_0;
    ParameterExpression[] S_258 = S_256;
    S_258[1] = V_1;
    return Expression.Lambda<Func<int, int, bool>>(S_257, S_258);
}
```

- Valid: True
- Correct: True

Honest factory-call form: valid and behavior-preserving, but not raised.

### After

```csharp
public static System.Linq.Expressions.Expression<System.Func<int, int, bool>> GreaterThanComparison() => (x, y) => x > y;
```

- Valid: True
- Correct: True

The recovered lambda recompiles to exactly the matched 2-arg
`Expression.GreaterThan(Parameter, Parameter)` node (`Method == null`,
`!IsLiftedToNull`), so the returned expression tree is identical.

### Fully raised

For the supported single-`int`-comparison predicate slice, the After
decompilation is in the fully raised state. Issue #2864 remains open for the
non-`int`, captured/member, boolean-composition (`AndAlso`/`OrElse`), and broader
expression-node slices.

## Why no `unchecked` wrapper on a pure comparison

A pure comparison body carries no overflow-context form — there is no
"checked comparison" factory — so `x > y` needs no `unchecked(...)`. When a
comparison operand is itself arithmetic (`(x, y) => x + 1 > y`), the operand is
raised through the same arithmetic subset and keeps its load-bearing
`unchecked(...)` spelling: the recovered text is `(x, y) => unchecked(x + 1) > y`,
pinning `Expression.Add` (not `AddChecked`) under a checked-default consuming
project, exactly as in the arithmetic slice (#2926).

## Boundary (declines, stays factory calls / `Partial`)

- The lifted/method-carrying **4-arg** comparison overload (nullable-lifted or
  user-defined-operator) — different argument count, bails.
- **Boolean composition** roots (`x > 0 && x < 10` → `AndAlso`), method-call,
  member, and convert operands.
- **Non-`int`** operands (`Func<long,long,bool>` comparison) — rejected by the
  int-parameter guard.
- **Constant-only** comparisons (`2 > 3`) — fold to a single `Constant` on
  recompile, so ≥1 parameter-dependent operand is required.

## Evidence

| Check | Baseline (origin/main) | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused expression-tree tests | n/a (fixtures new) | `ExpressionTreeFidelityTests` + `ExpressionTreeLambdaTests`: pass |
| Decompiler fast suite | 3,298, 0 failed | 3,298, 0 failed |
| Dynamic-site inventory | n/a (fingerprint updated) | Pass (32 files / 40 sites) |
| Compile-back / tree oracle | n/a | Pass (2-arg node identity; constant-only folds to `Constant`) |
| Close negatives | — | long comparison, `AndAlso` composition, manual constant-only comparison, and the existing `Member` predicate all decline |

Before/After above are verbatim `dotnet-inspect member … -S "Decompiled Source"`
output: base tool vs. head tool over the same head-compiled fixture IL.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — recovery is limited to a compiler-shaped, fully-owned
`int` comparison-predicate graph. Unsupported graphs retain their explicit
factory calls or existing honest `Partial` output; the general corpus does not
contain source expression-tree factory runs of this shape, so no aggregate
movement is expected.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.ExpressionTreeFidelityTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.ExpressionTreeLambdaTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
```
