### PR TITLE
Cast enum shift operand to underlying integer (#3011)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5123,6 +5123,32 @@ public static class EnumCastSamples
 
     public static int IntEnumRightShift(CfgPriority flags, int n) => (int)flags >> n;
 
+    // #3011 (review): the source may reinterpret the enum to the opposite-signedness
+    // same-width integer before shifting — an IL no-op — so the shift opcode
+    // (shr vs shr.un), not the enum backing, records the real signedness. An
+    // int-backed enum shifted as `(uint)e >> n` emits shr.un; a uint-backed enum
+    // shifted as `(int)e >> n` emits shr. The printed cast must follow the opcode.
+    public static uint IntEnumUnsignedRightShift(CfgPriority flags, int n) => (uint)flags >> n;
+
+    public static int UIntEnumSignedRightShift(CfgFlags flags, int n) => (int)flags >> n;
+
+    // #3011 (review): a compound shift on an enum lvalue (`flags <<= n`) is also
+    // CS0019. An int-backed enum shifted and stored back to itself folds to a
+    // compound with a bare enum left operand; the printer must decompose it to a
+    // plain cast-back assignment. The unsigned variant confirms the decomposed
+    // left-operand cast follows the shr.un opcode, not the enum backing.
+    public static CfgPriority IntEnumCompoundLeftShift(CfgPriority flags, int n)
+    {
+        flags = (CfgPriority)((int)flags << n);
+        return flags;
+    }
+
+    public static CfgPriority IntEnumCompoundUnsignedRightShift(CfgPriority flags, int n)
+    {
+        flags = (CfgPriority)((uint)flags >> n);
+        return flags;
+    }
+
     // #1766: ternary with enum-constant arms stored to a cross-assembly enum
     // local (StringComparison.Ordinal = 4, OrdinalIgnoreCase = 5).
     public static bool EnumConditional(string name, bool ci)

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5104,6 +5104,25 @@ public static class UserGridCalls
 // must cast structurally.
 public static class EnumCastSamples
 {
+    // #3011: an enum-typed value shifted (`>>`/`<<`) has no predefined C# shift
+    // operator (CS0019), though the IL shifts the enum's underlying integer. The
+    // identity `(long)`/`(uint)`/`(ulong)` cast the source carried leaves no IL
+    // trace, so the importer sees a bare enum-typed shift left operand; the printer
+    // must re-insert the underlying-integer cast. Witness: MySqlConnector's
+    // HandshakeResponse41Payload.CreateCapabilitiesPayload — `(int)(clientCapabilities >> 32)`
+    // on a long-backed [Flags] enum. Same-assembly enums with a known backing width.
+    public static long LongEnumRightShift(CfgLongPriority flags, int n) => (long)flags >> n;
+
+    public static long LongEnumLeftShift(CfgLongPriority flags, int n) => (long)flags << n;
+
+    public static int LongEnumRightShiftToInt(CfgLongPriority flags) => (int)((long)flags >> 32);
+
+    public static ulong ULongEnumRightShift(CfgULong flags, int n) => (ulong)flags >> n;
+
+    public static uint UIntEnumRightShift(CfgFlags flags, int n) => (uint)flags >> n;
+
+    public static int IntEnumRightShift(CfgPriority flags, int n) => (int)flags >> n;
+
     // #1766: ternary with enum-constant arms stored to a cross-assembly enum
     // local (StringComparison.Ordinal = 4, OrdinalIgnoreCase = 5).
     public static bool EnumConditional(string name, bool ci)

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5149,6 +5149,21 @@ public static class EnumCastSamples
         return flags;
     }
 
+    // #3011 (review): a typed `ldelem.i4`/`ldind.i4` over an enum array or by-ref
+    // loads the enum's primitive storage width, so the shift operand's stack type
+    // is the primitive even though the rendered expression (`values[i]`, `e`) is
+    // enum-typed and rejects a bare shift (CS0019). The printer must recover the
+    // enum from the array element / pointee type and force the reinterpret cast.
+    public static int IntEnumArrayRightShift(CfgPriority[] values, int i, int n) => (int)values[i] >> n;
+
+    public static int IntEnumArrayLeftShift(CfgPriority[] values, int i, int n) => (int)values[i] << n;
+
+    public static long LongEnumArrayRightShift(CfgLongPriority[] values, int i, int n) => (long)values[i] >> n;
+
+    public static uint IntEnumArrayUnsignedRightShift(CfgPriority[] values, int i, int n) => (uint)values[i] >> n;
+
+    public static int RefIntEnumLeftShift(ref CfgPriority e, int n) => (int)e << n;
+
     // #1766: ternary with enum-constant arms stored to a cross-assembly enum
     // local (StringComparison.Ordinal = 4, OrdinalIgnoreCase = 5).
     public static bool EnumConditional(string name, bool ci)

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -12,6 +12,131 @@ namespace ILInspector.Decompiler.Tests;
 // cast the integer to the enum structurally.
 public class EnumCastPrinterTests
 {
+    // #3011: an enum-typed value shifted has no predefined C# shift operator
+    // (CS0019); the printer reinterprets the enum left operand to its underlying
+    // integer so the shift type-checks and the shr/shr.un opcode round-trips.
+    [Fact]
+    public void EnumRightShift_LongBackedEnum_CastsLeftOperandToUnderlying()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.LongEnumRightShift));
+
+        Assert.Contains("(long)flags >>", body);
+        Assert.DoesNotContain(" flags >>", body);
+        AssertCompiles("public static long M(CfgLongPriority flags, int n)", body, "public enum CfgLongPriority : long { Low = 0, High = 2 }");
+    }
+
+    [Fact]
+    public void EnumLeftShift_LongBackedEnum_CastsLeftOperandToUnderlying()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.LongEnumLeftShift));
+
+        Assert.Contains("(long)flags <<", body);
+        AssertCompiles("public static long M(CfgLongPriority flags, int n)", body, "public enum CfgLongPriority : long { Low = 0, High = 2 }");
+    }
+
+    [Fact]
+    public void EnumRightShiftToInt_LongBackedEnum_MirrorsWitness()
+    {
+        // The reported MySqlConnector shape: `(int)((long)clientCapabilities >> 32)`.
+        string body = RenderFixture(nameof(EnumCastSamples.LongEnumRightShiftToInt));
+
+        Assert.Contains("(long)flags >> 32", body);
+        AssertCompiles("public static int M(CfgLongPriority flags)", body, "public enum CfgLongPriority : long { Low = 0, High = 2 }");
+    }
+
+    [Fact]
+    public void EnumRightShift_ULongBackedEnum_KeepsUnsignedShiftFaithful()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.ULongEnumRightShift));
+
+        Assert.Contains("(ulong)flags >>", body);
+        AssertCompiles("public static ulong M(CfgULong flags, int n)", body, "public enum CfgULong : ulong { None = 0, All = 18446744073709551615UL }");
+    }
+
+    [Fact]
+    public void EnumRightShift_UIntBackedEnum_KeepsUnsignedShiftFaithful()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.UIntEnumRightShift));
+
+        Assert.Contains("(uint)flags >>", body);
+        AssertCompiles("public static uint M(CfgFlags flags, int n)", body, "public enum CfgFlags : uint { None = 0, Top = 0x80000000u }");
+    }
+
+    [Fact]
+    public void EnumRightShift_IntBackedEnum_CastsToUnderlying()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.IntEnumRightShift));
+
+        Assert.Contains("(int)flags >>", body);
+        Assert.DoesNotContain(" flags >>", body);
+        AssertCompiles("public static int M(CfgPriority flags, int n)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    // A sub-int (byte) backing promotes to int in a C# shift; the underlying-type
+    // cast still type-checks and stays opcode-exact. Synthetic to keep the enum
+    // load a bare operand (a compiled `(byte)` narrowing could add a conv node).
+    [Fact]
+    public void EnumLeftShift_ByteBackedEnum_CastsToUnderlying()
+    {
+        var enumType = TypeRef.Definition("test", "", "CfgTiny");
+        var byteType = TypeRef.CoreLib("System", "Byte");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var shift = new Binary(
+            BinaryKind.ShiftLeft,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadArgument(0, "flags", enumType),
+            new LoadArgument(1, "n", intType));
+        var block = new Block(0);
+        block.Add(new Return(shift));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(
+            intType,
+            [new Parameter("flags", enumType), new Parameter("n", intType)],
+            HasThis: false,
+            GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.Definition("test", "", "Holder"), signature, [], container)
+        {
+            TypeShapes = new Dictionary<TypeRef, TypeShape> { [enumType] = TypeShape.Enum },
+            EnumUnderlyingTypes = new Dictionary<TypeRef, TypeRef> { [enumType] = byteType },
+        };
+
+        string body = CSharpPrinter.Print(function).Output!.Trim();
+
+        Assert.Contains("(byte)flags << n", body);
+        AssertCompiles("public static int M(CfgTiny flags, int n)", body, "public enum CfgTiny : byte { A = 1, B = 2 }");
+    }
+
+    // Close negative: a plain (non-enum) integer shift keeps its bare operands —
+    // the enum branch must not perturb ordinary shifts.
+    [Fact]
+    public void IntegerShift_NonEnum_KeepsBareOperands()
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var shift = new Binary(
+            BinaryKind.ShiftRight,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadArgument(0, "x", intType),
+            new LoadArgument(1, "n", intType));
+        var block = new Block(0);
+        block.Add(new Return(shift));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(
+            intType,
+            [new Parameter("x", intType), new Parameter("n", intType)],
+            HasThis: false,
+            GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.Definition("test", "", "Holder"), signature, [], container);
+
+        string body = CSharpPrinter.Print(function).Output!.Trim();
+
+        Assert.Contains("x >> n", body);
+        Assert.DoesNotContain("(int)x", body);
+    }
+
     [Fact]
     public void EnumConstantConditionalArms_IntoCrossAssemblyEnum_CastsEachArm()
     {

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -72,11 +72,63 @@ public class EnumCastPrinterTests
         AssertCompiles("public static int M(CfgPriority flags, int n)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
     }
 
-    // A sub-int (byte) backing promotes to int in a C# shift; the underlying-type
-    // cast still type-checks and stays opcode-exact. Synthetic to keep the enum
-    // load a bare operand (a compiled `(byte)` narrowing could add a conv node).
+    // The shift opcode's signedness, not the enum backing's, drives the cast: a
+    // same-width signedness reinterpret in the source leaves no IL trace, so the
+    // enum backing is a misleading signedness signal. shr.un on an int-backed enum
+    // must render `(uint)`, and shr on a uint-backed enum must render `(int)`,
+    // else the recompiled shift flips opcode and silently changes the result.
     [Fact]
-    public void EnumLeftShift_ByteBackedEnum_CastsToUnderlying()
+    public void EnumRightShift_IntBackedButUnsignedOpcode_CastsToUnsigned()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.IntEnumUnsignedRightShift));
+
+        Assert.Contains("(uint)flags >>", body);
+        Assert.DoesNotContain("(int)flags >>", body);
+        AssertCompiles("public static uint M(CfgPriority flags, int n)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    [Fact]
+    public void EnumRightShift_UIntBackedButSignedOpcode_CastsToSigned()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.UIntEnumSignedRightShift));
+
+        Assert.Contains("(int)flags >>", body);
+        Assert.DoesNotContain("(uint)flags >>", body);
+        AssertCompiles("public static int M(CfgFlags flags, int n)", body, "public enum CfgFlags : uint { None = 0, Top = 0x80000000u }");
+    }
+
+    // A compound shift on an enum lvalue (`flags <<= n`) is CS0019 just like the
+    // expression form: C# has no compound shift operator on an enum. The printer
+    // decomposes it to a plain assignment that reinterprets the enum and casts the
+    // shift result back — `flags = (CfgPriority)((int)flags << (n & 31))`.
+    [Fact]
+    public void EnumCompoundLeftShift_IntBackedEnum_DecomposesToCastBackAssignment()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.IntEnumCompoundLeftShift));
+
+        Assert.Contains("flags = (CfgPriority)((int)flags <<", body);
+        Assert.DoesNotContain("flags <<=", body);
+        AssertCompiles("public static CfgPriority M(CfgPriority flags, int n)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    // The decomposed compound's left-operand cast follows the shift opcode: an
+    // int-backed enum shifted as shr.un must reinterpret to `(uint)`, not `(int)`.
+    [Fact]
+    public void EnumCompoundRightShift_IntBackedButUnsignedOpcode_CastsToUnsigned()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.IntEnumCompoundUnsignedRightShift));
+
+        Assert.Contains("flags = (CfgPriority)((uint)flags >>", body);
+        Assert.DoesNotContain("flags >>=", body);
+        Assert.DoesNotContain("(int)flags >>", body);
+        AssertCompiles("public static CfgPriority M(CfgPriority flags, int n)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    // A sub-int (byte) backing promotes to int in a C# shift; the reinterpret
+    // targets the 4-byte width the shift runs on. Synthetic to keep the enum load
+    // a bare operand (a compiled `(byte)` narrowing could add a conv node).
+    [Fact]
+    public void EnumLeftShift_ByteBackedEnum_CastsToShiftWidth()
     {
         var enumType = TypeRef.Definition("test", "", "CfgTiny");
         var byteType = TypeRef.CoreLib("System", "Byte");
@@ -104,7 +156,7 @@ public class EnumCastPrinterTests
 
         string body = CSharpPrinter.Print(function).Output!.Trim();
 
-        Assert.Contains("(byte)flags << n", body);
+        Assert.Contains("(int)flags << n", body);
         AssertCompiles("public static int M(CfgTiny flags, int n)", body, "public enum CfgTiny : byte { A = 1, B = 2 }");
     }
 

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -22,6 +22,9 @@ public class EnumCastPrinterTests
 
         Assert.Contains("(long)flags >>", body);
         Assert.DoesNotContain(" flags >>", body);
+        // #3011 (review): the shift-count width mask is keyed off the enum backing
+        // (63 for the 8-byte underlying), so it strips instead of double-masking.
+        Assert.DoesNotContain("& 63", body);
         AssertCompiles("public static long M(CfgLongPriority flags, int n)", body, "public enum CfgLongPriority : long { Low = 0, High = 2 }");
     }
 
