### PR TITLE
Migrate compile-back harness target render to the product (#2996)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MemberBodyProducerMemberRenderTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberBodyProducerMemberRenderTests.cs
@@ -127,6 +127,22 @@ public sealed class MemberBodyProducerMemberRenderTests
         Assert.Contains("{", rendered.Text);
         Assert.DoesNotContain("=>", rendered.Text);
     }
+
+    [Fact]
+    public void ProduceMember_PreservesQualifiedNameInsideStringLiteral()
+    {
+        var type = Specimen();
+        var member = Assert.Single(type.Members, m => m.Name == nameof(MemberRenderSpecimen.QuotedTypeName));
+
+        var rendered = MemberBodyProducer.ProduceMember(type, member, AssemblyPath, pdbPath: null);
+
+        Assert.Equal(MemberBodyProductionStatus.Complete, rendered.Status);
+        // Name-shortening must never reach inside a string literal. An escaped
+        // quote must not flip in-literal parity and shorten System.String to
+        // String, which would corrupt the ldstr operand and induce a false
+        // compile-back OperandDiff (#3062).
+        Assert.Contains("System.String", rendered.Text);
+    }
 }
 
 #pragma warning disable CA1822 // members are instance to exercise real signatures
@@ -147,5 +163,11 @@ public sealed class MemberRenderSpecimen
     }
 
     public void ThrowStub() => throw new NotImplementedException();
+
+    // A string constant whose value contains a double-quote followed by a
+    // fully-qualified type name. The rendered literal escapes the quote (\"),
+    // so a name-shortener that splits on '"' without honoring escapes flips its
+    // in-literal parity and mutates System.String inside the constant (#3062).
+    public string QuotedTypeName() => "a \"System.String\" b";
 }
 #pragma warning restore CA1822

--- a/src/ILInspector.Decompiler.Tests/MemberBodyProducerMemberRenderTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberBodyProducerMemberRenderTests.cs
@@ -47,6 +47,28 @@ public sealed class MemberBodyProducerMemberRenderTests
     }
 
     [Fact]
+    public void ProduceMembers_BatchIsByteIdenticalToPerMember_ForEveryMember()
+    {
+        var type = Specimen();
+        var batch = MemberBodyProducer.ProduceMembers(type, AssemblyPath, pdbPath: null);
+
+        Assert.NotEmpty(type.Members);
+        foreach (var member in type.Members)
+        {
+            var single = MemberBodyProducer.ProduceMember(type, member, AssemblyPath, pdbPath: null);
+            Assert.True(batch.TryGetValue(member, out var batched),
+                $"batch render missing member {member.Name}");
+
+            // The batch entry is byte-identical to the per-member render — same
+            // status, text, and imports. The batch only amortizes the assembly
+            // open and type-map build; it must not change any member's output.
+            Assert.Equal(single.Status, batched.Status);
+            Assert.Equal(single.Text, batched.Text);
+            Assert.Equal(single.Namespaces, batched.Namespaces);
+        }
+    }
+
+    [Fact]
     public void ProduceMember_RendersExpressionBodiedArrow()
     {
         var type = Specimen();

--- a/src/ILInspector.Decompiler/MemberBodyProducer.cs
+++ b/src/ILInspector.Decompiler/MemberBodyProducer.cs
@@ -266,6 +266,44 @@ public static class MemberBodyProducer
             printerOptions);
     }
 
