### PR TITLE
Duplicate scattered switch default into each guard (#2978)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchSample.cs
+++ b/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchSample.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Fixtures for issue #2978: a nested type-pattern <c>switch</c> expression whose
+/// shared <c>_ =&gt; Fail</c> default is reached by two conditional guards at
+/// different nesting levels (the outer <c>is not int</c> and the inner
+/// <c>i &lt;= 0</c>). In block order a self-contained sibling region (the inner
+/// <c>string</c>-length switch) is interleaved between the two guards, so
+/// <see cref="ILInspector.Decompiler.Pipeline.StructuringPass"/> must recognize
+/// the guards as a scattered dispatch and duplicate the default return into each
+/// guard — otherwise the <c>i &lt;= 0</c> path falls off the end of a non-void
+/// method (CS0177: <c>out</c> parameter unassigned).
+///
+/// The <see cref="PlainAnd"/> and <see cref="ThrowTernaryChain"/> canaries are the
+/// close negatives: contiguous short-circuit <c>&amp;&amp;</c> guard chains whose
+/// shared return must stay combined under one condition (the #640 fidelity
+/// canary), not unrolled into duplicated returns.
+/// </summary>
+public static class ScatteredReturnDispatchSample
+{
+    // #2978 witness: the i <= 0 path must return the duplicated default.
+    public static bool Dispatch(object o, out int x) => o switch
+    {
+        string s => s.Length switch
+        {
+            0 => Fail(out x),
+            1 => Win(1, out x),
+            _ => Fail(out x)
+        },
+        int i when i > 0 => Win(i, out x),
+        _ => Fail(out x)
+    };
+
+    static bool Win(int v, out int x) { x = v; return true; }
+
+    static bool Fail(out int x) { x = 0; return false; }
+
+    // #640 canary: two contiguous guards on a shared return — must stay `a && b`.
+    public static int PlainAnd(int a, int b)
+    {
+        if (a > 0 && b > 0)
+        {
+            return 1;
+        }
+
+        return 2;
+    }
+
+    // Round-2 witness: a throw in a ternary inside `&&` — must stay combined.
+    public static bool ThrowTernaryChain(bool a, bool b, bool c)
+        => a && (b ? c : throw new Exception()) && Other();
+
+    static bool Other() => true;
+}

--- a/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchStructuringTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ScatteredReturnDispatchStructuringTests.cs
@@ -1,0 +1,85 @@
+using System;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Issue #2978: a nested type-pattern <c>switch</c> expression whose shared
+/// <c>_ =&gt; Fail</c> default is reached by two conditional guards at different
+/// nesting levels, with a self-contained sibling region (an inner
+/// <c>string</c>-length switch) interleaved between them in block order.
+/// <see cref="StructuringPass"/> must classify the two guards as a scattered
+/// dispatch and duplicate the default return into each guard; otherwise the
+/// failing <c>int</c> arm (<c>i &lt;= 0</c>) falls off the end of the non-void
+/// method, leaving the <c>out</c> parameter unassigned (CS0177).
+///
+/// The discriminator that recognizes this shape (an interior block entered by a
+/// jump from before the guard span) must not fire on a contiguous short-circuit
+/// <c>&amp;&amp;</c> guard chain, which threads entirely within its own span and
+/// must stay combined under one condition — the #640 fidelity canary. The two
+/// canaries below (<see cref="ScatteredReturnDispatchSample.PlainAnd"/> and
+/// <see cref="ScatteredReturnDispatchSample.ThrowTernaryChain"/>) pin that the
+/// shared return is not unrolled and the condition stays a single <c>&amp;&amp;</c>.
+/// </summary>
+[Trait("Area", "Pass")]
+public class ScatteredReturnDispatchStructuringTests
+{
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(ScatteredReturnDispatchSample).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(ScatteredReturnDispatchSample).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return function;
+    }
+
+    static string Print(string methodName) =>
+        CSharpPrinter.Print(Raised(methodName)).Output!.ReplaceLineEndings("\n").TrimEnd();
+
+    // ── Compiler-backed positive ───────────────────────────────────────────
+
+    [Fact]
+    public void ScatteredDefault_IsDuplicatedIntoBothGuards_SoEveryPathReturns()
+    {
+        string output = Print(nameof(ScatteredReturnDispatchSample.Dispatch));
+
+        // The failing int arm (i <= 0) now returns the duplicated default instead
+        // of falling off the end — the CS0177 fix.
+        int guard = output.IndexOf("if (i <= 0)", StringComparison.Ordinal);
+        Assert.True(guard >= 0, output);
+        Assert.Contains("return Fail(out x);", output[guard..]);
+
+        // Every path returns: the method body ends with an unconditional return.
+        Assert.EndsWith("return Win(i, out x);", output);
+
+        // The default is duplicated into each guard rather than dropped: no goto
+        // label survives and the raised body has no fall-through terminator.
+        Assert.DoesNotContain("goto", output);
+    }
+
+    // ── Compiler-backed negatives (the #640 canary) ────────────────────────
+
+    [Fact]
+    public void ContiguousShortCircuitChain_StaysCombined_NotUnrolled()
+    {
+        string output = Print(nameof(ScatteredReturnDispatchSample.PlainAnd));
+
+        // Two contiguous guards on the shared `return 2` stay one condition.
+        Assert.Contains("if (a > 0 && b > 0)", output);
+        Assert.EndsWith("return 2;", output);
+    }
+
+    [Fact]
+    public void ThrowTernaryInsideChain_StaysCombined_NotScattered()
+    {
+        string output = Print(nameof(ScatteredReturnDispatchSample.ThrowTernaryChain));
+
+        // The throw sub-expression is a within-span arm of the same short-circuit
+        // condition, so the chain is not treated as a scattered dispatch: the
+        // shared `return false` is not duplicated into each guard.
+        Assert.Contains("if (a)", output);
+        Assert.Contains("throw new Exception();", output);
+        Assert.EndsWith("return false;", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -106,6 +106,10 @@ public sealed class StructuringPass : IIrPass
         var conditionalTargetCounts = new Dictionary<int, int>();
         var conditionalPredecessorIndices = new Dictionary<int, List<int>>();
         var branchPredecessorIndices = new Dictionary<int, List<int>>();
+        // Every jump-edge predecessor (unconditional, conditional, or switch) of
+        // each target offset, by source block index. Used to detect a sibling
+        // region interleaved between a shared return's scattered guards (#2978).
+        var jumpPredecessorIndices = new Dictionary<int, List<int>>();
         var switchTargets = new HashSet<int>();
         var branchTargets = new HashSet<int>();
         for (int blockIndex = 0; blockIndex < blocks.Count; blockIndex++)
@@ -120,6 +124,7 @@ public sealed class StructuringPass : IIrPass
                         branchPredecessorIndices[branch.TargetOffset] = branchPreds = new List<int>();
                     branchPreds.Add(blockIndex);
                     branchTargets.Add(branch.TargetOffset);
+                    AddPredecessor(jumpPredecessorIndices, branch.TargetOffset, blockIndex);
                 }
                 else if (child is Leave leave)
                 {
@@ -133,6 +138,7 @@ public sealed class StructuringPass : IIrPass
                         conditionalPredecessorIndices[conditional.TargetOffset] = preds = new List<int>();
                     preds.Add(blockIndex);
                     branchTargets.Add(conditional.TargetOffset);
+                    AddPredecessor(jumpPredecessorIndices, conditional.TargetOffset, blockIndex);
                 }
                 else if (child is SwitchBranch switchBranch)
                 {
@@ -141,6 +147,7 @@ public sealed class StructuringPass : IIrPass
                         unconditionalTargets.Add(target);
                         switchTargets.Add(target);
                         branchTargets.Add(target);
+                        AddPredecessor(jumpPredecessorIndices, target, blockIndex);
                     }
                 }
             }