@@ -69,6 +72,9 @@ public class EnumCastPrinterTests
 
         Assert.Contains("(int)flags >>", body);
         Assert.DoesNotContain(" flags >>", body);
+        // The 4-byte backing masks the count by 31; keyed off the underlying it
+        // strips rather than re-spelling `n & 31` (which double-masks on recompile).
+        Assert.DoesNotContain("& 31", body);
         AssertCompiles("public static int M(CfgPriority flags, int n)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
     }
 
@@ -100,7 +106,7 @@ public class EnumCastPrinterTests
     // A compound shift on an enum lvalue (`flags <<= n`) is CS0019 just like the
     // expression form: C# has no compound shift operator on an enum. The printer
     // decomposes it to a plain assignment that reinterprets the enum and casts the
-    // shift result back — `flags = (CfgPriority)((int)flags << (n & 31))`.
+    // shift result back — `flags = (CfgPriority)((int)flags << n)`.
     [Fact]
     public void EnumCompoundLeftShift_IntBackedEnum_DecomposesToCastBackAssignment()
     {
@@ -108,6 +114,7 @@ public class EnumCastPrinterTests
 
         Assert.Contains("flags = (CfgPriority)((int)flags <<", body);
         Assert.DoesNotContain("flags <<=", body);
+        Assert.DoesNotContain("& 31", body);
         AssertCompiles("public static CfgPriority M(CfgPriority flags, int n)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
     }
 

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -131,6 +131,69 @@ public class EnumCastPrinterTests
         AssertCompiles("public static CfgPriority M(CfgPriority flags, int n)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
     }
 
+    // #3011 (review): a typed `ldelem.i4`/`ldind.i4` over an enum array or by-ref
+    // masks the operand's stack type as the primitive storage width, but the
+    // rendered `values[i]`/`e` is enum-typed and still rejects a bare shift. The
+    // printer recovers the enum from the array element / pointee type and forces
+    // the reinterpret cast (which `CoerceText` would drop as an int→int identity).
+    [Fact]
+    public void EnumArrayRightShift_IntBackedEnum_CastsElementToUnderlying()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.IntEnumArrayRightShift));
+
+        Assert.Contains("(int)values[i] >>", body);
+        Assert.DoesNotContain(" values[i] >>", body);
+        Assert.DoesNotContain("& 31", body);
+        AssertCompiles("public static int M(CfgPriority[] values, int i, int n)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    [Fact]
+    public void EnumArrayLeftShift_IntBackedEnum_CastsElementToUnderlying()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.IntEnumArrayLeftShift));
+
+        Assert.Contains("(int)values[i] <<", body);
+        Assert.DoesNotContain(" values[i] <<", body);
+        AssertCompiles("public static int M(CfgPriority[] values, int i, int n)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    // Width recovery for the array element: a long-backed enum array casts to long
+    // and strips the 6-bit (& 63) count mask, not the 5-bit int mask.
+    [Fact]
+    public void EnumArrayRightShift_LongBackedEnum_CastsElementToUnderlying()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.LongEnumArrayRightShift));
+
+        Assert.Contains("(long)values[i] >>", body);
+        Assert.DoesNotContain("& 63", body);
+        AssertCompiles("public static long M(CfgLongPriority[] values, int i, int n)", body, "public enum CfgLongPriority : long { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    // Signedness still follows the opcode for the recovered element cast: shr.un on
+    // an int-backed enum array reinterprets to `(uint)`, not the backing's `(int)`.
+    [Fact]
+    public void EnumArrayRightShift_IntBackedButUnsignedOpcode_CastsElementToUnsigned()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.IntEnumArrayUnsignedRightShift));
+
+        Assert.Contains("(uint)values[i] >>", body);
+        Assert.DoesNotContain("(int)values[i] >>", body);
+        AssertCompiles("public static uint M(CfgPriority[] values, int i, int n)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    // The by-ref sibling: a `ref` enum loaded through `ldind.i4` is masked as the
+    // primitive too, so the pointee-recovered cast reinterprets `e`.
+    [Fact]
+    public void RefEnumLeftShift_IntBackedEnum_CastsPointeeToUnderlying()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.RefIntEnumLeftShift));
+
+        Assert.Contains("(int)", body);
+        Assert.Contains("<<", body);
+        Assert.DoesNotContain(" e <<", body);
+        AssertCompiles("public static int M(ref CfgPriority e, int n)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
     // A sub-int (byte) backing promotes to int in a C# shift; the reinterpret
     // targets the 4-byte width the shift runs on. Synthetic to keep the enum load
     // a bare operand (a compiled `(byte)` narrowing could add a conv node).

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -355,20 +355,57 @@ public sealed partial class CSharpPrinter
     /// enum to the opposite-signedness same-width integer (<c>(uint)intEnum &gt;&gt; n</c>),
     /// an IL no-op that leaves no trace, so the shift opcode is the only faithful
     /// record of its signedness. Width comes from the backing — a width change would
-    /// leave a <c>conv</c> in the IL and the operand would not be a bare enum. The
-    /// cast runs through <see cref="CoerceText"/> (the one enum→integer door, shared
-    /// with the enum div/rem operands) so a signed→unsigned reinterpret inside a
-    /// <c>checked</c> region keeps its <c>unchecked</c> guard. A cross-assembly enum
-    /// whose backing width is unknown has no underlying type and is left alone.
+    /// leave a <c>conv</c> in the IL and the operand would not be a bare enum.
+    /// <para>
+    /// The enum type comes from the rendered spelling, not the stack
+    /// <c>ResultType</c>: a typed <c>ldelem.i4</c>/<c>ldind.i4</c> over an enum array
+    /// or by-ref masks the operand as its primitive storage width, yet the rendered
+    /// expression (<c>values[i]</c>, <c>e</c>) is still enum-typed and rejects a bare
+    /// shift. When the operand's own <c>ResultType</c> is the enum, the cast runs
+    /// through <see cref="CoerceText"/> (the one enum→integer door, shared with the
+    /// enum div/rem operands). When it is the masked primitive, CoerceText would see
+    /// an int→int identity and drop the cast, so the reinterpret is spelled directly
+    /// — with the same <c>checked</c>-region <c>unchecked</c> guard for a
+    /// sign-flipping cast. A cross-assembly enum whose backing width is unknown has
+    /// no underlying type and is left alone.
+    /// </para>
     /// </summary>
     string? ShiftEnumLeftOperand(IrExpression operand, bool isUnsigned)
     {
-        if (EnumUnderlyingType(operand.ResultType) is not { } underlying)
+        if (ShiftLeftEnumType(operand) is not { } enumType
+            || EnumUnderlyingType(enumType) is not { } underlying)
+        {
             return null;
+        }
         var target = Is8ByteInteger(underlying)
             ? (isUnsigned ? TypeRef.CoreLib("System", "UInt64") : TypeRef.CoreLib("System", "Int64"))
             : (isUnsigned ? TypeRef.CoreLib("System", "UInt32") : TypeRef.CoreLib("System", "Int32"));
-        return CoerceText(operand, target);
+        if (EnumUnderlyingType(operand.ResultType) is not null)
+            return CoerceText(operand, target);
+        return CSharpConversionRules.CheckedConversionCanThrow(underlying, target)
+            ? CheckedSafeCast(() => $"({TypeText(target)}){Operand(operand)}")
+            : $"({TypeText(target)}){Operand(operand)}";
+    }
+
+    /// <summary>
+    /// The enum type a shift's left operand renders as, or null when it is not a
+    /// resolvable enum. A bare load carries the enum in its <c>ResultType</c>; a
+    /// typed <c>ldelem</c>/<c>ldind</c> masks it as the primitive storage width, so
+    /// recover the enum from the array element or by-ref/pointer pointee type — the
+    /// type the operand is actually spelled with (mirrors <see cref="WideIndexOperandType"/>).
+    /// </summary>
+    TypeRef? ShiftLeftEnumType(IrExpression operand)
+    {
+        if (EnumUnderlyingType(operand.ResultType) is not null)
+            return operand.ResultType;
+        return operand switch
+        {
+            LoadElement { Array.ResultType: { Kind: TypeRefKind.SzArray or TypeRefKind.Array, ElementType: { } element } }
+                when EnumUnderlyingType(element) is not null => element,
+            LoadIndirect load when WideIndexPointee(load.Address) is { } pointee
+                && EnumUnderlyingType(pointee) is not null => pointee,
+            _ => null,
+        };
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -987,10 +987,19 @@ public sealed partial class CSharpPrinter
     string ShiftCount(Binary shift)
     {
         if (shift.Right is Binary { Kind: BinaryKind.And, Right: Constant { Value: int mask } } masked
-            && ShiftWidthMask(EffectiveType(shift.Left)) is { } width && mask == width)
+            && ShiftWidthMask(ShiftWidthType(shift.Left)) is { } width && mask == width)
             return IntShiftCount(masked.Left);
         return IntShiftCount(shift.Right);
     }
+
+    // The integer width a shift runs on. An enum left operand shifts its underlying
+    // integer (the enum has no primitive stack family of its own), so the count's
+    // implicit width mask — 31 for a 4-byte backing, 63 for an 8-byte one — is the
+    // backing's, not the enum's. Resolve to that backing so ShiftCount strips the
+    // compiler-baked mask instead of re-spelling it (which would double-mask on
+    // recompile). A non-enum operand keeps its own effective type.
+    TypeRef? ShiftWidthType(IrExpression operand)
+        => EnumUnderlyingType(operand.ResultType) ?? EffectiveType(operand);
 
     // C#'s shift operators take an `int` count; a `uint` or enum count is CS0019.
     // IL's shl/shr take an int32 count, so reinterpreting a uint or a 32-bit enum as

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -345,21 +345,31 @@ public sealed partial class CSharpPrinter
     }
 
     /// <summary>