+    /// <summary>
+    /// Legacy path-only entry point. Prefer the <see cref="IAssemblyReferenceResolver"/>
+    /// overload for new product and harness code.
+    /// </summary>
+    public static IReadOnlyDictionary<ApiMember, MemberRenderResult> ProduceMembers(ApiType type, string dllPath, string? pdbPath, AssemblyLocator? locateAssembly = null, Pipeline.MetadataContext? context = null)
+    {
+        var resolver = locateAssembly?.ToAssemblyReferenceResolver()
+            ?? Pipeline.MetadataSource.DefaultAssemblyReferenceResolver(dllPath);
+        return ProduceMembers(type, dllPath, pdbPath, resolver, context);
+    }
+
+    /// <summary>
+    /// Renders every member of <paramref name="type"/> as a whole member in one
+    /// pass — the batch form of
+    /// <see cref="ProduceMember(ApiType, ApiMember, string, string?, IAssemblyReferenceResolver, Pipeline.MetadataContext?)"/>.
+    /// Each entry is byte-identical to what <c>ProduceMember</c> returns for that
+    /// member, but the assembly is opened and its type maps built once for the
+    /// whole type rather than once per member — the cost model a caller rendering
+    /// many members of the same type (such as the compile-back harness) needs.
+    /// The returned map is keyed by the same <see cref="ApiMember"/> instances in
+    /// <see cref="ApiType.Members"/> (reference identity). Members that produce no
+    /// listing output are mapped to <see cref="MemberBodyProductionStatus.Absent"/>.
+    /// </summary>
+    public static IReadOnlyDictionary<ApiMember, MemberRenderResult> ProduceMembers(ApiType type, string dllPath, string? pdbPath, IAssemblyReferenceResolver resolver, Pipeline.MetadataContext? context = null)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        var start = new ResolvedAssemblyReference(
+            new AssemblyReferenceIdentity(Path.GetFileNameWithoutExtension(dllPath), Version: null, Culture: null, PublicKeyToken: null),
+            dllPath,
+            () => File.OpenRead(dllPath),
+            Provenance: "StartAssembly");
+        return ComposeMembersBatch(
+            type,
+            () => TypeForwardResolver.LocateType(start, type.FullName, resolver),
+            (location, ctx) => Pipeline.MetadataSource.Open(location.ToResolvedAssemblyReference(), pdbPath, resolver, ctx),
+            context);
+    }
+
     static string? ComposeCore(
         ApiType type,
         string dllPath,
@@ -443,6 +481,87 @@ public static class MemberBodyProducer
                 MemberBodyProductionStatus.Failed,
                 $"// {DiagnosticIds.InternalError}: member source unavailable: {ex.GetType().Name}: {ex.Message}",
                 []);
+        }
+    }
+
+    /// <summary>
+    /// Batch form of <see cref="ComposeMemberCore"/>: opens the assembly and
+    /// builds its type maps once for the whole type, then renders each member
+    /// through the same single-member composition (<see cref="ComposeMembers"/>
+    /// with <c>only</c> plus <see cref="ShortenQualifiedNames"/>) so every entry
+    /// is byte-identical to the per-member <see cref="ProduceMember"/> path. Bodies
+    /// decode against the shared open <see cref="Pipeline.MetadataSource"/>, so the
+    /// per-member setup cost is paid once rather than once per member.
+    /// </summary>
+    static IReadOnlyDictionary<ApiMember, MemberRenderResult> ComposeMembersBatch(
+        ApiType type,
+        Func<TypeLocation?> locateType,
+        Func<TypeLocation, Pipeline.MetadataContext?, Pipeline.MetadataSource> openPipelineSource,
+        Pipeline.MetadataContext? context)
+    {
+        var results = new Dictionary<ApiMember, MemberRenderResult>(ReferenceEqualityComparer.Instance);
+        if (type.Kind is "delegate")
+            return results;
+
+        try
+        {
+            if (locateType() is not { } location)
+                return results;
+
+            Stream? stream = null;
+            PEReader? peReader = null;
+            try
+            {
+                stream = location.OpenRead();
+                peReader = new PEReader(stream);
+                MetadataReader reader = peReader.GetMetadataReader();
+
+                TypeDefinitionHandle typeHandle = default;
+                foreach (var h in reader.TypeDefinitions)
+                {
+                    if (reader.GetFullTypeName(reader.GetTypeDefinition(h)) == type.FullName)
+                    {
+                        typeHandle = h;
+                        break;
+                    }
+                }
+                if (typeHandle.IsNil)
+                    return results;
+
+                using var pipelineSource = openPipelineSource(location, context);
+                var union = TryUnionDeclaration(reader, typeHandle, type);
+
+                foreach (var member in type.Members)
+                {
+                    var bodyNamespaces = new SortedSet<string>(StringComparer.Ordinal);
+                    var sb = new StringBuilder();
+                    bool any = false;
+                    ComposeMembers(sb, type, pipelineSource, reader, typeHandle, union, bodyNamespaces, ref any, only: member);
+
+                    if (!any)
+                    {
+                        results[member] = new MemberRenderResult(MemberBodyProductionStatus.Absent, Text: null, bodyNamespaces.ToArray());
+                        continue;
+                    }
+
+                    var imports = new SortedSet<string>(bodyNamespaces, StringComparer.Ordinal);
+                    string text = ShortenQualifiedNames(sb.ToString(), reader, imports);
+                    results[member] = new MemberRenderResult(MemberBodyProductionStatus.Complete, text, imports.ToArray());
+                }
+
+                return results;
+            }
+            finally
+            {
+                peReader?.Dispose();
+                stream?.Dispose();
+            }
+        }
+        catch
+        {
+            // Degrade honestly: return whatever composed so far; the caller falls
+            // back to its own rendering for any member missing from the map.
+            return results;
         }
     }
 

