### PR TITLE
Fold spilled struct rvalue receivers to recompose && return chains (#3051)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/StructReceiverInliningPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StructReceiverInliningPassTests.cs
@@ -8,11 +8,14 @@ namespace ILInspector.Decompiler.Tests;
 // can nest and boolean folding can recompose into one && return.
 //
 // The pass is gated for soundness: the definition must be a fresh rvalue (a
-// call/property load, never an address/place), the temp must have exactly one
-// reader in its live range and that read must be a member-access receiver, and
-// the read must sit in the statement immediately after the store with no
-// order-sensitive node evaluated before it. Opcode-preservation of the fold is
-// proven by the compiled-fixture round-trip described at the end of this file.
+// call/property load, never an address/place), and the slot must be fold-safe
+// method-wide — every read of it is a member-receiver address load whose
+// statement immediately follows a store to the same slot in the same block, so
+// each read's reaching definition is the adjacent store and the slot is never
+// live across a block boundary. The folded store's use must additionally be the
+// slot's only read in the adjacent statement with no order-sensitive node
+// evaluated before it. Opcode-preservation of the fold is proven by the
+// compiled-fixture round-trip described at the end of this file.
 [Trait("Area", "Pass")]
 public class StructReceiverInliningPassTests
 {
@@ -199,9 +202,9 @@ public class StructReceiverInliningPassTests
 
     // A back-edge routes execution, on a later iteration, from the loop-body
     // store back to a read at the loop head that precedes the store in document
-    // order. That read observes the store's value, so folding the store away
-    // would leave it stale. The forward single-reader window cannot see the head
-    // read (lower document position); the back-edge gate must decline.
+    // order. That head read is not immediately preceded by a store to the slot,
+    // so the whole-slot fold-safety check fails and the fold declines — no
+    // reasoning about document order or back-edge spans is required.
     [Fact]
     public void LoopCarriedReader_IsNotFolded()
     {
@@ -218,6 +221,35 @@ public class StructReceiverInliningPassTests
         RunPass(function);
 
         Assert.Equal(1, StoreCount(function, 0));
+        function.CheckInvariant();
+    }
+
+    // Forward bypass: the store's adjacent use looks single, but a later read
+    // sits after a conditionally-taken second store to the same slot. On the
+    // path that skips the second store, that later read observes the first
+    // store's value — so folding the first store away would leave it reading a
+    // removed value. The later read is not immediately preceded by a store, so
+    // the whole-slot check fails and both stores survive.
+    [Fact]
+    public void ForwardBypassReader_IsNotFolded()
+    {
+        // block0: v = a.Inner; v.Value; if (cond) goto block2 (skip the second store)
+        var block0 = MakeBlock(0,
+            new StoreLocal(0, S, Inner(new LoadArgument(0, "a", Outer))),
+            new ExpressionStatement(Value(new LoadLocalAddress(0, S))),
+            new ConditionalBranch(new LoadArgument(1, "cond", Bool), 32));
+        // block1: v = b.Inner (the conditionally-executed redefinition)
+        var block1 = MakeBlock(16,
+            new StoreLocal(0, S, Inner(new LoadArgument(2, "b", Outer))));
+        // block2: return v.Value — the join read, reached with block0's value on
+        // the bypass path.
+        var block2 = MakeBlock(32,
+            new Return(Value(new LoadLocalAddress(0, S))));
+        var function = BuildFunction([block0, block1, block2]);
+
+        RunPass(function);
+
+        Assert.Equal(2, StoreCount(function, 0));
         function.CheckInvariant();
     }
 }

--- a/src/ILInspector.Decompiler.Tests/StructReceiverInliningPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StructReceiverInliningPassTests.cs
@@ -196,4 +196,28 @@ public class StructReceiverInliningPassTests
         Assert.Equal(1, StoreCount(function, 0));
         function.CheckInvariant();
     }