-    /// Reinterprets an enum-typed shift left operand to its underlying integer so
-    /// a C# shift type-checks (an enum has no predefined <c>&lt;&lt;</c>/<c>&gt;&gt;</c>,
+    /// Reinterprets an enum-typed shift left operand to an integer so a C# shift
+    /// type-checks (an enum has no predefined <c>&lt;&lt;</c>/<c>&gt;&gt;</c>,
     /// CS0019), or null when the operand is not a resolvable enum and the caller
     /// keeps its own spelling. The IL loaded the enum's underlying integer onto the
-    /// stack and shifted that, so the reinterpret is a no-op; casting to the exact
-    /// underlying type keeps a signed <c>shr</c> or an unsigned <c>shr.un</c>
-    /// opcode-exact on recompile. The coercion runs through <see cref="CoerceText"/>
-    /// — the one enum→integer door, shared with the enum div/rem operands — so a
-    /// cross-assembly enum whose backing width is unknown (no underlying type) is
-    /// left alone rather than reinterpreted through an unverifiable width.
+    /// stack and shifted that, so the reinterpret is a no-op. The opcode's own
+    /// signedness (<paramref name="isUnsigned"/> — <c>shr.un</c> vs <c>shr</c>) is
+    /// authoritative, not the enum backing's: the source may have reinterpreted the
+    /// enum to the opposite-signedness same-width integer (<c>(uint)intEnum &gt;&gt; n</c>),
+    /// an IL no-op that leaves no trace, so the shift opcode is the only faithful
+    /// record of its signedness. Width comes from the backing — a width change would
+    /// leave a <c>conv</c> in the IL and the operand would not be a bare enum. The
+    /// cast runs through <see cref="CoerceText"/> (the one enum→integer door, shared
+    /// with the enum div/rem operands) so a signed→unsigned reinterpret inside a
+    /// <c>checked</c> region keeps its <c>unchecked</c> guard. A cross-assembly enum
+    /// whose backing width is unknown has no underlying type and is left alone.
     /// </summary>