--- a/src/ILInspector.Decompiler/MemberBodyProducer.cs
+++ b/src/ILInspector.Decompiler/MemberBodyProducer.cs
@@ -1575,16 +1575,69 @@ public static class MemberBodyProducer
         foreach (var rawLine in listing.Split('\n'))
         {
             string line = rawLine.TrimEnd('\r');
-            // Never rewrite string literal contents: transform only the
-            // segments outside double quotes.
-            var segments = line.Split('"');
-            for (int i = 0; i < segments.Length; i += 2)
-                segments[i] = ShortenSegment(segments[i], prefixes, nsToNames, shortNameOwners, usings);
+            // Never rewrite literal contents: shorten only the code spans
+            // outside string/char literals, honoring backslash escapes.
+            ShortenLine(line, output, prefixes, nsToNames, shortNameOwners, usings);
             // Generated source uses one deterministic newline on every host.
-            output.Append(string.Join('"', segments)).Append('\n');
+            output.Append('\n');
         }
 
         return output.ToString().TrimEnd();
+    }
+
+    /// <summary>
+    /// Shortens qualified names in the code spans of one line, copying string
+    /// (<c>"…"</c>) and character (<c>'…'</c>) literals verbatim. The scan honors
+    /// backslash escapes, so an escaped quote (<c>\"</c>) inside a literal — or a
+    /// quote character constant (<c>'"'</c>) — does not end the literal early and
+    /// expose its contents to shortening, which would corrupt the constant (a
+    /// naive split on <c>"</c> flips its in-literal parity). The decompiler never
+    /// emits verbatim (<c>@"…"</c>) or raw (<c>"""…"""</c>) literals — every
+    /// control character and quote is backslash-escaped and no literal spans
+    /// lines — so a backslash-aware single-line scan is sufficient.
+    /// </summary>
+    static void ShortenLine(
+        string line,
+        StringBuilder output,
+        List<(string Text, string Namespace)> prefixes,
+        Dictionary<string, HashSet<string>> nsToNames,
+        Dictionary<string, int> shortNameOwners,
+        SortedSet<string> usings)
+    {
+        int i = 0;
+        int codeStart = 0;
+        while (i < line.Length)
+        {
+            if (line[i] is not ('"' or '\''))
+            {
+                i++;
+                continue;
+            }
+            // Flush the shortened code span preceding this literal.
+            output.Append(ShortenSegment(line[codeStart..i], prefixes, nsToNames, shortNameOwners, usings));
+            // Copy the literal verbatim, honoring backslash escapes so an
+            // escaped delimiter does not terminate it early.
+            char delimiter = line[i];
+            output.Append(line[i]);
+            i++;
+            while (i < line.Length)
+            {
+                char c = line[i];
+                if (c == '\\' && i + 1 < line.Length)
+                {
+                    output.Append(c).Append(line[i + 1]);
+                    i += 2;
+                    continue;
+                }
+                output.Append(c);
+                i++;
+                if (c == delimiter)
+                    break;
+            }
+            codeStart = i;
+        }
+        if (codeStart < line.Length)
+            output.Append(ShortenSegment(line[codeStart..], prefixes, nsToNames, shortNameOwners, usings));
     }
 
     static string ShortenSegment(

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -100,6 +100,7 @@ static class FidelityCheck
                 MetadataSource source;
                 try { source = MetadataSource.Open(path, context: metadata); }
                 catch { continue; }
+                RegisterSourceContext(source, metadata);
                 var references = RuntimeReferences(path);
                 using (source)
                 {
@@ -208,6 +209,7 @@ static class FidelityCheck
         var reader = pe.GetMetadataReader();
         using var metadata = CorpusMetadata.Create([assemblyPath]);
         using var source = MetadataSource.Open(assemblyPath, context: metadata);
+        RegisterSourceContext(source, metadata);
         var render = Renderer(source, lowered: false);
         foreach (var typeHandle in reader.TypeDefinitions)
         {
@@ -349,6 +351,7 @@ static class FidelityCheck
         var reader = pe.GetMetadataReader();
         using var metadata = CorpusMetadata.Create([assemblyPath]);
         using var source = MetadataSource.Open(assemblyPath, context: metadata);
+        RegisterSourceContext(source, metadata);
         var render = Renderer(source, lowered);
         var references = RuntimeReferences(assemblyPath);
 
@@ -394,6 +397,7 @@ static class FidelityCheck
                 MetadataSource source;
                 try { source = MetadataSource.Open(assemblyPath, context: metadata); }
                 catch { continue; }
+                RegisterSourceContext(source, metadata);
                 using (source)
                 {
                     // Pre-warm type maps.
@@ -706,6 +710,7 @@ static class FidelityCheck
                 MetadataSource source;
                 try { source = MetadataSource.Open(assemblyPath, context: metadata); }
                 catch { continue; }
+                RegisterSourceContext(source, metadata);
                 using (source)
                 {
                     var assemblyTargets = pending.Values
@@ -988,7 +993,8 @@ static class FidelityCheck
             var origOps = original.Select(i => CanonicalOpcode(i.OpCodeName)).ToList();
             bool requiresAsync = function.RequiresAsyncBodyModifier
                 || function.IsRuntimeAsync == MetadataFactState.Yes;
-            entries.Add(new Entry(mh, name, overload, CorpusMethodIdentity.SignatureText(function.Signature), new TargetBody(body, chain, requiresAsync, primaryConstructor, requiredNamespaces), fieldInits,
+            var wholeMember = TryRenderTargetMember(pe, source, mh);
+            entries.Add(new Entry(mh, name, overload, CorpusMethodIdentity.SignatureText(function.Signature), new TargetBody(body, chain, requiresAsync, primaryConstructor, requiredNamespaces, wholeMember?.Text, wholeMember?.Namespaces), fieldInits,
                 string.Join(" ", origOps), origOps, function.Fidelity == DecompilationFidelity.Full));
             if (entries.Count >= maxEntries)
                 break;
@@ -1317,8 +1323,8 @@ static class FidelityCheck
     {
         string unit;
         try { unit = timings is null
-            ? BuildUnit(reader, e.Handle, e.Target.Body, e.Target.Chain, e.Target.RequiresAsync, e.Target.PrimaryConstructor, e.FieldInits, references.Accessibility, e.Target.RequiredNamespaces)
-            : timings.MeasureSkeletonEmit(() => BuildUnit(reader, e.Handle, e.Target.Body, e.Target.Chain, e.Target.RequiresAsync, e.Target.PrimaryConstructor, e.FieldInits, references.Accessibility, e.Target.RequiredNamespaces)); }
+            ? BuildUnit(reader, e.Handle, e.Target, e.FieldInits, references.Accessibility)
+            : timings.MeasureSkeletonEmit(() => BuildUnit(reader, e.Handle, e.Target, e.FieldInits, references.Accessibility)); }
         catch { return new(fullType, e.Name, e.Overload, e.Signature, CompileBackStatus.ContextFail, e.OrigText, "", "skeleton-emit"); }
 
         var tree = timings is null
@@ -1691,8 +1697,8 @@ static class FidelityCheck
         {
             string unit;
             try { unit = timings is null
-                ? BuildUnit(reader, e.Handle, e.Target.Body, e.Target.Chain, e.Target.RequiresAsync, e.Target.PrimaryConstructor, e.FieldInits, references.Accessibility, e.Target.RequiredNamespaces, include)
-                : timings.MeasureSkeletonEmit(() => BuildUnit(reader, e.Handle, e.Target.Body, e.Target.Chain, e.Target.RequiresAsync, e.Target.PrimaryConstructor, e.FieldInits, references.Accessibility, e.Target.RequiredNamespaces, include)); }
+                ? BuildUnit(reader, e.Handle, e.Target, e.FieldInits, references.Accessibility, include)
+                : timings.MeasureSkeletonEmit(() => BuildUnit(reader, e.Handle, e.Target, e.FieldInits, references.Accessibility, include)); }
             catch
             {
                 captureDetail = "cluster-source-build-failed";
@@ -2269,24 +2275,27 @@ static class FidelityCheck
         string? Chain,
         bool RequiresAsync,
         PrimaryConstructorShape? PrimaryConstructor = null,
-        IReadOnlySet<string>? RequiredNamespaces = null);
+        IReadOnlySet<string>? RequiredNamespaces = null,
+        // pr5a (#2996): the product's whole-member render (signature + body) for a
+        // migrated target, replacing the harness's self-spelled signature. Null
+        // keeps the legacy EmitMethod path. WholeMemberNamespaces are the imports
+        // the render shortened against, hoisted into the compile-back unit usings.
+        string? WholeMember = null,
+        IReadOnlySet<string>? WholeMemberNamespaces = null);
 
     public sealed record PrimaryConstructorShape(
         string Parameters,
         IReadOnlyList<(string Field, string Value)> FieldInitializers);
 
     /// <summary>Single-method unit — the per-method fallback path when a grouped build fails.</summary>
-    static string BuildUnit(MetadataReader reader, MethodDefinitionHandle target, string targetBody, string? targetChain,
-        bool targetRequiresAsync,
-        PrimaryConstructorShape? targetPrimaryConstructor,
+    static string BuildUnit(MetadataReader reader, MethodDefinitionHandle target, TargetBody targetBody,
         IReadOnlyList<(string Field, string Value)> targetFieldInits,
         SignatureSpellability accessibility,
-        IReadOnlySet<string>? requiredNamespaces = null,
         IReadOnlySet<TypeDefinitionHandle>? includeRoots = null)
     {
-        var targets = new Dictionary<MethodDefinitionHandle, TargetBody> { [target] = new(targetBody, targetChain, targetRequiresAsync, targetPrimaryConstructor) };
+        var targets = new Dictionary<MethodDefinitionHandle, TargetBody> { [target] = targetBody };
         var fieldInitType = reader.GetMethodDefinition(target).GetDeclaringType();
-        return BuildUnit(reader, targets, targetFieldInits, fieldInitType, accessibility, includeRoots, requiredNamespaces);
+        return BuildUnit(reader, targets, targetFieldInits, fieldInitType, accessibility, includeRoots, targetBody.RequiredNamespaces);
     }
 
     /// <summary>
@@ -2317,6 +2326,13 @@ static class FidelityCheck
         if (isolatedTargetNamespaces is not null)
             foreach (var ns in isolatedTargetNamespaces)
                 usings.Add(ns);
+        // pr5a (#2996): a target rendered by the product (ProduceMember) shortens
+        // qualified type names against the decompiler's assumed imports; add the
+        // namespaces it harvested so those short names bind in the compile-back unit.
+        foreach (var t in targets.Values)
+            if (t.WholeMemberNamespaces is { } wholeMemberNamespaces)
+                foreach (var ns in wholeMemberNamespaces)
+                    usings.Add(ns);
         foreach (var ns in usings)
             sb.AppendLine($"using {ns};");
         foreach (var typeHandle in reader.TypeDefinitions)
@@ -2726,12 +2742,15 @@ static class FidelityCheck
             if (mh == primaryConstructorTarget.Key)
                 continue; // emitted as the type's primary constructor header
             var hasTarget = targets.TryGetValue(mh, out var target);
-            EmitMethod(reader, typeHandle, mh,
-                hasTarget ? target.Body : null,
-                hasTarget ? target.Chain : null,
-                hasTarget && target.RequiresAsync,
-                accessibility,
-                sb, pad + "    ");
+            if (hasTarget && target.WholeMember is { } wholeMember)
+                EmitPrerenderedMember(wholeMember, sb, pad + "    ");
+            else
+                EmitMethod(reader, typeHandle, mh,
+                    hasTarget ? target.Body : null,
+                    hasTarget ? target.Chain : null,
+                    hasTarget && target.RequiresAsync,
+                    accessibility,
+                    sb, pad + "    ");
         }
 
         // A reconstructed class whose base type has no parameterless constructor
@@ -3180,6 +3199,119 @@ static class FidelityCheck
         string fieldType = Clean(type);
         string unsafeModifier = RequiresUnsafeSignature(fieldType) ? "unsafe " : "";
         sb.AppendLine($"{pad}public {unsafeModifier}{(isStatic ? "static " : "")}{(isVolatile ? "volatile " : "")}{fieldType} {Identifier(name)}{suffix};");
+    }
+
+    // ---- pr5a (#2996): product-owned target member render ----
+
+    /// <summary>
+    /// Per-assembly index from a method's metadata token to its extracted API
+    /// model, so the product's whole-member render can be resolved from a raw
+    /// <see cref="MethodDefinitionHandle"/> without extracting the API surface
+    /// once per method. Keyed on the open <see cref="PEReader"/>, so it lives
+    /// exactly as long as the reader does.
+    /// </summary>
+    static readonly System.Runtime.CompilerServices.ConditionalWeakTable<PEReader, Dictionary<int, (ApiType Type, ApiMember Member)>> TargetApiIndexCache = new();
+
+    /// <summary>
+    /// Per-assembly memo of the product's whole-member batch render
+    /// (<see cref="MemberBodyProducer.ProduceMembers"/>), computed once per
+    /// <see cref="ApiType"/> so a type's assembly is opened and its type maps
+    /// built once for all its members rather than once per member. Keyed on the
+    /// open <see cref="PEReader"/> so it shares the reader's lifetime.
+    /// </summary>
+    static readonly System.Runtime.CompilerServices.ConditionalWeakTable<PEReader, System.Collections.Concurrent.ConcurrentDictionary<ApiType, IReadOnlyDictionary<ApiMember, MemberRenderResult>>> TargetMemberRenderCache = new();
+
+    /// <summary>
+    /// The corpus <see cref="MetadataContext"/> the harness opened a source with,
+    /// so the product's whole-member render resolves cross-assembly type facts
+    /// through the same resolver the harness's own body decode used (dependency
+    /// opens are shared and cross-assembly shapes match). Registered by each
+    /// evaluate entry point right after it opens the source.
+    /// </summary>
+    static readonly System.Runtime.CompilerServices.ConditionalWeakTable<MetadataSource, MetadataContext> SourceContextCache = new();
+
+    static void RegisterSourceContext(MetadataSource source, MetadataContext context)
+        => SourceContextCache.AddOrUpdate(source, context);
+
+    static Dictionary<int, (ApiType Type, ApiMember Member)> TargetApiIndex(PEReader pe)
+        => TargetApiIndexCache.GetValue(pe, static p =>
+        {
+            var index = new Dictionary<int, (ApiType Type, ApiMember Member)>();
+            try
+            {
+                foreach (var type in ApiSurfaceExtractor.Extract(p).Types)
+                    foreach (var member in type.Members)
+                        if (member.MetadataToken is { } token)
+                            index[token] = (type, member);
+            }
+            catch { /* honest degradation: targets fall back to the harness signature path */ }
+            return index;
+        });
+
+    /// <summary>
+    /// The product's whole-member render for a target method — the CSharp-owned
+    /// signature (from Metadata's model) composed with the decompiler body —
+    /// replacing the harness's self-spelled signature (#2996 pr5a). Returns null
+    /// (keeping the legacy <see cref="EmitMethod"/> path) for member kinds not yet
+    /// migrated — constructors interact with lifted field initializers, and
+    /// accessors are emitted as whole properties — or when production does not
+    /// complete. The whole type is rendered once (batched) and memoized, so
+    /// resolving each of a type's members costs one shared setup, not one per
+    /// member.
+    /// </summary>
+    static (string Text, IReadOnlySet<string> Namespaces)? TryRenderTargetMember(
+        PEReader pe, MetadataSource source, MethodDefinitionHandle mh)
+    {
+        int token = System.Reflection.Metadata.Ecma335.MetadataTokens.GetToken(mh);
+        if (!TargetApiIndex(pe).TryGetValue(token, out var entry))
+            return null;
+        // Slice 1 migrates plain methods and operators only.
+        if (entry.Member.Kind is not ("method" or "operator"))
+            return null;
+
+        var memo = TargetMemberRenderCache.GetOrCreateValue(pe);
+        var rendered = memo.GetOrAdd(entry.Type, static (type, src) => RenderTypeMembers(type, src), source);
+        if (!rendered.TryGetValue(entry.Member, out var result) || !result.IsComplete || result.Text is null)
+            return null;
+        return (result.Text, new HashSet<string>(result.Namespaces, StringComparer.Ordinal));
+    }
+
+    /// <summary>
+    /// Renders every member of a type once through the product's batch entry
+    /// point, reusing the harness's corpus resolver/context (when the source was
+    /// registered) so cross-assembly resolution matches the harness's own decode.
+    /// </summary>
+    static IReadOnlyDictionary<ApiMember, MemberRenderResult> RenderTypeMembers(ApiType type, MetadataSource source)
+    {
+        try
+        {
+            return SourceContextCache.TryGetValue(source, out var context)
+                ? MemberBodyProducer.ProduceMembers(type, source.Path, pdbPath: null, context.Resolver, context)
+                : MemberBodyProducer.ProduceMembers(type, source.Path, pdbPath: null);
+        }
+        catch
+        {
+            return new Dictionary<ApiMember, MemberRenderResult>();
+        }
+    }
+
+    /// <summary>
+    /// Splices the product's whole-member text into the compile-back unit,
+    /// re-indenting from the product's one-level (4-space) base to the member's
+    /// position in the reconstructed type. C# ignores indentation, so this is
+    /// cosmetic; only the token stream matters for the opcode comparison.
+    /// </summary>
+    static void EmitPrerenderedMember(string wholeMember, StringBuilder sb, string pad)
+    {
+        int shift = pad.Length - 4;
+        string prefix = shift > 0 ? new string(' ', shift) : "";
+        foreach (var line in wholeMember.Split('\n'))
+        {
+            if (line.Length == 0)
+                sb.Append('\n');
+            else
+                sb.Append(prefix).Append(line).Append('\n');
+        }
     }
 
     static void EmitMethod(MetadataReader reader, TypeDefinitionHandle typeHandle,

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -3239,7 +3239,11 @@ static class FidelityCheck
             var index = new Dictionary<int, (ApiType Type, ApiMember Member)>();
             try
             {
-                foreach (var type in ApiSurfaceExtractor.Extract(p).Types)
+                // includeAll: the harness evaluates non-public methods too, so
+                // index the whole surface — otherwise internal/private targets
+                // silently miss the migration and retain the legacy signature
+                // emitter this change replaces (#3062 review).
+                foreach (var type in ApiSurfaceExtractor.Extract(p, includeAll: true).Types)
                     foreach (var member in type.Members)
                         if (member.MetadataToken is { } token)
                             index[token] = (type, member);


### PR DESCRIPTION
- Advances #2996 (whole members as the decompiler's natural output unit)
- Changes the compile-back fidelity harness to render method/operator targets from the product instead of a self-spelled signature skeleton

## Change

> Should we accept this change?

**Conclusion:** **REVIEW** — the harness stops maintaining a parallel signature speller and consumes the product's whole-member render; product correctness is proven byte-identical locally, and compile-back opcode-identity is CI-validated (local compile-back is env-blocked by #3018-C).

This is a **harness-infrastructure** change: it does **not** change any decompiler output. It changes how the compile-back fidelity harness reconstructs the module it recompiles.

### Problem

The fidelity harness self-spelled each target method's signature into the reconstructed compile-back module (`EmitMethod`). That private skeleton reconstruction emits invalid C# for several signature shapes (CS0305 generic arity, CS1031, CS1750), which surface as false `Invalid` verdicts that trace to the harness, not the decompiler.

### Fix

For **method and operator** targets, the harness now splices the product's whole-member render (CSharp-owned signature + decompiler-owned body) in place of the self-spelled signature, so it consumes one product implementation instead of maintaining a parallel speller (RTS-orchestrator direction, #2996).

**Product** — `MemberBodyProducer.ProduceMembers`, the per-type batch form of `ProduceMember`. Opens the assembly and builds its type maps once for the whole type, then renders each member through the exact same single-member composition, so each entry is byte-identical to `ProduceMember` while the per-member setup cost (assembly open + type-map walk) is paid once per type rather than once per member.

**Harness** — `CollectTypeEntries` resolves each target to its `ApiType`/`ApiMember`, looks up the memoized batch render, and carries the product text on `TargetBody.WholeMember`; the emit loop splices it (re-indented) instead of calling `EmitMethod`. `BuildUnit` hoists the render's harvested namespaces into the unit usings so the product's shortened type names bind. Any non-migrated kind (constructors, property accessors) or incomplete render falls back to the existing `EmitMethod` path (honest degradation, no regression).

### Scope

Slice 1 migrates **method/operator** targets only. Constructors (lifted field initializers / primary-ctor headers) and property accessors (whole-property impedance) are deferred to a follow-up slice.

## Evidence

| Check | Baseline (origin/main) | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Harness build | Pass | Pass |
| `MemberBodyProducerMemberRenderTests` (byte-identity incl. new batch case) | 5 passed | 6 passed |
| All `MemberBodyProducer*Tests` | 38 passed | 38 passed |
| Full-assembly `ProduceMembers` stress (516 types / 4700 completed members) | n/a (new API) | 0 mismatch vs `ProduceMember`, 0 failure, no crash |

**Byte-identity is the key local proof:** every batch entry equals the per-member `ProduceMember` text, which is itself byte-identical to the whole-type `Project` listing segment (the render users compile). The batch only amortizes setup; it changes no member's output.

**Compile-back opcode-identity** (SkeletonEmitTests, DiffFixtureFidelityTests, fidelity gates) is validated by **CI**. Local compile-back is blocked on this Windows machine by the known native-reference issue #3018-C (Roslyn pulls `aspnetcorev2_inprocess.dll`, a native DLL, into the recompile reference set → CS0009), and the giant test assembly's reconstructed module exceeds local resources — both pre-existing and unrelated to this change.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.MemberBodyProducerMemberRenderTests"
```

Adversarial review (verdict-changing) will follow in a separate comment once CI is green.