### PR TITLE
Render target-typed new() when the LHS target type equals the constructed type (#3058)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CollectionExpressionFrontierTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CollectionExpressionFrontierTests.cs
@@ -93,7 +93,8 @@ public class CollectionExpressionFrontierTests
         Assert.Contains(function.Descendants.OfType<Call>(), call => call.Callee.Name == "AddRange");
 
         var output = Print(nameof(CfgSampleClass.CollectionWithCapacity));
-        Assert.Contains("new List<string>(values.Count * 2)", output);
+        Assert.Contains("List<string>", output);
+        Assert.Contains("= new(values.Count * 2)", output);
         Assert.Contains(".AddRange(", output);
         Assert.DoesNotContain("[with", output);
     }

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2120,13 +2120,14 @@ public class RaisingPassTests
     public void StructConstructor_InPlaceCtor_PrintsNewObject()
     {
         // The in-place struct .ctor (ldloca; call S::.ctor) must print as an
-        // assignment of a fresh value, never the illegal handler..ctor(...).
+        // assignment of a fresh value, never the illegal handler..ctor(...). The
+        // type is apparent on the declaration, so the creation renders target-typed.
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
         var result = CSharpPrinter.Print(RunThroughStructConstructor(nameof(CfgSampleClass.InterpolatedStruct), source));
         Assert.True(result.Succeeded);
         string output = result.Output!.ReplaceLineEndings("\n").TrimEnd();
 
-        Assert.Contains("new DefaultInterpolatedStringHandler(", output);
+        Assert.Contains("DefaultInterpolatedStringHandler V_0 = new(", output);
         Assert.DoesNotContain("..ctor", output);
     }
 
@@ -2170,7 +2171,7 @@ public class RaisingPassTests
         Assert.Equal(0, store.Index);
         var value = Assert.IsType<NewObject>(store.Value);
         Assert.Equal(ctor, value.Constructor);