-    string? ShiftEnumLeftOperand(IrExpression operand)
-        => EnumUnderlyingType(operand.ResultType) is { } underlying
-            ? CoerceText(operand, underlying)
-            : null;
+    string? ShiftEnumLeftOperand(IrExpression operand, bool isUnsigned)
+    {
+        if (EnumUnderlyingType(operand.ResultType) is not { } underlying)
+            return null;
+        var target = Is8ByteInteger(underlying)
+            ? (isUnsigned ? TypeRef.CoreLib("System", "UInt64") : TypeRef.CoreLib("System", "Int64"))
+            : (isUnsigned ? TypeRef.CoreLib("System", "UInt32") : TypeRef.CoreLib("System", "Int32"));
+        return CoerceText(operand, target);
+    }
 
     /// <summary>
     /// Casts an integer operand to the enum type it is compared or combined with
@@ -563,10 +573,10 @@ public sealed partial class CSharpPrinter
         var demand = CSharpPrecedence.Of(binary);
         // C# has no shift operator for an enum operand (CS0019), though the IL
         // shifts the enum's underlying integer directly. Reinterpret the enum
-        // left operand to that underlying integer — `(long)flags >> 32` — so the
-        // shift type-checks; the underlying type's signedness keeps a shr/shr.un
-        // opcode-exact on recompile. (The count is always int.)
-        string left = isShift && ShiftEnumLeftOperand(binary.Left) is { } shiftedEnum ? shiftedEnum
+        // left operand to that integer — `(long)flags >> 32` — so the shift
+        // type-checks; the cast's signedness follows the shift opcode (shr/shr.un),
+        // not the enum backing, so it round-trips opcode-exact. (Count is int.)
+        string left = isShift && ShiftEnumLeftOperand(binary.Left, binary.IsUnsigned) is { } shiftedEnum ? shiftedEnum
             : mixedSign ? BitwiseUnsignedOperand(binary.Left, wrapConstantCast: !covered)
             : castLeft ? UnsignedOperand(binary.Left)
             : preserveUnsignedConstants ? UnsignedConstantArithmeticOperand(binary.Left, EffectiveType(binary))

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -345,6 +345,23 @@ public sealed partial class CSharpPrinter
     }
 
     /// <summary>