@@ -199,7 +206,7 @@ public sealed class StructuringPass : IIrPass
             {
                 continue;
             }
-            if (IsScatteredDispatch(blocks, conditionalPredecessorIndices[offset], branchTargets))
+            if (IsScatteredDispatch(blocks, conditionalPredecessorIndices[offset], branchTargets, jumpPredecessorIndices))
                 scatteredReturnDispatchTargets.Add(offset);
         }
 
@@ -1155,26 +1162,46 @@ public sealed class StructuringPass : IIrPass
         };
     }
 
+    static void AddPredecessor(Dictionary<int, List<int>> map, int targetOffset, int predecessorIndex)
+    {
+        if (!map.TryGetValue(targetOffset, out var preds))
+            map[targetOffset] = preds = new List<int>();
+        preds.Add(predecessorIndex);
+    }
+
     /// <summary>
     /// Whether the conditional predecessors of a shared return are scattered
     /// across nesting levels (a <c>return</c>/<c>throw</c> dispatch arm sits
     /// between two of them in block order) rather than forming a single
-    /// contiguous <c>&amp;&amp;</c>/<c>||</c> guard chain. For each interleaved
-    /// terminator, the guard that produced it (found by walking back over the
-    /// arm's plain fall-through statement blocks) must branch forward PAST the
-    /// predecessor span — to the shared return or another downstream terminal —
-    /// which marks a genuine dispatch arm closing a region strict nesting cannot
-    /// keep open, so the return must be duplicated into each guard. A
-    /// <c>throw</c>/<c>return</c> sub-expression nested inside a short-circuit
+    /// contiguous <c>&amp;&amp;</c>/<c>||</c> guard chain. Two structural signals
+    /// mark a scattered dispatch:
+    /// <list type="bullet">
+    ///   <item>An interleaved terminator whose guard (found by walking back over
+    ///   the arm's plain fall-through statement blocks) branches forward PAST the
+    ///   predecessor span — to the shared return or another downstream terminal —
+    ///   marking a genuine dispatch arm closing a region strict nesting cannot
+    ///   keep open.</item>
+    ///   <item>A block strictly inside the guard span that is entered by a jump
+    ///   from BEFORE the span (issue #2978): fall-through into an interior block
+    ///   always comes from index ≥ <c>lo</c>, so an interior jump target whose
+    ///   source precedes the first guard is a sibling region (e.g. another
+    ///   switch arm) interleaved in block order between the guards. Strict
+    ///   nesting cannot linearize that region between them, so the shared return
+    ///   must be duplicated into each guard.</item>
+    /// </list>
+    /// A <c>throw</c>/<c>return</c> sub-expression nested inside a short-circuit
     /// condition is instead the fall-through arm of a test that branches forward