-        Assert.Equal("Carrier V_0 = new Carrier(42);", CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").Trim());
+        Assert.Equal("Carrier V_0 = new(42);", CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").Trim());
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/LadderRung1GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung1GateTests.cs
@@ -107,7 +107,7 @@ public class LadderRung1GateTests
 
         // Object construction, property/method calls, Console.WriteLine, branch.
         var main = Body("Main");
-        Assert.Contains("new Program()", main);
+        Assert.Contains("Program program = new();", main);
         Assert.Contains("program.Greet(\"world\")", main);
         Assert.Contains("program.IsPositive(program.Count)", main);
         Assert.Contains("Console.WriteLine(", main);

--- a/src/ILInspector.Decompiler.Tests/RefStructLayoutFrontierTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RefStructLayoutFrontierTests.cs
@@ -29,7 +29,7 @@ public class RefStructLayoutFrontierTests
 
         Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
         Assert.Empty(function.Diagnostics);
-        Assert.Contains("SpanBackedView view = new SpanBackedView(span);", output);
+        Assert.Contains("SpanBackedView view = new(span);", output);
         Assert.Contains("return view.At(index) + view.Length;", output);
         Assert.DoesNotContain("IsByRefLike", output);
         Assert.DoesNotContain("/*", output);

--- a/src/ILInspector.Decompiler.Tests/TargetTypedNewFixtures.cs
+++ b/src/ILInspector.Decompiler.Tests/TargetTypedNewFixtures.cs
@@ -77,6 +77,26 @@ public class TargetTypedNewFixtures
     public int ArgumentPositionDeclines(int n)
         => Accept(new StringBuilder(n));
 
+    // Negative: a bare `object` target. `object o = new object()` is a valid
+    // target-typed-new, but the raw `object` target is indistinguishable at this seam
+    // from a `dynamic` place (which the IR erases to `object`), where `new()` is
+    // CS8752 — so all bare `System.Object` constructions decline. `new object()` has
+    // no type name to drop anyway.
+    public bool ObjectTargetDeclines()
+    {
+        object o = new object();
+        object p = new object();
+        return ReferenceEquals(o, p);
+    }
+
+    // Negative: a `dynamic` parameter reassignment. The signature spells `dynamic
+    // value`, but the IR store carries the erased `object` type; shortening to
+    // `value = new()` would be CS8752. The bare-object decline keeps `new object()`.
+    public void DynamicParamDeclines(dynamic value)
+    {
+        value = new object();
+    }
+
     static int Accept(StringBuilder builder) => builder.Length;
     static int Accept(object value) => value.GetHashCode();
 

--- a/src/ILInspector.Decompiler.Tests/TargetTypedNewFixtures.cs
+++ b/src/ILInspector.Decompiler.Tests/TargetTypedNewFixtures.cs
@@ -1,0 +1,90 @@
+namespace ILInspector.Decompiler.Tests;
+
+using System.Collections.Generic;
+using System.Text;
+
+// Fixtures for the target-typed `new()` rendering transform. Each method below is
+// decompiled by TargetTypedNewPassTests; the transform shortens `new T(args)` to
+// `new(args)` only when the contextual target type is exactly the constructed type.
+public class TargetTypedNewFixtures
+{
+    StringBuilder _builder = new StringBuilder();
+
+    // Positive: a local whose declared type is exactly the constructed type — the
+    // canonical `StringBuilder sb = new(n)` case.
+    public int LocalDeclaration(int n)
+    {
+        StringBuilder sb = new StringBuilder(n);
+        sb.Append('x');
+        return sb.Length;
+    }
+
+    // Positive: an instance field store whose field type equals the constructed
+    // type (reached through the assignment path).
+    public void FieldStore(int n)
+    {
+        _builder = new StringBuilder(n);
+    }
+
+    // Boundary: return positions are out of the v1 LHS-only scope, so these stay
+    // explicit (the transform never fires here yet).
+    public StringBuilder ReturnPosition(int n)
+    {
+        if (n > 0)
+            return new StringBuilder(n);
+        return new StringBuilder();
+    }
+
+    // Positive: a value-type construction (newobj on a struct) into a local of the
+    // same struct type.
+    public int StructLocal(int n)
+    {
+        Box box = new Box(n);
+        box.Bump();
+        return box.Value;
+    }
+
+    // Positive: an array element store whose element type equals the constructed
+    // type. A value-type element array (`stelem` carries the element token) exposes
+    // the real element target; a reference-type array's `stelem.ref` is untyped
+    // (object) and would soundly decline instead.
+    public void ElementStore(Box[] boxes, int n)
+    {
+        boxes[0] = new Box(n);
+    }
+
+    // Negative: the target is an interface the constructed type implements, not the
+    // constructed type itself — target-typed `new()` would bind the wrong type.
+    public int InterfaceTargetDeclines()
+    {
+        IList<int> list = new List<int>(4);
+        list.Add(1);
+        return list.Count;
+    }
+
+    // Negative: a rectangular array creation is modeled as a `newobj`, but its
+    // array type is never the target-typed-new form.
+    public int[,] MultiDimArrayDeclines(int n)
+    {
+        int[,] grid = new int[n, n];
+        grid[0, 0] = 1;
+        return grid;
+    }
+
+    // Negative: an argument position. Target-typed `new()` there would participate
+    // in overload resolution (Accept(StringBuilder) vs Accept(object)), so the
+    // explicit type must stay.
+    public int ArgumentPositionDeclines(int n)
+        => Accept(new StringBuilder(n));
+
+    static int Accept(StringBuilder builder) => builder.Length;
+    static int Accept(object value) => value.GetHashCode();
+
+    public struct Box
+    {
+        int _value;
+        public Box(int value) => _value = value;
+        public void Bump() => _value++;
+        public readonly int Value => _value;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/TargetTypedNewPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TargetTypedNewPassTests.cs
@@ -98,4 +98,83 @@ public class TargetTypedNewPassTests
 
         Assert.Contains("new StringBuilder(", output);
     }
+
+    [Fact]
+    public void BareObjectTarget_KeepsExplicitType()
+    {
+        // A bare `object` target admits target-typed `new()` in C#, but the raw
+        // `object` type is indistinguishable at this seam from a `dynamic` place
+        // (erased to `object`), where `new()` is CS8752 — so `new object()` stays
+        // explicit. Conservative and free: `new object()` has no type name to drop.
+        string output = PrintRaised(nameof(TargetTypedNewFixtures.ObjectTargetDeclines));
+
+        Assert.Contains("new object(", output);
+        Assert.DoesNotContain("= new(", output);
+    }
+
+    [Fact]
+    public void DynamicParameterTarget_KeepsExplicitType()
+    {
+        // A `dynamic` parameter is spelled `dynamic value` in the signature but the IR
+        // store carries the erased `object` type; shortening `value = new object()` to
+        // `value = new()` would be CS8752. The bare-object decline keeps it valid.
+        string output = PrintRaised(nameof(TargetTypedNewFixtures.DynamicParamDeclines));
+
+        Assert.Contains("new object(", output);
+        Assert.DoesNotContain("value = new()", output);
+    }
+
+    // A covariant / adversarial array element store: the `stelem` token (the value
+    // stored, here `Base`) is wider than the array expression's static element type
+    // (`Derived`). C# types `items[0] = new()` from the array's element type, so
+    // `new()` would bind `Derived` and construct `newobj Derived`, diverging from the
+    // `newobj Base` the IL performs. The element-store guard requires the array's
+    // static element type to equal the `stelem` token, so this declines and keeps the
+    // explicit `new Base()`. Not producible from C# source (it is CS0029), so the IR
+    // is built directly.
+    [Fact]
+    public void CovariantElementStore_TokenWiderThanArrayElement_KeepsExplicitType()
+    {
+        var baseType = TypeRef.Definition("synthetic", "N", "Base");
+        var derivedType = TypeRef.Definition("synthetic", "N", "Derived");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var derivedArray = TypeRef.SzArray(derivedType);
+
+        var ctor = new MethodRef(baseType, ".ctor", voidType, [], HasThis: true);
+        var store = new StoreElement(
+            baseType,                                     // stelem token: Base
+            new LoadArgument(1, "items", derivedArray),   // array static element: Derived
+            new Constant(0, intType),
+            new NewObject(ctor, []));
+
+        string output = RenderElementStore(store, derivedArray);
+
+        Assert.Contains("new Base(", output);
+        Assert.DoesNotContain("= new(", output);
+    }
+
+    static string RenderElementStore(StoreElement store, TypeRef arrayParameterType)
+    {
+        var block = new Block(0);
+        block.Add(store);
+        block.Add(new Return(null));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(
+            TypeRef.CoreLib("System", "Void"),
+            [new Parameter("items", arrayParameterType)],
+            HasThis: false,
+            GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.Definition("synthetic", "N", "Holder"), signature, [], container)
+        {
+            TypeShapes = new Dictionary<TypeRef, TypeShape>
+            {
+                [TypeRef.Definition("synthetic", "N", "Base")] = TypeShape.Reference,
+                [TypeRef.Definition("synthetic", "N", "Derived")] = TypeShape.Reference,
+            },
+        };
+
+        return CSharpPrinter.Print(function).Output!.Trim();
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/TargetTypedNewPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TargetTypedNewPassTests.cs
@@ -1,0 +1,101 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class TargetTypedNewPassTests
+{
+    static readonly ILInspector.Metadata.IAssemblyReferenceResolver RuntimeResolver =
+        TestAssemblyReferenceResolvers.RuntimeAssemblies();
+
+    static string PrintRaised(string methodName)
+    {
+        using var context = new MetadataContext(RuntimeResolver);
+        using var source = MetadataSource.Open(typeof(TargetTypedNewFixtures).Assembly.Location, null, RuntimeResolver, context);
+        var function = IrImporter.Import(source, typeof(TargetTypedNewFixtures).FullName!, methodName);
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(function!, method => IrImporter.Import(source, method));
+        Assert.True(result.Succeeded, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+        Assert.NotNull(result.Output);
+        return result.Output!.ReplaceLineEndings("\n").Trim();
+    }
+
+    [Fact]
+    public void LocalDeclaration_ShortensToTargetTypedNew()
+    {
+        string output = PrintRaised(nameof(TargetTypedNewFixtures.LocalDeclaration));
+
+        Assert.Contains("= new(", output);
+        Assert.DoesNotContain("new StringBuilder(", output);
+    }
+
+    [Fact]
+    public void FieldStore_ShortensToTargetTypedNew()
+    {
+        string output = PrintRaised(nameof(TargetTypedNewFixtures.FieldStore));
+
+        Assert.Contains("= new(", output);
+        Assert.DoesNotContain("new StringBuilder(", output);
+    }
+
+    [Fact]
+    public void ReturnPosition_KeepsExplicitType_OutOfScopeForNow()
+    {
+        // Return positions are intentionally out of the v1 LHS-only scope: the type
+        // is apparent from the signature but not on an assignment target, so the
+        // explicit spelling is kept until a follow-up extends the transform there.
+        string output = PrintRaised(nameof(TargetTypedNewFixtures.ReturnPosition));
+
+        Assert.Contains("return new StringBuilder(", output);
+        Assert.DoesNotContain("return new(", output);
+    }
+
+    [Fact]
+    public void StructLocal_ShortensToTargetTypedNew()
+    {
+        string output = PrintRaised(nameof(TargetTypedNewFixtures.StructLocal));
+
+        Assert.Contains("= new(", output);
+        Assert.DoesNotContain("new Box(", output);
+    }
+
+    [Fact]
+    public void ArrayElementStore_ShortensToTargetTypedNew()
+    {
+        string output = PrintRaised(nameof(TargetTypedNewFixtures.ElementStore));
+
+        Assert.Contains("] = new(", output);
+        Assert.DoesNotContain("new Box(", output);
+    }
+
+    [Fact]
+    public void InterfaceTarget_KeepsExplicitType()
+    {
+        // Target IList<int> is not the constructed List<int>, so `new()` would bind
+        // the wrong type — the explicit spelling must stay.
+        string output = PrintRaised(nameof(TargetTypedNewFixtures.InterfaceTargetDeclines));
+
+        Assert.Contains("new List<int>(", output);
+        Assert.DoesNotContain("= new(", output);
+    }
+
+    [Fact]
+    public void MultiDimArray_KeepsArrayCreation()
+    {
+        // A rectangular-array `newobj` has no target-typed-new form.
+        string output = PrintRaised(nameof(TargetTypedNewFixtures.MultiDimArrayDeclines));
+
+        Assert.Contains("new int[", output);
+        Assert.DoesNotContain("= new(", output);
+    }
+
+    [Fact]
+    public void ArgumentPosition_KeepsExplicitType()
+    {
+        // An argument-position `new()` would participate in overload resolution; the
+        // transform never fires there.
+        string output = PrintRaised(nameof(TargetTypedNewFixtures.ArgumentPositionDeclines));
+
+        Assert.Contains("new StringBuilder(", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2179,7 +2179,7 @@ public sealed partial class CSharpPrinter
             ? $"{TypeText(s.Type)} {LocalName(s.Index)} = ref {Deref(s.Value)};"
             : $"{LocalName(s.Index)} = ref {Deref(s.Value)};",
         StoreLocal s => _declaringStores.Contains(s)
-            ? $"{DeclarationTypeText(s.Type, s.Value)} {LocalName(s.Index)} = {CoerceText(s.Value, s.Type)};"
+            ? $"{DeclarationTypeText(s.Type, s.Value)} {LocalName(s.Index)} = {InitializerText(s.Value, s.Type)};"
             : AssignmentText($"{LocalName(s.Index)}", s.Value, left => left is LoadLocal load && load.Index == s.Index, s.Type),
         DeconstructionAssignment d => $"({string.Join(", ", d.Targets.Select(DeconstructionTargetText))}) = {Expression(d.Source)};",
         ChainedAssignment c => $"{string.Join(" = ", c.Targets.Select(ChainedAssignmentTargetText))} = {CoerceText(c.Value, c.InnermostTargetType)};",
@@ -2193,7 +2193,7 @@ public sealed partial class CSharpPrinter
             ? $"{TypeText(refType)} {StackSlotName(s)} = ref {Deref(s.Value)};"
             : $"{StackSlotName(s)} = ref {Deref(s.Value)};",
         StoreStackSlot s => _declaringStores.Contains(s)
-            ? $"{DeclarationTypeText(StackSlotTargetType(s)!, s.Value)} {StackSlotName(s)} = {CoerceText(s.Value, StackSlotTargetType(s))};"
+            ? $"{DeclarationTypeText(StackSlotTargetType(s)!, s.Value)} {StackSlotName(s)} = {InitializerText(s.Value, StackSlotTargetType(s))};"
             : AssignmentText(StackSlotName(s), s.Value, left => left is LoadStackSlot load && StackSlotName(load) == StackSlotName(s), StackSlotTargetType(s)),
         StoreField s => AssignmentText(
             FieldTarget(s.Field, s.Instance), s.Value,
@@ -2213,7 +2213,7 @@ public sealed partial class CSharpPrinter
             StorePropertyTargetType(s)),
         EventSubscription e => $"{PropertyTarget(e.Accessor, e.HasInstance ? e.Instance : null, [], e.EventName, e.IsVirtual)} {(e.IsAdd ? "+=" : "-=")} {CoerceText(e.Value, e.Accessor.ParameterTypes[0])};",
         StoreElement s when InlineReceiverTempStoreValue(s) is { } value => $"{Operand(s.Array)}[{ArrayIndexText(s.Index)}] = {value};",
-        StoreElement s => $"{Operand(s.Array)}[{ArrayIndexText(s.Index)}] = {CoerceText(s.Value, StoreElementTargetType(s))};",
+        StoreElement s => $"{Operand(s.Array)}[{ArrayIndexText(s.Index)}] = {InitializerText(s.Value, StoreElementTargetType(s))};",
         StoreIndirect s => AssignmentText(
             IndirectTarget(s.Address, IndirectStoreType(s.Address, s.Type)),
             s.Value,
@@ -3684,6 +3684,67 @@ public sealed partial class CSharpPrinter
             : $"return {CoerceText(value, _function.Signature.ReturnType)};";
 
     /// <summary>
+    /// Renders the initializer for a place whose static type is <paramref name="target"/>:
+    /// a target-typed object creation (<c>new(args)</c>) when the value is a plain
+    /// <c>new T(args)</c> whose constructed type is exactly the target, otherwise the
+    /// ordinary coerced spelling. Reached only from single-target assignment/declaration
+    /// positions (local/field/property/stack-slot/indirect store, array-element store)
+    /// where the C# target type is unambiguous — never from a call argument, where a
+    /// target-typed <c>new</c> would participate in overload resolution and could change
+    /// binding. Return positions are intentionally out of scope for now.
+    /// </summary>
+    string InitializerText(IrExpression value, TypeRef? target)
+        => TargetTypedNewText(value, target) ?? CoerceText(value, target);
+
+    /// <summary>
+    /// Target-typed object creation: <c>T x = new T(args)</c> shortens to
+    /// <c>T x = new(args)</c> when the contextual target type is exactly the
+    /// constructed type. IL-identical — the target type fixes the constructed type
+    /// and therefore the constructor overload set, so both spellings emit the same
+    /// <c>newobj T::.ctor(args)</c> — and matches dotnet/runtime's editorconfig
+    /// (<c>csharp_style_implicit_object_creation_when_type_is_apparent</c>). Returns
+    /// null (keep the explicit spelling) unless the value is a plain object creation
+    /// whose type Equals the target: arrays (incl. multi-dimensional, modeled as
+    /// <see cref="NewObject"/>), object/collection initializers (a separate node),
+    /// tuple and nullable targets, and any base/interface/other target all decline.
+    /// </summary>
+    string? TargetTypedNewText(IrExpression value, TypeRef? target)
+    {
+        if (target is null
+            || value is not NewObject creation
+            || MultiDimArrayCreationText(creation) is not null
+            || !IsTargetTypedNewEligible(target)
+            || !target.Equals(creation.Constructor.DeclaringType))
+        {
+            return null;
+        }
+
+        return $"new({Arguments(creation.Arguments, creation.Constructor.ParameterTypes, creation.Constructor.ParameterRefKinds)})";
+    }
+
+    /// <summary>
+    /// A target type admits target-typed <c>new</c> only when it is spelled as a plain
+    /// constructible type name: a class or struct definition, or a generic instance
+    /// that is not <see cref="Nullable{T}"/> (spelled <c>T?</c>) or a
+    /// <c>ValueTuple</c> (spelled as a tuple). Pointers, by-refs, arrays, function
+    /// pointers, and open generic parameters are all excluded by the kind filter.
+    /// </summary>
+    static bool IsTargetTypedNewEligible(TypeRef target) => target.Kind switch
+    {
+        TypeRefKind.Definition => !IsNullableDefinition(target),
+        TypeRefKind.GenericInstance => !TypeFamilies.IsNullableType(target) && !IsValueTupleType(target),
+        _ => false,
+    };
+
+    static bool IsValueTupleType(TypeRef type)
+        => type is
+        {
+            Kind: TypeRefKind.GenericInstance,
+            ElementType: { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" } element,
+        }
+        && element.Name.StartsWith("ValueTuple`", StringComparison.Ordinal);
+
+    /// <summary>
     /// Assignment spelling with compound/increment sugar: when the value is
     /// an unchecked binary whose left operand reads the assignment target,
     /// the runtime style is x++/x-- for ±1 and x op= rest otherwise.
@@ -3702,7 +3763,7 @@ public sealed partial class CSharpPrinter
             // overflow-honoring operators ever carry IsChecked here.
             return binary.IsChecked ? $"checked {{ {statement} }}" : statement;
         }
-        return $"{target} = {CoerceText(value, targetType)};";
+        return $"{target} = {InitializerText(value, targetType)};";
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2213,7 +2213,7 @@ public sealed partial class CSharpPrinter
             StorePropertyTargetType(s)),
         EventSubscription e => $"{PropertyTarget(e.Accessor, e.HasInstance ? e.Instance : null, [], e.EventName, e.IsVirtual)} {(e.IsAdd ? "+=" : "-=")} {CoerceText(e.Value, e.Accessor.ParameterTypes[0])};",
         StoreElement s when InlineReceiverTempStoreValue(s) is { } value => $"{Operand(s.Array)}[{ArrayIndexText(s.Index)}] = {value};",
-        StoreElement s => $"{Operand(s.Array)}[{ArrayIndexText(s.Index)}] = {InitializerText(s.Value, StoreElementTargetType(s))};",
+        StoreElement s => $"{Operand(s.Array)}[{ArrayIndexText(s.Index)}] = {InitializerText(s.Value, StoreElementTargetType(s), StoreElementNewTarget(s))};",
         StoreIndirect s => AssignmentText(
             IndirectTarget(s.Address, IndirectStoreType(s.Address, s.Type)),
             s.Value,
@@ -2298,6 +2298,27 @@ public sealed partial class CSharpPrinter
     // non-primitive definition), matching `Coerce`'s enum-cast reasoning.
     TypeRef? StoreElementTargetType(StoreElement store)
         => CoercionSinks.StoreElementTarget(store, _function.TypeShapes);
+
+    /// <summary>
+    /// The type C# binds a target-typed <c>new()</c> to at an array element store —
+    /// the array expression's static element type, which is what <c>a[i] = new()</c>
+    /// constructs. Offered only when that element type is exactly the coercion target
+    /// (<see cref="StoreElementTargetType"/>): a <c>stelem.ref</c> erases its token to
+    /// <c>object</c>, and a covariant <c>stelem</c> token can be wider than the
+    /// array's static element type, so when they disagree the exact-type-equality
+    /// guard would not reflect the constructed type — decline (return null) and keep
+    /// the explicit spelling. Never widens the reviewed firing set: value-type element
+    /// arrays (token == element) still fire, reference-type arrays still decline.
+    /// </summary>
+    TypeRef? StoreElementNewTarget(StoreElement store)
+    {
+        var coercionTarget = StoreElementTargetType(store);
+        return store.Array.ResultType is { Kind: TypeRefKind.SzArray or TypeRefKind.Array, ElementType: { } element }
+            && coercionTarget is not null
+            && element.Equals(coercionTarget)
+            ? coercionTarget
+            : null;
+    }
 
     /// <summary>
     /// The C# text for a single-dimension array element index. C# implicitly
@@ -3694,7 +3715,18 @@ public sealed partial class CSharpPrinter
     /// binding. Return positions are intentionally out of scope for now.
     /// </summary>
     string InitializerText(IrExpression value, TypeRef? target)
-        => TargetTypedNewText(value, target) ?? CoerceText(value, target);
+        => InitializerText(value, target, target);
+
+    /// <summary>
+    /// Initializer spelling where the type C# binds a target-typed <c>new()</c> to
+    /// (<paramref name="newTarget"/>) can differ from the coercion target
+    /// (<paramref name="coercionTarget"/>). They differ only for an array element
+    /// store: <c>a[i] = new()</c> binds to the array's static element type, while the
+    /// coercion runs through the (possibly wider or <c>stelem.ref</c>-erased)
+    /// <c>stelem</c> token. Every other site passes the same type for both.
+    /// </summary>
+    string InitializerText(IrExpression value, TypeRef? coercionTarget, TypeRef? newTarget)
+        => TargetTypedNewText(value, newTarget) ?? CoerceText(value, coercionTarget);
 
     /// <summary>
     /// Target-typed object creation: <c>T x = new T(args)</c> shortens to
@@ -3707,12 +3739,17 @@ public sealed partial class CSharpPrinter
     /// whose type Equals the target: arrays (incl. multi-dimensional, modeled as
     /// <see cref="NewObject"/>), object/collection initializers (a separate node),
     /// tuple and nullable targets, and any base/interface/other target all decline.
+    /// A bare <c>System.Object</c> target also declines: the target type may be a
+    /// <c>dynamic</c> place (erased to <c>object</c> in the IR), and target-typed
+    /// <c>new()</c> is illegal for a <c>dynamic</c> target (CS8752); <c>new object()</c>
+    /// carries no type name to drop anyway, so the conservative decline costs nothing.
     /// </summary>
     string? TargetTypedNewText(IrExpression value, TypeRef? target)
     {
         if (target is null
             || value is not NewObject creation
             || MultiDimArrayCreationText(creation) is not null
+            || IsSystemObjectType(creation.Constructor.DeclaringType)
             || !IsTargetTypedNewEligible(target)
             || !target.Equals(creation.Constructor.DeclaringType))
         {
@@ -3721,6 +3758,15 @@ public sealed partial class CSharpPrinter
 
         return $"new({Arguments(creation.Arguments, creation.Constructor.ParameterTypes, creation.Constructor.ParameterRefKinds)})";
     }
+
+    /// <summary>
+    /// The bare <c>System.Object</c> type, by name — assembly-agnostic so a facade or
+    /// spoofed core-library scope still matches. Used to decline target-typed
+    /// <c>new()</c> for an <c>object</c>/<c>dynamic</c> target (see
+    /// <see cref="TargetTypedNewText"/>).
+    /// </summary>
+    static bool IsSystemObjectType(TypeRef type)
+        => type is { Kind: TypeRefKind.Definition, Namespace: "System", Name: "Object" };
 
     /// <summary>
     /// A target type admits target-typed <c>new</c> only when it is spelled as a plain


### PR DESCRIPTION
- Fixes #3058
- Changes decompiler rendering: at LHS assignment/declaration sites, render
  target-typed `T x = new(args)` when the target type equals the constructed
  type (was always the explicit `T x = new T(args)`).
- Card revision: `a98b974b`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — class-3 taste transform, IL-identical by
construction (exact target/constructed-type equality fixes the overload set and
the emitted `newobj` token), scoped to LHS positions so it never touches
overload-resolving call-argument positions; a corpus blast-radius read shows
100% of changes are exactly the intended shortening with zero collateral.

### Original source

The authored C# that compiles to the IL under decompilation
(`ILInspector.CSharp.CSharpDeclarationWriter.EscapeReservedKeywordIdentifiers`):

```csharp
static string EscapeReservedKeywordIdentifiers(string text)
{
    var sb = new StringBuilder(text.Length);
    for (int i = 0; i < text.Length;)
    {
        if (IsIdentifierStart(text[i]))
        {
            int start = i++;
            while (i < text.Length && IsIdentifierPart(text[i]))
                i++;
            string token = text[start..i];
            bool alreadyEscaped = start > 0 && text[start - 1] == '@';
            sb.Append(!alreadyEscaped && CSharpKeywords.RequiresDeclarationEscape(token) ? EscapeIdentifier(token) : token);
            continue;
        }
        sb.Append(text[i++]);
    }
    return sb.ToString();
}
```

The author expressed "the type is apparent" as **`var sb = new StringBuilder(text.Length)`** —
`var` on the left, explicit `new StringBuilder` on the right. IL does not preserve `var`,
so the decompiler always spells the local's type explicitly (`StringBuilder sb = ...`).
With the type now on the **left**, the equivalent "type is apparent" idiom is a
target-typed `new(text.Length)` on the right — the same C# preference
(`csharp_style_implicit_object_creation_when_type_is_apparent`), mirrored.

### Before

`dotnet-inspect` decompiled body at base `ca3f09a8` (harness `--lowered`). The decompiler
spells the explicit local type and lowers the authored `for` to a `while`; the constructor
is the fully-explicit `new StringBuilder(text.Length)`:

```csharp
// ILInspector.CSharp.CSharpDeclarationWriter::EscapeReservedKeywordIdentifiers
StringBuilder sb = new StringBuilder(text.Length);
int i = 0;
while (i < text.Length)
{
    // ...identifier-run escaping, appended to sb...
}
return sb.ToString();
```

- Valid: True
- Correct: True

Valid-but-different: with the explicit `StringBuilder sb` type on the LHS,
`new StringBuilder(text.Length)` is idiomatically written `new(text.Length)` — the same
intent the author expressed with `var`.

### After

`dotnet-inspect` decompiled body at head `a98b974b` (harness `--lowered`). Only the
constructor spelling changes; the body is otherwise identical to Before:

```csharp
// ILInspector.CSharp.CSharpDeclarationWriter::EscapeReservedKeywordIdentifiers
StringBuilder sb = new(text.Length);
int i = 0;
while (i < text.Length)
{
    // ...identifier-run escaping, appended to sb...
}
return sb.ToString();
```

- Valid: True
- Correct: True

The decompiled declaration now matches how the author expressed the same "type is apparent"
intent: authored `var sb = new StringBuilder(...)` ⇔ decompiled `StringBuilder sb = new(...)`.

### Target-typed `new()` fully applied (body otherwise unchanged)

This is a render-stage transform, not a raising pass, so this section is scoped
to the transform — **not** a claim that the whole body is fully raised. The After
body is the same decompiled C# as Before with exactly one change: the LHS
`new StringBuilder(text.Length)` is shortened to `new(text.Length)`. No further
target-typed-`new()` shortening is possible at this site; return-position and
call-argument-position `new()` are intentionally out of scope (they participate
in overload resolution) and are tracked as follow-up in #3058.

The surrounding body is **not** otherwise fully raised, and this PR does not try
to raise it. The `--lowered` view shown above deliberately omits the cosmetic
`for`/`++`/`lock` sugar passes (so the authored `for` shows as `while`), and even
the shipped view still carries unrelated lowering residue — synthetic
temporaries, hoisted declarations, and an un-raised range indexer (authored
`text[start..i]` renders as `text.Substring(...)`). Those belong to other passes
and are out of scope here.

## Change details

`InitializerText(value, target) => TargetTypedNewText(value, target) ?? CoerceText(value, target)`.
`TargetTypedNewText` returns `new(args)` only when the value is a plain
`NewObject` whose constructor's declaring type `Equals` the contextual target
type, the target is a constructible definition/generic-instance (not
`Nullable<T>`, not `ValueTuple`, not a multi-dim array), and the creation is not
a rectangular-array `newobj`.

Hook sites (LHS only): declaring `StoreLocal`, declaring `StoreStackSlot`,
typed-`stelem` `StoreElement`, and the `AssignmentText` tail. The general
`CoerceText` helper is deliberately **not** hooked, because a target-typed
`new()` in a **call-argument** position participates in overload resolution and
could change binding. Return positions are excluded for v1 (kept explicit) to
honor the LHS scope and preserve two type-name regression guards.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build (decompiler + harness) | Pass | Pass |
| Focused tests `TargetTypedNewPassTests` | n/a (new) | 8 passed |
| Snapshot classes (`RaisingPassTests`, `RefStructLayoutFrontierTests`, `KeywordIdentifierTests`) | 133 passed | 133 passed |
| Real witness `CSharpDeclarationWriter::EscapeReservedKeywordIdentifiers` | `new StringBuilder(text.Length)` | `new(text.Length)` |
| Compile-back fidelity | environmental-red locally (CS0009 aspnetcorev2) — see below | Linux CI backstop |

Compile-back / fidelity tests fail wholesale on this Windows box with CS0009 on
a native `aspnetcorev2_inprocess.dll` pulled into Roslyn references (a
pre-existing environmental issue, identical on Baseline); the recompile /
opcode-exact corpus fidelity is validated by Linux CI as with #3042.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — presentation-only render-stage change; it does not
touch raising/structuring, so lowering/branch residue and fully-raised counts
are unchanged. The relevant corpus signal is the blast-radius read below.

### Blast-radius read (printer-level equivalent of `--pass-impact`)

`--pass-impact` measures registered IR **passes**; this is a render-stage
(printer) change with no pass, so the equivalent is a baseline-vs-head corpus
render diff. Rendered the first 8000 methods of `System.Private.CoreLib`
(5866 with output) with and without the printer change (stash printer-only for
baseline):

| Metric | Value |
| --- | ---: |
| Methods rendered | 5866 |
| Methods changed | 229 (3.90%) |
| Lines changed | 357 |
| Changed lines that are exactly outer `new T(...)` -> `new(...)` (LHS) | 357 / 357 (100%) |
| Collateral (non-transform) changes | 0 |

Every changed line is the intended target-typed shortening. Lines containing an
inner argument-position `new` confirm the argument-position decline — only the
outer LHS `new` shortens, the inner is untouched, e.g.
`new Guid(new ReadOnlySpan<Guid>(this))` -> `new(new ReadOnlySpan<Guid>(this))`.

## Validation

```bash
dotnet build src/ILInspector.Decompiler.Tests -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.TargetTypedNewPassTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.RaisingPassTests -class ILInspector.Decompiler.Tests.RefStructLayoutFrontierTests -class ILInspector.Decompiler.Tests.KeywordIdentifierTests
```