+    /// Reinterprets an enum-typed shift left operand to its underlying integer so
+    /// a C# shift type-checks (an enum has no predefined <c>&lt;&lt;</c>/<c>&gt;&gt;</c>,
+    /// CS0019), or null when the operand is not a resolvable enum and the caller
+    /// keeps its own spelling. The IL loaded the enum's underlying integer onto the
+    /// stack and shifted that, so the reinterpret is a no-op; casting to the exact
+    /// underlying type keeps a signed <c>shr</c> or an unsigned <c>shr.un</c>
+    /// opcode-exact on recompile. The coercion runs through <see cref="CoerceText"/>
+    /// — the one enum→integer door, shared with the enum div/rem operands — so a
+    /// cross-assembly enum whose backing width is unknown (no underlying type) is
+    /// left alone rather than reinterpreted through an unverifiable width.
+    /// </summary>
+    string? ShiftEnumLeftOperand(IrExpression operand)
+        => EnumUnderlyingType(operand.ResultType) is { } underlying
+            ? CoerceText(operand, underlying)
+            : null;
+
+    /// <summary>
     /// Casts an integer operand to the enum type it is compared or combined with
     /// — <c>(MethodAttributes)access</c> — so an enum-vs-integer comparison or
     /// bitwise op type-checks (CS0019). The cast reinterprets the integer bits