+
+    // A back-edge routes execution, on a later iteration, from the loop-body
+    // store back to a read at the loop head that precedes the store in document
+    // order. That read observes the store's value, so folding the store away
+    // would leave it stale. The forward single-reader window cannot see the head
+    // read (lower document position); the back-edge gate must decline.
+    [Fact]
+    public void LoopCarriedReader_IsNotFolded()
+    {
+        // Head (offset 0): r = v.Value  — the loop-carried read of slot 0.
+        var head = MakeBlock(0,
+            new StoreLocal(1, Bool, Value(new LoadLocalAddress(0, S))));
+        // Body (offset 16): v = outer.Inner; if (v.Value) goto head — store,
+        // adjacent member-receiver use, and the back-edge to the head.
+        var body = MakeBlock(16,
+            new StoreLocal(0, S, Inner(new LoadArgument(0, "outer", Outer))),
+            new ConditionalBranch(Value(new LoadLocalAddress(0, S)), 0));
+        var function = BuildFunction([head, body]);
+
+        RunPass(function);
+
+        Assert.Equal(1, StoreCount(function, 0));
+        function.CheckInvariant();
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/StructReceiverInliningPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StructReceiverInliningPassTests.cs
@@ -1,0 +1,199 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// #3051: StructReceiverInliningPass folds a single-use struct rvalue temporary
+// back into its member-access receiver (V = a.Prop; ... V.Member -> a.Prop.Member)
+// so the guard block the spill sat in becomes a pure condition that structuring
+// can nest and boolean folding can recompose into one && return.
+//
+// The pass is gated for soundness: the definition must be a fresh rvalue (a
+// call/property load, never an address/place), the temp must have exactly one
+// reader in its live range and that read must be a member-access receiver, and
+// the read must sit in the statement immediately after the store with no
+// order-sensitive node evaluated before it. Opcode-preservation of the fold is
+// proven by the compiled-fixture round-trip described at the end of this file.
+[Trait("Area", "Pass")]
+public class StructReceiverInliningPassTests
+{
+    static readonly TypeRef Holder = TypeRef.Definition("synthetic", "", "Holder");
+    static readonly TypeRef Outer = TypeRef.Definition("synthetic", "", "Outer");
+    static readonly TypeRef S = TypeRef.Definition("synthetic", "", "S");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");
+
+    // Outer.Inner is a struct-valued property; S.Value is a member read on that struct.
+    static readonly MethodRef GetInner = new(Outer, "get_Inner", S, [], HasThis: true);
+    static readonly MethodRef GetValue = new(S, "get_Value", Int32, [], HasThis: true);
+
+    static readonly FieldRef InnerField = new(Outer, "InnerField", S);
+
+    static LoadProperty Inner(IrExpression receiver) => new(GetInner, receiver, []);
+    static LoadProperty Value(IrExpression receiver) => new(GetValue, receiver, []);
+
+    static IrFunction BuildFunction(params IrNode[] statements)
+    {
+        var block = new Block(0);
+        foreach (var statement in statements)
+            block.Add(statement);
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(Int32, [], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", Holder, signature, [], container);
+    }
+
+    static IrFunction BuildFunction(Block[] blocks)
+    {
+        var container = new BlockContainer();
+        foreach (var block in blocks)
+            container.Add(block);
+        var signature = new MethodSignature(Int32, [], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", Holder, signature, [], container);
+    }
+
+    static Block MakeBlock(int offset, params IrNode[] statements)
+    {
+        var block = new Block(offset);
+        foreach (var statement in statements)
+            block.Add(statement);
+        return block;
+    }
+
+    static void RunPass(IrFunction function) => new StructReceiverInliningPass().Run(function, PassContext.None);
+
+    static int StoreCount(IrFunction function, int index)
+        => function.Descendants.OfType<StoreLocal>().Count(s => s.Index == index);
+
+    // V_0 = outer.Inner; return V_0.Value  ->  return outer.Inner.Value
+    // The spilled struct rvalue folds into the member receiver and the store is gone.
+    [Fact]
+    public void StructRvalueReceiver_IsFoldedIntoMemberReceiver()
+    {
+        var function = BuildFunction(
+            new StoreLocal(0, S, Inner(new LoadArgument(0, "outer", Outer))),
+            new Return(Value(new LoadLocalAddress(0, S))));
+
+        RunPass(function);
+
+        Assert.Equal(0, StoreCount(function, 0));
+        var block = Assert.IsType<Block>(Assert.IsType<BlockContainer>(function.Body).Children[0]);
+        var ret = Assert.IsType<Return>(Assert.Single(block.Children));
+        var value = Assert.IsType<LoadProperty>(ret.Value);
+        Assert.Equal("Value", value.PropertyName);
+        // The receiver is now the struct rvalue directly, not a spilled local address.
+        var inner = Assert.IsType<LoadProperty>(value.Instance);
+        Assert.Equal("Inner", inner.PropertyName);
+        function.CheckInvariant();
+    }
+
+    // A slot csc reused for two independent struct temporaries folds per live
+    // range: each store is adjacent to its own single receiver use, so both fold
+    // and the reused local is eliminated entirely.
+    [Fact]
+    public void ReusedSlot_FoldsEachLiveRange()
+    {
+        var block0 = MakeBlock(0,
+            new StoreLocal(0, S, Inner(new LoadArgument(0, "a", Outer))),
+            new ConditionalBranch(new Comparison(ComparisonKind.Equal, false, Value(new LoadLocalAddress(0, S)), new Constant(1, Int32)), 99));
+        var block1 = MakeBlock(50,
+            new StoreLocal(0, S, Inner(new LoadArgument(1, "b", Outer))),
+            new Return(Value(new LoadLocalAddress(0, S))));
+        var function = BuildFunction([block0, block1]);
+
+        RunPass(function);
+
+        Assert.Equal(0, StoreCount(function, 0));
+        // Both receivers are now the folded Inner rvalue.
+        var loads = function.Descendants.OfType<LoadProperty>().Where(p => p.PropertyName == "Value").ToList();
+        Assert.Equal(2, loads.Count);
+        Assert.All(loads, v => Assert.IsType<LoadProperty>(v.Instance));
+        Assert.Empty(function.Descendants.OfType<LoadLocalAddress>());
+        function.CheckInvariant();
+    }
+
+    // Two reads of the temp in one live range is not a single-use receiver: the
+    // fold would remove a store a second reader still needs. Both reads survive.
+    [Fact]
+    public void MultiUseTemp_IsNotFolded()
+    {
+        var twoArg = new MethodRef(Holder, "Combine", Int32, [Int32, Int32], HasThis: false);
+        var function = BuildFunction(
+            new StoreLocal(0, S, Inner(new LoadArgument(0, "outer", Outer))),
+            new Return(new Call(twoArg, isVirtual: false,
+            [
+                Value(new LoadLocalAddress(0, S)),
+                Value(new LoadLocalAddress(0, S)),
+            ])));
+
+        RunPass(function);
+
+        Assert.Equal(1, StoreCount(function, 0));
+        function.CheckInvariant();
+    }
+
+    // The address feeds a by-ref argument of a static call, not a member
+    // receiver. Folding an rvalue there would be an illegal `ref (rvalue)`.
+    [Fact]
+    public void AddressAsByRefArgument_IsNotFolded()
+    {
+        var consume = new MethodRef(Holder, "Consume", Int32, [TypeRef.ByRef(S)], HasThis: false);
+        var function = BuildFunction(
+            new StoreLocal(0, S, Inner(new LoadArgument(0, "outer", Outer))),
+            new Return(new Call(consume, isVirtual: false, [new LoadLocalAddress(0, S)])));
+
+        RunPass(function);
+
+        Assert.Equal(1, StoreCount(function, 0));
+        function.CheckInvariant();
+    }
+
+    // The definition is a field access (a place/lvalue), not a fresh rvalue: a
+    // mutating member folded onto it would act on real storage. Declined.
+    [Fact]
+    public void PlaceDefinition_IsNotFolded()
+    {
+        var function = BuildFunction(
+            new StoreLocal(0, S, new LoadField(InnerField, new LoadArgument(0, "outer", Outer))),
+            new Return(Value(new LoadLocalAddress(0, S))));
+
+        RunPass(function);
+
+        Assert.Equal(1, StoreCount(function, 0));
+        function.CheckInvariant();
+    }
+
+    // An effectful sibling evaluates before the receiver in the use statement, so
+    // moving the store into the receiver position would reorder it past that
+    // effect. The barrier walk declines the fold.
+    [Fact]
+    public void BarrierBeforeReceiver_IsNotFolded()
+    {
+        var effect = new Call(new MethodRef(Holder, "Effect", Int32, [], HasThis: false), isVirtual: false, []);
+        var function = BuildFunction(
+            new StoreLocal(0, S, Inner(new LoadArgument(0, "outer", Outer))),
+            // Left operand (an effectful call) evaluates before the receiver read.
+            new Return(new Comparison(ComparisonKind.Equal, false, effect, Value(new LoadLocalAddress(0, S)))));
+
+        RunPass(function);
+
+        Assert.Equal(1, StoreCount(function, 0));
+        function.CheckInvariant();
+    }
+
+    // An unrelated statement sits between the store and the use, so the store is
+    // no longer the immediately-preceding definition. Adjacency fails; declined.
+    [Fact]
+    public void NonAdjacentStore_IsNotFolded()
+    {
+        var effect = new Call(new MethodRef(Holder, "Effect", Int32, [], HasThis: false), isVirtual: false, []);
+        var function = BuildFunction(
+            new StoreLocal(0, S, Inner(new LoadArgument(0, "outer", Outer))),
+            new ExpressionStatement(effect),
+            new Return(Value(new LoadLocalAddress(0, S))));
+
+        RunPass(function);
+
+        Assert.Equal(1, StoreCount(function, 0));
+        function.CheckInvariant();
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -170,6 +170,11 @@ public static class IrPasses
         // conditional store — the multi-arm sibling of the slot-store diamond
         // over a local — so its merge structures instead of staying flat.
         new ConditionalStoreChainPass(),
+        // Fold a spilled single-use struct rvalue back into its member receiver
+        // (V = a.Prop; V.Member -> a.Prop.Member) so the guard block it sat in
+        // becomes a pure single condition that structuring can nest and boolean
+        // folding can recompose into one && return (issue #3051).
+        new StructReceiverInliningPass(),
         new StructuringPass(),
         // Recover a destructor: a Finalize override's try/finally + base.Finalize()
         // scaffold, structured just above, collapses to the ~T() body.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -33,6 +33,8 @@ internal static class NativePasses
     public static StackSlotCopyPropagationPass StackSlotCopyPropagation => new();
     [Native(NativeCategory.EmitArtifact, "reused evaluation-stack slot live ranges split into distinct typed synthetic carriers")]
     public static StackSlotLiveRangePass StackSlotLiveRange => new();
+    [Native(NativeCategory.EmitArtifact, "a spilled single-use struct rvalue temp (V = a.Prop; ldloca V; call get_Member) folded back into its member receiver a.Prop.Member so the guard block it sat in becomes a pure condition structuring can nest")]
+    public static StructReceiverInliningPass StructReceiverInlining => new();
     [Native(NativeCategory.EmitArtifact, "in-place struct .ctor (ldloca; call S::.ctor) back to s = new S(...)")]
     public static StructConstructorPass StructConstructor => new();
     [Native(NativeCategory.EmitArtifact, "spilled-this base()/this() call back to a chain initializer")]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructReceiverInliningPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructReceiverInliningPass.cs
@@ -1,0 +1,247 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Folds a single-use struct rvalue temporary back into its member-access
+/// receiver: <c>V = obj.Prop; ... V.Member ...</c> → <c>obj.Prop.Member</c>.
+///
+/// <para>csc cannot take the address of an rvalue, so a member access on a
+/// struct-returning property/method receiver (<c>daylight.TimeOfDay.TimeOfDay</c>)
+/// is lowered to a spill: <c>stloc V (= daylight.TimeOfDay); ldloca V; call
+/// get_TimeOfDay</c>. That leading spill store makes an otherwise-pure guard
+/// block impure, which blocks <see cref="StructuringPass"/> from nesting the
+/// guard chain — and therefore <see cref="BooleanFoldingPass"/> from
+/// recomposing it into a single <c>&amp;&amp;</c> return (issue #3051). In
+/// straight-line code it just leaves an ugly <c>T V = a.Prop; ... V.Member</c>.</para>
+///
+/// <para>This pass runs immediately before <see cref="StructuringPass"/>, once
+/// the guard-forming passes have coalesced each spill store and its use into
+/// adjacent statements of one block. It matches a <see cref="StoreLocal"/>
+/// immediately followed (same block) by the local's single address-load use in
+/// a member-receiver position and — when the store's value is a fresh rvalue and
+/// the move reorders no effect — replaces the receiver with the value and
+/// removes the store. Because C# re-introduces the identical spill when the
+/// folded source is recompiled, the round-trip is opcode-preserving.</para>
+///
+/// <para>Soundness gates (all required):</para>
+/// <list type="bullet">
+/// <item>The store's value is a value-producing rvalue (a <see cref="Call"/> or
+/// <see cref="LoadProperty"/> with a non-<c>ByRef</c> result), never an
+/// address/ref/place — a byref temp aliases real storage, so folding could
+/// change defensive-copy or write semantics.</item>
+/// <item>That value has exactly one reader in its live range: the sole read of
+/// the local between this store and the next store to it (in document order,
+/// which is fallthrough order for the acyclic guard shape) is the address-load
+/// use. A reused slot (csc packs independent temporaries into one slot) folds
+/// per live range.</item>
+/// <item>The use is a member-access receiver — the instance of a
+/// <see cref="LoadProperty"/> or <see cref="LoadField"/>, or the receiver of an
+/// instance <see cref="Call"/> (all reads through the receiver; a write place
+/// would be an illegal assignment to an rvalue member).</item>
+/// <item>The use sits in the statement immediately after the store, is not in a
+/// short-circuit/ternary sub-position, and nothing order-sensitive evaluates
+/// before it in that statement — so the value's evaluation crosses no effect.</item>
+/// </list>
+///
+/// <para>Store/use adjacency in one block guarantees co-execution: a branch
+/// target between them would have split the block, so the pair is never entered
+/// apart. That, with the single-reader-in-window check, makes the fold sound
+/// without control-flow analysis.</para>
+/// </summary>
+public sealed class StructReceiverInliningPass : IIrPass
+{
+    public string Name => "struct-receiver-inlining";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        // Fold one site per pass, then re-scan: a chained spill
+        // (`V1 = a.P; V0 = V1.Q; ... V0.R`) exposes the earlier store only once
+        // the later one is removed, and re-scanning avoids reasoning about the
+        // index/document-order shifts a fold causes.
+        while (TryFoldOne(function, context))
+        {
+        }
+    }
+
+    static bool TryFoldOne(IrFunction function, PassContext context)
+    {
+        // Document order (a single pre-order index) doubles as a total order for
+        // the live-range window test. A StoreLocal is visited before its value
+        // subtree, so a self-referential read inside the value lands inside the
+        // window and is (conservatively) counted.
+        var docOrder = new Dictionary<IrNode, int>(ReferenceEqualityComparer.Instance);
+        var stores = new Dictionary<int, List<int>>();
+        var reads = new Dictionary<int, List<(int Pos, IrNode Node, bool IsAddress)>>();
+        int position = 0;
+        foreach (var node in function.Descendants)
+        {
+            docOrder[node] = position;
+            switch (node)
+            {
+                case StoreLocal store:
+                    (stores.TryGetValue(store.Index, out var s) ? s : stores[store.Index] = []).Add(position);
+                    break;
+                case LoadLocal load:
+                    (reads.TryGetValue(load.Index, out var r) ? r : reads[load.Index] = []).Add((position, load, false));
+                    break;
+                case LoadLocalAddress address:
+                    (reads.TryGetValue(address.Index, out var a) ? a : reads[address.Index] = []).Add((position, address, true));
+                    break;
+            }
+            position++;
+        }
+
+        foreach (var node in function.Descendants)
+        {
+            if (node is not StoreLocal store || store.Parent is not Block block)
+                continue;
+            if (!IsRvalueDefinition(store.Value))
+                continue;
+
+            int storePosition = docOrder[store];
+            int nextStorePosition = int.MaxValue;
+            if (stores.TryGetValue(store.Index, out var storePositions))
+            {
+                foreach (int p in storePositions)
+                {
+                    if (p > storePosition && p < nextStorePosition)
+                        nextStorePosition = p;
+                }
+            }
+
+            // Exactly one read of the local in this store's live range, and it is
+            // an address load (a value load in range would read the temp we are
+            // about to remove).
+            if (!reads.TryGetValue(store.Index, out var localReads))
+                continue;
+            (int Pos, IrNode Node, bool IsAddress)? only = null;
+            bool ambiguous = false;
+            foreach (var read in localReads)
+            {
+                if (read.Pos <= storePosition || read.Pos >= nextStorePosition)
+                    continue;
+                if (only is not null)
+                {
+                    ambiguous = true;
+                    break;
+                }
+                only = read;
+            }
+            if (ambiguous || only is not { IsAddress: true } use)
+                continue;
+
+            var addressUse = use.Node;
+            if (!IsMemberReceiver(addressUse))
+                continue;
+
+            // Adjacency: the use must live in the statement immediately after the
+            // store, in the same block. That makes store and use co-execute and
+            // bounds the effect-order proof to a single statement.
+            int storeIndex = store.ChildIndex;
+            if (storeIndex + 1 >= block.Children.Count)
+                continue;
+            var useStatement = block.Children[storeIndex + 1];
+            if (!ReferenceOwnership.IsInside(addressUse, useStatement))
+                continue;
+            if (!EvaluatesFirstWithoutBarrier(addressUse, useStatement))
+                continue;
+
+            var value = (IrExpression)store.DetachChildren()[0];
+            store.Detach();
+            context.Stepper.StepOver(
+                $"inline struct rvalue temp {store.Index} into its member receiver",
+                addressUse.Parent ?? addressUse);
+            addressUse.ReplaceWith(value);
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// A value the fold may move into a receiver position: a fresh rvalue whose
+    /// evaluation reproduces the compiler's own spill on recompile. A method call
+    /// or property getter returning a value (never a managed reference) qualifies;
+    /// an address/ref/place (<c>ldloca</c>/<c>ldflda</c>/<c>ldelema</c>, a field
+    /// or element access) does not — a byref temp aliases real storage, so a
+    /// mutating member or an assignment through it would diverge.
+    /// </summary>
+    static bool IsRvalueDefinition(IrExpression value) => value switch
+    {
+        Call call => call.ResultType is not { Kind: TypeRefKind.ByRef },
+        LoadProperty property => property.ResultType is not { Kind: TypeRefKind.ByRef },
+        _ => false,
+    };
+
+    /// <summary>
+    /// True when <paramref name="address"/> is the receiver of a member read: the
+    /// instance of a property/field load, or the receiver argument of an instance
+    /// call. Write places (<see cref="StoreProperty"/>/<see cref="StoreField"/>)
+    /// and address-of receivers are excluded — folding an rvalue into them would
+    /// assign to, or take the address of, a temporary.
+    /// </summary>
+    static bool IsMemberReceiver(IrNode address) => address.Parent switch
+    {
+        LoadProperty property => ReferenceEquals(property.Instance, address),
+        LoadField field => ReferenceEquals(field.Instance, address),
+        Call call => call.Callee.HasThis
+            && call.Arguments.Count > 0
+            && ReferenceEquals(call.Arguments[0], address),
+        _ => false,
+    };
+
+    /// <summary>
+    /// True when, walking <paramref name="statement"/> in evaluation order,
+    /// <paramref name="target"/> is reached before any order-sensitive node and
+    /// without passing through a conditionally-evaluated position (short-circuit,
+    /// ternary, coalesce, null-conditional, switch arm). Both conditions ensure
+    /// moving an unconditional pre-statement store into <paramref name="target"/>
+    /// neither reorders it past an effect nor makes it run conditionally.
+    /// </summary>
+    static bool EvaluatesFirstWithoutBarrier(IrNode target, IrNode statement)
+    {
+        for (var current = target.Parent; current is not null && !ReferenceEquals(current, statement); current = current.Parent)
+        {
+            if (current is Conditional or Coalesce or LogicalBinary or NullConditional
+                or SwitchExpression or SwitchExpressionArm)
+            {
+                return false;
+            }
+        }
+
+        bool found = false;
+        bool safe = true;
+
+        void Visit(IrNode node)
+        {
+            if (found || !safe)
+                return;
+            if (ReferenceEquals(node, target))
+            {
+                found = true;
+                return;
+            }
+            foreach (var child in node.Children)
+            {
+                Visit(child);
+                if (found || !safe)
+                    return;
+            }
+            // Registered post-children: a parent's own effect (a call, a place
+            // read) evaluates after its operands, so a target inside those
+            // operands is reached first and is safe.
+            if (IsOrderSensitive(node))
+                safe = false;
+        }
+
+        Visit(statement);
+        return found && safe;
+    }
+
+    /// <summary>
+    /// Deny-list: anything but a constant, <c>sizeof</c>, <c>ldtoken</c>, or an
+    /// argument load is treated as an evaluation barrier, so a moved value can
+    /// never cross it. Mirrors <see cref="SpilledReceiverFold"/> — an unrecognized
+    /// node is conservatively a barrier rather than silently reorderable.
+    /// </summary>
+    static bool IsOrderSensitive(IrNode node)
+        => node is not (Constant or SizeOf or LoadToken or LoadArgument);
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructReceiverInliningPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructReceiverInliningPass.cs
@@ -28,24 +28,32 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <see cref="LoadProperty"/> with a non-<c>ByRef</c> result), never an
 /// address/ref/place — a byref temp aliases real storage, so folding could
 /// change defensive-copy or write semantics.</item>
-/// <item>That value has exactly one reader in its live range: the sole read of
-/// the local between this store and the next store to it (in document order,
-/// which is fallthrough order for the acyclic guard shape) is the address-load
-/// use. A reused slot (csc packs independent temporaries into one slot) folds
-/// per live range.</item>
+/// <item>The slot is <em>fold-safe</em> method-wide: every read of it is a
+/// member-receiver address load whose enclosing statement immediately follows a
+/// store to that same slot in the same block. Then each read's reaching
+/// definition is the store one statement above it, so the slot is never live at
+/// a block boundary and no loop back-edge or conditional bypass can route a
+/// stale value to a read (a reused slot — csc packs independent temporaries into
+/// one slot — folds per store/use pair because each pair is independently
+/// adjacent).</item>
 /// <item>The use is a member-access receiver — the instance of a
 /// <see cref="LoadProperty"/> or <see cref="LoadField"/>, or the receiver of an
 /// instance <see cref="Call"/> (all reads through the receiver; a write place
 /// would be an illegal assignment to an rvalue member).</item>
-/// <item>The use sits in the statement immediately after the store, is not in a
-/// short-circuit/ternary sub-position, and nothing order-sensitive evaluates
-/// before it in that statement — so the value's evaluation crosses no effect.</item>
+/// <item>The use sits in the statement immediately after the store, is the only
+/// read of the slot in that statement, is not in a short-circuit/ternary
+/// sub-position, and nothing order-sensitive evaluates before it in that
+/// statement — so the value's evaluation crosses no effect.</item>
 /// </list>
 ///
 /// <para>Store/use adjacency in one block guarantees co-execution: a branch
 /// target between them would have split the block, so the pair is never entered
-/// apart. That, with the single-reader-in-window check, makes the fold sound
-/// without control-flow analysis.</para>
+/// apart. The fold reasons only about basic-block-local adjacency — never
+/// document order, which is an unsound liveness proxy across loop back-edges
+/// (a store re-reached at the loop head) and conditional bypasses (a read
+/// reached past a skipped redefinition). Requiring <em>every</em> read of the
+/// slot to be a store-adjacent receiver makes each read locally defined, so the
+/// fold is sound without whole-CFG liveness analysis.</para>
 /// </summary>
 public sealed class StructReceiverInliningPass : IIrPass
 {
@@ -64,55 +72,21 @@ public sealed class StructReceiverInliningPass : IIrPass
 
     static bool TryFoldOne(IrFunction function, PassContext context)
     {
-        // Document order (a single pre-order index) doubles as a total order for
-        // the live-range window test. A StoreLocal is visited before its value
-        // subtree, so a self-referential read inside the value lands inside the
-        // window and is (conservatively) counted.
-        var docOrder = new Dictionary<IrNode, int>(ReferenceEqualityComparer.Instance);
-        var stores = new Dictionary<int, List<int>>();
-        var reads = new Dictionary<int, List<(int Pos, IrNode Node, bool IsAddress)>>();
-        var blockPositionByOffset = new Dictionary<int, int>();
-        var branches = new List<(int TargetOffset, int Position)>();
-        int position = 0;
+        // Every read of every slot, so the fold can require a slot to be
+        // fold-safe method-wide before touching any of its stores. Reads are
+        // grouped by slot index; a value load (LoadLocal) and an address load
+        // (LoadLocalAddress) are both reads.
+        var reads = new Dictionary<int, List<IrNode>>();
         foreach (var node in function.Descendants)
         {
-            docOrder[node] = position;
             switch (node)
             {
-                case StoreLocal store:
-                    (stores.TryGetValue(store.Index, out var s) ? s : stores[store.Index] = []).Add(position);
-                    break;
                 case LoadLocal load:
-                    (reads.TryGetValue(load.Index, out var r) ? r : reads[load.Index] = []).Add((position, load, false));
+                    (reads.TryGetValue(load.Index, out var r) ? r : reads[load.Index] = []).Add(load);
                     break;
                 case LoadLocalAddress address:
-                    (reads.TryGetValue(address.Index, out var a) ? a : reads[address.Index] = []).Add((position, address, true));
+                    (reads.TryGetValue(address.Index, out var a) ? a : reads[address.Index] = []).Add(address);
                     break;
-                case Block b:
-                    blockPositionByOffset[b.StartOffset] = position;
-                    break;
-                case Branch br:
-                    branches.Add((br.TargetOffset, position));
-                    break;
-                case ConditionalBranch cbr:
-                    branches.Add((cbr.TargetOffset, position));
-                    break;
-            }
-            position++;
-        }
-
-        // Loop back-edges make the forward document-order window an unsound
-        // liveness proxy: a store inside a loop can flow, on a later iteration,
-        // to a read that precedes it in document order (the top of the loop). A
-        // back-edge is a branch whose target block precedes the branch; the loop
-        // it closes spans [targetBlockPosition, branchPosition].
-        var backEdgeSpans = new List<(int Start, int End)>();
-        foreach (var (targetOffset, branchPosition) in branches)
-        {
-            if (blockPositionByOffset.TryGetValue(targetOffset, out int targetPosition)
-                && targetPosition < branchPosition)
-            {
-                backEdgeSpans.Add((targetPosition, branchPosition));
             }
         }
 
@@ -122,61 +96,46 @@ public sealed class StructReceiverInliningPass : IIrPass
                 continue;
             if (!IsRvalueDefinition(store.Value))
                 continue;
-
-            int storePosition = docOrder[store];
-            int nextStorePosition = int.MaxValue;
-            if (stores.TryGetValue(store.Index, out var storePositions))
-            {
-                foreach (int p in storePositions)
-                {
-                    if (p > storePosition && p < nextStorePosition)
-                        nextStorePosition = p;
-                }
-            }
-
-            // Exactly one read of the local in this store's live range, and it is
-            // an address load (a value load in range would read the temp we are
-            // about to remove).
-            if (!reads.TryGetValue(store.Index, out var localReads))
+            if (!reads.TryGetValue(store.Index, out var slotReads))
                 continue;
 
-            // A back-edge that spans this store can route execution, on a later
-            // iteration, back to a read of the local that precedes the store in
-            // document order — so folding this store away would leave that
-            // loop-carried read observing a stale value. The forward window
-            // cannot see that read; decline when any exists inside a spanning
-            // loop.
-            if (HasLoopCarriedReader(store.Index, storePosition, localReads, backEdgeSpans))
-                continue;
-
-            (int Pos, IrNode Node, bool IsAddress)? only = null;
-            bool ambiguous = false;
-            foreach (var read in localReads)
-            {
-                if (read.Pos <= storePosition || read.Pos >= nextStorePosition)
-                    continue;
-                if (only is not null)
-                {
-                    ambiguous = true;
-                    break;
-                }
-                only = read;
-            }
-            if (ambiguous || only is not { IsAddress: true } use)
-                continue;
-
-            var addressUse = use.Node;
-            if (!IsMemberReceiver(addressUse))
+            // Fold-safety is a whole-slot property: every read of the slot must be
+            // a member-receiver address load whose statement immediately follows a
+            // store to the slot in the same block. Then each read's reaching
+            // definition is the store directly above it, the slot is dead at every
+            // block boundary, and neither a loop back-edge nor a conditional
+            // bypass can carry a stale value to a read. This replaces the unsound
+            // document-order live-range window: no read is ever "far" from its
+            // definition, so folding a store into its adjacent use cannot strand
+            // another read of the same value.
+            if (!IsSlotFoldSafe(store.Index, slotReads))
                 continue;
 
             // Adjacency: the use must live in the statement immediately after the
-            // store, in the same block. That makes store and use co-execute and
-            // bounds the effect-order proof to a single statement.
+            // store, in the same block, and be the slot's only read there (two
+            // reads would need the value evaluated twice). That makes store and
+            // use co-execute and bounds the effect-order proof to one statement.
             int storeIndex = store.ChildIndex;
             if (storeIndex + 1 >= block.Children.Count)
                 continue;
             var useStatement = block.Children[storeIndex + 1];
-            if (!ReferenceOwnership.IsInside(addressUse, useStatement))
+
+            IrNode? addressUse = null;
+            bool ambiguous = false;
+            foreach (var read in slotReads)
+            {
+                if (!ReferenceOwnership.IsInside(read, useStatement))
+                    continue;
+                if (addressUse is not null)
+                {
+                    ambiguous = true;
+                    break;
+                }
+                addressUse = read;
+            }
+            if (ambiguous || addressUse is not LoadLocalAddress)
+                continue;
+            if (!IsMemberReceiver(addressUse))
                 continue;
             if (!EvaluatesFirstWithoutBarrier(addressUse, useStatement))
                 continue;
@@ -193,6 +152,50 @@ public sealed class StructReceiverInliningPass : IIrPass
     }
 
     /// <summary>
+    /// True when every read of <paramref name="index"/> is a member-receiver
+    /// address load whose enclosing statement is immediately preceded, in the same
+    /// block, by a <see cref="StoreLocal"/> to the same slot. Under that property
+    /// each read's unique reaching definition is the adjacent store (a block is a
+    /// basic block, so the store one statement above always executes first), the
+    /// slot is never live across a block boundary, and every store's value is read
+    /// only by the use(s) directly below it. A reused slot stays foldable because
+    /// each store/use pair is checked independently. A single stray read — a value
+    /// load, a byref argument, a loop-header read, a post-<c>if</c> read — fails
+    /// the check and declines the whole slot, since document order cannot prove
+    /// such a read is not reached by the store being removed.
+    /// </summary>
+    static bool IsSlotFoldSafe(int index, List<IrNode> slotReads)
+    {
+        foreach (var read in slotReads)
+        {
+            if (read is not LoadLocalAddress || !IsMemberReceiver(read))
+                return false;
+            if (!FollowsStoreToSlot(read, index))
+                return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// True when the block-level statement enclosing <paramref name="read"/> is
+    /// immediately preceded in its block by a <see cref="StoreLocal"/> to
+    /// <paramref name="index"/>. The enclosing statement is the ancestor whose
+    /// parent is a <see cref="Block"/>.
+    /// </summary>
+    static bool FollowsStoreToSlot(IrNode read, int index)
+    {
+        var statement = read;
+        while (statement.Parent is { } parent and not Block)
+            statement = parent;
+        if (statement.Parent is not Block block)
+            return false;
+        int position = statement.ChildIndex;
+        return position > 0
+            && block.Children[position - 1] is StoreLocal store
+            && store.Index == index;
+    }
+
+    /// <summary>
     /// A value the fold may move into a receiver position: a fresh rvalue whose
     /// evaluation reproduces the compiler's own spill on recompile. A method call
     /// or property getter returning a value (never a managed reference) qualifies;
@@ -206,34 +209,6 @@ public sealed class StructReceiverInliningPass : IIrPass
         LoadProperty property => property.ResultType is not { Kind: TypeRefKind.ByRef },
         _ => false,
     };
-
-    /// <summary>
-    /// True when a read of the local precedes the store in document order yet sits
-    /// inside a loop that also contains the store (a back-edge span covering the
-    /// store position). Such a read is re-reached after the store on a later
-    /// iteration, so it observes this store's value; removing the store would make
-    /// it read a stale value. The forward single-reader window never sees this
-    /// read (it is at a lower document position), which is why it is checked
-    /// separately.
-    /// </summary>
-    static bool HasLoopCarriedReader(
-        int index,
-        int storePosition,
-        List<(int Pos, IrNode Node, bool IsAddress)> localReads,
-        List<(int Start, int End)> backEdgeSpans)
-    {
-        foreach (var (start, end) in backEdgeSpans)
-        {
-            if (start > storePosition || storePosition > end)
-                continue;
-            foreach (var read in localReads)
-            {
-                if (read.Pos >= start && read.Pos < storePosition)
-                    return true;
-            }
-        }
-        return false;
-    }
 
     /// <summary>
     /// True when <paramref name="address"/> is the receiver of a member read: the

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructReceiverInliningPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructReceiverInliningPass.cs
@@ -71,6 +71,8 @@ public sealed class StructReceiverInliningPass : IIrPass
         var docOrder = new Dictionary<IrNode, int>(ReferenceEqualityComparer.Instance);
         var stores = new Dictionary<int, List<int>>();
         var reads = new Dictionary<int, List<(int Pos, IrNode Node, bool IsAddress)>>();
+        var blockPositionByOffset = new Dictionary<int, int>();
+        var branches = new List<(int TargetOffset, int Position)>();
         int position = 0;
         foreach (var node in function.Descendants)
         {
@@ -86,8 +88,32 @@ public sealed class StructReceiverInliningPass : IIrPass
                 case LoadLocalAddress address:
                     (reads.TryGetValue(address.Index, out var a) ? a : reads[address.Index] = []).Add((position, address, true));
                     break;
+                case Block b:
+                    blockPositionByOffset[b.StartOffset] = position;
+                    break;
+                case Branch br:
+                    branches.Add((br.TargetOffset, position));
+                    break;
+                case ConditionalBranch cbr:
+                    branches.Add((cbr.TargetOffset, position));
+                    break;
             }
             position++;
+        }
+
+        // Loop back-edges make the forward document-order window an unsound
+        // liveness proxy: a store inside a loop can flow, on a later iteration,
+        // to a read that precedes it in document order (the top of the loop). A
+        // back-edge is a branch whose target block precedes the branch; the loop
+        // it closes spans [targetBlockPosition, branchPosition].
+        var backEdgeSpans = new List<(int Start, int End)>();
+        foreach (var (targetOffset, branchPosition) in branches)
+        {
+            if (blockPositionByOffset.TryGetValue(targetOffset, out int targetPosition)
+                && targetPosition < branchPosition)
+            {
+                backEdgeSpans.Add((targetPosition, branchPosition));
+            }
         }
 
         foreach (var node in function.Descendants)
@@ -113,6 +139,16 @@ public sealed class StructReceiverInliningPass : IIrPass
             // about to remove).
             if (!reads.TryGetValue(store.Index, out var localReads))
                 continue;
+
+            // A back-edge that spans this store can route execution, on a later
+            // iteration, back to a read of the local that precedes the store in
+            // document order — so folding this store away would leave that
+            // loop-carried read observing a stale value. The forward window
+            // cannot see that read; decline when any exists inside a spanning
+            // loop.
+            if (HasLoopCarriedReader(store.Index, storePosition, localReads, backEdgeSpans))
+                continue;
+
             (int Pos, IrNode Node, bool IsAddress)? only = null;
             bool ambiguous = false;
             foreach (var read in localReads)
@@ -170,6 +206,34 @@ public sealed class StructReceiverInliningPass : IIrPass
         LoadProperty property => property.ResultType is not { Kind: TypeRefKind.ByRef },
         _ => false,
     };
+
+    /// <summary>
+    /// True when a read of the local precedes the store in document order yet sits
+    /// inside a loop that also contains the store (a back-edge span covering the
+    /// store position). Such a read is re-reached after the store on a later
+    /// iteration, so it observes this store's value; removing the store would make
+    /// it read a stale value. The forward single-reader window never sees this
+    /// read (it is at a lower document position), which is why it is checked
+    /// separately.
+    /// </summary>
+    static bool HasLoopCarriedReader(
+        int index,
+        int storePosition,
+        List<(int Pos, IrNode Node, bool IsAddress)> localReads,
+        List<(int Start, int End)> backEdgeSpans)
+    {
+        foreach (var (start, end) in backEdgeSpans)
+        {
+            if (start > storePosition || storePosition > end)
+                continue;
+            foreach (var read in localReads)
+            {
+                if (read.Pos >= start && read.Pos < storePosition)
+                    return true;
+            }
+        }
+        return false;
+    }
 
     /// <summary>
     /// True when <paramref name="address"/> is the receiver of a member read: the


### PR DESCRIPTION
- Fixes #3051
- Recomposes short-circuit `&&` boolean-return chains that a spilled struct rvalue receiver had fragmented into a guard cascade.
- Card revision: `1bca0bd8`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — a conservatively-gated, opcode-preserving de-spill fold turns the NodaTime witness back into its exact one-line source shape; every gate declines on the close negatives; and adversarial review drove the fold's liveness reasoning from an unsound document-order proxy to a sound whole-slot basic-block check.

A member access on a struct-returning property/method receiver
(`daylight.TimeOfDay.TimeOfDay`) cannot take the address of an rvalue, so csc
spills it: `stloc V (= daylight.TimeOfDay); ldloca V; call get_TimeOfDay`. That
leading spill store makes an otherwise-pure guard block impure, which blocks
`StructuringPass` from nesting the guard chain and therefore
`BooleanFoldingPass` from recomposing it into a single `&&` return. The result
is a cascade of `if (...) return false;` guards.

`StructReceiverInliningPass` runs immediately before `StructuringPass` and folds
a single-use struct rvalue temporary back into its member-access receiver
(`V = a.Prop; ... V.Member` → `a.Prop.Member`), so the guard block becomes pure
and the chain recomposes.

### Original source

<!-- NodaTime BclDateTimeZone.BclAdjustmentRule.IsStandardOffsetOnlyRule -->

```csharp
private static bool IsStandardOffsetOnlyRule(TimeZoneInfo.AdjustmentRule rule)
{
    var daylight = rule.DaylightTransitionStart;
    var standard = rule.DaylightTransitionEnd;
    return daylight.IsFixedDateRule && daylight.Day == 1 && daylight.Month == 1 &&
           daylight.TimeOfDay.TimeOfDay < TimeSpan.FromMinutes(1) &&
           standard.IsFixedDateRule && standard.Day == 1 && standard.Month == 1 &&
           standard.TimeOfDay.TimeOfDay < TimeSpan.FromMinutes(1);
}
```

### Before

<!-- decompiler-harness --dump at base abe0eef6 -->

```csharp
TimeZoneInfo.TransitionTime daylight = rule.DaylightTransitionStart;
TimeZoneInfo.TransitionTime standard = rule.DaylightTransitionEnd;
if (!daylight.IsFixedDateRule) { return false; }
if (daylight.Day != 1) { return false; }
if (daylight.Month != 1) { return false; }
DateTime V_2 = daylight.TimeOfDay;
if (V_2.TimeOfDay >= TimeSpan.FromMinutes(1d)) { return false; }
if (!standard.IsFixedDateRule) { return false; }
if (standard.Day != 1) { return false; }
if (standard.Month != 1) { return false; }
V_2 = standard.TimeOfDay;
return V_2.TimeOfDay < TimeSpan.FromMinutes(1d);
```

- Valid: True
- Correct: True

Behavior-correct, but the `DateTime V_2 = daylight.TimeOfDay;` spill breaks
guard-block purity, so the chain stays a cascade instead of the source `&&`
chain (the two spilled predicates even invert to `>=` guards).

### After

<!-- decompiler-harness --dump at head 1bca0bd8 -->

```csharp
TimeZoneInfo.TransitionTime daylight = rule.DaylightTransitionStart;
TimeZoneInfo.TransitionTime standard = rule.DaylightTransitionEnd;
return daylight.IsFixedDateRule && daylight.Day == 1 && daylight.Month == 1 && daylight.TimeOfDay.TimeOfDay < TimeSpan.FromMinutes(1d) && standard.IsFixedDateRule && standard.Day == 1 && standard.Month == 1 && standard.TimeOfDay.TimeOfDay < TimeSpan.FromMinutes(1d);
```

- Valid: True
- Correct: True

Matches the original source shape exactly; fidelity remains `Full`. This method
also exercises a **reused slot** — csc packs both `daylight.TimeOfDay` and
`standard.TimeOfDay` into one `DateTime` temporary — so the fold must handle
per-store live ranges, not just method-wide single-use temporaries.

### Fully raised

The After decompilation is in the fully raised state.

## Soundness gates

The fold reasons only about **basic-block-local adjacency**, never document
order. It fires for a store `S` to slot `k` only when all hold (see
`StructReceiverInliningPass` XML doc):

- **Fresh rvalue definition** — `S`'s value is a `Call`/`LoadProperty` with a
  non-`ByRef` result, never an address/ref/place. A byref temp aliases real
  storage, so folding could change defensive-copy or write semantics.
- **Whole-slot fold-safety** — *every* read of slot `k` in the method is a
  member-receiver address load whose enclosing statement immediately follows a
  store to `k` in the same block. Because a `Block` is a basic block, that
  adjacent store is each read's unique reaching definition, so the slot is never
  live across a block boundary and no loop back-edge or conditional-redefinition
  bypass can route a stale value to a read. A reused slot stays foldable because
  each store/use pair is checked independently.
- **Single adjacent member-receiver use** — the fold's use sits in the statement
  immediately after `S`, is the slot's only read there, and is the instance of a
  property/field load or the receiver of an instance call (write places
  excluded).
- **Effect order** — the use is not in a short-circuit/ternary sub-position and
  nothing order-sensitive evaluates before it.

Because C# re-introduces the identical spill on recompile, the round-trip is
opcode-preserving.

## Adversarial review

Two independent adversarial reviewers (GPT-5.6 and Gemini 3.1 Pro) drove the
correctness of this change; see the reconciliation comment for full attribution.
In summary they found — with runtime repros — that the fold's original
document-order live-range proxy was unsound in **both** directions (loop
back-edge and forward conditional bypass). The final head replaces all
document-order reasoning with the whole-slot basic-block check above; both
reviewers re-reviewed the fixed head `1bca0bd8` and returned **CLEAN**.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| `StructReceiverInliningPassTests` | new | 9 passed |
| `LoweringCoverageTests` (classification) | 6 passed | 6 passed |
| Real witness `BclAdjustmentRule::IsStandardOffsetOnlyRule` | guard cascade | single `&&` return (Full) |
| Loop / conditional-bypass repros (do/while, for, if-bypass) | — | all decline (0 changed) |
| NodaTime blast radius | — | 91/2866 methods, 0 pass bugs |
| CoreLib blast radius (stress) | — | 601/37093 methods, 0 pass bugs |
| CI compile-back / fidelity (`test`, Linux) | — | green at `1bca0bd8` |

Compile-back / fidelity gates are the authoritative opcode-preservation signal
and run in CI (Linux). They are not runnable on this local Windows box — the
harness pulls all runtime references and the aspnetcore native shim fails Roslyn
with CS0009, which stalls the compile-back suite (2039/2039 recompile-fail) — so
local soundness was verified via pass tests plus runtime repros, and
opcode-exact fidelity is confirmed at scale by the green Linux `test` job.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.StructReceiverInliningPassTests
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.LoweringCoverageTests
```
