### PR TITLE
Harness: --repo for authored-corpus harvest (skip remote source fetch for own libs) [#3052]

### DIFF
--- a/tools/DecompilerHarness/AuthoredSourceHarvest.cs
+++ b/tools/DecompilerHarness/AuthoredSourceHarvest.cs
@@ -66,10 +66,20 @@ static class AuthoredSourceHarvest
         public required Queue<RealMethodTargetEnumerator.RealMethodTarget> Candidates { get; init; }
     }
 
-    public static int Run(IReadOnlyList<string> assemblies, string outputPath, int target, bool evil = false)
-        => RunAsync(assemblies, outputPath, target, evil).GetAwaiter().GetResult();
+    public static int Run(
+        IReadOnlyList<string> assemblies,
+        string outputPath,
+        int target,
+        bool evil = false,
+        IReadOnlyList<string>? repositoryPaths = null)
+        => RunAsync(assemblies, outputPath, target, evil, repositoryPaths).GetAwaiter().GetResult();
 
-    static async Task<int> RunAsync(IReadOnlyList<string> assemblies, string outputPath, int target, bool evil)
+    static async Task<int> RunAsync(
+        IReadOnlyList<string> assemblies,
+        string outputPath,
+        int target,
+        bool evil,
+        IReadOnlyList<string>? repositoryPaths)
     {
         if (assemblies.Count == 0)
         {
@@ -128,7 +138,7 @@ static class AuthoredSourceHarvest
                     var candidate = library.Candidates.Dequeue();
                     attempts++;
 
-                    var record = await TryHarvestAsync(library, candidate, fetcher, evil);
+                    var record = await TryHarvestAsync(library, candidate, fetcher, evil, repositoryPaths);
                     if (record is null)
                     {
                         skipped++;
@@ -228,7 +238,8 @@ static class AuthoredSourceHarvest
         LibraryState library,
         RealMethodTargetEnumerator.RealMethodTarget candidate,
         SourceFetcher fetcher,
-        bool evil)
+        bool evil,
+        IReadOnlyList<string>? repositoryPaths)
     {
         var subject = new FindingSubject(
             $"{candidate.Type}::{candidate.Method}#{candidate.Overload}",
@@ -242,7 +253,8 @@ static class AuthoredSourceHarvest
                 candidate.MetadataToken,
                 candidate.Method,
                 subject,
-                fetcher);
+                fetcher,
+                repositoryPaths);
         }
         catch (Exception ex) when (ex is IOException
             or InvalidOperationException

--- a/tools/DecompilerHarness/AuthoredSourceHarvest.cs
+++ b/tools/DecompilerHarness/AuthoredSourceHarvest.cs
@@ -96,7 +96,7 @@ static class AuthoredSourceHarvest
         {
             foreach (string assemblyPath in assemblies)
             {
-                var library = TryOpenLibrary(assemblyPath, httpClient, evil).GetAwaiter().GetResult();
+                var library = await TryOpenLibrary(assemblyPath, httpClient, evil);
                 if (library is not null)
                     libraries.Add(library);
             }

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -135,6 +135,7 @@ static class Program
         int? topLibraries = null;
         int cap = int.MaxValue;
         var packages = new List<string>();
+        var sourceRepositories = new List<string>();
         string? packageVersion = null;
         string? packageTfm = null;
         string? packageAssembly = null;
@@ -287,6 +288,7 @@ static class Program
                     case "--top-libraries": topLibraries = int.Parse(NextArg(args, ref i, flag)); break;
                     case "--cap": cap = int.Parse(NextArg(args, ref i, flag)); break;
                     case "--package": packages.Add(NextArg(args, ref i, flag)); break;
+                    case "--repo": sourceRepositories.Add(NextArg(args, ref i, flag)); break;
                     case "--package-version": packageVersion = NextArg(args, ref i, flag); break;
                     case "--package-tfm": packageTfm = NextArg(args, ref i, flag); break;
                     case "--package-assembly": packageAssembly = NextArg(args, ref i, flag); break;
@@ -451,10 +453,10 @@ static class Program
             return RunEnumerateRealMethods(assemblies, maxExamples);
 
         if (harvestAuthoredCorpus)
-            return AuthoredSourceHarvest.Run(assemblies, harvestOutputPath!, harvestTarget);
+            return AuthoredSourceHarvest.Run(assemblies, harvestOutputPath!, harvestTarget, repositoryPaths: sourceRepositories);
 
         if (harvestEvilCorpus)
-            return AuthoredSourceHarvest.Run(assemblies, harvestOutputPath!, harvestTarget, evil: true);
+            return AuthoredSourceHarvest.Run(assemblies, harvestOutputPath!, harvestTarget, evil: true, repositoryPaths: sourceRepositories);
 
         if (benchmarkAuthoredCorpus)
             return AuthoredCorpusBenchmark.Run(assemblies, benchmarkCorpusPath!, json);
@@ -1993,6 +1995,12 @@ static class Program
           --package-tfm <tfm>    select a specific TFM from --package.
           --package-assembly <dll>
                                 select a specific assembly inside --package.
+          --repo <path>          with --harvest-authored-corpus/--harvest-evil-corpus:
+                                read authored source from a local git clone
+                                (checksum-arbitrated) instead of the network;
+                                repeatable. Point at this checkout to skip
+                                remote fetches for dotnet-inspect's own
+                                libraries.
           --fidelity-timings      with --fidelity-check: print phase timings for collect/render,
                                 skeleton emit, parse, compilation create, emit, and opcode compare
           --fidelity-zero-signal-guard <n>

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -266,14 +266,21 @@ harvested from the same 14 pinned assemblies as the fixed real-world corpus
 bash eng/prepare-decompiler-corpus.sh /tmp/corpus-assemblies.txt
 dotnet run --project tools/DecompilerHarness -c Release -- \
   --harvest-authored-corpus /tmp/authored-corpus.jsonl --harvest-target 12000 \
+  --repo "$(git rev-parse --show-toplevel)" \
   $(cat /tmp/corpus-assemblies.txt)
 ```
 
 `--repo <path>` (repeatable) makes harvest read each target's authored source
 from a local git clone instead of the network, arbitrated by the same PDB
 checksum, falling back to the network on any mismatch or miss. Pointing it at
-this checkout skips the remote SourceLink fetch for dotnet-inspect's own
-libraries, and it also unlocks private, large, or offline source repositories.
+this checkout resolves the dotnet-inspect self-corpus rows entirely from local
+git: those assemblies come from the pinned `dotnet-inspect.any` package
+(`prepare-decompiler-corpus.sh`), whose SourceLink targets this repository, so
+their authored bodies are read from the local object store with no GitHub
+round-trip. Third-party rows are checksum-arbitrated and fall back to the
+network. This only requires the checkout to contain the commit the pinned
+self-package was built from, which normal `origin/main` history already carries;
+`--repo` also unlocks private, large, or offline source repositories.
 
 `--benchmark-authored-corpus <corpus.jsonl> <assembly...>` runs the benchmark. It
 groups corpus rows by assembly, matches them to the supplied pinned assemblies by

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -269,6 +269,12 @@ dotnet run --project tools/DecompilerHarness -c Release -- \
   $(cat /tmp/corpus-assemblies.txt)
 ```
 
+`--repo <path>` (repeatable) makes harvest read each target's authored source
+from a local git clone instead of the network, arbitrated by the same PDB
+checksum, falling back to the network on any mismatch or miss. Pointing it at
+this checkout skips the remote SourceLink fetch for dotnet-inspect's own
+libraries, and it also unlocks private, large, or offline source repositories.
+
 `--benchmark-authored-corpus <corpus.jsonl> <assembly...>` runs the benchmark. It
 groups corpus rows by assembly, matches them to the supplied pinned assemblies by
 assembly name, feeds the vendored authored bodies into the same


### PR DESCRIPTION
## What

Adds a repeatable `--repo <path>` option to the decompiler harness's authored-corpus **harvest** flow (`--harvest-authored-corpus` / `--harvest-evil-corpus`). It threads the merged `AuthoredSourceAcquisition.AcquireMemberAsync(repositoryPaths)` capability (#3040) into `AuthoredSourceHarvest`, so harvest can read a target's authored source from a local git clone — arbitrated by the same PDB checksum, falling back to the network on any mismatch or miss.

Implements **Scope A/B of #3052**. The benchmark, the vendored `vendor/authored-source-corpus` snapshot, and `eng/restore-authored-source-corpus.sh` are unchanged and stay hermetic (Scope C — drift detection — is not in this PR).

## Why

- **Primary win (own libraries):** for dotnet-inspect's own libraries the SourceLink commit lives in this checkout, so pointing `--repo` at it **skips the remote SourceLink fetch entirely** and always matches the code under test.
- **Secondary:** unlocks private, large, or offline third-party source repositories for harvest.

## Changes

- `tools/DecompilerHarness/AuthoredSourceHarvest.cs` — `Run`/`RunAsync`/`TryHarvestAsync` take an optional `IReadOnlyList<string>? repositoryPaths`, passed as the 6th positional arg to `AcquireMemberAsync`.
- `tools/DecompilerHarness/Program.cs` — new `sourceRepositories` list + `--repo` case (mirrors the existing repeatable `--package` option); threaded into both harvest calls; usage text.
- `tools/DecompilerHarness/README.md` — documents `--repo` in the harvest section.

## Evidence

- `dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release` — clean (0 warnings/errors).
- `--help` shows `--repo`; parser accepts it.
- End-to-end harvest run through the new `repositoryPaths` path resolved a real row with a github raw `sourceUrl`; the local-repo provider correctly declined a non-matching repo and fell back to the network (the merged, adversarially-reviewed provider in `LocalRepoSourceAcquisition` and its Services unit tests already cover the blob-read + checksum arbitration).

## Risk

Low / mechanical: harness-only (no product-path behavior change), no new heuristics or shapes, and it forwards an already-merged, already-adversarially-reviewed capability. Default behavior is unchanged when `--repo` is omitted (empty list → network as before). No adversarial review requested per AGENTS.md.