@@ -542,12 +559,18 @@ public sealed partial class CSharpPrinter
             && IsIntegerConstantExpression(binary)
             && IsUnsignedFixedWidthInteger(EffectiveType(binary))
             && !mixedSign;
+        bool isShift = binary.Kind is BinaryKind.ShiftLeft or BinaryKind.ShiftRight;
         var demand = CSharpPrecedence.Of(binary);
-        string left = mixedSign ? BitwiseUnsignedOperand(binary.Left, wrapConstantCast: !covered)
+        // C# has no shift operator for an enum operand (CS0019), though the IL
+        // shifts the enum's underlying integer directly. Reinterpret the enum
+        // left operand to that underlying integer — `(long)flags >> 32` — so the
+        // shift type-checks; the underlying type's signedness keeps a shr/shr.un
+        // opcode-exact on recompile. (The count is always int.)
+        string left = isShift && ShiftEnumLeftOperand(binary.Left) is { } shiftedEnum ? shiftedEnum
+            : mixedSign ? BitwiseUnsignedOperand(binary.Left, wrapConstantCast: !covered)
             : castLeft ? UnsignedOperand(binary.Left)
             : preserveUnsignedConstants ? UnsignedConstantArithmeticOperand(binary.Left, EffectiveType(binary))
             : BinaryOperand(binary.Left, demand, rightSide: false);