-    /// WITHIN the span to continue evaluating the same condition; that arm stays
-    /// combined under one guard (the #640-style fidelity canary), so it is
-    /// excluded.
+    /// WITHIN the span to continue evaluating the same condition, and a single
+    /// short-circuit condition threads entirely within its own span (no interior
+    /// block is entered from before the first guard); such chains stay combined
+    /// under one guard (the #640-style fidelity canary), so both signals exclude
+    /// them.
     /// </summary>
     static bool IsScatteredDispatch(
         IReadOnlyList<Block> blocks,
         List<int> predecessorIndices,
-        HashSet<int> branchTargets)
+        HashSet<int> branchTargets,
+        Dictionary<int, List<int>> jumpPredecessorIndices)
     {
         int lo = int.MaxValue;
         int hi = int.MinValue;
@@ -1182,6 +1209,21 @@ public sealed class StructuringPass : IIrPass
         {
             if (index < lo) lo = index;
             if (index > hi) hi = index;
+        }
+        // A sibling region interleaved in block order between the guards: an
+        // interior block reached by a jump from before the first guard (issue
+        // #2978's nested-switch arm). Fall-through never enters an interior block
+        // from before the span, so this signals a foreign dispatch subtree that
+        // strict nesting cannot place between the scattered guards.
+        for (int i = lo + 1; i < hi; i++)
+        {
+            if (!jumpPredecessorIndices.TryGetValue(blocks[i].StartOffset, out var interiorPreds))
+                continue;
+            foreach (int predIndex in interiorPreds)
+            {
+                if (predIndex < lo)
+                    return true;
+            }
         }
         int spanEndOffset = blocks[hi].StartOffset;
         for (int i = lo + 1; i < hi; i++)


### PR DESCRIPTION
- Fixes #2978
- Changes structuring so a nested type-pattern `switch` whose shared default is reached by two scattered guards duplicates that default into each guard, instead of leaving one path unassigned.
- Card revision: `ffbd7ff8`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the fix turns invalid decompiled C# (a non-void method that falls off the end, CS0161, leaving `out x` unassigned, CS0177) into valid C# where every path returns, and the #640 short-circuit canaries stay opcode-exact.

### Original source

```csharp
public static bool Dispatch(object o, out int x) => o switch
{
    string s => s.Length switch
    {
        0 => Fail(out x),
        1 => Win(1, out x),
        _ => Fail(out x)
    },
    int i when i > 0 => Win(i, out x),
    _ => Fail(out x)
};
```

### Before

```csharp
public static bool Dispatch(object o, out int x)
{
    int i;
    int V_5;

    object V_3 = o;
    string s = V_3 as string;
    if (s is null)
    {
        if (V_3 is not int)
        {
            return Fail(out x);
        }
        i = (int)V_3;
    }
    else
    {
        V_5 = s.Length;
        if (V_5 != 0)
        {
            if (V_5 == 1)
            {
                return Win(1, out x);
            }
            return Fail(out x);
        }
        return Fail(out x);
    }
    if (i > 0)
    {
        return Win(i, out x);
    }
}
```

- Valid: False
- Correct: False

The `i <= 0` path has no `return`: the method falls off the end (CS0161) and `out x` is never assigned on that path (CS0177). The shared `_ => Fail` default was inlined into the inner `string` arm only; the outer failing `int` guard lost its path to it.

### After

```csharp
public static bool Dispatch(object o, out int x)
{
    int i;
    int V_5;

    object V_3 = o;
    string s = V_3 as string;
    if (s is null)
    {
        if (V_3 is not int)
        {
            return Fail(out x);
        }
        i = (int)V_3;
    }
    else
    {
        V_5 = s.Length;
        if (V_5 != 0)
        {
            if (V_5 == 1)
            {
                return Win(1, out x);
            }
            return Fail(out x);
        }
        return Fail(out x);
    }
    if (i <= 0)
    {
        return Fail(out x);
    }
    return Win(i, out x);
}
```

- Valid: True
- Correct: True

Every path now returns and assigns `out x`. The shared default is duplicated into the failing `int` guard (`if (i <= 0) return Fail(out x);`), matching the #2959 precedent that duplicates a scattered dispatch return to fix CS0161.

### Fully raised

The intended endpoint is the original nested `switch` expression. This PR raises it to valid, behavior-preserving statement C# but not back to the `switch`-expression spelling (the original lowering stores to a result temp and returns once; the duplicated-return structuring emits per-arm returns — `valid_different`, not opcode-exact). Full `switch`-expression reconstruction is a separate feature.

```csharp
public static bool Dispatch(object o, out int x) => o switch
{
    string s => s.Length switch
    {
        0 => Fail(out x),
        1 => Win(1, out x),
        _ => Fail(out x)
    },
    int i when i > 0 => Win(i, out x),
    _ => Fail(out x)
};
```

- Required tracking issue: #2978 — reconstruct the nested `switch`-expression spelling (result-temp single-return shape) for opcode-exact fidelity.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `ScatteredReturnDispatchStructuringTests`: 3 passed | `ScatteredReturnDispatchStructuringTests`: 3 passed |
| Decompiler fast suite | Pass (RoundTrip 316; Pass 1207; Fidelity fast 27) | Pass (RoundTrip 316; Pass 1207; Fidelity fast 27) |
| Reduced fixture validity | self-decompilation CS0161 census pinned at 8 | 8 (unchanged) |
| Reduced fixture fidelity | 2 pre-existing environmental reds (`FidelityGateTests.NoNewFidelityDiffsBeyondKnownDocket`, `LoweredFidelityGateTests`) | same 2 reds, unchanged |
| Real witness | `ScatteredReturnDispatchSample::Dispatch` invalid (CS0177) | fixed (valid) |

The two Slow fidelity-gate reds are the documented lambda-cache/compile-back ordinal artifacts on this machine, not a regression from this PR. Verified by dumping the raised C# of the two methods that surfaced in the current diff set (`ManualConstantOnlyComparisonFactory`, `StatementBodyLambdaInsideIf`) head-vs-base: **identical raised output**, so this structuring change does not touch them.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — pinned-subset gate matched baseline (0 pp on both gated metrics); aggregate residue improved by one method on two metrics with 0 pass bugs.

### PR quick gate

Run: PR quick corpus, hash-stable 100 methods per assembly; 15 assemblies, 1,500 methods; validity/fidelity not run (structural sensors).

| Metric (goal) | Baseline | PR | Rate delta |
| --- | ---: | ---: | ---: |
| Detected lowering residue (-) | 17.67% | 17.67% | 0 pp |
| Conditional-branch residue (-) | 3.00% | 3.00% | 0 pp |
| Pass bugs (-) | 0 | 0 | 0 |

> **Conclusion:** **PASS** — pinned-subset gate matched baseline tolerances.

### Aggregate context

Corpus: 15 assemblies, 1,500 methods. Baseline drift: none.

| Metric (goal) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Detected lowering residue (-) | 251 (16.73%) | 251 (16.73%) | 0 |
| Conditional-branch residue (-) | 46 (3.07%) | 45 (3.00%) | -1 |
| Forward-merge stops (-) | 32 (2.13%) | 31 (2.07%) | -1 |
| Pass bugs (-) | 0 | 0 | 0 |

> **Conclusion:** **PASS** — corpus sensor matched baseline tolerances; two residue metrics improved by one method.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.ScatteredReturnDispatchStructuringTests
```