-        bool isShift = binary.Kind is BinaryKind.ShiftLeft or BinaryKind.ShiftRight;
         string right = isShift ? ShiftCount(binary)
             : mixedSign ? BitwiseUnsignedOperand(binary.Right, wrapConstantCast: !covered)
             : castBoth ? UnsignedOperand(binary.Right)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -3732,6 +3732,19 @@ public sealed partial class CSharpPrinter
         // `IntPtr` even for a `ref nuint`, so the bare `binary.Left` type loses the
         // lvalue's real signedness.
         var lvalueType = targetType ?? binary.Left.ResultType;
+        // C# has no compound shift operator on an enum lvalue (CS0019, the compound
+        // sibling of the enum-shift expression fix): an int-backed `flags <<= n`
+        // folds to `store flags = shl(load flags, n)` with a bare enum left operand,
+        // yet C# rejects `flags <<= n`. Decompose to a plain assignment that
+        // reinterprets the enum to its shift integer (BinaryBody spells the left
+        // operand and count-mask) and casts the shift result back to the enum:
+        // `flags = (E)((int)flags >> (n & 31))`. The int→enum cast is a reinterpret
+        // that never overflows, so it stays a bare cast even inside `checked`.
+        if (binary.Kind is BinaryKind.ShiftLeft or BinaryKind.ShiftRight
+            && EnumUnderlyingType(lvalueType) is not null)
+        {
+            return $"{target} = ({TypeText(lvalueType!)}){RenderedExpression(binary).At(Precedence.Unary)};";
+        }
         string rightText = binary.Kind is BinaryKind.ShiftLeft or BinaryKind.ShiftRight
             ? ShiftCount(binary)
             // A bitwise &=/|=/^= against an enum lvalue whose right operand is still


### PR DESCRIPTION
- Fixes #3011
- Renders an enum-typed value shifted (`>>`/`<<`) with an integer cast on the left operand, so the shift compiles (was CS0019). The cast's signedness follows the shift **opcode** (`shr`/`shr.un`), not the enum backing. Covers both the expression form and the compound-assignment form (`flags <<= n`, also CS0019).
- Also recovers the enum type for shift operands loaded through a typed `ldelem`/`ldind` (enum **array elements** and **by-ref** enums), whose stack type is the masked primitive.
- Card revision: `0491e4a27dab339ee9457f88585add19e4fc1298`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — an enum has no predefined C# shift operator (CS0019); the IL shifts the enum's underlying integer, so re-inserting an integer cast is faithful and makes the render valid.

### Original source

<!-- Fixture: ILInspector.Decompiler.Tests.EnumCastSamples.LongEnumRightShiftToInt (long-backed enum, mirrors the MySqlConnector witness). -->

```csharp
public static int LongEnumRightShiftToInt(CfgLongPriority flags) => (int)((long)flags >> 32);
```

### Before

```csharp
public static int LongEnumRightShiftToInt(ILInspector.Decompiler.Tests.CfgLongPriority flags) => (int)(flags >> 32);
```

- Valid: **False** — `CS0019: Operator '>>' cannot be applied to operands of type 'CfgLongPriority' and 'int'`.
- Correct: False — does not compile.

### After

```csharp
public static int LongEnumRightShiftToInt(ILInspector.Decompiler.Tests.CfgLongPriority flags) => (int)((long)flags >> 32);
```

- Valid: **True** — compiles and binds.
- Correct: **True** — the `(long)` cast is a no-op over the enum's already-int64 stack value, so `shr` round-trips opcode-exact; identical to the original source.

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `EnumCastPrinterTests`: n/a (tests new) | `EnumCastPrinterTests`: 42 passed |
| Decompiler fast suite | RoundTrip area: 142, 0 failed | RoundTrip area: 142, 0 failed |
| Real witness | `CfgLongPriority >> 32` → `(int)(flags >> 32)` (CS0019) | `CfgLongPriority >> 32` → `(int)((long)flags >> 32)` (valid) |

Before/After acquired via `dotnet-inspect member ... -S "Decompiled Source"`: Before from the base tool (`ca3f09a8`), After from this PR's head tool, both run against the same head-built fixture DLL. CS0019 on the Before spelling confirmed by a direct `csc` compile.

### Signedness follows the opcode, not the backing

A same-width signedness reinterpret in the source (`(uint)intEnum >> n`) is an **IL no-op** — the enum is already its underlying integer on the stack — so the enum's declared backing is a misleading signedness signal. The shift **opcode** (`shr` vs `shr.un`, recorded in `Binary.IsUnsigned`) is the only faithful record. The cast therefore selects `uint`/`ulong` for `shr.un` and `int`/`long` for `shr`; width comes from the backing (a width change would leave a `conv` in the IL and the operand would not be a bare enum). Casting to the declared backing instead would flip the opcode and silently change the result for negative/high-bit values.

Width/sign matrix covered by new tests (all recompile opcode-exact):

| Backing | Opcode | Rendered left | Note |
| --- | --- | --- | --- |
| `int` | `shr` | `(int)flags` | matching |
| `long` | `shr` | `(long)flags` | matching |
| `uint` | `shr.un` | `(uint)flags` | matching |
| `ulong` | `shr.un` | `(ulong)flags` | matching |
| `byte` | `shl` | `(int)flags` | sub-int promotes to int |
| `int` | `shr.un` | `(uint)flags` | **mismatch** — opcode wins |
| `uint` | `shr` | `(int)flags` | **mismatch** — opcode wins |

Close negative: a plain non-enum `int >> n` keeps bare operands.

### Compound assignment form

A compound shift on an enum lvalue (`flags <<= n`) is CS0019 too. It decomposes to a plain cast-back assignment:

```csharp
// Before (CS0019):
flags <<= (n & 31);
// After:
flags = (CfgPriority)((int)flags << (n & 31));
```

The left-operand cast follows the same opcode-signedness rule; the int→enum cast is a reinterpret that never overflows, so it stays a bare cast even inside `checked`.

### Array-element and by-ref operands

An enum loaded from an array element or through a `ref`/pointer uses a **typed** `ldelem.i4`/`ldind.i4`, so the shift operand's stack `ResultType` is the primitive storage width even though the rendered expression (`values[i]`, `e`) is enum-typed and still rejects a bare shift. The printer recovers the enum from the array element / by-ref pointee type (mirroring the existing wide-index recovery) and forces the reinterpret cast:

```csharp
// Before (CS0019):
public static int ArrShl(CfgPriority[] values, int i, int n) => values[i] << n;
// After:
public static int ArrShl(CfgPriority[] values, int i, int n) => (int)values[i] << n;
```

Compound shift on an enum array/by-ref lvalue is unreachable — C# rejects `values[i] <<= n` (CS0019), so no such IL compound is produced.

## Notes

Reuses the `CoerceText` enum→integer choke point (the same door the enum div/rem operands use), rather than open-coding a cast. A cross-assembly enum with an unknown backing width has no resolved underlying type and is intentionally left unchanged (no unverifiable-width cast) — it renders a bare, **visibly** invalid shift rather than a silently-wrong cast, and is tracked as follow-up **#3066**.

The witness is MySqlConnector `HandshakeResponse41Payload.CreateCapabilitiesPayload`, which rendered `(int)(clientCapabilities >> 32)` on a long-backed `[Flags]` enum.

